### PR TITLE
Optimize ByteString.grouped(size)

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -52,6 +52,15 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
     } yield (xs, from, until)
   }
 
+  case class ByteStringGrouped(bs: ByteString, size: Int)
+
+  implicit val arbitraryByteStringGrouped = Arbitrary {
+    for {
+      xs ← arbitraryByteString.arbitrary
+      size ← Gen.choose(1, 1 max (xs.length - 1))
+    } yield ByteStringGrouped(xs, size)
+  }
+
   type ArraySlice[A] = (Array[A], Int, Int)
 
   def arbSlice[A](arbArray: Arbitrary[Array[A]]): Arbitrary[ArraySlice[A]] = Arbitrary {
@@ -726,6 +735,14 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
             case (xs, from, until) ⇒ likeVector(xs)({
               _.drop(from).take(until - from)
             })
+          }
+        }
+      }
+
+      "calling grouped" in {
+        check { grouped: ByteStringGrouped ⇒
+          likeVector(grouped.bs) {
+            _.grouped(grouped.size).toIndexedSeq
           }
         }
       }

--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -57,7 +57,7 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
   implicit val arbitraryByteStringGrouped = Arbitrary {
     for {
       xs ← arbitraryByteString.arbitrary
-      size ← Gen.choose(1, 1 max (xs.length - 1))
+      size ← Gen.choose(1, 1 max xs.length)
     } yield ByteStringGrouped(xs, size)
   }
 

--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -703,7 +703,10 @@ sealed abstract class ByteString extends IndexedSeq[Byte] with IndexedSeqOptimiz
   override def indexOf[B >: Byte](elem: B): Int = indexOf(elem, 0)
 
   override def grouped(size: Int): Iterator[ByteString] = {
-    require(size >= 1, s"size=$size must be positive")
+    if (size <= 0) {
+      throw new IllegalArgumentException(s"size=$size must be positive")
+    }
+
     Iterator.iterate(this)(_.drop(size))
       .takeWhile(_.nonEmpty)
       .map(_.take(size))

--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -702,6 +702,13 @@ sealed abstract class ByteString extends IndexedSeq[Byte] with IndexedSeqOptimiz
   // optimized in subclasses
   override def indexOf[B >: Byte](elem: B): Int = indexOf(elem, 0)
 
+  override def grouped(size: Int): Iterator[ByteString] = {
+    require(size >= 1, s"size=$size must be positive")
+    Iterator.iterate(this)(_.drop(size))
+      .takeWhile(_.nonEmpty)
+      .map(_.take(size))
+  }
+
   override def toString(): String = {
     val maxSize = 100
     if (size > maxSize)

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_grouped_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_grouped_Benchmark.scala
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2014-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+class ByteString_grouped_Benchmark {
+
+  private val bsLarge = ByteString(Array.ofDim[Byte](1000 * 1000))
+
+  /*
+    > akka-bench-jmh/jmh:run -t1 -f1 .*ByteString_grouped_Benchmark
+    [info] Benchmark                             Mode  Cnt      Score      Error  Units
+    [info] ByteString_grouped_Benchmark.grouped  avgt   10  59386.328 ± 1466.045  ns/op
+   */
+
+  @Benchmark
+  def grouped(bh: Blackhole): Unit = {
+    bh.consume(bsLarge.grouped(1000).foreach(bh.consume))
+  }
+}

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_grouped_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_grouped_Benchmark.scala
@@ -19,7 +19,7 @@ class ByteString_grouped_Benchmark {
   private val bsLarge = ByteString(Array.ofDim[Byte](1000 * 1000))
 
   /*
-    > akka-bench-jmh/jmh:run -t1 -f1 .*ByteString_grouped_Benchmark
+    > akka-bench-jmh/jmh:run -f1 .*ByteString_grouped_Benchmark
     [info] Benchmark                             Mode  Cnt      Score      Error  Units
     [info] ByteString_grouped_Benchmark.grouped  avgt   10  59386.328 ± 1466.045  ns/op
    */


### PR DESCRIPTION
## Motivation
I'd love to cap the size of elements in my `Flow[ByteString]`. Downstream has a size limit.

## Temptation
```scala
Flow[ByteString].mapConcat(_.grouped(1000).toStream)
```

## Benchmarks
Performance is pretty rough.

```
[info] Benchmark                             Mode  Cnt         Score        Error  Units
[info] ByteString_grouped_Benchmark.grouped  avgt   10  23141221.139 ± 672740.132  ns/op   // before
[info] ByteString_grouped_Benchmark.grouped  avgt   10     59386.328 ±   1466.045  ns/op   // after
```

This PR adds an optimized implementation of `ByteString.grouped()`, rather than inheriting from `IterableLike`.

Benchmarked scenario improves by ~390x.