### PR TITLE
Improve JsonObjectParser performance

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/JsonFramingBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/JsonFramingBenchmark.scala
@@ -15,48 +15,47 @@ import org.openjdk.jmh.annotations._
 @BenchmarkMode(Array(Mode.Throughput))
 class JsonFramingBenchmark {
 
-  /*
-    Benchmark                                 Mode  Cnt      Score      Error  Units
-    // old
-    JsonFramingBenchmark.collecting_1        thrpt   20     81.476 ±   14.793  ops/s
-    JsonFramingBenchmark.collecting_offer_5  thrpt   20     20.187 ±    2.291  ops/s
-
-    // new
-    JsonFramingBenchmark.counting_1          thrpt   20  10766.738 ± 1278.300  ops/s
-    JsonFramingBenchmark.counting_offer_5    thrpt   20  28798.255 ± 2670.163  ops/s
-   */
-
   val json =
     ByteString(
+      """{"fname":"Frank","name":"Smith","age":42,"id":1337,"boardMember":false}"""
+    )
+
+  val json5 =
+    ByteString(
       """|{"fname":"Frank","name":"Smith","age":42,"id":1337,"boardMember":false},
-        |{"fname":"Bob","name":"Smith","age":42,"id":1337,"boardMember":false},
-        |{"fname":"Bob","name":"Smith","age":42,"id":1337,"boardMember":false},
-        |{"fname":"Bob","name":"Smith","age":42,"id":1337,"boardMember":false},
-        |{"fname":"Bob","name":"Smith","age":42,"id":1337,"boardMember":false},
-        |{"fname":"Bob","name":"Smith","age":42,"id":1337,"boardMember":false},
-        |{"fname":"Hank","name":"Smith","age":42,"id":1337,"boardMember":false}""".stripMargin
+         |{"fname":"Bob","name":"Smith","age":42,"id":1337,"boardMember":false},
+         |{"fname":"Bob","name":"Smith","age":42,"id":1337,"boardMember":false},
+         |{"fname":"Bob","name":"Smith","age":42,"id":1337,"boardMember":false},
+         |{"fname":"Hank","name":"Smith","age":42,"id":1337,"boardMember":false}""".stripMargin
+    )
+
+  val jsonLong =
+    ByteString(
+      s"""{"fname":"Frank","name":"Smith","age":42,"id":1337,"boardMember":false,"description":"${"a" * 1000000}"}"""
     )
 
   val bracket = new JsonObjectParser
 
-  @Setup(Level.Invocation)
-  def init(): Unit = {
-    bracket.offer(json)
-  }
-
   @Benchmark
-  def counting_1: ByteString =
+  def counting_1: ByteString = {
+    bracket.offer(json)
     bracket.poll().get
+  }
 
   @Benchmark
   @OperationsPerInvocation(5)
   def counting_offer_5: ByteString = {
-    bracket.offer(json)
+    bracket.offer(json5)
     bracket.poll().get
     bracket.poll().get
     bracket.poll().get
     bracket.poll().get
     bracket.poll().get
+  }
+
+  @Benchmark
+  def counting_long_document: ByteString = {
+    bracket.offer(jsonLong)
     bracket.poll().get
   }
 

--- a/akka-stream/src/main/mima-filters/2.5.13.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.13.backwards.excludes
@@ -3,3 +3,10 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.javadsl.Flow.tak
 
 # Wrong return type of FlowMonitorState.finished #24885
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.FlowMonitorState.finished")
+
+# JsonObjectParser.Whitespace removal #25260
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.JsonObjectParser.Whitespace")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.Tab")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.Space")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.LineBreak2")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.LineBreak")

--- a/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
@@ -23,15 +23,18 @@ import scala.annotation.switch
   final val Backslash = '\\'.toByte
   final val Comma = ','.toByte
 
-  final val LineBreak = '\n'.toByte
-  final val LineBreak2 = '\r'.toByte
-  final val Tab = '\t'.toByte
-  final val Space = ' '.toByte
+  final val LineBreak = 10 // '\n'
+  final val LineBreak2 = 13 // '\r'
+  final val Tab = 9 // '\t'
+  final val Space = 32 // ' '
 
-  final val Whitespace = Set(LineBreak, LineBreak2, Tab, Space)
-
-  def isWhitespace(input: Byte): Boolean =
-    Whitespace.contains(input)
+  def isWhitespace(b: Byte): Boolean = (b: @switch) match {
+    case Space      ⇒ true
+    case LineBreak  ⇒ true
+    case LineBreak2 ⇒ true
+    case Tab        ⇒ true
+    case _          ⇒ false
+  }
 
 }
 


### PR DESCRIPTION
In our application, users (other apps) are uploading big (few GBs) files with Json lines. Each document is around 50kB
To split them I use `JsonFraming.objectScanner`
When profiling that code I noticed many calls to `scala.runtime.BoxesRunTime`:
![screen shot 2018-06-21 at 16 29 47](https://user-images.githubusercontent.com/177043/41726098-b00c99f6-7571-11e8-8492-02049b3ca2ea.png)

This PR replaces usage of `Set.contains` with normal pattern match, and improves overall performance for both small and large documents.

```
  Benchmark                                     Mode  Cnt        Score       Error  Units
    //old
    JsonFramingBenchmark.counting_1              thrpt   25  4255350.000 ± 18824.499  ops/s
    JsonFramingBenchmark.counting_long_document  thrpt   25      344.765 ±     0.452  ops/s
    JsonFramingBenchmark.counting_offer_5        thrpt   25  4501980.800 ± 11976.386  ops/s

    // new
    JsonFramingBenchmark.counting_1              thrpt   25  5654469.050 ±  9360.659  ops/s
    JsonFramingBenchmark.counting_long_document  thrpt   25      425.550 ±     0.524  ops/s
    JsonFramingBenchmark.counting_offer_5        thrpt   25  5300042.946 ± 24006.358  ops/s
```


Also I noticed that `JsonFramingBenchmark` is broken on `master` as it leaks memory in every run - more data is `offered` than `polled` causing internal buffer to grow.