### PR TITLE
In the DeviceGroupQueryTest#testReturnDeviceTimedOutIfDeviceDoesNotAnswerInTime, reduce the timeout of the DeviceGroupQuery actor from 3 to 1 second.

### DIFF
--- a/akka-docs/src/test/java/jdocs/tutorial_5/DeviceGroupQueryTest.java
+++ b/akka-docs/src/test/java/jdocs/tutorial_5/DeviceGroupQueryTest.java
@@ -195,7 +195,7 @@ public class DeviceGroupQueryTest extends JUnitSuite {
             actorToDeviceId,
             1L,
             requester.getRef(),
-            new FiniteDuration(3, TimeUnit.SECONDS)));
+            new FiniteDuration(1, TimeUnit.SECONDS)));
 
     assertEquals(0L, device1.expectMsgClass(Device.ReadTemperature.class).requestId);
     assertEquals(0L, device2.expectMsgClass(Device.ReadTemperature.class).requestId);

--- a/akka-docs/src/test/java/jdocs/tutorial_6/DeviceGroupQueryTest.java
+++ b/akka-docs/src/test/java/jdocs/tutorial_6/DeviceGroupQueryTest.java
@@ -186,7 +186,7 @@ public class DeviceGroupQueryTest extends JUnitSuite {
             actorToDeviceId,
             1L,
             requester.getRef(),
-            new FiniteDuration(3, TimeUnit.SECONDS)));
+            new FiniteDuration(1, TimeUnit.SECONDS)));
 
     assertEquals(0L, device1.expectMsgClass(Device.ReadTemperature.class).requestId);
     assertEquals(0L, device2.expectMsgClass(Device.ReadTemperature.class).requestId);


### PR DESCRIPTION
This makes the timeout in the Java code equal to the one in the Scala code and also makes it better match what the tutorial text says: "To keep our test relatively fast, we will construct the DeviceGroupQuery actor with a smaller timeout".