### PR TITLE
Allow nested typed timers 

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
@@ -231,7 +231,7 @@ class TimerSpec extends ActorTestKit with WordSpecLike with TypedAkkaSpecWithShu
         outerTimer.startPeriodicTimer("outer-key", "outer-msg", 50.millis)
         Behaviors.withTimers { innerTimer ⇒
           innerTimer.startPeriodicTimer("inner-key", "inner-msg", 50.millis)
-          Behaviors.immutable { (ctx, msg) ⇒
+          Behaviors.receiveMessage { msg ⇒
             if (msg == "stop") Behaviors.stopped
             else {
               probe.ref ! msg
@@ -256,7 +256,7 @@ class TimerSpec extends ActorTestKit with WordSpecLike with TypedAkkaSpecWithShu
       val probe = TestProbe[String]()
       def newBehavior(n: Int): Behavior[String] = Behaviors.withTimers[String] { timers ⇒
         timers.startPeriodicTimer(s"key${n}", s"msg${n}", 50.milli)
-        Behaviors.immutable[String] { (ctx, msg) ⇒
+        Behaviors.receiveMessage { msg ⇒
           if (msg == "stop") Behaviors.stopped
           else {
             probe.ref ! msg

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
@@ -28,6 +28,16 @@ import akka.util.Timeout
 
   private var messageAdapterRef: OptionVal[ActorRef[Any]] = OptionVal.None
   private var _messageAdapters: List[(Class[_], Any ⇒ T)] = Nil
+  private var _timer: OptionVal[TimerSchedulerImpl[T]] = OptionVal.None
+
+  // context-shared timer needed to allow for nested timer usage
+  def timer: TimerSchedulerImpl[T] = _timer match {
+    case OptionVal.Some(timer) ⇒ timer
+    case OptionVal.None ⇒
+      val timer = new TimerSchedulerImpl[T](this)
+      _timer = OptionVal.Some(timer)
+      timer
+  }
 
   override def asJava: javadsl.ActorContext[T] = this
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
@@ -33,7 +33,7 @@ import scala.reflect.ClassTag
         val timerScheduler = ctxImpl.timer
         val behavior = factory(timerScheduler)
         timerScheduler.intercept(behavior)
-      case _ => throw new IllegalArgumentException(s"timers not supported with [${ctx.getClass}]")
+      case _ ⇒ throw new IllegalArgumentException(s"timers not supported with [${ctx.getClass}]")
     }
 
 }


### PR DESCRIPTION
Fixes #24366 by keeping a single `TimerSchedulerImpl` in the typed context, which means that nested `withTimer()` will actually see the same instance, and can cancel each others jobs etc. 

It also means that returning a new `Behavior` doesn't clear the timers - I'm not 100% sure that is the behavior we want.