### PR TITLE
Upgrade Aeron and make use of channelStatus on subscription

### DIFF
--- a/akka-remote/src/main/mima-filters/2.5.12.backwards.excludes
+++ b/akka-remote/src/main/mima-filters/2.5.12.backwards.excludes
@@ -1,3 +1,13 @@
+# Internal API changes
+ProblemFilters.exclude[MissingTypesProblem]("akka.remote.artery.ArteryTransport$InboundStreamMatValues$")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.remote.artery.ArteryTransport#InboundStreamMatValues.apply")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.remote.artery.ArteryTransport#InboundStreamMatValues.copy$default$1")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.remote.artery.ArteryTransport#InboundStreamMatValues.copy$default$2")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.ArteryTransport#InboundStreamMatValues.aeronSourceLifecycle")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.remote.artery.ArteryTransport#InboundStreamMatValues.copy")
+ProblemFilters.exclude[MissingClassProblem]("akka.remote.artery.aeron.AeronSource$ResourceLifecycle")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.remote.artery.ArteryTransport#InboundStreamMatValues.this")
+
 # #23732 SSLEngineProvider, changes to internal classes
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.transport.netty.SSLSettings.getOrCreateContext")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.transport.netty.SSLSettings.createSecureRandom")

--- a/akka-remote/src/main/scala/akka/remote/artery/aeron/AeronSource.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/aeron/AeronSource.scala
@@ -18,9 +18,12 @@ import io.aeron.logbuffer.Header
 import org.agrona.DirectBuffer
 import org.agrona.hints.ThreadHints
 import akka.stream.stage.GraphStageWithMaterializedValue
+
 import scala.util.control.NonFatal
 import akka.stream.stage.StageLogging
 import io.aeron.exceptions.DriverTimeoutException
+
+import scala.concurrent.{ Future, Promise }
 
 /**
  * INTERNAL API
@@ -59,8 +62,10 @@ private[remote] object AeronSource {
     }
   })
 
-  trait ResourceLifecycle {
+  trait AeronLifecycle {
     def onUnavailableImage(sessionId: Int): Unit
+    // See  [io.aeron.status.ChannelEndpointStatus]
+    def channelEndpointStatus(): Future[Long]
   }
 }
 
@@ -78,7 +83,8 @@ private[remote] class AeronSource(
   pool:           EnvelopeBufferPool,
   flightRecorder: EventSink,
   spinning:       Int)
-  extends GraphStageWithMaterializedValue[SourceShape[EnvelopeBuffer], AeronSource.ResourceLifecycle] {
+  extends GraphStageWithMaterializedValue[SourceShape[EnvelopeBuffer], AeronSource.AeronLifecycle] {
+
   import AeronSource._
   import TaskRunner._
   import FlightRecorderEvents._
@@ -87,16 +93,16 @@ private[remote] class AeronSource(
   override val shape: SourceShape[EnvelopeBuffer] = SourceShape(out)
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
-    val logic = new GraphStageLogic(shape) with OutHandler with ResourceLifecycle with StageLogging {
+    val logic = new GraphStageLogic(shape) with OutHandler with AeronLifecycle with StageLogging {
 
-      private val sub = aeron.addSubscription(channel, streamId)
+      private val subscription = aeron.addSubscription(channel, streamId)
       private var backoffCount = spinning
       private var delegateTaskStartTime = 0L
       private var countBeforeDelegate = 0L
 
       // the fragmentHandler is called from `poll` in same thread, i.e. no async callback is needed
       private val messageHandler = new MessageHandler(pool)
-      private val addPollTask: Add = Add(pollTask(sub, messageHandler, getAsyncCallback(taskOnMessage)))
+      private val addPollTask: Add = Add(pollTask(subscription, messageHandler, getAsyncCallback(taskOnMessage)))
 
       private val channelMetadata = channel.getBytes("US-ASCII")
 
@@ -107,6 +113,9 @@ private[remote] class AeronSource(
         pendingUnavailableImages = sessionId :: pendingUnavailableImages
         freeSessionBuffers()
       }
+      private val getStatusCb = getAsyncCallback[Promise[Long]] { promise ⇒
+        promise.success(subscription.channelStatus())
+      }
 
       override protected def logSource = classOf[AeronSource]
 
@@ -116,7 +125,7 @@ private[remote] class AeronSource(
 
       override def postStop(): Unit = {
         taskRunner.command(Remove(addPollTask.task))
-        try sub.close() catch {
+        try subscription.close() catch {
           case e: DriverTimeoutException ⇒
             // media driver was shutdown
             log.debug("DriverTimeout when closing subscription. {}", e)
@@ -132,7 +141,7 @@ private[remote] class AeronSource(
 
       @tailrec private def subscriberLoop(): Unit = {
         messageHandler.reset()
-        val fragmentsRead = sub.poll(messageHandler.fragmentsHandler, 1)
+        val fragmentsRead = subscription.poll(messageHandler.fragmentsHandler, 1)
         val msg = messageHandler.messageReceived
         messageHandler.reset() // for GC
         if (fragmentsRead > 0) {
@@ -154,6 +163,12 @@ private[remote] class AeronSource(
             taskRunner.command(addPollTask)
           }
         }
+      }
+
+      override def channelEndpointStatus(): Future[Long] = {
+        val promise = Promise[Long]
+        getStatusCb.invoke(promise)
+        promise.future
       }
 
       private def taskOnMessage(data: EnvelopeBuffer): Unit = {

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -69,6 +69,8 @@ private[remote] class ArteryTcpTransport(_system: ExtendedActorSystem, _provider
   import ArteryTcpTransport._
   import FlightRecorderEvents._
 
+  override type LifeCycle = NotUsed
+
   // may change when inbound streams are restarted
   @volatile private var inboundKillSwitch: SharedKillSwitch = KillSwitches.shared("inboundKillSwitch")
   // may change when inbound streams are restarted
@@ -408,8 +410,8 @@ private[remote] class ArteryTcpTransport(_system: ExtendedActorSystem, _provider
 
   private def updateStreamMatValues(streamId: Int, completed: Future[Done]): Unit = {
     implicit val ec: ExecutionContext = materializer.executionContext
-    updateStreamMatValues(ControlStreamId, InboundStreamMatValues(
-      None,
+    updateStreamMatValues(ControlStreamId, InboundStreamMatValues[NotUsed](
+      NotUsed,
       completed.recover { case _ ⇒ Done }))
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val sslConfigVersion = "0.2.3"
   val slf4jVersion = "1.7.25"
   val scalaXmlVersion = "1.0.6"
-  val aeronVersion = "1.7.0"
+  val aeronVersion = "1.9.1"
 
   val Versions = Seq(
     crossScalaVersions := Seq("2.11.12", "2.12.6"),


### PR DESCRIPTION
Aeron 1.9.1 is wire compatible with 1.7 so nothing to do when doing an rolling upgrade.

We asked for an easier way to get hold of a channel status. It was added to subscription which isn't that easy for us to get hold of but used it anyway rather than scanning all counters.