### PR TITLE
Optimize flatMapConcat for single element source, #25241

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/FlatMapConcatBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FlatMapConcatBenchmark.scala
@@ -64,7 +64,7 @@ class FlatMapConcatBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(OperationsPerInvocation)
-  def single(): Unit = {
+  def sourceDotSingle(): Unit = {
     val latch = new CountDownLatch(1)
 
     testSource
@@ -76,11 +76,23 @@ class FlatMapConcatBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(OperationsPerInvocation)
-  def optimizedSingle(): Unit = {
+  def internalSingleSource(): Unit = {
     val latch = new CountDownLatch(1)
 
     testSource
       .flatMapConcat(elem ⇒ new GraphStages.SingleSource(elem))
+      .runWith(new LatchSink(OperationsPerInvocation, latch))(materializer)
+
+    awaitLatch(latch)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(OperationsPerInvocation)
+  def oneElementList(): Unit = {
+    val latch = new CountDownLatch(1)
+
+    testSource
+      .flatMapConcat(n ⇒ Source(n :: Nil))
       .runWith(new LatchSink(OperationsPerInvocation, latch))(materializer)
 
     awaitLatch(latch)

--- a/akka-bench-jmh/src/main/scala/akka/stream/FlatMapConcatBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FlatMapConcatBenchmark.scala
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.remote.artery.BenchTestSource
+import akka.remote.artery.LatchSink
+import akka.stream.impl.PhasedFusingActorMaterializer
+import akka.stream.impl.StreamSupervisor
+import akka.stream.scaladsl._
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations._
+import akka.stream.impl.fusing.GraphStages
+
+object FlatMapConcatBenchmark {
+  final val OperationsPerInvocation = 100000
+}
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+class FlatMapConcatBenchmark {
+  import FlatMapConcatBenchmark._
+
+  private val config = ConfigFactory.parseString(
+    """
+    akka.actor.default-dispatcher {
+      executor = "fork-join-executor"
+      fork-join-executor {
+        parallelism-factor = 1
+      }
+    }
+    """
+  )
+
+  private implicit val system: ActorSystem = ActorSystem("FlatMapConcatBenchmark", config)
+
+  var materializer: ActorMaterializer = _
+
+  var testSource: Source[java.lang.Integer, NotUsed] = _
+
+  @Setup
+  def setup(): Unit = {
+    val settings = ActorMaterializerSettings(system)
+    materializer = ActorMaterializer(settings)
+
+    testSource = Source.fromGraph(new BenchTestSource(OperationsPerInvocation))
+  }
+
+  @TearDown
+  def shutdown(): Unit = {
+    Await.result(system.terminate(), 5.seconds)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(OperationsPerInvocation)
+  def single(): Unit = {
+    val latch = new CountDownLatch(1)
+
+    testSource
+      .flatMapConcat(Source.single)
+      .runWith(new LatchSink(OperationsPerInvocation, latch))(materializer)
+
+    awaitLatch(latch)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(OperationsPerInvocation)
+  def optimizedSingle(): Unit = {
+    val latch = new CountDownLatch(1)
+
+    testSource
+      .flatMapConcat(elem ⇒ new GraphStages.SingleSource(elem))
+      .runWith(new LatchSink(OperationsPerInvocation, latch))(materializer)
+
+    awaitLatch(latch)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(OperationsPerInvocation)
+  def mapBaseline(): Unit = {
+    val latch = new CountDownLatch(1)
+
+    testSource
+      .map(elem ⇒ elem)
+      .runWith(new LatchSink(OperationsPerInvocation, latch))(materializer)
+
+    awaitLatch(latch)
+  }
+
+  private def awaitLatch(latch: CountDownLatch): Unit = {
+    if (!latch.await(30, TimeUnit.SECONDS)) {
+      dumpMaterializer()
+      throw new RuntimeException("Latch didn't complete in time")
+    }
+  }
+
+  private def dumpMaterializer(): Unit = {
+    materializer match {
+      case impl: PhasedFusingActorMaterializer ⇒
+        val probe = TestProbe()(system)
+        impl.supervisor.tell(StreamSupervisor.GetChildren, probe.ref)
+        val children = probe.expectMsgType[StreamSupervisor.Children].children
+        children.foreach(_ ! StreamSupervisor.PrintDebugDump)
+    }
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlattenMergeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlattenMergeSpec.scala
@@ -12,6 +12,8 @@ import akka.stream.testkit.scaladsl.StreamTestKit._
 
 import scala.concurrent._
 import scala.concurrent.duration._
+
+import akka.stream.impl.fusing.GraphStages
 import akka.stream.testkit.{ StreamSpec, TestPublisher }
 import org.scalatest.exceptions.TestFailedException
 import akka.stream.testkit.scaladsl.TestSink
@@ -208,6 +210,13 @@ class FlowFlattenMergeSpec extends StreamSpec {
       attributes should contain(Attributes.Name("inner"))
       attributes should contain(Attributes.Name("outer"))
       attributes.indexOf(Attributes.Name("inner")) < attributes.indexOf(Attributes.Name("outer")) should be(true)
+    }
+
+    "work with flatMapConcat optimized GraphStages.SingleSource" in assertAllStagesStopped {
+      Source(0 to 3)
+        .flatMapConcat(elem ⇒ new GraphStages.SingleSource(elem))
+        .runWith(toSeq)
+        .futureValue should ===(0 to 3)
     }
 
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlattenMergeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlattenMergeSpec.scala
@@ -290,6 +290,9 @@ class FlowFlattenMergeSpec extends StreamSpec {
 
       val singleSourceA = new SingleSource("a")
       TraversalBuilder.getSingleSource(singleSourceA) should be(OptionVal.Some(singleSourceA))
+
+      TraversalBuilder.getSingleSource(Source.single("c").async) should be(OptionVal.None)
+      TraversalBuilder.getSingleSource(Source.single("d").mapMaterializedValue(_ ⇒ "Mat")) should be(OptionVal.None)
     }
 
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
@@ -338,12 +338,12 @@ import akka.stream.impl.fusing.GraphStages.SingleSource
   }
 
   /**
-   * Try to find the element of SingleSource or wrapped such. This is used as a
+   * Try to find `SingleSource` or wrapped such. This is used as a
    * performance optimization in FlattenMerge and possibly other places.
    */
-  def getSingleSourceValue[A >: Null](graph: Graph[SourceShape[A], _]): OptionVal[A] = {
+  def getSingleSource[A >: Null](graph: Graph[SourceShape[A], _]): OptionVal[SingleSource[A]] = {
     graph match {
-      case single: SingleSource[A] @unchecked ⇒ OptionVal.Some(single.elem)
+      case single: SingleSource[A] @unchecked ⇒ OptionVal.Some(single)
       case _ ⇒
         graph.traversalBuilder match {
           case l: LinearTraversalBuilder ⇒
@@ -352,7 +352,7 @@ import akka.stream.impl.fusing.GraphStages.SingleSource
                 a.module match {
                   case m: GraphStageModule[_, _] ⇒
                     m.stage match {
-                      case single: SingleSource[A] @unchecked ⇒ OptionVal.Some(single.elem)
+                      case single: SingleSource[A] @unchecked ⇒ OptionVal.Some(single)
                       case _                                  ⇒ OptionVal.None
                     }
                   case _ ⇒ OptionVal.None

--- a/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
@@ -10,9 +10,11 @@ import akka.stream.impl.StreamLayout.AtomicModule
 import akka.stream.impl.TraversalBuilder.{ AnyFunction1, AnyFunction2 }
 import akka.stream.scaladsl.Keep
 import akka.util.OptionVal
-
 import scala.language.existentials
 import scala.collection.immutable.Map.Map1
+
+import akka.stream.impl.fusing.GraphStageModule
+import akka.stream.impl.fusing.GraphStages.SingleSource
 
 /**
  * INTERNAL API
@@ -333,6 +335,33 @@ import scala.collection.immutable.Map.Map1
       current = nextStep
     }
     slot
+  }
+
+  /**
+   * Try to find the element of SingleSource or wrapped such. This is used as a
+   * performance optimization in FlattenMerge and possibly other places.
+   */
+  def getSingleSourceValue[A >: Null](graph: Graph[SourceShape[A], _]): OptionVal[A] = {
+    graph match {
+      case single: SingleSource[A] @unchecked ⇒ OptionVal.Some(single.elem)
+      case _ ⇒
+        graph.traversalBuilder match {
+          case l: LinearTraversalBuilder ⇒
+            l.pendingBuilder match {
+              case OptionVal.Some(a: AtomicTraversalBuilder) ⇒
+                a.module match {
+                  case m: GraphStageModule[_, _] ⇒
+                    m.stage match {
+                      case single: SingleSource[A] @unchecked ⇒ OptionVal.Some(single.elem)
+                      case _                                  ⇒ OptionVal.None
+                    }
+                  case _ ⇒ OptionVal.None
+                }
+              case _ ⇒ OptionVal.None
+            }
+          case _ ⇒ OptionVal.None
+        }
+    }
   }
 }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
@@ -352,8 +352,12 @@ import akka.stream.impl.fusing.GraphStages.SingleSource
                 a.module match {
                   case m: GraphStageModule[_, _] ⇒
                     m.stage match {
-                      case single: SingleSource[A] @unchecked ⇒ OptionVal.Some(single)
-                      case _                                  ⇒ OptionVal.None
+                      case single: SingleSource[A] @unchecked ⇒
+                        // It would be != EmptyTraversal if mapMaterializedValue was used and then we can't optimize.
+                        if ((l.traversalSoFar eq EmptyTraversal) && !l.attributes.isAsync)
+                          OptionVal.Some(single)
+                        else OptionVal.None
+                      case _ ⇒ OptionVal.None
                     }
                   case _ ⇒ OptionVal.None
                 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -17,15 +17,16 @@ import akka.stream.{ Outlet, SourceShape, _ }
 import akka.util.ConstantFun
 import akka.{ Done, NotUsed }
 import org.reactivestreams.{ Publisher, Subscriber }
-
 import scala.annotation.tailrec
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ Future, Promise }
-import akka.stream.stage.GraphStageWithMaterializedValue
 
+import akka.stream.stage.GraphStageWithMaterializedValue
 import scala.compat.java8.FutureConverters._
+
+import akka.stream.impl.fusing.GraphStageModule
 
 /**
  * A `Source` is a set of stream processing steps that has one open output. It can comprise


### PR DESCRIPTION
* This first stab is only looking for `SingleSource` and note
  that `Source.single` is not returning that. Source.single has
  wrap with fromGraph and then the original `SingleSource` is
  lost.

Refs #25241

Benchmark results speak for themselves, 287k vs 6641k elements/s:
```
jmh:run -prof gc -i 5 -wi 5 -f2 -t1 akka.stream.FlatMapConcatBenchmark

[info] FlatMapConcatBenchmark.single                                        thrpt   10    287130.513 ±    4748.851   ops/s
[info] FlatMapConcatBenchmark.single:·gc.alloc.rate                         thrpt   10      1327.483 ±    1058.667  MB/sec
[info] FlatMapConcatBenchmark.single:·gc.alloc.rate.norm                    thrpt   10      5095.151 ±    4060.888    B/op

[info] FlatMapConcatBenchmark.optimizedSingle                               thrpt   10   6641485.752 ±   42696.132   ops/s
[info] FlatMapConcatBenchmark.optimizedSingle:·gc.alloc.rate                thrpt   10       502.781 ±     400.356  MB/sec
[info] FlatMapConcatBenchmark.optimizedSingle:·gc.alloc.rate.norm           thrpt   10        83.397 ±      66.405    B/op

[info] Benchmark                                                             Mode  Cnt         Score         Error   Units
[info] FlatMapConcatBenchmark.mapBaseline                                   thrpt   10  14275746.640 ± 1653684.721   ops/s
[info] FlatMapConcatBenchmark.mapBaseline:·gc.alloc.rate                    thrpt   10         1.847 ±       1.005  MB/sec
[info] FlatMapConcatBenchmark.mapBaseline:·gc.alloc.rate.norm               thrpt   10         0.143 ±       0.076    B/op
```

