### PR TITLE
[WIP] Typed tests that extend testkit not run as part of build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -391,6 +391,7 @@ lazy val persistenceTyped = akkaModule("akka-persistence-typed")
     typedTestkit % "test->test",
     actorTypedTests % "test->test"
   )
+  .settings(Dependencies.persistenceTyped)
   .settings(AkkaBuild.mayChangeSettings)
   .settings(AutomaticModuleName.settings("akka.persistence.typed"))
   .disablePlugins(MimaPlugin)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,6 +83,7 @@ object Dependencies {
       val commonsIo = "commons-io" % "commons-io" % "2.5" % "test" // ApacheV2
       val commonsCodec = "commons-codec" % "commons-codec" % "1.10" % "test" // ApacheV2
       val junit = "junit" % "junit" % junitVersion % "test" // Common Public License 1.0
+      val junitInterface = "com.novocode" % "junit-interface" % "0.11" % "test" // BSD 2-clause
       val logback = "ch.qos.logback" % "logback-classic" % "1.2.3" % "test" // EPL 1.0 / LGPL 2.1
       val mockito = "org.mockito" % "mockito-core" % "2.7.16" % "test" // MIT
       // changing the scalatest dependency must be reflected in akka-docs/rst/dev/multi-jvm-testing.rst
@@ -151,6 +152,8 @@ object Dependencies {
   val agent = l ++= Seq(scalaStm.value, Test.scalatest.value, Test.junit)
 
   val persistence = l ++= Seq(Provided.levelDB, Provided.levelDBNative, Test.scalatest.value, Test.junit, Test.commonsIo, Test.commonsCodec, Test.scalaXml)
+
+  val persistenceTyped = l ++= Seq(Test.junitInterface)
 
   val persistenceQuery = l ++= Seq(Test.scalatest.value, Test.junit, Test.commonsIo)
 


### PR DESCRIPTION
We usually extend JUnitSuite so scala test runs them but
we can't do that if we extend out test kit as we do
for the tests in typed persistence.

Not really sure what's best here as we have a mixture in some
projects and don't want to run them twice