### PR TITLE
Revert "Look for perf-java-flames on path in MultiJVM perf support"

### DIFF
--- a/akka-multi-node-testkit/src/main/mima-filters/2.5.12.backwards.excludes
+++ b/akka-multi-node-testkit/src/main/mima-filters/2.5.12.backwards.excludes
@@ -1,2 +1,0 @@
-# Internal API changes
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.testkit.PerfFlamesSupport.perfJavaFlamesPath")

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/PerfFlamesSupport.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/PerfFlamesSupport.scala
@@ -4,17 +4,12 @@
 
 package akka.remote.testkit
 
-import PerfFlamesSupport._
+import java.io.File
+
 import akka.remote.testconductor.RoleName
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-
-import scala.language.postfixOps
-
-object PerfFlamesSupport {
-  val Command = "perf-java-flames"
-}
 
 /**
  * INTERNAL API: Support trait allowing trivially recording perf metrics from [[MultiNodeSpec]]s
@@ -37,7 +32,7 @@ private[akka] trait PerfFlamesSupport { _: MultiNodeSpec ⇒
         val name = ManagementFactory.getRuntimeMXBean.getName
         val pid = name.substring(0, name.indexOf('@')).toInt
 
-        val perfCommand = s"$Command $pid"
+        val perfCommand = s"$perfJavaFlamesPath $pid"
         println(s"[perf @ $myself($pid)][OUT]: " + perfCommand)
 
         import scala.sys.process._
@@ -50,10 +45,13 @@ private[akka] trait PerfFlamesSupport { _: MultiNodeSpec ⇒
     }
   }
 
+  def perfJavaFlamesPath: String =
+    "/home/ubuntu/perf-java-flames"
+
   def isPerfJavaFlamesAvailable: Boolean = {
-    import scala.sys.process._
-    val isIt = (s"type $Command" !) == 0
-    if (!isIt) println(s"WARN: perf-java-flames not on the path! Skipping perf profiling.")
+    val isIt = new File(perfJavaFlamesPath).exists()
+    if (!isIt) println(s"WARN: perf-java-flames not available under [$perfJavaFlamesPath]! Skipping perf profiling.")
     isIt
   }
+
 }

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanInThrougputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanInThrougputSpec.scala
@@ -4,17 +4,26 @@
 
 package akka.remote.artery
 
+import java.nio.ByteBuffer
+import java.text.SimpleDateFormat
+import java.util.Date
 import java.util.concurrent.Executors
-
-import akka.actor._
-import akka.remote.artery.MaxThroughputSpec._
-import akka.remote.testconductor.RoleName
-import akka.remote.testkit.{ MultiNodeConfig, PerfFlamesSupport }
-import akka.remote.{ RemoteActorRefProvider, RemotingMultiNodeSpec }
-import akka.testkit._
-import com.typesafe.config.ConfigFactory
+import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import scala.concurrent.duration._
+import akka.actor._
+import akka.remote.{ RARP, RemoteActorRefProvider, RemotingMultiNodeSpec }
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.remote.testkit.PerfFlamesSupport
+import akka.remote.testkit.STMultiNodeSpec
+import akka.serialization.ByteBufferSerializer
+import akka.serialization.SerializerWithStringManifest
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
+import akka.remote.artery.compress.CompressionProtocol.Events.ReceivedActorRefCompressionTable
+import akka.remote.artery.MaxThroughputSpec._
 
 object FanInThroughputSpec extends MultiNodeConfig {
   val totalNumberOfNodes =


### PR DESCRIPTION
Reverts akka/akka#25003

This doesn't work on jenkins multi node job so reverting for now.