### PR TITLE
Add java duration support for Source.tick (Java DSL) #24339

### DIFF
--- a/akka-actor/src/main/mima-filters/2.5.11.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.11.backwards.excludes
@@ -1,0 +1,3 @@
+# result type changed from Duration to FiniteDuration
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.util.JavaDurationConverters#JavaDurationOps.asScala")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.util.JavaDurationConverters#JavaDurationOps.asScala$extension")

--- a/akka-actor/src/main/mima-filters/2.5.11.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.11.backwards.excludes
@@ -1,3 +1,3 @@
-# result type changed from Duration to FiniteDuration
+# Internal API changes
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.util.JavaDurationConverters#JavaDurationOps.asScala")
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.util.JavaDurationConverters#JavaDurationOps.asScala$extension")

--- a/akka-actor/src/main/scala/akka/util/JavaDurationConverters.scala
+++ b/akka-actor/src/main/scala/akka/util/JavaDurationConverters.scala
@@ -3,13 +3,13 @@
  */
 package akka.util
 import java.time.{ Duration ⇒ JDuration }
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 /**
  * INTERNAL API
  */
 private[akka] object JavaDurationConverters {
   final implicit class JavaDurationOps(val self: JDuration) extends AnyVal {
-    def asScala: Duration = Duration.fromNanos(self.toNanos)
+    def asScala: FiniteDuration = Duration.fromNanos(self.toNanos)
   }
 
   final implicit class ScalaDurationOps(val self: Duration) extends AnyVal {

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java
@@ -430,7 +430,13 @@ public class SourceTest extends StreamTest {
     probe.expectNoMsg(FiniteDuration.create(200, TimeUnit.MILLISECONDS));
     probe.expectMsgEquals("tick");
     probe.expectNoMsg(FiniteDuration.create(200, TimeUnit.MILLISECONDS));
+  }
 
+  @Test
+  @SuppressWarnings("unused")
+  public void mustCompileMethodsWithJavaDuration() {
+    Source<NotUsed, Cancellable> tickSource = Source.tick(java.time.Duration.ofSeconds(1),
+            java.time.Duration.ofMillis(500), NotUsed.getInstance());
   }
 
   @Test

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -7,6 +7,7 @@ import java.util
 import java.util.Optional
 
 import akka.util.{ ConstantFun, Timeout }
+import akka.util.JavaDurationConverters._
 import akka.{ Done, NotUsed }
 import akka.actor.{ ActorRef, Cancellable, Props }
 import akka.event.LoggingAdapter
@@ -208,6 +209,12 @@ object Source {
    */
   def tick[O](initialDelay: FiniteDuration, interval: FiniteDuration, tick: O): javadsl.Source[O, Cancellable] =
     new Source(scaladsl.Source.tick(initialDelay, interval, tick))
+
+  /**
+   * Same as [[tick]], but accepts Java [[java.time.Duration]] instead of Scala ones.
+   */
+  def tick[O](initialDelay: java.time.Duration, interval: java.time.Duration, tick: O): javadsl.Source[O, Cancellable] =
+    Source.tick(initialDelay.asScala, interval.asScala, tick)
 
   /**
    * Create a `Source` with one element.


### PR DESCRIPTION
Hi, this is my first PR. I've added the method overload and duplicated a test case, which I think would be enough because it reuse the `tick()` that takes FiniteDuration.

Fixes #24339