### PR TITLE
Fix MultiByteArrayIterator.copyToArray silently drops bytes. #16303

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -895,6 +895,15 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
           bytes == array.toSeq
         }
       }
+
+      "copying chunks to an array" in {
+        val iterator = (ByteString("123") ++ ByteString("456")).iterator
+        val array = Array.ofDim[Byte](6)
+        iterator.copyToArray(array, 0, 2)
+        iterator.copyToArray(array, 2, 2)
+        iterator.copyToArray(array, 4, 2)
+        assert(new String(array) === "123456")
+      }
     }
 
     "decode data correctly" when {

--- a/akka-actor/src/main/scala/akka/util/ByteIterator.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteIterator.scala
@@ -290,7 +290,9 @@ object ByteIterator {
         current.copyToArray(xs, pos, n)
         pos += n
         rest -= n
-        dropCurrent()
+        if (current.isEmpty) {
+          dropCurrent()
+        }
       }
       normalize()
     }


### PR DESCRIPTION
I just got burned by #16303.

Answering https://github.com/akka/akka/issues/16303#issuecomment-62957914, it looks like `copyToArray[B >: Byte](Array[B])` can't call `getBytes(Array[Byte], Int, Int)` due to the type constraint (defined by `GenTraversableOnce`).

Instead, I'm going with the simple `isEmpty` check proposed in the description of #16303 by @kpatrick-kixeye.

Fixes #16303