### PR TITLE
Fix issue with dead actors in pubsub topics

### DIFF
--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
@@ -330,6 +330,8 @@ object DistributedPubSubMediator {
           remove(ref)
           context.parent ! Unsubscribed(UnsubscribeAck(msg), sender())
         case Terminated(ref) ⇒
+          //this doesn't seem to be called anymore since Topic business logic overrides it
+          //causing actors to leave in subscribers map after they have died
           remove(ref)
         case Prune ⇒
           for (d ← pruneDeadline if d.isOverdue) {
@@ -388,6 +390,7 @@ object DistributedPubSubMediator {
           val key = mkKey(sender())
           forwardMessages(key, sender())
         case Terminated(ref) ⇒
+          remove(ref)   //we need to remove the ref from the subscribers set as well since the TopicLike handling won't be called
           val key = mkKey(ref)
           recreateAndForwardMessagesIfNeeded(key, newGroupActor(ref.path.name))
       }


### PR DESCRIPTION
We have run into out-of-memory problems and it seems like the subscribers list is never emptied in the pubsub topic class. By looking at the code it seems like the remove code indeed isn't run. Here's a guess on how it could be fixed, there's a lot of details here that I don't know anything about so please correct me if I'm wrong.