### PR TITLE
Make copyUSAsciiStrToBytes more robust w.r.t. JDK

### DIFF
--- a/akka-actor/src/main/scala/akka/util/Unsafe.java
+++ b/akka-actor/src/main/scala/akka/util/Unsafe.java
@@ -50,7 +50,7 @@ public final class Unsafe {
         } else {
             final char[] chars = (char[]) instance.getObject(str, stringValueFieldOffset);
             int i = 0;
-            while (i < chars.length) {
+            while (i < str.length()) {
                 bytes[i] = (byte) chars[i++];
             }
         }


### PR DESCRIPTION
* The `copyUSAsciiStrToBytes` API assumes that the JDK's representation of String value arrays are always of equal length to the String object itself. This may not be the case for all JDKs, and in particular it is not the case in Java 8 version of OpenJ9 [1].

* To make akka more robust we use the `length()` method to retrieve the length of the String object rather than assuming the value array is always of the same size. This should not cause any performance differences as the length method is quite small and should always be inlined.

Fixes: #25161

[1] https://github.com/eclipse/openj9

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>