### PR TITLE
Add ref directive to GraphStage in .md files

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/Source/unfold.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/unfold.md
@@ -18,7 +18,7 @@ Stream the result of a function as long as it returns a @scala[`Some`] @java[`Op
 consists of a @scala[tuple] @java[pair] where the first value is a state passed back into the next call to the function allowing
 to pass a state. The first invocation of the provided fold function will receive the `zero` state.
 
-Can be used to implement many stateful sources without having to touch the more low level `GraphStage` API.
+Can be used to implement many stateful sources without having to touch the more low level @ref[`GraphStage`](../../stream-customize.md) API.
 
 
 @@@div { .callout }

--- a/akka-docs/src/main/paradox/stream/operators/Source/unfoldAsync.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/unfoldAsync.md
@@ -17,7 +17,7 @@ Just like `unfold` but the fold function returns a @scala[`Future`] @java[`Compl
 Just like `unfold` but the fold function returns a @scala[`Future`] @java[`CompletionStage`] which will cause the source to
 complete or emit when it completes.
 
-Can be used to implement many stateful sources without having to touch the more low level `GraphStage` API.
+Can be used to implement many stateful sources without having to touch the more low level @ref[`GraphStage`](../../stream-customize.md) API.
 
 
 @@@div { .callout }

--- a/akka-docs/src/main/paradox/stream/stream-cookbook.md
+++ b/akka-docs/src/main/paradox/stream/stream-cookbook.md
@@ -111,7 +111,7 @@ Java
 **Situation:** A stream of bytes is given as a stream of `ByteString` s and we want to calculate the cryptographic digest
 of the stream.
 
-This recipe uses a `GraphStage` to host a mutable `MessageDigest` class (part of the Java Cryptography
+This recipe uses a @ref[`GraphStage`](stream-customize.md) to define a custom Akka Stream operator, to host a mutable `MessageDigest` class (part of the Java Cryptography
 API) and update it with the bytes arriving from the stream. When the stream starts, the `onPull` handler of the
 stage is called, which bubbles up the `pull` event to its upstream. As a response to this pull, a ByteString
 chunk will arrive (`onPush`) which we use to update the digest, then it will pull for the next chunk.
@@ -373,8 +373,8 @@ Java
 of them is slowing down the other by dropping earlier unconsumed elements from the upstream if necessary, and repeating
 the last value for the downstream if necessary.
 
-We have two options to implement this feature. In both cases we will use `GraphStage` to build our custom
-element. In the first version we will use a provided initial value `initial` that will be used
+We have two options to implement this feature. In both cases we will use @ref[`GraphStage`](stream-customize.md), to build our custom
+operator. In the first version we will use a provided initial value `initial` that will be used
 to feed the downstream if no upstream element is ready yet. In the `onPush()` handler we overwrite the
 `currentValue` variable and immediately relieve the upstream by calling `pull()`. The downstream `onPull` handler
 is very similar, we immediately relieve the downstream by emitting `currentValue`.
@@ -451,7 +451,7 @@ for this actor.
 the same sequence, but capping the size of `ByteString` s. In other words we want to slice up `ByteString` s into smaller
 chunks if they exceed a size threshold.
 
-This can be achieved with a single `GraphStage`. The main logic of our stage is in `emitChunk()`
+This can be achieved with a single @ref[`GraphStage`](stream-customize.md) to define a custom Akka Stream operator. The main logic of our stage is in `emitChunk()`
 which implements the following logic:
 
  * if the buffer is empty, and upstream is not closed we pull for more bytes, if it is closed we complete
@@ -473,7 +473,7 @@ Java
 **Situation:** Given a stream of `ByteString` s we want to fail the stream if more than a given maximum of bytes has been
 consumed.
 
-This recipe uses a `GraphStage` to implement the desired feature. In the only handler we override,
+This recipe uses a @ref[`GraphStage`](stream-customize.md) to implement the desired feature. In the only handler we override,
 `onPush()` we update a counter and see if it gets larger than `maximumBytes`. If a violation happens
 we signal failure, otherwise we forward the chunk we have received.
 

--- a/akka-docs/src/main/paradox/stream/stream-customize.md
+++ b/akka-docs/src/main/paradox/stream/stream-customize.md
@@ -21,7 +21,7 @@ junctions of various kinds.
 
 A custom graph stage should not be the first tool you reach for, defining graphs using flows
 and the graph DSL is in general easier and does to a larger extent protect you from mistakes that
-might be easy to make with a custom `GraphStage`
+might be easy to make with a custom @ref[`GraphStage`](stream-customize.md)
 
 @@@
 

--- a/akka-docs/src/main/paradox/stream/stream-error.md
+++ b/akka-docs/src/main/paradox/stream/stream-error.md
@@ -144,7 +144,7 @@ it cancels, while the `RestartFlow` is restarted when either the in port cancels
 
 @@@ note
 
-Care should be taken when using `GraphStage`s that conditionally propagate termination signals inside a 
+Care should be taken when using @ref[`GraphStage`s](stream-customize.md) that conditionally propagate termination signals inside a
 `RestartSource`, `RestartSink` or `RestartFlow`.  
 
 An example is a `Broadcast` stage with the default `eagerCancel = false` where 

--- a/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
+++ b/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
@@ -47,7 +47,7 @@ is running.
 
 Processing Stage
 : The common name for all building blocks that build up a Graph.
-Examples of a processing stage would be  operations like `map()`, `filter()`, custom `GraphStage` s and graph
+Examples of a processing stage would be operations like `map()`, `filter()`, custom operators extending @ref[`GraphStage`s](stream-customize.md) and graph
 junctions like `Merge` or `Broadcast`. For the full list of built-in processing stages see the @ref:[operator index](operators/index.md)
 
 
@@ -375,7 +375,7 @@ such as `Zip` however *do guarantee* their outputs order, as each output element
 been signalled already – thus the ordering in the case of zipping is defined by this property.
 
 If you find yourself in need of fine grained control over order of emitted elements in fan-in
-scenarios consider using `MergePreferred`, `MergePrioritized` or `GraphStage` – which gives you full control over how the
+scenarios consider using `MergePreferred`, `MergePrioritized` or @ref[`GraphStage`](stream-customize.md) – which gives you full control over how the
 merge is performed.
 
 ## Actor Materializer Lifecycle

--- a/akka-docs/src/main/paradox/stream/stream-graphs.md
+++ b/akka-docs/src/main/paradox/stream/stream-graphs.md
@@ -329,7 +329,7 @@ turns an object into a sequence of bytes.
 
 The other stage that we talked about is a little more involved since reversing
 a framing protocol means that any received chunk of bytes may correspond to
-zero or more messages. This is best implemented using a `GraphStage`
+zero or more messages. This is best implemented using @ref[`GraphStage`](stream-customize.md)
 (see also @ref[Custom processing with GraphStage](stream-customize.md#graphstage)).
 
 Scala

--- a/akka-docs/src/main/paradox/stream/stream-integrations.md
+++ b/akka-docs/src/main/paradox/stream/stream-integrations.md
@@ -548,9 +548,9 @@ the stream may deadlock.
 @@@ warning
 
 **Deprecation warning:** `ActorPublisher` is deprecated in favour of the vastly more
-type-safe and safe to implement `akka.stream.stage.GraphStage`. It can also
+type-safe and safe to implement @ref[`GraphStage`](stream-customize.md). It can also
 expose a "stage actor ref" is needed to be addressed as-if an Actor.
-Custom stages implemented using `GraphStage` are also automatically fusable.
+Custom stages implemented using @ref[`GraphStage`](stream-customize.md) are also automatically fusable.
 
 To learn more about implementing custom stages using it refer to @ref:[Custom processing with GraphStage](stream-customize.md#graphstage).
 
@@ -614,9 +614,9 @@ Java
 @@@ warning
 
 **Deprecation warning:** `ActorSubscriber` is deprecated in favour of the vastly more
-type-safe and safe to implement `akka.stream.stage.GraphStage`. It can also
+type-safe and safe to implement @ref[`GraphStage`](stream-customize.md). It can also
 expose a "stage actor ref" is needed to be addressed as-if an Actor.
-Custom stages implemented using `GraphStage` are also automatically fusable.
+Custom stages implemented using @ref[`GraphStage`](stream-customize.md) are also automatically fusable.
 
 To learn more about implementing custom stages using it refer to @ref:[Custom processing with GraphStage](stream-customize.md#graphstage).
 

--- a/akka-docs/src/main/paradox/stream/stream-io.md
+++ b/akka-docs/src/main/paradox/stream/stream-io.md
@@ -119,7 +119,7 @@ framing and transformation to `ByteString` s this way we do not have to repeat s
 
 In this example both client and server may need to close the stream based on a parsed command - `BYE` in the case
 of the server, and `q` in the case of the client. This is implemented by @scala[taking from the stream until `q` and
-and concatenating a `Source` with a single `BYE` element which will then be sent after the original source completed]@java[using a custom `GraphStage`
+and concatenating a `Source` with a single `BYE` element which will then be sent after the original source completed]@java[using a custom operator extending @ref[`GraphStage`](stream-customize.md)
 which completes the stream once it encounters such command].
 
 ### Using framing in your protocol


### PR DESCRIPTION
Refs #24995
Only taking care of the word `GraphStage`. 

All other words, graph, graph stage, stage, ... etc to be taken care in other PRs for easier review. If you would rather want me to go with a single big PR replacing everything for #24995, please let me know