### PR TITLE
Optimize mapAsync(1) by using mapAsyncUnordered for that case

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/MapAsyncBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/MapAsyncBenchmark.scala
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2014-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.remote.artery.BenchTestSource
+import akka.remote.artery.LatchSink
+import akka.stream.impl.PhasedFusingActorMaterializer
+import akka.stream.impl.StreamSupervisor
+import akka.stream.scaladsl._
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations._
+
+object MapAsyncBenchmark {
+  final val OperationsPerInvocation = 100000
+}
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+class MapAsyncBenchmark {
+  import MapAsyncBenchmark._
+
+  val config = ConfigFactory.parseString(
+    """
+    akka.actor.default-dispatcher {
+      executor = "fork-join-executor"
+      fork-join-executor {
+        parallelism-factor = 1
+      }
+    }
+    """
+  )
+
+  implicit val system = ActorSystem("MapAsyncBenchmark", config)
+  import system.dispatcher
+
+  var materializer: ActorMaterializer = _
+
+  var testSource: Source[java.lang.Integer, NotUsed] = _
+
+  @Param(Array("1", "4"))
+  var parallelism = 0
+
+  @Param(Array("false", "true"))
+  var spawn = false
+
+  @Setup
+  def setup(): Unit = {
+    val settings = ActorMaterializerSettings(system)
+    materializer = ActorMaterializer(settings)
+
+    testSource = Source.fromGraph(new BenchTestSource(OperationsPerInvocation))
+  }
+
+  @TearDown
+  def shutdown(): Unit = {
+    Await.result(system.terminate(), 5.seconds)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(OperationsPerInvocation)
+  def mapAsync(): Unit = {
+    val latch = new CountDownLatch(1)
+
+    testSource
+      .mapAsync(parallelism)(elem ⇒ if (spawn) Future(elem) else Future.successful(elem))
+      .runWith(new LatchSink(OperationsPerInvocation, latch))(materializer)
+
+    awaitLatch(latch)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(OperationsPerInvocation)
+  def mapAsyncUnordered(): Unit = {
+    val latch = new CountDownLatch(1)
+
+    testSource
+      .mapAsyncUnordered(parallelism)(elem ⇒ if (spawn) Future(elem) else Future.successful(elem))
+      .runWith(new LatchSink(OperationsPerInvocation, latch))(materializer)
+
+    awaitLatch(latch)
+  }
+
+  private def awaitLatch(latch: CountDownLatch): Unit = {
+    if (!latch.await(30, TimeUnit.SECONDS)) {
+      dumpMaterializer()
+      throw new RuntimeException("Latch didn't complete in time")
+    }
+  }
+
+  private def dumpMaterializer(): Unit = {
+    materializer match {
+      case impl: PhasedFusingActorMaterializer ⇒
+        val probe = TestProbe()(system)
+        impl.supervisor.tell(StreamSupervisor.GetChildren, probe.ref)
+        val children = probe.expectMsgType[StreamSupervisor.Children].children
+        children.foreach(_ ! StreamSupervisor.PrintDebugDump)
+    }
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -869,7 +869,9 @@ trait FlowOps[+Out, +Mat] {
    *
    * @see [[#mapAsyncUnordered]]
    */
-  def mapAsync[T](parallelism: Int)(f: Out ⇒ Future[T]): Repr[T] = via(MapAsync(parallelism, f))
+  def mapAsync[T](parallelism: Int)(f: Out ⇒ Future[T]): Repr[T] =
+    if (parallelism == 1) mapAsyncUnordered[T](parallelism = 1)(f) // optimization for parallelism 1
+    else via(MapAsync(parallelism, f))
 
   /**
    * Transform this stream by applying the given function to each of the elements


### PR DESCRIPTION
When I used mapAsync(1) the other day I had the thought that it must be possible to optimize that case, since MapAsync does quite a lot complicated stuff that is not needed when there is only one in flight.

When using `Future.successful`:

* mapAsync(1): 8.6 M ops/s
* mapAsyncUnordered(1): 10.5 M ops/s
* optimized mapAsync(1): 12.5 M ops/s

When using `Future()`:

* mapAsync(1): 6.8 M ops/s
* mapAsyncUnordered(1): 6.9 M ops/s
* optimized mapAsync(1): 7.2 M ops/s

The difference might not be big enough that it's worth it, but we might want to use `mapAsyncUnordered(1)` for ` mapAsync(1)`?

Full JMH results...

mapAsync BEFORE:

```
[info] Benchmark                                                    (parallelism)  (spawn)   Mode  Cnt        Score        Error   Units

[info] MapAsyncBenchmark.mapAsync                                               1    false  thrpt    7  8614632.046 ±  82412.306   ops/s
[info] MapAsyncBenchmark.mapAsync:·gc.alloc.rate                                1    false  thrpt    7      376.693 ±    373.743  MB/sec
[info] MapAsyncBenchmark.mapAsync:·gc.alloc.rate.norm                           1    false  thrpt    7       48.193 ±     47.813    B/op

[info] MapAsyncBenchmark.mapAsync                                               1     true  thrpt    7   680788.032 ±  47103.195   ops/s
[info] MapAsyncBenchmark.mapAsync:·gc.alloc.rate                                1     true  thrpt    7      188.596 ±    187.759  MB/sec
[info] MapAsyncBenchmark.mapAsync:·gc.alloc.rate.norm                           1     true  thrpt    7      305.172 ±    303.073    B/op

[info] MapAsyncBenchmark.mapAsync                                               4    false  thrpt    7  8667431.696 ± 133254.579   ops/s
[info] MapAsyncBenchmark.mapAsync:·gc.alloc.rate                                4    false  thrpt    7      378.744 ±    375.798  MB/sec
[info] MapAsyncBenchmark.mapAsync:·gc.alloc.rate.norm                           4    false  thrpt    7       48.193 ±     47.813    B/op

[info] MapAsyncBenchmark.mapAsync                                               4     true  thrpt    7  1427994.684 ± 112244.938   ops/s
[info] MapAsyncBenchmark.mapAsync:·gc.alloc.rate                                4     true  thrpt    7      503.824 ±    501.985  MB/sec
[info] MapAsyncBenchmark.mapAsync:·gc.alloc.rate.norm                           4     true  thrpt    7      391.061 ±    388.332    B/op
```

mapAsyncUnordered BEFORE:

```
[info] Benchmark                                                             (parallelism)  (spawn)   Mode  Cnt         Score        Error   Units

[info] MapAsyncBenchmark.mapAsyncUnordered                                               1    false  thrpt    7  10474676.600 ± 150504.248   ops/s
[info] MapAsyncBenchmark.mapAsyncUnordered:·gc.alloc.rate                                1    false  thrpt    7       262.752 ±    260.511  MB/sec
[info] MapAsyncBenchmark.mapAsyncUnordered:·gc.alloc.rate.norm                           1    false  thrpt    7        27.622 ±     27.382    B/op

[info] MapAsyncBenchmark.mapAsyncUnordered                                               1     true  thrpt    7    692651.397 ±  44656.452   ops/s
[info] MapAsyncBenchmark.mapAsyncUnordered:·gc.alloc.rate                                1     true  thrpt    7       179.075 ±    177.979  MB/sec
[info] MapAsyncBenchmark.mapAsyncUnordered:·gc.alloc.rate.norm                           1     true  thrpt    7       287.285 ±    285.277    B/op

[info] MapAsyncBenchmark.mapAsyncUnordered                                               4    false  thrpt    7   9638834.848 ± 281914.749   ops/s
[info] MapAsyncBenchmark.mapAsyncUnordered:·gc.alloc.rate                                4    false  thrpt    7       241.832 ±    239.873  MB/sec
[info] MapAsyncBenchmark.mapAsyncUnordered:·gc.alloc.rate.norm                           4    false  thrpt    7        27.623 ±     27.383    B/op

[info] MapAsyncBenchmark.mapAsyncUnordered                                               4     true  thrpt    7    939854.818 ±  61280.301   ops/s
[info] MapAsyncBenchmark.mapAsyncUnordered:·gc.alloc.rate                                4     true  thrpt    7       254.399 ±    253.069  MB/sec
[info] MapAsyncBenchmark.mapAsyncUnordered:·gc.alloc.rate.norm                           4     true  thrpt    7       298.419 ±    296.447    B/op
```

mapAsync AFTER:

```
[info] Benchmark                                                    (parallelism)  (spawn)   Mode  Cnt         Score        Error   Units

[info] MapAsyncBenchmark.mapAsync                                               1    false  thrpt    7  12532555.990 ± 163069.153   ops/s
[info] MapAsyncBenchmark.mapAsync:·gc.alloc.rate                                1    false  thrpt    7       313.709 ±    311.030  MB/sec
[info] MapAsyncBenchmark.mapAsync:·gc.alloc.rate.norm                           1    false  thrpt    7        27.579 ±     27.341    B/op

[info] MapAsyncBenchmark.mapAsync                                               1     true  thrpt    7    720838.128 ±  64305.436   ops/s
[info] MapAsyncBenchmark.mapAsync:·gc.alloc.rate                                1     true  thrpt    7       179.311 ±    178.688  MB/sec
[info] MapAsyncBenchmark.mapAsync:·gc.alloc.rate.norm                           1     true  thrpt    7       274.868 ±    273.123    B/op
```