### PR TITLE
Receptionist message improvements

### DIFF
--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/receptionist/ReceptionistApiTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/receptionist/ReceptionistApiTest.java
@@ -3,21 +3,95 @@
  */
 package akka.actor.typed.receptionist;
 
-
 import akka.actor.typed.ActorRef;
+import akka.actor.typed.ActorSystem;
+import akka.actor.typed.javadsl.AskPattern;
+import akka.actor.typed.javadsl.Behaviors;
+import akka.util.Timeout;
+
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 public class ReceptionistApiTest {
 
   public void compileOnlyApiTest() {
-    ActorRef<String> ref = null;
-    ActorRef<Receptionist.Registered<String>> respondTo = null;
-    ServiceKey<String> key = ServiceKey.create(String.class, "id");
-    Receptionist.Register register = new Receptionist.Register<>(key, ref, respondTo);
-    Receptionist.Register registerNoAck = new Receptionist.Register<>(key, ref);
+    // some dummy prerequisites
+    final Timeout timeout = Timeout.apply(3, TimeUnit.SECONDS);
+    final ActorRef<String> service = null;
+    final ServiceKey<String> key = ServiceKey.create(String.class, "id");
+    final ActorSystem<Void> system = null;
 
-    ActorRef<Receptionist.Listing<String>> listingRecipient = null;
-    Receptionist.Find find = new Receptionist.Find<>(key, listingRecipient);
+    // registration from outside, without ack, should be rare
+    system.receptionist().tell(Receptionist.register(key, service));
 
-    Receptionist.Subscribe subscribe = new Receptionist.Subscribe<>(key, listingRecipient);
+    // registration from outside with ack, should be rare
+    CompletionStage<Receptionist.Registered> registeredCS = AskPattern.ask(
+      system.receptionist(),
+      sendRegTo -> Receptionist.register(key, service, sendRegTo),
+      timeout,
+      system.scheduler()
+    );
+    registeredCS.whenComplete((r, failure) -> {
+      if (r != null) {
+        r.getServiceInstance(key);
+      } else {
+        throw new RuntimeException("Not registered");
+      }
+    });
+
+    // one-off ask outside of actor, should be uncommon but not rare
+    CompletionStage<Receptionist.Listing> result = AskPattern.ask(
+      system.receptionist(),
+      sendListingTo -> Receptionist.find(key, sendListingTo),
+      timeout,
+      system.scheduler()
+    );
+    result.whenComplete((listing, throwable) -> {
+      if (listing != null && listing.isForKey(key)) {
+        Set<ActorRef<String>> serviceInstances = listing.getServiceInstances(key);
+      } else {
+        throw new RuntimeException("not what I wanted");
+      }
+    });
+
+    Behaviors.setup(ctx -> {
+      // oneoff ask inside of actor
+      // this is somewhat verbose, however this should be a rare use case
+      ctx.ask(
+        Receptionist.Listing.class,
+        ctx.getSystem().receptionist(),
+        timeout,
+        resRef -> Receptionist.find(key, resRef),
+        (listing, throwable) -> {
+          if (listing != null) return listing.getServiceInstances(key);
+          else return "listing failed";
+        }
+      );
+
+      // this is a more "normal" use case which is clean
+      ctx.getSystem().receptionist().tell(Receptionist.subscribe(key, ctx.getSelf().narrow()));
+
+      // another more "normal" is subscribe using an adapter
+      ActorRef<Receptionist.Listing> listingAdapter = ctx.messageAdapter(
+        Receptionist.Listing.class,
+        (listing) -> listing.serviceInstances(key)
+      );
+      ctx.getSystem().receptionist().tell(Receptionist.subscribe(key, listingAdapter));
+
+      // ofc this doesn't make sense to do in the same actor, this is just
+      // to cover as much of the API as possible
+      ctx.getSystem().receptionist().tell(Receptionist.register(key, ctx.getSelf().narrow(), ctx.getSelf().narrow()));
+
+      return Behaviors.immutable(Object.class)
+        // matching is done best using the predicate version
+        .onMessage(Receptionist.Listing.class, listing -> listing.isForKey(key), (msgCtx, listing) -> {
+          Set<ActorRef<String>> services = listing.getServiceInstances(key);
+          return Behaviors.same();
+        }).onMessage(Receptionist.Registered.class, registered -> registered.isForKey(key), (msgCtx, registered) -> {
+          ActorRef<String> registree = registered.getServiceInstance(key);
+          return Behaviors.same();
+        }).build();
+    });
   }
 }

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/receptionist/ReceptionistApiTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/receptionist/ReceptionistApiTest.java
@@ -10,9 +10,10 @@ public class ReceptionistApiTest {
 
   public void compileOnlyApiTest() {
     ActorRef<String> ref = null;
-    ActorRef<Receptionist.Registered<String>> listener = null;
+    ActorRef<Receptionist.Registered<String>> respondTo = null;
     ServiceKey<String> key = ServiceKey.create(String.class, "id");
-    Receptionist.Register register = new Receptionist.Register<>(key, ref, listener);
+    Receptionist.Register register = new Receptionist.Register<>(key, ref, respondTo);
+    Receptionist.Register registerNoAck = new Receptionist.Register<>(key, ref);
 
     ActorRef<Receptionist.Listing<String>> listingRecipient = null;
     Receptionist.Find find = new Receptionist.Find<>(key, listingRecipient);

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/LocalReceptionistSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/LocalReceptionistSpec.scala
@@ -45,7 +45,7 @@ class LocalReceptionistSpec extends TestKit with TypedAkkaSpecWithShutdown with 
       val testkit = BehaviorTestkit(receptionistBehavior)
       val a = TestInbox[ServiceA]("a")
       val r = TestInbox[Registered[_]]("r")
-      testkit.run(Register(ServiceKeyA, a.ref)(r.ref))
+      testkit.run(Register(ServiceKeyA, a.ref, r.ref))
       testkit.retrieveEffect() // watching however that is implemented
       r.receiveMsg() should be(Registered(ServiceKeyA, a.ref))
       val q = TestInbox[Listing[ServiceA]]("q")
@@ -59,7 +59,7 @@ class LocalReceptionistSpec extends TestKit with TypedAkkaSpecWithShutdown with 
       val testkit = BehaviorTestkit(receptionistBehavior)
       val a = TestInbox[ServiceA]("a")
       val r = TestInbox[Registered[_]]("r")
-      testkit.run(Register(ServiceKeyA, a.ref)(r.ref))
+      testkit.run(Register(ServiceKeyA, a.ref, r.ref))
       r.receiveMsg() should be(Registered(ServiceKeyA, a.ref))
       val b = TestInbox[ServiceB]("b")
       testkit.run(Register(ServiceKeyB, b.ref)(r.ref))
@@ -76,7 +76,7 @@ class LocalReceptionistSpec extends TestKit with TypedAkkaSpecWithShutdown with 
       val testkit = BehaviorTestkit(receptionistBehavior)
       val a1 = TestInbox[ServiceA]("a1")
       val r = TestInbox[Registered[_]]("r")
-      testkit.run(Register(ServiceKeyA, a1.ref)(r.ref))
+      testkit.run(Register(ServiceKeyA, a1.ref, r.ref))
       r.receiveMsg() should be(Registered(ServiceKeyA, a1.ref))
       val a2 = TestInbox[ServiceA]("a2")
       testkit.run(Register(ServiceKeyA, a2.ref)(r.ref))
@@ -154,7 +154,7 @@ class LocalReceptionistSpec extends TestKit with TypedAkkaSpecWithShutdown with 
     "work with ask" in {
       val receptionist = spawn(receptionistBehavior)
       val serviceA = spawn(behaviorA)
-      val f: Future[Registered[ServiceA]] = receptionist ? Register(ServiceKeyA, serviceA)
+      val f: Future[Registered[ServiceA]] = receptionist ? (Register(ServiceKeyA, serviceA, _))
       f.futureValue should be(Registered(ServiceKeyA, serviceA))
     }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/LocalReceptionistSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/LocalReceptionistSpec.scala
@@ -44,12 +44,12 @@ class LocalReceptionistSpec extends TestKit with TypedAkkaSpecWithShutdown with 
     "register a service" in {
       val testkit = BehaviorTestkit(receptionistBehavior)
       val a = TestInbox[ServiceA]("a")
-      val r = TestInbox[Registered[_]]("r")
+      val r = TestInbox[Registered]("r")
       testkit.run(Register(ServiceKeyA, a.ref, r.ref))
       testkit.retrieveEffect() // watching however that is implemented
       r.receiveMsg() should be(Registered(ServiceKeyA, a.ref))
-      val q = TestInbox[Listing[ServiceA]]("q")
-      testkit.run(Find(ServiceKeyA)(q.ref))
+      val q = TestInbox[Listing]("q")
+      testkit.run(Find(ServiceKeyA, q.ref))
       testkit.retrieveAllEffects() should be(Nil)
       q.receiveMsg() should be(Listing(ServiceKeyA, Set(a.ref)))
       assertEmpty(a, r, q)
@@ -58,16 +58,16 @@ class LocalReceptionistSpec extends TestKit with TypedAkkaSpecWithShutdown with 
     "register two services" in {
       val testkit = BehaviorTestkit(receptionistBehavior)
       val a = TestInbox[ServiceA]("a")
-      val r = TestInbox[Registered[_]]("r")
+      val r = TestInbox[Registered]("r")
       testkit.run(Register(ServiceKeyA, a.ref, r.ref))
       r.receiveMsg() should be(Registered(ServiceKeyA, a.ref))
       val b = TestInbox[ServiceB]("b")
-      testkit.run(Register(ServiceKeyB, b.ref)(r.ref))
+      testkit.run(Register(ServiceKeyB, b.ref, r.ref))
       r.receiveMsg() should be(Registered(ServiceKeyB, b.ref))
-      val q = TestInbox[Listing[_]]("q")
-      testkit.run(Find(ServiceKeyA)(q.ref))
+      val q = TestInbox[Listing]("q")
+      testkit.run(Find(ServiceKeyA, q.ref))
       q.receiveMsg() should be(Listing(ServiceKeyA, Set(a.ref)))
-      testkit.run(Find(ServiceKeyB)(q.ref))
+      testkit.run(Find(ServiceKeyB, q.ref))
       q.receiveMsg() should be(Listing(ServiceKeyB, Set(b.ref)))
       assertEmpty(a, b, r, q)
     }
@@ -75,16 +75,16 @@ class LocalReceptionistSpec extends TestKit with TypedAkkaSpecWithShutdown with 
     "register two services with the same key" in {
       val testkit = BehaviorTestkit(receptionistBehavior)
       val a1 = TestInbox[ServiceA]("a1")
-      val r = TestInbox[Registered[_]]("r")
+      val r = TestInbox[Registered]("r")
       testkit.run(Register(ServiceKeyA, a1.ref, r.ref))
       r.receiveMsg() should be(Registered(ServiceKeyA, a1.ref))
       val a2 = TestInbox[ServiceA]("a2")
-      testkit.run(Register(ServiceKeyA, a2.ref)(r.ref))
+      testkit.run(Register(ServiceKeyA, a2.ref, r.ref))
       r.receiveMsg() should be(Registered(ServiceKeyA, a2.ref))
-      val q = TestInbox[Listing[_]]("q")
-      testkit.run(Find(ServiceKeyA)(q.ref))
+      val q = TestInbox[Listing]("q")
+      testkit.run(Find(ServiceKeyA, q.ref))
       q.receiveMsg() should be(Listing(ServiceKeyA, Set(a1.ref, a2.ref)))
-      testkit.run(Find(ServiceKeyB)(q.ref))
+      testkit.run(Find(ServiceKeyB, q.ref))
       q.receiveMsg() should be(Listing(ServiceKeyB, Set.empty[ActorRef[ServiceB]]))
       assertEmpty(a1, a2, r, q)
     }
@@ -125,9 +125,9 @@ class LocalReceptionistSpec extends TestKit with TypedAkkaSpecWithShutdown with 
 
     "support subscribing to service changes" in {
       new TestSetup {
-        val regProbe = TestProbe[Registered[_]]("regProbe")
+        val regProbe = TestProbe[Registered]("regProbe")
 
-        val aSubscriber = TestProbe[Listing[ServiceA]]("aUser")
+        val aSubscriber = TestProbe[Listing]("aUser")
         receptionist ! Subscribe(ServiceKeyA, aSubscriber.ref)
 
         aSubscriber.expectMessage(Listing(ServiceKeyA, Set.empty[ActorRef[ServiceA]]))
@@ -154,15 +154,16 @@ class LocalReceptionistSpec extends TestKit with TypedAkkaSpecWithShutdown with 
     "work with ask" in {
       val receptionist = spawn(receptionistBehavior)
       val serviceA = spawn(behaviorA)
-      val f: Future[Registered[ServiceA]] = receptionist ? (Register(ServiceKeyA, serviceA, _))
+      val f: Future[Registered] = receptionist ? (Register(ServiceKeyA, serviceA, _))
       f.futureValue should be(Registered(ServiceKeyA, serviceA))
     }
 
     "be present in the system" in {
-      val probe = TestProbe[Receptionist.Listing[_]]()
-      system.receptionist ! Find(ServiceKeyA)(probe.ref)
-      val listing: Listing[_] = probe.expectMessageType[Listing[_]]
-      listing.serviceInstances should be(Set())
+      val probe = TestProbe[Receptionist.Listing]()
+      system.receptionist ! Find(ServiceKeyA, probe.ref)
+      val listing: Listing = probe.expectMessageType[Listing]
+      listing.isForKey(ServiceKeyA) should ===(true)
+      listing.serviceInstances(ServiceKeyA) should be(Set())
     }
   }
 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/ReceptionistApiSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/ReceptionistApiSpec.scala
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2009-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.actor.typed.receptionist
+
+import akka.actor.typed.{ ActorRef, ActorSystem }
+import akka.actor.typed.scaladsl.AskPattern._
+import akka.actor.typed.scaladsl.Behaviors
+import akka.util.Timeout
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Success
+
+object ReceptionistApiSpec {
+
+  def compileOnlySpec() {
+    // some dummy prerequisites
+    implicit val timeout: Timeout = 3.seconds
+    val service: ActorRef[String] = ???
+    val key: ServiceKey[String] = ServiceKey[String]("id")
+    val system: ActorSystem[Void] = ???
+    implicit val scheduler = system.scheduler
+    import system.executionContext
+
+    // registration from outside, without ack, should be rare
+    system.receptionist ! Receptionist.Register(key, service)
+
+    // registration from outside with ack, should be rare
+    // needs the explicit type on the future and the extra parenthesises
+    // to work
+    val registered: Future[Receptionist.Registered] =
+      system.receptionist ? (Receptionist.Register(key, service, _))
+    registered.onSuccess {
+      case key.Registered(ref) ⇒
+        // ref is the right type here
+        ref ! "woho"
+    }
+
+    // one-off ask outside of actor, should be uncommon but not rare
+    val found: Future[Receptionist.Listing] =
+      system.receptionist ? (Receptionist.Find(key, _))
+    found.onSuccess {
+      case key.Listing(instances) ⇒
+        instances.foreach(_ ! "woho")
+    }
+
+    Behaviors.setup[Any] { ctx ⇒
+      // oneoff ask inside of actor, this should be a rare use case
+      // FIXME not good friends with type inference here (I think this is #24511)
+      ctx.ask(system.receptionist)((ref: ActorRef[Receptionist.Listing]) ⇒ Receptionist.Find(key, ref)) {
+        case Success(key.Listing(services)) ⇒ services // Set[ActorRef[String]] !!
+        case _                              ⇒ "unexpected"
+      }
+
+      // this is a more "normal" use case which is clean
+      ctx.system.receptionist ! Receptionist.Subscribe(key, ctx.self.narrow)
+
+      // another more "normal" is subscribe using an adapter
+      // FIXME inference doesn't work with partial function
+      val adapter = ctx.spawnMessageAdapter { listing: Receptionist.Listing ⇒
+        listing.serviceInstances(key) // Set[ActorRef[String]] !!
+      }
+      ctx.system.receptionist ! Receptionist.Subscribe(key, adapter)
+
+      // ofc this doesn't make sense to do in the same actor, this is just
+      // to cover as much of the API as possible
+      ctx.system.receptionist ! Receptionist.Register(key, ctx.self.narrow, ctx.self.narrow)
+
+      Behaviors.immutable { (ctx, msg) ⇒
+        msg match {
+          case key.Listing(services) ⇒
+            services.foreach(_ ! "woho")
+            Behaviors.same
+          case key.Registered(service) ⇒ // ack on Register above
+            service ! "woho"
+            Behaviors.same
+        }
+      }
+    }
+  }
+
+}
+

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/ReceptionistApiSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/ReceptionistApiSpec.scala
@@ -47,8 +47,7 @@ object ReceptionistApiSpec {
 
     Behaviors.setup[Any] { ctx ⇒
       // oneoff ask inside of actor, this should be a rare use case
-      // FIXME not good friends with type inference here (I think this is #24511)
-      ctx.ask(system.receptionist)((ref: ActorRef[Receptionist.Listing]) ⇒ Receptionist.Find(key, ref)) {
+      ctx.ask(system.receptionist)(Receptionist.Find(key)) {
         case Success(key.Listing(services)) ⇒ services // Set[ActorRef[String]] !!
         case _                              ⇒ "unexpected"
       }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistImpl.scala
@@ -15,8 +15,6 @@ import akka.actor.typed.scaladsl.Behaviors.same
 import akka.actor.typed.scaladsl.ActorContext
 import akka.util.TypedMultiMap
 
-import scala.reflect.ClassTag
-
 /**
  * Marker interface to use with dynamic access
  *

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistImpl.scala
@@ -117,10 +117,13 @@ private[akka] object ReceptionistImpl extends ReceptionistBehaviorProvider {
 
     immutable[AllCommands] { (ctx, msg) ⇒
       msg match {
-        case Register(key, serviceInstance, replyTo) ⇒
+        case Register(key, serviceInstance, maybeReplyTo) ⇒
           ctx.log.debug("Actor was registered: {} {}", key, serviceInstance)
           watchWith(ctx, serviceInstance, RegisteredActorTerminated(key, serviceInstance))
-          replyTo ! Registered(key, serviceInstance)
+          maybeReplyTo match {
+            case Some(replyTo) => replyTo ! Registered(key, serviceInstance)
+            case None =>
+          }
           externalInterface.onRegister(key, serviceInstance)
 
           updateRegistry(Set(key), _.inserted(key)(serviceInstance))

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -133,7 +133,7 @@ object Receptionist extends ExtensionId[Receptionist] {
    * Internal API
    */
   @InternalApi
-  object MessageImpls {
+  private[akka] object MessageImpls {
     // some trixery here to provide a nice _and_ safe API in the face
     // of type erasure, more type safe factory methods for each message
     // is the user API below while still hiding the type parameter so that

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -3,13 +3,14 @@
  */
 package akka.actor.typed.receptionist
 
-import akka.annotation.InternalApi
+import akka.annotation.{ DoNotInherit, InternalApi }
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Extension
 import akka.actor.typed.ExtensionId
 import akka.actor.typed.internal.receptionist.ReceptionistBehaviorProvider
 import akka.actor.typed.internal.receptionist.ReceptionistImpl
+import akka.actor.typed.receptionist.Receptionist.{ Find, Registered }
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
@@ -51,7 +52,7 @@ object ServiceKey {
   /**
    * Scala API: Creates a service key. The given ID should uniquely define a service with a given protocol.
    */
-  def apply[T](id: String)(implicit tTag: ClassTag[T]): ServiceKey[T] =
+  def apply[T: ClassTag](id: String): ServiceKey[T] =
     ReceptionistImpl.DefaultServiceKey(id, implicitly[ClassTag[T]].runtimeClass.getName)
 
   /**
@@ -68,10 +69,28 @@ object ServiceKey {
  * protocol spoken by that service (think of it as the set of first messages
  * that a client could send).
  */
-abstract class ServiceKey[T] extends Receptionist.AbstractServiceKey {
-  final type Protocol = T
+abstract class ServiceKey[T] extends Receptionist.AbstractServiceKey { key ⇒
+  type Protocol = T
   def id: String
   def asServiceKey: ServiceKey[T] = this
+
+  /**
+   * Scala API: Provides a type safe pattern match for listings
+   */
+  object Listing {
+    def unapply(l: Receptionist.Listing): Option[Set[ActorRef[T]]] =
+      if (l.isForKey(key)) Some(l.serviceInstances(key))
+      else None
+  }
+
+  /**
+   * Scala API: Provides a type safe pattern match for registration acks
+   */
+  object Registered {
+    def unapply(l: Receptionist.Registered): Option[ActorRef[T]] =
+      if (l.isForKey(key)) Some(l.serviceInstance(key))
+      else None
+  }
 }
 
 /**
@@ -111,44 +130,120 @@ object Receptionist extends ExtensionId[Receptionist] {
   private[typed] abstract class InternalCommand extends AllCommands
 
   /**
+   * Internal API
+   */
+  @InternalApi
+  object MessageImpls {
+    // some trixery here to provide a nice _and_ safe API in the face
+    // of type erasure, more type safe factory methods for each message
+    // is the user API below while still hiding the type parameter so that
+    // users don't incorrecly match against it
+
+    final case class Register[T] private[akka] (
+      key:             ServiceKey[T],
+      serviceInstance: ActorRef[T],
+      replyTo:         Option[ActorRef[Receptionist.Registered]]) extends Command
+
+    final case class Registered[T] private[akka] (key: ServiceKey[T], _serviceInstance: ActorRef[T]) extends Receptionist.Registered {
+      def isForKey(key: ServiceKey[_]): Boolean = key == this.key
+      def serviceInstance[M](key: ServiceKey[M]): ActorRef[M] = {
+        if (key != this.key) throw new IllegalArgumentException(s"Wrong key [$key] used, must use listing key [${this.key}]")
+        _serviceInstance.asInstanceOf[ActorRef[M]]
+      }
+
+      def getServiceInstance[M](key: ServiceKey[M]): ActorRef[M] =
+        serviceInstance(key)
+    }
+
+    final case class Find[T] private[akka] (key: ServiceKey[T], replyTo: ActorRef[Receptionist.Listing]) extends Command
+
+    final case class Listing[T] private[akka] (key: ServiceKey[T], _serviceInstances: Set[ActorRef[T]]) extends Receptionist.Listing {
+
+      def isForKey(key: ServiceKey[_]): Boolean = key == this.key
+
+      def serviceInstances[M](key: ServiceKey[M]): Set[ActorRef[M]] = {
+        if (key != this.key) throw new IllegalArgumentException(s"Wrong key [$key] used, must use listing key [${this.key}]")
+        _serviceInstances.asInstanceOf[Set[ActorRef[M]]]
+      }
+
+      def getServiceInstances[M](key: ServiceKey[M]): java.util.Set[ActorRef[M]] =
+        serviceInstances(key).asJava
+    }
+
+    final case class Subscribe[T] private[akka] (key: ServiceKey[T], subscriber: ActorRef[Receptionist.Listing]) extends Command
+
+  }
+
+  /**
    * Associate the given [[akka.actor.typed.ActorRef]] with the given [[ServiceKey]]. Multiple
    * registrations can be made for the same key. De-registration is implied by
    * the end of the referenced Actor’s lifecycle.
    *
-   * Registration will be acknowledged with the [[Registered]] message to the given replyTo actor.
+   * Registration will be acknowledged with the [[Registered]] message to the given replyTo actor
+   * if there is one.
    */
-  final case class Register[T](key: ServiceKey[T], serviceInstance: ActorRef[T], replyTo: Option[ActorRef[Registered[T]]]) extends Command {
-
-    /**
-     * Java API: A Register message without Ack that the service was registered
-     */
-    def this(key: ServiceKey[T], service: ActorRef[T]) = this(key, service, None)
-    /**
-     * Java API: A Register message with Ack that the service was registered
-     */
-    def this(key: ServiceKey[T], service: ActorRef[T], replyTo: ActorRef[Registered[T]]) = this(key, service, Some(replyTo))
-
-  }
   object Register {
 
     /**
      * Create a Register without Ack that the service was registered
      */
-    def apply[T](key: ServiceKey[T], service: ActorRef[T]): Register[T] = new Register(key, service, None)
-
+    def apply[T](key: ServiceKey[T], service: ActorRef[T]): Command =
+      new MessageImpls.Register[T](key, service, None)
     /**
      * Create a Register with an actor that will get an ack that the service was registered
      */
-    def apply[T](key: ServiceKey[T], service: ActorRef[T], replyTo: ActorRef[Registered[T]]): Register[T] =
-      new Register(key, service, Some(replyTo))
-
-
+    def apply[T](key: ServiceKey[T], service: ActorRef[T], replyTo: ActorRef[Registered]): Command =
+      new MessageImpls.Register[T](key, service, Some(replyTo))
   }
+  /**
+   * Java API: A Register message without Ack that the service was registered
+   */
+  def register[T](key: ServiceKey[T], service: ActorRef[T]): Command = Register(key, service)
+  /**
+   * Java API: A Register message with Ack that the service was registered
+   */
+  def register[T](key: ServiceKey[T], service: ActorRef[T], replyTo: ActorRef[Registered]): Command =
+    Register(key, service, replyTo)
 
   /**
    * Confirmation that the given [[akka.actor.typed.ActorRef]] has been associated with the [[ServiceKey]].
+   *
+   * Can not be pattern matched from Scala, use [[ServiceKey.Registered]] instead
    */
-  final case class Registered[T](key: ServiceKey[T], serviceInstance: ActorRef[T])
+  trait Registered {
+
+    def isForKey(key: ServiceKey[_]): Boolean
+
+    /** Scala API */
+    def key: ServiceKey[_]
+    /** Java API */
+    def getKey: ServiceKey[_] = key
+    /**
+     * Scala API
+     *
+     * Also, see [[ServiceKey.Listing]] for more convenient pattern matching
+     */
+    def serviceInstance[T](key: ServiceKey[T]): ActorRef[T]
+    /** Java API */
+    def getServiceInstance[T](key: ServiceKey[T]): ActorRef[T]
+  }
+
+  /**
+   * Sent by the receptionist, available here for easier testing
+   */
+  object Registered {
+    /**
+     * Scala API
+     */
+    def apply[T](key: ServiceKey[T], serviceInstance: ActorRef[T]): Registered =
+      new MessageImpls.Registered(key, serviceInstance)
+
+  }
+  /**
+   * Java API: Sent by the receptionist, available here for easier testing
+   */
+  def registered[T](key: ServiceKey[T], serviceInstance: ActorRef[T]): Registered =
+    Registered(key, serviceInstance)
 
   /**
    * Subscribe the given actor to service updates. When new instances are registered or unregistered to the given key
@@ -157,24 +252,84 @@ object Receptionist extends ExtensionId[Receptionist] {
    * The subscription will be acknowledged by sending out a first [[Listing]]. The subscription automatically ends
    * with the termination of the subscriber.
    */
-  final case class Subscribe[T](key: ServiceKey[T], subscriber: ActorRef[Listing[T]]) extends Command
+  object Subscribe {
+    /**
+     * Scala API:
+     */
+    def apply[T](key: ServiceKey[T], subscriber: ActorRef[Listing]): Command =
+      new MessageImpls.Subscribe(key, subscriber)
+
+  }
+
+  /**
+   * Java API: Subscribe the given actor to service updates. When new instances are registered or unregistered to the given key
+   * the given subscriber will be sent a [[Listing]] with the new set of instances for that service.
+   *
+   * The subscription will be acknowledged by sending out a first [[Listing]]. The subscription automatically ends
+   * with the termination of the subscriber.
+   */
+  def subscribe[T](key: ServiceKey[T], subscriber: ActorRef[Listing]): Command = Subscribe(key, subscriber)
 
   /**
    * Query the Receptionist for a list of all Actors implementing the given
-   * protocol.
+   * protocol at one point in time.
    */
-  final case class Find[T](key: ServiceKey[T], replyTo: ActorRef[Listing[T]]) extends Command
   object Find {
-    /** Auxiliary constructor to use with the ask pattern */
-    def apply[T](key: ServiceKey[T]): ActorRef[Listing[T]] ⇒ Find[T] =
-      replyTo ⇒ Find(key, replyTo)
+    /** Scala API: */
+    def apply[T](key: ServiceKey[T], replyTo: ActorRef[Listing]): Command =
+      new MessageImpls.Find(key, replyTo)
+
   }
 
   /**
-   * Current listing of all Actors that implement the protocol given by the [[ServiceKey]].
+   * Java API: Query the Receptionist for a list of all Actors implementing the given
+   * protocol at one point in time.
    */
-  final case class Listing[T](key: ServiceKey[T], serviceInstances: Set[ActorRef[T]]) {
+  def find[T](key: ServiceKey[T], replyTo: ActorRef[Listing]): Command =
+    Find(key, replyTo)
+
+  /**
+   * Current listing of all Actors that implement the protocol given by the [[ServiceKey]].
+   *
+   * Can not be pattern matched from Scala, use [[ServiceKey.Listing]] instead
+   *
+   * Not for user extension.
+   */
+  @DoNotInherit
+  trait Listing {
+    /** Scala API */
+    def key: ServiceKey[_]
     /** Java API */
-    def getServiceInstances: java.util.Set[ActorRef[T]] = serviceInstances.asJava
+    def getKey: ServiceKey[_] = key
+
+    def isForKey(key: ServiceKey[_]): Boolean
+
+    /**
+     * Scala API
+     *
+     * Also, see [[ServiceKey.Listing]] for more convenient pattern matching
+     */
+    def serviceInstances[T](key: ServiceKey[T]): Set[ActorRef[T]]
+
+    /** Java API */
+    def getServiceInstances[T](key: ServiceKey[T]): java.util.Set[ActorRef[T]]
+
   }
+
+  /**
+   * Sent by the receptionist, available here for easier testing
+   */
+  object Listing {
+    /** Scala API: */
+    def apply[T](key: ServiceKey[T], serviceInstances: Set[ActorRef[T]]): Listing =
+      new MessageImpls.Listing[T](key, serviceInstances)
+
+  }
+
+  /**
+   * Java API: Sent by the receptionist, available here for easier testing
+   */
+  def listing[T](key: ServiceKey[T], serviceInstances: java.util.Set[ActorRef[T]]): Listing =
+    Listing(key, Set[ActorRef[T]](serviceInstances.asScala.toSeq: _*))
+
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -117,11 +117,32 @@ object Receptionist extends ExtensionId[Receptionist] {
    *
    * Registration will be acknowledged with the [[Registered]] message to the given replyTo actor.
    */
-  final case class Register[T](key: ServiceKey[T], serviceInstance: ActorRef[T], replyTo: ActorRef[Registered[T]]) extends Command
+  final case class Register[T](key: ServiceKey[T], serviceInstance: ActorRef[T], replyTo: Option[ActorRef[Registered[T]]]) extends Command {
+
+    /**
+     * Java API: A Register message without Ack that the service was registered
+     */
+    def this(key: ServiceKey[T], service: ActorRef[T]) = this(key, service, None)
+    /**
+     * Java API: A Register message with Ack that the service was registered
+     */
+    def this(key: ServiceKey[T], service: ActorRef[T], replyTo: ActorRef[Registered[T]]) = this(key, service, Some(replyTo))
+
+  }
   object Register {
-    /** Auxiliary constructor to be used with the ask pattern */
-    def apply[T](key: ServiceKey[T], service: ActorRef[T]): ActorRef[Registered[T]] ⇒ Register[T] =
-      replyTo ⇒ Register(key, service, replyTo)
+
+    /**
+     * Create a Register without Ack that the service was registered
+     */
+    def apply[T](key: ServiceKey[T], service: ActorRef[T]): Register[T] = new Register(key, service, None)
+
+    /**
+     * Create a Register with an actor that will get an ack that the service was registered
+     */
+    def apply[T](key: ServiceKey[T], service: ActorRef[T], replyTo: ActorRef[Registered[T]]): Register[T] =
+      new Register(key, service, Some(replyTo))
+
+
   }
 
   /**

--- a/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/ReceptionistExampleTest.java
+++ b/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/ReceptionistExampleTest.java
@@ -1,23 +1,142 @@
 package jdocs.akka.cluster.typed;
 
+import akka.actor.Address;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.ActorSystem;
 import akka.actor.typed.Behavior;
+import akka.actor.typed.javadsl.ActorContext;
 import akka.actor.typed.javadsl.Behaviors;
 import akka.actor.typed.receptionist.Receptionist;
 import akka.actor.typed.receptionist.ServiceKey;
+import akka.cluster.ClusterEvent;
+import akka.cluster.typed.Cluster;
+import akka.cluster.typed.Subscribe;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 public class ReceptionistExampleTest extends JUnitSuite {
 
+  static class RandomRouter {
+
+    private static class RouterBehavior<T> extends Behaviors.MutableBehavior<Object> {
+      private final Class<T> messageClass;
+      private final ServiceKey<T> serviceKey;
+      private final List<ActorRef<T>> routees = new ArrayList<>();
+      public RouterBehavior(ActorContext<Object> ctx, Class<T> messageClass, ServiceKey<T> serviceKey) {
+        this.messageClass = messageClass;
+        this.serviceKey = serviceKey;
+
+        ctx.getSystem().receptionist().tell(Receptionist.subscribe(serviceKey, ctx.getSelf().narrow()));
+      }
+
+      @Override
+      public Behaviors.Receive<Object> createReceive() {
+        return receiveBuilder()
+          .onMessage(Receptionist.Listing.class, listing -> listing.isForKey(serviceKey), (listing) -> {
+            routees.clear();
+            routees.addAll(listing.getServiceInstances(serviceKey));
+            return this;
+          }).onMessage(messageClass, (msg) -> {
+            int i = ThreadLocalRandom.current().nextInt(routees.size());
+            routees.get(i).tell(msg);
+            return this;
+          }).build();
+      }
+    }
+
+    public static <T> Behavior<T> router(ServiceKey<T> serviceKey, Class<T> messageClass) {
+      return Behaviors.mutable(ctx -> new RouterBehavior<T>(ctx, messageClass, serviceKey)).narrow();
+    }
+  }
+
+  // same as above, but also subscribes to cluster reachability events and
+  // avoids routees that are unreachable
+  static class ClusterRouter {
+
+    private static class WrappedReachabilityEvent {
+      final ClusterEvent.ReachabilityEvent event;
+      public WrappedReachabilityEvent(ClusterEvent.ReachabilityEvent event) {
+        this.event = event;
+      }
+    }
+
+    private static class ClusterRouterBehavior<T> extends Behaviors.MutableBehavior<Object> {
+      private final Class<T> messageClass;
+      private final ServiceKey<T> serviceKey;
+      private final List<ActorRef<T>> routees = new ArrayList<>();
+      private final Set<Address> unreachable = new HashSet<>();
+      private final List<ActorRef<T>> reachable = new ArrayList<>();
+
+      public ClusterRouterBehavior(ActorContext<Object> ctx, Class<T> messageClass, ServiceKey<T> serviceKey) {
+        this.messageClass = messageClass;
+        this.serviceKey = serviceKey;
+        ctx.getSystem().receptionist().tell(Receptionist.subscribe(serviceKey, ctx.getSelf().narrow()));
+
+        Cluster cluster = Cluster.get(ctx.getSystem());
+        // typically you have to map such external messages into this
+        // actor's protocol with a message adapter
+        /* this is how it is done in the scala sample, but that is awkward with Java
+        ActorRef<ClusterEvent.ReachabilityEvent> reachabilityAdapter =
+          ctx.messageAdapter(
+            ClusterEvent.ReachabilityEvent.class,
+            (event) -> new WrappedReachabilityEvent(event));
+        cluster.subscriptions().tell(Subscribe.create(reachabilityAdapter, ClusterEvent.ReachabilityEvent.class));
+        */
+        cluster.subscriptions().tell(Subscribe.create(ctx.getSelf().narrow(), ClusterEvent.UnreachableMember.class));
+        cluster.subscriptions().tell(Subscribe.create(ctx.getSelf().narrow(), ClusterEvent.ReachableMember.class));
+      }
+
+      private void updateReachable() {
+        reachable.clear();
+        for (ActorRef<T> routee: routees) {
+          if (!unreachable.contains(routee.path().address())) {
+            reachable.add(routee);
+          }
+        }
+      }
+
+      @Override
+      public Behaviors.Receive<Object> createReceive() {
+        return receiveBuilder()
+          .onMessage(Receptionist.Listing.class, listing -> listing.isForKey(serviceKey), listing -> {
+            routees.clear();
+            routees.addAll(listing.getServiceInstances(serviceKey));
+            updateReachable();
+            return this;
+          }).onMessage(ClusterEvent.ReachableMember.class, reachableMember -> {
+            unreachable.remove(reachableMember.member().address());
+            updateReachable();
+            return this;
+          }).onMessage(ClusterEvent.UnreachableMember.class, unreachableMember -> {
+            unreachable.add(unreachableMember.member().address());
+            updateReachable();
+            return this;
+          }).onMessage(messageClass, msg -> {
+            int i = ThreadLocalRandom.current().nextInt(reachable.size());
+            reachable.get(i).tell(msg);
+            return this;
+          }).build();
+      }
+    }
+
+    public static <T> Behavior<T> clusterRouter(ServiceKey<T> serviceKey, Class<T> messageClass) {
+      return Behaviors.mutable((ctx) -> new ClusterRouterBehavior<T>(ctx, messageClass, serviceKey)).narrow();
+    }
+  }
+
+
   public static class PingPongExample {
     //#ping-service
-    static ServiceKey<Ping> PingServiceKey =
+    static final ServiceKey<Ping> PingServiceKey =
       ServiceKey.create(Ping.class, "pingService");
 
     public static class Pong {}
@@ -31,7 +150,7 @@ public class ReceptionistExampleTest extends JUnitSuite {
     static Behavior<Ping> pingService() {
       return Behaviors.setup((ctx) -> {
         ctx.getSystem().receptionist()
-          .tell(new Receptionist.Register<>(PingServiceKey, ctx.getSelf()));
+          .tell(Receptionist.register(PingServiceKey, ctx.getSelf()));
         return Behaviors.immutable(Ping.class)
           .onMessage(Ping.class, (c, msg) -> {
             msg.replyTo.tell(new Pong());
@@ -55,24 +174,25 @@ public class ReceptionistExampleTest extends JUnitSuite {
     //#pinger
 
     //#pinger-guardian
-    static Behavior<Receptionist.Listing<Ping>> guardian() {
+    static Behavior<Void> guardian() {
       return Behaviors.setup((ctx) -> {
         ctx.getSystem().receptionist()
-          .tell(new Receptionist.Subscribe<>(PingServiceKey, ctx.getSelf()));
+          .tell(Receptionist.subscribe(PingServiceKey, ctx.getSelf().narrow()));
         ActorRef<Ping> ps = ctx.spawnAnonymous(pingService());
         ctx.watch(ps);
-        return Behaviors.immutable((c, msg) -> {
-          msg.getServiceInstances().forEach(ar -> ctx.spawnAnonymous(pinger(ar)));
+        return Behaviors.immutable(Object.class)
+          .onMessage(Receptionist.Listing.class, listing -> listing.isForKey(PingServiceKey), (c, msg) -> {
+          msg.getServiceInstances(PingServiceKey).forEach(ar -> ctx.spawnAnonymous(pinger(ar)));
           return Behaviors.same();
-        });
-      });
+        }).build();
+      }).narrow();
     }
     //#pinger-guardian
   }
 
   @Test
   public void workPlease() throws Exception {
-    ActorSystem<Receptionist.Listing<PingPongExample.Ping>> system =
+    ActorSystem<Void> system =
       ActorSystem.create(PingPongExample.guardian(), "ReceptionistExample");
 
     Await.ready(system.terminate(), Duration.create(2, TimeUnit.SECONDS));

--- a/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/ReceptionistExampleTest.java
+++ b/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/ReceptionistExampleTest.java
@@ -31,7 +31,7 @@ public class ReceptionistExampleTest extends JUnitSuite {
     static Behavior<Ping> pingService() {
       return Behaviors.setup((ctx) -> {
         ctx.getSystem().receptionist()
-          .tell(new Receptionist.Register<>(PingServiceKey, ctx.getSelf(), ctx.getSystem().deadLetters()));
+          .tell(new Receptionist.Register<>(PingServiceKey, ctx.getSelf()));
         return Behaviors.immutable(Ping.class)
           .onMessage(Ping.class, (c, msg) -> {
             msg.replyTo.tell(new Pong());

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
@@ -95,7 +95,7 @@ class RemoteContextAskSpec extends TestKit(RemoteContextAskSpec.config) with Typ
       node1.manager ! Join(node1.selfMember.address)
 
       Receptionist(system).ref ! Receptionist.Subscribe(pingPongKey, node1Probe.ref)
-      node1Probe.expectMessageType[Receptionist.Listing[_]]
+      node1Probe.expectMessageType[Receptionist.Listing]
 
       val system2 = ActorSystem(pingPong, system.name, system.settings.config)
       val node2 = Cluster(system2)
@@ -103,10 +103,10 @@ class RemoteContextAskSpec extends TestKit(RemoteContextAskSpec.config) with Typ
 
       val node2Probe = TestProbe[AnyRef]()(system2)
       Receptionist(system2).ref ! Receptionist.Register(pingPongKey, system2, node2Probe.ref)
-      node2Probe.expectMessageType[Registered[_]]
+      node2Probe.expectMessageType[Registered]
 
       // wait until the service is seen on the first node
-      val remoteRef = node1Probe.expectMessageType[Receptionist.Listing[Ping]].serviceInstances.head
+      val remoteRef = node1Probe.expectMessageType[Receptionist.Listing].serviceInstances(pingPongKey).head
 
       spawn(Behaviors.setup[AnyRef] { (ctx) ⇒
         implicit val timeout: Timeout = 3.seconds

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -118,7 +118,7 @@ class ClusterReceptionistSpec extends TestKit("ClusterReceptionistSpec", Cluster
       system.receptionist ! Register(PingKey, service, regProbe.ref)
       regProbe.expectMessage(Registered(PingKey, service))
 
-      val Listing(PingKey, remoteServiceRefs) = regProbe2.expectMessageType[Listing[PingProtocol]]
+      val PingKey.Listing(remoteServiceRefs) = regProbe2.expectMessageType[Listing]
       val theRef = remoteServiceRefs.head
       theRef ! Ping(regProbe2.ref)
       regProbe2.expectMessage(Pong)

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/ReceptionistExampleSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/ReceptionistExampleSpec.scala
@@ -94,7 +94,7 @@ object PingPongExample {
 
   val pingService: Behavior[Ping] =
     Behaviors.setup { ctx ⇒
-      ctx.system.receptionist ! Receptionist.Register(PingServiceKey, ctx.self, ctx.system.deadLetters)
+      ctx.system.receptionist ! Receptionist.Register(PingServiceKey, ctx.self)
       Behaviors.immutable[Ping] { (_, msg) ⇒
         msg match {
           case Ping(replyTo) ⇒

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/ReceptionistExampleSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/ReceptionistExampleSpec.scala
@@ -14,19 +14,20 @@ import org.scalatest.WordSpec
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.collection.immutable.Set
+import scala.reflect.ClassTag
 
 object RandomRouter {
 
-  def router[T](serviceKey: ServiceKey[T]): Behavior[T] =
+  def router[T: ClassTag](serviceKey: ServiceKey[T]): Behavior[T] =
     Behaviors.setup[Any] { ctx ⇒
       ctx.system.receptionist ! Receptionist.Subscribe(serviceKey, ctx.self)
 
       def routingBehavior(routees: Vector[ActorRef[T]]): Behavior[Any] =
         Behaviors.immutable { (_, msg) ⇒
           msg match {
-            case Listing(_, services: Set[ActorRef[T]]) ⇒
+            case serviceKey.Listing(services) ⇒
               routingBehavior(services.toVector)
-            case other: T @unchecked ⇒
+            case other: T ⇒
               if (routees.isEmpty)
                 Behaviors.unhandled
               else {
@@ -57,7 +58,7 @@ object RandomRouter {
       def routingBehavior(routees: Vector[ActorRef[T]], unreachable: Set[Address]): Behavior[Any] =
         Behaviors.immutable { (_, msg) ⇒
           msg match {
-            case Listing(_, services: Set[ActorRef[T]]) ⇒
+            case serviceKey.Listing(services: Set[ActorRef[T]]) ⇒
               routingBehavior(services.toVector, unreachable)
             case WrappedReachabilityEvent(event) ⇒ event match {
               case UnreachableMember(m) ⇒
@@ -116,12 +117,12 @@ object PingPongExample {
   //#pinger
 
   //#pinger-guardian
-  val guardian: Behavior[Listing[Ping]] = Behaviors.setup { ctx ⇒
+  val guardian: Behavior[Nothing] = Behaviors.setup[Listing] { ctx ⇒
     ctx.system.receptionist ! Receptionist.Subscribe(PingServiceKey, ctx.self)
     val ps = ctx.spawnAnonymous(pingService)
     ctx.watch(ps)
-    Behaviors.immutablePartial[Listing[Ping]] {
-      case (c, Listing(PingServiceKey, listings)) if listings.nonEmpty ⇒
+    Behaviors.immutablePartial[Listing] {
+      case (_, PingServiceKey.Listing(listings)) if listings.nonEmpty ⇒
         listings.foreach(ps ⇒ ctx.spawnAnonymous(pinger(ps)))
         Behaviors.same
     } onSignal {
@@ -129,15 +130,15 @@ object PingPongExample {
         println("Ping service has shut down")
         Behaviors.stopped
     }
-  }
+  }.narrow
   //#pinger-guardian
 
   //#pinger-guardian-pinger-service
-  val guardianJustPingService: Behavior[Listing[Ping]] = Behaviors.setup { ctx ⇒
+  val guardianJustPingService: Behavior[Nothing] = Behaviors.setup[Listing] { ctx ⇒
     val ps = ctx.spawnAnonymous(pingService)
     ctx.watch(ps)
-    Behaviors.immutablePartial[Listing[Ping]] {
-      case (c, Listing(PingServiceKey, listings)) if listings.nonEmpty ⇒
+    Behaviors.immutablePartial[Listing] {
+      case (c, PingServiceKey.Listing(listings)) if listings.nonEmpty ⇒
         listings.foreach(ps ⇒ ctx.spawnAnonymous(pinger(ps)))
         Behaviors.same
     } onSignal {
@@ -145,18 +146,18 @@ object PingPongExample {
         println("Ping service has shut down")
         Behaviors.stopped
     }
-  }
+  }.narrow
   //#pinger-guardian-pinger-service
 
   //#pinger-guardian-just-pinger
-  val guardianJustPinger: Behavior[Listing[Ping]] = Behaviors.setup { ctx ⇒
+  val guardianJustPinger: Behavior[Nothing] = Behaviors.setup[Listing] { ctx ⇒
     ctx.system.receptionist ! Receptionist.Subscribe(PingServiceKey, ctx.self)
-    Behaviors.immutablePartial[Listing[Ping]] {
-      case (c, Listing(PingServiceKey, listings)) if listings.nonEmpty ⇒
+    Behaviors.immutablePartial[Listing] {
+      case (c, PingServiceKey.Listing(listings)) if listings.nonEmpty ⇒
         listings.foreach(ps ⇒ ctx.spawnAnonymous(pinger(ps)))
         Behaviors.same
     }
-  }
+  }.narrow
   //#pinger-guardian-just-pinger
 
 }
@@ -190,15 +191,15 @@ class ReceptionistExampleSpec extends WordSpec with ScalaFutures {
 
   "A local basic example" must {
     "show register" in {
-      val system = ActorSystem(guardian, "PingPongExample")
+      val system = ActorSystem[Nothing](guardian, "PingPongExample")
       system.whenTerminated.futureValue
     }
   }
 
   "A remote basic example" must {
     "show register" in {
-      val system1 = ActorSystem(guardianJustPingService, "PingPongExample", clusterConfig)
-      val system2 = ActorSystem(guardianJustPinger, "PingPongExample", clusterConfig)
+      val system1 = ActorSystem[Nothing](guardianJustPingService, "PingPongExample", clusterConfig)
+      val system2 = ActorSystem[Nothing](guardianJustPinger, "PingPongExample", clusterConfig)
 
       val cluster1 = Cluster(system1)
       val cluster2 = Cluster(system2)


### PR DESCRIPTION
Refs #24511 and #24492

But the biggest thing it does is deal with the fact that we cannot safely have type parameters on messages and match/detect those in Java nor Scala. It does so by mimicking ddata to some extent with some nice unapply-magic for Scala that Johannes came up with.

Sadly those changes lead to a big can of moving things around to make them accessible from both Java and Scala etc.