### PR TITLE
fix akka-cluster-tools compile error

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
@@ -23,7 +23,7 @@ import scala.collection.immutable
 import java.util.concurrent.ConcurrentHashMap
 
 import akka.remote.DefaultFailureDetectorRegistry
-import akka.cluster.ClusterEvent.{ CurrentClusterState, MemberEvent, MemberExited, MemberRemoved }
+import akka.cluster.ClusterEvent.{ MemberEvent, MemberRemoved }
 
 import scala.concurrent.Await
 
@@ -95,7 +95,7 @@ object MultiNodeClusterSpec {
 
 trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec with WatchedByCoroner with FlightRecordingSupport { self: MultiNodeSpec ⇒
 
-  final override def initialParticipants = roles.size
+  override def initialParticipants = roles.size
 
   private val cachedAddresses = new ConcurrentHashMap[RoleName, Address]
 


### PR DESCRIPTION
Fixes the below compilation error:
```
akka/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientHandoverSpec.scala:43:16: overriding method initialParticipants in trait MultiNodeClusterSpec of type => Int;
[error]  method initialParticipants cannot override final member
[error]   override def initialParticipants: Int = 3
[error]                ^
[error] one error found
```
must have have been introduced with #25201, not sure why it eluded the Jenkins check