### PR TITLE
Fix link to substreams documentation

### DIFF
--- a/akka-docs/src/main/categories/nesting-and-flattening-operators.md
+++ b/akka-docs/src/main/categories/nesting-and-flattening-operators.md
@@ -1,4 +1,4 @@
 These operators either take a stream and turn it into a stream of streams (nesting) or they take a stream that contains
 nested streams and turn them into a stream of elements instead (flattening).
 
-See the [Substreams](stream-substream.md) page for more detail and code samples.
+See the @ref:[Substreams](../stream-substream.md) page for more detail and code samples.

--- a/akka-docs/src/main/paradox/stream/operators/index.md
+++ b/akka-docs/src/main/paradox/stream/operators/index.md
@@ -203,7 +203,8 @@ These operators are aware of the backpressure provided by their downstreams and 
 These operators either take a stream and turn it into a stream of streams (nesting) or they take a stream that contains
 nested streams and turn them into a stream of elements instead (flattening).
 
-See the [Substreams](stream-substream.md) page for more detail and code samples.
+See the @ref:[Substreams](../stream-substream.md) page for more detail and code samples.
+
 
 | |Operator|Description|
 |--|--|--|


### PR DESCRIPTION
Pretty self-explanatory: the old link was wrong, resulting in a 404. You can see it here:
https://doc.akka.io/docs/akka/current/stream/operators/index.html#nesting-and-flattening-operators

I've tested it locally using `sbt akka-docs/paradox` and the link is working fine for me now.