### PR TITLE
WIP: Optimized first recovery, #25072

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/PersistentActor.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/PersistentActor.scala
@@ -105,9 +105,22 @@ object Recovery {
    * previous event with that sequence number.
    *
    * @see [[Recovery]]
+   * @see [[Recovery#first]]
    */
   val none: Recovery = Recovery(toSequenceNr = 0L, fromSnapshot = SnapshotSelectionCriteria.None)
 
+  /**
+   * Optimized recovery in [[PersistentActor]] when it is known that it is started the very
+   * first time. It will completely skip the recovery process and the first persisted event
+   * will have sequence number 1.
+   *
+   * This must not be used if there might already be persisted events for this `persistenceId`,
+   * since sequence numbers must be unique and not be reused after deletion.
+   *
+   * @see [[Recovery]]
+   * @see [[Recovery#none]]
+   */
+  val first: Recovery = Recovery(toSequenceNr = -1, fromSnapshot = SnapshotSelectionCriteria.None)
 }
 
 final class RecoveryTimedOut(message: String) extends RuntimeException(message) with NoStackTrace

--- a/akka-persistence/src/test/scala/akka/persistence/OptimizedRecoverySpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/OptimizedRecoverySpec.scala
@@ -97,5 +97,20 @@ class OptimizedRecoverySpec extends PersistenceSpec(PersistenceSpec.config(
       expectMsg("d")
     }
 
+    "get RecoveryCompleted but no SnapshotOffer and events when Recovery.first" in {
+      val persistenceId = "p2"
+      setup(persistenceId)
+
+      val ref = system.actorOf(TestPersistentActor.props(persistenceId, Recovery.first, testActor))
+      expectMsg(RecoveryCompleted)
+      expectMsg(PersistFromRecoveryCompleted)
+
+      // and highest sequence number not retrieved, so starting from 1, PersistFromRecoveryCompleted is 1
+      ref ! Save("d")
+      expectMsg(Saved("d", 2))
+      ref ! GetState
+      expectMsg("d")
+    }
+
   }
 }


### PR DESCRIPTION
* Introduce a new Recovery.first that can be used if it's known that it's
  the very first time the persistent actor is started.

Refs #25072

Marked as WIP because we still don't know if this will be needed or if the other more safe optimizations in https://github.com/akka/akka/pull/25132 are enough.