### PR TITLE
Fix def getDetails in StreamOperatorsIndexGenerator for paradox on Windows

### DIFF
--- a/project/StreamOperatorsIndexGenerator.scala
+++ b/project/StreamOperatorsIndexGenerator.scala
@@ -191,12 +191,18 @@ object StreamOperatorsIndexGenerator extends AutoPlugin {
   }
 
   def getDetails(file: File): (String, String) = {
-    val contents = IO.read(file).dropWhile(_ != '\n').drop(2)
+    val contents = IO.read(file)
+    val lines = contents.split("\\r?\\n")
+    require(
+      lines.size >= 5,
+      s"There must be at least 5 lines in $file, including the title, description, category link and an empty line between each two of them"
+    )
     // This forces the short description to be on a single line. We could make this smarter,
     // but 'forcing' the short description to be really short seems nice as well.
-    val description = contents.takeWhile(_ != '\n')
-    val categoryLink = contents.dropWhile(_ != '\n').drop(2).takeWhile(_ != '\n')
-    require(categoryLink.startsWith("@ref"), s"category link in $file, saw $categoryLink")
+    val description = lines(2) //line 3
+    require(!description.isEmpty, s"description in $file must be non-empty, single-line description at the 3rd line")
+    val categoryLink = lines(4) //line 5
+    require(categoryLink.startsWith("@ref"), s"""category link in $file should start with @ref, but saw \"$categoryLink\"""")
     val categoryName = categoryLink.drop(5).takeWhile(_ != ']')
     val categoryLinkId = categoryLink.dropWhile(_ != '#').drop(1).takeWhile(_ != ')')
     require(categories.contains(categoryName), s"category $categoryName in $file should be known")

--- a/project/StreamOperatorsIndexGenerator.scala
+++ b/project/StreamOperatorsIndexGenerator.scala
@@ -199,9 +199,9 @@ object StreamOperatorsIndexGenerator extends AutoPlugin {
     )
     // This forces the short description to be on a single line. We could make this smarter,
     // but 'forcing' the short description to be really short seems nice as well.
-    val description = lines(2) //line 3
+    val description = lines(2)
     require(!description.isEmpty, s"description in $file must be non-empty, single-line description at the 3rd line")
-    val categoryLink = lines(4) //line 5
+    val categoryLink = lines(4)
     require(categoryLink.startsWith("@ref"), s"""category link in $file should start with @ref, but saw \"$categoryLink\"""")
     val categoryName = categoryLink.drop(5).takeWhile(_ != ']')
     val categoryLinkId = categoryLink.dropWhile(_ != '#').drop(1).takeWhile(_ != ')')


### PR DESCRIPTION
Closes #25004

https://github.com/akka/akka/blob/054b70c41b58d911829057872eac08f92b6db66f/project/StreamOperatorsIndexGenerator.scala#L199

As in the issue, the above line fails with this exception:

```
ombine several sources, using a given strategy such as merge or concat, into one source.
[error] java.lang.IllegalArgumentException: requirement failed: category link in C:\Users\*****\akka\akka\akka-docs\src\main\paradox\stream\operators\Source\combine.md, saw ombine several sources, using a given strategy such as merge or concat, into one source.
```

You see it "ombine" not even "Combine", and it is supposed to be `description` not `categoryLink`. This happened because of the end-line character difference as below.

Given the content of [Source/combine.md](https://github.com/akka/akka/blob/054b70c41b58d911829057872eac08f92b6db66f/akka-docs/src/main/paradox/stream/operators/Source/combine.md): 

```
# combine

Combine several sinks into one using a user specified strategy

@ref[Sink stages](../index.md#sink-stages)

... //omitted further text here
```

On Linux/Mac, `.dropWhile(_ != '\n').drop(2)`  or `.takeWhile(_ != '\n').drop(2)` will drop `\n\n` which is end-line and the following empty line, and that just works fine. 

https://github.com/akka/akka/blob/054b70c41b58d911829057872eac08f92b6db66f/project/StreamOperatorsIndexGenerator.scala#L194

However on Windows, it drops only a single end-line because it is `\r\n`.

So I found a technique explained in https://www.mkyong.com/java/java-how-to-split-string-by-new-line/ and `split("\\r?\\n")` worked fine on my Windows and Mac as far as I tested. 