### PR TITLE
Fix for contradictory OSGi meta data in akka-stream (#25055).

### DIFF
--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -92,8 +92,7 @@ object OSGi {
       packages = Seq(
         "akka.stream.*",
         "com.typesafe.sslconfig.akka.*"),
-      imports = Seq(scalaJava8CompatImport(), scalaParsingCombinatorImport())) ++
-      Seq(OsgiKeys.requireBundle := Seq(s"""com.typesafe.sslconfig;bundle-version="${Dependencies.sslConfigVersion}""""))
+      imports = Seq(scalaJava8CompatImport(), scalaParsingCombinatorImport(), sslConfigCoreImport()))
 
   val streamTestkit = exports(Seq("akka.stream.testkit.*"))
 
@@ -127,7 +126,8 @@ object OSGi {
     versionedImport(packageName, s"$epoch.$major", s"$epoch.${major.toInt + 1}")
   }
   def scalaJava8CompatImport(packageName: String = "scala.compat.java8.*") = versionedImport(packageName, "0.7.0", "1.0.0")
-  def scalaParsingCombinatorImport(packageName: String = "scala.util.parsing.combinator.*") = versionedImport(packageName, "1.0.4", "1.1.0")
+  def scalaParsingCombinatorImport(packageName: String = "scala.util.parsing.combinator.*") = versionedImport(packageName, "1.1.0", "1.2.0")
+  def sslConfigCoreImport(packageName: String = "com.typesafe.sslconfig.*") = versionedImport(packageName, "0.2.3", "1.0.0")
   def kamonImport(packageName: String = "kamon.sigar.*") = optionalResolution(versionedImport(packageName, "1.6.5", "1.6.6"))
   def sigarImport(packageName: String = "org.hyperic.*") = optionalResolution(versionedImport(packageName, "1.6.5", "1.6.6"))
   def optionalResolution(packageName: String) = "%s;resolution:=optional".format(packageName)


### PR DESCRIPTION
The dependency to parsing combinator has been upgraded to version 1.1.0,
which is required by ssl-config-core. For generating the ssl-config-core
import a new function has been added; it replaces the Require-Bundle
directive. This has the same effect, but is more OSGi-like.