### PR TITLE
change 10.0.0.1 to 127.0.0.1 in remote examples

### DIFF
--- a/akka-docs/src/main/paradox/remoting.md
+++ b/akka-docs/src/main/paradox/remoting.md
@@ -91,13 +91,13 @@ In the next sections the two alternatives are described in detail.
 Scala
 :   ```
 val selection =
-  context.actorSelection("akka.tcp://actorSystemName@10.0.0.1:2552/user/actorName")
+  context.actorSelection("akka.tcp://actorSystemName@127.0.0.1:2552/user/actorName")
 ```
 
 Java
 :   ```
 ActorSelection selection =
-  context.actorSelection("akka.tcp://app@10.0.0.1:2552/user/serviceA/worker");
+  context.actorSelection("akka.tcp://app@127.0.0.1:2552/user/serviceA/worker");
 ```
 
 As you can see from the example above the following pattern is used to find an actor on a remote node:


### PR DESCRIPTION
Since the `hostname` in `application.conf` is 127.0.0.1, `actorSelection` may use 127.0.0.1 as well.