### PR TITLE
Widen operation docs clear about unhandled effect

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
@@ -107,7 +107,7 @@ object Behavior {
      * receive[String] { (ctx, msg) => println(msg); same }.widen[Number] {
      *   case b: BigDecimal => s"BigDecimal(&dollar;b)"
      *   case i: BigInteger => s"BigInteger(&dollar;i)"
-     *   // drop all other kinds of Number
+     *   // all other kinds of Number will be `unhandled`
      * }
      * }}}
      */


### PR DESCRIPTION
"drop" is not entirely clear; The widen operation specifically does "unhandled" on things that don't match, improved docs a bit