### PR TITLE
Allow named pipes / FIFOs when using `FileIO` (fixes #25328).

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/io/IOSources.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/IOSources.scala
@@ -73,7 +73,7 @@ private[akka] final class FileSource(path: Path, chunkSize: Int, startPosition: 
           // this is a bit weird but required to keep existing semantics
           if (!Files.exists(path)) throw new NoSuchFileException(path.toString)
 
-          require(Files.isRegularFile(path), s"Path '$path' is not a regular file")
+          require(!Files.isDirectory(path), s"Path '$path' is a directory")
           require(Files.isReadable(path), s"Missing read permission for '$path'")
 
           channel = FileChannel.open(path, StandardOpenOption.READ)


### PR DESCRIPTION
`FileIO` was using NIO's `isRegularFile` to check whether the path
passed was a file and not a directory (added in #21801) - however this
has the side-effect of also excluding things that are not considered
regular files in POSIX terminology, like named pipes / FIFOs.

The requirement has been swapped to only check if something is not a
directory, allowing anything else - this could mean a user can try to
open other non-regular files like devices, but that check is probably
not necessary.

Tests have been added to ensure that named pipes / FIFOs can be read,
but the POSIX standard `mkfifo` is the only way to create one (the JVM
does not supply a cross-platform method for doing that) - this should
still work on Windows thanks to the Linux Subsystem support for this
command.