### PR TITLE
ArteryMessageLoggingSpec pick up command line overrides for akka settings

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/MessageLoggingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/MessageLoggingSpec.scala
@@ -52,8 +52,9 @@ class ClassicMessageLoggingSpec extends MessageLoggingSpec(config(false))
 
 abstract class MessageLoggingSpec(config: Config) extends AkkaSpec(config) with ImplicitSender {
 
-  val remoteSystem = ActorSystem("remote-sys", config)
+  val remoteSystem = ActorSystem("remote-sys", ConfigFactory.load(config))
   val remoteAddress = remoteSystem.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
+
   "Message logging" must {
     "not be on if debug logging not enabled" in {
       remoteSystem.actorOf(Props[BadActor], "bad")


### PR DESCRIPTION
Use ConfigFactory.load to pick up overrides in the additional actor
system. Otherwise one runs with udp and other tcp for the artery-tcp
job.

Fixes #24806