### PR TITLE
prune entries in ClusterReceptionist from nodes that have been removed, #23683

### DIFF
--- a/akka-cluster-typed/src/main/resources/reference.conf
+++ b/akka-cluster-typed/src/main/resources/reference.conf
@@ -1,1 +1,16 @@
+############################################
+# Akka Cluster Typed Reference Config File #
+############################################
 
+# This is the reference config file that contains all the default settings.
+# Make your edits/overrides in your application.conf.
+
+akka.cluster.typed.receptionist {
+  # Updates with Distributed Data are done with this consistency level.
+  # Possible values: local, majority, all, 2, 3, 4 (n)
+  write-consistency = local
+
+  # Period task to remove actor references that are hosted by removed nodes,
+  # in case of abrupt termination.
+  pruning-interval = 3 s
+}

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
@@ -3,6 +3,8 @@
  */
 package akka.cluster.typed.internal.receptionist
 
+import scala.concurrent.duration._
+
 import akka.annotation.InternalApi
 import akka.cluster.Cluster
 import akka.cluster.ddata.DistributedData
@@ -20,9 +22,15 @@ import akka.actor.typed.receptionist.Receptionist.AllCommands
 import akka.actor.typed.receptionist.Receptionist.Command
 import akka.actor.typed.receptionist.ServiceKey
 import akka.actor.typed.scaladsl.ActorContext
-
 import scala.language.existentials
 import scala.language.higherKinds
+
+import akka.actor.typed.ActorSystem
+import akka.actor.Address
+import akka.cluster.ClusterEvent
+import akka.cluster.ClusterEvent.MemberRemoved
+import akka.util.Helpers.toRootLowerCase
+import com.typesafe.config.Config
 
 /** Internal API */
 @InternalApi
@@ -53,19 +61,45 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
     def apply(map: ORMultiMap[ServiceKey[_], ActorRef[_]]): ServiceRegistry = TypedORMultiMap[ServiceKey, ActorRef](map)
   }
 
+  private case object RemoveTick
+
   def behavior: Behavior[Command] = clusterBehavior
-  val clusterBehavior: Behavior[Command] = ReceptionistImpl.init(clusteredReceptionist())
+  val clusterBehavior: Behavior[Command] = ReceptionistImpl.init(ctx ⇒ clusteredReceptionist(ctx))
+
+  object ClusterReceptionistSettings {
+    def apply(system: ActorSystem[_]): ClusterReceptionistSettings =
+      apply(system.settings.config.getConfig("akka.cluster.typed.receptionist"))
+
+    def apply(config: Config): ClusterReceptionistSettings = {
+      val writeTimeout = 5.seconds // the timeout is not important
+      val writeConsistency = {
+        val key = "write-consistency"
+        toRootLowerCase(config.getString(key)) match {
+          case "local"    ⇒ Replicator.WriteLocal
+          case "majority" ⇒ Replicator.WriteMajority(writeTimeout)
+          case "all"      ⇒ Replicator.WriteAll(writeTimeout)
+          case _          ⇒ Replicator.WriteTo(config.getInt(key), writeTimeout)
+        }
+      }
+      ClusterReceptionistSettings(
+        writeConsistency,
+        pruningInterval = config.getDuration("pruning-interval", MILLISECONDS).millis
+      )
+    }
+  }
 
   case class ClusterReceptionistSettings(
-    writeConsistency: WriteConsistency = Replicator.WriteLocal
-  )
+    writeConsistency: WriteConsistency,
+    pruningInterval:  FiniteDuration)
 
   /**
    * Returns an ReceptionistImpl.ExternalInterface that synchronizes registered services with
    */
-  def clusteredReceptionist(settings: ClusterReceptionistSettings = ClusterReceptionistSettings())(ctx: ActorContext[AllCommands]): ReceptionistImpl.ExternalInterface[ServiceRegistry] = {
+  def clusteredReceptionist(ctx: ActorContext[AllCommands]): ReceptionistImpl.ExternalInterface[ServiceRegistry] = {
     import akka.actor.typed.scaladsl.adapter._
     val untypedSystem = ctx.system.toUntyped
+
+    val settings = ClusterReceptionistSettings(ctx.system)
 
     val replicator = DistributedData(untypedSystem).replicator
     implicit val cluster = Cluster(untypedSystem)
@@ -106,7 +140,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
       }
     }
 
-    val adapter: ActorRef[Replicator.ReplicatorMessage] =
+    val replicatorMessageAdapter: ActorRef[Replicator.ReplicatorMessage] =
       ctx.messageAdapter[Replicator.ReplicatorMessage] {
         case changed @ Replicator.Changed(ReceptionistKey) ⇒
           val value = changed.get(ReceptionistKey)
@@ -116,7 +150,42 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
           externalInterface.RegistrationsChangedExternally(changes, newState)
       }
 
-    replicator ! Replicator.Subscribe(ReceptionistKey, adapter.toUntyped)
+    replicator ! Replicator.Subscribe(ReceptionistKey, replicatorMessageAdapter.toUntyped)
+
+    // remove entries when members are removed
+    val clusterEventMessageAdapter: ActorRef[MemberRemoved] =
+      ctx.messageAdapter[MemberRemoved] {
+        case MemberRemoved(member, _) ⇒
+          // ok to update from several nodes but more efficient to try to do it from one node
+          if (cluster.state.leader.contains(cluster.selfAddress)) {
+            if (member.address == cluster.selfAddress) NodesRemoved.empty
+            else NodesRemoved(Set(member.address))
+          } else
+            NodesRemoved.empty
+      }
+
+    cluster.subscribe(clusterEventMessageAdapter.toUntyped, ClusterEvent.InitialStateAsEvents, classOf[MemberRemoved])
+
+    // also periodic cleanup in case removal from ORMultiMap is skipped due to concurrent update,
+    // which is possible for OR CRDTs
+    val removeTickMessageAdapter: ActorRef[RemoveTick.type] =
+      ctx.messageAdapter[RemoveTick.type] { _ ⇒
+        // ok to update from several nodes but more efficient to try to do it from one node
+        if (cluster.state.leader.contains(cluster.selfAddress)) {
+          val allAddressesInState: Set[Address] = state.map.entries.flatMap {
+            case (_, values) ⇒
+              // don't care about local (empty host:port addresses)
+              values.collect { case ref if ref.path.address.hasGlobalScope ⇒ ref.path.address }
+          }(collection.breakOut)
+          val clusterAddresses = cluster.state.members.map(_.address)
+          val diff = allAddressesInState diff clusterAddresses
+          if (diff.isEmpty) NodesRemoved.empty else NodesRemoved(diff)
+        } else
+          NodesRemoved.empty
+      }
+
+    ctx.system.scheduler.schedule(settings.pruningInterval, settings.pruningInterval,
+      removeTickMessageAdapter.toUntyped, RemoveTick)(ctx.system.executionContext)
 
     externalInterface
   }

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -11,18 +11,20 @@ import akka.actor.typed.internal.adapter.ActorSystemAdapter
 import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
-import akka.cluster.Cluster
+import akka.cluster.typed.Cluster
 import akka.serialization.SerializerWithStringManifest
 import akka.testkit.typed.{ TestKit, TestKitSettings }
 import akka.testkit.typed.scaladsl.TestProbe
 import com.typesafe.config.ConfigFactory
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
+
+import akka.cluster.typed.Join
 
 object ClusterReceptionistSpec {
   val config = ConfigFactory.parseString(
     s"""
+      akka.loglevel = DEBUG
       akka.actor {
         provider = cluster
         serialize-messages = off
@@ -42,7 +44,10 @@ object ClusterReceptionistSpec {
       akka.remote.netty.tcp.port = 0
       akka.remote.artery.canonical.port = 0
       akka.remote.artery.canonical.hostname = 127.0.0.1
-      akka.cluster.jmx.multi-mbeans-in-same-jvm = on
+      akka.cluster {
+        auto-down-unreachable-after = 0s
+        jmx.multi-mbeans-in-same-jvm = on
+      }
     """)
 
   case object Pong
@@ -91,17 +96,14 @@ class ClusterReceptionistSpec extends TestKit("ClusterReceptionistSpec", Cluster
   import ClusterReceptionistSpec._
 
   implicit val testSettings = TestKitSettings(system)
-  val untypedSystem1 = ActorSystemAdapter.toUntyped(system)
-  val clusterNode1 = Cluster(untypedSystem1)
+  val clusterNode1 = Cluster(system)
 
-  val system2 = akka.actor.ActorSystem(
-    system.name,
-    system.settings.config)
-  val adaptedSystem2 = system2.toTyped
+  val testKit2 = new TestKit(system.name, system.settings.config)
+  val system2 = testKit2.system
   val clusterNode2 = Cluster(system2)
 
-  clusterNode1.join(clusterNode1.selfAddress)
-  clusterNode2.join(clusterNode1.selfAddress)
+  clusterNode1.manager ! Join(clusterNode1.selfMember.address)
+  clusterNode2.manager ! Join(clusterNode1.selfMember.address)
 
   import Receptionist._
 
@@ -109,9 +111,9 @@ class ClusterReceptionistSpec extends TestKit("ClusterReceptionistSpec", Cluster
 
     "must eventually replicate registrations to the other side" in {
       val regProbe = TestProbe[Any]()(system)
-      val regProbe2 = TestProbe[Any]()(adaptedSystem2)
+      val regProbe2 = TestProbe[Any]()(system2)
 
-      adaptedSystem2.receptionist ! Subscribe(PingKey, regProbe2.ref)
+      system2.receptionist ! Subscribe(PingKey, regProbe2.ref)
       regProbe2.expectMessage(Listing(PingKey, Set.empty[ActorRef[PingProtocol]]))
 
       val service = spawn(pingPongBehavior)
@@ -126,11 +128,33 @@ class ClusterReceptionistSpec extends TestKit("ClusterReceptionistSpec", Cluster
       service ! Perish
       regProbe2.expectMessage(Listing(PingKey, Set.empty[ActorRef[PingProtocol]]))
     }
+
+    "must remove registrations when node dies" in {
+
+      val regProbe = TestProbe[Any]()(system)
+      val regProbe2 = TestProbe[Any]()(system2)
+
+      system.receptionist ! Subscribe(PingKey, regProbe.ref)
+      regProbe.expectMessage(Listing(PingKey, Set.empty[ActorRef[PingProtocol]]))
+
+      val service2 = testKit2.spawn(pingPongBehavior)
+      system2.receptionist ! Register(PingKey, service2, regProbe2.ref)
+      regProbe2.expectMessage(Registered(PingKey, service2))
+
+      val Listing(PingKey, remoteServiceRefs) = regProbe.expectMessageType[Listing[PingProtocol]]
+      val theRef = remoteServiceRefs.head
+      theRef ! Ping(regProbe.ref)
+      regProbe.expectMessage(Pong)
+
+      // abrupt termination
+      system2.terminate()
+      regProbe.expectMessage(10.seconds, Listing(PingKey, Set.empty[ActorRef[PingProtocol]]))
+    }
+
   }
 
   override def afterAll(): Unit = {
     super.afterAll()
-    Await.result(system.terminate(), 3.seconds)
-    Await.result(system2.terminate(), 3.seconds)
+    TestKit.shutdown(system2, 10.seconds)
   }
 }


### PR DESCRIPTION
I think we need a better solution, but this can be a first start to remove the most urgent leak.

The problem with this solution is that if a node with same hostname:port joins again there is risk that we miss the removal of some refs that belongs to the old incarnation. I think we need a data structure that also includes the owning system's uid for each ref.

Refs #23683