### PR TITLE
Use 'same thread' execution context in UnfoldResourceSourceAsync

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/UnfoldResourceSourceAsync.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/UnfoldResourceSourceAsync.scala
@@ -6,6 +6,7 @@ package akka.stream.impl
 
 import akka.Done
 import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts.sameThreadExecutionContext
 import akka.stream.ActorAttributes.SupervisionStrategy
 import akka.stream._
 import akka.stream.impl.Stages.DefaultAttributes
@@ -74,7 +75,7 @@ import scala.util.control.NonFatal
       state match {
         case Some(resource) ⇒
           try {
-            readData(resource).onComplete(readCallback)
+            readData(resource).onComplete(readCallback)(sameThreadExecutionContext)
           } catch errorHandler
         case None ⇒
         // we got a pull but there is no open resource, we are either


### PR DESCRIPTION
This makes the difference between 15k msg\sec and 40k msg\sec in our system. I think we should revert it back to _sameThreadExecutionContext_.