### PR TITLE
add java.time.Duration support in akka-actor module for the javadsl

### DIFF
--- a/akka-actor/src/main/mima-filters/2.5.12.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.12.backwards.excludes
@@ -1,0 +1,3 @@
+# #24646 java.time.Duration
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.AbstractActor#ActorContext.cancelReceiveTimeout")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.AbstractActor#ActorContext.setReceiveTimeout")

--- a/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
@@ -4,9 +4,7 @@
 
 package akka.actor.dungeon
 
-import ReceiveTimeout.emptyReceiveTimeoutData
 import akka.actor.ActorCell
-import akka.actor.ActorCell.emptyCancellable
 import akka.actor.Cancellable
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
@@ -40,7 +38,7 @@ private[akka] trait ReceiveTimeout { this: ActorCell ⇒
 
   }
 
-  final def cancelReceiveTimeout(): Unit =
+  override final def cancelReceiveTimeout(): Unit =
     if (receiveTimeoutData._2 ne emptyCancellable) {
       receiveTimeoutData._2.cancel()
       receiveTimeoutData = (receiveTimeoutData._1, emptyCancellable)

--- a/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
+++ b/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
@@ -535,7 +535,7 @@ public class ActorDocTest extends AbstractJavaTest {
     //#receive-timeout
     public ReceiveTimeoutActor() {
       // To set an initial delay
-      getContext().setReceiveTimeout(Duration.create(10, TimeUnit.SECONDS));
+      getContext().setReceiveTimeout(java.time.Duration.ofSeconds(10));
     }
     
     @Override
@@ -543,7 +543,7 @@ public class ActorDocTest extends AbstractJavaTest {
       return receiveBuilder()
         .matchEquals("Hello", s -> {
           // To set in a response to a message
-          getContext().setReceiveTimeout(Duration.create(1, TimeUnit.SECONDS));
+          getContext().setReceiveTimeout(java.time.Duration.ofSeconds(1));
           //#receive-timeout
           target = getSender();
           target.tell("Hello world", getSelf());
@@ -551,7 +551,7 @@ public class ActorDocTest extends AbstractJavaTest {
         })
         .match(ReceiveTimeout.class, r -> {
           // To turn it off
-          getContext().setReceiveTimeout(Duration.Undefined());
+          getContext().cancelReceiveTimeout();
           //#receive-timeout
           target.tell("timeout", getSelf());
           //#receive-timeout

--- a/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
+++ b/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.time.Duration;
 import akka.testkit.TestActors;
-import scala.concurrent.Await;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -73,8 +72,8 @@ public class ActorDocTest extends AbstractJavaTest {
   }
 
   @AfterClass
-  public static void afterClass() throws Exception {
-    Await.ready(system.terminate(), scala.concurrent.duration.Duration.create(5, TimeUnit.SECONDS));
+  public static void afterClass() {
+    TestKit.shutdownActorSystem(system);
   }
 
   static
@@ -628,7 +627,7 @@ public class ActorDocTest extends AbstractJavaTest {
         actor.tell("foo", getRef());
         actor.tell("foo", getRef());
         expectMsgEquals("I am already angry?");
-        expectNoMsg(scala.concurrent.duration.Duration.create(1, TimeUnit.SECONDS));
+        expectNoMessage(Duration.ofSeconds(1));
       }
     };
   }
@@ -755,7 +754,7 @@ public class ActorDocTest extends AbstractJavaTest {
         ActorRef actorC = getRef();
 
         //#ask-pipe
-        Timeout t = new Timeout(scala.concurrent.duration.Duration.create(5, TimeUnit.SECONDS));
+        Timeout t = Timeout.create(Duration.ofSeconds(5));
 
         // using 1000ms timeout
         CompletableFuture<Object> future1 =
@@ -791,7 +790,7 @@ public class ActorDocTest extends AbstractJavaTest {
         victim.tell(akka.actor.Kill.getInstance(), ActorRef.noSender());
         
         // expecting the actor to indeed terminate:
-        expectTerminated(scala.concurrent.duration.Duration.create(3, TimeUnit.SECONDS), victim);
+        expectTerminated(Duration.ofSeconds(3), victim);
         //#kill
       }
     };
@@ -806,7 +805,7 @@ public class ActorDocTest extends AbstractJavaTest {
         //#poison-pill
         victim.tell(akka.actor.PoisonPill.getInstance(), ActorRef.noSender());
         //#poison-pill
-        expectTerminated(scala.concurrent.duration.Duration.create(3, TimeUnit.SECONDS), victim);
+        expectTerminated(Duration.ofSeconds(3), victim);
       }
     };
   }

--- a/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
+++ b/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
@@ -18,6 +18,7 @@ import akka.Done;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 import akka.testkit.TestActors;
 import scala.concurrent.Await;
 
@@ -47,7 +48,6 @@ import java.util.concurrent.CompletableFuture;
 //#import-gracefulStop
 import static akka.pattern.PatternsCS.gracefulStop;
 import akka.pattern.AskTimeoutException;
-import scala.concurrent.duration.Duration;
 import java.util.concurrent.CompletionStage;
 
 //#import-gracefulStop
@@ -74,7 +74,7 @@ public class ActorDocTest extends AbstractJavaTest {
 
   @AfterClass
   public static void afterClass() throws Exception {
-    Await.ready(system.terminate(), Duration.create(5, TimeUnit.SECONDS));
+    Await.ready(system.terminate(), scala.concurrent.duration.Duration.create(5, TimeUnit.SECONDS));
   }
 
   static
@@ -412,7 +412,7 @@ public class ActorDocTest extends AbstractJavaTest {
     //#gracefulStop
     try {
       CompletionStage<Boolean> stopped =
-        gracefulStop(actorRef, java.time.Duration.ofSeconds(5), Manager.SHUTDOWN);
+        gracefulStop(actorRef, Duration.ofSeconds(5), Manager.SHUTDOWN);
       stopped.toCompletableFuture().get(6, TimeUnit.SECONDS);
       // the actor has been stopped
     } catch (AskTimeoutException e) {
@@ -535,7 +535,7 @@ public class ActorDocTest extends AbstractJavaTest {
     //#receive-timeout
     public ReceiveTimeoutActor() {
       // To set an initial delay
-      getContext().setReceiveTimeout(java.time.Duration.ofSeconds(10));
+      getContext().setReceiveTimeout(Duration.ofSeconds(10));
     }
     
     @Override
@@ -543,7 +543,7 @@ public class ActorDocTest extends AbstractJavaTest {
       return receiveBuilder()
         .matchEquals("Hello", s -> {
           // To set in a response to a message
-          getContext().setReceiveTimeout(java.time.Duration.ofSeconds(1));
+          getContext().setReceiveTimeout(Duration.ofSeconds(1));
           //#receive-timeout
           target = getSender();
           target.tell("Hello world", getSelf());
@@ -628,7 +628,7 @@ public class ActorDocTest extends AbstractJavaTest {
         actor.tell("foo", getRef());
         actor.tell("foo", getRef());
         expectMsgEquals("I am already angry?");
-        expectNoMsg(Duration.create(1, TimeUnit.SECONDS));
+        expectNoMsg(scala.concurrent.duration.Duration.create(1, TimeUnit.SECONDS));
       }
     };
   }
@@ -741,7 +741,7 @@ public class ActorDocTest extends AbstractJavaTest {
       {
         watch(b);
         system.stop(a);
-        assertEquals(expectMsgClass(java.time.Duration.ofSeconds(2), Terminated.class).actor(), b);
+        assertEquals(expectMsgClass(Duration.ofSeconds(2), Terminated.class).actor(), b);
       }
     };
   }
@@ -755,7 +755,7 @@ public class ActorDocTest extends AbstractJavaTest {
         ActorRef actorC = getRef();
 
         //#ask-pipe
-        Timeout t = new Timeout(Duration.create(5, TimeUnit.SECONDS));
+        Timeout t = new Timeout(scala.concurrent.duration.Duration.create(5, TimeUnit.SECONDS));
 
         // using 1000ms timeout
         CompletableFuture<Object> future1 =
@@ -791,7 +791,7 @@ public class ActorDocTest extends AbstractJavaTest {
         victim.tell(akka.actor.Kill.getInstance(), ActorRef.noSender());
         
         // expecting the actor to indeed terminate:
-        expectTerminated(Duration.create(3, TimeUnit.SECONDS), victim);
+        expectTerminated(scala.concurrent.duration.Duration.create(3, TimeUnit.SECONDS), victim);
         //#kill
       }
     };
@@ -806,7 +806,7 @@ public class ActorDocTest extends AbstractJavaTest {
         //#poison-pill
         victim.tell(akka.actor.PoisonPill.getInstance(), ActorRef.noSender());
         //#poison-pill
-        expectTerminated(Duration.create(3, TimeUnit.SECONDS), victim);
+        expectTerminated(scala.concurrent.duration.Duration.create(3, TimeUnit.SECONDS), victim);
       }
     };
   }

--- a/akka-docs/src/test/java/jdocs/actor/FaultHandlingDocSample.java
+++ b/akka-docs/src/test/java/jdocs/actor/FaultHandlingDocSample.java
@@ -67,7 +67,7 @@ public class FaultHandlingDocSample {
     public void preStart() {
       // If we don't get any progress within 15 seconds then the service
       // is unavailable
-      getContext().setReceiveTimeout(Duration.create("15 seconds"));
+      getContext().setReceiveTimeout(java.time.Duration.ofSeconds(15));
     }
 
     @Override

--- a/akka-docs/src/test/java/jdocs/actor/FaultHandlingDocSample.java
+++ b/akka-docs/src/test/java/jdocs/actor/FaultHandlingDocSample.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.time.Duration;
 
 import akka.actor.*;
 import akka.dispatch.Mapper;
@@ -19,7 +20,6 @@ import akka.pattern.Patterns;
 import akka.util.Timeout;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import scala.concurrent.duration.Duration;
 
 import static akka.japi.Util.classTag;
 import static akka.actor.SupervisorStrategy.restart;
@@ -67,7 +67,7 @@ public class FaultHandlingDocSample {
     public void preStart() {
       // If we don't get any progress within 15 seconds then the service
       // is unavailable
-      getContext().setReceiveTimeout(java.time.Duration.ofSeconds(15));
+      getContext().setReceiveTimeout(Duration.ofSeconds(15));
     }
 
     @Override
@@ -114,7 +114,7 @@ public class FaultHandlingDocSample {
    * The Worker supervise the CounterService.
    */
   public static class Worker extends AbstractLoggingActor {
-    final Timeout askTimeout = new Timeout(Duration.create(5, "seconds"));
+    final Timeout askTimeout = Timeout.create(Duration.ofSeconds(5));
 
     // The sender of the initial Start message will continuously be notified
     // about progress
@@ -140,7 +140,7 @@ public class FaultHandlingDocSample {
         matchEquals(Start, x -> progressListener == null, x -> {
           progressListener = getSender();
           getContext().getSystem().scheduler().schedule(
-            java.time.Duration.ZERO,  java.time.Duration.ofSeconds(1L), getSelf(), Do,
+            Duration.ZERO,  Duration.ofSeconds(1L), getSelf(), Do,
             getContext().dispatcher(), null
           );
         }).
@@ -232,7 +232,7 @@ public class FaultHandlingDocSample {
     // Restart the storage child when StorageException is thrown.
     // After 3 restarts within 5 seconds it will be stopped.
     private static final SupervisorStrategy strategy =
-      new OneForOneStrategy(3, Duration.create("5 seconds"), DeciderBuilder.
+      new OneForOneStrategy(3, scala.concurrent.duration.Duration.create("5 seconds"), DeciderBuilder.
        match(StorageException.class, e -> restart()).
        matchAny(o -> escalate()).build());
 
@@ -292,7 +292,7 @@ public class FaultHandlingDocSample {
           counter.tell(new UseStorage(null), getSelf());
           // Try to re-establish storage after while
           getContext().getSystem().scheduler().scheduleOnce(
-            Duration.create(10, "seconds"), getSelf(), Reconnect,
+            Duration.ofSeconds(10), getSelf(), Reconnect,
             getContext().dispatcher(), null);
         }).
         matchEquals(Reconnect, o -> {

--- a/akka-docs/src/test/java/jdocs/cluster/FactorialFrontend.java
+++ b/akka-docs/src/test/java/jdocs/cluster/FactorialFrontend.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import akka.actor.Props;
 import akka.cluster.metrics.AdaptiveLoadBalancingGroup;
@@ -19,7 +19,6 @@ import akka.cluster.routing.ClusterRouterGroup;
 import akka.cluster.routing.ClusterRouterGroupSettings;
 import akka.cluster.routing.ClusterRouterPool;
 import akka.cluster.routing.ClusterRouterPoolSettings;
-import scala.concurrent.duration.Duration;
 import akka.actor.ActorRef;
 import akka.actor.ReceiveTimeout;
 import akka.actor.AbstractActor;
@@ -45,7 +44,7 @@ public class FactorialFrontend extends AbstractActor {
   @Override
   public void preStart() {
     sendJobs();
-    getContext().setReceiveTimeout(Duration.create(10, TimeUnit.SECONDS));
+    getContext().setReceiveTimeout(Duration.ofSeconds(10));
   }
 
   @Override

--- a/akka-docs/src/test/java/jdocs/cluster/StatsAggregator.java
+++ b/akka-docs/src/test/java/jdocs/cluster/StatsAggregator.java
@@ -6,11 +6,10 @@ package jdocs.cluster;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import jdocs.cluster.StatsMessages.JobFailed;
 import jdocs.cluster.StatsMessages.StatsResult;
-import scala.concurrent.duration.Duration;
 import akka.actor.ActorRef;
 import akka.actor.ReceiveTimeout;
 import akka.actor.AbstractActor;
@@ -29,7 +28,7 @@ public class StatsAggregator extends AbstractActor {
 
   @Override
   public void preStart() {
-    getContext().setReceiveTimeout(Duration.create(3, TimeUnit.SECONDS));
+    getContext().setReceiveTimeout(Duration.ofSeconds(3));
   }
 
   @Override

--- a/akka-docs/src/test/java/jdocs/sharding/ClusterShardingTest.java
+++ b/akka-docs/src/test/java/jdocs/sharding/ClusterShardingTest.java
@@ -4,10 +4,9 @@
 
 package jdocs.sharding;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.Optional;
-import scala.concurrent.duration.Duration;
+import java.time.Duration;
 
 import akka.actor.AbstractActor;
 import akka.actor.ActorInitializationException;
@@ -17,7 +16,6 @@ import akka.actor.OneForOneStrategy;
 import akka.actor.PoisonPill;
 import akka.actor.Props;
 import akka.actor.SupervisorStrategy;
-import akka.actor.Terminated;
 import akka.actor.ReceiveTimeout;
 //#counter-extractor
 import akka.cluster.sharding.ShardRegion;
@@ -31,7 +29,6 @@ import akka.cluster.sharding.ClusterShardingSettings;
 
 //#counter-start
 import akka.persistence.AbstractPersistentActor;
-import akka.cluster.Cluster;
 import akka.japi.pf.DeciderBuilder;
 
 // Doc code, compile only
@@ -200,7 +197,7 @@ public class ClusterShardingTest {
     @Override
     public void preStart() throws Exception {
       super.preStart();
-      getContext().setReceiveTimeout(Duration.create(120, SECONDS));
+      getContext().setReceiveTimeout(Duration.ofSeconds(120));
     }
 
     void updateState(CounterChanged event) {

--- a/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
@@ -638,6 +638,17 @@ class TestKit(system: ActorSystem) {
    * Before calling this method, you have to `watch` the target actor ref.
    * Wait time is bounded by the given duration, with an AssertionFailure being thrown in case of timeout.
    *
+   * @param max wait no more than max time, otherwise throw AssertionFailure
+   * @param target the actor ref expected to be Terminated
+   * @return the received Terminated message
+   */
+  def expectTerminated(max: java.time.Duration, target: ActorRef): Terminated = tp.expectTerminated(target, max.asScala)
+
+  /**
+   * Receive one message from the test actor and assert that it is the Terminated message of the given ActorRef.
+   * Before calling this method, you have to `watch` the target actor ref.
+   * Wait time is bounded by the given duration, with an AssertionFailure being thrown in case of timeout.
+   *
    * @param target the actor ref expected to be Terminated
    * @return the received Terminated message
    */


### PR DESCRIPTION
Add java.time.Duration support for javadsl by adding the setReceiveTimeout and cancelReceiveTimeout in the class Abstract.ActorContext 