### PR TITLE
Add serializer for ServiceKey

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/ServiceKeySerializationSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/ServiceKeySerializationSpec.scala
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.actor.typed.receptionist
+
+import akka.actor.typed.TypedAkkaSpecWithShutdown
+import akka.actor.typed.internal.ActorRefSerializationSpec
+import akka.actor.typed.internal.receptionist.ServiceKeySerializer
+import akka.actor.typed.scaladsl.adapter._
+import akka.serialization.SerializationExtension
+import akka.testkit.typed.TestKit
+
+class ServiceKeySerializationSpec extends TestKit(ActorRefSerializationSpec.config) with TypedAkkaSpecWithShutdown {
+
+  val serialization = SerializationExtension(system.toUntyped)
+
+  "ServiceKey[T]" must {
+    "be serialized and deserialized by ServiceKeySerializer" in {
+      val obj = ServiceKey[Int]("testKey")
+      serialization.findSerializerFor(obj) match {
+        case serializer: ServiceKeySerializer ⇒
+          val blob = serializer.toBinary(obj)
+          val ref = serializer.fromBinary(blob, serializer.manifest(obj))
+          ref should be(obj)
+        case s ⇒
+          throw new IllegalStateException(s"Wrong serializer ${s.getClass} for ${obj.getClass}")
+      }
+    }
+  }
+}

--- a/akka-actor-typed/src/main/resources/reference.conf
+++ b/akka-actor-typed/src/main/resources/reference.conf
@@ -36,6 +36,6 @@ akka.actor {
   serialization-bindings {
     "akka.actor.typed.ActorRef" = typed-misc
     "akka.actor.typed.internal.adapter.ActorRefAdapter" = typed-misc
-    "akka.actor.typed.receptionist.ServiceKey" = service-key
+    "akka.actor.typed.internal.receptionist.ReceptionistImpl$DefaultServiceKey" = service-key
   }
 }

--- a/akka-actor-typed/src/main/resources/reference.conf
+++ b/akka-actor-typed/src/main/resources/reference.conf
@@ -25,14 +25,17 @@ akka.library-extensions += "akka.actor.typed.internal.adapter.ActorSystemAdapter
 akka.actor {
   serializers {
     typed-misc = "akka.actor.typed.internal.MiscMessageSerializer"
+    service-key = "akka.actor.typed.internal.receptionist.ServiceKeySerializer"
   }
 
   serialization-identifiers {
     "akka.actor.typed.internal.MiscMessageSerializer" = 24
+    "akka.actor.typed.internal.receptionist.ServiceKeySerializer" = 26
   }
 
   serialization-bindings {
     "akka.actor.typed.ActorRef" = typed-misc
     "akka.actor.typed.internal.adapter.ActorRefAdapter" = typed-misc
+    "akka.actor.typed.receptionist.ServiceKey" = service-key
   }
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/MiscMessageSerializer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/MiscMessageSerializer.scala
@@ -19,7 +19,7 @@ class MiscMessageSerializer(val system: akka.actor.ExtendedActorSystem) extends 
   private val ActorRefManifest = "a"
 
   def manifest(o: AnyRef): String = o match {
-    case ref: ActorRef[_] ⇒ ActorRefManifest
+    case _: ActorRef[_] ⇒ ActorRefManifest
     case _ ⇒
       throw new IllegalArgumentException(s"Can't serialize object of type ${o.getClass} in [${getClass.getName}]")
   }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ServiceKeySerializer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ServiceKeySerializer.scala
@@ -3,34 +3,29 @@
  */
 package akka.actor.typed.internal.receptionist
 
-import java.io.NotSerializableException
 import java.nio.charset.StandardCharsets
 
+import akka.actor.typed.internal.receptionist.ReceptionistImpl.DefaultServiceKey
 import akka.actor.typed.receptionist.ServiceKey
 import akka.annotation.InternalApi
 import akka.serialization.{ BaseSerializer, SerializerWithStringManifest }
 
 @InternalApi
 class ServiceKeySerializer(val system: akka.actor.ExtendedActorSystem) extends SerializerWithStringManifest with BaseSerializer {
-
-  private val ServiceKeyManifest = "a"
-
   def manifest(o: AnyRef): String = o match {
-    case _: ServiceKey[_] ⇒ ServiceKeyManifest
+    case key: DefaultServiceKey[_] ⇒ key.typeName
     case _ ⇒
       throw new IllegalArgumentException(s"Can't serialize object of type ${o.getClass} in [${getClass.getName}]")
   }
 
   def toBinary(o: AnyRef): Array[Byte] = o match {
-    case serviceKey: ServiceKey[_] ⇒ serviceKey.id.getBytes(StandardCharsets.UTF_8)
+    case serviceKey: DefaultServiceKey[_] ⇒ serviceKey.id.getBytes(StandardCharsets.UTF_8)
     case _ ⇒
       throw new IllegalArgumentException(s"Cannot serialize object of type [${o.getClass.getName}]")
   }
 
-  def fromBinary(bytes: Array[Byte], manifest: String): ServiceKey[Any] = manifest match {
-    case ServiceKeyManifest ⇒ ServiceKey[Any](new String(bytes, StandardCharsets.UTF_8))
-    case _ ⇒
-      throw new NotSerializableException(
-        s"Unimplemented deserialization of message with manifest [$manifest] in [${getClass.getName}]")
+  def fromBinary(bytes: Array[Byte], manifest: String): ServiceKey[Any] = {
+    println(s"manifest = $manifest")
+    DefaultServiceKey[Any](new String(bytes, StandardCharsets.UTF_8), manifest)
   }
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ServiceKeySerializer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ServiceKeySerializer.scala
@@ -24,8 +24,6 @@ class ServiceKeySerializer(val system: akka.actor.ExtendedActorSystem) extends S
       throw new IllegalArgumentException(s"Cannot serialize object of type [${o.getClass.getName}]")
   }
 
-  def fromBinary(bytes: Array[Byte], manifest: String): ServiceKey[Any] = {
-    println(s"manifest = $manifest")
+  def fromBinary(bytes: Array[Byte], manifest: String): ServiceKey[Any] =
     DefaultServiceKey[Any](new String(bytes, StandardCharsets.UTF_8), manifest)
-  }
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ServiceKeySerializer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ServiceKeySerializer.scala
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.actor.typed.internal.receptionist
+
+import java.io.NotSerializableException
+import java.nio.charset.StandardCharsets
+
+import akka.actor.typed.receptionist.ServiceKey
+import akka.annotation.InternalApi
+import akka.serialization.{ BaseSerializer, SerializerWithStringManifest }
+
+@InternalApi
+class ServiceKeySerializer(val system: akka.actor.ExtendedActorSystem) extends SerializerWithStringManifest with BaseSerializer {
+
+  private val ServiceKeyManifest = "a"
+
+  def manifest(o: AnyRef): String = o match {
+    case _: ServiceKey[_] ⇒ ServiceKeyManifest
+    case _ ⇒
+      throw new IllegalArgumentException(s"Can't serialize object of type ${o.getClass} in [${getClass.getName}]")
+  }
+
+  def toBinary(o: AnyRef): Array[Byte] = o match {
+    case serviceKey: ServiceKey[_] ⇒ serviceKey.id.getBytes(StandardCharsets.UTF_8)
+    case _ ⇒
+      throw new IllegalArgumentException(s"Cannot serialize object of type [${o.getClass.getName}]")
+  }
+
+  def fromBinary(bytes: Array[Byte], manifest: String): ServiceKey[Any] = manifest match {
+    case ServiceKeyManifest ⇒ ServiceKey[Any](new String(bytes, StandardCharsets.UTF_8))
+    case _ ⇒
+      throw new NotSerializableException(
+        s"Unimplemented deserialization of message with manifest [$manifest] in [${getClass.getName}]")
+  }
+}


### PR DESCRIPTION
Closes #23687

This is **still work in progress**, but I would like advice from the Akka team.

Modeled after [MiscMessageSerializer](https://github.com/akka/akka/blob/e33db45139b325e2a573ed51cbaf149f5fc23adc/akka-actor-typed/src/main/scala/akka/actor/typed/internal/MiscMessageSerializer.scala) and [ActorRefSerializationSpec](https://github.com/akka/akka/blob/e33db45139b325e2a573ed51cbaf149f5fc23adc/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorRefSerializationSpec.scala).

## Issue

How to restore the type `T` of `ServiceKey[T]` in `fromBinary`? 

Currently `ServiceKeySerializationSpec` I added is failing, as I couldn't figure out how to supply `T` there, and used `ServiceKey[Any]` as a place holder.

```scala
def fromBinary(...): ServiceKey[Any] = ...
  ServiceKeyManifest ⇒ ServiceKey[Any](new String(bytes, StandardCharsets.UTF_8))
```

`[FAILED] ServiceKey[java.lang.Object](testKey) was not equal to ServiceKey[int](testKey) (ServiceKeySerializationSpec.scala:24)`

## Comparison with `ActorRef[T]`

[MiscMessageSerializer](https://github.com/akka/akka/blob/e33db45139b325e2a573ed51cbaf149f5fc23adc/akka-actor-typed/src/main/scala/akka/actor/typed/internal/MiscMessageSerializer.scala#L34) which I modeled after has this:

```scala
def fromBinary(bytes: Array[Byte], manifest: String): ActorRef[Any] = manifest match {
  case ActorRefManifest ⇒ resolver.resolveActorRef(new String(bytes, StandardCharsets.UTF_8))
```

where `resolveActorRef` in [ActorRefResolver](https://github.com/akka/akka/blob/e33db45139b325e2a573ed51cbaf149f5fc23adc/akka-actor-typed/src/main/scala/akka/actor/typed/ActorRefResolver.scala#L37) is:

```scala
def resolveActorRef[T](serializedActorRef: String): ActorRef[T] =
  untypedSystem.provider.resolveActorRef(serializedActorRef)
```

The untyped `ActorRef` returned by `untypedSystem.provider.resolveActorRef` should be converted to typed `ActorRef[T]`, by this implicit conversion:

https://github.com/akka/akka/blob/e33db45139b325e2a573ed51cbaf149f5fc23adc/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/adapter/package.scala#L105

Here, this is what I couldn't really get... the `apply` of `ActorRefAdapter` returns `ActorRef[T]` but the code doesn't supply what `T` should be ? but it still compiles.

https://github.com/akka/akka/blob/e33db45139b325e2a573ed51cbaf149f5fc23adc/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala#L34
