### PR TITLE
Many recoveries spec: Transferred

### DIFF
--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed
+
+import akka.actor.typed.TypedAkkaSpecWithShutdown
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
+import akka.persistence.typed.scaladsl.PersistentBehaviors.CommandHandler
+import akka.persistence.typed.scaladsl.{ Effect, PersistentBehavior, PersistentBehaviors }
+import akka.testkit.TestLatch
+import akka.testkit.typed.scaladsl.{ ActorTestKit, TestProbe }
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.concurrent.Eventually
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object ManyRecoveriesSpec {
+
+  sealed case class Cmd(s: String)
+
+  final case class Evt(s: String)
+
+  def persistentBehavior(
+    name:  String,
+    probe: TestProbe[String],
+    latch: Option[TestLatch]): PersistentBehavior[Cmd, Evt, String] =
+    PersistentBehaviors.receive[Cmd, Evt, String](
+      persistenceId = name,
+      initialState = "",
+      commandHandler = CommandHandler.command {
+        case Cmd(s) ⇒ Effect.persist(Evt(s)).andThen(_ ⇒ probe.ref ! s"$name-$s")
+      },
+      eventHandler = {
+        case (state, _) ⇒ latch.foreach(Await.ready(_, 10.seconds)); state
+      }
+    )
+
+  def forwardBehavior(sender: TestProbe[String]): Behaviors.Receive[Int] =
+    Behaviors.receivePartial[Int] {
+      case (_, value) ⇒
+        sender.ref ! value.toString
+        Behaviors.same
+    }
+
+  def forN(n: Int)(mapper: Int ⇒ String): Set[String] =
+    (1 to n).map(mapper).toSet
+}
+
+class ManyRecoveriesSpec extends ActorTestKit with TypedAkkaSpecWithShutdown with Eventually {
+
+  import ManyRecoveriesSpec._
+
+  override def config: Config = ConfigFactory.parseString(
+    s"""
+    akka.actor.default-dispatcher {
+      type = Dispatcher
+      executor = "thread-pool-executor"
+      thread-pool-executor {
+        fixed-pool-size = 5
+      }
+    }
+    akka.persistence.max-concurrent-recoveries = 3
+    akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+    akka.actor.warn-about-java-serializer-usage = off
+  """)
+
+  "Many persistent actors" must {
+    "be able to recover without overloading" in {
+      val probe = TestProbe[String]()
+      (1 to 100).foreach { n ⇒
+        val name = s"a$n"
+        spawn(persistentBehavior(s"a$n", probe, latch = None), name) ! Cmd("A")
+        probe.expectMessage(s"a$n-A")
+      }
+
+      // this would starve (block) all threads without max-concurrent-recoveries
+      val latch = TestLatch()(system.toUntyped)
+      (1 to 100).foreach { n ⇒
+        spawn(persistentBehavior(s"a$n", probe, Some(latch))) ! Cmd("B")
+      }
+      // this should be able to progress even though above is blocking,
+      // 2 remaining non-blocked threads
+      (1 to 10).foreach { n ⇒
+        spawn(forwardBehavior(probe)) ! n
+        probe.expectMessage(n.toString)
+      }
+
+      latch.countDown()
+
+      forN(100)(_ ⇒ probe.expectMessageType[String]) should
+        be(forN(100)(i ⇒ s"a$i-B"))
+    }
+  }
+}

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
@@ -39,8 +39,8 @@ object ManyRecoveriesSpec {
     )
 
   def forwardBehavior(sender: TestProbe[String]): Behaviors.Receive[Int] =
-    Behaviors.receivePartial[Int] {
-      case (_, value) ⇒
+    Behaviors.receiveMessagePartial[Int] {
+      case value ⇒
         sender.ref ! value.toString
         Behaviors.same
     }


### PR DESCRIPTION
This PR partially addresses issue #24687. Port of `akka.persistence.ManyRecoveriesSpec`.