### PR TITLE
Harden ClusterClientHandoverSpec

### DIFF
--- a/akka-testkit-typed/src/test/scala/akka/testkit/typed/scaladsl/ManualTimerExampleSpec.scala
+++ b/akka-testkit-typed/src/test/scala/akka/testkit/typed/scaladsl/ManualTimerExampleSpec.scala
@@ -6,7 +6,6 @@ package akka.testkit.typed.scaladsl
 
 //#manual-scheduling-simple
 import akka.actor.typed.scaladsl.Behaviors
-import org.scalatest.WordSpecLike
 
 import scala.concurrent.duration._
 
@@ -14,7 +13,7 @@ class ManualTimerExampleSpec extends AbstractActorSpec {
 
   override def config = ManualTime.config
 
-  val manualTime = ManualTime()
+  val manualTime: ManualTime = ManualTime()
 
   "A timer" must {
     "schedule non-repeated ticks" in {
@@ -24,7 +23,7 @@ class ManualTimerExampleSpec extends AbstractActorSpec {
       val probe = TestProbe[Tock.type]()
       val behavior = Behaviors.withTimers[Tick.type] { timer ⇒
         timer.startSingleTimer("T", Tick, 10.millis)
-        Behaviors.receive { (ctx, Tick) ⇒
+        Behaviors.receiveMessage { _ ⇒
           probe.ref ! Tock
           Behaviors.same
         }


### PR DESCRIPTION
The test failed timing out waiting for a cluster to remove a member. It
was nearly done. This change uses the common configuration used for
cluster tests to speed up membership changes rather than increasing the
timeout.

Refs #24959