### PR TITLE
fix a race condition in ClusterReadView #24710

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala
@@ -88,7 +88,9 @@ private[akka] class ClusterReadView(cluster: Cluster) extends Closeable {
               _cachedSelf = e.member
             case _ ⇒
           }
-        case s: CurrentClusterState ⇒ _state = s
+        case s: CurrentClusterState ⇒
+          _state = s
+          _cachedSelf = s.members.find(_.uniqueAddress == cluster.selfUniqueAddress).getOrElse(_cachedSelf)
       }
     }).withDispatcher(cluster.settings.UseDispatcher).withDeploy(Deploy.local), name = "clusterEventBusListener")
   }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MinMembersBeforeUpSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MinMembersBeforeUpSpec.scala
@@ -5,16 +5,10 @@
 package akka.cluster
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.BeforeAndAfter
-import scala.collection.immutable.SortedSet
-import scala.concurrent.duration._
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
 import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
-import java.util.concurrent.atomic.AtomicReference
-import akka.actor.Props
-import akka.actor.Actor
 import akka.cluster.MemberStatus._
 
 object MinMembersBeforeUpMultiJvmSpec extends MultiNodeConfig {
@@ -108,8 +102,6 @@ abstract class MinMembersOfRoleBeforeUpSpec extends MinMembersBeforeUpBase(MinMe
 abstract class MinMembersBeforeUpBase(multiNodeConfig: MultiNodeConfig)
   extends MultiNodeSpec(multiNodeConfig)
   with MultiNodeClusterSpec {
-
-  import ClusterEvent._
 
   def first: RoleName
   def second: RoleName

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MinMembersBeforeUpSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MinMembersBeforeUpSpec.scala
@@ -114,7 +114,6 @@ abstract class MinMembersBeforeUpBase(multiNodeConfig: MultiNodeConfig)
     runOn(first) {
       cluster join myself
       awaitAssert {
-        clusterView.refreshCurrentState()
         clusterView.status should ===(Joining)
       }
     }
@@ -128,7 +127,6 @@ abstract class MinMembersBeforeUpBase(multiNodeConfig: MultiNodeConfig)
     runOn(first, second) {
       val expectedAddresses = Set(first, second) map address
       awaitAssert {
-        clusterView.refreshCurrentState()
         clusterView.members.map(_.address) should ===(expectedAddresses)
       }
       clusterView.members.map(_.status) should ===(Set(Joining))

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
@@ -243,7 +243,6 @@ trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec with WatchedByCoro
 
     cluster.join(joinNode)
     awaitCond({
-      clusterView.refreshCurrentState()
       if (memberInState(joinNode, List(MemberStatus.up)) &&
         memberInState(myself, List(MemberStatus.Joining, MemberStatus.Up)))
         true

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/TransitionSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/TransitionSpec.scala
@@ -63,7 +63,6 @@ abstract class TransitionSpec
   }
 
   def awaitMembers(addresses: Address*): Unit = awaitAssert {
-    clusterView.refreshCurrentState()
     memberAddresses should ===(addresses.toSet)
   }
 


### PR DESCRIPTION
 * remove lazy initialization for `_cachedSelf`

The race condition can be reproduced by replacing `akka.cluster.ClusterReadView#self` https://github.com/akka/akka/blob/836347fe08d6b880e73d56c3201e453ebc009285/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala#L100  with
```
  def self: Member = {
    _cachedSelf match {
      case OptionVal.None ⇒
        // lazy initialization here, later updated from elsewhere
        val tmp = OptionVal.Some(selfFromStateOrPlaceholder)
        Thread.sleep(500)
        _cachedSelf = tmp
        _cachedSelf.get
      case OptionVal.Some(member) ⇒ member
    }
  }
```
and running a test:
```
sbt "akka-cluster/multi-jvm:testOnly akka.cluster.MinMembersBeforeUp"
```
Here, mutating `_cachedSelf` in the lazy initialization overwrites changes done in response to these cluster domain events: 
```
MemberJoined(Member(address = akka.tcp://MinMembersBeforeUpBase@localhost:54134, status = Joining))
LeaderChanged(Some(akka.tcp://MinMembersBeforeUpBase@localhost:54134))
```

ref #24710