### PR TITLE
Require taskname to be non empty

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
+++ b/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
@@ -344,6 +344,7 @@ final class CoordinatedShutdown private[akka] (
       knownPhases(phase),
       s"Unknown phase [$phase], known phases [$knownPhases]. " +
         "All phases (along with their optional dependencies) must be defined in configuration")
+    require(!taskName.isEmpty)
     val current = tasks.get(phase)
     if (current == null) {
       if (tasks.putIfAbsent(phase, Vector(taskName → task)) != null)

--- a/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
+++ b/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
@@ -344,7 +344,8 @@ final class CoordinatedShutdown private[akka] (
       knownPhases(phase),
       s"Unknown phase [$phase], known phases [$knownPhases]. " +
         "All phases (along with their optional dependencies) must be defined in configuration")
-    require(!taskName.isEmpty)
+    require(taskName.nonEmpty, "Set a task name when adding tasks to the Coordinated Shutdown. " +
+      "Try to use unique, self-explanatory names.")
     val current = tasks.get(phase)
     if (current == null) {
       if (tasks.putIfAbsent(phase, Vector(taskName → task)) != null)


### PR DESCRIPTION
This avoids cases like:

```
13:25:07.722 [application-akka.actor.default-dispatcher-128] DEBUG akka.actor.CoordinatedShutdown - Performing phase [service-unbind] with [2] tasks: [, akka-http-server-unbind]
```