### PR TITLE
fix dependency blocks in documentation (#25240)

### DIFF
--- a/akka-docs/src/main/paradox/cluster-client.md
+++ b/akka-docs/src/main/paradox/cluster-client.md
@@ -6,7 +6,7 @@ To use Cluster Client, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-tools_$scala.major_version$
+  artifact=akka-cluster-tools_$scala.binary_version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/remoting-artery.md
+++ b/akka-docs/src/main/paradox/remoting-artery.md
@@ -6,7 +6,7 @@ To use Remoting (codename Artery), you must add the following dependency in your
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-remote_$scala.major_version$
+  artifact=akka-remote_$scala.binary_version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/remoting.md
+++ b/akka-docs/src/main/paradox/remoting.md
@@ -6,7 +6,7 @@ To use Akka Remoting, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-remote_$scala.major_version$
+  artifact=akka-remote_$scala.binary_version$
   version=$akka.version$
 }
 


### PR DESCRIPTION
changes `$scala.major_version$` to `$scala.binary_version$` to align with the rest of the docs

ref #25240 