### PR TITLE
=str clarify invocation semantics of wireTap, make test less flaky

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWireTapSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWireTapSpec.scala
@@ -5,11 +5,12 @@
 package akka.stream.scaladsl
 
 import akka.Done
-
-import scala.util.control.NoStackTrace
 import akka.stream.ActorMaterializer
-import akka.stream.testkit._
 import akka.stream.testkit.Utils._
+import akka.stream.testkit._
+
+import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
 
 class FlowWireTapSpec extends StreamSpec {
 
@@ -19,7 +20,11 @@ class FlowWireTapSpec extends StreamSpec {
   "A wireTap" must {
 
     "call the procedure for each element" in assertAllStagesStopped {
-      Source(1 to 3).wireTap(x ⇒ { testActor ! x }).runWith(Sink.ignore).futureValue
+      Source(1 to 3).throttle(1, 100.millis)
+        .wireTap(x ⇒ {
+          testActor ! x
+        })
+        .runWith(Sink.ignore).futureValue
       expectMsg(1)
       expectMsg(2)
       expectMsg(3)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWireTapSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWireTapSpec.scala
@@ -12,22 +12,15 @@ import akka.stream.testkit._
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-class FlowWireTapSpec extends StreamSpec {
-
+class FlowWireTapSpec extends StreamSpec("akka.stream.materializer.debug.fuzzing-mode = off") {
   implicit val materializer = ActorMaterializer()
   import system.dispatcher
 
   "A wireTap" must {
 
     "call the procedure for each element" in assertAllStagesStopped {
-      Source(1 to 3).throttle(1, 100.millis)
-        .wireTap(x ⇒ {
-          testActor ! x
-        })
-        .runWith(Sink.ignore).futureValue
-      expectMsg(1)
-      expectMsg(2)
-      expectMsg(3)
+      Source(1 to 100).wireTap(testActor ! _).runWith(Sink.ignore).futureValue
+      1 to 100 foreach { i => expectMsg(i) }
     }
 
     "complete the future for an empty stream" in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWireTapSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWireTapSpec.scala
@@ -20,7 +20,7 @@ class FlowWireTapSpec extends StreamSpec("akka.stream.materializer.debug.fuzzing
 
     "call the procedure for each element" in assertAllStagesStopped {
       Source(1 to 100).wireTap(testActor ! _).runWith(Sink.ignore).futureValue
-      1 to 100 foreach { i => expectMsg(i) }
+      1 to 100 foreach { i ⇒ expectMsg(i) }
     }
 
     "complete the future for an empty stream" in assertAllStagesStopped {

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -487,6 +487,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * This is a simplified version of `wireTap(Sink)` that takes only a simple procedure.
    * Elements will be passed into this "side channel" function, and any of its results will be ignored.
    *
+   * If the wire-tap operation is slow (it backpressures), elements that would've been sent to it will be dropped instead.
+   *
    * This operation is useful for inspecting the passed through element, usually by means of side-effecting
    * operations (such as `println`, or emitting metrics), for each element without having to modify it.
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -1076,6 +1076,8 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * This is a simplified version of `wireTap(Sink)` that takes only a simple procedure.
    * Elements will be passed into this "side channel" function, and any of its results will be ignored.
    *
+   * If the wire-tap operation is slow (it backpressures), elements that would've been sent to it will be dropped instead.
+   *
    * This operation is useful for inspecting the passed through element, usually by means of side-effecting
    * operations (such as `println`, or emitting metrics), for each element without having to modify it.
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -139,6 +139,8 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    * This is a simplified version of `wireTap(Sink)` that takes only a simple procedure.
    * Elements will be passed into this "side channel" function, and any of its results will be ignored.
    *
+   * If the wire-tap operation is slow (it backpressures), elements that would've been sent to it will be dropped instead.
+   *
    * This operation is useful for inspecting the passed through element, usually by means of side-effecting
    * operations (such as `println`, or emitting metrics), for each element without having to modify it.
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -132,6 +132,8 @@ class SubSource[Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[O
    * This is a simplified version of `wireTap(Sink)` that takes only a simple procedure.
    * Elements will be passed into this "side channel" function, and any of its results will be ignored.
    *
+   * If the wire-tap operation is slow (it backpressures), elements that would've been sent to it will be dropped instead.
+   *
    * This operation is useful for inspecting the passed through element, usually by means of side-effecting
    * operations (such as `println`, or emitting metrics), for each element without having to modify it.
    *

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -770,6 +770,8 @@ trait FlowOps[+Out, +Mat] {
    * This is a simplified version of `wireTap(Sink)` that takes only a simple function.
    * Elements will be passed into this "side channel" function, and any of its results will be ignored.
    *
+   * If the wire-tap operation is slow (it backpressures), elements that would've been sent to it will be dropped instead.
+   *
    * This operation is useful for inspecting the passed through element, usually by means of side-effecting
    * operations (such as `println`, or emitting metrics), for each element without having to modify it.
    *


### PR DESCRIPTION
Resolves https://github.com/akka/akka/issues/24979

As "that's how wireTap works", it may drop elements.
Perhaps sub optimal for the function version but anyway, documented it and it is consistent with the normal GraphWireTap after all.

Made the test more stable.