### PR TITLE
Remove unnecesary drop() from ByteString1.writeToBuffer(ByteBuffer)

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -611,7 +611,7 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
       "dropping" in { check((a: ByteString, b: ByteString) ⇒ (a ++ b).drop(b.size).size == a.size) }
       "taking" in { check((a: ByteString, b: ByteString) ⇒ (a ++ b).take(a.size) == a) }
       "takingRight" in { check((a: ByteString, b: ByteString) ⇒ (a ++ b).takeRight(b.size) == b) }
-      "droppnig then taking" in { check((a: ByteString, b: ByteString) ⇒ (b ++ a ++ b).drop(b.size).take(a.size) == a) }
+      "dropping then taking" in { check((a: ByteString, b: ByteString) ⇒ (b ++ a ++ b).drop(b.size).take(a.size) == a) }
       "droppingRight" in { check((a: ByteString, b: ByteString) ⇒ (b ++ a ++ b).drop(b.size).dropRight(b.size) == a) }
     }
 

--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -330,7 +330,6 @@ object ByteString {
       val copyLength = Math.min(buffer.remaining, length)
       if (copyLength > 0) {
         buffer.put(bytes, startIndex, copyLength)
-        drop(copyLength)
       }
       copyLength
     }


### PR DESCRIPTION
I found a strange call to `drop()` in `ByteString1.writeToBuffer(ByteBuffer)`. `drop()` instantiates a new `ByteString1` which is immediately discarded to GC. Appears unnecessary.

Removing it makes the `ByteString1` implementation consistent with `ByteString1C`.

I did a cursory search for github issues, but didn't find any relevant ones.