### PR TITLE
Configure exit code and Coordinated Shutdown per-reason overrides

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/CoordinatedShutdownSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/CoordinatedShutdownSpec.scala
@@ -138,7 +138,7 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
         "a" → emptyPhase,
         "b" → phase("a"),
         "c" → phase("b", "a"))
-      val co = new CoordinatedShutdown(extSys, phases)
+      val co = new CoordinatedShutdown(extSys, phases, 0)
       co.addTask("a", "a1") { () ⇒
         testActor ! "A"
         Future.successful(Done)
@@ -168,7 +168,7 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
         "a" → emptyPhase,
         "b" → phase("a"),
         "c" → phase("b", "a"))
-      val co = new CoordinatedShutdown(extSys, phases)
+      val co = new CoordinatedShutdown(extSys, phases, 0)
       co.addTask("a", "a1") { () ⇒
         testActor ! "A"
         Future.successful(Done)
@@ -188,7 +188,7 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
 
     "only run once" in {
       val phases = Map("a" → emptyPhase)
-      val co = new CoordinatedShutdown(extSys, phases)
+      val co = new CoordinatedShutdown(extSys, phases, 0)
       co.addTask("a", "a1") { () ⇒
         testActor ! "A"
         Future.successful(Done)
@@ -209,7 +209,7 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
         "a" → emptyPhase,
         "b" → Phase(dependsOn = Set("a"), timeout = 100.millis, recover = true, enabled = true),
         "c" → phase("b", "a"))
-      val co = new CoordinatedShutdown(extSys, phases)
+      val co = new CoordinatedShutdown(extSys, phases, 0)
       co.addTask("a", "a1") { () ⇒
         testActor ! "A"
         Future.failed(new RuntimeException("boom"))
@@ -246,7 +246,7 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
         "a" → emptyPhase,
         "b" → Phase(dependsOn = Set("a"), timeout = 100.millis, recover = false, enabled = true),
         "c" → phase("b", "a"))
-      val co = new CoordinatedShutdown(extSys, phases)
+      val co = new CoordinatedShutdown(extSys, phases, 0)
       co.addTask("b", "b1") { () ⇒
         testActor ! "B"
         Promise[Done]().future // never completed
@@ -268,7 +268,7 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
         "a" → emptyPhase,
         "b" → Phase(dependsOn = Set("a"), timeout = 100.millis, recover = false, enabled = false),
         "c" → phase("b", "a"))
-      val co = new CoordinatedShutdown(extSys, phases)
+      val co = new CoordinatedShutdown(extSys, phases, 0)
       co.addTask("b", "b1") { () ⇒
         testActor ! "B"
         Future.failed(new RuntimeException("Was expected to not be executed"))
@@ -288,7 +288,7 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
       val phases = Map(
         "a" → emptyPhase,
         "b" → phase("a"))
-      val co = new CoordinatedShutdown(extSys, phases)
+      val co = new CoordinatedShutdown(extSys, phases, 0)
       co.addTask("a", "a1") { () ⇒
         testActor ! "A"
         co.addTask("b", "b1") { () ⇒
@@ -321,6 +321,10 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
         "a" → Phase(dependsOn = Set.empty, timeout = 10.seconds, recover = true, enabled = true),
         "b" → Phase(dependsOn = Set("a"), timeout = 15.seconds, recover = true, enabled = true),
         "c" → Phase(dependsOn = Set("a", "b"), timeout = 10.seconds, recover = false, enabled = true)))
+    }
+
+    "default exit status code to 0" in {
+      CoordinatedShutdown(system).exitStatus should ===(0)
     }
 
     // this must be the last test, since it terminates the ActorSystem

--- a/akka-actor-tests/src/test/scala/akka/actor/CoordinatedShutdownSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/CoordinatedShutdownSpec.scala
@@ -325,12 +325,14 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
 
     "default exit code to 0" in {
       lazy val conf = ConfigFactory.load().getConfig("akka.coordinated-shutdown")
-      CoordinatedShutdown.readExitCode(conf, None) should ===(0)
+      val confWithOverrides = CoordinatedShutdown.confWithOverrides(conf, None)
+      confWithOverrides.getInt("exit-code") should ===(0)
     }
 
     "default exit code to -1 when the Reason is ClusterDowning" in {
       lazy val conf = ConfigFactory.load().getConfig("akka.coordinated-shutdown")
-      CoordinatedShutdown.readExitCode(conf, Some(CoordinatedShutdown.ClusterDowningReason)) should ===(-1)
+      val confWithOverrides = CoordinatedShutdown.confWithOverrides(conf, Some(CoordinatedShutdown.ClusterDowningReason))
+      confWithOverrides.getInt("exit-code") should ===(-1)
     }
 
     // this must be the last test, since it terminates the ActorSystem

--- a/akka-actor-tests/src/test/scala/akka/actor/CoordinatedShutdownSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/CoordinatedShutdownSpec.scala
@@ -323,14 +323,14 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
         "c" → Phase(dependsOn = Set("a", "b"), timeout = 10.seconds, recover = false, enabled = true)))
     }
 
-    "default exit code is 0" in {
+    "default exit code to 0" in {
       lazy val conf = ConfigFactory.load().getConfig("akka.coordinated-shutdown")
-      CoordinatedShutdown.readExitCodeFromConf(conf, None) should ===(0)
+      CoordinatedShutdown.readExitCode(conf, None) should ===(0)
     }
 
-    "default exit code when the Reason is Downing is -1" in {
+    "default exit code to -1 when the Reason is ClusterDowning" in {
       lazy val conf = ConfigFactory.load().getConfig("akka.coordinated-shutdown")
-      CoordinatedShutdown.readExitCodeFromConf(conf, Some(CoordinatedShutdown.ClusterDowningReason)) should ===(-1)
+      CoordinatedShutdown.readExitCode(conf, Some(CoordinatedShutdown.ClusterDowningReason)) should ===(-1)
     }
 
     // this must be the last test, since it terminates the ActorSystem

--- a/akka-actor-tests/src/test/scala/akka/actor/CoordinatedShutdownSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/CoordinatedShutdownSpec.scala
@@ -138,7 +138,7 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
         "a" → emptyPhase,
         "b" → phase("a"),
         "c" → phase("b", "a"))
-      val co = new CoordinatedShutdown(extSys, phases, 0)
+      val co = new CoordinatedShutdown(extSys, phases)
       co.addTask("a", "a1") { () ⇒
         testActor ! "A"
         Future.successful(Done)
@@ -168,7 +168,7 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
         "a" → emptyPhase,
         "b" → phase("a"),
         "c" → phase("b", "a"))
-      val co = new CoordinatedShutdown(extSys, phases, 0)
+      val co = new CoordinatedShutdown(extSys, phases)
       co.addTask("a", "a1") { () ⇒
         testActor ! "A"
         Future.successful(Done)
@@ -188,7 +188,7 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
 
     "only run once" in {
       val phases = Map("a" → emptyPhase)
-      val co = new CoordinatedShutdown(extSys, phases, 0)
+      val co = new CoordinatedShutdown(extSys, phases)
       co.addTask("a", "a1") { () ⇒
         testActor ! "A"
         Future.successful(Done)
@@ -209,7 +209,7 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
         "a" → emptyPhase,
         "b" → Phase(dependsOn = Set("a"), timeout = 100.millis, recover = true, enabled = true),
         "c" → phase("b", "a"))
-      val co = new CoordinatedShutdown(extSys, phases, 0)
+      val co = new CoordinatedShutdown(extSys, phases)
       co.addTask("a", "a1") { () ⇒
         testActor ! "A"
         Future.failed(new RuntimeException("boom"))
@@ -246,7 +246,7 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
         "a" → emptyPhase,
         "b" → Phase(dependsOn = Set("a"), timeout = 100.millis, recover = false, enabled = true),
         "c" → phase("b", "a"))
-      val co = new CoordinatedShutdown(extSys, phases, 0)
+      val co = new CoordinatedShutdown(extSys, phases)
       co.addTask("b", "b1") { () ⇒
         testActor ! "B"
         Promise[Done]().future // never completed
@@ -268,7 +268,7 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
         "a" → emptyPhase,
         "b" → Phase(dependsOn = Set("a"), timeout = 100.millis, recover = false, enabled = false),
         "c" → phase("b", "a"))
-      val co = new CoordinatedShutdown(extSys, phases, 0)
+      val co = new CoordinatedShutdown(extSys, phases)
       co.addTask("b", "b1") { () ⇒
         testActor ! "B"
         Future.failed(new RuntimeException("Was expected to not be executed"))
@@ -288,7 +288,7 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
       val phases = Map(
         "a" → emptyPhase,
         "b" → phase("a"))
-      val co = new CoordinatedShutdown(extSys, phases, 0)
+      val co = new CoordinatedShutdown(extSys, phases)
       co.addTask("a", "a1") { () ⇒
         testActor ! "A"
         co.addTask("b", "b1") { () ⇒
@@ -323,8 +323,14 @@ class CoordinatedShutdownSpec extends AkkaSpec(ConfigFactory.parseString(
         "c" → Phase(dependsOn = Set("a", "b"), timeout = 10.seconds, recover = false, enabled = true)))
     }
 
-    "default exit status code to 0" in {
-      CoordinatedShutdown(system).exitStatus should ===(0)
+    "default exit code is 0" in {
+      lazy val conf = ConfigFactory.load().getConfig("akka.coordinated-shutdown")
+      CoordinatedShutdown.readExitCodeFromConf(conf, None) should ===(0)
+    }
+
+    "default exit code when the Reason is Downing is -1" in {
+      lazy val conf = ConfigFactory.load().getConfig("akka.coordinated-shutdown")
+      CoordinatedShutdown.readExitCodeFromConf(conf, Some(CoordinatedShutdown.ClusterDowningReason)) should ===(-1)
     }
 
     // this must be the last test, since it terminates the ActorSystem

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -1056,6 +1056,9 @@ akka {
     # immediately when the last phase is reached.
     exit-jvm = off
 
+    # Exit status to use on (System.exit(int)) when 'exit-jvm' is 'on'.
+    exit-status = 0
+
     # Run the coordinated shutdown when the JVM process exits, e.g.
     # via kill SIGTERM signal (SIGINT ctrl-c doesn't work).
     # This property is related to `akka.jvm-shutdown-hooks` above.

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -1069,10 +1069,12 @@ akka {
     # Only 'exit-jvm', 'exit-code' and 'terminate-actor-system' may be
     # overriden depending on the reason.
     reason-overrides {
-      "akka.actor.CoordinatedShutdown.ClusterDowningReason$" {
+      # Overrides are applied using the `reason.getClass.getName`. This
+      # default overrides the `exit-code` when the `Reason` is a cluster
+      # Downing event (identified by the object
+      # "akka.actor.CoordinatedShutdown$ClusterDowningReason$").
+      "akka.actor.CoordinatedShutdown$ClusterDowningReason$" {
         exit-code = -1
-        exit-jvm = on
-        terminate-actor-system = on
       }
     }
 

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -1056,7 +1056,7 @@ akka {
     # immediately when the last phase is reached.
     exit-jvm = off
 
-    # Exit status to use on (System.exit(int)) when 'exit-jvm' is 'on'.
+    # Exit status to use on System.exit(int) when 'exit-jvm' is 'on'.
     exit-code = 0
 
     # Run the coordinated shutdown when the JVM process exits, e.g.

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -1066,9 +1066,13 @@ akka {
 
     # When Coordinated Shutdown is triggered an instance of `Reason` is
     # required. That value can be used to override the default settings.
+    # Only 'exit-jvm', 'exit-code' and 'terminate-actor-system' may be
+    # overriden depending on the reason.
     reason-overrides {
       "akka.actor.CoordinatedShutdown.ClusterDowningReason$" {
         exit-code = -1
+        exit-jvm = on
+        terminate-actor-system = on
       }
     }
 

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -1057,12 +1057,20 @@ akka {
     exit-jvm = off
 
     # Exit status to use on (System.exit(int)) when 'exit-jvm' is 'on'.
-    exit-status = 0
+    exit-code = 0
 
     # Run the coordinated shutdown when the JVM process exits, e.g.
     # via kill SIGTERM signal (SIGINT ctrl-c doesn't work).
     # This property is related to `akka.jvm-shutdown-hooks` above.
     run-by-jvm-shutdown-hook = on
+
+    # When Coordinated Shutdown is triggered an instance of `Reason` is
+    # required. That value can be used to override the default settings.
+    reason-overrides {
+      "akka.actor.CoordinatedShutdown.ClusterDowningReason$" {
+        exit-code = -1
+      }
+    }
 
     #//#coordinated-shutdown-phases
     # CoordinatedShutdown is enabled by default and will run the tasks that

--- a/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
+++ b/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
@@ -172,7 +172,7 @@ object CoordinatedShutdown extends ExtensionId[CoordinatedShutdown] with Extensi
     coord
   }
 
-  // locate reason-specifi overrides and merge with defaults.
+  // locate reason-specific overrides and merge with defaults.
   @InternalApi private[akka] def confWithOverrides(conf: Config, reason: Option[Reason]): Config = {
     reason.flatMap { r ⇒
       val basePath = s"""reason-overrides."${r.getClass.getName}""""

--- a/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
+++ b/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Supplier
 import java.util.Optional
 
+import akka.annotation.InternalApi
 import akka.util.OptionVal
 
 object CoordinatedShutdown extends ExtensionId[CoordinatedShutdown] with ExtensionIdProvider {
@@ -172,9 +173,9 @@ object CoordinatedShutdown extends ExtensionId[CoordinatedShutdown] with Extensi
   }
 
   // locate reason-specifi overrides and merge with defaults.
-  private[akka] def confWithOverrides(conf: Config, reason: Option[Reason]): Config = {
+  @InternalApi private[akka] def confWithOverrides(conf: Config, reason: Option[Reason]): Config = {
     reason.flatMap { r ⇒
-      val basePath = s"""reason-overrides."${r.getClass.getCanonicalName}""""
+      val basePath = s"""reason-overrides."${r.getClass.getName}""""
       if (conf.hasPath(basePath)) Some(conf.getConfig(basePath).withFallback(conf)) else None
     }.getOrElse(
       conf


### PR DESCRIPTION
Fixes #24183 

Coordinated Shutdown hardcode the exit statatus code to `0` (`System.exit(0)`). In some scenarios it would be useful to overwrite that value (and maybe other coordinated shutdown settings) depending on the `Reason` that triggered the execution of `CoordinatedShutdown`.