### PR TITLE
[wip] artery-tcp: prefix connection with stream id and remove from EnvelopeBuffer frame

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/remote/artery/CodecBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/remote/artery/CodecBenchmark.scala
@@ -127,8 +127,8 @@ class CodecBenchmark {
     } else null
     val envelope = new EnvelopeBuffer(envelopeTemplateBuffer)
     val outboundEnvelope = OutboundEnvelope(OptionVal.None, payload, OptionVal.None)
-    headerIn setFrameLength 100
-    headerIn setStreamId 1
+    //headerIn setFrameLength 100
+    //headerIn setStreamId 1
     headerIn setVersion ArteryTransport.HighestVersion
     headerIn setUid 42
     headerIn setSenderActorRef actorOnSystemA
@@ -147,7 +147,7 @@ class CodecBenchmark {
     val compressions = new InboundCompressionsImpl(system, inboundContext, inboundContext.settings.Advanced.Compression)
     val decoder: Flow[EnvelopeBuffer, InboundEnvelope, InboundCompressionAccess] =
       Flow.fromGraph(new Decoder(inboundContext, system.asInstanceOf[ExtendedActorSystem],
-        uniqueLocalAddress, inboundContext.settings, envelopePool, compressions, inboundEnvelopePool))
+        uniqueLocalAddress, inboundContext.settings, compressions, inboundEnvelopePool))
     val deserializer: Flow[InboundEnvelope, InboundEnvelope, NotUsed] =
       Flow.fromGraph(new Deserializer(inboundContext, system.asInstanceOf[ExtendedActorSystem], envelopePool))
     val decoderInput: Flow[String, EnvelopeBuffer, NotUsed] = Flow[String]

--- a/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
@@ -353,7 +353,6 @@ private[remote] class Decoder(
   system:              ExtendedActorSystem,
   uniqueLocalAddress:  UniqueAddress,
   settings:            ArterySettings,
-  bufferPool:          EnvelopeBufferPool,
   inboundCompressions: InboundCompressions,
   inEnvelopePool:      ObjectPool[ReusableInboundEnvelope])
   extends GraphStageWithMaterializedValue[FlowShape[EnvelopeBuffer, InboundEnvelope], InboundCompressionAccess] {

--- a/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
@@ -65,7 +65,7 @@ private[remote] class Encoder(
       private val headerBuilder = HeaderBuilder.out()
       headerBuilder setVersion version
       headerBuilder setUid uniqueLocalAddress.uid
-      headerBuilder setStreamId streamId.toByte
+      //headerBuilder setStreamId streamId.toByte
       private val localAddress = uniqueLocalAddress.address
       private val serialization = SerializationExtension(system)
       private val serializationInfo = Serialization.Information(localAddress, system)
@@ -136,11 +136,11 @@ private[remote] class Encoder(
             }
           } finally Serialization.currentTransportInformation.value = oldValue
 
-          if (headerBuilder.version >= 1) {
+          /*if (headerBuilder.version >= 1) {
             // Framing.lengthField need the length after the length field, not the total frame size
             val frameLength = envelope.byteBuffer.position() - EnvelopeBuffer.FrameLengthOffset - 4
             envelope.byteBuffer.putInt(EnvelopeBuffer.FrameLengthOffset, frameLength)
-          }
+          }*/
 
           envelope.byteBuffer.flip()
 

--- a/akka-remote/src/main/scala/akka/remote/artery/EnvelopeBufferPool.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/EnvelopeBufferPool.scala
@@ -73,7 +73,7 @@ private[remote] object EnvelopeBuffer {
 
   val VersionOffset = 0 // Byte
 
-  val FrameLengthOffset = 1 // Int
+  //val FrameLengthOffset = 1 // Int
   val StreamIdOffset = 5 // Byte
 
   val FlagsOffset = 6 // Byte
@@ -117,11 +117,11 @@ private[remote] sealed trait HeaderBuilder {
   def versionPositionAdjust: Int
   def positionOfMetaData: Int
 
-  def setFrameLength(length: Int): Unit
-  def frameLength: Int
+  //def setFrameLength(length: Int): Unit
+  //def frameLength: Int
 
-  def setStreamId(id: Byte): Unit
-  def streamId: Byte
+  //def setStreamId(id: Byte): Unit
+  //def streamId: Byte
 
   def setFlags(v: Byte): Unit
   def flags: Byte
@@ -216,8 +216,8 @@ private[remote] final class HeaderBuilderImpl(
 
   // Fields only available for EnvelopeBuffer
   var _version: Byte = 0
-  var _frameLength: Int = 0
-  var _streamId: Byte = 0
+  //var _frameLength: Int = 0
+  //var _streamId: Byte = 0
   var _flags: Byte = 0
   var _uid: Long = 0
   var _inboundActorRefCompressionTableVersion: Byte = 0
@@ -240,7 +240,7 @@ private[remote] final class HeaderBuilderImpl(
     // which owns the HeaderBuilder instance. Those are never changed.
     // version, uid, streamId
 
-    _frameLength = 0
+    //_frameLength = 0
     _flags = 0
     _senderActorRef = null
     _senderActorRefIdx = -1
@@ -265,11 +265,11 @@ private[remote] final class HeaderBuilderImpl(
 
   def positionOfMetaData: Int = EnvelopeBuffer.MetadataContainerAndLiteralSectionOffset - versionPositionAdjust
 
-  def setFrameLength(length: Int): Unit = _frameLength = length
-  def frameLength: Int = _frameLength
+  //def setFrameLength(length: Int): Unit = _frameLength = length
+  //def frameLength: Int = _frameLength
 
-  def setStreamId(id: Byte): Unit = _streamId = id
-  def streamId: Byte = _streamId
+  //def setStreamId(id: Byte): Unit = _streamId = id
+  //def streamId: Byte = _streamId
 
   override def setFlags(v: Byte) = _flags = v
   override def flags = _flags
@@ -373,8 +373,8 @@ private[remote] final class HeaderBuilderImpl(
 
   override def toString =
     "HeaderBuilderImpl(" +
-      "frameLength:" + frameLength + ", " +
-      "streamId:" + streamId + ", " +
+      //"frameLength:" + frameLength + ", " +
+      //"streamId:" + streamId + ", " +
       "version:" + version + ", " +
       "flags:" + ByteFlag.binaryLeftPad(flags) + ", " +
       "UID:" + uid + ", " +
@@ -397,6 +397,12 @@ private[remote] final class EnvelopeBuffer(val byteBuffer: ByteBuffer) {
 
   private var literalChars = new Array[Char](64)
   private var literalBytes = new Array[Byte](64)
+  private var _streamId: Int = -1
+  def streamId: Int =
+    if (_streamId != -1) _streamId
+    else
+      throw new IllegalStateException("StreamId was not set")
+  def setStreamId(newStreamId: Int): Unit = _streamId = newStreamId
 
   def writeHeader(h: HeaderBuilder): Unit = writeHeader(h, null)
 
@@ -408,10 +414,10 @@ private[remote] final class EnvelopeBuffer(val byteBuffer: ByteBuffer) {
     byteBuffer.put(VersionOffset, header.version)
 
     // frameLength and streamId were added in version 1
-    if (header.version >= 1) {
+    /*if (header.version >= 1) {
       byteBuffer.putInt(FrameLengthOffset, header.frameLength)
       byteBuffer.putInt(StreamIdOffset, header.streamId)
-    }
+    }*/
     val adjust = header.versionPositionAdjust
 
     byteBuffer.put(FlagsOffset - adjust, header.flags)
@@ -464,10 +470,10 @@ private[remote] final class EnvelopeBuffer(val byteBuffer: ByteBuffer) {
           s"highest known version for this node is [${ArteryTransport.HighestVersion}]")
 
     // frameLength and streamId were added in version 1
-    if (header.version >= 1) {
+    /*if (header.version >= 1) {
       header.setFrameLength(byteBuffer.getInt(FrameLengthOffset))
       header.setStreamId(byteBuffer.get(StreamIdOffset))
-    }
+    }*/
     val adjust = header.versionPositionAdjust
 
     header.setFlags(byteBuffer.get(FlagsOffset - adjust))

--- a/akka-remote/src/main/scala/akka/remote/artery/LogByteStringTools.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/LogByteStringTools.scala
@@ -1,0 +1,96 @@
+package akka.remote.artery
+
+import akka.NotUsed
+import akka.annotation.InternalApi
+import akka.event.Logging
+import akka.stream.Attributes
+import akka.stream.TLSProtocol._
+import akka.stream.scaladsl.{ BidiFlow, Flow }
+import akka.util.ByteString
+
+import scala.reflect.ClassTag
+
+/**
+ * INTERNAL API
+ *
+ * Flow and BidiFlow stages to log streams of ByteString.
+ */
+@InternalApi
+private[akka] object LogByteStringTools {
+  val MaxBytesPrinted = 16 * 5
+
+  private val LogFailuresOnDebugAttributes = Attributes.logLevels(onFailure = Logging.DebugLevel)
+
+  def logByteStringBidi(name: String, maxBytes: Int = MaxBytesPrinted): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] =
+    BidiFlow.fromFlows(
+      logByteString(s"$name DOWN", maxBytes),
+      logByteString(s"$name UP  ", maxBytes)
+    )
+
+  def logToStringBidi[A: ClassTag, B: ClassTag](name: String, maxBytes: Int = MaxBytesPrinted): BidiFlow[A, A, B, B, NotUsed] = {
+    def limitedName[T](implicit tag: ClassTag[T]): String = Logging.simpleName(tag.runtimeClass).take(20).mkString
+    BidiFlow.fromFlows(
+      logToString(s"$name ${limitedName[A]}", maxBytes),
+      logToString(s"$name ${limitedName[B]}", maxBytes)
+    )
+  }
+
+  def logByteString(name: String, maxBytes: Int = MaxBytesPrinted): Flow[ByteString, ByteString, NotUsed] =
+    Flow[ByteString].log(name, printByteString(_, maxBytes)).addAttributes(LogFailuresOnDebugAttributes)
+
+  def logToString[A](name: String, maxBytes: Int = MaxBytesPrinted): Flow[A, A, NotUsed] =
+    Flow[A].log(name, _.toString().take(maxBytes)).addAttributes(LogFailuresOnDebugAttributes)
+
+  def logTLSBidi(name: String, maxBytes: Int = MaxBytesPrinted): BidiFlow[SslTlsOutbound, SslTlsOutbound, SslTlsInbound, SslTlsInbound, NotUsed] =
+    BidiFlow.fromFlows(
+      logTlsOutbound(s"$name ToNet  ", maxBytes),
+      logTlsInbound(s"$name FromNet", maxBytes))
+
+  def logTlsOutbound(name: String, maxBytes: Int = MaxBytesPrinted): Flow[SslTlsOutbound, SslTlsOutbound, NotUsed] =
+    Flow[SslTlsOutbound].log(name, {
+      case SendBytes(bytes)       ⇒ "SendBytes " + printByteString(bytes, maxBytes)
+      case n: NegotiateNewSession ⇒ n.toString
+    }).addAttributes(LogFailuresOnDebugAttributes)
+
+  def logTlsInbound(name: String, maxBytes: Int = MaxBytesPrinted): Flow[SslTlsInbound, SslTlsInbound, NotUsed] =
+    Flow[SslTlsInbound].log(name, {
+      case s: SessionTruncated          ⇒ s
+      case SessionBytes(session, bytes) ⇒ "SessionBytes " + printByteString(bytes, maxBytes)
+    }).addAttributes(LogFailuresOnDebugAttributes)
+
+  def printByteString(bytes: ByteString, maxBytes: Int = MaxBytesPrinted): String = {
+    val indent = " "
+
+    def formatBytes(bs: ByteString): Iterator[String] = {
+      def asHex(b: Byte): String = b formatted "%02X"
+      def asASCII(b: Byte): Char =
+        if (b >= 0x20 && b < 0x7f) b.toChar
+        else '.'
+
+      def formatLine(bs: ByteString): String = {
+        val hex = bs.map(asHex).mkString(" ")
+        val ascii = bs.map(asASCII).mkString
+        f"$indent%s  $hex%-48s | $ascii"
+      }
+      def formatBytes(bs: ByteString): String =
+        bs.grouped(16).map(formatLine).mkString("\n")
+
+      val prefix = s"${indent}ByteString(${bs.size} bytes)"
+
+      if (bs.size <= maxBytes * 2) Iterator(prefix + "\n", formatBytes(bs))
+      else
+        Iterator(
+          s"$prefix first + last $maxBytes:\n",
+          formatBytes(bs.take(maxBytes)),
+          s"\n$indent                    ... [${bs.size - (maxBytes * 2)} bytes omitted] ...\n",
+          formatBytes(bs.takeRight(maxBytes)))
+    }
+
+    formatBytes(bytes).mkString("")
+  }
+
+  def logTLSBidiBySetting(tag: String, maxBytesSetting: Option[Int]): BidiFlow[SslTlsOutbound, SslTlsOutbound, SslTlsInbound, SslTlsInbound, Any] =
+    maxBytesSetting
+      .map(logTLSBidi(tag, _)).
+      getOrElse(BidiFlow.identity)
+}

--- a/akka-remote/src/test/scala/akka/remote/artery/EnvelopeBufferSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/EnvelopeBufferSpec.scala
@@ -71,8 +71,8 @@ abstract class EnvelopeBufferSpec(version: Byte) extends AkkaSpec {
 
     "be able to encode and decode headers with compressed literals" in {
       headerIn setVersion version
-      headerIn setFrameLength 1024
-      headerIn setStreamId 1
+      /*headerIn setFrameLength 1024
+      headerIn setStreamId 1*/
       headerIn setUid 42
       headerIn setSerializer 4
       headerIn setRecipientActorRef minimalRef("compressable1")
@@ -103,8 +103,8 @@ abstract class EnvelopeBufferSpec(version: Byte) extends AkkaSpec {
       val recipientRef = minimalRef("uncompressable11")
 
       headerIn setVersion version
-      headerIn setFrameLength 1024
-      headerIn setStreamId 1
+      /*headerIn setFrameLength 1024
+      headerIn setStreamId 1*/
       headerIn setUid 42
       headerIn setSerializer 4
       headerIn setSenderActorRef senderRef
@@ -124,13 +124,13 @@ abstract class EnvelopeBufferSpec(version: Byte) extends AkkaSpec {
       envelope.parseHeader(headerOut)
 
       headerOut.version should ===(version)
-      if (version == 0) {
+      /*if (version == 0) {
         headerOut.frameLength should ===(0)
         headerOut.streamId should ===(0)
       } else {
         headerOut.frameLength should ===(1024)
         headerOut.streamId should ===(1)
-      }
+      }*/
       headerOut.uid should ===(42)
       headerOut.serializer should ===(4)
       headerOut.senderActorRefPath should ===(OptionVal.Some("akka://EnvelopeBufferSpec/uncompressable0"))
@@ -186,13 +186,13 @@ abstract class EnvelopeBufferSpec(version: Byte) extends AkkaSpec {
       envelope.parseHeader(headerOut)
 
       headerOut.version should ===(version)
-      if (version == 0) {
+      /*if (version == 0) {
         headerOut.frameLength should ===(0)
         headerOut.streamId should ===(0)
       } else {
         headerOut.frameLength should ===(1024)
         headerOut.streamId should ===(1)
-      }
+      }*/
       headerOut.uid should ===(Long.MinValue)
       headerOut.serializer should ===(-1)
       headerOut.senderActorRefPath should ===(OptionVal.Some("akka://EnvelopeBufferSpec/uncompressable0"))


### PR DESCRIPTION
Here's an attempt at the idea of not transmitting streamIds once per frame but only once per stream. That would probably allow us to keep the existing EnvelopeBuffer.

It also moved the actual framing out into a custom stage (currrently implemented with `statefulMapConcat`) which reads the initial streamId and then collects frames and sets a new field in EnvelopeBuffer (I guess we can even find better ways to transport the streamId between that stage and the partition).