### PR TITLE
MultiDcSplitBain: only subscribe to unreachable after split

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
@@ -596,9 +596,6 @@ private[cluster] final class ClusterDomainEventPublisher extends Actor with Acto
   }
 
   def publishDiff(oldState: MembershipState, newState: MembershipState, pub: AnyRef ⇒ Unit): Unit = {
-    def inSameDc(reachabilityEvent: ReachabilityEvent): Boolean =
-      reachabilityEvent.member.dataCenter == selfDc
-
     diffMemberEvents(oldState, newState) foreach pub
     diffUnreachable(oldState, newState) foreach pub
     diffReachable(oldState, newState) foreach pub


### PR DESCRIPTION
Test would fail picking up the reachable from the previous unsplit
as it is a new probe.

Also change barrierCounter to split/unsplit so easier to see
where the failure is on a barrier fail

This is the main reason it fails, i've seen it fail for one other reason so let's not close the issue.

Refs #24175
