### PR TITLE
 Rename scaladsl/javadsl Behavior to ActorBehavior, #24071

### DIFF
--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorCompile.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorCompile.java
@@ -6,7 +6,7 @@ package akka.actor.typed.javadsl;
 import akka.actor.typed.*;
 import akka.actor.typed.ActorContext;
 
-import static akka.actor.typed.javadsl.Actor.*;
+import static akka.actor.typed.javadsl.ActorBehavior.*;
 
 import java.util.concurrent.TimeUnit;
 import scala.concurrent.duration.Duration;
@@ -48,7 +48,7 @@ public class ActorCompile {
   ActorSystem<MyMsg> system = ActorSystem.create(actor1, "Sys");
 
   {
-    Actor.<MyMsg>immutable((ctx, msg) -> {
+    ActorBehavior.<MyMsg>immutable((ctx, msg) -> {
       if (msg instanceof MyMsgA) {
         return immutable((ctx2, msg2) -> {
           if (msg2 instanceof MyMsgB) {
@@ -63,9 +63,9 @@ public class ActorCompile {
   }
 
   {
-    Behavior<MyMsg> b = Actor.withTimers(timers -> {
+    Behavior<MyMsg> b = ActorBehavior.withTimers(timers -> {
       timers.startPeriodicTimer("key", new MyMsgB("tick"), Duration.create(1, TimeUnit.SECONDS));
-      return Actor.ignore();
+      return ActorBehavior.ignore();
     });
   }
 
@@ -107,8 +107,8 @@ public class ActorCompile {
     SupervisorStrategy strategy7 = strategy6.withResetBackoffAfter(Duration.create(2, TimeUnit.SECONDS));
 
     Behavior<MyMsg> behv =
-      Actor.supervise(
-        Actor.supervise(Actor.<MyMsg>ignore()).onFailure(IllegalStateException.class, strategy6)
+      ActorBehavior.supervise(
+        ActorBehavior.supervise(ActorBehavior.<MyMsg>ignore()).onFailure(IllegalStateException.class, strategy6)
       ).onFailure(RuntimeException.class, strategy1);
   }
 

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/AdapterTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/AdapterTest.java
@@ -19,7 +19,7 @@ import akka.actor.typed.Signal;
 import akka.actor.typed.Terminated;
 import akka.testkit.javadsl.TestKit;
 import akka.actor.SupervisorStrategy;
-import static akka.actor.typed.javadsl.Actor.*;
+import static akka.actor.typed.javadsl.ActorBehavior.*;
 
 public class AdapterTest extends JUnitSuite {
 
@@ -187,7 +187,7 @@ public class AdapterTest extends JUnitSuite {
   }
 
   static Behavior<Typed2Msg> typed2() {
-      return Actor.immutable((ctx, msg) -> {
+      return ActorBehavior.immutable((ctx, msg) -> {
         if (msg instanceof Ping) {
           ActorRef<String> replyTo = ((Ping) msg).replyTo;
           replyTo.tell("pong");

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/BehaviorBuilderTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/BehaviorBuilderTest.java
@@ -12,8 +12,8 @@ import akka.actor.typed.ActorRef;
 
 import java.util.ArrayList;
 
-import static akka.actor.typed.javadsl.Actor.same;
-import static akka.actor.typed.javadsl.Actor.stopped;
+import static akka.actor.typed.javadsl.ActorBehavior.same;
+import static akka.actor.typed.javadsl.ActorBehavior.stopped;
 
 /**
  * Test creating [[Behavior]]s using [[BehaviorBuilder]]
@@ -32,7 +32,7 @@ public class BehaviorBuilderTest extends JUnitSuite {
 
     @Test
     public void shouldCompile() {
-      Behavior<Message> b = Actor.immutable(Message.class)
+      Behavior<Message> b = ActorBehavior.immutable(Message.class)
         .onMessage(One.class, (ctx, o) -> {
           o.foo();
           return same();
@@ -40,7 +40,7 @@ public class BehaviorBuilderTest extends JUnitSuite {
         .onMessage(One.class, o -> o.foo().startsWith("a"), (ctx, o) -> same())
         .onMessageUnchecked(MyList.class, (ActorContext<Message> ctx, MyList<String> l) -> {
           String first = l.get(0);
-          return Actor.<Message>same();
+          return ActorBehavior.<Message>same();
         })
         .onSignal(Terminated.class, (ctx, t) -> {
           System.out.println("Terminating along with " + t.getRef());
@@ -65,7 +65,7 @@ public class BehaviorBuilderTest extends JUnitSuite {
     }
 
     public Behavior<CounterMessage> immutableCounter(int currentValue) {
-      return Actor.immutable(CounterMessage.class)
+      return ActorBehavior.immutable(CounterMessage.class)
           .onMessage(Increase.class, (ctx, o) -> {
             return immutableCounter(currentValue + 1);
           })

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ReceiveBuilderTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ReceiveBuilderTest.java
@@ -17,7 +17,7 @@ public class ReceiveBuilderTest extends JUnitSuite {
 
   @Test
   public void testMutableCounter() {
-    Behavior<BehaviorBuilderTest.CounterMessage> mutable = Actor.mutable(ctx -> new Actor.MutableBehavior<BehaviorBuilderTest.CounterMessage>() {
+    Behavior<BehaviorBuilderTest.CounterMessage> mutable = ActorBehavior.mutable(ctx -> new ActorBehavior.MutableBehavior<BehaviorBuilderTest.CounterMessage>() {
       int currentValue = 0;
 
       private Behavior<BehaviorBuilderTest.CounterMessage> receiveIncrease(BehaviorBuilderTest.Increase msg) {
@@ -31,7 +31,7 @@ public class ReceiveBuilderTest extends JUnitSuite {
       }
 
       @Override
-      public Actor.Receive<BehaviorBuilderTest.CounterMessage> createReceive() {
+      public ActorBehavior.Receive<BehaviorBuilderTest.CounterMessage> createReceive() {
         return receiveBuilder()
           .onMessage(BehaviorBuilderTest.Increase.class, this::receiveIncrease)
           .onMessage(BehaviorBuilderTest.Get.class, this::receiveGet)
@@ -40,7 +40,7 @@ public class ReceiveBuilderTest extends JUnitSuite {
     });
   }
 
-  private static class MyMutableBehavior extends Actor.MutableBehavior<BehaviorBuilderTest.CounterMessage> {
+  private static class MyMutableBehavior extends ActorBehavior.MutableBehavior<BehaviorBuilderTest.CounterMessage> {
     private int value;
 
     public MyMutableBehavior(int initialValue) {
@@ -49,7 +49,7 @@ public class ReceiveBuilderTest extends JUnitSuite {
     }
 
     @Override
-    public Actor.Receive<BehaviorBuilderTest.CounterMessage> createReceive() {
+    public ActorBehavior.Receive<BehaviorBuilderTest.CounterMessage> createReceive() {
       assertEquals(42, value);
       return receiveBuilder().build();
     }
@@ -58,6 +58,6 @@ public class ReceiveBuilderTest extends JUnitSuite {
   @Test
   public void testInitializationOrder() throws Exception {
     MyMutableBehavior mutable = new MyMutableBehavior(42);
-    assertEquals(Actor.unhandled(), mutable.receiveMessage(null, new BehaviorBuilderTest.Increase()));
+    assertEquals(ActorBehavior.unhandled(), mutable.receiveMessage(null, new BehaviorBuilderTest.Increase()));
   }
 }

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/WatchTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/WatchTest.java
@@ -14,8 +14,7 @@ import akka.util.Timeout;
 import org.junit.Test;
 
 import akka.actor.typed.*;
-import static akka.actor.typed.javadsl.Actor.*;
-import static akka.actor.typed.javadsl.AskPattern.*;
+import static akka.actor.typed.javadsl.ActorBehavior.*;
 
 public class WatchTest extends JUnitSuite {
 

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/IntroTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/IntroTest.java
@@ -8,7 +8,7 @@ import akka.actor.typed.ActorRef;
 import akka.actor.typed.ActorSystem;
 import akka.actor.typed.Behavior;
 import akka.actor.typed.Terminated;
-import akka.actor.typed.javadsl.Actor;
+import akka.actor.typed.javadsl.ActorBehavior;
 import akka.actor.typed.javadsl.AskPattern;
 import akka.util.Timeout;
 
@@ -47,10 +47,10 @@ public class IntroTest {
       }
     }
 
-    public static final Behavior<Greet> greeter = Actor.immutable((ctx, msg) -> {
+    public static final Behavior<Greet> greeter = ActorBehavior.immutable((ctx, msg) -> {
       System.out.println("Hello " + msg.whom + "!");
       msg.replyTo.tell(new Greeted(msg.whom));
-      return Actor.same();
+      return ActorBehavior.same();
     });
   }
   //#hello-world-actor
@@ -133,7 +133,7 @@ public class IntroTest {
     }
 
     private static Behavior<Command> chatRoom(List<ActorRef<SessionEvent>> sessions) {
-      return Actor.immutable(Command.class)
+      return ActorBehavior.immutable(Command.class)
         .onMessage(GetSession.class, (ctx, getSession) -> {
           ActorRef<PostMessage> wrapper = ctx.spawnAdapter(p ->
             new PostSessionMessage(getSession.screenName, p.message));
@@ -146,7 +146,7 @@ public class IntroTest {
         .onMessage(PostSessionMessage.class, (ctx, post) -> {
           MessagePosted mp = new MessagePosted(post.screenName, post.message);
           sessions.forEach(s -> s.tell(mp));
-          return Actor.same();
+          return ActorBehavior.same();
         })
         .build();
     }
@@ -161,19 +161,19 @@ public class IntroTest {
     }
 
     public static Behavior<ChatRoom.SessionEvent> behavior() {
-      return Actor.immutable(ChatRoom.SessionEvent.class)
+      return ActorBehavior.immutable(ChatRoom.SessionEvent.class)
         .onMessage(ChatRoom.SessionDenied.class, (ctx, msg) -> {
           System.out.println("cannot start chat room session: " + msg.reason);
-          return Actor.stopped();
+          return ActorBehavior.stopped();
         })
         .onMessage(ChatRoom.SessionGranted.class, (ctx, msg) -> {
           msg.handle.tell(new ChatRoom.PostMessage("Hello World!"));
-          return Actor.same();
+          return ActorBehavior.same();
         })
         .onMessage(ChatRoom.MessagePosted.class, (ctx, msg) -> {
           System.out.println("message has been posted by '" +
             msg.screenName +"': " + msg.message);
-          return Actor.stopped();
+          return ActorBehavior.stopped();
         })
         .build();
     }
@@ -184,7 +184,7 @@ public class IntroTest {
   public static void runChatRoom() throws Exception {
 
     //#chatroom-main
-    Behavior<Void> main = Actor.deferred(ctx -> {
+    Behavior<Void> main = ActorBehavior.deferred(ctx -> {
       ActorRef<ChatRoom.Command> chatRoom =
         ctx.spawn(ChatRoom.behavior(), "chatRoom");
       ActorRef<ChatRoom.SessionEvent> gabbler =
@@ -192,8 +192,8 @@ public class IntroTest {
       ctx.watch(gabbler);
       chatRoom.tell(new ChatRoom.GetSession("ol’ Gabbler", gabbler));
 
-      return Actor.immutable(Void.class)
-        .onSignal(Terminated.class, (c, sig) -> Actor.stopped())
+      return ActorBehavior.immutable(Void.class)
+        .onSignal(Terminated.class, (c, sig) -> ActorBehavior.stopped())
         .build();
     });
 

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/MutableIntroTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/MutableIntroTest.java
@@ -6,8 +6,8 @@ package jdocs.akka.actor.typed;
 //#imports
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
-import akka.actor.typed.javadsl.Actor;
-import akka.actor.typed.javadsl.Actor.Receive;
+import akka.actor.typed.javadsl.ActorBehavior;
+import akka.actor.typed.javadsl.ActorBehavior.Receive;
 import akka.actor.typed.javadsl.ActorContext;
 //#imports
 import java.util.ArrayList;
@@ -72,10 +72,10 @@ public class MutableIntroTest {
     //#chatroom-behavior
 
     public static Behavior<Command> behavior() {
-      return Actor.mutable(ChatRoomBehavior::new);
+      return ActorBehavior.mutable(ChatRoomBehavior::new);
     }
 
-    public static class ChatRoomBehavior extends Actor.MutableBehavior<Command> {
+    public static class ChatRoomBehavior extends ActorBehavior.MutableBehavior<Command> {
       final ActorContext<Command> ctx;
       final List<ActorRef<SessionEvent>> sessions = new ArrayList<ActorRef<SessionEvent>>();
 
@@ -91,7 +91,7 @@ public class MutableIntroTest {
               new PostSessionMessage(getSession.screenName, p.message));
             getSession.replyTo.tell(new SessionGranted(wrapper));
             sessions.add(getSession.replyTo);
-            return Actor.same();
+            return ActorBehavior.same();
           })
           .onMessage(PostSessionMessage.class, post -> {
             MessagePosted mp = new MessagePosted(post.screenName, post.message);

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingUntypedTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingUntypedTest.java
@@ -17,8 +17,8 @@ import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 
-import static akka.actor.typed.javadsl.Actor.same;
-import static akka.actor.typed.javadsl.Actor.stopped;
+import static akka.actor.typed.javadsl.ActorBehavior.same;
+import static akka.actor.typed.javadsl.ActorBehavior.stopped;
 
 public class TypedWatchingUntypedTest extends JUnitSuite {
 
@@ -36,7 +36,7 @@ public class TypedWatchingUntypedTest extends JUnitSuite {
     public static class Pong implements Command { }
 
     public static Behavior<Command> behavior() {
-      return akka.actor.typed.javadsl.Actor.deferred(context -> {
+      return akka.actor.typed.javadsl.ActorBehavior.deferred(context -> {
         akka.actor.ActorRef second = Adapter.actorOf(context, Untyped.props(), "second");
 
         Adapter.watch(context, second);
@@ -44,7 +44,7 @@ public class TypedWatchingUntypedTest extends JUnitSuite {
         second.tell(new Typed.Ping(context.getSelf().narrow()),
           Adapter.toUntyped(context.getSelf()));
 
-        return akka.actor.typed.javadsl.Actor.immutable(Typed.Command.class)
+        return akka.actor.typed.javadsl.ActorBehavior.immutable(Typed.Command.class)
           .onMessage(Typed.Pong.class, (ctx, msg) -> {
             Adapter.stop(ctx, second);
             return same();

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/UntypedWatchingTypedTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/UntypedWatchingTypedTest.java
@@ -7,7 +7,7 @@ import akka.actor.AbstractActor;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.ActorSystem;
 import akka.actor.typed.Behavior;
-import akka.actor.typed.javadsl.Actor;
+import akka.actor.typed.javadsl.ActorBehavior;
 //#adapter-import
 // In java use the static methods on Adapter to convert from typed to untyped
 import akka.actor.typed.javadsl.Adapter;
@@ -18,7 +18,7 @@ import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 
-import static akka.actor.typed.javadsl.Actor.same;
+import static akka.actor.typed.javadsl.ActorBehavior.same;
 
 public class UntypedWatchingTypedTest extends JUnitSuite {
 
@@ -66,7 +66,7 @@ public class UntypedWatchingTypedTest extends JUnitSuite {
     public static class Pong { }
 
     public static Behavior<Command> behavior() {
-      return Actor.immutable(Typed.Command.class)
+      return ActorBehavior.immutable(Typed.Command.class)
         .onMessage(Typed.Ping.class, (ctx, msg) -> {
           msg.replyTo.tell(new Pong());
           return same();

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/testing/async/BasicAsyncTestingTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/testing/async/BasicAsyncTestingTest.java
@@ -5,7 +5,7 @@ package jdocs.akka.typed.testing.async;
 
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
-import akka.actor.typed.javadsl.Actor;
+import akka.actor.typed.javadsl.ActorBehavior;
 import akka.testkit.typed.javadsl.TestProbe;
 import akka.testkit.typed.TestKit;
 import org.junit.AfterClass;
@@ -33,9 +33,9 @@ public class BasicAsyncTestingTest extends TestKit {
     }
   }
 
-  Behavior<Ping> echoActor = Actor.immutable((ctx, ping) -> {
+  Behavior<Ping> echoActor = ActorBehavior.immutable((ctx, ping) -> {
     ping.replyTo.tell(new Pong(ping.msg));
-    return Actor.same();
+    return ActorBehavior.same();
   });
   //#under-test
 

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/testing/sync/BasicSyncTestingTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/testing/sync/BasicSyncTestingTest.java
@@ -11,7 +11,7 @@ import org.scalatest.junit.JUnitSuite;
 public class BasicSyncTestingTest extends JUnitSuite {
 
   //#child
-  public static Behavior<String> childActor = Actor.immutable((ctx, msg) -> Actor.same());
+  public static Behavior<String> childActor = ActorBehavior.immutable((ctx, msg) -> ActorBehavior.same());
   //#child
 
   //#under-test
@@ -38,27 +38,27 @@ public class BasicSyncTestingTest extends JUnitSuite {
     }
   }
 
-  public static Behavior<Command> myBehaviour = Actor.immutable(Command.class)
+  public static Behavior<Command> myBehaviour = ActorBehavior.immutable(Command.class)
     .onMessage(CreateAChild.class, (ctx, msg) -> {
       ctx.spawn(childActor, msg.childName);
-      return Actor.same();
+      return ActorBehavior.same();
     })
     .onMessage(CreateAnAnonymousChild.class, (ctx, msg) -> {
       ctx.spawnAnonymous(childActor);
-      return Actor.same();
+      return ActorBehavior.same();
     })
     .onMessage(SayHelloToChild.class, (ctx, msg) -> {
       ActorRef<String> child = ctx.spawn(childActor, msg.childName);
       child.tell("hello");
-      return Actor.same();
+      return ActorBehavior.same();
     })
     .onMessage(SayHelloToAnonymousChild.class, (ctx, msg) -> {
       ActorRef<String> child = ctx.spawnAnonymous(childActor);
       child.tell("hello stranger");
-      return Actor.same();
+      return ActorBehavior.same();
     }).onMessage(SayHello.class, (ctx, msg) -> {
       msg.who.tell("hello");
-      return Actor.same();
+      return ActorBehavior.same();
     }).build();
   //#under-test
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
@@ -3,8 +3,8 @@
  */
 package akka.actor.typed
 
-import akka.actor.typed.scaladsl.Actor._
-import akka.actor.typed.scaladsl.{ Actor, AskPattern }
+import akka.actor.typed.scaladsl.ActorBehavior._
+import akka.actor.typed.scaladsl.{ ActorBehavior, AskPattern }
 import akka.actor.{ ActorInitializationException, DeadLetterSuppression, InvalidMessageException }
 import akka.testkit.AkkaSpec
 import akka.testkit.TestEvent.Mute
@@ -84,18 +84,18 @@ object ActorContextSpec {
   final case class Adapter(a: ActorRef[Command]) extends Event
 
   def subject(monitor: ActorRef[Monitor], ignorePostStop: Boolean): Behavior[Command] =
-    Actor.immutable[Command] {
+    ActorBehavior.immutable[Command] {
       (ctx, message) ⇒
         message match {
           case ReceiveTimeout ⇒
             monitor ! GotReceiveTimeout
-            Actor.same
+            ActorBehavior.same
           case Ping(replyTo) ⇒
             replyTo ! Pong1
-            Actor.same
+            ActorBehavior.same
           case Miss(replyTo) ⇒
             replyTo ! Missed
-            Actor.unhandled
+            ActorBehavior.unhandled
           case Renew(replyTo) ⇒
             replyTo ! Renewed
             subject(monitor, ignorePostStop)
@@ -103,87 +103,87 @@ object ActorContextSpec {
             throw ex
           case MkChild(name, mon, replyTo) ⇒
             val child = name match {
-              case None    ⇒ ctx.spawnAnonymous(Actor.supervise(subject(mon, ignorePostStop)).onFailure(SupervisorStrategy.restart))
-              case Some(n) ⇒ ctx.spawn(Actor.supervise(subject(mon, ignorePostStop)).onFailure(SupervisorStrategy.restart), n)
+              case None    ⇒ ctx.spawnAnonymous(ActorBehavior.supervise(subject(mon, ignorePostStop)).onFailure(SupervisorStrategy.restart))
+              case Some(n) ⇒ ctx.spawn(ActorBehavior.supervise(subject(mon, ignorePostStop)).onFailure(SupervisorStrategy.restart), n)
             }
             replyTo ! Created(child)
-            Actor.same
+            ActorBehavior.same
           case SetTimeout(d, replyTo) ⇒
             d match {
               case f: FiniteDuration ⇒ ctx.setReceiveTimeout(f, ReceiveTimeout)
               case _                 ⇒ ctx.cancelReceiveTimeout()
             }
             replyTo ! TimeoutSet
-            Actor.same
+            ActorBehavior.same
           case Schedule(delay, target, msg, replyTo) ⇒
             replyTo ! Scheduled
             ctx.schedule(delay, target, msg)
-            Actor.same
+            ActorBehavior.same
           case Stop ⇒
-            Actor.stopped
+            ActorBehavior.stopped
           case Kill(ref, replyTo) ⇒
             if (ctx.stop(ref)) replyTo ! Killed
             else replyTo ! NotKilled
-            Actor.same
+            ActorBehavior.same
           case Watch(ref, replyTo) ⇒
             ctx.watch(ref)
             replyTo ! Watched
-            Actor.same
+            ActorBehavior.same
           case Unwatch(ref, replyTo) ⇒
             ctx.unwatch(ref)
             replyTo ! Unwatched
-            Actor.same
+            ActorBehavior.same
           case GetInfo(replyTo) ⇒
             replyTo ! Info(ctx.self, ctx.system)
-            Actor.same
+            ActorBehavior.same
           case GetChild(name, replyTo) ⇒
             replyTo ! Child(ctx.child(name))
-            Actor.same
+            ActorBehavior.same
           case GetChildren(replyTo) ⇒
             replyTo ! Children(ctx.children.toSet)
-            Actor.same
+            ActorBehavior.same
           case BecomeInert(replyTo) ⇒
             replyTo ! BecameInert
-            Actor.immutable {
+            ActorBehavior.immutable {
               case (_, Ping(replyTo)) ⇒
                 replyTo ! Pong2
-                Actor.same
+                ActorBehavior.same
               case (_, Throw(ex)) ⇒
                 throw ex
-              case _ ⇒ Actor.unhandled
+              case _ ⇒ ActorBehavior.unhandled
             }
           case BecomeCareless(replyTo) ⇒
             replyTo ! BecameCareless
-            Actor.immutable[Command] {
-              case (_, _) ⇒ Actor.unhandled
+            ActorBehavior.immutable[Command] {
+              case (_, _) ⇒ ActorBehavior.unhandled
             } onSignal {
-              case (_, PostStop) if ignorePostStop ⇒ Actor.same // ignore PostStop here
-              case (_, Terminated(_))              ⇒ Actor.unhandled
+              case (_, PostStop) if ignorePostStop ⇒ ActorBehavior.same // ignore PostStop here
+              case (_, Terminated(_))              ⇒ ActorBehavior.unhandled
               case (_, sig) ⇒
                 monitor ! GotSignal(sig)
-                Actor.same
+                ActorBehavior.same
             }
           case GetAdapter(replyTo, name) ⇒
             replyTo ! Adapter(ctx.spawnAdapter(identity, name))
-            Actor.same
+            ActorBehavior.same
         }
     } onSignal {
-      case (_, PostStop) if ignorePostStop ⇒ Actor.same // ignore PostStop here
-      case (ctx, signal)                   ⇒ monitor ! GotSignal(signal); Actor.same
+      case (_, PostStop) if ignorePostStop ⇒ ActorBehavior.same // ignore PostStop here
+      case (ctx, signal)                   ⇒ monitor ! GotSignal(signal); ActorBehavior.same
     }
 
   def oldSubject(monitor: ActorRef[Monitor], ignorePostStop: Boolean): Behavior[Command] = {
-    Actor.immutable[Command] {
+    ActorBehavior.immutable[Command] {
       case (ctx, message) ⇒ message match {
         case ReceiveTimeout ⇒
           monitor ! GotReceiveTimeout
-          Actor.same
+          ActorBehavior.same
         case Ping(replyTo) ⇒
           replyTo ! Pong1
-          Actor.same
+          ActorBehavior.same
         case Miss(replyTo) ⇒
           replyTo ! Missed
-          Actor.unhandled
+          ActorBehavior.unhandled
         case Renew(replyTo) ⇒
           replyTo ! Renewed
           subject(monitor, ignorePostStop)
@@ -191,75 +191,75 @@ object ActorContextSpec {
           throw ex
         case MkChild(name, mon, replyTo) ⇒
           val child = name match {
-            case None    ⇒ ctx.spawnAnonymous(Actor.supervise(subject(mon, ignorePostStop)).onFailure[Throwable](SupervisorStrategy.restart))
-            case Some(n) ⇒ ctx.spawn(Actor.supervise(subject(mon, ignorePostStop)).onFailure[Throwable](SupervisorStrategy.restart), n)
+            case None    ⇒ ctx.spawnAnonymous(ActorBehavior.supervise(subject(mon, ignorePostStop)).onFailure[Throwable](SupervisorStrategy.restart))
+            case Some(n) ⇒ ctx.spawn(ActorBehavior.supervise(subject(mon, ignorePostStop)).onFailure[Throwable](SupervisorStrategy.restart), n)
           }
           replyTo ! Created(child)
-          Actor.same
+          ActorBehavior.same
         case SetTimeout(d, replyTo) ⇒
           d match {
             case f: FiniteDuration ⇒ ctx.setReceiveTimeout(f, ReceiveTimeout)
             case _                 ⇒ ctx.cancelReceiveTimeout()
           }
           replyTo ! TimeoutSet
-          Actor.same
+          ActorBehavior.same
         case Schedule(delay, target, msg, replyTo) ⇒
           replyTo ! Scheduled
           ctx.schedule(delay, target, msg)
-          Actor.same
+          ActorBehavior.same
         case Stop ⇒
-          Actor.stopped
+          ActorBehavior.stopped
         case Kill(ref, replyTo) ⇒
           if (ctx.stop(ref)) replyTo ! Killed
           else replyTo ! NotKilled
-          Actor.same
+          ActorBehavior.same
         case Watch(ref, replyTo) ⇒
           ctx.watch(ref)
           replyTo ! Watched
-          Actor.same
+          ActorBehavior.same
         case Unwatch(ref, replyTo) ⇒
           ctx.unwatch(ref)
           replyTo ! Unwatched
-          Actor.same
+          ActorBehavior.same
         case GetInfo(replyTo) ⇒
           replyTo ! Info(ctx.self, ctx.system)
-          Actor.same
+          ActorBehavior.same
         case GetChild(name, replyTo) ⇒
           replyTo ! Child(ctx.child(name))
-          Actor.same
+          ActorBehavior.same
         case GetChildren(replyTo) ⇒
           replyTo ! Children(ctx.children.toSet)
-          Actor.same
+          ActorBehavior.same
         case BecomeInert(replyTo) ⇒
           replyTo ! BecameInert
-          Actor.immutable[Command] {
+          ActorBehavior.immutable[Command] {
             case (_, Ping(r)) ⇒
               r ! Pong2
-              Actor.same
+              ActorBehavior.same
             case (_, Throw(ex)) ⇒
               throw ex
-            case _ ⇒ Actor.same
+            case _ ⇒ ActorBehavior.same
           }
         case BecomeCareless(replyTo) ⇒
           replyTo ! BecameCareless
-          Actor.immutable[Command] {
-            case _ ⇒ Actor.unhandled
+          ActorBehavior.immutable[Command] {
+            case _ ⇒ ActorBehavior.unhandled
           } onSignal {
-            case (_, PostStop) if ignorePostStop ⇒ Actor.same // ignore PostStop here
-            case (_, Terminated(_))              ⇒ Actor.unhandled
+            case (_, PostStop) if ignorePostStop ⇒ ActorBehavior.same // ignore PostStop here
+            case (_, Terminated(_))              ⇒ ActorBehavior.unhandled
             case (_, sig) ⇒
               monitor ! GotSignal(sig)
-              Actor.same
+              ActorBehavior.same
           }
         case GetAdapter(replyTo, name) ⇒
           replyTo ! Adapter(ctx.spawnAdapter(identity, name))
-          Actor.same
+          ActorBehavior.same
       }
     } onSignal {
-      case (_, PostStop) if ignorePostStop ⇒ Actor.same // ignore PostStop here
+      case (_, PostStop) if ignorePostStop ⇒ ActorBehavior.same // ignore PostStop here
       case (_, signal) ⇒
         monitor ! GotSignal(signal)
-        Actor.same
+        ActorBehavior.same
     }
   }
 
@@ -279,7 +279,7 @@ object ActorContextSpec {
   class SimulatedException(message: String) extends RuntimeException(message) with NoStackTrace
 
   def guardian(outstanding: Map[ActorRef[_], ActorRef[Status]] = Map.empty): Behavior[GuardianCommand] =
-    Actor.immutable[GuardianCommand] {
+    ActorBehavior.immutable[GuardianCommand] {
       case (ctx, r: RunTest[t]) ⇒
         val test = ctx.spawn(r.behavior, r.name)
         ctx.schedule(r.timeout, r.replyTo, Timedout)
@@ -477,7 +477,7 @@ abstract class ActorContextSpec extends TypedAkkaSpec {
     }
 
     "correctly wire the lifecycle hooks" in {
-      sync(setup("ctx01", Some(b ⇒ Actor.supervise(b).onFailure[Throwable](SupervisorStrategy.restart)), ignorePostStop = false) { (ctx, startWith) ⇒
+      sync(setup("ctx01", Some(b ⇒ ActorBehavior.supervise(b).onFailure[Throwable](SupervisorStrategy.restart)), ignorePostStop = false) { (ctx, startWith) ⇒
         val self = ctx.self
         val ex = new Exception("KABOOM1")
         startWith { subj ⇒
@@ -555,7 +555,7 @@ abstract class ActorContextSpec extends TypedAkkaSpec {
     }
 
     "reset behavior upon Restart" in {
-      sync(setup("ctx05", Some(Actor.supervise(_).onFailure(SupervisorStrategy.restart))) { (ctx, startWith) ⇒
+      sync(setup("ctx05", Some(ActorBehavior.supervise(_).onFailure(SupervisorStrategy.restart))) { (ctx, startWith) ⇒
         val self = ctx.self
         val ex = new Exception("KABOOM05")
         startWith
@@ -572,7 +572,7 @@ abstract class ActorContextSpec extends TypedAkkaSpec {
     "not reset behavior upon Resume" in {
       sync(setup(
         "ctx06",
-        Some(b ⇒ Actor.supervise(b).onFailure(SupervisorStrategy.resume))) { (ctx, startWith) ⇒
+        Some(b ⇒ ActorBehavior.supervise(b).onFailure(SupervisorStrategy.resume))) { (ctx, startWith) ⇒
           val self = ctx.self
           val ex = new Exception("KABOOM06")
           startWith
@@ -802,7 +802,7 @@ class NormalActorContextSpec extends ActorContextSpec {
 
 class WidenedActorContextSpec extends ActorContextSpec {
 
-  import Actor._
+  import ActorBehavior._
 
   override def suite = "widened"
   override def behavior(ctx: scaladsl.ActorContext[Event], ignorePostStop: Boolean): Behavior[Command] =
@@ -812,17 +812,17 @@ class WidenedActorContextSpec extends ActorContextSpec {
 class DeferredActorContextSpec extends ActorContextSpec {
   override def suite = "deferred"
   override def behavior(ctx: scaladsl.ActorContext[Event], ignorePostStop: Boolean): Behavior[Command] =
-    Actor.deferred(_ ⇒ subject(ctx.self, ignorePostStop))
+    ActorBehavior.deferred(_ ⇒ subject(ctx.self, ignorePostStop))
 }
 
 class NestedDeferredActorContextSpec extends ActorContextSpec {
   override def suite = "nexted-deferred"
   override def behavior(ctx: scaladsl.ActorContext[Event], ignorePostStop: Boolean): Behavior[Command] =
-    Actor.deferred(_ ⇒ Actor.deferred(_ ⇒ subject(ctx.self, ignorePostStop)))
+    ActorBehavior.deferred(_ ⇒ ActorBehavior.deferred(_ ⇒ subject(ctx.self, ignorePostStop)))
 }
 
 class TapActorContextSpec extends ActorContextSpec {
   override def suite = "tap"
   override def behavior(ctx: scaladsl.ActorContext[Event], ignorePostStop: Boolean): Behavior[Command] =
-    Actor.tap((_, _) ⇒ (), (_, _) ⇒ (), subject(ctx.self, ignorePostStop))
+    ActorBehavior.tap((_, _) ⇒ (), (_, _) ⇒ (), subject(ctx.self, ignorePostStop))
 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -4,8 +4,8 @@
 package akka.actor.typed
 
 import akka.actor.typed.internal.adapter.ActorSystemAdapter
-import akka.actor.typed.scaladsl.Actor
-import akka.actor.typed.scaladsl.Actor._
+import akka.actor.typed.scaladsl.ActorBehavior
+import akka.actor.typed.scaladsl.ActorBehavior._
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.pattern.AskTimeoutException
 import akka.testkit.typed.TestKit
@@ -29,10 +29,10 @@ class AskSpec extends TestKit("AskSpec") with TypedAkkaSpec with ScalaFutures {
   val behavior: Behavior[Msg] = immutable[Msg] {
     case (_, foo: Foo) ⇒
       foo.replyTo ! "foo"
-      Actor.same
+      ActorBehavior.same
     case (_, Stop(r)) ⇒
       r ! ()
-      Actor.stopped
+      ActorBehavior.stopped
   }
 
   "Ask pattern" must {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
@@ -3,8 +3,8 @@
  */
 package akka.actor.typed
 
-import akka.actor.typed.scaladsl.{ Actor ⇒ SActor }
-import akka.actor.typed.javadsl.{ Actor ⇒ JActor, ActorContext ⇒ JActorContext }
+import akka.actor.typed.scaladsl.{ ActorBehavior ⇒ SActor }
+import akka.actor.typed.javadsl.{ ActorBehavior ⇒ JActor, ActorContext ⇒ JActorContext }
 import akka.japi.function.{ Function ⇒ F1e, Function2 ⇒ F2, Procedure2 ⇒ P2 }
 import akka.japi.pf.{ FI, PFBuilder }
 import java.util.function.{ Function ⇒ F1 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/StepWise.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/StepWise.scala
@@ -6,7 +6,7 @@ package akka.actor.typed
 import scala.concurrent.duration.FiniteDuration
 import java.util.concurrent.TimeoutException
 
-import akka.actor.typed.scaladsl.Actor._
+import akka.actor.typed.scaladsl.ActorBehavior._
 
 import scala.concurrent.duration.Deadline
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -3,10 +3,10 @@
  */
 package akka.actor.typed
 
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 
 import scala.concurrent.duration._
-import akka.actor.typed.scaladsl.Actor._
+import akka.actor.typed.scaladsl.ActorBehavior._
 import akka.testkit.typed.{ BehaviorTestkit, TestInbox, TestKit, TestKitSettings }
 
 import scala.util.control.NoStackTrace
@@ -37,23 +37,23 @@ object SupervisionSpec {
       cmd match {
         case Ping ⇒
           monitor ! Pong
-          Actor.same
+          ActorBehavior.same
         case IncrementState ⇒
           targetBehavior(monitor, state.copy(n = state.n + 1))
         case GetState ⇒
           val reply = state.copy(children = ctx.children.map(c ⇒ c.path.name → c.upcast[Command]).toMap)
           monitor ! reply
-          Actor.same
+          ActorBehavior.same
         case CreateChild(childBehv, childName) ⇒
           ctx.spawn(childBehv, childName)
-          Actor.same
+          ActorBehavior.same
         case Throw(e) ⇒
           throw e
       }
     } onSignal {
       case (_, sig) ⇒
         monitor ! GotSignal(sig)
-        Actor.same
+        ActorBehavior.same
     }
 
   class FailingConstructor(monitor: ActorRef[Event]) extends MutableBehavior[Command] {
@@ -62,7 +62,7 @@ object SupervisionSpec {
 
     override def onMessage(msg: Command): Behavior[Command] = {
       monitor ! Pong
-      Actor.same
+      ActorBehavior.same
     }
   }
 }
@@ -163,7 +163,7 @@ class StubbedSupervisionSpec extends WordSpec with Matchers {
 
     "not catch fatal error" in {
       val inbox = TestInbox[Event]()
-      val behv = Actor.supervise(targetBehavior(inbox.ref))
+      val behv = ActorBehavior.supervise(targetBehavior(inbox.ref))
         .onFailure[Throwable](SupervisorStrategy.restart)
       val testkit = BehaviorTestkit(behv)
       intercept[StackOverflowError] {
@@ -245,7 +245,7 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
   "A supervised actor" must {
     "receive message" in {
       val probe = TestProbe[Event]("evt")
-      val behv = Actor.supervise(targetBehavior(probe.ref))
+      val behv = ActorBehavior.supervise(targetBehavior(probe.ref))
         .onFailure[Throwable](SupervisorStrategy.restart)
       val ref = spawn(behv)
       ref ! Ping
@@ -263,7 +263,7 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
 
     "stop when unhandled exception" in {
       val probe = TestProbe[Event]("evt")
-      val behv = Actor.supervise(targetBehavior(probe.ref))
+      val behv = ActorBehavior.supervise(targetBehavior(probe.ref))
         .onFailure[Exc1](SupervisorStrategy.restart)
       val ref = spawn(behv)
       ref ! Throw(new Exc3)
@@ -272,7 +272,7 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
 
     "restart when handled exception" in {
       val probe = TestProbe[Event]("evt")
-      val behv = Actor.supervise(targetBehavior(probe.ref))
+      val behv = ActorBehavior.supervise(targetBehavior(probe.ref))
         .onFailure[Exc1](SupervisorStrategy.restart)
       val ref = spawn(behv)
       ref ! IncrementState
@@ -287,7 +287,7 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
 
     "NOT stop children when restarting" in {
       val parentProbe = TestProbe[Event]("evt")
-      val behv = Actor.supervise(targetBehavior(parentProbe.ref))
+      val behv = ActorBehavior.supervise(targetBehavior(parentProbe.ref))
         .onFailure[Exc1](SupervisorStrategy.restart)
       val ref = spawn(behv)
 
@@ -321,8 +321,8 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
 
     "support nesting to handle different exceptions" in {
       val probe = TestProbe[Event]("evt")
-      val behv = Actor.supervise(
-        Actor.supervise(targetBehavior(probe.ref))
+      val behv = ActorBehavior.supervise(
+        ActorBehavior.supervise(targetBehavior(probe.ref))
           .onFailure[Exc2](SupervisorStrategy.resume)
       ).onFailure[Exc3](SupervisorStrategy.restart)
       val ref = spawn(behv)
@@ -354,7 +354,7 @@ class SupervisionSpec extends TestKit("SupervisionSpec") with TypedAkkaSpecWithS
       val strategy = SupervisorStrategy
         .restartWithBackoff(minBackoff, 10.seconds, 0.0)
         .withResetBackoffAfter(10.seconds)
-      val behv = Actor.supervise(Actor.deferred[Command] { _ ⇒
+      val behv = ActorBehavior.supervise(ActorBehavior.deferred[Command] { _ ⇒
         startedProbe.ref ! Started
         targetBehavior(probe.ref)
       }).onFailure[Exception](strategy)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.scaladsl.TimerScheduler
 import akka.testkit.typed.TestKitSettings
 import akka.testkit.typed.TestKit
@@ -46,21 +46,21 @@ class TimerSpec extends TestKit("TimerSpec")
       target(monitor, timer, nextCount)
     }
 
-    Actor.immutable[Command] { (ctx, cmd) ⇒
+    ActorBehavior.immutable[Command] { (ctx, cmd) ⇒
       cmd match {
         case Tick(n) ⇒
           monitor ! Tock(n)
-          Actor.same
+          ActorBehavior.same
         case Bump ⇒
           bump()
         case SlowThenBump(latch) ⇒
           latch.await(10, TimeUnit.SECONDS)
           bump()
         case End ⇒
-          Actor.stopped
+          ActorBehavior.stopped
         case Cancel ⇒
           timer.cancel("T")
-          Actor.same
+          ActorBehavior.same
         case Throw(e) ⇒
           throw e
         case SlowThenThrow(latch, e) ⇒
@@ -70,17 +70,17 @@ class TimerSpec extends TestKit("TimerSpec")
     } onSignal {
       case (ctx, PreRestart) ⇒
         monitor ! GotPreRestart(timer.isTimerActive("T"))
-        Actor.same
+        ActorBehavior.same
       case (ctx, PostStop) ⇒
         monitor ! GotPostStop(timer.isTimerActive("T"))
-        Actor.same
+        ActorBehavior.same
     }
   }
 
   "A timer" must {
     "schedule non-repeated ticks" in {
       val probe = TestProbe[Event]("evt")
-      val behv = Actor.withTimers[Command] { timer ⇒
+      val behv = ActorBehavior.withTimers[Command] { timer ⇒
         timer.startSingleTimer("T", Tick(1), 10.millis)
         target(probe.ref, timer, 1)
       }
@@ -95,7 +95,7 @@ class TimerSpec extends TestKit("TimerSpec")
 
     "schedule repeated ticks" in {
       val probe = TestProbe[Event]("evt")
-      val behv = Actor.withTimers[Command] { timer ⇒
+      val behv = ActorBehavior.withTimers[Command] { timer ⇒
         timer.startPeriodicTimer("T", Tick(1), interval)
         target(probe.ref, timer, 1)
       }
@@ -113,7 +113,7 @@ class TimerSpec extends TestKit("TimerSpec")
 
     "replace timer" in {
       val probe = TestProbe[Event]("evt")
-      val behv = Actor.withTimers[Command] { timer ⇒
+      val behv = ActorBehavior.withTimers[Command] { timer ⇒
         timer.startPeriodicTimer("T", Tick(1), interval)
         target(probe.ref, timer, 1)
       }
@@ -133,7 +133,7 @@ class TimerSpec extends TestKit("TimerSpec")
 
     "cancel timer" in {
       val probe = TestProbe[Event]("evt")
-      val behv = Actor.withTimers[Command] { timer ⇒
+      val behv = ActorBehavior.withTimers[Command] { timer ⇒
         timer.startPeriodicTimer("T", Tick(1), interval)
         target(probe.ref, timer, 1)
       }
@@ -150,7 +150,7 @@ class TimerSpec extends TestKit("TimerSpec")
     "discard timers from old incarnation after restart, alt 1" in {
       val probe = TestProbe[Event]("evt")
       val startCounter = new AtomicInteger(0)
-      val behv = Actor.supervise(Actor.withTimers[Command] { timer ⇒
+      val behv = ActorBehavior.supervise(ActorBehavior.withTimers[Command] { timer ⇒
         timer.startPeriodicTimer("T", Tick(startCounter.incrementAndGet()), interval)
         target(probe.ref, timer, 1)
       }).onFailure[Exception](SupervisorStrategy.restart)
@@ -173,7 +173,7 @@ class TimerSpec extends TestKit("TimerSpec")
 
     "discard timers from old incarnation after restart, alt 2" in {
       val probe = TestProbe[Event]("evt")
-      val behv = Actor.supervise(Actor.withTimers[Command] { timer ⇒
+      val behv = ActorBehavior.supervise(ActorBehavior.withTimers[Command] { timer ⇒
         timer.startPeriodicTimer("T", Tick(1), interval)
         target(probe.ref, timer, 1)
       }).onFailure[Exception](SupervisorStrategy.restart)
@@ -199,7 +199,7 @@ class TimerSpec extends TestKit("TimerSpec")
 
     "cancel timers when stopped from exception" in {
       val probe = TestProbe[Event]()
-      val behv = Actor.withTimers[Command] { timer ⇒
+      val behv = ActorBehavior.withTimers[Command] { timer ⇒
         timer.startPeriodicTimer("T", Tick(1), interval)
         target(probe.ref, timer, 1)
       }
@@ -210,7 +210,7 @@ class TimerSpec extends TestKit("TimerSpec")
 
     "cancel timers when stopped voluntarily" in {
       val probe = TestProbe[Event]()
-      val behv = Actor.withTimers[Command] { timer ⇒
+      val behv = ActorBehavior.withTimers[Command] { timer ⇒
         timer.startPeriodicTimer("T", Tick(1), interval)
         target(probe.ref, timer, 1)
       }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
@@ -3,7 +3,7 @@
  */
 package akka.actor.typed
 
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 
 import scala.concurrent._
 import akka.testkit.typed.TestKit
@@ -12,8 +12,8 @@ object WatchSpec {
   case object Stop
 
   val terminatorBehavior =
-    Actor.immutable[Stop.type] {
-      case (_, Stop) ⇒ Actor.stopped
+    ActorBehavior.immutable[Stop.type] {
+      case (_, Stop) ⇒ ActorBehavior.stopped
     }
 
   sealed trait Message
@@ -32,14 +32,14 @@ class WatchSpec extends TestKit("WordSpec")
       val terminator = systemActor(terminatorBehavior)
       val receivedTerminationSignal: Promise[ActorRef[Nothing]] = Promise()
 
-      val watcher = systemActor(Actor.immutable[StartWatching] {
+      val watcher = systemActor(ActorBehavior.immutable[StartWatching] {
         case (ctx, StartWatching(watchee)) ⇒
           ctx.watch(watchee)
-          Actor.same
+          ActorBehavior.same
       }.onSignal {
         case (_, Terminated(stopped)) ⇒
           receivedTerminationSignal.success(stopped)
-          Actor.stopped
+          ActorBehavior.stopped
       })
 
       watcher ! StartWatching(terminator)
@@ -52,13 +52,13 @@ class WatchSpec extends TestKit("WordSpec")
       val terminator = systemActor(terminatorBehavior)
       val receivedTerminationSignal: Promise[Message] = Promise()
 
-      val watcher = systemActor(Actor.immutable[Message] {
+      val watcher = systemActor(ActorBehavior.immutable[Message] {
         case (ctx, StartWatchingWith(watchee, msg)) ⇒
           ctx.watchWith(watchee, msg)
-          Actor.same
+          ActorBehavior.same
         case (_, msg) ⇒
           receivedTerminationSignal.success(msg)
-          Actor.stopped
+          ActorBehavior.stopped
       })
 
       watcher ! StartWatchingWith(terminator, CustomTerminationMessage)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
@@ -5,7 +5,7 @@ package akka.actor.typed
 package internal
 
 import akka.actor.InvalidMessageException
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.testkit.typed.TestInbox
 import org.scalatest._
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
@@ -39,7 +39,7 @@ class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll
     "start the guardian actor and terminate when it terminates" in {
       val t = withSystem(
         "a",
-        Actor.immutable[Probe] { case (_, p) ⇒ p.replyTo ! p.msg; Actor.stopped }, doTerminate = false) { sys ⇒
+        ActorBehavior.immutable[Probe] { case (_, p) ⇒ p.replyTo ! p.msg; ActorBehavior.stopped }, doTerminate = false) { sys ⇒
           val inbox = TestInbox[String]("a")
           sys ! Probe("hello", inbox.ref)
           eventually {
@@ -55,7 +55,7 @@ class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll
     // see issue #24172
     "shutdown if guardian shuts down immediately" in {
       pending
-      withSystem("shutdown", Actor.stopped[String], doTerminate = false) { sys: ActorSystem[String] ⇒
+      withSystem("shutdown", ActorBehavior.stopped[String], doTerminate = false) { sys: ActorSystem[String] ⇒
         sys.whenTerminated.futureValue
       }
     }
@@ -63,12 +63,12 @@ class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll
     "terminate the guardian actor" in {
       val inbox = TestInbox[String]("terminate")
       val sys = system(
-        Actor.immutable[Probe] {
-          case (_, _) ⇒ Actor.unhandled
+        ActorBehavior.immutable[Probe] {
+          case (_, _) ⇒ ActorBehavior.unhandled
         } onSignal {
           case (_, PostStop) ⇒
             inbox.ref ! "done"
-            Actor.same
+            ActorBehavior.same
         },
         "terminate")
       sys.terminate().futureValue
@@ -80,13 +80,13 @@ class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll
     }
 
     "have a name" in {
-      withSystem("name", Actor.empty[String]) { sys ⇒
+      withSystem("name", ActorBehavior.empty[String]) { sys ⇒
         sys.name should ===(suite + "-name")
       }
     }
 
     "report its uptime" in {
-      withSystem("uptime", Actor.empty[String]) { sys ⇒
+      withSystem("uptime", ActorBehavior.empty[String]) { sys ⇒
         sys.uptime should be < 1L
         Thread.sleep(1000)
         sys.uptime should be >= 1L
@@ -94,7 +94,7 @@ class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll
     }
 
     "have a working thread factory" in {
-      withSystem("thread", Actor.empty[String]) { sys ⇒
+      withSystem("thread", ActorBehavior.empty[String]) { sys ⇒
         val p = Promise[Int]
         sys.threadFactory.newThread(new Runnable {
           def run(): Unit = p.success(42)
@@ -104,14 +104,14 @@ class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll
     }
 
     "be able to run Futures" in {
-      withSystem("futures", Actor.empty[String]) { sys ⇒
+      withSystem("futures", ActorBehavior.empty[String]) { sys ⇒
         val f = Future(42)(sys.executionContext)
         f.futureValue should ===(42)
       }
     }
 
     "not allow null messages" in {
-      withSystem("null-messages", Actor.empty[String]) { sys ⇒
+      withSystem("null-messages", ActorBehavior.empty[String]) { sys ⇒
         intercept[InvalidMessageException] {
           sys ! null
         }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/MiscMessageSerializerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/MiscMessageSerializerSpec.scala
@@ -4,7 +4,7 @@
 package akka.actor.typed.internal
 
 import akka.actor.typed.TypedAkkaSpecWithShutdown
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.scaladsl.adapter._
 import akka.serialization.SerializationExtension
 import akka.testkit.typed.TestKit
@@ -39,7 +39,7 @@ class MiscMessageSerializerSpec extends TestKit(MiscMessageSerializerSpec.config
     }
 
     "must serialize and deserialize typed actor refs" in {
-      val ref = spawn(Actor.empty[Unit])
+      val ref = spawn(ActorBehavior.empty[Unit])
       checkSerialization(ref)
     }
   }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/LocalReceptionistSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/LocalReceptionistSpec.scala
@@ -5,7 +5,7 @@ package akka.actor.typed.receptionist
 
 import akka.actor.typed._
 import akka.actor.typed.receptionist.Receptionist._
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.testkit.typed.{ BehaviorTestkit, TestInbox, TestKit, TestKitSettings }
 import akka.testkit.typed.scaladsl.TestProbe
@@ -17,14 +17,14 @@ class LocalReceptionistSpec extends TestKit with TypedAkkaSpecWithShutdown with 
 
   trait ServiceA
   val ServiceKeyA = ServiceKey[ServiceA]("service-a")
-  val behaviorA = Actor.empty[ServiceA]
+  val behaviorA = ActorBehavior.empty[ServiceA]
 
   trait ServiceB
   val ServiceKeyB = ServiceKey[ServiceB]("service-b")
-  val behaviorB = Actor.empty[ServiceB]
+  val behaviorB = ActorBehavior.empty[ServiceB]
 
   case object Stop extends ServiceA with ServiceB
-  val stoppableBehavior = Actor.immutable[Any] { (_, msg) ⇒
+  val stoppableBehavior = ActorBehavior.immutable[Any] { (_, msg) ⇒
     msg match {
       case Stop ⇒ Behavior.stopped
       case _    ⇒ Behavior.same

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ImmutablePartialSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ImmutablePartialSpec.scala
@@ -16,10 +16,10 @@ class ImmutablePartialSpec extends TestKit with TypedAkkaSpecWithShutdown {
     "correctly install the message handler" in {
       val probe = TestProbe[Command]("probe")
       val behavior =
-        Actor.immutablePartial[Command] {
+        ActorBehavior.immutablePartial[Command] {
           case (_, Command2) ⇒
             probe.ref ! Command2
-            Actor.same
+            ActorBehavior.same
         }
       val testkit = BehaviorTestkit(behavior)
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/OnSignalSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/OnSignalSpec.scala
@@ -14,13 +14,13 @@ final class OnSignalSpec extends TestKit with TypedAkkaSpecWithShutdown {
     "must correctly install the signal handler" in {
       val probe = TestProbe[Done]("probe")
       val behavior =
-        Actor.deferred[Nothing] { context ⇒
-          val stoppedChild = context.spawn(Actor.stopped, "stopped-child")
+        ActorBehavior.deferred[Nothing] { context ⇒
+          val stoppedChild = context.spawn(ActorBehavior.stopped, "stopped-child")
           context.watch(stoppedChild)
-          Actor.onSignal[Nothing] {
+          ActorBehavior.onSignal[Nothing] {
             case (_, Terminated(`stoppedChild`)) ⇒
               probe.ref ! Done
-              Actor.stopped
+              ActorBehavior.stopped
           }
         }
       spawn[Nothing](behavior)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/AdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/AdapterSpec.scala
@@ -9,7 +9,7 @@ import akka.actor.typed.ActorRef
 import akka.actor.{ InvalidMessageException, Props }
 import akka.actor.typed.Behavior
 import akka.actor.typed.Terminated
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.{ actor ⇒ untyped }
 import akka.testkit._
 import akka.actor.typed.Behavior.UntypedBehavior
@@ -33,39 +33,39 @@ object AdapterSpec {
   }
 
   def typed1(ref: untyped.ActorRef, probe: ActorRef[String]): Behavior[String] =
-    Actor.immutable[String] {
+    ActorBehavior.immutable[String] {
       (ctx, msg) ⇒
         msg match {
           case "send" ⇒
             val replyTo = ctx.self.toUntyped
             ref.tell("ping", replyTo)
-            Actor.same
+            ActorBehavior.same
           case "pong" ⇒
             probe ! "ok"
-            Actor.same
+            ActorBehavior.same
           case "actorOf" ⇒
             val child = ctx.actorOf(untyped1)
             child.tell("ping", ctx.self.toUntyped)
-            Actor.same
+            ActorBehavior.same
           case "watch" ⇒
             ctx.watch(ref)
-            Actor.same
+            ActorBehavior.same
           case "supervise-stop" ⇒
             val child = ctx.actorOf(untyped1)
             ctx.watch(child)
             child ! ThrowIt3
             child.tell("ping", ctx.self.toUntyped)
-            Actor.same
+            ActorBehavior.same
           case "stop-child" ⇒
             val child = ctx.actorOf(untyped1)
             ctx.watch(child)
             ctx.stop(child)
-            Actor.same
+            ActorBehavior.same
         }
     } onSignal {
       case (ctx, Terminated(ref)) ⇒
         probe ! "terminated"
-        Actor.same
+        ActorBehavior.same
     }
 
   sealed trait Typed2Msg
@@ -131,13 +131,13 @@ object AdapterSpec {
   }
 
   def typed2: Behavior[Typed2Msg] =
-    Actor.immutable { (ctx, msg) ⇒
+    ActorBehavior.immutable { (ctx, msg) ⇒
       msg match {
         case Ping(replyTo) ⇒
           replyTo ! "pong"
-          Actor.same
+          ActorBehavior.same
         case StopIt ⇒
-          Actor.stopped
+          ActorBehavior.stopped
         case t: ThrowIt ⇒
           throw t
       }
@@ -188,7 +188,7 @@ class AdapterSpec extends AkkaSpec {
 
     "spawn typed child from untyped parent" in {
       val probe = TestProbe()
-      val ign = system.spawnAnonymous(Actor.ignore[Ping])
+      val ign = system.spawnAnonymous(ActorBehavior.ignore[Ping])
       val untypedRef = system.actorOf(untyped2(ign, probe.ref))
       untypedRef ! "spawn"
       probe.expectMsg("ok")
@@ -196,7 +196,7 @@ class AdapterSpec extends AkkaSpec {
 
     "actorOf typed child via Props from untyped parent" in {
       val probe = TestProbe()
-      val ign = system.spawnAnonymous(Actor.ignore[Ping])
+      val ign = system.spawnAnonymous(ActorBehavior.ignore[Ping])
       val untypedRef = system.actorOf(untyped2(ign, probe.ref))
       untypedRef ! "actorOf-props"
       probe.expectMsg("ok")
@@ -230,7 +230,7 @@ class AdapterSpec extends AkkaSpec {
 
     "supervise typed child from untyped parent" in {
       val probe = TestProbe()
-      val ign = system.spawnAnonymous(Actor.ignore[Ping])
+      val ign = system.spawnAnonymous(ActorBehavior.ignore[Ping])
       val untypedRef = system.actorOf(untyped2(ign, probe.ref))
 
       untypedRef ! "supervise-stop"
@@ -260,7 +260,7 @@ class AdapterSpec extends AkkaSpec {
 
     "stop typed child from untyped parent" in {
       val probe = TestProbe()
-      val ignore = system.spawnAnonymous(Actor.ignore[Ping])
+      val ignore = system.spawnAnonymous(ActorBehavior.ignore[Ping])
       val untypedRef = system.actorOf(untyped2(ignore, probe.ref))
       untypedRef ! "stop-child"
       probe.expectMsg("terminated")

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
@@ -4,15 +4,20 @@
 package docs.akka.typed
 
 //#imports
-import akka.actor.typed._
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.Behavior
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Terminated
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.scaladsl.AskPattern._
-import akka.testkit.typed.TestKit
 
+import akka.testkit.typed.TestKit
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.concurrent.Await
 //#imports
+
+import akka.actor.typed.TypedAkkaSpecWithShutdown
 
 object IntroSpec {
 
@@ -21,10 +26,10 @@ object IntroSpec {
     final case class Greet(whom: String, replyTo: ActorRef[Greeted])
     final case class Greeted(whom: String)
 
-    val greeter = Actor.immutable[Greet] { (_, msg) ⇒
+    val greeter = ActorBehavior.immutable[Greet] { (_, msg) ⇒
       println(s"Hello ${msg.whom}!")
       msg.replyTo ! Greeted(msg.whom)
-      Actor.same
+      ActorBehavior.same
     }
   }
   //#hello-world-actor
@@ -55,7 +60,7 @@ object IntroSpec {
       chatRoom(List.empty)
 
     private def chatRoom(sessions: List[ActorRef[SessionEvent]]): Behavior[Command] =
-      Actor.immutable[Command] { (ctx, msg) ⇒
+      ActorBehavior.immutable[Command] { (ctx, msg) ⇒
         msg match {
           case GetSession(screenName, client) ⇒
             val wrapper = ctx.spawnAdapter {
@@ -66,7 +71,7 @@ object IntroSpec {
           case PostSessionMessage(screenName, message) ⇒
             val mp = MessagePosted(screenName, message)
             sessions foreach (_ ! mp)
-            Actor.same
+            ActorBehavior.same
         }
       }
     //#chatroom-behavior
@@ -106,38 +111,38 @@ class IntroSpec extends TestKit with TypedAkkaSpecWithShutdown {
       import ChatRoom._
 
       val gabbler =
-        Actor.immutable[SessionEvent] { (_, msg) ⇒
+        ActorBehavior.immutable[SessionEvent] { (_, msg) ⇒
           msg match {
             //#chatroom-gabbler
             // We document that the compiler warns about the missing handler for `SessionDenied`
             case SessionDenied(reason) ⇒
               println(s"cannot start chat room session: $reason")
-              Actor.stopped
+              ActorBehavior.stopped
             //#chatroom-gabbler
             case SessionGranted(handle) ⇒
               handle ! PostMessage("Hello World!")
-              Actor.same
+              ActorBehavior.same
             case MessagePosted(screenName, message) ⇒
               println(s"message has been posted by '$screenName': $message")
-              Actor.stopped
+              ActorBehavior.stopped
           }
         }
       //#chatroom-gabbler
 
       //#chatroom-main
       val main: Behavior[String] =
-        Actor.deferred { ctx ⇒
+        ActorBehavior.deferred { ctx ⇒
           val chatRoom = ctx.spawn(ChatRoom.behavior, "chatroom")
           val gabblerRef = ctx.spawn(gabbler, "gabbler")
           ctx.watch(gabblerRef)
 
-          Actor.immutablePartial[String] {
+          ActorBehavior.immutablePartial[String] {
             case (_, "go") ⇒
               chatRoom ! GetSession("ol’ Gabbler", gabblerRef)
-              Actor.same
+              ActorBehavior.same
           } onSignal {
             case (_, Terminated(ref)) ⇒
-              Actor.stopped
+              ActorBehavior.stopped
           }
         }
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingUntypedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingUntypedSpec.scala
@@ -1,7 +1,7 @@
 package docs.akka.typed.coexistence
 
 import akka.actor.typed._
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.testkit.TestKit
 //#adapter-import
 // adds support for typed actors to an untyped actor system and context
@@ -23,7 +23,7 @@ object TypedWatchingUntypedSpec {
     case object Pong extends Command
 
     val behavior: Behavior[Command] =
-      Actor.deferred { context ⇒
+      ActorBehavior.deferred { context ⇒
         // context.spawn is an implicit extension method
         val untyped = context.actorOf(Untyped.props(), "second")
 
@@ -33,15 +33,15 @@ object TypedWatchingUntypedSpec {
         // illustrating how to pass sender, toUntyped is an implicit extension method
         untyped.tell(Typed.Ping(context.self), context.self.toUntyped)
 
-        Actor.immutablePartial[Command] {
+        ActorBehavior.immutablePartial[Command] {
           case (ctx, Pong) ⇒
             // it's not possible to get the sender, that must be sent in message
             // context.stop is an implicit extension method
             ctx.stop(untyped)
-            Actor.same
+            ActorBehavior.same
         } onSignal {
           case (_, akka.actor.typed.Terminated(_)) ⇒
-            Actor.stopped
+            ActorBehavior.stopped
         }
       }
   }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala
@@ -1,7 +1,7 @@
 package docs.akka.typed.coexistence
 
 import akka.actor.typed._
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.testkit.TestKit
 //#adapter-import
 // adds support for typed actors to an untyped actor system and context
@@ -53,13 +53,13 @@ object UntypedWatchingTypedSpec {
     case object Pong
 
     val behavior: Behavior[Command] =
-      Actor.immutable { (ctx, msg) ⇒
+      ActorBehavior.immutable { (ctx, msg) ⇒
         msg match {
           case Ping(replyTo) ⇒
             println(s"${ctx.self} got Ping from $replyTo")
             // replyTo is an untyped actor that has been converted for coexistence
             replyTo ! Pong
-            Actor.same
+            ActorBehavior.same
         }
       }
   }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/testing/async/BasicAsyncTestingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/testing/async/BasicAsyncTestingSpec.scala
@@ -1,6 +1,6 @@
 package docs.akka.typed.testing.async
 
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed._
 import akka.testkit.typed.TestKit
 import akka.testkit.typed.scaladsl._
@@ -11,11 +11,11 @@ object BasicAsyncTestingSpec {
   case class Ping(msg: String, response: ActorRef[Pong])
   case class Pong(msg: String)
 
-  val echoActor = Actor.immutable[Ping] { (_, msg) ⇒
+  val echoActor = ActorBehavior.immutable[Ping] { (_, msg) ⇒
     msg match {
       case Ping(m, replyTo) ⇒
         replyTo ! Pong(m)
-        Actor.same
+        ActorBehavior.same
     }
   }
   //#under-test

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/testing/sync/BasicSyncTestingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/testing/sync/BasicSyncTestingSpec.scala
@@ -10,8 +10,8 @@ import org.scalatest.{ Matchers, WordSpec }
 
 object BasicSyncTestingSpec {
   //#child
-  val childActor = Actor.immutable[String] { (_, _) ⇒
-    Actor.same[String]
+  val childActor = ActorBehavior.immutable[String] { (_, _) ⇒
+    ActorBehavior.same[String]
   }
   //#child
 
@@ -23,24 +23,24 @@ object BasicSyncTestingSpec {
   case object SayHelloToAnonymousChild extends Cmd
   case class SayHello(who: ActorRef[String]) extends Cmd
 
-  val myBehaviour = Actor.immutablePartial[Cmd] {
+  val myBehaviour = ActorBehavior.immutablePartial[Cmd] {
     case (ctx, CreateChild(name)) ⇒
       ctx.spawn(childActor, name)
-      Actor.same
+      ActorBehavior.same
     case (ctx, CreateAnonymousChild) ⇒
       ctx.spawnAnonymous(childActor)
-      Actor.same
+      ActorBehavior.same
     case (ctx, SayHelloToChild(childName)) ⇒
       val child: ActorRef[String] = ctx.spawn(childActor, childName)
       child ! "hello"
-      Actor.same
+      ActorBehavior.same
     case (ctx, SayHelloToAnonymousChild) ⇒
       val child: ActorRef[String] = ctx.spawnAnonymous(childActor)
       child ! "hello stranger"
-      Actor.same
+      ActorBehavior.same
     case (_, SayHello(who)) ⇒
       who ! "hello"
-      Actor.same
+      ActorBehavior.same
     //#under-test
   }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
@@ -19,7 +19,7 @@ import akka.util.OptionVal
  * its child actors.
  *
  * Behaviors can be formulated in a number of different ways, either by
- * using the DSLs in [[akka.actor.typed.scaladsl.Actor]] and [[akka.actor.typed.javadsl.Actor]]
+ * using the DSLs in [[akka.actor.typed.scaladsl.ActorBehavior]] and [[akka.actor.typed.javadsl.ActorBehavior]]
  * or extending the abstract [[ExtensibleBehavior]] class.
  *
  * Closing over ActorContext makes a Behavior immobile: it cannot be moved to
@@ -42,7 +42,7 @@ sealed abstract class Behavior[T] {
 
 /**
  * Extension point for implementing custom behaviors in addition to the existing
- * set of behaviors available through the DSLs in [[akka.actor.typed.scaladsl.Actor]] and [[akka.actor.typed.javadsl.Actor]]
+ * set of behaviors available through the DSLs in [[akka.actor.typed.scaladsl.ActorBehavior]] and [[akka.actor.typed.javadsl.ActorBehavior]]
  */
 abstract class ExtensibleBehavior[T] extends Behavior[T] {
   /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Restarter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Restarter.scala
@@ -23,16 +23,16 @@ import akka.actor.typed.ExtensibleBehavior
 import akka.actor.typed.PreRestart
 import akka.actor.typed.Signal
 import akka.actor.typed.SupervisorStrategy._
-import akka.actor.typed.scaladsl.Actor._
+import akka.actor.typed.scaladsl.ActorBehavior._
 import akka.util.OptionVal
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 
 /**
  * INTERNAL API
  */
 @InternalApi private[akka] object Restarter {
   def apply[T, Thr <: Throwable: ClassTag](initialBehavior: Behavior[T], strategy: SupervisorStrategy): Behavior[T] =
-    Actor.deferred[T] { ctx ⇒
+    ActorBehavior.deferred[T] { ctx ⇒
       val c = ctx.asInstanceOf[akka.actor.typed.ActorContext[T]]
       val startedBehavior = initialUndefer(c, initialBehavior)
       strategy match {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
@@ -26,7 +26,7 @@ import scala.reflect.ClassTag
   final case class TimerMsg(key: Any, generation: Int, owner: AnyRef)
 
   def withTimers[T](factory: TimerSchedulerImpl[T] ⇒ Behavior[T]): Behavior[T] = {
-    scaladsl.Actor.deferred[T] { ctx ⇒
+    scaladsl.ActorBehavior.deferred[T] { ctx ⇒
       val timerScheduler = new TimerSchedulerImpl[T](ctx)
       val behavior = factory(timerScheduler)
       timerScheduler.intercept(behavior)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistImpl.scala
@@ -9,9 +9,9 @@ import akka.actor.typed.Behavior
 import akka.actor.typed.Terminated
 import akka.actor.typed.receptionist.Receptionist._
 import akka.actor.typed.receptionist.ServiceKey
-import akka.actor.typed.scaladsl.Actor
-import akka.actor.typed.scaladsl.Actor.immutable
-import akka.actor.typed.scaladsl.Actor.same
+import akka.actor.typed.scaladsl.ActorBehavior
+import akka.actor.typed.scaladsl.ActorBehavior.immutable
+import akka.actor.typed.scaladsl.ActorBehavior.same
 import akka.actor.typed.scaladsl.ActorContext
 import akka.util.TypedMultiMap
 
@@ -63,7 +63,7 @@ private[akka] object ReceptionistImpl extends ReceptionistBehaviorProvider {
   type SubscriptionRegistry = TypedMultiMap[AbstractServiceKey, SubscriptionsKV]
 
   private[akka] def init(externalInterfaceFactory: ActorContext[AllCommands] ⇒ ExternalInterface): Behavior[Command] =
-    Actor.deferred[AllCommands] { ctx ⇒
+    ActorBehavior.deferred[AllCommands] { ctx ⇒
       val externalInterface = externalInterfaceFactory(ctx)
       behavior(
         TypedMultiMap.empty[AbstractServiceKey, KV],
@@ -85,13 +85,13 @@ private[akka] object ReceptionistImpl extends ReceptionistBehaviorProvider {
      * FIXME: replace by simple map in our state
      */
     def watchWith(ctx: ActorContext[AllCommands], target: ActorRef[_], msg: AllCommands): Unit =
-      ctx.spawnAnonymous[Nothing](Actor.deferred[Nothing] { innerCtx ⇒
+      ctx.spawnAnonymous[Nothing](ActorBehavior.deferred[Nothing] { innerCtx ⇒
         innerCtx.watch(target)
-        Actor.immutable[Nothing]((_, _) ⇒ Actor.same)
+        ActorBehavior.immutable[Nothing]((_, _) ⇒ ActorBehavior.same)
           .onSignal {
             case (_, Terminated(`target`)) ⇒
               ctx.self ! msg
-              Actor.stopped
+              ActorBehavior.stopped
           }
       })
 
@@ -157,7 +157,7 @@ private[akka] object ReceptionistImpl extends ReceptionistBehaviorProvider {
 
         case _: InternalCommand ⇒
           // silence compiler exhaustive check
-          Actor.unhandled
+          ActorBehavior.unhandled
       }
     }
   }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ActorBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ActorBehavior.scala
@@ -23,7 +23,7 @@ import akka.actor.typed.internal.BehaviorImpl
 import akka.actor.typed.internal.Restarter
 import akka.actor.typed.internal.TimerSchedulerImpl
 
-object Actor {
+object ActorBehavior {
 
   private val _unitFunction = (_: SAC[Any], _: Any) ⇒ ()
   private def unitFunction[T] = _unitFunction.asInstanceOf[((SAC[T], Signal) ⇒ Unit)]
@@ -62,11 +62,11 @@ object Actor {
    * abstract method [[MutableBehavior#onMessage]] and optionally override
    * [[MutableBehavior#onSignal]].
    *
-   * Instances of this behavior should be created via [[Actor#mutable]] and if
+   * Instances of this behavior should be created via [[ActorBehavior#mutable]] and if
    * the [[ActorContext]] is needed it can be passed as a constructor parameter
    * from the factory function.
    *
-   * @see [[Actor#mutable]]
+   * @see [[ActorBehavior#mutable]]
    */
   abstract class MutableBehavior[T] extends ExtensibleBehavior[T] {
     private var _receive: OptionVal[Receive[T]] = OptionVal.None

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ReceiveBuilder.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ReceiveBuilder.scala
@@ -6,13 +6,13 @@ package akka.actor.typed.javadsl
 
 import scala.annotation.tailrec
 import akka.japi.function.{ Creator, Function, Predicate }
-import akka.actor.typed.javadsl.Actor.Receive
+import akka.actor.typed.javadsl.ActorBehavior.Receive
 import akka.actor.typed.{ Behavior, Signal }
 import ReceiveBuilder._
 import akka.annotation.InternalApi
 
 /**
- * Used when implementing [[Actor.MutableBehavior]].
+ * Used when implementing [[ActorBehavior.MutableBehavior]].
  *
  * When handling a message or signal, this [[Behavior]] will consider all handlers in the order they were added,
  * looking for the first handler for which both the type and the (optional) predicate match.
@@ -145,7 +145,7 @@ object ReceiveBuilder {
 }
 
 /**
- * Receive type for [[Actor.MutableBehavior]]
+ * Receive type for [[ActorBehavior.MutableBehavior]]
  */
 private class BuiltReceive[T](
   private val messageHandlers: List[Case[T, T]],
@@ -163,7 +163,7 @@ private class BuiltReceive[T](
         if (cls.isAssignableFrom(msg.getClass) && (predicate.isEmpty || predicate.get.apply(msg))) handler(msg)
         else receive[M](msg, tail)
       case _ ⇒
-        Actor.unhandled
+        ActorBehavior.unhandled
     }
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorBehavior.scala
@@ -11,7 +11,7 @@ import scala.reflect.ClassTag
 import scala.util.control.Exception.Catcher
 
 @ApiMayChange
-object Actor {
+object ActorBehavior {
 
   private val _unitFunction = (_: ActorContext[Any], _: Any) ⇒ ()
   private def unitFunction[T] = _unitFunction.asInstanceOf[((ActorContext[T], Signal) ⇒ Unit)]
@@ -38,7 +38,7 @@ object Actor {
 
   /**
    * `deferred` is a factory for a behavior. Creation of the behavior instance is deferred until
-   * the actor is started, as opposed to [[Actor.immutable]] that creates the behavior instance
+   * the actor is started, as opposed to [[ActorBehavior.immutable]] that creates the behavior instance
    * immediately before the actor is running. The `factory` function pass the `ActorContext`
    * as parameter and that can for example be used for spawning child actors.
    *
@@ -70,11 +70,11 @@ object Actor {
    * abstract method [[MutableBehavior#onMessage]] and optionally override
    * [[MutableBehavior#onSignal]].
    *
-   * Instances of this behavior should be created via [[Actor#Mutable]] and if
+   * Instances of this behavior should be created via [[ActorBehavior#Mutable]] and if
    * the [[ActorContext]] is needed it can be passed as a constructor parameter
    * from the factory function.
    *
-   * @see [[Actor#Mutable]]
+   * @see [[ActorBehavior#Mutable]]
    */
   abstract class MutableBehavior[T] extends ExtensibleBehavior[T] {
     @throws(classOf[Exception])
@@ -189,7 +189,7 @@ object Actor {
    * Construct an immutable actor behavior from a partial message handler which treats undefined messages as unhandled.
    */
   def immutablePartial[T](onMessage: PartialFunction[(ActorContext[T], T), Behavior[T]]): Immutable[T] =
-    Actor.immutable[T] { (ctx, t) ⇒ onMessage.applyOrElse((ctx, t), (_: (ActorContext[T], T)) ⇒ Actor.unhandled[T]) }
+    ActorBehavior.immutable[T] { (ctx, t) ⇒ onMessage.applyOrElse((ctx, t), (_: (ActorContext[T], T)) ⇒ ActorBehavior.unhandled[T]) }
 
   /**
    * Construct an actor behavior that can react to lifecycle signals only.

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingPersistenceSpec.scala
@@ -4,7 +4,7 @@
 package akka.cluster.sharding.typed
 
 import akka.actor.typed.{ ActorRef, Behavior, Props, TypedAkkaSpecWithShutdown }
-import akka.persistence.typed.scaladsl.PersistentActor
+import akka.persistence.typed.scaladsl.PersistentBehavior
 import akka.testkit.typed.TestKit
 import akka.testkit.typed.scaladsl.TestProbe
 import com.typesafe.config.ConfigFactory
@@ -36,10 +36,10 @@ object ClusterShardingPersistenceSpec {
   final case class Get(replyTo: ActorRef[String]) extends Command
   final case object StopPlz extends Command
 
-  import PersistentActor._
+  import PersistentBehavior._
 
   val persistentActor: Behavior[Command] =
-    PersistentActor.persistentEntity[Command, String, String](
+    PersistentBehavior.persistentEntity[Command, String, String](
       persistenceIdFromActorName = name ⇒ "Test-" + name,
       initialState = "",
       commandHandler = (_, state, cmd) ⇒ cmd match {

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingSpec.scala
@@ -8,7 +8,7 @@ import java.nio.charset.StandardCharsets
 
 import akka.actor.ExtendedActorSystem
 import akka.actor.typed.{ ActorRef, ActorRefResolver, Props, TypedAkkaSpecWithShutdown }
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.scaladsl.adapter._
 import akka.cluster.MemberStatus
 import akka.cluster.typed.{ Cluster, Join }
@@ -135,31 +135,31 @@ class ClusterShardingSpec extends TestKit("ClusterShardingSpec", ClusterSharding
   }
 
   val typeKey = EntityTypeKey[TestProtocol]("envelope-shard")
-  val behavior = Actor.immutable[TestProtocol] {
+  val behavior = ActorBehavior.immutable[TestProtocol] {
     case (_, StopPlz()) ⇒
-      Actor.stopped
+      ActorBehavior.stopped
 
     case (ctx, WhoAreYou(replyTo)) ⇒
       replyTo ! s"I'm ${ctx.self.path.name}"
-      Actor.same
+      ActorBehavior.same
 
     case (_, ReplyPlz(toMe)) ⇒
       toMe ! "Hello!"
-      Actor.same
+      ActorBehavior.same
   }
 
   val typeKey2 = EntityTypeKey[IdTestProtocol]("no-envelope-shard")
-  val behaviorWithId = Actor.immutable[IdTestProtocol] {
+  val behaviorWithId = ActorBehavior.immutable[IdTestProtocol] {
     case (_, IdStopPlz(_)) ⇒
-      Actor.stopped
+      ActorBehavior.stopped
 
     case (ctx, IdWhoAreYou(_, replyTo)) ⇒
       replyTo ! s"I'm ${ctx.self.path.name}"
-      Actor.same
+      ActorBehavior.same
 
     case (_, IdReplyPlz(_, toMe)) ⇒
       toMe ! "Hello!"
-      Actor.same
+      ActorBehavior.same
   }
 
   "Typed cluster sharding" must {

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/internal/ReplicatorBehavior.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/internal/ReplicatorBehavior.scala
@@ -13,7 +13,7 @@ import akka.cluster.{ ddata ⇒ dd }
 import akka.pattern.ask
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.scaladsl.adapter._
 import akka.util.Timeout
 import akka.cluster.ddata.ReplicatedData
@@ -35,7 +35,7 @@ import akka.actor.typed.Terminated
 
   def behavior(settings: dd.ReplicatorSettings, underlyingReplicator: Option[akka.actor.ActorRef]): Behavior[SReplicator.Command] = {
 
-    Actor.deferred { ctx ⇒
+    ActorBehavior.deferred { ctx ⇒
       val untypedReplicator = underlyingReplicator match {
         case Some(ref) ⇒ ref
         case None ⇒
@@ -54,17 +54,17 @@ import akka.actor.typed.Terminated
               ctx.stop(adapter)
               withState(subscribeAdapters - subscriber)
             case None ⇒ // already unsubscribed or terminated
-              Actor.same
+              ActorBehavior.same
           }
         }
 
-        Actor.immutable[SReplicator.Command] { (ctx, msg) ⇒
+        ActorBehavior.immutable[SReplicator.Command] { (ctx, msg) ⇒
           msg match {
             case cmd: SReplicator.Get[_] ⇒
               untypedReplicator.tell(
                 dd.Replicator.Get(cmd.key, cmd.consistency, cmd.request),
                 sender = cmd.replyTo.toUntyped)
-              Actor.same
+              ActorBehavior.same
 
             case cmd: JReplicator.Get[d] ⇒
               implicit val timeout = Timeout(cmd.consistency.timeout match {
@@ -82,13 +82,13 @@ import akka.actor.typed.Terminated
                     case _ ⇒ JReplicator.GetFailure(cmd.key, cmd.request)
                   }
               reply.foreach { cmd.replyTo ! _ }
-              Actor.same
+              ActorBehavior.same
 
             case cmd: SReplicator.Update[_] ⇒
               untypedReplicator.tell(
                 dd.Replicator.Update(cmd.key, cmd.writeConsistency, cmd.request)(cmd.modify),
                 sender = cmd.replyTo.toUntyped)
-              Actor.same
+              ActorBehavior.same
 
             case cmd: JReplicator.Update[d] ⇒
               implicit val timeout = Timeout(cmd.writeConsistency.timeout match {
@@ -107,14 +107,14 @@ import akka.actor.typed.Terminated
                     case _ ⇒ JReplicator.UpdateTimeout(cmd.key, cmd.request)
                   }
               reply.foreach { cmd.replyTo ! _ }
-              Actor.same
+              ActorBehavior.same
 
             case cmd: SReplicator.Subscribe[_] ⇒
               // For the Scala API the Changed messages can be sent directly to the subscriber
               untypedReplicator.tell(
                 dd.Replicator.Subscribe(cmd.key, cmd.subscriber.toUntyped),
                 sender = cmd.subscriber.toUntyped)
-              Actor.same
+              ActorBehavior.same
 
             case cmd: JReplicator.Subscribe[ReplicatedData] @unchecked ⇒
               // For the Java API the Changed messages must be mapped to the JReplicator.Changed class.
@@ -134,7 +134,7 @@ import akka.actor.typed.Terminated
 
             case InternalChanged(chg, subscriber) ⇒
               subscriber ! JReplicator.Changed(chg.key)(chg.dataValue)
-              Actor.same
+              ActorBehavior.same
 
             case cmd: JReplicator.Unsubscribe[ReplicatedData] @unchecked ⇒
               stopSubscribeAdapter(cmd.subscriber)
@@ -143,7 +143,7 @@ import akka.actor.typed.Terminated
               untypedReplicator.tell(
                 dd.Replicator.Delete(cmd.key, cmd.consistency, cmd.request),
                 sender = cmd.replyTo.toUntyped)
-              Actor.same
+              ActorBehavior.same
 
             case cmd: JReplicator.Delete[d] ⇒
               implicit val timeout = Timeout(cmd.consistency.timeout match {
@@ -162,11 +162,11 @@ import akka.actor.typed.Terminated
                     case _ ⇒ JReplicator.ReplicationDeleteFailure(cmd.key, cmd.request)
                   }
               reply.foreach { cmd.replyTo ! _ }
-              Actor.same
+              ActorBehavior.same
 
             case SReplicator.GetReplicaCount(replyTo) ⇒
               untypedReplicator.tell(dd.Replicator.GetReplicaCount, sender = replyTo.toUntyped)
-              Actor.same
+              ActorBehavior.same
 
             case JReplicator.GetReplicaCount(replyTo) ⇒
               implicit val timeout = Timeout(localAskTimeout)
@@ -175,11 +175,11 @@ import akka.actor.typed.Terminated
                 (untypedReplicator ? dd.Replicator.GetReplicaCount)
                   .mapTo[dd.Replicator.ReplicaCount].map(rsp ⇒ JReplicator.ReplicaCount(rsp.n))
               reply.foreach { replyTo ! _ }
-              Actor.same
+              ActorBehavior.same
 
             case SReplicator.FlushChanges | JReplicator.FlushChanges ⇒
               untypedReplicator.tell(dd.Replicator.FlushChanges, sender = akka.actor.ActorRef.noSender)
-              Actor.same
+              ActorBehavior.same
 
           }
         }

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/AdaptedClusterImpl.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/AdaptedClusterImpl.scala
@@ -10,7 +10,7 @@ import akka.cluster.{ ClusterEvent, MemberStatus }
 import akka.actor.typed.{ ActorRef, ActorSystem, Terminated }
 import akka.cluster.typed._
 import akka.actor.typed.internal.adapter.ActorSystemAdapter
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.scaladsl.adapter._
 
 /**
@@ -24,7 +24,7 @@ private[akka] object AdapterClusterImpl {
   private case object Up extends SeenState
   private case class Removed(previousStatus: MemberStatus) extends SeenState
 
-  private def subscriptionsBehavior(adaptedCluster: akka.cluster.Cluster) = Actor.deferred[ClusterStateSubscription] { ctx ⇒
+  private def subscriptionsBehavior(adaptedCluster: akka.cluster.Cluster) = ActorBehavior.deferred[ClusterStateSubscription] { ctx ⇒
     var seenState: SeenState = BeforeUp
     var upSubscribers: List[ActorRef[SelfUp]] = Nil
     var removedSubscribers: List[ActorRef[SelfRemoved]] = Nil
@@ -51,7 +51,7 @@ private[akka] object AdapterClusterImpl {
       }
     }
 
-    Actor.immutable[AnyRef] { (ctx, msg) ⇒
+    ActorBehavior.immutable[AnyRef] { (ctx, msg) ⇒
 
       msg match {
         case Subscribe(subscriber: ActorRef[SelfUp] @unchecked, clazz) if clazz == classOf[SelfUp] ⇒
@@ -64,33 +64,33 @@ private[akka] object AdapterClusterImpl {
             // self did join, but is now no longer up, we want to avoid subscribing
             // to not get a memory leak, but also not signal anything
           }
-          Actor.same
+          ActorBehavior.same
 
         case Subscribe(subscriber: ActorRef[SelfRemoved] @unchecked, clazz) if clazz == classOf[SelfRemoved] ⇒
           seenState match {
             case BeforeUp | Up ⇒ removedSubscribers = subscriber :: removedSubscribers
             case Removed(s)    ⇒ subscriber ! SelfRemoved(s)
           }
-          Actor.same
+          ActorBehavior.same
 
         case Subscribe(subscriber, eventClass) ⇒
           adaptedCluster.subscribe(subscriber.toUntyped, initialStateMode = ClusterEvent.initialStateAsEvents, eventClass)
-          Actor.same
+          ActorBehavior.same
 
         case Unsubscribe(subscriber) ⇒
           adaptedCluster.unsubscribe(subscriber.toUntyped)
-          Actor.same
+          ActorBehavior.same
 
         case GetCurrentState(sender) ⇒
           adaptedCluster.sendCurrentClusterState(sender.toUntyped)
-          Actor.same
+          ActorBehavior.same
 
         case evt: MemberEvent if evt.member.uniqueAddress == cluster.selfMember.uniqueAddress ⇒
           onSelfMemberEvent(evt)
-          Actor.same
+          ActorBehavior.same
 
         case _: MemberEvent ⇒
-          Actor.same
+          ActorBehavior.same
 
       }
     }.onSignal {
@@ -98,28 +98,28 @@ private[akka] object AdapterClusterImpl {
       case (_, Terminated(ref)) ⇒
         upSubscribers = upSubscribers.filterNot(_ == ref)
         removedSubscribers = removedSubscribers.filterNot(_ == ref)
-        Actor.same
+        ActorBehavior.same
 
     }.narrow[ClusterStateSubscription]
   }
 
-  private def managerBehavior(adaptedCluster: akka.cluster.Cluster) = Actor.immutable[ClusterCommand]((ctx, msg) ⇒
+  private def managerBehavior(adaptedCluster: akka.cluster.Cluster) = ActorBehavior.immutable[ClusterCommand]((ctx, msg) ⇒
     msg match {
       case Join(address) ⇒
         adaptedCluster.join(address)
-        Actor.same
+        ActorBehavior.same
 
       case Leave(address) ⇒
         adaptedCluster.leave(address)
-        Actor.same
+        ActorBehavior.same
 
       case Down(address) ⇒
         adaptedCluster.down(address)
-        Actor.same
+        ActorBehavior.same
 
       case JoinSeedNodes(addresses) ⇒
         adaptedCluster.joinSeedNodes(addresses)
-        Actor.same
+        ActorBehavior.same
 
     }
 

--- a/akka-cluster-typed/src/test/java/akka/cluster/ddata/typed/javadsl/ReplicatorTest.java
+++ b/akka-cluster-typed/src/test/java/akka/cluster/ddata/typed/javadsl/ReplicatorTest.java
@@ -24,9 +24,9 @@ import akka.testkit.javadsl.TestKit;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
 import akka.cluster.ddata.typed.javadsl.Replicator.Command;
-import akka.actor.typed.javadsl.Actor;
+import akka.actor.typed.javadsl.ActorBehavior;
 import akka.actor.typed.javadsl.Adapter;
-import akka.actor.typed.javadsl.Actor.MutableBehavior;
+import akka.actor.typed.javadsl.ActorBehavior.MutableBehavior;
 import akka.actor.typed.javadsl.ActorContext;
 
 public class ReplicatorTest extends JUnitSuite {
@@ -105,11 +105,11 @@ public class ReplicatorTest extends JUnitSuite {
     }
 
     public static Behavior<ClientCommand> create(ActorRef<Command> replicator, Cluster node) {
-      return Actor.mutable(ctx -> new Client(replicator, node, ctx));
+      return ActorBehavior.mutable(ctx -> new Client(replicator, node, ctx));
     }
 
     @Override
-    public Actor.Receive<ClientCommand> createReceive() {
+    public ActorBehavior.Receive<ClientCommand> createReceive() {
       return receiveBuilder()
         .onMessage(Increment.class, cmd -> {
           replicator.tell(

--- a/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/BasicClusterExampleTest.java
+++ b/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/BasicClusterExampleTest.java
@@ -13,8 +13,8 @@ import docs.akka.cluster.typed.BasicClusterManualSpec;
 //FIXME make these tests
 public class BasicClusterExampleTest {
   public void clusterApiExample() {
-    ActorSystem<Object> system = ActorSystem.create(Actor.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
-    ActorSystem<Object> system2 = ActorSystem.create(Actor.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
+    ActorSystem<Object> system = ActorSystem.create(ActorBehavior.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
+    ActorSystem<Object> system2 = ActorSystem.create(ActorBehavior.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
 
     try {
       //#cluster-create
@@ -36,8 +36,8 @@ public class BasicClusterExampleTest {
   }
 
   public void clusterLeave() throws Exception {
-    ActorSystem<Object> system = ActorSystem.create(Actor.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
-    ActorSystem<Object> system2 = ActorSystem.create(Actor.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
+    ActorSystem<Object> system = ActorSystem.create(ActorBehavior.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
+    ActorSystem<Object> system2 = ActorSystem.create(ActorBehavior.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
 
     try {
       Cluster cluster = Cluster.get(system);

--- a/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/ReceptionistExampleTest.java
+++ b/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/ReceptionistExampleTest.java
@@ -3,7 +3,7 @@ package jdocs.akka.cluster.typed;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.ActorSystem;
 import akka.actor.typed.Behavior;
-import akka.actor.typed.javadsl.Actor;
+import akka.actor.typed.javadsl.ActorBehavior;
 import akka.actor.typed.receptionist.Receptionist;
 import akka.actor.typed.receptionist.ServiceKey;
 import scala.concurrent.Await;
@@ -27,13 +27,13 @@ public class ReceptionistExampleTest {
     }
 
     static Behavior<Ping> pingService() {
-      return Actor.deferred((ctx) -> {
+      return ActorBehavior.deferred((ctx) -> {
         ctx.getSystem().receptionist()
           .tell(new Receptionist.Register<>(PingServiceKey, ctx.getSelf(), ctx.getSystem().deadLetters()));
-        return Actor.immutable(Ping.class)
+        return ActorBehavior.immutable(Ping.class)
           .onMessage(Ping.class, (c, msg) -> {
             msg.replyTo.tell(new Pong());
-            return Actor.same();
+            return ActorBehavior.same();
           }).build();
       });
     }
@@ -41,12 +41,12 @@ public class ReceptionistExampleTest {
 
     //#pinger
     static Behavior<Pong> pinger(ActorRef<Ping> pingService) {
-      return Actor.deferred((ctx) -> {
+      return ActorBehavior.deferred((ctx) -> {
         pingService.tell(new Ping(ctx.getSelf()));
-        return Actor.immutable(Pong.class)
+        return ActorBehavior.immutable(Pong.class)
           .onMessage(Pong.class, (c, msg) -> {
             System.out.println("I was ponged! " + msg);
-            return Actor.same();
+            return ActorBehavior.same();
           }).build();
       });
     }
@@ -54,14 +54,14 @@ public class ReceptionistExampleTest {
 
     //#pinger-guardian
     static Behavior<Receptionist.Listing<Ping>> guardian() {
-      return Actor.deferred((ctx) -> {
+      return ActorBehavior.deferred((ctx) -> {
         ctx.getSystem().receptionist()
           .tell(new Receptionist.Subscribe<>(PingServiceKey, ctx.getSelf()));
         ActorRef<Ping> ps = ctx.spawnAnonymous(pingService());
         ctx.watch(ps);
-        return Actor.immutable((c, msg) -> {
+        return ActorBehavior.immutable((c, msg) -> {
           msg.getServiceInstances().forEach(ar -> ctx.spawnAnonymous(pinger(ar)));
-          return Actor.same();
+          return ActorBehavior.same();
         });
       });
     }

--- a/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
@@ -6,7 +6,7 @@ package akka.cluster.ddata.typed.scaladsl
 import akka.actor.Scheduler
 import akka.actor.typed.{ ActorRef, Behavior, TypedAkkaSpecWithShutdown }
 import akka.actor.typed.scaladsl.AskPattern._
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.scaladsl.adapter._
 import akka.cluster.Cluster
 import akka.cluster.ddata.typed.scaladsl.Replicator._
@@ -42,7 +42,7 @@ object ReplicatorSpec {
   val Key = GCounterKey("counter")
 
   def client(replicator: ActorRef[Replicator.Command])(implicit cluster: Cluster): Behavior[ClientCommand] =
-    Actor.deferred[ClientCommand] { ctx ⇒
+    ActorBehavior.deferred[ClientCommand] { ctx ⇒
       val updateResponseAdapter: ActorRef[Replicator.UpdateResponse[GCounter]] =
         ctx.spawnAdapter(InternalUpdateResponse.apply)
 
@@ -55,30 +55,30 @@ object ReplicatorSpec {
       replicator ! Replicator.Subscribe(Key, changedAdapter)
 
       def behavior(cachedValue: Int): Behavior[ClientCommand] = {
-        Actor.immutable[ClientCommand] { (ctx, msg) ⇒
+        ActorBehavior.immutable[ClientCommand] { (ctx, msg) ⇒
           msg match {
             case Increment ⇒
               replicator ! Replicator.Update(Key, GCounter.empty, Replicator.WriteLocal, updateResponseAdapter)(_ + 1)
-              Actor.same
+              ActorBehavior.same
 
             case GetValue(replyTo) ⇒
               replicator ! Replicator.Get(Key, Replicator.ReadLocal, getResponseAdapter, Some(replyTo))
-              Actor.same
+              ActorBehavior.same
 
             case GetCachedValue(replyTo) ⇒
               replicator ! Replicator.Get(Key, Replicator.ReadLocal, getResponseAdapter, Some(replyTo))
-              Actor.same
+              ActorBehavior.same
 
             case internal: InternalMsg ⇒ internal match {
-              case InternalUpdateResponse(_) ⇒ Actor.same // ok
+              case InternalUpdateResponse(_) ⇒ ActorBehavior.same // ok
 
               case InternalGetResponse(rsp @ Replicator.GetSuccess(Key, Some(replyTo: ActorRef[Int] @unchecked))) ⇒
                 val value = rsp.get(Key).value.toInt
                 replyTo ! value
-                Actor.same
+                ActorBehavior.same
 
               case InternalGetResponse(rsp) ⇒
-                Actor.unhandled // not dealing with failures
+                ActorBehavior.unhandled // not dealing with failures
 
               case InternalChanged(chg @ Replicator.Changed(Key)) ⇒
                 val value = chg.get(Key).value.intValue

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
@@ -6,7 +6,7 @@ package akka.cluster.typed
 import java.nio.charset.StandardCharsets
 
 import akka.actor.ExtendedActorSystem
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.scaladsl.adapter._
 import akka.testkit.typed.{ TestKit, TestKitSettings }
 import akka.testkit.typed.scaladsl.TestProbe
@@ -48,15 +48,15 @@ object ClusterSingletonApiSpec {
 
   case object Perish extends PingProtocol
 
-  val pingPong = Actor.immutable[PingProtocol] { (_, msg) ⇒
+  val pingPong = ActorBehavior.immutable[PingProtocol] { (_, msg) ⇒
 
     msg match {
       case Ping(respondTo) ⇒
         respondTo ! Pong
-        Actor.same
+        ActorBehavior.same
 
       case Perish ⇒
-        Actor.stopped
+        ActorBehavior.stopped
     }
 
   }

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
@@ -5,8 +5,8 @@
 package akka.cluster.typed
 
 import akka.actor.typed.{ ActorRef, Behavior, Props, TypedAkkaSpecWithShutdown }
-import akka.persistence.typed.scaladsl.PersistentActor
-import akka.persistence.typed.scaladsl.PersistentActor.{ CommandHandler, Effect }
+import akka.persistence.typed.scaladsl.PersistentBehavior
+import akka.persistence.typed.scaladsl.PersistentBehavior.{ CommandHandler, Effect }
 import akka.testkit.typed.TestKit
 import akka.testkit.typed.scaladsl.TestProbe
 import com.typesafe.config.ConfigFactory
@@ -37,7 +37,7 @@ object ClusterSingletonPersistenceSpec {
   private final case object StopPlz extends Command
 
   val persistentActor: Behavior[Command] =
-    PersistentActor.immutable[Command, String, String](
+    PersistentBehavior.immutable[Command, String, String](
       persistenceId = "TheSingleton",
       initialState = "",
       commandHandler = (_, state, cmd) ⇒ cmd match {

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteMessageSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteMessageSpec.scala
@@ -8,7 +8,7 @@ import java.nio.charset.StandardCharsets
 import akka.Done
 import akka.testkit.AkkaSpec
 import akka.actor.typed.{ ActorRef, ActorRefResolver }
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.{ ExtendedActorSystem, ActorSystem ⇒ UntypedActorSystem }
 import akka.serialization.SerializerWithStringManifest
 import com.typesafe.config.ConfigFactory
@@ -70,12 +70,12 @@ class RemoteMessageSpec extends AkkaSpec(RemoteMessageSpec.config) {
     "something something" in {
 
       val pingPromise = Promise[Done]()
-      val ponger = Actor.immutable[Ping]((_, msg) ⇒
+      val ponger = ActorBehavior.immutable[Ping]((_, msg) ⇒
         msg match {
           case Ping(sender) ⇒
             pingPromise.success(Done)
             sender ! "pong"
-            Actor.stopped
+            ActorBehavior.stopped
         })
 
       // typed actor on system1
@@ -91,9 +91,9 @@ class RemoteMessageSpec extends AkkaSpec(RemoteMessageSpec.config) {
           ActorRefResolver(typedSystem2).resolveActorRef[Ping](remoteRefStr)
 
         val pongPromise = Promise[Done]()
-        val recipient = system2.spawn(Actor.immutable[String] { (_, _) ⇒
+        val recipient = system2.spawn(ActorBehavior.immutable[String] { (_, _) ⇒
           pongPromise.success(Done)
-          Actor.stopped
+          ActorBehavior.stopped
         }, "recipient")
         remoteRef ! Ping(recipient)
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -9,7 +9,7 @@ import akka.actor.ExtendedActorSystem
 import akka.actor.typed.{ ActorRef, ActorRefResolver, TypedAkkaSpecWithShutdown }
 import akka.actor.typed.internal.adapter.ActorSystemAdapter
 import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.scaladsl.adapter._
 import akka.cluster.Cluster
 import akka.serialization.SerializerWithStringManifest
@@ -50,14 +50,14 @@ object ClusterReceptionistSpec {
   case class Ping(respondTo: ActorRef[Pong.type]) extends PingProtocol
   case object Perish extends PingProtocol
 
-  val pingPongBehavior = Actor.immutable[PingProtocol] { (_, msg) ⇒
+  val pingPongBehavior = ActorBehavior.immutable[PingProtocol] { (_, msg) ⇒
     msg match {
       case Ping(respondTo) ⇒
         respondTo ! Pong
-        Actor.same
+        ActorBehavior.same
 
       case Perish ⇒
-        Actor.stopped
+        ActorBehavior.stopped
     }
   }
 

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
@@ -61,8 +61,8 @@ class BasicClusterConfigSpec extends WordSpec with ScalaFutures with Eventually 
           akka.cluster.seed-nodes = [ "akka.tcp://ClusterSystem@127.0.0.1:$sys1Port", "akka.tcp://ClusterSystem@127.0.0.1:$sys2Port" ]
         """)
 
-      val system1 = ActorSystem[Nothing](Actor.empty, "ClusterSystem", config(sys1Port).withFallback(configSystem1))
-      val system2 = ActorSystem[Nothing](Actor.empty, "ClusterSystem", config(sys2Port).withFallback(configSystem2))
+      val system1 = ActorSystem[Nothing](ActorBehavior.empty, "ClusterSystem", config(sys1Port).withFallback(configSystem1))
+      val system2 = ActorSystem[Nothing](ActorBehavior.empty, "ClusterSystem", config(sys2Port).withFallback(configSystem2))
       try {
         val cluster1 = Cluster(system1)
         val cluster2 = Cluster(system2)
@@ -105,8 +105,8 @@ class BasicClusterManualSpec extends WordSpec with ScalaFutures with Eventually 
   "Cluster API" must {
     "init cluster" in {
 
-      val system = ActorSystem[Nothing](Actor.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
-      val system2 = ActorSystem[Nothing](Actor.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
+      val system = ActorSystem[Nothing](ActorBehavior.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
+      val system2 = ActorSystem[Nothing](ActorBehavior.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
 
       try {
         //#cluster-create
@@ -139,9 +139,9 @@ class BasicClusterManualSpec extends WordSpec with ScalaFutures with Eventually 
     }
 
     "subscribe to cluster events" in {
-      implicit val system1 = ActorSystem[Nothing](Actor.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
-      val system2 = ActorSystem[Nothing](Actor.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
-      val system3 = ActorSystem[Nothing](Actor.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
+      implicit val system1 = ActorSystem[Nothing](ActorBehavior.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
+      val system2 = ActorSystem[Nothing](ActorBehavior.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
+      val system3 = ActorSystem[Nothing](ActorBehavior.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
 
       try {
         val cluster1 = Cluster(system1)

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/ReceptionistExampleSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/ReceptionistExampleSpec.scala
@@ -18,21 +18,21 @@ import scala.collection.immutable.Set
 object RandomRouter {
 
   def router[T](serviceKey: ServiceKey[T]): Behavior[T] =
-    Actor.deferred[Any] { ctx ⇒
+    ActorBehavior.deferred[Any] { ctx ⇒
       ctx.system.receptionist ! Receptionist.Subscribe(serviceKey, ctx.self)
 
       def routingBehavior(routees: Vector[ActorRef[T]]): Behavior[Any] =
-        Actor.immutable { (_, msg) ⇒
+        ActorBehavior.immutable { (_, msg) ⇒
           msg match {
             case Listing(_, services: Set[ActorRef[T]]) ⇒
               routingBehavior(services.toVector)
             case other: T @unchecked ⇒
               if (routees.isEmpty)
-                Actor.unhandled
+                ActorBehavior.unhandled
               else {
                 val i = ThreadLocalRandom.current.nextInt(routees.size)
                 routees(i) ! other
-                Actor.same
+                ActorBehavior.same
               }
           }
         }
@@ -45,7 +45,7 @@ object RandomRouter {
   // same as above, but also subscribes to cluster reachability events and
   // avoids routees that are unreachable
   def clusterRouter[T](serviceKey: ServiceKey[T]): Behavior[T] =
-    Actor.deferred[Any] { ctx ⇒
+    ActorBehavior.deferred[Any] { ctx ⇒
       ctx.system.receptionist ! Receptionist.Subscribe(serviceKey, ctx.self)
 
       val cluster = Cluster(ctx.system)
@@ -55,7 +55,7 @@ object RandomRouter {
       cluster.subscriptions ! Subscribe(reachabilityAdapter, classOf[ReachabilityEvent])
 
       def routingBehavior(routees: Vector[ActorRef[T]], unreachable: Set[Address]): Behavior[Any] =
-        Actor.immutable { (_, msg) ⇒
+        ActorBehavior.immutable { (_, msg) ⇒
           msg match {
             case Listing(_, services: Set[ActorRef[T]]) ⇒
               routingBehavior(services.toVector, unreachable)
@@ -68,7 +68,7 @@ object RandomRouter {
 
             case other: T @unchecked ⇒
               if (routees.isEmpty)
-                Actor.unhandled
+                ActorBehavior.unhandled
               else {
                 val reachableRoutes =
                   if (unreachable.isEmpty) routees
@@ -76,7 +76,7 @@ object RandomRouter {
 
                 val i = ThreadLocalRandom.current.nextInt(reachableRoutes.size)
                 reachableRoutes(i) ! other
-                Actor.same
+                ActorBehavior.same
               }
           }
         }
@@ -93,68 +93,68 @@ object PingPongExample {
   final case object Pong
 
   val pingService: Behavior[Ping] =
-    Actor.deferred { ctx ⇒
+    ActorBehavior.deferred { ctx ⇒
       ctx.system.receptionist ! Receptionist.Register(PingServiceKey, ctx.self, ctx.system.deadLetters)
-      Actor.immutable[Ping] { (_, msg) ⇒
+      ActorBehavior.immutable[Ping] { (_, msg) ⇒
         msg match {
           case Ping(replyTo) ⇒
             replyTo ! Pong
-            Actor.stopped
+            ActorBehavior.stopped
         }
       }
     }
   //#ping-service
 
   //#pinger
-  def pinger(pingService: ActorRef[Ping]) = Actor.deferred[Pong.type] { ctx ⇒
+  def pinger(pingService: ActorRef[Ping]) = ActorBehavior.deferred[Pong.type] { ctx ⇒
     pingService ! Ping(ctx.self)
-    Actor.immutable { (_, msg) ⇒
+    ActorBehavior.immutable { (_, msg) ⇒
       println("I was ponged!!" + msg)
-      Actor.same
+      ActorBehavior.same
     }
   }
   //#pinger
 
   //#pinger-guardian
-  val guardian: Behavior[Listing[Ping]] = Actor.deferred { ctx ⇒
+  val guardian: Behavior[Listing[Ping]] = ActorBehavior.deferred { ctx ⇒
     ctx.system.receptionist ! Receptionist.Subscribe(PingServiceKey, ctx.self)
     val ps = ctx.spawnAnonymous(pingService)
     ctx.watch(ps)
-    Actor.immutablePartial[Listing[Ping]] {
+    ActorBehavior.immutablePartial[Listing[Ping]] {
       case (c, Listing(PingServiceKey, listings)) if listings.nonEmpty ⇒
         listings.foreach(ps ⇒ ctx.spawnAnonymous(pinger(ps)))
-        Actor.same
+        ActorBehavior.same
     } onSignal {
       case (_, Terminated(`ps`)) ⇒
         println("Ping service has shut down")
-        Actor.stopped
+        ActorBehavior.stopped
     }
   }
   //#pinger-guardian
 
   //#pinger-guardian-pinger-service
-  val guardianJustPingService: Behavior[Listing[Ping]] = Actor.deferred { ctx ⇒
+  val guardianJustPingService: Behavior[Listing[Ping]] = ActorBehavior.deferred { ctx ⇒
     val ps = ctx.spawnAnonymous(pingService)
     ctx.watch(ps)
-    Actor.immutablePartial[Listing[Ping]] {
+    ActorBehavior.immutablePartial[Listing[Ping]] {
       case (c, Listing(PingServiceKey, listings)) if listings.nonEmpty ⇒
         listings.foreach(ps ⇒ ctx.spawnAnonymous(pinger(ps)))
-        Actor.same
+        ActorBehavior.same
     } onSignal {
       case (_, Terminated(`ps`)) ⇒
         println("Ping service has shut down")
-        Actor.stopped
+        ActorBehavior.stopped
     }
   }
   //#pinger-guardian-pinger-service
 
   //#pinger-guardian-just-pinger
-  val guardianJustPinger: Behavior[Listing[Ping]] = Actor.deferred { ctx ⇒
+  val guardianJustPinger: Behavior[Listing[Ping]] = ActorBehavior.deferred { ctx ⇒
     ctx.system.receptionist ! Receptionist.Subscribe(PingServiceKey, ctx.self)
-    Actor.immutablePartial[Listing[Ping]] {
+    ActorBehavior.immutablePartial[Listing[Ping]] {
       case (c, Listing(PingServiceKey, listings)) if listings.nonEmpty ⇒
         listings.foreach(ps ⇒ ctx.spawnAnonymous(pinger(ps)))
-        Actor.same
+        ActorBehavior.same
     }
   }
   //#pinger-guardian-just-pinger

--- a/akka-docs/src/main/paradox/actors-typed.md
+++ b/akka-docs/src/main/paradox/actors-typed.md
@@ -258,8 +258,8 @@ particular one using the `immutable` behavior decorator. The
 provided `onSignal` function will be invoked for signals (subclasses of `Signal`)
 or the `onMessage` function for user messages.
 
-This particular `main` Actor is created using `Actor.deferred`, which is like a factory for a behavior.
-Creation of the behavior instance is deferred until the actor is started, as opposed to `Actor.immutable`
+This particular `main` Actor is created using `ActorBehavior.deferred`, which is like a factory for a behavior.
+Creation of the behavior instance is deferred until the actor is started, as opposed to `ActorBehavior.immutable`
 that creates the behavior instance immediately before the actor is running. The factory function in 
 `deferred` pass the `ActorContext` as parameter and that can for example be used for spawning child actors.
 This `main` Actor creates the chat room and the gabbler and the session between them is initiated, and when the

--- a/akka-docs/src/main/paradox/persistence-typed.md
+++ b/akka-docs/src/main/paradox/persistence-typed.md
@@ -30,16 +30,16 @@ Akka Persistence is a library for building event sourced actors. For background 
 see the @ref:[untyped Akka Persistence section](persistence.md). This documentation shows how the typed API for persistence
 works and assumes you know what is meant by `Command`, `Event` and `State`.
 
-Let's start with a simple example. The minimum required for a `PersistentActor` is:
+Let's start with a simple example. The minimum required for a `PersistentBehavior` is:
 
 Scala
-:  @@snip [BasicPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentActorSpec.scala) { #structure }
+:  @@snip [BasicPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorSpec.scala) { #structure }
 
-The first important thing to notice is the `Behavior` of a `PersistentActor` is typed to the type of the `Command` 
+The first important thing to notice is the `Behavior` of a `PersistentBehavior` is typed to the type of the `Command`
 because this type of message a persistent actor should receive. In Akka Typed this is now enforced by the type system.
 The event and state are only used internally.
 
-The parameters to `PersistentActor.immutable` are::
+The parameters to `PersistentBehavior.immutable` are::
 
 * `persistenceId` is the unique identifier for the persistent actor.
 * `initialState` defines the `State` when the entity is first created e.g. a Counter would start wiht 0 as state.
@@ -79,28 +79,28 @@ in the event handler, as those are also executed during recovery of an persisten
 Command and event:
 
 Scala
-:  @@snip [PersistentActorCompileOnyTest.scala]($akka$/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala) { #command }
+:  @@snip [PersistentBehaviorCompileOnyTest.scala]($akka$/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorCompileOnlyTest.scala) { #command }
 
 State is a List containing all the events:
 
 Scala
-:  @@snip [PersistentActorCompileOnyTest.scala]($akka$/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala) { #state }
+:  @@snip [PersistentBehaviorCompileOnyTest.scala]($akka$/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorCompileOnlyTest.scala) { #state }
 
 The command handler just persists the `Cmd` payload in an `Evt`:
 
 Scala
-:  @@snip [PersistentActorCompileOnyTest.scala]($akka$/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala) { #command-handler }
+:  @@snip [PersistentBehaviorCompileOnyTest.scala]($akka$/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorCompileOnlyTest.scala) { #command-handler }
 
 The event handler appends the event to the state. This is called after successfully
 persisting the event in the database:
 
 Scala
-:  @@snip [PersistentActorCompileOnyTest.scala]($akka$/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala) { #event-handler }
+:  @@snip [PersistentBehaviorCompileOnyTest.scala]($akka$/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorCompileOnlyTest.scala) { #event-handler }
 
 These are used to create a `PersistentBehavior`:
 
 Scala
-:  @@snip [PersistentActorCompileOnyTest.scala]($akka$/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala) { #behavior }
+:  @@snip [PersistentBehaviorCompileOnyTest.scala]($akka$/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorCompileOnlyTest.scala) { #behavior }
 
 The behavior can then be run as with any normal typed actor as described in [typed actors documentation](actors-typed.md).
 
@@ -126,40 +126,40 @@ then it we can look it up with `GetPost`, modify it with `ChangeBody` or publish
 The state is captured by:
 
 Scala
-:  @@snip [InDepthPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala) { #state }
+:  @@snip [InDepthPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala) { #state }
 
 The commands (only a subset are valid depending on state):
 
 Scala
-:  @@snip [InDepthPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala) { #commands }
+:  @@snip [InDepthPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala) { #commands }
 
 The command handler to process each command is decided by a `CommandHandler.byState` command handler, 
 which is a function from `State => CommandHandler`:
 
 Scala
-:  @@snip [InDepthPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala) { #by-state-command-handler }
+:  @@snip [InDepthPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala) { #by-state-command-handler }
 
 This can refer to many other `CommandHandler`s e.g one for a post that hasn't been started:
 
 Scala
-:  @@snip [InDepthPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala) { #initial-command-handler }
+:  @@snip [InDepthPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala) { #initial-command-handler }
 
 And a different `CommandHandler` for after the post has been added:
 
 Scala
-:  @@snip [InDepthPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala) { #post-added-command-handler }
+:  @@snip [InDepthPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala) { #post-added-command-handler }
 
 The event handler is always the same independent of state. The main reason for not making the event handler 
 part of the `CommandHandler` is that all events must be handled and that is typically independent of what the 
 current state is. The event handler can of course still decide what to do based on the state if that is needed.
 
 Scala
-:  @@snip [InDepthPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala) { #event-handler }
+:  @@snip [InDepthPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala) { #event-handler }
 
 And finally the behavior is created from the `byState` command handler:
 
 Scala
-:  @@snip [InDepthPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala) { #behavior }
+:  @@snip [InDepthPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala) { #behavior }
 
 ## Serialization
 
@@ -174,7 +174,7 @@ Since it is strongly discouraged to perform side effects in applyEvent ,
 side effects should be performed once recovery has completed in the `onRecoveryCompleted` callback
 
 Scala
-:  @@snip [BasicPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentActorSpec.scala) { #recovery }
+:  @@snip [BasicPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorSpec.scala) { #recovery }
 
 The `onRecoveryCompleted` takes on an `ActorContext` and the current `State`.
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/PersistentActorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/PersistentActorImpl.scala
@@ -11,7 +11,7 @@ import akka.persistence.RecoveryCompleted
 import akka.persistence.SnapshotOffer
 import akka.actor.typed.Signal
 import akka.actor.typed.internal.adapter.ActorContextAdapter
-import akka.persistence.typed.scaladsl.PersistentActor
+import akka.persistence.typed.scaladsl.PersistentBehavior
 import akka.persistence.typed.scaladsl.PersistentBehavior
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.Terminated
@@ -42,7 +42,7 @@ import akka.actor.typed.internal.adapter.ActorRefAdapter
   behavior: PersistentBehavior[C, E, S]) extends UntypedPersistentActor {
 
   import PersistentActorImpl._
-  import PersistentActor._
+  import PersistentBehavior._
 
   override val persistenceId: String = behavior.persistenceIdFromActorName(self.path.name)
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/PersistentBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/PersistentBehavior.scala
@@ -9,7 +9,7 @@ import akka.actor.typed.Behavior.UntypedBehavior
 import akka.persistence.typed.internal.PersistentActorImpl
 import akka.actor.typed.scaladsl.ActorContext
 
-object PersistentActor {
+object PersistentBehavior {
 
   /**
    * Create a `Behavior` for a persistent actor.
@@ -185,10 +185,10 @@ object PersistentActor {
 class PersistentBehavior[Command, Event, State](
   @InternalApi private[akka] val persistenceIdFromActorName: String ⇒ String,
   val initialState:                                          State,
-  val commandHandler:                                        PersistentActor.CommandHandler[Command, Event, State],
+  val commandHandler:                                        PersistentBehavior.CommandHandler[Command, Event, State],
   val eventHandler:                                          (State, Event) ⇒ State,
   val recoveryCompleted:                                     (ActorContext[Command], State) ⇒ Unit) extends UntypedBehavior[Command] {
-  import PersistentActor._
+  import PersistentBehavior._
 
   /** INTERNAL API */
   @InternalApi private[akka] override def untypedProps: akka.actor.Props = PersistentActorImpl.props(() ⇒ this)

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
@@ -6,7 +6,7 @@ package akka.persistence.typed.scaladsl
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, Terminated }
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.TimerScheduler
 
@@ -171,7 +171,7 @@ object PersistentActorCompileOnlyTest {
       })
 
     // FIXME this doesn't work, wrapping is not supported
-    Actor.withTimers((timers: TimerScheduler[Command]) ⇒ {
+    ActorBehavior.withTimers((timers: TimerScheduler[Command]) ⇒ {
       timers.startPeriodicTimer("swing", MoodSwing, 10.seconds)
       b
     })
@@ -268,7 +268,7 @@ object PersistentActorCompileOnlyTest {
 
     def isFullyHydrated(basket: Basket, ids: List[Id]) = basket.items.map(_.id) == ids
 
-    Actor.deferred { ctx: ActorContext[Command] ⇒
+    ActorBehavior.deferred { ctx: ActorContext[Command] ⇒
       // FIXME this doesn't work, wrapping not supported
 
       var basket = Basket(Nil)

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorSpec.scala
@@ -5,7 +5,7 @@ package akka.persistence.typed.scaladsl
 
 import scala.concurrent.duration._
 import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, SupervisorStrategy, Terminated, TypedAkkaSpecWithShutdown }
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.testkit.typed.TestKitSettings
 import akka.testkit.typed.TestKit
 import akka.testkit.typed.scaladsl._
@@ -57,10 +57,10 @@ object PersistentActorSpec {
           Effect.none
         case IncrementLater ⇒
           // purpose is to test signals
-          val delay = ctx.spawnAnonymous(Actor.withTimers[Tick.type] { timers ⇒
+          val delay = ctx.spawnAnonymous(ActorBehavior.withTimers[Tick.type] { timers ⇒
             timers.startSingleTimer(Tick, Tick, 10.millis)
-            Actor.immutable((_, msg) ⇒ msg match {
-              case Tick ⇒ Actor.stopped
+            ActorBehavior.immutable((_, msg) ⇒ msg match {
+              case Tick ⇒ ActorBehavior.stopped
             })
           })
           ctx.watchWith(delay, DelayFinished)
@@ -214,7 +214,7 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
       // wrap it in Actor.deferred or Actor.supervise
       pending
       val probe = TestProbe[State]
-      val behavior = Actor.supervise[Command](counter("c13"))
+      val behavior = ActorBehavior.supervise[Command](counter("c13"))
         .onFailure(SupervisorStrategy.restartWithBackoff(1.second, 10.seconds, 0.1))
       val c = spawn(behavior)
       c ! Increment

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorCompileOnlyTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorCompileOnlyTest.scala
@@ -10,9 +10,9 @@ import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.TimerScheduler
 
-object PersistentActorCompileOnlyTest {
+object PersistentBehaviorCompileOnlyTest {
 
-  import akka.persistence.typed.scaladsl.PersistentActor._
+  import akka.persistence.typed.scaladsl.PersistentBehavior._
 
   object Simple {
     //#command
@@ -42,7 +42,7 @@ object PersistentActorCompileOnlyTest {
 
     //#behavior
     val simpleBehavior: PersistentBehavior[SimpleCommand, SimpleEvent, ExampleState] =
-      PersistentActor.immutable[SimpleCommand, SimpleEvent, ExampleState](
+      PersistentBehavior.immutable[SimpleCommand, SimpleEvent, ExampleState](
         persistenceId = "sample-id-1",
         initialState = ExampleState(Nil),
         commandHandler = commandHandler,
@@ -62,7 +62,7 @@ object PersistentActorCompileOnlyTest {
 
     case class ExampleState(events: List[String] = Nil)
 
-    PersistentActor.immutable[MyCommand, MyEvent, ExampleState](
+    PersistentBehavior.immutable[MyCommand, MyEvent, ExampleState](
       persistenceId = "sample-id-1",
 
       initialState = ExampleState(Nil),
@@ -106,7 +106,7 @@ object PersistentActorCompileOnlyTest {
         .foreach(sender ! _)
     }
 
-    PersistentActor.immutable[Command, Event, EventsInFlight](
+    PersistentBehavior.immutable[Command, Event, EventsInFlight](
       persistenceId = "recovery-complete-id",
 
       initialState = EventsInFlight(0, Map.empty),
@@ -149,7 +149,7 @@ object PersistentActorCompileOnlyTest {
     sealed trait Event
     case class MoodChanged(to: Mood) extends Event
 
-    val b: Behavior[Command] = PersistentActor.immutable[Command, Event, Mood](
+    val b: Behavior[Command] = PersistentBehavior.immutable[Command, Event, Mood](
       persistenceId = "myPersistenceId",
       initialState = Happy,
       commandHandler = CommandHandler.byState {
@@ -190,7 +190,7 @@ object PersistentActorCompileOnlyTest {
 
     case class State(tasksInFlight: List[Task])
 
-    PersistentActor.immutable[Command, Event, State](
+    PersistentBehavior.immutable[Command, Event, State](
       persistenceId = "asdf",
       initialState = State(Nil),
       commandHandler = CommandHandler.command {
@@ -217,7 +217,7 @@ object PersistentActorCompileOnlyTest {
 
     def worker(task: Task): Behavior[Nothing] = ???
 
-    PersistentActor.immutable[Command, Event, State](
+    PersistentBehavior.immutable[Command, Event, State](
       persistenceId = "asdf",
       initialState = State(Nil),
       commandHandler = (ctx, _, cmd) ⇒ cmd match {
@@ -280,7 +280,7 @@ object PersistentActorCompileOnlyTest {
           .persist[Event, List[Id]](ItemAdded(id))
           .andThen(metadataRegistry ! GetMetaData(id, adapt))
 
-      PersistentActor.immutable[Command, Event, List[Id]](
+      PersistentBehavior.immutable[Command, Event, List[Id]](
         persistenceId = "basket-1",
         initialState = Nil,
         commandHandler =
@@ -342,7 +342,7 @@ object PersistentActorCompileOnlyTest {
       if (currentState == newMood) Effect.none
       else Effect.persist(MoodChanged(newMood))
 
-    PersistentActor.immutable[Command, Event, Mood](
+    PersistentBehavior.immutable[Command, Event, Mood](
       persistenceId = "myPersistenceId",
       initialState = Sad,
       commandHandler = (_, state, cmd) ⇒
@@ -378,7 +378,7 @@ object PersistentActorCompileOnlyTest {
 
     class State
 
-    PersistentActor.immutable[Command, Event, State](
+    PersistentBehavior.immutable[Command, Event, State](
       persistenceId = "myPersistenceId",
       initialState = new State,
       commandHandler = CommandHandler.command {

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorSpec.scala
@@ -11,9 +11,9 @@ import akka.testkit.typed.TestKit
 import akka.testkit.typed.scaladsl._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.Eventually
-import akka.persistence.typed.scaladsl.PersistentActor._
+import akka.persistence.typed.scaladsl.PersistentBehavior._
 
-object PersistentActorSpec {
+object PersistentBehaviorSpec {
 
   val config = ConfigFactory.parseString(
     """
@@ -46,7 +46,7 @@ object PersistentActorSpec {
 
   def counter(persistenceId: String, loggingActor: ActorRef[String]): Behavior[Command] = {
 
-    PersistentActor.immutable[Command, Event, State](
+    PersistentBehavior.immutable[Command, Event, State](
       persistenceId,
       initialState = State(0, Vector.empty),
       commandHandler = (ctx, state, cmd) ⇒ cmd match {
@@ -106,8 +106,8 @@ object PersistentActorSpec {
 
 }
 
-class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Eventually with TypedAkkaSpecWithShutdown {
-  import PersistentActorSpec._
+class PersistentBehaviorSpec extends TestKit(PersistentBehaviorSpec.config) with Eventually with TypedAkkaSpecWithShutdown {
+  import PersistentBehaviorSpec._
 
   implicit val testSettings = TestKitSettings(system)
 

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorSpec.scala
@@ -4,9 +4,9 @@
 package docs.akka.persistence.typed
 
 import akka.actor.typed.Behavior
-import akka.persistence.typed.scaladsl.PersistentActor
+import akka.persistence.typed.scaladsl.PersistentBehavior
 
-object BasicPersistentActorSpec {
+object BasicPersistentBehaviorSpec {
 
   //#structure
   sealed trait Command
@@ -14,7 +14,7 @@ object BasicPersistentActorSpec {
   case class State()
 
   val behavior: Behavior[Command] =
-    PersistentActor.immutable[Command, Event, State](
+    PersistentBehavior.immutable[Command, Event, State](
       persistenceId = "abc",
       initialState = State(),
       commandHandler = (ctx, state, cmd) ⇒ ???,
@@ -23,7 +23,7 @@ object BasicPersistentActorSpec {
 
   //#recovery
   val recoveryBehavior: Behavior[Command] =
-    PersistentActor.immutable[Command, Event, State](
+    PersistentBehavior.immutable[Command, Event, State](
       persistenceId = "abc",
       initialState = State(),
       commandHandler = (ctx, state, cmd) ⇒ ???,

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala
@@ -5,10 +5,10 @@ package docs.akka.persistence.typed
 
 import akka.Done
 import akka.actor.typed.{ ActorRef, Behavior }
-import akka.persistence.typed.scaladsl.PersistentActor
-import akka.persistence.typed.scaladsl.PersistentActor.{ CommandHandler, Effect }
+import akka.persistence.typed.scaladsl.PersistentBehavior
+import akka.persistence.typed.scaladsl.PersistentBehavior.{ CommandHandler, Effect }
 
-object InDepthPersistentActorSpec {
+object InDepthPersistentBehaviorSpec {
 
   //#event
   sealed trait BlogEvent extends Serializable
@@ -117,7 +117,7 @@ object InDepthPersistentActorSpec {
 
   //#behavior
   def behavior: Behavior[BlogCommand] =
-    PersistentActor.immutable[BlogCommand, BlogEvent, BlogState](
+    PersistentBehavior.immutable[BlogCommand, BlogEvent, BlogState](
       persistenceId = "abc",
       initialState = BlogState.empty,
       commandHandler,
@@ -125,6 +125,6 @@ object InDepthPersistentActorSpec {
   //#behavior
 }
 
-class InDepthPersistentActorSpec {
+class InDepthPersistentBehaviorSpec {
 
 }

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/TestEventListener.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/TestEventListener.scala
@@ -5,7 +5,7 @@ import akka.testkit.{ EventFilter, TestEvent ⇒ TE }
 import akka.event.typed.Logger.{ Command, Initialize }
 
 import scala.annotation.tailrec
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.Behavior
 import akka.event.typed.Logger
 
@@ -23,10 +23,10 @@ import akka.event.typed.Logger
 class TestEventListener extends Logger with StdOutLogger {
 
   override val initialBehavior: Behavior[Command] = {
-    Actor.deferred[Command] { _ ⇒
-      Actor.immutable[Command] {
+    ActorBehavior.deferred[Command] { _ ⇒
+      ActorBehavior.immutable[Command] {
         case (ctx, Initialize(eventStream, replyTo)) ⇒
-          val log = ctx.spawn(Actor.deferred[AnyRef] { childCtx ⇒
+          val log = ctx.spawn(ActorBehavior.deferred[AnyRef] { childCtx ⇒
             var filters: List[EventFilter] = Nil
 
             def filter(event: LogEvent): Boolean = filters exists (f ⇒ try { f(event) } catch { case e: Exception ⇒ false })
@@ -42,17 +42,17 @@ class TestEventListener extends Logger with StdOutLogger {
               filters = removeFirst(filters)
             }
 
-            Actor.immutable[AnyRef] {
+            ActorBehavior.immutable[AnyRef] {
               case (_, TE.Mute(filters)) ⇒
                 filters foreach addFilter
-                Actor.same
+                ActorBehavior.same
               case (_, TE.UnMute(filters)) ⇒
                 filters foreach removeFilter
-                Actor.same
+                ActorBehavior.same
               case (_, event: LogEvent) ⇒
                 if (!filter(event)) print(event)
-                Actor.same
-              case _ ⇒ Actor.unhandled
+                ActorBehavior.same
+              case _ ⇒ ActorBehavior.unhandled
             }
           }, "logger")
 
@@ -61,7 +61,7 @@ class TestEventListener extends Logger with StdOutLogger {
           ctx.watch(log) // sign death pact
           replyTo ! log
 
-          Actor.empty
+          ActorBehavior.empty
       }
     }
   }

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/TestKit.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/TestKit.scala
@@ -1,6 +1,6 @@
 package akka.testkit.typed
 
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.{ ActorRef, ActorSystem, Behavior }
 import akka.annotation.ApiMayChange
@@ -17,13 +17,13 @@ object TestKit {
   private[akka] case class SpawnActor[T](name: String, behavior: Behavior[T], replyTo: ActorRef[ActorRef[T]]) extends TestKitCommand
   private[akka] case class SpawnActorAnonymous[T](behavior: Behavior[T], replyTo: ActorRef[ActorRef[T]]) extends TestKitCommand
 
-  private val testKitGuardian = Actor.immutable[TestKitCommand] {
+  private val testKitGuardian = ActorBehavior.immutable[TestKitCommand] {
     case (ctx, SpawnActor(name, behavior, reply)) ⇒
       reply ! ctx.spawn(behavior, name)
-      Actor.same
+      ActorBehavior.same
     case (ctx, SpawnActorAnonymous(behavior, reply)) ⇒
       reply ! ctx.spawnAnonymous(behavior)
-      Actor.same
+      ActorBehavior.same
   }
 
   private def getCallerName(clazz: Class[_]): String = {

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/scaladsl/TestProbe.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/scaladsl/TestProbe.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration._
 import java.util.concurrent.BlockingDeque
 
 import akka.actor.typed.Behavior
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.ActorSystem
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.atomic.AtomicInteger
@@ -34,9 +34,9 @@ object TestProbe {
   def apply[M](name: String)(implicit system: ActorSystem[_]): TestProbe[M] =
     new TestProbe(name)
 
-  private def testActor[M](queue: BlockingDeque[M]): Behavior[M] = Actor.immutable { (ctx, msg) ⇒
+  private def testActor[M](queue: BlockingDeque[M]): Behavior[M] = ActorBehavior.immutable { (ctx, msg) ⇒
     queue.offerLast(msg)
-    Actor.same
+    ActorBehavior.same
   }
 }
 

--- a/akka-testkit-typed/src/test/scala/akka/testkit/typed/BehaviorTestkitSpec.scala
+++ b/akka-testkit-typed/src/test/scala/akka/testkit/typed/BehaviorTestkitSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.testkit.typed
 
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.ActorBehavior
 import akka.actor.typed.{ Behavior, Props }
 import akka.testkit.typed.BehaviorTestkitSpec.Father._
 import akka.testkit.typed.BehaviorTestkitSpec.{ Child, Father }
@@ -27,38 +27,38 @@ object BehaviorTestkitSpec {
 
     def behavior: Behavior[Command] = init()
 
-    def init(): Behavior[Command] = Actor.immutable[Command] { (ctx, msg) ⇒
+    def init(): Behavior[Command] = ActorBehavior.immutable[Command] { (ctx, msg) ⇒
       msg match {
         case SpawnChildren(numberOfChildren) if numberOfChildren > 0 ⇒
           0.until(numberOfChildren).foreach { i ⇒
             ctx.spawn(Child.initial, s"child$i")
           }
-          Actor.same
+          ActorBehavior.same
         case SpawnChildrenWithProps(numberOfChildren, props) if numberOfChildren > 0 ⇒
           0.until(numberOfChildren).foreach { i ⇒
             ctx.spawn(Child.initial, s"child$i", props)
           }
-          Actor.same
+          ActorBehavior.same
         case SpawnAnonymous(numberOfChildren) if numberOfChildren > 0 ⇒
           0.until(numberOfChildren).foreach { _ ⇒
             ctx.spawnAnonymous(Child.initial)
           }
-          Actor.same
+          ActorBehavior.same
         case SpawnAnonymousWithProps(numberOfChildren, props) if numberOfChildren > 0 ⇒
           0.until(numberOfChildren).foreach { _ ⇒
             ctx.spawnAnonymous(Child.initial, props)
           }
-          Actor.same
+          ActorBehavior.same
         case SpawnAdapter ⇒
           ctx.spawnAdapter {
             r: Reproduce ⇒ SpawnAnonymous(r.times)
           }
-          Actor.same
+          ActorBehavior.same
         case SpawnAdapterWithName(name) ⇒
           ctx.spawnAdapter({
             r: Reproduce ⇒ SpawnAnonymous(r.times)
           }, name)
-          Actor.same
+          ActorBehavior.same
       }
     }
   }
@@ -67,10 +67,10 @@ object BehaviorTestkitSpec {
 
     sealed trait Action
 
-    val initial: Behavior[Action] = Actor.immutable[Action] { (_, msg) ⇒
+    val initial: Behavior[Action] = ActorBehavior.immutable[Action] { (_, msg) ⇒
       msg match {
         case _ ⇒
-          Actor.empty
+          ActorBehavior.empty
       }
     }
 


### PR DESCRIPTION
The technical reason for not naming it Behavior is that iit would be duplicate import conflicts of   `akka.actor.typed.Behavior` and `akka.actor.typed.scaladsl.Behavior`

For example this would not work:
```scala
import akka.actor.typed.ActorRef
import akka.actor.typed.Behavior
import akka.actor.typed.scaladsl.Behavior

object ChatRoom {

  val behavior: Behavior[Command] =
    chatRoom(List.empty)

  private def chatRoom(sessions: List[ActorRef[SessionEvent]]): Behavior[Command] =
    Behavior.immutable[Command] { (ctx, msg) ⇒
```


Also renaming PersistentActor to PersistentBehavior.

Refs #24071