### PR TITLE
Add WindowsDiscoverConfig to find JDK

### DIFF
--- a/project/CrossJava.scala
+++ b/project/CrossJava.scala
@@ -117,6 +117,17 @@ object CrossJava {
             }
     }
 
+    class WindowsDiscoverConfig extends JavaDiscoverConf {
+      val base: File = file("C://Program Files/Java")
+      val JavaHomeDir = """jdk-?(1\.)?([0-9]+).*""".r
+
+      def javaHomes: Vector[(String, File)] =
+        wrapNull(base.list())
+          .collect {
+            case dir@JavaHomeDir(m, n) => JavaVersion(nullBlank(m) + n).toString -> (base / dir)
+          }
+    }
+
     // See https://github.com/shyiko/jabba
     class JabbaDiscoverConfig extends JavaDiscoverConf {
       val base: File = Path.userHome / ".jabba" / "jdk"
@@ -137,6 +148,7 @@ object CrossJava {
       new LinuxDiscoverConfig(file("/usr") / "java"),
       new LinuxDiscoverConfig(file("/usr") / "lib" / "jvm"),
       new MacOsDiscoverConfig,
+      new WindowsDiscoverConfig
     )
   }
 


### PR DESCRIPTION
Fixes  #25368

I **think** the standard JDK installation location on Windows is `"C://Program Files/Java"`, as the default location chosen by Oracle JDK is this:

![2018-07-27_20h44_51](https://user-images.githubusercontent.com/7414320/43319168-af428542-91de-11e8-8a76-c617d06bd7f3.png)

![2018-07-27_20h45_44](https://user-images.githubusercontent.com/7414320/43319169-af69c792-91de-11e8-82e2-08b58698cec1.png)

Previously, I had the same error as in the linked issue,

```
[error] java.util.NoSuchElementException: key not found: 8
[error]         at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:98)
[error]         at scala.collection.immutable.Map$EmptyMap$.apply(Map.scala:96)
[error]         at akka.AkkaBuild$.$anonfun$defaultSettings$6(AkkaBuild.scala:104)
[error]         at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error]         at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:39)
[error]         at sbt.std.Transform$$anon$4.work(System.scala:66)
[error]         at sbt.Execute.$anonfun$submit$2(Execute.scala:263)
[error]         at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error]         at sbt.Execute.work(Execute.scala:272)
[error]         at sbt.Execute.$anonfun$submit$1(Execute.scala:263)
[error]         at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:174)
[error]         at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error]         at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error]         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error]         at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error]         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error]         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error]         at java.lang.Thread.run(Thread.java:748)
```

but after doing this change, I got akka compiled on Widows. 