### PR TITLE
Extrapolate stage and expand redoc

### DIFF
--- a/akka-docs/src/main/paradox/stream/stages-overview.md
+++ b/akka-docs/src/main/paradox/stream/stages-overview.md
@@ -1447,10 +1447,13 @@ aggregated to the batched value.
 Allow for a faster downstream by expanding the last emitted element to an `Iterator`. For example, an
 `Iterator.continually(element)` will cause `extrapolate` to keep repeating the last emitted element. 
 
-All original elements are always emitted unchanged - the `Iterator` is only used whenever downstream signals demand, and
-there are no new elements from the upstream.
+All original elements are always emitted unchanged - the `Iterator` is only used whenever there is downstream
+ demand before upstream emits a new element.
 
 Includes an optional `initial` argument to prevent blocking the entire stream when there are multiple producers.
+
+See @ref:[Understanding extrapolate and expand](stream-rate.md#understanding-extrapolate-and-expand) for more information
+and examples.
 
 **emits** when downstream stops backpressuring
 
@@ -1464,6 +1467,9 @@ Includes an optional `initial` argument to prevent blocking the entire stream wh
 
 Like `extrapolate`, but does not have the `initial` argument, and the `Iterator` is also used in lieu of the original 
 element, allowing for it to be rewritten and/or filtered.
+
+See @ref:[Understanding extrapolate and expand](stream-rate.md#understanding-extrapolate-and-expand) for more information
+and examples.
 
 **emits** when downstream stops backpressuring
 

--- a/akka-docs/src/main/paradox/stream/stages-overview.md
+++ b/akka-docs/src/main/paradox/stream/stages-overview.md
@@ -1442,10 +1442,28 @@ aggregated to the batched value.
 
 ---------------------------------------------------------------
 
+### extrapolate
+
+Allow for a faster downstream by expanding the last emitted element to an `Iterator`. For example, an
+`Iterator.continually(element)` will cause `extrapolate` to keep repeating the last emitted element. 
+
+All original elements are always emitted unchanged - the `Iterator` is only used whenever downstream signals demand, and
+there are no new elements from the upstream.
+
+Includes an optional `initial` argument to prevent blocking the entire stream when there are multiple producers.
+
+**emits** when downstream stops backpressuring
+
+**backpressures** when downstream backpressures
+
+**completes** when upstream completes
+
+---------------------------------------------------------------
+
 ### expand
 
-Allow for a faster downstream by expanding the last incoming element to an `Iterator`. For example
-`Iterator.continually(element)` to keep repeating the last incoming element.
+Like `extrapolate`, but does not have the `initial` argument, and the `Iterator` is also used in lieu of the original 
+element, allowing for it to be rewritten and/or filtered.
 
 **emits** when downstream stops backpressuring
 

--- a/akka-docs/src/main/paradox/stream/stream-rate.md
+++ b/akka-docs/src/main/paradox/stream/stream-rate.md
@@ -203,22 +203,37 @@ Scala
 Java
 :   @@snip [RateTransformationDocTest.java]($code$/java/jdocs/stream/RateTransformationDocTest.java) { #conflate-sample }
 
-### Understanding expand
+### Understanding extrapolate and expand
 
-Expand helps to deal with slow producers which are unable to keep up with the demand coming from consumers.
-Expand allows to extrapolate a value to be sent as an element to a consumer.
+Now we will discuss two stages, `extrapolate` and `expand`, helping to deal with slow producers that are unable to keep up with the demand coming from consumers.
+They allow for additional values to be sent as elements to a consumer.
 
-As a simple use of `expand` here is a flow that sends the same element to consumer when producer does not send
-any new elements.
+As a simple use case of `extrapolate`, here is a flow that repeats the last emitted element to a consumer, whenever the consumer signals demand and the producer cannot supply new elements yet.
 
 Scala
-:   @@snip [RateTransformationDocSpec.scala]($code$/scala/docs/stream/RateTransformationDocSpec.scala) { #expand-last }
+:   @@snip [RateTransformationDocSpec.scala]($code$/scala/docs/stream/RateTransformationDocSpec.scala) { #extrapolate-last }
 
 Java
-:   @@snip [RateTransformationDocTest.java]($code$/java/jdocs/stream/RateTransformationDocTest.java) { #expand-last }
+:   @@snip [RateTransformationDocTest.java]($code$/java/jdocs/stream/RateTransformationDocTest.java) { #extrapolate-last }
 
-Expand also allows to keep some state between demand requests from the downstream. Leveraging this, here is a flow
-that tracks and reports a drift between fast consumer and slow producer.
+For situations where you have several producers, and the entire stream may become blocked by a non-emitting one, you can use the `initial` parameter of `extrapolate` to "seed" the stream.
+
+Scala
+:   @@snip [RateTransformationDocSpec.scala]($code$/scala/docs/stream/RateTransformationDocSpec.scala) { #extrapolate-seed }
+
+Java
+:   @@snip [RateTransformationDocTest.java]($code$/java/jdocs/stream/RateTransformationDocTest.java) { #extrapolate-seed }
+
+`extrapolate` and `expand` also allow to produce metainformation based on demand signalled from the downstream. Leveraging this, here is a flow
+that tracks and reports a drift between a fast consumer and a slow producer. 
+
+Scala
+:   @@snip [RateTransformationDocSpec.scala]($code$/scala/docs/stream/RateTransformationDocSpec.scala) { #extrapolate-drift }
+
+Java
+:   @@snip [RateTransformationDocTest.java]($code$/java/jdocs/stream/RateTransformationDocTest.java) { #extrapolate-drift }
+
+And here's a more concise representation with `expand`.
 
 Scala
 :   @@snip [RateTransformationDocSpec.scala]($code$/scala/docs/stream/RateTransformationDocSpec.scala) { #expand-drift }
@@ -226,5 +241,10 @@ Scala
 Java
 :   @@snip [RateTransformationDocTest.java]($code$/java/jdocs/stream/RateTransformationDocTest.java) { #expand-drift }
 
-Note that all of the elements coming from upstream will go through `expand` at least once. This means that the
-output of this flow is going to report a drift of zero if producer is fast enough, or a larger drift otherwise.
+Note that all of the elements coming from upstream will go through:
+
+ - `extrapolate` at least once, 
+ - while `expand` provides you with the option to replace the "original" element with something else entirely - potentially even filtering it out with an empty `Iterator`.
+ 
+Regardless, since we provide a non-empty `Iterator` in both examples, this means that the
+output of this flow is going to report a drift of zero if the producer is fast enough - or a larger drift otherwise.

--- a/akka-docs/src/main/paradox/stream/stream-rate.md
+++ b/akka-docs/src/main/paradox/stream/stream-rate.md
@@ -205,10 +205,12 @@ Java
 
 ### Understanding extrapolate and expand
 
-Now we will discuss two stages, `extrapolate` and `expand`, helping to deal with slow producers that are unable to keep up with the demand coming from consumers.
+Now we will discuss two stages, `extrapolate` and `expand`, helping to deal with slow producers that are unable to keep 
+up with the demand coming from consumers.
 They allow for additional values to be sent as elements to a consumer.
 
-As a simple use case of `extrapolate`, here is a flow that repeats the last emitted element to a consumer, whenever the consumer signals demand and the producer cannot supply new elements yet.
+As a simple use case of `extrapolate`, here is a flow that repeats the last emitted element to a consumer, whenever 
+the consumer signals demand and the producer cannot supply new elements yet.
 
 Scala
 :   @@snip [RateTransformationDocSpec.scala]($code$/scala/docs/stream/RateTransformationDocSpec.scala) { #extrapolate-last }
@@ -216,7 +218,8 @@ Scala
 Java
 :   @@snip [RateTransformationDocTest.java]($code$/java/jdocs/stream/RateTransformationDocTest.java) { #extrapolate-last }
 
-For situations where you have several producers, and the entire stream may become blocked by a non-emitting one, you can use the `initial` parameter of `extrapolate` to "seed" the stream.
+For situations where there may be downstream demand before any element is emitted from upstream, 
+you can use the `initial` parameter of `extrapolate` to "seed" the stream.
 
 Scala
 :   @@snip [RateTransformationDocSpec.scala]($code$/scala/docs/stream/RateTransformationDocSpec.scala) { #extrapolate-seed }
@@ -224,8 +227,8 @@ Scala
 Java
 :   @@snip [RateTransformationDocTest.java]($code$/java/jdocs/stream/RateTransformationDocTest.java) { #extrapolate-seed }
 
-`extrapolate` and `expand` also allow to produce metainformation based on demand signalled from the downstream. Leveraging this, here is a flow
-that tracks and reports a drift between a fast consumer and a slow producer. 
+`extrapolate` and `expand` also allow to produce metainformation based on demand signalled from the downstream. 
+Leveraging this, here is a flow that tracks and reports a drift between a fast consumer and a slow producer. 
 
 Scala
 :   @@snip [RateTransformationDocSpec.scala]($code$/scala/docs/stream/RateTransformationDocSpec.scala) { #extrapolate-drift }
@@ -241,10 +244,12 @@ Scala
 Java
 :   @@snip [RateTransformationDocTest.java]($code$/java/jdocs/stream/RateTransformationDocTest.java) { #expand-drift }
 
-Note that all of the elements coming from upstream will go through:
+The difference is due to the different handling of the `Iterator`-generating argument.
 
- - `extrapolate` at least once, 
- - while `expand` provides you with the option to replace the "original" element with something else entirely - potentially even filtering it out with an empty `Iterator`.
+While `extrapolate` uses an `Iterator` only when there is unmet downstream demand, `expand` _always_ creates 
+an `Iterator` and emits elements downstream from it.
+
+This makes `expand` able to transform or even filter out (by providing an empty `Iterator`) the "original" elements.
  
 Regardless, since we provide a non-empty `Iterator` in both examples, this means that the
 output of this flow is going to report a drift of zero if the producer is fast enough - or a larger drift otherwise.

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSupervisionSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSupervisionSpec.scala
@@ -163,7 +163,7 @@ class InterpreterSupervisionSpec extends StreamSpec with GraphInterpreterSpecKit
       lastEvents() should be(Set(OnError(TE), Cancel))
     }
 
-    "fail when Expand `extrapolate` throws" in new OneBoundedSetup[Int](
+    "fail when Expand `expander` throws" in new OneBoundedSetup[Int](
       new Expand((in: Int) ⇒ if (in == 2) Iterator.continually(throw TE) else Iterator(in) ++ Iterator.continually(-math.abs(in)))) {
 
       lastEvents() should be(Set(RequestOne))

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowExpandSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowExpandSpec.scala
@@ -29,7 +29,7 @@ class FlowExpandSpec extends StreamSpec {
       val subscriber = TestSubscriber.probe[Int]()
 
       // Simply repeat the last element as an extrapolation step
-      Source.fromPublisher(publisher).expand(Iterator.continually(_)).to(Sink.fromSubscriber(subscriber)).run()
+      Source.fromPublisher(publisher).expand(Iterator.single).to(Sink.fromSubscriber(subscriber)).run()
 
       for (i ← 1 to 100) {
         // Order is important here: If the request comes first it will be extrapolated!
@@ -49,7 +49,7 @@ class FlowExpandSpec extends StreamSpec {
 
       publisher.sendNext(42)
 
-      for (i ← 1 to 100) {
+      for (_ ← 1 to 100) {
         subscriber.requestNext(42)
       }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowExtrapolateSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowExtrapolateSpec.scala
@@ -1,6 +1,7 @@
 /**
  * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.stream.scaladsl
 
 import java.util.concurrent.ThreadLocalRandom

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowExtrapolateSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowExtrapolateSpec.scala
@@ -19,7 +19,7 @@ class FlowExtrapolateSpec extends StreamSpec {
 
   implicit val materializer = ActorMaterializer(settings)
 
-  "Pressurize" must {
+  "Extrapolate" must {
 
     "pass-through elements unchanged when there is no rate difference" in {
       // Shadow the fuzzed materializer (see the ordering guarantee needed by the for loop below).

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPressurizeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPressurizeSpec.scala
@@ -1,0 +1,168 @@
+/**
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.stream.scaladsl
+
+import java.util.concurrent.ThreadLocalRandom
+
+import akka.stream.testkit._
+import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class FlowPressurizeSpec extends StreamSpec {
+
+  val settings = ActorMaterializerSettings(system)
+    .withInputBuffer(initialSize = 2, maxSize = 2)
+
+  implicit val materializer = ActorMaterializer(settings)
+
+  "Pressurize" must {
+
+    "pass-through elements unchanged when there is no rate difference" in {
+      // Shadow the fuzzed materializer (see the ordering guarantee needed by the for loop below).
+      implicit val materializer = ActorMaterializer(settings.withFuzzing(false))
+
+      val publisher = TestPublisher.probe[Int]()
+      val subscriber = TestSubscriber.probe[Int]()
+
+      // Provide an empty stream
+      Source.fromPublisher(publisher).pressurize(_ ⇒ Stream.empty[Int]).to(Sink.fromSubscriber(subscriber)).run()
+
+      for (i ← 1 to 100) {
+        // Order is important here: If the request comes first it will be extrapolated!
+        publisher.sendNext(i)
+        subscriber.requestNext(i)
+      }
+
+      subscriber.cancel()
+    }
+
+    "extrapolate from elements while upstream is silent" in {
+      val publisher = TestPublisher.probe[Int]()
+      val subscriber = TestSubscriber.probe[Int]()
+
+      // Simply repeat the last element as an extrapolation step
+      Source.fromPublisher(publisher).pressurize(e ⇒ Stream.continually(e + 1)).to(Sink.fromSubscriber(subscriber)).run()
+
+      publisher.sendNext(42)
+      subscriber.requestNext(42)
+
+      for (_ ← 1 to 100) {
+        subscriber.requestNext(42 + 1)
+      }
+
+      publisher.sendNext(-42)
+
+      // The request below is otherwise in race with the above sendNext
+      subscriber.expectNoMsg(500.millis)
+      subscriber.requestNext(-42)
+
+      subscriber.cancel()
+    }
+
+    "always emit the initial element first" in {
+      val publisher = TestPublisher.probe[Int]()
+      val subscriber = TestSubscriber.probe[Int]()
+
+      val testInit = 44
+
+      // Simply repeat the last element as an extrapolation step
+      Source.fromPublisher(publisher).pressurize(Stream.continually(_), initial = Some(testInit)).to(Sink.fromSubscriber(subscriber)).run()
+
+      publisher.sendNext(42)
+      subscriber.requestNext(testInit)
+      subscriber.requestNext(42)
+
+      subscriber.cancel()
+    }
+
+    "do not drop the last element" in {
+      val publisher = TestPublisher.probe[Int]()
+      val subscriber = TestSubscriber.probe[Int]()
+
+      // Simply repeat the last element as an extrapolation step
+      Source.fromPublisher(publisher).pressurize(_ ⇒ Stream.empty[Int]).to(Sink.fromSubscriber(subscriber)).run()
+
+      publisher.sendNext(1)
+      subscriber.requestNext(1)
+
+      publisher.sendNext(2)
+      publisher.sendComplete()
+
+      // The request below is otherwise in race with the above sendNext(2) (and completion)
+      subscriber.expectNoMsg(500.millis)
+
+      subscriber.requestNext(2)
+      subscriber.expectComplete()
+    }
+
+    "work on a variable rate chain" in {
+      val future = Source(1 to 100)
+        .map { i ⇒ if (ThreadLocalRandom.current().nextBoolean()) Thread.sleep(10); i }
+        .pressurize(Stream.continually(_))
+        .runFold(Set.empty[Int])(_ + _)
+
+      Await.result(future, 10.seconds) should contain theSameElementsAs (1 to 100).toSet
+    }
+
+    "backpressure publisher when subscriber is slower" in {
+      val publisher = TestPublisher.probe[Int]()
+      val subscriber = TestSubscriber.probe[Int]()
+
+      Source.fromPublisher(publisher).pressurize(Stream.continually(_)).to(Sink.fromSubscriber(subscriber)).run()
+
+      publisher.sendNext(1)
+      subscriber.requestNext(1)
+      subscriber.requestNext(1)
+
+      var pending = publisher.pending
+      // Deplete pending requests coming from input buffer
+      while (pending > 0) {
+        publisher.unsafeSendNext(2)
+        pending -= 1
+      }
+
+      // The above sends are absorbed in the input buffer, and will result in two one-sized batch requests
+      pending += publisher.expectRequest()
+      pending += publisher.expectRequest()
+      while (pending > 0) {
+        publisher.unsafeSendNext(2)
+        pending -= 1
+      }
+
+      publisher.expectNoMsg(1.second)
+
+      subscriber.request(2)
+      subscriber.expectNext(2)
+      subscriber.expectNext(2)
+
+      // Now production is resumed
+      publisher.expectRequest()
+
+    }
+
+    "work properly with finite extrapolations" in {
+      val (source, sink) =
+        TestSource.probe[Int]
+          .expand(i ⇒ Iterator.from(0).map(i → _).take(3))
+          .toMat(TestSink.probe)(Keep.both)
+          .run()
+      source
+        .sendNext(1)
+      sink
+        .request(4)
+        .expectNext(1 → 0, 1 → 1, 1 → 2)
+        .expectNoMsg(100.millis)
+      source
+        .sendNext(2)
+        .sendComplete()
+      sink
+        .expectNext(2 → 0)
+        .expectComplete()
+    }
+  }
+
+}

--- a/akka-stream/src/main/mima-filters/2.5.11.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.11.backwards.excludes
@@ -8,3 +8,7 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.LazySink.th
 # #24581 RS violation
 ProblemFilters.exclude[FinalClassProblem]("akka.stream.impl.VirtualProcessor$Both")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.VirtualProcessor#Both.create")
+
+# #23804 Added extrapolate stage
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.extrapolate")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.extrapolate$default$2")

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1583,6 +1583,55 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     new Flow(delegate.expand(in ⇒ extrapolate(in).asScala))
 
   /**
+   * Allows a faster downstream to progress of a slower upstream.
+   *
+   * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
+   * signals demand.
+   *
+   * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
+   * Exceptions from the `extrapolate` function will complete the stream with failure.
+   *
+   * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR
+   * `extrapolate` is non-empty and applicable
+   *
+   * '''Backpressures when''' downstream backpressures or current `extrapolate` runs empty
+   *
+   * '''Completes when''' upstream completes and current `extrapolate` runs empty
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @param extrapolate takes the current upstream element and provides a sequence of "extrapolated" elements based
+   *                    on the original, to be emitted in case downstream signals demand
+   */
+  def pressurize[U >: Out](extrapolate: function.Function[U, java.util.Iterator[U]]): javadsl.Flow[In, U, Mat] =
+    new Flow(delegate.pressurize[U](in ⇒ extrapolate(in).asScala.toStream))
+
+  /**
+   * Allows a faster downstream to progress of a slower upstream.
+   *
+   * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
+   * signals demand.
+   *
+   * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
+   * Exceptions from the `extrapolate` function will complete the stream with failure.
+   *
+   * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR
+   * `extrapolate` is non-empty and applicable
+   *
+   * '''Backpressures when''' downstream backpressures or current `extrapolate` runs empty
+   *
+   * '''Completes when''' upstream completes and current `extrapolate` runs empty
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @param extrapolate takes the current upstream element and provides a sequence of "extrapolated" elements based
+   *                    on the original, to be emitted in case downstream signals demand
+   * @param initial the initial element to be emitted, in case upstream is able to stall the entire stream
+   */
+  def pressurize[U >: Out](extrapolate: function.Function[U, java.util.Iterator[U]], initial: U): javadsl.Flow[In, U, Mat] =
+    new Flow(delegate.pressurize[U](in ⇒ extrapolate(in).asScala.toStream, Some(initial)))
+
+  /**
    * Adds a fixed size buffer in the flow that allows to store elements from a faster upstream until it becomes full.
    * Depending on the defined [[akka.stream.OverflowStrategy]] it might drop elements or backpressure the upstream if
    * there is no space available

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1590,7 +1590,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
    *
-   * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
+   * Extrapolate does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
    * See also [[#expand]] for a version that can overwrite the original element.
@@ -1617,7 +1617,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
    *
-   * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
+   * Extrapolate does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
    * See also [[#expand]] for a version that can overwrite the original element.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1556,7 +1556,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     new Flow(delegate.batchWeighted(max, costFn.apply, seed.apply)(aggregate.apply))
 
   /**
-   * Allows a faster downstream to progress independently of a slower publisher by extrapolating elements from an older
+   * Allows a faster downstream to progress independently of a slower upstream by extrapolating elements from an older
    * element until new element comes from the upstream. For example an expand step might repeat the last element for
    * the subscriber until it receives an update from upstream.
    *
@@ -1575,7 +1575,6 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    *
-   * @param seed Provides the first state for extrapolation using the first unconsumed element
    * @param extrapolate Takes the current extrapolation state to produce an output element and the next extrapolation
    *                    state.
    */

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1565,7 +1565,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * subscriber.
    *
    * Expand does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
-   * Exceptions from the `seed` or `extrapolate` functions will complete the stream with failure.
+   * Exceptions from the `seed` function will complete the stream with failure.
    *
    * '''Emits when''' downstream stops backpressuring
    *
@@ -1575,14 +1575,16 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    *
-   * @param extrapolate Takes the current extrapolation state to produce an output element and the next extrapolation
-   *                    state.
+   * @param expander       Takes the current extrapolation state to produce an output element and the next extrapolation
+   *                       state.
+   * @see [[#extrapolate]] for a version that always preserves the original element and allows for an initial "startup"
+   *                       element.
    */
-  def expand[U](extrapolate: function.Function[Out, java.util.Iterator[U]]): javadsl.Flow[In, U, Mat] =
-    new Flow(delegate.expand(in ⇒ extrapolate(in).asScala))
+  def expand[U](expander: function.Function[Out, java.util.Iterator[U]]): javadsl.Flow[In, U, Mat] =
+    new Flow(delegate.expand(in ⇒ expander(in).asScala))
 
   /**
-   * Allows a faster downstream to progress of a slower upstream.
+   * Allows a faster downstream to progress independent of a slower upstream.
    *
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
@@ -1599,14 +1601,15 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    *
-   * @param extrapolate takes the current upstream element and provides a sequence of "extrapolated" elements based
-   *                    on the original, to be emitted in case downstream signals demand
+   * @param extrapolator Takes the current upstream element and provides a sequence of "extrapolated" elements based
+   *                     on the original, to be emitted in case downstream signals demand.
+   * @see [[#expand]]    for a version that can overwrite the original element.
    */
-  def pressurize[U >: Out](extrapolate: function.Function[U, java.util.Iterator[U]]): javadsl.Flow[In, U, Mat] =
-    new Flow(delegate.pressurize[U](in ⇒ extrapolate(in).asScala.toStream))
+  def extrapolate[U >: Out](extrapolator: function.Function[U, java.util.Iterator[U]]): javadsl.Flow[In, U, Mat] =
+    new Flow(delegate.extrapolate[U](in ⇒ extrapolator(in).asScala))
 
   /**
-   * Allows a faster downstream to progress of a slower upstream.
+   * Allows a faster downstream to progress independent of a slower upstream.
    *
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
@@ -1623,12 +1626,13 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    *
-   * @param extrapolate takes the current upstream element and provides a sequence of "extrapolated" elements based
-   *                    on the original, to be emitted in case downstream signals demand
-   * @param initial the initial element to be emitted, in case upstream is able to stall the entire stream
+   * @param extrapolator Takes the current upstream element and provides a sequence of "extrapolated" elements based
+   *                     on the original, to be emitted in case downstream signals demand.
+   * @param initial      The initial element to be emitted, in case upstream is able to stall the entire stream.
+   * @see [[#expand]]    for a version that can overwrite the original element.
    */
-  def pressurize[U >: Out](extrapolate: function.Function[U, java.util.Iterator[U]], initial: U): javadsl.Flow[In, U, Mat] =
-    new Flow(delegate.pressurize[U](in ⇒ extrapolate(in).asScala.toStream, Some(initial)))
+  def extrapolate[U >: Out](extrapolator: function.Function[U, java.util.Iterator[U]], initial: U): javadsl.Flow[In, U, Mat] =
+    new Flow(delegate.extrapolate[U](in ⇒ extrapolator(in).asScala, Some(initial)))
 
   /**
    * Adds a fixed size buffer in the flow that allows to store elements from a faster upstream until it becomes full.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1605,8 +1605,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *                     on the original, to be emitted in case downstream signals demand.
    * @see [[#expand]]    for a version that can overwrite the original element.
    */
-  def extrapolate[U >: Out](extrapolator: function.Function[U, java.util.Iterator[U]]): javadsl.Flow[In, U, Mat] =
-    new Flow(delegate.extrapolate[U](in ⇒ extrapolator(in).asScala))
+  def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]]): javadsl.Flow[In, Out, Mat] =
+    new Flow(delegate.extrapolate(in ⇒ extrapolator(in).asScala))
 
   /**
    * Allows a faster downstream to progress independent of a slower upstream.
@@ -1631,8 +1631,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * @param initial      The initial element to be emitted, in case upstream is able to stall the entire stream.
    * @see [[#expand]]    for a version that can overwrite the original element.
    */
-  def extrapolate[U >: Out](extrapolator: function.Function[U, java.util.Iterator[U]], initial: U): javadsl.Flow[In, U, Mat] =
-    new Flow(delegate.extrapolate[U](in ⇒ extrapolator(in).asScala, Some(initial)))
+  def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]], initial: Out @uncheckedVariance): javadsl.Flow[In, Out, Mat] =
+    new Flow(delegate.extrapolate(in ⇒ extrapolator(in).asScala, Some(initial)))
 
   /**
    * Adds a fixed size buffer in the flow that allows to store elements from a faster upstream until it becomes full.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1565,7 +1565,9 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * subscriber.
    *
    * Expand does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
-   * Exceptions from the `seed` function will complete the stream with failure.
+   * Exceptions from the `expander` function will complete the stream with failure.
+   *
+   * See also [[#extrapolate]] for a version that always preserves the original element and allows for an initial "startup" element.
    *
    * '''Emits when''' downstream stops backpressuring
    *
@@ -1577,8 +1579,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * @param expander       Takes the current extrapolation state to produce an output element and the next extrapolation
    *                       state.
-   * @see [[#extrapolate]] for a version that always preserves the original element and allows for an initial "startup"
-   *                       element.
+   * @see [[#extrapolate]]
    */
   def expand[U](expander: function.Function[Out, java.util.Iterator[U]]): javadsl.Flow[In, U, Mat] =
     new Flow(delegate.expand(in ⇒ expander(in).asScala))
@@ -1592,6 +1593,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
+   * See also [[#expand]] for a version that can overwrite the original element.
+   *
    * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR
    * `extrapolate` is non-empty and applicable
    *
@@ -1603,7 +1606,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * @param extrapolator Takes the current upstream element and provides a sequence of "extrapolated" elements based
    *                     on the original, to be emitted in case downstream signals demand.
-   * @see [[#expand]]    for a version that can overwrite the original element.
+   * @see [[#expand]]
    */
   def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]]): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.extrapolate(in ⇒ extrapolator(in).asScala))
@@ -1617,6 +1620,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
+   * See also [[#expand]] for a version that can overwrite the original element.
+   *
    * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR
    * `extrapolate` is non-empty and applicable
    *
@@ -1629,7 +1634,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * @param extrapolator Takes the current upstream element and provides a sequence of "extrapolated" elements based
    *                     on the original, to be emitted in case downstream signals demand.
    * @param initial      The initial element to be emitted, in case upstream is able to stall the entire stream.
-   * @see [[#expand]]    for a version that can overwrite the original element.
+   * @see [[#expand]]
    */
   def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]], initial: Out @uncheckedVariance): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.extrapolate(in ⇒ extrapolator(in).asScala, Some(initial)))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -20,6 +20,7 @@ import akka.actor.ActorRef
 import akka.dispatch.ExecutionContexts
 import akka.stream.impl.fusing.LazyFlow
 
+import scala.annotation.unchecked.uncheckedVariance
 import scala.compat.java8.FutureConverters._
 import scala.reflect.ClassTag
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2138,7 +2138,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
    *
-   * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
+   * Extrapolate does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
    * See also [[#expand]] for a version that can overwrite the original element.
@@ -2165,7 +2165,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
    *
-   * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
+   * Extrapolate does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
    * See also [[#expand]] for a version that can overwrite the original element.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2113,7 +2113,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * subscriber.
    *
    * Expand does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
-   * Exceptions from the `seed` or `extrapolate` functions will complete the stream with failure.
+   * Exceptions from the `seed` function will complete the stream with failure.
    *
    * '''Emits when''' downstream stops backpressuring
    *
@@ -2123,14 +2123,16 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    *
-   * @param extrapolate Takes the current extrapolation state to produce an output element and the next extrapolation
-   *                    state.
+   * @param expander       Takes the current extrapolation state to produce an output element and the next extrapolation
+   *                       state.
+   * @see [[#extrapolate]] for a version that always preserves the original element and allows for an initial "startup"
+   *                       element.
    */
-  def expand[U](extrapolate: function.Function[Out, java.util.Iterator[U]]): javadsl.Source[U, Mat] =
-    new Source(delegate.expand(in ⇒ extrapolate(in).asScala))
+  def expand[U](expander: function.Function[Out, java.util.Iterator[U]]): javadsl.Source[U, Mat] =
+    new Source(delegate.expand(in ⇒ expander(in).asScala))
 
   /**
-   * Allows a faster downstream to progress of a slower upstream.
+   * Allows a faster downstream to progress independent of a slower upstream.
    *
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
@@ -2147,14 +2149,15 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    *
-   * @param extrapolate takes the current upstream element and provides a sequence of "extrapolated" elements based
-   *                    on the original, to be emitted in case downstream signals demand
+   * @param extrapolator Takes the current upstream element and provides a sequence of "extrapolated" elements based
+   *                    on the original, to be emitted in case downstream signals demand.
+   * @see [[#expand]]    for a version that can overwrite the original element.
    */
-  def pressurize[U >: Out](extrapolate: function.Function[U, java.util.Iterator[U]]): Source[U, Mat] =
-    new Source(delegate.pressurize[U](in ⇒ extrapolate(in).asScala.toStream))
+  def extrapolate[U >: Out](extrapolator: function.Function[U, java.util.Iterator[U]]): Source[U, Mat] =
+    new Source(delegate.extrapolate[U](in ⇒ extrapolator(in).asScala))
 
   /**
-   * Allows a faster downstream to progress of a slower upstream.
+   * Allows a faster downstream to progress independent of a slower upstream.
    *
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
@@ -2171,12 +2174,13 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    *
-   * @param extrapolate takes the current upstream element and provides a sequence of "extrapolated" elements based
-   *                    on the original, to be emitted in case downstream signals demand
-   * @param initial the initial element to be emitted, in case upstream is able to stall the entire stream
+   * @param extrapolator takes the current upstream element and provides a sequence of "extrapolated" elements based
+   *                     on the original, to be emitted in case downstream signals demand.
+   * @param initial      the initial element to be emitted, in case upstream is able to stall the entire stream.
+   * @see [[#expand]]    for a version that can overwrite the original element.
    */
-  def pressurize[U >: Out](extrapolate: function.Function[U, java.util.Iterator[U]], initial: U): Source[U, Mat] =
-    new Source(delegate.pressurize[U](in ⇒ extrapolate(in).asScala.toStream, Some(initial)))
+  def extrapolate[U >: Out](extrapolator: function.Function[U, java.util.Iterator[U]], initial: U): Source[U, Mat] =
+    new Source(delegate.extrapolate[U](in ⇒ extrapolator(in).asScala, Some(initial)))
 
   /**
    * Adds a fixed size buffer in the flow that allows to store elements from a faster upstream until it becomes full.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2130,6 +2130,55 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
     new Source(delegate.expand(in ⇒ extrapolate(in).asScala))
 
   /**
+   * Allows a faster downstream to progress of a slower upstream.
+   *
+   * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
+   * signals demand.
+   *
+   * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
+   * Exceptions from the `extrapolate` function will complete the stream with failure.
+   *
+   * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR
+   * `extrapolate` is non-empty and applicable
+   *
+   * '''Backpressures when''' downstream backpressures or current `extrapolate` runs empty
+   *
+   * '''Completes when''' upstream completes and current `extrapolate` runs empty
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @param extrapolate takes the current upstream element and provides a sequence of "extrapolated" elements based
+   *                    on the original, to be emitted in case downstream signals demand
+   */
+  def pressurize[U >: Out](extrapolate: function.Function[U, java.util.Iterator[U]]): Source[U, Mat] =
+    new Source(delegate.pressurize[U](in ⇒ extrapolate(in).asScala.toStream))
+
+  /**
+   * Allows a faster downstream to progress of a slower upstream.
+   *
+   * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
+   * signals demand.
+   *
+   * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
+   * Exceptions from the `extrapolate` function will complete the stream with failure.
+   *
+   * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR
+   * `extrapolate` is non-empty and applicable
+   *
+   * '''Backpressures when''' downstream backpressures or current `extrapolate` runs empty
+   *
+   * '''Completes when''' upstream completes and current `extrapolate` runs empty
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @param extrapolate takes the current upstream element and provides a sequence of "extrapolated" elements based
+   *                    on the original, to be emitted in case downstream signals demand
+   * @param initial the initial element to be emitted, in case upstream is able to stall the entire stream
+   */
+  def pressurize[U >: Out](extrapolate: function.Function[U, java.util.Iterator[U]], initial: U): Source[U, Mat] =
+    new Source(delegate.pressurize[U](in ⇒ extrapolate(in).asScala.toStream, Some(initial)))
+
+  /**
    * Adds a fixed size buffer in the flow that allows to store elements from a faster upstream until it becomes full.
    * Depending on the defined [[akka.stream.OverflowStrategy]] it might drop elements or backpressure the upstream if
    * there is no space available

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2153,8 +2153,8 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *                    on the original, to be emitted in case downstream signals demand.
    * @see [[#expand]]    for a version that can overwrite the original element.
    */
-  def extrapolate[U >: Out](extrapolator: function.Function[U, java.util.Iterator[U]]): Source[U, Mat] =
-    new Source(delegate.extrapolate[U](in ⇒ extrapolator(in).asScala))
+  def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]]): Source[Out, Mat] =
+    new Source(delegate.extrapolate(in ⇒ extrapolator(in).asScala))
 
   /**
    * Allows a faster downstream to progress independent of a slower upstream.
@@ -2179,8 +2179,8 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * @param initial      the initial element to be emitted, in case upstream is able to stall the entire stream.
    * @see [[#expand]]    for a version that can overwrite the original element.
    */
-  def extrapolate[U >: Out](extrapolator: function.Function[U, java.util.Iterator[U]], initial: U): Source[U, Mat] =
-    new Source(delegate.extrapolate[U](in ⇒ extrapolator(in).asScala, Some(initial)))
+  def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]], initial: Out @uncheckedVariance): Source[Out, Mat] =
+    new Source(delegate.extrapolate(in ⇒ extrapolator(in).asScala, Some(initial)))
 
   /**
    * Adds a fixed size buffer in the flow that allows to store elements from a faster upstream until it becomes full.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2113,7 +2113,9 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * subscriber.
    *
    * Expand does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
-   * Exceptions from the `seed` function will complete the stream with failure.
+   * Exceptions from the `expander` function will complete the stream with failure.
+   *
+   * See also [[#extrapolate]] for a version that always preserves the original element and allows for an initial "startup" element.
    *
    * '''Emits when''' downstream stops backpressuring
    *
@@ -2125,8 +2127,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * @param expander       Takes the current extrapolation state to produce an output element and the next extrapolation
    *                       state.
-   * @see [[#extrapolate]] for a version that always preserves the original element and allows for an initial "startup"
-   *                       element.
+   * @see [[#extrapolate]]
    */
   def expand[U](expander: function.Function[Out, java.util.Iterator[U]]): javadsl.Source[U, Mat] =
     new Source(delegate.expand(in ⇒ expander(in).asScala))
@@ -2140,6 +2141,8 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
+   * See also [[#expand]] for a version that can overwrite the original element.
+   *
    * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR
    * `extrapolate` is non-empty and applicable
    *
@@ -2151,7 +2154,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * @param extrapolator Takes the current upstream element and provides a sequence of "extrapolated" elements based
    *                    on the original, to be emitted in case downstream signals demand.
-   * @see [[#expand]]    for a version that can overwrite the original element.
+   * @see [[#expand]]
    */
   def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]]): Source[Out, Mat] =
     new Source(delegate.extrapolate(in ⇒ extrapolator(in).asScala))
@@ -2165,6 +2168,8 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
+   * See also [[#expand]] for a version that can overwrite the original element.
+   *
    * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR
    * `extrapolate` is non-empty and applicable
    *
@@ -2177,7 +2182,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * @param extrapolator takes the current upstream element and provides a sequence of "extrapolated" elements based
    *                     on the original, to be emitted in case downstream signals demand.
    * @param initial      the initial element to be emitted, in case upstream is able to stall the entire stream.
-   * @see [[#expand]]    for a version that can overwrite the original element.
+   * @see [[#expand]]
    */
   def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]], initial: Out @uncheckedVariance): Source[Out, Mat] =
     new Source(delegate.extrapolate(in ⇒ extrapolator(in).asScala, Some(initial)))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -1118,7 +1118,7 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
     new SubFlow(delegate.batchWeighted(max, costFn.apply, seed.apply)(aggregate.apply))
 
   /**
-   * Allows a faster downstream to progress independently of a slower publisher by extrapolating elements from an older
+   * Allows a faster downstream to progress independently of a slower upstream by extrapolating elements from an older
    * element until new element comes from the upstream. For example an expand step might repeat the last element for
    * the subscriber until it receives an update from upstream.
    *
@@ -1137,7 +1137,6 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    *
    * '''Cancels when''' downstream cancels
    *
-   * @param seed Provides the first state for extrapolation using the first unconsumed element
    * @param extrapolate Takes the current extrapolation state to produce an output element and the next extrapolation
    *                    state.
    */

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -1153,7 +1153,7 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
    *
-   * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
+   * Extrapolate does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
    * See also [[#expand]] for a version that can overwrite the original element.
@@ -1180,7 +1180,7 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
    *
-   * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
+   * Extrapolate does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
    * See also [[#expand]] for a version that can overwrite the original element.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -1127,7 +1127,7 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    * subscriber.
    *
    * Expand does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
-   * Exceptions from the `seed` or `extrapolate` functions will complete the stream with failure.
+   * Exceptions from the `seed` function will complete the stream with failure.
    *
    * '''Emits when''' downstream stops backpressuring
    *
@@ -1137,14 +1137,16 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    *
    * '''Cancels when''' downstream cancels
    *
-   * @param extrapolate Takes the current extrapolation state to produce an output element and the next extrapolation
-   *                    state.
+   * @param expander       Takes the current extrapolation state to produce an output element and the next extrapolation
+   *                       state.
+   * @see [[#extrapolate]] for a version that always preserves the original element and allows for an initial "startup"
+   *                       element.
    */
-  def expand[U](extrapolate: function.Function[Out, java.util.Iterator[U]]): SubFlow[In, U, Mat] =
-    new SubFlow(delegate.expand(in ⇒ extrapolate(in).asScala))
+  def expand[U](expander: function.Function[Out, java.util.Iterator[U]]): SubFlow[In, U, Mat] =
+    new SubFlow(delegate.expand(in ⇒ expander(in).asScala))
 
   /**
-   * Allows a faster downstream to progress of a slower upstream.
+   * Allows a faster downstream to progress independent of a slower upstream.
    *
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
@@ -1161,14 +1163,15 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    *
    * '''Cancels when''' downstream cancels
    *
-   * @param extrapolate takes the current upstream element and provides a sequence of "extrapolated" elements based
-   *                    on the original, to be emitted in case downstream signals demand
+   * @param extrapolator takes the current upstream element and provides a sequence of "extrapolated" elements based
+   *                    on the original, to be emitted in case downstream signals demand.
+   * @see [[#expand]]    for a version that can overwrite the original element.
    */
-  def pressurize[U >: Out](extrapolate: function.Function[U, java.util.Iterator[U]]): SubFlow[In, U, Mat] =
-    new SubFlow(delegate.pressurize[U](in ⇒ extrapolate(in).asScala.toStream))
+  def extrapolate[U >: Out](extrapolator: function.Function[U, java.util.Iterator[U]]): SubFlow[In, U, Mat] =
+    new SubFlow(delegate.extrapolate[U](in ⇒ extrapolator(in).asScala))
 
   /**
-   * Allows a faster downstream to progress of a slower upstream.
+   * Allows a faster downstream to progress independent of a slower upstream.
    *
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
@@ -1185,12 +1188,13 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    *
    * '''Cancels when''' downstream cancels
    *
-   * @param extrapolate takes the current upstream element and provides a sequence of "extrapolated" elements based
-   *                    on the original, to be emitted in case downstream signals demand
-   * @param initial the initial element to be emitted, in case upstream is able to stall the entire stream
+   * @param extrapolator takes the current upstream element and provides a sequence of "extrapolated" elements based
+   *                    on the original, to be emitted in case downstream signals demand.
+   * @param initial the initial element to be emitted, in case upstream is able to stall the entire stream.
+   * @see [[#expand]]    for a version that can overwrite the original element.
    */
-  def pressurize[U >: Out](extrapolate: function.Function[U, java.util.Iterator[U]], initial: U): SubFlow[In, U, Mat] =
-    new SubFlow(delegate.pressurize[U](in ⇒ extrapolate(in).asScala.toStream, Some(initial)))
+  def extrapolate[U >: Out](extrapolator: function.Function[U, java.util.Iterator[U]], initial: U): SubFlow[In, U, Mat] =
+    new SubFlow(delegate.extrapolate[U](in ⇒ extrapolator(in).asScala, Some(initial)))
 
   /**
    * Adds a fixed size buffer in the flow that allows to store elements from a faster upstream until it becomes full.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -1145,6 +1145,55 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
     new SubFlow(delegate.expand(in ⇒ extrapolate(in).asScala))
 
   /**
+   * Allows a faster downstream to progress of a slower upstream.
+   *
+   * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
+   * signals demand.
+   *
+   * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
+   * Exceptions from the `extrapolate` function will complete the stream with failure.
+   *
+   * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR
+   * `extrapolate` is non-empty and applicable
+   *
+   * '''Backpressures when''' downstream backpressures or current `extrapolate` runs empty
+   *
+   * '''Completes when''' upstream completes and current `extrapolate` runs empty
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @param extrapolate takes the current upstream element and provides a sequence of "extrapolated" elements based
+   *                    on the original, to be emitted in case downstream signals demand
+   */
+  def pressurize[U >: Out](extrapolate: function.Function[U, java.util.Iterator[U]]): SubFlow[In, U, Mat] =
+    new SubFlow(delegate.pressurize[U](in ⇒ extrapolate(in).asScala.toStream))
+
+  /**
+   * Allows a faster downstream to progress of a slower upstream.
+   *
+   * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
+   * signals demand.
+   *
+   * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
+   * Exceptions from the `extrapolate` function will complete the stream with failure.
+   *
+   * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR
+   * `extrapolate` is non-empty and applicable
+   *
+   * '''Backpressures when''' downstream backpressures or current `extrapolate` runs empty
+   *
+   * '''Completes when''' upstream completes and current `extrapolate` runs empty
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @param extrapolate takes the current upstream element and provides a sequence of "extrapolated" elements based
+   *                    on the original, to be emitted in case downstream signals demand
+   * @param initial the initial element to be emitted, in case upstream is able to stall the entire stream
+   */
+  def pressurize[U >: Out](extrapolate: function.Function[U, java.util.Iterator[U]], initial: U): SubFlow[In, U, Mat] =
+    new SubFlow(delegate.pressurize[U](in ⇒ extrapolate(in).asScala.toStream, Some(initial)))
+
+  /**
    * Adds a fixed size buffer in the flow that allows to store elements from a faster upstream until it becomes full.
    * Depending on the defined [[akka.stream.OverflowStrategy]] it might drop elements or backpressure the upstream if
    * there is no space available

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -1127,7 +1127,9 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    * subscriber.
    *
    * Expand does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
-   * Exceptions from the `seed` function will complete the stream with failure.
+   * Exceptions from the `expander` function will complete the stream with failure.
+   *
+   * See also [[#extrapolate]] for a version that always preserves the original element and allows for an initial "startup" element.
    *
    * '''Emits when''' downstream stops backpressuring
    *
@@ -1154,6 +1156,8 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
+   * See also [[#expand]] for a version that can overwrite the original element.
+   *
    * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR
    * `extrapolate` is non-empty and applicable
    *
@@ -1165,7 +1169,7 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    *
    * @param extrapolator takes the current upstream element and provides a sequence of "extrapolated" elements based
    *                    on the original, to be emitted in case downstream signals demand.
-   * @see [[#expand]]    for a version that can overwrite the original element.
+   * @see [[#expand]]
    */
   def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]]): SubFlow[In, Out, Mat] =
     new SubFlow(delegate.extrapolate(in ⇒ extrapolator(in).asScala))
@@ -1179,6 +1183,8 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
+   * See also [[#expand]] for a version that can overwrite the original element.
+   *
    * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR
    * `extrapolate` is non-empty and applicable
    *
@@ -1191,7 +1197,7 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    * @param extrapolator takes the current upstream element and provides a sequence of "extrapolated" elements based
    *                    on the original, to be emitted in case downstream signals demand.
    * @param initial the initial element to be emitted, in case upstream is able to stall the entire stream.
-   * @see [[#expand]]    for a version that can overwrite the original element.
+   * @see [[#expand]]
    */
   def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]], initial: Out @uncheckedVariance): SubFlow[In, Out, Mat] =
     new SubFlow(delegate.extrapolate(in ⇒ extrapolator(in).asScala, Some(initial)))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -1167,8 +1167,8 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    *                    on the original, to be emitted in case downstream signals demand.
    * @see [[#expand]]    for a version that can overwrite the original element.
    */
-  def extrapolate[U >: Out](extrapolator: function.Function[U, java.util.Iterator[U]]): SubFlow[In, U, Mat] =
-    new SubFlow(delegate.extrapolate[U](in ⇒ extrapolator(in).asScala))
+  def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]]): SubFlow[In, Out, Mat] =
+    new SubFlow(delegate.extrapolate(in ⇒ extrapolator(in).asScala))
 
   /**
    * Allows a faster downstream to progress independent of a slower upstream.
@@ -1193,8 +1193,8 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    * @param initial the initial element to be emitted, in case upstream is able to stall the entire stream.
    * @see [[#expand]]    for a version that can overwrite the original element.
    */
-  def extrapolate[U >: Out](extrapolator: function.Function[U, java.util.Iterator[U]], initial: U): SubFlow[In, U, Mat] =
-    new SubFlow(delegate.extrapolate[U](in ⇒ extrapolator(in).asScala, Some(initial)))
+  def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]], initial: Out @uncheckedVariance): SubFlow[In, Out, Mat] =
+    new SubFlow(delegate.extrapolate(in ⇒ extrapolator(in).asScala, Some(initial)))
 
   /**
    * Adds a fixed size buffer in the flow that allows to store elements from a faster upstream until it becomes full.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -1112,7 +1112,9 @@ class SubSource[Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[O
    * subscriber.
    *
    * Expand does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
-   * Exceptions from the `seed` function will complete the stream with failure.
+   * Exceptions from the `expander` function will complete the stream with failure.
+   *
+   * See also [[#extrapolate]] for a version that always preserves the original element and allows for an initial "startup" element.
    *
    * '''Emits when''' downstream stops backpressuring
    *
@@ -1124,8 +1126,7 @@ class SubSource[Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[O
    *
    * @param expander       Takes the current extrapolation state to produce an output element and the next extrapolation
    *                       state.
-   * @see [[#extrapolate]] for a version that always preserves the original element and allows for an initial "startup"
-   *                       element.
+   * @see [[#extrapolate]]
    */
   def expand[U](expander: function.Function[Out, java.util.Iterator[U]]): SubSource[U, Mat] =
     new SubSource(delegate.expand(in ⇒ expander(in).asScala))
@@ -1139,6 +1140,8 @@ class SubSource[Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[O
    * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
+   * See also [[#expand]] for a version that can overwrite the original element.
+   *
    * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR
    * `extrapolate` is non-empty and applicable
    *
@@ -1150,7 +1153,7 @@ class SubSource[Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[O
    *
    * @param extrapolator takes the current upstream element and provides a sequence of "extrapolated" elements based
    *                    on the original, to be emitted in case downstream signals demand.
-   * @see [[#expand]]    for a version that can overwrite the original element.
+   * @see [[#expand]]
    */
   def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]]): SubSource[Out, Mat] =
     new SubSource(delegate.extrapolate(in ⇒ extrapolator(in).asScala))
@@ -1164,6 +1167,8 @@ class SubSource[Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[O
    * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
+   * See also [[#expand]] for a version that can overwrite the original element.
+   *
    * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR
    * `extrapolate` is non-empty and applicable
    *
@@ -1176,7 +1181,7 @@ class SubSource[Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[O
    * @param extrapolator takes the current upstream element and provides a sequence of "extrapolated" elements based
    *                    on the original, to be emitted in case downstream signals demand.
    * @param initial the initial element to be emitted, in case upstream is able to stall the entire stream.
-   * @see [[#expand]]    for a version that can overwrite the original element.
+   * @see [[#expand]]
    */
   def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]], initial: Out @uncheckedVariance): SubSource[Out, Mat] =
     new SubSource(delegate.extrapolate(in ⇒ extrapolator(in).asScala, Some(initial)))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -1152,8 +1152,8 @@ class SubSource[Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[O
    *                    on the original, to be emitted in case downstream signals demand.
    * @see [[#expand]]    for a version that can overwrite the original element.
    */
-  def extrapolate[U >: Out](extrapolator: function.Function[U, java.util.Iterator[U]]): SubSource[U, Mat] =
-    new SubSource(delegate.extrapolate[U](in ⇒ extrapolator(in).asScala))
+  def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]]): SubSource[Out, Mat] =
+    new SubSource(delegate.extrapolate(in ⇒ extrapolator(in).asScala))
 
   /**
    * Allows a faster downstream to progress independent of a slower upstream.
@@ -1178,8 +1178,8 @@ class SubSource[Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[O
    * @param initial the initial element to be emitted, in case upstream is able to stall the entire stream.
    * @see [[#expand]]    for a version that can overwrite the original element.
    */
-  def extrapolate[U >: Out](extrapolator: function.Function[U, java.util.Iterator[U]], initial: U): SubSource[U, Mat] =
-    new SubSource(delegate.extrapolate[U](in ⇒ extrapolator(in).asScala, Some(initial)))
+  def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]], initial: Out @uncheckedVariance): SubSource[Out, Mat] =
+    new SubSource(delegate.extrapolate(in ⇒ extrapolator(in).asScala, Some(initial)))
 
   /**
    * Adds a fixed size buffer in the flow that allows to store elements from a faster upstream until it becomes full.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -1103,7 +1103,7 @@ class SubSource[Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[O
     new SubSource(delegate.batchWeighted(max, costFn.apply, seed.apply)(aggregate.apply))
 
   /**
-   * Allows a faster downstream to progress independently of a slower publisher by extrapolating elements from an older
+   * Allows a faster downstream to progress independently of a slower upstream by extrapolating elements from an older
    * element until new element comes from the upstream. For example an expand step might repeat the last element for
    * the subscriber until it receives an update from upstream.
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -1137,7 +1137,7 @@ class SubSource[Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[O
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
    *
-   * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
+   * Extrapolate does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
    * See also [[#expand]] for a version that can overwrite the original element.
@@ -1164,7 +1164,7 @@ class SubSource[Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[O
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
    *
-   * Pressurize does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
+   * Extrapolate does not support [[akka.stream.Supervision#restart]] and [[akka.stream.Supervision#resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
    * See also [[#expand]] for a version that can overwrite the original element.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1632,7 +1632,7 @@ trait FlowOps[+Out, +Mat] {
     via(Batch(max, costFn, seed, aggregate).withAttributes(DefaultAttributes.batchWeighted))
 
   /**
-   * Allows a faster downstream to progress independently of a slower publisher by extrapolating elements from an older
+   * Allows a faster downstream to progress independently of a slower upstream by extrapolating elements from an older
    * element until new element comes from the upstream. For example an expand step might repeat the last element for
    * the subscriber until it receives an update from upstream.
    *
@@ -1651,7 +1651,6 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    *
-   * @param seed Provides the first state for extrapolation using the first unconsumed element
    * @param extrapolate Takes the current extrapolation state to produce an output element and the next extrapolation
    *                    state.
    */

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1664,7 +1664,7 @@ trait FlowOps[+Out, +Mat] {
    * This is achieved by introducing "extrapolated" elements - based on those from upstream - whenever downstream
    * signals demand.
    *
-   * Pressurize does not support [[akka.stream.Supervision.Restart]] and [[akka.stream.Supervision.Resume]].
+   * Extrapolate does not support [[akka.stream.Supervision.Restart]] and [[akka.stream.Supervision.Resume]].
    * Exceptions from the `extrapolate` function will complete the stream with failure.
    *
    * '''Emits when''' downstream stops backpressuring, AND EITHER upstream emits OR initial element is present OR


### PR DESCRIPTION
PR for #23804 . Adds a new stage `pressurize`, and clarifies documentation of `expand`.

--------------
Naming the stage:

This was probably the most difficult portion of the PR. Here are the notes on various possibilities I've come up with:

 - `replay`: as in http://reactivex.io/documentation/operators/replay.html
   - does not imply existence of original element
   - has quite different meaning in semantic contexts of other frameworks
 - `extrapolate`
   - good name
   - but but too phonetically close to `expand` to not be confusing
   - on top of that, `expand` already has an *argument* `extrapolate` (which as far as I understand can't be renamed without breaking binary compatibility, correct me if I'm wrong on this)
 - `project` 
   - not really intuitive
   - already has a different meaning in e.g. functional programming
 - `pressurize`
   - is a completely new term in the reactive context
   - however, very á propos the use case
 - `bounce`: as antonym from debounce e.g. https://monix.io/api/2.3/monix/reactive/observables/ObservableLike.html#debounce(timeout:scala.concurrent.duration.FiniteDuration):Self[A] , http://reactivex.io/documentation/operators/debounce.html
   - usage here does not make sense for anyone knowing the etymology
 - `echo`: analogous to https://monix.io/api/2.3/monix/reactive/observables/ObservableLike.html#echoRepeated(timeout:scala.concurrent.duration.FiniteDuration):Self[A]
    - similar problem as extrapolate (echo / expand)

-------------
Other notes:

0. The binary compatibility check failed, but as I understand in this case (adding new API elements), this is fine, correct?
1. Originally, I started with implementing `pressurize` as a completely new stage, but I remembered that some stages, e.g. `Sink.foreach`, are already written as "compositions" of multiple existing stages, so I went with that approach in the end.
2. I'm not sure if I handled the variance of the stage correctly. The intent was to limit the `extrapolate` function to the original element type, so as to prevent using it as a "poor man's map with bells and whistles".
3. I used `collection.Stream` as the return value of the `extrapolate` function, please let me know if this unorthodox.
4. The tests are mostly copied from `Expand` (since WET seems to be in effect here anyway), and adjusted accordingly.
5. I also applied the Scouts' Rule and cleaned up `expand` - removed the reference to the `seed` argument, and (subjectively) clarified in the tests what `expand` actually does, and replaced references to "publisher" with "upstream" for consistency's sake.
6. I'm not sure whether to include a reference to `pressurize` in the Cookbook. Should I, and, if so, where?

