### PR TITLE
throwing in postStop should be more consistent

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StopSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StopSpec.scala
@@ -5,8 +5,10 @@
 package akka.actor.typed.scaladsl
 
 import akka.Done
-import akka.actor.typed.{ PostStop, TypedAkkaSpecWithShutdown }
-import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import akka.actor.testkit.typed.TE
+import akka.actor.testkit.typed.scaladsl.{ ActorTestKit, TestProbe }
+import akka.actor.typed.{ Behavior, PostStop, SupervisorStrategy, Terminated, TypedAkkaSpecWithShutdown }
+import akka.testkit.EventFilter
 
 import scala.concurrent.Promise
 
@@ -56,6 +58,21 @@ class StopSpec extends ActorTestKit with TypedAkkaSpecWithShutdown {
       sawSignal.future.futureValue should ===(Done)
     }
 
+  }
+
+  "PostStop" should {
+    "immediately throw when a deferred behavior (setup) is passed in as postStop" in {
+      val ex = intercept[IllegalArgumentException] {
+        Behaviors.stopped(
+          // illegal:
+          Behaviors.setup[String] { _ ⇒
+            throw TE("boom!")
+          }
+        )
+      }
+
+      ex.getMessage should include("Behavior used as `postStop` behavior in Stopped(...) was a deferred one ")
+    }
   }
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
@@ -233,7 +233,23 @@ object Behavior {
    * that PostStop can be sent to previous behavior from `finishTerminate`.
    */
   private[akka] class StoppedBehavior[T](val postStop: OptionVal[Behavior[T]]) extends Behavior[T] {
-    override def toString = "Stopped"
+    validatePostStop(postStop)
+
+    @throws[IllegalArgumentException]
+    private final def validatePostStop(postStop: OptionVal[Behavior[T]]): Unit = {
+      postStop match {
+        case OptionVal.Some(b: DeferredBehavior[_]) ⇒
+          throw new IllegalArgumentException(s"Behavior used as `postStop` behavior in Stopped(...) was a deferred one [${b.toString}], which is not supported (it would never be evaluated).")
+        case _ ⇒ // all good
+      }
+    }
+
+    override def toString = "Stopped" + {
+      postStop match {
+        case OptionVal.Some(_) ⇒ "(postStop)"
+        case _                 ⇒ "()"
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Please check the semantics first (the test), if we agree that that's what we want I'll clean up impl a bit.
The same special casing has to be there as otherwise we'd explode when the postStop would return a `same`; not sure how to best solve that there (likely other cases there as well?)

Resolves https://github.com/akka/akka/issues/24725 eventually