### PR TITLE
Docs: fix bounded mailbox with non-zero mailbox-push-timeout-time

### DIFF
--- a/akka-docs/src/test/scala/docs/dispatcher/DispatcherDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/dispatcher/DispatcherDocSpec.scala
@@ -179,9 +179,8 @@ object DispatcherDocSpec {
 
     //#bounded-mailbox-config
     bounded-mailbox {
-      mailbox-type = "akka.dispatch.BoundedMailbox"
-      mailbox-capacity = 1000
-      mailbox-push-timeout-time = 10s
+      mailbox-type = "akka.dispatch.NonBlockingBoundedMailbox"
+      mailbox-capacity = 1000 
     }
     //#bounded-mailbox-config
 


### PR DESCRIPTION
See #24355

I'm suggesting changing the first example to use NonBlockingBoundedMailbox instead of BoundedMailbox since BoundedMailbox with 10s(!!) push-timeout is kinda not a good example. Note that the first example on a doc page is always important since it's what users (people :-)) tends to copy-and-paste. 