### PR TITLE
actor-typed: remove unsupported DispatcherSelectors #24337

### DIFF
--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/DispatcherSelectorTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/DispatcherSelectorTest.java
@@ -10,7 +10,4 @@ public class DispatcherSelectorTest {
 
   private DispatcherSelector def = DispatcherSelector.defaultDispatcher();
   private DispatcherSelector conf = DispatcherSelector.fromConfig("somepath");
-  private DispatcherSelector ex = DispatcherSelector.fromExecutor((Executor) null);
-  private DispatcherSelector ec = DispatcherSelector.fromExecutionContext((ExecutionContext) null);
-
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
@@ -3,12 +3,11 @@
  */
 package akka.actor.typed
 
-import java.util.concurrent.Executor
-
-import akka.annotation.{ ApiMayChange, DoNotInherit, InternalApi }
+import akka.annotation.ApiMayChange
+import akka.annotation.DoNotInherit
+import akka.annotation.InternalApi
 
 import scala.annotation.tailrec
-import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
 
 object Props {
@@ -67,16 +66,6 @@ abstract class Props private[akka] () extends Product with Serializable {
    * executor.
    */
   def withDispatcherFromConfig(path: String): Props = DispatcherFromConfig(path, this)
-
-  /**
-   * Prepend a selection of the given executor to this Props.
-   */
-  def withDispatcherFromExecutor(executor: Executor): Props = DispatcherFromExecutor(executor, this)
-
-  /**
-   * Prepend a selection of the given execution context to this Props.
-   */
-  def withDispatcherFromExecutionContext(ec: ExecutionContext): Props = DispatcherFromExecutionContext(ec, this)
 
   /**
    * Find the first occurrence of a configuration node of the given type, falling
@@ -149,7 +138,7 @@ private[akka] case object EmptyProps extends Props {
  * Not intended for user extension.
  */
 @DoNotInherit
-abstract class DispatcherSelector extends Props
+sealed abstract class DispatcherSelector extends Props
 
 /**
  * Factories for [[DispatcherSelector]]s which describe which thread pool shall be used to run
@@ -179,20 +168,6 @@ object DispatcherSelector {
    * ActorSystem terminates.
    */
   def fromConfig(path: String): DispatcherSelector = DispatcherFromConfig(path)
-
-  /**
-   * Directly use the given Executor whenever the actor needs to be run.
-   * No attempt will be made to shut down this thread pool when the [[ActorSystem]] terminates.
-   */
-  def fromExecutor(executor: Executor): DispatcherSelector = DispatcherFromExecutor(executor)
-
-  /**
-   * Directly use the given ExecutionContext whenever the actor needs to be run.
-   * No attempt will be made to shut down this thread pool when the [[ActorSystem]] terminates.
-   */
-  def fromExecutionContext(executionContext: ExecutionContext): DispatcherSelector =
-    DispatcherFromExecutionContext(executionContext)
-
 }
 
 /**
@@ -224,29 +199,5 @@ object DispatcherDefault {
  */
 @InternalApi
 private[akka] final case class DispatcherFromConfig(path: String, next: Props = Props.empty) extends DispatcherSelector {
-  override def withNext(next: Props): Props = copy(next = next)
-}
-
-/**
- * Directly use the given Executor whenever the actor needs to be run.
- * No attempt will be made to shut down this thread pool, even if it is an
- * instance of ExecutorService.
- *
- * INTERNAL API
- */
-@InternalApi
-private[akka] final case class DispatcherFromExecutor(executor: Executor, next: Props = Props.empty) extends DispatcherSelector {
-  override def withNext(next: Props): Props = copy(next = next)
-}
-
-/**
- * Directly use the given ExecutionContext whenever the actor needs to be run.
- * No attempt will be made to shut down this thread pool, even if it is an
- * instance of ExecutorService.
- *
- * INTERNAL API
- */
-@InternalApi
-private[akka] final case class DispatcherFromExecutionContext(ec: ExecutionContext, next: Props = Props.empty) extends DispatcherSelector {
   override def withNext(next: Props): Props = copy(next = next)
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -53,10 +53,6 @@ import scala.compat.java8.FutureConverters
       selector match {
         case DispatcherDefault(_)         ⇒ untyped.dispatcher
         case DispatcherFromConfig(str, _) ⇒ untyped.dispatchers.lookup(str)
-        case DispatcherFromExecutionContext(_, _) ⇒
-          throw new UnsupportedOperationException("Cannot use DispatcherFromExecutionContext with ActorSystemAdapter")
-        case DispatcherFromExecutor(_, _) ⇒
-          throw new UnsupportedOperationException("Cannot use DispatcherFromExecutor with ActorSystemAdapter")
       }
     override def shutdown(): Unit = () // there was no shutdown in untyped Akka
   }


### PR DESCRIPTION
Untyped actor systems currently only support specifying dispatchers via a
name reference to the config. The other selectors can be revived when other
ways of configuring dispatchers are available for untyped actor systems
(see #17568).

Fixes #24337.