### PR TITLE
Rename scaladsl/javadsl Actor to Behaviors, #24071

### DIFF
--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorCompile.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorCompile.java
@@ -6,7 +6,7 @@ package akka.actor.typed.javadsl;
 import akka.actor.typed.*;
 import akka.actor.typed.ActorContext;
 
-import static akka.actor.typed.javadsl.Actor.*;
+import static akka.actor.typed.javadsl.Behaviors.*;
 
 import java.util.concurrent.TimeUnit;
 import scala.concurrent.duration.Duration;
@@ -48,7 +48,7 @@ public class ActorCompile {
   ActorSystem<MyMsg> system = ActorSystem.create(actor1, "Sys");
 
   {
-    Actor.<MyMsg>immutable((ctx, msg) -> {
+    Behaviors.<MyMsg>immutable((ctx, msg) -> {
       if (msg instanceof MyMsgA) {
         return immutable((ctx2, msg2) -> {
           if (msg2 instanceof MyMsgB) {
@@ -63,9 +63,9 @@ public class ActorCompile {
   }
 
   {
-    Behavior<MyMsg> b = Actor.withTimers(timers -> {
+    Behavior<MyMsg> b = Behaviors.withTimers(timers -> {
       timers.startPeriodicTimer("key", new MyMsgB("tick"), Duration.create(1, TimeUnit.SECONDS));
-      return Actor.ignore();
+      return Behaviors.ignore();
     });
   }
 
@@ -107,8 +107,8 @@ public class ActorCompile {
     SupervisorStrategy strategy7 = strategy6.withResetBackoffAfter(Duration.create(2, TimeUnit.SECONDS));
 
     Behavior<MyMsg> behv =
-      Actor.supervise(
-        Actor.supervise(Actor.<MyMsg>ignore()).onFailure(IllegalStateException.class, strategy6)
+      Behaviors.supervise(
+        Behaviors.supervise(Behaviors.<MyMsg>ignore()).onFailure(IllegalStateException.class, strategy6)
       ).onFailure(RuntimeException.class, strategy1);
   }
 

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/AdapterTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/AdapterTest.java
@@ -19,7 +19,7 @@ import akka.actor.typed.Signal;
 import akka.actor.typed.Terminated;
 import akka.testkit.javadsl.TestKit;
 import akka.actor.SupervisorStrategy;
-import static akka.actor.typed.javadsl.Actor.*;
+import static akka.actor.typed.javadsl.Behaviors.*;
 
 public class AdapterTest extends JUnitSuite {
 
@@ -187,7 +187,7 @@ public class AdapterTest extends JUnitSuite {
   }
 
   static Behavior<Typed2Msg> typed2() {
-      return Actor.immutable((ctx, msg) -> {
+      return Behaviors.immutable((ctx, msg) -> {
         if (msg instanceof Ping) {
           ActorRef<String> replyTo = ((Ping) msg).replyTo;
           replyTo.tell("pong");

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/BehaviorBuilderTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/BehaviorBuilderTest.java
@@ -12,8 +12,8 @@ import akka.actor.typed.ActorRef;
 
 import java.util.ArrayList;
 
-import static akka.actor.typed.javadsl.Actor.same;
-import static akka.actor.typed.javadsl.Actor.stopped;
+import static akka.actor.typed.javadsl.Behaviors.same;
+import static akka.actor.typed.javadsl.Behaviors.stopped;
 
 /**
  * Test creating [[Behavior]]s using [[BehaviorBuilder]]
@@ -32,7 +32,7 @@ public class BehaviorBuilderTest extends JUnitSuite {
 
     @Test
     public void shouldCompile() {
-      Behavior<Message> b = Actor.immutable(Message.class)
+      Behavior<Message> b = Behaviors.immutable(Message.class)
         .onMessage(One.class, (ctx, o) -> {
           o.foo();
           return same();
@@ -40,7 +40,7 @@ public class BehaviorBuilderTest extends JUnitSuite {
         .onMessage(One.class, o -> o.foo().startsWith("a"), (ctx, o) -> same())
         .onMessageUnchecked(MyList.class, (ActorContext<Message> ctx, MyList<String> l) -> {
           String first = l.get(0);
-          return Actor.<Message>same();
+          return Behaviors.<Message>same();
         })
         .onSignal(Terminated.class, (ctx, t) -> {
           System.out.println("Terminating along with " + t.getRef());
@@ -65,7 +65,7 @@ public class BehaviorBuilderTest extends JUnitSuite {
     }
 
     public Behavior<CounterMessage> immutableCounter(int currentValue) {
-      return Actor.immutable(CounterMessage.class)
+      return Behaviors.immutable(CounterMessage.class)
           .onMessage(Increase.class, (ctx, o) -> {
             return immutableCounter(currentValue + 1);
           })

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ReceiveBuilderTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ReceiveBuilderTest.java
@@ -17,7 +17,7 @@ public class ReceiveBuilderTest extends JUnitSuite {
 
   @Test
   public void testMutableCounter() {
-    Behavior<BehaviorBuilderTest.CounterMessage> mutable = Actor.mutable(ctx -> new Actor.MutableBehavior<BehaviorBuilderTest.CounterMessage>() {
+    Behavior<BehaviorBuilderTest.CounterMessage> mutable = Behaviors.mutable(ctx -> new Behaviors.MutableBehavior<BehaviorBuilderTest.CounterMessage>() {
       int currentValue = 0;
 
       private Behavior<BehaviorBuilderTest.CounterMessage> receiveIncrease(BehaviorBuilderTest.Increase msg) {
@@ -31,7 +31,7 @@ public class ReceiveBuilderTest extends JUnitSuite {
       }
 
       @Override
-      public Actor.Receive<BehaviorBuilderTest.CounterMessage> createReceive() {
+      public Behaviors.Receive<BehaviorBuilderTest.CounterMessage> createReceive() {
         return receiveBuilder()
           .onMessage(BehaviorBuilderTest.Increase.class, this::receiveIncrease)
           .onMessage(BehaviorBuilderTest.Get.class, this::receiveGet)
@@ -40,7 +40,7 @@ public class ReceiveBuilderTest extends JUnitSuite {
     });
   }
 
-  private static class MyMutableBehavior extends Actor.MutableBehavior<BehaviorBuilderTest.CounterMessage> {
+  private static class MyMutableBehavior extends Behaviors.MutableBehavior<BehaviorBuilderTest.CounterMessage> {
     private int value;
 
     public MyMutableBehavior(int initialValue) {
@@ -49,7 +49,7 @@ public class ReceiveBuilderTest extends JUnitSuite {
     }
 
     @Override
-    public Actor.Receive<BehaviorBuilderTest.CounterMessage> createReceive() {
+    public Behaviors.Receive<BehaviorBuilderTest.CounterMessage> createReceive() {
       assertEquals(42, value);
       return receiveBuilder().build();
     }
@@ -58,6 +58,6 @@ public class ReceiveBuilderTest extends JUnitSuite {
   @Test
   public void testInitializationOrder() throws Exception {
     MyMutableBehavior mutable = new MyMutableBehavior(42);
-    assertEquals(Actor.unhandled(), mutable.receiveMessage(null, new BehaviorBuilderTest.Increase()));
+    assertEquals(Behaviors.unhandled(), mutable.receiveMessage(null, new BehaviorBuilderTest.Increase()));
   }
 }

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/WatchTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/WatchTest.java
@@ -14,8 +14,7 @@ import akka.util.Timeout;
 import org.junit.Test;
 
 import akka.actor.typed.*;
-import static akka.actor.typed.javadsl.Actor.*;
-import static akka.actor.typed.javadsl.AskPattern.*;
+import static akka.actor.typed.javadsl.Behaviors.*;
 
 public class WatchTest extends JUnitSuite {
 

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/IntroTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/IntroTest.java
@@ -8,7 +8,7 @@ import akka.actor.typed.ActorRef;
 import akka.actor.typed.ActorSystem;
 import akka.actor.typed.Behavior;
 import akka.actor.typed.Terminated;
-import akka.actor.typed.javadsl.Actor;
+import akka.actor.typed.javadsl.Behaviors;
 import akka.actor.typed.javadsl.AskPattern;
 import akka.util.Timeout;
 
@@ -47,10 +47,10 @@ public class IntroTest {
       }
     }
 
-    public static final Behavior<Greet> greeter = Actor.immutable((ctx, msg) -> {
+    public static final Behavior<Greet> greeter = Behaviors.immutable((ctx, msg) -> {
       System.out.println("Hello " + msg.whom + "!");
       msg.replyTo.tell(new Greeted(msg.whom));
-      return Actor.same();
+      return Behaviors.same();
     });
   }
   //#hello-world-actor
@@ -133,7 +133,7 @@ public class IntroTest {
     }
 
     private static Behavior<Command> chatRoom(List<ActorRef<SessionEvent>> sessions) {
-      return Actor.immutable(Command.class)
+      return Behaviors.immutable(Command.class)
         .onMessage(GetSession.class, (ctx, getSession) -> {
           ActorRef<PostMessage> wrapper = ctx.spawnAdapter(p ->
             new PostSessionMessage(getSession.screenName, p.message));
@@ -146,7 +146,7 @@ public class IntroTest {
         .onMessage(PostSessionMessage.class, (ctx, post) -> {
           MessagePosted mp = new MessagePosted(post.screenName, post.message);
           sessions.forEach(s -> s.tell(mp));
-          return Actor.same();
+          return Behaviors.same();
         })
         .build();
     }
@@ -161,19 +161,19 @@ public class IntroTest {
     }
 
     public static Behavior<ChatRoom.SessionEvent> behavior() {
-      return Actor.immutable(ChatRoom.SessionEvent.class)
+      return Behaviors.immutable(ChatRoom.SessionEvent.class)
         .onMessage(ChatRoom.SessionDenied.class, (ctx, msg) -> {
           System.out.println("cannot start chat room session: " + msg.reason);
-          return Actor.stopped();
+          return Behaviors.stopped();
         })
         .onMessage(ChatRoom.SessionGranted.class, (ctx, msg) -> {
           msg.handle.tell(new ChatRoom.PostMessage("Hello World!"));
-          return Actor.same();
+          return Behaviors.same();
         })
         .onMessage(ChatRoom.MessagePosted.class, (ctx, msg) -> {
           System.out.println("message has been posted by '" +
             msg.screenName +"': " + msg.message);
-          return Actor.stopped();
+          return Behaviors.stopped();
         })
         .build();
     }
@@ -184,7 +184,7 @@ public class IntroTest {
   public static void runChatRoom() throws Exception {
 
     //#chatroom-main
-    Behavior<Void> main = Actor.deferred(ctx -> {
+    Behavior<Void> main = Behaviors.deferred(ctx -> {
       ActorRef<ChatRoom.Command> chatRoom =
         ctx.spawn(ChatRoom.behavior(), "chatRoom");
       ActorRef<ChatRoom.SessionEvent> gabbler =
@@ -192,8 +192,8 @@ public class IntroTest {
       ctx.watch(gabbler);
       chatRoom.tell(new ChatRoom.GetSession("ol’ Gabbler", gabbler));
 
-      return Actor.immutable(Void.class)
-        .onSignal(Terminated.class, (c, sig) -> Actor.stopped())
+      return Behaviors.immutable(Void.class)
+        .onSignal(Terminated.class, (c, sig) -> Behaviors.stopped())
         .build();
     });
 

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/MutableIntroTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/MutableIntroTest.java
@@ -6,8 +6,8 @@ package jdocs.akka.actor.typed;
 //#imports
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
-import akka.actor.typed.javadsl.Actor;
-import akka.actor.typed.javadsl.Actor.Receive;
+import akka.actor.typed.javadsl.Behaviors;
+import akka.actor.typed.javadsl.Behaviors.Receive;
 import akka.actor.typed.javadsl.ActorContext;
 //#imports
 import java.util.ArrayList;
@@ -72,10 +72,10 @@ public class MutableIntroTest {
     //#chatroom-behavior
 
     public static Behavior<Command> behavior() {
-      return Actor.mutable(ChatRoomBehavior::new);
+      return Behaviors.mutable(ChatRoomBehavior::new);
     }
 
-    public static class ChatRoomBehavior extends Actor.MutableBehavior<Command> {
+    public static class ChatRoomBehavior extends Behaviors.MutableBehavior<Command> {
       final ActorContext<Command> ctx;
       final List<ActorRef<SessionEvent>> sessions = new ArrayList<ActorRef<SessionEvent>>();
 
@@ -91,7 +91,7 @@ public class MutableIntroTest {
               new PostSessionMessage(getSession.screenName, p.message));
             getSession.replyTo.tell(new SessionGranted(wrapper));
             sessions.add(getSession.replyTo);
-            return Actor.same();
+            return Behaviors.same();
           })
           .onMessage(PostSessionMessage.class, post -> {
             MessagePosted mp = new MessagePosted(post.screenName, post.message);

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingUntypedTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingUntypedTest.java
@@ -17,8 +17,8 @@ import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 
-import static akka.actor.typed.javadsl.Actor.same;
-import static akka.actor.typed.javadsl.Actor.stopped;
+import static akka.actor.typed.javadsl.Behaviors.same;
+import static akka.actor.typed.javadsl.Behaviors.stopped;
 
 public class TypedWatchingUntypedTest extends JUnitSuite {
 
@@ -36,7 +36,7 @@ public class TypedWatchingUntypedTest extends JUnitSuite {
     public static class Pong implements Command { }
 
     public static Behavior<Command> behavior() {
-      return akka.actor.typed.javadsl.Actor.deferred(context -> {
+      return akka.actor.typed.javadsl.Behaviors.deferred(context -> {
         akka.actor.ActorRef second = Adapter.actorOf(context, Untyped.props(), "second");
 
         Adapter.watch(context, second);
@@ -44,7 +44,7 @@ public class TypedWatchingUntypedTest extends JUnitSuite {
         second.tell(new Typed.Ping(context.getSelf().narrow()),
           Adapter.toUntyped(context.getSelf()));
 
-        return akka.actor.typed.javadsl.Actor.immutable(Typed.Command.class)
+        return akka.actor.typed.javadsl.Behaviors.immutable(Typed.Command.class)
           .onMessage(Typed.Pong.class, (ctx, msg) -> {
             Adapter.stop(ctx, second);
             return same();

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/UntypedWatchingTypedTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/UntypedWatchingTypedTest.java
@@ -7,7 +7,7 @@ import akka.actor.AbstractActor;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.ActorSystem;
 import akka.actor.typed.Behavior;
-import akka.actor.typed.javadsl.Actor;
+import akka.actor.typed.javadsl.Behaviors;
 //#adapter-import
 // In java use the static methods on Adapter to convert from typed to untyped
 import akka.actor.typed.javadsl.Adapter;
@@ -18,7 +18,7 @@ import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 
-import static akka.actor.typed.javadsl.Actor.same;
+import static akka.actor.typed.javadsl.Behaviors.same;
 
 public class UntypedWatchingTypedTest extends JUnitSuite {
 
@@ -66,7 +66,7 @@ public class UntypedWatchingTypedTest extends JUnitSuite {
     public static class Pong { }
 
     public static Behavior<Command> behavior() {
-      return Actor.immutable(Typed.Command.class)
+      return Behaviors.immutable(Typed.Command.class)
         .onMessage(Typed.Ping.class, (ctx, msg) -> {
           msg.replyTo.tell(new Pong());
           return same();

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/testing/async/BasicAsyncTestingTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/testing/async/BasicAsyncTestingTest.java
@@ -5,7 +5,7 @@ package jdocs.akka.typed.testing.async;
 
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
-import akka.actor.typed.javadsl.Actor;
+import akka.actor.typed.javadsl.Behaviors;
 import akka.testkit.typed.javadsl.TestProbe;
 import akka.testkit.typed.TestKit;
 import org.junit.AfterClass;
@@ -33,9 +33,9 @@ public class BasicAsyncTestingTest extends TestKit {
     }
   }
 
-  Behavior<Ping> echoActor = Actor.immutable((ctx, ping) -> {
+  Behavior<Ping> echoActor = Behaviors.immutable((ctx, ping) -> {
     ping.replyTo.tell(new Pong(ping.msg));
-    return Actor.same();
+    return Behaviors.same();
   });
   //#under-test
 

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/testing/sync/BasicSyncTestingTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/testing/sync/BasicSyncTestingTest.java
@@ -11,7 +11,7 @@ import org.scalatest.junit.JUnitSuite;
 public class BasicSyncTestingTest extends JUnitSuite {
 
   //#child
-  public static Behavior<String> childActor = Actor.immutable((ctx, msg) -> Actor.same());
+  public static Behavior<String> childActor = Behaviors.immutable((ctx, msg) -> Behaviors.same());
   //#child
 
   //#under-test
@@ -38,27 +38,27 @@ public class BasicSyncTestingTest extends JUnitSuite {
     }
   }
 
-  public static Behavior<Command> myBehaviour = Actor.immutable(Command.class)
+  public static Behavior<Command> myBehaviour = Behaviors.immutable(Command.class)
     .onMessage(CreateAChild.class, (ctx, msg) -> {
       ctx.spawn(childActor, msg.childName);
-      return Actor.same();
+      return Behaviors.same();
     })
     .onMessage(CreateAnAnonymousChild.class, (ctx, msg) -> {
       ctx.spawnAnonymous(childActor);
-      return Actor.same();
+      return Behaviors.same();
     })
     .onMessage(SayHelloToChild.class, (ctx, msg) -> {
       ActorRef<String> child = ctx.spawn(childActor, msg.childName);
       child.tell("hello");
-      return Actor.same();
+      return Behaviors.same();
     })
     .onMessage(SayHelloToAnonymousChild.class, (ctx, msg) -> {
       ActorRef<String> child = ctx.spawnAnonymous(childActor);
       child.tell("hello stranger");
-      return Actor.same();
+      return Behaviors.same();
     }).onMessage(SayHello.class, (ctx, msg) -> {
       msg.who.tell("hello");
-      return Actor.same();
+      return Behaviors.same();
     }).build();
   //#under-test
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -4,8 +4,8 @@
 package akka.actor.typed
 
 import akka.actor.typed.internal.adapter.ActorSystemAdapter
-import akka.actor.typed.scaladsl.Actor
-import akka.actor.typed.scaladsl.Actor._
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.Behaviors._
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.pattern.AskTimeoutException
 import akka.testkit.typed.TestKit
@@ -29,10 +29,10 @@ class AskSpec extends TestKit("AskSpec") with TypedAkkaSpec with ScalaFutures {
   val behavior: Behavior[Msg] = immutable[Msg] {
     case (_, foo: Foo) ⇒
       foo.replyTo ! "foo"
-      Actor.same
+      Behaviors.same
     case (_, Stop(r)) ⇒
       r ! ()
-      Actor.stopped
+      Behaviors.stopped
   }
 
   "Ask pattern" must {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
@@ -3,8 +3,8 @@
  */
 package akka.actor.typed
 
-import akka.actor.typed.scaladsl.{ Actor ⇒ SActor }
-import akka.actor.typed.javadsl.{ Actor ⇒ JActor, ActorContext ⇒ JActorContext }
+import akka.actor.typed.scaladsl.{ Behaviors ⇒ SActor }
+import akka.actor.typed.javadsl.{ Behaviors ⇒ JActor, ActorContext ⇒ JActorContext }
 import akka.japi.function.{ Function ⇒ F1e, Function2 ⇒ F2, Procedure2 ⇒ P2 }
 import akka.japi.pf.{ FI, PFBuilder }
 import java.util.function.{ Function ⇒ F1 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
@@ -5,8 +5,8 @@ package akka.actor.typed
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
-import akka.actor.typed.scaladsl.Actor
-import akka.actor.typed.scaladsl.Actor.BehaviorDecorators
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.Behaviors.BehaviorDecorators
 import akka.testkit.typed.{ BehaviorTestkit, TestInbox, TestKit, TestKitSettings }
 import akka.testkit.typed.scaladsl._
 
@@ -19,10 +19,10 @@ object DeferredSpec {
   case object Started extends Event
 
   def target(monitor: ActorRef[Event]): Behavior[Command] =
-    Actor.immutable((_, cmd) ⇒ cmd match {
+    Behaviors.immutable((_, cmd) ⇒ cmd match {
       case Ping ⇒
         monitor ! Pong
-        Actor.same
+        Behaviors.same
     })
 }
 
@@ -34,7 +34,7 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
   "Deferred behaviour" must {
     "must create underlying" in {
       val probe = TestProbe[Event]("evt")
-      val behv = Actor.deferred[Command] { _ ⇒
+      val behv = Behaviors.deferred[Command] { _ ⇒
         probe.ref ! Started
         target(probe.ref)
       }
@@ -46,16 +46,16 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
 
     "must stop when exception from factory" in {
       val probe = TestProbe[Event]("evt")
-      val behv = Actor.deferred[Command] { ctx ⇒
-        val child = ctx.spawnAnonymous(Actor.deferred[Command] { _ ⇒
+      val behv = Behaviors.deferred[Command] { ctx ⇒
+        val child = ctx.spawnAnonymous(Behaviors.deferred[Command] { _ ⇒
           probe.ref ! Started
           throw new RuntimeException("simulated exc from factory") with NoStackTrace
         })
         ctx.watch(child)
-        Actor.immutable[Command]((_, _) ⇒ Actor.same).onSignal {
+        Behaviors.immutable[Command]((_, _) ⇒ Behaviors.same).onSignal {
           case (_, Terminated(`child`)) ⇒
             probe.ref ! Pong
-            Actor.stopped
+            Behaviors.stopped
         }
       }
       spawn(behv)
@@ -65,13 +65,13 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
 
     "must stop when deferred result it Stopped" in {
       val probe = TestProbe[Event]("evt")
-      val behv = Actor.deferred[Command] { ctx ⇒
-        val child = ctx.spawnAnonymous(Actor.deferred[Command](_ ⇒ Actor.stopped))
+      val behv = Behaviors.deferred[Command] { ctx ⇒
+        val child = ctx.spawnAnonymous(Behaviors.deferred[Command](_ ⇒ Behaviors.stopped))
         ctx.watch(child)
-        Actor.immutable[Command]((_, _) ⇒ Actor.same).onSignal {
+        Behaviors.immutable[Command]((_, _) ⇒ Behaviors.same).onSignal {
           case (_, Terminated(`child`)) ⇒
             probe.ref ! Pong
-            Actor.stopped
+            Behaviors.stopped
         }
       }
       spawn(behv)
@@ -80,8 +80,8 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
 
     "must create underlying when nested" in {
       val probe = TestProbe[Event]("evt")
-      val behv = Actor.deferred[Command] { _ ⇒
-        Actor.deferred[Command] { _ ⇒
+      val behv = Behaviors.deferred[Command] { _ ⇒
+        Behaviors.deferred[Command] { _ ⇒
           probe.ref ! Started
           target(probe.ref)
         }
@@ -92,7 +92,7 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
 
     "must un-defer underlying when wrapped by widen" in {
       val probe = TestProbe[Event]("evt")
-      val behv = Actor.deferred[Command] { _ ⇒
+      val behv = Behaviors.deferred[Command] { _ ⇒
         probe.ref ! Started
         target(probe.ref)
       }.widen[Command] {
@@ -110,7 +110,7 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
       // monitor is implemented with tap, so this is testing both
       val probe = TestProbe[Event]("evt")
       val monitorProbe = TestProbe[Command]("monitor")
-      val behv = Actor.monitor(monitorProbe.ref, Actor.deferred[Command] { _ ⇒
+      val behv = Behaviors.monitor(monitorProbe.ref, Behaviors.deferred[Command] { _ ⇒
         probe.ref ! Started
         target(probe.ref)
       })
@@ -131,7 +131,7 @@ class DeferredStubbedSpec extends TypedAkkaSpec {
 
   "must create underlying deferred behavior immediately" in {
     val inbox = TestInbox[Event]("evt")
-    val behv = Actor.deferred[Command] { _ ⇒
+    val behv = Behaviors.deferred[Command] { _ ⇒
       inbox.ref ! Started
       target(inbox.ref)
     }
@@ -143,7 +143,7 @@ class DeferredStubbedSpec extends TypedAkkaSpec {
   "must stop when exception from factory" in {
     val inbox = TestInbox[Event]("evt")
     val exc = new RuntimeException("simulated exc from factory") with NoStackTrace
-    val behv = Actor.deferred[Command] { _ ⇒
+    val behv = Behaviors.deferred[Command] { _ ⇒
       inbox.ref ! Started
       throw exc
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/StepWise.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/StepWise.scala
@@ -6,7 +6,7 @@ package akka.actor.typed
 import scala.concurrent.duration.FiniteDuration
 import java.util.concurrent.TimeoutException
 
-import akka.actor.typed.scaladsl.Actor._
+import akka.actor.typed.scaladsl.Behaviors._
 
 import scala.concurrent.duration.Deadline
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
@@ -3,7 +3,7 @@
  */
 package akka.actor.typed
 
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 
 import scala.concurrent._
 import akka.testkit.typed.TestKit
@@ -12,8 +12,8 @@ object WatchSpec {
   case object Stop
 
   val terminatorBehavior =
-    Actor.immutable[Stop.type] {
-      case (_, Stop) ⇒ Actor.stopped
+    Behaviors.immutable[Stop.type] {
+      case (_, Stop) ⇒ Behaviors.stopped
     }
 
   sealed trait Message
@@ -32,14 +32,14 @@ class WatchSpec extends TestKit("WordSpec")
       val terminator = systemActor(terminatorBehavior)
       val receivedTerminationSignal: Promise[ActorRef[Nothing]] = Promise()
 
-      val watcher = systemActor(Actor.immutable[StartWatching] {
+      val watcher = systemActor(Behaviors.immutable[StartWatching] {
         case (ctx, StartWatching(watchee)) ⇒
           ctx.watch(watchee)
-          Actor.same
+          Behaviors.same
       }.onSignal {
         case (_, Terminated(stopped)) ⇒
           receivedTerminationSignal.success(stopped)
-          Actor.stopped
+          Behaviors.stopped
       })
 
       watcher ! StartWatching(terminator)
@@ -52,13 +52,13 @@ class WatchSpec extends TestKit("WordSpec")
       val terminator = systemActor(terminatorBehavior)
       val receivedTerminationSignal: Promise[Message] = Promise()
 
-      val watcher = systemActor(Actor.immutable[Message] {
+      val watcher = systemActor(Behaviors.immutable[Message] {
         case (ctx, StartWatchingWith(watchee, msg)) ⇒
           ctx.watchWith(watchee, msg)
-          Actor.same
+          Behaviors.same
         case (_, msg) ⇒
           receivedTerminationSignal.success(msg)
-          Actor.stopped
+          Behaviors.stopped
       })
 
       watcher ! StartWatchingWith(terminator, CustomTerminationMessage)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
@@ -5,7 +5,7 @@ package akka.actor.typed
 package internal
 
 import akka.actor.InvalidMessageException
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 import akka.testkit.typed.TestInbox
 import org.scalatest._
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
@@ -39,7 +39,7 @@ class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll
     "start the guardian actor and terminate when it terminates" in {
       val t = withSystem(
         "a",
-        Actor.immutable[Probe] { case (_, p) ⇒ p.replyTo ! p.msg; Actor.stopped }, doTerminate = false) { sys ⇒
+        Behaviors.immutable[Probe] { case (_, p) ⇒ p.replyTo ! p.msg; Behaviors.stopped }, doTerminate = false) { sys ⇒
           val inbox = TestInbox[String]("a")
           sys ! Probe("hello", inbox.ref)
           eventually {
@@ -55,7 +55,7 @@ class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll
     // see issue #24172
     "shutdown if guardian shuts down immediately" in {
       pending
-      withSystem("shutdown", Actor.stopped[String], doTerminate = false) { sys: ActorSystem[String] ⇒
+      withSystem("shutdown", Behaviors.stopped[String], doTerminate = false) { sys: ActorSystem[String] ⇒
         sys.whenTerminated.futureValue
       }
     }
@@ -63,12 +63,12 @@ class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll
     "terminate the guardian actor" in {
       val inbox = TestInbox[String]("terminate")
       val sys = system(
-        Actor.immutable[Probe] {
-          case (_, _) ⇒ Actor.unhandled
+        Behaviors.immutable[Probe] {
+          case (_, _) ⇒ Behaviors.unhandled
         } onSignal {
           case (_, PostStop) ⇒
             inbox.ref ! "done"
-            Actor.same
+            Behaviors.same
         },
         "terminate")
       sys.terminate().futureValue
@@ -80,13 +80,13 @@ class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll
     }
 
     "have a name" in {
-      withSystem("name", Actor.empty[String]) { sys ⇒
+      withSystem("name", Behaviors.empty[String]) { sys ⇒
         sys.name should ===(suite + "-name")
       }
     }
 
     "report its uptime" in {
-      withSystem("uptime", Actor.empty[String]) { sys ⇒
+      withSystem("uptime", Behaviors.empty[String]) { sys ⇒
         sys.uptime should be < 1L
         Thread.sleep(1000)
         sys.uptime should be >= 1L
@@ -94,7 +94,7 @@ class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll
     }
 
     "have a working thread factory" in {
-      withSystem("thread", Actor.empty[String]) { sys ⇒
+      withSystem("thread", Behaviors.empty[String]) { sys ⇒
         val p = Promise[Int]
         sys.threadFactory.newThread(new Runnable {
           def run(): Unit = p.success(42)
@@ -104,14 +104,14 @@ class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll
     }
 
     "be able to run Futures" in {
-      withSystem("futures", Actor.empty[String]) { sys ⇒
+      withSystem("futures", Behaviors.empty[String]) { sys ⇒
         val f = Future(42)(sys.executionContext)
         f.futureValue should ===(42)
       }
     }
 
     "not allow null messages" in {
-      withSystem("null-messages", Actor.empty[String]) { sys ⇒
+      withSystem("null-messages", Behaviors.empty[String]) { sys ⇒
         intercept[InvalidMessageException] {
           sys ! null
         }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/MiscMessageSerializerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/MiscMessageSerializerSpec.scala
@@ -4,7 +4,7 @@
 package akka.actor.typed.internal
 
 import akka.actor.typed.TypedAkkaSpecWithShutdown
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
 import akka.serialization.SerializationExtension
 import akka.testkit.typed.TestKit
@@ -39,7 +39,7 @@ class MiscMessageSerializerSpec extends TestKit(MiscMessageSerializerSpec.config
     }
 
     "must serialize and deserialize typed actor refs" in {
-      val ref = spawn(Actor.empty[Unit])
+      val ref = spawn(Behaviors.empty[Unit])
       checkSerialization(ref)
     }
   }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/LocalReceptionistSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/LocalReceptionistSpec.scala
@@ -5,7 +5,7 @@ package akka.actor.typed.receptionist
 
 import akka.actor.typed._
 import akka.actor.typed.receptionist.Receptionist._
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.testkit.typed.{ BehaviorTestkit, TestInbox, TestKit, TestKitSettings }
 import akka.testkit.typed.scaladsl.TestProbe
@@ -17,14 +17,14 @@ class LocalReceptionistSpec extends TestKit with TypedAkkaSpecWithShutdown with 
 
   trait ServiceA
   val ServiceKeyA = ServiceKey[ServiceA]("service-a")
-  val behaviorA = Actor.empty[ServiceA]
+  val behaviorA = Behaviors.empty[ServiceA]
 
   trait ServiceB
   val ServiceKeyB = ServiceKey[ServiceB]("service-b")
-  val behaviorB = Actor.empty[ServiceB]
+  val behaviorB = Behaviors.empty[ServiceB]
 
   case object Stop extends ServiceA with ServiceB
-  val stoppableBehavior = Actor.immutable[Any] { (_, msg) ⇒
+  val stoppableBehavior = Behaviors.immutable[Any] { (_, msg) ⇒
     msg match {
       case Stop ⇒ Behavior.stopped
       case _    ⇒ Behavior.same

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ImmutablePartialSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ImmutablePartialSpec.scala
@@ -16,10 +16,10 @@ class ImmutablePartialSpec extends TestKit with TypedAkkaSpecWithShutdown {
     "correctly install the message handler" in {
       val probe = TestProbe[Command]("probe")
       val behavior =
-        Actor.immutablePartial[Command] {
+        Behaviors.immutablePartial[Command] {
           case (_, Command2) ⇒
             probe.ref ! Command2
-            Actor.same
+            Behaviors.same
         }
       val testkit = BehaviorTestkit(behavior)
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/OnSignalSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/OnSignalSpec.scala
@@ -14,13 +14,13 @@ final class OnSignalSpec extends TestKit with TypedAkkaSpecWithShutdown {
     "must correctly install the signal handler" in {
       val probe = TestProbe[Done]("probe")
       val behavior =
-        Actor.deferred[Nothing] { context ⇒
-          val stoppedChild = context.spawn(Actor.stopped, "stopped-child")
+        Behaviors.deferred[Nothing] { context ⇒
+          val stoppedChild = context.spawn(Behaviors.stopped, "stopped-child")
           context.watch(stoppedChild)
-          Actor.onSignal[Nothing] {
+          Behaviors.onSignal[Nothing] {
             case (_, Terminated(`stoppedChild`)) ⇒
               probe.ref ! Done
-              Actor.stopped
+              Behaviors.stopped
           }
         }
       spawn[Nothing](behavior)

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingUntypedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingUntypedSpec.scala
@@ -1,7 +1,7 @@
 package docs.akka.typed.coexistence
 
 import akka.actor.typed._
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 import akka.testkit.TestKit
 //#adapter-import
 // adds support for typed actors to an untyped actor system and context
@@ -23,7 +23,7 @@ object TypedWatchingUntypedSpec {
     case object Pong extends Command
 
     val behavior: Behavior[Command] =
-      Actor.deferred { context ⇒
+      Behaviors.deferred { context ⇒
         // context.spawn is an implicit extension method
         val untyped = context.actorOf(Untyped.props(), "second")
 
@@ -33,15 +33,15 @@ object TypedWatchingUntypedSpec {
         // illustrating how to pass sender, toUntyped is an implicit extension method
         untyped.tell(Typed.Ping(context.self), context.self.toUntyped)
 
-        Actor.immutablePartial[Command] {
+        Behaviors.immutablePartial[Command] {
           case (ctx, Pong) ⇒
             // it's not possible to get the sender, that must be sent in message
             // context.stop is an implicit extension method
             ctx.stop(untyped)
-            Actor.same
+            Behaviors.same
         } onSignal {
           case (_, akka.actor.typed.Terminated(_)) ⇒
-            Actor.stopped
+            Behaviors.stopped
         }
       }
   }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala
@@ -1,7 +1,7 @@
 package docs.akka.typed.coexistence
 
 import akka.actor.typed._
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 import akka.testkit.TestKit
 //#adapter-import
 // adds support for typed actors to an untyped actor system and context
@@ -53,13 +53,13 @@ object UntypedWatchingTypedSpec {
     case object Pong
 
     val behavior: Behavior[Command] =
-      Actor.immutable { (ctx, msg) ⇒
+      Behaviors.immutable { (ctx, msg) ⇒
         msg match {
           case Ping(replyTo) ⇒
             println(s"${ctx.self} got Ping from $replyTo")
             // replyTo is an untyped actor that has been converted for coexistence
             replyTo ! Pong
-            Actor.same
+            Behaviors.same
         }
       }
   }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/testing/async/BasicAsyncTestingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/testing/async/BasicAsyncTestingSpec.scala
@@ -1,6 +1,6 @@
 package docs.akka.typed.testing.async
 
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed._
 import akka.testkit.typed.TestKit
 import akka.testkit.typed.scaladsl._
@@ -11,11 +11,11 @@ object BasicAsyncTestingSpec {
   case class Ping(msg: String, response: ActorRef[Pong])
   case class Pong(msg: String)
 
-  val echoActor = Actor.immutable[Ping] { (_, msg) ⇒
+  val echoActor = Behaviors.immutable[Ping] { (_, msg) ⇒
     msg match {
       case Ping(m, replyTo) ⇒
         replyTo ! Pong(m)
-        Actor.same
+        Behaviors.same
     }
   }
   //#under-test

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/testing/sync/BasicSyncTestingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/testing/sync/BasicSyncTestingSpec.scala
@@ -10,8 +10,8 @@ import org.scalatest.{ Matchers, WordSpec }
 
 object BasicSyncTestingSpec {
   //#child
-  val childActor = Actor.immutable[String] { (_, _) ⇒
-    Actor.same[String]
+  val childActor = Behaviors.immutable[String] { (_, _) ⇒
+    Behaviors.same[String]
   }
   //#child
 
@@ -23,24 +23,24 @@ object BasicSyncTestingSpec {
   case object SayHelloToAnonymousChild extends Cmd
   case class SayHello(who: ActorRef[String]) extends Cmd
 
-  val myBehaviour = Actor.immutablePartial[Cmd] {
+  val myBehaviour = Behaviors.immutablePartial[Cmd] {
     case (ctx, CreateChild(name)) ⇒
       ctx.spawn(childActor, name)
-      Actor.same
+      Behaviors.same
     case (ctx, CreateAnonymousChild) ⇒
       ctx.spawnAnonymous(childActor)
-      Actor.same
+      Behaviors.same
     case (ctx, SayHelloToChild(childName)) ⇒
       val child: ActorRef[String] = ctx.spawn(childActor, childName)
       child ! "hello"
-      Actor.same
+      Behaviors.same
     case (ctx, SayHelloToAnonymousChild) ⇒
       val child: ActorRef[String] = ctx.spawnAnonymous(childActor)
       child ! "hello stranger"
-      Actor.same
+      Behaviors.same
     case (_, SayHello(who)) ⇒
       who ! "hello"
-      Actor.same
+      Behaviors.same
     //#under-test
   }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
@@ -19,7 +19,7 @@ import akka.util.OptionVal
  * its child actors.
  *
  * Behaviors can be formulated in a number of different ways, either by
- * using the DSLs in [[akka.actor.typed.scaladsl.Actor]] and [[akka.actor.typed.javadsl.Actor]]
+ * using the DSLs in [[akka.actor.typed.scaladsl.Behaviors]] and [[akka.actor.typed.javadsl.Behaviors]]
  * or extending the abstract [[ExtensibleBehavior]] class.
  *
  * Closing over ActorContext makes a Behavior immobile: it cannot be moved to
@@ -42,7 +42,7 @@ sealed abstract class Behavior[T] {
 
 /**
  * Extension point for implementing custom behaviors in addition to the existing
- * set of behaviors available through the DSLs in [[akka.actor.typed.scaladsl.Actor]] and [[akka.actor.typed.javadsl.Actor]]
+ * set of behaviors available through the DSLs in [[akka.actor.typed.scaladsl.Behaviors]] and [[akka.actor.typed.javadsl.Behaviors]]
  */
 abstract class ExtensibleBehavior[T] extends Behavior[T] {
   /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Restarter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Restarter.scala
@@ -23,16 +23,16 @@ import akka.actor.typed.ExtensibleBehavior
 import akka.actor.typed.PreRestart
 import akka.actor.typed.Signal
 import akka.actor.typed.SupervisorStrategy._
-import akka.actor.typed.scaladsl.Actor._
+import akka.actor.typed.scaladsl.Behaviors._
 import akka.util.OptionVal
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 
 /**
  * INTERNAL API
  */
 @InternalApi private[akka] object Restarter {
   def apply[T, Thr <: Throwable: ClassTag](initialBehavior: Behavior[T], strategy: SupervisorStrategy): Behavior[T] =
-    Actor.deferred[T] { ctx ⇒
+    Behaviors.deferred[T] { ctx ⇒
       val c = ctx.asInstanceOf[akka.actor.typed.ActorContext[T]]
       val startedBehavior = initialUndefer(c, initialBehavior)
       strategy match {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
@@ -26,7 +26,7 @@ import scala.reflect.ClassTag
   final case class TimerMsg(key: Any, generation: Int, owner: AnyRef)
 
   def withTimers[T](factory: TimerSchedulerImpl[T] ⇒ Behavior[T]): Behavior[T] = {
-    scaladsl.Actor.deferred[T] { ctx ⇒
+    scaladsl.Behaviors.deferred[T] { ctx ⇒
       val timerScheduler = new TimerSchedulerImpl[T](ctx)
       val behavior = factory(timerScheduler)
       timerScheduler.intercept(behavior)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistImpl.scala
@@ -9,9 +9,9 @@ import akka.actor.typed.Behavior
 import akka.actor.typed.Terminated
 import akka.actor.typed.receptionist.Receptionist._
 import akka.actor.typed.receptionist.ServiceKey
-import akka.actor.typed.scaladsl.Actor
-import akka.actor.typed.scaladsl.Actor.immutable
-import akka.actor.typed.scaladsl.Actor.same
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.Behaviors.immutable
+import akka.actor.typed.scaladsl.Behaviors.same
 import akka.actor.typed.scaladsl.ActorContext
 import akka.util.TypedMultiMap
 
@@ -63,7 +63,7 @@ private[akka] object ReceptionistImpl extends ReceptionistBehaviorProvider {
   type SubscriptionRegistry = TypedMultiMap[AbstractServiceKey, SubscriptionsKV]
 
   private[akka] def init(externalInterfaceFactory: ActorContext[AllCommands] ⇒ ExternalInterface): Behavior[Command] =
-    Actor.deferred[AllCommands] { ctx ⇒
+    Behaviors.deferred[AllCommands] { ctx ⇒
       val externalInterface = externalInterfaceFactory(ctx)
       behavior(
         TypedMultiMap.empty[AbstractServiceKey, KV],
@@ -85,13 +85,13 @@ private[akka] object ReceptionistImpl extends ReceptionistBehaviorProvider {
      * FIXME: replace by simple map in our state
      */
     def watchWith(ctx: ActorContext[AllCommands], target: ActorRef[_], msg: AllCommands): Unit =
-      ctx.spawnAnonymous[Nothing](Actor.deferred[Nothing] { innerCtx ⇒
+      ctx.spawnAnonymous[Nothing](Behaviors.deferred[Nothing] { innerCtx ⇒
         innerCtx.watch(target)
-        Actor.immutable[Nothing]((_, _) ⇒ Actor.same)
+        Behaviors.immutable[Nothing]((_, _) ⇒ Behaviors.same)
           .onSignal {
             case (_, Terminated(`target`)) ⇒
               ctx.self ! msg
-              Actor.stopped
+              Behaviors.stopped
           }
       })
 
@@ -157,7 +157,7 @@ private[akka] object ReceptionistImpl extends ReceptionistBehaviorProvider {
 
         case _: InternalCommand ⇒
           // silence compiler exhaustive check
-          Actor.unhandled
+          Behaviors.unhandled
       }
     }
   }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
@@ -11,19 +11,22 @@ import akka.util.OptionVal
 import akka.japi.function.{ Function2 ⇒ JapiFunction2 }
 import akka.japi.function.{ Procedure, Procedure2 }
 import akka.japi.pf.PFBuilder
-
 import akka.actor.typed.Behavior
 import akka.actor.typed.ExtensibleBehavior
 import akka.actor.typed.Signal
 import akka.actor.typed.ActorRef
 import akka.actor.typed.SupervisorStrategy
 import akka.actor.typed.scaladsl.{ ActorContext ⇒ SAC }
-
 import akka.actor.typed.internal.BehaviorImpl
 import akka.actor.typed.internal.Restarter
 import akka.actor.typed.internal.TimerSchedulerImpl
+import akka.annotation.ApiMayChange
 
-object Actor {
+/**
+ * Factories for [[akka.actor.typed.Behavior]].
+ */
+@ApiMayChange
+object Behaviors {
 
   private val _unitFunction = (_: SAC[Any], _: Any) ⇒ ()
   private def unitFunction[T] = _unitFunction.asInstanceOf[((SAC[T], Signal) ⇒ Unit)]
@@ -62,11 +65,11 @@ object Actor {
    * abstract method [[MutableBehavior#onMessage]] and optionally override
    * [[MutableBehavior#onSignal]].
    *
-   * Instances of this behavior should be created via [[Actor#mutable]] and if
+   * Instances of this behavior should be created via [[Behaviors#mutable]] and if
    * the [[ActorContext]] is needed it can be passed as a constructor parameter
    * from the factory function.
    *
-   * @see [[Actor#mutable]]
+   * @see [[Behaviors#mutable]]
    */
   abstract class MutableBehavior[T] extends ExtensibleBehavior[T] {
     private var _receive: OptionVal[Receive[T]] = OptionVal.None

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ReceiveBuilder.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ReceiveBuilder.scala
@@ -6,13 +6,13 @@ package akka.actor.typed.javadsl
 
 import scala.annotation.tailrec
 import akka.japi.function.{ Creator, Function, Predicate }
-import akka.actor.typed.javadsl.Actor.Receive
+import akka.actor.typed.javadsl.Behaviors.Receive
 import akka.actor.typed.{ Behavior, Signal }
 import ReceiveBuilder._
 import akka.annotation.InternalApi
 
 /**
- * Used when implementing [[Actor.MutableBehavior]].
+ * Used when implementing [[Behaviors.MutableBehavior]].
  *
  * When handling a message or signal, this [[Behavior]] will consider all handlers in the order they were added,
  * looking for the first handler for which both the type and the (optional) predicate match.
@@ -145,7 +145,7 @@ object ReceiveBuilder {
 }
 
 /**
- * Receive type for [[Actor.MutableBehavior]]
+ * Receive type for [[Behaviors.MutableBehavior]]
  */
 private class BuiltReceive[T](
   private val messageHandlers: List[Case[T, T]],
@@ -163,7 +163,7 @@ private class BuiltReceive[T](
         if (cls.isAssignableFrom(msg.getClass) && (predicate.isEmpty || predicate.get.apply(msg))) handler(msg)
         else receive[M](msg, tail)
       case _ ⇒
-        Actor.unhandled
+        Behaviors.unhandled
     }
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
@@ -10,8 +10,11 @@ import akka.actor.typed.internal.{ BehaviorImpl, Supervisor, TimerSchedulerImpl 
 import scala.reflect.ClassTag
 import scala.util.control.Exception.Catcher
 
+/**
+ * Factories for [[akka.actor.typed.Behavior]].
+ */
 @ApiMayChange
-object Actor {
+object Behaviors {
 
   private val _unitFunction = (_: ActorContext[Any], _: Any) ⇒ ()
   private def unitFunction[T] = _unitFunction.asInstanceOf[((ActorContext[T], Signal) ⇒ Unit)]
@@ -38,7 +41,7 @@ object Actor {
 
   /**
    * `deferred` is a factory for a behavior. Creation of the behavior instance is deferred until
-   * the actor is started, as opposed to [[Actor.immutable]] that creates the behavior instance
+   * the actor is started, as opposed to [[Behaviors.immutable]] that creates the behavior instance
    * immediately before the actor is running. The `factory` function pass the `ActorContext`
    * as parameter and that can for example be used for spawning child actors.
    *
@@ -70,11 +73,11 @@ object Actor {
    * abstract method [[MutableBehavior#onMessage]] and optionally override
    * [[MutableBehavior#onSignal]].
    *
-   * Instances of this behavior should be created via [[Actor#Mutable]] and if
+   * Instances of this behavior should be created via [[Behaviors#Mutable]] and if
    * the [[ActorContext]] is needed it can be passed as a constructor parameter
    * from the factory function.
    *
-   * @see [[Actor#Mutable]]
+   * @see [[Behaviors#Mutable]]
    */
   abstract class MutableBehavior[T] extends ExtensibleBehavior[T] {
     @throws(classOf[Exception])
@@ -189,7 +192,7 @@ object Actor {
    * Construct an immutable actor behavior from a partial message handler which treats undefined messages as unhandled.
    */
   def immutablePartial[T](onMessage: PartialFunction[(ActorContext[T], T), Behavior[T]]): Immutable[T] =
-    Actor.immutable[T] { (ctx, t) ⇒ onMessage.applyOrElse((ctx, t), (_: (ActorContext[T], T)) ⇒ Actor.unhandled[T]) }
+    Behaviors.immutable[T] { (ctx, t) ⇒ onMessage.applyOrElse((ctx, t), (_: (ActorContext[T], T)) ⇒ Behaviors.unhandled[T]) }
 
   /**
    * Construct an actor behavior that can react to lifecycle signals only.

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingPersistenceSpec.scala
@@ -4,7 +4,7 @@
 package akka.cluster.sharding.typed
 
 import akka.actor.typed.{ ActorRef, Behavior, Props, TypedAkkaSpecWithShutdown }
-import akka.persistence.typed.scaladsl.PersistentActor
+import akka.persistence.typed.scaladsl.PersistentBehaviors
 import akka.testkit.typed.TestKit
 import akka.testkit.typed.scaladsl.TestProbe
 import com.typesafe.config.ConfigFactory
@@ -36,10 +36,10 @@ object ClusterShardingPersistenceSpec {
   final case class Get(replyTo: ActorRef[String]) extends Command
   final case object StopPlz extends Command
 
-  import PersistentActor._
+  import PersistentBehaviors._
 
   val persistentActor: Behavior[Command] =
-    PersistentActor.persistentEntity[Command, String, String](
+    PersistentBehaviors.persistentEntity[Command, String, String](
       persistenceIdFromActorName = name ⇒ "Test-" + name,
       initialState = "",
       commandHandler = (_, state, cmd) ⇒ cmd match {

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingSpec.scala
@@ -8,7 +8,7 @@ import java.nio.charset.StandardCharsets
 
 import akka.actor.ExtendedActorSystem
 import akka.actor.typed.{ ActorRef, ActorRefResolver, Props, TypedAkkaSpecWithShutdown }
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
 import akka.cluster.MemberStatus
 import akka.cluster.typed.{ Cluster, Join }
@@ -135,31 +135,31 @@ class ClusterShardingSpec extends TestKit("ClusterShardingSpec", ClusterSharding
   }
 
   val typeKey = EntityTypeKey[TestProtocol]("envelope-shard")
-  val behavior = Actor.immutable[TestProtocol] {
+  val behavior = Behaviors.immutable[TestProtocol] {
     case (_, StopPlz()) ⇒
-      Actor.stopped
+      Behaviors.stopped
 
     case (ctx, WhoAreYou(replyTo)) ⇒
       replyTo ! s"I'm ${ctx.self.path.name}"
-      Actor.same
+      Behaviors.same
 
     case (_, ReplyPlz(toMe)) ⇒
       toMe ! "Hello!"
-      Actor.same
+      Behaviors.same
   }
 
   val typeKey2 = EntityTypeKey[IdTestProtocol]("no-envelope-shard")
-  val behaviorWithId = Actor.immutable[IdTestProtocol] {
+  val behaviorWithId = Behaviors.immutable[IdTestProtocol] {
     case (_, IdStopPlz(_)) ⇒
-      Actor.stopped
+      Behaviors.stopped
 
     case (ctx, IdWhoAreYou(_, replyTo)) ⇒
       replyTo ! s"I'm ${ctx.self.path.name}"
-      Actor.same
+      Behaviors.same
 
     case (_, IdReplyPlz(_, toMe)) ⇒
       toMe ! "Hello!"
-      Actor.same
+      Behaviors.same
   }
 
   "Typed cluster sharding" must {

--- a/akka-cluster-typed/src/test/java/akka/cluster/ddata/typed/javadsl/ReplicatorTest.java
+++ b/akka-cluster-typed/src/test/java/akka/cluster/ddata/typed/javadsl/ReplicatorTest.java
@@ -24,9 +24,9 @@ import akka.testkit.javadsl.TestKit;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
 import akka.cluster.ddata.typed.javadsl.Replicator.Command;
-import akka.actor.typed.javadsl.Actor;
+import akka.actor.typed.javadsl.Behaviors;
 import akka.actor.typed.javadsl.Adapter;
-import akka.actor.typed.javadsl.Actor.MutableBehavior;
+import akka.actor.typed.javadsl.Behaviors.MutableBehavior;
 import akka.actor.typed.javadsl.ActorContext;
 
 public class ReplicatorTest extends JUnitSuite {
@@ -105,11 +105,11 @@ public class ReplicatorTest extends JUnitSuite {
     }
 
     public static Behavior<ClientCommand> create(ActorRef<Command> replicator, Cluster node) {
-      return Actor.mutable(ctx -> new Client(replicator, node, ctx));
+      return Behaviors.mutable(ctx -> new Client(replicator, node, ctx));
     }
 
     @Override
-    public Actor.Receive<ClientCommand> createReceive() {
+    public Behaviors.Receive<ClientCommand> createReceive() {
       return receiveBuilder()
         .onMessage(Increment.class, cmd -> {
           replicator.tell(

--- a/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/BasicClusterExampleTest.java
+++ b/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/BasicClusterExampleTest.java
@@ -13,8 +13,8 @@ import docs.akka.cluster.typed.BasicClusterManualSpec;
 //FIXME make these tests
 public class BasicClusterExampleTest {
   public void clusterApiExample() {
-    ActorSystem<Object> system = ActorSystem.create(Actor.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
-    ActorSystem<Object> system2 = ActorSystem.create(Actor.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
+    ActorSystem<Object> system = ActorSystem.create(Behaviors.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
+    ActorSystem<Object> system2 = ActorSystem.create(Behaviors.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
 
     try {
       //#cluster-create
@@ -36,8 +36,8 @@ public class BasicClusterExampleTest {
   }
 
   public void clusterLeave() throws Exception {
-    ActorSystem<Object> system = ActorSystem.create(Actor.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
-    ActorSystem<Object> system2 = ActorSystem.create(Actor.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
+    ActorSystem<Object> system = ActorSystem.create(Behaviors.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
+    ActorSystem<Object> system2 = ActorSystem.create(Behaviors.empty(), "ClusterSystem", BasicClusterManualSpec.clusterConfig());
 
     try {
       Cluster cluster = Cluster.get(system);

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
@@ -6,7 +6,7 @@ package akka.cluster.typed
 import java.nio.charset.StandardCharsets
 
 import akka.actor.ExtendedActorSystem
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
 import akka.testkit.typed.{ TestKit, TestKitSettings }
 import akka.testkit.typed.scaladsl.TestProbe
@@ -48,15 +48,15 @@ object ClusterSingletonApiSpec {
 
   case object Perish extends PingProtocol
 
-  val pingPong = Actor.immutable[PingProtocol] { (_, msg) ⇒
+  val pingPong = Behaviors.immutable[PingProtocol] { (_, msg) ⇒
 
     msg match {
       case Ping(respondTo) ⇒
         respondTo ! Pong
-        Actor.same
+        Behaviors.same
 
       case Perish ⇒
-        Actor.stopped
+        Behaviors.stopped
     }
 
   }

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
@@ -5,8 +5,8 @@
 package akka.cluster.typed
 
 import akka.actor.typed.{ ActorRef, Behavior, Props, TypedAkkaSpecWithShutdown }
-import akka.persistence.typed.scaladsl.PersistentActor
-import akka.persistence.typed.scaladsl.PersistentActor.{ CommandHandler, Effect }
+import akka.persistence.typed.scaladsl.PersistentBehaviors
+import akka.persistence.typed.scaladsl.PersistentBehaviors.{ CommandHandler, Effect }
 import akka.testkit.typed.TestKit
 import akka.testkit.typed.scaladsl.TestProbe
 import com.typesafe.config.ConfigFactory
@@ -37,7 +37,7 @@ object ClusterSingletonPersistenceSpec {
   private final case object StopPlz extends Command
 
   val persistentActor: Behavior[Command] =
-    PersistentActor.immutable[Command, String, String](
+    PersistentBehaviors.immutable[Command, String, String](
       persistenceId = "TheSingleton",
       initialState = "",
       commandHandler = (_, state, cmd) ⇒ cmd match {

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteMessageSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteMessageSpec.scala
@@ -8,7 +8,7 @@ import java.nio.charset.StandardCharsets
 import akka.Done
 import akka.testkit.AkkaSpec
 import akka.actor.typed.{ ActorRef, ActorRefResolver }
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.{ ExtendedActorSystem, ActorSystem ⇒ UntypedActorSystem }
 import akka.serialization.SerializerWithStringManifest
 import com.typesafe.config.ConfigFactory
@@ -70,12 +70,12 @@ class RemoteMessageSpec extends AkkaSpec(RemoteMessageSpec.config) {
     "something something" in {
 
       val pingPromise = Promise[Done]()
-      val ponger = Actor.immutable[Ping]((_, msg) ⇒
+      val ponger = Behaviors.immutable[Ping]((_, msg) ⇒
         msg match {
           case Ping(sender) ⇒
             pingPromise.success(Done)
             sender ! "pong"
-            Actor.stopped
+            Behaviors.stopped
         })
 
       // typed actor on system1
@@ -91,9 +91,9 @@ class RemoteMessageSpec extends AkkaSpec(RemoteMessageSpec.config) {
           ActorRefResolver(typedSystem2).resolveActorRef[Ping](remoteRefStr)
 
         val pongPromise = Promise[Done]()
-        val recipient = system2.spawn(Actor.immutable[String] { (_, _) ⇒
+        val recipient = system2.spawn(Behaviors.immutable[String] { (_, _) ⇒
           pongPromise.success(Done)
-          Actor.stopped
+          Behaviors.stopped
         }, "recipient")
         remoteRef ! Ping(recipient)
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -9,7 +9,7 @@ import akka.actor.ExtendedActorSystem
 import akka.actor.typed.{ ActorRef, ActorRefResolver, TypedAkkaSpecWithShutdown }
 import akka.actor.typed.internal.adapter.ActorSystemAdapter
 import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
 import akka.cluster.Cluster
 import akka.serialization.SerializerWithStringManifest
@@ -50,14 +50,14 @@ object ClusterReceptionistSpec {
   case class Ping(respondTo: ActorRef[Pong.type]) extends PingProtocol
   case object Perish extends PingProtocol
 
-  val pingPongBehavior = Actor.immutable[PingProtocol] { (_, msg) ⇒
+  val pingPongBehavior = Behaviors.immutable[PingProtocol] { (_, msg) ⇒
     msg match {
       case Ping(respondTo) ⇒
         respondTo ! Pong
-        Actor.same
+        Behaviors.same
 
       case Perish ⇒
-        Actor.stopped
+        Behaviors.stopped
     }
   }
 

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
@@ -61,8 +61,8 @@ class BasicClusterConfigSpec extends WordSpec with ScalaFutures with Eventually 
           akka.cluster.seed-nodes = [ "akka.tcp://ClusterSystem@127.0.0.1:$sys1Port", "akka.tcp://ClusterSystem@127.0.0.1:$sys2Port" ]
         """)
 
-      val system1 = ActorSystem[Nothing](Actor.empty, "ClusterSystem", config(sys1Port).withFallback(configSystem1))
-      val system2 = ActorSystem[Nothing](Actor.empty, "ClusterSystem", config(sys2Port).withFallback(configSystem2))
+      val system1 = ActorSystem[Nothing](Behaviors.empty, "ClusterSystem", config(sys1Port).withFallback(configSystem1))
+      val system2 = ActorSystem[Nothing](Behaviors.empty, "ClusterSystem", config(sys2Port).withFallback(configSystem2))
       try {
         val cluster1 = Cluster(system1)
         val cluster2 = Cluster(system2)
@@ -105,8 +105,8 @@ class BasicClusterManualSpec extends WordSpec with ScalaFutures with Eventually 
   "Cluster API" must {
     "init cluster" in {
 
-      val system = ActorSystem[Nothing](Actor.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
-      val system2 = ActorSystem[Nothing](Actor.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
+      val system = ActorSystem[Nothing](Behaviors.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
+      val system2 = ActorSystem[Nothing](Behaviors.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
 
       try {
         //#cluster-create
@@ -139,9 +139,9 @@ class BasicClusterManualSpec extends WordSpec with ScalaFutures with Eventually 
     }
 
     "subscribe to cluster events" in {
-      implicit val system1 = ActorSystem[Nothing](Actor.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
-      val system2 = ActorSystem[Nothing](Actor.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
-      val system3 = ActorSystem[Nothing](Actor.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
+      implicit val system1 = ActorSystem[Nothing](Behaviors.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
+      val system2 = ActorSystem[Nothing](Behaviors.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
+      val system3 = ActorSystem[Nothing](Behaviors.empty, "ClusterSystem", noPort.withFallback(clusterConfig))
 
       try {
         val cluster1 = Cluster(system1)

--- a/akka-docs/src/main/paradox/actors-typed.md
+++ b/akka-docs/src/main/paradox/actors-typed.md
@@ -258,8 +258,8 @@ particular one using the `immutable` behavior decorator. The
 provided `onSignal` function will be invoked for signals (subclasses of `Signal`)
 or the `onMessage` function for user messages.
 
-This particular `main` Actor is created using `Actor.deferred`, which is like a factory for a behavior.
-Creation of the behavior instance is deferred until the actor is started, as opposed to `Actor.immutable`
+This particular `main` Actor is created using `Behaviors.deferred`, which is like a factory for a behavior.
+Creation of the behavior instance is deferred until the actor is started, as opposed to `Behaviors.immutable`
 that creates the behavior instance immediately before the actor is running. The factory function in 
 `deferred` pass the `ActorContext` as parameter and that can for example be used for spawning child actors.
 This `main` Actor creates the chat room and the gabbler and the session between them is initiated, and when the

--- a/akka-docs/src/main/paradox/persistence-typed.md
+++ b/akka-docs/src/main/paradox/persistence-typed.md
@@ -30,16 +30,16 @@ Akka Persistence is a library for building event sourced actors. For background 
 see the @ref:[untyped Akka Persistence section](persistence.md). This documentation shows how the typed API for persistence
 works and assumes you know what is meant by `Command`, `Event` and `State`.
 
-Let's start with a simple example. The minimum required for a `PersistentActor` is:
+Let's start with a simple example. The minimum required for a `PersistentBehavior` is:
 
 Scala
-:  @@snip [BasicPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentActorSpec.scala) { #structure }
+:  @@snip [BasicPersistentBehaviorsSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala) { #structure }
 
-The first important thing to notice is the `Behavior` of a `PersistentActor` is typed to the type of the `Command` 
+The first important thing to notice is the `Behavior` of a persistent actor is typed to the type of the `Command` 
 because this type of message a persistent actor should receive. In Akka Typed this is now enforced by the type system.
 The event and state are only used internally.
 
-The parameters to `PersistentActor.immutable` are::
+The parameters to `PersistentBehaviors.immutable` are::
 
 * `persistenceId` is the unique identifier for the persistent actor.
 * `initialState` defines the `State` when the entity is first created e.g. a Counter would start wiht 0 as state.
@@ -126,40 +126,40 @@ then it we can look it up with `GetPost`, modify it with `ChangeBody` or publish
 The state is captured by:
 
 Scala
-:  @@snip [InDepthPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala) { #state }
+:  @@snip [InDepthPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala) { #state }
 
 The commands (only a subset are valid depending on state):
 
 Scala
-:  @@snip [InDepthPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala) { #commands }
+:  @@snip [InDepthPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala) { #commands }
 
 The command handler to process each command is decided by a `CommandHandler.byState` command handler, 
 which is a function from `State => CommandHandler`:
 
 Scala
-:  @@snip [InDepthPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala) { #by-state-command-handler }
+:  @@snip [InDepthPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala) { #by-state-command-handler }
 
 This can refer to many other `CommandHandler`s e.g one for a post that hasn't been started:
 
 Scala
-:  @@snip [InDepthPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala) { #initial-command-handler }
+:  @@snip [InDepthPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala) { #initial-command-handler }
 
 And a different `CommandHandler` for after the post has been added:
 
 Scala
-:  @@snip [InDepthPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala) { #post-added-command-handler }
+:  @@snip [InDepthPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala) { #post-added-command-handler }
 
 The event handler is always the same independent of state. The main reason for not making the event handler 
 part of the `CommandHandler` is that all events must be handled and that is typically independent of what the 
 current state is. The event handler can of course still decide what to do based on the state if that is needed.
 
 Scala
-:  @@snip [InDepthPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala) { #event-handler }
+:  @@snip [InDepthPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala) { #event-handler }
 
 And finally the behavior is created from the `byState` command handler:
 
 Scala
-:  @@snip [InDepthPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentActorSpec.scala) { #behavior }
+:  @@snip [InDepthPersistentBehaviorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala) { #behavior }
 
 ## Serialization
 
@@ -174,7 +174,7 @@ Since it is strongly discouraged to perform side effects in applyEvent ,
 side effects should be performed once recovery has completed in the `onRecoveryCompleted` callback
 
 Scala
-:  @@snip [BasicPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentActorSpec.scala) { #recovery }
+:  @@snip [BasicPersistentBehaviorsSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala) { #recovery }
 
 The `onRecoveryCompleted` takes on an `ActorContext` and the current `State`.
 
@@ -184,11 +184,11 @@ Persistence typed allows you to use event tags with the following `withTagging` 
 without using @ref[`EventAdapter`](persistence.md#event-adapters).
 
 Scala
-:  @@snip [BasicPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentActorSpec.scala) { #tagging }
+:  @@snip [BasicPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala) { #tagging }
 
 ## Current limitations
 
-* The `PersistentBehavior` can't be wrapped in other behaviors, such as `Actor.deferred`. See [#23694](https://github.com/akka/akka/issues/23694)
+* The `PersistentBehavior` can't be wrapped in other behaviors, such as `Behaviors.deferred`. See [#23694](https://github.com/akka/akka/issues/23694)
 * Can only tag events with event adapters. See [#23817](https://github.com/akka/akka/issues/23817)
 * Missing Java DSL. See [#24193](https://github.com/akka/akka/issues/24193)
 * Snapshot support. See [#24196](https://github.com/akka/akka/issues/24196)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/PersistentActorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/PersistentActorImpl.scala
@@ -11,7 +11,7 @@ import akka.persistence.RecoveryCompleted
 import akka.persistence.SnapshotOffer
 import akka.actor.typed.Signal
 import akka.actor.typed.internal.adapter.ActorContextAdapter
-import akka.persistence.typed.scaladsl.PersistentActor
+import akka.persistence.typed.scaladsl.PersistentBehaviors
 import akka.persistence.typed.scaladsl.PersistentBehavior
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.Terminated
@@ -43,7 +43,7 @@ import akka.persistence.journal.Tagged
   behavior: PersistentBehavior[C, E, S]) extends UntypedPersistentActor {
 
   import PersistentActorImpl._
-  import PersistentActor._
+  import PersistentBehaviors._
 
   override val persistenceId: String = behavior.persistenceIdFromActorName(self.path.name)
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/PersistentBehaviors.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/PersistentBehaviors.scala
@@ -10,7 +10,7 @@ import akka.persistence.typed.internal.PersistentActorImpl
 
 import scala.collection.{ immutable ⇒ im }
 
-object PersistentActor {
+object PersistentBehaviors {
 
   /**
    * Create a `Behavior` for a persistent actor.
@@ -187,11 +187,11 @@ object PersistentActor {
 class PersistentBehavior[Command, Event, State](
   @InternalApi private[akka] val persistenceIdFromActorName: String ⇒ String,
   val initialState:                                          State,
-  val commandHandler:                                        PersistentActor.CommandHandler[Command, Event, State],
+  val commandHandler:                                        PersistentBehaviors.CommandHandler[Command, Event, State],
   val eventHandler:                                          (State, Event) ⇒ State,
   val recoveryCompleted:                                     (ActorContext[Command], State) ⇒ Unit,
   val tagger:                                                Event ⇒ Set[String]) extends UntypedBehavior[Command] {
-  import PersistentActor._
+  import PersistentBehaviors._
 
   /** INTERNAL API */
   @InternalApi private[akka] override def untypedProps: akka.actor.Props = PersistentActorImpl.props(() ⇒ this)

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala
@@ -4,9 +4,9 @@
 package docs.akka.persistence.typed
 
 import akka.actor.typed.Behavior
-import akka.persistence.typed.scaladsl.PersistentActor
+import akka.persistence.typed.scaladsl.PersistentBehaviors
 
-object BasicPersistentActorSpec {
+object BasicPersistentBehaviorsSpec {
 
   //#structure
   sealed trait Command
@@ -14,7 +14,7 @@ object BasicPersistentActorSpec {
   case class State()
 
   val behavior: Behavior[Command] =
-    PersistentActor.immutable[Command, Event, State](
+    PersistentBehaviors.immutable[Command, Event, State](
       persistenceId = "abc",
       initialState = State(),
       commandHandler = (ctx, state, cmd) ⇒ ???,
@@ -23,7 +23,7 @@ object BasicPersistentActorSpec {
 
   //#recovery
   val recoveryBehavior: Behavior[Command] =
-    PersistentActor.immutable[Command, Event, State](
+    PersistentBehaviors.immutable[Command, Event, State](
       persistenceId = "abc",
       initialState = State(),
       commandHandler = (ctx, state, cmd) ⇒ ???,
@@ -35,7 +35,7 @@ object BasicPersistentActorSpec {
 
   //#tagging
   val taggingBehavior: Behavior[Command] =
-    PersistentActor.immutable[Command, Event, State](
+    PersistentBehaviors.immutable[Command, Event, State](
       persistenceId = "abc",
       initialState = State(),
       commandHandler = (ctx, state, cmd) ⇒ ???,

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala
@@ -5,10 +5,10 @@ package docs.akka.persistence.typed
 
 import akka.Done
 import akka.actor.typed.{ ActorRef, Behavior }
-import akka.persistence.typed.scaladsl.PersistentActor
-import akka.persistence.typed.scaladsl.PersistentActor.{ CommandHandler, Effect }
+import akka.persistence.typed.scaladsl.PersistentBehaviors
+import akka.persistence.typed.scaladsl.PersistentBehaviors.{ CommandHandler, Effect }
 
-object InDepthPersistentActorSpec {
+object InDepthPersistentBehaviorSpec {
 
   //#event
   sealed trait BlogEvent extends Serializable
@@ -117,7 +117,7 @@ object InDepthPersistentActorSpec {
 
   //#behavior
   def behavior: Behavior[BlogCommand] =
-    PersistentActor.immutable[BlogCommand, BlogEvent, BlogState](
+    PersistentBehaviors.immutable[BlogCommand, BlogEvent, BlogState](
       persistenceId = "abc",
       initialState = BlogState.empty,
       commandHandler,
@@ -125,6 +125,6 @@ object InDepthPersistentActorSpec {
   //#behavior
 }
 
-class InDepthPersistentActorSpec {
+class InDepthPersistentBehaviorSpec {
 
 }

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/TestKit.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/TestKit.scala
@@ -1,6 +1,6 @@
 package akka.testkit.typed
 
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.{ ActorRef, ActorSystem, Behavior }
 import akka.annotation.ApiMayChange
@@ -17,13 +17,13 @@ object TestKit {
   private[akka] case class SpawnActor[T](name: String, behavior: Behavior[T], replyTo: ActorRef[ActorRef[T]]) extends TestKitCommand
   private[akka] case class SpawnActorAnonymous[T](behavior: Behavior[T], replyTo: ActorRef[ActorRef[T]]) extends TestKitCommand
 
-  private val testKitGuardian = Actor.immutable[TestKitCommand] {
+  private val testKitGuardian = Behaviors.immutable[TestKitCommand] {
     case (ctx, SpawnActor(name, behavior, reply)) ⇒
       reply ! ctx.spawn(behavior, name)
-      Actor.same
+      Behaviors.same
     case (ctx, SpawnActorAnonymous(behavior, reply)) ⇒
       reply ! ctx.spawnAnonymous(behavior)
-      Actor.same
+      Behaviors.same
   }
 
   private def getCallerName(clazz: Class[_]): String = {

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/scaladsl/TestProbe.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/scaladsl/TestProbe.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration._
 import java.util.concurrent.BlockingDeque
 
 import akka.actor.typed.Behavior
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.ActorSystem
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.atomic.AtomicInteger
@@ -34,9 +34,9 @@ object TestProbe {
   def apply[M](name: String)(implicit system: ActorSystem[_]): TestProbe[M] =
     new TestProbe(name)
 
-  private def testActor[M](queue: BlockingDeque[M]): Behavior[M] = Actor.immutable { (ctx, msg) ⇒
+  private def testActor[M](queue: BlockingDeque[M]): Behavior[M] = Behaviors.immutable { (ctx, msg) ⇒
     queue.offerLast(msg)
-    Actor.same
+    Behaviors.same
   }
 }
 

--- a/akka-testkit-typed/src/test/scala/akka/testkit/typed/BehaviorTestkitSpec.scala
+++ b/akka-testkit-typed/src/test/scala/akka/testkit/typed/BehaviorTestkitSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.testkit.typed
 
-import akka.actor.typed.scaladsl.Actor
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ Behavior, Props }
 import akka.testkit.typed.BehaviorTestkitSpec.Father._
 import akka.testkit.typed.BehaviorTestkitSpec.{ Child, Father }
@@ -27,38 +27,38 @@ object BehaviorTestkitSpec {
 
     def behavior: Behavior[Command] = init()
 
-    def init(): Behavior[Command] = Actor.immutable[Command] { (ctx, msg) ⇒
+    def init(): Behavior[Command] = Behaviors.immutable[Command] { (ctx, msg) ⇒
       msg match {
         case SpawnChildren(numberOfChildren) if numberOfChildren > 0 ⇒
           0.until(numberOfChildren).foreach { i ⇒
             ctx.spawn(Child.initial, s"child$i")
           }
-          Actor.same
+          Behaviors.same
         case SpawnChildrenWithProps(numberOfChildren, props) if numberOfChildren > 0 ⇒
           0.until(numberOfChildren).foreach { i ⇒
             ctx.spawn(Child.initial, s"child$i", props)
           }
-          Actor.same
+          Behaviors.same
         case SpawnAnonymous(numberOfChildren) if numberOfChildren > 0 ⇒
           0.until(numberOfChildren).foreach { _ ⇒
             ctx.spawnAnonymous(Child.initial)
           }
-          Actor.same
+          Behaviors.same
         case SpawnAnonymousWithProps(numberOfChildren, props) if numberOfChildren > 0 ⇒
           0.until(numberOfChildren).foreach { _ ⇒
             ctx.spawnAnonymous(Child.initial, props)
           }
-          Actor.same
+          Behaviors.same
         case SpawnAdapter ⇒
           ctx.spawnAdapter {
             r: Reproduce ⇒ SpawnAnonymous(r.times)
           }
-          Actor.same
+          Behaviors.same
         case SpawnAdapterWithName(name) ⇒
           ctx.spawnAdapter({
             r: Reproduce ⇒ SpawnAnonymous(r.times)
           }, name)
-          Actor.same
+          Behaviors.same
       }
     }
   }
@@ -67,10 +67,10 @@ object BehaviorTestkitSpec {
 
     sealed trait Action
 
-    val initial: Behavior[Action] = Actor.immutable[Action] { (_, msg) ⇒
+    val initial: Behavior[Action] = Behaviors.immutable[Action] { (_, msg) ⇒
       msg match {
         case _ ⇒
-          Actor.empty
+          Behaviors.empty
       }
     }
 


### PR DESCRIPTION
* The technical reason for not naming it Behavior is that
  it would be duplicate import conflicts of
  akka.actor.typed.Behavior and akka.actor.typed.scaladsl.Behavior
* Plural naming is pretty common for factories like this,
  e.g. java.util.Collections

For example this would not work:
```scala
import akka.actor.typed.ActorRef
import akka.actor.typed.Behavior
import akka.actor.typed.scaladsl.Behavior

object ChatRoom {

  val behavior: Behavior[Command] =
    chatRoom(List.empty)

  private def chatRoom(sessions: List[ActorRef[SessionEvent]]): Behavior[Command] =
    Behavior.immutable[Command] { (ctx, msg) ⇒
```


Also renaming PersistentActor to PersistentBehaviors.

Refs #24071