### PR TITLE
Changed log-level of ShutDownAssociation from Error to Warning

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -556,7 +556,8 @@ private[remote] class EndpointWriter(
   var lastAck: Option[Ack] = None
 
   override val supervisorStrategy = OneForOneStrategy(loggingEnabled = false) {
-    case NonFatal(e) ⇒ publishAndThrow(e, Logging.ErrorLevel)
+    case e: ShutDownAssociation ⇒ publishAndThrow(e, Logging.InfoLevel)
+    case NonFatal(e)            ⇒ publishAndThrow(e, Logging.ErrorLevel)
   }
 
   val provider = RARP(extendedSystem).provider


### PR DESCRIPTION
When the node has left the cluster, existed nodes throw `akka.remote.transport.Transport$InvalidAssociationException` with message `The remote system terminated the association because it is shutting down`.

This error normally happened when node is leaving the cluster in redeployment proposal and it isn't an error but it creates a noise in monitoring/alert system.

So, I propose to log it as Warning.