### PR TITLE
Generate file to use instead of assuming class loader type

### DIFF
--- a/akka-actor/src/main/mima-filters/2.5.10.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.10.backwards.excludes
@@ -3,3 +3,6 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.CoordinatedShutdo
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.CoordinatedShutdown#Phase.this")
 ProblemFilters.exclude[MissingTypesProblem]("akka.actor.CoordinatedShutdown$Phase$")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.CoordinatedShutdown#Phase.apply")
+
+# Path based WriteFile command #23902
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.io.TcpConnection.PendingWriteFile")

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -349,7 +349,6 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
     require(count > 0, "WriteFile.count must be > 0")
   }
 
-
   /**
    * Write `count` bytes starting at `position` from file at `filePath` to the connection.
    * The count must be &gt; 0. The connection actor will reply with a [[CommandFailed]]

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -17,6 +17,7 @@ import akka.util.{ ByteString, Helpers }
 import akka.util.Helpers.Requiring
 import akka.actor._
 import java.lang.{ Iterable ⇒ JIterable }
+import java.nio.file.Path
 
 import akka.annotation.InternalApi
 
@@ -350,6 +351,14 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    * a particular write has been sent by the O/S.
    */
   final case class WriteFile(filePath: String, position: Long, count: Long, ack: Event) extends SimpleWriteCommand {
+    require(position >= 0, "WriteFile.position must be >= 0")
+    require(count > 0, "WriteFile.count must be > 0")
+  }
+
+  /**
+   * @see [[WriteFile]]
+   */
+  final case class WritePath(path: Path, position: Long, count: Long, ack: Event) extends SimpleWriteCommand {
     require(position >= 0, "WriteFile.position must be >= 0")
     require(count > 0, "WriteFile.count must be > 0")
   }

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -341,6 +341,16 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
   }
 
   /**
+   * @see [[WritePath]]
+   */
+  @deprecated("Use WritePath instead", "2.5.10")
+  final case class WriteFile(filePath: String, position: Long, count: Long, ack: Event) extends SimpleWriteCommand {
+    require(position >= 0, "WriteFile.position must be >= 0")
+    require(count > 0, "WriteFile.count must be > 0")
+  }
+
+
+  /**
    * Write `count` bytes starting at `position` from file at `filePath` to the connection.
    * The count must be &gt; 0. The connection actor will reply with a [[CommandFailed]]
    * message if the write could not be enqueued. If [[SimpleWriteCommand#wantsAck]]
@@ -349,14 +359,6 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    * <b>Note that this does not in any way guarantee that the data will be
    * or have been sent!</b> Unfortunately there is no way to determine whether
    * a particular write has been sent by the O/S.
-   */
-  final case class WriteFile(filePath: String, position: Long, count: Long, ack: Event) extends SimpleWriteCommand {
-    require(position >= 0, "WriteFile.position must be >= 0")
-    require(count > 0, "WriteFile.count must be > 0")
-  }
-
-  /**
-   * @see [[WriteFile]]
    */
   final case class WritePath(path: Path, position: Long, count: Long, ack: Event) extends SimpleWriteCommand {
     require(position >= 0, "WriteFile.position must be >= 0")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -130,7 +130,8 @@ object Dependencies {
 
   val testkit = l ++= Seq(Test.junit, Test.scalatest.value) ++ Test.metricsAll
 
-  val actorTests = l ++= Seq(Test.junit, Test.scalatest.value, Test.commonsCodec, Test.commonsMath, Test.mockito, Test.scalacheck.value)
+  val actorTests = l ++= Seq(Test.junit, Test.scalatest.value, Test.commonsCodec, Test.commonsMath,
+    Test.mockito, Test.scalacheck.value, Test.jimfs)
 
   val remote = l ++= Seq(netty, aeronDriver, aeronClient, Test.junit, Test.scalatest.value, Test.jimfs)
 


### PR DESCRIPTION
In TcpConnectionSpec (as it fails in JDK 9) Fixes #23902