### PR TITLE
Fixed an empty ByteStrings problem in InputStreamSinkStage

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
@@ -25,9 +25,8 @@ private[stream] object InputStreamSinkStage {
   case object Close extends AdapterToStageMessage
 
   sealed trait StreamToAdapterMessage
-  case class Data(data: ByteString) extends StreamToAdapterMessage {
-    require(data.nonEmpty)
-  }
+  // Only non-empty ByteString is expected as Data
+  case class Data(data: ByteString) extends StreamToAdapterMessage
   case object Finished extends StreamToAdapterMessage
   case object Initialized extends StreamToAdapterMessage
   case class Failed(cause: Throwable) extends StreamToAdapterMessage

--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
@@ -132,8 +132,11 @@ private[stream] object InputStreamSinkStage {
   @scala.throws(classOf[IOException])
   override def read(): Int = {
     val a = new Array[Byte](1)
-    if (read(a, 0, 1) != -1) a(0) & 0xff
-    else -1
+    read(a, 0, 1) match {
+      case 1   ⇒ a(0) & 0xff
+      case -1  ⇒ -1
+      case len ⇒ throw new IllegalStateException(s"Invalid length [$len]")
+    }
   }
 
   @scala.throws(classOf[IOException])


### PR DESCRIPTION
InputStreamSinkStage returns an additional byte (0x01) when an empty ByteString comes from upstream. It breaks contents. Please see a test in this PR.

I modified to drop empty ByteStrings to fix an issue because we have no interest in empty ByteStrings.