### PR TITLE
Decrease the uninitialized connection counter as late as possible

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -7,8 +7,8 @@ package akka.stream.io
 import java.net._
 import java.security.SecureRandom
 import java.util.concurrent.atomic.AtomicInteger
-import javax.net.ssl.{ KeyManagerFactory, SSLContext, TrustManagerFactory }
 
+import javax.net.ssl.{ KeyManagerFactory, SSLContext, TrustManagerFactory }
 import akka.actor.{ ActorIdentity, ActorSystem, ExtendedActorSystem, Identify, Kill }
 import akka.io.Tcp._
 import akka.stream._
@@ -26,7 +26,7 @@ import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
 import scala.collection.immutable
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future, Promise }
+import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 import scala.util.control.NonFatal
 
 class TcpSpec extends StreamSpec("""
@@ -413,7 +413,7 @@ class TcpSpec extends StreamSpec("""
         """).withFallback(system.settings.config))
 
       try {
-        import system2.dispatcher
+        implicit val ec: ExecutionContext = system2.dispatcher
         val mat2 = ActorMaterializer.create(system2)
 
         val serverAddress = temporaryServerAddress()
@@ -620,22 +620,21 @@ class TcpSpec extends StreamSpec("""
     }
 
     "handle single connection when connection flow is immediately cancelled" in assertAllStagesStopped {
-      import system.dispatcher
+      implicit val ec: ExecutionContext = system.dispatcher
 
-      val address = temporaryServerAddress()
-      val (binding, connection) = Tcp(system).bind(address.getHostString, address.getPort).toMat(Sink.head)(Keep.both).run()
+      val (bindingFuture, connection) = Tcp(system).bind("localhost", 0).toMat(Sink.head)(Keep.both).run()
 
       val proxy = connection.map { c ⇒
         c.handleWith(Flow[ByteString])
       }
 
-      binding.futureValue
+      val binding = bindingFuture.futureValue
 
       val expected = ByteString("test")
-      val msg = Source.single(expected).via(Tcp(system).outgoingConnection(address)).runWith(Sink.head)
+      val msg = Source.single(expected).via(Tcp(system).outgoingConnection(binding.localAddress)).runWith(Sink.head)
       msg.futureValue shouldBe expected
 
-      binding.futureValue.unbind()
+      binding.unbind()
     }
 
     "shut down properly even if some accepted connection Flows have not been subscribed to" in assertAllStagesStopped {

--- a/akka-stream/src/main/mima-filters/2.5.12.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.12.backwards.excludes
@@ -8,5 +8,6 @@ ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowO
 # #25135 Decrease the uninitialized connection counter as late as possible
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.IncomingConnectionStage.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.TcpConnectionStage#Inbound.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.TcpConnectionStage#Inbound.this")
 ProblemFilters.exclude[MissingTypesProblem]("akka.stream.impl.io.TcpConnectionStage$Inbound$")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.TcpConnectionStage#Inbound.apply")

--- a/akka-stream/src/main/mima-filters/2.5.12.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.12.backwards.excludes
@@ -4,3 +4,9 @@ ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowO
 # #24758 recreate already closed substreams 
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.GroupBy.this")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.groupBy")
+
+# #25135 Decrease the uninitialized connection counter as late as possible
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.IncomingConnectionStage.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.TcpConnectionStage#Inbound.copy")
+ProblemFilters.exclude[MissingTypesProblem]("akka.stream.impl.io.TcpConnectionStage$Inbound$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.io.TcpConnectionStage#Inbound.apply")


### PR DESCRIPTION
This fixes (or decreases the chances significantly for) a situation where a stream of incoming connections is closed and the incoming connection does not have a chance to startup properly.

This has been found in [Alpakka test code](https://github.com/akka/alpakka/blob/70f40b1e1f910fadc36a41fdd6e97764a7829ef6/mqtt/src/test/scala/akka/stream/alpakka/mqtt/scaladsl/MqttSourceSpec.scala#L351-L361) where TCP Streams are used to create a proxy server that only handles the first connection.
