### PR TITLE
fix broken link to actorRefWithAck

### DIFF
--- a/akka-docs/src/main/paradox/stream/stream-integrations.md
+++ b/akka-docs/src/main/paradox/stream/stream-integrations.md
@@ -72,7 +72,7 @@ since multiple actors are being asked concurrently to begin with, and no single 
 ### Sink.actorRefWithAck
 
 @@@ note
-  See also: [Sink.actorRefWithAck operator reference docs](operators/Sink/actorRefWithAck.md)
+  See also: @ref[Sink.actorRefWithAck operator reference docs](operators/Sink/actorRefWithAck.md)
 @@@
 
 The sink sends the elements of the stream to the given `ActorRef` that sends back back-pressure signal.


### PR DESCRIPTION
Thanks for reporting @ennru 
I have patched the html page for 2.5.13.