### PR TITLE
Optimized recovery, #25072

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/PersistentActor.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/PersistentActor.scala
@@ -99,9 +99,15 @@ object Recovery {
 
   /**
    * Convenience method for skipping recovery in [[PersistentActor]].
+   *
+   * It will still retrieve previously highest sequence number so that new events are persisted with
+   * higher sequence numbers rather than starting from 1 and assuming that there are no
+   * previous event with that sequence number.
+   *
    * @see [[Recovery]]
    */
   val none: Recovery = Recovery(toSequenceNr = 0L, fromSnapshot = SnapshotSelectionCriteria.None)
+
 }
 
 final class RecoveryTimedOut(message: String) extends RuntimeException(message) with NoStackTrace

--- a/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
@@ -137,7 +137,7 @@ trait AsyncWriteJournal extends Actor with WriteJournalBase with AsyncRecovery {
         breaker.withCircuitBreaker(asyncReadHighestSequenceNr(persistenceId, readHighestSequenceNrFrom))
           .flatMap { highSeqNr ⇒
             val toSeqNr = math.min(toSequenceNr, highSeqNr)
-            if (highSeqNr == 0L || fromSequenceNr > toSeqNr)
+            if (toSeqNr <= 0L || fromSequenceNr > toSeqNr)
               Future.successful(highSeqNr)
             else {
               // Send replayed messages and replay result to persistentActor directly. No need

--- a/akka-persistence/src/main/scala/akka/persistence/snapshot/SnapshotStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/snapshot/SnapshotStore.scala
@@ -34,11 +34,15 @@ trait SnapshotStore extends Actor with ActorLogging {
 
   final val receiveSnapshotStore: Actor.Receive = {
     case LoadSnapshot(persistenceId, criteria, toSequenceNr) ⇒
-      breaker.withCircuitBreaker(loadAsync(persistenceId, criteria.limit(toSequenceNr))) map {
-        sso ⇒ LoadSnapshotResult(sso, toSequenceNr)
-      } recover {
-        case e ⇒ LoadSnapshotFailed(e)
-      } pipeTo senderPersistentActor()
+      if (criteria == SnapshotSelectionCriteria.None) {
+        senderPersistentActor() ! LoadSnapshotResult(snapshot = None, toSequenceNr)
+      } else {
+        breaker.withCircuitBreaker(loadAsync(persistenceId, criteria.limit(toSequenceNr))) map {
+          sso ⇒ LoadSnapshotResult(sso, toSequenceNr)
+        } recover {
+          case e ⇒ LoadSnapshotFailed(e)
+        } pipeTo senderPersistentActor()
+      }
 
     case SaveSnapshot(metadata, snapshot) ⇒
       val md = metadata.copy(timestamp = System.currentTimeMillis)

--- a/akka-persistence/src/test/scala/akka/persistence/OptimizedRecoverySpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/OptimizedRecoverySpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence
+
+import akka.actor.ActorLogging
+import akka.actor.ActorRef
+import akka.actor.Props
+import akka.testkit.ImplicitSender
+
+object OptimizedRecoverySpec {
+
+  object TestPersistentActor {
+    case object TakeSnapshot
+    final case class Save(s: String)
+    final case class Saved(s: String, seqNr: Long)
+    final case object PersistFromRecoveryCompleted
+
+    def props(name: String, recovery: Recovery, probe: ActorRef): Props = {
+      Props(new TestPersistentActor(name, recovery, probe))
+    }
+  }
+
+  class TestPersistentActor(name: String, override val recovery: Recovery, probe: ActorRef) extends NamedPersistentActor(name) {
+    import TestPersistentActor._
+
+    override def persistenceId: String = name
+
+    var state = ""
+
+    def receiveCommand = {
+      case TakeSnapshot           ⇒ saveSnapshot(state)
+      case s: SaveSnapshotSuccess ⇒ probe ! s
+      case GetState               ⇒ probe ! state
+      case Save(s) ⇒ persist(Saved(s, lastSequenceNr + 1)) { evt ⇒
+        state += evt.s
+        probe ! evt
+      }
+    }
+
+    def receiveRecover = {
+      case s: SnapshotOffer ⇒
+        probe ! s
+        state = s.snapshot.toString
+      case evt: Saved ⇒
+        state += evt.s
+        probe ! evt
+
+      case RecoveryCompleted ⇒
+        require(!recoveryRunning, "expected !recoveryRunning in RecoveryCompleted")
+        probe ! RecoveryCompleted
+        // verify that persist can be used here
+        persist(PersistFromRecoveryCompleted)(_ ⇒ probe ! PersistFromRecoveryCompleted)
+    }
+  }
+
+}
+
+class OptimizedRecoverySpec extends PersistenceSpec(PersistenceSpec.config(
+  "inmem",
+  "OptimizedRecoverySpec")) with ImplicitSender {
+
+  import OptimizedRecoverySpec.TestPersistentActor
+  import OptimizedRecoverySpec.TestPersistentActor._
+
+  def setup(persistenceId: String): ActorRef = {
+    val ref = system.actorOf(TestPersistentActor.props(persistenceId, Recovery(), testActor))
+    expectMsg(RecoveryCompleted)
+    expectMsg(PersistFromRecoveryCompleted)
+    ref ! Save("a")
+    ref ! Save("b")
+    expectMsg(Saved("a", 2))
+    expectMsg(Saved("b", 3))
+    ref ! TakeSnapshot
+    expectMsgType[SaveSnapshotSuccess]
+    ref ! Save("c")
+    expectMsg(Saved("c", 4))
+    ref ! GetState
+    expectMsg("abc")
+    ref
+  }
+
+  "Optimized recovery of persistent actor" must {
+    "get RecoveryCompleted but no SnapshotOffer and events when Recovery.none" in {
+      val persistenceId = "p1"
+      setup(persistenceId)
+
+      val ref = system.actorOf(TestPersistentActor.props(persistenceId, Recovery.none, testActor))
+      expectMsg(RecoveryCompleted)
+      expectMsg(PersistFromRecoveryCompleted)
+
+      // and highest sequence number should be used, PersistFromRecoveryCompleted is 5
+      ref ! Save("d")
+      expectMsg(Saved("d", 6))
+      ref ! GetState
+      expectMsg("d")
+    }
+
+  }
+}


### PR DESCRIPTION
* ~~Introduce a new Recovery.first that can be used if it's known that it's
  the very first time the persistent actor is started.~~
* Optimize LoadSnapshot if toSequenceNr == 0, i.e. SnapshotCriteria.none,
  then no need to involve the snapshot store
* Optimize ReplayMessages if toSequenceNr == 0, i.e. Recovery.none,
  then no need to do asyncReplayMessages, but asyncReadHighestSequenceNr
  is still needed

Refs #25072