### PR TITLE
Cluster sharding: Set waiting for state timeout for tests

### DIFF
--- a/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/MultiDcClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/MultiDcClusterShardingSpec.scala
@@ -10,6 +10,7 @@ import akka.cluster.sharding.typed.scaladsl.ClusterSharding
 import akka.cluster.typed.{ MultiDcClusterActors, MultiNodeTypedClusterSpec }
 import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.cluster.MultiNodeClusterSpec
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
@@ -29,7 +30,7 @@ object MultiDcClusterShardingSpecConfig extends MultiNodeConfig {
           retry-interval = 0.2s
         }
       """).withFallback(
-        MultiNodeTypedClusterSpec.clusterConfig))
+        MultiNodeClusterSpec.clusterConfig))
 
   nodeConfig(first, second)(ConfigFactory.parseString(
     """

--- a/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/MultiDcClusterSingletonSpec.scala
+++ b/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/MultiDcClusterSingletonSpec.scala
@@ -6,7 +6,7 @@ package akka.cluster.typed
 
 import akka.actor.typed.Props
 import akka.actor.typed.scaladsl.adapter._
-import akka.cluster.MemberStatus
+import akka.cluster.{ MemberStatus, MultiNodeClusterSpec }
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
 import akka.actor.testkit.typed.scaladsl.TestProbe
@@ -24,7 +24,7 @@ object MultiDcClusterSingletonSpecConfig extends MultiNodeConfig {
       """
         akka.loglevel = DEBUG
       """).withFallback(
-        MultiNodeTypedClusterSpec.clusterConfig))
+        MultiNodeClusterSpec.clusterConfig))
 
   nodeConfig(first)(ConfigFactory.parseString(
     """

--- a/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/MultiNodeTypedClusterSpec.scala
+++ b/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/MultiNodeTypedClusterSpec.scala
@@ -20,41 +20,6 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import scala.concurrent.duration._
 import scala.language.implicitConversions
 
-object MultiNodeTypedClusterSpec {
-  def clusterConfig: Config = ConfigFactory.parseString(
-    s"""
-    akka.actor.provider = cluster
-    akka.actor.warn-about-java-serializer-usage = off
-    akka.cluster {
-      jmx.enabled                         = off
-      gossip-interval                     = 200 ms
-      leader-actions-interval             = 200 ms
-      unreachable-nodes-reaper-interval   = 500 ms
-      periodic-tasks-initial-delay        = 300 ms
-      publish-stats-interval              = 0 s # always, when it happens
-      failure-detector.heartbeat-interval = 500 ms
-
-      run-coordinated-shutdown-when-down = off
-    }
-    akka.loglevel = INFO
-    akka.log-dead-letters = off
-    akka.log-dead-letters-during-shutdown = off
-    akka.remote {
-      log-remote-lifecycle-events = off
-      artery.advanced.flight-recorder {
-        enabled=on
-        destination=target/flight-recorder-${UUID.randomUUID().toString}.afr
-      }
-    }
-    akka.loggers = ["akka.testkit.TestEventListener"]
-    akka.test {
-      single-expect-default = 10 s
-    }
-
-    """)
-
-}
-
 trait MultiNodeTypedClusterSpec extends Suite with STMultiNodeSpec with WatchedByCoroner with FlightRecordingSupport with Matchers {
   self: MultiNodeSpec ⇒
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
@@ -51,6 +51,7 @@ object MultiNodeClusterSpec {
 
       sharding {
         retry-interval = 200ms
+        waiting-for-state-timeout = 200ms
       }
     }
     akka.loglevel = INFO

--- a/build.sbt
+++ b/build.sbt
@@ -409,7 +409,7 @@ lazy val persistenceTyped = akkaModule("akka-persistence-typed")
 lazy val clusterTyped = akkaModule("akka-cluster-typed")
   .dependsOn(
     actorTyped,
-    cluster,
+    cluster % "compile->compile;test->test",
     clusterTools,
     distributedData,
     persistence % "test->test",


### PR DESCRIPTION
Default is 5s which means if the first Read is lost and
 ddata have any secondary nodes to query it'll
timeout waiting to get the state.

E.g. read being ignored due to loading durable state then
never gets retried

Also merged the common config from typed and untyped cluster tests.