### PR TITLE
Improve performance of DData delta updates, #25310

### DIFF
--- a/akka-distributed-data/src/main/mima-filters/2.5.13.backwards.excludes
+++ b/akka-distributed-data/src/main/mima-filters/2.5.13.backwards.excludes
@@ -1,3 +1,7 @@
+# #25310 Improve performance of DData delta updates
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ddata.ReadWriteAggregator.secondaryNodes")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ddata.ReadWriteAggregator.primaryNodes")
+
 # #23703 Optimized serializer for ORSet[ActorRef]
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages#GSetOrBuilder.getActorRefElementsCount")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.ddata.protobuf.msg.ReplicatedDataMessages#GSetOrBuilder.getActorRefElementsList")


### PR DESCRIPTION
* Use deterministic order of the target nodes for the writes when
  type RequiresCausalDeliveryOfDeltas, otherwise the random pick
  of targets caused that delta sequence numbers were missing for
  susequent updates
* Resend immediately when receiving DeltaNack instead of waiting
  for timeout. DeltaNack can happen when there are multiple
  concurrent updates from same node because each starts a WriteAggregator
  and a later Update might bypass an earlier

Refs #25310