### PR TITLE
Add keep alive from buffer graph stage

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowIdleInjectSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowIdleInjectSpec.scala
@@ -1,3 +1,6 @@
+/**
+ * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 package akka.stream.scaladsl
 
 import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowKeepAliveFromBufferSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowKeepAliveFromBufferSpec.scala
@@ -1,0 +1,98 @@
+package akka.stream.scaladsl
+
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
+import akka.stream.testkit.{ StreamSpec, TestSubscriber, TestPublisher, Utils }
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class FlowKeepAliveFromBufferSpec extends StreamSpec {
+
+  val settings = ActorMaterializerSettings(system)
+    .withInputBuffer(initialSize = 2, maxSize = 16)
+
+  implicit val materializer = ActorMaterializer(settings)
+
+  val sampleSource = Source((1 to 10).grouped(3).toVector)
+  val expand = (lst: IndexedSeq[Int]) ⇒ lst.toList.map(Vector(_))
+
+  "keepAliveFromBuffer" must {
+
+    "not emit additional elements if upstream is fast enough" in Utils.assertAllStagesStopped {
+      Await.result(
+        sampleSource
+          .keepAliveFromBuffer(5, 1.second, expand)
+          .grouped(1000)
+          .runWith(Sink.head),
+        3.seconds
+      ).flatten should ===(1 to 10)
+    }
+
+    "emit elements periodically after silent periods" in Utils.assertAllStagesStopped {
+      val sourceWithIdleGap = Source((1 to 5).grouped(3).toList) ++
+        Source((6 to 10).grouped(3).toList).initialDelay(2.second)
+
+      Await.result(
+        sourceWithIdleGap
+          .keepAliveFromBuffer(5, 0.6.seconds, expand)
+          .grouped(1000)
+          .runWith(Sink.head),
+        3.seconds
+      ).flatten should ===(1 to 10)
+    }
+
+    "immediately pull upstream" in {
+      val upstream = TestPublisher.probe[Vector[Int]]()
+      val downstream = TestSubscriber.probe[Vector[Int]]()
+
+      Source.fromPublisher(upstream).keepAliveFromBuffer(2, 1.second, expand).runWith(Sink.fromSubscriber(downstream))
+
+      downstream.request(1)
+
+      upstream.sendNext(Vector(1))
+      downstream.expectNext(Vector(1))
+
+      upstream.sendComplete()
+      downstream.expectComplete()
+    }
+
+    "immediately pull upstream after busy period" in {
+      val upstream = TestPublisher.probe[IndexedSeq[Int]]()
+      val downstream = TestSubscriber.probe[IndexedSeq[Int]]()
+
+      (sampleSource ++ Source.fromPublisher(upstream))
+        .keepAliveFromBuffer(2, 1.second, expand)
+        .runWith(Sink.fromSubscriber(downstream))
+
+      downstream.request(10)
+      downstream.expectNextN((1 to 3).grouped(1).toVector ++ (4 to 10).grouped(3).toVector)
+
+      downstream.request(1)
+
+      upstream.sendNext(Vector(1))
+      downstream.expectNext(Vector(1))
+
+      upstream.sendComplete()
+      downstream.expectComplete()
+    }
+
+    "work if timer fires before initial request after busy period" in {
+      val upstream = TestPublisher.probe[IndexedSeq[Int]]()
+      val downstream = TestSubscriber.probe[IndexedSeq[Int]]()
+
+      (sampleSource ++ Source.fromPublisher(upstream))
+        .keepAliveFromBuffer(2, 1.second, expand)
+        .runWith(Sink.fromSubscriber(downstream))
+
+      downstream.request(10)
+      downstream.expectNextN((1 to 3).grouped(1).toVector ++ (4 to 10).grouped(3).toVector)
+
+      downstream.expectNoMsg(1.5.second)
+      downstream.request(1)
+
+      upstream.sendComplete()
+      downstream.expectComplete()
+    }
+
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/Timers.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Timers.scala
@@ -11,6 +11,7 @@ import akka.stream.impl.Stages.DefaultAttributes
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import akka.stream.stage._
 
+import scala.collection.JavaConverters._
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 /**
@@ -267,6 +268,58 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
 
     override def toString = "IdleTimer"
 
+  }
+
+  final case class KeepAliveFromBuffer[T](size: Int, interval: FiniteDuration, extrapolate: T ⇒ Seq[T])
+    extends GraphStage[FlowShape[T, T]] {
+
+    require(size > 0, "The buffer size must be greater than 0.")
+
+    val in = Inlet[T]("KeepAliveFromBuffer.in")
+    val out = Outlet[T]("KeepAliveFromBuffer.out")
+
+    override val shape = FlowShape(in, out)
+
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+      new TimerGraphStageLogic(shape) with InHandler with OutHandler {
+
+        private val buffer = new java.util.ArrayDeque[T](size)
+
+        override def preStart(): Unit = {
+          schedulePeriodically(None, interval)
+          pull(in)
+        }
+
+        override def onPush(): Unit = {
+          val elem = grab(in)
+          if (buffer.size() < size) buffer.addAll(extrapolate(elem).asJava)
+          else buffer.addLast(elem)
+
+          if (isAvailable(out)) push(out, buffer.removeFirst())
+          else pull(in)
+        }
+
+        override def onPull(): Unit = {
+          if (isClosed(in)) {
+            if (buffer.isEmpty) completeStage()
+            else push(out, buffer.removeFirst())
+          } else if (buffer.size() > size) {
+            push(out, buffer.removeFirst())
+          } else if (!hasBeenPulled(in)) {
+            pull(in)
+          }
+        }
+
+        override def onTimer(timerKey: Any) = {
+          if (!buffer.isEmpty) push(out, buffer.removeFirst())
+        }
+
+        override def onUpstreamFinish(): Unit = {
+          if (buffer.isEmpty) completeStage()
+        }
+
+        setHandlers(in, out, this)
+      }
   }
 
   case object GraphStageLogicTimer

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -2231,6 +2231,31 @@ final class Flow[-In, +Out, +Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends
     new Flow(delegate.keepAlive(maxIdle, () ⇒ injectedElem.create()))
 
   /**
+   * Sends elements from buffer if upstream does not emit for a configured amount of time. In other words, this
+   * stage attempts to maintains a base rate of emitted elements towards the downstream using elements from upstream.
+   *
+   * If upstream emits new elements until the accumulated elements in the buffer exceed the specified minimum size
+   * used as the keep alive elements, then the base rate is no longer maintained until we reach another period without
+   * elements form upstream.
+   *
+   * The keep alive period is the keep alive failover size times the interval.
+   *
+   * '''Emits when''' upstream emits an element or if the upstream was idle for the configured period
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @see [[keepAlive]]
+   * @see [[expand]]
+   */
+  def keepAliveConcat[U >: Out](keepAliveFailoverSize: Int, interval: FiniteDuration,
+                                extrapolate: function.Function[U, java.util.List[U]]): javadsl.Flow[In, U, Mat] =
+    new Flow(delegate.keepAliveConcat(keepAliveFailoverSize, interval, (in: U) ⇒ extrapolate.apply(in).asScala))
+
+  /**
    * Sends elements downstream with speed limited to `elements/per`. In other words, this stage set the maximum rate
    * for emitting messages. This combinator works for streams where all elements have the same cost or length.
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2280,6 +2280,31 @@ final class Source[+Out, +Mat](delegate: scaladsl.Source[Out, Mat]) extends Grap
     new Source(delegate.keepAlive(maxIdle, () ⇒ injectedElem.create()))
 
   /**
+   * Sends elements from buffer if upstream does not emit for a configured amount of time. In other words, this
+   * stage attempts to maintains a base rate of emitted elements towards the downstream using elements from upstream.
+   *
+   * If upstream emits new elements until the accumulated elements in the buffer exceed the specified minimum size
+   * used as the keep alive elements, then the base rate is no longer maintained until we reach another period without
+   * elements form upstream.
+   *
+   * The keep alive period is the keep alive failover size times the interval.
+   *
+   * '''Emits when''' upstream emits an element or if the upstream was idle for the configured period
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @see [[keepAlive]]
+   * @see [[expand]]
+   */
+  def keepAliveConcat[U >: Out](keepAliveFailoverSize: Int, interval: FiniteDuration,
+                                extrapolate: function.Function[U, java.util.List[U]]): javadsl.Source[U, Mat] =
+    new Source(delegate.keepAliveConcat(keepAliveFailoverSize, interval, (in: U) ⇒ extrapolate.apply(in).asScala))
+
+  /**
    * Sends elements downstream with speed limited to `elements/per`. In other words, this stage set the maximum rate
    * for emitting messages. This combinator works for streams where all elements have the same cost or length.
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -1390,6 +1390,31 @@ class SubFlow[-In, +Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flo
     new SubFlow(delegate.keepAlive(maxIdle, () ⇒ injectedElem.create()))
 
   /**
+   * Sends elements from buffer if upstream does not emit for a configured amount of time. In other words, this
+   * stage attempts to maintains a base rate of emitted elements towards the downstream using elements from upstream.
+   *
+   * If upstream emits new elements until the accumulated elements in the buffer exceed the specified minimum size
+   * used as the keep alive elements, then the base rate is no longer maintained until we reach another period without
+   * elements form upstream.
+   *
+   * The keep alive period is the keep alive failover size times the interval.
+   *
+   * '''Emits when''' upstream emits an element or if the upstream was idle for the configured period
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @see [[keepAlive]]
+   * @see [[expand]]
+   */
+  def keepAliveConcat[U >: Out](keepAliveFailoverSize: Int, interval: FiniteDuration,
+                                extrapolate: function.Function[U, java.util.List[U]]): SubFlow[In, U, Mat] =
+    new SubFlow(delegate.keepAliveConcat(keepAliveFailoverSize, interval, (in: U) ⇒ extrapolate.apply(in).asScala))
+
+  /**
    * Sends elements downstream with speed limited to `elements/per`. In other words, this stage set the maximum rate
    * for emitting messages. This combinator works for streams where all elements have the same cost or length.
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -1382,6 +1382,31 @@ class SubSource[+Out, +Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source
     new SubSource(delegate.keepAlive(maxIdle, () ⇒ injectedElem.create()))
 
   /**
+   * Sends elements from buffer if upstream does not emit for a configured amount of time. In other words, this
+   * stage attempts to maintains a base rate of emitted elements towards the downstream using elements from upstream.
+   *
+   * If upstream emits new elements until the accumulated elements in the buffer exceed the specified minimum size
+   * used as the keep alive elements, then the base rate is no longer maintained until we reach another period without
+   * elements form upstream.
+   *
+   * The keep alive period is the keep alive failover size times the interval.
+   *
+   * '''Emits when''' upstream emits an element or if the upstream was idle for the configured period
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @see [[keepAlive]]
+   * @see [[expand]]
+   */
+  def keepAliveConcat[U >: Out](keepAliveFailoverSize: Int, interval: FiniteDuration,
+                                extrapolate: function.Function[U, java.util.List[U]]): javadsl.SubSource[U, Mat] =
+    new SubSource(delegate.keepAliveConcat(keepAliveFailoverSize, interval, (in: U) ⇒ extrapolate.apply(in).asScala))
+
+  /**
    * Sends elements downstream with speed limited to `elements/per`. In other words, this stage set the maximum rate
    * for emitting messages. This combinator works for streams where all elements have the same cost or length.
    *

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -21,7 +21,7 @@ import akka.stream.impl.fusing.FlattenMerge
 import akka.NotUsed
 import akka.actor.ActorRef
 import akka.annotation.DoNotInherit
-import akka.stream.impl.Timers.KeepAliveFromBuffer
+import akka.stream.impl.Timers.KeepAliveConcat
 
 import scala.annotation.implicitNotFound
 import scala.reflect.ClassTag
@@ -1992,7 +1992,7 @@ trait FlowOps[+Out, +Mat] {
    * used as the keep alive elements, then the base rate is no longer maintained until we reach another period without
    * elements form upstream.
    *
-   * The keep alive period is the size times the interval.
+   * The keep alive period is the keep alive failover size times the interval.
    *
    * '''Emits when''' upstream emits an element or if the upstream was idle for the configured period
    *
@@ -2005,8 +2005,8 @@ trait FlowOps[+Out, +Mat] {
    * @see [[keepAlive]]
    * @see [[expand]]
    */
-  def keepAliveFromBuffer[U >: Out](size: Int, interval: FiniteDuration, extrapolate: U ⇒ List[U]): Repr[U] =
-    via(KeepAliveFromBuffer[U](size, interval, extrapolate))
+  def keepAliveConcat[U >: Out](keepAliveFailoverSize: Int, interval: FiniteDuration, extrapolate: U ⇒ Seq[U]): Repr[U] =
+    via(KeepAliveConcat[U](keepAliveFailoverSize, interval, extrapolate))
 
   /**
    * Sends elements downstream with speed limited to `elements/per`. In other words, this stage set the maximum rate


### PR DESCRIPTION
This stage helps when we want keep alive functionality, but without injecting random elements, but use a buffer and inject elements from it.