### PR TITLE
Avoids memory being retained for groupBy

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala
@@ -148,7 +148,7 @@ class FlowGroupBySpec extends StreamSpec {
     }
 
     "accept cancellation of substreams" in assertAllStagesStopped {
-      new SubstreamsSupport(groupCount = 2) {
+      new SubstreamsSupport(groupCount = 2, maxSubstreams = 3) {
         StreamPuppet(getSubFlow(1).runWith(Sink.asPublisher(false))).cancel()
 
         val substream = StreamPuppet(getSubFlow(0).runWith(Sink.asPublisher(false)))

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
@@ -306,7 +306,7 @@ import scala.collection.JavaConverters._
           nextElementValue = elem
         }
       } else {
-        if (activeSubstreamsMap.size == maxSubstreams)
+        if (activeSubstreamsMap.size + closedSubstreams.size == maxSubstreams)
           throw tooManySubstreamsOpenException
         else if (closedSubstreams.contains(key) && !hasBeenPulled(in))
           pull(in)


### PR DESCRIPTION
This PR avoids memory being retained for `FlowOps` `groupBy`. Prior to the commit, `closedSubstreams` could grow unbounded. This PR includes the size of `closedSubstreams` when considering to take on a new substream while retaining the semantics described by the `Flow` API.

The PR partially addresses https://github.com/akka/akka/issues/24758 and remains after a conversation on https://github.com/akka/akka/pull/24783.

The PR remains WIP as I'd prefer to test the committer response before adjusting the test to suit the tightened semantics.

The PR also depends on #24988 being merged and so should remain WIP until it is.