### PR TITLE
Change Artery TCP to use bind address

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -253,21 +253,21 @@ private[remote] class ArteryTcpTransport(_system: ExtendedActorSystem, _provider
         .map(_ ⇒ ByteString.empty) // make it a Flow[ByteString] again
     }
 
-    val host = bindAddress.address.host.get
-    val port = bindAddress.address.port.get
+    val bindHost = bindAddress.address.host.get
+    val bindPort = bindAddress.address.port.get
 
     val connectionSource: Source[Tcp.IncomingConnection, Future[ServerBinding]] =
       if (tlsEnabled) {
         val sslProvider = sslEngineProvider.get
         Tcp().bindTlsWithSSLEngine(
-          interface = host,
-          port = port,
-          createSSLEngine = () ⇒ sslProvider.createServerSSLEngine(host, port),
-          verifySession = session ⇒ optionToTry(sslProvider.verifyServerSession(host, session)))
+          interface = bindHost,
+          port = bindPort,
+          createSSLEngine = () ⇒ sslProvider.createServerSSLEngine(bindHost, bindPort),
+          verifySession = session ⇒ optionToTry(sslProvider.verifyServerSession(bindHost, session)))
       } else {
         Tcp().bind(
-          interface = host,
-          port = port,
+          interface = bindHost,
+          port = bindPort,
           halfClose = false)
       }
 
@@ -290,7 +290,7 @@ private[remote] class ArteryTcpTransport(_system: ExtendedActorSystem, _provider
 
         // only on initial startup, when ActorSystem is starting
         Await.result(binding, settings.Bind.BindTimeout)
-        afr.loFreq(TcpInbound_Bound, s"$host:$port")
+        afr.loFreq(TcpInbound_Bound, s"$bindHost:$bindPort")
         Some(binding)
       case s @ Some(_) ⇒
         // already bound, when restarting

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -253,8 +253,8 @@ private[remote] class ArteryTcpTransport(_system: ExtendedActorSystem, _provider
         .map(_ ⇒ ByteString.empty) // make it a Flow[ByteString] again
     }
 
-    val host = localAddress.address.host.get
-    val port = localAddress.address.port.get
+    val host = bindAddress.address.host.get
+    val port = bindAddress.address.port.get
 
     val connectionSource: Source[Tcp.IncomingConnection, Future[ServerBinding]] =
       if (tlsEnabled) {

--- a/akka-remote/src/test/scala/akka/remote/artery/BindCanonicalAddressSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/BindCanonicalAddressSpec.scala
@@ -4,23 +4,27 @@
 
 package akka.remote.artery
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ Config, ConfigFactory }
 import akka.actor.ActorSystem
 import akka.remote.transport.netty.NettyTransportSpec._
+
 import scala.concurrent.Await
 import org.scalatest.WordSpec
 import org.scalatest.Matchers
+
 import scala.concurrent.duration.Duration
 import akka.testkit.SocketUtil
 import java.net.InetAddress
 
-class BindCanonicalAddressSpec extends WordSpec with Matchers {
-  import BindCanonicalAddressSpec._
+trait BindCanonicalAddressBehaviors {
+  this: WordSpec with Matchers ⇒
+  def arteryConnectionTest(transport: String, isUDP: Boolean) {
 
-  "artery" should {
+    val commonConfig = BindCanonicalAddressSpec.commonConfig(transport)
 
     "bind to a random port" in {
-      val config = ConfigFactory.parseString(s"""
+      val config = ConfigFactory.parseString(
+        s"""
         akka.remote.artery.canonical.port = 0
       """)
 
@@ -31,9 +35,10 @@ class BindCanonicalAddressSpec extends WordSpec with Matchers {
     }
 
     "bind to a random port but remoting accepts from a specified port" in {
-      val address = SocketUtil.temporaryServerAddress(InetAddress.getLocalHost.getHostAddress, udp = true)
+      val address = SocketUtil.temporaryServerAddress(InetAddress.getLocalHost.getHostAddress, udp = isUDP)
 
-      val config = ConfigFactory.parseString(s"""
+      val config = ConfigFactory.parseString(
+        s"""
         akka.remote.artery.canonical.port = ${address.getPort}
         akka.remote.artery.bind.port = 0
       """)
@@ -46,10 +51,25 @@ class BindCanonicalAddressSpec extends WordSpec with Matchers {
       Await.result(sys.terminate(), Duration.Inf)
     }
 
-    "bind to a specified port and remoting accepts from a bound port" in {
-      val address = SocketUtil.temporaryServerAddress(InetAddress.getLocalHost.getHostAddress, udp = true)
+    "bind to a specified bind hostname and remoting aspects from canonical hostname" in {
+      val config = ConfigFactory.parseString(
+        s"""
+        akka.remote.artery.canonical.port = 0
+        akka.remote.artery.canonical.hostname = "127.0.0.1"
+        akka.remote.artery.bind.hostname = "localhost"
+      """)
 
-      val config = ConfigFactory.parseString(s"""
+      implicit val sys = ActorSystem("sys", config.withFallback(commonConfig))
+
+      getInternal().flatMap(_.host) should contain("localhost")
+      getExternal().host should contain("127.0.0.1")
+    }
+
+    "bind to a specified port and remoting accepts from a bound port" in {
+      val address = SocketUtil.temporaryServerAddress(InetAddress.getLocalHost.getHostAddress, udp = isUDP)
+
+      val config = ConfigFactory.parseString(
+        s"""
         akka.remote.artery.canonical.port = 0
         akka.remote.artery.bind.port = ${address.getPort}
       """)
@@ -61,7 +81,8 @@ class BindCanonicalAddressSpec extends WordSpec with Matchers {
     }
 
     "bind to all interfaces" in {
-      val config = ConfigFactory.parseString(s"""
+      val config = ConfigFactory.parseString(
+        s"""
         akka.remote.artery.bind.hostname = "0.0.0.0"
       """)
 
@@ -73,14 +94,27 @@ class BindCanonicalAddressSpec extends WordSpec with Matchers {
       Await.result(sys.terminate(), Duration.Inf)
     }
   }
+}
 
+class BindCanonicalAddressSpec extends WordSpec with Matchers with BindCanonicalAddressBehaviors {
+  s"artery with aeron-udp transport" should {
+    behave like arteryConnectionTest("aeron-udp", true)
+  }
+  s"artery with tcp transport" should {
+    behave like arteryConnectionTest("tcp", false)
+  }
+  s"artery with tls-tcp transport" should {
+    behave like arteryConnectionTest("tls-tcp", false)
+  }
 }
 
 object BindCanonicalAddressSpec {
-  val commonConfig = ConfigFactory.parseString("""
+  def commonConfig(transport: String) = ConfigFactory.parseString(
+    s"""
     akka {
       actor.provider = remote
       remote.artery.enabled = true
+      remote.artery.transport = "${transport}"
     }
   """)
 }


### PR DESCRIPTION
Changing the Artery TCP  transport to use the bind address rather than the local address. Also refactoring the bind/canonical address spec to test all 3 transports and add checking the binding addresses are correctly set. This fixes #24766