### PR TITLE
doc Replace the word graph by operator in stream doc

### DIFF
--- a/akka-docs/src/main/paradox/general/stream/stream-design.md
+++ b/akka-docs/src/main/paradox/general/stream/stream-design.md
@@ -49,10 +49,10 @@ This means that `Sink.asPublisher(true)` (for enabling fan-out support) must be 
 
 We expect libraries to be built on top of Akka Streams, in fact Akka HTTP is one such example that lives within the Akka project itself. In order to allow users to profit from the principles that are described for Akka Streams above, the following rules are established:
 
- * libraries shall provide their users with reusable pieces, i.e. expose factories that return graphs, allowing full compositionality
- * libraries may optionally and additionally provide facilities that consume and materialize graphs
+ * libraries shall provide their users with reusable pieces, i.e. expose factories that return operators, allowing full compositionality
+ * libraries may optionally and additionally provide facilities that consume and materialize operators
 
-The reasoning behind the first rule is that compositionality would be destroyed if different libraries only accepted graphs and expected to materialize them: using two of these together would be impossible because materialization can only happen once. As a consequence, the functionality of a library must be expressed such that materialization can be done by the user, outside of the library’s control.
+The reasoning behind the first rule is that compositionality would be destroyed if different libraries only accepted operators and expected to materialize them: using two of these together would be impossible because materialization can only happen once. As a consequence, the functionality of a library must be expressed such that materialization can be done by the user, outside of the library’s control.
 
 The second rule allows a library to additionally provide nice sugar for the common case, an example of which is the Akka HTTP API that provides a `handleWith` method for convenient materialization.
 

--- a/akka-docs/src/main/paradox/stream/stream-composition.md
+++ b/akka-docs/src/main/paradox/stream/stream-composition.md
@@ -116,7 +116,7 @@ Java
 ## Composing complex systems
 
 In the previous section we explored the possibility of composition, and hierarchy, but we stayed away from non-linear,
-generalized graph components. There is nothing in Akka Streams though that enforces that stream processing layouts
+generalized operators. There is nothing in Akka Streams though that enforces that stream processing layouts
 can only be linear. The DSL for `Source` and friends is optimized for creating such linear chains, as they are
 the most common in practice. There is a more advanced DSL for building complex graphs, that can be used if more
 flexibility is needed. We will see that the difference between the two DSLs is only on the surface: the concepts they
@@ -162,7 +162,7 @@ Scala
 Java
 :   @@snip [CompositionDocTest.java]($code$/java/jdocs/stream/CompositionDocTest.java) { #partial-graph }
 
-The only new addition is the return value of the builder block, which is a `Shape`. All graphs (including
+The only new addition is the return value of the builder block, which is a `Shape`. All operators (including
 `Source`, `BidiFlow`, etc) have a shape, which encodes the *typed* ports of the module. In our example
 there is exactly one input and output port left, so we can declare it to have a `FlowShape` by returning an
 instance of it. While it is possible to create new `Shape` types, it is usually recommended to use one of the
@@ -183,7 +183,7 @@ Java
 
 It is not possible to use it as a `Flow` yet, though (i.e. we cannot call `.filter()` on it), but `Flow`
 has a `fromGraph()` method that adds the DSL to a `FlowShape`. There are similar methods on `Source`,
-`Sink` and `BidiShape`, so it is easy to get back to the simpler DSL if a graph has the right shape.
+`Sink` and `BidiShape`, so it is easy to get back to the simpler DSL if an operator has the right shape.
 For convenience, it is also possible to skip the partial graph creation, and use one of the convenience creator methods.
 To demonstrate this, we will create the following graph:
 

--- a/akka-docs/src/main/paradox/stream/stream-cookbook.md
+++ b/akka-docs/src/main/paradox/stream/stream-cookbook.md
@@ -246,9 +246,9 @@ Java
 :   @@snip [RecipeAdhocSourceTest.scala]($code$/java/jdocs/stream/javadsl/cookbook/RecipeAdhocSourceTest.java) { #adhoc-source }
 
 
-## Working with Graphs
+## Working with Operators
 
-In this collection we show recipes that use stream graph elements to achieve various goals.
+In this collection we show recipes that use stream operators to achieve various goals.
 
 ### Triggering the flow of elements programmatically
 
@@ -284,9 +284,9 @@ that automatically balances incoming jobs to available workers, then merges the 
 
 We will express our solution as a function that takes a worker flow and the number of workers to be allocated and gives
 a flow that internally contains a pool of these workers. To achieve the desired result we will create a `Flow`
-from a graph.
+from an operator.
 
-The graph consists of a `Balance` node which is a special fan-out operation that tries to route elements to available
+The operator consists of a `Balance` node which is a special fan-out operation that tries to route elements to available
 downstream consumers. In a `for` loop we wire all of our desired workers as outputs of this balancer element, then
 we wire the outputs of these workers to a `Merge` element that will collect the results from the workers.
 
@@ -327,7 +327,7 @@ similar to a `fold`.
 
 ### Dropping broadcast
 
-**Situation:** The default `Broadcast` graph element is properly backpressured, but that means that a slow downstream
+**Situation:** The default `Broadcast` operator is properly backpressured, but that means that a slow downstream
 consumer can hold back the other downstream consumers resulting in lowered throughput. In other words the rate of
 `Broadcast` is the rate of its slowest downstream consumer. In certain cases it is desirable to allow faster consumers
 to progress independently of their slower siblings by dropping elements if necessary.

--- a/akka-docs/src/main/paradox/stream/stream-customize.md
+++ b/akka-docs/src/main/paradox/stream/stream-customize.md
@@ -19,7 +19,7 @@ junctions of various kinds.
 
 @@@ note
 
-A custom operator should not be the first tool you reach for, defining graphs using flows
+A custom operator should not be the first tool you reach for, defining operators using flows
 and the graph DSL is in general easier and does to a larger extent protect you from mistakes that
 might be easy to make with a custom @ref[`GraphStage`](stream-customize.md)
 
@@ -71,7 +71,7 @@ Scala
 Instances of the above `GraphStage` are subclasses of @scala[`Graph[SourceShape[Int],NotUsed]`] @java[`Graph<SourceShape<Integer>,NotUsed>`] which means
 that they are already usable in many situations, but do not provide the DSL methods we usually have for other
 `Source` s. In order to convert this `Graph` to a proper `Source` we need to wrap it using
-`Source.fromGraph` (see @ref:[Modularity, Composition and Hierarchy](stream-composition.md) for more details about graphs and DSLs). Now we can use the
+`Source.fromGraph` (see @ref:[Modularity, Composition and Hierarchy](stream-composition.md) for more details about operators and DSLs). Now we can use the
 source as any other built-in one:
 
 Scala
@@ -498,7 +498,7 @@ or the downstreams. Even for operators that do not complete or fail in this mann
 ## Extending Flow Operators with Custom Operators
 
 The most general way of extending any `Source`, `Flow` or `SubFlow` (e.g. from `groupBy`) is
-demonstrated above: create a graph of flow-shape like the `Duplicator` example given above and use the `.via(...)`
+demonstrated above: create a operator of flow-shape like the `Duplicator` example given above and use the `.via(...)`
 operator to integrate it into your stream topology. This works with all `FlowOps` sub-types, including the
 ports that you connect with the graph DSL.
 

--- a/akka-docs/src/main/paradox/stream/stream-dynamic.md
+++ b/akka-docs/src/main/paradox/stream/stream-dynamic.md
@@ -13,21 +13,21 @@ To use Akka Streams, add the module to your project:
 ## Introduction
 
 <a id="kill-switch"></a>
-## Controlling graph completion with KillSwitch
+## Controlling operator completion with KillSwitch
 
-A `KillSwitch` allows the completion of graphs of `FlowShape` from the outside. It consists of a flow element that
-can be linked to a graph of `FlowShape` needing completion control.
+A `KillSwitch` allows the completion of operators of `FlowShape` from the outside. It consists of a flow element that
+can be linked to an operator of `FlowShape` needing completion control.
 The `KillSwitch` @scala[trait] @java[interface] allows to:
  
- * complete the graph(s) via `shutdown()`
- * fail the graph(s) via `abort(Throwable error)`
+ * complete the operator(s) via `shutdown()`
+ * fail the operator(s) via `abort(Throwable error)`
 
 
 Scala
 :   @@snip [KillSwitch.scala]($akka$/akka-stream/src/main/scala/akka/stream/KillSwitch.scala) { #kill-switch }
 
 After the first call to either `shutdown` or `abort`, all subsequent calls to any of these methods will be ignored.
-Graph completion is performed by both
+Operator completion is performed by both
 
  * cancelling its upstream.
  * completing (in case of `shutdown`) or failing (in case of `abort`) its downstream
@@ -59,8 +59,8 @@ Java
 <a id="shared-kill-switch"></a>
 ### SharedKillSwitch
 
-A `SharedKillSwitch` allows to control the completion of an arbitrary number graphs of `FlowShape`. It can be
-materialized multiple times via its `flow` method, and all materialized graphs linked to it are controlled by the switch.
+A `SharedKillSwitch` allows to control the completion of an arbitrary number operators of `FlowShape`. It can be
+materialized multiple times via its `flow` method, and all materialized operators linked to it are controlled by the switch.
 Refer to the below for usage examples.
 
  * **Shutdown**

--- a/akka-docs/src/main/paradox/stream/stream-dynamic.md
+++ b/akka-docs/src/main/paradox/stream/stream-dynamic.md
@@ -13,21 +13,21 @@ To use Akka Streams, add the module to your project:
 ## Introduction
 
 <a id="kill-switch"></a>
-## Controlling operator completion with KillSwitch
+## Controlling stream completion with KillSwitch
 
 A `KillSwitch` allows the completion of operators of `FlowShape` from the outside. It consists of a flow element that
 can be linked to an operator of `FlowShape` needing completion control.
 The `KillSwitch` @scala[trait] @java[interface] allows to:
  
- * complete the operator(s) via `shutdown()`
- * fail the operator(s) via `abort(Throwable error)`
+ * complete the stream(s) via `shutdown()`
+ * fail the stream(s) via `abort(Throwable error)`
 
 
 Scala
 :   @@snip [KillSwitch.scala]($akka$/akka-stream/src/main/scala/akka/stream/KillSwitch.scala) { #kill-switch }
 
 After the first call to either `shutdown` or `abort`, all subsequent calls to any of these methods will be ignored.
-Operator completion is performed by both
+Stream completion is performed by both
 
  * cancelling its upstream.
  * completing (in case of `shutdown`) or failing (in case of `abort`) its downstream

--- a/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
+++ b/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
@@ -260,7 +260,7 @@ this mode of operation is referred to as pull-based back-pressure.
 ## Stream Materialization
 
 When constructing flows and graphs in Akka Streams think of them as preparing a blueprint, an execution plan.
-Stream materialization is the process of taking a stream description (the graph) and allocating all the necessary resources
+Stream materialization is the process of taking a stream description (`RunnableGraph`) and allocating all the necessary resources
 it needs in order to run. In the case of Akka Streams this often means starting up Actors which power the processing,
 but is not restricted to that—it could also mean opening files or socket connections etc.—depending on what the stream needs.
 
@@ -285,7 +285,7 @@ yet will materialize that operator multiple times.
 ### Operator Fusion
 
 By default Akka Streams will fuse the stream operators. This means that the processing steps of a flow or
-stream graph can be executed within the same Actor and has two consequences:
+stream can be executed within the same Actor and has two consequences:
 
  * passing elements from one operator to the next is a lot faster between fused
 operators due to avoiding the asynchronous messaging overhead
@@ -293,8 +293,8 @@ operators due to avoiding the asynchronous messaging overhead
 only up to one CPU core is used for each fused part
 
 To allow for parallel processing you will have to insert asynchronous boundaries manually into your flows and
-graphs by way of adding `Attributes.asyncBoundary` using the method `async` on `Source`, `Sink` and `Flow`
-to pieces that shall communicate with the rest of the graph in an asynchronous fashion.
+operators by way of adding `Attributes.asyncBoundary` using the method `async` on `Source`, `Sink` and `Flow`
+to operators that shall communicate with the downstream of the graph in an asynchronous fashion.
 
 Scala
 :   @@snip [FlowDocSpec.scala]($code$/scala/docs/stream/FlowDocSpec.scala) { #flow-async }
@@ -341,7 +341,7 @@ Java
 
 @@@ note
 
-In Graphs it is possible to access the materialized value from inside the stream processing graph. For details see @ref:[Accessing the materialized value inside the Graph](stream-graphs.md#graph-matvalue).
+In Graphs it is possible to access the materialized value from inside the stream. For details see @ref:[Accessing the materialized value inside the Graph](stream-graphs.md#graph-matvalue).
 
 @@@
 

--- a/akka-docs/src/main/paradox/stream/stream-graphs.md
+++ b/akka-docs/src/main/paradox/stream/stream-graphs.md
@@ -19,7 +19,7 @@ dive into the multiple ways of constructing and re-using graphs, as well as expl
 
 Graphs are needed whenever you want to perform any kind of fan-in ("multiple inputs") or fan-out ("multiple outputs") operations.
 Considering linear Flows to be like roads, we can picture graph operations as junctions: multiple flows being connected at a single point.
-Some graph operations which are common enough and fit the linear style of Flows, such as `concat` (which concatenates two
+Some operators which are common enough and fit the linear style of Flows, such as `concat` (which concatenates two
 streams, such that the second one is consumed after the first one has completed), may have shorthand methods defined on
 `Flow` or `Source` themselves, however you should keep in mind that those are also implemented as graph junctions.
 
@@ -80,7 +80,7 @@ By looking at the snippets above, it should be apparent that the @scala[`GraphDS
 @scala[It is used (implicitly) by the `~>` operator, also making it a mutable operation as well.]
 The reason for this design choice is to enable simpler creation of complex graphs, which may even contain cycles.
 Once the GraphDSL has been constructed though, the @scala[`GraphDSL`]@java[`RunnableGraph`] instance *is immutable, thread-safe, and freely shareable*.
-The same is true of all graph pieces—sources, sinks, and flows—once they are constructed.
+The same is true of all operators—sources, sinks, and flows—once they are constructed.
 This means that you can safely re-use one given Flow or junction in multiple places in a processing graph.
 
 We have seen examples of such re-use already above: the merge and broadcast junctions were imported

--- a/akka-docs/src/main/paradox/stream/stream-quickstart.md
+++ b/akka-docs/src/main/paradox/stream/stream-quickstart.md
@@ -259,7 +259,7 @@ Java
 :   @@snip [TwitterStreamQuickstartDocTest.java]($code$/java/jdocs/stream/TwitterStreamQuickstartDocTest.java) { #tweet-source }
 
 Streams always start flowing from a @scala[`Source[Out,M1]`]@java[`Source<Out,M1>`] then can continue through @scala[`Flow[In,Out,M2]`]@java[`Flow<In,Out,M2>`] elements or
-more advanced graph elements to finally be consumed by a @scala[`Sink[In,M3]`]@java[`Sink<In,M3>`] @scala[(ignore the type parameters `M1`, `M2`
+more advanced operators to finally be consumed by a @scala[`Sink[In,M3]`]@java[`Sink<In,M3>`] @scala[(ignore the type parameters `M1`, `M2`
 and `M3` for now, they are not relevant to the types of the elements produced/consumed by these classes – they are
 "materialized types", which we'll talk about [below](#materialized-values-quick))]@java[. The first type parameter—`Tweet` in this case—designates the kind of elements produced
 by the source while the `M` type parameters describe the object that is created during
@@ -362,7 +362,7 @@ by importing `GraphDSL.Implicits._`]@java[we use graph builder `b` to construct 
 `GraphDSL.create` returns a `Graph`, in this example a @scala[`Graph[ClosedShape, NotUsed]`]@java[`Graph<ClosedShape,NotUsed>`] where
 `ClosedShape` means that it is *a fully connected graph* or "closed" - there are no unconnected inputs or outputs.
 Since it is closed it is possible to transform the graph into a `RunnableGraph` using `RunnableGraph.fromGraph`.
-The runnable graph can then be `run()` to materialize a stream out of it.
+The `RunnableGraph` can then be `run()` to materialize a stream out of it.
 
 Both `Graph` and `RunnableGraph` are *immutable, thread-safe, and freely shareable*.
 

--- a/akka-docs/src/main/paradox/stream/stream-substream.md
+++ b/akka-docs/src/main/paradox/stream/stream-substream.md
@@ -16,7 +16,7 @@ Substreams are represented as `SubSource` or `SubFlow` instances, on which you c
 into a stream of streams.
 
 SubFlows cannot contribute to the super-flow’s materialized value since they are materialized later,
-during the runtime of the flow graph processing.
+during the runtime of the stream processing.
 
 operators that create substreams are listed on @ref[Nesting and flattening operators](operators/index.md#nesting-and-flattening-operators)
 


### PR DESCRIPTION
Refs #24995

Replacement from "graph" to "operator" was not very straightforward, as the word "graph" was actually appropriate and didn't need replacement in many places, which represented complex or general shape, tied to `Graph` or `RunnableGraph`.

So I changed only the ones which I thought should be replaced.

For the ones remained same, unfortunately git diff doesn't show which ones I intentionally kept same. So I listed files below, which had frequent mentions to "graph" and didn't change, although some other files still had few occurrences of "graph".

* [stream-composition.md](https://github.com/akka/akka/blob/57615f1e8880bdbc9ac173553203f73b66476484/akka-docs/src/main/paradox/stream/stream-composition.md)
* [stream-customize.md](https://github.com/akka/akka/blob/57615f1e8880bdbc9ac173553203f73b66476484/akka-docs/src/main/paradox/stream/stream-customize.md)
* [stream-flows-and-basics.md ](https://github.com/akka/akka/blob/57615f1e8880bdbc9ac173553203f73b66476484/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md)
* [stream-graphs.md](https://github.com/akka/akka/blob/57615f1e8880bdbc9ac173553203f73b66476484/akka-docs/src/main/paradox/stream/stream-graphs.md)

