### PR TITLE
ambiguous method byteBuffer.limit with jdk9

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -171,10 +171,10 @@ private[remote] class ArteryTcpTransport(_system: ExtendedActorSystem, _provider
 
     Flow[EnvelopeBuffer]
       .map { env ⇒
-        // TODO Possible performance improvement, could we reduce the copying of bytes?
-        afr.hiFreq(TcpOutbound_Sent, env.byteBuffer.limit)
-        val size = env.byteBuffer.limit
+        val size = env.byteBuffer.limit()
+        afr.hiFreq(TcpOutbound_Sent, size)
 
+        // TODO Possible performance improvement, could we reduce the copying of bytes?
         val bytes = ByteString(env.byteBuffer)
         bufferPool.release(env)
 

--- a/akka-remote/src/test/scala/akka/remote/artery/tcp/TcpFramingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/tcp/TcpFramingSpec.scala
@@ -87,8 +87,8 @@ class TcpFramingSpec extends AkkaSpec with ImplicitSender {
         val frames = Source.fromIterator(() ⇒ rechunk(bytes)).via(framingFlow).runWith(Sink.seq).futureValue
         frames.size should ===(numberOfFrames)
         frames.foreach { frame ⇒
-          frame.byteBuffer.limit should ===(payload5.size)
-          val payload = new Array[Byte](frame.byteBuffer.limit)
+          frame.byteBuffer.limit() should ===(payload5.size)
+          val payload = new Array[Byte](frame.byteBuffer.limit())
           frame.byteBuffer.get(payload)
           ByteString(payload) should ===(payload5)
           frame.streamId should ===(3)


### PR DESCRIPTION
```
[error] /localhome/jenkinsakka/workspace/akka-nightly-jdk9/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala:160:35: ambiguous reference to overloaded definition,
[error] both method limit in class ByteBuffer of type (x$1: Int)java.nio.ByteBuffer
[error] and  method limit in class Buffer of type ()Int
[error] match expected type ?
[error]         val size = env.byteBuffer.limit
```

fixed by using `limit()`

@retronym You might be interested in this one. Is it something that scalac could handle better? This was with 2.12.4 (and same with 2.11).