### PR TITLE
Add classtag to tap/monitor for interception

### DIFF
--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorCompile.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorCompile.java
@@ -37,11 +37,11 @@ public class ActorCompile {
   Behavior<MyMsg> actor2 = Behaviors.receive((ctx, msg) -> unhandled());
   Behavior<MyMsg> actor4 = empty();
   Behavior<MyMsg> actor5 = ignore();
-  Behavior<MyMsg> actor6 = tap((ctx, signal) -> {}, (ctx, msg) -> {}, actor5);
+  Behavior<MyMsg> actor6 = tap(MyMsg.class, (ctx, signal) -> {}, (ctx, msg) -> {}, actor5);
   Behavior<MyMsgA> actor7 = actor6.narrow();
   Behavior<MyMsg> actor8 = setup(ctx -> {
     final ActorRef<MyMsg> self = ctx.getSelf();
-    return monitor(self, ignore());
+    return monitor(MyMsg.class, self, ignore());
   });
   Behavior<MyMsg> actor9 = widened(actor7, pf -> pf.match(MyMsgA.class, x -> x));
   Behavior<MyMsg> actor10 = Behaviors.receive((ctx, msg) -> stopped(actor4), (ctx, signal) -> same());

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
@@ -9,6 +9,7 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.testkit.typed.scaladsl.{ ActorTestKit, TestProbe }
 
 import scala.concurrent.duration._
+import scala.reflect.ClassTag
 
 object ActorSpecMessages {
 
@@ -62,10 +63,10 @@ abstract class ActorContextSpec extends ActorTestKit with TypedAkkaSpecWithShutd
 
   import ActorSpecMessages._
 
-  def decoration[T]: Behavior[T] ⇒ Behavior[T]
+  def decoration[T: ClassTag]: Behavior[T] ⇒ Behavior[T]
 
-  implicit class BehaviorDecorator[T](behavior: Behavior[T]) {
-    def decorate: Behavior[T] = decoration(behavior)
+  implicit class BehaviorDecorator[T](behavior: Behavior[T])(implicit ev: ClassTag[T]) {
+    def decorate: Behavior[T] = decoration[T](ev)(behavior)
   }
 
   "An ActorContext" must {
@@ -588,25 +589,25 @@ abstract class ActorContextSpec extends ActorTestKit with TypedAkkaSpecWithShutd
 
 class NormalActorContextSpec extends ActorContextSpec {
 
-  override def decoration[T] = x ⇒ x
+  override def decoration[T: ClassTag] = x ⇒ x
 }
 
 class WidenActorContextSpec extends ActorContextSpec {
 
-  override def decoration[T] = b ⇒ b.widen { case x ⇒ x }
+  override def decoration[T: ClassTag] = b ⇒ b.widen { case x ⇒ x }
 }
 
 class DeferredActorContextSpec extends ActorContextSpec {
 
-  override def decoration[T] = b ⇒ Behaviors.setup(_ ⇒ b)
+  override def decoration[T: ClassTag] = b ⇒ Behaviors.setup(_ ⇒ b)
 }
 
 class NestedDeferredActorContextSpec extends ActorContextSpec {
 
-  override def decoration[T] = b ⇒ Behaviors.setup(_ ⇒ Behaviors.setup(_ ⇒ b))
+  override def decoration[T: ClassTag] = b ⇒ Behaviors.setup(_ ⇒ Behaviors.setup(_ ⇒ b))
 }
 
 class TapActorContextSpec extends ActorContextSpec {
 
-  override def decoration[T] = b ⇒ Behaviors.tap((_, _) ⇒ (), (_, _) ⇒ (), b)
+  override def decoration[T: ClassTag]: Behavior[T] ⇒ Behavior[T] = b ⇒ Behaviors.tap[T](b)((_, _) ⇒ (), (_, _) ⇒ ())
 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
@@ -608,6 +608,7 @@ class TapJavaBehaviorSpec extends ImmutableWithSignalJavaBehaviorSpec with Reuse
   override def behavior(monitor: ActorRef[Event]): (Behavior[Command], Aux) = {
     val inbox = TestInbox[Either[Signal, Command]]("tapListener")
     (JBehaviors.tap(
+      classOf[Command],
       pc((_, msg) ⇒ inbox.ref ! Right(msg)),
       ps((_, sig) ⇒ inbox.ref ! Left(sig)),
       super.behavior(monitor)._1), inbox)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/BehaviorImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/BehaviorImpl.scala
@@ -85,7 +85,7 @@ import scala.reflect.ClassTag
     override def toString = s"ReceiveMessage(${LineNumbers(onMessage)})"
   }
 
-  def tap[T](
+  def tap[T: ClassTag](
     onMessage: (SAC[T], T) ⇒ _,
     onSignal:  (SAC[T], Signal) ⇒ _,
     behavior:  Behavior[T]): Behavior[T] = {
@@ -100,7 +100,7 @@ import scala.reflect.ClassTag
       },
       afterMessage = ConstantFun.scalaAnyThreeToThird,
       afterSignal = ConstantFun.scalaAnyThreeToThird,
-      behavior)(ClassTag(classOf[Any]))
+      behavior)
   }
 
   /**
@@ -118,7 +118,7 @@ import scala.reflect.ClassTag
    * `afterMessage` is the message returned from `beforeMessage` (possibly
    * different than the incoming message).
    */
-  def intercept[T, U <: Any: ClassTag](
+  def intercept[T, U: ClassTag](
     beforeMessage:  (SAC[U], U) ⇒ T,
     beforeSignal:   (SAC[T], Signal) ⇒ Boolean,
     afterMessage:   (SAC[T], T, Behavior[T]) ⇒ Behavior[T],

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
@@ -172,13 +172,13 @@ object Behaviors {
    * for logging or tracing what a certain Actor does.
    */
   def tap[T](
+    clazz:     Class[T],
     onMessage: Procedure2[ActorContext[T], T],
     onSignal:  Procedure2[ActorContext[T], Signal],
     behavior:  Behavior[T]): Behavior[T] = {
-    BehaviorImpl.tap(
+    akka.actor.typed.scaladsl.Behaviors.tap[T](behavior)(
       (ctx, msg) ⇒ onMessage.apply(ctx.asJava, msg),
-      (ctx, sig) ⇒ onSignal.apply(ctx.asJava, sig),
-      behavior)
+      (ctx, sig) ⇒ onSignal.apply(ctx.asJava, sig))(ClassTag[T](clazz))
   }
 
   /**
@@ -187,11 +187,8 @@ object Behaviors {
    * wrapped behavior can evolve (i.e. return different behavior) without needing to be
    * wrapped in a `monitor` call again.
    */
-  def monitor[T](monitor: ActorRef[T], behavior: Behavior[T]): Behavior[T] = {
-    BehaviorImpl.tap(
-      (ctx, msg) ⇒ monitor ! msg,
-      ConstantFun.scalaAnyTwoToUnit,
-      behavior)
+  def monitor[T](clazz: Class[T], monitor: ActorRef[T], behavior: Behavior[T]): Behavior[T] = {
+    akka.actor.typed.scaladsl.Behaviors.monitor(monitor, behavior)(reflect.ClassTag(clazz))
   }
 
   /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
@@ -140,10 +140,21 @@ object Behaviors {
    * some action upon each received message or signal. It is most commonly used
    * for logging or tracing what a certain Actor does.
    */
-  def tap[T](
+  @deprecated("Use overloaded tap", "2.5.13")
+  def tap[T: ClassTag](
     onMessage: (ActorContext[T], T) ⇒ _,
     onSignal:  (ActorContext[T], Signal) ⇒ _, // FIXME use partial function here also?
     behavior:  Behavior[T]): Behavior[T] =
+    tap(behavior)((ctx, msg) ⇒ onMessage(ctx, msg), (ctx, signal) ⇒ onSignal(ctx, signal))
+
+  /**
+   * This type of Behavior wraps another Behavior while allowing you to perform
+   * some action upon each received message or signal. It is most commonly used
+   * for logging or tracing what a certain Actor does.
+   */
+  def tap[T: ClassTag](behavior: Behavior[T])(
+    onMessage: (ActorContext[T], T) ⇒ Unit,
+    onSignal:  (ActorContext[T], Signal) ⇒ Unit): Behavior[T] =
     BehaviorImpl.tap(onMessage, onSignal, behavior)
 
   /**
@@ -152,8 +163,8 @@ object Behaviors {
    * wrapped behavior can evolve (i.e. return different behavior) without needing to be
    * wrapped in a `monitor` call again.
    */
-  def monitor[T](monitor: ActorRef[T], behavior: Behavior[T]): Behavior[T] =
-    tap((_, msg) ⇒ monitor ! msg, unitFunction, behavior)
+  def monitor[T: ClassTag](monitor: ActorRef[T], behavior: Behavior[T]): Behavior[T] =
+    tap(behavior)((_, msg) ⇒ monitor ! msg, unitFunction)
 
   /**
    * Wrap the given behavior with the given [[SupervisorStrategy]] for


### PR DESCRIPTION
Interception handles a message that is of the incorrect type as a result
of widening however tap/monitor passed Any as the classtag.

Also change the signature of tap for superior type inference.

Refs #24915