### PR TITLE
[wip] #24456

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/MessageAndSignals.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/MessageAndSignals.scala
@@ -34,6 +34,12 @@ final case class DeadLetter(msg: Any)
 trait Signal
 
 /**
+ * A message that needs to be created first before it can be handled. Is used
+ * by the infrastructure to allow injecting processing into the Behavior interpreter.
+ */
+final case class DeferredMessage(messageCons: () ⇒ Any) extends Signal
+
+/**
  * Lifecycle signal that is fired upon restart of the Actor before replacing
  * the behavior with the fresh one (i.e. this signal is received within the
  * behavior that failed). The replacement behavior will receive PreStart as its

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
@@ -38,7 +38,8 @@ import akka.util.OptionVal
     case a.ReceiveTimeout ⇒
       next(Behavior.interpretMessage(behavior, ctx, ctx.receiveTimeoutMsg), ctx.receiveTimeoutMsg)
     case wrapped: AskResponse[Any, T] @unchecked ⇒
-      handleMessage(wrapped.adapted)
+      handleSignal(DeferredMessage(() ⇒ wrapped.adapted))
+
     case wrapped: AdaptMessage[Any, T] @unchecked ⇒
       wrapped.adapted match {
         case AdaptWithRegisteredMessageAdapter(msg) ⇒
@@ -55,6 +56,9 @@ import akka.util.OptionVal
   private def handleMessage(msg: T): Unit = {
     next(Behavior.interpretMessage(behavior, ctx, msg), msg)
   }
+
+  private def handleSignal(msg: Signal): Unit =
+    next(Behavior.interpretSignal(behavior, ctx, msg), msg)
 
   private def next(b: Behavior[T], msg: Any): Unit = {
     if (Behavior.isUnhandled(b)) unhandled(msg)


### PR DESCRIPTION
The idea is to create a new signal `DeferredMessage` that behaviors need to handle by executing the thunk and pass the result into `receiveMessage`. That works but I guess it's easy to forget handling this signal.

Could it be viable to request this from every single implementor of `ExtensibleBehavior`?

Refs #24456