### PR TITLE
MergeSortedN

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/Source/mergeSortedN.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/mergeSortedN.md
@@ -8,7 +8,7 @@ Combine the elements of multiple pre-sorted streams into a single sorted stream.
 
 ## Signature
 
-@@signature [Source.scala]($akka$/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #mergeSortedN }
+@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #mergeSortedN }
 
 @@@
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/mergeSortedN.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/mergeSortedN.md
@@ -1,0 +1,27 @@
+# Source.mergeSortedN
+
+Combine the elements of multiple pre-sorted streams into a single sorted stream.
+
+@ref[Source operators](../index.md#source-operators)
+
+@@@div { .group-scala }
+
+## Signature
+
+@@signature [Source.scala]($akka$/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #mergeSortedN }
+
+@@@
+
+## Description
+
+Combine the elements of multiple pre-sorted streams into a single sorted stream.
+
+
+@@@div { .callout }
+
+**emits** when all of the inputs has an element available
+
+**completes** when all upstream completes
+
+@@@
+

--- a/akka-docs/src/main/paradox/stream/operators/index.md
+++ b/akka-docs/src/main/paradox/stream/operators/index.md
@@ -35,6 +35,7 @@ These built-in sources are available from @scala[`akka.stream.scaladsl.Source`] 
 |Source|<a name="lazysingle"></a>@ref[lazySingle](Source/lazySingle.md)|Defers creation of a single element source until there is demand.|
 |Source|<a name="lazysource"></a>@ref[lazySource](Source/lazySource.md)|Defers creation and materialization of a `Source` until there is demand.|
 |Source|<a name="maybe"></a>@ref[maybe](Source/maybe.md)|Create a source that emits once the materialized @scala[`Promise`] @java[`CompletableFuture`] is completed with a value.|
+|Source|<a name="mergesortedn"></a>@ref[mergeSortedN](Source/mergeSortedN.md)|Combine the elements of multiple pre-sorted streams into a single sorted stream.|
 |Source|<a name="queue"></a>@ref[queue](Source/queue.md)|Materialize a `SourceQueue` onto which elements can be pushed for emitting from the source. |
 |Source|<a name="range"></a>@ref[range](Source/range.md)|Emit each integer in a range, with an option to take bigger steps than 1.|
 |Source|<a name="repeat"></a>@ref[repeat](Source/repeat.md)|Stream a single object repeatedly|
@@ -369,6 +370,7 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 * [actorRefWithBackpressure](Source/actorRefWithBackpressure.md)
 * [zipN](Source/zipN.md)
 * [zipWithN](Source/zipWithN.md)
+* [mergeSortedN](Source/mergeSortedN.md)
 * [queue](Source/queue.md)
 * [unfoldResource](Source/unfoldResource.md)
 * [unfoldResourceAsync](Source/unfoldResourceAsync.md)

--- a/akka-stream-tests/src/test/scala/akka/stream/DslFactoriesConsistencySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/DslFactoriesConsistencySpec.scala
@@ -62,6 +62,7 @@ class DslFactoriesConsistencySpec extends WordSpec with Matchers {
       (classOf[akka.stream.scaladsl.Sink[_, _]],           classOf[akka.stream.javadsl.Sink[_, _]]) ::
       (classOf[akka.stream.scaladsl.Flow[_, _, _]],        classOf[akka.stream.javadsl.Flow[_, _, _]]) ::
       (classOf[akka.stream.scaladsl.RunnableGraph[_]],     classOf[akka.stream.javadsl.RunnableGraph[_]]) ::
+      (classOf[scala.math.Ordering[_]],                    classOf[java.util.Comparator[_]]) ::
       (2 to 22) .map { i => (Class.forName(s"scala.Function$i"), Class.forName(s"akka.japi.function.Function$i")) }.toList
   // format: ON
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedNSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedNSpec.scala
@@ -1,5 +1,5 @@
-/**
- * Copyright (C) 2014-2018 Lightbend Inc. <https://www.lightbend.com>
+/*
+ * Copyright (C) 2014-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.stream.scaladsl

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedNSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedNSpec.scala
@@ -19,7 +19,7 @@ class GraphMergeSortedNSpec extends TwoStreamsSetup with ScalaCheckDrivenPropert
 
   override type Outputs = Int
 
-  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture(b) {
+  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture() {
     val mergeSortedN = b.add(MergeSortedN[Int](2))
 
     override def left: Inlet[Int] = mergeSortedN.in(0)
@@ -211,7 +211,7 @@ class GraphMergeSortedNSpec extends TwoStreamsSetup with ScalaCheckDrivenPropert
       subscriber1.expectSubscriptionAndError(TestException)
 
       val subscriber2 = setup(nonemptyPublisher(1 to 4), soonToFailPublisher)
-      val subscription2 = subscriber2.expectSubscriptionAndError(TestException)
+      subscriber2.expectSubscriptionAndError(TestException)
     }
 
     "never emit if a source does not emit" in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedNSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedNSpec.scala
@@ -147,7 +147,7 @@ class GraphMergeSortedNSpec extends TwoStreamsSetup {
 
     "work with one delayed completed and one nonempty publisher" in assertAllStagesStopped {
       val subscriber1 = setup(soonToCompletePublisher, nonemptyPublisher(1 to 4))
-      
+
       subscriber1.requestNext(1)
       subscriber1.requestNext(2)
       subscriber1.requestNext(3)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedNSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedNSpec.scala
@@ -178,6 +178,13 @@ class GraphMergeSortedNSpec extends TwoStreamsSetup {
       val subscription2 = subscriber2.expectSubscriptionAndError(TestException)
     }
 
+    "never emit if a source does not emit" in {
+      val subscriber1 = setup(soonToCompletePublisher, nonemptyPublisher(1 to 2))
+
+      subscriber1.expectSubscription()
+      subscriber1.expectNoMessage(100 millis)
+    }
+
   }
 
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedNSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedNSpec.scala
@@ -1,0 +1,183 @@
+/**
+ * Copyright (C) 2014-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.scaladsl
+
+import akka.stream._
+import akka.stream.testkit.Utils._
+import akka.stream.testkit._
+
+import scala.collection.immutable
+import scala.concurrent.duration._
+import akka.stream.testkit.scaladsl.StreamTestKit._
+
+class GraphMergeSortedNSpec extends TwoStreamsSetup {
+  import GraphDSL.Implicits._
+
+  override type Outputs = Int
+
+  override def fixture(b: GraphDSL.Builder[_]): Fixture = new Fixture(b) {
+    val mergeSortedN = b.add(MergeSortedN[Int](2))
+
+    override def left: Inlet[Int] = mergeSortedN.in(0)
+    override def right: Inlet[Int] = mergeSortedN.in(1)
+    override def out: Outlet[Int] = mergeSortedN.out
+  }
+
+  "GraphMergeSortedN" must {
+
+    "work in the happy case" in assertAllStagesStopped {
+      val probe = TestSubscriber.manualProbe[Int]()
+
+      RunnableGraph.fromGraph(GraphDSL.create() { implicit b ⇒
+        val mergeSortedN = b.add(MergeSortedN[Int](2))
+
+        Source(1 to 4) ~> mergeSortedN.in(0)
+        Source(2 to 5) ~> mergeSortedN.in(1)
+
+        mergeSortedN.out ~> Sink.fromSubscriber(probe)
+
+        ClosedShape
+      }).run()
+
+      val subscription = probe.expectSubscription()
+
+      subscription.request(4)
+      probe.expectNext(1, 2, 2, 3)
+
+      subscription.request(2)
+      probe.expectNext(3, 4)
+      subscription.request(4)
+      probe.expectNext(4, 5)
+
+      probe.expectComplete()
+    }
+
+    "not complete if one side is available but other completed" in {
+      val upstream1 = TestPublisher.probe[Int]()
+      val upstream2 = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[Int]()
+
+      RunnableGraph.fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b ⇒ out ⇒
+        val mergeSortedN = b.add(MergeSortedN[Int](2))
+
+        Source.fromPublisher(upstream1) ~> mergeSortedN.in(0)
+        Source.fromPublisher(upstream2) ~> mergeSortedN.in(1)
+        mergeSortedN.out ~> out
+
+        ClosedShape
+      }).run()
+
+      upstream1.sendNext(1)
+      upstream1.sendNext(2)
+      upstream2.sendNext(2)
+      upstream1.sendComplete()
+
+      downstream.requestNext(1)
+      downstream.requestNext(2)
+      downstream.requestNext(2)
+      downstream.expectNoMessage(200.millis)
+    }
+
+    "complete even if no pending demand" in {
+      val upstream1 = TestPublisher.probe[Int]()
+      val upstream2 = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[Int]()
+
+      RunnableGraph.fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b ⇒ out ⇒
+        val mergeSortedN = b.add(MergeSortedN[Int](2))
+
+        Source.fromPublisher(upstream1) ~> mergeSortedN.in(0)
+        Source.fromPublisher(upstream2) ~> mergeSortedN.in(1)
+        mergeSortedN.out ~> out
+
+        ClosedShape
+      }).run()
+
+      downstream.request(2)
+
+      upstream1.sendNext(1)
+      upstream2.sendNext(2)
+
+      upstream2.sendComplete()
+      upstream1.sendComplete()
+      downstream.expectNext(1, 2)
+      downstream.expectComplete()
+    }
+
+    "complete if both sides complete before requested with elements pending" in {
+      val upstream1 = TestPublisher.probe[Int]()
+      val upstream2 = TestPublisher.probe[Int]()
+      val downstream = TestSubscriber.probe[Int]()
+
+      RunnableGraph.fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b ⇒ out ⇒
+        val mergeSortedN = b.add(MergeSortedN[Int](2))
+
+        Source.fromPublisher(upstream1) ~> mergeSortedN.in(0)
+        Source.fromPublisher(upstream2) ~> mergeSortedN.in(1)
+        mergeSortedN.out ~> out
+
+        ClosedShape
+      }).run()
+
+      upstream1.sendNext(1)
+      upstream2.sendNext(2)
+
+      upstream1.sendComplete()
+      upstream2.sendComplete()
+
+      downstream.request(2)
+      downstream.expectNext(1, 2)
+      downstream.expectComplete()
+    }
+    commonTests()
+
+    "work with one immediately completed and one nonempty publisher" in assertAllStagesStopped {
+      val subscriber1 = setup(completedPublisher, nonemptyPublisher(1 to 1))
+      subscriber1.request(10)
+      subscriber1.expectNext(1)
+      subscriber1.expectComplete()
+
+      val subscriber2 = setup(nonemptyPublisher(1 to 1), completedPublisher)
+      subscriber2.request(10)
+      subscriber2.requestNext(1)
+      subscriber2.expectComplete()
+    }
+
+    "work with one delayed completed and one nonempty publisher" in assertAllStagesStopped {
+      val subscriber1 = setup(soonToCompletePublisher, nonemptyPublisher(1 to 4))
+      
+      subscriber1.requestNext(1)
+      subscriber1.requestNext(2)
+      subscriber1.requestNext(3)
+      subscriber1.requestNext(4)
+      subscriber1.onComplete()
+
+      val subscriber2 = setup(nonemptyPublisher(1 to 4), soonToCompletePublisher)
+      subscriber2.requestNext(1)
+      subscriber2.requestNext(2)
+      subscriber2.requestNext(3)
+      subscriber2.requestNext(4)
+      subscriber2.expectComplete()
+    }
+
+    "work with one immediately failed and one nonempty publisher" in assertAllStagesStopped {
+      val subscriber1 = setup(failedPublisher, nonemptyPublisher(1 to 4))
+      subscriber1.expectSubscriptionAndError(TestException)
+
+      val subscriber2 = setup(nonemptyPublisher(1 to 4), failedPublisher)
+      subscriber2.expectSubscriptionAndError(TestException)
+    }
+
+    "work with one delayed failed and one nonempty publisher" in assertAllStagesStopped {
+      val subscriber1 = setup(soonToFailPublisher, nonemptyPublisher(1 to 4))
+      subscriber1.expectSubscriptionAndError(TestException)
+
+      val subscriber2 = setup(nonemptyPublisher(1 to 4), soonToFailPublisher)
+      val subscription2 = subscriber2.expectSubscriptionAndError(TestException)
+    }
+
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedNSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedNSpec.scala
@@ -32,16 +32,18 @@ class GraphMergeSortedNSpec extends TwoStreamsSetup with ScalaCheckDrivenPropert
     "work in the happy case" in assertAllStagesStopped {
       val probe = TestSubscriber.manualProbe[Int]()
 
-      RunnableGraph.fromGraph(GraphDSL.create() { implicit b ⇒
-        val mergeSortedN = b.add(MergeSortedN[Int](2))
+      RunnableGraph
+        .fromGraph(GraphDSL.create() { implicit b =>
+          val mergeSortedN = b.add(MergeSortedN[Int](2))
 
-        Source(1 to 4) ~> mergeSortedN.in(0)
-        Source(2 to 5) ~> mergeSortedN.in(1)
+          Source(1 to 4) ~> mergeSortedN.in(0)
+          Source(2 to 5) ~> mergeSortedN.in(1)
 
-        mergeSortedN.out ~> Sink.fromSubscriber(probe)
+          mergeSortedN.out ~> Sink.fromSubscriber(probe)
 
-        ClosedShape
-      }).run()
+          ClosedShape
+        })
+        .run()
 
       val subscription = probe.expectSubscription()
 
@@ -61,15 +63,17 @@ class GraphMergeSortedNSpec extends TwoStreamsSetup with ScalaCheckDrivenPropert
       val upstream2 = TestPublisher.probe[Int]()
       val downstream = TestSubscriber.probe[Int]()
 
-      RunnableGraph.fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b ⇒ out ⇒
-        val mergeSortedN = b.add(MergeSortedN[Int](2))
+      RunnableGraph
+        .fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b => out =>
+          val mergeSortedN = b.add(MergeSortedN[Int](2))
 
-        Source.fromPublisher(upstream1) ~> mergeSortedN.in(0)
-        Source.fromPublisher(upstream2) ~> mergeSortedN.in(1)
-        mergeSortedN.out ~> out
+          Source.fromPublisher(upstream1) ~> mergeSortedN.in(0)
+          Source.fromPublisher(upstream2) ~> mergeSortedN.in(1)
+          mergeSortedN.out ~> out
 
-        ClosedShape
-      }).run()
+          ClosedShape
+        })
+        .run()
 
       upstream1.sendNext(1)
       upstream1.sendNext(2)
@@ -89,15 +93,17 @@ class GraphMergeSortedNSpec extends TwoStreamsSetup with ScalaCheckDrivenPropert
       val upstream2 = TestPublisher.probe[Int]()
       val downstream = TestSubscriber.probe[Int]()
 
-      RunnableGraph.fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b ⇒ out ⇒
-        val mergeSortedN = b.add(MergeSortedN[Int](2))
+      RunnableGraph
+        .fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b => out =>
+          val mergeSortedN = b.add(MergeSortedN[Int](2))
 
-        Source.fromPublisher(upstream1) ~> mergeSortedN.in(0)
-        Source.fromPublisher(upstream2) ~> mergeSortedN.in(1)
-        mergeSortedN.out ~> out
+          Source.fromPublisher(upstream1) ~> mergeSortedN.in(0)
+          Source.fromPublisher(upstream2) ~> mergeSortedN.in(1)
+          mergeSortedN.out ~> out
 
-        ClosedShape
-      }).run()
+          ClosedShape
+        })
+        .run()
 
       downstream.request(2)
 
@@ -115,15 +121,17 @@ class GraphMergeSortedNSpec extends TwoStreamsSetup with ScalaCheckDrivenPropert
       val upstream2 = TestPublisher.probe[Int]()
       val downstream = TestSubscriber.probe[Int]()
 
-      RunnableGraph.fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b ⇒ out ⇒
-        val mergeSortedN = b.add(MergeSortedN[Int](2))
+      RunnableGraph
+        .fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b => out =>
+          val mergeSortedN = b.add(MergeSortedN[Int](2))
 
-        Source.fromPublisher(upstream1) ~> mergeSortedN.in(0)
-        Source.fromPublisher(upstream2) ~> mergeSortedN.in(1)
-        mergeSortedN.out ~> out
+          Source.fromPublisher(upstream1) ~> mergeSortedN.in(0)
+          Source.fromPublisher(upstream2) ~> mergeSortedN.in(1)
+          mergeSortedN.out ~> out
 
-        ClosedShape
-      }).run()
+          ClosedShape
+        })
+        .run()
 
       upstream1.sendNext(1)
       upstream2.sendNext(2)
@@ -139,10 +147,11 @@ class GraphMergeSortedNSpec extends TwoStreamsSetup with ScalaCheckDrivenPropert
     "work with generated booleans" in {
       val gen = Gen.listOf(Gen.oneOf(false, true))
 
-      forAll(gen) { picks ⇒
+      forAll(gen) { picks =>
         val N = picks.size
         val (left, right) = picks.zipWithIndex.partition(_._1)
-        Source.mergeSortedN(List(Source(left.map(_._2)), Source(right.map(_._2))))
+        Source
+          .mergeSortedN(List(Source(left.map(_._2)), Source(right.map(_._2))))
           .grouped(N max 1)
           .concat(Source.single(Nil))
           .runWith(Sink.head)
@@ -156,13 +165,9 @@ class GraphMergeSortedNSpec extends TwoStreamsSetup with ScalaCheckDrivenPropert
 
       val underTest: Source[Int, NotUsed] = Source.mergeSortedN(List(leftSource, rightSource))
 
-      val grouped: Source[immutable.Seq[Int], NotUsed] = underTest
-        .grouped(4)
+      val grouped: Source[immutable.Seq[Int], NotUsed] = underTest.grouped(4)
 
-      val sortedResult: immutable.Seq[Int] = grouped
-        .concat(Source.single(Nil))
-        .runWith(Sink.head)
-        .futureValue
+      val sortedResult: immutable.Seq[Int] = grouped.concat(Source.single(Nil)).runWith(Sink.head).futureValue
 
       sortedResult shouldBe List(0, 1, 2)
     }
@@ -219,15 +224,17 @@ class GraphMergeSortedNSpec extends TwoStreamsSetup with ScalaCheckDrivenPropert
       val upstream2 = TestPublisher.probe[Int]()
       val downstream = TestSubscriber.probe[Int]()
 
-      RunnableGraph.fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b ⇒ out ⇒
-        val mergeSortedN = b.add(MergeSortedN[Int](2))
+      RunnableGraph
+        .fromGraph(GraphDSL.create(Sink.fromSubscriber(downstream)) { implicit b => out =>
+          val mergeSortedN = b.add(MergeSortedN[Int](2))
 
-        Source.fromPublisher(upstream1) ~> mergeSortedN.in(0)
-        Source.fromPublisher(upstream2) ~> mergeSortedN.in(1)
-        mergeSortedN.out ~> out
+          Source.fromPublisher(upstream1) ~> mergeSortedN.in(0)
+          Source.fromPublisher(upstream2) ~> mergeSortedN.in(1)
+          mergeSortedN.out ~> out
 
-        ClosedShape
-      }).run()
+          ClosedShape
+        })
+        .run()
 
       upstream2.sendNext(2)
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedSpec.scala
@@ -4,15 +4,12 @@
 
 package akka.stream.scaladsl
 
-import akka.NotUsed
 import akka.stream._
 import akka.stream.testkit.TwoStreamsSetup
 import com.github.ghik.silencer.silent
-import org.scalacheck.{ Gen, Shrink }
+import org.scalacheck.Gen
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalacheck.Shrink
-
-import scala.collection.immutable
 
 @silent // tests deprecated apis
 class GraphMergeSortedSpec extends TwoStreamsSetup with GeneratorDrivenPropertyChecks {
@@ -44,38 +41,6 @@ class GraphMergeSortedSpec extends TwoStreamsSetup with GeneratorDrivenPropertyC
           .runWith(Sink.head)
           .futureValue should ===(0 until N)
       }
-    }
-
-    "work as a special case of MergeSortedN with N=2" in {
-      val gen = Gen.listOf(Gen.oneOf(false, true))
-
-      forAll(gen) { picks ⇒
-        val N = picks.size
-        val (left, right) = picks.zipWithIndex.partition(_._1)
-        Source.mergeSortedN(List(Source(left.map(_._2)), Source(right.map(_._2))))
-          .grouped(N max 1)
-          .concat(Source.single(Nil))
-          .runWith(Sink.head)
-          .futureValue should ===(0 until N)
-      }
-    }
-
-    "work" in {
-      // List(false, false, false, true, false, true, false, true, true, false)
-      val leftSource: Source[Int, NotUsed] = Source(List(0, 2))
-      val rightSource: Source[Int, NotUsed] = Source(List(1))
-
-      val underTest: Source[Int, NotUsed] = Source.mergeSortedN(List(leftSource, rightSource))
-
-      val grouped: Source[immutable.Seq[Int], NotUsed] = underTest
-        .grouped(4)
-
-      val sortedResult: immutable.Seq[Int] = grouped
-        .concat(Source.single(Nil))
-        .runWith(Sink.head)
-        .futureValue
-
-      sortedResult shouldBe List(0, 1, 2)
     }
 
     commonTests()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedSpec.scala
@@ -4,12 +4,15 @@
 
 package akka.stream.scaladsl
 
+import akka.NotUsed
 import akka.stream._
 import akka.stream.testkit.TwoStreamsSetup
 import com.github.ghik.silencer.silent
-import org.scalacheck.Gen
+import org.scalacheck.{Gen, Shrink}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalacheck.Shrink
+
+import scala.collection.immutable
 
 @silent // tests deprecated apis
 class GraphMergeSortedSpec extends TwoStreamsSetup with GeneratorDrivenPropertyChecks {
@@ -41,6 +44,40 @@ class GraphMergeSortedSpec extends TwoStreamsSetup with GeneratorDrivenPropertyC
           .runWith(Sink.head)
           .futureValue should ===(0 until N)
       }
+    }
+
+    "work as a special case of MergeSortedN with N=2" in {
+      val gen = Gen.listOf(Gen.oneOf(false, true))
+
+      forAll(gen) { picks ⇒
+        val N = picks.size
+        val (left, right) = picks.zipWithIndex.partition(_._1)
+        Source.mergeSortedN(List(Source(left.map(_._2)), Source(right.map(_._2))))
+          .grouped(N max 1)
+          .concat(Source.single(Nil))
+          .runWith(Sink.head)
+          .futureValue should ===(0 until N)
+      }
+    }
+
+    "work" in {
+      // List(false, false, false, true, false, true, false, true, true, false)
+      val leftSource: Source[Int, NotUsed] = Source(List(0, 2))
+      val rightSource: Source[Int, NotUsed] = Source(List(1))
+
+
+      val underTest: Source[Int, NotUsed] = Source.mergeSortedN(List(leftSource, rightSource))
+
+      val grouped: Source[immutable.Seq[Int], NotUsed] = underTest
+        .grouped(4)
+
+      val sortedResult: immutable.Seq[Int] = grouped
+        .concat(Source.single(Nil))
+        .runWith(Sink.head)
+        .futureValue
+
+
+      sortedResult shouldBe List(0,1,2)
     }
 
     commonTests()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedSpec.scala
@@ -8,7 +8,7 @@ import akka.NotUsed
 import akka.stream._
 import akka.stream.testkit.TwoStreamsSetup
 import com.github.ghik.silencer.silent
-import org.scalacheck.{Gen, Shrink}
+import org.scalacheck.{ Gen, Shrink }
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalacheck.Shrink
 
@@ -65,7 +65,6 @@ class GraphMergeSortedSpec extends TwoStreamsSetup with GeneratorDrivenPropertyC
       val leftSource: Source[Int, NotUsed] = Source(List(0, 2))
       val rightSource: Source[Int, NotUsed] = Source(List(1))
 
-
       val underTest: Source[Int, NotUsed] = Source.mergeSortedN(List(leftSource, rightSource))
 
       val grouped: Source[immutable.Seq[Int], NotUsed] = underTest
@@ -76,8 +75,7 @@ class GraphMergeSortedSpec extends TwoStreamsSetup with GeneratorDrivenPropertyC
         .runWith(Sink.head)
         .futureValue
 
-
-      sortedResult shouldBe List(0,1,2)
+      sortedResult shouldBe List(0, 1, 2)
     }
 
     commonTests()

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -73,6 +73,7 @@ import akka.stream._
     val merge = name("merge")
     val mergePreferred = name("mergePreferred")
     val mergePrioritized = name("mergePrioritized")
+    val mergeSortedN = name("mergeSortedN")
     val flattenMerge = name("flattenMerge")
     val recoverWith = name("recoverWith")
     val broadcast = name("broadcast")

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -9,7 +9,7 @@ import java.util.Comparator
 
 import akka.NotUsed
 import akka.stream._
-import akka.japi.{Pair, function}
+import akka.japi.{ Pair, function }
 import akka.util.ConstantFun
 
 import scala.annotation.unchecked.uncheckedVariance

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -9,7 +9,7 @@ import java.util.Comparator
 
 import akka.NotUsed
 import akka.stream._
-import akka.japi.{ Pair, function }
+import akka.japi.{ function, Pair }
 import akka.util.ConstantFun
 
 import scala.annotation.unchecked.uncheckedVariance
@@ -188,6 +188,7 @@ object MergePrioritized {
  * '''Cancels when''' downstream cancels
  */
 object MergeSortedN {
+
   /**
    * Create a new `MergeSortedN`.
    */

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -5,10 +5,11 @@
 package akka.stream.javadsl
 
 import java.util
+import java.util.Comparator
 
 import akka.NotUsed
 import akka.stream._
-import akka.japi.{ function, Pair }
+import akka.japi.{Pair, function}
 import akka.util.ConstantFun
 
 import scala.annotation.unchecked.uncheckedVariance
@@ -169,6 +170,24 @@ object MergePrioritized {
       eagerComplete: Boolean): Graph[UniformFanInShape[T, T], NotUsed] =
     create(priorities, eagerComplete)
 
+}
+
+/**
+  * Merge multiple pre-sorted streams such that the resulting stream is sorted.
+  *
+  * '''Emits when''' all inputs have an element available
+  *
+  * '''Backpressures when''' downstream backpressures
+  *
+  * '''Completes when''' all upstreams complete
+  *
+  * '''Cancels when''' downstream cancels
+  */
+object MergeSortedN {
+  /**
+    * Create a new `MergeSortedN`.
+    */
+  def create[T](n: Int, comp: Comparator[T]) = scaladsl.MergeSortedN(n)(Ordering.comparatorToOrdering(comp))
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -173,20 +173,20 @@ object MergePrioritized {
 }
 
 /**
-  * Merge multiple pre-sorted streams such that the resulting stream is sorted.
-  *
-  * '''Emits when''' all inputs have an element available
-  *
-  * '''Backpressures when''' downstream backpressures
-  *
-  * '''Completes when''' all upstreams complete
-  *
-  * '''Cancels when''' downstream cancels
-  */
+ * Merge multiple pre-sorted streams such that the resulting stream is sorted.
+ *
+ * '''Emits when''' all inputs have an element available
+ *
+ * '''Backpressures when''' downstream backpressures
+ *
+ * '''Completes when''' all upstreams complete
+ *
+ * '''Cancels when''' downstream cancels
+ */
 object MergeSortedN {
   /**
-    * Create a new `MergeSortedN`.
-    */
+   * Create a new `MergeSortedN`.
+   */
   def create[T](n: Int, comp: Comparator[T]) = scaladsl.MergeSortedN(n)(Ordering.comparatorToOrdering(comp))
 }
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -175,6 +175,10 @@ object MergePrioritized {
 /**
  * Merge multiple pre-sorted streams such that the resulting stream is sorted.
  *
+ * The stage pulls and buffers one element from each of the given inlets. It does not emit until
+ * all inlets have an available element (or have been closed) at which point it will emit the smallest
+ * element and pull the corresponding inlet.
+ *
  * '''Emits when''' all inputs have an element available
  *
  * '''Backpressures when''' downstream backpressures

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -687,7 +687,9 @@ object Source {
    *
    * '''Cancels when''' downstream cancels
    */
-  def mergeSortedN[T](sources: java.util.List[Source[T, _ <: Any]], comp: util.Comparator[T]): javadsl.Source[T, _ <: Any] = {
+  def mergeSortedN[T](
+      sources: java.util.List[Source[T, _ <: Any]],
+      comp: util.Comparator[T]): javadsl.Source[T, _ <: Any] = {
     val seq = if (sources != null) Util.immutableSeq(sources).map(_.asScala) else immutable.Seq()
     new Source(scaladsl.Source.mergeSortedN(seq)(Ordering.comparatorToOrdering(comp)))
   }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -673,6 +673,26 @@ object Source {
   }
 
   /**
+   * Merge the given [[Source]]s, taking elements as they arrive from input streams,
+   * picking always the smallest of the available elements (waiting for one element from all inputs
+   * to be available). This means that possible contiguity of the input streams is not exploited to avoid
+   * waiting for elements, this merge will block when one of the inputs does not have more elements (and
+   * does not complete).
+   *
+   * '''Emits when''' all of the inputs have an element available
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' all upstreams complete
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def mergeSortedN[T](sources: java.util.List[Source[T, _ <: Any]], comp: util.Comparator[T]): javadsl.Source[T, _ <: Any] = {
+    val seq = if (sources != null) Util.immutableSeq(sources).map(_.asScala) else immutable.Seq()
+    new Source(scaladsl.Source.mergeSortedN(seq)(Ordering.comparatorToOrdering(comp)))
+  }
+
+  /**
    * Creates a `Source` that is materialized as an [[akka.stream.javadsl.SourceQueueWithComplete]].
    * You can push elements to the queue and they will be emitted to the stream if there is demand from downstream,
    * otherwise they will be buffered until request for demand is received. Elements in the buffer will be discarded

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -571,8 +571,8 @@ final class MergeSorted[T: Ordering] extends GraphStage[FanInShape2[T, T, T]] {
 
 object MergeSortedN {
   /**
-    * Create a new `MergeSortedN`.
-    */
+   * Create a new `MergeSortedN`.
+   */
   def apply[A: Ordering](n: Int) = new MergeSortedN[A](n)
 }
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -653,7 +653,7 @@ final class MergeSortedN[T: Ordering](inputPorts: Int) extends GraphStage[Unifor
     setHandler(out, this)
   }
 
-  override def toString = "MergeSortedN"
+  override def toString = s"MergeSortedN($inputPorts)"
 }
 
 object Broadcast {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -569,16 +569,16 @@ final class MergeSorted[T: Ordering] extends GraphStage[FanInShape2[T, T, T]] {
 }
 
 /**
-  * Merge multiple pre-sorted streams such that the resulting stream is sorted.
-  *
-  * '''Emits when''' all inputs have an element available
-  *
-  * '''Backpressures when''' downstream backpressures
-  *
-  * '''Completes when''' all upstreams complete
-  *
-  * '''Cancels when''' downstream cancels
-  */
+ * Merge multiple pre-sorted streams such that the resulting stream is sorted.
+ *
+ * '''Emits when''' all inputs have an element available
+ *
+ * '''Backpressures when''' downstream backpressures
+ *
+ * '''Completes when''' all upstreams complete
+ *
+ * '''Cancels when''' downstream cancels
+ */
 object MergeSortedN {
   /**
    * Create a new `MergeSortedN`.
@@ -586,7 +586,10 @@ object MergeSortedN {
   def apply[A: Ordering](n: Int) = new MergeSortedN[A](n)
 }
 
-final class MergeSortedN[T: Ordering](inputPorts: Int) extends GraphStage[UniformFanInShape[T, T]] {
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] final class MergeSortedN[T: Ordering](inputPorts: Int) extends GraphStage[UniformFanInShape[T, T]] {
   val inlets: immutable.IndexedSeq[Inlet[T]] = Vector.tabulate(inputPorts)(i ⇒ Inlet[T]("MergeSortedN.in" + i))
   val out: Outlet[T] = Outlet[T]("MergeSortedN.out")
   override val shape: UniformFanInShape[T, T] = UniformFanInShape(out, inlets: _*)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -584,6 +584,7 @@ final class MergeSorted[T: Ordering] extends GraphStage[FanInShape2[T, T, T]] {
  * '''Cancels when''' downstream cancels
  */
 object MergeSortedN {
+
   /**
    * Create a new `MergeSortedN`.
    */
@@ -593,71 +594,73 @@ object MergeSortedN {
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] final class MergeSortedN[T: Ordering](inputPorts: Int) extends GraphStage[UniformFanInShape[T, T]] {
-  val inlets: immutable.IndexedSeq[Inlet[T]] = Vector.tabulate(inputPorts)(i ⇒ Inlet[T]("MergeSortedN.in" + i))
+@InternalApi private[akka] final class MergeSortedN[T: Ordering](inputPorts: Int)
+    extends GraphStage[UniformFanInShape[T, T]] {
+  val inlets: immutable.IndexedSeq[Inlet[T]] = Vector.tabulate(inputPorts)(i => Inlet[T]("MergeSortedN.in" + i))
   val out: Outlet[T] = Outlet[T]("MergeSortedN.out")
   override val shape: UniformFanInShape[T, T] = UniformFanInShape(out, inlets: _*)
 
-  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with OutHandler {
-    private val bufferedElements = new mutable.TreeSet[(T, Int)]()
-    private val inletsBeingPulled = new mutable.HashSet[Inlet[T]]
-    private var runningInlets = inputPorts
-    private def canPush = inletsBeingPulled.isEmpty && bufferedElements.nonEmpty && isAvailable(out)
-    private def upstreamsClosed = runningInlets == 0
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with OutHandler {
+      private val bufferedElements = new mutable.TreeSet[(T, Int)]()
+      private val inletsBeingPulled = new mutable.HashSet[Inlet[T]]
+      private var runningInlets = inputPorts
+      private def canPush = inletsBeingPulled.isEmpty && bufferedElements.nonEmpty && isAvailable(out)
+      private def upstreamsClosed = runningInlets == 0
 
-    override def preStart(): Unit = {
-      for (i ← inlets) {
-        tryPull(i)
-        inletsBeingPulled.add(i)
-      }
-    }
-
-    private def maybeCompleteStage(): Unit = {
-      if (bufferedElements.isEmpty && upstreamsClosed) {
-        completeStage()
-      }
-    }
-
-    private def maybePush(): Unit = {
-      if (canPush) {
-        val next = bufferedElements.firstKey
-        bufferedElements.remove(next)
-        push(out, next._1)
-        val inlet = inlets(next._2)
-        if (!isClosed(inlet)) {
-          pull(inlet)
-          inletsBeingPulled.add(inlet)
+      override def preStart(): Unit = {
+        for (i <- inlets) {
+          tryPull(i)
+          inletsBeingPulled.add(i)
         }
       }
 
-      maybeCompleteStage()
-    }
+      private def maybeCompleteStage(): Unit = {
+        if (bufferedElements.isEmpty && upstreamsClosed) {
+          completeStage()
+        }
+      }
 
-    for (i ← inlets.indices) {
-      val inlet = inlets(i)
-      val index = i
-      setHandler(inlet, new InHandler {
-        override def onPush(): Unit = {
-          val element = grab(inlet)
-          bufferedElements.add((element, index))
-          inletsBeingPulled.remove(inlet)
-          maybePush()
+      private def maybePush(): Unit = {
+        if (canPush) {
+          val next = bufferedElements.firstKey
+          bufferedElements.remove(next)
+          push(out, next._1)
+          val inlet = inlets(next._2)
+          if (!isClosed(inlet)) {
+            pull(inlet)
+            inletsBeingPulled.add(inlet)
+          }
         }
 
-        override def onUpstreamFinish(): Unit = {
-          inletsBeingPulled.remove(inlet)
-          runningInlets -= 1
-          maybePush()
-        }
-      })
-    }
+        maybeCompleteStage()
+      }
 
-    override def onPull(): Unit = {
-      maybePush()
-    }
+      for (i <- inlets.indices) {
+        val inlet = inlets(i)
+        val index = i
+        setHandler(inlet, new InHandler {
+          override def onPush(): Unit = {
+            val element = grab(inlet)
+            bufferedElements.add((element, index))
+            inletsBeingPulled.remove(inlet)
+            maybePush()
+          }
 
-    setHandler(out, this)
-  }
+          override def onUpstreamFinish(): Unit = {
+            inletsBeingPulled.remove(inlet)
+            runningInlets -= 1
+            maybePush()
+          }
+        })
+      }
+
+      override def onPull(): Unit = {
+        maybePush()
+      }
+
+      setHandler(out, this)
+    }
 
   override def toString = s"MergeSortedN($inputPorts)"
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -571,6 +571,10 @@ final class MergeSorted[T: Ordering] extends GraphStage[FanInShape2[T, T, T]] {
 /**
  * Merge multiple pre-sorted streams such that the resulting stream is sorted.
  *
+ * The stage pulls and buffers one element from each of the given inlets. It does not emit until
+ * all inlets have an available element (or have been closed) at which point it will emit the smallest
+ * element and pull the corresponding inlet.
+ *
  * '''Emits when''' all inputs have an element available
  *
  * '''Backpressures when''' downstream backpressures

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -18,7 +18,6 @@ import akka.util.ConstantFun
 
 import scala.annotation.tailrec
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.mutable.ArrayBuffer
 import scala.collection.{ immutable, mutable }
 import scala.concurrent.Promise
 import scala.util.control.{ NoStackTrace, NonFatal }
@@ -569,6 +568,17 @@ final class MergeSorted[T: Ordering] extends GraphStage[FanInShape2[T, T, T]] {
   }
 }
 
+/**
+  * Merge multiple pre-sorted streams such that the resulting stream is sorted.
+  *
+  * '''Emits when''' all inputs have an element available
+  *
+  * '''Backpressures when''' downstream backpressures
+  *
+  * '''Completes when''' all upstreams complete
+  *
+  * '''Cancels when''' downstream cancels
+  */
 object MergeSortedN {
   /**
    * Create a new `MergeSortedN`.
@@ -576,17 +586,6 @@ object MergeSortedN {
   def apply[A: Ordering](n: Int) = new MergeSortedN[A](n)
 }
 
-/**
- * Merge multiple pre-sorted streams such that the resulting stream is sorted.
- *
- * '''Emits when''' all inputs have an element available
- *
- * '''Backpressures when''' downstream backpressures
- *
- * '''Completes when''' all upstreams complete
- *
- * '''Cancels when''' downstream cancels
- */
 final class MergeSortedN[T: Ordering](inputPorts: Int) extends GraphStage[UniformFanInShape[T, T]] {
   val inlets: immutable.IndexedSeq[Inlet[T]] = Vector.tabulate(inputPorts)(i ⇒ Inlet[T]("MergeSortedN.in" + i))
   val out: Outlet[T] = Outlet[T]("MergeSortedN.out")

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -784,6 +784,19 @@ object Source {
   }
 
   /**
+   * Combine the elements of multiple pre-sorted streams into a single sorted stream.
+   */
+  def mergeSortedN[T: Ordering](sources: immutable.Seq[Source[T, _]]): Source[T, NotUsed] = {
+    val source = sources match {
+      case immutable.Seq()   ⇒ empty[T]
+      case immutable.Seq(s1) ⇒ s1.mapMaterializedValue(_ ⇒ NotUsed)
+      case s1 +: s2 +: ss    ⇒ combine(s1, s2, ss: _*)(new MergeSortedN[T](_))
+    }
+
+    source.addAttributes(DefaultAttributes.mergeSortedN)
+  }
+
+  /**
    * Creates a `Source` that is materialized as an [[akka.stream.scaladsl.SourceQueueWithComplete]].
    * You can push elements to the queue and they will be emitted to the stream if there is demand from downstream,
    * otherwise they will be buffered until request for demand is received. Elements in the buffer will be discarded

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -788,9 +788,9 @@ object Source {
    */
   def mergeSortedN[T: Ordering](sources: immutable.Seq[Source[T, _]]): Source[T, NotUsed] = {
     val source = sources match {
-      case immutable.Seq()   ⇒ empty[T]
-      case immutable.Seq(s1) ⇒ s1.mapMaterializedValue(_ ⇒ NotUsed)
-      case s1 +: s2 +: ss    ⇒ combine(s1, s2, ss: _*)(new MergeSortedN[T](_))
+      case immutable.Seq()   => empty[T]
+      case immutable.Seq(s1) => s1.mapMaterializedValue(_ => NotUsed)
+      case s1 +: s2 +: ss    => combine(s1, s2, ss: _*)(new MergeSortedN[T](_))
     }
 
     source.addAttributes(DefaultAttributes.mergeSortedN)


### PR DESCRIPTION
akka-streams: Add an operator for merging multiple pre sorted streams into a single ordered steam.

fixes #24369