### PR TITLE
Reduce size of jenkins logs

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/event/LoggerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggerSpec.scala
@@ -27,7 +27,7 @@ object LoggerSpec {
   val defaultConfig = ConfigFactory.parseString("""
       akka {
         stdout-loglevel = "WARNING"
-        loglevel = "DEBUG"
+        loglevel = "DEBUG" # test verifies debug
         loggers = ["akka.event.LoggerSpec$TestLogger1"]
       }
     """).withFallback(AkkaSpec.testConf)
@@ -59,7 +59,7 @@ object LoggerSpec {
   val ticket3165Config = ConfigFactory.parseString(s"""
       akka {
         stdout-loglevel = "WARNING"
-        loglevel = "DEBUG"
+        loglevel = "DEBUG" # test verifies debug
         loggers = ["akka.event.LoggerSpec$$TestLogger1"]
         actor {
           serialize-messages = on

--- a/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
@@ -27,7 +27,7 @@ class LoggingReceiveSpec extends WordSpec with BeforeAndAfterAll {
 
   import LoggingReceiveSpec._
   val config = ConfigFactory.parseString("""
-    akka.loglevel=DEBUG
+    akka.loglevel=DEBUG # test verifies debug
     akka.actor.serialize-messages = off # debug noise from serialization
     """).withFallback(AkkaSpec.testConf)
   val appLogging = ActorSystem("logging", ConfigFactory.parseMap(Map("akka.actor.debug.receive" → true).asJava).withFallback(config))

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
@@ -18,7 +18,7 @@ class ActorLoggingSpec extends ActorTestKit with TypedAkkaSpec {
 
   override def config = ConfigFactory.parseString(
     """
-    akka.loglevel = DEBUG
+    akka.loglevel = DEBUG # test verifies debug
     akka.loggers = ["akka.testkit.TestEventListener"]
   """)
 

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingCustomShardAllocationSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingCustomShardAllocationSpec.scala
@@ -80,7 +80,6 @@ abstract class ClusterShardingCustomShardAllocationSpecConfig(val mode: String) 
   val second = role("second")
 
   commonConfig(ConfigFactory.parseString(s"""
-    akka.loglevel = DEBUG
     akka.actor.provider = "cluster"
     akka.remote.log-remote-lifecycle-events = off
     akka.persistence.journal.plugin = "akka.persistence.journal.leveldb-shared"

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingRememberEntitiesNewExtractorSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingRememberEntitiesNewExtractorSpec.scala
@@ -57,7 +57,6 @@ abstract class ClusterShardingRememberEntitiesNewExtractorSpecConfig(val mode: S
   val third = role("third")
 
   commonConfig(ConfigFactory.parseString(s"""
-    akka.loglevel = DEBUG
     akka.actor.provider = "cluster"
     akka.cluster.auto-down-unreachable-after = 0s
     akka.remote.log-remote-lifecycle-events = off

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/MultiDcClusterShardingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/MultiDcClusterShardingSpec.scala
@@ -54,8 +54,7 @@ object MultiDcClusterShardingSpecConfig extends MultiNodeConfig {
   val fourth = role("fourth")
 
   commonConfig(ConfigFactory.parseString(s"""
-    # DEBUG because of failing test, issue #23741
-    akka.loglevel = DEBUG
+    akka.loglevel = DEBUG # issue #23741
     akka.cluster.debug.verbose-heartbeat-logging = on
     akka.cluster.debug.verbose-gossip-logging = on
     akka.actor.provider = "cluster"

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/CoordinatedShutdownShardingSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/CoordinatedShutdownShardingSpec.scala
@@ -20,7 +20,6 @@ import akka.testkit.WithLogCapturing
 object CoordinatedShutdownShardingSpec {
   val config =
     """
-    akka.loglevel = DEBUG
     akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
     akka.actor.provider = "cluster"
     akka.remote.netty.tcp.port = 0

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/MultiDcSingletonManagerSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/MultiDcSingletonManagerSpec.scala
@@ -21,7 +21,6 @@ object MultiDcSingletonManagerSpec extends MultiNodeConfig {
   val third = role("third")
 
   commonConfig(ConfigFactory.parseString("""
-    akka.loglevel = DEBUG
     akka.actor.provider = "cluster"
     akka.actor.serialize-creators = off
     akka.remote.log-remote-lifecycle-events = off"""))

--- a/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
@@ -25,7 +25,6 @@ object ReplicatorSpec {
 
   val config = ConfigFactory.parseString(
     """
-    akka.loglevel = DEBUG
     akka.actor.provider = "cluster"
     akka.remote.netty.tcp.port = 0
     akka.remote.artery.canonical.port = 0

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -25,7 +25,7 @@ import scala.concurrent.duration._
 object ClusterReceptionistSpec {
   val config = ConfigFactory.parseString(
     s"""
-      akka.loglevel = DEBUG
+      akka.loglevel = DEBUG # issue #24960
       akka.actor {
         provider = cluster
         serialize-messages = off

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcClusterSpec.scala
@@ -19,8 +19,6 @@ class MultiDcSpecConfig(crossDcConnections: Int = 5) extends MultiNodeConfig {
 
   commonConfig(ConfigFactory.parseString(
     s"""
-      # DEBUG On for issue #23864
-      akka.loglevel = DEBUG
       akka.cluster.multi-data-center.cross-data-center-connections = $crossDcConnections
     """).withFallback(MultiNodeClusterSpec.clusterConfig))
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcLastNodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcLastNodeSpec.scala
@@ -15,7 +15,7 @@ object MultiDcLastNodeSpec extends MultiNodeConfig {
 
   commonConfig(ConfigFactory.parseString(
     s"""
-      #akka.loglevel = DEBUG
+      akka.loglevel = INFO
     """).withFallback(MultiNodeClusterSpec.clusterConfig))
 
   nodeConfig(first, second)(ConfigFactory.parseString(

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcSplitBrainSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcSplitBrainSpec.scala
@@ -23,7 +23,7 @@ object MultiDcSplitBrainMultiJvmSpec extends MultiNodeConfig {
 
   commonConfig(ConfigFactory.parseString(
     """
-      akka.loglevel = DEBUG
+      akka.loglevel = DEBUG # issue #24955
       akka.cluster.debug.verbose-heartbeat-logging = on
       akka.cluster.debug.verbose-gossip-logging = on
       akka.remote.netty.tcp.connection-timeout = 5 s # speedup in case of connection issue

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterSpec.scala
@@ -235,7 +235,6 @@ class ClusterSpec extends AkkaSpec(ClusterSpec.config) with ImplicitSender {
         akka.remote.artery.canonical.port = 0
         akka.coordinated-shutdown.terminate-actor-system = on
         akka.cluster.run-coordinated-shutdown-when-down = on
-akka.loglevel=DEBUG
         """))
       try {
         val probe = TestProbe()(sys3)

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurableDataSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurableDataSpec.scala
@@ -23,7 +23,6 @@ final case class DurableDataSpecConfig(writeBehind: Boolean) extends MultiNodeCo
   val second = role("second")
 
   commonConfig(ConfigFactory.parseString(s"""
-    akka.loglevel = DEBUG
     akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
     akka.log-dead-letters-during-shutdown = off
     akka.cluster.distributed-data.durable.keys = ["durable*"]

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteRestartedQuarantinedSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteRestartedQuarantinedSpec.scala
@@ -26,9 +26,6 @@ object RemoteRestartedQuarantinedSpec extends MultiNodeConfig {
 
   commonConfig(debugConfig(on = false).withFallback(
     ConfigFactory.parseString("""
-      akka.loglevel = DEBUG
-      akka.remote.log-remote-lifecycle-events = DEBUG
-
       # Keep it long, we don't want reconnects
       akka.remote.retry-gate-closed-for  = 1 s
 

--- a/akka-remote/src/test/scala/akka/remote/ActorsLeakSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/ActorsLeakSpec.scala
@@ -22,7 +22,6 @@ object ActorsLeakSpec {
   val config = ConfigFactory.parseString(
     """
       | akka.actor.provider = remote
-      | #akka.loglevel = DEBUG
       | akka.remote.netty.tcp.applied-adapters = ["trttl"]
       | #akka.remote.log-lifecycle-events = on
       | akka.remote.transport-failure-detector.heartbeat-interval = 1 s

--- a/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemotingSpec.scala
@@ -634,7 +634,6 @@ class RemotingSpec extends AkkaSpec(RemotingSpec.cfg) with ImplicitSender with D
         akka.remote.enabled-transports = ["akka.remote.test"]
         akka.remote.retry-gate-closed-for = 5s
         akka.remote.log-remote-lifecycle-events = on
-        #akka.loglevel = DEBUG
 
         akka.remote.test {
           registry-key = TRKAzR

--- a/akka-remote/src/test/scala/akka/remote/UntrustedSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/UntrustedSpec.scala
@@ -64,7 +64,7 @@ akka.actor.provider = remote
 akka.remote.untrusted-mode = on
 akka.remote.trusted-selection-paths = ["/user/receptionist", ]    
 akka.remote.netty.tcp.port = 0
-akka.loglevel = DEBUG
+akka.loglevel = DEBUG # test verifies debug
 """) with ImplicitSender {
 
   import UntrustedSpec._
@@ -140,13 +140,13 @@ akka.loglevel = DEBUG
       receptionist ! StopChild("child2")
       expectMsg("child2 stopped")
       // no Terminated msg, since watch was discarded
-      expectNoMsg(1.second)
+      expectNoMessage(1.second)
     }
 
     "discard actor selection" in {
       val sel = client.actorSelection(RootActorPath(address) / testActor.path.elements)
       sel ! "hello"
-      expectNoMsg(1.second)
+      expectNoMessage(1.second)
     }
 
     "discard actor selection with non root anchor" in {
@@ -157,25 +157,25 @@ akka.loglevel = DEBUG
 
       val sel = ActorSelection(clientReceptionistRef, receptionist.path.toStringWithoutAddress)
       sel ! "hello"
-      expectNoMsg(1.second)
+      expectNoMessage(1.second)
     }
 
     "discard actor selection to child of matching white list" in {
       val sel = client.actorSelection(RootActorPath(address) / receptionist.path.elements / "child1")
       sel ! "hello"
-      expectNoMsg(1.second)
+      expectNoMessage(1.second)
     }
 
     "discard actor selection with wildcard" in {
       val sel = client.actorSelection(RootActorPath(address) / receptionist.path.elements / "*")
       sel ! "hello"
-      expectNoMsg(1.second)
+      expectNoMessage(1.second)
     }
 
     "discard actor selection containing harmful message" in {
       val sel = client.actorSelection(RootActorPath(address) / receptionist.path.elements)
       sel ! PoisonPill
-      expectNoMsg(1.second)
+      expectNoMessage(1.second)
     }
 
   }

--- a/akka-remote/src/test/scala/akka/remote/artery/UntrustedSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/UntrustedSpec.scala
@@ -60,7 +60,7 @@ object UntrustedSpec {
     """
       akka.remote.artery.untrusted-mode = on
       akka.remote.artery.trusted-selection-paths = ["/user/receptionist", ]
-      akka.loglevel = DEBUG # the test is verifying some Debug logging
+      akka.loglevel = DEBUG # test verifies debug
     """
   ).withFallback(ArterySpecSupport.defaultConfig)
 

--- a/akka-remote/src/test/scala/akka/remote/artery/compress/CompressionIntegrationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/compress/CompressionIntegrationSpec.scala
@@ -258,8 +258,6 @@ class CompressionIntegrationSpec extends ArteryMultiNodeSpec(CompressionIntegrat
   "wrap around" in {
     val extraConfig =
       """
-      akka.loglevel = DEBUG
-
       akka.remote.artery.advanced.compression {
         actor-refs.advertisement-interval = 100 millis
         manifests.advertisement-interval = 10 minutes

--- a/akka-remote/src/test/scala/akka/remote/artery/tcp/TlsTcpSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/tcp/TlsTcpSpec.scala
@@ -61,7 +61,6 @@ object TlsTcpSpec {
 
   lazy val config: Config = {
     ConfigFactory.parseString(s"""
-      akka.loglevel = DEBUG
       akka.remote.artery {
         transport = tls-tcp
         large-message-destinations = [ "/user/large" ]

--- a/akka-slf4j/src/test/scala/akka/event/slf4j/Slf4jLoggingFilterSpec.scala
+++ b/akka-slf4j/src/test/scala/akka/event/slf4j/Slf4jLoggingFilterSpec.scala
@@ -24,7 +24,7 @@ object Slf4jLoggingFilterSpec {
 
   val config = """
     akka {
-      loglevel = DEBUG
+      loglevel = DEBUG # test verifies debug
       loggers = ["akka.event.slf4j.Slf4jLoggingFilterSpec$TestLogger"]
       logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -409,7 +409,7 @@ class TcpSpec extends StreamSpec("""
     "handle when connection actor terminates unexpectedly" in {
       val system2 = ActorSystem("TcpSpec-unexpected-system2", ConfigFactory.parseString(
         """
-          akka.loglevel = DEBUG
+          akka.loglevel = DEBUG # issue #21660
         """).withFallback(system.settings.config))
 
       try {

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
@@ -88,7 +88,7 @@ object TlsSpec {
 
   val configOverrides =
     """
-      akka.loglevel = DEBUG
+      akka.loglevel = DEBUG # issue 21660
       akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
       akka.actor.debug.receive=off
     """

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLogSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLogSpec.scala
@@ -18,7 +18,7 @@ import scala.concurrent.Await
 import scala.util.control.NoStackTrace
 
 class FlowLogSpec extends StreamSpec("""
-     akka.loglevel = DEBUG
+     akka.loglevel = DEBUG # test verifies logging
      akka.actor.serialize-messages = off
      """) with ScriptedTest {
 


### PR DESCRIPTION
Each build is now over 40mb logs.

A lot of DEBUG logging was left on for test failures that have been
fixed. Added an issue # for ones that are still valid or if if it on
as the test verifies debug