### PR TITLE
Fix bug in Flow.scanAsync when upstream completion is delayed

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowScanAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowScanAsyncSpec.scala
@@ -61,6 +61,21 @@ class FlowScanAsyncSpec extends StreamSpec {
       sub.expectError(TE("bang"))
     }
 
+    "complete after an element has been consumed and upstream's completion is delayed" in {
+      val (pub, sub) =
+        TestSource.probe[Int]
+          .via(Flow[Int].scanAsync(0)((acc, in) ⇒ Future.successful(acc + in)))
+          .toMat(TestSink.probe)(Keep.both)
+          .run()
+
+      pub.sendNext(1)
+      sub.request(10)
+      sub.expectNext(0)
+      sub.expectNext(1)
+      pub.sendComplete()
+      sub.expectComplete()
+    }
+
     "work with a single source" in {
       Source.single(1)
         .via(sumScanFlow)


### PR DESCRIPTION
I'm not really confident that this is the best solution to the problem (see the new testcase) as I'm new to Akka (or asynchronous programming in general) and it doesn't really "feel" like the proper way but I was unable to think of anything else (which also passed the test).
I'm hoping that someone more knowledgeable can guide me if there's indeed a better solution.
related to: #24036 