### PR TITLE
harden DistributedPubSubRestart, #24100

### DIFF
--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/pubsub/DistributedPubSubRestartSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/pubsub/DistributedPubSubRestartSpec.scala
@@ -122,8 +122,9 @@ class DistributedPubSubRestartSpec extends MultiNodeSpec(DistributedPubSubRestar
 
         within(20.seconds) {
           awaitAssert {
-            system.actorSelection(RootActorPath(thirdAddress) / "user" / "shutdown") ! Identify(None)
-            expectMsgType[ActorIdentity](1.second).ref.get
+            val p = TestProbe()
+            system.actorSelection(RootActorPath(thirdAddress) / "user" / "shutdown").tell(Identify(None), p.ref)
+            p.expectMsgType[ActorIdentity](1.second).ref.get
           }
         }
 
@@ -163,7 +164,7 @@ class DistributedPubSubRestartSpec extends MultiNodeSpec(DistributedPubSubRestar
           probe.expectMsg(0L)
 
           newSystem.actorOf(Props[Shutdown], "shutdown")
-          Await.ready(newSystem.whenTerminated, 10.seconds)
+          Await.ready(newSystem.whenTerminated, 20.seconds)
         } finally newSystem.terminate()
       }
 


### PR DESCRIPTION
Not sure I'm fixing the same thing as reported in the ticket, but could be related. The thing I noticed and fixing here is:
```
[JVM-1] - must handle restart of nodes with same address (on node 'first', class akka.cluster.pubsub.DistributedPubSubRestartMultiJvmNode1) *** FAILED ***
[JVM-1]   java.lang.AssertionError: assertion failed: expected long, found class akka.actor.ActorIdentity (ActorIdentity(None,Some(Actor[akka://DistributedPubSubRestartSpec@localhost:42433/user/shutdown#1174471491])))
[JVM-1]   at scala.Predef$.assert(Predef.scala:170)
[JVM-1]   at akka.testkit.TestKitBase$class.expectMsgClass_internal(TestKit.scala:509)
[JVM-1]   at akka.testkit.TestKitBase$class.expectMsgType(TestKit.scala:481)
[JVM-1]   at akka.testkit.TestKit.expectMsgType(TestKit.scala:890)
[JVM-1]   at akka.cluster.pubsub.DistributedPubSubRestartSpec$$anonfun$1$$anonfun$apply$mcV$sp$3$$anonfun$apply$mcV$sp$4$$anonfun$apply$mcV$sp$7.apply$mcV$sp(DistributedPubSubRestartSpec.scala:135)
```

Refs #24100