### PR TITLE
add EventHandler type alias, #24856

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSetup.scala
@@ -29,7 +29,7 @@ private[persistence] final class EventsourcedSetup[C, E, S](
   val persistenceId:         String,
   val emptyState:            S,
   val commandHandler:        PersistentBehaviors.CommandHandler[C, E, S],
-  val eventHandler:          (S, E) ⇒ S,
+  val eventHandler:          PersistentBehaviors.EventHandler[S, E],
   val writerIdentity:        WriterIdentity,
   val recoveryCompleted:     (ActorContext[C], S) ⇒ Unit,
   val onSnapshot:            (ActorContext[C], SnapshotMetadata, Try[Done]) ⇒ Unit,

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/PersistentBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/PersistentBehaviorImpl.scala
@@ -35,7 +35,7 @@ private[akka] final case class PersistentBehaviorImpl[Command, Event, State](
   persistenceId:     String,
   emptyState:        State,
   commandHandler:    PersistentBehaviors.CommandHandler[Command, Event, State],
-  eventHandler:      (State, Event) ⇒ State,
+  eventHandler:      PersistentBehaviors.EventHandler[State, Event],
   journalPluginId:   Option[String]                                              = None,
   snapshotPluginId:  Option[String]                                              = None,
   recoveryCompleted: (ActorContext[Command], State) ⇒ Unit                       = ConstantFun.scalaAnyTwoToUnit,


### PR DESCRIPTION
* for completeness, since we have one for CommandHandler, and sometimes
  it might be useful with the shorter type signature
* use the explicit function type for CommandHandler in API signatures,
  because it's easier to see what it actually is

Refs #24856