### PR TITLE
Suppress 'match is not exhaustive!' warning

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
@@ -88,10 +88,8 @@ class ActorContextAskSpec extends TestKit(ActorContextAskSpec.config) with Typed
 
       val snitch = Behaviors.deferred[AnyRef] { (ctx) ⇒
         ctx.ask(pingPong)(Ping) {
-          (_: scala.util.Try[Pong.type] @unchecked) match {
-            // uh oh, missing case for the response, this can never end well
-            case Failure(x) ⇒ x
-          }
+          case Success(msg) ⇒ throw new NotImplementedError(msg.toString)
+          case Failure(x)   ⇒ x
         }
 
         Behaviors.immutable[AnyRef] {
@@ -106,11 +104,11 @@ class ActorContextAskSpec extends TestKit(ActorContextAskSpec.config) with Typed
         }
       }
 
-      EventFilter[MatchError](occurrences = 1, start = "Success(Pong)").intercept {
+      EventFilter[NotImplementedError](occurrences = 1, start = "Pong").intercept {
         spawn(snitch)
       }
 
-      // no-match should cause failure and subsequent stop of actor
+      // the exception should cause a failure which should stop the actor
       probe.expectMsg("stopped")
     }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
@@ -88,8 +88,10 @@ class ActorContextAskSpec extends TestKit(ActorContextAskSpec.config) with Typed
 
       val snitch = Behaviors.deferred[AnyRef] { (ctx) ⇒
         ctx.ask(pingPong)(Ping) {
-          // uh oh, missing case for the response, this can never end well
-          case Failure(x) ⇒ x
+          (_: scala.util.Try[Pong.type] @unchecked) match {
+            // uh oh, missing case for the response, this can never end well
+            case Failure(x) ⇒ x
+          }
         }
 
         Behaviors.immutable[AnyRef] {


### PR DESCRIPTION
Not super clean, but gets rid of the compiler warning shown every time this
file is compiled.