### PR TITLE
BehaviorTestKit - hasEffects and expectEffectPF

### DIFF
--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -76,6 +76,16 @@ private[akka] final class BehaviorTestKitImpl[T](_name: String, _initialBehavior
     }
   }
 
+  def expectEffectPF[R](f: PartialFunction[Effect, R]): R = {
+    ctx.effectQueue.poll() match {
+      case null ⇒ throw new AssertionError(s"expected matching effect but no effects were recorded")
+      case eff if f.isDefinedAt(eff) ⇒
+        f.apply(eff)
+      case other ⇒
+        throw new AssertionError(s"expected matching effect but got: $other")
+    }
+  }
+
   def expectEffectType[E <: Effect](implicit classTag: ClassTag[E]): E =
     expectEffectClass(classTag.runtimeClass.asInstanceOf[Class[E]])
 
@@ -114,4 +124,5 @@ private[akka] final class BehaviorTestKitImpl[T](_name: String, _initialBehavior
     } catch handleException
   }
 
+  override def hasEffects(): Boolean = !ctx.effectQueue.isEmpty
 }

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/javadsl/BehaviorTestKit.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/javadsl/BehaviorTestKit.scala
@@ -58,6 +58,11 @@ abstract class BehaviorTestKit[T] {
   def getAllEffects(): java.util.List[Effect]
 
   /**
+   * Returns if there have been any effects.
+   */
+  def hasEffects(): Boolean
+
+  /**
    * Asserts that the oldest effect is the expectedEffect. Removing it from
    * further assertions.
    */

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/scaladsl/BehaviorTestKit.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/scaladsl/BehaviorTestKit.scala
@@ -59,6 +59,11 @@ trait BehaviorTestKit[T] {
   def retrieveAllEffects(): immutable.Seq[Effect]
 
   /**
+   * Returns if there have been any effects.
+   */
+  def hasEffects(): Boolean
+
+  /**
    * Asserts that the oldest effect is the expectedEffect. Removing it from
    * further assertions.
    */
@@ -68,7 +73,12 @@ trait BehaviorTestKit[T] {
    * Asserts that the oldest effect is of type T. Consumes and returns the concrete effect for
    * further direct assertions.
    */
-  def expectEffectType[T <: Effect](implicit classTag: ClassTag[T]): T
+  def expectEffectType[E <: Effect](implicit classTag: ClassTag[E]): E
+
+  /**
+   * Asserts that the oldest effect matches the given partial function.
+   */
+  def expectEffectPF[R](f: PartialFunction[Effect, R]): R
 
   /**
    * The current behavior, can change any time `run` is called


### PR DESCRIPTION
I didn't add the partial function API to the javadsl, didn't seem very javary. Tho in untyped I see we have it on the testkit but not on the test probe.

Refs #24781