### PR TITLE
Harden typed MultiDcClusterSharding

### DIFF
--- a/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/MultiDcClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/MultiDcClusterShardingSpec.scala
@@ -24,6 +24,10 @@ object MultiDcClusterShardingSpecConfig extends MultiNodeConfig {
     ConfigFactory.parseString(
       """
         akka.loglevel = DEBUG
+        akka.cluster.sharding {
+          # First is likely to be ignored as shard coordinator not ready
+          retry-interval = 0.2s
+        }
       """).withFallback(
         MultiNodeTypedClusterSpec.clusterConfig))
 


### PR DESCRIPTION
The test failed as the Register message is ignored the first time and
the timeout (3s) doesn't give much time for further retries.

Reduce the retry interval rahter than incrase the timeout.

Fixes #25190 