### PR TITLE
Fix sharding logging multi-jvm test

### DIFF
--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingIncorrectSetupSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingIncorrectSetupSpec.scala
@@ -55,8 +55,8 @@ abstract class ClusterShardingIncorrectSetupSpec extends MultiNodeSpec(ClusterSh
             extractEntityId = extractEntityId,
             extractShardId = extractShardId)
         }
-        enterBarrier("helpful error message logged")
       }
+      enterBarrier("helpful error message logged")
     }
   }
 }


### PR DESCRIPTION
Fixes #25196

By waiting until the test succeeded on the first node before
shutting down the second node.