### PR TITLE
Correct parameter order in FSM transition-syntax snippet

### DIFF
--- a/akka-docs/src/test/java/jdocs/actor/fsm/FSMDocTest.java
+++ b/akka-docs/src/test/java/jdocs/actor/fsm/FSMDocTest.java
@@ -74,7 +74,7 @@ public class FSMDocTest extends AbstractJavaTest {
 
     //#transition-syntax
     onTransition(
-      matchState(Active, Idle, () -> setTimer("timeout",
+      matchState(Idle, Active, () -> setTimer("timeout",
         Tick, Duration.ofSeconds(1L), true)).
       state(Active, null, () -> cancelTimer("timeout")).
       state(null, Idle, (f, t) -> log().info("entering Idle from " + f)));


### PR DESCRIPTION
To match example context and Scala version.