### PR TITLE
=str #24934 sub timeout must be cancelled when streams establish conn

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/streamref/SinkRefImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/streamref/SinkRefImpl.scala
@@ -175,6 +175,7 @@ private[stream] final class SinkRefStageImpl[In] private[akka] (
       def observeAndValidateSender(partner: ActorRef, failureMsg: String): Unit = {
         if (partnerRef.isEmpty) {
           partnerRef = OptionVal(partner)
+          partner ! StreamRefsProtocol.OnSubscribeHandshake(self.ref) //
           cancelTimer(SubscriptionTimeoutTimerKey)
           self.watch(partner)
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -253,7 +253,7 @@ object Sink {
    * A `Sink` that will invoke the given procedure for each received element. The sink is materialized
    * into a [[scala.concurrent.Future]] which will be completed with `Success` when reaching the
    * normal end of the stream, or completed with `Failure` if there is a failure signaled in
-   * the stream. 
+   * the stream.
    */
   def foreach[T](f: T ⇒ Unit): Sink[T, Future[Done]] =
     Flow[T].map(f).toMat(Sink.ignore)(Keep.right).named("foreachSink")

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/StreamRefs.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/StreamRefs.scala
@@ -25,7 +25,7 @@ object StreamRefs {
    * A local [[Sink]] which materializes a [[SourceRef]] which can be used by other streams (including remote ones),
    * to consume data from this local stream, as if they were attached in the spot of the local Sink directly.
    *
-   * Adheres to [[StreamRefAttributes]].
+   * Adheres to [[akka.stream.StreamRefAttributes]].
    *
    * See more detailed documentation on [[SourceRef]].
    */
@@ -37,7 +37,7 @@ object StreamRefs {
    * A local [[Sink]] which materializes a [[SourceRef]] which can be used by other streams (including remote ones),
    * to consume data from this local stream, as if they were attached in the spot of the local Sink directly.
    *
-   * Adheres to [[StreamRefAttributes]].
+   * Adheres to [[akka.stream.StreamRefAttributes]].
    *
    * See more detailed documentation on [[SinkRef]].
    */


### PR DESCRIPTION
Resolves https://github.com/akka/akka/issues/24934

was a missing handshake send, worked without but we should have done the handshake bothways like this I think, since the code was expecting it to do so anyway