### PR TITLE
Separate out Effects and ChainedEffects in typed persistence

### DIFF
--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -54,8 +54,7 @@ The command handler is a function with @java[2 parameters for]@scala[3 parameter
 current `State` and `Command`.
 
 A command handler returns an `Effect` directive that defines what event or events, if any, to persist. 
-@java[Effects are created using a factory that is returned via the `Effect()` method]
-@scala[Effects are created using the `Effect` factory]
+Effects are created using @java[a factory that is returned via the `Effect()` method] @scala[the `Effect` factory]
 and can be one of: 
 
 * `persist` will persist one single event or several events atomically, i.e. all events
@@ -65,12 +64,12 @@ and can be one of:
 * `stop` stop this actor
 
 In addition to returning the primary `Effect` for the command `PersistentBehavior`s can also 
-chain side effects (`ChainedEffect`s) are to be performed after successful persist which is achieved with the `andThen`  and `andChain`
-function e.g @scala[`Effect.persist(..).andThen`]@java[`Effect().persist(..).andThen`]. The `andThen` function
-is a convenience around creating a `ChainedEffect`.
+chain side effects (`SideEffect`s) are to be performed after successful persist which is achieved with the `andThen`  and `thenRun`
+function e.g @scala[`Effect.persist(..).andThen`]@java[`Effect().persist(..).andThen`]. The `thenRun` function
+is a convenience around creating a `SideEffect`.
 
 In the example below a reply is sent to the `replyTo` ActorRef. Note that the new state after applying 
-the event is passed as parameter to the `andThen` function. All `andThen*` registered callbacks
+the event is passed as parameter to the `thenRun` function. All `thenRun` registered callbacks
 are executed sequentially after successful execution of the persist statement (or immediately, in case of `none` and `unhandled`).
 
 ### Event handler
@@ -212,7 +211,7 @@ Java
 :  @@snip [InDepthPersistentBehaviorTest.java]($akka$/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/InDepthPersistentBehaviorTest.java) { #behavior }
 
 
-## Effects and Chained Effects
+## Effects and Side Effects
 
 Each command has a single `Effect` which can be:
 
@@ -221,12 +220,12 @@ Each command has a single `Effect` which can be:
 * Unhandled: Don't handle this message 
 
 Note that there is only one of these. It is not possible to both persist and say none/unhandled.
-@java[These are created using a factory that is returned via the `Effect()` method]
-@scala[These are created using the `Effect` factory] and once created
-additional `ChainedEffects` can be added.
+These are created using @java[a factory that is returned via the `Effect()` method]
+@scala[the `Effect` factory] and once created
+additional `SideEffects` can be added.
 
-Most of them time this will be done with the `andThen` method on the `Effect` above. It is also possible
-factor out common `ChainedEffect`s. For example:
+Most of them time this will be done with the `thenRun` method on the `Effect` above. It is also possible
+factor out common `SideEffect`s. For example:
 
 Scala
 :  @@snip [BasicPersistentBehaviorsCompileOnly.scala]($akka$/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala) { #commonChainedEffects }
@@ -234,10 +233,10 @@ Scala
 Java
 :  @@snip [BasicPersistentBehaviorsCompileOnly.scala]($akka$/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java) { #commonChainedEffects }
 
-### Chained effects ordering and guarantees
+### Side effects ordering and guarantees
 
-Any `ChainedEffect`s are executed on an at once basis and won't be executed if the persist fails.
-The `ChainedEffect`s are executed sequentially, it is not possible to execute `ChainedEffect`s in parallel.
+Any `SideEffect`s are executed on an at-once basis and will not be executed if the persist fails.
+The `SideEffect`s are executed sequentially, it is not possible to execute `SideEffect`s in parallel.
 
 ## Serialization
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/SideEffect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/SideEffect.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed
+
+import akka.japi.function
+import akka.annotation.{ DoNotInherit, InternalApi }
+
+/**
+ * A [[SideEffect]] is an side effect that can be chained after a main effect.
+ *
+ * Persist, none and unhandled are main effects. Then any number of
+ * call backs can be added to these effects with `andThen`.
+ *
+ * Not for user extension
+ */
+sealed abstract class SideEffect[State]
+
+/** INTERNAL API */
+@InternalApi
+final private[akka] case class Callback[State](effect: State ⇒ Unit) extends SideEffect[State]
+
+/** INTERNAL API */
+@InternalApi
+private[akka] case object Stop extends SideEffect[Nothing]
+
+object SideEffect {
+  /**
+   * Create a ChainedEffect that can be run after Effects
+   */
+  def apply[State](callback: State ⇒ Unit): SideEffect[State] =
+    Callback(callback)
+
+  /**
+   * Java API
+   *
+   * Create a ChainedEffect that can be run after Effects
+   */
+  def create[State](callback: function.Procedure[State]): SideEffect[State] =
+    Callback(s ⇒ callback.apply(s))
+
+  def stop[State](): SideEffect[State] = Stop.asInstanceOf[SideEffect[State]]
+}
+

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedRunning.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedRunning.scala
@@ -12,10 +12,10 @@ import akka.annotation.InternalApi
 import akka.persistence.JournalProtocol._
 import akka.persistence._
 import akka.persistence.journal.Tagged
-import akka.persistence.typed.EventRejectedException
+import akka.persistence.typed.{ Callback, EventRejectedException, SideEffect, Stop }
 import akka.persistence.typed.internal.EventsourcedBehavior.{ InternalProtocol, MDC }
 import akka.persistence.typed.internal.EventsourcedBehavior.InternalProtocol._
-import akka.persistence.typed.scaladsl.{ ChainedEffect, Effect }
+import akka.persistence.typed.scaladsl.Effect
 
 import scala.annotation.tailrec
 import scala.collection.immutable
@@ -86,7 +86,7 @@ private[akka] object EventsourcedRunning {
       msg:         Any,
       state:       EventsourcedState[S],
       effect:      Effect[E, S],
-      sideEffects: immutable.Seq[ChainedEffect[S]] = Nil
+      sideEffects: immutable.Seq[SideEffect[S]] = Nil
     ): Behavior[InternalProtocol] = {
       if (setup.log.isDebugEnabled)
         setup.log.debug(
@@ -170,7 +170,7 @@ private[akka] object EventsourcedRunning {
     state:                      EventsourcedState[S],
     numberOfEvents:             Int,
     shouldSnapshotAfterPersist: Boolean,
-    sideEffects:                immutable.Seq[ChainedEffect[S]]
+    sideEffects:                immutable.Seq[SideEffect[S]]
   ): Behavior[InternalProtocol] = {
     setup.setMdc(persistingEventsMdc)
     new PersistingEvents(state, numberOfEvents, shouldSnapshotAfterPersist, sideEffects)
@@ -180,7 +180,7 @@ private[akka] object EventsourcedRunning {
     var state:                  EventsourcedState[S],
     numberOfEvents:             Int,
     shouldSnapshotAfterPersist: Boolean,
-    var sideEffects:            immutable.Seq[ChainedEffect[S]])
+    var sideEffects:            immutable.Seq[SideEffect[S]])
     extends MutableBehavior[EventsourcedBehavior.InternalProtocol] {
 
     private var eventCounter = 0
@@ -275,7 +275,7 @@ private[akka] object EventsourcedRunning {
 
   // --------------------------
 
-  def applySideEffects(effects: immutable.Seq[ChainedEffect[S]], state: EventsourcedState[S]): Behavior[InternalProtocol] = {
+  def applySideEffects(effects: immutable.Seq[SideEffect[S]], state: EventsourcedState[S]): Behavior[InternalProtocol] = {
     var res: Behavior[InternalProtocol] = handlingCommands(state)
     val it = effects.iterator
 
@@ -290,16 +290,16 @@ private[akka] object EventsourcedRunning {
     res
   }
 
-  def applySideEffect(effect: ChainedEffect[S], state: EventsourcedState[S]): Behavior[InternalProtocol] = effect match {
+  def applySideEffect(effect: SideEffect[S], state: EventsourcedState[S]): Behavior[InternalProtocol] = effect match {
     case _: Stop.type @unchecked ⇒
       Behaviors.stopped
 
-    case SideEffect(sideEffects) ⇒
+    case Callback(sideEffects) ⇒
       sideEffects(state.state)
       Behaviors.same
 
     case _ ⇒
-      throw new IllegalArgumentException(s"Not supported effect detected [${effect.getClass.getName}]!")
+      throw new IllegalArgumentException(s"Not supported side effect detected [${effect.getClass.getName}]!")
   }
 
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedRunning.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedRunning.scala
@@ -15,6 +15,7 @@ import akka.persistence.journal.Tagged
 import akka.persistence.typed.EventRejectedException
 import akka.persistence.typed.internal.EventsourcedBehavior.{ InternalProtocol, MDC }
 import akka.persistence.typed.internal.EventsourcedBehavior.InternalProtocol._
+import akka.persistence.typed.scaladsl.{ ChainedEffect, Effect }
 
 import scala.annotation.tailrec
 import scala.collection.immutable
@@ -84,8 +85,8 @@ private[akka] object EventsourcedRunning {
     @tailrec def applyEffects(
       msg:         Any,
       state:       EventsourcedState[S],
-      effect:      EffectImpl[E, S],
-      sideEffects: immutable.Seq[ChainableEffect[_, S]] = Nil
+      effect:      Effect[E, S],
+      sideEffects: immutable.Seq[ChainedEffect[S]] = Nil
     ): Behavior[InternalProtocol] = {
       if (setup.log.isDebugEnabled)
         setup.log.debug(
@@ -135,15 +136,12 @@ private[akka] object EventsourcedRunning {
             tryUnstash(applySideEffects(sideEffects, state))
           }
 
-        case _: PersistNothing.type @unchecked ⇒
+        case _: PersistNothing.type ⇒
           tryUnstash(applySideEffects(sideEffects, state))
 
-        case _: Unhandled.type @unchecked ⇒
+        case _: Unhandled.type ⇒
           applySideEffects(sideEffects, state)
           Behavior.unhandled
-
-        case c: ChainableEffect[_, S] ⇒
-          applySideEffect(c, state)
       }
     }
 
@@ -172,7 +170,7 @@ private[akka] object EventsourcedRunning {
     state:                      EventsourcedState[S],
     numberOfEvents:             Int,
     shouldSnapshotAfterPersist: Boolean,
-    sideEffects:                immutable.Seq[ChainableEffect[_, S]]
+    sideEffects:                immutable.Seq[ChainedEffect[S]]
   ): Behavior[InternalProtocol] = {
     setup.setMdc(persistingEventsMdc)
     new PersistingEvents(state, numberOfEvents, shouldSnapshotAfterPersist, sideEffects)
@@ -182,7 +180,7 @@ private[akka] object EventsourcedRunning {
     var state:                  EventsourcedState[S],
     numberOfEvents:             Int,
     shouldSnapshotAfterPersist: Boolean,
-    var sideEffects:            immutable.Seq[ChainableEffect[_, S]])
+    var sideEffects:            immutable.Seq[ChainedEffect[S]])
     extends MutableBehavior[EventsourcedBehavior.InternalProtocol] {
 
     private var eventCounter = 0
@@ -277,7 +275,7 @@ private[akka] object EventsourcedRunning {
 
   // --------------------------
 
-  def applySideEffects(effects: immutable.Seq[ChainableEffect[_, S]], state: EventsourcedState[S]): Behavior[InternalProtocol] = {
+  def applySideEffects(effects: immutable.Seq[ChainedEffect[S]], state: EventsourcedState[S]): Behavior[InternalProtocol] = {
     var res: Behavior[InternalProtocol] = handlingCommands(state)
     val it = effects.iterator
 
@@ -292,7 +290,7 @@ private[akka] object EventsourcedRunning {
     res
   }
 
-  def applySideEffect(effect: ChainableEffect[_, S], state: EventsourcedState[S]): Behavior[InternalProtocol] = effect match {
+  def applySideEffect(effect: ChainedEffect[S], state: EventsourcedState[S]): Behavior[InternalProtocol] = effect match {
     case _: Stop.type @unchecked ⇒
       Behaviors.stopped
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Effect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Effect.scala
@@ -7,6 +7,7 @@ package akka.persistence.typed.javadsl
 import akka.annotation.DoNotInherit
 import akka.japi.function
 import akka.persistence.typed.internal._
+import akka.persistence.typed.scaladsl.ChainedEffect
 
 import scala.collection.JavaConverters._
 
@@ -33,7 +34,7 @@ object EffectFactory extends EffectFactories[Nothing, Nothing, Nothing]
   /**
    * Stop this persistent actor
    */
-  def stop: Effect[Event, State] = Stop.asInstanceOf[ChainableEffect[Event, State]]
+  def stop: Effect[Event, State] = none.thenStop()
 
   /**
    * This command is not handled, but it is not an error that it isn't.
@@ -54,9 +55,16 @@ object EffectFactory extends EffectFactories[Nothing, Nothing, Nothing]
   self: EffectImpl[Event, State] ⇒
   /** Convenience method to register a side effect with just a callback function */
   final def andThen(callback: function.Procedure[State]): Effect[Event, State] =
-    CompositeEffect(this, SideEffect[Event, State](s ⇒ callback.apply(s)))
+    CompositeEffect(this, SideEffect[State](s ⇒ callback.apply(s)))
 
   /** Convenience method to register a side effect that doesn't need access to state */
   final def andThen(callback: function.Effect): Effect[Event, State] =
-    CompositeEffect(this, SideEffect[Event, State]((_: State) ⇒ callback.apply()))
+    CompositeEffect(this, SideEffect[State]((_: State) ⇒ callback.apply()))
+
+  final def andThen(chainedEffect: ChainedEffect[State]): Effect[Event, State] =
+    CompositeEffect(this, chainedEffect)
+
+  final def thenStop(): Effect[Event, State] =
+    CompositeEffect(this, Stop.asInstanceOf[ChainedEffect[State]])
+
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Effect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Effect.scala
@@ -7,7 +7,7 @@ package akka.persistence.typed.javadsl
 import akka.annotation.DoNotInherit
 import akka.japi.function
 import akka.persistence.typed.internal._
-import akka.persistence.typed.scaladsl.ChainedEffect
+import akka.persistence.typed.{ SideEffect, Stop }
 
 import scala.collection.JavaConverters._
 
@@ -61,10 +61,9 @@ object EffectFactory extends EffectFactories[Nothing, Nothing, Nothing]
   final def andThen(callback: function.Effect): Effect[Event, State] =
     CompositeEffect(this, SideEffect[State]((_: State) ⇒ callback.apply()))
 
-  final def andThen(chainedEffect: ChainedEffect[State]): Effect[Event, State] =
-    CompositeEffect(this, chainedEffect)
+  def andThen(chainedEffect: SideEffect[State]): Effect[Event, State]
 
   final def thenStop(): Effect[Event, State] =
-    CompositeEffect(this, Stop.asInstanceOf[ChainedEffect[State]])
+    CompositeEffect(this, Stop.asInstanceOf[SideEffect[State]])
 
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/Effect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/Effect.scala
@@ -6,6 +6,7 @@ package akka.persistence.typed.scaladsl
 
 import akka.japi.function
 import akka.annotation.DoNotInherit
+import akka.persistence.typed.{ SideEffect, Stop }
 import akka.persistence.typed.internal._
 
 import scala.collection.{ immutable ⇒ im }
@@ -16,34 +17,45 @@ import scala.collection.{ immutable ⇒ im }
 object Effect {
 
   /**
-   * Persist a single event.
+   * Persist a single event
+   *
+   * Side effects can be chained with `andThen`
    */
   def persist[Event, State](event: Event): Effect[Event, State] = Persist(event)
 
   /**
    * Persist multiple events
+   *
+   * Side effects can be chained with `andThen`
    */
   def persist[Event, A <: Event, B <: Event, State](evt1: A, evt2: B, events: Event*): Effect[Event, State] =
     persist(evt1 :: evt2 :: events.toList)
 
   /**
    * Persist multiple events
+   *
+   * Side effects can be chained with `andThen`
    */
   def persist[Event, State](events: im.Seq[Event]): Effect[Event, State] =
     PersistAll(events)
 
   /**
    * Do not persist anything
+   *
+   * Side effects can be chained with `andThen`
    */
   def none[Event, State]: Effect[Event, State] = PersistNothing.asInstanceOf[Effect[Event, State]]
 
   /**
    * This command is not handled, but it is not an error that it isn't.
+   *
+   * Side effects can be chained with `andThen`
    */
   def unhandled[Event, State]: Effect[Event, State] = Unhandled.asInstanceOf[Effect[Event, State]]
 
   /**
    * Stop this persistent actor
+   * Side effects can be chained with `andThen`
    */
   def stop[Event, State]: Effect[Event, State] = none.andThenStop()
 }
@@ -61,55 +73,23 @@ trait Effect[+Event, State] {
   /**
    * Run the given callback. Callbacks are run sequentially.
    */
-  final def andThen(callback: State ⇒ Unit): Effect[Event, State] =
-    CompositeEffect(this, ChainedEffect(callback))
-
-  // not named andThen so can pass a pattern match to andThen
+  final def thenRun(callback: State ⇒ Unit): Effect[Event, State] =
+    CompositeEffect(this, SideEffect(callback))
 
   /**
    *  Run the given callback after the current Effect
    */
-  final def andChain(chainedEffect: ChainedEffect[State]): Effect[Event, State] =
-    CompositeEffect(this, chainedEffect)
+  def andThen(chainedEffect: SideEffect[State]): Effect[Event, State]
 
   /**
    *  Run the given callbacks sequentially after the current Effect
    */
-  final def andChain(chainedEffects: im.Seq[ChainedEffect[State]]): Effect[Event, State] =
+  final def andThen(chainedEffects: im.Seq[SideEffect[State]]): Effect[Event, State] =
     CompositeEffect(this, chainedEffects)
 
   /** The side effect is to stop the actor */
   def andThenStop(): Effect[Event, State] = {
-    CompositeEffect(this, Stop.asInstanceOf[ChainedEffect[State]])
+    CompositeEffect(this, Stop.asInstanceOf[SideEffect[State]])
   }
-}
-
-/**
- * A ChainedEffect is an side effect that can be chained after a main effect.
- *
- * Persist, none and unhandled are main effects. Then any number of
- * call backs can be added to these effects with `andThen`.
- *
- * Not for user extension
- */
-@DoNotInherit
-abstract class ChainedEffect[State]
-
-object ChainedEffect {
-  /**
-   * Create a ChainedEffect that can be run after Effects
-   */
-  def apply[State](callback: State ⇒ Unit): ChainedEffect[State] =
-    SideEffect(callback)
-
-  /**
-   * Java API
-   *
-   * Create a ChainedEffect that can be run after Effects
-   */
-  def create[State](callback: function.Procedure[State]): ChainedEffect[State] =
-    SideEffect(s ⇒ callback.apply(s))
-
-  def stop[State](): ChainedEffect[State] = Stop.asInstanceOf[ChainedEffect[State]]
 }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/Effect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/Effect.scala
@@ -4,6 +4,7 @@
 
 package akka.persistence.typed.scaladsl
 
+import akka.japi.function
 import akka.annotation.DoNotInherit
 import akka.persistence.typed.internal._
 
@@ -14,27 +15,22 @@ import scala.collection.{ immutable ⇒ im }
  */
 object Effect {
 
-  // TODO docs
+  /**
+   * Persist a single event.
+   */
   def persist[Event, State](event: Event): Effect[Event, State] = Persist(event)
 
-  // TODO docs
+  /**
+   * Persist multiple events
+   */
   def persist[Event, A <: Event, B <: Event, State](evt1: A, evt2: B, events: Event*): Effect[Event, State] =
     persist(evt1 :: evt2 :: events.toList)
 
-  // TODO docs
-  def persist[Event, State](eventOpt: Option[Event]): Effect[Event, State] =
-    eventOpt match {
-      case Some(evt) ⇒ persist[Event, State](evt)
-      case _         ⇒ none[Event, State]
-    }
-
-  // TODO docs
+  /**
+   * Persist multiple events
+   */
   def persist[Event, State](events: im.Seq[Event]): Effect[Event, State] =
     PersistAll(events)
-
-  // TODO docs
-  def persist[Event, State](events: im.Seq[Event], sideEffects: im.Seq[ChainableEffect[Event, State]]): Effect[Event, State] =
-    new CompositeEffect[Event, State](PersistAll[Event, State](events), sideEffects)
 
   /**
    * Do not persist anything
@@ -49,7 +45,7 @@ object Effect {
   /**
    * Stop this persistent actor
    */
-  def stop[Event, State]: ChainableEffect[Event, State] = Stop.asInstanceOf[ChainableEffect[Event, State]]
+  def stop[Event, State]: Effect[Event, State] = none.andThenStop()
 }
 
 /**
@@ -58,17 +54,62 @@ object Effect {
  * Not for user extension.
  */
 @DoNotInherit
-trait Effect[+Event, State] { self: EffectImpl[Event, State] ⇒
+trait Effect[+Event, State] {
   /* All events that will be persisted in this effect */
   def events: im.Seq[Event]
 
-  def sideEffects[E >: Event]: im.Seq[ChainableEffect[E, State]]
-
-  /** Convenience method to register a side effect with just a callback function */
+  /**
+   * Run the given callback. Callbacks are run sequentially.
+   */
   final def andThen(callback: State ⇒ Unit): Effect[Event, State] =
-    CompositeEffect(this, SideEffect[Event, State](callback))
+    CompositeEffect(this, ChainedEffect(callback))
+
+  // not named andThen so can pass a pattern match to andThen
+
+  /**
+   *  Run the given callback after the current Effect
+   */
+  final def andChain(chainedEffect: ChainedEffect[State]): Effect[Event, State] =
+    CompositeEffect(this, chainedEffect)
+
+  /**
+   *  Run the given callbacks sequentially after the current Effect
+   */
+  final def andChain(chainedEffects: im.Seq[ChainedEffect[State]]): Effect[Event, State] =
+    CompositeEffect(this, chainedEffects)
 
   /** The side effect is to stop the actor */
-  def andThenStop: Effect[Event, State] =
-    CompositeEffect(this, Effect.stop[Event, State])
+  def andThenStop(): Effect[Event, State] = {
+    CompositeEffect(this, Stop.asInstanceOf[ChainedEffect[State]])
+  }
 }
+
+/**
+ * A ChainedEffect is an side effect that can be chained after a main effect.
+ *
+ * Persist, none and unhandled are main effects. Then any number of
+ * call backs can be added to these effects with `andThen`.
+ *
+ * Not for user extension
+ */
+@DoNotInherit
+abstract class ChainedEffect[State]
+
+object ChainedEffect {
+  /**
+   * Create a ChainedEffect that can be run after Effects
+   */
+  def apply[State](callback: State ⇒ Unit): ChainedEffect[State] =
+    SideEffect(callback)
+
+  /**
+   * Java API
+   *
+   * Create a ChainedEffect that can be run after Effects
+   */
+  def create[State](callback: function.Procedure[State]): ChainedEffect[State] =
+    SideEffect(s ⇒ callback.apply(s))
+
+  def stop[State](): ChainedEffect[State] = Stop.asInstanceOf[ChainedEffect[State]]
+}
+

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java
@@ -9,7 +9,7 @@ import akka.actor.typed.javadsl.ActorContext;
 import akka.actor.typed.ActorRef;
 import akka.persistence.typed.EventAdapter;
 import akka.actor.testkit.typed.javadsl.TestInbox;
-import akka.persistence.typed.scaladsl.ChainedEffect;
+import akka.persistence.typed.SideEffect;
 import akka.util.Timeout;
 
 import java.util.*;
@@ -152,7 +152,7 @@ public class PersistentActorCompileOnlyTest {
 
     //#commonChainedEffects
     // Factored out Chained effect
-    static final ChainedEffect<ExampleState>  commonChainedEffect = ChainedEffect.create(s -> System.out.println("Command handled!"));
+    static final SideEffect<ExampleState>  commonChainedEffect = SideEffect.create(s -> System.out.println("Command handled!"));
 
     //#commonChainedEffects
 

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java
@@ -9,6 +9,7 @@ import akka.actor.typed.javadsl.ActorContext;
 import akka.actor.typed.ActorRef;
 import akka.persistence.typed.EventAdapter;
 import akka.actor.testkit.typed.javadsl.TestInbox;
+import akka.persistence.typed.scaladsl.ChainedEffect;
 import akka.util.Timeout;
 
 import java.util.*;
@@ -149,6 +150,12 @@ public class PersistentActorCompileOnlyTest {
       private List<String> events = new ArrayList<>();
     }
 
+    //#commonChainedEffects
+    // Factored out Chained effect
+    static final ChainedEffect<ExampleState>  commonChainedEffect = ChainedEffect.create(s -> System.out.println("Command handled!"));
+
+    //#commonChainedEffects
+
     private PersistentBehavior<MyCommand, MyEvent, ExampleState> pa = new PersistentBehavior<MyCommand, MyEvent, ExampleState>("pa") {
       @Override
       public ExampleState emptyState() {
@@ -157,10 +164,15 @@ public class PersistentActorCompileOnlyTest {
 
       @Override
       public CommandHandler<MyCommand, MyEvent, ExampleState> commandHandler() {
-        return commandHandlerBuilder(ExampleState.class)
-          .matchCommand(Cmd.class, (state, cmd) -> Effect().persist(new Evt(cmd.data))
-            .andThen(() -> cmd.sender.tell(new Ack())))
-          .build();
+
+     //#commonChainedEffects
+     return commandHandlerBuilder(ExampleState.class)
+       .matchCommand(Cmd.class, (state, cmd) -> Effect().persist(new Evt(cmd.data))
+         .andThen(() -> cmd.sender.tell(new Ack()))
+         .andThen(commonChainedEffect)
+       )
+       .build();
+     //#commonChainedEffects
       }
 
       @Override

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
@@ -31,7 +31,7 @@ object ManyRecoveriesSpec {
       persistenceId = name,
       emptyState = "",
       commandHandler = CommandHandler.command {
-        case Cmd(s) ⇒ Effect.persist(Evt(s)).andThen(_ ⇒ probe.ref ! s"$name-$s")
+        case Cmd(s) ⇒ Effect.persist(Evt(s)).thenRun(_ ⇒ probe.ref ! s"$name-$s")
       },
       eventHandler = {
         case (state, _) ⇒ latch.foreach(Await.ready(_, 10.seconds)); state

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
@@ -31,7 +31,7 @@ object OptionalSnapshotStoreSpec {
       persistenceId = name,
       emptyState = State(),
       commandHandler = CommandHandler.command {
-        _ ⇒ Effect.persist(Event()).andThen(probe.ref ! _)
+        _ ⇒ Effect.persist(Event()).thenRun(probe.ref ! _)
       },
       eventHandler = {
         case (_, _) ⇒ State()

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
@@ -64,8 +64,8 @@ object PerformanceSpec {
         persistenceId = name,
         "",
         commandHandler = CommandHandler.command {
-          case StopMeasure      ⇒ Effect.none.andThen(_ ⇒ probe.ref ! StopMeasure)
-          case FailAt(sequence) ⇒ Effect.none.andThen(_ ⇒ parameters.failAt = sequence)
+          case StopMeasure      ⇒ Effect.none.thenRun(_ ⇒ probe.ref ! StopMeasure)
+          case FailAt(sequence) ⇒ Effect.none.thenRun(_ ⇒ parameters.failAt = sequence)
           case command          ⇒ other(command, parameters)
         },
         eventHandler = {
@@ -80,7 +80,7 @@ object PerformanceSpec {
   def eventSourcedTestPersistenceBehavior(name: String, probe: TestProbe[Command]) =
     behavior(name, probe) {
       case (CommandWithEvent(evt), parameters) ⇒
-        Effect.persist(evt).andThen(_ ⇒ {
+        Effect.persist(evt).thenRun(_ ⇒ {
           parameters.persistCalls += 1
           if (parameters.every(1000)) print(".")
           if (parameters.shouldFail) throw TE("boom")

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorSpec.scala
@@ -126,14 +126,14 @@ object PersistentBehaviorSpec {
 
         case IncrementThenLogThenStop ⇒
           Effect.persist(Incremented(1))
-            .andThen { (_: State) ⇒
+            .thenRun { (_: State) ⇒
               loggingActor ! firstLogging
             }
             .andThenStop
 
         case IncrementTwiceThenLogThenStop ⇒
           Effect.persist(Incremented(1), Incremented(2))
-            .andThen { (_: State) ⇒
+            .thenRun { (_: State) ⇒
               loggingActor ! firstLogging
             }
             .andThenStop
@@ -170,30 +170,30 @@ object PersistentBehaviorSpec {
         case IncrementTwiceAndThenLog ⇒
           Effect
             .persist(Incremented(1), Incremented(1))
-            .andThen { (_: State) ⇒
+            .thenRun { (_: State) ⇒
               loggingActor ! firstLogging
             }
-            .andThen { _ ⇒
+            .thenRun { _ ⇒
               loggingActor ! secondLogging
             }
 
         case EmptyEventsListAndThenLog ⇒
           Effect
             .persist(List.empty) // send empty list of events
-            .andThen { _ ⇒
+            .thenRun { _ ⇒
               loggingActor ! firstLogging
             }
 
         case DoNothingAndThenLog ⇒
           Effect
             .none
-            .andThen { _ ⇒
+            .thenRun { _ ⇒
               loggingActor ! firstLogging
             }
 
         case LogThenStop ⇒
           Effect.none[Event, State]
-            .andThen { _ ⇒
+            .thenRun { _ ⇒
               loggingActor ! firstLogging
             }
             .andThenStop

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/AccountExample1.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/AccountExample1.scala
@@ -43,7 +43,7 @@ object AccountExample1 {
         else {
           Effect
             .persist(Withdrawn(amount))
-            .andThen {
+            .thenRun {
               case Some(OpenedAccount(balance)) ⇒
                 // do some side-effect using balance
                 println(balance)

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/AccountExample2.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/AccountExample2.scala
@@ -61,7 +61,7 @@ object AccountExample2 {
         else {
           Effect
             .persist(Withdrawn(amount))
-            .andThen {
+            .thenRun {
               case OpenedAccount(balance) ⇒
                 // do some side-effect using balance
                 println(balance)

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsCompileOnly.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorsCompileOnly.scala
@@ -4,6 +4,7 @@
 
 package docs.akka.persistence.typed
 
+import akka.actor.typed.ActorRef
 import akka.actor.typed.{ Behavior, SupervisorStrategy }
 import akka.actor.typed.scaladsl.Behaviors
 import akka.persistence.typed.scaladsl.PersistentBehaviors
@@ -29,6 +30,9 @@ object BasicPersistentBehaviorsCompileOnly {
           throw new RuntimeException("TODO: process the event return the next state")
     )
   //#structure
+
+  case class CommandWithSender(reply: ActorRef[String]) extends Command
+  case class VeryImportantEvent() extends Event
 
   //#recovery
   val recoveryBehavior: Behavior[Command] =
@@ -58,7 +62,6 @@ object BasicPersistentBehaviorsCompileOnly {
         (state, evt) ⇒
           throw new RuntimeException("TODO: process the event return the next state")
     ).withTagger(_ ⇒ Set("tag1", "tag2"))
-
   //#tagging
 
   //#wrapPersistentBehavior
@@ -94,4 +97,5 @@ object BasicPersistentBehaviorsCompileOnly {
       randomFactor = 0.1
     ))
   //#supervision
+
 }

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/InDepthPersistentBehaviorSpec.scala
@@ -58,7 +58,7 @@ object InDepthPersistentBehaviorSpec {
       cmd match {
         case AddPost(content, replyTo) ⇒
           val evt = PostAdded(content.postId, content)
-          Effect.persist(evt).andThen { state2 ⇒
+          Effect.persist(evt).thenRun { state2 ⇒
             // After persist is done additional side effects can be performed
             replyTo ! AddPostDone(content.postId)
           }
@@ -75,11 +75,11 @@ object InDepthPersistentBehaviorSpec {
       cmd match {
         case ChangeBody(newBody, replyTo) ⇒
           val evt = BodyChanged(state.postId, newBody)
-          Effect.persist(evt).andThen { _ ⇒
+          Effect.persist(evt).thenRun { _ ⇒
             replyTo ! Done
           }
         case Publish(replyTo) ⇒
-          Effect.persist(Published(state.postId)).andThen { _ ⇒
+          Effect.persist(Published(state.postId)).thenRun { _ ⇒
             println(s"Blog post ${state.postId} was published")
             replyTo ! Done
           }


### PR DESCRIPTION
* Document order of execution for SideEffects
* Change stop to a just a SideEffect rather than both

Closes #25042
Closes #25041