### PR TITLE
Log a warning if 'akka.remote.log-frame-size-exceeding' contains a bad value

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/RemoteMetricsExtension.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteMetricsExtension.scala
@@ -13,10 +13,11 @@ import akka.actor.Extension
 import akka.actor.ExtensionId
 import akka.actor.ExtensionIdProvider
 import akka.event.Logging
+import akka.remote.RemoteMetricsOn.LogFrameSizeExceedingConfigKey
 import akka.routing.RouterEnvelope
+import com.typesafe.config.ConfigException
 
 import scala.annotation.tailrec
-import scala.util.Try
 
 /**
  * INTERNAL API
@@ -57,50 +58,56 @@ private[akka] class RemoteMetricsOff extends RemoteMetrics {
 /**
  * INTERNAL API
  */
+private object RemoteMetricsOn {
+  val LogFrameSizeExceedingConfigKey = "akka.remote.log-frame-size-exceeding"
+}
+
+/**
+ * INTERNAL API
+ */
 private[akka] class RemoteMetricsOn(system: ExtendedActorSystem) extends RemoteMetrics {
 
   private val log = Logging(system, this.getClass)
 
-  private val logFrameSizeExceeding: Try[Int] = Try(
-    system.settings.config.getBytes("akka.remote.log-frame-size-exceeding").toInt
-  )
-
-  logFrameSizeExceeding.failed.foreach { e ⇒
-    val value = system.settings.config.getAnyRef("akka.remote.log-frame-size-exceeding")
-    val msg = "Caught exception of type \"" + e.getClass.getSimpleName + "\" " +
-              "while parsing \"akka.remote.log-frame-size-exceeding\". Expected a value in bytes, " +
-              "got: \"" + value + "\". For reference, check https://github.com/lightbend/config/blob/master/HOCON.md"
-    log.warning(msg)
+  private val logFrameSizeExceeding: Int = {
+    if (system.settings.config.getString(LogFrameSizeExceedingConfigKey) == "off") {
+      Int.MaxValue
+    } else {
+      try {
+        system.settings.config.getBytes(LogFrameSizeExceedingConfigKey).toInt
+      } catch {
+        case e: ConfigException ⇒
+          log.warning(e.getMessage + ". For reference, check https://github.com/lightbend/config/blob/master/HOCON.md")
+          Int.MaxValue
+      }
+    }
   }
 
   private val maxPayloadBytes: ConcurrentHashMap[Class[_], Integer] = new ConcurrentHashMap
 
   override def logPayloadBytes(msg: Any, payloadBytes: Int): Unit =
-    logFrameSizeExceeding.foreach { frameSize ⇒
-      if (payloadBytes >= frameSize) {
-        val clazz = msg match {
-          case x: ActorSelectionMessage ⇒ x.msg.getClass
-          case x: RouterEnvelope        ⇒ x.message.getClass
-          case _                        ⇒ msg.getClass
-        }
-
-        // 10% threshold until next log
-        def newMax = (payloadBytes * 1.1).toInt
-
-        @tailrec def check(): Unit = {
-          val max = maxPayloadBytes.get(clazz)
-          if (max eq null) {
-            if (maxPayloadBytes.putIfAbsent(clazz, newMax) eq null)
-              log.info("Payload size for [{}] is [{}] bytes", clazz.getName, payloadBytes)
-            else check()
-          } else if (payloadBytes > max) {
-            if (maxPayloadBytes.replace(clazz, max, newMax))
-              log.info("New maximum payload size for [{}] is [{}] bytes", clazz.getName, payloadBytes)
-            else check()
-          }
-        }
-        check()
+    if (payloadBytes >= logFrameSizeExceeding) {
+      val clazz = msg match {
+        case x: ActorSelectionMessage ⇒ x.msg.getClass
+        case x: RouterEnvelope        ⇒ x.message.getClass
+        case _                        ⇒ msg.getClass
       }
+
+      // 10% threshold until next log
+      def newMax = (payloadBytes * 1.1).toInt
+
+      @tailrec def check(): Unit = {
+        val max = maxPayloadBytes.get(clazz)
+        if (max eq null) {
+          if (maxPayloadBytes.putIfAbsent(clazz, newMax) eq null)
+            log.info("Payload size for [{}] is [{}] bytes", clazz.getName, payloadBytes)
+          else check()
+        } else if (payloadBytes > max) {
+          if (maxPayloadBytes.replace(clazz, max, newMax))
+            log.info("New maximum payload size for [{}] is [{}] bytes", clazz.getName, payloadBytes)
+          else check()
+        }
+      }
+      check()
     }
 }
-

--- a/akka-remote/src/main/scala/akka/remote/RemoteMetricsExtension.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteMetricsExtension.scala
@@ -86,7 +86,7 @@ private[akka] class RemoteMetricsOn(system: ExtendedActorSystem) extends RemoteM
   private val maxPayloadBytes: ConcurrentHashMap[Class[_], Integer] = new ConcurrentHashMap
 
   override def logPayloadBytes(msg: Any, payloadBytes: Int): Unit =
-    if (payloadBytes >= logFrameSizeExceeding) {
+    if (logFrameSizeExceeding != Int.MaxValue && payloadBytes >= logFrameSizeExceeding) {
       val clazz = msg match {
         case x: ActorSelectionMessage ⇒ x.msg.getClass
         case x: RouterEnvelope        ⇒ x.message.getClass

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -26,6 +26,11 @@ final class RemoteSettings(val config: Config) {
 
   val LogSend: Boolean = getBoolean("akka.remote.log-sent-messages")
 
+  val LogFrameSizeExceeding: Option[Int] = {
+    if (config.getString("akka.remote.log-frame-size-exceeding").toLowerCase == "off") None
+    else Some(getInt("akka.remote.log-frame-size-exceeding"))
+  }
+
   val UntrustedMode: Boolean = getBoolean("akka.remote.untrusted-mode")
 
   val TrustedSelectionPaths: Set[String] =


### PR DESCRIPTION
Currently, if 'akka.remote.log-frame-size-exceeding' is accidentally set
to an invalid value (e.g. 'on') the developer does not get warned but
remote communication fails with a not-very-helpful error message:

```
[INFO] [06/29/2018 15:07:41.657] [run-main-0] [akka.remote.Remoting] Starting remoting
[INFO] [06/29/2018 15:07:41.847] [run-main-0] [akka.remote.Remoting] Remoting started; listening on addresses :[akka.tcp://akkaremotenull@localhost:2553]
[INFO] [06/29/2018 15:07:41.849] [run-main-0] [akka.remote.Remoting] Remoting now listens on addresses: [akka.tcp://akkaremotenull@localhost:2553]
[WARN] [06/29/2018 15:07:41.986] [akkaremotenull-akka.remote.default-remote-dispatcher-5] [akka.tcp://akkaremotenull@localhost:2553/system/endpointManager/reliableEndpointWriter-akka.tcp%3A%2F%2Fakkaremotenull%40localhost%3A2552-0] Association with remote system [akka.tcp://akkaremotenull@localhost:2552] has failed, address is now gated for [5000] ms. Reason: [akka://akkaremotenull/system/endpointManager/reliableEndpointWriter-akka.tcp%3A%2F%2Fakkaremotenull%40localhost%3A2552-0/endpointWriter: exception during creation] Caused by: [null]
[INFO] [06/29/2018 15:07:41.993] [akkaremotenull-akka.actor.default-dispatcher-3] [akka://akkaremotenull/deadLetters] Message [io.ino.akkaremotenull.Greeter$Greet] from Actor[akka://akkaremotenull/temp/$a] to Actor[akka://akkaremotenull/deadLetters] was not delivered. [1] dead letters encountered. If this is not an expected behavior, then [Actor[akka://akkaremotenull/deadLetters]] may have terminated unexpectedly, This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' and 'akka.log-dead-letters-during-shutdown'.
```

This commit fixes the issue by a) printing a warning message and b)
ignoring the config setting.