### PR TITLE
Allow stack traces for warning logging

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/event/LoggerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggerSpec.scala
@@ -192,6 +192,22 @@ class LoggerSpec extends WordSpec with Matchers {
       logMessages.size should ===(3)
     }
 
+    "log an exception along with a warning" in {
+      val out = new java.io.ByteArrayOutputStream()
+      Console.withOut(out) {
+        val sys = ActorSystem("defaultLogger", defaultConfig)
+        sys.log.warning(new NullPointerException(), "msg1")
+        TestKit.shutdownActorSystem(sys, verifySystemShutdown = true)
+        out.flush()
+        out.close()
+      }
+
+      val logMessages = new String(out.toByteArray)
+      logMessages should include("msg1")
+      logMessages should include("NullPointerException")
+      logMessages should include("at akka.event.LoggerSpec")
+    }
+
   }
 
   "An actor system configured with the logging turned off" must {

--- a/akka-actor/src/main/mima-filters/2.5.12.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.12.backwards.excludes
@@ -1,0 +1,2 @@
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.event.LoggingAdapter.warning")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.event.LoggingAdapter.notifyWarning")

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -1104,7 +1104,6 @@ object Logging {
  * More than four arguments can be defined by using an `Array` with the method with
  * one argument parameter.
  */
-@DoNotInherit
 trait LoggingAdapter {
 
   type MDC = Logging.MDC
@@ -1126,7 +1125,8 @@ trait LoggingAdapter {
   protected def notifyError(message: String): Unit
   protected def notifyError(cause: Throwable, message: String): Unit
   protected def notifyWarning(message: String): Unit
-  protected def notifyWarning(cause: Throwable, message: String): Unit
+  // Default implementation for backwards compatibility
+  protected def notifyWarning(cause: Throwable, message: String): Unit = notifyWarning(message)
   protected def notifyInfo(message: String): Unit
   protected def notifyDebug(message: String): Unit
 
@@ -1768,17 +1768,17 @@ class BusLogging(val bus: LoggingBus, val logSource: String, val logClass: Class
   def isInfoEnabled = loggingFilter.isInfoEnabled(logClass, logSource)
   def isDebugEnabled = loggingFilter.isDebugEnabled(logClass, logSource)
 
-  protected def notifyError(message: String): Unit =
+  override protected def notifyError(message: String): Unit =
     bus.publish(Error(logSource, logClass, message, mdc))
-  protected def notifyError(cause: Throwable, message: String): Unit =
+  override protected def notifyError(cause: Throwable, message: String): Unit =
     bus.publish(Error(cause, logSource, logClass, message, mdc))
-  protected def notifyWarning(message: String): Unit =
+  override protected def notifyWarning(message: String): Unit =
     bus.publish(Warning(logSource, logClass, message, mdc))
-  protected def notifyWarning(cause: Throwable, message: String): Unit =
+  override protected def notifyWarning(cause: Throwable, message: String): Unit =
     bus.publish(Warning(cause, logSource, logClass, message, mdc))
-  protected def notifyInfo(message: String): Unit =
+  override protected def notifyInfo(message: String): Unit =
     bus.publish(Info(logSource, logClass, message, mdc))
-  protected def notifyDebug(message: String): Unit =
+  override protected def notifyDebug(message: String): Unit =
     bus.publish(Debug(logSource, logClass, message, mdc))
 }
 

--- a/akka-contrib/src/main/scala/akka/contrib/jul/JavaLogger.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/jul/JavaLogger.scala
@@ -74,19 +74,22 @@ trait JavaLoggingAdapter extends LoggingAdapter {
 
   def isDebugEnabled = logger.isLoggable(logging.Level.CONFIG)
 
-  protected def notifyError(message: String): Unit =
+  override protected def notifyError(message: String): Unit =
     log(logging.Level.SEVERE, null, message)
 
-  protected def notifyError(cause: Throwable, message: String): Unit =
+  override protected def notifyError(cause: Throwable, message: String): Unit =
     log(logging.Level.SEVERE, cause, message)
 
-  protected def notifyWarning(message: String): Unit =
+  override protected def notifyWarning(message: String): Unit =
     log(logging.Level.WARNING, null, message)
 
-  protected def notifyInfo(message: String): Unit =
+  override protected def notifyWarning(cause: Throwable, message: String): Unit =
+    log(logging.Level.WARNING, cause, message)
+
+  override protected def notifyInfo(message: String): Unit =
     log(logging.Level.INFO, null, message)
 
-  protected def notifyDebug(message: String): Unit =
+  override protected def notifyDebug(message: String): Unit =
     log(logging.Level.CONFIG, null, message)
 
   @inline


### PR DESCRIPTION
I don't think LoggingAdapter was intended to be subclassed, right? We could
provide a default implementation to `notifyWarning(cause, message)` that just
calls `notifyWarning(message)` to be safer in terms of bincompat, but it
doesn't seem worth it.