### PR TITLE
Set Terminated.failure when guardian actor terminates with a failure Refs #25345

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
@@ -66,6 +66,20 @@ class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll
       }
     }
 
+    "shutdown with exception if guardian throws" in {
+      object MyException extends Exception("test throw")
+
+      val throwing =
+        Behaviors.receive[Done] {
+          case (ctx, Done) ⇒ throw MyException
+        }
+      withSystem("exception", throwing, doTerminate = false) { sys: ActorSystem[Done] ⇒
+        sys ! Done
+        val terminated = sys.whenTerminated.futureValue
+        terminated.failure shouldBe Some(MyException)
+      }
+    }
+
     "terminate the guardian actor" in {
       val inbox = TestInbox[String]("terminate")
       val sys = system(

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/adapter/WhenTerminatedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/adapter/WhenTerminatedSpec.scala
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.internal.adapter
+
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+import akka.Done
+import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, Terminated }
+import akka.actor.typed.scaladsl.Behaviors
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec, Inside }
+import org.scalatest.concurrent.{ Eventually, ScalaFutures }
+
+class WhenTerminatedSpec extends WordSpec with Matchers with BeforeAndAfterAll
+  with Inside with ScalaFutures with Eventually {
+
+  override implicit val patienceConfig = PatienceConfig(1.second)
+
+  def system[T](behavior: Behavior[T], name: String) = ActorSystem(behavior, name)
+
+  def suite = "adapter"
+
+  case class Probe(msg: String, replyTo: ActorRef[String])
+
+  def withSystem[T](name: String, behavior: Behavior[T], doTerminate: Boolean = true)(block: ActorSystem[T] ⇒ Unit): Terminated = {
+    val sys = system(behavior, s"$suite-$name")
+    try {
+      block(sys)
+      if (doTerminate) sys.terminate().futureValue else sys.whenTerminated.futureValue
+    } catch {
+      case NonFatal(ex) ⇒
+        sys.terminate()
+        throw ex
+    }
+  }
+
+  class MyException(val counter: Int) extends Exception(counter.toString)
+
+  sealed trait Request
+
+  case object Next extends Request
+
+  case object Stop extends Request
+
+  case object Throw extends Request
+
+  def actor(counter: Int): Behavior[Request] =
+    Behaviors.receiveMessage[Request] {
+      case Next  ⇒ actor(counter + 1)
+      case Stop  ⇒ Behaviors.stopped
+      case Throw ⇒ throw new MyException(counter)
+    }
+
+  "A WhenTerminated" must {
+    "complete future with exception if guardian throws" in {
+
+      val promise = Promise[Terminated]()
+      val wrapped = WhenTerminated(actor(0), promise)
+      withSystem("exception", wrapped, doTerminate = false) { sys: ActorSystem[Request] ⇒
+        sys ! Throw
+
+        val terminated1 = sys.whenTerminated.futureValue
+        val terminated2 = promise.future.futureValue
+
+        inside(terminated2.failure) {
+          case Some(t: MyException) ⇒ t.counter shouldBe 0
+        }
+      }
+    }
+
+    "complete future without exception if guardian stops" in {
+
+      val promise = Promise[Terminated]()
+      val wrapped = WhenTerminated(actor(0), promise)
+      withSystem("exception", wrapped, doTerminate = false) { sys: ActorSystem[Request] ⇒
+        sys ! Stop
+
+        val terminated1 = sys.whenTerminated.futureValue
+        val terminated2 = promise.future.futureValue
+        terminated2.failure shouldBe None
+      }
+    }
+
+    "complete future with exception if guardian throws (after changing behavior" in {
+
+      val promise = Promise[Terminated]()
+      val wrapped = WhenTerminated(actor(0), promise)
+      withSystem("exception", wrapped, doTerminate = false) { sys: ActorSystem[Request] ⇒
+        sys ! Next
+        sys ! Throw
+
+        val terminated1 = sys.whenTerminated.futureValue
+        val terminated2 = promise.future.futureValue
+        inside(terminated2.failure) {
+          case Some(t: MyException) ⇒ t.counter shouldBe 1
+        }
+      }
+    }
+
+    "complete future without exception if guardian stops (after changing behavior)" in {
+
+      val promise = Promise[Terminated]()
+      val wrapped = WhenTerminated(actor(0), promise)
+      withSystem("exception", wrapped, doTerminate = false) { sys: ActorSystem[Request] ⇒
+        sys ! Next
+        sys ! Stop
+
+        val terminated1 = sys.whenTerminated.futureValue
+        val terminated2 = promise.future.futureValue
+        terminated2.failure shouldBe None
+      }
+    }
+
+    "complete future without exception if guardian stops (deferred)" in {
+
+      val promise = Promise[Terminated]()
+      val wrapped = WhenTerminated(Behaviors.setup[Request](_ ⇒ actor(0)), promise)
+      withSystem("exception", wrapped, doTerminate = false) { sys: ActorSystem[Request] ⇒
+        sys ! Stop
+
+        val terminated1 = sys.whenTerminated.futureValue
+        val terminated2 = promise.future.futureValue
+        terminated2.failure shouldBe None
+      }
+    }
+
+    "complete future when behavior is empty" in {
+      val promise = Promise[Terminated]()
+      val wrapped = WhenTerminated(Behaviors.empty[Request], promise)
+      withSystem("exception", wrapped, doTerminate = false) { sys: ActorSystem[Request] ⇒
+
+        sys.terminate()
+
+        val terminated1 = sys.whenTerminated.futureValue
+        val terminated2 = promise.future.futureValue
+        terminated2.failure shouldBe None
+      }
+    }
+  }
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/WhenTerminated.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/WhenTerminated.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed
+package internal
+package adapter
+
+import scala.concurrent.{ Future, Promise }
+import scala.util.Success
+import scala.util.control.NonFatal
+
+import akka.actor.setup.Setup
+import akka.actor.typed.scaladsl.Behaviors
+import akka.annotation.InternalApi
+
+/**
+ * Wrap a behavior and complete a promise when that behavior stops or terminates.
+ * This is used to wrap the guardian actor and implement the `ActorSystem.whenTerminated`.
+ */
+@InternalApi private[akka] object WhenTerminated {
+  def apply[T](currentBehavior: Behavior[T], completionPromise: Promise[Terminated]): Behavior[T] = {
+    Behaviors.setup[T] { ctx ⇒
+      withCompletion(completionPromise, ctx) {
+        val started = Behavior.validateAsInitial(Behavior.start(currentBehavior, ctx))
+        if (Behavior.isAlive(started)) new WrappedBehavior(started, completionPromise)
+        else started
+      }
+    }
+  }
+
+  private def withCompletion[T](completionPromise: Promise[Terminated], ctx: ActorContext[T])(calculateBehavior: ⇒ Behavior[T]): Behavior[T] = {
+    try {
+      val behavior = calculateBehavior
+      if (!Behavior.isAlive(behavior) && !completionPromise.isCompleted) {
+        completionPromise.complete(Success(Terminated(ctx.asScala.self)(null)))
+      }
+      behavior
+    } catch {
+      case NonFatal(t) if !completionPromise.isCompleted ⇒
+        completionPromise.complete(Success(Terminated(ctx.asScala.self)(t)))
+        throw t
+    }
+  }
+
+  /**
+   * Wrap a behavior and complete a promise when that behavior stops or terminates.
+   *
+   * @param currentBehavior
+   * @param completionPromise
+   * @tparam T
+   */
+  final private class WrappedBehavior[T](currentBehavior: Behavior[T], completionPromise: Promise[Terminated]) extends ExtensibleBehavior[T] {
+    override def receive(ctx: ActorContext[T], msg: T): Behavior[T] = {
+      withCompletion(completionPromise, ctx) {
+        wrap(Behavior.interpretMessage(currentBehavior, ctx, msg), ctx)
+      }
+    }
+
+    override def receiveSignal(ctx: ActorContext[T], msg: Signal): Behavior[T] = {
+      // This is probably not required (advise??)
+      if (msg == PostStop && !completionPromise.isCompleted) {
+        completionPromise.complete(Success(Terminated(ctx.asScala.self)(null)))
+      }
+
+      withCompletion(completionPromise, ctx) {
+        wrap(Behavior.interpretSignal(currentBehavior, ctx, msg), ctx)
+      }
+    }
+
+    private def wrap(next: Behavior[T], ctx: ActorContext[T]): Behavior[T] = {
+      Behavior.wrap(this, next, ctx) {
+        WhenTerminated(_, completionPromise)
+      }
+    }
+  }
+}
+
+@InternalApi private[akka] final case class WhenTerminatedSetup(whenGuardianTerminated: Future[Terminated]) extends Setup


### PR DESCRIPTION
Set Terminated.failure when guardian actor terminates with a failure Refs #25345

Wrap the guardian actor in a behavior that completes a promise when that
actor terminates. This behavior wrapper records exceptions that
terminate the actor too.

The future generated from this promise is passed into the ActorSystem
using a specialised Setup. This is required as there is no easy way to
pass values from the method which creates the actor and the untyped
ActorSystem to ActorSystemAdaptor where whenTerminated is
implemented.