### PR TITLE
!str #24812 fix signature of monitor()

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMonitorSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMonitorSpec.scala
@@ -72,8 +72,8 @@ class FlowMonitorSpec extends StreamSpec {
 
     "return Failed when stream is abruptly terminated" in {
       val mat = ActorMaterializer()
-      val (source, monitor) =
-        TestSource.probe[Any].monitorMat(Keep.both).to(Sink.ignore).run()(mat)
+      val (source, monitor) = // notice that `monitor` is like a Keep.both
+        TestSource.probe[Any].monitor.to(Sink.ignore).run()(mat)
       mat.shutdown()
 
       awaitAssert(

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMonitorSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMonitorSpec.scala
@@ -20,7 +20,7 @@ class FlowMonitorSpec extends StreamSpec {
   "A FlowMonitor" must {
     "return Finished when stream is completed" in {
       val ((source, monitor), sink) =
-        TestSource.probe[Any].monitor()(Keep.both).toMat(TestSink.probe[Any])(Keep.both).run()
+        TestSource.probe[Any].monitorMat(Keep.both).toMat(TestSink.probe[Any])(Keep.both).run()
       source.sendComplete()
       awaitAssert(monitor.state == Finished, 3.seconds)
       sink.expectSubscriptionAndComplete()
@@ -28,14 +28,14 @@ class FlowMonitorSpec extends StreamSpec {
 
     "return Finished when stream is cancelled from downstream" in {
       val ((source, monitor), sink) =
-        TestSource.probe[Any].monitor()(Keep.both).toMat(TestSink.probe[Any])(Keep.both).run()
+        TestSource.probe[Any].monitorMat(Keep.both).toMat(TestSink.probe[Any])(Keep.both).run()
       sink.cancel()
       awaitAssert(monitor.state == Finished, 3.seconds)
     }
 
     "return Failed when stream fails, and propagate the error" in {
       val ((source, monitor), sink) =
-        TestSource.probe[Any].monitor()(Keep.both).toMat(TestSink.probe[Any])(Keep.both).run()
+        TestSource.probe[Any].monitorMat(Keep.both).toMat(TestSink.probe[Any])(Keep.both).run()
       val ex = new Exception("Source failed")
       source.sendError(ex)
       awaitAssert(monitor.state == Failed(ex), 3.seconds)
@@ -44,7 +44,7 @@ class FlowMonitorSpec extends StreamSpec {
 
     "return Initialized for an empty stream" in {
       val ((source, monitor), sink) =
-        TestSource.probe[Any].monitor()(Keep.both).toMat(TestSink.probe[Any])(Keep.both).run()
+        TestSource.probe[Any].monitorMat(Keep.both).toMat(TestSink.probe[Any])(Keep.both).run()
       awaitAssert(monitor.state == Initialized, 3.seconds)
       source.expectRequest()
       sink.expectSubscription()
@@ -52,7 +52,7 @@ class FlowMonitorSpec extends StreamSpec {
 
     "return Received after receiving a message" in {
       val ((source, monitor), sink) =
-        TestSource.probe[Any].monitor()(Keep.both).toMat(TestSink.probe[Any])(Keep.both).run()
+        TestSource.probe[Any].monitorMat(Keep.both).toMat(TestSink.probe[Any])(Keep.both).run()
       val msg = "message"
       source.sendNext(msg)
       sink.requestNext(msg)
@@ -63,7 +63,7 @@ class FlowMonitorSpec extends StreamSpec {
     // (to avoid allocating an object for each message) doesn't introduce a bug
     "return Received after receiving a StreamState message" in {
       val ((source, monitor), sink) =
-        TestSource.probe[Any].monitor()(Keep.both).toMat(TestSink.probe[Any])(Keep.both).run()
+        TestSource.probe[Any].monitorMat(Keep.both).toMat(TestSink.probe[Any])(Keep.both).run()
       val msg = Received("message")
       source.sendNext(msg)
       sink.requestNext(msg)
@@ -73,7 +73,7 @@ class FlowMonitorSpec extends StreamSpec {
     "return Failed when stream is abruptly terminated" in {
       val mat = ActorMaterializer()
       val (source, monitor) =
-        TestSource.probe[Any].monitor()(Keep.both).to(Sink.ignore).run()(mat)
+        TestSource.probe[Any].monitorMat(Keep.both).to(Sink.ignore).run()(mat)
       mat.shutdown()
 
       awaitAssert(

--- a/akka-stream/src/main/mima-filters/2.5.11.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.11.backwards.excludes
@@ -15,7 +15,3 @@ ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowO
 
 # #24699 throttle overload
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.throttle")
-
-# #24812 fix signature of monitor()
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOpsMat.monitorMat")
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOpsMat.monitor")

--- a/akka-stream/src/main/mima-filters/2.5.11.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.11.backwards.excludes
@@ -16,3 +16,6 @@ ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowO
 # #24699 throttle overload
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.throttle")
 
+# #24812 fix signature of monitor()
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOpsMat.monitorMat")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOpsMat.monitor")

--- a/akka-stream/src/main/mima-filters/2.5.12.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.12.backwards.excludes
@@ -14,3 +14,7 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.TcpConne
 
 # #24891 add return type for FlowMonitorState.finished
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.FlowMonitorState.finished")
+
+# #24812 fix signature of monitor()
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOpsMat.monitorMat")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOpsMat.monitor")

--- a/akka-stream/src/main/mima-filters/2.5.12.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.12.backwards.excludes
@@ -1,7 +1,7 @@
 # +str add in-line inspect operator for side effecting #24610
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.wireTap")
 
-# #24758 recreate already closed substreams 
+# #24758 recreate already closed substreams
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.GroupBy.this")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.groupBy")
 
@@ -14,7 +14,3 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.TcpConne
 
 # #24891 add return type for FlowMonitorState.finished
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.FlowMonitorState.finished")
-
-# #24812 fix signature of monitor()
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOpsMat.monitorMat")
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOpsMat.monitor")

--- a/akka-stream/src/main/mima-filters/2.5.16.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.16.backwards.excludes
@@ -2,3 +2,7 @@
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.streamref.StreamRefSettingsImpl.*")
 ProblemFilters.exclude[MissingTypesProblem]("akka.stream.impl.streamref.StreamRefSettingsImpl$")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.StreamRefSettings.*")
+
+# #24812 fix signature of monitor()
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOpsMat.monitorMat")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOpsMat.monitor")

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -2991,9 +2991,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * Materializes to `FlowMonitor[Out]` that allows monitoring of the current flow. All events are propagated
    * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
    * event, and may therefor affect performance.
-   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
    *
-   * @deprecated Use monitor() or monitorMat(combine) instead
+   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
    */
   @Deprecated
   @deprecated("2.5.12", "Use monitor() or monitorMat(combine) instead")
@@ -3004,18 +3003,21 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * Materializes to `FlowMonitor[Out]` that allows monitoring of the current flow. All events are propagated
    * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
    * event, and may therefor affect performance.
-   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
    *
-   * @deprecated Use monitor() or monitorMat(combine) instead
+   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
    */
   def monitorMat[M](combine: function.Function2[Mat, FlowMonitor[Out], M]): javadsl.Flow[In, Out, M] =
     new Flow(delegate.monitorMat(combinerToScala(combine)))
 
   /**
-   * Materializes to `FlowMonitor[Out]` that allows monitoring of the current flow. All events are propagated
+   * Materializes to `Pair<Mat, FlowMonitor<<Out>>`, which is unlike most other operators (!),
+   * in which usually the default materialized value keeping semantics is to keep the left value
+   * (by passing `Keep.left()` to a `*Mat` version of a method). In this operator is an exception from
+   * that rule and keeps both values since dropping its sole purpose is to introduce that materialized value.
+   *
+   * The `FlowMonitor[Out]` allows monitoring of the current flow. All events are propagated
    * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
    * event, and may therefor affect performance.
-   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
    */
   def monitor(): Flow[In, Out, FlowMonitor[Out]] =
     monitorMat(Keep.right)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -2992,9 +2992,33 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
    * event, and may therefor affect performance.
    * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
+   *
+   * @deprecated Use monitor() or monitorMat(combine) instead
    */
+  @Deprecated
+  @deprecated("2.5.12", "Use monitor() or monitorMat(combine) instead")
   def monitor[M]()(combine: function.Function2[Mat, FlowMonitor[Out], M]): javadsl.Flow[In, Out, M] =
-    new Flow(delegate.monitor()(combinerToScala(combine)))
+    new Flow(delegate.monitorMat(combinerToScala(combine)))
+
+  /**
+   * Materializes to `FlowMonitor[Out]` that allows monitoring of the current flow. All events are propagated
+   * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
+   * event, and may therefor affect performance.
+   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
+   *
+   * @deprecated Use monitor() or monitorMat(combine) instead
+   */
+  def monitorMat[M](combine: function.Function2[Mat, FlowMonitor[Out], M]): javadsl.Flow[In, Out, M] =
+    new Flow(delegate.monitorMat(combinerToScala(combine)))
+
+  /**
+   * Materializes to `FlowMonitor[Out]` that allows monitoring of the current flow. All events are propagated
+   * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
+   * event, and may therefor affect performance.
+   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
+   */
+  def monitor(): Flow[In, Out, FlowMonitor[Out]] =
+    monitorMat(Keep.right)
 
   /**
    * Delays the initial element by the specified duration.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -3012,15 +3012,15 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
   /**
    * Materializes to `Pair<Mat, FlowMonitor<<Out>>`, which is unlike most other operators (!),
    * in which usually the default materialized value keeping semantics is to keep the left value
-   * (by passing `Keep.left()` to a `*Mat` version of a method). In this operator is an exception from
+   * (by passing `Keep.left()` to a `*Mat` version of a method). This operator is an exception from
    * that rule and keeps both values since dropping its sole purpose is to introduce that materialized value.
    *
    * The `FlowMonitor[Out]` allows monitoring of the current flow. All events are propagated
    * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
    * event, and may therefor affect performance.
    */
-  def monitor(): Flow[In, Out, FlowMonitor[Out]] =
-    monitorMat(Keep.right)
+  def monitor(): Flow[In, Out, Pair[Mat, FlowMonitor[Out]]] =
+    monitorMat(Keep.both)
 
   /**
    * Delays the initial element by the specified duration.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -3194,9 +3194,31 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
    * event, and may therefor affect performance.
    * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
+   *
+   * @deprecated Use monitor() or monitorMat(combine) instead
    */
+  @Deprecated
+  @deprecated("2.5.12", "Use monitor() or monitorMat(combine) instead")
   def monitor[M]()(combine: function.Function2[Mat, FlowMonitor[Out], M]): javadsl.Source[Out, M] =
-    new Source(delegate.monitor()(combinerToScala(combine)))
+    new Source(delegate.monitorMat(combinerToScala(combine)))
+
+  /**
+   * Materializes to `FlowMonitor[Out]` that allows monitoring of the current flow. All events are propagated
+   * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
+   * event, and may therefor affect performance.
+   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
+   */
+  def monitorMat[M](combine: function.Function2[Mat, FlowMonitor[Out], M]): javadsl.Source[Out, M] =
+    new Source(delegate.monitorMat(combinerToScala(combine)))
+
+  /**
+   * Materializes to `FlowMonitor[Out]` that allows monitoring of the current flow. All events are propagated
+   * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
+   * event, and may therefor affect performance.
+   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
+   */
+  def monitor(): javadsl.Source[Out, FlowMonitor[Out]] =
+    monitorMat(Keep.right)
 
   /**
    * Delays the initial element by the specified duration.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -3212,7 +3212,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
   /**
    * Materializes to `Pair<Mat, FlowMonitor<<Out>>`, which is unlike most other operators (!),
    * in which usually the default materialized value keeping semantics is to keep the left value
-   * (by passing `Keep.left()` to a `*Mat` version of a method). In this operator is an exception from
+   * (by passing `Keep.left()` to a `*Mat` version of a method). This operator is an exception from
    * that rule and keeps both values since dropping its sole purpose is to introduce that materialized value.
    *
    * The `FlowMonitor` allows monitoring of the current flow. All events are propagated

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -3190,12 +3190,10 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
     new Source(delegate.watchTermination()((left, right) ⇒ matF(left, right.toJava)))
 
   /**
-   * Materializes to `FlowMonitor[Out]` that allows monitoring of the current flow. All events are propagated
+   * Materializes to `FlowMonitor<Out>` that allows monitoring of the current flow. All events are propagated
    * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
    * event, and may therefor affect performance.
    * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
-   *
-   * @deprecated Use monitor() or monitorMat(combine) instead
    */
   @Deprecated
   @deprecated("2.5.12", "Use monitor() or monitorMat(combine) instead")
@@ -3212,13 +3210,17 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
     new Source(delegate.monitorMat(combinerToScala(combine)))
 
   /**
-   * Materializes to `FlowMonitor[Out]` that allows monitoring of the current flow. All events are propagated
+   * Materializes to `Pair<Mat, FlowMonitor<<Out>>`, which is unlike most other operators (!),
+   * in which usually the default materialized value keeping semantics is to keep the left value
+   * (by passing `Keep.left()` to a `*Mat` version of a method). In this operator is an exception from
+   * that rule and keeps both values since dropping its sole purpose is to introduce that materialized value.
+   *
+   * The `FlowMonitor` allows monitoring of the current flow. All events are propagated
    * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
    * event, and may therefor affect performance.
-   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
    */
-  def monitor(): javadsl.Source[Out, FlowMonitor[Out]] =
-    monitorMat(Keep.right)
+  def monitor(): Source[Out, Pair[Mat, FlowMonitor[Out]]] =
+    monitorMat(Keep.both)
 
   /**
    * Delays the initial element by the specified duration.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -6,8 +6,7 @@ package akka.stream.javadsl
 
 import akka.NotUsed
 import akka.event.LoggingAdapter
-import akka.japi.function
-import akka.japi.Util
+import akka.japi.{ Pair, Util, function }
 import akka.stream._
 import akka.util.ConstantFun
 import akka.util.JavaDurationConverters._

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -2981,8 +2981,31 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
    * event, and may therefor affect performance.
    * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
+   *
+   *
+   * @deprecated Use monitor() or monitorMat(combine) instead
    */
+  @Deprecated
+  @deprecated("2.5.12", "Use monitor() or monitorMat(combine) instead")
   def monitor[Mat2]()(combine: (Mat, FlowMonitor[Out]) ⇒ Mat2): ReprMat[Out, Mat2] =
     viaMat(GraphStages.monitor)(combine)
+
+  /**
+   * Materializes to `FlowMonitor[Out]` that allows monitoring of the current flow. All events are propagated
+   * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
+   * event, and may therefor affect performance.
+   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
+   */
+  def monitorMat[Mat2](combine: (Mat, FlowMonitor[Out]) ⇒ Mat2): ReprMat[Out, Mat2] =
+    viaMat(GraphStages.monitor)(combine)
+
+  /**
+   * Materializes to `FlowMonitor[Out]` that allows monitoring of the current flow. All events are propagated
+   * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
+   * event, and may therefor affect performance.
+   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
+   */
+  def monitor: ReprMat[Out, FlowMonitor[Out]] =
+    monitorMat(Keep.right)
 
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -3001,7 +3001,7 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
   /**
    * Materializes to `(Mat, FlowMonitor[Out])`, which is unlike most other operators (!),
    * in which usually the default materialized value keeping semantics is to keep the left value
-   * (by passing `Keep.left()` to a `*Mat` version of a method). In this operator is an exception from
+   * (by passing `Keep.left()` to a `*Mat` version of a method). This operator is an exception from
    * that rule and keeps both values since dropping its sole purpose is to introduce that materialized value.
    *
    * The `FlowMonitor[Out]` allows monitoring of the current flow. All events are propagated

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -2980,10 +2980,8 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * Materializes to `FlowMonitor[Out]` that allows monitoring of the current flow. All events are propagated
    * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
    * event, and may therefor affect performance.
+   *
    * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
-   *
-   *
-   * @deprecated Use monitor() or monitorMat(combine) instead
    */
   @Deprecated
   @deprecated("2.5.12", "Use monitor() or monitorMat(combine) instead")
@@ -2994,18 +2992,23 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * Materializes to `FlowMonitor[Out]` that allows monitoring of the current flow. All events are propagated
    * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
    * event, and may therefor affect performance.
+   *
    * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
    */
   def monitorMat[Mat2](combine: (Mat, FlowMonitor[Out]) ⇒ Mat2): ReprMat[Out, Mat2] =
     viaMat(GraphStages.monitor)(combine)
 
   /**
-   * Materializes to `FlowMonitor[Out]` that allows monitoring of the current flow. All events are propagated
+   * Materializes to `(Mat, FlowMonitor[Out])`, which is unlike most other operators (!),
+   * in which usually the default materialized value keeping semantics is to keep the left value
+   * (by passing `Keep.left()` to a `*Mat` version of a method). In this operator is an exception from
+   * that rule and keeps both values since dropping its sole purpose is to introduce that materialized value.
+   *
+   * The `FlowMonitor[Out]` allows monitoring of the current flow. All events are propagated
    * by the monitor unchanged. Note that the monitor inserts a memory barrier every time it processes an
    * event, and may therefor affect performance.
-   * The `combine` function is used to combine the `FlowMonitor` with this flow's materialized value.
    */
-  def monitor: ReprMat[Out, FlowMonitor[Out]] =
-    monitorMat(Keep.right)
+  def monitor: ReprMat[Out, (Mat, FlowMonitor[Out])] =
+    monitorMat(Keep.both)
 
 }


### PR DESCRIPTION
Resolves https://github.com/akka/akka/issues/24812 but would ~~cause source incompatibility in scala -- while retaining binary compatibility though.~~

In https://github.com/akka/akka/pull/24864/commits/d7a9eab45db495ddab67149f1140deba121b1277 I was able to make it source compatible -- one can't do an overload with `monitor()` since it conflicts with the `monitor()(keep)` but doing `def monitor`  will work okey.