### PR TITLE
Make stashing timer messages work 

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/TimerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/TimerSpec.scala
@@ -292,7 +292,7 @@ class TimersAndStashSpec extends AkkaSpec {
 
   "Timers combined with stashing" should {
 
-    "something" in {
+    "work" in {
       val probe = TestProbe()
       val actor = system.actorOf(Props(new ActorWithTimerAndStash(probe.ref)))
       probe.expectMsg("saw-scheduled")

--- a/akka-actor-tests/src/test/scala/akka/actor/TimerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/TimerSpec.scala
@@ -264,3 +264,41 @@ abstract class AbstractTimerSpec extends AkkaSpec {
     }
   }
 }
+
+object TimersAndStashSpec {
+
+  case object StopStashing
+
+}
+class TimersAndStashSpec extends AkkaSpec {
+  import TimersAndStashSpec._
+
+  class ActorWithTimerAndStash(probe: ActorRef) extends Actor with Timers with Stash {
+    timers.startSingleTimer("key", "scheduled", 50.millis)
+    def receive: Receive = stashing
+    def notStashing: Receive = {
+      case msg           ⇒ probe ! msg
+    }
+
+    def stashing: Receive = {
+      case StopStashing ⇒
+        context.become(notStashing)
+        unstashAll()
+      case "scheduled" ⇒
+        probe ! "saw-scheduled"
+        stash()
+    }
+  }
+
+  "Timers combined with stashing" should {
+
+    "something" in {
+      val probe = TestProbe()
+      val actor = system.actorOf(Props(new ActorWithTimerAndStash(probe.ref)))
+      probe.expectMsg("saw-scheduled")
+      actor ! StopStashing
+      probe.expectMsg("scheduled")
+    }
+  }
+
+}

--- a/akka-actor-tests/src/test/scala/akka/actor/TimerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/TimerSpec.scala
@@ -277,7 +277,7 @@ class TimersAndStashSpec extends AkkaSpec {
     timers.startSingleTimer("key", "scheduled", 50.millis)
     def receive: Receive = stashing
     def notStashing: Receive = {
-      case msg           ⇒ probe ! msg
+      case msg ⇒ probe ! msg
     }
 
     def stashing: Receive = {


### PR DESCRIPTION
Fixes #24557

Not 100% sure it is a good idea, but played around with other workarounds first but couldn't see a way to make them work given that Stash looks directly at `actorCell.currentMessage`.