### PR TITLE
Harden ReplicatorDeltaSpec, #25342

### DIFF
--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
@@ -847,6 +847,7 @@ object Replicator {
           override def zero: DeltaReplicatedData = this
           override def delta: Option[ReplicatedDelta] = None
           override def resetDelta: ReplicatedData = this
+          override def toString: String = "NoDeltaPlaceholder"
         }
     }
     case object DeltaNack extends ReplicatorMessage with DeadLetterSuppression

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorDeltaSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorDeltaSpec.scala
@@ -331,6 +331,13 @@ class ReplicatorDeltaSpec extends MultiNodeSpec(ReplicatorDeltaSpec) with STMult
         // Thereafter delta can be propagated and applied again.
         deltaReplicator.tell(Update(KeyHigh, Highest(0), writeAll)(_.incr(100)), p1.ref)
         p1.expectMsgType[UpdateSuccess[_]]
+        // Flush the deltaPropagation buffer, otherwise it will contain
+        // NoDeltaPlaceholder from previous updates and the incr(4) delta will also
+        // be folded into NoDeltaPlaceholder and not propagated as delta. A few DeltaPropagationTick
+        // are needed to send to all and flush buffer.
+        roles.foreach { _ ⇒
+          deltaReplicator ! Replicator.Internal.DeltaPropagationTick
+        }
         deltaReplicator.tell(Update(KeyHigh, Highest(0), WriteLocal)(_.incr(4)), p1.ref)
         p1.expectMsgType[UpdateSuccess[_]]
       }


### PR DESCRIPTION
* It was a timing race condition in the test that was exposed
  by the change in PR #25315. Full state is now sent immediately
  when receiving the DeltaNack and that makes the Update complete
  much faster for that case than before.
* That resulted in that the delta propagations from previous
  updates were still in the buffer to be sent out when the
  incr(4) was performed. Those deltas contained the NoDeltaPlaceholder,
  which caused the inrc(4) delta to also be folded into NoDeltaPlaceholder
  and thereby not propagated.
* Before the DeltaNack the buffer had time to be flushed before the incr(4)
  and therefore no NoDeltaPlaceholder.

Refs #25342