### PR TITLE
Create Source from Sink

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/Source/sinkToSource.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/sinkToSource.md
@@ -1,0 +1,19 @@
+# Source.sinkToSource
+
+Materializes into a sink connected to a source.
+
+@ref[Source stages](../index.md#source-stages)
+
+@@@div { .group-scala }
+
+## Signature
+
+@@signature [Source.scala]($akka$/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #sinkToSource }
+
+@@@
+
+## Description
+
+@@@div { .callout }
+
+@@@

--- a/akka-docs/src/main/paradox/stream/operators/index.md
+++ b/akka-docs/src/main/paradox/stream/operators/index.md
@@ -34,6 +34,7 @@ These built-in sources are available from @scala[`akka.stream.scaladsl.Source`] 
 |Source|<a name="unfoldresourceasync"></a>@ref[unfoldResourceAsync](Source/unfoldResourceAsync.md)|Wrap any resource that can be opened, queried for next element (in a blocking way) and closed using three distinct functions into a source.|
 |Source|<a name="zipn"></a>@ref[zipN](Source/zipN.md)|Combine the elements of multiple streams into a stream of sequences.|
 |Source|<a name="zipwithn"></a>@ref[zipWithN](Source/zipWithN.md)|Combine the elements of multiple streams into a stream of sequences using a combiner function.|
+|Source|<a name="sinkToSource"></a>@ref[sinkToSource](Source/sinkToSource.md)|Materializes into a sink connected to a source.|
 
 ## Sink stages
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
@@ -445,4 +445,18 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
       a[RuntimeException] shouldBe thrownBy(matValPoweredSource.preMaterialize())
     }
   }
+
+  "Source connect" must {
+    "correctly connects a source to a sink" in {
+      val (sink, src) = Source.connect[Int]
+      Source(1 to 3).runWith(sink)
+      val probe = src.runWith(TestSink.probe)
+
+      probe.request(3)
+      probe.expectNext(1)
+      probe.expectNext(2)
+      probe.expectNext(3)
+      probe.expectComplete()
+    }
+  }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
@@ -446,9 +446,9 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
     }
   }
 
-  "Source connect" must {
+  "Source sinkToSource" must {
     "correctly connects a source to a sink" in {
-      val (sink, src) = Source.connect[Int]
+      val (sink, src) = Source.sinkToSource[Int].run
       Source(1 to 3).runWith(sink)
       val probe = src.runWith(TestSink.probe)
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -680,12 +680,11 @@ object Source {
    *
    * Should be provided by Akka Streams, see https://github.com/akka/akka/issues/24853.
    */
-  def connect[Mat2]()(implicit materializer: Materializer): (Sink[Mat2, NotUsed], Source[Mat2, NotUsed]) =
+  def sinkToSource[M]: RunnableGraph[(Sink[M, NotUsed], Source[M, NotUsed])] =
     Source
-      .asSubscriber[Mat2]
-      .toMat(Sink.asPublisher[Mat2](fanout = false))(Keep.both)
+      .asSubscriber[M]
+      .toMat(Sink.asPublisher[M](fanout = false))(Keep.both)
       .mapMaterializedValue {
         case (sub, pub) ⇒ (Sink.fromSubscriber(sub), Source.fromPublisher(pub))
       }
-      .run()
 }


### PR DESCRIPTION
Refs #24853

Add `connect` to Source.
It easily connects a source to a sink, based on https://github.com/akka/akka/issues/24853#issuecomment-388616085.