### PR TITLE
Cancel GroupBy when all substreams cancel

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
@@ -250,6 +250,13 @@ import scala.collection.JavaConverters._
         true
       } else false
 
+    private def tryCancel(): Boolean =
+      // if there's no active substreams or there's only one but it's not been pushed yet
+      if (activeSubstreamsMap.isEmpty || (activeSubstreamsMap.size == substreamWaitingToBePushed.size)) {
+        completeStage()
+        true
+      } else false
+
     private def fail(ex: Throwable): Unit = {
       for (value ← activeSubstreamsMap.values().asScala) value.fail(ex)
       failStage(ex)
@@ -280,8 +287,9 @@ import scala.collection.JavaConverters._
 
     override def onUpstreamFailure(ex: Throwable): Unit = fail(ex)
 
-    override def onDownstreamFinish(): Unit =
-      if (activeSubstreamsMap.isEmpty) completeStage() else setKeepGoing(true)
+    override def onUpstreamFinish(): Unit = if (!tryCompleteAll()) setKeepGoing(true)
+
+    override def onDownstreamFinish(): Unit = if (!tryCancel()) setKeepGoing(true)
 
     override def onPush(): Unit = try {
       val elem = grab(in)
@@ -307,10 +315,6 @@ import scala.collection.JavaConverters._
           case Supervision.Stop                         ⇒ fail(ex)
           case Supervision.Resume | Supervision.Restart ⇒ if (!hasBeenPulled(in)) pull(in)
         }
-    }
-
-    override def onUpstreamFinish(): Unit = {
-      if (!tryCompleteAll()) setKeepGoing(true)
     }
 
     private def runSubstream(key: K, value: T): Unit = {
@@ -376,6 +380,7 @@ import scala.collection.JavaConverters._
         if (hasNextElement && nextElementKey == key) clearNextElement()
         if (firstPush()) firstPushCounter -= 1
         completeSubStream()
+        if (parent.isClosed(out)) tryCancel()
         if (parent.isClosed(in)) tryCompleteAll() else if (needToPull) pull(in)
       }
 


### PR DESCRIPTION
Fixes: https://github.com/akka/akka/issues/24370

Whenever a substream is cancelled, it attempts to cancel the GroupBy stage if its out port is closed. The last of the substreams cancelling will succesfully cancel the GroupBy stage.

Please, tell me if this approach is valid. If you're ok with it I'll add a test for it.