### PR TITLE
[#24294] Fix DistributedPubSubMediator not unsubscribing actors from …

### DIFF
--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
@@ -222,6 +222,7 @@ object DistributedPubSubMediator {
 
   // Only for testing purposes, to poll/await replication
   case object Count
+  case class CountSubscribers(topic: String)
 
   /**
    * INTERNAL API
@@ -341,6 +342,8 @@ object DistributedPubSubMediator {
             context stop self
           else
             context.parent ! NewSubscriberArrived
+        case Count ⇒
+          sender() ! subscribers.size
         case msg ⇒
           subscribers foreach { _ forward msg }
       }
@@ -390,6 +393,7 @@ object DistributedPubSubMediator {
         case Terminated(ref) ⇒
           val key = mkKey(ref)
           recreateAndForwardMessagesIfNeeded(key, newGroupActor(ref.path.name))
+          remove(ref)
       }
 
       def newGroupActor(encGroup: String): ActorRef = {
@@ -723,6 +727,15 @@ class DistributedPubSubMediator(settings: DistributedPubSubSettings) extends Act
 
     case DeltaCount ⇒
       sender() ! deltaCount
+
+    case msg @ CountSubscribers(topic) ⇒
+      val encTopic = encName(topic)
+      bufferOr(mkKey(self.path / encTopic), msg, sender()) {
+        context.child(encTopic) match {
+          case Some(ref) ⇒ ref.tell(Count, sender())
+          case None      ⇒ sender() ! 0
+        }
+      }
   }
 
   private def ignoreOrSendToDeadLetters(msg: Any) =

--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
@@ -222,7 +222,7 @@ object DistributedPubSubMediator {
 
   // Only for testing purposes, to poll/await replication
   case object Count
-  case class CountSubscribers(topic: String)
+  final case class CountSubscribers(topic: String)
 
   /**
    * INTERNAL API

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/pubsub/DistributedPubSubMediatorSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/pubsub/DistributedPubSubMediatorSpec.scala
@@ -125,7 +125,7 @@ class DistributedPubSubMediatorMultiJvmNode1 extends DistributedPubSubMediatorSp
 class DistributedPubSubMediatorMultiJvmNode2 extends DistributedPubSubMediatorSpec
 class DistributedPubSubMediatorMultiJvmNode3 extends DistributedPubSubMediatorSpec
 
-class DistributedPubSubMediatorSpec extends MultiNodeSpec(DistributedPubSubMediatorSpec) with STMultiNodeSpec with ImplicitSender with DeadLettersProbe {
+class DistributedPubSubMediatorSpec extends MultiNodeSpec(DistributedPubSubMediatorSpec) with STMultiNodeSpec with ImplicitSender {
   import DistributedPubSubMediatorSpec._
   import DistributedPubSubMediatorSpec.TestChatUser._
   import DistributedPubSubMediator._


### PR DESCRIPTION
Resolves #24294 - Actors are not unsubscrubed from DistributedPubSubMediator topics when they terminate.

The actual fix for this issue was only one line (DistributedPubSubMediator.scala L396 in the diff), to remove the ActorRef from the subscriber list when it terminates. I have written some infrastructure to observe changes to topic subscribers in test, but as I don't have prior experience writing Multi-JVM tests, I would definitely appreciate feedback on that front.

Additionally, I ran the same Gist that I posted to reproduce the original issue (https://gist.github.com/naiello/f97a77398e5bce8fe9937dad5171a999) against the patch, and observed that no dead-letter for the terminated actor was logged. Finally, I ran a test in VisualVM which continually created, subscribed and terminated actors, observing that in the patched version, invoking the GC manually causes the stale ActorRefs on the heap to be reclaimed.