### PR TITLE
Akka stream groupBy does not invoke decider

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupBySpec.scala
@@ -336,6 +336,18 @@ class FlowGroupBySpec extends StreamSpec {
       s1.expectError(ex)
     }
 
+    "resume when exceeding maxSubstreams" in {
+      val (up, down) = Flow[Int]
+        .groupBy(0, identity).mergeSubstreams
+        .withAttributes(ActorAttributes.supervisionStrategy(resumingDecider))
+        .runWith(TestSource.probe[Int], TestSink.probe)
+
+      down.request(1)
+
+      up.sendNext(1)
+      down.expectNoMessage(1.second)
+    }
+
     "emit subscribe before completed" in assertAllStagesStopped {
       val futureGroupSource =
         Source.single(0)

--- a/akka-stream/src/main/scala/akka/stream/TooManySubstreamsOpenException.scala
+++ b/akka-stream/src/main/scala/akka/stream/TooManySubstreamsOpenException.scala
@@ -1,0 +1,16 @@
+/**
+ * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream
+
+import scala.util.control.NoStackTrace
+
+/**
+ * This exception signals that the maximum number of substreams declared has been exceeded.
+ * A finite limit is imposed so that memory usage is controlled.
+ */
+final class TooManySubstreamsOpenException
+  extends IllegalStateException("Cannot open a new substream as there are too many substreams open")
+  with NoStackTrace {
+}


### PR DESCRIPTION
`groupBy` does not invoke a decider when the maximum number of substreams has been exceeded. This PR fixes that.