### PR TITLE
Quarantine and cleanup idle associations, #24972

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
@@ -108,7 +108,8 @@ private[cluster] class ClusterRemoteWatcher(
       clusterNodes -= m.address
 
       if (previousStatus == MemberStatus.Down) {
-        quarantine(m.address, Some(m.uniqueAddress.longUid), s"Cluster member removed, previous status [$previousStatus]")
+        quarantine(m.address, Some(m.uniqueAddress.longUid),
+          s"Cluster member removed, previous status [$previousStatus]", harmless = false)
       } else if (arteryEnabled) {
         // Don't quarantine gracefully removed members (leaving) directly,
         // give Cluster Singleton some time to exchange TakeOver/HandOver messages.
@@ -128,14 +129,15 @@ private[cluster] class ClusterRemoteWatcher(
       pendingDelayedQuarantine.find(_.address == newIncarnation.address).foreach { oldIncarnation ⇒
         pendingDelayedQuarantine -= oldIncarnation
         quarantine(oldIncarnation.address, Some(oldIncarnation.longUid),
-          s"Cluster member removed, new incarnation joined")
+          s"Cluster member removed, new incarnation joined", harmless = true)
       }
   }
 
   def delayedQuarantine(m: Member, previousStatus: MemberStatus): Unit = {
     if (pendingDelayedQuarantine(m.uniqueAddress)) {
       pendingDelayedQuarantine -= m.uniqueAddress
-      quarantine(m.address, Some(m.uniqueAddress.longUid), s"Cluster member removed, previous status [$previousStatus]")
+      quarantine(m.address, Some(m.uniqueAddress.longUid), s"Cluster member removed, previous status [$previousStatus]",
+        harmless = true)
     }
   }
 

--- a/akka-remote/src/main/mima-filters/2.5.12.backwards.excludes
+++ b/akka-remote/src/main/mima-filters/2.5.12.backwards.excludes
@@ -1,3 +1,10 @@
+# #24972 Artery internals
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.compress.InboundCompression.confirmAdvertisement")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.OutboundHandshake.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.ArteryTransport.terminationHintReplier")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.RemoteWatcher.quarantine")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.Association.quarantine")
+
 # Internal API changes
 ProblemFilters.exclude[MissingTypesProblem]("akka.remote.artery.ArteryTransport$InboundStreamMatValues$")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.remote.artery.ArteryTransport#InboundStreamMatValues.apply")

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -967,16 +967,17 @@ akka {
         # Only used when transport is tcp or tls-tcp.
         connection-timeout = 5 seconds
 
-        # The timeout for outbound associations to perform the handshake.
-        # This timeout must be greater than the 'image-liveness-timeout'.
+        # The timeout for outbound associations to perform the initial handshake.
+        # This timeout must be greater than the 'image-liveness-timeout' when
+        # transport is aeron-udp.
         handshake-timeout = 20 seconds
 
-        # incomplete handshake attempt is retried with this interval
+        # incomplete initial handshake attempt is retried with this interval
         handshake-retry-interval = 1 second
 
-        # handshake requests are performed periodically with this interval,
+        # Handshake requests are performed periodically with this interval,
         # also after the handshake has been completed to be able to establish
-        # a new session with a restarted destination system
+        # a new session with a restarted destination system.
         inject-handshake-interval = 1 second
 
         # messages that are not accepted by Aeron are dropped after retrying for this period
@@ -988,6 +989,27 @@ akka {
         # of a network partition that you need to survive.
         give-up-system-message-after = 6 hours
 
+        # Outbound streams are stopped when they haven't been used for this duration.
+        # They are started again when new messages are sent.
+        stop-idle-outbound-after = 5 minutes
+
+        # Outbound streams are quarantined when they haven't been used for this duration
+        # to cleanup resources used by the association, such as compression tables.
+        # This will cleanup association to crashed systems that didn't announce their
+        # termination.
+        # The value should be longer than the length of a network partition that you
+        # need to survive.
+        # The value must also be greater than stop-idle-outbound-after.
+        # Once every 1/10 of this duration an extra handshake message will be sent.
+        # Therfore it's also recommended to use a value that is greater than 10 times
+        # the stop-idle-outbound-after, since otherwise the idle streams will not be
+        # stopped.
+        quarantine-idle-outbound-after = 6 hours
+
+        # Stop outbound stream of a quarantined association after this idle timeout, i.e.
+        # when not used any more.
+        stop-quarantined-after-idle = 3 seconds
+
         # After catastrophic communication failures that could result in the loss of system
         # messages or after the remote DeathWatch triggers the remote system gets
         # quarantined to prevent inconsistent behavior.
@@ -998,10 +1020,6 @@ akka {
         # gone which could result in communication with a previously quarantined node
         # if it wakes up again. Therfore this shouldn't be set too low.
         remove-quarantined-association-after = 1 h
-
-        # Outbound streams are stopped when they haven't been used for this duration.
-        # They are started again when new messages are sent.
-        stop-idle-outbound-after = 5.minutes
 
         # during ActorSystem termination the remoting will wait this long for
         # an acknowledgment by the destination system that flushing of outstanding
@@ -1025,10 +1043,6 @@ akka {
         # Max number of restarts within 'outbound-restart-timeout' for the outbound streams.
         # If more restarts occurs the ActorSystem will be terminated.
         outbound-max-restarts = 5
-
-        # Stop outbound stream of a quarantined association after this idle timeout, i.e.
-        # when not used any more.
-        stop-quarantined-after-idle = 3 seconds
 
         # Timeout after which aeron driver has not had keepalive messages
         # from a client before it considers the client dead.

--- a/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
@@ -9,9 +9,10 @@ import akka.dispatch.sysmsg.{ DeathWatchNotification, Watch }
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.event.AddressTerminatedTopic
 import akka.remote.artery.ArteryMessage
-
 import scala.collection.mutable
 import scala.concurrent.duration._
+
+import akka.remote.artery.ArteryTransport
 
 /**
  * INTERNAL API
@@ -163,7 +164,7 @@ private[akka] class RemoteWatcher(
     watchingNodes foreach { a ⇒
       if (!unreachable(a) && !failureDetector.isAvailable(a)) {
         log.warning("Detected unreachable: [{}]", a)
-        quarantine(a, addressUids.get(a), "Deemed unreachable by remote failure detector")
+        quarantine(a, addressUids.get(a), "Deemed unreachable by remote failure detector", harmless = false)
         publishAddressTerminated(a)
         unreachable += a
       }
@@ -172,8 +173,12 @@ private[akka] class RemoteWatcher(
   def publishAddressTerminated(address: Address): Unit =
     AddressTerminatedTopic(context.system).publish(AddressTerminated(address))
 
-  def quarantine(address: Address, uid: Option[Long], reason: String): Unit =
-    remoteProvider.quarantine(address, uid, reason)
+  def quarantine(address: Address, uid: Option[Long], reason: String, harmless: Boolean): Unit = {
+    remoteProvider.transport match {
+      case t: ArteryTransport if harmless ⇒ t.quarantine(address, uid, reason, harmless)
+      case _                              ⇒ remoteProvider.quarantine(address, uid, reason)
+    }
+  }
 
   def addWatch(watchee: InternalActorRef, watcher: InternalActorRef): Unit = {
     assert(watcher != self)

--- a/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
@@ -95,7 +95,7 @@ final case class QuarantinedEvent(address: Address, longUid: Long) extends Remot
   override def logLevel: Logging.LogLevel = Logging.WarningLevel
   override val toString: String =
     s"Association to [$address] having UID [$longUid] is irrecoverably failed. UID is now quarantined and all " +
-      "messages to this UID will be delivered to dead letters. Remote actorsystem must be restarted to recover " +
+      "messages to this UID will be delivered to dead letters. Remote ActorSystem must be restarted to recover " +
       "from this situation."
 
   // For binary compatibility
@@ -108,6 +108,17 @@ final case class QuarantinedEvent(address: Address, longUid: Long) extends Remot
 
   @deprecated("Use long uid copy method", "2.4.x")
   def copy(address: Address = address, uid: Int = uid) = new QuarantinedEvent(address, uid)
+}
+
+/**
+ * The `uniqueAddress` was quarantined but it was due to normal shutdown or cluster leaving/exiting.
+ */
+@SerialVersionUID(1L)
+final case class GracefulShutdownQuarantinedEvent(uniqueAddress: UniqueAddress, reason: String) extends RemotingLifecycleEvent {
+  override def logLevel: Logging.LogLevel = Logging.InfoLevel
+  override val toString: String =
+    s"Association to [${uniqueAddress.address}] having UID [${uniqueAddress.uid}] has been stopped. All " +
+      s"messages to this UID will be delivered to dead letters. Reason: $reason "
 }
 
 @SerialVersionUID(1L)

--- a/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
@@ -144,11 +144,18 @@ private[akka] final class ArterySettings private (config: Config) {
     val GiveUpSystemMessageAfter: FiniteDuration =
       config.getMillisDuration("give-up-system-message-after").requiring(interval ⇒
         interval > Duration.Zero, "give-up-system-message-after must be more than zero")
+    val StopIdleOutboundAfter: FiniteDuration = config.getMillisDuration("stop-idle-outbound-after")
+      .requiring(interval ⇒ interval > Duration.Zero, "stop-idle-outbound-after must be more than zero")
+    val QuarantineIdleOutboundAfter: FiniteDuration = config.getMillisDuration("quarantine-idle-outbound-after")
+      .requiring(
+        interval ⇒ interval > StopIdleOutboundAfter,
+        "quarantine-idle-outbound-after must be greater than stop-idle-outbound-after")
+    val StopQuarantinedAfterIdle: FiniteDuration =
+      config.getMillisDuration("stop-quarantined-after-idle").requiring(interval ⇒
+        interval > Duration.Zero, "stop-quarantined-after-idle must be more than zero")
     val RemoveQuarantinedAssociationAfter: FiniteDuration =
       config.getMillisDuration("remove-quarantined-association-after").requiring(interval ⇒
         interval > Duration.Zero, "remove-quarantined-association-after must be more than zero")
-    val StopIdleOutboundAfter: FiniteDuration = config.getMillisDuration("stop-idle-outbound-after").requiring(interval ⇒
-      interval > Duration.Zero, "stop-idle-outbound-after must be more than zero")
     val ShutdownFlushTimeout: FiniteDuration =
       config.getMillisDuration("shutdown-flush-timeout").requiring(interval ⇒
         interval > Duration.Zero, "shutdown-flush-timeout must be more than zero")
@@ -163,9 +170,6 @@ private[akka] final class ArterySettings private (config: Config) {
       config.getMillisDuration("outbound-restart-timeout").requiring(interval ⇒
         interval > Duration.Zero, "outbound-restart-timeout must be more than zero")
     val OutboundMaxRestarts: Int = getInt("outbound-max-restarts")
-    val StopQuarantinedAfterIdle: FiniteDuration =
-      config.getMillisDuration("stop-quarantined-after-idle").requiring(interval ⇒
-        interval > Duration.Zero, "stop-quarantined-after-idle must be more than zero")
     val ClientLivenessTimeout: FiniteDuration =
       config.getMillisDuration("client-liveness-timeout").requiring(interval ⇒
         interval > Duration.Zero, "client-liveness-timeout must be more than zero")

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -128,7 +128,7 @@ private[remote] class ArteryTcpTransport(_system: ExtendedActorSystem, _provider
     def connectionFlowWithRestart: Flow[ByteString, ByteString, NotUsed] = {
       val flowFactory = () ⇒ {
 
-        val flow =
+        def flow(controlIdleKillSwitch: OptionVal[SharedKillSwitch]) =
           Flow[ByteString]
             .via(Flow.lazyInitAsync(() ⇒ {
               // only open the actual connection if any new messages are sent
@@ -136,6 +136,8 @@ private[remote] class ArteryTcpTransport(_system: ExtendedActorSystem, _provider
                 TcpOutbound_Connected,
                 s"${outboundContext.remoteAddress.host.get}:${outboundContext.remoteAddress.port.get} " +
                   s"/ ${streamName(streamId)}")
+              if (controlIdleKillSwitch.isDefined)
+                outboundContext.asInstanceOf[Association].setControlIdleKillSwitch(controlIdleKillSwitch)
               Future.successful(
                 Flow[ByteString]
                   .prepend(Source.single(TcpFraming.encodeConnectionHeader(streamId)))
@@ -150,29 +152,19 @@ private[remote] class ArteryTcpTransport(_system: ExtendedActorSystem, _provider
           val controlIdleKillSwitch = KillSwitches.shared("outboundControlStreamIdleKillSwitch")
           Flow[ByteString]
             .via(controlIdleKillSwitch.flow)
-            .via(flow)
-            .mapMaterializedValue { _ ⇒
-              outboundContext.asInstanceOf[Association].setControlIdleKillSwitch(OptionVal.Some(controlIdleKillSwitch))
-              NotUsed
-            }
+            .via(flow(OptionVal.Some(controlIdleKillSwitch)))
         } else {
-          flow
+          flow(OptionVal.None)
         }
       }
 
-      if (streamId == ControlStreamId) {
-        // restart of inner connection part important in control flow, since system messages
-        // are buffered and resent from the outer SystemMessageDelivery stage.
-        RestartFlow.withBackoff[ByteString, ByteString](
-          settings.Advanced.OutboundRestartBackoff,
-          settings.Advanced.GiveUpSystemMessageAfter, 0.1)(flowFactory)
-      } else {
-        // Best effort retry a few times
-        RestartFlow.withBackoff[ByteString, ByteString](
-          settings.Advanced.OutboundRestartBackoff,
-          settings.Advanced.OutboundRestartBackoff * 5, 0.1, maxRestarts = 3)(flowFactory)
-      }
-
+      val maxRestarts = if (streamId == ControlStreamId) Int.MaxValue else 3
+      // Restart of inner connection part important in control stream, since system messages
+      // are buffered and resent from the outer SystemMessageDelivery stage. No maxRestarts limit for control
+      // stream. For message stream it's best effort retry a few times.
+      RestartFlow.withBackoff[ByteString, ByteString](
+        settings.Advanced.OutboundRestartBackoff,
+        settings.Advanced.OutboundRestartBackoff * 5, 0.1, maxRestarts)(flowFactory)
     }
 
     Flow[EnvelopeBuffer]
@@ -416,7 +408,7 @@ private[remote] class ArteryTcpTransport(_system: ExtendedActorSystem, _provider
   }
 
   override protected def shutdownTransport(): Future[Done] = {
-    implicit val ec: ExecutionContext = materializer.executionContext
+    import system.dispatcher
     inboundKillSwitch.shutdown()
     unbind().map { _ ⇒
       topLevelFlightRecorder.loFreq(Transport_Stopped, NoMetaData)
@@ -425,9 +417,9 @@ private[remote] class ArteryTcpTransport(_system: ExtendedActorSystem, _provider
   }
 
   private def unbind(): Future[Done] = {
-    implicit val ec: ExecutionContext = materializer.executionContext
     serverBinding match {
       case Some(binding) ⇒
+        import system.dispatcher
         for {
           b ← binding
           _ ← b.unbind()

--- a/akka-remote/src/test/scala/akka/remote/RemoteWatcherSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteWatcherSpec.scala
@@ -54,7 +54,7 @@ object RemoteWatcherSpec {
       // that doesn't interfere with the real watch that is going on in the background
       context.system.eventStream.publish(TestRemoteWatcher.AddressTerm(address))
 
-    override def quarantine(address: Address, uid: Option[Long], reason: String): Unit = {
+    override def quarantine(address: Address, uid: Option[Long], reason: String, harmless: Boolean): Unit = {
       // don't quarantine in remoting, but publish a testable message
       context.system.eventStream.publish(TestRemoteWatcher.Quarantined(address, uid))
     }

--- a/akka-remote/src/test/scala/akka/remote/artery/OutboundHandshakeSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/OutboundHandshakeSpec.scala
@@ -33,11 +33,13 @@ class OutboundHandshakeSpec extends AkkaSpec with ImplicitSender {
   private def setupStream(
     outboundContext: OutboundContext, timeout: FiniteDuration = 5.seconds,
     retryInterval:           FiniteDuration = 10.seconds,
-    injectHandshakeInterval: FiniteDuration = 10.seconds): (TestPublisher.Probe[String], TestSubscriber.Probe[Any]) = {
+    injectHandshakeInterval: FiniteDuration = 10.seconds,
+    livenessProbeInterval:   Duration       = Duration.Undefined): (TestPublisher.Probe[String], TestSubscriber.Probe[Any]) = {
 
     TestSource.probe[String]
       .map(msg ⇒ outboundEnvelopePool.acquire().init(OptionVal.None, msg, OptionVal.None))
-      .via(new OutboundHandshake(system, outboundContext, outboundEnvelopePool, timeout, retryInterval, injectHandshakeInterval))
+      .via(new OutboundHandshake(system, outboundContext, outboundEnvelopePool, timeout, retryInterval,
+        injectHandshakeInterval, livenessProbeInterval))
       .map(env ⇒ env.message)
       .toMat(TestSink.probe[Any])(Keep.both)
       .run()
@@ -127,6 +129,21 @@ class OutboundHandshakeSpec extends AkkaSpec with ImplicitSender {
       downstream.expectNext("msg4")
       downstream.expectNoMsg(600.millis)
 
+      downstream.cancel()
+    }
+
+    "send HandshakeReq for liveness probing" in {
+      val inboundContext = new TestInboundContext(localAddress = addressA)
+      val outboundContext = inboundContext.association(addressB.address)
+      val (upstream, downstream) = setupStream(outboundContext, livenessProbeInterval = 200.millis)
+
+      downstream.request(10)
+      // this is from the initial
+      downstream.expectNext(HandshakeReq(addressA, addressB.address))
+      inboundContext.completeHandshake(addressB)
+      // these are from  livenessProbeInterval
+      downstream.expectNext(HandshakeReq(addressA, addressB.address))
+      downstream.expectNext(HandshakeReq(addressA, addressB.address))
       downstream.cancel()
     }
 

--- a/akka-remote/src/test/scala/akka/remote/artery/OutboundIdleShutdownSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/OutboundIdleShutdownSpec.scala
@@ -105,9 +105,6 @@ class OutboundIdleShutdownSpec extends ArteryMultiNodeSpec(s"""
           assertStreamActive(association, Association.OrdinaryQueueIndex, expected = false)
         }
 
-        Thread.sleep(2000)
-        //        localArtery.quarantine(remoteAddress, Some(remoteUid), "Test")
-
         // the outbound streams are inactive and association quarantined, then it's completely removed
         eventually {
           localArtery.remoteAddresses should not contain remoteAddress

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteWatcherSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteWatcherSpec.scala
@@ -55,7 +55,7 @@ object RemoteWatcherSpec {
       // that doesn't interfere with the real watch that is going on in the background
       context.system.eventStream.publish(TestRemoteWatcher.AddressTerm(address))
 
-    override def quarantine(address: Address, uid: Option[Long], reason: String): Unit = {
+    override def quarantine(address: Address, uid: Option[Long], reason: String, harmless: Boolean): Unit = {
       // don't quarantine in remoting, but publish a testable message
       context.system.eventStream.publish(TestRemoteWatcher.Quarantined(address, uid))
     }


### PR DESCRIPTION
Some first improvements related to #24972

The reproducer app can be run with:
```
sbt "akka-remote/test:runMain akka.remote.artery.tcp.LeakyServer"
sbt "akka-remote/test:runMain akka.remote.artery.tcp.PingClient"
```

or corresponding with cluster:
```
sbt "akka-cluster/test:runMain akka.cluster.LeakyServer"
sbt "akka-cluster/test:runMain akka.cluster.PingClient"
```
