### PR TITLE
Make typed test probe names consistent

### DIFF
--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/ManualTimerTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/ManualTimerTest.java
@@ -44,7 +44,7 @@ public class ManualTimerTest extends TestKit {
     scheduler.expectNoMessageFor(Duration.create(9, TimeUnit.MILLISECONDS), probe);
 
     scheduler.timePasses(Duration.create(2, TimeUnit.MILLISECONDS));
-    probe.expectMsgType(Tock.class);
+    probe.expectMessageType(Tock.class);
 
     scheduler.expectNoMessageFor(Duration.create(10, TimeUnit.SECONDS), probe);
   }

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorContextAskTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorContextAskTest.java
@@ -62,7 +62,7 @@ public class ActorContextAskTest extends JUnitSuite {
 
     Adapter.spawnAnonymous(system, snitch);
 
-    probe.expectMsgType(Pong.class);
+    probe.expectMessageType(Pong.class);
   }
 
 

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java
@@ -308,7 +308,7 @@ public class InteractionPatternsTest extends JUnitSuite {
     bufferer.tell(msgOne);
     bufferer.tell(msgTwo);
     probe.expectNoMessage(new FiniteDuration(1, TimeUnit.MILLISECONDS));
-    probe.expectMsg(new FiniteDuration(2, TimeUnit.SECONDS),
+    probe.expectMessage(new FiniteDuration(2, TimeUnit.SECONDS),
       new Batch(Arrays.asList(msgOne, msgTwo)));
 
     Await.ready(system.terminate(), Duration.create(3, TimeUnit.SECONDS));

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/testing/async/BasicAsyncTestingTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/testing/async/BasicAsyncTestingTest.java
@@ -52,7 +52,7 @@ public class BasicAsyncTestingTest extends TestKit {
     TestProbe<Pong> probe = new TestProbe<>(system());
     ActorRef<Ping> pinger = spawn(echoActor, "ping");
     pinger.tell(new Ping("hello", probe.ref()));
-    probe.expectMsg(new Pong("hello"));
+    probe.expectMessage(new Pong("hello"));
     //#test-spawn
   }
 
@@ -62,7 +62,7 @@ public class BasicAsyncTestingTest extends TestKit {
     TestProbe<Pong> probe = new TestProbe<>(system());
     ActorRef<Ping> pinger = spawn(echoActor);
     pinger.tell(new Ping("hello", probe.ref()));
-    probe.expectMsg(new Pong("hello"));
+    probe.expectMessage(new Pong("hello"));
     //#test-spawn-anonymous
   }
 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
@@ -41,7 +41,7 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
       probe.expectNoMessage() // not yet
       spawn(behv)
       // it's supposed to be created immediately (not waiting for first message)
-      probe.expectMsg(Started)
+      probe.expectMessage(Started)
     }
 
     "must stop when exception from factory" in {
@@ -59,8 +59,8 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
         }
       }
       spawn(behv)
-      probe.expectMsg(Started)
-      probe.expectMsg(Pong)
+      probe.expectMessage(Started)
+      probe.expectMessage(Pong)
     }
 
     "must stop when deferred result it Stopped" in {
@@ -75,7 +75,7 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
         }
       }
       spawn(behv)
-      probe.expectMsg(Pong)
+      probe.expectMessage(Pong)
     }
 
     "must create underlying when nested" in {
@@ -87,7 +87,7 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
         }
       }
       spawn(behv)
-      probe.expectMsg(Started)
+      probe.expectMessage(Started)
     }
 
     "must un-defer underlying when wrapped by widen" in {
@@ -101,9 +101,9 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
       probe.expectNoMessage() // not yet
       val ref = spawn(behv)
       // it's supposed to be created immediately (not waiting for first message)
-      probe.expectMsg(Started)
+      probe.expectMessage(Started)
       ref ! Ping
-      probe.expectMsg(Pong)
+      probe.expectMessage(Pong)
     }
 
     "must un-defer underlying when wrapped by monitor" in {
@@ -117,10 +117,10 @@ class DeferredSpec extends TestKit with TypedAkkaSpec {
       probe.expectNoMessage() // not yet
       val ref = spawn(behv)
       // it's supposed to be created immediately (not waiting for first message)
-      probe.expectMsg(Started)
+      probe.expectMessage(Started)
       ref ! Ping
-      monitorProbe.expectMsg(Ping)
-      probe.expectMsg(Pong)
+      monitorProbe.expectMessage(Ping)
+      probe.expectMessage(Pong)
     }
   }
 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ManualTimerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ManualTimerSpec.scala
@@ -31,7 +31,7 @@ class ManualTimerSpec extends TestKit(ManualTime.config) with ManualTime with Wo
       scheduler.expectNoMessageFor(9.millis, probe)
 
       scheduler.timePasses(2.millis)
-      probe.expectMsg(Tock)
+      probe.expectMessage(Tock)
 
       scheduler.expectNoMessageFor(10.seconds, probe)
     }
@@ -56,7 +56,7 @@ class ManualTimerSpec extends TestKit(ManualTime.config) with ManualTime with Wo
         scheduler.expectNoMessageFor(9.millis, probe)
 
         scheduler.timePasses(1.milli)
-        probe.expectMsg(Tock)
+        probe.expectMessage(Tock)
       }
     }
 
@@ -88,14 +88,14 @@ class ManualTimerSpec extends TestKit(ManualTime.config) with ManualTime with Wo
       val ref = spawn(behavior)
 
       scheduler.timePasses(11.millis)
-      probe.expectMsg(Tock(1))
+      probe.expectMessage(Tock(1))
 
       // next Tock(1) enqueued in mailboxed, but should be discarded because of new timer
       ref ! SlowThenBump(2)
       scheduler.expectNoMessageFor(interval, probe)
 
       scheduler.timePasses(interval)
-      probe.expectMsg(Tock(2))
+      probe.expectMessage(Tock(2))
     }
 
     //#manual-scheduling-simple

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -251,7 +251,7 @@ class SupervisionSpec extends TestKit with TypedAkkaSpecWithShutdown {
         .onFailure[Throwable](SupervisorStrategy.restart)
       val ref = spawn(behv)
       ref ! Ping
-      probe.expectMsg(Pong)
+      probe.expectMessage(Pong)
     }
 
     "stop when strategy is stop" in {
@@ -260,7 +260,7 @@ class SupervisionSpec extends TestKit with TypedAkkaSpecWithShutdown {
         .onFailure[Throwable](SupervisorStrategy.stop)
       val ref = spawn(behv)
       ref ! Throw(new Exc3)
-      probe.expectMsg(GotSignal(PostStop))
+      probe.expectMessage(GotSignal(PostStop))
     }
 
     "support nesting exceptions with different strategies" in {
@@ -274,10 +274,10 @@ class SupervisionSpec extends TestKit with TypedAkkaSpecWithShutdown {
       val ref = spawn(behv)
 
       ref ! Throw(new IOException())
-      probe.expectMsg(GotSignal(PreRestart))
+      probe.expectMessage(GotSignal(PreRestart))
 
       ref ! Throw(new IllegalArgumentException("cat"))
-      probe.expectMsg(GotSignal(PostStop))
+      probe.expectMessage(GotSignal(PostStop))
     }
 
     "stop when not supervised" in {
@@ -285,7 +285,7 @@ class SupervisionSpec extends TestKit with TypedAkkaSpecWithShutdown {
       val behv = targetBehavior(probe.ref)
       val ref = spawn(behv)
       ref ! Throw(new Exc3)
-      probe.expectMsg(GotSignal(PostStop))
+      probe.expectMessage(GotSignal(PostStop))
     }
 
     "stop when unhandled exception" in {
@@ -294,7 +294,7 @@ class SupervisionSpec extends TestKit with TypedAkkaSpecWithShutdown {
         .onFailure[Exc1](SupervisorStrategy.restart)
       val ref = spawn(behv)
       ref ! Throw(new Exc3)
-      probe.expectMsg(GotSignal(PostStop))
+      probe.expectMessage(GotSignal(PostStop))
     }
 
     "restart when handled exception" in {
@@ -304,12 +304,12 @@ class SupervisionSpec extends TestKit with TypedAkkaSpecWithShutdown {
       val ref = spawn(behv)
       ref ! IncrementState
       ref ! GetState
-      probe.expectMsg(State(1, Map.empty))
+      probe.expectMessage(State(1, Map.empty))
 
       ref ! Throw(new Exc2)
-      probe.expectMsg(GotSignal(PreRestart))
+      probe.expectMessage(GotSignal(PreRestart))
       ref ! GetState
-      probe.expectMsg(State(0, Map.empty))
+      probe.expectMessage(State(0, Map.empty))
     }
 
     "NOT stop children when restarting" in {
@@ -322,14 +322,14 @@ class SupervisionSpec extends TestKit with TypedAkkaSpecWithShutdown {
       val childName = nextName()
       ref ! CreateChild(targetBehavior(childProbe.ref), childName)
       ref ! GetState
-      parentProbe.expectMsgType[State].children.keySet should contain(childName)
+      parentProbe.expectMessageType[State].children.keySet should contain(childName)
 
       ref ! Throw(new Exc1)
-      parentProbe.expectMsg(GotSignal(PreRestart))
+      parentProbe.expectMessage(GotSignal(PreRestart))
       ref ! GetState
       // TODO document this difference compared to classic actors, and that
       //      children can be stopped if needed in PreRestart
-      parentProbe.expectMsgType[State].children.keySet should contain(childName)
+      parentProbe.expectMessageType[State].children.keySet should contain(childName)
       childProbe.expectNoMessage()
     }
 
@@ -339,11 +339,11 @@ class SupervisionSpec extends TestKit with TypedAkkaSpecWithShutdown {
       val ref = spawn(behv)
       ref ! IncrementState
       ref ! GetState
-      probe.expectMsg(State(1, Map.empty))
+      probe.expectMessage(State(1, Map.empty))
 
       ref ! Throw(new Exc2)
       ref ! GetState
-      probe.expectMsg(State(1, Map.empty))
+      probe.expectMessage(State(1, Map.empty))
     }
 
     "support nesting to handle different exceptions" in {
@@ -355,23 +355,23 @@ class SupervisionSpec extends TestKit with TypedAkkaSpecWithShutdown {
       val ref = spawn(behv)
       ref ! IncrementState
       ref ! GetState
-      probe.expectMsg(State(1, Map.empty))
+      probe.expectMessage(State(1, Map.empty))
 
       // resume
       ref ! Throw(new Exc2)
       probe.expectNoMessage()
       ref ! GetState
-      probe.expectMsg(State(1, Map.empty))
+      probe.expectMessage(State(1, Map.empty))
 
       // restart
       ref ! Throw(new Exc3)
-      probe.expectMsg(GotSignal(PreRestart))
+      probe.expectMessage(GotSignal(PreRestart))
       ref ! GetState
-      probe.expectMsg(State(0, Map.empty))
+      probe.expectMessage(State(0, Map.empty))
 
       // stop
       ref ! Throw(new Exc1)
-      probe.expectMsg(GotSignal(PostStop))
+      probe.expectMessage(GotSignal(PostStop))
     }
 
     "restart after exponential backoff" in {
@@ -387,29 +387,29 @@ class SupervisionSpec extends TestKit with TypedAkkaSpecWithShutdown {
       }).onFailure[Exception](strategy)
       val ref = spawn(behv)
 
-      startedProbe.expectMsg(Started)
+      startedProbe.expectMessage(Started)
       ref ! IncrementState
       ref ! Throw(new Exc1)
-      probe.expectMsg(GotSignal(PreRestart))
+      probe.expectMessage(GotSignal(PreRestart))
       ref ! Ping // dropped due to backoff
 
       startedProbe.expectNoMessage(minBackoff - 100.millis)
       probe.expectNoMessage(minBackoff + 100.millis)
-      startedProbe.expectMsg(Started)
+      startedProbe.expectMessage(Started)
       ref ! GetState
-      probe.expectMsg(State(0, Map.empty))
+      probe.expectMessage(State(0, Map.empty))
 
       // one more time
       ref ! IncrementState
       ref ! Throw(new Exc1)
-      probe.expectMsg(GotSignal(PreRestart))
+      probe.expectMessage(GotSignal(PreRestart))
       ref ! Ping // dropped due to backoff
 
       startedProbe.expectNoMessage((minBackoff * 2) - 100.millis)
       probe.expectNoMessage((minBackoff * 2) + 100.millis)
-      startedProbe.expectMsg(Started)
+      startedProbe.expectMessage(Started)
       ref ! GetState
-      probe.expectMsg(State(0, Map.empty))
+      probe.expectMessage(State(0, Map.empty))
     }
 
     "reset exponential backoff count after reset timeout" in {
@@ -422,24 +422,24 @@ class SupervisionSpec extends TestKit with TypedAkkaSpecWithShutdown {
 
       ref ! IncrementState
       ref ! Throw(new Exc1)
-      probe.expectMsg(GotSignal(PreRestart))
+      probe.expectMessage(GotSignal(PreRestart))
       ref ! Ping // dropped due to backoff
 
       probe.expectNoMessage(minBackoff + 100.millis.dilated)
       ref ! GetState
-      probe.expectMsg(State(0, Map.empty))
+      probe.expectMessage(State(0, Map.empty))
 
       // one more time after the reset timeout
       probe.expectNoMessage(strategy.resetBackoffAfter + 100.millis.dilated)
       ref ! IncrementState
       ref ! Throw(new Exc1)
-      probe.expectMsg(GotSignal(PreRestart))
+      probe.expectMessage(GotSignal(PreRestart))
       ref ! Ping // dropped due to backoff
 
       // backoff was reset, so restarted after the minBackoff
       probe.expectNoMessage(minBackoff + 100.millis.dilated)
       ref ! GetState
-      probe.expectMsg(State(0, Map.empty))
+      probe.expectMessage(State(0, Map.empty))
     }
 
     "create underlying deferred behavior immediately" in {
@@ -451,7 +451,7 @@ class SupervisionSpec extends TestKit with TypedAkkaSpecWithShutdown {
       probe.expectNoMessage() // not yet
       spawn(behv)
       // it's supposed to be created immediately (not waiting for first message)
-      probe.expectMsg(Started)
+      probe.expectMessage(Started)
     }
 
     "stop when exception from MutableBehavior constructor" in {
@@ -459,7 +459,7 @@ class SupervisionSpec extends TestKit with TypedAkkaSpecWithShutdown {
       val behv = supervise(mutable[Command](_ ⇒ new FailingConstructor(probe.ref)))
         .onFailure[Exception](SupervisorStrategy.restart)
       val ref = spawn(behv)
-      probe.expectMsg(Started)
+      probe.expectMessage(Started)
       ref ! Ping
       probe.expectNoMessage()
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
@@ -86,11 +86,11 @@ class TimerSpec extends TestKit("TimerSpec")
       }
 
       val ref = spawn(behv)
-      probe.expectMsg(Tock(1))
+      probe.expectMessage(Tock(1))
       probe.expectNoMessage()
 
       ref ! End
-      probe.expectMsg(GotPostStop(false))
+      probe.expectMessage(GotPostStop(false))
     }
 
     "schedule repeated ticks" in {
@@ -102,13 +102,13 @@ class TimerSpec extends TestKit("TimerSpec")
 
       val ref = spawn(behv)
       probe.within((interval * 4) - 100.millis) {
-        probe.expectMsg(Tock(1))
-        probe.expectMsg(Tock(1))
-        probe.expectMsg(Tock(1))
+        probe.expectMessage(Tock(1))
+        probe.expectMessage(Tock(1))
+        probe.expectMessage(Tock(1))
       }
 
       ref ! End
-      probe.expectMsg(GotPostStop(false))
+      probe.expectMessage(GotPostStop(false))
     }
 
     "replace timer" in {
@@ -119,16 +119,16 @@ class TimerSpec extends TestKit("TimerSpec")
       }
 
       val ref = spawn(behv)
-      probe.expectMsg(Tock(1))
+      probe.expectMessage(Tock(1))
       val latch = new CountDownLatch(1)
       // next Tock(1) enqueued in mailboxed, but should be discarded because of new timer
       ref ! SlowThenBump(latch)
       probe.expectNoMessage(interval + 100.millis.dilated)
       latch.countDown()
-      probe.expectMsg(Tock(2))
+      probe.expectMessage(Tock(2))
 
       ref ! End
-      probe.expectMsg(GotPostStop(false))
+      probe.expectMessage(GotPostStop(false))
     }
 
     "cancel timer" in {
@@ -139,12 +139,12 @@ class TimerSpec extends TestKit("TimerSpec")
       }
 
       val ref = spawn(behv)
-      probe.expectMsg(Tock(1))
+      probe.expectMessage(Tock(1))
       ref ! Cancel
       probe.expectNoMessage(interval + 100.millis.dilated)
 
       ref ! End
-      probe.expectMsg(GotPostStop(false))
+      probe.expectMessage(GotPostStop(false))
     }
 
     "discard timers from old incarnation after restart, alt 1" in {
@@ -156,19 +156,19 @@ class TimerSpec extends TestKit("TimerSpec")
       }).onFailure[Exception](SupervisorStrategy.restart)
 
       val ref = spawn(behv)
-      probe.expectMsg(Tock(1))
+      probe.expectMessage(Tock(1))
 
       val latch = new CountDownLatch(1)
       // next Tock(1) is enqueued in mailbox, but should be discarded by new incarnation
       ref ! SlowThenThrow(latch, new Exc)
       probe.expectNoMessage(interval + 100.millis.dilated)
       latch.countDown()
-      probe.expectMsg(GotPreRestart(false))
+      probe.expectMessage(GotPreRestart(false))
       probe.expectNoMessage(interval / 2)
-      probe.expectMsg(Tock(2))
+      probe.expectMessage(Tock(2))
 
       ref ! End
-      probe.expectMsg(GotPostStop(false))
+      probe.expectMessage(GotPostStop(false))
     }
 
     "discard timers from old incarnation after restart, alt 2" in {
@@ -179,22 +179,22 @@ class TimerSpec extends TestKit("TimerSpec")
       }).onFailure[Exception](SupervisorStrategy.restart)
 
       val ref = spawn(behv)
-      probe.expectMsg(Tock(1))
+      probe.expectMessage(Tock(1))
       // change state so that we see that the restart starts over again
       ref ! Bump
 
-      probe.expectMsg(Tock(2))
+      probe.expectMessage(Tock(2))
 
       val latch = new CountDownLatch(1)
       // next Tock(2) is enqueued in mailbox, but should be discarded by new incarnation
       ref ! SlowThenThrow(latch, new Exc)
       probe.expectNoMessage(interval + 100.millis.dilated)
       latch.countDown()
-      probe.expectMsg(GotPreRestart(false))
-      probe.expectMsg(Tock(1))
+      probe.expectMessage(GotPreRestart(false))
+      probe.expectMessage(Tock(1))
 
       ref ! End
-      probe.expectMsg(GotPostStop(false))
+      probe.expectMessage(GotPostStop(false))
     }
 
     "cancel timers when stopped from exception" in {
@@ -205,7 +205,7 @@ class TimerSpec extends TestKit("TimerSpec")
       }
       val ref = spawn(behv)
       ref ! Throw(new Exc)
-      probe.expectMsg(GotPostStop(false))
+      probe.expectMessage(GotPostStop(false))
     }
 
     "cancel timers when stopped voluntarily" in {
@@ -216,7 +216,7 @@ class TimerSpec extends TestKit("TimerSpec")
       }
       val ref = spawn(behv)
       ref ! End
-      probe.expectMsg(GotPostStop(false))
+      probe.expectMessage(GotPostStop(false))
     }
   }
 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
@@ -60,17 +60,17 @@ class WatchSpec extends TestKit("WordSpec", WatchSpec.config)
     }
     "get notified of actor termination" in new WatchSetup {
       watcher ! StartWatching(terminator)
-      watchProbe.expectMsg(Done)
+      watchProbe.expectMessage(Done)
       terminator ! Stop
 
       receivedTerminationSignal.future.futureValue shouldEqual terminator
     }
     "allow idempotent invocations of watch" in new WatchSetup {
       watcher ! StartWatching(terminator)
-      watchProbe.expectMsg(Done)
+      watchProbe.expectMessage(Done)
       // shouldn't fail when watched twice
       watcher ! StartWatching(terminator)
-      watchProbe.expectMsg(Done)
+      watchProbe.expectMessage(Done)
       terminator ! Stop
 
       receivedTerminationSignal.future.futureValue shouldEqual terminator
@@ -96,17 +96,17 @@ class WatchSpec extends TestKit("WordSpec", WatchSpec.config)
     }
     "get notified of actor termination with a custom message" in new WatchWithSetup {
       watcher ! StartWatchingWith(terminator, CustomTerminationMessage)
-      watchProbe.expectMsg(Done)
+      watchProbe.expectMessage(Done)
       terminator ! Stop
 
       receivedTerminationSignal.future.futureValue shouldEqual CustomTerminationMessage
     }
     "allow idempotent invocations of watchWith with matching msgs" in new WatchWithSetup {
       watcher ! StartWatchingWith(terminator, CustomTerminationMessage)
-      watchProbe.expectMsg(Done)
+      watchProbe.expectMessage(Done)
       // shouldn't fail when watchWith'd twice
       watcher ! StartWatchingWith(terminator, CustomTerminationMessage)
-      watchProbe.expectMsg(Done)
+      watchProbe.expectMessage(Done)
       terminator ! Stop
 
       receivedTerminationSignal.future.futureValue shouldEqual CustomTerminationMessage
@@ -136,7 +136,7 @@ class WatchSpec extends TestKit("WordSpec", WatchSpec.config)
 
       watcher ! StartWatching(terminator)
       watcher ! StartWatchingWith(terminator, CustomTerminationMessage)
-      watchProbe.expectMsg(Done)
+      watchProbe.expectMessage(Done)
       terminator ! Stop
 
       receivedTerminationSignal.future.futureValue shouldEqual CustomTerminationMessage
@@ -163,7 +163,7 @@ class WatchSpec extends TestKit("WordSpec", WatchSpec.config)
 
       watcher ! StartWatchingWith(terminator, CustomTerminationMessage)
       watcher ! StartWatchingWith(terminator, CustomTerminationMessage2)
-      watchProbe.expectMsg(Done)
+      watchProbe.expectMessage(Done)
       terminator ! Stop
 
       receivedTerminationSignal.future.futureValue shouldEqual CustomTerminationMessage2

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/LocalReceptionistSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/LocalReceptionistSpec.scala
@@ -95,30 +95,30 @@ class LocalReceptionistSpec extends TestKit with TypedAkkaSpecWithShutdown with 
 
         val serviceA = spawn(stoppableBehavior.narrow[ServiceA])
         receptionist ! Register(ServiceKeyA, serviceA, regProbe.ref)
-        regProbe.expectMsg(Registered(ServiceKeyA, serviceA))
+        regProbe.expectMessage(Registered(ServiceKeyA, serviceA))
 
         val serviceB = spawn(stoppableBehavior.narrow[ServiceB])
         receptionist ! Register(ServiceKeyB, serviceB, regProbe.ref)
-        regProbe.expectMsg(Registered(ServiceKeyB, serviceB))
+        regProbe.expectMessage(Registered(ServiceKeyB, serviceB))
 
         val serviceC = spawn(stoppableBehavior)
         receptionist ! Register(ServiceKeyA, serviceC, regProbe.ref)
         receptionist ! Register(ServiceKeyB, serviceC, regProbe.ref)
-        regProbe.expectMsg(Registered(ServiceKeyA, serviceC))
-        regProbe.expectMsg(Registered(ServiceKeyB, serviceC))
+        regProbe.expectMessage(Registered(ServiceKeyA, serviceC))
+        regProbe.expectMessage(Registered(ServiceKeyB, serviceC))
 
         receptionist ! Find(ServiceKeyA, regProbe.ref)
-        regProbe.expectMsg(Listing(ServiceKeyA, Set(serviceA, serviceC)))
+        regProbe.expectMessage(Listing(ServiceKeyA, Set(serviceA, serviceC)))
         receptionist ! Find(ServiceKeyB, regProbe.ref)
-        regProbe.expectMsg(Listing(ServiceKeyB, Set(serviceB, serviceC)))
+        regProbe.expectMessage(Listing(ServiceKeyB, Set(serviceB, serviceC)))
 
         serviceC ! Stop
 
         eventually {
           receptionist ! Find(ServiceKeyA, regProbe.ref)
-          regProbe.expectMsg(Listing(ServiceKeyA, Set(serviceA)))
+          regProbe.expectMessage(Listing(ServiceKeyA, Set(serviceA)))
           receptionist ! Find(ServiceKeyB, regProbe.ref)
-          regProbe.expectMsg(Listing(ServiceKeyB, Set(serviceB)))
+          regProbe.expectMessage(Listing(ServiceKeyB, Set(serviceB)))
         }
       }
     }
@@ -130,24 +130,24 @@ class LocalReceptionistSpec extends TestKit with TypedAkkaSpecWithShutdown with 
         val aSubscriber = TestProbe[Listing[ServiceA]]("aUser")
         receptionist ! Subscribe(ServiceKeyA, aSubscriber.ref)
 
-        aSubscriber.expectMsg(Listing(ServiceKeyA, Set.empty[ActorRef[ServiceA]]))
+        aSubscriber.expectMessage(Listing(ServiceKeyA, Set.empty[ActorRef[ServiceA]]))
 
         val serviceA: ActorRef[ServiceA] = spawn(stoppableBehavior)
         receptionist ! Register(ServiceKeyA, serviceA, regProbe.ref)
-        regProbe.expectMsg(Registered(ServiceKeyA, serviceA))
+        regProbe.expectMessage(Registered(ServiceKeyA, serviceA))
 
-        aSubscriber.expectMsg(Listing(ServiceKeyA, Set(serviceA)))
+        aSubscriber.expectMessage(Listing(ServiceKeyA, Set(serviceA)))
 
         val serviceA2: ActorRef[ServiceA] = spawn(stoppableBehavior)
         receptionist ! Register(ServiceKeyA, serviceA2, regProbe.ref)
-        regProbe.expectMsg(Registered(ServiceKeyA, serviceA2))
+        regProbe.expectMessage(Registered(ServiceKeyA, serviceA2))
 
-        aSubscriber.expectMsg(Listing(ServiceKeyA, Set(serviceA, serviceA2)))
+        aSubscriber.expectMessage(Listing(ServiceKeyA, Set(serviceA, serviceA2)))
 
         serviceA ! Stop
-        aSubscriber.expectMsg(Listing(ServiceKeyA, Set(serviceA2)))
+        aSubscriber.expectMessage(Listing(ServiceKeyA, Set(serviceA2)))
         serviceA2 ! Stop
-        aSubscriber.expectMsg(Listing(ServiceKeyA, Set.empty[ActorRef[ServiceA]]))
+        aSubscriber.expectMessage(Listing(ServiceKeyA, Set.empty[ActorRef[ServiceA]]))
       }
     }
 
@@ -161,7 +161,7 @@ class LocalReceptionistSpec extends TestKit with TypedAkkaSpecWithShutdown with 
     "be present in the system" in {
       val probe = TestProbe[Receptionist.Listing[_]]()
       system.receptionist ! Find(ServiceKeyA)(probe.ref)
-      val listing: Listing[_] = probe.expectMsgType[Listing[_]]
+      val listing: Listing[_] = probe.expectMessageType[Listing[_]]
       listing.serviceInstances should be(Set())
     }
   }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
@@ -65,7 +65,7 @@ class ActorContextAskSpec extends TestKit(ActorContextAskSpec.config) with Typed
 
       spawn(snitch, "snitch", Props.empty.withDispatcherFromConfig("snitch-dispatcher"))
 
-      val pong = probe.expectMsgType[Pong]
+      val pong = probe.expectMessageType[Pong]
 
       pong.selfName should ===("snitch1")
       pong.threadName should startWith("ActorContextAskSpec-snitch-dispatcher")
@@ -109,7 +109,7 @@ class ActorContextAskSpec extends TestKit(ActorContextAskSpec.config) with Typed
       }
 
       // the exception should cause a failure which should stop the actor
-      probe.expectMsg("stopped")
+      probe.expectMessage("stopped")
     }
 
     "deal with timeouts in ask" in {
@@ -134,7 +134,7 @@ class ActorContextAskSpec extends TestKit(ActorContextAskSpec.config) with Typed
         }
       }
 
-      probe.expectMsgType[TimeoutException]
+      probe.expectMessageType[TimeoutException]
 
     }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/GracefulStopSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/GracefulStopSpec.scala
@@ -41,9 +41,9 @@ final class GracefulStopSpec extends TestKit with TypedAkkaSpecWithShutdown {
         }
 
       spawn(behavior)
-      probe.expectMsg("child-done")
-      probe.expectMsg("child-done")
-      probe.expectMsg("parent-done")
+      probe.expectMessage("child-done")
+      probe.expectMessage("child-done")
+      probe.expectMessage("parent-done")
     }
 
     "properly perform the cleanup and stop itself for no children case" in {
@@ -63,7 +63,7 @@ final class GracefulStopSpec extends TestKit with TypedAkkaSpecWithShutdown {
         }
 
       spawn(behavior)
-      probe.expectMsg(Done)
+      probe.expectMessage(Done)
     }
   }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ImmutablePartialSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ImmutablePartialSpec.scala
@@ -25,7 +25,7 @@ class ImmutablePartialSpec extends TestKit with TypedAkkaSpecWithShutdown {
       probe.expectNoMessage()
 
       actor ! Command2
-      probe.expectMsg(Command2)
+      probe.expectMessage(Command2)
     }
   }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
@@ -76,12 +76,12 @@ class MessageAdapterSpec extends TestKit(MessageAdapterSpec.config) with TypedAk
 
       spawn(snitch, "snitch", Props.empty.withDispatcherFromConfig("snitch-dispatcher"))
 
-      val response1 = probe.expectMsgType[AnotherPong]
+      val response1 = probe.expectMessageType[AnotherPong]
       response1.selfName should ===("snitch")
       response1.threadName should startWith("MessageAdapterSpec-snitch-dispatcher")
 
       // and from the spawnMessageAdapter
-      val response2 = probe.expectMsgType[AnotherPong]
+      val response2 = probe.expectMessageType[AnotherPong]
       response2.selfName should ===("snitch")
       response2.threadName should startWith("MessageAdapterSpec-snitch-dispatcher")
     }
@@ -126,8 +126,8 @@ class MessageAdapterSpec extends TestKit(MessageAdapterSpec.config) with TypedAk
 
       spawn(snitch)
 
-      probe.expectMsg(Wrapped("1", Pong1("hello-1")))
-      probe.expectMsg(Wrapped("2", Pong2("hello-2")))
+      probe.expectMessage(Wrapped("1", Pong1("hello-1")))
+      probe.expectMessage(Wrapped("2", Pong2("hello-2")))
     }
 
     "not break if wrong/unknown response type" in {
@@ -174,9 +174,9 @@ class MessageAdapterSpec extends TestKit(MessageAdapterSpec.config) with TypedAk
         spawn(snitch)
       }
 
-      probe.expectMsg(Wrapped("1", Pong1("hello-1")))
+      probe.expectMessage(Wrapped("1", Pong1("hello-1")))
       // hello-2 discarded because it was wrong type
-      probe.expectMsg(Wrapped("1", Pong1("hello-1")))
+      probe.expectMessage(Wrapped("1", Pong1("hello-1")))
     }
 
     "stop when exception from adapter" in {
@@ -220,14 +220,14 @@ class MessageAdapterSpec extends TestKit(MessageAdapterSpec.config) with TypedAk
         }
       }
 
-      probe.expectMsg(Wrapped(1, Pong("hello")))
-      probe.expectMsg(Wrapped(2, Pong("hello")))
+      probe.expectMessage(Wrapped(1, Pong("hello")))
+      probe.expectMessage(Wrapped(2, Pong("hello")))
       // exception was thrown for  3
 
       // FIXME One thing to be aware of is that the supervision strategy of the Behavior is not
       // used for exceptions from adapters. Should we instead catch, log, unhandled, and resume?
       // It's kind of "before" the message arrives.
-      probe.expectMsg("stopped")
+      probe.expectMessage("stopped")
     }
 
   }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/OnSignalSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/OnSignalSpec.scala
@@ -24,7 +24,7 @@ final class OnSignalSpec extends TestKit with TypedAkkaSpecWithShutdown {
           }
         }
       spawn[Nothing](behavior)
-      probe.expectMsg(Done)
+      probe.expectMessage(Done)
     }
   }
 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashSpec.scala
@@ -208,11 +208,11 @@ abstract class StashSpec extends TestKit with TypedAkkaSpecWithShutdown {
       actor ! Msg("e")
       actor ! Msg("f")
       actor ! GetStashSize(sizeProbe.ref)
-      sizeProbe.expectMsg(3)
+      sizeProbe.expectMessage(3)
 
       actor ! UnstashAll
       actor ! GetProcessed(probe.ref)
-      probe.expectMsg(Vector("a", "b", "c", "d", "e", "f"))
+      probe.expectMessage(Vector("a", "b", "c", "d", "e", "f"))
     }
 
     "support unstash a few at a time" in {
@@ -229,12 +229,12 @@ abstract class StashSpec extends TestKit with TypedAkkaSpecWithShutdown {
       actor ! Msg("e")
       actor ! Msg("f")
       actor ! GetStashSize(sizeProbe.ref)
-      sizeProbe.expectMsg(3)
+      sizeProbe.expectMessage(3)
 
       actor ! Unstash
       actor ! Msg("g") // might arrive in the middle of the unstashing
       actor ! GetProcessed(probe.ref) // this is also stashed until all unstashed
-      probe.expectMsg(Vector("a", "b", "c", "d", "e", "f", "g"))
+      probe.expectMessage(Vector("a", "b", "c", "d", "e", "f", "g"))
     }
 
   }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
@@ -134,7 +134,7 @@ class InteractionPatternsSpec extends TestKit with TypedAkkaSpecWithShutdown {
       val frontend = spawn(Frontend.translator(backend))
       val probe = TestProbe[URI]()
       frontend ! Frontend.Translate(new URI("https://akka.io/docs/"), probe.ref)
-      probe.expectMsg(new URI("https://akka.io/docs/sv/"))
+      probe.expectMessage(new URI("https://akka.io/docs/sv/"))
 
     }
 
@@ -187,6 +187,6 @@ class InteractionPatternsSpec extends TestKit with TypedAkkaSpecWithShutdown {
     bufferer ! ExcitingMessage("one")
     bufferer ! ExcitingMessage("two")
     probe.expectNoMessage(1.millisecond)
-    probe.expectMsg(2.seconds, Batch(Vector[Msg](ExcitingMessage("one"), ExcitingMessage("two"))))
+    probe.expectMessage(2.seconds, Batch(Vector[Msg](ExcitingMessage("one"), ExcitingMessage("two"))))
   }
 }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/testing/async/BasicAsyncTestingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/testing/async/BasicAsyncTestingSpec.scala
@@ -34,7 +34,7 @@ class BasicAsyncTestingSpec extends TestKit("BasicTestingSpec")
       val probe = TestProbe[Pong]()
       val pinger = spawn(echoActor, "ping")
       pinger ! Ping("hello", probe.ref)
-      probe.expectMsg(Pong("hello"))
+      probe.expectMessage(Pong("hello"))
       //#test-spawn
     }
 
@@ -43,7 +43,7 @@ class BasicAsyncTestingSpec extends TestKit("BasicTestingSpec")
       val probe = TestProbe[Pong]()
       val pinger = spawn(echoActor)
       pinger ! Ping("hello", probe.ref)
-      probe.expectMsg(Pong("hello"))
+      probe.expectMessage(Pong("hello"))
       //#test-spawn-anonymous
     }
   }

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingPersistenceSpec.scala
@@ -81,7 +81,7 @@ class ClusterShardingPersistenceSpec extends TestKit("ClusterShardingPersistence
       ref ! Add("b")
       ref ! Add("c")
       ref ! Get(p.ref)
-      p.expectMsg("a|b|c")
+      p.expectMessage("a|b|c")
     }
   }
 }

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ClusterShardingSpec.scala
@@ -198,7 +198,7 @@ class ClusterShardingSpec extends TestKit("ClusterShardingSpec", ClusterSharding
       (1 to 10).foreach { n ⇒
         val p = TestProbe[String]()
         ref ! ShardingEnvelope(s"test$n", ReplyPlz(p.ref))
-        p.expectMsg(3.seconds, "Hello!")
+        p.expectMessage(3.seconds, "Hello!")
         ref ! ShardingEnvelope(s"test$n", StopPlz())
       }
     }
@@ -222,7 +222,7 @@ class ClusterShardingSpec extends TestKit("ClusterShardingSpec", ClusterSharding
       (1 to 10).foreach { n ⇒
         val p = TestProbe[String]()
         ref ! IdReplyPlz(s"test$n", p.ref)
-        p.expectMsg(3.seconds, "Hello!")
+        p.expectMessage(3.seconds, "Hello!")
         ref ! IdStopPlz(s"test$n")
       }
     }
@@ -248,10 +248,10 @@ class ClusterShardingSpec extends TestKit("ClusterShardingSpec", ClusterSharding
       val p = TestProbe[String]()
 
       charlieRef ! WhoAreYou(p.ref)
-      p.expectMsg(3.seconds, "I'm charlie")
+      p.expectMessage(3.seconds, "I'm charlie")
 
       charlieRef tell WhoAreYou(p.ref)
-      p.expectMsg(3.seconds, "I'm charlie")
+      p.expectMessage(3.seconds, "I'm charlie")
 
       charlieRef ! StopPlz()
     }

--- a/akka-cluster-typed/src/test/java/akka/cluster/typed/ClusterApiTest.java
+++ b/akka-cluster-typed/src/test/java/akka/cluster/typed/ClusterApiTest.java
@@ -2,7 +2,6 @@ package akka.cluster.typed;
 
 import akka.cluster.ClusterEvent;
 import akka.actor.typed.ActorSystem;
-import akka.testkit.typed.TestKitSettings;
 import akka.testkit.typed.javadsl.TestProbe;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -40,18 +39,18 @@ public class ClusterApiTest extends JUnitSuite {
 
       cluster1.subscriptions().tell(new Subscribe<>(probe1.ref().narrow(), SelfUp.class));
       cluster1.manager().tell(new Join(cluster1.selfMember().address()));
-      probe1.expectMsgType(SelfUp.class);
+      probe1.expectMessageType(SelfUp.class);
 
       TestProbe<ClusterEvent.ClusterDomainEvent> probe2 = new TestProbe<>(system2);
       cluster2.subscriptions().tell(new Subscribe<>(probe2.ref().narrow(), SelfUp.class));
       cluster2.manager().tell(new Join(cluster1.selfMember().address()));
-      probe2.expectMsgType(SelfUp.class);
+      probe2.expectMessageType(SelfUp.class);
 
 
       cluster2.subscriptions().tell(new Subscribe<>(probe2.ref().narrow(), SelfRemoved.class));
       cluster2.manager().tell(new Leave(cluster2.selfMember().address()));
 
-      probe2.expectMsgType(SelfRemoved.class);
+      probe2.expectMessageType(SelfRemoved.class);
     } finally {
       // TODO no java API to terminate actor system
       Await.result(system1.terminate().zip(system2.terminate()), Duration.create("5 seconds"));

--- a/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/BasicClusterExampleTest.java
+++ b/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/BasicClusterExampleTest.java
@@ -50,9 +50,9 @@ public class BasicClusterExampleTest {
 
       //#cluster-leave-example
       cluster.manager().tell(Leave.create(cluster2.selfMember().address()));
-      testProbe.expectMsgType(ClusterEvent.MemberLeft.class);
-      testProbe.expectMsgType(ClusterEvent.MemberExited.class);
-      testProbe.expectMsgType(ClusterEvent.MemberRemoved.class);
+      testProbe.expectMessageType(ClusterEvent.MemberLeft.class);
+      testProbe.expectMessageType(ClusterEvent.MemberExited.class);
+      testProbe.expectMessageType(ClusterEvent.MemberRemoved.class);
       //#cluster-leave-example
 
     } finally {

--- a/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
@@ -133,7 +133,7 @@ class ReplicatorSpec extends TestKit(ReplicatorSpec.config) with TypedAkkaSpecWi
       val probe = TestProbe[Int]
       c ! Increment
       c ! GetValue(probe.ref)
-      probe.expectMsg(1)
+      probe.expectMessage(1)
     }
 
     "have API for Subscribe" in {
@@ -145,12 +145,12 @@ class ReplicatorSpec extends TestKit(ReplicatorSpec.config) with TypedAkkaSpecWi
       c ! Increment
       eventually {
         c ! GetCachedValue(probe.ref)
-        probe.expectMsg(2)
+        probe.expectMessage(2)
       }
       c ! Increment
       eventually {
         c ! GetCachedValue(probe.ref)
-        probe.expectMsg(3)
+        probe.expectMessage(3)
       }
     }
 
@@ -161,7 +161,7 @@ class ReplicatorSpec extends TestKit(ReplicatorSpec.config) with TypedAkkaSpecWi
       val probe = TestProbe[Int]
       c ! Increment
       c ! GetValue(probe.ref)
-      probe.expectMsg(1)
+      probe.expectMessage(1)
     }
   }
 }

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
@@ -58,7 +58,7 @@ class ClusterApiSpec extends TestKit("ClusterApiSpec", ClusterApiSpec.config) wi
         // check that subscriptions work
         clusterNode1.subscriptions ! Subscribe(node1Probe.ref, classOf[MemberEvent])
         clusterNode1.manager ! Join(clusterNode1.selfMember.address)
-        node1Probe.expectMsgType[MemberUp].member.uniqueAddress == clusterNode1.selfMember.uniqueAddress
+        node1Probe.expectMessageType[MemberUp].member.uniqueAddress == clusterNode1.selfMember.uniqueAddress
 
         // check that cached selfMember is updated
         node1Probe.awaitAssert(
@@ -66,36 +66,36 @@ class ClusterApiSpec extends TestKit("ClusterApiSpec", ClusterApiSpec.config) wi
 
         // subscribing to OnSelfUp when already up
         clusterNode1.subscriptions ! Subscribe(node1Probe.ref, classOf[SelfUp])
-        node1Probe.expectMsgType[SelfUp]
+        node1Probe.expectMessageType[SelfUp]
 
         // selfMember update and on up subscription on node 2 when joining
         clusterNode2.subscriptions ! Subscribe(node2Probe.ref, classOf[SelfUp])
         clusterNode2.manager ! Join(clusterNode1.selfMember.address)
         node2Probe.awaitAssert(
           clusterNode2.selfMember.status should ===(MemberStatus.Up))
-        node2Probe.expectMsgType[SelfUp]
+        node2Probe.expectMessageType[SelfUp]
 
         // events about node2 joining to subscriber on node1
-        node1Probe.expectMsgType[MemberJoined].member.uniqueAddress == clusterNode2.selfMember.uniqueAddress
-        node1Probe.expectMsgType[MemberUp].member.uniqueAddress == clusterNode1.selfMember.uniqueAddress
+        node1Probe.expectMessageType[MemberJoined].member.uniqueAddress == clusterNode2.selfMember.uniqueAddress
+        node1Probe.expectMessageType[MemberUp].member.uniqueAddress == clusterNode1.selfMember.uniqueAddress
 
         // OnSelfRemoved and subscription events around node2 leaving
         clusterNode2.subscriptions ! Subscribe(node2Probe.ref, classOf[SelfRemoved])
         clusterNode2.manager ! Leave(clusterNode2.selfMember.address)
 
         // node1 seeing all those transition events
-        node1Probe.expectMsgType[MemberLeft].member.uniqueAddress == clusterNode2.selfMember.uniqueAddress
-        node1Probe.expectMsgType[MemberExited].member.uniqueAddress == clusterNode2.selfMember.uniqueAddress
-        node1Probe.expectMsgType[MemberRemoved].member.uniqueAddress == clusterNode2.selfMember.uniqueAddress
+        node1Probe.expectMessageType[MemberLeft].member.uniqueAddress == clusterNode2.selfMember.uniqueAddress
+        node1Probe.expectMessageType[MemberExited].member.uniqueAddress == clusterNode2.selfMember.uniqueAddress
+        node1Probe.expectMessageType[MemberRemoved].member.uniqueAddress == clusterNode2.selfMember.uniqueAddress
 
         // selfMember updated and self removed event gotten
         node2Probe.awaitAssert(
           clusterNode2.selfMember.status should ===(MemberStatus.Removed))
-        node2Probe.expectMsg(SelfRemoved(MemberStatus.Exiting))
+        node2Probe.expectMessage(SelfRemoved(MemberStatus.Exiting))
 
         // subscribing to SelfRemoved when already removed yields immediate message back
         clusterNode2.subscriptions ! Subscribe(node2Probe.ref, classOf[SelfRemoved])
-        node2Probe.expectMsg(SelfRemoved(MemberStatus.Exiting))
+        node2Probe.expectMessage(SelfRemoved(MemberStatus.Exiting))
 
         // subscribing to SelfUp when already removed yields nothing
         clusterNode2.subscriptions ! Subscribe(node2Probe.ref, classOf[SelfUp])

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
@@ -111,8 +111,8 @@ class ClusterSingletonApiSpec extends TestKit("ClusterSingletonApiSpec", Cluster
       clusterNode1.manager ! Join(clusterNode1.selfMember.address)
       clusterNode2.manager ! Join(clusterNode1.selfMember.address)
 
-      node1UpProbe.expectMsgType[SelfUp]
-      node2UpProbe.expectMsgType[SelfUp]
+      node1UpProbe.expectMessageType[SelfUp]
+      node2UpProbe.expectMessageType[SelfUp]
 
       val cs1: ClusterSingleton = ClusterSingleton(system)
       val cs2 = ClusterSingleton(adaptedSystem2)
@@ -130,12 +130,12 @@ class ClusterSingletonApiSpec extends TestKit("ClusterSingletonApiSpec", Cluster
 
       node1PongProbe.awaitAssert({
         node1ref ! Ping(node1PongProbe.ref)
-        node1PongProbe.expectMsg(Pong)
+        node1PongProbe.expectMessage(Pong)
       }, 3.seconds)
 
       node2PongProbe.awaitAssert({
         node2ref ! Ping(node2PongProbe.ref)
-        node2PongProbe.expectMsg(Pong)
+        node2PongProbe.expectMessage(Pong)
       }, 3.seconds)
 
     }

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
@@ -78,7 +78,7 @@ class ClusterSingletonPersistenceSpec extends TestKit(ClusterSingletonPersistenc
       ref ! Add("b")
       ref ! Add("c")
       ref ! Get(p.ref)
-      p.expectMsg("a|b|c")
+      p.expectMessage("a|b|c")
     }
   }
 }

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
@@ -95,7 +95,7 @@ class RemoteContextAskSpec extends TestKit(RemoteContextAskSpec.config) with Typ
       node1.manager ! Join(node1.selfMember.address)
 
       Receptionist(system).ref ! Receptionist.Subscribe(pingPongKey, node1Probe.ref)
-      node1Probe.expectMsgType[Receptionist.Listing[_]]
+      node1Probe.expectMessageType[Receptionist.Listing[_]]
 
       val system2 = ActorSystem(pingPong, system.name, system.settings.config)
       val node2 = Cluster(system2)
@@ -103,10 +103,10 @@ class RemoteContextAskSpec extends TestKit(RemoteContextAskSpec.config) with Typ
 
       val node2Probe = TestProbe[AnyRef]()(system2)
       Receptionist(system2).ref ! Receptionist.Register(pingPongKey, system2, node2Probe.ref)
-      node2Probe.expectMsgType[Registered[_]]
+      node2Probe.expectMessageType[Registered[_]]
 
       // wait until the service is seen on the first node
-      val remoteRef = node1Probe.expectMsgType[Receptionist.Listing[Ping]].serviceInstances.head
+      val remoteRef = node1Probe.expectMessageType[Receptionist.Listing[Ping]].serviceInstances.head
 
       spawn(Behaviors.deferred[AnyRef] { (ctx) ⇒
         implicit val timeout: Timeout = 3.seconds
@@ -122,7 +122,7 @@ class RemoteContextAskSpec extends TestKit(RemoteContextAskSpec.config) with Typ
         }
       })
 
-      node1Probe.expectMsgType[Pong.type]
+      node1Probe.expectMessageType[Pong.type]
 
     }
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteDeployNotAllowedSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteDeployNotAllowedSpec.scala
@@ -88,10 +88,10 @@ class RemoteDeployNotAllowedSpec extends TestKit(RemoteDeployNotAllowedSpec.conf
         node2.manager ! Join(node1.selfMember.address)
 
         system2 ! SpawnChild("remoteDeployed")
-        probe.expectMsgType[Exception].getMessage should ===("Remote deployment not allowed for typed actors")
+        probe.expectMessageType[Exception].getMessage should ===("Remote deployment not allowed for typed actors")
 
         system2 ! SpawnAnonymous
-        probe.expectMsgType[Exception].getMessage should ===("Remote deployment not allowed for typed actors")
+        probe.expectMessageType[Exception].getMessage should ===("Remote deployment not allowed for typed actors")
       } finally {
         TestKit.shutdown(system2, 5.seconds)
       }

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -112,19 +112,19 @@ class ClusterReceptionistSpec extends TestKit("ClusterReceptionistSpec", Cluster
       val regProbe2 = TestProbe[Any]()(adaptedSystem2)
 
       adaptedSystem2.receptionist ! Subscribe(PingKey, regProbe2.ref)
-      regProbe2.expectMsg(Listing(PingKey, Set.empty[ActorRef[PingProtocol]]))
+      regProbe2.expectMessage(Listing(PingKey, Set.empty[ActorRef[PingProtocol]]))
 
       val service = spawn(pingPongBehavior)
       system.receptionist ! Register(PingKey, service, regProbe.ref)
-      regProbe.expectMsg(Registered(PingKey, service))
+      regProbe.expectMessage(Registered(PingKey, service))
 
-      val Listing(PingKey, remoteServiceRefs) = regProbe2.expectMsgType[Listing[PingProtocol]]
+      val Listing(PingKey, remoteServiceRefs) = regProbe2.expectMessageType[Listing[PingProtocol]]
       val theRef = remoteServiceRefs.head
       theRef ! Ping(regProbe2.ref)
-      regProbe2.expectMsg(Pong)
+      regProbe2.expectMessage(Pong)
 
       service ! Perish
-      regProbe2.expectMsg(Listing(PingKey, Set.empty[ActorRef[PingProtocol]]))
+      regProbe2.expectMessage(Listing(PingKey, Set.empty[ActorRef[PingProtocol]]))
     }
   }
 

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
@@ -157,12 +157,12 @@ class BasicClusterManualSpec extends WordSpec with ScalaFutures with Eventually 
         eventually {
           cluster1.state.members.toList.map(_.status) shouldEqual List(MemberStatus.up)
         }
-        probe1.expectMsg(MemberUp(cluster1.selfMember))
+        probe1.expectMessage(MemberUp(cluster1.selfMember))
 
         cluster2.manager ! Join(cluster1.selfMember.address)
         probe1.within(10.seconds) {
-          probe1.expectMsgType[MemberJoined].member.address shouldEqual cluster2.selfMember.address
-          probe1.expectMsgType[MemberUp].member.address shouldEqual cluster2.selfMember.address
+          probe1.expectMessageType[MemberJoined].member.address shouldEqual cluster2.selfMember.address
+          probe1.expectMessageType[MemberUp].member.address shouldEqual cluster2.selfMember.address
         }
         eventually {
           cluster1.state.members.toList.map(_.status) shouldEqual List(MemberStatus.up, MemberStatus.up)
@@ -171,8 +171,8 @@ class BasicClusterManualSpec extends WordSpec with ScalaFutures with Eventually 
 
         cluster3.manager ! Join(cluster1.selfMember.address)
         probe1.within(10.seconds) {
-          probe1.expectMsgType[MemberJoined].member.address shouldEqual cluster3.selfMember.address
-          probe1.expectMsgType[MemberUp].member.address shouldEqual cluster3.selfMember.address
+          probe1.expectMessageType[MemberJoined].member.address shouldEqual cluster3.selfMember.address
+          probe1.expectMessageType[MemberUp].member.address shouldEqual cluster3.selfMember.address
         }
         eventually {
           cluster1.state.members.toList.map(_.status) shouldEqual List(MemberStatus.up, MemberStatus.up, MemberStatus.up)
@@ -183,9 +183,9 @@ class BasicClusterManualSpec extends WordSpec with ScalaFutures with Eventually 
         //#cluster-leave-example
         cluster1.manager ! Leave(cluster2.selfMember.address)
         probe1.within(10.seconds) {
-          probe1.expectMsgType[MemberLeft].member.address shouldEqual cluster2.selfMember.address
-          probe1.expectMsgType[MemberExited].member.address shouldEqual cluster2.selfMember.address
-          probe1.expectMsgType[MemberRemoved].member.address shouldEqual cluster2.selfMember.address
+          probe1.expectMessageType[MemberLeft].member.address shouldEqual cluster2.selfMember.address
+          probe1.expectMessageType[MemberExited].member.address shouldEqual cluster2.selfMember.address
+          probe1.expectMessageType[MemberRemoved].member.address shouldEqual cluster2.selfMember.address
         }
         //#cluster-leave-example
 
@@ -202,7 +202,7 @@ class BasicClusterManualSpec extends WordSpec with ScalaFutures with Eventually 
 
         system1.log.info("Downing node 3")
         cluster1.manager ! Down(cluster3.selfMember.address)
-        probe1.expectMsgType[MemberRemoved](10.seconds).member.address shouldEqual cluster3.selfMember.address
+        probe1.expectMessageType[MemberRemoved](10.seconds).member.address shouldEqual cluster3.selfMember.address
 
         probe1.expectNoMessage()
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorSpec.scala
@@ -160,7 +160,7 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
       val probe = TestProbe[State]
       c ! Increment
       c ! GetValue(probe.ref)
-      probe.expectMsg(State(1, Vector(0)))
+      probe.expectMessage(State(1, Vector(0)))
     }
 
     "replay stored events" in {
@@ -171,14 +171,14 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
       c ! Increment
       c ! Increment
       c ! GetValue(probe.ref)
-      probe.expectMsg(State(3, Vector(0, 1, 2)))
+      probe.expectMessage(State(3, Vector(0, 1, 2)))
 
       val c2 = spawn(counter("c2"))
       c2 ! GetValue(probe.ref)
-      probe.expectMsg(State(3, Vector(0, 1, 2)))
+      probe.expectMessage(State(3, Vector(0, 1, 2)))
       c2 ! Increment
       c2 ! GetValue(probe.ref)
-      probe.expectMsg(State(4, Vector(0, 1, 2, 3)))
+      probe.expectMessage(State(4, Vector(0, 1, 2, 3)))
     }
 
     "handle Terminated signal" in {
@@ -189,7 +189,7 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
       c ! IncrementLater
       eventually {
         c ! GetValue(probe.ref)
-        probe.expectMsg(State(11, Vector(0, 1)))
+        probe.expectMessage(State(11, Vector(0, 1)))
       }
     }
 
@@ -203,7 +203,7 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
       Thread.sleep(500)
       eventually {
         c ! GetValue(probe.ref)
-        probe.expectMsg(State(101, Vector(0, 1)))
+        probe.expectMessage(State(101, Vector(0, 1)))
       }
     }
 
@@ -219,10 +219,10 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
 
       c ! IncrementTwiceAndThenLog
       c ! GetValue(probe.ref)
-      probe.expectMsg(State(2, Vector(0, 1)))
+      probe.expectMessage(State(2, Vector(0, 1)))
 
-      loggingProbe.expectMsg(firstLogging)
-      loggingProbe.expectMsg(secondLogging)
+      loggingProbe.expectMessage(firstLogging)
+      loggingProbe.expectMessage(secondLogging)
     }
 
     /** Proves that side-effects are called when emitting an empty list of events */
@@ -233,8 +233,8 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
       val probe = TestProbe[State]
       c ! EmptyEventsListAndThenLog
       c ! GetValue(probe.ref)
-      probe.expectMsg(State(0, Vector.empty))
-      loggingProbe.expectMsg(firstLogging)
+      probe.expectMessage(State(0, Vector.empty))
+      loggingProbe.expectMessage(firstLogging)
     }
 
     /** Proves that side-effects are called when explicitly calling Effect.none */
@@ -245,8 +245,8 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
       val probe = TestProbe[State]
       c ! DoNothingAndThenLog
       c ! GetValue(probe.ref)
-      probe.expectMsg(State(0, Vector.empty))
-      loggingProbe.expectMsg(firstLogging)
+      probe.expectMessage(State(0, Vector.empty))
+      loggingProbe.expectMessage(firstLogging)
     }
 
     "work when wrapped in other behavior" in {
@@ -260,7 +260,7 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
       val c = spawn(behavior)
       c ! Increment
       c ! GetValue(probe.ref)
-      probe.expectMsg(State(1, Vector(0)))
+      probe.expectMessage(State(1, Vector(0)))
     }
 
     "stop after persisting" in {
@@ -268,8 +268,8 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
       val c: ActorRef[Command] = spawn(counter("c8", loggingProbe.ref))
       val watchProbe = watcher(c)
       c ! LogThenStop
-      loggingProbe.expectMsg(firstLogging)
-      watchProbe.expectMsg("Terminated")
+      loggingProbe.expectMessage(firstLogging)
+      watchProbe.expectMessage("Terminated")
     }
 
     "snapshot via predicate" in {
@@ -280,9 +280,9 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
 
       c ! Increment
       c ! GetValue(replyProbe.ref)
-      replyProbe.expectMsg(State(1, Vector(0)))
+      replyProbe.expectMessage(State(1, Vector(0)))
       c ! LogThenStop
-      watchProbe.expectMsg("Terminated")
+      watchProbe.expectMessage("Terminated")
 
       val probe = TestProbe[(State, Event)]()
       val c2 = spawn(counterWithProbe("c9", probe.ref))
@@ -290,7 +290,7 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
       probe.expectNoMessage()
       c2 ! Increment
       c2 ! GetValue(replyProbe.ref)
-      replyProbe.expectMsg(State(2, Vector(0, 1)))
+      replyProbe.expectMessage(State(2, Vector(0, 1)))
     }
 
     "check all events for snapshot in PersistAll" in {
@@ -303,16 +303,16 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
 
       c ! IncrementWithPersistAll(3)
       c ! GetValue(replyProbe.ref)
-      replyProbe.expectMsg(State(3, Vector(0, 1, 2)))
+      replyProbe.expectMessage(State(3, Vector(0, 1, 2)))
       c ! LogThenStop
-      watchProbe.expectMsg("Terminated")
+      watchProbe.expectMessage("Terminated")
 
       val probeC2 = TestProbe[(State, Event)]()
       val c2 = spawn(counterWithProbe("c11", probeC2.ref))
       // middle event triggered all to be snapshot
       probeC2.expectNoMessage()
       c2 ! GetValue(replyProbe.ref)
-      replyProbe.expectMsg(State(3, Vector(0, 1, 2)))
+      replyProbe.expectMessage(State(3, Vector(0, 1, 2)))
     }
 
     "snapshot every N sequence nrs" in {
@@ -322,25 +322,25 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
 
       c ! Increment
       c ! GetValue(replyProbe.ref)
-      replyProbe.expectMsg(State(1, Vector(0)))
+      replyProbe.expectMessage(State(1, Vector(0)))
       c ! LogThenStop
-      watchProbe.expectMsg("Terminated")
+      watchProbe.expectMessage("Terminated")
 
       // no shapshot should have happened
       val probeC2 = TestProbe[(State, Event)]()
       val c2 = spawn(counterWithProbe("c10", probeC2.ref).snapshotEvery(2))
-      probeC2.expectMsg[(State, Event)]((State(0, Vector()), Incremented(1)))
+      probeC2.expectMessage[(State, Event)]((State(0, Vector()), Incremented(1)))
       val watchProbeC2 = watcher(c2)
       c2 ! Increment
       c2 ! LogThenStop
-      watchProbeC2.expectMsg("Terminated")
+      watchProbeC2.expectMessage("Terminated")
 
       val probeC3 = TestProbe[(State, Event)]()
       val c3 = spawn(counterWithProbe("c10", probeC3.ref).snapshotEvery(2))
       // this time it should have been snapshotted so no events to replay
       probeC3.expectNoMessage()
       c3 ! GetValue(replyProbe.ref)
-      replyProbe.expectMsg(State(2, Vector(0, 1)))
+      replyProbe.expectMessage(State(2, Vector(0, 1)))
     }
 
     "snapshot every N sequence nrs when persisting multiple events" in {
@@ -350,15 +350,15 @@ class PersistentActorSpec extends TestKit(PersistentActorSpec.config) with Event
 
       c ! IncrementWithPersistAll(3)
       c ! GetValue(replyProbe.ref)
-      replyProbe.expectMsg(State(3, Vector(0, 1, 2)))
+      replyProbe.expectMessage(State(3, Vector(0, 1, 2)))
       c ! LogThenStop
-      watchProbe.expectMsg("Terminated")
+      watchProbe.expectMessage("Terminated")
 
       val probeC2 = TestProbe[(State, Event)]()
       val c2 = spawn(counterWithProbe("c12", probeC2.ref).snapshotEvery(2))
       probeC2.expectNoMessage()
       c2 ! GetValue(replyProbe.ref)
-      replyProbe.expectMsg(State(3, Vector(0, 1, 2)))
+      replyProbe.expectMessage(State(3, Vector(0, 1, 2)))
     }
 
     def watcher(toWatch: ActorRef[_]): TestProbe[String] = {

--- a/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorSourceSinkSpec.scala
+++ b/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorSourceSinkSpec.scala
@@ -42,7 +42,7 @@ class ActorSourceSinkSpec extends TestKit with TypedAkkaSpecWithShutdown {
       val msg = "Zug zug"
 
       in.offer(msg)
-      p.expectMsg(msg + "!")
+      p.expectMessage(msg + "!")
     }
 
     "obey protocol" in {
@@ -72,16 +72,16 @@ class ActorSourceSinkSpec extends TestKit with TypedAkkaSpecWithShutdown {
           .to(ActorSink.actorRefWithAck(pilotRef, Msg.apply, Init.apply, "ACK", Complete, _ ⇒ Failed))
           .run()
 
-      p.expectMsgType[Init]
+      p.expectMessageType[Init]
 
       in.offer("Dabu!")
-      p.expectMsgType[Msg].msg shouldBe "Dabu!"
+      p.expectMessageType[Msg].msg shouldBe "Dabu!"
 
       in.offer("Lok'tar!")
-      p.expectMsgType[Msg].msg shouldBe "Lok'tar!"
+      p.expectMessageType[Msg].msg shouldBe "Lok'tar!"
 
       in.offer("Swobu!")
-      p.expectMsgType[Msg].msg shouldBe "Swobu!"
+      p.expectMessageType[Msg].msg shouldBe "Swobu!"
     }
   }
 

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/javadsl/TestProbe.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/javadsl/TestProbe.scala
@@ -15,7 +15,7 @@ class TestProbe[M](name: String, system: ActorSystem[_]) extends akka.testkit.ty
   /**
    * Same as `expectMsgType[T](remainingOrDefault)`, but correctly treating the timeFactor.
    */
-  def expectMsgType[T <: M](t: Class[T]): T =
-    expectMsgClass_internal(remainingOrDefault, t)
+  def expectMessageType[T <: M](t: Class[T]): T =
+    expectMessageClass_internal(remainingOrDefault, t)
 
 }


### PR DESCRIPTION
We have expectMsg but expectNoMessage

We have lots of pixels these days so went with the full word