### PR TITLE
WIP - DO NOT MERGE - GroupBy no longer retains closedSubstreams

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1711,6 +1711,10 @@ trait FlowOps[+Out, +Mat] {
    * a new substream is opened and subsequently fed with all elements belonging to
    * that key.
    *
+   * Note that when a substream completes, if its key appears subsequently then
+   * it is treated as a new key. This operation does not retain a memory of what keys
+   * were previously encountered; only the keys that are active.
+   *
    * The object returned from this method is not a normal [[Source]] or [[Flow]],
    * it is a [[SubFlow]]. This means that after this combinator all transformations
    * are applied to all encountered substreams in the same fashion. Substream mode


### PR DESCRIPTION
Created as a WIP as a placeholder for further discussion. I remain unenlightened as to the utility of retaining state for previously closed substreams, particularly given that the existing implementation consumes memory for every new key and never releases it.

If we need to retain the existing behaviour then please advise on what the API may look like in consideration of maintaining binary compatibility. 

Please also consider that the existing closed substream/key behaviour is not articulated as well as it could be.

This PR currently addresses:

* the infinite addition of substreams to `closedSubstreams` (this is a memory retention issue)
* the need to reuse keys post their substream being closed
* clarification of behaviour in the API doc

[An existing test is broken](https://github.com/akka/akka/blob/3685ce619e21406fa4ab4a357d2a7bca6fe98e7a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala#L148) and I've not yet taken the time to thoroughly understand why.

Fixes #24758