### PR TITLE
+ben add DirectBufferPoolBenchmark, just for reference

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/actor/DirectByteBufferPoolBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/DirectByteBufferPoolBenchmark.scala
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor
+
+import java.nio.ByteBuffer
+import java.util.Random
+import java.util.concurrent.TimeUnit
+
+import akka.dispatch.forkjoin.ThreadLocalRandom
+import akka.io.DirectByteBufferPool
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+class DirectByteBufferPoolBenchmark {
+  import DirectByteBufferPoolBenchmark._
+
+  private val MAX_LIVE_BUFFERS = 8192
+
+  @Param(Array("00000", "00256", "01024", "04096", "16384", "65536"))
+  var size = 0
+
+  val random = new Random
+
+  var arteryPool: DirectByteBufferPool = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    arteryPool = new DirectByteBufferPool(size, MAX_LIVE_BUFFERS)
+  }
+
+  @TearDown(Level.Trial)
+  def tearDown(): Unit = {
+    var i = 0
+    while (i < MAX_LIVE_BUFFERS) {
+      arteryPool.release(pooledDirectBuffers(i))
+      pooledDirectBuffers(i) = null
+
+      DirectByteBufferPool.tryCleanDirectByteBuffer(unpooledDirectBuffers(i))
+      unpooledDirectBuffers(i) = null
+
+      DirectByteBufferPool.tryCleanDirectByteBuffer(unpooledHeapBuffers(i))
+      unpooledHeapBuffers(i) = null
+
+      i += 1
+    }
+  }
+
+  private val unpooledHeapBuffers = new Array[ByteBuffer](MAX_LIVE_BUFFERS)
+
+  private val pooledDirectBuffers = new Array[ByteBuffer](MAX_LIVE_BUFFERS)
+  private val unpooledDirectBuffers = new Array[ByteBuffer](MAX_LIVE_BUFFERS)
+
+  import org.openjdk.jmh.annotations.Benchmark
+
+  @Benchmark
+  def unpooledHeapAllocAndRelease(): Unit = {
+    val idx = random.nextInt(unpooledHeapBuffers.length)
+    val oldBuf = unpooledHeapBuffers(idx)
+    if (oldBuf != null) DirectByteBufferPool.tryCleanDirectByteBuffer(oldBuf)
+    unpooledHeapBuffers(idx) = ByteBuffer.allocateDirect(size)
+  }
+
+  @Benchmark
+  def unpooledDirectAllocAndRelease(): Unit = {
+    val idx = random.nextInt(unpooledDirectBuffers.length)
+    val oldBuf = unpooledDirectBuffers(idx)
+    if (oldBuf != null) DirectByteBufferPool.tryCleanDirectByteBuffer(oldBuf)
+    unpooledDirectBuffers(idx) = ByteBuffer.allocateDirect(size)
+  }
+
+  @Benchmark
+  def pooledDirectAllocAndRelease(): Unit = {
+    val idx = random.nextInt(pooledDirectBuffers.length)
+    val oldBuf = pooledDirectBuffers(idx)
+    if (oldBuf != null) arteryPool.release(oldBuf)
+    pooledDirectBuffers(idx) = arteryPool.acquire()
+  }
+
+}
+
+object DirectByteBufferPoolBenchmark {
+  final val numMessages = 2000000 // messages per actor pair
+
+  // Constants because they are used in annotations
+  // update according to cpu
+  final val cores = 8
+  final val coresStr = "8"
+  final val cores2xStr = "16"
+  final val cores4xStr = "24"
+
+  final val twoActors = 2
+  final val moreThanCoresActors = cores * 2
+  final val lessThanCoresActors = cores / 2
+  final val sameAsCoresActors = cores
+
+  final val totalMessagesTwoActors = numMessages
+  final val totalMessagesMoreThanCores = (moreThanCoresActors * numMessages) / 2
+  final val totalMessagesLessThanCores = (lessThanCoresActors * numMessages) / 2
+  final val totalMessagesSameAsCores = (sameAsCoresActors * numMessages) / 2
+}


### PR DESCRIPTION
Was poking around this benchmark during a talk yesterday since I noticed we didn't have one for the DirectByteBufferPool.

Nothing unexpected AFAICS, since we always work with the same size of buffer it's doing pretty well, and perf does not really change with regards to size since we remain within the size of max allowed buffers.

```
[info] Benchmark                                                    (size)  Mode  Cnt     Score     Error  Units
[info] DirectByteBufferPoolBenchmark.pooledDirectAllocAndRelease     00000  avgt   10    51.591 ±   3.824  ns/op
[info] DirectByteBufferPoolBenchmark.pooledDirectAllocAndRelease     00256  avgt   10    58.496 ±  10.748  ns/op
[info] DirectByteBufferPoolBenchmark.pooledDirectAllocAndRelease     01024  avgt   10    58.818 ±   9.905  ns/op
[info] DirectByteBufferPoolBenchmark.pooledDirectAllocAndRelease     04096  avgt   10    53.677 ±   3.620  ns/op
[info] DirectByteBufferPoolBenchmark.pooledDirectAllocAndRelease     16384  avgt   10    50.216 ±   3.802  ns/op
[info] DirectByteBufferPoolBenchmark.unpooledDirectAllocAndRelease   00000  avgt   10   441.060 ±  95.290  ns/op
[info] DirectByteBufferPoolBenchmark.unpooledDirectAllocAndRelease   00256  avgt   10   657.614 ± 165.713  ns/op
[info] DirectByteBufferPoolBenchmark.unpooledDirectAllocAndRelease   01024  avgt   10   765.275 ± 193.497  ns/op
[info] DirectByteBufferPoolBenchmark.unpooledDirectAllocAndRelease   04096  avgt   10  1413.883 ± 183.882  ns/op
[info] DirectByteBufferPoolBenchmark.unpooledDirectAllocAndRelease   16384  avgt   10  4190.581 ± 253.693  ns/op
[info] DirectByteBufferPoolBenchmark.unpooledHeapAllocAndRelease     00000  avgt   10   461.832 ± 112.604  ns/op
[info] DirectByteBufferPoolBenchmark.unpooledHeapAllocAndRelease     00256  avgt   10   864.642 ± 189.678  ns/op
[info] DirectByteBufferPoolBenchmark.unpooledHeapAllocAndRelease     01024  avgt   10   990.773 ± 334.452  ns/op
[info] DirectByteBufferPoolBenchmark.unpooledHeapAllocAndRelease     04096  avgt   10  1500.676 ± 200.080  ns/op
[info] DirectByteBufferPoolBenchmark.unpooledHeapAllocAndRelease     16384  avgt   10  3817.164 ± 265.010  ns/op
```

Before anyone asks for comparing to netty: It's not an apples-to-apples, since we do strictly (much!) less than the netty one, but benchmark replicates that one https://github.com/netty/netty/blob/4.1/microbench/src/main/java/io/netty/microbench/buffer/PooledByteBufAllocatorAlignBenchmark.java