### PR TITLE
fix contramap documentation typo

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -40,7 +40,7 @@ final class Sink[-In, +Mat](
    *
    * '''Backpressures when''' original [[Sink]] backpressures
    *
-   * '''Cancels when''' original [[Sink]] backpressures
+   * '''Cancels when''' original [[Sink]] cancels
    */
   def contramap[In2](f: In2 ⇒ In): Sink[In2, Mat] = Flow.fromFunction(f).toMat(this)(Keep.right)
 


### PR DESCRIPTION
`Sink.contramap(f)` simply applies a function and then materializes using the original sink. It would seem very odd if backpressure would cause the Flow to cancel...