### PR TITLE
Testkit docs use deprecated messages

### DIFF
--- a/akka-docs/src/test/java/jdocs/testkit/TestKitDocTest.java
+++ b/akka-docs/src/test/java/jdocs/testkit/TestKitDocTest.java
@@ -6,7 +6,6 @@ package jdocs.testkit;
 import static org.junit.Assert.*;
 
 import akka.pattern.PatternsCS;
-import akka.testkit.*;
 import jdocs.AbstractJavaTest;
 import org.junit.Assert;
 import akka.japi.JavaPartialFunction;
@@ -198,7 +197,7 @@ public class TestKitDocTest extends AbstractJavaTest {
       final List<String> all = expectMsgAllOf("hello", "world");
       final int i        = expectMsgClass(Integer.class);
       final Number j     = expectMsgAnyClassOf(Integer.class, Long.class);
-      expectNoMsg();
+      expectNoMessage();
       //#test-expect
       getRef().tell("receveN-1", ActorRef.noSender());
       getRef().tell("receveN-2", ActorRef.noSender());
@@ -381,7 +380,7 @@ public class TestKitDocTest extends AbstractJavaTest {
       expectMsgEquals("hello");
       // ... but then the auto-pilot switched itself off
       probe.getRef().tell("world", getRef());
-      expectNoMsg();
+      expectNoMessage();
     }};
     //#test-auto-pilot
   }

--- a/akka-docs/src/test/scala/docs/testkit/TestkitDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/testkit/TestkitDocSpec.scala
@@ -6,11 +6,9 @@ package docs.testkit
 import language.postfixOps
 import scala.util.Success
 import akka.testkit._
-import org.junit.Assert.{ assertArrayEquals, assertEquals }
 
 //#imports-test-probe
 import scala.concurrent.duration._
-import scala.concurrent.Future
 import akka.actor._
 import akka.testkit.TestProbe
 
@@ -56,8 +54,6 @@ object TestKitDocSpec {
 
   //#my-double-echo
 
-  import akka.testkit.TestProbe
-
   //#test-probe-forward-actors
   class Source(target: ActorRef) extends Actor {
     def receive = {
@@ -99,7 +95,6 @@ class TestKitDocSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
   }
 
   "demonstrate built-in expect methods" in {
-    import akka.testkit.TestActorRef
 
     testActor.tell("hello", ActorRef.noSender)
     testActor.tell("hello", ActorRef.noSender)
@@ -111,7 +106,7 @@ class TestKitDocSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
     val any: String = expectMsgAnyOf("hello", "world")
     val all: immutable.Seq[String] = expectMsgAllOf("hello", "world")
     val i: Int = expectMsgType[Int]
-    expectNoMsg(200.millis)
+    expectNoMessage(200.millis)
     //#test-expect
     testActor.tell("receveN-1", ActorRef.noSender)
     testActor.tell("receveN-2", ActorRef.noSender)
@@ -126,7 +121,6 @@ class TestKitDocSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
   "demonstrate usage of TestFSMRef" in {
     //#test-fsm-ref
     import akka.testkit.TestFSMRef
-    import akka.actor.FSM
     import scala.concurrent.duration._
 
     val fsm = TestFSMRef(new TestFsmActor)
@@ -154,8 +148,6 @@ class TestKitDocSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
 
     //#test-behavior
     import akka.testkit.TestActorRef
-    import scala.concurrent.duration._
-    import scala.concurrent.Await
     import akka.pattern.ask
 
     val actorRef = TestActorRef(new MyActor)
@@ -199,7 +191,7 @@ class TestKitDocSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
     within(200 millis) {
       worker ! "some work"
       expectMsg("some result")
-      expectNoMsg // will block for the rest of the 200ms
+      expectNoMessage // will block for the rest of the 200ms
       Thread.sleep(300) // will NOT make this block fail
     }
     //#test-within
@@ -268,7 +260,7 @@ class TestKitDocSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
     val future = probe.ref ? "hello"
     probe.expectMsg(0 millis, "hello") // TestActor runs on CallingThreadDispatcher
     probe.reply("world")
-    assert(future.isCompleted && future.value == Some(Success("world")))
+    assert(future.isCompleted && future.value.contains(Success("world")))
     //#test-probe-reply
   }
 

--- a/akka-testkit/src/main/mima-filters/2.5.10.backwards.excludes
+++ b/akka-testkit/src/main/mima-filters/2.5.10.backwards.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.testkit.TestKitBase.expectNoMessage")

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -660,6 +660,11 @@ trait TestKitBase {
     expectNoMsg_internal(max)
   }
 
+  /**
+   * Same as `expectNoMessage(remainingOrDefault)`, but correctly treating the timeFactor.
+   */
+  def expectNoMessage() { expectNoMsg_internal(remainingOrDefault) }
+
   private def expectNoMsg_internal(max: FiniteDuration) {
     val finish = System.nanoTime() + max.toNanos
     val pollInterval = 100.millis

--- a/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
@@ -325,12 +325,25 @@ class TestKit(system: ActorSystem) {
   /**
    * Same as `expectNoMsg(remainingOrDefault)`, but correctly treating the timeFactor.
    */
-  def expectNoMsg(): Unit = tp.expectNoMsg()
+  @deprecated(message = "Use expectNoMessage instead", since = "2.5.10")
+  def expectNoMsg(): Unit = tp.expectNoMessage()
+
+  /**
+   * Same as `expectNoMessage(remainingOrDefault)`, but correctly treating the timeFactor.
+   */
+  def expectNoMessage(): Unit = tp.expectNoMessage()
 
   /**
    * Assert that no message is received for the specified time.
    */
+  @deprecated(message = "Use expectNoMessage instead", since = "2.5.10")
   def expectNoMsg(max: FiniteDuration): Unit = tp.expectNoMsg(max)
+
+  /**
+   * Assert that no message is received for the specified time.
+   * Supplied value is not dilated.
+   */
+  def expectNoMessage(max: FiniteDuration): Unit = tp.expectNoMessage(max)
 
   /**
    * Receive one message from the test actor and assert that it is the Terminated message of the given ActorRef.


### PR DESCRIPTION
Noticed this when seeing what was missing in typed

We also had a deprecated method without implementing
the alternative