### PR TITLE
Additional tests for async boundaries and GroupBy

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
@@ -84,7 +84,7 @@ class FusingSpec extends StreamSpec {
       val refs = receiveN(in.size + in.size) // each element through the first map, then the second map
       refs.toSet should have size (in.size + 1) // outer/main actor + 1 actor per subflow
     }
-    
+
   }
 
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
@@ -4,6 +4,8 @@
 
 package akka.stream
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import akka.stream.scaladsl._
 import akka.stream.testkit.StreamSpec
 import akka.stream.impl.fusing.GraphInterpreter
@@ -95,6 +97,7 @@ class FusingSpec extends StreamSpec {
         val bus = GraphInterpreter.currentInterpreter.log.asInstanceOf[BusLogging]
         bus.logSource
       }
+
       val flow = Flow[Int].map(x ⇒ { testActor ! ref; x })
       Source(0 to 9)
         .map(x ⇒ { testActor ! ref; x })

--- a/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
@@ -70,6 +70,26 @@ class FusingSpec extends StreamSpec {
       }
     }
 
+    "use one actor per grouped substream when there is an async boundary around it" in {
+      def ref = {
+        val bus = GraphInterpreter.currentInterpreter.log.asInstanceOf[BusLogging]
+        bus.logSource
+      }
+      val async = Flow[Int].map(x ⇒ { testActor ! ref; x }).async
+      Source(0 to 9)
+        .map(x ⇒ { testActor ! ref; x })
+        .groupBy(10, identity)
+        .via(async)
+        .mergeSubstreams
+        .runWith(Sink.seq)
+        .futureValue
+        .sorted should ===(0 to 9)
+      val refs = receiveN(10)
+      withClue(s"refs=\n${refs.mkString("\n")}") {
+        refs.toSet should have size (11) // main flow + 10 subflows
+      }
+    }
+
   }
 
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala
@@ -596,13 +596,9 @@ class FlowGroupBySpec extends StreamSpec {
       val threeProcessed = TestLatch()
       val queue = Source.queue[Elem](3, OverflowStrategy.backpressure)
         .groupBy(2, _.substream)
-        .to(
-          Flow[Elem]
-            .buffer(2, OverflowStrategy.backpressure)
-            .map { _.f() }
-            .to(Sink.ignore)
-            .async
-        )
+        .buffer(2, OverflowStrategy.backpressure)
+        .map { _.f() }.async
+        .to(Sink.ignore)
         .run()
 
       List(

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala
@@ -603,13 +603,19 @@ class FlowGroupBySpec extends StreamSpec {
       val threeProcessed = Promise[Done]()
       val blockSubStream1 = TestLatch()
       List(
-        Elem(1, 1, () ⇒ { Await.result(blockSubStream1, remainingOrDefault); 1 }),
+        Elem(1, 1, () ⇒ {
+          // timeout just to not wait forever if something is wrong, not really relevant for test
+          Await.result(blockSubStream1, 10.seconds)
+          1
+        }),
         Elem(2, 1, () ⇒ 2),
         Elem(3, 2, () ⇒ {
           threeProcessed.success(Done)
           3
         })).foreach(queue.offer)
+      // two and three are processed as fast as possible, not blocked by substream 1 being clogged
       threeProcessed.future.futureValue should ===(Done)
+      // let 1 pass so stream can complete
       blockSubStream1.open()
       queue.complete()
     }

--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -33,6 +33,7 @@ import akka.util.OptionVal
 @InternalApi private[akka] object PhasedFusingActorMaterializer {
 
   val Debug = false
+  val DebugSpawnIsland = false
 
   val DefaultPhase: Phase[Any] = new Phase[Any] {
     override def apply(settings: ActorMaterializerSettings, effectiveAttributes: Attributes,
@@ -743,7 +744,11 @@ private final case class SavedIslandData(islandGlobalOffset: Int, lastVisitedOff
           case OptionVal.Some(n) ⇒ n
           case OptionVal.None    ⇒ islandName
         }
-        materializer.actorOf(props, actorName)
+
+        val ref = materializer.actorOf(props, actorName)
+        if (PhasedFusingActorMaterializer.DebugSpawnIsland) {
+          println(s"Spawned actor [$ref] with shell: $shell")
+        }
     }
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -33,7 +33,6 @@ import akka.util.OptionVal
 @InternalApi private[akka] object PhasedFusingActorMaterializer {
 
   val Debug = false
-  val DebugSpawnIsland = false
 
   val DefaultPhase: Phase[Any] = new Phase[Any] {
     override def apply(settings: ActorMaterializerSettings, effectiveAttributes: Attributes,
@@ -746,7 +745,7 @@ private final case class SavedIslandData(islandGlobalOffset: Int, lastVisitedOff
         }
 
         val ref = materializer.actorOf(props, actorName)
-        if (PhasedFusingActorMaterializer.DebugSpawnIsland) {
+        if (PhasedFusingActorMaterializer.Debug) {
           println(s"Spawned actor [$ref] with shell: $shell")
         }
     }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -113,6 +113,9 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    *     |  +------+        +------+  |
    *     +----------------------------+
    * }}}
+   *
+   * Note that attributes set on the returned graph, including async boundaries are now for the entire graph and not
+   * the `SubFlow`. for example `async` will not have any effect as the returned graph is the entire, closed graph.
    */
   def to(sink: Graph[SinkShape[Out], _]): Sink[In, Mat] =
     new Sink(delegate.to(sink))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/SubFlow.scala
@@ -21,6 +21,9 @@ trait SubFlow[+Out, +Mat, +F[+_], C] extends FlowOps[Out, Mat] {
   /**
    * Attach a [[Sink]] to each sub-flow, closing the overall Graph that is being
    * constructed.
+   *
+   * Note that attributes set on the returned graph, including async boundaries are now for the entire graph and not
+   * the `SubFlow`. for example `async` will not have any effect as the returned graph is the entire, closed graph.
    */
   def to[M](sink: Graph[SinkShape[Out], M]): C
 


### PR DESCRIPTION
A few new tests, some test cleanup, and a tiny docs addition to clarify how `async` works in the context of `groupBy`

Refs #24676 