### PR TITLE
Fix recovery timeout in Typed PersistentBehavior, #25268

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
@@ -110,6 +110,9 @@ object Behavior {
      *   // all other kinds of Number will be `unhandled`
      * }
      * }}}
+     *
+     * Scheduled messages via [[akka.actor.typed.scaladsl.TimerScheduler]] can currently
+     * not be used together with `widen`, see issue #25318.
      */
     def widen[U](matcher: PartialFunction[U, T]): Behavior[U] =
       BehaviorImpl.widened(behavior, matcher)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
@@ -255,6 +255,9 @@ object Behaviors {
    *     );
    * }}}
    *
+   * Scheduled messages via [[TimerScheduler]] can currently not be used
+   * together with `widen`, see issue #25318.
+   *
    * @param behavior
    *          the behavior that will receive the selected messages
    * @param selector

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSettings.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedSettings.scala
@@ -13,31 +13,15 @@ import com.typesafe.config.Config
 
 import scala.concurrent.duration._
 
-/** INTERNAL API */
-@InternalApi
-private[akka] trait EventsourcedSettings {
-
-  def stashCapacity: Int
-  def logOnStashing: Boolean
-  def stashOverflowStrategyConfigurator: String
-
-  def recoveryEventTimeout: FiniteDuration
-
-  def journalPluginId: String
-  def withJournalPluginId(id: String): EventsourcedSettings
-  def snapshotPluginId: String
-  def withSnapshotPluginId(id: String): EventsourcedSettings
-}
-
 /**
  * INTERNAL API
  */
 @InternalApi private[akka] object EventsourcedSettings {
 
-  def apply(system: ActorSystem[_]): EventsourcedSettings =
-    apply(system.settings.config)
+  def apply(system: ActorSystem[_], journalPluginId: String, snapshotPluginId: String): EventsourcedSettings =
+    apply(system.settings.config, journalPluginId, snapshotPluginId)
 
-  def apply(config: Config): EventsourcedSettings = {
+  def apply(config: Config, journalPluginId: String, snapshotPluginId: String): EventsourcedSettings = {
     val typedConfig = config.getConfig("akka.persistence.typed")
 
     // StashOverflowStrategy
@@ -48,13 +32,17 @@ private[akka] trait EventsourcedSettings {
 
     val logOnStashing = typedConfig.getBoolean("log-stashing")
 
-    EventsourcedSettingsImpl(
-      config,
+    val journalConfig = journalConfigFor(config, journalPluginId)
+    val recoveryEventTimeout: FiniteDuration =
+      journalConfig.getDuration("recovery-event-timeout", TimeUnit.MILLISECONDS).millis
+
+    EventsourcedSettings(
       stashCapacity = stashCapacity,
       stashOverflowStrategyConfigurator,
       logOnStashing = logOnStashing,
-      journalPluginId = "",
-      snapshotPluginId = ""
+      recoveryEventTimeout,
+      journalPluginId,
+      snapshotPluginId
     )
   }
 
@@ -71,26 +59,16 @@ private[akka] trait EventsourcedSettings {
 }
 
 @InternalApi
-private[persistence] final case class EventsourcedSettingsImpl(
-  private val config:                Config,
+private[akka] final case class EventsourcedSettings(
   stashCapacity:                     Int,
   stashOverflowStrategyConfigurator: String,
   logOnStashing:                     Boolean,
+  recoveryEventTimeout:              FiniteDuration,
   journalPluginId:                   String,
-  snapshotPluginId:                  String
-) extends EventsourcedSettings {
+  snapshotPluginId:                  String) {
 
-  def withJournalPluginId(id: String): EventsourcedSettings = {
-    require(id != null, "journal plugin id must not be null; use empty string for 'default' journal")
-    copy(journalPluginId = id)
-  }
-  def withSnapshotPluginId(id: String): EventsourcedSettings = {
-    require(id != null, "snapshot plugin id must not be null; use empty string for 'default' snapshot store")
-    copy(snapshotPluginId = id)
-  }
-
-  private val journalConfig = EventsourcedSettings.journalConfigFor(config, journalPluginId)
-  val recoveryEventTimeout = journalConfig.getDuration("recovery-event-timeout", TimeUnit.MILLISECONDS).millis
+  require(journalPluginId != null, "journal plugin id must not be null; use empty string for 'default' journal")
+  require(snapshotPluginId != null, "snapshot plugin id must not be null; use empty string for 'default' snapshot store")
 
 }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedStashReferenceManagement.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedStashReferenceManagement.scala
@@ -4,18 +4,17 @@
 
 package akka.persistence.typed.internal
 
-import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
-import akka.actor.typed.{ PostStop, Signal }
+import akka.actor.typed.scaladsl.StashBuffer
 import akka.annotation.InternalApi
 import akka.persistence.typed.internal.EventsourcedBehavior.InternalProtocol
 import akka.util.OptionVal
 
 /**
+ * INTERNAL API
  * Main reason for introduction of this trait is stash buffer reference management
  * in order to survive restart of internal behavior
  */
-@InternalApi
-trait EventsourcedStashReferenceManagement {
+@InternalApi private[akka] trait EventsourcedStashReferenceManagement {
 
   private var stashBuffer: OptionVal[StashBuffer[InternalProtocol]] = OptionVal.None
 
@@ -28,12 +27,5 @@ trait EventsourcedStashReferenceManagement {
     stashBuffer.get
   }
 
-  def onSignalCleanup: (ActorContext[InternalProtocol], Signal) ⇒ Unit = {
-    case (ctx, PostStop) ⇒
-      stashBuffer match {
-        case OptionVal.Some(buffer) ⇒ buffer.unstashAll(ctx, Behaviors.ignore)
-        case _                      ⇒ Unit
-      }
-    case _ ⇒ Unit
-  }
+  def clearStashBuffer(): Unit = stashBuffer = OptionVal.None
 }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/EventsourcedStashReferenceManagementTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/EventsourcedStashReferenceManagementTest.scala
@@ -9,8 +9,9 @@ import akka.actor.typed.{ Behavior, Signal, TypedAkkaSpecWithShutdown }
 import akka.persistence.typed.internal.EventsourcedBehavior.InternalProtocol
 import akka.persistence.typed.internal.EventsourcedBehavior.InternalProtocol.{ IncomingCommand, RecoveryPermitGranted }
 import akka.actor.testkit.typed.scaladsl.{ ActorTestKit, TestProbe }
-
 import scala.concurrent.duration.{ FiniteDuration, _ }
+
+import com.typesafe.config.ConfigFactory
 
 class EventsourcedStashReferenceManagementTest extends ActorTestKit with TypedAkkaSpecWithShutdown {
 
@@ -55,28 +56,20 @@ class EventsourcedStashReferenceManagementTest extends ActorTestKit with TypedAk
           case _: IncomingCommand[_] ⇒ Behaviors.stopped
         }.receiveSignal {
           case (_, signal: Signal) ⇒
-            onSignalCleanup.apply(ctx, signal); Behaviors.stopped[InternalProtocol]
+            clearStashBuffer()
+            Behaviors.stopped[InternalProtocol]
         }
       )
     }
   }
 
-  private def dummySettings(capacity: Int = 42) = new EventsourcedSettings {
+  private def dummySettings(capacity: Int = 42) =
+    EventsourcedSettings(
+      stashCapacity = capacity,
+      stashOverflowStrategyConfigurator = "akka.persistence.ThrowExceptionConfigurator",
+      logOnStashing = false,
+      recoveryEventTimeout = 3.seconds,
+      journalPluginId = "",
+      snapshotPluginId = "")
 
-    override def stashCapacity: Int = capacity
-
-    override def logOnStashing: Boolean = ???
-
-    override def stashOverflowStrategyConfigurator: String = ???
-
-    override def recoveryEventTimeout: FiniteDuration = ???
-
-    override def journalPluginId: String = ???
-
-    override def withJournalPluginId(id: String): EventsourcedSettings = ???
-
-    override def snapshotPluginId: String = ???
-
-    override def withSnapshotPluginId(id: String): EventsourcedSettings = ???
-  }
 }


### PR DESCRIPTION
* The TimerMsg was wrapped in IncomingCommand and therefore stashed,
  and when unstashed causing the ClassCastException
* Solved by not using timers here but plain scheduler
* Also fixing journalPluginId and snapshotPluginId

Refs #25268

Created https://github.com/akka/akka/issues/25318 for the limitation that TimerScheduler can't be used together with widen