### PR TITLE
[WIP] introduces onCreation and onUpdate phases

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedJournalInteractions.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedJournalInteractions.scala
@@ -107,8 +107,8 @@ private[akka] trait EventsourcedJournalInteractions[C, E, S] {
     setup.snapshotStore.tell(LoadSnapshot(setup.persistenceId, criteria, toSequenceNr), setup.selfUntyped)
   }
 
-  protected def internalSaveSnapshot(state: EventsourcedRunning.EventsourcedState[S]): Unit = {
-    setup.snapshotStore.tell(SnapshotProtocol.SaveSnapshot(SnapshotMetadata(setup.persistenceId, state.seqNr), state.state), setup.selfUntyped)
-  }
-
+  protected def internalSaveSnapshot(state: EventsourcedRunning.EventsourcedState[S]): Unit =
+    state.stateOpt.foreach { currentState ⇒
+      setup.snapshotStore.tell(SnapshotProtocol.SaveSnapshot(SnapshotMetadata(setup.persistenceId, state.seqNr), currentState), setup.selfUntyped)
+    }
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSetup.scala
@@ -20,20 +20,21 @@ import akka.util.OptionVal
  */
 @InternalApi
 private[persistence] final class EventsourcedSetup[C, E, S](
-  val context:               ActorContext[InternalProtocol],
-  val timers:                TimerScheduler[InternalProtocol],
-  val persistenceId:         String,
-  val initialState:          S,
-  val commandHandler:        PersistentBehaviors.CommandHandler[C, E, S],
-  val eventHandler:          (S, E) ⇒ S,
-  val writerIdentity:        WriterIdentity,
-  val recoveryCompleted:     (ActorContext[C], S) ⇒ Unit,
-  val tagger:                E ⇒ Set[String],
-  val snapshotWhen:          (S, E, Long) ⇒ Boolean,
-  val recovery:              Recovery,
-  var holdingRecoveryPermit: Boolean,
-  val settings:              EventsourcedSettings,
-  val internalStash:         StashBuffer[InternalProtocol]
+  val context:                  ActorContext[InternalProtocol],
+  val timers:                   TimerScheduler[InternalProtocol],
+  val persistenceId:            String,
+  val commandHandlerOnCreation: PersistentBehaviors.CommandHandler[C, E, S],
+  val eventHandlerOnCreation:   PersistentBehaviors.EventHandler[E, S],
+  val commandHandlerOnUpdate:   S ⇒ PersistentBehaviors.CommandHandler[C, E, S],
+  val eventHandlerOnUpdate:     S ⇒ PersistentBehaviors.EventHandler[E, S],
+  val writerIdentity:           WriterIdentity,
+  val recoveryCompleted:        (ActorContext[C], Option[S]) ⇒ Unit,
+  val tagger:                   E ⇒ Set[String],
+  val snapshotWhen:             (S, E, Long) ⇒ Boolean,
+  val recovery:                 Recovery,
+  var holdingRecoveryPermit:    Boolean,
+  val settings:                 EventsourcedSettings,
+  val internalStash:            StashBuffer[InternalProtocol]
 ) {
   import akka.actor.typed.scaladsl.adapter._
 

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorsTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorsTest.java
@@ -8,11 +8,11 @@ import akka.actor.typed.Behavior;
 import akka.actor.typed.javadsl.ActorContext;
 import akka.actor.typed.javadsl.Behaviors;
 import akka.persistence.typed.javadsl.CommandHandler;
-import akka.persistence.typed.javadsl.Effect;
 import akka.persistence.typed.javadsl.EventHandler;
 import akka.persistence.typed.javadsl.PersistentBehavior;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 
 public class BasicPersistentBehaviorsTest {
@@ -29,23 +29,28 @@ public class BasicPersistentBehaviorsTest {
     }
 
     @Override
-    public State initialState() {
-      return new State();
+    public CommandHandler<Command, Event, State> commandHandler() {
+      return (ctx, command) -> Effect().none();
     }
 
     @Override
-    public CommandHandler<Command, Event, State> commandHandler() {
-      return (ctx, state, command) -> Effect().none();
+    public CommandHandler<Command, Event, State> commandHandler(State state) {
+      return commandHandler();
     }
 
     @Override
     public EventHandler<Event, State> eventHandler() {
-      return (state, event) -> state;
+      return eventHandler(new State());
+    }
+
+    @Override
+    public EventHandler<Event, State> eventHandler(State state) {
+      return event -> state;
     }
 
     //#recovery
     @Override
-    public void onRecoveryCompleted(ActorContext<Command> ctx, State state) {
+    public void onRecoveryCompleted(ActorContext<Command> ctx, Optional<State> stateOpt) {
       // called once recovery is completed
     }
     //#recovery

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/InDepthPersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/InDepthPersistentBehaviorTest.java
@@ -7,194 +7,193 @@ package jdocs.akka.persistence.typed;
 import akka.Done;
 import akka.actor.typed.ActorRef;
 import akka.persistence.typed.javadsl.CommandHandler;
+import akka.persistence.typed.javadsl.CommandHandlerBuilder;
 import akka.persistence.typed.javadsl.EventHandler;
 import akka.persistence.typed.javadsl.PersistentBehavior;
 
-import java.util.Optional;
-
 public class InDepthPersistentBehaviorTest {
 
-  //#event
-  interface BlogEvent {
+  static class Blog {
+
+    //#event
+    interface BlogEvent {
+    }
+    public static class PostAdded implements BlogEvent {
+      private final String postId;
+      private final PostContent content;
+
+      public PostAdded(String postId, PostContent content) {
+        this.postId = postId;
+        this.content = content;
+      }
+    }
+
+    public static class BodyChanged implements BlogEvent {
+      private final String postId;
+      private final String newBody;
+
+      public BodyChanged(String postId, String newBody) {
+        this.postId = postId;
+        this.newBody = newBody;
+      }
+    }
+
+    public static class Published implements BlogEvent {
+      private final String postId;
+
+      public Published(String postId) {
+        this.postId = postId;
+      }
+    }
+    //#event
+
+    //#state
+    public static class BlogState {
+      final PostContent postContent;
+      final boolean published;
+
+      BlogState(PostContent postContent, boolean published) {
+        this.postContent = postContent;
+        this.published = published;
+      }
+
+      public BlogState withContent(PostContent newContent) {
+        return new BlogState(newContent, this.published);
+      }
+
+
+      public String postId() {
+        return postContent.postId;
+      }
+    }
+    //#state
+
+    //#commands
+    public interface BlogCommand {
+    }
+    public static class AddPost implements BlogCommand {
+      final PostContent content;
+      final ActorRef<AddPostDone> replyTo;
+
+      public AddPost(PostContent content, ActorRef<AddPostDone> replyTo) {
+        this.content = content;
+        this.replyTo = replyTo;
+      }
+    }
+    public static class AddPostDone implements BlogCommand {
+      final String postId;
+
+      public AddPostDone(String postId) {
+        this.postId = postId;
+      }
+    }
+    public static class GetPost implements BlogCommand {
+      final ActorRef<PostContent> replyTo;
+
+      public GetPost(ActorRef<PostContent> replyTo) {
+        this.replyTo = replyTo;
+      }
+    }
+    public static class ChangeBody implements BlogCommand {
+      final String newBody;
+      final ActorRef<Done> replyTo;
+
+      public ChangeBody(String newBody, ActorRef<Done> replyTo) {
+        this.newBody = newBody;
+        this.replyTo = replyTo;
+      }
+    }
+    public static class Publish implements BlogCommand {
+      final ActorRef<Done> replyTo;
+
+      public Publish(ActorRef<Done> replyTo) {
+        this.replyTo = replyTo;
+      }
+    }
+    public static class PassivatePost implements BlogCommand {
+
+    }
+    public static class PostContent implements BlogCommand {
+      final String postId;
+      final String title;
+      final String body;
+
+      public PostContent(String postId, String title, String body) {
+        this.postId = postId;
+        this.title = title;
+        this.body = body;
+      }
+    }
+    //#commands
+
+    //#behavior
+    public static class BlogBehavior extends PersistentBehavior<BlogCommand, BlogEvent, BlogState> {
+
+      //#initial-command-handler
+      @Override
+      public CommandHandler<BlogCommand, BlogEvent, BlogState> commandHandler() {
+        return commandHandlerBuilder()
+                .matchCommand(AddPost.class, (ctx, cmd) -> {
+                  PostAdded event = new PostAdded(cmd.content.postId, cmd.content);
+                  return Effect()
+                          .persist(event)
+                          .andThen(() -> cmd.replyTo.tell(new AddPostDone(cmd.content.postId)));
+                })
+                .matchCommand(PassivatePost.class, (ctx, cmd) -> Effect().stop())
+                .build();
+      }
+      //#initial-command-handler
+
+
+
+      public BlogBehavior(String persistenceId) {
+        super(persistenceId);
+      }
+
+
+
+      //#post-added-command-handler
+      @Override
+      public CommandHandler<BlogCommand, BlogEvent, BlogState> commandHandler(BlogState blogState) {
+        return commandHandlerBuilder()
+                .matchCommand(ChangeBody.class, (ctx, cmd) -> {
+                  BodyChanged event = new BodyChanged(blogState.postId(), cmd.newBody);
+                  return Effect().persist(event).andThen(() -> cmd.replyTo.tell(Done.getInstance()));
+                })
+                .matchCommand(Publish.class, (ctx, cmd) -> Effect()
+                        .persist(new Published(blogState.postId())).andThen(() -> {
+                          System.out.println("Blog post published: " + blogState.postId());
+                          cmd.replyTo.tell(Done.getInstance());
+                        }))
+                .matchCommand(GetPost.class, (ctx, cmd) -> {
+                  cmd.replyTo.tell(blogState.postContent);
+                  return Effect().none();
+                })
+                .matchCommand(AddPost.class, (ctx, cmd) -> Effect().unhandled())
+                .matchCommand(PassivatePost.class, (ctx, cmd) -> Effect().stop())
+                .build();
+      }
+      //#post-added-command-handler
+
+      @Override
+      public EventHandler<BlogEvent, BlogState> eventHandler() {
+        return eventHandlerBuilder()
+                .matchEvent(PostAdded.class, event -> new BlogState(event.content, false))
+                .build();
+      }
+
+      //#event-handler
+      @Override
+      public EventHandler<BlogEvent, BlogState> eventHandler(BlogState blogState) {
+        return eventHandlerBuilder()
+                .matchEvent(BodyChanged.class, newBody ->
+                        new BlogState(new PostContent(blogState.postContent.postId, blogState.postContent.title, newBody.newBody), blogState.published))
+                .matchEvent(Published.class,  event -> new BlogState(blogState.postContent, true))
+                .build();
+      }
+      //#event-handler
+    }
+    //#behavior
   }
-  public static class PostAdded implements BlogEvent {
-    private final String postId;
-    private final PostContent content;
 
-    public PostAdded(String postId, PostContent content) {
-      this.postId = postId;
-      this.content = content;
-    }
-  }
-
-  public static class BodyChanged implements BlogEvent {
-    private final String postId;
-    private final String newBody;
-
-    public BodyChanged(String postId, String newBody) {
-      this.postId = postId;
-      this.newBody = newBody;
-    }
-  }
-
-  public static class Published implements BlogEvent {
-    private final String postId;
-
-    public Published(String postId) {
-      this.postId = postId;
-    }
-  }
-  //#event
-
-  //#state
-  public static class BlogState {
-    final Optional<PostContent> postContent;
-    final boolean published;
-
-    BlogState(Optional<PostContent> postContent, boolean published) {
-      this.postContent = postContent;
-      this.published = published;
-    }
-
-    public BlogState withContent(PostContent newContent) {
-      return new BlogState(Optional.of(newContent), this.published);
-    }
-
-    public boolean isEmpty() {
-      return postContent.isPresent();
-    }
-
-    public String postId() {
-      return postContent.orElseGet(() -> {
-        throw new IllegalStateException("postId unknown before post is created");
-      }).postId;
-    }
-  }
-  //#state
-
-  //#commands
-  public interface BlogCommand {
-  }
-  public static class AddPost implements BlogCommand {
-    final PostContent content;
-    final ActorRef<AddPostDone> replyTo;
-
-    public AddPost(PostContent content, ActorRef<AddPostDone> replyTo) {
-      this.content = content;
-      this.replyTo = replyTo;
-    }
-  }
-  public static class AddPostDone implements BlogCommand {
-    final String postId;
-
-    public AddPostDone(String postId) {
-      this.postId = postId;
-    }
-  }
-  public static class GetPost implements BlogCommand {
-    final ActorRef<PostContent> replyTo;
-
-    public GetPost(ActorRef<PostContent> replyTo) {
-      this.replyTo = replyTo;
-    }
-  }
-  public static class ChangeBody implements BlogCommand {
-    final String newBody;
-    final ActorRef<Done> replyTo;
-
-    public ChangeBody(String newBody, ActorRef<Done> replyTo) {
-      this.newBody = newBody;
-      this.replyTo = replyTo;
-    }
-  }
-  public static class Publish implements BlogCommand {
-    final ActorRef<Done> replyTo;
-
-    public Publish(ActorRef<Done> replyTo) {
-      this.replyTo = replyTo;
-    }
-  }
-  public static class PassivatePost implements BlogCommand {
-
-  }
-  public static class PostContent implements BlogCommand {
-    final String postId;
-    final String title;
-    final String body;
-
-    public PostContent(String postId, String title, String body) {
-      this.postId = postId;
-      this.title = title;
-      this.body = body;
-    }
-  }
-  //#commands
-
-  //#behavior
-  public static class BlogBehavior extends PersistentBehavior<BlogCommand, BlogEvent, BlogState> {
-
-    //#initial-command-handler
-    private CommandHandler<BlogCommand, BlogEvent, BlogState> initialCommandHandler = commandHandlerBuilder()
-      .matchCommand(AddPost.class, (ctx, state, cmd) -> {
-        PostAdded event = new PostAdded(cmd.content.postId, cmd.content);
-        return Effect().persist(event)
-          .andThen(() -> cmd.replyTo.tell(new AddPostDone(cmd.content.postId)));
-      })
-      .matchCommand(PassivatePost.class, (ctx, state, cmd) -> Effect().stop())
-      .build();
-    //#initial-command-handler
-
-    //#post-added-command-handler
-    private CommandHandler<BlogCommand, BlogEvent, BlogState> postCommandHandler = commandHandlerBuilder()
-      .matchCommand(ChangeBody.class, (ctx, state, cmd) -> {
-        BodyChanged event = new BodyChanged(state.postId(), cmd.newBody);
-        return Effect().persist(event).andThen(() -> cmd.replyTo.tell(Done.getInstance()));
-      })
-      .matchCommand(Publish.class, (ctx, state, cmd) -> Effect()
-        .persist(new Published(state.postId())).andThen(() -> {
-          System.out.println("Blog post published: " + state.postId());
-          cmd.replyTo.tell(Done.getInstance());
-        }))
-      .matchCommand(GetPost.class, (ctx, state, cmd) -> {
-        cmd.replyTo.tell(state.postContent.get());
-        return Effect().none();
-      })
-      .matchCommand(AddPost.class, (ctx, state, cmd) -> Effect().unhandled())
-      .matchCommand(PassivatePost.class, (ctx, state, cmd) -> Effect().stop())
-      .build();
-    //#post-added-command-handler
-
-
-    public BlogBehavior(String persistenceId) {
-      super(persistenceId);
-    }
-
-    @Override
-    public BlogState initialState() {
-      return new BlogState(Optional.empty(), false);
-    }
-
-    //#by-state-command-handler
-    @Override
-    public CommandHandler<BlogCommand, BlogEvent, BlogState> commandHandler() {
-      return byStateCommandHandlerBuilder()
-        .matchState(BlogState.class, (state) -> !state.postContent.isPresent(), initialCommandHandler)
-        .matchState(BlogState.class, (state) -> state.postContent.isPresent(), postCommandHandler)
-        .build();
-    }
-    //#by-state-command-handler
-
-    //#event-handler
-    @Override
-    public EventHandler<BlogEvent, BlogState> eventHandler() {
-      return eventHandlerBuilder()
-        .matchEvent(PostAdded.class, (state, event) -> state.withContent(event.content))
-        .matchEvent(BodyChanged.class, (state, newBody) ->
-          new BlogState(state.postContent.map(pc -> new PostContent(pc.postId, pc.title, newBody.newBody)), state.published))
-        .matchEvent(Published.class, (state, event) -> new BlogState(state.postContent, true))
-        .build();
-    }
-    //#event-handler
-  }
-  //#behavior
 }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
@@ -10,6 +10,8 @@ import akka.actor.typed.{ ActorRef, Behavior }
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.TimerScheduler
+import akka.persistence.typed.scaladsl.PersistentActorCompileOnlyTest.Simple._
+import akka.persistence.typed.scaladsl.PersistentBehaviors.CommandHandler.command
 
 object PersistentActorCompileOnlyTest {
 
@@ -29,25 +31,24 @@ object PersistentActorCompileOnlyTest {
     //#state
 
     //#command-handler
-    val commandHandler: CommandHandler[SimpleCommand, SimpleEvent, ExampleState] =
-      CommandHandler.command {
+    def commandHandler(state: ExampleState): CommandHandler[SimpleCommand, SimpleEvent, ExampleState] =
+      command {
         case Cmd(data) ⇒ Effect.persist(Evt(data))
       }
     //#command-handler
 
     //#event-handler
-    val eventHandler: (ExampleState, SimpleEvent) ⇒ (ExampleState) = {
-      case (state, Evt(data)) ⇒ state.copy(data :: state.events)
+    def eventHandler(state: ExampleState): EventHandler[SimpleEvent, ExampleState] = {
+      case Evt(data) ⇒ state.copy(data :: state.events)
     }
     //#event-handler
 
     //#behavior
     val simpleBehavior: PersistentBehavior[SimpleCommand, SimpleEvent, ExampleState] =
-      PersistentBehaviors.receive[SimpleCommand, SimpleEvent, ExampleState](
-        persistenceId = "sample-id-1",
-        initialState = ExampleState(Nil),
-        commandHandler = commandHandler,
-        eventHandler = eventHandler)
+      PersistentBehaviors[SimpleCommand, SimpleEvent, ExampleState]
+        .identifiedBy("sample-id-1")
+        .onCreation(commandHandler(ExampleState(Nil)), eventHandler(ExampleState(Nil)))
+        .onUpdate(commandHandler, eventHandler)
     //#behavior
 
   }
@@ -63,30 +64,34 @@ object PersistentActorCompileOnlyTest {
 
     case class ExampleState(events: List[String] = Nil)
 
-    PersistentBehaviors.receive[MyCommand, MyEvent, ExampleState](
-      persistenceId = "sample-id-1",
-
-      initialState = ExampleState(Nil),
-
-      commandHandler = CommandHandler.command {
+    def commandHandler(state: ExampleState): CommandHandler[MyCommand, MyEvent, ExampleState] =
+      command {
         case Cmd(data, sender) ⇒
-          Effect.persist(Evt(data))
-            .andThen {
-              sender ! Ack
-            }
-      },
+          Effect
+            .persist(Evt(data))
+            .andThen { sender ! Ack }
+      }
 
-      eventHandler = {
-        case (state, Evt(data)) ⇒ state.copy(data :: state.events)
-      })
+    def eventHandler(state: ExampleState): EventHandler[MyEvent, ExampleState] = {
+      case Evt(data) ⇒ state.copy(data :: state.events)
+    }
+
+    PersistentBehaviors[MyCommand, MyEvent, ExampleState]
+      .identifiedBy("sample-id-1")
+      .onCreation(commandHandler(ExampleState(Nil)), eventHandler(ExampleState(Nil)))
+      .onUpdate(commandHandler, eventHandler)
+
   }
 
   object RecoveryComplete {
     sealed trait Command
+
+    case object CreateFlight extends Command
     case class DoSideEffect(data: String) extends Command
     case class AcknowledgeSideEffect(correlationId: Int) extends Command
 
     sealed trait Event
+    case object FlightCreated extends Event
     case class IntentRecorded(correlationId: Int, data: String) extends Event
     case class SideEffectAcknowledged(correlationId: Int) extends Event
 
@@ -107,34 +112,47 @@ object PersistentActorCompileOnlyTest {
         .foreach(sender ! _)
     }
 
-    PersistentBehaviors.receive[Command, Event, EventsInFlight](
-      persistenceId = "recovery-complete-id",
+    def commandHandler(state: EventsInFlight): CommandHandler[Command, Event, EventsInFlight] = {
+      (ctx: ActorContext[Command], cmd) ⇒
+        cmd match {
+          case DoSideEffect(data) ⇒
+            Effect.persist(IntentRecorded(state.nextCorrelationId, data)).andThen {
+              performSideEffect(ctx.self, state.nextCorrelationId, data)
+            }
+          case AcknowledgeSideEffect(correlationId) ⇒
+            Effect.persist(SideEffectAcknowledged(correlationId))
+        }
+    }
 
-      initialState = EventsInFlight(0, Map.empty),
+    def eventHandler(state: EventsInFlight): EventHandler[Event, EventsInFlight] = {
+      case IntentRecorded(correlationId, data) ⇒
+        EventsInFlight(
+          nextCorrelationId = correlationId + 1,
+          dataByCorrelationId = state.dataByCorrelationId + (correlationId → data))
+      case SideEffectAcknowledged(correlationId) ⇒
+        state.copy(dataByCorrelationId = state.dataByCorrelationId - correlationId)
+    }
 
-      commandHandler = (ctx: ActorContext[Command], state, cmd) ⇒ cmd match {
-        case DoSideEffect(data) ⇒
-          Effect.persist(IntentRecorded(state.nextCorrelationId, data)).andThen {
-            performSideEffect(ctx.self, state.nextCorrelationId, data)
-          }
-        case AcknowledgeSideEffect(correlationId) ⇒
-          Effect.persist(SideEffectAcknowledged(correlationId))
-      },
-
-      eventHandler = (state, evt) ⇒ evt match {
-        case IntentRecorded(correlationId, data) ⇒
-          EventsInFlight(
-            nextCorrelationId = correlationId + 1,
-            dataByCorrelationId = state.dataByCorrelationId + (correlationId → data))
-        case SideEffectAcknowledged(correlationId) ⇒
-          state.copy(dataByCorrelationId = state.dataByCorrelationId - correlationId)
-      }).onRecoveryCompleted {
-        case (ctx, state) ⇒
+    PersistentBehaviors[Command, Event, EventsInFlight]
+      .identifiedBy(persistenceId = "recovery-complete-id")
+      .onCreation(
+        commandHandler = command {
+          case CreateFlight ⇒ Effect.persist(FlightCreated)
+        },
+        eventHandler = {
+          case FlightCreated ⇒ EventsInFlight(0, Map.empty)
+        }
+      )
+      .onUpdate(
+        commandHandler = state ⇒ commandHandler(state),
+        eventHandler = state ⇒ eventHandler(state)
+      )
+      .onRecoveryCompleted {
+        case (ctx, Some(state)) ⇒
           state.dataByCorrelationId.foreach {
             case (correlationId, data) ⇒ performSideEffect(ctx.self, correlationId, data)
           }
       }
-
   }
 
   object Become {
@@ -149,26 +167,38 @@ object PersistentActorCompileOnlyTest {
     sealed trait Event
     case class MoodChanged(to: Mood) extends Event
 
-    val b: Behavior[Command] = PersistentBehaviors.receive[Command, Event, Mood](
-      persistenceId = "myPersistenceId",
-      initialState = Happy,
-      commandHandler = CommandHandler.byState {
-        case Happy ⇒ CommandHandler.command {
+    def commandHandler(mood: Mood): CommandHandler[Command, Event, Mood] = {
+      mood match {
+        case Happy ⇒ command {
           case Greet(whom) ⇒
             println(s"Super happy to meet you $whom!")
             Effect.none
           case MoodSwing ⇒ Effect.persist(MoodChanged(Sad))
         }
-        case Sad ⇒ CommandHandler.command {
+        case Sad ⇒ command {
           case Greet(whom) ⇒
             println(s"hi $whom")
             Effect.none
           case MoodSwing ⇒ Effect.persist(MoodChanged(Happy))
         }
-      },
-      eventHandler = {
-        case (_, MoodChanged(to)) ⇒ to
-      })
+      }
+    }
+
+    def eventHandler(mood: Mood): EventHandler[Event, Mood] = {
+      case MoodChanged(to) ⇒ to
+    }
+
+    val b: Behavior[Command] =
+      PersistentBehaviors[Command, Event, Mood]
+        .identifiedBy("myPersistenceId")
+        .onCreation(
+          commandHandler = commandHandler(Happy),
+          eventHandler = eventHandler(Happy)
+        )
+        .onUpdate(
+          commandHandler = mood ⇒ commandHandler(mood),
+          eventHandler = mood ⇒ eventHandler(mood)
+        )
 
     // FIXME this doesn't work, wrapping is not supported
     Behaviors.withTimers((timers: TimerScheduler[Command]) ⇒ {
@@ -181,215 +211,228 @@ object PersistentActorCompileOnlyTest {
     type Task = String
 
     sealed trait Command
+    case object CreateTaskTracker extends Command
     case class RegisterTask(task: Task) extends Command
     case class TaskDone(task: Task) extends Command
 
     sealed trait Event
+    case object TaskTrackerCreated extends Event
     case class TaskRegistered(task: Task) extends Event
     case class TaskRemoved(task: Task) extends Event
 
     case class State(tasksInFlight: List[Task])
 
-    PersistentBehaviors.receive[Command, Event, State](
-      persistenceId = "asdf",
-      initialState = State(Nil),
-      commandHandler = CommandHandler.command {
-        case RegisterTask(task) ⇒ Effect.persist(TaskRegistered(task))
-        case TaskDone(task)     ⇒ Effect.persist(TaskRemoved(task))
-      },
-      eventHandler = (state, evt) ⇒ evt match {
-        case TaskRegistered(task) ⇒ State(task :: state.tasksInFlight)
-        case TaskRemoved(task)    ⇒ State(state.tasksInFlight.filter(_ != task))
-      }).snapshotWhen { (state, e, seqNr) ⇒ state.tasksInFlight.isEmpty }
-  }
-
-  object SpawnChild {
-    type Task = String
-    sealed trait Command
-    case class RegisterTask(task: Task) extends Command
-    case class TaskDone(task: Task) extends Command
-
-    sealed trait Event
-    case class TaskRegistered(task: Task) extends Event
-    case class TaskRemoved(task: Task) extends Event
-
-    case class State(tasksInFlight: List[Task])
-
-    def worker(task: Task): Behavior[Nothing] = ???
-
-    PersistentBehaviors.receive[Command, Event, State](
-      persistenceId = "asdf",
-      initialState = State(Nil),
-      commandHandler = (ctx, _, cmd) ⇒ cmd match {
-        case RegisterTask(task) ⇒
-          Effect.persist(TaskRegistered(task))
-            .andThen {
-              val child = ctx.spawn[Nothing](worker(task), task)
-              // This assumes *any* termination of the child may trigger a `TaskDone`:
-              ctx.watchWith(child, TaskDone(task))
-            }
-        case TaskDone(task) ⇒ Effect.persist(TaskRemoved(task))
-      },
-      eventHandler = (state, evt) ⇒ evt match {
-        case TaskRegistered(task) ⇒ State(task :: state.tasksInFlight)
-        case TaskRemoved(task)    ⇒ State(state.tasksInFlight.filter(_ != task))
-      })
-  }
-
-  object Rehydrating {
-    type Id = String
-
-    sealed trait Command
-    case class AddItem(id: Id) extends Command
-    case class RemoveItem(id: Id) extends Command
-    case class GetTotalPrice(sender: ActorRef[Int]) extends Command
-    /* Internal: */
-    case class GotMetaData(data: MetaData) extends Command
-
-    /**
-     * Items have all kinds of metadata, but we only persist the 'id', and
-     * rehydrate the metadata on recovery from a registry
-     */
-    case class Item(id: Id, name: String, price: Int)
-    case class Basket(items: Seq[Item]) {
-      def updatedWith(data: MetaData): Basket = ???
-    }
-
-    sealed trait Event
-    case class ItemAdded(id: Id) extends Event
-    case class ItemRemoved(id: Id) extends Event
-
-    /*
-      * The metadata registry
-      */
-    case class GetMetaData(id: Id, sender: ActorRef[MetaData])
-    case class MetaData(id: Id, name: String, price: Int)
-    val metadataRegistry: ActorRef[GetMetaData] = ???
-
-    def isFullyHydrated(basket: Basket, ids: List[Id]) = basket.items.map(_.id) == ids
-
-    Behaviors.setup { ctx: ActorContext[Command] ⇒
-      // FIXME this doesn't work, wrapping not supported
-
-      var basket = Basket(Nil)
-      var stash: Seq[Command] = Nil
-      val adapt = ctx.messageAdapter((m: MetaData) ⇒ GotMetaData(m))
-
-      def addItem(id: Id, self: ActorRef[Command]) =
-        Effect
-          .persist[Event, List[Id]](ItemAdded(id))
-          .andThen(metadataRegistry ! GetMetaData(id, adapt))
-
-      PersistentBehaviors.receive[Command, Event, List[Id]](
-        persistenceId = "basket-1",
-        initialState = Nil,
-        commandHandler =
-          CommandHandler.byState(state ⇒
-            if (isFullyHydrated(basket, state)) (ctx, state, cmd) ⇒
-              cmd match {
-                case AddItem(id)    ⇒ addItem(id, ctx.self)
-                case RemoveItem(id) ⇒ Effect.persist(ItemRemoved(id))
-                case GotMetaData(data) ⇒
-                  basket = basket.updatedWith(data)
-                  Effect.none
-                case GetTotalPrice(sender) ⇒
-                  sender ! basket.items.map(_.price).sum
-                  Effect.none
-              }
-            else (ctx, state, cmd) ⇒
-              cmd match {
-                case AddItem(id)    ⇒ addItem(id, ctx.self)
-                case RemoveItem(id) ⇒ Effect.persist(ItemRemoved(id))
-                case GotMetaData(data) ⇒
-                  basket = basket.updatedWith(data)
-                  if (isFullyHydrated(basket, state)) {
-                    stash.foreach(ctx.self ! _)
-                    stash = Nil
-                  }
-                  Effect.none
-                case cmd: GetTotalPrice ⇒
-                  stash :+= cmd
-                  Effect.none
-              }
-          ),
-        eventHandler = (state, evt) ⇒ evt match {
-          case ItemAdded(id)   ⇒ id +: state
-          case ItemRemoved(id) ⇒ state.filter(_ != id)
-        }).onRecoveryCompleted((ctx, state) ⇒ {
-          state.foreach(id ⇒ metadataRegistry ! GetMetaData(id, adapt))
-        })
-    }
-  }
-
-  object FactoringOutEventHandling {
-    sealed trait Mood
-    case object Happy extends Mood
-    case object Sad extends Mood
-
-    case object Ack
-
-    sealed trait Command
-    case class Greet(name: String) extends Command
-    case class CheerUp(sender: ActorRef[Ack.type]) extends Command
-    case class Remember(memory: String) extends Command
-
-    sealed trait Event
-    case class MoodChanged(to: Mood) extends Event
-    case class Remembered(memory: String) extends Event
-
-    def changeMoodIfNeeded(currentState: Mood, newMood: Mood): Effect[Event, Mood] =
-      if (currentState == newMood) Effect.none
-      else Effect.persist(MoodChanged(newMood))
-
-    PersistentBehaviors.receive[Command, Event, Mood](
-      persistenceId = "myPersistenceId",
-      initialState = Sad,
-      commandHandler = (_, state, cmd) ⇒
-        cmd match {
-          case Greet(whom) ⇒
-            println(s"Hi there, I'm $state!")
-            Effect.none
-          case CheerUp(sender) ⇒
-            changeMoodIfNeeded(state, Happy)
-              .andThen {
-                sender ! Ack
-              }
-          case Remember(memory) ⇒
-            // A more elaborate example to show we still have full control over the effects
-            // if needed (e.g. when some logic is factored out but you want to add more effects)
-            val commonEffects: Effect[Event, Mood] = changeMoodIfNeeded(state, Happy)
-            Effect.persist(commonEffects.events :+ Remembered(memory), commonEffects.sideEffects)
-
+    PersistentBehaviors[Command, Event, State]
+      .identifiedBy("task")
+      .onCreation(
+        commandHandler = command {
+          case CreateTaskTracker ⇒ Effect.persist(TaskTrackerCreated)
         },
-      eventHandler = {
-        case (_, MoodChanged(to))   ⇒ to
-        case (state, Remembered(_)) ⇒ state
-      })
-
+        eventHandler = {
+          case TaskTrackerCreated ⇒ State(Nil)
+        }
+      )
+      .onUpdate(
+        commandHandler = _ ⇒ command {
+          case RegisterTask(task) ⇒ Effect.persist(TaskRegistered(task))
+          case TaskDone(task)     ⇒ Effect.persist(TaskRemoved(task))
+        },
+        eventHandler = state ⇒ {
+          case TaskRegistered(task) ⇒ State(task :: state.tasksInFlight)
+          case TaskRemoved(task)    ⇒ State(state.tasksInFlight.filter(_ != task))
+        }
+      )
+      .snapshotWhen { (state, e, seqNr) ⇒ state.tasksInFlight.isEmpty }
   }
 
-  object Stopping {
-    sealed trait Command
-    case object Enough extends Command
-
-    sealed trait Event
-    case object Done extends Event
-
-    class State
-
-    PersistentBehaviors.receive[Command, Event, State](
-      persistenceId = "myPersistenceId",
-      initialState = new State,
-      commandHandler = CommandHandler.command {
-        case Enough ⇒
-          Effect.persist(Done)
-            .andThen(println("yay"))
-            .andThenStop
-
-      },
-      eventHandler = {
-        case (state, Done) ⇒ state
-      })
-  }
+  //
+  //  object SpawnChild {
+  //    type Task = String
+  //    sealed trait Command
+  //    case class RegisterTask(task: Task) extends Command
+  //    case class TaskDone(task: Task) extends Command
+  //
+  //    sealed trait Event
+  //    case class TaskRegistered(task: Task) extends Event
+  //    case class TaskRemoved(task: Task) extends Event
+  //
+  //    case class State(tasksInFlight: List[Task])
+  //
+  //    def worker(task: Task): Behavior[Nothing] = ???
+  //
+  //    PersistentBehaviors.receive[Command, Event, State](
+  //      persistenceId = "asdf",
+  //      initialState = State(Nil),
+  //      commandHandler = (ctx, _, cmd) ⇒ cmd match {
+  //        case RegisterTask(task) ⇒
+  //          Effect.persist(TaskRegistered(task))
+  //            .andThen {
+  //              val child = ctx.spawn[Nothing](worker(task), task)
+  //              // This assumes *any* termination of the child may trigger a `TaskDone`:
+  //              ctx.watchWith(child, TaskDone(task))
+  //            }
+  //        case TaskDone(task) ⇒ Effect.persist(TaskRemoved(task))
+  //      },
+  //      eventHandler = (state, evt) ⇒ evt match {
+  //        case TaskRegistered(task) ⇒ State(task :: state.tasksInFlight)
+  //        case TaskRemoved(task)    ⇒ State(state.tasksInFlight.filter(_ != task))
+  //      })
+  //  }
+  //
+  //  object Rehydrating {
+  //    type Id = String
+  //
+  //    sealed trait Command
+  //    case class AddItem(id: Id) extends Command
+  //    case class RemoveItem(id: Id) extends Command
+  //    case class GetTotalPrice(sender: ActorRef[Int]) extends Command
+  //    /* Internal: */
+  //    case class GotMetaData(data: MetaData) extends Command
+  //
+  //    /**
+  //     * Items have all kinds of metadata, but we only persist the 'id', and
+  //     * rehydrate the metadata on recovery from a registry
+  //     */
+  //    case class Item(id: Id, name: String, price: Int)
+  //    case class Basket(items: Seq[Item]) {
+  //      def updatedWith(data: MetaData): Basket = ???
+  //    }
+  //
+  //    sealed trait Event
+  //    case class ItemAdded(id: Id) extends Event
+  //    case class ItemRemoved(id: Id) extends Event
+  //
+  //    /*
+  //      * The metadata registry
+  //      */
+  //    case class GetMetaData(id: Id, sender: ActorRef[MetaData])
+  //    case class MetaData(id: Id, name: String, price: Int)
+  //    val metadataRegistry: ActorRef[GetMetaData] = ???
+  //
+  //    def isFullyHydrated(basket: Basket, ids: List[Id]) = basket.items.map(_.id) == ids
+  //
+  //    Behaviors.setup { ctx: ActorContext[Command] ⇒
+  //      // FIXME this doesn't work, wrapping not supported
+  //
+  //      var basket = Basket(Nil)
+  //      var stash: Seq[Command] = Nil
+  //      val adapt = ctx.messageAdapter((m: MetaData) ⇒ GotMetaData(m))
+  //
+  //      def addItem(id: Id, self: ActorRef[Command]) =
+  //        Effect
+  //          .persist[Event, List[Id]](ItemAdded(id))
+  //          .andThen(metadataRegistry ! GetMetaData(id, adapt))
+  //
+  //      PersistentBehaviors.receive[Command, Event, List[Id]](
+  //        persistenceId = "basket-1",
+  //        initialState = Nil,
+  //        commandHandler =
+  //          CommandHandler.byState(state ⇒
+  //            if (isFullyHydrated(basket, state)) (ctx, state, cmd) ⇒
+  //              cmd match {
+  //                case AddItem(id)    ⇒ addItem(id, ctx.self)
+  //                case RemoveItem(id) ⇒ Effect.persist(ItemRemoved(id))
+  //                case GotMetaData(data) ⇒
+  //                  basket = basket.updatedWith(data)
+  //                  Effect.none
+  //                case GetTotalPrice(sender) ⇒
+  //                  sender ! basket.items.map(_.price).sum
+  //                  Effect.none
+  //              }
+  //            else (ctx, state, cmd) ⇒
+  //              cmd match {
+  //                case AddItem(id)    ⇒ addItem(id, ctx.self)
+  //                case RemoveItem(id) ⇒ Effect.persist(ItemRemoved(id))
+  //                case GotMetaData(data) ⇒
+  //                  basket = basket.updatedWith(data)
+  //                  if (isFullyHydrated(basket, state)) {
+  //                    stash.foreach(ctx.self ! _)
+  //                    stash = Nil
+  //                  }
+  //                  Effect.none
+  //                case cmd: GetTotalPrice ⇒
+  //                  stash :+= cmd
+  //                  Effect.none
+  //              }
+  //          ),
+  //        eventHandler = (state, evt) ⇒ evt match {
+  //          case ItemAdded(id)   ⇒ id +: state
+  //          case ItemRemoved(id) ⇒ state.filter(_ != id)
+  //        }).onRecoveryCompleted((ctx, state) ⇒ {
+  //          state.foreach(id ⇒ metadataRegistry ! GetMetaData(id, adapt))
+  //        })
+  //    }
+  //  }
+  //
+  //  object FactoringOutEventHandling {
+  //    sealed trait Mood
+  //    case object Happy extends Mood
+  //    case object Sad extends Mood
+  //
+  //    case object Ack
+  //
+  //    sealed trait Command
+  //    case class Greet(name: String) extends Command
+  //    case class CheerUp(sender: ActorRef[Ack.type]) extends Command
+  //    case class Remember(memory: String) extends Command
+  //
+  //    sealed trait Event
+  //    case class MoodChanged(to: Mood) extends Event
+  //    case class Remembered(memory: String) extends Event
+  //
+  //    def changeMoodIfNeeded(currentState: Mood, newMood: Mood): Effect[Event, Mood] =
+  //      if (currentState == newMood) Effect.none
+  //      else Effect.persist(MoodChanged(newMood))
+  //
+  //    PersistentBehaviors.receive[Command, Event, Mood](
+  //      persistenceId = "myPersistenceId",
+  //      initialState = Sad,
+  //      commandHandler = (_, state, cmd) ⇒
+  //        cmd match {
+  //          case Greet(whom) ⇒
+  //            println(s"Hi there, I'm $state!")
+  //            Effect.none
+  //          case CheerUp(sender) ⇒
+  //            changeMoodIfNeeded(state, Happy)
+  //              .andThen {
+  //                sender ! Ack
+  //              }
+  //          case Remember(memory) ⇒
+  //            // A more elaborate example to show we still have full control over the effects
+  //            // if needed (e.g. when some logic is factored out but you want to add more effects)
+  //            val commonEffects: Effect[Event, Mood] = changeMoodIfNeeded(state, Happy)
+  //            Effect.persist(commonEffects.events :+ Remembered(memory), commonEffects.sideEffects)
+  //
+  //        },
+  //      eventHandler = {
+  //        case (_, MoodChanged(to))   ⇒ to
+  //        case (state, Remembered(_)) ⇒ state
+  //      })
+  //
+  //  }
+  //
+  //  object Stopping {
+  //    sealed trait Command
+  //    case object Enough extends Command
+  //
+  //    sealed trait Event
+  //    case object Done extends Event
+  //
+  //    class State
+  //
+  //    PersistentBehaviors.receive[Command, Event, State](
+  //      persistenceId = "myPersistenceId",
+  //      initialState = new State,
+  //      commandHandler = CommandHandler.command {
+  //        case Enough ⇒
+  //          Effect.persist(Done)
+  //            .andThen(println("yay"))
+  //            .andThenStop
+  //
+  //      },
+  //      eventHandler = {
+  //        case (state, Done) ⇒ state
+  //      })
+  //  }
 
 }

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsSpec.scala
@@ -16,20 +16,18 @@ object BasicPersistentBehaviorsSpec {
   case class State()
 
   val behavior: Behavior[Command] =
-    PersistentBehaviors.receive[Command, Event, State](
-      persistenceId = "abc",
-      initialState = State(),
-      commandHandler = (ctx, state, cmd) ⇒ ???,
-      eventHandler = (state, evt) ⇒ ???)
+    PersistentBehaviors[Command, Event, State]
+      .identifiedBy("abc")
+      .onCreation(???, ???)
+      .onUpdate(???, ???)
   //#structure
 
   //#recovery
   val recoveryBehavior: Behavior[Command] =
-    PersistentBehaviors.receive[Command, Event, State](
-      persistenceId = "abc",
-      initialState = State(),
-      commandHandler = (ctx, state, cmd) ⇒ ???,
-      eventHandler = (state, evt) ⇒ ???)
+    PersistentBehaviors[Command, Event, State]
+      .identifiedBy("abc")
+      .onCreation(???, ???)
+      .onUpdate(???, ???)
       .onRecoveryCompleted { (ctx, state) ⇒
         ???
       }
@@ -37,24 +35,22 @@ object BasicPersistentBehaviorsSpec {
 
   //#tagging
   val taggingBehavior: Behavior[Command] =
-    PersistentBehaviors.receive[Command, Event, State](
-      persistenceId = "abc",
-      initialState = State(),
-      commandHandler = (ctx, state, cmd) ⇒ ???,
-      eventHandler = (state, evt) ⇒ ???
-    ).withTagger(_ ⇒ Set("tag1", "tag2"))
-
+    PersistentBehaviors[Command, Event, State]
+      .identifiedBy("abc")
+      .onCreation(???, ???)
+      .onUpdate(???, ???)
+      .withTagger(_ ⇒ Set("tag1", "tag2"))
   //#tagging
 
   //#wrapPersistentBehavior
-  val samplePersistentBehavior = PersistentBehaviors.receive[Command, Event, State](
-    persistenceId = "abc",
-    initialState = State(),
-    commandHandler = (ctx, state, cmd) ⇒ ???,
-    eventHandler = (state, evt) ⇒ ???)
-    .onRecoveryCompleted { (ctx, state) ⇒
-      ???
-    }
+  val samplePersistentBehavior =
+    PersistentBehaviors[Command, Event, State]
+      .identifiedBy("abc")
+      .onCreation(???, ???)
+      .onUpdate(???, ???)
+      .onRecoveryCompleted { (ctx, state) ⇒
+        ???
+      }
 
   val debugAlwaysSnapshot: Behavior[Command] = Behaviors.setup {
     context ⇒


### PR DESCRIPTION

Here is thus the PR with some of the changes we discussed in Lisbon.
 It’s not yet finished. The documentation needs to be addressed and some clean-up may also be needed. Test are not passing and I didn't touch the sharding module.

I’m sending the PR in WIP in order to get earlier feedback. There are still some important points to discuss. 

## Highlights
The Java API has now two command handlers and two event handlers reflecting the fact the a state must first be initialised.

```scala
protected def commandHandler(): CommandHandler[Command, Event, State]
protected def commandHandler(state: State): CommandHandler[Command, Event, State]

protected def eventHandler(): EventHandler[Event, State]
protected def eventHandler(state: State): EventHandler[Event, State]
```

The Scala API has a builder that guides the user through the different steps. The user can’t create a behavior without following the first three steps, ie: `identifiedBy`, `onCreation` and `onUpdate`. Only after defining the basic behavior the user can configure the “extras”, ie: `snapshotWhen`, `onRecoveryCompleted`, etc.

```scala
PersistentBehaviors[Command, Event, State]
  .identifiedBy("abc-def")
  .onCreation(
    commandHandler = ???, // CommandHandler
    eventHandler = ???    // EventHandler
  )
  .onUpdate(
    commandHandler = ???, // State => CommandHandler
    eventHandler = ???    // State => EventHandler
  )
``` 

### onRecoveryCompleted

Needs to be defined as: 
```
def onRecoveryCompleted(callback: (ActorContext[Command], Option[State]) ⇒ Unit)
```

I was surprised to discover that this method gets called even when there is nothing to recover, for instance when you initialise the actor for the very first time. 

I believe that in untyped there was not much one could do because there wasn’t an easy way to detect if it was a fresh entity or one that was being re-hydrated (the state wasn’t managed). 
The same can be said about the current typed impl. That can change with this PR if we let it receive a `Option` and let the user decide what to do. Otherwise, we can keep it as `State => Unit`, but only call it when we do have a `State`.

I don’t find it a huge impact and again aligns with the idea that there must be no state prior to the first event.

### CommandHandler.byState

This utility method becomes obsolete. It doesn’t make any sense for `onCreation` and for `onUpdate` we have already a function from `State` to `CommandHandler`.

### SideEffects without State

Here we have an annoying situation. The side-effect callbacks are defined as `andThen(callback: State ⇒ Unit)`.

In principle this should not be a problem because side-effects are run after events are persisted and applied. However there is a border case which is when there is no `State` yet and a command handler is defined that doesn’t persist anything but still try to run some side-effect. 

If someone is explicitly not emitting any events, doesn’t having any State and is stil running side-effects just for the fun, I would say: the persistent actor is being abused. The problem is that some business logic may have decided that there is no event to emit and that is not yet the time to initialise the State. But then the question is, should the side-effect take place or not?

In that specific situation we don’t have a State to offer. To solve that we have a few options, none of them ideal.
* We change the callback to `andThen(callback: Option[State] ⇒ Unit)`
That’s inconvenient because in the huge majority of the cases we will have a `Some` 
* We can emit a warning that side-effects won’t be run because there is no `State`.
Kind of surprising to user, but this will only happen on this very specific and probably rare scenario.
* Keep the initial state. That will be a big pity because we open the doors for some other subtle bugs and because of a rather rare scenario.
* Pass `null` , pray and then eventually catch NPE (I don’t believe I’m writing this). 