### PR TITLE
=doc Fix Config links in testing (#25421)

### DIFF
--- a/akka-docs/src/main/paradox/general/configuration.md
+++ b/akka-docs/src/main/paradox/general/configuration.md
@@ -14,7 +14,7 @@ might amend:
 Akka uses the [Typesafe Config Library](https://github.com/typesafehub/config), which might also be a good choice
 for the configuration of your own application or library built with or without
 Akka. This library is implemented in Java with no external dependencies; you
-should have a look at its documentation (in particular about [ConfigFactory](http://typesafehub.github.io/config/v1.2.0/com/typesafe/config/ConfigFactory.html)),
+should have a look at its documentation (in particular about [ConfigFactory](https://lightbend.github.io/config/latest/api/com/typesafe/config/ConfigFactory.html)),
 which is only summarized in the following.
 
 @@@ warning

--- a/akka-docs/src/main/paradox/testing.md
+++ b/akka-docs/src/main/paradox/testing.md
@@ -311,7 +311,7 @@ His full example is also available @ref:[here](testing.md#example).
 The tight timeouts you use during testing on your lightning-fast notebook will
 invariably lead to spurious test failures on the heavily loaded Jenkins server
 (or similar). To account for this situation, all maximum durations are
-internally scaled by a factor taken from the [Configuration](),
+internally scaled by a factor taken from the @ref:[Configuration](general/configuration.md#config-akka-testkit),
 `akka.test.timefactor`, which defaults to 1.
 
 You can scale other durations with the same factor by using the @scala[implicit conversion
@@ -714,13 +714,13 @@ options:
 
 @@@ div { .group-scala }
 * *Logging of message invocations on certain actors*
-   This is enabled by a setting in the [Configuration]() — namely
+   This is enabled by a setting in the @ref:[Configuration](general/configuration.md#config-akka-actor) — namely
 `akka.actor.debug.receive` — which enables the `loggable`
 statement to be applied to an actor’s `receive` function:
 
 @@snip [TestkitDocSpec.scala]($code$/scala/docs/testkit/TestkitDocSpec.scala) { #logging-receive }
 
-If the aforementioned setting is not given in the [Configuration](), this method will
+If the aforementioned setting is not given in the @ref:[Configuration](general/configuration.md#config-akka-actor), this method will
 pass through the given `Receive` function unmodified, meaning that
 there is no runtime cost unless actually enabled.
 
@@ -815,7 +815,7 @@ to the @ref:[reference configuration](general/configuration.md#config-akka-testk
 
 ## Example
 
-Ray Roestenburg's example code from [his blog](http://roestenburg.agilesquad.com/2011/02/unit-testing-akka-actors-with-testkit_12.html) adapted to work with Akka 2.x.
+Ray Roestenburg's example code from his blog, which unfortunately is not online anymore, adapted to work with Akka 2.x.
 
 @@snip [TestKitUsageSpec.scala]($code$/scala/docs/testkit/TestKitUsageSpec.scala) { #testkit-usage }
 

--- a/akka-docs/src/main/paradox/testing.md
+++ b/akka-docs/src/main/paradox/testing.md
@@ -301,7 +301,7 @@ wall time, not CPU time or system time.
 @@@ div { .group-scala }
 
 Ray Roestenburg has written a great article on using the TestKit:
-[http://roestenburg.agilesquad.com/2011/02/unit-testing-akka-actors-with-testkit_12.html](http://roestenburg.agilesquad.com/2011/02/unit-testing-akka-actors-with-testkit_12.html).
+[https://web.archive.org/web/20180114133958/http://roestenburg.agilesquad.com/2011/02/unit-testing-akka-actors-with-testkit_12.html](https://web.archive.org/web/20180114133958/http://roestenburg.agilesquad.com/2011/02/unit-testing-akka-actors-with-testkit_12.html).
 His full example is also available @ref:[here](testing.md#example).
 
 @@@
@@ -815,7 +815,9 @@ to the @ref:[reference configuration](general/configuration.md#config-akka-testk
 
 ## Example
 
-Ray Roestenburg's example code from his blog, which unfortunately is not online anymore, adapted to work with Akka 2.x.
+Ray Roestenburg's example code from his blog, which unfortunately is only available on
+[web archive](https://web.archive.org/web/20180114133958/http://roestenburg.agilesquad.com/2011/02/unit-testing-akka-actors-with-testkit_12.html),
+adapted to work with Akka 2.x.
 
 @@snip [TestKitUsageSpec.scala]($code$/scala/docs/testkit/TestKitUsageSpec.scala) { #testkit-usage }
 


### PR DESCRIPTION
refs: #25421
Fixes links to Configuration html page
Removes link to Ray Roestenburg blog page as it's now returning 404
Fixes link to `ConfigFactory` in Configuration doc page