### PR TITLE
+tkt Provide run method that doesn't canonicalize behavior #24486

### DIFF
--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/BehaviorTestkit.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/BehaviorTestkit.scala
@@ -172,17 +172,16 @@ class BehaviorTestkit[T] private (_name: String, _initialBehavior: Behavior[T]) 
   }
 
   private var current = Behavior.validateAsInitial(Behavior.start(_initialBehavior, ctx))
-  private var currentUncanonical = current
+  private var currentUncanonical = _initialBehavior
 
-  /**
-   * Returns the current canonical behavior
-   */
   def currentBehavior: Behavior[T] = current
 
   /**
-   * Returns the current behavior before being converted to the canonical one
+   * Returns the current behavior as it was returned from processing the previous message.
+   * For example if [[Behavior.unhandled]] is returned it will be kept here, but not in
+   * [[currentBehavior]].
    */
-  def currentUncanonicalBehavior: Behavior[T] = currentUncanonical
+  def returnedBehavior: Behavior[T] = currentUncanonical
   def isAlive: Boolean = Behavior.isAlive(current)
 
   private def handleException: Catcher[Unit] = {

--- a/akka-testkit-typed/src/test/scala/akka/testkit/typed/BehaviorTestkitSpec.scala
+++ b/akka-testkit-typed/src/test/scala/akka/testkit/typed/BehaviorTestkitSpec.scala
@@ -130,4 +130,12 @@ class BehaviorTestkitSpec extends WordSpec with Matchers {
       effects shouldBe Seq(SpawnedAdapter)
     }
   }
+
+  "BehaviorTestkit's run" can {
+    "run behaviors with messages without canonicalization" in {
+      val testkit = BehaviorTestkit[Father.Command](Father.init())
+      testkit.runUncanonical(SpawnAdapterWithName("adapter"))
+      testkit.currentBehavior shouldBe Behavior.same
+    }
+  }
 }

--- a/akka-testkit-typed/src/test/scala/akka/testkit/typed/BehaviorTestkitSpec.scala
+++ b/akka-testkit-typed/src/test/scala/akka/testkit/typed/BehaviorTestkitSpec.scala
@@ -136,7 +136,7 @@ class BehaviorTestkitSpec extends WordSpec with Matchers {
       val testkit = BehaviorTestkit[Father.Command](Father.init())
       testkit.run(SpawnAdapterWithName("adapter"))
       testkit.currentBehavior should not be Behavior.same
-      testkit.currentUncanonicalBehavior shouldBe Behavior.same
+      testkit.returnedBehavior shouldBe Behavior.same
     }
   }
 }

--- a/akka-testkit-typed/src/test/scala/akka/testkit/typed/BehaviorTestkitSpec.scala
+++ b/akka-testkit-typed/src/test/scala/akka/testkit/typed/BehaviorTestkitSpec.scala
@@ -134,8 +134,9 @@ class BehaviorTestkitSpec extends WordSpec with Matchers {
   "BehaviorTestkit's run" can {
     "run behaviors with messages without canonicalization" in {
       val testkit = BehaviorTestkit[Father.Command](Father.init())
-      testkit.runUncanonical(SpawnAdapterWithName("adapter"))
-      testkit.currentBehavior shouldBe Behavior.same
+      testkit.run(SpawnAdapterWithName("adapter"))
+      testkit.currentBehavior should not be Behavior.same
+      testkit.currentUncanonicalBehavior shouldBe Behavior.same
     }
   }
 }


### PR DESCRIPTION
Refs: #24486
New method `runUncanonical` method is not canonicalizing the resulting behavior.
Useful when testing behaviors that might be composed.