### PR TITLE
eliminate extraneous takeWhile$default$2 method in Java DSL

### DIFF
--- a/akka-stream/src/main/mima-filters/2.5.13.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.13.backwards.excludes
@@ -1,0 +1,2 @@
+# #25175 eliminate extraneous takeWhile$default$2 method in Java DSL
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.javadsl.Flow.takeWhile$default$2")

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1256,7 +1256,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * See also [[Flow.limit]], [[Flow.limitWeighted]]
    */
-  def takeWhile(p: function.Predicate[Out], inclusive: Boolean = false): javadsl.Flow[In, Out, Mat] = new Flow(delegate.takeWhile(p.test, inclusive))
+  def takeWhile(p: function.Predicate[Out], inclusive: Boolean): javadsl.Flow[In, Out, Mat] = new Flow(delegate.takeWhile(p.test, inclusive))
 
   /**
    * Terminate processing (and cancel the upstream publisher) after predicate


### PR DESCRIPTION
Java doesn't have default argument values, yet the two-arg `takeWhile` method on the Java DSL Flow has `false` as the default value for the second argument. This doesn't add anything useful, and it adds a confusing `takeWhile$default$2` method to the signature of `Flow`.