### PR TITLE
Fix ClusterShardingIncorrectSetup barrier

### DIFF
--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingIncorrectSetupSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingIncorrectSetupSpec.scala
@@ -55,8 +55,8 @@ abstract class ClusterShardingIncorrectSetupSpec extends MultiNodeSpec(ClusterSh
             extractEntityId = extractEntityId,
             extractShardId = extractShardId)
         }
-        enterBarrier("helpful error message logged")
       }
+      enterBarrier("helpful error message logged")
     }
   }
 }


### PR DESCRIPTION
I am a doofus! Does pass most of the time as is.

Barrier needs to be one line down otherwise can fail:
http://jenkins.akka.io:8498/job/akka-artery-cluster-tests/1364/consoleFulllusterShardingIncorrectSetupMultiJvmNode1