### PR TITLE
Fix BoundedBlockingQueueSpec against spurious wakeups

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/BoundedBlockingQueueSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/BoundedBlockingQueueSpec.scala
@@ -118,7 +118,7 @@ class BoundedBlockingQueueSpec
         queue.take()
       }
 
-      Await.result(f, 100 milliseconds)
+      Await.result(f, 3 seconds)
       events should contain inOrder (offer("a"), poll, offer("b"))
     }
 
@@ -177,7 +177,7 @@ class BoundedBlockingQueueSpec
         queue.put("a")
       }
 
-      Await.ready(f, 100 milliseconds)
+      Await.ready(f, 3 seconds)
       events should contain inOrder (awaitNotEmpty, offer("a"), poll)
     }
 
@@ -277,7 +277,7 @@ class BoundedBlockingQueueSpec
         f.isCompleted should be(false)
         queue.take()
       }
-      Await.result(f, 100 milliseconds) should equal(true)
+      Await.result(f, 3 seconds) should equal(true)
       events should contain inOrder (awaitNotFull, signalNotFull, offer("World"))
     }
 
@@ -384,7 +384,7 @@ class BoundedBlockingQueueSpec
         f.isCompleted should be(false)
         queue.put("Hello")
       }
-      Await.result(f, 100 milliseconds) should equal("Hello")
+      Await.result(f, 3 seconds) should equal("Hello")
       events should contain inOrder (awaitNotEmpty, signalNotEmpty, poll)
     }
   }

--- a/akka-actor-tests/src/test/scala/akka/util/BoundedBlockingQueueSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/BoundedBlockingQueueSpec.scala
@@ -47,7 +47,7 @@ class BoundedBlockingQueueSpec
       }
     }
 
-    "accept and empty backing Queue" in {
+    "accept an empty backing Queue" in {
       new BoundedBlockingQueue(10, new util.LinkedList()).size() should equal(0)
     }
 
@@ -57,11 +57,10 @@ class BoundedBlockingQueueSpec
       }
     }
 
-    "check remainingCapacity for BlockingQueue" in {
+    "not accept a backing queue with lower capacity" in {
       intercept[IllegalArgumentException] {
-        new BoundedBlockingQueue(0, new LinkedBlockingQueue(1))
+        new BoundedBlockingQueue(2, new LinkedBlockingQueue(1))
       }
-      new BoundedBlockingQueue(1, new LinkedBlockingQueue(1)).remainingCapacity() should equal(1)
     }
 
   }
@@ -115,6 +114,7 @@ class BoundedBlockingQueueSpec
       val f = Future(queue.put("b"))
 
       after(10 milliseconds) {
+        f.isCompleted should be(false)
         queue.take()
       }
 
@@ -130,6 +130,7 @@ class BoundedBlockingQueueSpec
       val f = Future(queue.put("b"))
 
       after(10 milliseconds) {
+        f.isCompleted should be(false)
         lock.lockInterruptibly()
         notFull.signal()
         lock.unlock()
@@ -172,6 +173,7 @@ class BoundedBlockingQueueSpec
 
       val f = Future(queue.take())
       after(10 milliseconds) {
+        f.isCompleted should be(false)
         queue.put("a")
       }
 
@@ -187,6 +189,7 @@ class BoundedBlockingQueueSpec
 
       // Cause `notFull` signal, but don't fill the queue
       after(10 milliseconds) {
+        f.isCompleted should be(false)
         lock.lockInterruptibly()
         notEmpty.signal()
         lock.unlock()
@@ -249,6 +252,7 @@ class BoundedBlockingQueueSpec
 
       val f = Future(queue.offer("World", 100, TimeUnit.MILLISECONDS))
       after(10 milliseconds) {
+        f.isCompleted should be(false)
         notFull.advanceTime(99 milliseconds)
       }
       mustBlockFor(100 milliseconds, f)
@@ -270,6 +274,7 @@ class BoundedBlockingQueueSpec
       val f = Future(queue.offer("World", 100, TimeUnit.MILLISECONDS))
       notFull.advanceTime(99 milliseconds)
       after(50 milliseconds) {
+        f.isCompleted should be(false)
         queue.take()
       }
       Await.result(f, 100 milliseconds) should equal(true)
@@ -284,6 +289,7 @@ class BoundedBlockingQueueSpec
 
       // Cause `notFull` signal, but don't fill the queue
       after(10 milliseconds) {
+        f.isCompleted should be(false)
         lock.lockInterruptibly()
         notFull.signal()
         lock.unlock()
@@ -346,6 +352,7 @@ class BoundedBlockingQueueSpec
       val f = Future(queue.poll(100, TimeUnit.MILLISECONDS))
 
       after(10 milliseconds) {
+        f.isCompleted should be(false)
         notEmpty.advanceTime(99 milliseconds)
       }
       mustBlockFor(100 milliseconds, f)
@@ -374,6 +381,7 @@ class BoundedBlockingQueueSpec
 
       notEmpty.advanceTime(99 milliseconds)
       after(50 milliseconds) {
+        f.isCompleted should be(false)
         queue.put("Hello")
       }
       Await.result(f, 100 milliseconds) should equal("Hello")

--- a/akka-actor-tests/src/test/scala/akka/util/BoundedBlockingQueueSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/BoundedBlockingQueueSpec.scala
@@ -758,7 +758,7 @@ trait QueueSetupHelper {
         } catch {
           case e: InterruptedException ⇒
         }
-        0
+        waitTime
       }
     }
 


### PR DESCRIPTION
So I think I found the issue for the failing test in #24991.
The test can only fail in the way it did if the call to [`offer(...)`](https://github.com/akka/akka/blob/master/akka-actor-tests/src/test/scala/akka/util/BoundedBlockingQueueSpec.scala#L270) times out. This in turn can only be caused when [`awaitNanos(...)`](https://github.com/akka/akka/blob/master/akka-actor-tests/src/test/scala/akka/util/BoundedBlockingQueueSpec.scala#L748) in the mocked `Condition` returns `0`. Previously it did this as soon as the `await()` returned. Since this can happen unexpectedly in the case of a spurious wakeup, I fixed it by returning the remaining time to wait instead.

This is a bit tricky though since I can't reproduce the issue locally (tried to run the test *lots* of times, no failures came up), so I can only kind of guess. 

Maybe someone can confirm whether this makes sense or whether I'm missing something. 
(I also fixed some review comments from the previous PR in the second commit)

Fixes #24991 