### PR TITLE
Documentation of wrapping PersistentBehavior in typed actor persistence #24679

### DIFF
--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -231,8 +231,13 @@ Scala
 Java
 :  @@snip [BasicPersistentBehaviorsTest.java]($akka$/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorsTest.java) { #tagging }
 
-## Current limitations
+## Wrapping Persistent Behaviors
+When creating/setting up `PersistentBehavior`, it is possible to wrap `PersistentBehaviors` in
+other behaviors such as `Behaviors.setup` in order to access `ActorContext` object. For instance
+to access actor logging upon taking snapshots for debug purpose.
 
-* The `PersistentBehavior` can't be wrapped in other behaviors, such as `Behaviors.setup`. See [#23694](https://github.com/akka/akka/issues/23694)
+Scala
+:  @@snip [BasicPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala) { #wrapPersistentBehavior }
 
-
+Java
+:  @@snip [BasicPersistentBehaviorsTest.java]($akka$/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorsTest.java) { #wrapPersistentBehavior }

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -233,7 +233,7 @@ Java
 
 ## Wrapping Persistent Behaviors
 When creating a `PersistentBehavior`, it is possible to wrap `PersistentBehavior` in
-other behaviors such as `Behaviors.setup` in order to access `ActorContext` object. For instance
+other behaviors such as `Behaviors.setup` in order to access the `ActorContext` object. For instance
 to access the actor logging upon taking snapshots for debug purpose.
 
 Scala

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -232,9 +232,9 @@ Java
 :  @@snip [BasicPersistentBehaviorsTest.java]($akka$/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorsTest.java) { #tagging }
 
 ## Wrapping Persistent Behaviors
-When creating/setting up `PersistentBehavior`, it is possible to wrap `PersistentBehaviors` in
+When creating a `PersistentBehavior`, it is possible to wrap `PersistentBehavior` in
 other behaviors such as `Behaviors.setup` in order to access `ActorContext` object. For instance
-to access actor logging upon taking snapshots for debug purpose.
+to access the actor logging upon taking snapshots for debug purpose.
 
 Scala
 :  @@snip [BasicPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala) { #wrapPersistentBehavior }

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorsTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorsTest.java
@@ -6,6 +6,7 @@ package jdocs.akka.persistence.typed;
 
 import akka.actor.typed.Behavior;
 import akka.actor.typed.javadsl.ActorContext;
+import akka.actor.typed.javadsl.Behaviors;
 import akka.persistence.typed.javadsl.CommandHandler;
 import akka.persistence.typed.javadsl.Effect;
 import akka.persistence.typed.javadsl.EventHandler;
@@ -60,4 +61,18 @@ public class BasicPersistentBehaviorsTest {
 
   static Behavior<Command> persistentBehavior = new MyPersistentBehavior("pid");
   //#structure
+
+  //#wrapPersistentBehavior
+  static Behavior<Command> debugAlwaysSnapshot = Behaviors.setup((context) -> {
+            return new MyPersistentBehavior("pid") {
+              @Override
+              public boolean shouldSnapshot(State state, Event event, long sequenceNr) {
+                context.getLog().info("Snapshot actor {} => state: {}",
+                        context.getSelf().path().name(), state);
+                return true;
+              }
+            };
+          }
+  );
+  //#wrapPersistentBehavior
 }

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala
@@ -5,6 +5,7 @@
 package docs.akka.persistence.typed
 
 import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
 import akka.persistence.typed.scaladsl.PersistentBehaviors
 
 object BasicPersistentBehaviorsSpec {
@@ -44,4 +45,25 @@ object BasicPersistentBehaviorsSpec {
     ).withTagger(_ ⇒ Set("tag1", "tag2"))
 
   //#tagging
+
+  //#wrapPersistentBehavior
+  val samplePersistentBehavior = PersistentBehaviors.receive[Command, Event, State](
+    persistenceId = "abc",
+    initialState = State(),
+    commandHandler = (ctx, state, cmd) ⇒ ???,
+    eventHandler = (state, evt) ⇒ ???)
+    .onRecoveryCompleted { (ctx, state) ⇒
+      ???
+    }
+
+  val debugAlwaysSnapshot: Behavior[Command] = Behaviors.setup {
+    context ⇒
+      samplePersistentBehavior.snapshotWhen((state, _, _) ⇒ {
+        context.log.info(
+          "Snapshot actor {} => state: {}",
+          context.self.path.name, state)
+        true
+      })
+  }
+  //#wrapPersistentBehavior
 }


### PR DESCRIPTION
addressing issue #24679 on documentation of wrapping PersistentBehavior inside other Behavior construct.

* Removed "Current Limitations" section
* Added description on wrapping PersistentBehavior
* Added Scala and Java example for the pattern