### PR TITLE
WIP auto confirmation

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
@@ -13,9 +13,10 @@ import akka.actor.typed.scaladsl.ActorContext
 import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts
 import akka.util.JavaDurationConverters._
-
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
+
+import akka.util.ConstantFun
 
 /**
  * INTERNAL API
@@ -147,8 +148,8 @@ import scala.reflect.ClassTag
         }
         true
       },
-      afterMessage = (ctx, msg, b) ⇒ b, // TODO optimize by using more ConstantFun
-      afterSignal = (ctx, sig, b) ⇒ b,
+      afterMessage = ConstantFun.scalaAnyThreeToThird,
+      afterSignal = ConstantFun.scalaAnyThreeToThird,
       behavior)(ClassTag(classOf[TimerSchedulerImpl.TimerMsg]))
   }
 

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/ClusterSharding.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/ClusterSharding.scala
@@ -9,9 +9,9 @@ import scala.concurrent.Future
 
 import akka.actor.Scheduler
 import akka.util.Timeout
-
 import scala.reflect.ClassTag
 
+import akka.Done
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -24,6 +24,7 @@ import akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
 import akka.cluster.sharding.typed.internal.ClusterShardingImpl
 import akka.cluster.sharding.typed.internal.EntityTypeKeyImpl
 import akka.cluster.sharding.ShardRegion.{ StartEntity ⇒ UntypedStartEntity }
+import akka.persistence.typed.scaladsl.CommandConfirmation
 
 object ClusterSharding extends ExtensionId[ClusterSharding] {
 
@@ -273,6 +274,8 @@ object EntityTypeKey {
    * Please note that an implicit [[akka.util.Timeout]] and [[akka.actor.Scheduler]] must be available to use this pattern.
    */
   def ask[U](f: ActorRef[U] ⇒ A)(implicit timeout: Timeout, scheduler: Scheduler): Future[U]
+
+  def askWithConfirmation(req: A)(implicit timeout: Timeout, scheduler: Scheduler): Future[CommandConfirmation]
 
 }
 

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/ClusterSharding.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/ClusterSharding.scala
@@ -197,6 +197,9 @@ trait ClusterSharding extends Extension { javadslSelf: javadsl.ClusterSharding â
    */
   def entityRefFor[A](typeKey: EntityTypeKey[A], entityId: String): EntityRef[A]
 
+  // FIXME document
+  def persistentEntityRefFor[A](typeKey: EntityTypeKey[A], entityId: String): PersistentEntityRef[A]
+
   /** The default ShardAllocationStrategy currently is [[LeastShardAllocationStrategy]] however could be changed in the future. */
   def defaultShardAllocationStrategy(settings: ClusterShardingSettings): ShardAllocationStrategy
 
@@ -275,8 +278,6 @@ object EntityTypeKey {
    */
   def ask[U](f: ActorRef[U] â‡’ A)(implicit timeout: Timeout, scheduler: Scheduler): Future[U]
 
-  def askWithConfirmation(req: A)(implicit timeout: Timeout, scheduler: Scheduler): Future[CommandConfirmation]
-
 }
 
 object EntityRef {
@@ -308,3 +309,7 @@ object EntityRef {
   }
 }
 
+// FIXME document
+@DoNotInherit trait PersistentEntityRef[A] extends EntityRef[A] {
+  def askWithConfirmation(req: A)(implicit timeout: Timeout, scheduler: Scheduler): Future[CommandConfirmation]
+}

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
@@ -95,7 +95,7 @@ class ClusterShardingPersistenceSpec extends ActorTestKit
 
       val p = TestProbe[String]()
 
-      val ref = ClusterSharding(system).entityRefFor(typeKey, "4")
+      val ref = ClusterSharding(system).persistentEntityRefFor(typeKey, "4")
       ref ! Add("a")
       ref.askWithConfirmation(Add("b")).futureValue should ===(CommandConfirmation.Success)
       ref.askWithConfirmation(Add("c")).futureValue should ===(CommandConfirmation.Success)

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -7,7 +7,6 @@ package akka.cluster.sharding.typed.scaladsl
 import java.nio.charset.StandardCharsets
 
 import scala.concurrent.duration._
-
 import akka.actor.ExtendedActorSystem
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorRefResolver
@@ -21,7 +20,6 @@ import akka.cluster.sharding.typed.{ ClusterShardingSettings, ShardingEnvelope, 
 import akka.cluster.typed.Cluster
 import akka.cluster.typed.Join
 import akka.cluster.typed.Leave
-import akka.persistence.typed.scaladsl.CommandConfirmation
 import akka.serialization.SerializerWithStringManifest
 import akka.testkit.typed.scaladsl.{ ActorTestKit, TestProbe }
 import akka.util.Timeout
@@ -290,16 +288,6 @@ class ClusterShardingSpec extends ActorTestKit with TypedAkkaSpecWithShutdown {
       bobRef ! StopPlz()
     }
 
-    "EntityRef - auto confirmation" in {
-      val aliceRef = sharding.entityRefFor(typeKey, "alice")
-      val p = TestProbe[String]()
-
-      aliceRef.askWithConfirmation(WhoAreYou(p.ref)).futureValue should ===(CommandConfirmation.Success)
-      p.expectMessageType[String] should startWith("I'm alice")
-
-      aliceRef ! StopPlz()
-    }
-
     "handle untyped StartEntity message" in {
       // it is normally using envolopes, but the untyped StartEntity message can be sent internally,
       // e.g. for remember entities
@@ -353,6 +341,5 @@ class ClusterShardingSpec extends ActorTestKit with TypedAkkaSpecWithShutdown {
       replies2.size should ===(10)
       replies2 should !==(replies1) // different addresses
     }
-
   }
 }

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/AdaptedClusterSingletonImpl.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/AdaptedClusterSingletonImpl.scala
@@ -40,7 +40,7 @@ private[akka] final class AdaptedClusterSingletonImpl(system: ActorSystem[_]) ex
       val managerName = managerNameFor(singletonName)
       // start singleton on this node
       val untypedProps = behavior match {
-        case u: UntypedPropsBehavior[_] ⇒ u.untypedProps(props) // PersistentBehavior
+        case u: UntypedPropsBehavior[_] ⇒ u.untypedProps(props)
         case _                          ⇒ PropsAdapter(behavior, props)
       }
       try {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/CommandWithAutoConfirmation.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/CommandWithAutoConfirmation.scala
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.internal
+
+import scala.reflect.ClassTag
+
+import akka.actor.typed.ActorRef
+import akka.actor.typed.Behavior
+import akka.actor.typed.internal.BehaviorImpl
+import akka.annotation.InternalApi
+import akka.persistence.typed.scaladsl.CommandConfirmation
+import akka.util.ConstantFun
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] final case class CommandWithAutoConfirmation[+C](command: C, replyTo: ActorRef[CommandConfirmation])
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object CommandWithAutoConfirmation {
+  def autoReplyAfter[T](behavior: Behavior[T]): Behavior[T] = {
+    BehaviorImpl.intercept[T, CommandWithAutoConfirmation[T]](
+      beforeMessage = (_, msg) ⇒ {
+        msg.command
+      },
+      beforeSignal = ConstantFun.scalaAnyTwoToTrue,
+      afterMessage = (_, msg, b) ⇒ {
+        println(s"# AUTO reply to $msg, behavior ${b.getClass}") // FIXME
+        msg.replyTo ! CommandConfirmation.Success
+        b
+      },
+      afterSignal = ConstantFun.scalaAnyThreeToThird,
+      behavior)(ClassTag(classOf[CommandWithAutoConfirmation[T]]))
+  }
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/CommandWithAutoConfirmation.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/CommandWithAutoConfirmation.scala
@@ -4,36 +4,11 @@
 
 package akka.persistence.typed.internal
 
-import scala.reflect.ClassTag
-
 import akka.actor.typed.ActorRef
-import akka.actor.typed.Behavior
-import akka.actor.typed.internal.BehaviorImpl
 import akka.annotation.InternalApi
 import akka.persistence.typed.scaladsl.CommandConfirmation
-import akka.util.ConstantFun
 
 /**
  * INTERNAL API
  */
 @InternalApi private[akka] final case class CommandWithAutoConfirmation[+C](command: C, replyTo: ActorRef[CommandConfirmation])
-
-/**
- * INTERNAL API
- */
-@InternalApi private[akka] object CommandWithAutoConfirmation {
-  def autoReplyAfter[T](behavior: Behavior[T]): Behavior[T] = {
-    BehaviorImpl.intercept[T, CommandWithAutoConfirmation[T]](
-      beforeMessage = (_, msg) ⇒ {
-        msg.command
-      },
-      beforeSignal = ConstantFun.scalaAnyTwoToTrue,
-      afterMessage = (_, msg, b) ⇒ {
-        println(s"# AUTO reply to $msg, behavior ${b.getClass}") // FIXME
-        msg.replyTo ! CommandConfirmation.Success
-        b
-      },
-      afterSignal = ConstantFun.scalaAnyThreeToThird,
-      behavior)(ClassTag(classOf[CommandWithAutoConfirmation[T]]))
-  }
-}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EffectImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EffectImpl.scala
@@ -47,6 +47,10 @@ private[akka] case object PersistNothing extends EffectImpl[Nothing, Nothing]
 
 /** INTERNAL API */
 @InternalApi
+private[akka] case class InvalidCommand(message: String) extends EffectImpl[Nothing, Nothing]
+
+/** INTERNAL API */
+@InternalApi
 private[akka] case class Persist[Event, State](event: Event) extends EffectImpl[Event, State] {
   override def events = event :: Nil
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedBehavior.scala
@@ -52,5 +52,6 @@ private[akka] object EventsourcedBehavior {
     final case class SnapshotterResponse(msg: akka.persistence.SnapshotProtocol.Response) extends InternalProtocol
     final case class RecoveryTickEvent(snapshot: Boolean) extends InternalProtocol
     final case class IncomingCommand[C](c: C) extends InternalProtocol
+    final case class IncomingCommandWithAutoConfirmation[C](req: CommandWithAutoConfirmation[C]) extends InternalProtocol
   }
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedReplayingEvents.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedReplayingEvents.scala
@@ -69,7 +69,7 @@ private[persistence] class EventsourcedReplayingEvents[C, E, S](override val set
       case JournalResponse(r)      ⇒ onJournalResponse(state, r)
       case SnapshotterResponse(r)  ⇒ onSnapshotterResponse(r)
       case RecoveryTickEvent(snap) ⇒ onRecoveryTick(state, snap)
-      case cmd: IncomingCommand[C] ⇒ onCommand(cmd)
+      case cmd: IncomingCommand[C] ⇒ onCommand(cmd) // FIXME handle IncomingCommandWithAutoConfirmation
       case RecoveryPermitGranted   ⇒ Behaviors.unhandled // should not happen, we already have the permit
     }.receiveSignal(returnPermitOnStop)
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedReplayingSnapshot.scala
@@ -49,7 +49,7 @@ private[akka] class EventsourcedReplayingSnapshot[C, E, S](override val setup: E
       case SnapshotterResponse(r)      ⇒ onSnapshotterResponse(r)
       case JournalResponse(r)          ⇒ onJournalResponse(r)
       case RecoveryTickEvent(snapshot) ⇒ onRecoveryTick(snapshot)
-      case cmd: IncomingCommand[C]     ⇒ onCommand(cmd)
+      case cmd: IncomingCommand[C]     ⇒ onCommand(cmd) // FIXME handle IncomingCommandWithAutoConfirmation
       case RecoveryPermitGranted       ⇒ Behaviors.unhandled // should not happen, we already have the permit
     }.receiveSignal(returnPermitOnStop)
   }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/PersistentBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/PersistentBehaviorImpl.scala
@@ -56,7 +56,10 @@ private[akka] final case class PersistentBehaviorImpl[Command, Event, State](
       case res: JournalProtocol.Response           ⇒ InternalProtocol.JournalResponse(res)
       case res: SnapshotProtocol.Response          ⇒ InternalProtocol.SnapshotterResponse(res)
       case RecoveryPermitter.RecoveryPermitGranted ⇒ InternalProtocol.RecoveryPermitGranted
-      case cmd: Command @unchecked                 ⇒ InternalProtocol.IncomingCommand(cmd)
+      case req: CommandWithAutoConfirmation[Command] @unchecked ⇒
+        println(s"# IncomingCommandWithAutoConfirmation $req") // FIXME
+        InternalProtocol.IncomingCommandWithAutoConfirmation(req)
+      case cmd: Command @unchecked ⇒ InternalProtocol.IncomingCommand(cmd)
     }.narrow[Command]
   }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/CommandConfirmation.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/CommandConfirmation.scala
@@ -13,6 +13,9 @@ object CommandConfirmation {
     CommandConfirmation(error = Some(err))
 
   val Success: CommandConfirmation = CommandConfirmation(error = None)
+
+  // FIXME naming: Accepted / Rejected, and use trait + impl classes instead
+
 }
 
 final case class CommandConfirmation(error: Option[CommandConfirmation.Error])

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/CommandConfirmation.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/CommandConfirmation.scala
@@ -1,0 +1,18 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.scaladsl
+
+object CommandConfirmation {
+  trait Error
+  final case class Invalid(message: String) extends Error
+  case object PersistFailed extends Error
+
+  def error(err: Error): CommandConfirmation =
+    CommandConfirmation(error = Some(err))
+
+  val Success: CommandConfirmation = CommandConfirmation(error = None)
+}
+
+final case class CommandConfirmation(error: Option[CommandConfirmation.Error])

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/Effect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/Effect.scala
@@ -50,6 +50,9 @@ object Effect {
    * Stop this persistent actor
    */
   def stop[Event, State]: ChainableEffect[Event, State] = Stop.asInstanceOf[ChainableEffect[Event, State]]
+
+  def invalidCommand[Event, State](message: String): Effect[Event, State] =
+    InvalidCommand(message).asInstanceOf[Effect[Event, State]]
 }
 
 /**


### PR DESCRIPTION
Experiment with the auto reply for persistent commands that we discussed with @renatocaval in Lisbon.

The naming and the API is not up to date with what we discussed yet.

We talked about where to add the new `askWithConfirmation` (which is not a good name). The problem with having it in `EntityRef` is that Cluster Sharding can also be used with non-persistent entity actors and then nobody will reply. Therefore I experimented with an idea of always adding an auto reply by a behavior decorator for sharded actors. See first commit here.

That has the problem that we can't avoid adding this decorator when it is actually a PersistentBehavior and then there will be two competing replies. We can't simply look for PersistentBehavior because it can be wrapped in other things, like supervision.

I reverted that attempt, and simply added the new method in a `PersistentEntityRef`, see second commit. Would have been nice to have it in akka-persistence-typed, but the that doesn't work because of dependencies. persistence should be independent of sharding. The opposite is ok since it's the canonical use case for sharding.