### PR TITLE
Typed persistent event adapters/wrappers

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -11,7 +11,7 @@ import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.internal.{ ActorTestKitGuardian, TestKitUtils }
 import com.typesafe.config.{ Config, ConfigFactory }
 
-import scala.concurrent.Await
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
 object ActorTestKit {
@@ -115,6 +115,11 @@ trait ActorTestKit {
    */
   final def spawn[T](behavior: Behavior[T], name: String): ActorRef[T] =
     spawn(behavior, name, Props.empty)
+
+  final def stop[T](actorRef: ActorRef[T]): Unit = {
+    val x: Future[ActorTestKitGuardian.Ack.type] = internalSystem ? (ActorTestKitGuardian.StopActor(actorRef, _))
+    Await.result(x, timeout.duration)
+  }
 
   /**
    * Spawn the given behavior. This is created as a child of the test kit

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -117,14 +117,6 @@ trait ActorTestKit {
     spawn(behavior, name, Props.empty)
 
   /**
-   * Stop an actor previously created with spawn.
-   */
-  final def stop[T](actorRef: ActorRef[T]): Unit = {
-    val x: Future[ActorTestKitGuardian.Ack.type] = internalSystem ? (ActorTestKitGuardian.StopActor(actorRef, _))
-    Await.result(x, timeout.duration)
-  }
-
-  /**
    * Spawn the given behavior. This is created as a child of the test kit
    * guardian
    */

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -116,6 +116,9 @@ trait ActorTestKit {
   final def spawn[T](behavior: Behavior[T], name: String): ActorRef[T] =
     spawn(behavior, name, Props.empty)
 
+  /**
+   * Stop an actor previously created with spawn.
+   */
   final def stop[T](actorRef: ActorRef[T]): Unit = {
     val x: Future[ActorTestKitGuardian.Ack.type] = internalSystem ? (ActorTestKitGuardian.StopActor(actorRef, _))
     Await.result(x, timeout.duration)

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/ExtensionsTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/ExtensionsTest.java
@@ -4,14 +4,12 @@
 
 package akka.actor.typed;
 
-import akka.actor.*;
 import akka.actor.setup.ActorSystemSetup;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 import static junit.framework.TestCase.assertSame;
@@ -106,6 +104,5 @@ public class ExtensionsTest extends JUnitSuite {
       system.terminate();
     }
   }
-
 
 }

--- a/akka-actor/src/main/scala/akka/util/ConstantFun.scala
+++ b/akka-actor/src/main/scala/akka/util/ConstantFun.scala
@@ -29,6 +29,7 @@ import akka.japi.{ Pair ⇒ JPair }
   def scalaAnyToNone[A, B]: A ⇒ Option[B] = none
   def scalaAnyTwoToNone[A, B, C]: (A, B) ⇒ Option[C] = two2none
   def scalaAnyTwoToUnit[A, B]: (A, B) ⇒ Unit = two2unit
+  def scalaAnyThreeToUnit[A, B, C]: (A, B, C) ⇒ Unit = three2unit
   def scalaAnyTwoToTrue[A, B]: (A, B) ⇒ Boolean = two2true
   def scalaAnyThreeToFalse[A, B, C]: (A, B, C) ⇒ Boolean = three2false
   def scalaAnyThreeToThird[A, B, C]: (A, B, C) ⇒ C = three2third.asInstanceOf[(A, B, C) ⇒ C]
@@ -52,6 +53,8 @@ import akka.japi.{ Pair ⇒ JPair }
   private val two2true = (_: Any, _: Any) ⇒ true
 
   private val two2unit = (_: Any, _: Any) ⇒ ()
+
+  private val three2unit = (_: Any, _: Any, _: Any) ⇒ ()
 
   private val three2false = (_: Any, _: Any, _: Any) ⇒ false
 

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -233,7 +233,29 @@ Scala
 Java
 :  @@snip [BasicPersistentBehaviorsTest.java]($akka$/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorsTest.java) { #tagging }
 
+## Event adapters
+
+Event adapters can be programmatically added to your `PersistentBehavior`s that can convert from your `Event` type
+to another type that is then passed to the journal.
+
+Defining an event adapter is done by extending an EventAdapter:
+
+Scala
+:  @@snip [x]($akka$/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorSpec.scala) { #event-wrapper }
+
+Java
+:  @@snip [x]($akka$/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java) { #event-wrapper }
+
+Then install it on a persistent behavior:
+
+Scala
+:  @@snip [x]($akka$/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorSpec.scala) { #install-event-adapter }
+
+Java
+:  @@snip [x]($akka$/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java) { #install-event-adapter }
+
 ## Wrapping Persistent Behaviors
+
 When creating a `PersistentBehavior`, it is possible to wrap `PersistentBehavior` in
 other behaviors such as `Behaviors.setup` in order to access the `ActorContext` object. For instance
 to access the actor logging upon taking snapshots for debug purpose.

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -30,7 +30,7 @@ This module is currently marked as @ref:[may change](../common/may-change.md) in
 Let's start with a simple example. The minimum required for a `PersistentBehavior` is:
 
 Scala
-:  @@snip [BasicPersistentBehaviorsSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala) { #structure }
+:  @@snip [BasicPersistentBehaviorsCompileOnly.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsCompileOnly.scala) { #structure }
 
 Java
 :  @@snip [BasicPersistentBehaviorsTest.java]($akka$/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorsTest.java) { #structure }
@@ -216,7 +216,7 @@ Since it is strongly discouraged to perform side effects in applyEvent,
 side effects should be performed once recovery has completed @scala[in the `onRecoveryCompleted` callback.] @java[by overriding `onRecoveryCompleted`]
 
 Scala
-:  @@snip [BasicPersistentBehaviorsSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala) { #recovery }
+:  @@snip [BasicPersistentBehaviorsCompileOnly.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsCompileOnly.scala) { #recovery }
 
 Java
 :  @@snip [BasicPersistentBehaviorsTest.java]($akka$/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorsTest.java) { #recovery }
@@ -228,7 +228,7 @@ The `onRecoveryCompleted` takes on an `ActorContext` and the current `State`.
 Persistence typed allows you to use event tags without using @ref[`EventAdapter`](../persistence.md#event-adapters):
 
 Scala
-:  @@snip [BasicPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala) { #tagging }
+:  @@snip [BasicPersistentActorCompileOnly.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsCompileOnly.scala) { #tagging }
 
 Java
 :  @@snip [BasicPersistentBehaviorsTest.java]($akka$/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorsTest.java) { #tagging }
@@ -239,7 +239,7 @@ other behaviors such as `Behaviors.setup` in order to access the `ActorContext` 
 to access the actor logging upon taking snapshots for debug purpose.
 
 Scala
-:  @@snip [BasicPersistentActorSpec.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala) { #wrapPersistentBehavior }
+:  @@snip [BasicPersistentActorCompileOnly.scala]($akka$/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsCompileOnly.scala) { #wrapPersistentBehavior }
 
 Java
 :  @@snip [BasicPersistentBehaviorsTest.java]($akka$/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorsTest.java) { #wrapPersistentBehavior }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/EventAdapter.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/EventAdapter.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed
+
+import akka.annotation.InternalApi
+
+abstract class EventAdapter[E, P] {
+  /**
+   * Type of the event to persist
+   */
+  type Per = P
+  /**
+   * Transform event on the way to the journal
+   */
+  def toJournal(e: E): Per
+
+  /**
+   * Transform the event on recovery from the journal.
+   * Note that this is not called in any read side so will need to be applied
+   * manually when using Query.
+   */
+  def fromJournal(p: Per): E
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object NoOpEventAdapter {
+  private val i = new NoOpEventAdapter[Nothing]
+  def instance[E]: NoOpEventAdapter[E] = i.asInstanceOf[NoOpEventAdapter[E]]
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] class NoOpEventAdapter[E] extends EventAdapter[E, Any] {
+  override def toJournal(e: E): Any = e
+  override def fromJournal(p: Any): E = p.asInstanceOf[E]
+}
+

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedReplayingEvents.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedReplayingEvents.scala
@@ -79,7 +79,7 @@ private[persistence] class EventsourcedReplayingEvents[C, E, S](override val set
     try {
       response match {
         case ReplayedMessage(repr) ⇒
-          val event = setup.eventAdapter.fromJournal(repr.payload.asInstanceOf[setup.eventAdapter.P])
+          val event = setup.eventAdapter.fromJournal(repr.payload.asInstanceOf[setup.eventAdapter.Per])
 
           try {
             val newState = state.copy(

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedReplayingEvents.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedReplayingEvents.scala
@@ -79,7 +79,7 @@ private[persistence] class EventsourcedReplayingEvents[C, E, S](override val set
     try {
       response match {
         case ReplayedMessage(repr) ⇒
-          val event = setup.wrapper.fromJournal(repr.payload.asInstanceOf[setup.wrapper.P])
+          val event = setup.eventAdapter.fromJournal(repr.payload.asInstanceOf[setup.eventAdapter.P])
 
           try {
             val newState = state.copy(

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedReplayingEvents.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedReplayingEvents.scala
@@ -79,7 +79,7 @@ private[persistence] class EventsourcedReplayingEvents[C, E, S](override val set
     try {
       response match {
         case ReplayedMessage(repr) ⇒
-          val event = repr.payload.asInstanceOf[E]
+          val event = setup.wrapper.fromJournal(repr.payload.asInstanceOf[setup.wrapper.P])
 
           try {
             val newState = state.copy(

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedRunning.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedRunning.scala
@@ -99,7 +99,8 @@ private[akka] object EventsourcedRunning {
           // the invalid event, in case such validation is implemented in the event handler.
           // also, ensure that there is an event handler for each single event
           val newState = state.applyEvent(setup, event)
-          val eventToPersist = tagEvent(event)
+
+          val eventToPersist = setup.wrapper.toJournal(event)
 
           val newState2 = internalPersist(newState, eventToPersist)
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedRunning.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedRunning.scala
@@ -12,12 +12,12 @@ import akka.annotation.InternalApi
 import akka.persistence.JournalProtocol._
 import akka.persistence._
 import akka.persistence.journal.Tagged
-import akka.persistence.typed.internal.EventsourcedBehavior.{InternalProtocol, MDC}
+import akka.persistence.typed.internal.EventsourcedBehavior.{ InternalProtocol, MDC }
 import akka.persistence.typed.internal.EventsourcedBehavior.InternalProtocol._
 
 import scala.annotation.tailrec
 import scala.collection.immutable
-import scala.util.{Failure, Success}
+import scala.util.{ Failure, Success }
 
 /**
  * INTERNAL API

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedRunning.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedRunning.scala
@@ -148,12 +148,11 @@ private[akka] object EventsourcedRunning {
 
     def adaptEvent(event: E): Any = {
       val tags = setup.tagger(event)
-      if (tags.isEmpty) {
-        setup.eventAdapter.toJournal(event)
-      } else {
-        // Tags always need to be on the outside as journals match on it
-        Tagged(setup.eventAdapter.toJournal(event), tags)
-      }
+      val adaptedEvent = setup.eventAdapter.toJournal(event)
+      if (tags.isEmpty)
+        adaptedEvent
+      else
+        Tagged(adaptedEvent, tags)
     }
 
     setup.setMdc(runningCmdsMdc)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSetup.scala
@@ -12,7 +12,7 @@ import akka.annotation.InternalApi
 import akka.persistence._
 import akka.persistence.typed.internal.EventsourcedBehavior.MDC
 import akka.persistence.typed.internal.EventsourcedBehavior.{ InternalProtocol, WriterIdentity }
-import akka.persistence.typed.scaladsl.{ EventTransformer, PersistentBehaviors }
+import akka.persistence.typed.scaladsl.{ EventAdapter, PersistentBehaviors }
 import akka.util.Collections.EmptyImmutableSeq
 import akka.util.OptionVal
 
@@ -33,7 +33,7 @@ private[persistence] final class EventsourcedSetup[C, E, S](
   val recoveryCompleted:     (ActorContext[C], S) ⇒ Unit,
   val onSnapshot:            (ActorContext[C], SnapshotMetadata, Try[Done]) ⇒ Unit,
   val tagger:                E ⇒ Set[String],
-  val wrapper:               EventTransformer[E],
+  val eventAdapter:          EventAdapter[E],
   val snapshotWhen:          (S, E, Long) ⇒ Boolean,
   val recovery:              Recovery,
   var holdingRecoveryPermit: Boolean,

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSetup.scala
@@ -6,13 +6,13 @@ package akka.persistence.typed.internal
 
 import akka.Done
 import akka.actor.typed.Logger
-import akka.actor.{ActorRef, ExtendedActorSystem}
-import akka.actor.typed.scaladsl.{ActorContext, StashBuffer, TimerScheduler}
+import akka.actor.{ ActorRef, ExtendedActorSystem }
+import akka.actor.typed.scaladsl.{ ActorContext, StashBuffer, TimerScheduler }
 import akka.annotation.InternalApi
 import akka.persistence._
 import akka.persistence.typed.internal.EventsourcedBehavior.MDC
-import akka.persistence.typed.internal.EventsourcedBehavior.{InternalProtocol, WriterIdentity}
-import akka.persistence.typed.scaladsl.{EventWrapper, PersistentBehaviors}
+import akka.persistence.typed.internal.EventsourcedBehavior.{ InternalProtocol, WriterIdentity }
+import akka.persistence.typed.scaladsl.{ EventTransformer, PersistentBehaviors }
 import akka.util.Collections.EmptyImmutableSeq
 import akka.util.OptionVal
 
@@ -31,9 +31,9 @@ private[persistence] final class EventsourcedSetup[C, E, S](
   val eventHandler:          (S, E) ⇒ S,
   val writerIdentity:        WriterIdentity,
   val recoveryCompleted:     (ActorContext[C], S) ⇒ Unit,
-  val onSnapshot:            (ActorContext[C], SnapshotMetadata, Try[Done]) => Unit,
+  val onSnapshot:            (ActorContext[C], SnapshotMetadata, Try[Done]) ⇒ Unit,
   val tagger:                E ⇒ Set[String],
-  val wrapper:               EventWrapper[E],
+  val wrapper:               EventTransformer[E],
   val snapshotWhen:          (S, E, Long) ⇒ Boolean,
   val recovery:              Recovery,
   var holdingRecoveryPermit: Boolean,

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSetup.scala
@@ -11,7 +11,7 @@ import akka.annotation.InternalApi
 import akka.persistence._
 import akka.persistence.typed.internal.EventsourcedBehavior.MDC
 import akka.persistence.typed.internal.EventsourcedBehavior.{ InternalProtocol, WriterIdentity }
-import akka.persistence.typed.scaladsl.PersistentBehaviors
+import akka.persistence.typed.scaladsl.{ EventWrapper, PersistentBehaviors }
 import akka.util.Collections.EmptyImmutableSeq
 import akka.util.OptionVal
 
@@ -29,6 +29,7 @@ private[persistence] final class EventsourcedSetup[C, E, S](
   val writerIdentity:        WriterIdentity,
   val recoveryCompleted:     (ActorContext[C], S) ⇒ Unit,
   val tagger:                E ⇒ Set[String],
+  val wrapper:               EventWrapper[E],
   val snapshotWhen:          (S, E, Long) ⇒ Boolean,
   val recovery:              Recovery,
   var holdingRecoveryPermit: Boolean,

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSetup.scala
@@ -4,16 +4,19 @@
 
 package akka.persistence.typed.internal
 
+import akka.Done
 import akka.actor.typed.Logger
-import akka.actor.{ ActorRef, ExtendedActorSystem }
-import akka.actor.typed.scaladsl.{ ActorContext, StashBuffer, TimerScheduler }
+import akka.actor.{ActorRef, ExtendedActorSystem}
+import akka.actor.typed.scaladsl.{ActorContext, StashBuffer, TimerScheduler}
 import akka.annotation.InternalApi
 import akka.persistence._
 import akka.persistence.typed.internal.EventsourcedBehavior.MDC
-import akka.persistence.typed.internal.EventsourcedBehavior.{ InternalProtocol, WriterIdentity }
-import akka.persistence.typed.scaladsl.{ EventWrapper, PersistentBehaviors }
+import akka.persistence.typed.internal.EventsourcedBehavior.{InternalProtocol, WriterIdentity}
+import akka.persistence.typed.scaladsl.{EventWrapper, PersistentBehaviors}
 import akka.util.Collections.EmptyImmutableSeq
 import akka.util.OptionVal
+
+import scala.util.Try
 
 /**
  * INTERNAL API: Carry state for the Persistent behavior implementation behaviors
@@ -28,6 +31,7 @@ private[persistence] final class EventsourcedSetup[C, E, S](
   val eventHandler:          (S, E) ⇒ S,
   val writerIdentity:        WriterIdentity,
   val recoveryCompleted:     (ActorContext[C], S) ⇒ Unit,
+  val onSnapshot:            (ActorContext[C], SnapshotMetadata, Try[Done]) => Unit,
   val tagger:                E ⇒ Set[String],
   val wrapper:               EventWrapper[E],
   val snapshotWhen:          (S, E, Long) ⇒ Boolean,

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSetup.scala
@@ -10,9 +10,10 @@ import akka.actor.{ ActorRef, ExtendedActorSystem }
 import akka.actor.typed.scaladsl.{ ActorContext, StashBuffer, TimerScheduler }
 import akka.annotation.InternalApi
 import akka.persistence._
+import akka.persistence.typed.EventAdapter
 import akka.persistence.typed.internal.EventsourcedBehavior.MDC
 import akka.persistence.typed.internal.EventsourcedBehavior.{ InternalProtocol, WriterIdentity }
-import akka.persistence.typed.scaladsl.{ EventAdapter, PersistentBehaviors }
+import akka.persistence.typed.scaladsl.PersistentBehaviors
 import akka.util.Collections.EmptyImmutableSeq
 import akka.util.OptionVal
 
@@ -33,7 +34,7 @@ private[persistence] final class EventsourcedSetup[C, E, S](
   val recoveryCompleted:     (ActorContext[C], S) ⇒ Unit,
   val onSnapshot:            (ActorContext[C], SnapshotMetadata, Try[Done]) ⇒ Unit,
   val tagger:                E ⇒ Set[String],
-  val eventAdapter:          EventAdapter[E],
+  val eventAdapter:          EventAdapter[E, _],
   val snapshotWhen:          (S, E, Long) ⇒ Boolean,
   val recovery:              Recovery,
   var holdingRecoveryPermit: Boolean,

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/PersistentBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/PersistentBehaviorImpl.scala
@@ -26,7 +26,7 @@ private[akka] final case class PersistentBehaviorImpl[Command, Event, State](
   snapshotPluginId:  Option[String]                                              = None,
   recoveryCompleted: (ActorContext[Command], State) ⇒ Unit                       = ConstantFun.scalaAnyTwoToUnit,
   tagger:            Event ⇒ Set[String]                                         = (_: Event) ⇒ Set.empty[String],
-  eventAdapter:      EventTransformer[Event]                                     = new NoOpEventTransformer[Event](),
+  eventAdapter:      EventTransformer[Event]                                     = NoOpEventTransformer.instance[Event],
   snapshotWhen:      (State, Event, Long) ⇒ Boolean                              = ConstantFun.scalaAnyThreeToFalse,
   recovery:          Recovery                                                    = Recovery(),
   onSnapshot:        (ActorContext[Command], SnapshotMetadata, Try[Done]) ⇒ Unit = ConstantFun.scalaAnyThreeToUnit

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/PersistentBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/PersistentBehaviorImpl.scala
@@ -22,14 +22,14 @@ private[akka] final case class PersistentBehaviorImpl[Command, Event, State](
   initialState:      State,
   commandHandler:    PersistentBehaviors.CommandHandler[Command, Event, State],
   eventHandler:      (State, Event) ⇒ State,
-  journalPluginId:   Option[String]                                            = None,
-  snapshotPluginId:  Option[String]                                            = None,
-  recoveryCompleted: (ActorContext[Command], State) ⇒ Unit                     = ConstantFun.scalaAnyTwoToUnit,
-  tagger:            Event ⇒ Set[String]                                       = (_: Event) ⇒ Set.empty[String],
-  eventAdapter:      EventWrapper[Event]                                       = new NoOpEventWrapper[Event](),
-  snapshotWhen:      (State, Event, Long) ⇒ Boolean                            = ConstantFun.scalaAnyThreeToFalse,
-  recovery:          Recovery                                                  = Recovery(),
-  onSnapshot: (ActorContext[Command], SnapshotMetadata, Try[Done]) => Unit     = ConstantFun.scalaAnyThreeToUnit
+  journalPluginId:   Option[String]                                              = None,
+  snapshotPluginId:  Option[String]                                              = None,
+  recoveryCompleted: (ActorContext[Command], State) ⇒ Unit                       = ConstantFun.scalaAnyTwoToUnit,
+  tagger:            Event ⇒ Set[String]                                         = (_: Event) ⇒ Set.empty[String],
+  eventAdapter:      EventTransformer[Event]                                     = new NoOpEventTransformer[Event](),
+  snapshotWhen:      (State, Event, Long) ⇒ Boolean                              = ConstantFun.scalaAnyThreeToFalse,
+  recovery:          Recovery                                                    = Recovery(),
+  onSnapshot:        (ActorContext[Command], SnapshotMetadata, Try[Done]) ⇒ Unit = ConstantFun.scalaAnyThreeToUnit
 ) extends PersistentBehavior[Command, Event, State] with EventsourcedStashReferenceManagement {
 
   override def apply(context: typed.ActorContext[Command]): Behavior[Command] = {
@@ -140,12 +140,12 @@ private[akka] final case class PersistentBehaviorImpl[Command, Event, State](
    * with event adapters and journals that expect types to be wrapped in classes like [Tagged]
    *
    */
-  def eventWrapper[A](adapter: EventWrapper[Event]): PersistentBehavior[Command, Event, State] =
+  def eventTransformer(adapter: EventTransformer[Event]): PersistentBehavior[Command, Event, State] =
     copy(eventAdapter = adapter)
 
   /**
-    * The `callback` function is called to notify the actor that a snapshot has finished
-    */
-  def onSnapshot(callback: (ActorContext[Command], SnapshotMetadata, Try[Done]) => Unit): PersistentBehavior[Command, Event, State] =
+   * The `callback` function is called to notify the actor that a snapshot has finished
+   */
+  def onSnapshot(callback: (ActorContext[Command], SnapshotMetadata, Try[Done]) ⇒ Unit): PersistentBehavior[Command, Event, State] =
     copy(onSnapshot = callback)
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventHandler.scala
@@ -73,7 +73,7 @@ final class EventHandlerBuilder[Event, State >: Null]() {
         }
 
         result match {
-          case OptionVal.None    ⇒ throw new MatchError(s"No match found for event [${event.getClass}] and state [${state.getClass}]. Has this event been stored using an EventTransformer?")
+          case OptionVal.None    ⇒ throw new MatchError(s"No match found for event [${event.getClass}] and state [${state.getClass}]. Has this event been stored using an EventAdapter?")
           case OptionVal.Some(s) ⇒ s
         }
       }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventHandler.scala
@@ -73,7 +73,7 @@ final class EventHandlerBuilder[Event, State >: Null]() {
         }
 
         result match {
-          case OptionVal.None    ⇒ throw new MatchError(s"No match found for event [${event.getClass}] and state [${state.getClass}]")
+          case OptionVal.None    ⇒ throw new MatchError(s"No match found for event [${event.getClass}] and state [${state.getClass}]. Has this event been stored using an EventTransformer?")
           case OptionVal.Some(s) ⇒ s
         }
       }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/PersistentBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/PersistentBehavior.scala
@@ -82,9 +82,11 @@ abstract class PersistentBehavior[Command, Event, State >: Null](val persistence
   def onRecoveryCompleted(ctx: ActorContext[Command], state: State): Unit = {}
 
   /**
-   * The `callback` function is called to notify the actor that the recovery process
-   * is finished. The default implementation logs failures at error and success writes at
+   * Override to get notified when a snapshot is finished.
+   * The default implementation logs failures at error and success writes at
    * debug.
+   *
+   * @param result None if successful otherwise contains the exception thrown when snapshotting
    */
   def onSnapshot(ctx: ActorContext[Command], meta: SnapshotMetadata, result: Optional[Throwable]): Unit = {
     if (result.isPresent) {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/PersistentBehaviors.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/PersistentBehaviors.scala
@@ -9,6 +9,7 @@ import akka.actor.typed.Behavior.DeferredBehavior
 import akka.actor.typed.scaladsl.ActorContext
 import akka.annotation.InternalApi
 import akka.persistence._
+import akka.persistence.typed.EventAdapter
 import akka.persistence.typed.internal._
 
 import scala.util.Try
@@ -122,41 +123,6 @@ trait PersistentBehavior[Command, Event, State] extends DeferredBehavior[Command
    * Transform the event in another type before giving to the journal. Can be used to wrap events
    * in types Journals and Adapters understand as well as simple event migrations.
    */
-  def eventTransformer(adapter: EventAdapter[Event]): PersistentBehavior[Command, Event, State]
-}
-
-trait EventAdapter[E] {
-  /**
-   * Type of the event to persist
-   */
-  type P
-  /**
-   * Transform event on the way to the journal
-   */
-  def toJournal(e: E): P
-
-  /**
-   * Transform the event on recovery from the journal.
-   * Note that this is not called in any read side so will need to be applied
-   * manually when using Query.
-   */
-  def fromJournal(p: P): E
-}
-
-/**
- * INTERNAL API
- */
-@InternalApi private[akka] object NoOpEventAdapter {
-  private val i = new NoOpEventAdapter[Nothing]
-  def instance[E]: NoOpEventAdapter[E] = i.asInstanceOf[NoOpEventAdapter[E]]
-}
-
-/**
- * INTERNAL API
- */
-@InternalApi private[akka] class NoOpEventAdapter[E] extends EventAdapter[E] {
-  type P = E
-  override def toJournal(e: E): E = e
-  override def fromJournal(p: E): E = p
+  def eventAdapter(adapter: EventAdapter[Event, _]): PersistentBehavior[Command, Event, State]
 }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/PersistentBehaviors.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/PersistentBehaviors.scala
@@ -145,6 +145,11 @@ trait EventTransformer[E] {
   def fromJournal(p: P): E
 }
 
+object NoOpEventTransformer {
+  private val i = new NoOpEventTransformer[Nothing]
+  def instance[E] = i.asInstanceOf[NoOpEventTransformer[E]]
+}
+
 /**
  * INTERNAL API
  */

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/PersistentBehaviors.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/PersistentBehaviors.scala
@@ -73,7 +73,7 @@ trait PersistentBehavior[Command, Event, State] extends DeferredBehavior[Command
    */
   def onRecoveryCompleted(callback: (ActorContext[Command], State) ⇒ Unit): PersistentBehavior[Command, Event, State]
 
-   /**
+  /**
    * The `callback` function is called to notify the actor that the recovery process
    * is finished.
    *
@@ -121,39 +121,36 @@ trait PersistentBehavior[Command, Event, State] extends DeferredBehavior[Command
   def withTagger(tagger: Event ⇒ Set[String]): PersistentBehavior[Command, Event, State]
 
   /**
-   * Adapt the event in another type before giving to the journal. This can be used to work
-   * with event adapters and journals that expect types to be wrapped in classes like [Tagged] or to
-   * separate domain types from persistent types.
+   * Transform the event in another type before giving to the journal. Can be used to wrap events
+   * in types Journals and Adapters understand as well as simple event migrations.
    */
-  def eventWrapper[A](adapter: EventWrapper[Event]): PersistentBehavior[Command, Event, State]
+  def eventTransformer(adapter: EventTransformer[Event]): PersistentBehavior[Command, Event, State]
 }
 
-trait EventWrapper[E] {
+trait EventTransformer[E] {
   /**
-    * Type of the event to persist
-    */
+   * Type of the event to persist
+   */
   type P
   /**
-    * Wrap event on the way to the journal
-    */
+   * Transform event on the way to the journal
+   */
   def toJournal(e: E): P
 
   /**
-    * Unwrap the event on recovery from the journal.
-    * Note that this is not called in any read side so will need to be applied
-    * manually when using Query.
-    */
+   * Transform the event on recovery from the journal.
+   * Note that this is not called in any read side so will need to be applied
+   * manually when using Query.
+   */
   def fromJournal(p: P): E
 }
 
-
 /**
-  * INTERNAL API
-  */
-@InternalApi private[akka] class NoOpEventWrapper[E] extends EventWrapper[E] {
+ * INTERNAL API
+ */
+@InternalApi private[akka] class NoOpEventTransformer[E] extends EventTransformer[E] {
   type P = E
   override def toJournal(e: E): E = e
   override def fromJournal(p: E): E = p
 }
-
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/PersistentBehaviors.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/PersistentBehaviors.scala
@@ -74,8 +74,7 @@ trait PersistentBehavior[Command, Event, State] extends DeferredBehavior[Command
   def onRecoveryCompleted(callback: (ActorContext[Command], State) ⇒ Unit): PersistentBehavior[Command, Event, State]
 
   /**
-   * The `callback` function is called to notify the actor that the recovery process
-   * is finished.
+   * The `callback` function is called to notify when a snapshot is complete.
    */
   def onSnapshot(callback: (ActorContext[Command], SnapshotMetadata, Try[Done]) ⇒ Unit): PersistentBehavior[Command, Event, State]
 
@@ -121,7 +120,7 @@ trait PersistentBehavior[Command, Event, State] extends DeferredBehavior[Command
 
   /**
    * Transform the event in another type before giving to the journal. Can be used to wrap events
-   * in types Journals and Adapters understand as well as simple event migrations.
+   * in types Journals understand but is of a different type than `Event`.
    */
   def eventAdapter(adapter: EventAdapter[Event, _]): PersistentBehavior[Command, Event, State]
 }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorSpec.scala
@@ -30,7 +30,7 @@ object PersistentBehaviorSpec {
 
   case class Wrapper[T](t: T)
 
-  class WrapperEventWrapper[T] extends EventWrapper[T] {
+  class WrapperEventTransformer[T] extends EventTransformer[T] {
     override type P = Wrapper[T]
     override def toJournal(e: T): Wrapper[T] = Wrapper(e)
     override def fromJournal(p: Wrapper[T]): T = p.t
@@ -487,7 +487,7 @@ class PersistentBehaviorSpec extends ActorTestKit with TypedAkkaSpecWithShutdown
 
     "adapt events" in {
       val pid = nextPid
-      val c = spawn(counter(pid).eventWrapper(new WrapperEventWrapper[Event]))
+      val c = spawn(counter(pid).eventTransformer(new WrapperEventTransformer[Event]))
       val replyProbe = TestProbe[State]()
 
       c ! Increment
@@ -497,7 +497,7 @@ class PersistentBehaviorSpec extends ActorTestKit with TypedAkkaSpecWithShutdown
       val events = queries.currentEventsByPersistenceId(pid).runWith(Sink.seq).futureValue
       events shouldEqual List(EventEnvelope(Sequence(1), pid, 1, Wrapper(Incremented(1))))
 
-      val c2 = spawn(counter(pid).eventWrapper(new WrapperEventWrapper[Event]))
+      val c2 = spawn(counter(pid).eventTransformer(new WrapperEventTransformer[Event]))
       c2 ! GetValue(replyProbe.ref)
       replyProbe.expectMessage(State(1, Vector(0)))
 
@@ -507,7 +507,7 @@ class PersistentBehaviorSpec extends ActorTestKit with TypedAkkaSpecWithShutdown
       val pid = nextPid
       val c = spawn(counter(pid)
         .withTagger(_ ⇒ Set("tag99"))
-        .eventWrapper(new WrapperEventWrapper[Event]))
+        .eventTransformer(new WrapperEventTransformer[Event]))
       val replyProbe = TestProbe[State]()
 
       c ! Increment
@@ -517,7 +517,7 @@ class PersistentBehaviorSpec extends ActorTestKit with TypedAkkaSpecWithShutdown
       val events = queries.currentEventsByPersistenceId(pid).runWith(Sink.seq).futureValue
       events shouldEqual List(EventEnvelope(Sequence(1), pid, 1, Wrapper(Incremented(1))))
 
-      val c2 = spawn(counter(pid).eventWrapper(new WrapperEventWrapper[Event]))
+      val c2 = spawn(counter(pid).eventTransformer(new WrapperEventTransformer[Event]))
       c2 ! GetValue(replyProbe.ref)
       replyProbe.expectMessage(State(1, Vector(0)))
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorSpec.scala
@@ -214,7 +214,7 @@ class PersistentBehaviorSpec extends ActorTestKit with TypedAkkaSpecWithShutdown
   import akka.actor.typed.scaladsl.adapter._
 
   implicit val materializer = ActorMaterializer()(system.toUntyped)
-  val queries = PersistenceQuery(system.toUntyped).readJournalFor[LeveldbReadJournal](
+  val queries: LeveldbReadJournal = PersistenceQuery(system.toUntyped).readJournalFor[LeveldbReadJournal](
     LeveldbReadJournal.Identifier)
 
   val pidCounter = new AtomicInteger(0)

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsCompileOnly.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsCompileOnly.scala
@@ -8,7 +8,7 @@ import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
 import akka.persistence.typed.scaladsl.PersistentBehaviors
 
-object BasicPersistentBehaviorsSpec {
+object BasicPersistentBehaviorsCompileOnly {
 
   //#structure
   sealed trait Command

--- a/build.sbt
+++ b/build.sbt
@@ -398,8 +398,8 @@ lazy val persistenceTyped = akkaModule("akka-persistence-typed")
     actorTyped,
     persistence % "compile->compile;test->test",
     persistenceQuery % "test",
-    actorTestkitTyped % "test->test",
-    actorTypedTests % "test->test"
+    actorTypedTests % "test->test",
+    actorTestkitTyped % "compile->compile;test->test"
   )
   .settings(Dependencies.persistenceShared)
   .settings(AkkaBuild.mayChangeSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -396,7 +396,8 @@ lazy val actorTyped = akkaModule("akka-actor-typed")
 lazy val persistenceTyped = akkaModule("akka-persistence-typed")
   .dependsOn(
     actorTyped,
-    persistence,
+    persistence % "compile->compile;test->test",
+    persistenceQuery % "test",
     actorTestkitTyped % "test->test",
     actorTypedTests % "test->test"
   )


### PR DESCRIPTION
Not ready for merge or code review.

Just wanted an opinion on a possible API that could replace the need for basic event adapters.

I called it wrapper for now as that is the current use case.