### PR TITLE
=act don't initialize Serializer extension in `RemoteActorRefProvider`

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/serialization/SerializationSetupSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/SerializationSetupSpec.scala
@@ -99,6 +99,21 @@ class SerializationSetupSpec extends AkkaSpec(
       serializer shouldBe theSameInstanceAs(programmaticDummySerializer)
     }
 
+    "fail during ActorSystem creation when misconfigured" in {
+      val config =
+        ConfigFactory.parseString(
+          """
+             akka.loglevel = OFF
+             akka.stdout-loglevel = OFF
+             akka.actor.serializers.doe = "john.is.not.here"
+          """).withFallback(ConfigFactory.load())
+
+      a[ClassNotFoundException] should be thrownBy {
+        val system = ActorSystem("SerializationSetupSpec-FailingSystem", config)
+        system.terminate()
+      }
+    }
+
   }
 
   // This is a weird edge case, someone creating a JavaSerializer manually and using it in a system means

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -67,7 +67,7 @@ akka {
   #
   # Should not be set by end user applications in 'application.conf', use the extensions property for that
   #
-  library-extensions = ${?akka.library-extensions} []
+  library-extensions = ${?akka.library-extensions} ["akka.serialization.SerializationExtension"]
 
   # List FQCN of extensions which shall be loaded at actor system startup.
   # Should be on the format: 'extensions = ["foo", "bar"]' etc.

--- a/akka-remote/src/main/mima-filters/2.5.9.backwards.excludes
+++ b/akka-remote/src/main/mima-filters/2.5.9.backwards.excludes
@@ -1,0 +1,9 @@
+# change to private[akka] class
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.RemoteActorRefProvider.serialization")
+ProblemFilters.exclude[MissingTypesProblem]("akka.remote.RemoteActorRefProvider$Internals$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.RemoteActorRefProvider#Internals.apply")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.remote.RemoteActorRefProvider#Internals.copy$default$2")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.RemoteActorRefProvider#Internals.serialization")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.RemoteActorRefProvider#Internals.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.RemoteActorRefProvider#Internals.copy$default$3")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.RemoteActorRefProvider#Internals.this")

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -11,11 +11,14 @@ import akka.event.{ EventStream, Logging, LoggingAdapter }
 import akka.event.Logging.Error
 import akka.serialization.{ Serialization, SerializationExtension }
 import akka.pattern.pipe
+
 import scala.util.control.NonFatal
 import akka.actor.SystemGuardian.{ RegisterTerminationHook, TerminationHook, TerminationHookDone }
+
 import scala.util.control.Exception.Catcher
 import scala.concurrent.Future
 import akka.ConfigurationException
+import akka.annotation.InternalApi
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.remote.artery.ArteryTransport
 import akka.util.OptionVal
@@ -27,8 +30,9 @@ import akka.remote.serialization.ActorRefResolveThreadLocalCache
 /**
  * INTERNAL API
  */
+@InternalApi
 private[akka] object RemoteActorRefProvider {
-  private final case class Internals(transport: RemoteTransport, serialization: Serialization, remoteDaemon: InternalActorRef)
+  private final case class Internals(transport: RemoteTransport, remoteDaemon: InternalActorRef)
     extends NoSerializationVerificationNeeded
 
   sealed trait TerminatorState
@@ -166,7 +170,6 @@ private[akka] class RemoteActorRefProvider(
   @volatile private var _internals: Internals = _
 
   def transport: RemoteTransport = _internals.transport
-  def serialization: Serialization = _internals.serialization
   def remoteDaemon: InternalActorRef = _internals.remoteDaemon
 
   // This actor ensures the ordering of shutdown between remoteDaemon and the transport
@@ -200,7 +203,6 @@ private[akka] class RemoteActorRefProvider(
         local.registerExtraNames(Map(("remote", d)))
         d
       },
-      serialization = SerializationExtension(system),
       transport = if (remoteSettings.Artery.Enabled) new ArteryTransport(system, this) else new Remoting(system, this))
 
     _internals = internals


### PR DESCRIPTION
It seems to be somewhat useless to initialize it here. On the other hand, artery will start a streams during initialization and those will also initialize Serialization.

So, this one is basically a code cleanup, but let's see what PR validation says.