### PR TITLE
Harden BindCanonicalAddressSpec

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/BoundAddressesExtension.scala
+++ b/akka-remote/src/main/scala/akka/remote/BoundAddressesExtension.scala
@@ -30,7 +30,7 @@ class BoundAddressesExtension(val system: ExtendedActorSystem) extends Extension
    */
   def boundAddresses: Map[String, Set[Address]] = system.provider
     .asInstanceOf[RemoteActorRefProvider].transport match {
-      case artery: ArteryTransport ⇒ Map((ArteryTransport.ProtocolName → Set(artery.bindAddress.address)))
+      case artery: ArteryTransport ⇒ Map(ArteryTransport.ProtocolName → Set(artery.bindAddress.address))
       case remoting: Remoting      ⇒ remoting.boundAddresses
     }
 }


### PR DESCRIPTION
The randomly selected port by Artery could be the same as the randomly
selected port the test generates.

Fixes #25403