### PR TITLE
fail fast if Typed Cluster.sharding.spawn is called several times wit…

### DIFF
--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -173,7 +173,7 @@ import akka.japi.function.{ Function ⇒ JFunction }
 
     typeNames.putIfAbsent(typeKey.name, messageClassName) match {
       case spawnedMessageClassName: String if messageClassName != spawnedMessageClassName ⇒
-        throw new IllegalArgumentException(s"${typeKey.name} already spawned for $spawnedMessageClassName")
+        throw new IllegalArgumentException(s"[${typeKey.name}] already spawned for [$spawnedMessageClassName]")
       case _ ⇒ ()
     }
 

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -7,7 +7,6 @@ package akka.cluster.sharding.typed.scaladsl
 import java.nio.charset.StandardCharsets
 
 import scala.concurrent.duration._
-
 import akka.actor.ExtendedActorSystem
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorRefResolver
@@ -17,9 +16,7 @@ import akka.actor.typed.TypedAkkaSpecWithShutdown
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
 import akka.cluster.MemberStatus
-import akka.cluster.sharding.typed.ClusterShardingSettings
-import akka.cluster.sharding.typed.ShardingEnvelope
-import akka.cluster.sharding.typed.ShardingMessageExtractor
+import akka.cluster.sharding.typed.{ ClusterShardingSettings, ShardingEnvelope, ShardingMessageExtractor }
 import akka.cluster.typed.Cluster
 import akka.cluster.typed.Join
 import akka.cluster.typed.Leave
@@ -248,20 +245,20 @@ class ClusterShardingSpec extends TestKit("ClusterShardingSpec", ClusterSharding
       }
     }
 
-    //    "04 fail if starting sharding for already used typeName, but with wrong type" in  {
-    //      val ex = intercept[Exception] {
-    //        sharding.spawn(
-    //          Actor.empty[String],
-    //          Props.empty,
-    //          "example-02",
-    //          ClusterShardingSettings(adaptedSystem),
-    //          10,
-    //          "STOP"
-    //        )
-    //      }
-    //
-    //      ex.getMessage should include("already started")
-    //    }
+    "fail if starting sharding for already used typeName, but with a different type" in {
+      // sharding has been already started with EntityTypeKey[TestProtocol]("envelope-shard")
+      val ex = intercept[Exception] {
+        sharding.spawn(
+          _ ⇒ behaviorWithId,
+          Props.empty,
+          EntityTypeKey[IdTestProtocol]("envelope-shard"),
+          ClusterShardingSettings(system),
+          10,
+          IdStopPlz())
+      }
+
+      ex.getMessage should include("already spawned")
+    }
 
     "EntityRef - tell" in {
       val charlieRef = sharding.entityRefFor(typeKey, "charlie")

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -21,7 +21,6 @@ import akka.actor.NoSerializationVerificationNeeded
 import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.cluster.Cluster
-import akka.cluster.ddata.DistributedData
 import akka.cluster.singleton.ClusterSingletonManager
 import akka.pattern.BackoffSupervisor
 import akka.util.ByteString
@@ -34,7 +33,6 @@ import scala.util.control.NonFatal
 import akka.actor.Status
 import akka.cluster.ClusterSettings
 import akka.cluster.ClusterSettings.DataCenter
-import akka.stream.{ Inlet, Outlet }
 import scala.collection.immutable
 import scala.collection.JavaConverters._
 
@@ -662,7 +660,6 @@ private[akka] class ClusterShardingGuardian extends Actor {
       extractShardId) ⇒
       try {
         val encName = URLEncoder.encode(s"${typeName}Proxy", ByteString.UTF_8)
-        val cName = coordinatorSingletonManagerName(encName)
         val cPath = coordinatorPath(URLEncoder.encode(typeName, ByteString.UTF_8))
         // it must be possible to start several proxies, one per data center
         val actorName = dataCenter match {


### PR DESCRIPTION
ref #23708

 * maintain a map in ClusterShardingImpl to track type names and class names
 * fix a bug in ClusterShardingImpl.spawnWithMessageExtractor - actually use allocationStrategy param
 * remove unused calls/imports in untyped ClusterSharding