### PR TITLE
Jackson serializer that may become default in 2.6, #24155

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/jackson/JacksonSerializationBench.scala
+++ b/akka-bench-jmh/src/main/scala/akka/jackson/JacksonSerializationBench.scala
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.jackson
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import akka.actor._
+import akka.serialization.Serialization
+import akka.serialization.SerializationExtension
+import akka.serialization.SerializerWithStringManifest
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations._
+
+object JacksonSerializationBench {
+  final case class Small(name: String, num: Int)
+
+  final case class Medium(
+    field1:  String,
+    field2:  String,
+    field3:  String,
+    num1:    Int,
+    num2:    Int,
+    num3:    Int,
+    nested1: Small,
+    nested2: Small,
+    nested3: Small)
+
+  final case class Large(
+    nested1: Medium,
+    nested2: Medium,
+    nested3: Medium,
+    vector:  Vector[Medium],
+    map:     Map[String, Medium])
+
+}
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+@Fork(2)
+@Warmup(iterations = 4)
+@Measurement(iterations = 5)
+class JacksonSerializationBench {
+  import JacksonSerializationBench._
+
+  val smallMsg1 = Small("abc", 17)
+  val smallMsg2 = Small("def", 18)
+  val smallMsg3 = Small("ghi", 19)
+  val mediumMsg1 = Medium("abc", "def", "ghi", 1, 2, 3, smallMsg1, smallMsg2, smallMsg3)
+  val mediumMsg2 = Medium("ABC", "DEF", "GHI", 10, 20, 30, smallMsg1, smallMsg2, smallMsg3)
+  val mediumMsg3 = Medium("abcABC", "defDEF", "ghiGHI", 100, 200, 300, smallMsg1, smallMsg2, smallMsg3)
+  val largeMsg = Large(mediumMsg1, mediumMsg2, mediumMsg3,
+    Vector(mediumMsg1, mediumMsg2, mediumMsg3),
+    Map("a" -> mediumMsg1, "b" -> mediumMsg2, "c" -> mediumMsg3))
+
+  var system: ActorSystem = _
+  var serialization: Serialization = _
+
+  @Param(Array("jackson-json", "jackson-smile", "jackson-cbor", "java"))
+  private var serializerName: String = _
+
+  @Setup(Level.Trial)
+  def setupTrial(): Unit = {
+    val config = ConfigFactory.parseString(
+      s"""
+        akka {
+          loglevel = WARNING
+          actor {
+            serialization-bindings {
+              "java.lang.Object" = $serializerName
+              "java.io.Serializable" = $serializerName
+            }
+          }
+          jackson {
+            #compress-larger-than = 100 b
+          }
+        }
+      """)
+
+    system = ActorSystem("JacksonSerializationBench", config)
+    serialization = SerializationExtension(system)
+  }
+
+  @TearDown(Level.Trial)
+  def tearDownTrial(): Unit = {
+    Await.result(system.terminate(), 5.seconds)
+  }
+
+  private def serializeDeserialize[T <: AnyRef](msg: T): T = {
+    serialization.findSerializerFor(msg) match {
+      case serializer: SerializerWithStringManifest ⇒
+        val blob = serializer.toBinary(msg)
+        serializer.fromBinary(blob, serializer.manifest(msg)).asInstanceOf[T]
+      case serializer ⇒
+        val blob = serializer.toBinary(msg)
+        if (serializer.includeManifest)
+          serializer.fromBinary(blob, Some(msg.getClass)).asInstanceOf[T]
+        else
+          serializer.fromBinary(blob, None).asInstanceOf[T]
+    }
+
+  }
+
+  @Benchmark
+  def small(): Small = {
+    serializeDeserialize(smallMsg1)
+  }
+
+  @Benchmark
+  def medium(): Medium = {
+    serializeDeserialize(mediumMsg1)
+  }
+
+  @Benchmark
+  def large(): Large = {
+    serializeDeserialize(largeMsg)
+  }
+
+}
+

--- a/akka-jackson/src/main/java/akka/jackson/JavaTestEventMigration.java
+++ b/akka-jackson/src/main/java/akka/jackson/JavaTestEventMigration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.jackson;
+
+import com.fasterxml.jackson.databind.node.IntNode;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.JsonNode;
+import static akka.jackson.JavaTestMessages.*;
+
+public class JavaTestEventMigration extends JacksonMigration {
+
+  @Override
+  public int currentVersion() {
+    return 3;
+  }
+
+  @Override
+  public String transformClassName(int fromVersion, String className) {
+    return Event2.class.getName();
+  }
+
+  @Override
+  public JsonNode transform(int fromVersion, JsonNode json) {
+    ObjectNode root = (ObjectNode) json;
+    root.set("field1V2", root.get("field1"));
+    root.remove("field1");
+    root.set("field2", IntNode.valueOf(17));
+    return root;
+  }
+
+}

--- a/akka-jackson/src/main/java/akka/jackson/JavaTestMessages.java
+++ b/akka-jackson/src/main/java/akka/jackson/JavaTestMessages.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.jackson;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+
+public interface JavaTestMessages {
+
+  public class SimpleCommand  {
+    private final String name;
+
+    // @JsonProperty needed due to single argument constructor, see
+    // https://github.com/FasterXML/jackson-modules-java8/tree/master/parameter-names
+    public SimpleCommand(@JsonProperty("name") String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SimpleCommand that = (SimpleCommand) o;
+      return name != null ? name.equals(that.name) : that.name == null;
+    }
+
+    @Override
+    public int hashCode() {
+      return name != null ? name.hashCode() : 0;
+    }
+  }
+
+  public class SimpleCommand2  {
+    public final String name;
+    public final String name2;
+
+    // note that no annotation needed here, `javac -parameters` and not single param constructor
+    public SimpleCommand2(String name, String name2) {
+      this.name = name;
+      this.name2 = name2;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      SimpleCommand2 that = (SimpleCommand2) o;
+
+      if (name != null ? !name.equals(that.name) : that.name != null) return false;
+      return name2 != null ? name2.equals(that.name2) : that.name2 == null;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = name != null ? name.hashCode() : 0;
+      result = 31 * result + (name2 != null ? name2.hashCode() : 0);
+      return result;
+    }
+  }
+
+  public class OptionalCommand  {
+    private final Optional<String> maybe;
+
+    public OptionalCommand(@JsonProperty("maybe") Optional<String> maybe) {
+      this.maybe = maybe;
+    }
+
+    public Optional<String> getMaybe() {
+      return maybe;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      OptionalCommand that = (OptionalCommand) o;
+
+      return maybe != null ? maybe.equals(that.maybe) : that.maybe == null;
+    }
+
+    @Override
+    public int hashCode() {
+      return maybe != null ? maybe.hashCode() : 0;
+    }
+  }
+
+  public class BooleanCommand  {
+    private final boolean published;
+
+    public BooleanCommand(@JsonProperty("published") boolean published) {
+      this.published = published;
+    }
+
+    public boolean isPublished() {
+      return published;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      BooleanCommand that = (BooleanCommand) o;
+
+      return published == that.published;
+    }
+
+    @Override
+    public int hashCode() {
+      return (published ? 1 : 0);
+    }
+  }
+
+  public class CollectionsCommand  {
+    private final List<String> strings;
+    // if this was List<Object> it would not automatically work,
+    // which is good, otherwise arbitrary classes could be loaded
+    private final List<SimpleCommand> objects;
+
+    public CollectionsCommand(List<String> strings,
+                              List<SimpleCommand> objects) {
+      this.strings = strings;
+      this.objects = objects;
+    }
+
+    public List<String> getStrings() {
+      return strings;
+    }
+
+    public List<SimpleCommand> getObjects() {
+      return objects;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      CollectionsCommand that = (CollectionsCommand) o;
+
+      if (strings != null ? !strings.equals(that.strings) : that.strings != null) return false;
+      return objects != null ? objects.equals(that.objects) : that.objects == null;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = strings != null ? strings.hashCode() : 0;
+      result = 31 * result + (objects != null ? objects.hashCode() : 0);
+      return result;
+    }
+  }
+
+  public class TimeCommand {
+    public final LocalDateTime timestamp;
+    public final Duration duration;
+
+    public TimeCommand(LocalDateTime timestamp, Duration duration) {
+      this.timestamp = timestamp;
+      this.duration = duration;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      TimeCommand that = (TimeCommand) o;
+
+      if (timestamp != null ? !timestamp.equals(that.timestamp) : that.timestamp != null) return false;
+      return duration != null ? duration.equals(that.duration) : that.duration == null;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = timestamp != null ? timestamp.hashCode() : 0;
+      result = 31 * result + (duration != null ? duration.hashCode() : 0);
+      return result;
+    }
+  }
+
+  public class Event1 {
+
+    private final String field1;
+
+    public Event1(String field1) {
+      this.field1 = field1;
+    }
+
+    public String getField1() {
+      return field1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      Event1 event1 = (Event1) o;
+
+      return field1 != null ? field1.equals(event1.field1) : event1.field1 == null;
+    }
+
+    @Override
+    public int hashCode() {
+      return field1 != null ? field1.hashCode() : 0;
+    }
+  }
+
+  public class Event2 {
+    private final String field1V2; // renamed from field1
+    private final int field2; // new mandatory field
+
+    public Event2(String field1V2, int field2) {
+      this.field1V2 = field1V2;
+      this.field2 = field2;
+    }
+
+
+    public String getField1V2() {
+      return field1V2;
+    }
+
+    public int getField2() {
+      return field2;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      Event2 event2 = (Event2) o;
+
+      if (field2 != event2.field2) return false;
+      return field1V2 != null ? field1V2.equals(event2.field1V2) : event2.field1V2 == null;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = field1V2 != null ? field1V2.hashCode() : 0;
+      result = 31 * result + field2;
+      return result;
+    }
+  }
+
+}

--- a/akka-jackson/src/main/resources/reference.conf
+++ b/akka-jackson/src/main/resources/reference.conf
@@ -1,0 +1,55 @@
+############################
+# Akka Jackson Config File #
+############################
+
+# This is the reference config file that contains all the default settings.
+# Make your edits/overrides in your application.conf.
+
+akka.jackson {
+
+  #//#jackson-modules
+  # The Jackson JSON serializer will register these modules.
+  # It is also possible to use jackson-modules = ["*"] to dynamically
+  # find and register all modules in the classpath.
+  jackson-modules += "com.fasterxml.jackson.module.paramnames.ParameterNamesModule"
+  jackson-modules += "com.fasterxml.jackson.datatype.jdk8.Jdk8Module"
+  jackson-modules += "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule"
+  jackson-modules += "com.fasterxml.jackson.module.scala.DefaultScalaModule"
+  jackson-modules += "com.fasterxml.jackson.module.afterburner.AfterburnerModule"
+  #jackson-modules += "com.fasterxml.jackson.datatype.pcollections.PCollectionsModule"
+  #jackson-modules += "com.fasterxml.jackson.datatype.guava.GuavaModule"
+  #//#jackson-modules
+
+  # The serializer will compress the payload it's larger than this value.
+  compress-larger-than = 10 KiB
+
+  # When enabled and akka.loglevel=DEBUG serialization time and payload size
+  # is logged for each messages.
+  verbose-debug-logging = off
+
+  # Define data migration transformations of old formats to current
+  # format here as a mapping between the (old) class name to be
+  # transformed to the JacksonJsonMigration class that implements
+  # the transformation.
+  migrations {
+  }
+}
+
+akka.actor {
+  serializers {
+    jackson-json = "akka.jackson.JacksonJsonSerializer"
+    jackson-cbor = "akka.jackson.JacksonCborSerializer"
+    jackson-smile = "akka.jackson.JacksonSmileSerializer"
+  }
+  serialization-bindings {
+    # Define the following to use Jackson instead of the default java serializer.
+    # "java.io.Serializable" = jackson-cbor
+    # "java.lang.Object" = jackson-cbor
+
+  }
+  serialization-identifiers {
+    "akka.jackson.JacksonJsonSerializer" = 27
+    "akka.jackson.JacksonCborSerializer" = 28
+    "akka.jackson.JacksonSmileSerializer" = 29
+  }
+}

--- a/akka-jackson/src/main/scala/akka/jackson/JacksonMigration.scala
+++ b/akka-jackson/src/main/scala/akka/jackson/JacksonMigration.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.jackson
+
+import com.fasterxml.jackson.databind.JsonNode
+
+/**
+ * Data migration of old formats to current format can
+ * be implemented in a concrete subclass and configured to
+ * be used by the `JacksonSerializer` for a changed class.
+ *
+ * It is used when deserializing data of older version than the
+ * [[#currentVersion]]. You implement the transformation of the
+ * JSON structure in the [[#transform]] method. If you have changed the
+ * class name you should override [[#transformClassName]] and return
+ * current class name.
+ */
+abstract class JacksonMigration {
+  /**
+   * Define current version. The first version, when no migration was used,
+   * is always 1.
+   */
+  def currentVersion: Int
+
+  /**
+   * Override this method if you have changed the class name. Return
+   * current class name.
+   */
+  def transformClassName(fromVersion: Int, className: String): String =
+    className
+
+  /**
+   * Implement the transformation of the old JSON structure to the new
+   * JSON structure. The `JsonNode` is mutable so you can add and remove fields,
+   * or change values. Note that you have to cast to specific sub-classes such
+   * as `ObjectNode` and `ArrayNode` to get access to mutators.
+   *
+   * @param fromVersion the version of the old data
+   * @param json the old JSON data
+   */
+  def transform(fromVersion: Int, json: JsonNode): JsonNode
+}

--- a/akka-jackson/src/main/scala/akka/jackson/JacksonObjectMapperProvider.scala
+++ b/akka-jackson/src/main/scala/akka/jackson/JacksonObjectMapperProvider.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.jackson
+
+import scala.util.Failure
+import scala.util.Success
+
+import akka.actor.DynamicAccess
+import akka.actor.ExtendedActorSystem
+import akka.actor.Extension
+import akka.annotation.InternalApi
+import akka.event.Logging
+import akka.event.LoggingAdapter
+import com.fasterxml.jackson.annotation.JsonAutoDetect
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.PropertyAccessor
+import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.Module
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
+import com.typesafe.config.Config
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object JacksonObjectMapperProvider {
+
+  /**
+   * Creates Jackson `ObjectMapper` with sensible defaults and modules configured
+   * in `akka.jackson.jackson-modules`.
+   */
+  def create(system: ExtendedActorSystem, jsonFactory: Option[JsonFactory]): ObjectMapper =
+    create(
+      system.settings.config,
+      system.dynamicAccess,
+      Some(Logging.getLogger(system, JacksonObjectMapperProvider.getClass)),
+      jsonFactory)
+
+  /**
+   * Creates Jackson `ObjectMapper` with sensible defaults and modules configured
+   * in `akka.jackson.jackson-modules`.
+   */
+  def create(
+    config:        Config,
+    dynamicAccess: DynamicAccess,
+    log:           Option[LoggingAdapter],
+    jsonFactory:   Option[JsonFactory]): ObjectMapper = {
+    import scala.collection.JavaConverters._
+
+    val mapper = new ObjectMapper(jsonFactory.orNull)
+
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+
+    val configuredModules = config.getStringList(
+      "akka.jackson.jackson-modules"
+    ).asScala
+    val modules =
+      if (configuredModules.contains("*"))
+        ObjectMapper.findModules(dynamicAccess.classLoader).asScala
+      else configuredModules.flatMap { fqcn ⇒
+        dynamicAccess.createInstanceFor[Module](fqcn, Nil) match {
+          case Success(m) ⇒ Some(m)
+          case Failure(e) ⇒
+            log.foreach(_.error(e, s"Could not load configured Jackson module [$fqcn], " +
+              "please verify classpath dependencies or amend the configuration " +
+              "[akka.jackson-modules]. Continuing without this module."))
+            None
+        }
+      }
+
+    modules.foreach { module ⇒
+      if (module.isInstanceOf[ParameterNamesModule])
+        // ParameterNamesModule needs a special case for the constructor to ensure that single-parameter
+        // constructors are handled the same way as constructors with multiple parameters.
+        // See https://github.com/FasterXML/jackson-module-parameter-names#delegating-creator
+        mapper.registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES))
+      else mapper.registerModule(module)
+      log.foreach(_.debug("Registered Jackson module [{}]", module.getClass.getName))
+    }
+
+    mapper
+  }
+}

--- a/akka-jackson/src/main/scala/akka/jackson/JacksonSerializer.scala
+++ b/akka-jackson/src/main/scala/akka/jackson/JacksonSerializer.scala
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.jackson
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.NotSerializableException
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
+
+import scala.annotation.tailrec
+import scala.util.Failure
+import scala.util.Success
+
+import akka.actor.ExtendedActorSystem
+import akka.annotation.InternalApi
+import akka.event.Logging
+import akka.serialization.BaseSerializer
+import akka.serialization.SerializerWithStringManifest
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.cbor.CBORFactory
+import com.fasterxml.jackson.dataformat.smile.SmileFactory
+
+/**
+ * INTERNAL API: only public by configuration
+ *
+ * Akka serializer for Jackson with JSON.
+ */
+@InternalApi private[akka] class JacksonJsonSerializer(system: ExtendedActorSystem)
+  extends JacksonSerializer(system, JacksonObjectMapperProvider.create(system, None))
+
+/**
+ * INTERNAL API: only public by configuration
+ *
+ * Akka serializer for Jackson with Smile.
+ */
+@InternalApi private[akka] class JacksonSmileSerializer(system: ExtendedActorSystem)
+  extends JacksonSerializer(system, JacksonObjectMapperProvider.create(system, Some(new SmileFactory)))
+
+/**
+ * INTERNAL API: only public by configuration
+ *
+ * Akka serializer for Jackson with CBOR.
+ */
+@InternalApi private[akka] class JacksonCborSerializer(system: ExtendedActorSystem)
+  extends JacksonSerializer(system, JacksonObjectMapperProvider.create(system, Some(new CBORFactory)))
+
+/**
+ * INTERNAL API: Base class for Jackson serializers.
+ *
+ * Configuration in `akka.jackson` section.
+ * It will load Jackson modules defined in configuration `jackson-modules`.
+ *
+ * It will compress the payload if the the payload is larger than the configured
+ * `compress-larger-than` value.
+ */
+@InternalApi private[akka] abstract class JacksonSerializer(
+  val system: ExtendedActorSystem, objectMapper: ObjectMapper)
+  extends SerializerWithStringManifest with BaseSerializer {
+
+  private val log = Logging.getLogger(system, getClass)
+  private val conf = system.settings.config.getConfig("akka.jackson")
+  private val isDebugEnabled = conf.getBoolean("verbose-debug-logging") && log.isDebugEnabled
+  private final val BufferSize = 1024 * 4
+  private val migrations: Map[String, JacksonMigration] = {
+    import scala.collection.JavaConverters._
+    conf.getConfig("migrations").root.unwrapped.asScala.toMap.map {
+      case (k, v) ⇒
+        val transformer = system.dynamicAccess.createInstanceFor[JacksonMigration](v.toString, Nil).get
+        k -> transformer
+    }(collection.breakOut)
+  }
+
+  private val compressLargerThan: Long = conf.getBytes("compress-larger-than")
+
+  override def manifest(obj: AnyRef): String = {
+    val className = obj.getClass.getName
+    migrations.get(className) match {
+      case Some(transformer) ⇒ className + "#" + transformer.currentVersion
+      case None              ⇒ className
+    }
+  }
+
+  override def toBinary(obj: AnyRef): Array[Byte] = {
+    val startTime = if (isDebugEnabled) System.nanoTime else 0L
+    val bytes = objectMapper.writeValueAsBytes(obj)
+    val result =
+      if (bytes.length > compressLargerThan) compress(bytes)
+      else bytes
+
+    if (isDebugEnabled) {
+      val durationMicros = (System.nanoTime - startTime) / 1000
+      if (bytes.length == result.length)
+        log.debug(
+          "Serialization of [{}] took [{}] µs, size [{}] bytes",
+          obj.getClass.getName, durationMicros, result.length
+        )
+      else
+        log.debug(
+          "Serialization of [{}] took [{}] µs, compressed size [{}] bytes, uncompressed size [{}] bytes",
+          obj.getClass.getName, durationMicros, result.length, bytes.length
+        )
+    }
+
+    result
+  }
+
+  override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = {
+    val startTime = if (isDebugEnabled) System.nanoTime else 0L
+    val compressed = isGZipped(bytes)
+
+    val (fromVersion, manifestClassName) = parseManifest(manifest)
+
+    val migration = migrations.get(manifestClassName)
+
+    val className = migration match {
+      case Some(transformer) if fromVersion < transformer.currentVersion ⇒
+        transformer.transformClassName(fromVersion, manifestClassName)
+      case Some(transformer) if fromVersion > transformer.currentVersion ⇒
+        throw new IllegalStateException(s"Migration version ${transformer.currentVersion} is " +
+          s"behind version $fromVersion of deserialized type [$manifestClassName]")
+      case _ ⇒ manifestClassName
+    }
+
+    // FIXME Security concern: we would need a configured whitelist of class/package prefixes
+    // to prevent loading arbitary classes, i.e. app must at least configure its root package name
+
+    val clazz = system.dynamicAccess.getClassFor[AnyRef](className) match {
+      case Success(c) ⇒ c
+      case Failure(_) ⇒
+        throw new NotSerializableException(
+          s"Cannot find manifest class [$className] for serializer [${getClass.getName}]."
+        )
+    }
+
+    val decompressBytes = if (compressed) decompress(bytes) else bytes
+
+    if (isDebugEnabled) {
+      val durationMicros = (System.nanoTime - startTime) / 1000
+      if (bytes.length == decompressBytes.length)
+        log.debug(
+          "Deserialization of [{}] took [{}] µs, size [{}] bytes",
+          clazz.getName, durationMicros, decompressBytes.length
+        )
+      else
+        log.debug(
+          "Deserialization of [{}] took [{}] µs, compressed size [{}] bytes, uncompressed size [{}] bytes",
+          clazz.getName, durationMicros, decompressBytes.length, bytes.length
+        )
+    }
+
+    migration match {
+      case Some(transformer) if fromVersion < transformer.currentVersion ⇒
+        val jsonTree = objectMapper.readTree(decompressBytes)
+        val newJsonTree = transformer.transform(fromVersion, jsonTree)
+        objectMapper.treeToValue(newJsonTree, clazz)
+      case _ ⇒
+        objectMapper.readValue(decompressBytes, clazz)
+    }
+  }
+
+  private def parseManifest(manifest: String) = {
+    val i = manifest.lastIndexOf('#')
+    val fromVersion = if (i == -1) 1 else manifest.substring(i + 1).toInt
+    val manifestClassName = if (i == -1) manifest else manifest.substring(0, i)
+    (fromVersion, manifestClassName)
+  }
+
+  def compress(bytes: Array[Byte]): Array[Byte] = {
+    val bos = new ByteArrayOutputStream(BufferSize)
+    val zip = new GZIPOutputStream(bos)
+    try zip.write(bytes)
+    finally zip.close()
+    bos.toByteArray
+  }
+
+  def decompress(bytes: Array[Byte]): Array[Byte] = {
+    val in = new GZIPInputStream(new ByteArrayInputStream(bytes))
+    val out = new ByteArrayOutputStream()
+    val buffer = new Array[Byte](BufferSize)
+
+    @tailrec def readChunk(): Unit = in.read(buffer) match {
+      case -1 ⇒ ()
+      case n ⇒
+        out.write(buffer, 0, n)
+        readChunk()
+    }
+
+    try readChunk()
+    finally in.close()
+    out.toByteArray
+  }
+
+  def isGZipped(bytes: Array[Byte]): Boolean = {
+    (bytes != null) && (bytes.length >= 2) &&
+      (bytes(0) == GZIPInputStream.GZIP_MAGIC.toByte) &&
+      (bytes(1) == (GZIPInputStream.GZIP_MAGIC >> 8).toByte)
+  }
+}

--- a/akka-jackson/src/test/scala/akka/jackson/JacksonSerializerSpec.scala
+++ b/akka-jackson/src/test/scala/akka/jackson/JacksonSerializerSpec.scala
@@ -1,0 +1,204 @@
+/**
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.jackson
+
+import scala.concurrent.duration._
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import java.util.Arrays
+
+import akka.actor.ActorSystem
+import akka.serialization.SerializationExtension
+import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.Matchers
+import org.scalatest.WordSpecLike
+import java.util.Optional
+
+import scala.concurrent.duration.FiniteDuration
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.IntNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+
+object ScalaTestMessages {
+  final case class SimpleCommand(name: String)
+  final case class SimpleCommand2(name: String, name2: String)
+  final case class OptionCommand(maybe: Option[String])
+  final case class BooleanCommand(published: Boolean)
+  final case class TimeCommand(timestamp: LocalDateTime, duration: FiniteDuration)
+  final case class CollectionsCommand(strings: List[String], objects: Vector[SimpleCommand])
+
+  final case class Event1(field1: String)
+  final case class Event2(field1V2: String, field2: Int)
+}
+
+class ScalaTestEventMigration extends JacksonMigration {
+  override def currentVersion = 3
+
+  override def transformClassName(fromVersion: Int, className: String): String =
+    classOf[ScalaTestMessages.Event2].getName
+
+  override def transform(fromVersion: Int, json: JsonNode): JsonNode = {
+    val root = json.asInstanceOf[ObjectNode]
+    root.set("field1V2", root.get("field1"))
+    root.remove("field1")
+    root.set("field2", IntNode.valueOf(17))
+    root
+  }
+}
+
+class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json")
+class JacksonCborSerializerSpec extends JacksonSerializerSpec("jackson-cbor")
+class JacksonSmileSerializerSpec extends JacksonSerializerSpec("jackson-smile")
+
+abstract class JacksonSerializerSpec(serializerName: String) extends TestKit(ActorSystem(
+  "JacksonJsonSerializerSpec",
+  ConfigFactory.parseString(s"""
+    akka.jackson.migrations {
+      "akka.jackson.JavaTestMessages$$Event1" = "akka.jackson.JavaTestEventMigration"
+      "akka.jackson.JavaTestMessages$$Event2" = "akka.jackson.JavaTestEventMigration"
+      "akka.jackson.ScalaTestMessages$$Event1" = "akka.jackson.ScalaTestEventMigration"
+      "akka.jackson.ScalaTestMessages$$Event2" = "akka.jackson.ScalaTestEventMigration"
+    }
+    akka.actor {
+      allow-java-serialization = off
+      serialization-bindings {
+        "java.lang.Object" = $serializerName
+        "java.io.Serializable" = $serializerName
+      }
+    }
+    """))) with WordSpecLike with Matchers with BeforeAndAfterAll {
+
+  val serialization = SerializationExtension(system)
+
+  override def afterAll {
+    shutdown()
+  }
+
+  def checkSerialization(obj: AnyRef): Unit = {
+    val serializer = serializerFor(obj)
+    val blob = serializer.toBinary(obj)
+    val deserialized = serializer.fromBinary(blob, serializer.manifest(obj))
+    deserialized should ===(obj)
+  }
+
+  def serializerFor(obj: AnyRef): JacksonSerializer =
+    serialization.findSerializerFor(obj) match {
+      case serializer: JacksonSerializer ⇒ serializer
+      case s ⇒
+        throw new IllegalStateException(s"Wrong serializer ${s.getClass} for ${obj.getClass}")
+    }
+
+  "JacksonSerializer with Java message classes" must {
+    import JavaTestMessages._
+
+    "serialize simple message with one constructor parameter" in {
+      checkSerialization(new SimpleCommand("Bob"))
+    }
+
+    "serialize simple message with two constructor parameters" in {
+      checkSerialization(new SimpleCommand2("Bob", "Alice"))
+      checkSerialization(new SimpleCommand2("Bob", ""))
+      checkSerialization(new SimpleCommand2("Bob", null))
+    }
+
+    "serialize message with boolean property" in {
+      checkSerialization(new BooleanCommand(true))
+      checkSerialization(new BooleanCommand(false))
+    }
+
+    "serialize message with Optional property" in {
+      checkSerialization(new OptionalCommand(Optional.of("abc")))
+      checkSerialization(new OptionalCommand(Optional.empty()))
+    }
+
+    "serialize message with collections" in {
+      val strings = Arrays.asList("a", "b", "c")
+      val objects = Arrays.asList(new SimpleCommand("a"), new SimpleCommand("2"))
+      val msg = new CollectionsCommand(strings, objects)
+      checkSerialization(msg)
+    }
+
+    "serialize message with time" in {
+      val msg = new TimeCommand(LocalDateTime.now(), Duration.of(5, ChronoUnit.SECONDS))
+      checkSerialization(msg)
+    }
+
+    "deserialize with migrations" in {
+      val event1 = new Event1("a")
+      val serializer = serializerFor(event1)
+      val blob = serializer.toBinary(event1)
+      val event2 = serializer.fromBinary(blob, classOf[Event1].getName).asInstanceOf[Event2]
+      event1.getField1 should ===(event2.getField1V2)
+      event2.getField2 should ===(17)
+    }
+
+    "deserialize with migrations from V2" in {
+      val event1 = new Event1("a")
+      val serializer = serializerFor(event1)
+      val blob = serializer.toBinary(event1)
+      val event2 = serializer.fromBinary(blob, classOf[Event1].getName + "#2").asInstanceOf[Event2]
+      event1.getField1 should ===(event2.getField1V2)
+      event2.getField2 should ===(17)
+    }
+  }
+
+  "JacksonSerializer with Scala message classes" must {
+    import ScalaTestMessages._
+
+    "serialize simple message with one constructor parameter" in {
+      checkSerialization(SimpleCommand("Bob"))
+    }
+
+    "serialize simple message with two constructor parameters" in {
+      checkSerialization(SimpleCommand2("Bob", "Alice"))
+      checkSerialization(SimpleCommand2("Bob", ""))
+      checkSerialization(SimpleCommand2("Bob", null))
+    }
+
+    "serialize message with boolean property" in {
+      checkSerialization(BooleanCommand(true))
+      checkSerialization(BooleanCommand(false))
+    }
+
+    "serialize message with Optional property" in {
+      checkSerialization(OptionCommand(Some("abc")))
+      checkSerialization(OptionCommand(None))
+    }
+
+    "serialize message with collections" in {
+      val strings = "a" :: "b" :: "c" :: Nil
+      val objects = Vector(SimpleCommand("a"), SimpleCommand("2"))
+      val msg = CollectionsCommand(strings, objects)
+      checkSerialization(msg)
+    }
+
+    "serialize message with time" in {
+      val msg = TimeCommand(LocalDateTime.now(), 5.seconds)
+      checkSerialization(msg)
+    }
+
+    "deserialize with migrations" in {
+      val event1 = Event1("a")
+      val serializer = serializerFor(event1)
+      val blob = serializer.toBinary(event1)
+      val event2 = serializer.fromBinary(blob, classOf[Event1].getName).asInstanceOf[Event2]
+      event1.field1 should ===(event2.field1V2)
+      event2.field2 should ===(17)
+    }
+
+    "deserialize with migrations from V2" in {
+      val event1 = Event1("a")
+      val serializer = serializerFor(event1)
+      val blob = serializer.toBinary(event1)
+      val event2 = serializer.fromBinary(blob, classOf[Event1].getName + "#2").asInstanceOf[Event2]
+      event1.field1 should ===(event2.field1V2)
+      event2.field2 should ===(17)
+    }
+  }
+}
+

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] = Seq(
   osgi,
   persistence, persistenceQuery, persistenceShared, persistenceTck,
   protobuf,
+  jackson,
   remote, remoteTests,
   slf4j,
   stream, streamTestkit, streamTests, streamTestsTck,
@@ -88,6 +89,7 @@ lazy val benchJmh = akkaModule("akka-bench-jmh")
       actor,
       stream, streamTests,
       persistence, distributedData,
+      jackson,
       testkit
     ).map(_ % "compile->compile;compile->test;provided->provided"): _*
   )
@@ -297,6 +299,14 @@ lazy val protobuf = akkaModule("akka-protobuf")
   .settings(AutomaticModuleName.settings("akka.protobuf"))
   .enablePlugins(ScaladocNoVerificationOfDiagrams)
   .disablePlugins(MimaPlugin)
+
+lazy val jackson = akkaModule("akka-jackson")
+  .dependsOn(actor, actorTests % "test->test", testkit % "test->test")
+  .settings(Dependencies.jackson)
+  .settings(AutomaticModuleName.settings("akka.jackson"))
+  .settings(OSGi.jackson)
+  .settings(javacOptions += "-parameters")
+  .enablePlugins(ScaladocNoVerificationOfDiagrams)
 
 lazy val remote = akkaModule("akka-remote")
   .dependsOn(actor, stream, actorTests % "test->test", testkit % "test->test", streamTestkit % "test", protobuf)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
   val slf4jVersion = "1.7.25"
   val scalaXmlVersion = "1.0.6"
   val aeronVersion = "1.7.0"
+  val jacksonVersion = "2.9.4"
 
   val Versions = Seq(
     crossScalaVersions := Seq("2.11.12", "2.12.4"),
@@ -73,6 +74,19 @@ object Dependencies {
 
     val aeronDriver = "io.aeron" % "aeron-driver" % aeronVersion // ApacheV2
     val aeronClient = "io.aeron" % "aeron-client" % aeronVersion // ApacheV2
+
+    // FIXME licence
+    val jacksonCore =           "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion // ApacheV2
+    val jacksonAnnotations =    "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion // ApacheV2
+    val jacksonDatabind =       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion // ApacheV2
+    val jacksonJdk8 =           "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion // ApacheV2
+    val jacksonJsr310 =         "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion // ApacheV2
+    val jacksonScala =          "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion // ApacheV2
+    val jacksonParameterNames = "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonVersion // ApacheV2
+    val jacksonAfterburner =    "com.fasterxml.jackson.module" % "jackson-module-afterburner" % jacksonVersion // ApacheV2
+    val jacksonCbor =           "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion // ApacheV2
+    val jacksonSmile =          "com.fasterxml.jackson.dataformat" % "jackson-dataformat-smile" % jacksonVersion % "optional;provided" // ApacheV2
+
     object Docs {
       val sprayJson = "io.spray" %% "spray-json" % "1.3.3" % "test"
       val gson = "com.google.code.gson" % "gson" % "2.8.2" % "test"
@@ -135,6 +149,9 @@ object Dependencies {
   val remote = l ++= Seq(netty, aeronDriver, aeronClient, Test.junit, Test.scalatest.value, Test.jimfs)
 
   val remoteTests = l ++= Seq(Test.junit, Test.scalatest.value, Test.scalaXml)
+
+  val jackson = l ++= Seq(jacksonCore, jacksonAnnotations, jacksonDatabind, jacksonScala, jacksonJdk8, jacksonJsr310,
+    jacksonParameterNames, jacksonAfterburner, jacksonSmile, jacksonCbor, Test.junit, Test.scalatest.value)
 
   val cluster = l ++= Seq(Test.junit, Test.scalatest.value)
 

--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -54,6 +54,8 @@ object OSGi {
 
   val protobuf = exports(Seq("akka.protobuf.*"))
 
+  val jackson = exports(Seq("akka.jackson.*"))
+
   val remote = exports(Seq("akka.remote.*"))
 
   val parsing = exports(


### PR DESCRIPTION
* Copied from Lagom, with the following differences
  * Jsonable and CompressedJsonable not included
  * pcollection and guava modules not enabled by default
  * added scala and afterburner modules
  * no Akka extension
* JSON, CBOR and Smile options (different serializers)
* JMH benchmark

Will add documentation, similar to [Lagom docs](https://www.lagomframework.com/documentation/1.4.x/java/Serialization.html)

Refs #24155 

cc @TimMoore 
