### PR TITLE
Add jaxb to camel test classpath

### DIFF
--- a/akka-docs/src/main/paradox/camel.md
+++ b/akka-docs/src/main/paradox/camel.md
@@ -10,8 +10,22 @@ To use Camel, you must add the following dependency in your project:
   version="$akka.version$"
 }
 
-## Introduction
+Camel depends on `jaxb-api` and `javax.activation` that were removed from the JDK. If running on a version of the JDK 9 or above also add
+the following dependencies:
 
+@@dependency[sbt,Maven,Gradle] {
+  group="javax.xml.bind"
+  artifact="jaxb-api"
+  version="2.3.0"
+}
+
+@@dependency[sbt,Maven,Gradle] {
+  group="com.sun.activation"
+  artifact="javax.activation"
+  version="1.2.0"
+}
+
+## Introduction
 
 @@@ warning
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,9 +77,6 @@ object Dependencies {
     val aeronDriver = "io.aeron" % "aeron-driver" % aeronVersion // ApacheV2
     val aeronClient = "io.aeron" % "aeron-client" % aeronVersion // ApacheV2
 
-    // Non-default module in Java9, removed in Java11. For Camel.
-    val jaxb = "javax.xml.bind" % "jaxb-api" % "2.3.0"
-    val activation = "com.sun.activation" % "javax.activation" % "1.2.0"
 
     object Docs {
       val sprayJson = "io.spray" %% "spray-json" % "1.3.4" % "test"
@@ -124,11 +121,17 @@ object Dependencies {
       // If changed, update akka-docs/build.sbt as well
       val sigarLoader = "io.kamon" % "sigar-loader" % "1.6.6-rev002" % "optional;provided;test" // ApacheV2
 
+       // Non-default module in Java9, removed in Java11. For Camel.
+      val jaxb = "javax.xml.bind" % "jaxb-api" % "2.3.0" % "provided"
+      val activation = "com.sun.activation" % "javax.activation" % "1.2.0" % "provided"
+
+
       val levelDB = "org.iq80.leveldb" % "leveldb" % "0.10" % "optional;provided" // ApacheV2
       val levelDBmultiJVM = "org.iq80.leveldb" % "leveldb" % "0.10" % "optional;provided;multi-jvm" // ApacheV2
       val levelDBNative = "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8" % "optional;provided" // New BSD
 
       val junit = Compile.junit % "optional;provided;test"
+
     }
 
   }
@@ -172,7 +175,7 @@ object Dependencies {
 
   val persistenceShared = l ++= Seq(Provided.levelDB, Provided.levelDBNative)
 
-  val camel = l ++= Seq(camelCore, jaxb, activation, Test.scalatest.value, Test.junit, Test.mockito, Test.logback, Test.commonsIo)
+  val camel = l ++= Seq(camelCore, Provided.jaxb, Provided.activation, Test.scalatest.value, Test.junit, Test.mockito, Test.logback, Test.commonsIo)
 
   val osgi = l ++= Seq(osgiCore, osgiCompendium, Test.logback, Test.commonsIo, Test.pojosr, Test.tinybundles, Test.scalatest.value, Test.junit)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,6 +76,10 @@ object Dependencies {
 
     val aeronDriver = "io.aeron" % "aeron-driver" % aeronVersion // ApacheV2
     val aeronClient = "io.aeron" % "aeron-client" % aeronVersion // ApacheV2
+
+    // Non-default module in Java9, removed in Java11. For Camel.
+    val jaxb = "javax.xml.bind" % "jaxb-api" % "2.3.0"
+
     object Docs {
       val sprayJson = "io.spray" %% "spray-json" % "1.3.4" % "test"
       val gson = "com.google.code.gson" % "gson" % "2.8.5" % "test"
@@ -167,7 +171,7 @@ object Dependencies {
 
   val persistenceShared = l ++= Seq(Provided.levelDB, Provided.levelDBNative)
 
-  val camel = l ++= Seq(camelCore, Test.scalatest.value, Test.junit, Test.mockito, Test.logback, Test.commonsIo)
+  val camel = l ++= Seq(camelCore, jaxb, Test.scalatest.value, Test.junit, Test.mockito, Test.logback, Test.commonsIo)
 
   val osgi = l ++= Seq(osgiCore, osgiCompendium, Test.logback, Test.commonsIo, Test.pojosr, Test.tinybundles, Test.scalatest.value, Test.junit)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,6 +79,7 @@ object Dependencies {
 
     // Non-default module in Java9, removed in Java11. For Camel.
     val jaxb = "javax.xml.bind" % "jaxb-api" % "2.3.0"
+    val activation = "com.sun.activation" % "javax.activation" % "1.2.0"
 
     object Docs {
       val sprayJson = "io.spray" %% "spray-json" % "1.3.4" % "test"
@@ -171,7 +172,7 @@ object Dependencies {
 
   val persistenceShared = l ++= Seq(Provided.levelDB, Provided.levelDBNative)
 
-  val camel = l ++= Seq(camelCore, jaxb, Test.scalatest.value, Test.junit, Test.mockito, Test.logback, Test.commonsIo)
+  val camel = l ++= Seq(camelCore, jaxb, activation, Test.scalatest.value, Test.junit, Test.mockito, Test.logback, Test.commonsIo)
 
   val osgi = l ++= Seq(osgiCore, osgiCompendium, Test.logback, Test.commonsIo, Test.pojosr, Test.tinybundles, Test.scalatest.value, Test.junit)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -122,8 +122,8 @@ object Dependencies {
       val sigarLoader = "io.kamon" % "sigar-loader" % "1.6.6-rev002" % "optional;provided;test" // ApacheV2
 
        // Non-default module in Java9, removed in Java11. For Camel.
-      val jaxb = "javax.xml.bind" % "jaxb-api" % "2.3.0" % "provided"
-      val activation = "com.sun.activation" % "javax.activation" % "1.2.0" % "provided"
+      val jaxb = "javax.xml.bind" % "jaxb-api" % "2.3.0" % "provided;test"
+      val activation = "com.sun.activation" % "javax.activation" % "1.2.0" % "provided;test"
 
 
       val levelDB = "org.iq80.leveldb" % "leveldb" % "0.10" % "optional;provided" // ApacheV2


### PR DESCRIPTION
Seems some parts of what used to be on the classpath have been moved to non-default modules for java 9 and removed fully in 11. Only seems to have affected camel with jaxb. This should work on all Java versions.