### PR TITLE
Remove explicit outlet selector from graph docs

### DIFF
--- a/akka-docs/src/test/scala/docs/stream/GraphDSLDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/GraphDSLDocSpec.scala
@@ -81,8 +81,8 @@ class GraphDSLDocSpec extends AkkaSpec {
       val broadcast = builder.add(Broadcast[Int](2))
       Source.single(1) ~> broadcast.in
 
-      broadcast.out(0) ~> sharedDoubler ~> topHS.in
-      broadcast.out(1) ~> sharedDoubler ~> bottomHS.in
+      broadcast ~> sharedDoubler ~> topHS.in
+      broadcast ~> sharedDoubler ~> bottomHS.in
       ClosedShape
     })
     //#graph-dsl-reusing-a-flow


### PR DESCRIPTION
It was found that some parts of the `GraphDSLDocSpec` used automatic port selection, and others used explicit `out(#)` selection. The preference is automatic when possible, though.