### PR TITLE
Too many Tocks in typed TimerSpec

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
@@ -11,6 +11,7 @@ import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.TimerScheduler
+import akka.testkit.TimingTest
 import akka.testkit.typed.TestKitSettings
 import akka.testkit.typed.TestKit
 import akka.testkit.typed.scaladsl._
@@ -78,7 +79,7 @@ class TimerSpec extends TestKit("TimerSpec")
   }
 
   "A timer" must {
-    "schedule non-repeated ticks" in {
+    "schedule non-repeated ticks" taggedAs TimingTest in {
       val probe = TestProbe[Event]("evt")
       val behv = Behaviors.withTimers[Command] { timer ⇒
         timer.startSingleTimer("T", Tick(1), 10.millis)
@@ -93,7 +94,7 @@ class TimerSpec extends TestKit("TimerSpec")
       probe.expectMessage(GotPostStop(false))
     }
 
-    "schedule repeated ticks" in {
+    "schedule repeated ticks" taggedAs TimingTest in {
       val probe = TestProbe[Event]("evt")
       val behv = Behaviors.withTimers[Command] { timer ⇒
         timer.startPeriodicTimer("T", Tick(1), interval)
@@ -111,7 +112,7 @@ class TimerSpec extends TestKit("TimerSpec")
       probe.expectMessage(GotPostStop(false))
     }
 
-    "replace timer" in {
+    "replace timer" taggedAs TimingTest in {
       val probe = TestProbe[Event]("evt")
       val behv = Behaviors.withTimers[Command] { timer ⇒
         timer.startPeriodicTimer("T", Tick(1), interval)
@@ -131,7 +132,7 @@ class TimerSpec extends TestKit("TimerSpec")
       probe.expectMessage(GotPostStop(false))
     }
 
-    "cancel timer" in {
+    "cancel timer" taggedAs TimingTest in {
       val probe = TestProbe[Event]("evt")
       val behv = Behaviors.withTimers[Command] { timer ⇒
         timer.startPeriodicTimer("T", Tick(1), interval)
@@ -147,7 +148,7 @@ class TimerSpec extends TestKit("TimerSpec")
       probe.expectMessage(GotPostStop(false))
     }
 
-    "discard timers from old incarnation after restart, alt 1" in {
+    "discard timers from old incarnation after restart, alt 1" taggedAs TimingTest in {
       val probe = TestProbe[Event]("evt")
       val startCounter = new AtomicInteger(0)
       val behv = Behaviors.supervise(Behaviors.withTimers[Command] { timer ⇒
@@ -171,7 +172,7 @@ class TimerSpec extends TestKit("TimerSpec")
       probe.expectMessage(GotPostStop(false))
     }
 
-    "discard timers from old incarnation after restart, alt 2" in {
+    "discard timers from old incarnation after restart, alt 2" taggedAs TimingTest in {
       val probe = TestProbe[Event]("evt")
       val behv = Behaviors.supervise(Behaviors.withTimers[Command] { timer ⇒
         timer.startPeriodicTimer("T", Tick(1), interval)
@@ -197,7 +198,7 @@ class TimerSpec extends TestKit("TimerSpec")
       probe.expectMessage(GotPostStop(false))
     }
 
-    "cancel timers when stopped from exception" in {
+    "cancel timers when stopped from exception" taggedAs TimingTest in {
       val probe = TestProbe[Event]()
       val behv = Behaviors.withTimers[Command] { timer ⇒
         timer.startPeriodicTimer("T", Tick(1), interval)
@@ -208,7 +209,7 @@ class TimerSpec extends TestKit("TimerSpec")
       probe.expectMessage(GotPostStop(false))
     }
 
-    "cancel timers when stopped voluntarily" in {
+    "cancel timers when stopped voluntarily" taggedAs TimingTest in {
       val probe = TestProbe[Event]()
       val behv = Behaviors.withTimers[Command] { timer ⇒
         timer.startPeriodicTimer("T", Tick(1), interval)

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/TestKit.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/TestKit.scala
@@ -20,7 +20,8 @@ case class TE(message: String) extends RuntimeException(message) with NoStackTra
 /**
  * Not for user extension.
  *
- * Instances are available from `FishingOutcomes` in the respective dsls
+ * Instances are available from `FishingOutcomes` in the respective dsls: [[akka.testkit.typed.scaladsl.FishingOutcomes]]
+ * and [[akka.testkit.typed.javadsl.FishingOutcomes]]
  */
 @DoNotInherit abstract class FishingOutcome private[akka] ()
 

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/TestKit.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/TestKit.scala
@@ -3,7 +3,7 @@ package akka.testkit.typed
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, Props }
-import akka.annotation.ApiMayChange
+import akka.annotation.{ ApiMayChange, DoNotInherit }
 import akka.testkit.typed.TestKit._
 import akka.util.Timeout
 import com.typesafe.config.Config
@@ -16,6 +16,13 @@ import scala.util.control.NoStackTrace
  * Exception without stack trace to use for verifying exceptions in tests
  */
 case class TE(message: String) extends RuntimeException(message) with NoStackTrace
+
+/**
+ * Not for user extension.
+ *
+ * Instances are available from `FishingOutcomes` in the respective dsls
+ */
+@DoNotInherit abstract class FishingOutcome private[akka] ()
 
 object TestKit {
 

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/javadsl/TestProbe.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/javadsl/TestProbe.scala
@@ -4,6 +4,27 @@
 package akka.testkit.typed.javadsl
 
 import akka.actor.typed.ActorSystem
+import akka.testkit.typed.FishingOutcome
+
+import scala.concurrent.duration.FiniteDuration
+
+object FishingOutcomes {
+
+  /**
+   * Consume this message and continue with the next
+   */
+  def continue(): FishingOutcome = akka.testkit.typed.scaladsl.FishingOutcomes.Continue
+
+  /**
+   * Complete fishing and return this message
+   */
+  def complete(): FishingOutcome = akka.testkit.typed.scaladsl.FishingOutcomes.Complete
+
+  /**
+   * Fail fishing with a custom error message
+   */
+  def fail(error: String): FishingOutcome = akka.testkit.typed.scaladsl.FishingOutcomes.Fail(error)
+}
 
 /**
  * Java API:
@@ -17,5 +38,26 @@ class TestProbe[M](name: String, system: ActorSystem[_]) extends akka.testkit.ty
    */
   def expectMessageType[T <: M](t: Class[T]): T =
     expectMessageClass_internal(remainingOrDefault, t)
+
+  /**
+   * Java API: Allows for flexible matching of multiple messages within a timeout, the fisher function is fed each incoming
+   * message, and returns one of the following effects to decide on what happens next:
+   *
+   *  * [[FishingOutcomes.continue()]] - continue with the next message given that the timeout has not been reached
+   *  * [[FishingOutcomes.complete()]] - successfully complete and return the message
+   *  * [[FishingOutcomes.fail(errorMsg)]] - fail the test with a custom message
+   *
+   * Additionally failures includes the list of messages consumed. If a message of type `M` but not of type `T` is
+   * received this will also fail the test, additionally if the `fisher` function throws a match error the error
+   * is decorated with some fishing details and the test is failed (making it convenient to use this method with a
+   * partial function).
+   *
+   * @param max Max total time without the fisher function returning `CompleteFishing` before failing
+   *            The timeout is dilated.
+   * @return The messages accepted in the order they arrived
+   */
+  // FIXME same name would cause ambiguity but I'm out of ideas how to fix, separate Scala/Java TestProbe APIs?
+  def fishForMessageJava(max: FiniteDuration, fisher: java.util.function.Function[M, FishingOutcome]): List[M] =
+    fishForMessage(max)(fisher.apply)
 
 }

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/javadsl/TestProbe.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/javadsl/TestProbe.scala
@@ -7,6 +7,7 @@ import akka.actor.typed.ActorSystem
 import akka.testkit.typed.FishingOutcome
 
 import scala.concurrent.duration.FiniteDuration
+import scala.collection.JavaConverters._
 
 object FishingOutcomes {
 
@@ -57,7 +58,13 @@ class TestProbe[M](name: String, system: ActorSystem[_]) extends akka.testkit.ty
    * @return The messages accepted in the order they arrived
    */
   // FIXME same name would cause ambiguity but I'm out of ideas how to fix, separate Scala/Java TestProbe APIs?
-  def fishForMessageJava(max: FiniteDuration, fisher: java.util.function.Function[M, FishingOutcome]): List[M] =
-    fishForMessage(max)(fisher.apply)
+  def fishForMessageJava(max: FiniteDuration, fisher: java.util.function.Function[M, FishingOutcome]): java.util.List[M] =
+    fishForMessage(max)(fisher.apply).asJava
+
+  /**
+   * Same as the other `fishForMessageJava` but includes the provided hint in all error messages
+   */
+  def fishForMessageJava(max: FiniteDuration, hint: String, fisher: java.util.function.Function[M, FishingOutcome]): java.util.List[M] =
+    fishForMessage(max, hint)(fisher.apply).asJava
 
 }


### PR DESCRIPTION
Fixes #24360

Adds a fishForMessages for typed teskit probes