### PR TITLE
Add convenient version of recover, recoverWith and recoverWithRetries for javadsl.Flow

### DIFF
--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
@@ -751,7 +751,7 @@ public class FlowTest extends StreamTest {
         })
         .recover(
             RuntimeException.class,
-            0
+            () -> 0
         );
 
     final CompletionStage<Done> future =
@@ -816,7 +816,7 @@ public class FlowTest extends StreamTest {
         })
         .recoverWith(
           RuntimeException.class,
-          Source.from(recover));
+          () -> Source.from(recover));
 
     final CompletionStage<Done> future =
         source.via(flow).runWith(Sink.foreach(elem -> probe.getRef().tell(elem, ActorRef.noSender())), materializer);
@@ -881,7 +881,7 @@ public class FlowTest extends StreamTest {
           .recoverWithRetries(
               3,
               RuntimeException.class,
-              Source.from(recover));
+              () -> Source.from(recover));
 
       final CompletionStage<Done> future =
           source.via(flow).runWith(Sink.foreach(elem -> probe.getRef().tell(elem, ActorRef.noSender())), materializer);

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
@@ -107,7 +107,7 @@ public class FlowTest extends StreamTest {
 
     probe.expectMsgEquals(2);
     probe.expectMsgEquals(3);
-    future.toCompletableFuture().get(200, TimeUnit.MILLISECONDS);
+    future.toCompletableFuture().get(3, TimeUnit.SECONDS);
   }
 
   @Test
@@ -150,7 +150,7 @@ public class FlowTest extends StreamTest {
     probe.expectMsgEquals(",");
     probe.expectMsgEquals("3");
     probe.expectMsgEquals("]");
-    future.toCompletableFuture().get(200, TimeUnit.MILLISECONDS);
+    future.toCompletableFuture().get(3, TimeUnit.SECONDS);
   }
 
   @Test
@@ -170,7 +170,7 @@ public class FlowTest extends StreamTest {
     probe.expectMsgEquals("2");
     probe.expectMsgEquals(",");
     probe.expectMsgEquals("3");
-    future.toCompletableFuture().get(200, TimeUnit.MILLISECONDS);
+    future.toCompletableFuture().get(3, TimeUnit.SECONDS);
   }
 
   @Test
@@ -193,7 +193,7 @@ public class FlowTest extends StreamTest {
     FiniteDuration duration = Duration.apply(200, TimeUnit.MILLISECONDS);
 
     probe.expectNoMsg(duration);
-    future.toCompletableFuture().get(200, TimeUnit.MILLISECONDS);
+    future.toCompletableFuture().get(3, TimeUnit.SECONDS);
   }
 
 
@@ -387,7 +387,7 @@ public class FlowTest extends StreamTest {
     final Publisher<String> pub = source.runWith(publisher, materializer);
     final CompletionStage<List<String>> all = Source.fromPublisher(pub).limit(100).runWith(Sink.<String>seq(), materializer);
 
-    final List<String> result = all.toCompletableFuture().get(200, TimeUnit.MILLISECONDS);
+    final List<String> result = all.toCompletableFuture().get(3, TimeUnit.SECONDS);
     assertEquals(new HashSet<Object>(Arrays.asList("a", "b", "c", "d", "e", "f")), new HashSet<String>(result));
   }
 
@@ -436,7 +436,7 @@ public class FlowTest extends StreamTest {
     final Publisher<String> pub = source.runWith(publisher, materializer);
     final CompletionStage<List<String>> all = Source.fromPublisher(pub).limit(100).runWith(Sink.<String>seq(), materializer);
 
-    final List<String> result = all.toCompletableFuture().get(200, TimeUnit.MILLISECONDS);
+    final List<String> result = all.toCompletableFuture().get(3, TimeUnit.SECONDS);
     assertEquals(new HashSet<Object>(Arrays.asList("a", "b", "c", "d", "e", "f")), new HashSet<String>(result));
   }
 
@@ -735,7 +735,7 @@ public class FlowTest extends StreamTest {
     probe.expectMsgEquals(1);
     s.sendNext(2);
     probe.expectMsgEquals(0);
-    future.toCompletableFuture().get(200, TimeUnit.MILLISECONDS);
+    future.toCompletableFuture().get(3, TimeUnit.SECONDS);
   }
 
   @Test
@@ -765,7 +765,7 @@ public class FlowTest extends StreamTest {
     probe.expectMsgEquals(1);
     s.sendNext(2);
     probe.expectMsgEquals(0);
-    future.toCompletableFuture().get(200, TimeUnit.MILLISECONDS);
+    future.toCompletableFuture().get(3, TimeUnit.SECONDS);
   }
 
   @Test
@@ -799,7 +799,7 @@ public class FlowTest extends StreamTest {
     s.sendNext(2);
     probe.expectMsgEquals(55);
     probe.expectMsgEquals(0);
-    future.toCompletableFuture().get(200, TimeUnit.MILLISECONDS);
+    future.toCompletableFuture().get(3, TimeUnit.SECONDS);
   }
 
   @Test
@@ -830,7 +830,7 @@ public class FlowTest extends StreamTest {
     s.sendNext(2);
     probe.expectMsgEquals(55);
     probe.expectMsgEquals(0);
-    future.toCompletableFuture().get(200, TimeUnit.MILLISECONDS);
+    future.toCompletableFuture().get(3, TimeUnit.SECONDS);
   }
 
   @Test
@@ -863,7 +863,7 @@ public class FlowTest extends StreamTest {
     s.sendNext(2);
     probe.expectMsgEquals(55);
     probe.expectMsgEquals(0);
-    future.toCompletableFuture().get(200, TimeUnit.MILLISECONDS);
+    future.toCompletableFuture().get(3, TimeUnit.SECONDS);
   }
 
     @Test
@@ -895,7 +895,7 @@ public class FlowTest extends StreamTest {
       s.sendNext(2);
       probe.expectMsgEquals(55);
       probe.expectMsgEquals(0);
-      future.toCompletableFuture().get(200, TimeUnit.MILLISECONDS);
+      future.toCompletableFuture().get(3, TimeUnit.SECONDS);
     }
 
   @Test

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -4,21 +4,21 @@
 
 package akka.stream.javadsl
 
-import akka.util.{ ConstantFun, Timeout }
-import akka.{ Done, NotUsed }
+import akka.util.{ConstantFun, Timeout}
+import akka.{Done, NotUsed}
 import akka.event.LoggingAdapter
-import akka.japi.{ Pair, function }
+import akka.japi.{JavaPartialFunction, Pair, Util, function}
 import akka.stream._
 import org.reactivestreams.Processor
 
 import scala.concurrent.duration.FiniteDuration
-import akka.japi.Util
-import java.util.{ Comparator, Optional }
+import java.util.{Comparator, Optional}
 import java.util.concurrent.CompletionStage
-import akka.util.JavaDurationConverters._
 
+import akka.util.JavaDurationConverters._
 import akka.actor.ActorRef
 import akka.dispatch.ExecutionContexts
+import akka.japi.pf.{FI, PFBuilder}
 import akka.stream.impl.fusing.LazyFlow
 
 import scala.annotation.unchecked.uncheckedVariance
@@ -1314,6 +1314,33 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     new Flow(delegate.recover(pf))
 
   /**
+    * Recover allows to send last element on failure and gracefully complete the stream
+    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+    *
+    * Throwing an exception inside `recover` _will_ be logged on ERROR level automatically.
+    *
+    * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
+    *
+    * '''Backpressures when''' downstream backpressures
+    *
+    * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+    *
+    * '''Cancels when''' downstream cancels
+    */
+  def recover(clazz: Class[_ <: Throwable], out: Out): javadsl.Flow[In, Out, Mat] = {
+    import JavaPartialFunction._
+
+    val pf = new JavaPartialFunction[Throwable, Out] {
+      override def apply(x: Throwable, isCheck: Boolean): Out =
+        if (x.getClass == clazz) out
+        else throw noMatch()
+    }
+
+    recover(pf)
+  }
+
+  /**
    * While similar to [[recover]] this stage can be used to transform an error signal to a different one *without* logging
    * it as an error in the process. So in that sense it is NOT exactly equivalent to `recover(t => throw t2)` since recover
    * would log the `t2` error.
@@ -1360,6 +1387,42 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     new Flow(delegate.recoverWith(pf))
 
   /**
+    * RecoverWith allows to switch to alternative Source on flow failure. It will stay in effect after
+    * a failure has been recovered so that each time there is a failure it is fed into the `pf` and a new
+    * Source may be materialized.
+    *
+    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+    *
+    * Throwing an exception inside `recoverWith` _will_ be logged on ERROR level automatically.
+    *
+    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
+    * from alternative Source
+    *
+    * '''Backpressures when''' downstream backpressures
+    *
+    * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+    *
+    * '''Cancels when''' downstream cancels
+    *
+    */
+  @deprecated("Use recoverWithRetries instead.", "2.4.4")
+  def recoverWith(clazz: Class[_ <: Throwable], graph: Graph[SourceShape[Out], NotUsed]): javadsl.Flow[In, Out, Mat] = {
+    import JavaPartialFunction._
+
+    val pf = new JavaPartialFunction[Throwable, Graph[SourceShape[Out], NotUsed]] {
+      override def apply(x: Throwable, isCheck: Boolean): Graph[SourceShape[Out], NotUsed] =
+        if (x.getClass == clazz) {
+          if (isCheck) null
+          else graph
+        }
+        else throw noMatch()
+    }
+
+    recoverWith(pf)
+  }
+
+  /**
    * RecoverWithRetries allows to switch to alternative Source on flow failure. It will stay in effect after
    * a failure has been recovered up to `attempts` number of times so that each time there is a failure
    * it is fed into the `pf` and a new Source may be materialized. Note that if you pass in 0, this won't
@@ -1386,6 +1449,47 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    */
   def recoverWithRetries(attempts: Int, pf: PartialFunction[Throwable, Graph[SourceShape[Out], NotUsed]]): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.recoverWithRetries(attempts, pf))
+
+  /**
+    * RecoverWithRetries allows to switch to alternative Source on flow failure. It will stay in effect after
+    * a failure has been recovered up to `attempts` number of times so that each time there is a failure
+    * it is fed into the `pf` and a new Source may be materialized. Note that if you pass in 0, this won't
+    * attempt to recover at all.
+    *
+    * A negative `attempts` number is interpreted as "infinite", which results in the exact same behavior as `recoverWith`.
+    *
+    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+    *
+    * Throwing an exception inside `recoverWithRetries` _will_ be logged on ERROR level automatically.
+    *
+    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
+    * from alternative Source
+    *
+    * '''Backpressures when''' downstream backpressures
+    *
+    * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+    *
+    * '''Cancels when''' downstream cancels
+    *
+    * @param attempts Maximum number of retries or -1 to retry indefinitely
+    * @param clazz the class object of the failure cause
+    * @param graph the new Source to be materialized
+    */
+  def recoverWithRetries(attempts: Int, clazz: Class[_ <: Throwable], graph: Graph[SourceShape[Out], NotUsed]): javadsl.Flow[In, Out, Mat] = {
+    import JavaPartialFunction._
+
+    val pf = new JavaPartialFunction[Throwable, Graph[SourceShape[Out], NotUsed]] {
+      override def apply(x: Throwable, isCheck: Boolean): Graph[SourceShape[Out], NotUsed] =
+        if (x.getClass == clazz) {
+          if (isCheck) null
+          else graph
+        }
+        else throw noMatch()
+    }
+
+    recoverWithRetries(attempts, pf)
+  }
 
   /**
    * Terminate processing (and cancel the upstream publisher) after the given

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1313,20 +1313,20 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     new Flow(delegate.recover(pf))
 
   /**
-    * Recover allows to send last element on failure and gracefully complete the stream
-    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
-    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
-    *
-    * Throwing an exception inside `recover` _will_ be logged on ERROR level automatically.
-    *
-    * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
-    *
-    * '''Backpressures when''' downstream backpressures
-    *
-    * '''Completes when''' upstream completes or upstream failed with exception pf can handle
-    *
-    * '''Cancels when''' downstream cancels
-    */
+   * Recover allows to send last element on failure and gracefully complete the stream
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Throwing an exception inside `recover` _will_ be logged on ERROR level automatically.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   */
   def recover(clazz: Class[_ <: Throwable], out: Out): javadsl.Flow[In, Out, Mat] =
     recover {
       case elem if clazz.isInstance(elem) ⇒ out
@@ -1379,25 +1379,25 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     new Flow(delegate.recoverWith(pf))
 
   /**
-    * RecoverWith allows to switch to alternative Source on flow failure. It will stay in effect after
-    * a failure has been recovered so that each time there is a failure it is fed into the `pf` and a new
-    * Source may be materialized.
-    *
-    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
-    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
-    *
-    * Throwing an exception inside `recoverWith` _will_ be logged on ERROR level automatically.
-    *
-    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
-    * from alternative Source
-    *
-    * '''Backpressures when''' downstream backpressures
-    *
-    * '''Completes when''' upstream completes or upstream failed with exception pf can handle
-    *
-    * '''Cancels when''' downstream cancels
-    *
-    */
+   * RecoverWith allows to switch to alternative Source on flow failure. It will stay in effect after
+   * a failure has been recovered so that each time there is a failure it is fed into the `pf` and a new
+   * Source may be materialized.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Throwing an exception inside `recoverWith` _will_ be logged on ERROR level automatically.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and element is available
+   * from alternative Source
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   */
   @deprecated("Use recoverWithRetries instead.", "2.4.4")
   def recoverWith(clazz: Class[_ <: Throwable], graph: Graph[SourceShape[Out], NotUsed]): javadsl.Flow[In, Out, Mat] =
     recoverWith {
@@ -1433,31 +1433,31 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     new Flow(delegate.recoverWithRetries(attempts, pf))
 
   /**
-    * RecoverWithRetries allows to switch to alternative Source on flow failure. It will stay in effect after
-    * a failure has been recovered up to `attempts` number of times so that each time there is a failure
-    * it is fed into the `pf` and a new Source may be materialized. Note that if you pass in 0, this won't
-    * attempt to recover at all.
-    *
-    * A negative `attempts` number is interpreted as "infinite", which results in the exact same behavior as `recoverWith`.
-    *
-    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
-    * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
-    *
-    * Throwing an exception inside `recoverWithRetries` _will_ be logged on ERROR level automatically.
-    *
-    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
-    * from alternative Source
-    *
-    * '''Backpressures when''' downstream backpressures
-    *
-    * '''Completes when''' upstream completes or upstream failed with exception pf can handle
-    *
-    * '''Cancels when''' downstream cancels
-    *
-    * @param attempts Maximum number of retries or -1 to retry indefinitely
-    * @param clazz the class object of the failure cause
-    * @param graph the new Source to be materialized
-    */
+   * RecoverWithRetries allows to switch to alternative Source on flow failure. It will stay in effect after
+   * a failure has been recovered up to `attempts` number of times so that each time there is a failure
+   * it is fed into the `pf` and a new Source may be materialized. Note that if you pass in 0, this won't
+   * attempt to recover at all.
+   *
+   * A negative `attempts` number is interpreted as "infinite", which results in the exact same behavior as `recoverWith`.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This stage can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Throwing an exception inside `recoverWithRetries` _will_ be logged on ERROR level automatically.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and element is available
+   * from alternative Source
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @param attempts Maximum number of retries or -1 to retry indefinitely
+   * @param clazz the class object of the failure cause
+   * @param graph the new Source to be materialized
+   */
   def recoverWithRetries(attempts: Int, clazz: Class[_ <: Throwable], graph: Graph[SourceShape[Out], NotUsed]): javadsl.Flow[In, Out, Mat] =
     recoverWithRetries(attempts, {
       case elem if clazz.isInstance(elem) ⇒ graph

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -5,7 +5,7 @@
 package akka.stream.javadsl
 
 import akka.util.{ ConstantFun, Timeout }
-import akka.{Done, NotUsed}
+import akka.{ Done, NotUsed }
 import akka.event.LoggingAdapter
 import akka.japi.{ Pair, Util, function }
 import akka.stream._


### PR DESCRIPTION
* The new method take a Class parameter to decide which failure to recover from.
* Also add corresponding unit tests for them.

Fix #24888.