### PR TITLE
[WIP] Non-function-ref spawnAdapter

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
@@ -770,6 +770,7 @@ abstract class ActorContextSpec extends TypedAkkaSpec {
     }
 
     "create a named adapter" in {
+      pending // does not make sense anymore
       sync(setup("ctx41") { (ctx, startWith) ⇒
         startWith.keep { subj ⇒
           subj ! GetAdapter(ctx.self, "named")

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/AdaptingActorRef.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/AdaptingActorRef.scala
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.actor.typed.internal
+
+import akka.actor.{ ActorPath, ActorRefProvider, ActorRefScope, InternalActorRef, ScalaActorRef, ActorRef ⇒ UntypedActorRef }
+import akka.actor.typed.ActorRef
+import akka.annotation.InternalApi
+import akka.dispatch.sysmsg
+
+@InternalApi final private[akka] class AdaptingActorRef[O, M](val actualRef: ActorRef[M], val transform: O ⇒ M) extends ActorRef[O] {
+
+  def tell(msg: O): Unit = {
+    // transform on sending side, but do not apply transformation
+    // AdaptedMessage has special handling to transform before processing message on the receiving actor thread
+    actualRef.asInstanceOf[ActorRef[AnyRef]] ! AdaptedMessage(msg, transform)
+  }
+
+  def narrow[U <: O]: ActorRef[U] = this.asInstanceOf[ActorRef[U]]
+
+  def upcast[U >: O]: ActorRef[U] = this.asInstanceOf[ActorRef[U]]
+
+  def path: ActorPath = actualRef.path
+
+  def compareTo(o: ActorRef[_]): Int = actualRef.compareTo(o)
+
+}
+
+@InternalApi final private[akka] class UntypedAdaptingActorRef[O, M](actual: InternalActorRef, transform: O ⇒ M) extends InternalActorRef with ActorRefScope {
+  def path: ActorPath = actual.path
+
+  private[akka] def isTerminated = actual.isTerminated
+
+  def !(message: Any)(implicit sender: UntypedActorRef): Unit = {
+    // FIXME what to do if sent something non O??
+    actual ! transform(message.asInstanceOf[O])
+  }
+
+  // I don't think these will ever be called on an untyped-adapted-adapted-ref, but not sure
+  def start(): Unit = actual.start()
+  def resume(causedByFailure: Throwable): Unit = actual.resume(causedByFailure)
+  def suspend(): Unit = actual.suspend()
+  def stop(): Unit = actual.stop()
+  def restart(cause: Throwable): Unit = actual.restart(cause)
+  def sendSystemMessage(message: sysmsg.SystemMessage): Unit = actual.sendSystemMessage(message)
+  def provider: ActorRefProvider = actual.provider
+
+  def getParent: InternalActorRef = actual.getParent
+  def getChild(name: Iterator[String]): InternalActorRef = actual.getChild(name)
+  def isLocal: Boolean = actual.isLocal
+}
+
+final private[akka] case class AdaptedMessage[O, M](payload: O, transform: O ⇒ M)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
@@ -35,6 +35,7 @@ import akka.util.OptionVal
       next(Behavior.interpretSignal(behavior, ctx, msg), msg)
     case a.ReceiveTimeout ⇒
       next(Behavior.interpretMessage(behavior, ctx, ctx.receiveTimeoutMsg), ctx.receiveTimeoutMsg)
+    case AdaptedMessage(msg: AnyRef, transform) ⇒ receive(transform(msg))
     case msg: T @unchecked ⇒
       next(Behavior.interpretMessage(behavior, ctx, msg), msg)
   }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
@@ -59,9 +59,8 @@ import akka.actor.typed.Behavior.UntypedBehavior
     untyped.system.scheduler.scheduleOnce(delay, toUntyped(target), msg)
   }
   override private[akka] def internalSpawnAdapter[U](f: U ⇒ T, _name: String): ActorRef[U] = {
-    val cell = untyped.asInstanceOf[akka.actor.ActorCell]
-    val ref = cell.addFunctionRef((_, msg) ⇒ untyped.self ! f(msg.asInstanceOf[U]), _name)
-    ActorRefAdapter[U](ref)
+    // FIXME name does not make sense anymore
+    new AdaptingActorRef[U, T](self, f)
   }
 }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala
@@ -33,6 +33,9 @@ private[akka] object ActorRefAdapter {
   def toUntyped[U](ref: ActorRef[U]): akka.actor.InternalActorRef =
     ref match {
       case adapter: ActorRefAdapter[_] ⇒ adapter.untyped
+      case adapted: AdaptingActorRef[_, _] ⇒
+        val untypedActualRef = toUntyped(adapted.actualRef)
+        new UntypedAdaptingActorRef(untypedActualRef, adapted.transform)
       case _ ⇒
         throw new UnsupportedOperationException("only adapted untyped ActorRefs permissible " +
           s"($ref of class ${ref.getClass.getName})")


### PR DESCRIPTION
This may not work out because of remote/serialization of functions and not having any lifecycle to trigger cleanup. At the same time, not having a lifecycle is the cool thing :)