### PR TITLE
remove dependencies of provided scope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val benchJmh = akkaModule("akka-bench-jmh")
       persistence, persistenceTyped,
       distributedData,
       testkit
-    ).map(_ % "compile->compile;compile->test;provided->provided"): _*
+    ).map(_ % "compile->compile;compile->test"): _*
   )
   .settings(Dependencies.benchJmh)
   .enablePlugins(JmhPlugin, ScaladocNoVerificationOfDiagrams, NoPublish, CopyrightHeader)
@@ -139,7 +139,7 @@ lazy val clusterSharding = akkaModule("akka-cluster-sharding")
   .dependsOn(
     cluster % "compile->compile;test->test;multi-jvm->multi-jvm",
     distributedData,
-    persistence % "compile->compile;test->provided",
+    persistence % "compile->compile",
     clusterTools
   )
   .settings(Dependencies.clusterSharding)
@@ -159,7 +159,7 @@ lazy val clusterTools = akkaModule("akka-cluster-tools")
   .enablePlugins(MultiNode, ScaladocNoVerificationOfDiagrams)
 
 lazy val contrib = akkaModule("akka-contrib")
-  .dependsOn(remote, remoteTests % "test->test", cluster, clusterTools, persistence % "compile->compile;test->provided")
+  .dependsOn(remote, remoteTests % "test->test", cluster, clusterTools, persistence % "compile->compile")
   .settings(Dependencies.contrib)
   .settings(AutomaticModuleName.settings("akka.contrib"))
   .settings(OSGi.contrib)
@@ -195,7 +195,7 @@ lazy val docs = akkaModule("akka-docs")
     clusterSharding % "compile->compile;test->test",
     testkit % "compile->compile;test->test",
     remote % "compile->compile;test->test",
-    persistence % "compile->compile;provided->provided;test->test",
+    persistence % "compile->compile;test->test",
     actorTyped % "compile->compile;test->test",
     persistenceTyped % "compile->compile;test->test",
     clusterTyped % "compile->compile;test->test",
@@ -266,7 +266,7 @@ lazy val persistence = akkaModule("akka-persistence")
 lazy val persistenceQuery = akkaModule("akka-persistence-query")
   .dependsOn(
     stream,
-    persistence % "compile->compile;provided->provided;test->test",
+    persistence % "compile->compile;test->test",
     streamTestkit % "test"
   )
   .settings(Dependencies.persistenceQuery)
@@ -288,7 +288,7 @@ lazy val persistenceShared = akkaModule("akka-persistence-shared")
   .disablePlugins(MimaPlugin, WhiteSourcePlugin)
 
 lazy val persistenceTck = akkaModule("akka-persistence-tck")
-  .dependsOn(persistence % "compile->compile;provided->provided;test->test", testkit % "compile->compile;test->test")
+  .dependsOn(persistence % "compile->compile;test->test", testkit % "compile->compile;test->test")
   .settings(Dependencies.persistenceTck)
   .settings(AutomaticModuleName.settings("akka.persistence.tck"))
 //.settings(OSGi.persistenceTck) TODO: we do need to export this as OSGi bundle too?
@@ -406,8 +406,8 @@ lazy val clusterTyped = akkaModule("akka-cluster-typed")
     cluster,
     clusterTools,
     distributedData,
-    persistence % "provided->test",
-    persistenceTyped % "provided->test",
+    persistence % "test->test",
+    persistenceTyped % "test->test",
     typedTestkit % "test->test",
     actorTypedTests % "test->test"
   )
@@ -451,7 +451,7 @@ lazy val typedTestkit = akkaModule("akka-testkit-typed")
 lazy val actorTypedTests = akkaModule("akka-actor-typed-tests")
   .dependsOn(
     actorTyped,
-    typedTestkit % "compile->compile;test->provided;test->test"
+    typedTestkit % "compile->compile;test->test"
   )
   .settings(AkkaBuild.mayChangeSettings)
   .disablePlugins(MimaPlugin)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -158,9 +158,9 @@ object Dependencies {
 
   val persistence = l ++= Seq(Provided.levelDB, Provided.levelDBNative, Test.scalatest.value, Test.junit, Test.commonsIo, Test.commonsCodec, Test.scalaXml)
 
-  val persistenceQuery = l ++= Seq(Test.scalatest.value, Test.junit, Test.commonsIo)
+  val persistenceQuery = l ++= Seq(Test.scalatest.value, Test.junit, Test.commonsIo, Provided.levelDB, Provided.levelDBNative)
 
-  val persistenceTck = l ++= Seq(Test.scalatest.value.withConfigurations(Some("compile")), Test.junit.withConfigurations(Some("compile")))
+  val persistenceTck = l ++= Seq(Test.scalatest.value.withConfigurations(Some("compile")), Test.junit.withConfigurations(Some("compile")), Provided.levelDB, Provided.levelDBNative)
 
   val persistenceShared = l ++= Seq(Provided.levelDB, Provided.levelDBNative)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -117,6 +117,7 @@ object Dependencies {
       val sigarLoader = "io.kamon" % "sigar-loader" % "1.6.6-rev002" % "optional;provided;test" // ApacheV2
 
       val levelDB = "org.iq80.leveldb" % "leveldb" % "0.10" % "optional;provided" // ApacheV2
+      val levelDBmultiJVM = "org.iq80.leveldb" % "leveldb" % "0.10" % "optional;provided;multi-jvm" // ApacheV2
       val levelDBNative = "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8" % "optional;provided" // New BSD
 
       val junit = Compile.junit % "optional;provided;test"
@@ -145,7 +146,7 @@ object Dependencies {
 
   val clusterTools = l ++= Seq(Test.junit, Test.scalatest.value)
 
-  val clusterSharding = l ++= Seq(Provided.levelDB, Provided.levelDBNative, Test.junit, Test.scalatest.value, Test.commonsIo)
+  val clusterSharding = l ++= Seq(Provided.levelDBmultiJVM, Provided.levelDBNative, Test.junit, Test.scalatest.value, Test.commonsIo)
 
   val clusterMetrics = l ++= Seq(Provided.sigarLoader, Test.slf4jJul, Test.slf4jLog4j, Test.logback, Test.mockito)
 
@@ -167,7 +168,7 @@ object Dependencies {
 
   val osgi = l ++= Seq(osgiCore, osgiCompendium, Test.logback, Test.commonsIo, Test.pojosr, Test.tinybundles, Test.scalatest.value, Test.junit)
 
-  val docs = l ++= Seq(Test.scalatest.value, Test.junit, Docs.sprayJson, Docs.gson)
+  val docs = l ++= Seq(Test.scalatest.value, Test.junit, Docs.sprayJson, Docs.gson, Provided.levelDB)
 
   val contrib = l ++= Seq(Test.commonsIo)
 


### PR DESCRIPTION
With these changes I can `sbt ensimeConfig` the build, so this is a test balloon to see what CI says (local `validatePullRequest` didn’t do anything).

In any case, it would be great if these seemingly nonsensical dependencies had an explanatory comment (if they are indeed needed).