### PR TITLE
Add Java annotation, @Deprecated, to existing Scala @deprecated

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
@@ -140,6 +140,7 @@ object Behaviors {
    * some action upon each received message or signal. It is most commonly used
    * for logging or tracing what a certain Actor does.
    */
+  @Deprecated
   @deprecated("Use overloaded tap", "2.5.13")
   def tap[T: ClassTag](
     onMessage: (ActorContext[T], T) ⇒ _,

--- a/akka-actor/src/main/scala/akka/actor/AbstractActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/AbstractActor.scala
@@ -62,6 +62,7 @@ object AbstractActor {
      * Returns a reference to the named child or null if no child with
      * that name exists.
      */
+    @Deprecated
     @deprecated("Use findChild instead", "2.5.0")
     def getChild(name: String): ActorRef
 
@@ -231,6 +232,7 @@ abstract class AbstractActor extends Actor {
   override def postStop(): Unit = super.postStop()
 
   // TODO In 2.6.0 we can remove deprecation and make the method final
+  @Deprecated
   @deprecated("Override preRestart with message parameter with Optional type instead", "2.5.0")
   @throws(classOf[Exception])
   override def preRestart(reason: Throwable, message: Option[Any]): Unit = {

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -84,6 +84,7 @@ final case class ActorIdentity(correlationId: Any, ref: Option[ActorRef]) {
    * Java API: `ActorRef` of the actor replying to the request or
    * null if no actor matched the request.
    */
+  @Deprecated
   @deprecated("Use getActorRef instead", "2.5.0")
   def getRef: ActorRef = ref.orNull
 

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -238,6 +238,7 @@ trait ActorContext extends ActorRefFactory {
  * UntypedActorContext is the UntypedActor equivalent of ActorContext,
  * containing the Java API
  */
+@Deprecated
 @deprecated("Use AbstractActor.ActorContext instead of UntypedActorContext.", since = "2.5.0")
 trait UntypedActorContext extends ActorContext {
 

--- a/akka-actor/src/main/scala/akka/actor/ActorDSL.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorDSL.scala
@@ -69,6 +69,7 @@ import akka.util.JavaDurationConverters._
  *
  * @deprecated Use the normal `actorOf` methods defined on `ActorSystem` and `ActorContext` to create Actors instead.
  */
+@Deprecated
 @deprecated("deprecated Use the normal `actorOf` methods defined on `ActorSystem` and `ActorContext` to create Actors instead.", since = "2.5.0")
 object ActorDSL extends dsl.Inbox with dsl.Creators {
 

--- a/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
+++ b/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
@@ -378,6 +378,7 @@ final class CoordinatedShutdown private[akka] (
    */
   def run(reason: Reason): Future[Done] = run(reason, None)
 
+  @Deprecated
   @deprecated("Use the method with `reason` parameter instead", since = "2.5.8")
   def run(): Future[Done] = run(UnknownReason)
 
@@ -390,6 +391,7 @@ final class CoordinatedShutdown private[akka] (
    */
   def runAll(reason: Reason): CompletionStage[Done] = run(reason).toJava
 
+  @Deprecated
   @deprecated("Use the method with `reason` parameter instead", since = "2.5.8")
   def runAll(): CompletionStage[Done] = runAll(UnknownReason)
 
@@ -484,6 +486,7 @@ final class CoordinatedShutdown private[akka] (
     runPromise.future
   }
 
+  @Deprecated
   @deprecated("Use the method with `reason` parameter instead", since = "2.5.8")
   def run(fromPhase: Option[String]): Future[Done] =
     run(UnknownReason, fromPhase)
@@ -498,6 +501,7 @@ final class CoordinatedShutdown private[akka] (
   def run(reason: Reason, fromPhase: Optional[String]): CompletionStage[Done] =
     run(reason, fromPhase.asScala).toJava
 
+  @Deprecated
   @deprecated("Use the method with `reason` parameter instead", since = "2.5.8")
   def run(fromPhase: Optional[String]): CompletionStage[Done] =
     run(UnknownReason, fromPhase)

--- a/akka-actor/src/main/scala/akka/actor/Extension.scala
+++ b/akka-actor/src/main/scala/akka/actor/Extension.scala
@@ -147,6 +147,7 @@ trait ExtensionIdProvider {
  * `get` method.
  *
  */
+@Deprecated
 @deprecated(message = "Use a regular Extension instead", since = "2.5.0")
 abstract class ExtensionKey[T <: Extension](implicit m: ClassTag[T]) extends ExtensionId[T] with ExtensionIdProvider {
   def this(clazz: Class[T]) = this()(ClassTag(clazz))

--- a/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
@@ -134,6 +134,7 @@ private[akka] class RepointableActorRef(
     case _                ⇒ true
   }
 
+  @Deprecated
   @deprecated("Use context.watch(actor) and receive Terminated(actor)", "2.2") def isTerminated: Boolean = underlying.isTerminated
 
   def provider: ActorRefProvider = system.provider

--- a/akka-actor/src/main/scala/akka/actor/UntypedActorWithStash.scala
+++ b/akka-actor/src/main/scala/akka/actor/UntypedActorWithStash.scala
@@ -44,6 +44,7 @@ package akka.actor
  * There is also an unrestricted version [[akka.actor.UntypedActorWithUnrestrictedStash]] that does not
  * enforce the mailbox type.
  */
+@Deprecated
 @deprecated("Use AbstractActorWithStash instead of UntypedActorWithStash.", since = "2.5.0")
 abstract class UntypedActorWithStash extends UntypedActor with Stash
 
@@ -51,6 +52,7 @@ abstract class UntypedActorWithStash extends UntypedActor with Stash
  * Actor base class with `Stash` that enforces an unbounded deque for the actor.
  * See [[akka.actor.UntypedActorWithStash]] for details on how `Stash` works.
  */
+@Deprecated
 @deprecated("Use AbstractActorWithUnboundedStash instead of UntypedActorWithUnboundedStash.", since = "2.5.0")
 abstract class UntypedActorWithUnboundedStash extends UntypedActor with UnboundedStash
 
@@ -59,5 +61,6 @@ abstract class UntypedActorWithUnboundedStash extends UntypedActor with Unbounde
  * manually, and the mailbox should extend the [[akka.dispatch.DequeBasedMessageQueueSemantics]] marker trait.
  * See [[akka.actor.UntypedActorWithStash]] for details on how `Stash` works.
  */
+@Deprecated
 @deprecated("Use AbstractActorWithUnrestrictedStash instead of UntypedActorWithUnrestrictedStash.", since = "2.5.0")
 abstract class UntypedActorWithUnrestrictedStash extends UntypedActor with UnrestrictedStash

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -180,6 +180,7 @@ object Futures {
  * Internal use only.
  */
 object japi {
+  @Deprecated
   @deprecated("Do not use this directly, use subclasses of this", "2.0")
   class CallbackBridge[-T] extends AbstractPartialFunction[T, BoxedUnit] {
     override final def isDefinedAt(t: T): Boolean = true
@@ -190,6 +191,7 @@ object japi {
     protected def internal(result: T): Unit = ()
   }
 
+  @Deprecated
   @deprecated("Do not use this directly, use 'Recover'", "2.0")
   class RecoverBridge[+T] extends AbstractPartialFunction[Throwable, T] {
     override final def isDefinedAt(t: Throwable): Boolean = true
@@ -197,12 +199,14 @@ object japi {
     protected def internal(result: Throwable): T = null.asInstanceOf[T]
   }
 
+  @Deprecated
   @deprecated("Do not use this directly, use subclasses of this", "2.0")
   class BooleanFunctionBridge[-T] extends scala.Function1[T, Boolean] {
     override final def apply(t: T): Boolean = internal(t)
     protected def internal(result: T): Boolean = false
   }
 
+  @Deprecated
   @deprecated("Do not use this directly, use subclasses of this", "2.0")
   class UnitFunctionBridge[-T] extends (T ⇒ BoxedUnit) {
     final def apply$mcLJ$sp(l: Long): BoxedUnit = { internal(l.asInstanceOf[T]); BoxedUnit.UNIT }

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -647,6 +647,7 @@ object Logging {
    * Obtain LoggingAdapter with MDC support for the given actor.
    * Don't use it outside its specific Actor as it isn't thread safe
    */
+  @Deprecated
   @deprecated("Use AbstractActor instead of UntypedActor.", since = "2.5.0")
   def getLogger(logSource: UntypedActor): DiagnosticLoggingAdapter = {
     val (str, clazz) = LogSource.fromAnyRef(logSource)

--- a/akka-actor/src/main/scala/akka/event/LoggingReceive.scala
+++ b/akka-actor/src/main/scala/akka/event/LoggingReceive.scala
@@ -41,6 +41,7 @@ object LoggingReceive {
   /**
    * Java API: compatible with lambda expressions
    */
+  @Deprecated
   @deprecated("Use the create method with `AbstractActor.Receive` parameter instead.", since = "2.5.0")
   def create(r: Receive, context: ActorContext): Receive = apply(r)(context)
 

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -344,6 +344,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
   /**
    * @see [[WritePath]]
    */
+  @Deprecated
   @deprecated("Use WritePath instead", "2.5.10")
   final case class WriteFile(filePath: String, position: Long, count: Long, ack: Event) extends SimpleWriteCommand {
     require(position >= 0, "WriteFile.position must be >= 0")

--- a/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
@@ -58,6 +58,7 @@ object CircuitBreaker {
    * @param callTimeout [[scala.concurrent.duration.FiniteDuration]] of time after which to consider a call a failure
    * @param resetTimeout [[scala.concurrent.duration.FiniteDuration]] of time after which to attempt to close the circuit
    */
+  @Deprecated
   @deprecated("Use the overloaded one which accepts java.time.Duration instead.", since = "2.5.12")
   def create(scheduler: Scheduler, maxFailures: Int, callTimeout: FiniteDuration, resetTimeout: FiniteDuration): CircuitBreaker =
     apply(scheduler, maxFailures, callTimeout, resetTimeout)
@@ -130,6 +131,7 @@ class CircuitBreaker(
 
   require(exponentialBackoffFactor >= 1.0, "factor must be >= 1.0")
 
+  @Deprecated
   @deprecated("Use the overloaded one which accepts java.time.Duration instead.", since = "2.5.12")
   def this(executor: ExecutionContext, scheduler: Scheduler, maxFailures: Int, callTimeout: FiniteDuration, resetTimeout: FiniteDuration) = {
     this(scheduler, maxFailures, callTimeout, resetTimeout, 36500.days, 1.0)(executor)
@@ -400,6 +402,7 @@ class CircuitBreaker(
    * @param callback Handler to be invoked on state change
    * @return CircuitBreaker for fluent usage
    */
+  @Deprecated
   @deprecated("Use addOnOpenListener instead", "2.5.0")
   def onOpen(callback: Runnable): CircuitBreaker = addOnOpenListener(callback)
 
@@ -429,6 +432,7 @@ class CircuitBreaker(
    * @param callback Handler to be invoked on state change
    * @return CircuitBreaker for fluent usage
    */
+  @Deprecated
   @deprecated("Use addOnHalfOpenListener instead", "2.5.0")
   def onHalfOpen(callback: Runnable): CircuitBreaker = addOnHalfOpenListener(callback)
 
@@ -459,6 +463,7 @@ class CircuitBreaker(
    * @param callback Handler to be invoked on state change
    * @return CircuitBreaker for fluent usage
    */
+  @Deprecated
   @deprecated("Use addOnCloseListener instead", "2.5.0")
   def onClose(callback: Runnable): CircuitBreaker = addOnCloseListener(callback)
 

--- a/akka-actor/src/main/scala/akka/pattern/Patterns.scala
+++ b/akka-actor/src/main/scala/akka/pattern/Patterns.scala
@@ -484,6 +484,7 @@ object PatternsCS {
    * If the target actor isn't terminated within the timeout the [[java.util.concurrent.CompletionStage]]
    * is completed with failure [[akka.pattern.AskTimeoutException]].
    */
+  @Deprecated
   @deprecated("Use the overloaded one which accepts java.time.Duration instead.", since = "2.5.12")
   def gracefulStop(target: ActorRef, timeout: FiniteDuration): CompletionStage[java.lang.Boolean] =
     scalaGracefulStop(target, timeout).toJava.asInstanceOf[CompletionStage[java.lang.Boolean]]
@@ -514,6 +515,7 @@ object PatternsCS {
    * If the target actor isn't terminated within the timeout the [[java.util.concurrent.CompletionStage]]
    * is completed with failure [[akka.pattern.AskTimeoutException]].
    */
+  @Deprecated
   @deprecated("Use the overloaded one which accepts java.time.Duration instead.", since = "2.5.12")
   def gracefulStop(target: ActorRef, timeout: FiniteDuration, stopMessage: Any): CompletionStage[java.lang.Boolean] =
     scalaGracefulStop(target, timeout, stopMessage).toJava.asInstanceOf[CompletionStage[java.lang.Boolean]]
@@ -538,6 +540,7 @@ object PatternsCS {
    * Returns a [[java.util.concurrent.CompletionStage]] that will be completed with the success or failure of the provided Callable
    * after the specified duration.
    */
+  @Deprecated
   @deprecated("Use the overloaded one which accepts java.time.Duration instead.", since = "2.5.12")
   def after[T](duration: FiniteDuration, scheduler: Scheduler, context: ExecutionContext, value: Callable[CompletionStage[T]]): CompletionStage[T] =
     afterCompletionStage(duration, scheduler)(value.call())(context)
@@ -553,6 +556,7 @@ object PatternsCS {
    * Returns a [[java.util.concurrent.CompletionStage]] that will be completed with the success or failure of the provided value
    * after the specified duration.
    */
+  @Deprecated
   @deprecated("Use the overloaded one which accepts java.time.Duration instead.", since = "2.5.12")
   def after[T](duration: FiniteDuration, scheduler: Scheduler, context: ExecutionContext, value: CompletionStage[T]): CompletionStage[T] =
     afterCompletionStage(duration, scheduler)(value)(context)

--- a/akka-agent/src/main/scala/akka/agent/Agent.scala
+++ b/akka-agent/src/main/scala/akka/agent/Agent.scala
@@ -8,11 +8,13 @@ import scala.concurrent.stm._
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import akka.util.SerializedSuspendableExecutionContext
 
+@Deprecated
 @deprecated("Agents are deprecated and scheduled for removal in the next major version, use Actors instead.", since = "2.5.0")
 object Agent {
   /**
    * Factory method for creating an Agent.
    */
+  @Deprecated
   @deprecated("Agents are deprecated and scheduled for removal in the next major version, use Actors instead.", since = "2.5.0")
   def apply[T](initialValue: T)(implicit context: ExecutionContext): Agent[T] = new SecretAgent(initialValue, context)
 
@@ -159,6 +161,7 @@ object Agent {
  *
  * @deprecated Agents are deprecated and scheduled for removal in the next major version, use Actors instead.
  */
+@Deprecated
 @deprecated("Agents are deprecated and scheduled for removal in the next major version, use Actors instead.", since = "2.5.0")
 abstract class Agent[T] {
 

--- a/akka-camel/src/main/scala/akka/camel/CamelMessage.scala
+++ b/akka-camel/src/main/scala/akka/camel/CamelMessage.scala
@@ -17,6 +17,7 @@ import akka.dispatch.Mapper
 /**
  * An immutable representation of a Camel message.
  */
+@Deprecated
 @deprecated("Akka Camel is deprecated in favour of 'Alpakka', the Akka Streams based collection of integrations to various endpoints (including Camel).", since = "2.5.0")
 class CamelMessage(val body: Any, val headers: Map[String, Any], val attachments: Map[String, DataHandler]) extends Serializable with Product {
   def this(body: Any, headers: JMap[String, Any]) = this(body, headers.toMap, Map.empty[String, DataHandler]) //Java

--- a/akka-camel/src/main/scala/akka/camel/Consumer.scala
+++ b/akka-camel/src/main/scala/akka/camel/Consumer.scala
@@ -13,6 +13,7 @@ import akka.dispatch.Mapper
 /**
  * Mixed in by Actor implementations that consume message from Camel endpoints.
  */
+@Deprecated
 @deprecated("Akka Camel is deprecated in favour of 'Alpakka', the Akka Streams based collection of integrations to various endpoints (including Camel).", since = "2.5.0")
 trait Consumer extends Actor with CamelSupport {
   import Consumer._

--- a/akka-camel/src/main/scala/akka/camel/Producer.scala
+++ b/akka-camel/src/main/scala/akka/camel/Producer.scala
@@ -150,6 +150,7 @@ trait ProducerSupport extends Actor with CamelSupport {
 /**
  * Mixed in by Actor implementations to produce messages to Camel endpoints.
  */
+@Deprecated
 @deprecated("Akka Camel is deprecated in favour of 'Alpakka', the Akka Streams based collection of integrations to various endpoints (including Camel).", since = "2.5.0")
 trait Producer extends ProducerSupport { this: Actor ⇒
 
@@ -175,6 +176,7 @@ private final case class FailureResult(cause: Throwable, headers: Map[String, An
  *
  *
  */
+@Deprecated
 @deprecated("Akka Camel is deprecated in favour of 'Alpakka', the Akka Streams based collection of integrations to various endpoints (including Camel).", since = "2.5.0")
 trait Oneway extends Producer { this: Actor ⇒
   override def oneway: Boolean = true

--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
@@ -95,6 +95,7 @@ final class DistributedPubSubSettings(
   val maxDeltaElements:                   Int,
   val sendToDeadLettersWhenNoSubscribers: Boolean) extends NoSerializationVerificationNeeded {
 
+  @Deprecated
   @deprecated("Use the other constructor instead.", "2.5.5")
   def this(
     role:              Option[String],

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
@@ -124,6 +124,7 @@ final class ClusterSettings(val config: Config, val systemName: String) {
    *   ``Cluster.downingProvider.downRemovalMargin`` should be used as it allows the downing provider to decide removal
    *   margins
    */
+  @Deprecated
   @deprecated("Use Cluster.downingProvider.downRemovalMargin", since = "2.4.5")
   val DownRemovalMargin: FiniteDuration = {
     val key = "down-removal-margin"

--- a/akka-cluster/src/main/scala/akka/cluster/Member.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Member.scala
@@ -161,6 +161,7 @@ object Member {
     (a, b) ⇒ a.isOlderThan(b)
   }
 
+  @Deprecated
   @deprecated("Was accidentally made a public API, internal", since = "2.5.4")
   def pickHighestPriority(a: Set[Member], b: Set[Member]): Set[Member] =
     pickHighestPriority(a, b, Map.empty)
@@ -278,6 +279,7 @@ object MemberStatus {
 object UniqueAddress extends AbstractFunction2[Address, Int, UniqueAddress] {
 
   // for binary compatibility
+  @Deprecated
   @deprecated("Use Long UID apply instead", since = "2.4.11")
   def apply(address: Address, uid: Int) = new UniqueAddress(address, uid.toLong)
 
@@ -300,10 +302,11 @@ final case class UniqueAddress(address: Address, longUid: Long) extends Ordered[
   }
 
   // for binary compatibility
-
+  @Deprecated
   @deprecated("Use Long UID constructor instead", since = "2.4.11")
   def this(address: Address, uid: Int) = this(address, uid.toLong)
 
+  @Deprecated
   @deprecated("Use longUid instead", since = "2.4.11")
   def uid = longUid.toInt
 
@@ -311,6 +314,7 @@ final case class UniqueAddress(address: Address, longUid: Long) extends Ordered[
    * For binary compatibility
    * Stops `copy(Address, Long)` copy from being generated, use `apply` instead.
    */
+  @Deprecated
   @deprecated("Use Long UID constructor instead", since = "2.4.11")
   def copy(address: Address = address, uid: Int = uid) = new UniqueAddress(address, uid)
 

--- a/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
@@ -32,6 +32,7 @@ import scala.collection.immutable
 import scala.collection.JavaConverters._
 
 object ClusterRouterGroupSettings {
+  @Deprecated
   @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def apply(totalInstances: Int, routeesPaths: immutable.Seq[String], allowLocalRoutees: Boolean, useRole: Option[String]): ClusterRouterGroupSettings =
     ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRole.toSet)
@@ -60,9 +61,11 @@ final case class ClusterRouterGroupSettings(
   useRoles:          Set[String]) extends ClusterRouterSettingsBase {
 
   // For binary compatibility
+  @Deprecated
   @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def useRole: Option[String] = useRoles.headOption
 
+  @Deprecated
   @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def this(totalInstances: Int, routeesPaths: immutable.Seq[String], allowLocalRoutees: Boolean, useRole: Option[String]) =
     this(totalInstances, routeesPaths, allowLocalRoutees, useRole.toSet)
@@ -70,6 +73,7 @@ final case class ClusterRouterGroupSettings(
   /**
    * Java API
    */
+  @Deprecated
   @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def this(totalInstances: Int, routeesPaths: java.lang.Iterable[String], allowLocalRoutees: Boolean, useRole: String) =
     this(totalInstances, immutableSeq(routeesPaths), allowLocalRoutees, Option(useRole).toSet)
@@ -81,6 +85,7 @@ final case class ClusterRouterGroupSettings(
     this(totalInstances, immutableSeq(routeesPaths), allowLocalRoutees, useRoles.asScala.toSet)
 
   // For binary compatibility
+  @Deprecated
   @deprecated("Use constructor with useRoles instead", since = "2.5.4")
   def copy(totalInstances: Int = totalInstances, routeesPaths: immutable.Seq[String] = routeesPaths, allowLocalRoutees: Boolean = allowLocalRoutees, useRole: Option[String] = useRole): ClusterRouterGroupSettings =
     new ClusterRouterGroupSettings(totalInstances, routeesPaths, allowLocalRoutees, useRole)
@@ -107,6 +112,7 @@ final case class ClusterRouterGroupSettings(
 }
 
 object ClusterRouterPoolSettings {
+  @Deprecated
   @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def apply(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRole: Option[String]): ClusterRouterPoolSettings =
     ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRole.toSet)
@@ -137,9 +143,11 @@ final case class ClusterRouterPoolSettings(
   useRoles:            Set[String]) extends ClusterRouterSettingsBase {
 
   // For binary compatibility
+  @Deprecated
   @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def useRole: Option[String] = useRoles.headOption
 
+  @Deprecated
   @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def this(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRole: Option[String]) =
     this(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRole.toSet)
@@ -147,6 +155,7 @@ final case class ClusterRouterPoolSettings(
   /**
    * Java API
    */
+  @Deprecated
   @deprecated("useRole has been replaced with useRoles", since = "2.5.4")
   def this(totalInstances: Int, maxInstancesPerNode: Int, allowLocalRoutees: Boolean, useRole: String) =
     this(totalInstances, maxInstancesPerNode, allowLocalRoutees, Option(useRole).toSet)
@@ -158,6 +167,7 @@ final case class ClusterRouterPoolSettings(
     this(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRoles.asScala.toSet)
 
   // For binary compatibility
+  @Deprecated
   @deprecated("Use copy with useRoles instead", since = "2.5.4")
   def copy(totalInstances: Int = totalInstances, maxInstancesPerNode: Int = maxInstancesPerNode, allowLocalRoutees: Boolean = allowLocalRoutees, useRole: Option[String] = useRole): ClusterRouterPoolSettings =
     new ClusterRouterPoolSettings(totalInstances, maxInstancesPerNode, allowLocalRoutees, useRole)

--- a/akka-contrib/src/main/scala/akka/contrib/circuitbreaker/CircuitBreakerProxy.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/circuitbreaker/CircuitBreakerProxy.scala
@@ -16,6 +16,7 @@ import scala.util.{ Failure, Success }
  * This is an Actor which implements the circuit breaker pattern,
  * you may also be interested in the raw circuit breaker [[akka.pattern.CircuitBreaker]]
  */
+@Deprecated
 @deprecated("Use akka.pattern.CircuitBreaker + ask instead", "2.5.0")
 object CircuitBreakerProxy {
 
@@ -102,6 +103,7 @@ object CircuitBreakerProxy {
 
 import akka.contrib.circuitbreaker.CircuitBreakerProxy._
 
+@Deprecated
 @deprecated("Use akka.pattern.CircuitBreaker + ask instead", "2.5.0")
 final class CircuitBreakerProxy(
   target:               ActorRef,

--- a/akka-contrib/src/main/scala/akka/contrib/circuitbreaker/askExtensions.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/circuitbreaker/askExtensions.scala
@@ -11,6 +11,7 @@ import scala.language.implicitConversions
 
 import scala.concurrent.{ ExecutionContext, Future }
 
+@Deprecated
 @deprecated("Use akka.pattern.CircuitBreaker + ask instead", "2.5.0")
 sealed class OpenCircuitException(message: String) extends RuntimeException(message)
 private[circuitbreaker] final object OpenCircuitException extends OpenCircuitException("Unable to complete operation since the Circuit Breaker Actor Proxy is in Open State")
@@ -21,6 +22,7 @@ private[circuitbreaker] final object OpenCircuitException extends OpenCircuitExc
  * `Future` result of an `ask` pattern to fail in case of
  * [[akka.contrib.circuitbreaker.CircuitBreakerProxy.CircuitOpenFailure]] response
  */
+@Deprecated
 @deprecated("Use akka.pattern.CircuitBreaker + ask instead", "2.5.0")
 object Implicits {
   /**
@@ -64,6 +66,7 @@ object Implicits {
  * [[akka.contrib.circuitbreaker.CircuitBreakerProxy.CircuitOpenFailure]] failure responses throwing
  * an exception built with the given exception builder
  */
+@Deprecated
 @deprecated("Use akka.pattern.CircuitBreaker + ask instead", "2.5.0")
 final class CircuitBreakerAwareFuture(val future: Future[Any]) extends AnyVal {
   @throws[OpenCircuitException]
@@ -79,6 +82,7 @@ final class CircuitBreakerAwareFuture(val future: Future[Any]) extends AnyVal {
   }
 }
 
+@Deprecated
 @deprecated("Use akka.pattern.CircuitBreaker + ask instead", "2.5.0")
 final class AskeableWithCircuitBreakerActor(val actorRef: ActorRef) extends AnyVal {
   def askWithCircuitBreaker(message: Any)(implicit executionContext: ExecutionContext, timeout: Timeout, sender: ActorRef = Actor.noSender): Future[Any] =
@@ -93,6 +97,7 @@ final class AskeableWithCircuitBreakerActor(val actorRef: ActorRef) extends AnyV
   }
 }
 
+@Deprecated
 @deprecated("Use akka.pattern.CircuitBreaker + ask instead", "2.5.0")
 final class AskeableWithCircuitBreakerActorSelection(val actorSelection: ActorSelection) extends AnyVal {
   def askWithCircuitBreaker(message: Any)(implicit executionContext: ExecutionContext, timeout: Timeout, sender: ActorRef = Actor.noSender): Future[Any] =

--- a/akka-contrib/src/main/scala/akka/contrib/jul/JavaLogger.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/jul/JavaLogger.scala
@@ -22,6 +22,7 @@ import akka.event.LoggerMessageQueueSemantics
  *
  * For `Actor`s, use `ActorLogging` instead.
  */
+@Deprecated
 @deprecated("Feel free to copy", "2.5.0")
 trait JavaLogging {
 
@@ -34,6 +35,7 @@ trait JavaLogging {
 /**
  * `java.util.logging` logger.
  */
+@Deprecated
 @deprecated("Use akka.event.jul.JavaLogger in akka-actor instead", "2.5.0")
 class JavaLogger extends Actor with RequiresMessageQueue[LoggerMessageQueueSemantics] {
 
@@ -58,6 +60,7 @@ class JavaLogger extends Actor with RequiresMessageQueue[LoggerMessageQueueSeman
   }
 }
 
+@Deprecated
 @deprecated("Feel free to copy", "2.5.0")
 trait JavaLoggingAdapter extends LoggingAdapter {
 

--- a/akka-contrib/src/main/scala/akka/contrib/mailbox/PeekMailbox.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/mailbox/PeekMailbox.scala
@@ -11,6 +11,7 @@ import com.typesafe.config.Config
 import akka.actor.{ ActorContext, ActorRef, ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
 import akka.dispatch.{ Envelope, MailboxType, MessageQueue, UnboundedQueueBasedMessageQueue }
 
+@Deprecated
 @deprecated("Use an explicit supervisor or proxy actor instead", "2.5.0")
 object PeekMailboxExtension extends ExtensionId[PeekMailboxExtension] with ExtensionIdProvider {
   def lookup = this
@@ -19,6 +20,7 @@ object PeekMailboxExtension extends ExtensionId[PeekMailboxExtension] with Exten
   def ack()(implicit context: ActorContext): Unit = PeekMailboxExtension(context.system).ack()
 }
 
+@Deprecated
 @deprecated("Use an explicit supervisor or proxy actor instead", "2.5.0")
 class PeekMailboxExtension(val system: ExtendedActorSystem) extends Extension {
   private val mailboxes = new ConcurrentHashMap[ActorRef, PeekMailbox]
@@ -43,6 +45,7 @@ class PeekMailboxExtension(val system: ExtendedActorSystem) extends Extension {
  *   }
  * }}}
  */
+@Deprecated
 @deprecated("Use an explicit supervisor or proxy actor instead", "2.5.0")
 class PeekMailboxType(settings: ActorSystem.Settings, config: Config) extends MailboxType {
   override def create(owner: Option[ActorRef], system: Option[ActorSystem]) = (owner, system) match {
@@ -56,6 +59,7 @@ class PeekMailboxType(settings: ActorSystem.Settings, config: Config) extends Ma
   }
 }
 
+@Deprecated
 @deprecated("Use an explicit supervisor or proxy actor instead", "2.5.0")
 class PeekMailbox(owner: ActorRef, system: ActorSystem, maxRetries: Int)
   extends UnboundedQueueBasedMessageQueue {

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/Aggregator.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/Aggregator.scala
@@ -10,6 +10,7 @@ import scala.annotation.tailrec
 /**
  * The aggregator is to be mixed into an actor for the aggregator behavior.
  */
+@Deprecated
 @deprecated("Feel free to copy", "2.5.0")
 trait Aggregator {
   this: Actor ⇒
@@ -82,6 +83,7 @@ trait Aggregator {
 /**
  * Provides the utility methods and constructors to the WorkList class.
  */
+@Deprecated
 @deprecated("Feel free to copy", "2.5.0")
 object WorkList {
 
@@ -104,6 +106,7 @@ object WorkList {
  * entries from the list while processing. Most important, a processing function can remove its own entry from the list.
  * The first remove must return true and any subsequent removes must return false.
  */
+@Deprecated
 @deprecated("Feel free to copy", "2.5.0")
 class WorkList[T] {
 

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReceivePipeline.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReceivePipeline.scala
@@ -6,6 +6,7 @@ package akka.contrib.pattern
 
 import akka.actor.Actor
 
+@Deprecated
 @deprecated("Feel free to copy", "2.5.0")
 object ReceivePipeline {
   /**
@@ -48,6 +49,7 @@ object ReceivePipeline {
  * for configuring a chain of interceptors to be applied around
  * Actor's current behavior.
  */
+@Deprecated
 @deprecated("Feel free to copy", "2.5.0")
 trait ReceivePipeline extends Actor {
   import ReceivePipeline._

--- a/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/pattern/ReliableProxy.scala
@@ -10,6 +10,7 @@ import scala.concurrent.duration._
 import scala.util.Try
 import java.util.concurrent.TimeUnit
 
+@Deprecated
 @deprecated("Use AtLeastOnceDelivery instead", "2.5.0")
 object ReliableProxy {
   /**
@@ -225,6 +226,7 @@ import ReliableProxy._
  * @param maxConnectAttempts &nbsp;is an optional maximum number of attempts to connect to the
  *   target actor. Use `None` for no limit. If `reconnectAfter` is `None` this value is ignored.
  */
+@Deprecated
 @deprecated("Use AtLeastOnceDelivery instead", "2.5.0")
 class ReliableProxy(targetPath: ActorPath, retryAfter: FiniteDuration,
                     reconnectAfter: Option[FiniteDuration], maxConnectAttempts: Option[Int])

--- a/akka-contrib/src/main/scala/akka/contrib/throttle/TimerBasedThrottler.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/throttle/TimerBasedThrottler.scala
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit
  * @see [[akka.contrib.throttle.Throttler.SetRate]]
  * @see [[akka.contrib.throttle.Throttler.SetTarget]]
  */
+@Deprecated
 @deprecated("Use streams, see migration guide", "2.5.0")
 object Throttler {
   /**
@@ -215,6 +216,7 @@ private[throttle] object TimerBasedThrottler {
  *
  * @see [[akka.contrib.throttle.Throttler]]
  */
+@Deprecated
 @deprecated("Use streams, see migration guide", "2.5.0")
 class TimerBasedThrottler(var rate: Rate) extends Actor with FSM[State, Data] {
   import FSM.`→`

--- a/akka-persistence/src/main/scala/akka/persistence/AtLeastOnceDelivery.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/AtLeastOnceDelivery.scala
@@ -388,6 +388,7 @@ trait AtLeastOnceDeliveryLike extends Eventsourced {
  * @see [[AtLeastOnceDelivery]]
  * @see [[AtLeastOnceDeliveryLike]]
  */
+@Deprecated
 @deprecated("Use AbstractPersistentActorWithAtLeastOnceDelivery instead.", since = "2.5.0")
 abstract class UntypedPersistentActorWithAtLeastOnceDelivery extends UntypedPersistentActor with AtLeastOnceDeliveryLike {
   /**

--- a/akka-persistence/src/main/scala/akka/persistence/PersistentActor.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/PersistentActor.scala
@@ -291,6 +291,7 @@ trait PersistentActor extends Eventsourced with PersistenceIdentity {
 /**
  * Java API: an persistent actor - can be used to implement command or event sourcing.
  */
+@Deprecated
 @deprecated("Use AbstractPersistentActor instead of UntypedPersistentActor.", since = "2.5.0")
 abstract class UntypedPersistentActor extends UntypedActor with Eventsourced with PersistenceIdentity {
 

--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSMBase.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSMBase.scala
@@ -309,6 +309,7 @@ trait PersistentFSMBase[S, D, E] extends Actor with Listeners with ActorLogging 
    *
    * @see [[akka.persistence.fsm.PersistentFSM#receiveRecover]]
    */
+  @Deprecated
   @deprecated("Removed from API, called internally", "2.4.5")
   private[akka] final def initialize(): Unit =
     if (currentState != null) makeTransition(currentState)

--- a/akka-remote/src/main/scala/akka/remote/AddressUidExtension.scala
+++ b/akka-remote/src/main/scala/akka/remote/AddressUidExtension.scala
@@ -48,6 +48,7 @@ class AddressUidExtension(val system: ExtendedActorSystem) extends Extension {
   }
 
   // used by old remoting and part of public api
+  @Deprecated
   @deprecated("Use longAddressUid instead", "2.4.x")
   def addressUid: Int = _addressUid
 }

--- a/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
@@ -85,6 +85,7 @@ final case class RemotingErrorEvent(cause: Throwable) extends RemotingLifecycleE
 // For binary compatibility
 object QuarantinedEvent extends AbstractFunction2[Address, Int, QuarantinedEvent] {
 
+  @Deprecated
   @deprecated("Use long uid apply", "2.4.x")
   def apply(address: Address, uid: Int) = new QuarantinedEvent(address, uid)
 }
@@ -99,13 +100,15 @@ final case class QuarantinedEvent(address: Address, longUid: Long) extends Remot
       "from this situation."
 
   // For binary compatibility
-
+  @Deprecated
   @deprecated("Use long uid constructor", "2.4.x")
   def this(address: Address, uid: Int) = this(address, uid.toLong)
 
+  @Deprecated
   @deprecated("Use long uid", "2.4.x")
   def uid: Int = longUid.toInt
 
+  @Deprecated
   @deprecated("Use long uid copy method", "2.4.x")
   def copy(address: Address = address, uid: Int = uid) = new QuarantinedEvent(address, uid)
 }

--- a/akka-remote/src/main/scala/akka/remote/transport/Transport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/Transport.scala
@@ -264,6 +264,7 @@ trait AssociationHandle {
    * could be called arbitrarily many times.
    *
    */
+  @Deprecated
   @deprecated(message = "Use method that states reasons to make sure disassociation reasons are logged.", since = "2.5.3")
   def disassociate(): Unit
 

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -165,9 +165,11 @@ class NettyTransportSettings(config: Config) {
     case value ⇒ value
   }
 
+  @Deprecated
   @deprecated("WARNING: This should only be used by professionals.", "2.0")
   val PortSelector: Int = getInt("port")
 
+  @Deprecated
   @deprecated("WARNING: This should only be used by professionals.", "2.4")
   val BindPortSelector: Int = getString("bind-port") match {
     case ""    ⇒ PortSelector

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -126,6 +126,7 @@ object TestPublisher {
      * Expect no messages.
      * NOTE! Timeout value is automatically multiplied by timeFactor.
      */
+    @Deprecated
     @deprecated(message = "Use expectNoMessage instead", since = "2.5.5")
     def expectNoMsg(): Self = executeAfterSubscription {
       probe.expectNoMsg()
@@ -136,6 +137,7 @@ object TestPublisher {
      * Expect no messages for a given duration.
      * NOTE! Timeout value is automatically multiplied by timeFactor.
      */
+    @Deprecated
     @deprecated(message = "Use expectNoMessage instead", since = "2.5.5")
     def expectNoMsg(max: FiniteDuration): Self = executeAfterSubscription {
       probe.expectNoMsg(max)
@@ -571,6 +573,7 @@ object TestSubscriber {
      * Same as `expectNoMsg(remaining)`, but correctly treating the timeFactor.
      * NOTE! Timeout value is automatically multiplied by timeFactor.
      */
+    @Deprecated
     @deprecated(message = "Use expectNoMessage instead", since = "2.5.5")
     def expectNoMsg(): Self = {
       probe.expectNoMsg()
@@ -583,6 +586,7 @@ object TestSubscriber {
      * Assert that no message is received for the specified time.
      * NOTE! Timeout value is automatically multiplied by timeFactor.
      */
+    @Deprecated
     @deprecated(message = "Use expectNoMessage instead", since = "2.5.5")
     def expectNoMsg(remaining: FiniteDuration): Self = {
       probe.expectNoMsg(remaining)

--- a/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
@@ -366,6 +366,7 @@ final class ActorMaterializerSettings @InternalApi private (
   require(initialInputBufferSize <= maxInputBufferSize, s"initialInputBufferSize($initialInputBufferSize) must be <= maxInputBufferSize($maxInputBufferSize)")
 
   // backwards compatibility when added IOSettings, shouldn't be needed since private, but added to satisfy mima
+  @Deprecated
   @deprecated("Use ActorMaterializerSettings.apply or ActorMaterializerSettings.create instead", "2.5.10")
   def this(
     initialInputBufferSize:      Int,
@@ -388,6 +389,7 @@ final class ActorMaterializerSettings @InternalApi private (
     )
 
   // backwards compatibility when added IOSettings, shouldn't be needed since private, but added to satisfy mima
+  @Deprecated
   @deprecated("Use ActorMaterializerSettings.apply or ActorMaterializerSettings.create instead", "2.5.10")
   def this(
     initialInputBufferSize:      Int,
@@ -409,6 +411,7 @@ final class ActorMaterializerSettings @InternalApi private (
     )
 
   // backwards compatibility when added IOSettings, shouldn't be needed since private, but added to satisfy mima
+  @Deprecated
   @deprecated("Use ActorMaterializerSettings.apply or ActorMaterializerSettings.create instead", "2.5.10")
   def this(
     initialInputBufferSize:      Int,
@@ -538,6 +541,7 @@ final class ActorMaterializerSettings @InternalApi private (
    * this may cause an initial runtime overhead, but most of the time fusing is
    * desirable since it reduces the number of Actors that are created.
    */
+  @Deprecated
   @deprecated("Turning off fusing is no longer possible with the traversal based materializer", since = "2.5.0")
   def withAutoFusing(enable: Boolean): ActorMaterializerSettings =
     if (enable == this.autoFusing) this

--- a/akka-stream/src/main/scala/akka/stream/Attributes.scala
+++ b/akka-stream/src/main/scala/akka/stream/Attributes.scala
@@ -245,6 +245,7 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
    * Java API: Get the least specific attribute (added first) of a given `Class` or subclass thereof.
    * If no such attribute exists the `default` value is returned.
    */
+  @Deprecated
   @deprecated("Attributes should always be most specific, use getAttribute[T]", "2.5.7")
   def getFirstAttribute[T <: Attribute](c: Class[T], default: T): T =
     getFirstAttribute(c).orElse(default)
@@ -252,6 +253,7 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
   /**
    * Java API: Get the least specific attribute (added first) of a given `Class` or subclass thereof.
    */
+  @Deprecated
   @deprecated("Attributes should always be most specific, use get[T]", "2.5.7")
   def getFirstAttribute[T <: Attribute](c: Class[T]): Optional[T] =
     attributeList.reverseIterator.collectFirst { case attr if c.isInstance(attr) ⇒ c cast attr }.asJava
@@ -260,6 +262,7 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
    * Scala API: Get the least specific attribute (added first) of a given type parameter T `Class` or subclass thereof.
    * If no such attribute exists the `default` value is returned.
    */
+  @Deprecated
   @deprecated("Attributes should always be most specific, use get[T]", "2.5.7")
   def getFirst[T <: Attribute: ClassTag](default: T): T = {
     getFirst[T] match {
@@ -271,6 +274,7 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
   /**
    * Scala API: Get the least specific attribute (added first) of a given type parameter T `Class` or subclass thereof.
    */
+  @Deprecated
   @deprecated("Attributes should always be most specific, use get[T]", "2.5.7")
   def getFirst[T <: Attribute: ClassTag]: Option[T] = {
     val c = classTag[T].runtimeClass.asInstanceOf[Class[T]]

--- a/akka-stream/src/main/scala/akka/stream/FanInShape1N.scala
+++ b/akka-stream/src/main/scala/akka/stream/FanInShape1N.scala
@@ -21,6 +21,7 @@ class FanInShape1N[-T0, -T1, +O](val n: Int, _init: FanInShape.Init[O]) extends 
   override protected def construct(init: FanInShape.Init[O @uncheckedVariance]): FanInShape[O] = new FanInShape1N(n, init)
   override def deepCopy(): FanInShape1N[T0, T1, O] = super.deepCopy().asInstanceOf[FanInShape1N[T0, T1, O]]
 
+  @Deprecated
   @deprecated("Use 'inlets' or 'in(id)' instead.", "2.5.5")
   def in1Seq: immutable.IndexedSeq[Inlet[T1 @uncheckedVariance]] = _in1Seq
 

--- a/akka-stream/src/main/scala/akka/stream/StreamTcpException.scala
+++ b/akka-stream/src/main/scala/akka/stream/StreamTcpException.scala
@@ -10,6 +10,7 @@ class StreamTcpException(msg: String) extends RuntimeException(msg) with NoStack
 
 class BindFailedException extends StreamTcpException("bind failed")
 
+@Deprecated
 @deprecated("BindFailedException object will never be thrown. Match on the class instead.")
 case object BindFailedException extends BindFailedException
 

--- a/akka-stream/src/main/scala/akka/stream/UniformFanInShape.scala
+++ b/akka-stream/src/main/scala/akka/stream/UniformFanInShape.scala
@@ -25,6 +25,7 @@ class UniformFanInShape[-T, +O](val n: Int, _init: FanInShape.Init[O]) extends F
 
   final override def inlets: immutable.Seq[Inlet[T @uncheckedVariance]] = super.inlets.asInstanceOf[immutable.Seq[Inlet[T]]]
 
+  @Deprecated
   @deprecated("Use 'inlets' or 'in(id)' instead.", "2.5.5")
   def inSeq: immutable.IndexedSeq[Inlet[T @uncheckedVariance]] = _inSeq
 

--- a/akka-stream/src/main/scala/akka/stream/actor/ActorPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/actor/ActorPublisher.scala
@@ -13,6 +13,7 @@ import concurrent.duration.FiniteDuration
 import akka.stream.impl.CancelledSubscription
 import akka.stream.impl.ReactiveStreamsCompliance._
 
+@Deprecated
 @deprecated("Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
 object ActorPublisher {
 
@@ -125,6 +126,7 @@ object ActorPublisherMessage {
  *
  * @deprecated Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
  */
+@Deprecated
 @deprecated("Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
 trait ActorPublisher[T] extends Actor {
   import ActorPublisher.Internal._
@@ -455,6 +457,7 @@ object UntypedActorPublisher {
  * Java API
  * @see [[akka.stream.actor.ActorPublisher]]
  */
+@Deprecated
 @deprecated("Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
 abstract class UntypedActorPublisher[T] extends UntypedActor with ActorPublisher[T]
 
@@ -476,6 +479,7 @@ object AbstractActorPublisher {
  *
  * @deprecated Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
  */
+@Deprecated
 @deprecated("Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
 abstract class AbstractActorPublisher[T] extends AbstractActor with ActorPublisher[T]
 
@@ -486,6 +490,7 @@ abstract class AbstractActorPublisher[T] extends AbstractActor with ActorPublish
  *
  * @deprecated Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
  */
+@Deprecated
 @deprecated("Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
 abstract class AbstractActorPublisherWithStash[T] extends AbstractActor with ActorPublisher[T] with Stash
 
@@ -496,6 +501,7 @@ abstract class AbstractActorPublisherWithStash[T] extends AbstractActor with Act
  *
  * @deprecated Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
  */
+@Deprecated
 @deprecated("Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
 abstract class AbstractActorPublisherWithUnboundedStash[T] extends AbstractActor with ActorPublisher[T] with UnboundedStash
 
@@ -506,5 +512,6 @@ abstract class AbstractActorPublisherWithUnboundedStash[T] extends AbstractActor
  *
  * @deprecated Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
  */
+@Deprecated
 @deprecated("Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
 abstract class AbstractActorPublisherWithUnrestrictedStash[T] extends AbstractActor with ActorPublisher[T] with UnrestrictedStash

--- a/akka-stream/src/main/scala/akka/stream/actor/ActorSubscriber.scala
+++ b/akka-stream/src/main/scala/akka/stream/actor/ActorSubscriber.scala
@@ -162,6 +162,7 @@ abstract class MaxInFlightRequestStrategy(max: Int) extends RequestStrategy {
  *
  * @deprecated Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
  */
+@Deprecated
 @deprecated("Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
 trait ActorSubscriber extends Actor {
   import ActorSubscriber._
@@ -354,6 +355,7 @@ object UntypedActorSubscriber {
  *
  * @deprecated Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
  */
+@Deprecated
 @deprecated("Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
 abstract class UntypedActorSubscriber extends UntypedActor with ActorSubscriber
 
@@ -362,6 +364,7 @@ abstract class UntypedActorSubscriber extends UntypedActor with ActorSubscriber
  *
  * @deprecated Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
  */
+@Deprecated
 @deprecated("Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
 object AbstractActorSubscriber {
   /**
@@ -378,5 +381,6 @@ object AbstractActorSubscriber {
  *
  * @deprecated Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
  */
+@Deprecated
 @deprecated("Use `akka.stream.stage.GraphStage` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
 abstract class AbstractActorSubscriber extends AbstractActor with ActorSubscriber

--- a/akka-stream/src/main/scala/akka/stream/extra/Timed.scala
+++ b/akka-stream/src/main/scala/akka/stream/extra/Timed.scala
@@ -82,6 +82,7 @@ private[akka] trait TimedIntervalBetweenOps {
   }
 }
 
+@Deprecated
 @deprecated("Moved to the akka/akka-stream-contrib project", since = "2.4.5")
 object Timed extends TimedOps with TimedIntervalBetweenOps {
 

--- a/akka-stream/src/main/scala/akka/stream/impl/ConstantFun.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ConstantFun.scala
@@ -11,6 +11,7 @@ import akka.japi.{ Pair ⇒ JPair }
 /**
  * INTERNAL API
  */
+@Deprecated
 @deprecated("Use akka.util.ConstantFun instead", "2.5.0")
 @InternalApi private[akka] object ConstantFun {
   private[this] val JavaIdentityFunction = new JFun[Any, Any] {

--- a/akka-stream/src/main/scala/akka/stream/javadsl/CoupledTerminationFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/CoupledTerminationFlow.scala
@@ -56,6 +56,7 @@ object CoupledTerminationFlow {
    *
    * The order in which the `in` and `out` sides receive their respective completion signals is not defined, do not rely on its ordering.
    */
+  @Deprecated
   @deprecated("Use `Flow.fromSinkAndSourceCoupledMat(..., ..., Keep.both())` instead", "2.5.2")
   def fromSinkAndSource[I, O, M1, M2](in: Sink[I, M1], out: Source[O, M2]): Flow[I, O, (M1, M2)] =
     akka.stream.scaladsl.Flow.fromSinkAndSourceCoupledMat(in, out)(akka.stream.scaladsl.Keep.both).asJava

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FileIO.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FileIO.scala
@@ -32,6 +32,7 @@ object FileIO {
    *
    * @param f The file to write to
    */
+  @Deprecated
   @deprecated("Use `toPath` instead.", "2.4.5")
   def toFile(f: File): javadsl.Sink[ByteString, CompletionStage[IOResult]] = toPath(f.toPath)
 
@@ -69,6 +70,7 @@ object FileIO {
    * @param f The file to write to
    * @param options File open options, see [[java.nio.file.StandardOpenOption]]
    */
+  @Deprecated
   @deprecated("Use `toPath` instead.", "2.4.5")
   def toFile[Opt <: OpenOption](f: File, options: util.Set[Opt]): javadsl.Sink[ByteString, CompletionStage[IOResult]] =
     toPath(f.toPath)
@@ -129,6 +131,7 @@ object FileIO {
    *
    * @param f         the file to read from
    */
+  @Deprecated
   @deprecated("Use `fromPath` instead.", "2.4.5")
   def fromFile(f: File): javadsl.Source[ByteString, CompletionStage[IOResult]] = fromPath(f.toPath)
 
@@ -160,6 +163,7 @@ object FileIO {
    * @param f         the file to read from
    * @param chunkSize the size of each read operation
    */
+  @Deprecated
   @deprecated("Use `fromPath` instead.", "2.4.5")
   def fromFile(f: File, chunkSize: Int): javadsl.Source[ByteString, CompletionStage[IOResult]] =
     fromPath(f.toPath, chunkSize)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -221,6 +221,7 @@ object Sink {
    *
    * @deprecated Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
    */
+  @Deprecated
   @deprecated("Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
   def actorSubscriber[T](props: Props): Sink[T, ActorRef] =
     new Sink(scaladsl.Sink.actorSubscriber(props))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -285,6 +285,7 @@ object Source {
    *
    * @deprecated Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
    */
+  @Deprecated
   @deprecated("Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
   def actorPublisher[T](props: Props): Source[T, ActorRef] =
     new Source(scaladsl.Source.actorPublisher(props))
@@ -1110,6 +1111,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
+  @Deprecated
   @deprecated("Use recoverWithRetries instead.", "2.4.4")
   def recover(pf: PartialFunction[Throwable, Out]): javadsl.Source[Out, Mat] =
     new Source(delegate.recover(pf))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -905,6 +905,7 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    * '''Cancels when''' downstream cancels
    *
    */
+  @Deprecated
   @deprecated("Use recoverWithRetries instead.", "2.4.4")
   def recoverWith(pf: PartialFunction[Throwable, Graph[SourceShape[Out], NotUsed]]): SubFlow[In, Out, Mat @uncheckedVariance] =
     new SubFlow(delegate.recoverWith(pf))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -889,6 +889,7 @@ class SubSource[Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[O
    * '''Cancels when''' downstream cancels
    *
    */
+  @Deprecated
   @deprecated("Use recoverWithRetries instead.", "2.4.4")
   def recoverWith(pf: PartialFunction[Throwable, Graph[SourceShape[Out], NotUsed]]): SubSource[Out, Mat] =
     new SubSource(delegate.recoverWith(pf))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/CoupledTerminationFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/CoupledTerminationFlow.scala
@@ -59,6 +59,7 @@ object CoupledTerminationFlow {
    *
    * The order in which the `in` and `out` sides receive their respective completion signals is not defined, do not rely on its ordering.
    */
+  @Deprecated
   @deprecated("Use `Flow.fromSinkAndSourceCoupledMat(..., ...)(Keep.both)` instead", "2.5.2")
   def fromSinkAndSource[I, O, M1, M2](in: Sink[I, M1], out: Source[O, M2]): Flow[I, O, (M1, M2)] =
     Flow.fromSinkAndSourceCoupledMat(in, out)(Keep.both)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FileIO.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FileIO.scala
@@ -36,6 +36,7 @@ object FileIO {
    * @param f         the file to read from
    * @param chunkSize the size of each read operation, defaults to 8192
    */
+  @Deprecated
   @deprecated("Use `fromPath` instead", "2.4.5")
   def fromFile(f: File, chunkSize: Int = 8192): Source[ByteString, Future[IOResult]] =
     fromPath(f.toPath, chunkSize)
@@ -88,6 +89,7 @@ object FileIO {
    * @param f the file to write to
    * @param options File open options, see [[java.nio.file.StandardOpenOption]], defaults to Set(WRITE, TRUNCATE_EXISTING, CREATE)
    */
+  @Deprecated
   @deprecated("Use `toPath` instead", "2.4.5")
   def toFile(f: File, options: Set[OpenOption] = Set(WRITE, TRUNCATE_EXISTING, CREATE)): Sink[ByteString, Future[IOResult]] =
     toPath(f.toPath, options)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -695,6 +695,7 @@ trait FlowOps[+Out, +Mat] {
    * '''Cancels when''' downstream cancels
    *
    */
+  @Deprecated
   @deprecated("Use recoverWithRetries instead.", "2.4.4")
   def recoverWith[T >: Out](pf: PartialFunction[Throwable, Graph[SourceShape[T], NotUsed]]): Repr[T] =
     via(new RecoverWith(-1, pf))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -745,6 +745,7 @@ final class Partition[T](val outputPorts: Int, val partitioner: T ⇒ Int, val e
   /**
    * Sets `eagerCancel` to `false`.
    */
+  @Deprecated
   @deprecated("Use the constructor which also specifies the `eagerCancel` parameter")
   def this(outputPorts: Int, partitioner: T ⇒ Int) = this(outputPorts, partitioner, false)
 
@@ -1070,6 +1071,7 @@ class ZipWithN[A, O](zipper: immutable.Seq[A] ⇒ O)(n: Int) extends GraphStage[
   override val shape = new UniformFanInShape[A, O](n)
   def out: Outlet[O] = shape.out
 
+  @Deprecated
   @deprecated("use `shape.inlets` or `shape.in(id)` instead", "2.5.5")
   def inSeq: immutable.IndexedSeq[Inlet[A]] = shape.inlets.asInstanceOf[immutable.IndexedSeq[Inlet[A]]]
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -471,6 +471,7 @@ object Sink {
    *
    * @deprecated Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
    */
+  @Deprecated
   @deprecated("Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
   def actorSubscriber[T](props: Props): Sink[T, ActorRef] = {
     require(classOf[ActorSubscriber].isAssignableFrom(props.actorClass()), "Actor must be ActorSubscriber")

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -200,6 +200,7 @@ final class Source[+Out, +Mat](
   /**
    * Combines several sources with fan-in strategy like `Merge` or `Concat` and returns `Source`.
    */
+  @Deprecated
   @deprecated("Use `Source.combine` on companion object instead", "2.5.5")
   def combine[T, U](first: Source[T, _], second: Source[T, _], rest: Source[T, _]*)(strategy: Int ⇒ Graph[UniformFanInShape[T, U], NotUsed]): Source[U, NotUsed] =
     Source.fromGraph(GraphDSL.create() { implicit b ⇒
@@ -445,6 +446,7 @@ object Source {
    *
    * @deprecated Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
    */
+  @Deprecated
   @deprecated("Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.", since = "2.5.0")
   def actorPublisher[T](props: Props): Source[T, ActorRef] = {
     require(classOf[ActorPublisher[_]].isAssignableFrom(props.actorClass()), "Actor must be ActorPublisher")

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -641,6 +641,7 @@ trait TestKitBase {
   /**
    * Same as `expectNoMsg(remainingOrDefault)`, but correctly treating the timeFactor.
    */
+  @Deprecated
   @deprecated(message = "Use expectNoMessage instead", since = "2.5.5")
   def expectNoMsg() { expectNoMsg_internal(remainingOrDefault) }
 
@@ -648,6 +649,7 @@ trait TestKitBase {
    * Assert that no message is received for the specified time.
    * NOTE! Supplied value is always dilated.
    */
+  @Deprecated
   @deprecated(message = "Use expectNoMessage instead", since = "2.5.5")
   def expectNoMsg(max: FiniteDuration) {
     expectNoMsg_internal(max.dilated)

--- a/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
@@ -621,6 +621,7 @@ class TestKit(system: ActorSystem) {
   /**
    * Same as `expectNoMsg(remainingOrDefault)`, but correctly treating the timeFactor.
    */
+  @Deprecated
   @deprecated(message = "Use expectNoMessage instead", since = "2.5.10")
   def expectNoMsg(): Unit = tp.expectNoMessage()
 
@@ -632,6 +633,7 @@ class TestKit(system: ActorSystem) {
   /**
    * Assert that no message is received for the specified time.
    */
+  @Deprecated
   @deprecated(message = "Use expectNoMessage instead", since = "2.5.10")
   def expectNoMsg(max: FiniteDuration): Unit = tp.expectNoMsg(max)
 


### PR DESCRIPTION
Fix #24813. I didn't add the annotations to the APIs are only used for the internal usage.