### PR TITLE
=doc cleaning up documentation on deprecated actorSubscriber and actorPublisher

### DIFF
--- a/akka-docs/src/main/paradox/stream/stages-overview.md
+++ b/akka-docs/src/main/paradox/stream/stages-overview.md
@@ -201,16 +201,6 @@ Defers creation and materialization of a `Source` until there is demand.
 
 ---------------------------------------------------------------
 
-### actorPublisher
-
-Wrap an actor extending `ActorPublisher` as a source.
-
-**emits** depends on the actor implementation
-
-**completes** when the actor stops
-
----------------------------------------------------------------
-
 ### actorRef
 
 Materialize an `ActorRef`, sending messages to it will emit them on the stream. The actor contain
@@ -505,19 +495,6 @@ to provide back pressure onto the sink.
 **cancels** when the actor terminates
 
 **backpressures** when the actor acknowledgement has not arrived
-
----------------------------------------------------------------
-
-### actorSubscriber
-
-Create an actor from a `Props` upon materialization, where the actor implements `ActorSubscriber`, which will
-receive the elements from the stream.
-
-Materializes into an `ActorRef` to the created actor.
-
-**cancels** when the actor terminates
-
-**backpressures** depends on the actor implementation
 
 ---------------------------------------------------------------
 

--- a/akka-docs/src/main/paradox/stream/stream-integrations.md
+++ b/akka-docs/src/main/paradox/stream/stream-integrations.md
@@ -503,12 +503,6 @@ These can be consumed by other Reactive Stream libraries or used as an Akka Stre
 
 @@@ warning
 
-`ActorPublisher` and `ActorSubscriber` will probably be deprecated in future versions of Akka.
-
-@@@
-
-@@@ warning
-
 `ActorPublisher` and `ActorSubscriber` cannot be used with remote actors,
 because if signals of the Reactive Streams protocol (e.g. `request`) are lost the
 the stream may deadlock.


### PR DESCRIPTION
I reckon there still should be documentation around these stages ([here](https://doc.akka.io/docs/akka/current/stream/stream-integrations.html#actorpublisher)), however it is probably worth removing them from stages overview?