### PR TITLE
Better warning message on cluster sharding registration 

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -676,10 +676,14 @@ private[akka] class ShardRegion(
 
   def register(): Unit = {
     coordinatorSelection.foreach(_ ! registrationMessage)
-    if (shardBuffers.nonEmpty && retryCount >= 5)
-      log.warning(
+    if (shardBuffers.nonEmpty && retryCount >= 5) coordinatorSelection match {
+      case Some(actorSelection) ⇒ log.warning(
         "Trying to register to coordinator at [{}], but no acknowledgement. Total [{}] buffered messages.",
-        coordinatorSelection, shardBuffers.totalSize)
+        actorSelection, shardBuffers.totalSize)
+      case None ⇒ log.warning(
+        "No coordinator found to register. Probably, no seed-nodes configured and manual cluster join not performed? Total [{}] buffered messages.",
+        shardBuffers.totalSize)
+    }
   }
 
   def registrationMessage: Any =

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -679,8 +679,8 @@ private[akka] class ShardRegion(
     if (shardBuffers.nonEmpty && retryCount >= 5) coordinatorSelection match {
       case Some(actorSelection) ⇒
         val coordinatorMessage =
-          if (cluster.state.unreachable(membersByAge.head)) s"Coordinator ${membersByAge.head} is unreachable."
-          else s"Coordinator ${membersByAge.head} is reachable."
+          if (cluster.state.unreachable(membersByAge.head)) s"Coordinator [${membersByAge.head}] is unreachable."
+          else s"Coordinator [${membersByAge.head}] is reachable."
         log.warning(
           "Trying to register to coordinator at [{}], but no acknowledgement. Total [{}] buffered messages. [{}]",
           actorSelection, shardBuffers.totalSize, coordinatorMessage


### PR DESCRIPTION
Closes #24295

>[info] [WARN] [04/14/2018 05:23:39.373] [ShardingSystem-akka.actor.default-dispatcher-19] [akka.tcp://ShardingSystem@127.0.0.1:2554/system/sharding/Device] No coordinator found to register. Probably, no seed-nodes configured and manual cluster join not performed? Total [44] buffered messages.