### PR TITLE
add missing returnRecoveryPermit

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -495,12 +495,14 @@ private[persistence] trait Eventsourced extends Snapshotter with PersistenceStas
       case LoadSnapshotFailed(cause) ⇒
         timeoutCancellable.cancel()
         try onRecoveryFailure(cause, event = None) finally context.stop(self)
+        returnRecoveryPermit()
 
       case RecoveryTick(true) ⇒
         try onRecoveryFailure(
           new RecoveryTimedOut(s"Recovery timed out, didn't get snapshot within $timeout"),
           event = None)
         finally context.stop(self)
+        returnRecoveryPermit()
 
       case other ⇒
         stashInternally(other)
@@ -565,12 +567,14 @@ private[persistence] trait Eventsourced extends Snapshotter with PersistenceStas
         case ReplayMessagesFailure(cause) ⇒
           timeoutCancellable.cancel()
           try onRecoveryFailure(cause, event = None) finally context.stop(self)
+          returnRecoveryPermit()
         case RecoveryTick(false) if !eventSeenInInterval ⇒
           timeoutCancellable.cancel()
           try onRecoveryFailure(
             new RecoveryTimedOut(s"Recovery timed out, didn't get event within $timeout, highest sequence number seen $lastSequenceNr"),
             event = None)
           finally context.stop(self)
+          returnRecoveryPermit()
         case RecoveryTick(false) ⇒
           eventSeenInInterval = false
         case RecoveryTick(true) ⇒


### PR DESCRIPTION
* missing for some error cases
* in the states recoveryStarted and recovering it has got the permit and
  it must returned if the actor is stopped due to some error in those
  states
* it would have been a lot easier to do such in postStop but we can't
  introduce new things in the trait Eventsourced due to BC