### PR TITLE
harden TransportFailSpec

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/TransportFailSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/TransportFailSpec.scala
@@ -102,8 +102,9 @@ abstract class TransportFailSpec extends RemotingMultiNodeSpec(TransportFailConf
   override def initialParticipants = roles.size
 
   def identify(role: RoleName, actorName: String): ActorRef = {
-    system.actorSelection(node(role) / "user" / actorName) ! Identify(actorName)
-    expectMsgType[ActorIdentity].ref.get
+    val p = TestProbe()
+    (system.actorSelection(node(role) / "user" / actorName)).tell(Identify(actorName), p.ref)
+    p.expectMsgType[ActorIdentity](remainingOrDefault).ref.get
   }
 
   "TransportFail" must {


### PR DESCRIPTION
failed in https://jenkins.akka.io:8498/job/akka-artery-perf/1413

ActorIdentity leaked from awaitAssert