### PR TITLE
#24752 Fix timestamped versions

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -20,6 +20,7 @@ object AkkaBuild {
 
   lazy val buildSettings = Dependencies.Versions ++ Seq(
     organization := "com.typesafe.akka",
+    // use the same value as in the build scope, so it can be overriden by stampVersion
     version := (version in ThisBuild).value)
 
   lazy val rootSettings = Release.settings ++

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -20,13 +20,15 @@ object AkkaBuild {
 
   lazy val buildSettings = Dependencies.Versions ++ Seq(
     organization := "com.typesafe.akka",
-    version := "2.5-SNAPSHOT")
+    version := (version in ThisBuild).value)
 
   lazy val rootSettings = Release.settings ++
     UnidocRoot.akkaSettings ++
     Formatting.formatSettings ++
     Protobuf.settings ++ Seq(
-      parallelExecution in GlobalScope := System.getProperty("akka.parallelExecution", parallelExecutionByDefault.toString).toBoolean)
+      parallelExecution in GlobalScope := System.getProperty("akka.parallelExecution", parallelExecutionByDefault.toString).toBoolean,
+      version in ThisBuild := "2.5-SNAPSHOT"
+    )
 
   lazy val mayChangeSettings = Seq(
     description := """|This module of Akka is marked as

--- a/project/TimeStampede.scala
+++ b/project/TimeStampede.scala
@@ -23,7 +23,7 @@ object TimeStampede extends AutoPlugin {
 
   def stampVersion = Command.command("stampVersion") { state ⇒
     val extracted = Project.extract(state)
-    extracted.append(List(version in ThisBuild ~= stamp), state)
+    extracted.appendWithSession(List(version in ThisBuild ~= stamp), state)
   }
 
   def stamp(version: String): String = {


### PR DESCRIPTION
Ideally we should use sbt-dynver, but currently version tagged commits are not part  of the direct history of master. Upon release we fork master and add a commit which only has version change. Then we tag that commit with a release tag. Therefore sbt-dynver can not currently derive version from history.

Fixes #24752