### PR TITLE
WIP Prototype of reliable delivery in Typed, #20984

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/ReliableDeliveryPoc.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/ReliableDeliveryPoc.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.delivery
+
+import scala.concurrent.duration._
+
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+
+/**
+ * This example illustrates Actor message flow control with
+ * "work pulling pattern".
+ */
+object ReliableDeliveryPoc {
+
+  /**
+   * The producer will not send more messages than requested by the consumer.
+   * It expects an initial [[Producer.Request]] message before sending anything, and that
+   * `Request` also contains the destination consumer `ActorRef` that the messages
+   * will be sent to.
+   *
+   * Each message is wrapped in [[Consumer.SequencedMessage]] with a monotonically increasing
+   * sequence number without gaps, starting at 1.
+   */
+  object Producer {
+    import Consumer.SequencedMessage
+
+    sealed trait ProducerMessage
+    final case class Request(seqNr: Long, consumer: ActorRef[SequencedMessage]) extends ProducerMessage
+    private final case object ProducerTick extends ProducerMessage
+
+    def producer(): Behavior[Request] = Behaviors.receiveMessage {
+      case Request(seqNr, receiver) ⇒
+        // simulate fast producer
+        Behaviors.withTimers[ProducerMessage] { timers ⇒
+          timers.startPeriodicTimer(ProducerTick, ProducerTick, 20.millis)
+          activeProducer(receiver, currentSeqNr = 1, requestedSeqNr = seqNr)
+        }.narrow
+    }
+
+    private def activeProducer(receiver: ActorRef[SequencedMessage], currentSeqNr: Long, requestedSeqNr: Long): Behavior[ProducerMessage] =
+      Behaviors.receive { (ctx, msg) ⇒
+        msg match {
+          case Request(seqNr, `receiver`) ⇒
+            if (seqNr > requestedSeqNr) activeProducer(receiver, currentSeqNr, seqNr)
+            else Behaviors.same
+
+          case ProducerTick ⇒
+            if (currentSeqNr == 500)
+              ctx.system.terminate()
+
+            if (currentSeqNr <= requestedSeqNr) {
+              ctx.log.info("sent {}", currentSeqNr)
+              receiver ! SequencedMessage(currentSeqNr, "msg")
+              activeProducer(receiver, currentSeqNr + 1, requestedSeqNr)
+            } else
+              Behaviors.same
+        }
+      }
+  }
+
+  /**
+   * The consumer will send [[Producer.Request]] to tell the `producer` that it's ready to
+   * receive up to the requested sequence number. It sends new `Request` when
+   * half of the requested window is remaining, but it also retries the `Request`
+   * if no messages are received because that could be caused by lost messages.
+   *
+   * The producer will not send more messages than requested.
+   */
+  object Consumer {
+    import Producer.Request
+    sealed trait ConsumerMessage
+    final case class SequencedMessage(seqNr: Long, msg: String) extends ConsumerMessage
+    private final case object RetryRequest extends ConsumerMessage
+
+    private val RequestWindow = 50
+
+    def consumer(producer: ActorRef[Request]): Behavior[SequencedMessage] = {
+      Behaviors.setup[ConsumerMessage] { ctx ⇒
+        producer ! Request(RequestWindow, ctx.self)
+        ctx.setReceiveTimeout(1.second, RetryRequest)
+        consumer(producer, receivedSeqNr = 0, requestedSeqNr = RequestWindow)
+      }.narrow
+    }
+
+    private def consumer(producer: ActorRef[Request], receivedSeqNr: Long, requestedSeqNr: Long): Behavior[ConsumerMessage] = {
+      Behaviors.receive { (ctx, msg) ⇒
+        msg match {
+          case SequencedMessage(seqNr, msg) ⇒
+            ctx.log.info("received {}", seqNr)
+            // simulate slow consumer
+            Thread.sleep(100)
+            if ((requestedSeqNr - seqNr) == RequestWindow / 2) {
+              val newRequestedSeqNr = requestedSeqNr + RequestWindow / 2
+              ctx.log.info("request seqNr: {}", newRequestedSeqNr)
+              producer ! Request(newRequestedSeqNr, ctx.self)
+              consumer(producer, seqNr, newRequestedSeqNr)
+            } else {
+              consumer(producer, seqNr, requestedSeqNr)
+            }
+
+          case RetryRequest ⇒
+            // in case the Request or the SequencedMessage triggering the Request is lost
+            val newRequestedSeqNr = receivedSeqNr + RequestWindow
+            ctx.log.info("resend request seqNr: {}", newRequestedSeqNr)
+            producer ! Request(newRequestedSeqNr, ctx.self)
+            consumer(producer, receivedSeqNr, newRequestedSeqNr)
+        }
+      }
+    }
+  }
+
+  // TODO could be expanded with detection of lost messages (gaps in sequence numbers)
+  // TODO could use watch to detect when producer or consumer are terminated
+
+  def main(args: Array[String]): Unit = {
+    ActorSystem[Nothing](mainBehavior, "DeliveryDemo")
+  }
+
+  def mainBehavior: Behavior[Nothing] = Behaviors.setup[Nothing] { ctx ⇒
+    val p = ctx.spawn(Producer.producer(), "producer")
+    ctx.spawn(Consumer.consumer(p), "consumer")
+    Behaviors.empty
+  }
+
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/ReliableDeliveryPoc.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/ReliableDeliveryPoc.scala
@@ -7,12 +7,13 @@ package akka.actor.typed.delivery
 import java.util.concurrent.ThreadLocalRandom
 
 import scala.concurrent.duration._
+import scala.reflect.ClassTag
 
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
-import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.StashBuffer
 
 /**
  * This example illustrates Actor message flow control with
@@ -22,157 +23,232 @@ import akka.actor.typed.scaladsl.Behaviors
 object ReliableDeliveryPoc {
 
   /**
-   * The producer will not send more messages than requested by the consumer.
-   * It expects an initial [[Producer.Request]] message before sending anything, and that
+   * The `ProducerController` will not send more messages than requested by the `ConsumerController`.
+   * It expects an initial [[ProducerController.Request]] message before sending anything, and that
    * `Request` also contains the destination consumer `ActorRef` that the messages
    * will be sent to.
    *
-   * Each message is wrapped in [[Consumer.SequencedMessage]] with a monotonically increasing
-   * sequence number without gaps, starting at 1.
+   * When there is demand from the consumer side the `ProducerController` sends `RequestNext` to the
+   * actual producer, which is then allowed to send one message to the `ProducerController`. The `RequestMessage`
+   * message is defined via a factory function so that the producer can decide what type to use.
+   * If there is still demand a new `RequestNext` is sent to the producer immediately. The producer
+   * and `ProducerController` are supposed to be local so that these messages are fast and not lost.
+   *
+   * Each message is wrapped by the `ProducerController` in [[ConsumerController.SequencedMessage]] with
+   * a monotonically increasing sequence number without gaps, starting at 1.
    *
    * The `Request` message also contains a `confirmedSeqNr` that is the acknowledgement
-   * from the consumer that it has received all messages up to that sequence number.
+   * from the consumer that it has received and processed all messages up to that sequence number.
    *
-   * The consumer can send [[Producer.Resend]] if a lost message is detected and then the
+   * The `ConsumerController` can send [[ProducerController.Resend]] if a lost message is detected and then the
    * producer will resend all messages from that sequence number. The producer keeps
    * unconfirmed messages in a buffer to be able to resend them. The buffer size is limited
    * by the request window size.
    */
-  object Producer {
-    import Consumer.SequencedMessage
+  object ProducerController {
+
+    import ConsumerController.SequencedMessage
 
     sealed trait ProducerMessage
-    final case class Request(upToSeqNr: Long, confirmedSeqNr: Long, consumer: ActorRef[SequencedMessage],
-      viaReceiveTimeout: Boolean) extends ProducerMessage
+    final case class Request[T](confirmedSeqNr: Long, upToSeqNr: Long, consumer: ActorRef[SequencedMessage[T]], viaReceiveTimeout: Boolean) extends ProducerMessage
     final case class Resend(fromSeqNr: Long) extends ProducerMessage
-    private final case object ProducerTick extends ProducerMessage
+    private case class Msg[T](msg: T) extends ProducerMessage
 
-    def producer(): Behavior[ProducerMessage] = Behaviors.receiveMessage {
-      case Request(upToSeqNr, _, receiver, _) ⇒
-        // simulate fast producer
-        Behaviors.withTimers { timers ⇒
-          timers.startPeriodicTimer(ProducerTick, ProducerTick, 20.millis)
-          activeProducer(receiver, currentSeqNr = 1, requestedSeqNr = upToSeqNr, Vector.empty)
+    def behavior[T: ClassTag, RequestNext](
+      requestNextFactory: ActorRef[T] ⇒ RequestNext,
+      producer:           ActorRef[RequestNext]): Behavior[ProducerMessage] = {
+
+      Behaviors.setup { ctx ⇒
+        val msgAdapter: ActorRef[T] = ctx.messageAdapter(msg ⇒ Msg(msg))
+        val requestNext = requestNextFactory(msgAdapter)
+
+        Behaviors.receiveMessagePartial {
+          case Request(_, upToSeqNr, receiver, _) ⇒
+            producer ! requestNext
+            active(producer, requestNext, requested = true, receiver,
+              currentSeqNr = 1, requestedSeqNr = upToSeqNr, Vector.empty)
         }
+      }
     }
 
-    private def activeProducer(
-      receiver:       ActorRef[SequencedMessage],
+    private def active[T: ClassTag, RequestNext](
+      producer:       ActorRef[RequestNext],
+      requestNext:    RequestNext,
+      requested:      Boolean,
+      receiver:       ActorRef[SequencedMessage[T]],
       currentSeqNr:   Long,
       requestedSeqNr: Long,
-      unconfirmed:    Vector[SequencedMessage]): Behavior[ProducerMessage] = {
+      unconfirmed:    Vector[SequencedMessage[T]]): Behavior[ProducerMessage] = {
+
+      def become(
+        requested:      Boolean,
+        currentSeqNr:   Long,
+        requestedSeqNr: Long,
+        unconfirmed:    Vector[SequencedMessage[T]]): Behavior[ProducerMessage] =
+        active(producer, requestNext, requested, receiver, currentSeqNr, requestedSeqNr, unconfirmed)
 
       Behaviors.receive { (ctx, msg) ⇒
         msg match {
-          case Request(seqNr, confirmedSeqNr, `receiver`, viaReceiveTimeout) ⇒
+          case Msg(m: T) ⇒
+            if (requested && currentSeqNr <= requestedSeqNr) {
+              ctx.log.info("sent {}", currentSeqNr)
+              val seqMsg = SequencedMessage(currentSeqNr, m)
+              val newUnconfirmed = unconfirmed :+ seqMsg
+              receiver ! seqMsg
+              val newRequested =
+                if (currentSeqNr == requestedSeqNr)
+                  false
+                else {
+                  producer ! requestNext
+                  true
+                }
+              become(newRequested, currentSeqNr + 1, requestedSeqNr, newUnconfirmed)
+            } else {
+              throw new IllegalStateException(s"Unexpected Msg when no demand, requested $requested, " +
+                s"requestedSeqNr $requestedSeqNr, currentSeqNr $currentSeqNr")
+            }
+          case Request(confirmedSeqNr, seqNr, `receiver`, viaReceiveTimeout) ⇒
             val newUnconfirmed = unconfirmed.dropWhile(_.seqNr <= confirmedSeqNr)
             if (viaReceiveTimeout && newUnconfirmed.nonEmpty) {
               // the last message was lost and no more message was sent that would trigger Resend
               ctx.log.info("resending after ReceiveTimeout {}", newUnconfirmed.map(_.seqNr).mkString(", "))
               newUnconfirmed.foreach(receiver ! _)
             }
-            if (seqNr > requestedSeqNr) activeProducer(receiver, currentSeqNr, seqNr, newUnconfirmed)
-            else Behaviors.same
+            if (seqNr > requestedSeqNr) {
+              if (!requested && (seqNr - currentSeqNr) > 0)
+                producer ! requestNext
+              become(requested = true, currentSeqNr, seqNr, newUnconfirmed)
+            } else Behaviors.same
 
           case Resend(fromSeqNr) ⇒
             val newUnconfirmed = unconfirmed.dropWhile(_.seqNr < fromSeqNr)
             ctx.log.info("resending {}", newUnconfirmed.map(_.seqNr).mkString(", "))
             newUnconfirmed.foreach(receiver ! _)
-            activeProducer(receiver, currentSeqNr, requestedSeqNr, newUnconfirmed)
+            become(requested, currentSeqNr, requestedSeqNr, newUnconfirmed)
 
-          case ProducerTick ⇒
-            if (currentSeqNr <= requestedSeqNr) {
-              ctx.log.info("sent {}", currentSeqNr)
-              val seqMsg = SequencedMessage(currentSeqNr, s"msg-$currentSeqNr")
-              val newUnconfirmed = unconfirmed :+ seqMsg
-              receiver ! seqMsg
-              activeProducer(receiver, currentSeqNr + 1, requestedSeqNr, newUnconfirmed)
-            } else
-              Behaviors.same
+          case Request(_, _, otherReceiver, _) ⇒
+            // FIXME change of receiver should be supported
+            ctx.log.warning(s"Unexpected receiver {}, expected {}", otherReceiver, receiver)
+            Behaviors.same
         }
       }
     }
   }
 
   /**
-   * The consumer will send [[Producer.Request]] to tell the `producer` that it's ready to
-   * receive up to the requested sequence number. It sends new `Request` when
+   * The destination (consumer) will start the flow by sending an initial `Confirmed` message
+   * to the `ConsumerController`. It can have sequence number 0 or from where it would like to start.
+   * The `ConsumerController` will then send [[ProducerController.Request]] to tell the `ProducerController`
+   * that it's ready to receive up to the requested sequence number. It sends new `Request` when
    * half of the requested window is remaining, but it also retries the `Request`
    * if no messages are received because that could be caused by lost messages.
    *
    * The producer will not send more messages than requested.
    *
-   * If the consumer receives a message with unexpected sequence number (not previous + 1)
-   * it sends [[Producer.Resend]] to the producer and will ignore all messages until
+   * Received messages are wrapped in [[ConsumerController.Delivery]] sent to the destination,
+   * which is supposed to reply with [[ConsumerController.Confirmed]] when it has processed the message.
+   * Next `Delivery` is not sent until the previous is confirmed, but we could support more than
+   * one if that would be preferred.
+   *
+   * If the `ConsumerController` receives a message with unexpected sequence number (not previous + 1)
+   * it sends [[ProducerController.Resend]] to the producer and will ignore all messages until
    * the expected sequence number arrives.
    */
-  object Consumer {
-    import Producer.ProducerMessage
-    import Producer.Request
-    import Producer.Resend
+  object ConsumerController {
+
+    import ProducerController.ProducerMessage
+    import ProducerController.Request
+    import ProducerController.Resend
+
     sealed trait ConsumerMessage
-    final case class SequencedMessage(seqNr: Long, msg: String) extends ConsumerMessage
+    final case class SequencedMessage[T](seqNr: Long, msg: T) extends ConsumerMessage
     private final case object RetryRequest extends ConsumerMessage
+
+    // FIXME name?
+    final case class Delivery[T](seqNr: Long, msg: T, confirmTo: ActorRef[Confirmed[T]])
+    final case class Confirmed[T](seqNr: Long, deliverNextTo: ActorRef[Delivery[T]]) extends ConsumerMessage
 
     private val RequestWindow = 50
 
-    def consumer(producer: ActorRef[ProducerMessage]): Behavior[SequencedMessage] = {
-      Behaviors.setup[ConsumerMessage] { ctx ⇒
-        // simulate lost messages
-        val flakySelf = ctx.spawn(flakyNetwork(ctx.self, dropProbability = 0.1), "flaky")
-        producer ! Request(RequestWindow, 0, flakySelf, viaReceiveTimeout = false)
-        ctx.setReceiveTimeout(1.second, RetryRequest)
-        consumer(flakySelf, producer, receivedSeqNr = 0, requestedSeqNr = RequestWindow)
-      }.narrow
+    def behavior[T](producer: ActorRef[ProducerMessage]): Behavior[ConsumerMessage] = {
+      Behaviors.receiveMessagePartial {
+        case Confirmed(seqNr, deliverTo: ActorRef[Delivery[T]] @unchecked) ⇒
+          Behaviors.setup[ConsumerMessage] { ctx ⇒
+            // simulate lost messages from producerController to consumerController
+            val flakySelf = ctx.spawn(flakyNetwork[SequencedMessage[T]](ctx.self, dropProbability = 0.1), "flaky")
+            producer ! Request(seqNr, RequestWindow, flakySelf, viaReceiveTimeout = false)
+            ctx.setReceiveTimeout(1.second, RetryRequest)
+            val stashBuffer = StashBuffer[ConsumerMessage](100)
+            active[T](flakySelf, producer, deliverTo, stashBuffer, receivedSeqNr = seqNr, requestedSeqNr = RequestWindow)
+          }
+      }
     }
 
-    private def consumer(flakySelf: ActorRef[SequencedMessage], producer: ActorRef[ProducerMessage], receivedSeqNr: Long, requestedSeqNr: Long): Behavior[ConsumerMessage] = {
-      def become(receivedSeqNr: Long = receivedSeqNr, requestedSeqNr: Long = requestedSeqNr) =
-        consumer(flakySelf, producer, receivedSeqNr, requestedSeqNr)
+    private def active[T](flakySelf: ActorRef[SequencedMessage[T]], producer: ActorRef[ProducerMessage],
+      destination: ActorRef[Delivery[T]], stashBuffer: StashBuffer[ConsumerMessage],
+      receivedSeqNr: Long, requestedSeqNr: Long): Behavior[ConsumerMessage] = {
+
+      def become(destination: ActorRef[Delivery[T]], receivedSeqNr: Long = receivedSeqNr, requestedSeqNr: Long = requestedSeqNr) =
+        active[T](flakySelf, producer, destination, stashBuffer, receivedSeqNr, requestedSeqNr)
 
       def becomeResending(): Behavior[ConsumerMessage] = {
         Behaviors.receive { (ctx, msg) ⇒
           msg match {
-            case SequencedMessage(seqNr, msg) ⇒
+            case SequencedMessage(seqNr, msg: T @unchecked) ⇒
               if (seqNr == receivedSeqNr + 1) {
                 ctx.log.info("received missing {}", seqNr)
-                processMsg(ctx, seqNr, msg)
+                destination ! Delivery(seqNr, msg, ctx.self)
+                becomeWaitingForConfirmation(seqNr)
               } else {
                 ctx.log.info("ignoring {}, waiting for {}", seqNr, receivedSeqNr + 1)
                 Behaviors.same // ignore until we receive the expected
               }
+
             case RetryRequest ⇒
               // in case the Resend message was lost
               ctx.log.info("retry resend {}", receivedSeqNr + 1)
               producer ! Resend(fromSeqNr = receivedSeqNr + 1)
               Behaviors.same
+
+            case Confirmed(seqNr, _) ⇒
+              // TODO if we would have more than one in flight we would have to keep track of these
+              ctx.log.warning("Unexpected confirmed {}", seqNr)
+              Behaviors.same
           }
         }
       }
 
-      def processMsg(ctx: ActorContext[ConsumerMessage], seqNr: Long, msg: String): Behavior[ConsumerMessage] = {
-        // simulate slow consumer
-        Thread.sleep(100)
-        ctx.log.info("processed {}", seqNr)
-        if (seqNr == 500) {
-          ctx.system.terminate()
-          Behaviors.same
-        } else if ((requestedSeqNr - seqNr) == RequestWindow / 2) {
-          val newRequestedSeqNr = requestedSeqNr + RequestWindow / 2
-          ctx.log.info("request {}", newRequestedSeqNr)
-          producer ! Request(newRequestedSeqNr, confirmedSeqNr = seqNr, flakySelf, viaReceiveTimeout = false)
-          become(seqNr, newRequestedSeqNr)
-        } else {
-          become(seqNr)
+      def becomeWaitingForConfirmation(seqNr: Long): Behavior[ConsumerMessage] = {
+        Behaviors.receive { (ctx, msg) ⇒
+          msg match {
+            case Confirmed(`seqNr`, deliverTo: ActorRef[Delivery[T]] @unchecked) ⇒
+              ctx.log.info("Confirmed {}, stashed {}", seqNr, stashBuffer.size)
+              val newRequestedSeqNr =
+                if ((requestedSeqNr - seqNr) == RequestWindow / 2) {
+                  val newRequestedSeqNr = requestedSeqNr + RequestWindow / 2
+                  ctx.log.info("request {}", newRequestedSeqNr)
+                  producer ! Request(confirmedSeqNr = seqNr, newRequestedSeqNr, flakySelf, viaReceiveTimeout = false)
+                  newRequestedSeqNr
+                } else {
+                  requestedSeqNr
+                }
+              // FIXME can we use unstashOne instead of all?
+              stashBuffer.unstashAll(ctx, become(deliverTo, seqNr, newRequestedSeqNr))
+            case _ ⇒
+              ctx.log.info("Stash [{}]", msg)
+              stashBuffer.stash(msg)
+              Behaviors.same
+          }
         }
       }
 
       Behaviors.receive { (ctx, msg) ⇒
         msg match {
-          case SequencedMessage(seqNr, msg) ⇒
+          case SequencedMessage(seqNr, msg: T @unchecked) ⇒
             val expectedSeqNr = receivedSeqNr + 1
             if (seqNr == expectedSeqNr) {
-              processMsg(ctx, seqNr, msg)
+              destination ! Delivery(seqNr, msg, ctx.self)
+              becomeWaitingForConfirmation(seqNr)
             } else if (seqNr > expectedSeqNr) {
               ctx.log.info("missing {}, received {}", expectedSeqNr, seqNr)
               producer ! Resend(fromSeqNr = expectedSeqNr)
@@ -186,11 +262,90 @@ object ReliableDeliveryPoc {
             // in case the Request or the SequencedMessage triggering the Request is lost
             val newRequestedSeqNr = receivedSeqNr + RequestWindow
             ctx.log.info("retry request {}", newRequestedSeqNr)
-            producer ! Request(newRequestedSeqNr, receivedSeqNr, flakySelf, viaReceiveTimeout = true)
-            become(requestedSeqNr = newRequestedSeqNr)
+            producer ! Request(receivedSeqNr, newRequestedSeqNr, flakySelf, viaReceiveTimeout = true)
+            become(destination, requestedSeqNr = newRequestedSeqNr)
+
+          case Confirmed(seqNr, _) ⇒
+            // TODO if we would have more than one in flight we would have to keep track of these
+            ctx.log.warning("Unexpected confirmed {}", seqNr)
+            Behaviors.same
         }
       }
     }
+  }
+
+  object MyProducer {
+
+    trait MyProducerMessage
+    final case class MyRequestNext(producer: ActorRef[String]) extends MyProducerMessage
+    private final case object ProducerTick extends MyProducerMessage
+
+    def behavior: Behavior[MyProducerMessage] = {
+      // simulate fast producer
+      Behaviors.withTimers { timers ⇒
+        timers.startPeriodicTimer(ProducerTick, ProducerTick, 20.millis)
+        idle
+      }
+    }
+
+    private val idle: Behavior[MyProducerMessage] = {
+      Behaviors.receiveMessage {
+        case ProducerTick              ⇒ Behaviors.same
+        case MyRequestNext(controller) ⇒ active(controller)
+      }
+    }
+
+    private def active(controller: ActorRef[String]): Behavior[MyProducerMessage] = {
+      Behaviors.receive { (ctx, msg) ⇒
+        msg match {
+          case ProducerTick ⇒
+            val msg = "msg"
+            ctx.log.info("sent {}", msg)
+            controller ! msg
+            idle
+
+          case MyRequestNext(_) ⇒
+            throw new IllegalStateException("Unexpected RequestNext, already got one.")
+        }
+      }
+    }
+
+    // FIXME it must be possible to restart the producer, and then it needs to retrieve the request state
+
+  }
+
+  object MyConsumer {
+
+    import ConsumerController.Confirmed
+    import ConsumerController.Delivery
+
+    trait MyConsumerMessage
+    final case class MyDelivery(d: Delivery[String]) extends MyConsumerMessage
+    final case class SomeAsyncJob(d: Delivery[String]) extends MyConsumerMessage
+
+    def behavior(controller: ActorRef[Confirmed[String]]): Behavior[MyConsumerMessage] =
+      Behaviors.setup { ctx ⇒
+        val deliverTo: ActorRef[Delivery[String]] = ctx.messageAdapter(MyDelivery.apply)
+        controller ! Confirmed(seqNr = 0L, deliverTo)
+
+        Behaviors.receiveMessage {
+          case MyDelivery(d) ⇒
+            // confirmation can be later, asynchronously
+            // schedule to simulate slow consumer
+            ctx.schedule(10.millis, ctx.self, SomeAsyncJob(d))
+            if (d.seqNr == 500) {
+              ctx.system.terminate()
+            }
+            Behaviors.same
+
+          case SomeAsyncJob(d) ⇒
+            ctx.log.info("processed {}", d.seqNr)
+            d.confirmTo ! Confirmed(d.seqNr, deliverTo)
+            Behaviors.same
+        }
+      }
+
+    // FIXME it must be possible to restart the consumer, then it might send a non-matching Confirmed(seqNr)
   }
 
   // TODO could use watch to detect when producer or consumer are terminated
@@ -200,20 +355,25 @@ object ReliableDeliveryPoc {
   }
 
   def mainBehavior: Behavior[Nothing] = Behaviors.setup[Nothing] { ctx ⇒
-    val p = ctx.spawn(Producer.producer(), "producer")
-    // simulate lost messages
-    val flakyP = ctx.spawn(flakyNetwork(p, dropProbability = 0.3), "flakyProducer")
-    ctx.spawn(Consumer.consumer(flakyP), "consumer")
+    val myProducer = ctx.spawn(MyProducer.behavior, name = "myProducer")
+    val producerController = ctx.spawn(
+      ProducerController.behavior(MyProducer.MyRequestNext.apply, myProducer),
+      "producerController")
+    // simulate lost messages from consumerController to producerController
+    val flaky = ctx.spawn(flakyNetwork(producerController, dropProbability = 0.3), "flakyProducer")
+    val consumerController = ctx.spawn(ConsumerController.behavior(flaky), "consumerController")
+    ctx.spawn(MyConsumer.behavior(consumerController), name = "destination")
     Behaviors.empty
   }
 
-  def flakyNetwork[T](destination: ActorRef[T], dropProbability: Double): Behavior[T] =
+  def flakyNetwork[T](destination: ActorRef[T], dropProbability: Double): Behavior[T] = {
     Behaviors.receive { (ctx, msg) ⇒
-      if (ThreadLocalRandom.current().nextDouble() <= dropProbability)
+      if (ThreadLocalRandom.current().nextDouble() < dropProbability)
         ctx.log.info("dropped {}", msg)
       else
         destination ! msg
       Behaviors.same
     }
+  }
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/ReliableDeliveryPoc.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/ReliableDeliveryPoc.scala
@@ -4,16 +4,20 @@
 
 package akka.actor.typed.delivery
 
+import java.util.concurrent.ThreadLocalRandom
+
 import scala.concurrent.duration._
 
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
 
 /**
  * This example illustrates Actor message flow control with
- * "work pulling pattern".
+ * "work pulling pattern" and reliable delivery by tracking
+ * sequence numbers and resending missing.
  */
 object ReliableDeliveryPoc {
 
@@ -25,42 +29,69 @@ object ReliableDeliveryPoc {
    *
    * Each message is wrapped in [[Consumer.SequencedMessage]] with a monotonically increasing
    * sequence number without gaps, starting at 1.
+   *
+   * The `Request` message also contains a `confirmedSeqNr` that is the acknowledgement
+   * from the consumer that it has received all messages up to that sequence number.
+   *
+   * The consumer can send [[Producer.Resend]] if a lost message is detected and then the
+   * producer will resend all messages from that sequence number. The producer keeps
+   * unconfirmed messages in a buffer to be able to resend them. The buffer size is limited
+   * by the request window size.
    */
   object Producer {
     import Consumer.SequencedMessage
 
     sealed trait ProducerMessage
-    final case class Request(seqNr: Long, consumer: ActorRef[SequencedMessage]) extends ProducerMessage
+    final case class Request(upToSeqNr: Long, confirmedSeqNr: Long, consumer: ActorRef[SequencedMessage],
+      viaReceiveTimeout: Boolean) extends ProducerMessage
+    final case class Resend(fromSeqNr: Long) extends ProducerMessage
     private final case object ProducerTick extends ProducerMessage
 
-    def producer(): Behavior[Request] = Behaviors.receiveMessage {
-      case Request(seqNr, receiver) ⇒
+    def producer(): Behavior[ProducerMessage] = Behaviors.receiveMessage {
+      case Request(upToSeqNr, _, receiver, _) ⇒
         // simulate fast producer
-        Behaviors.withTimers[ProducerMessage] { timers ⇒
+        Behaviors.withTimers { timers ⇒
           timers.startPeriodicTimer(ProducerTick, ProducerTick, 20.millis)
-          activeProducer(receiver, currentSeqNr = 1, requestedSeqNr = seqNr)
-        }.narrow
+          activeProducer(receiver, currentSeqNr = 1, requestedSeqNr = upToSeqNr, Vector.empty)
+        }
     }
 
-    private def activeProducer(receiver: ActorRef[SequencedMessage], currentSeqNr: Long, requestedSeqNr: Long): Behavior[ProducerMessage] =
+    private def activeProducer(
+      receiver:       ActorRef[SequencedMessage],
+      currentSeqNr:   Long,
+      requestedSeqNr: Long,
+      unconfirmed:    Vector[SequencedMessage]): Behavior[ProducerMessage] = {
+
       Behaviors.receive { (ctx, msg) ⇒
         msg match {
-          case Request(seqNr, `receiver`) ⇒
-            if (seqNr > requestedSeqNr) activeProducer(receiver, currentSeqNr, seqNr)
+          case Request(seqNr, confirmedSeqNr, `receiver`, viaReceiveTimeout) ⇒
+            val newUnconfirmed = unconfirmed.dropWhile(_.seqNr <= confirmedSeqNr)
+            if (viaReceiveTimeout && newUnconfirmed.nonEmpty) {
+              // the last message was lost and no more message was sent that would trigger Resend
+              ctx.log.info("resending after ReceiveTimeout {}", newUnconfirmed.map(_.seqNr).mkString(", "))
+              newUnconfirmed.foreach(receiver ! _)
+            }
+            if (seqNr > requestedSeqNr) activeProducer(receiver, currentSeqNr, seqNr, newUnconfirmed)
             else Behaviors.same
 
-          case ProducerTick ⇒
-            if (currentSeqNr == 500)
-              ctx.system.terminate()
+          case Resend(fromSeqNr) ⇒
+            val newUnconfirmed = unconfirmed.dropWhile(_.seqNr < fromSeqNr)
+            ctx.log.info("resending {}", newUnconfirmed.map(_.seqNr).mkString(", "))
+            newUnconfirmed.foreach(receiver ! _)
+            activeProducer(receiver, currentSeqNr, requestedSeqNr, newUnconfirmed)
 
+          case ProducerTick ⇒
             if (currentSeqNr <= requestedSeqNr) {
               ctx.log.info("sent {}", currentSeqNr)
-              receiver ! SequencedMessage(currentSeqNr, "msg")
-              activeProducer(receiver, currentSeqNr + 1, requestedSeqNr)
+              val seqMsg = SequencedMessage(currentSeqNr, s"msg-$currentSeqNr")
+              val newUnconfirmed = unconfirmed :+ seqMsg
+              receiver ! seqMsg
+              activeProducer(receiver, currentSeqNr + 1, requestedSeqNr, newUnconfirmed)
             } else
               Behaviors.same
         }
       }
+    }
   }
 
   /**
@@ -70,51 +101,98 @@ object ReliableDeliveryPoc {
    * if no messages are received because that could be caused by lost messages.
    *
    * The producer will not send more messages than requested.
+   *
+   * If the consumer receives a message with unexpected sequence number (not previous + 1)
+   * it sends [[Producer.Resend]] to the producer and will ignore all messages until
+   * the expected sequence number arrives.
    */
   object Consumer {
+    import Producer.ProducerMessage
     import Producer.Request
+    import Producer.Resend
     sealed trait ConsumerMessage
     final case class SequencedMessage(seqNr: Long, msg: String) extends ConsumerMessage
     private final case object RetryRequest extends ConsumerMessage
 
     private val RequestWindow = 50
 
-    def consumer(producer: ActorRef[Request]): Behavior[SequencedMessage] = {
+    def consumer(producer: ActorRef[ProducerMessage]): Behavior[SequencedMessage] = {
       Behaviors.setup[ConsumerMessage] { ctx ⇒
-        producer ! Request(RequestWindow, ctx.self)
+        // simulate lost messages
+        val flakySelf = ctx.spawn(flakyNetwork(ctx.self, dropProbability = 0.1), "flaky")
+        producer ! Request(RequestWindow, 0, flakySelf, viaReceiveTimeout = false)
         ctx.setReceiveTimeout(1.second, RetryRequest)
-        consumer(producer, receivedSeqNr = 0, requestedSeqNr = RequestWindow)
+        consumer(flakySelf, producer, receivedSeqNr = 0, requestedSeqNr = RequestWindow)
       }.narrow
     }
 
-    private def consumer(producer: ActorRef[Request], receivedSeqNr: Long, requestedSeqNr: Long): Behavior[ConsumerMessage] = {
+    private def consumer(flakySelf: ActorRef[SequencedMessage], producer: ActorRef[ProducerMessage], receivedSeqNr: Long, requestedSeqNr: Long): Behavior[ConsumerMessage] = {
+      def become(receivedSeqNr: Long = receivedSeqNr, requestedSeqNr: Long = requestedSeqNr) =
+        consumer(flakySelf, producer, receivedSeqNr, requestedSeqNr)
+
+      def becomeResending(): Behavior[ConsumerMessage] = {
+        Behaviors.receive { (ctx, msg) ⇒
+          msg match {
+            case SequencedMessage(seqNr, msg) ⇒
+              if (seqNr == receivedSeqNr + 1) {
+                ctx.log.info("received missing {}", seqNr)
+                processMsg(ctx, seqNr, msg)
+              } else {
+                ctx.log.info("ignoring {}, waiting for {}", seqNr, receivedSeqNr + 1)
+                Behaviors.same // ignore until we receive the expected
+              }
+            case RetryRequest ⇒
+              // in case the Resend message was lost
+              ctx.log.info("retry resend {}", receivedSeqNr + 1)
+              producer ! Resend(fromSeqNr = receivedSeqNr + 1)
+              Behaviors.same
+          }
+        }
+      }
+
+      def processMsg(ctx: ActorContext[ConsumerMessage], seqNr: Long, msg: String): Behavior[ConsumerMessage] = {
+        // simulate slow consumer
+        Thread.sleep(100)
+        ctx.log.info("processed {}", seqNr)
+        if (seqNr == 500) {
+          ctx.system.terminate()
+          Behaviors.same
+        } else if ((requestedSeqNr - seqNr) == RequestWindow / 2) {
+          val newRequestedSeqNr = requestedSeqNr + RequestWindow / 2
+          ctx.log.info("request {}", newRequestedSeqNr)
+          producer ! Request(newRequestedSeqNr, confirmedSeqNr = seqNr, flakySelf, viaReceiveTimeout = false)
+          become(seqNr, newRequestedSeqNr)
+        } else {
+          become(seqNr)
+        }
+      }
+
       Behaviors.receive { (ctx, msg) ⇒
         msg match {
           case SequencedMessage(seqNr, msg) ⇒
-            ctx.log.info("received {}", seqNr)
-            // simulate slow consumer
-            Thread.sleep(100)
-            if ((requestedSeqNr - seqNr) == RequestWindow / 2) {
-              val newRequestedSeqNr = requestedSeqNr + RequestWindow / 2
-              ctx.log.info("request seqNr: {}", newRequestedSeqNr)
-              producer ! Request(newRequestedSeqNr, ctx.self)
-              consumer(producer, seqNr, newRequestedSeqNr)
-            } else {
-              consumer(producer, seqNr, requestedSeqNr)
+            val expectedSeqNr = receivedSeqNr + 1
+            if (seqNr == expectedSeqNr) {
+              processMsg(ctx, seqNr, msg)
+            } else if (seqNr > expectedSeqNr) {
+              ctx.log.info("missing {}, received {}", expectedSeqNr, seqNr)
+              producer ! Resend(fromSeqNr = expectedSeqNr)
+              becomeResending()
+            } else { // seqNr < expectedSeqNr
+              ctx.log.info("deduplicate {}, expected {}", seqNr, expectedSeqNr)
+              Behaviors.same
             }
 
           case RetryRequest ⇒
             // in case the Request or the SequencedMessage triggering the Request is lost
             val newRequestedSeqNr = receivedSeqNr + RequestWindow
-            ctx.log.info("resend request seqNr: {}", newRequestedSeqNr)
-            producer ! Request(newRequestedSeqNr, ctx.self)
-            consumer(producer, receivedSeqNr, newRequestedSeqNr)
+            ctx.log.info("retry request {}", newRequestedSeqNr)
+            producer ! Request(newRequestedSeqNr, receivedSeqNr, flakySelf, viaReceiveTimeout = true)
+            become(requestedSeqNr = newRequestedSeqNr)
         }
       }
     }
   }
 
-  // TODO could be expanded with detection of lost messages (gaps in sequence numbers)
   // TODO could use watch to detect when producer or consumer are terminated
 
   def main(args: Array[String]): Unit = {
@@ -123,8 +201,19 @@ object ReliableDeliveryPoc {
 
   def mainBehavior: Behavior[Nothing] = Behaviors.setup[Nothing] { ctx ⇒
     val p = ctx.spawn(Producer.producer(), "producer")
-    ctx.spawn(Consumer.consumer(p), "consumer")
+    // simulate lost messages
+    val flakyP = ctx.spawn(flakyNetwork(p, dropProbability = 0.3), "flakyProducer")
+    ctx.spawn(Consumer.consumer(flakyP), "consumer")
     Behaviors.empty
   }
+
+  def flakyNetwork[T](destination: ActorRef[T], dropProbability: Double): Behavior[T] =
+    Behaviors.receive { (ctx, msg) ⇒
+      if (ThreadLocalRandom.current().nextDouble() <= dropProbability)
+        ctx.log.info("dropped {}", msg)
+      else
+        destination ! msg
+      Behaviors.same
+    }
 
 }


### PR DESCRIPTION
I had some spare time in the weekend to create a prototype of support for reliable delivery in Akka Typed. I'm taking a rather different approach than in untyped `AtLeastOnceDelivery` because I would like:

* support plain flow control, with a work pulling approach
* be possible to use with or without persistence (without it may loose messages if producer node crashes)
* detect lost messages on the consumer side and let that drive resends, instead of aggressively resending from producer side
* deliver messages in order
* have an efficient protocol for acknowledgments over the network (not ack each message), but still have a simple one-by-one protocol for the end user

I can imagine that it might be somewhat overwhelming to directly dive into the full 400 lines so I'd recommend that you first look at the [first commit](https://github.com/akka/akka/commit/5e35c4c63b105de9092bd80af4ffc659e9551a56) to understand how the work pulling works, then add the [resending of lost messages](https://github.com/akka/akka/commit/5ff163e684fb7bfc1f6840be70679c896538793a). Those two are written in application domain code.

Then I [extracted the Akka code](https://github.com/akka/akka/commit/e506dc52622f8f5ec452a5da2f3ce3084782f85c) into ProducerController and ConsumerController.

A sequence diagram illustrating the flow control protocol:

![reliabledelivery](https://user-images.githubusercontent.com/336161/40022283-c80fceb4-57c7-11e8-9f41-94d3ea4a95ab.png)

Refs #20984