### PR TITLE
Fix several minor typos detected by github.com/client9/misspell

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
@@ -164,7 +164,7 @@ abstract class TestProbe[M] {
   def expectNoMessage(): Unit
 
   /**
-   * Expect the given actor to be stopped or stop withing the given timeout or
+   * Expect the given actor to be stopped or stop within the given timeout or
    * throw an [[AssertionError]].
    */
   def expectTerminated[U](actorRef: ActorRef[U], max: Duration): Unit

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/TestProbe.scala
@@ -183,7 +183,7 @@ object TestProbe {
   protected def fishForMessage_internal(max: FiniteDuration, hint: String, fisher: M ⇒ FishingOutcome): immutable.Seq[M]
 
   /**
-   * Expect the given actor to be stopped or stop withing the given timeout or
+   * Expect the given actor to be stopped or stop within the given timeout or
    * throw an [[AssertionError]].
    */
   def expectTerminated[U](actorRef: ActorRef[U], max: FiniteDuration): Unit

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
@@ -49,7 +49,7 @@ class ActorTestKitSpec extends WordSpec with Matchers with ActorTestKit with Sca
 
 }
 
-// derivate classes should also work fine (esp the naming part
+// derivative classes should also work fine (esp the naming part
 trait MyBaseSpec extends WordSpec with ActorTestKit with Matchers with BeforeAndAfterAll {
   override protected def afterAll(): Unit = {
     shutdownTestKit()
@@ -57,7 +57,7 @@ trait MyBaseSpec extends WordSpec with ActorTestKit with Matchers with BeforeAnd
 }
 
 class MyConcreteDerivateSpec extends MyBaseSpec {
-  "A derivate test" should {
+  "A derivative test" should {
     "generate a default name from the test class" in {
       system.name should ===("MyConcreteDerivateSpec")
     }

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -24,19 +24,19 @@ object ActorSystemSpec {
 
   class Waves extends Actor {
     var master: ActorRef = _
-    var terminaters = Set[ActorRef]()
+    var terminators = Set[ActorRef]()
 
     def receive = {
       case n: Int ⇒
         master = sender()
-        terminaters = Set() ++ (for (i ← 1 to n) yield {
-          val man = context.watch(context.system.actorOf(Props[Terminater]))
+        terminators = Set() ++ (for (i ← 1 to n) yield {
+          val man = context.watch(context.system.actorOf(Props[Terminator]))
           man ! "run"
           man
         })
-      case Terminated(child) if terminaters contains child ⇒
-        terminaters -= child
-        if (terminaters.isEmpty) {
+      case Terminated(child) if terminators contains child ⇒
+        terminators -= child
+        if (terminators.isEmpty) {
           master ! "done"
           context stop self
         }
@@ -50,7 +50,7 @@ object ActorSystemSpec {
     }
   }
 
-  class Terminater extends Actor {
+  class Terminator extends Actor {
     def receive = {
       case "run" ⇒ context.stop(self)
     }
@@ -154,7 +154,7 @@ class ActorSystemSpec extends AkkaSpec(ActorSystemSpec.config) with ImplicitSend
       val sys = ActorSystem("LogDeadLetters", ConfigFactory.parseString("akka.loglevel=INFO").withFallback(AkkaSpec.testConf))
       try {
         val probe = TestProbe()(sys)
-        val a = sys.actorOf(Props[ActorSystemSpec.Terminater])
+        val a = sys.actorOf(Props[ActorSystemSpec.Terminator])
         probe.watch(a)
         a.tell("run", probe.ref)
         probe.expectTerminated(a)
@@ -171,7 +171,7 @@ class ActorSystemSpec extends AkkaSpec(ActorSystemSpec.config) with ImplicitSend
       val sys = ActorSystem("LogDeadLetters", ConfigFactory.parseString("akka.loglevel=INFO").withFallback(AkkaSpec.testConf))
       try {
         val probe = TestProbe()(sys)
-        val a = sys.actorOf(Props[ActorSystemSpec.Terminater])
+        val a = sys.actorOf(Props[ActorSystemSpec.Terminator])
         probe.watch(a)
         a.tell("run", probe.ref)
         probe.expectTerminated(a)
@@ -264,7 +264,7 @@ class ActorSystemSpec extends AkkaSpec(ActorSystemSpec.config) with ImplicitSend
       var created = Vector.empty[ActorRef]
       while (!system.whenTerminated.isCompleted) {
         try {
-          val t = system.actorOf(Props[ActorSystemSpec.Terminater])
+          val t = system.actorOf(Props[ActorSystemSpec.Terminator])
           failing should not be true // because once failing => always failing (it’s due to shutdown)
           created :+= t
           if (created.size % 1000 == 0) Thread.sleep(50) // in case of unfair thread scheduling

--- a/akka-actor-tests/src/test/scala/akka/actor/ExtensionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ExtensionSpec.scala
@@ -107,7 +107,7 @@ class ExtensionSpec extends WordSpec with Matchers {
       val system = ActorSystem("extensions")
       val listedExtensions = system.settings.config.getStringList("akka.library-extensions")
       listedExtensions.size should be > 0
-      // could be initalized by other tests, so at least once
+      // could be initialized by other tests, so at least once
       InstanceCountingExtension.createCount.get() should be > 0
 
       shutdownActorSystem(system)

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
@@ -817,7 +817,7 @@ class SupervisorHierarchySpec extends AkkaSpec(SupervisorHierarchySpec.config) w
       expectMsg("pong")
     }
 
-    "handle failure in creation when supervision startegy returns Resume and Restart" taggedAs LongRunningTest in {
+    "handle failure in creation when supervision strategy returns Resume and Restart" taggedAs LongRunningTest in {
       val createAttempt = new AtomicInteger(0)
       val preStartCalled = new AtomicInteger(0)
       val postRestartCalled = new AtomicInteger(0)

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorSpec.scala
@@ -357,7 +357,7 @@ class SupervisorSpec extends AkkaSpec(SupervisorSpec.config) with BeforeAndAfter
       expectMsg(Timeout, PingMessage)
     }
 
-    "restart killed actors in nested superviser hierarchy" in {
+    "restart killed actors in nested supervisor hierarchy" in {
       val (actor1, actor2, actor3, _) = nestedSupervisorsAllForOne
 
       ping(actor1)

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatchersSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatchersSpec.scala
@@ -163,7 +163,7 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
     }
 
     "get the correct types of dispatchers" in {
-      //All created/obtained dispatchers are of the expeced type/instance
+      //All created/obtained dispatchers are of the expected type/instance
       assert(typesAndValidators.forall(tuple ⇒ tuple._2(allDispatchers(tuple._1))))
     }
 

--- a/akka-actor-tests/src/test/scala/akka/dispatch/DispatcherShutdownSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/DispatcherShutdownSpec.scala
@@ -15,7 +15,7 @@ class DispatcherShutdownSpec extends WordSpec with Matchers {
 
   "akka dispatcher" should {
 
-    "eventualy shutdown when used after system terminate" in {
+    "eventually shutdown when used after system terminate" in {
 
       val threads = ManagementFactory.getThreadMXBean()
       def threadCount = threads

--- a/akka-actor-tests/src/test/scala/akka/routing/MetricsBasedResizerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/MetricsBasedResizerSpec.scala
@@ -241,7 +241,7 @@ class MetricsBasedResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultT
 
       msgs1.foreach(_.second.open()) //process two messages
 
-      // make sure some time passes inbetween
+      // make sure some time passes in-between
       Thread.sleep(300)
 
       // wait for routees to update their mail boxes
@@ -273,7 +273,7 @@ class MetricsBasedResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultT
 
       msgs1.foreach(_.second.open()) //process two messages
 
-      // make sure some time passes inbetween
+      // make sure some time passes in-between
       Thread.sleep(300)
 
       // wait for routees to update their mail boxes

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/AdapterTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/AdapterTest.java
@@ -309,7 +309,7 @@ public class AdapterTest extends JUnitSuite {
 
     int originalLogLevel = system.eventStream().logLevel();
     try {
-      // supress the logging with stack trace
+      // suppress the logging with stack trace
       system.eventStream().setLogLevel(Integer.MIN_VALUE); // OFF
 
       // only stop supervisorStrategy

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -88,7 +88,7 @@ class AskSpec extends ActorTestKit
     }
 
     "must transform a replied akka.actor.Status.Failure to a failed future" in {
-      // It's unlikely but possible that this happens, since the recieving actor would
+      // It's unlikely but possible that this happens, since the receiving actor would
       // have to accept a message with an actoref that accepts AnyRef or be doing crazy casting
       // For completeness sake though
       implicit val untypedSystem = akka.actor.ActorSystem("AskSpec-untyped-1")

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ExtensionsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ExtensionsSpec.scala
@@ -138,7 +138,7 @@ class ExtensionsSpec extends TypedAkkaSpec {
       withEmptyActorSystem("ExtensionsSpec06") { system ⇒
         val listedExtensions = system.settings.config.getStringList("akka.actor.typed.library-extensions")
         listedExtensions.size should be > 0
-        // could be initalized by other tests, so at least once
+        // could be initialized by other tests, so at least once
         InstanceCountingExtension.createCount.get() should be > 0
       }
 

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -297,7 +297,7 @@ akka {
           # exploration will be +- 5
           explore-step-size = 0.1
 
-          # Probabily of doing an exploration v.s. optmization.
+          # Probability of doing an exploration v.s. optmization.
           chance-of-exploration = 0.4
 
           # When downsizing after a long streak of underutilization, the resizer
@@ -387,7 +387,7 @@ akka {
 
         # Each worker in the pool uses a separate bounded MPSC queue. This value
         # indicates the upper bound of the queue. Whenever an attempt to enqueue
-        # a task is made and the queue does not have capacity to accomodate
+        # a task is made and the queue does not have capacity to accommodate
         # the task, the rejection handler created by the rejection handler specified
         # in "rejection-handler" is invoked.
         task-queue-size = 512
@@ -1100,7 +1100,7 @@ akka {
     # When Coordinated Shutdown is triggered an instance of `Reason` is
     # required. That value can be used to override the default settings.
     # Only 'exit-jvm', 'exit-code' and 'terminate-actor-system' may be
-    # overriden depending on the reason.
+    # overridden depending on the reason.
     reason-overrides {
       # Overrides are applied using the `reason.getClass.getName`. This
       # default overrides the `exit-code` when the `Reason` is a cluster

--- a/akka-actor/src/main/scala/akka/AkkaVersion.scala
+++ b/akka-actor/src/main/scala/akka/AkkaVersion.scala
@@ -33,7 +33,7 @@ object AkkaVersion {
       case VersionPattern(currentMajorStr, currentMinorStr, currentPatchStr, mOrRc) ⇒
         requiredVersion match {
           case requiredVersion @ VersionPattern(requiredMajorStr, requiredMinorStr, requiredPatchStr, _) ⇒
-            // a M or RC is basically inbetween versions, so offset
+            // a M or RC is basically in-between versions, so offset
             val currentPatch =
               if (mOrRc ne null) currentPatchStr.toInt - 1
               else currentPatchStr.toInt

--- a/akka-actor/src/main/scala/akka/util/PrettyDuration.scala
+++ b/akka-actor/src/main/scala/akka/util/PrettyDuration.scala
@@ -13,22 +13,22 @@ private[akka] object PrettyDuration {
 
   /**
    * JAVA API
-   * Selects most apropriate TimeUnit for given duration and formats it accordingly, with 4 digits precision
+   * Selects most appropriate TimeUnit for given duration and formats it accordingly, with 4 digits precision
    */
   def format(duration: Duration): String = duration.pretty
 
   /**
    * JAVA API
-   * Selects most apropriate TimeUnit for given duration and formats it accordingly
+   * Selects most appropriate TimeUnit for given duration and formats it accordingly
    */
   def format(duration: Duration, includeNanos: Boolean, precision: Int): String = duration.pretty(includeNanos, precision)
 
   implicit class PrettyPrintableDuration(val duration: Duration) extends AnyVal {
 
-    /** Selects most apropriate TimeUnit for given duration and formats it accordingly, with 4 digits precision **/
+    /** Selects most appropriate TimeUnit for given duration and formats it accordingly, with 4 digits precision **/
     def pretty: String = pretty(includeNanos = false)
 
-    /** Selects most apropriate TimeUnit for given duration and formats it accordingly */
+    /** Selects most appropriate TimeUnit for given duration and formats it accordingly */
     def pretty(includeNanos: Boolean, precision: Int = 4): String = {
       require(precision > 0, "precision must be > 0")
 

--- a/akka-bench-jmh/src/main/scala/akka/actor/typed/TypedBenchmarkActors.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/typed/TypedBenchmarkActors.scala
@@ -62,7 +62,7 @@ object TypedBenchmarkActors {
     Behaviors.receive { (ctx, msg) ⇒
       msg match {
         case Start(respondTo) ⇒
-          // note: no protection against accidentally running bench sessions in paralell
+          // note: no protection against accidentally running bench sessions in parallel
           val sessionBehavior = startEchoBenchSession(numMessagesPerActorPair, numActors, dispatcher, batchSize, respondTo)
           ctx.spawnAnonymous(sessionBehavior)
           Behaviors.same

--- a/akka-bench-jmh/src/main/scala/akka/stream/FusedGraphsBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FusedGraphsBenchmark.scala
@@ -317,7 +317,7 @@ class FusedGraphsBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(100 * 1000)
-  def boradcast_zip_balance_merge(blackhole: org.openjdk.jmh.infra.Blackhole): Unit = {
+  def broadcast_zip_balance_merge(blackhole: org.openjdk.jmh.infra.Blackhole): Unit = {
     FusedGraphsBenchmark.blackhole = blackhole
     broadcastZipBalanceMerge.run()(materializer).await()
   }

--- a/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
@@ -726,7 +726,7 @@ class ClusterSingletonManager(
         setTimer(TakeOverRetryTimer, TakeOverRetry(count + 1), handOverRetryInterval, repeat = false)
         stay
       } else
-        throw new ClusterSingletonManagerIsStuck(s"Expected hand-over to [${newOldestOption}] never occured")
+        throw new ClusterSingletonManagerIsStuck(s"Expected hand-over to [${newOldestOption}] never occurred")
 
     case Event(HandOverToMe, WasOldestData(singleton, singletonTerminated, _)) ⇒
       gotoHandingOver(singleton, singletonTerminated, Some(sender()))

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartFirstSeedNodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartFirstSeedNodeSpec.scala
@@ -93,7 +93,7 @@ abstract class RestartFirstSeedNodeSpec
           expectMsg(5 seconds, "ok")
         }
       }
-      enterBarrier("seed1-address-transfered")
+      enterBarrier("seed1-address-transferred")
 
       // now we can join seed1System, seed2, seed3 together
       runOn(seed1) {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNode2Spec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNode2Spec.scala
@@ -94,7 +94,7 @@ abstract class RestartNode2SpecSpec
           expectMsg(5.seconds, "ok")
         }
       }
-      enterBarrier("seed1-address-transfered")
+      enterBarrier("seed1-address-transferred")
 
       // now we can join seed1System, seed2 together
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNode3Spec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNode3Spec.scala
@@ -95,7 +95,7 @@ abstract class RestartNode3Spec
           expectMsg(5.seconds, "ok")
         }
       }
-      enterBarrier("second-address-transfered")
+      enterBarrier("second-address-transferred")
 
       // now we can join first, third together
       runOn(first, third) {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNodeSpec.scala
@@ -111,7 +111,7 @@ abstract class RestartNodeSpec
           expectMsg(5.seconds, "ok")
         }
       }
-      enterBarrier("second-address-transfered")
+      enterBarrier("second-address-transferred")
 
       // now we can join first, secondSystem, third together
       runOn(first, third) {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SharedMediaDriverSupport.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SharedMediaDriverSupport.scala
@@ -36,7 +36,7 @@ object SharedMediaDriverSupport {
       require(aeronDir.nonEmpty, "aeron-dir must be defined")
 
       // Check if the media driver is already started by another multi-node jvm.
-      // It checks more than one time with a sleep inbetween. The number of checks
+      // It checks more than one time with a sleep in-between. The number of checks
       // depends on the multi-node index (i).
       @tailrec def isDriverInactive(i: Int): Boolean = {
         if (i < 0) true

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -81,7 +81,7 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
       nr-of-nodes-factor = 1
       # not scaled
       nr-of-seed-nodes = 3
-      nr-of-nodes-joining-to-seed-initally = 2
+      nr-of-nodes-joining-to-seed-initially = 2
       nr-of-nodes-joining-one-by-one-small = 2
       nr-of-nodes-joining-one-by-one-large = 2
       nr-of-nodes-joining-to-one = 2
@@ -175,7 +175,7 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
     val infolog = getBoolean("infolog")
     val nFactor = getInt("nr-of-nodes-factor")
     val numberOfSeedNodes = getInt("nr-of-seed-nodes") // not scaled by nodes factor
-    val numberOfNodesJoiningToSeedNodesInitially = getInt("nr-of-nodes-joining-to-seed-initally") * nFactor
+    val numberOfNodesJoiningToSeedNodesInitially = getInt("nr-of-nodes-joining-to-seed-initially") * nFactor
     val numberOfNodesJoiningOneByOneSmall = getInt("nr-of-nodes-joining-one-by-one-small") * nFactor
     val numberOfNodesJoiningOneByOneLarge = getInt("nr-of-nodes-joining-one-by-one-large") * nFactor
     val numberOfNodesJoiningToOneNode = getInt("nr-of-nodes-joining-to-one") * nFactor

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/TransitionSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/TransitionSpec.scala
@@ -226,7 +226,7 @@ abstract class TransitionSpec
       enterBarrier("after-3")
     }
 
-    "perform correct transitions when second becomes unavailble" taggedAs LongRunningTest in {
+    "perform correct transitions when second becomes unavailable" taggedAs LongRunningTest in {
       runOn(third) {
         markNodeAsUnavailable(second)
         reapUnreachable()
@@ -234,7 +234,7 @@ abstract class TransitionSpec
         awaitAssert(seenLatestGossip should ===(Set(third)))
       }
 
-      enterBarrier("after-second-unavailble")
+      enterBarrier("after-second-unavailable")
 
       third gossipTo first
 

--- a/akka-cluster/src/test/scala/akka/cluster/AutoDownSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/AutoDownSpec.scala
@@ -84,7 +84,7 @@ class AutoDownSpec extends AkkaSpec("akka.actor.provider=remote") {
       expectMsg(DownCalled(memberB.address))
     }
 
-    "down unreachable when becoming leader inbetween detection and specified duration" in {
+    "down unreachable when becoming leader in-between detection and specified duration" in {
       val a = autoDownActor(2.seconds)
       a ! LeaderChanged(Some(memberB.address))
       a ! UnreachableMember(memberC)
@@ -93,7 +93,7 @@ class AutoDownSpec extends AkkaSpec("akka.actor.provider=remote") {
       expectMsg(DownCalled(memberC.address))
     }
 
-    "not down unreachable when losing leadership inbetween detection and specified duration" taggedAs TimingTest in {
+    "not down unreachable when losing leadership in-between detection and specified duration" taggedAs TimingTest in {
       val a = autoDownActor(2.seconds)
       a ! LeaderChanged(Some(memberA.address))
       a ! UnreachableMember(memberC)
@@ -101,7 +101,7 @@ class AutoDownSpec extends AkkaSpec("akka.actor.provider=remote") {
       expectNoMsg(3.second)
     }
 
-    "not down when unreachable become reachable inbetween detection and specified duration" taggedAs TimingTest in {
+    "not down when unreachable become reachable in-between detection and specified duration" taggedAs TimingTest in {
       val a = autoDownActor(2.seconds)
       a ! LeaderChanged(Some(memberA.address))
       a ! UnreachableMember(memberB)
@@ -109,7 +109,7 @@ class AutoDownSpec extends AkkaSpec("akka.actor.provider=remote") {
       expectNoMsg(3.second)
     }
 
-    "not down when unreachable is removed inbetween detection and specified duration" taggedAs TimingTest in {
+    "not down when unreachable is removed in-between detection and specified duration" taggedAs TimingTest in {
       val a = autoDownActor(2.seconds)
       a ! LeaderChanged(Some(memberA.address))
       a ! UnreachableMember(memberB)

--- a/akka-contrib/src/main/scala/akka/contrib/circuitbreaker/CircuitBreakerProxy.scala
+++ b/akka-contrib/src/main/scala/akka/contrib/circuitbreaker/CircuitBreakerProxy.scala
@@ -157,7 +157,7 @@ final class CircuitBreakerProxy(
         }
 
       case Event(message, state) ⇒
-        log.debug("CLOSED: Sending message {} expecting a response withing timeout {}", message, callTimeout)
+        log.debug("CLOSED: Sending message {} expecting a response within timeout {}", message, callTimeout)
         val currentSender = sender()
         forwardRequest(message, sender, state, log)
         stay

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurableDataSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurableDataSpec.scala
@@ -161,7 +161,7 @@ abstract class DurableDataSpec(multiNodeConfig: DurableDataSpecConfig)
         expectMsg(ReplicaCount(2))
       }
     }
-    enterBarrier("both-initalized")
+    enterBarrier("both-initialized")
 
     r ! Update(KeyA, GCounter(), writeTwo)(_ + 1)
     expectMsg(UpdateSuccess(KeyA, None))

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorSpec.scala
@@ -260,7 +260,7 @@ class ReplicatorSpec extends MultiNodeSpec(ReplicatorSpec) with STMultiNodeSpec 
     enterBarrierAfterTestStep()
   }
 
-  "be replicated after succesful update" in {
+  "be replicated after successful update" in {
     val changedProbe = TestProbe()
     runOn(first, second) {
       replicator ! Subscribe(KeyC, changedProbe.ref)
@@ -403,14 +403,14 @@ class ReplicatorSpec extends MultiNodeSpec(ReplicatorSpec) with STMultiNodeSpec 
       replicator ! Update(KeyE, GCounter(), writeMajority)(_ + 50)
       expectMsg(UpdateSuccess(KeyE, None))
     }
-    enterBarrier("write-inital-majority")
+    enterBarrier("write-initial-majority")
 
     runOn(first, second, third) {
       replicator ! Get(KeyE, readMajority)
       val c150 = expectMsgPF() { case g @ GetSuccess(KeyE, _) ⇒ g.get(KeyE) }
       c150.value should be(150)
     }
-    enterBarrier("read-inital-majority")
+    enterBarrier("read-initial-majority")
 
     runOn(first) {
       testConductor.blackhole(first, third, Direction.Both).await

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/DeltaPropagationSelectorSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/DeltaPropagationSelectorSpec.scala
@@ -176,7 +176,7 @@ class DeltaPropagationSelectorSpec extends WordSpec with Matchers with TypeCheck
       selector.collectPropagations() should ===(Map(nodes(0) → expected))
     }
 
-    "calcualte right slice size" in {
+    "calculate right slice size" in {
       val selector = new TestSelector(selfUniqueAddress, nodes)
       selector.nodesSliceSize(0) should ===(0)
       selector.nodesSliceSize(1) should ===(1)

--- a/akka-docs/src/main/paradox/distributed-data.md
+++ b/akka-docs/src/main/paradox/distributed-data.md
@@ -495,7 +495,7 @@ together.
 There is a special version of `ORMultiMap`, created by using separate constructor
 `ORMultiMap.emptyWithValueDeltas[A, B]`, that also propagates the updates to its values (of `ORSet` type) as deltas.
 This means that the `ORMultiMap` initiated with `ORMultiMap.emptyWithValueDeltas` propagates its updates as pairs
-consisting of delta of the key and delta of the value. It is much more efficient in terms of network bandwith consumed.
+consisting of delta of the key and delta of the value. It is much more efficient in terms of network bandwidth consumed.
 
 However, this behavior has not been made default for `ORMultiMap` and if you wish to use it in your code, you
 need to replace invocations of `ORMultiMap.empty[A, B]` (or `ORMultiMap()`) with `ORMultiMap.emptyWithValueDeltas[A, B]`

--- a/akka-docs/src/main/paradox/general/supervision.md
+++ b/akka-docs/src/main/paradox/general/supervision.md
@@ -197,7 +197,7 @@ This pattern is useful when the started actor fails <a id="^1" href="#1">[1]</a>
 and we need to give it some time to start-up again. One of the prime examples when this is useful is
 when a @ref:[PersistentActor](../persistence.md) fails (by stopping) with a persistence failure - which indicates that
 the database may be down or overloaded, in such situations it makes most sense to give it a little bit of time
-to recover before the peristent actor is started.
+to recover before the persistent actor is started.
 
 > <a id="1" href="#^1">[1]</a> A failure can be indicated in two different ways; by an actor stopping or crashing.
 

--- a/akka-docs/src/main/paradox/persistence-schema-evolution.md
+++ b/akka-docs/src/main/paradox/persistence-schema-evolution.md
@@ -356,7 +356,7 @@ that the type is no longer needed, and skip the deserialization all-together:
 
 ![persistence-drop-event-serializer.png](./images/persistence-drop-event-serializer.png)
  
-The serializer is aware of the old event types that need to be skipped (**O**), and can skip deserializing them alltogether
+The serializer is aware of the old event types that need to be skipped (**O**), and can skip deserializing them altogether
 by returning a "tombstone" (**T**), which the EventAdapter converts into an empty EventSeq.
 Other events (**E**) can just be passed through.
 
@@ -411,7 +411,7 @@ Java
 :  @@snip [PersistenceSchemaEvolutionDocTest.java]($code$/java/jdocs/persistence/PersistenceSchemaEvolutionDocTest.java) { #detach-models }
 
 The `EventAdapter` takes care of converting from one model to the other one (in both directions),
-alowing the models to be completely detached from each other, such that they can be optimised independently
+allowing the models to be completely detached from each other, such that they can be optimised independently
 as long as the mapping logic is able to convert between them:
 
 Scala
@@ -496,7 +496,7 @@ The `EventAdapter` splits the incoming event into smaller more fine grained even
 
 During recovery however, we now need to convert the old `V1` model into the `V2` representation of the change.
 Depending if the old event contains a name change, we either emit the `UserNameChanged` or we don't,
-and the address change is handled similarily:
+and the address change is handled similarly:
 
 
 Scala

--- a/akka-docs/src/main/paradox/persistence.md
+++ b/akka-docs/src/main/paradox/persistence.md
@@ -1126,7 +1126,7 @@ A snapshot store plugin can be activated with the following minimal configuratio
 
 The snapshot store instance is an actor so the methods corresponding to requests from persistent actors
 are executed sequentially. It may delegate to asynchronous libraries, spawn futures, or delegate to other
-actors to achive parallelism.
+actors to achieve parallelism.
 
 The snapshot store plugin class must have a constructor with one of these signatures:
 

--- a/akka-docs/src/main/paradox/project/migration-guide-2.4.x-2.5.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.4.x-2.5.x.md
@@ -293,7 +293,7 @@ as the `GraphStage` itself is a factory of logic instances.
 
 ### SubFlow.zip and SubSource.zip now emit akka.japi.Pair instead of Scala's Pair
 
-The the Java API's `zip` operator on `SubFlow` and `SubSource` has been emiting
+The the Java API's `zip` operator on `SubFlow` and `SubSource` has been emitting
 Scala's `Pair` (`Tuple2`) instead of `akka.japi.Pair`. This is fixed in Akka 2.5 where it emits the proper
 Java DSl type.
 
@@ -591,7 +591,7 @@ The class is now called `PersistenceIdsQuery`, and the method which used to be `
 
 ### Queries now use `Offset` instead of `Long` for offsets
 
-This change was made to better accomodate the various types of Journals and their understanding what an offset is.
+This change was made to better accommodate the various types of Journals and their understanding what an offset is.
 For example, in some journals an offset is always a time, while in others it is a numeric offset (like a sequence id).
 
 Instead of the previous `Long` offset you can now use the provided `Offset` factories (and types):

--- a/akka-docs/src/main/paradox/security/2017-02-10-java-serialization.md
+++ b/akka-docs/src/main/paradox/security/2017-02-10-java-serialization.md
@@ -2,7 +2,7 @@
 
 ### Date
 
-10 Feburary 2017
+10 February 2017
 
 ### Description of Vulnerability
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapError.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapError.md
@@ -21,7 +21,7 @@ would log the `t2` error.
 Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
 This operators can recover the failure signal, but not the skipped elements, which will be dropped.
 
-Similarily to `recover` throwing an exception inside `mapError` _will_ be logged on ERROR level automatically.
+Similarly to `recover` throwing an exception inside `mapError` _will_ be logged on ERROR level automatically.
 
 
 @@@div { .callout }

--- a/akka-docs/src/main/paradox/typed/interaction-patterns.md
+++ b/akka-docs/src/main/paradox/typed/interaction-patterns.md
@@ -172,7 +172,7 @@ The response adapting function is running in the receiving actor and can safely 
 
 ## Request-Response with ask from outside the ActorSystem
 
-Some times you need to interact with actors from outside of the actor system, this can be done with fire-and-forget as described above or through another version of `ask` that returns a @scala[`Future[Response]`]@java[`CompletionStage<Response>`] that is either completed with a succesful response or failed with a `TimeoutException` if there was no response within the specified timeout. 
+Some times you need to interact with actors from outside of the actor system, this can be done with fire-and-forget as described above or through another version of `ask` that returns a @scala[`Future[Response]`]@java[`CompletionStage<Response>`] that is either completed with a successful response or failed with a `TimeoutException` if there was no response within the specified timeout.
  
 To do this we use @scala[`ActorRef.ask` (or the symbolic `ActorRef.?`) implicitly provided by `akka.actor.typed.scaladsl.AskPattern`]@java[`akka.actor.typed.javadsl.AskPattern.ask`] to send a message to an actor and get a @scala[`Future[Response]`]@java[`CompletionState[Response]`] back.
 

--- a/akka-docs/src/main/paradox/typed/stream.md
+++ b/akka-docs/src/main/paradox/typed/stream.md
@@ -41,7 +41,7 @@ Java
 
 ## Actor Sink
 
-There are two sinks availabe that accept typed `ActorRef`s. To send all of the messages from a stream to an actor without considering backpressure, use @scala[@scaladoc[`ActorSink.actorRef`](akka.stream.typed.scaladsl.ActorSink#actorRef)]@java[@javadoc[`ActorSink.actorRef`](akka.stream.typed.javadsl.ActorSink#actorRef)].
+There are two sinks available that accept typed `ActorRef`s. To send all of the messages from a stream to an actor without considering backpressure, use @scala[@scaladoc[`ActorSink.actorRef`](akka.stream.typed.scaladsl.ActorSink#actorRef)]@java[@javadoc[`ActorSink.actorRef`](akka.stream.typed.javadsl.ActorSink#actorRef)].
 
 Scala
 :  @@snip [ActorSourceSinkExample.scala]($akka$/akka-stream-typed/src/test/scala/docs/akka/stream/typed/ActorSourceSinkExample.scala) { #actor-sink-ref }

--- a/akka-docs/src/test/java/jdocs/actor/ByteBufferSerializerDocTest.java
+++ b/akka-docs/src/test/java/jdocs/actor/ByteBufferSerializerDocTest.java
@@ -30,7 +30,7 @@ public class ByteBufferSerializerDocTest {
 
     @Override
     public byte[] toBinary(Object o) {
-      // in production code, aquire this from a BufferPool
+      // in production code, acquire this from a BufferPool
       final ByteBuffer buf = ByteBuffer.allocate(256);
 
       toBinary(o, buf);

--- a/akka-docs/src/test/java/jdocs/stream/SilenceSystemOut.java
+++ b/akka-docs/src/test/java/jdocs/stream/SilenceSystemOut.java
@@ -9,7 +9,7 @@ import akka.actor.ActorRef;
 import java.util.function.Predicate;
 
 /**
- * Acts as if `System.out.println()` yet swallows all messages. Useful for putting printlines in examples yet without poluting the build with them.
+ * Acts as if `System.out.println()` yet swallows all messages. Useful for putting printlines in examples yet without polluting the build with them.
  */
 public class SilenceSystemOut {
 

--- a/akka-docs/src/test/scala/docs/actor/ByteBufferSerializerDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/actor/ByteBufferSerializerDocSpec.scala
@@ -20,7 +20,7 @@ class ByteBufferSerializerDocSpec {
 
     // Implement this method for compatibility with `SerializerWithStringManifest`.
     override def toBinary(o: AnyRef): Array[Byte] = {
-      // in production code, aquire this from a BufferPool
+      // in production code, acquire this from a BufferPool
       val buf = ByteBuffer.allocate(256)
 
       toBinary(o, buf)

--- a/akka-docs/src/test/scala/docs/stream/StreamPartialGraphDSLDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/StreamPartialGraphDSLDocSpec.scala
@@ -117,7 +117,7 @@ class StreamPartialGraphDSLDocSpec extends AkkaSpec {
     val actorRef: ActorRef = testActor
     //#sink-combine
     val sendRmotely = Sink.actorRef(actorRef, "Done")
-    val localProcessing = Sink.foreach[Int](_ ⇒ /* do something usefull */ ())
+    val localProcessing = Sink.foreach[Int](_ ⇒ /* do something useful */ ())
 
     val sink = Sink.combine(sendRmotely, localProcessing)(Broadcast[Int](_))
 

--- a/akka-persistence-tck/src/main/scala/akka/persistence/scalatest/OptionalTests.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/scalatest/OptionalTests.scala
@@ -18,7 +18,7 @@ trait OptionalTests {
     if (flag.value)
       try test catch {
         case ex: Exception ⇒
-          throw new AssertionError("Imlpementation did not pass this spec. " +
+          throw new AssertionError("Implementation did not pass this spec. " +
             "If your journal will be (by definition) unable to abide the here tested rule, you can disable this test," +
             s"by overriding [${flag.name}] with CapabilityFlag.off in your test class.")
       }

--- a/akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala
@@ -69,7 +69,7 @@ abstract class SnapshotStoreSpec(config: Config) extends PluginSpec(config)
   /**
    * The limit defines a number of bytes persistence plugin can support to store the snapshot.
    * If plugin does not support persistence of the snapshots of 10000 bytes or may support more than default size,
-   * the value can be overriden by the SnapshotStoreSpec implementation with a note in a plugin documentation.
+   * the value can be overridden by the SnapshotStoreSpec implementation with a note in a plugin documentation.
    */
   def snapshotByteSizeLimit = 10000
 

--- a/akka-persistence/src/main/scala/akka/persistence/snapshot/local/LocalSnapshotStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/snapshot/local/LocalSnapshotStore.scala
@@ -132,7 +132,7 @@ private[persistence] class LocalSnapshotStore(config: Config) extends SnapshotSt
   private def withStream[A <: Closeable, B](stream: A, p: A ⇒ B): B =
     try { p(stream) } finally { stream.close() }
 
-  /** Only by persistenceId and sequenceNr, timestamp is informational - accomodates for 2.13.x series files */
+  /** Only by persistenceId and sequenceNr, timestamp is informational - accommodates for 2.13.x series files */
   protected def snapshotFileForWrite(metadata: SnapshotMetadata, extension: String = ""): File =
     new File(snapshotDir, s"snapshot-${URLEncoder.encode(metadata.persistenceId, UTF_8)}-${metadata.sequenceNr}-${metadata.timestamp}${extension}")
 

--- a/akka-protobuf/src/main/java/akka/protobuf/RepeatedFieldBuilder.java
+++ b/akka-protobuf/src/main/java/akka/protobuf/RepeatedFieldBuilder.java
@@ -58,7 +58,7 @@ import java.util.List;
  * that desires a Message instead of a Builder. In terms of the implementation,
  * the {@code SingleFieldBuilder} and {@code RepeatedFieldBuilder}
  * classes cache messages that were created so that messages only need to be
- * created when some change occured in its builder or a builder for one of its
+ * created when some change occurred in its builder or a builder for one of its
  * descendants.
  *
  * @param <MType> the type of message for the field

--- a/akka-protobuf/src/main/java/akka/protobuf/SingleFieldBuilder.java
+++ b/akka-protobuf/src/main/java/akka/protobuf/SingleFieldBuilder.java
@@ -51,7 +51,7 @@ package akka.protobuf;
  * that desires a Message instead of a Builder. In terms of the implementation,
  * the {@code SingleFieldBuilder} and {@code RepeatedFieldBuilder}
  * classes cache messages that were created so that messages only need to be
- * created when some change occured in its builder or a builder for one of its
+ * created when some change occurred in its builder or a builder for one of its
  * descendants.
  *
  * @param <MType> the type of message for the field

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -902,7 +902,7 @@ akka {
         # Only used when transport is aeron-udp.
         aeron-dir = ""
 
-        # Whether to delete aeron embeded driver directory upon driver stop.
+        # Whether to delete aeron embedded driver directory upon driver stop.
         # Only used when transport is aeron-udp.
         delete-aeron-dir = yes
 

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -409,7 +409,7 @@ private[akka] class RemoteActorRefProvider(
     // using thread local LRU cache, which will call internalRresolveActorRef
     // if the value is not cached
     actorRefResolveThreadLocalCache match {
-      case null ⇒ internalResolveActorRef(path) // not initalized yet
+      case null ⇒ internalResolveActorRef(path) // not initialized yet
       case c    ⇒ c.threadLocalCache(this).getOrCompute(path)
     }
   }

--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -1013,7 +1013,7 @@ private[remote] class AssociationRegistry(createAssociation: Address ⇒ Associa
           // make sure we don't overwrite same UID with different association
           throw new IllegalArgumentException(s"UID collision old [$previous] new [$a]")
       case _ ⇒
-        // update associationsByUid Map with the uid -> assocation
+        // update associationsByUid Map with the uid -> association
         val newMap = currentMap.updated(peer.uid, a)
         if (associationsByUid.compareAndSet(currentMap, newMap))
           a

--- a/akka-remote/src/main/scala/akka/remote/artery/FlightRecorder.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/FlightRecorder.scala
@@ -73,7 +73,7 @@ private[remote] class SynchronizedEventSink(delegate: EventSink) extends EventSi
 /**
  * INTERNAL API
  *
- * Update clock at various resolutions and aquire the resulting timestamp.
+ * Update clock at various resolutions and acquire the resulting timestamp.
  */
 private[remote] trait EventClock {
 

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala
@@ -226,7 +226,7 @@ private[remote] object InboundCompression {
    *
    * @param oldTables is guaranteed to always have at-least one and at-most [[keepOldTables]] elements.
    *                  It starts with containing only a single "disabled" table (versioned as `DecompressionTable.DisabledVersion`),
-   *                  and from there on continiously accumulates at most [[keepOldTables]] recently used tables.
+   *                  and from there on continuously accumulates at most [[keepOldTables]] recently used tables.
    */
   final case class Tables[T](
     oldTables:               List[DecompressionTable[T]],
@@ -485,14 +485,14 @@ private[akka] final class UnknownCompressedIdException(id: Long)
 private[remote] case object NoInboundCompressions extends InboundCompressions {
   override def hitActorRef(originUid: Long, remote: Address, ref: ActorRef, n: Int): Unit = ()
   override def decompressActorRef(originUid: Long, tableVersion: Byte, idx: Int): OptionVal[ActorRef] =
-    if (idx == -1) throw new IllegalArgumentException("Attemted decompression of illegal compression id: -1")
+    if (idx == -1) throw new IllegalArgumentException("Attempted decompression of illegal compression id: -1")
     else OptionVal.None
   override def confirmActorRefCompressionAdvertisement(originUid: Long, tableVersion: Byte): Unit = ()
   override def runNextActorRefAdvertisement(): Unit = ()
 
   override def hitClassManifest(originUid: Long, remote: Address, manifest: String, n: Int): Unit = ()
   override def decompressClassManifest(originUid: Long, tableVersion: Byte, idx: Int): OptionVal[String] =
-    if (idx == -1) throw new IllegalArgumentException("Attemted decompression of illegal compression id: -1")
+    if (idx == -1) throw new IllegalArgumentException("Attempted decompression of illegal compression id: -1")
     else OptionVal.None
   override def confirmClassManifestCompressionAdvertisement(originUid: Long, tableVersion: Byte): Unit = ()
   override def runNextClassManifestAdvertisement(): Unit = ()

--- a/akka-remote/src/main/scala/akka/remote/serialization/MiscMessageSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/MiscMessageSerializer.scala
@@ -436,7 +436,7 @@ class MiscMessageSerializer(val system: ExtendedActorSystem) extends SerializerW
     Address(
       a.getProtocol,
       a.getSystem,
-      // technicaly the presence of hostname and port are guaranteed, see our serializeAddressData
+      // technically the presence of hostname and port are guaranteed, see our serializeAddressData
       if (a.hasHostname) Some(a.getHostname) else None,
       if (a.hasPort) Some(a.getPort) else None
     )
@@ -445,7 +445,7 @@ class MiscMessageSerializer(val system: ExtendedActorSystem) extends SerializerW
     Address(
       a.getProtocol,
       a.getSystem,
-      // technicaly the presence of hostname and port are guaranteed, see our serializeAddressData
+      // technically the presence of hostname and port are guaranteed, see our serializeAddressData
       if (a.hasHostname) Some(a.getHostname) else None,
       if (a.hasPort) Some(a.getPort) else None
     )

--- a/akka-remote/src/test/scala/akka/remote/RemoteConsistentHashingRouterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConsistentHashingRouterSpec.scala
@@ -15,7 +15,7 @@ class RemoteConsistentHashingRouterSpec extends AkkaSpec("""
 
   "ConsistentHashingGroup" must {
 
-    "use same hash ring indepenent of self address" in {
+    "use same hash ring independent of self address" in {
       // simulating running router on two different nodes (a1, a2) with target routees on 3 other nodes (s1, s2, s3)
       val a1 = Address("akka.tcp", "Sys", "client1", 2552)
       val a2 = Address("akka.tcp", "Sys", "client2", 2552)

--- a/akka-remote/src/test/scala/akka/remote/serialization/AllowJavaSerializationOffSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/serialization/AllowJavaSerializationOffSpec.scala
@@ -72,7 +72,7 @@ class AllowJavaSerializationOffSpec extends AkkaSpec(
     akka {
       loglevel = debug
       actor {
-        enable-additional-serialization-bindings = off # this should be overriden by the setting below, which should force it to be on
+        enable-additional-serialization-bindings = off # this should be overridden by the setting below, which should force it to be on
         allow-java-serialization = off
         # this is by default on, but tests are running with off, use defaults here
         warn-about-java-serializer-usage = on

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -432,7 +432,7 @@ object TestSubscriber {
     }
 
     /**
-     * Expect subscription to be followed immediatly by an error signal.
+     * Expect subscription to be followed immediately by an error signal.
      *
      * By default `1` demand will be signalled in order to wake up a possibly lazy upstream.
      *
@@ -443,9 +443,9 @@ object TestSubscriber {
     }
 
     /**
-     * Expect subscription to be followed immediatly by an error signal.
+     * Expect subscription to be followed immediately by an error signal.
      *
-     * Depending on the `signalDemand` parameter demand may be signalled immediatly after obtaining the subscription
+     * Depending on the `signalDemand` parameter demand may be signalled immediately after obtaining the subscription
      * in order to wake up a possibly lazy upstream. You can disable this by setting the `signalDemand` parameter to `false`.
      *
      * See also [[#expectSubscriptionAndError()]].
@@ -499,7 +499,7 @@ object TestSubscriber {
      *
      * Expect subscription followed by immediate stream completion.
      *
-     * Depending on the `signalDemand` parameter demand may be signalled immediatly after obtaining the subscription
+     * Depending on the `signalDemand` parameter demand may be signalled immediately after obtaining the subscription
      * in order to wake up a possibly lazy upstream. You can disable this by setting the `signalDemand` parameter to `false`.
      *
      * See also [[#expectSubscriptionAndComplete]].

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpec.scala
@@ -599,7 +599,7 @@ class InterpreterSpec extends StreamSpec with GraphInterpreterSpecKit {
           push(out, lastElem)
         }
 
-        // note that the default value of lastElem will be always pushed if the upstream closed at the very begining without a pulling
+        // note that the default value of lastElem will be always pushed if the upstream closed at the very beginning without a pulling
         override def onPull(): Unit = {
           if (isClosed(in)) {
             push(out, lastElem)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
@@ -297,7 +297,7 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
           new ThreadNameSnitchingStage("akka.stream.default-blocking-io-dispatcher"))
           // this already introduces an async boundary here
           .map(identity)
-          // this is now just for map since there already is one inbetween stage and map
+          // this is now just for map since there already is one in-between stage and map
           .async // potential sugar .async("my-dispatcher")
           .addAttributes(ActorAttributes.dispatcher("my-dispatcher"))
           .runWith(Sink.head)
@@ -400,7 +400,7 @@ class AttributesSpec extends StreamSpec(ConfigFactory.parseString(
           new ThreadNameSnitchingStage("akka.stream.default-blocking-io-dispatcher"))
           // this already introduces an async boundary here
           .detach
-          // this is now just for map since there already is one inbetween stage and map
+          // this is now just for map since there already is one in-between stage and map
           .async
           .addAttributes(ActorAttributes.dispatcher("my-dispatcher"))
           .runWith(javadsl.Sink.head(), materializer)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
@@ -161,7 +161,7 @@ class FlowThrottleSpec extends StreamSpec {
       downstream.cancel()
     }
 
-    "throw exception when exceeding throughtput in enforced mode" in assertAllStagesStopped {
+    "throw exception when exceeding throughput in enforced mode" in assertAllStagesStopped {
       Await.result(
         Source(1 to 5).throttle(1, 200.millis, 5, Enforcing).runWith(Sink.seq),
         2.seconds) should ===(1 to 5) // Burst is 5 so this will not fail
@@ -282,7 +282,7 @@ class FlowThrottleSpec extends StreamSpec {
       downstream.cancel()
     }
 
-    "throw exception when exceeding throughtput in enforced mode" in assertAllStagesStopped {
+    "throw exception when exceeding throughput in enforced mode" in assertAllStagesStopped {
       Await.result(
         Source(1 to 4).throttle(2, 200.millis, 10, identity, Enforcing).runWith(Sink.seq),
         2.seconds) should ===(1 to 4) // Burst is 10 so this will not fail

--- a/akka-stream/src/main/resources/reference.conf
+++ b/akka-stream/src/main/resources/reference.conf
@@ -60,8 +60,8 @@ akka {
       max-fixed-buffer-size = 1000000000
 
       # Maximum number of sync messages that actor can process for stream to substream communication.
-      # Parameter allows to interrupt synchronous processing to get upsteam/downstream messages.
-      # Allows to accelerate message processing that happening withing same actor but keep system responsive.
+      # Parameter allows to interrupt synchronous processing to get upstream/downstream messages.
+      # Allows to accelerate message processing that happening within same actor but keep system responsive.
       sync-processing-limit = 1000
 
       debug {
@@ -115,7 +115,7 @@ akka {
 
     # Deprecated, use akka.stream.materializer.blocking-io-dispatcher, this setting
     # was never applied because of bug #24357
-    # It must still have a valid value becuase used from Akka HTTP.
+    # It must still have a valid value because used from Akka HTTP.
     blocking-io-dispatcher = "akka.stream.default-blocking-io-dispatcher"
 
     default-blocking-io-dispatcher {

--- a/akka-stream/src/main/scala/akka/stream/StreamRefs.scala
+++ b/akka-stream/src/main/scala/akka/stream/StreamRefs.scala
@@ -86,7 +86,7 @@ final case class InvalidSequenceNumberException(expectedSeqNr: Long, gotSeqNr: L
  * of a stream. Each such actor refers to the other side as its "partner". We make sure that no other actor than
  * the initial partner can send demand/messages to the other side accidentally.
  *
- * This exception is thrown when a message is recived from a non-partner actor,
+ * This exception is thrown when a message is received from a non-partner actor,
  * which could mean a bug or some actively malicient behavior from the other side.
  *
  * This is not meant as a security feature, but rather as plain sanity-check.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1351,7 +1351,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This operator can recover the failure signal, but not the skipped elements, which will be dropped.
    *
-   * Similarily to [[recover]] throwing an exception inside `mapError` _will_ be logged.
+   * Similarly to [[recover]] throwing an exception inside `mapError` _will_ be logged.
    *
    * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -1222,7 +1222,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This operator can recover the failure signal, but not the skipped elements, which will be dropped.
    *
-   * Similarily to [[recover]] throwing an exception inside `mapError` _will_ be logged.
+   * Similarly to [[recover]] throwing an exception inside `mapError` _will_ be logged.
    *
    * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -951,7 +951,7 @@ class SubFlow[In, Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Flow[I
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This operator can recover the failure signal, but not the skipped elements, which will be dropped.
    *
-   * Similarily to [[recover]] throwing an exception inside `mapError` _will_ be logged.
+   * Similarly to [[recover]] throwing an exception inside `mapError` _will_ be logged.
    *
    * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -933,7 +933,7 @@ class SubSource[Out, Mat](delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[O
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This operator can recover the failure signal, but not the skipped elements, which will be dropped.
    *
-   * Similarily to [[recover]] throwing an exception inside `mapError` _will_ be logged.
+   * Similarly to [[recover]] throwing an exception inside `mapError` _will_ be logged.
    *
    * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
    *

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -736,7 +736,7 @@ trait FlowOps[+Out, +Mat] {
    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
    * This operator can recover the failure signal, but not the skipped elements, which will be dropped.
    *
-   * Similarily to [[recover]] throwing an exception inside `mapError` _will_ be logged.
+   * Similarly to [[recover]] throwing an exception inside `mapError` _will_ be logged.
    *
    * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
    *

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -749,7 +749,7 @@ final class Partition[T](val outputPorts: Int, val partitioner: T ⇒ Int, val e
   def this(outputPorts: Int, partitioner: T ⇒ Int) = this(outputPorts, partitioner, false)
 
   val in: Inlet[T] = Inlet[T]("Partition.in")
-  val out: Seq[Outlet[T]] = Seq.tabulate(outputPorts)(i ⇒ Outlet[T]("Partition.out" + i)) // FIXME BC make this immutable.IndexedSeq as type + Vector as concret impl
+  val out: Seq[Outlet[T]] = Seq.tabulate(outputPorts)(i ⇒ Outlet[T]("Partition.out" + i)) // FIXME BC make this immutable.IndexedSeq as type + Vector as concrete impl
   override val shape: UniformFanOutShape[T, T] = UniformFanOutShape[T, T](in, out: _*)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with InHandler {

--- a/akka-testkit/src/test/java/akka/testkit/AkkaJUnitActorSystemResource.java
+++ b/akka-testkit/src/test/java/akka/testkit/AkkaJUnitActorSystemResource.java
@@ -41,7 +41,7 @@ import org.junit.rules.ExternalResource;
  * </code>
  *
  *         Note that it is important to not use <code>getSystem</code> from the
- *         constructor of the test, becuase some test runners may create an
+ *         constructor of the test, because some test runners may create an
  *         instance of the class without actually using it later, resulting in
  *         memory leaks because of not shutting down the actor system.
  */

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/MemoryUsageSnapshotting.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/MemoryUsageSnapshotting.scala
@@ -45,35 +45,35 @@ private[akka] trait MemoryUsageSnapshotting extends MetricsPrefix {
 
 }
 
-private[akka] case class TotalMemoryUsage(init: Long, used: Long, max: Long, comitted: Long) {
+private[akka] case class TotalMemoryUsage(init: Long, used: Long, max: Long, committed: Long) {
 
   def diff(other: TotalMemoryUsage): TotalMemoryUsage =
     TotalMemoryUsage(
       this.init - other.init,
       this.used - other.used,
       this.max - other.max,
-      this.comitted - other.comitted)
+      this.committed - other.committed)
 
 }
 
-private[akka] case class HeapMemoryUsage(init: Long, used: Long, max: Long, comitted: Long, usage: Double) {
+private[akka] case class HeapMemoryUsage(init: Long, used: Long, max: Long, committed: Long, usage: Double) {
 
   def diff(other: HeapMemoryUsage): HeapMemoryUsage =
     HeapMemoryUsage(
       this.init - other.init,
       this.used - other.used,
       this.max - other.max,
-      this.comitted - other.comitted,
+      this.committed - other.committed,
       this.usage - other.usage)
 }
 
-private[akka] case class NonHeapMemoryUsage(init: Long, used: Long, max: Long, comitted: Long, usage: Double) {
+private[akka] case class NonHeapMemoryUsage(init: Long, used: Long, max: Long, committed: Long, usage: Double) {
 
   def diff(other: NonHeapMemoryUsage): NonHeapMemoryUsage =
     NonHeapMemoryUsage(
       this.init - other.init,
       this.used - other.used,
       this.max - other.max,
-      this.comitted - other.comitted,
+      this.committed - other.committed,
       this.usage - other.usage)
 }


### PR DESCRIPTION
This pull request fixes several minor typos in the source code. Although I am not a native English speaker, [misspell](https://github.com/client9/misspell) detected obvious mistakes for us. I've fixed them except for false positives.

```
$ misspell */src
akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala:167:50: "withing" is a misspelling of "within"
akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/TestProbe.scala:186:50: "withing" is a misspelling of "within"
akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala:52:3: "derivate" is a misspelling of "derivative"
akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala:60:5: "derivate" is a misspelling of "derivative"
akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala:33:63: "Terminater" is a misspelling of "Terminator"
akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala:53:8: "Terminater" is a misspelling of "Terminator"
akka-actor-tests/src/test/scala/akka/actor/ExtensionSpec.scala:110:18: "initalized" is a misspelling of "initialized"
akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala:820:49: "startegy" is a misspelling of "strategy"
akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatchersSpec.scala:166:52: "expeced" is a misspelling of "expected"
akka-actor-tests/src/test/scala/akka/actor/SupervisorSpec.scala:360:37: "superviser" is a misspelling of "supervisor"
akka-actor-tests/src/test/scala/akka/dispatch/DispatcherShutdownSpec.scala:18:5: "eventualy" is a misspelling of "eventually"
akka-actor-tests/src/test/scala/akka/routing/MetricsBasedResizerSpec.scala:244:36: "inbetween" is a misspelling of "between"
akka-actor-tests/src/test/scala/akka/routing/MetricsBasedResizerSpec.scala:276:36: "inbetween" is a misspelling of "between"
akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/AdapterTest.java:312:9: "supress" is a misspelling of "suppress"
akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala:91:65: "recieving" is a misspelling of "receiving"
akka-actor-typed-tests/src/test/scala/akka/actor/typed/ExtensionsSpec.scala:141:20: "initalized" is a misspelling of "initialized"
akka-actor/src/main/scala/akka/AkkaVersion.scala:36:38: "inbetween" is a misspelling of "between"
akka-actor/src/main/resources/reference.conf:300:12: "Probabily" is a misspelling of "Probability"
akka-actor/src/main/resources/reference.conf:390:65: "accomodate" is a misspelling of "accommodate"
akka-actor/src/main/resources/reference.conf:1103:6: "overriden" is a misspelling of "overridden"
akka-actor/src/main/scala/akka/util/PrettyDuration.scala:16:18: "apropriate" is a misspelling of "appropriate"
akka-actor/src/main/scala/akka/util/PrettyDuration.scala:22:18: "apropriate" is a misspelling of "appropriate"
akka-actor/src/main/scala/akka/util/PrettyDuration.scala:28:21: "apropriate" is a misspelling of "appropriate"
akka-actor/src/main/scala/akka/util/PrettyDuration.scala:31:21: "apropriate" is a misspelling of "appropriate"
akka-bench-jmh/src/main/scala/akka/actor/typed/TypedBenchmarkActors.scala:65:80: "paralell" is a misspelling of "parallel"
akka-bench-jmh/src/main/scala/akka/stream/FusedGraphsBenchmark.scala:320:6: "boradcast" is a misspelling of "broadcast"
akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala:729:100: "occured" is a misspelling of "occurred"
akka-cluster/src/multi-jvm/scala/akka/cluster/RestartFirstSeedNodeSpec.scala:96:34: "transfered" is a misspelling of "transferred"
akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNode2Spec.scala:97:34: "transfered" is a misspelling of "transferred"
akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNode3Spec.scala:98:35: "transfered" is a misspelling of "transferred"
akka-cluster/src/multi-jvm/scala/akka/cluster/SharedMediaDriverSupport.scala:39:51: "inbetween" is a misspelling of "between"
akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNodeSpec.scala:114:35: "transfered" is a misspelling of "transferred"
akka-cluster/src/multi-jvm/scala/akka/cluster/TransitionSpec.scala:229:53: "unavailble" is a misspelling of "unavailable"
akka-cluster/src/multi-jvm/scala/akka/cluster/TransitionSpec.scala:237:33: "unavailble" is a misspelling of "unavailable"
akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala:84:34: "initally" is a misspelling of "initially"
akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala:178:87: "initally" is a misspelling of "initially"
akka-cluster/src/test/scala/akka/cluster/AutoDownSpec.scala:87:43: "inbetween" is a misspelling of "between"
akka-cluster/src/test/scala/akka/cluster/AutoDownSpec.scala:96:49: "inbetween" is a misspelling of "between"
akka-cluster/src/test/scala/akka/cluster/AutoDownSpec.scala:104:48: "inbetween" is a misspelling of "between"
akka-cluster/src/test/scala/akka/cluster/AutoDownSpec.scala:112:42: "inbetween" is a misspelling of "between"
akka-contrib/src/main/scala/akka/contrib/circuitbreaker/CircuitBreakerProxy.scala:160:67: "withing" is a misspelling of "within"
akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurableDataSpec.scala:164:23: "initalized" is a misspelling of "initialized"
akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorSpec.scala:263:23: "succesful" is a misspelling of "successful"
akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorSpec.scala:406:24: "inital" is a misspelling of "initial"
akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorSpec.scala:413:23: "inital" is a misspelling of "initial"
akka-distributed-data/src/test/scala/akka/cluster/ddata/DeltaPropagationSelectorSpec.scala:179:5: "calcualte" is a misspelling of "calculate"
akka-docs/src/main/paradox/distributed-data.md:498:101: "bandwith" is a misspelling of "bandwidth"
akka-docs/src/main/paradox/general/supervision.md:200:22: "peristent" is a misspelling of "persistent"
akka-docs/src/main/paradox/persistence-schema-evolution.md:359:112: "alltogether" is a misspelling of "altogether"
akka-docs/src/main/paradox/persistence-schema-evolution.md:414:0: "alowing" is a misspelling of "allowing"
akka-docs/src/main/paradox/persistence-schema-evolution.md:499:34: "similarily" is a misspelling of "similarly"
akka-docs/src/main/paradox/project/migration-guide-2.4.x-2.5.x.md:296:72: "emiting" is a misspelling of "emitting"
akka-docs/src/main/paradox/project/migration-guide-2.4.x-2.5.x.md:594:31: "accomodate" is a misspelling of "accommodate"
akka-docs/src/main/paradox/persistence.md:1129:10: "achive" is a misspelling of "achieve"
akka-docs/src/main/paradox/security/2017-02-10-java-serialization.md:5:3: "Feburary" is a misspelling of "February"
akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapError.md:24:0: "Similarily" is a misspelling of "Similarly"
akka-docs/src/main/paradox/stream/stream-flows-and-basics.md:411:143: "continiously" is a misspelling of "continuously"
akka-docs/src/main/paradox/typed/stream.md:44:20: "availabe" is a misspelling of "available"
akka-docs/src/main/paradox/typed/interaction-patterns.md:175:279: "succesful" is a misspelling of "successful"
akka-docs/src/test/java/jdocs/actor/ByteBufferSerializerDocTest.java:33:29: "aquire" is a misspelling of "acquire"
akka-docs/src/test/java/jdocs/stream/SilenceSystemOut.java:12:118: "poluting" is a misspelling of "polluting"
akka-docs/src/test/scala/docs/actor/ByteBufferSerializerDocSpec.scala:23:29: "aquire" is a misspelling of "acquire"
akka-docs/src/test/scala/docs/stream/StreamPartialGraphDSLDocSpec.scala:120:66: "usefull" is a misspelling of "useful"
akka-persistence-tck/src/main/scala/akka/persistence/scalatest/OptionalTests.scala:21:36: "Imlpementation" is a misspelling of "Implementations"
akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala:72:22: "overriden" is a misspelling of "overridden"
akka-persistence/src/main/java/akka/persistence/serialization/MessageFormats.java:5857:7: "estination" is a misspelling of "estimation"
akka-persistence/src/main/scala/akka/persistence/snapshot/local/LocalSnapshotStore.scala:135:73: "accomodates" is a misspelling of "accommodates"
akka-protobuf/src/main/java/akka/protobuf/RepeatedFieldBuilder.java:61:28: "occured" is a misspelling of "occurred"
akka-protobuf/src/main/java/akka/protobuf/SingleFieldBuilder.java:54:28: "occured" is a misspelling of "occurred"
akka-protobuf/src/main/java/akka/protobuf/DescriptorProtos.java:28326:7: "alse" is a misspelling of "else"
akka-remote/src/main/resources/reference.conf:905:34: "embeded" is a misspelling of "embedded"
akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala:412:57: "initalized" is a misspelling of "initialized"
akka-remote/src/main/scala/akka/remote/artery/Association.scala:1016:56: "assocation" is a misspelling of "association"
akka-remote/src/main/scala/akka/remote/artery/FlightRecorder.scala:76:43: "aquire" is a misspelling of "acquire"
akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala:229:40: "continiously" is a misspelling of "continuously"
akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala:488:55: "Attemted" is a misspelling of "Attempted"
akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala:495:55: "Attemted" is a misspelling of "Attempted"
akka-remote/src/main/scala/akka/remote/serialization/MiscMessageSerializer.scala:439:9: "technicaly" is a misspelling of "technically"
akka-remote/src/main/scala/akka/remote/serialization/MiscMessageSerializer.scala:448:9: "technicaly" is a misspelling of "technically"
akka-remote/src/test/scala/akka/remote/RemoteConsistentHashingRouterSpec.scala:18:24: "indepenent" is a misspelling of "independent"
akka-remote/src/test/scala/akka/remote/serialization/AllowJavaSerializationOffSpec.scala:75:72: "overriden" is a misspelling of "overridden"
akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala:435:42: "immediatly" is a misspelling of "immediately"
akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala:446:42: "immediatly" is a misspelling of "immediately"
akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala:448:73: "immediatly" is a misspelling of "immediately"
akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala:502:73: "immediatly" is a misspelling of "immediately"
akka-stream-tests/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala:50:54: "strat" is a misspelling of "start"
akka-stream-tests/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala:51:47: "strat" is a misspelling of "start"
akka-stream-tests/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala:53:51: "strat" is a misspelling of "start"
akka-stream-tests/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala:56:35: "strat" is a misspelling of "start"
akka-stream-tests/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala:195:5: "suport" is a misspelling of "support"
akka-stream-tests/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala:205:10: "strat" is a misspelling of "start"
akka-stream-tests/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala:212:10: "strat" is a misspelling of "start"
akka-stream-tests/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala:219:10: "strat" is a misspelling of "start"
akka-stream-tests/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala:229:10: "strat" is a misspelling of "start"
akka-stream-tests/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala:253:10: "strat" is a misspelling of "start"
akka-stream-tests/src/test/scala/akka/stream/actor/ActorSubscriberSpec.scala:276:10: "strat" is a misspelling of "start"
akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpec.scala:602:108: "begining" is a misspelling of "beginning"
akka-stream-tests/src/test/scala/akka/stream/io/compression/CodecSpecSupport.scala:43:24: "facilisi" is a misspelling of "facilities"
akka-stream-tests/src/test/scala/akka/stream/io/compression/CodecSpecSupport.scala:49:35: "facilisi" is a misspelling of "facilities"
akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala:300:65: "inbetween" is a misspelling of "between"
akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala:403:65: "inbetween" is a misspelling of "between"
akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala:164:36: "throughtput" is a misspelling of "throughput"
akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala:285:36: "throughtput" is a misspelling of "throughput"
akka-stream/src/main/resources/reference.conf:63:68: "upsteam" is a misspelling of "upstream"
akka-stream/src/main/resources/reference.conf:64:63: "withing" is a misspelling of "within"
akka-stream/src/main/resources/reference.conf:118:39: "becuase" is a misspelling of "because"
akka-stream/src/main/scala/akka/stream/StreamRefs.scala:89:46: "recived" is a misspelling of "received"
akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala:1352:5: "Similarily" is a misspelling of "Similarly"
akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala:954:5: "Similarily" is a misspelling of "Similarly"
akka-stream/src/main/scala/akka/stream/javadsl/Source.scala:1130:5: "Similarily" is a misspelling of "Similarly"
akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala:936:5: "Similarily" is a misspelling of "Similarly"
akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala:739:5: "Similarily" is a misspelling of "Similarly"
akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala:752:155: "concret" is a misspelling of "concert"
akka-testkit/src/test/java/akka/testkit/AkkaJUnitActorSystemResource.java:44:36: "becuase" is a misspelling of "because"
akka-testkit/src/test/scala/akka/testkit/metrics/MemoryUsageSnapshotting.scala:48:77: "comitted" is a misspelling of "committed"
akka-testkit/src/test/scala/akka/testkit/metrics/MemoryUsageSnapshotting.scala:59:76: "comitted" is a misspelling of "committed"
akka-testkit/src/test/scala/akka/testkit/metrics/MemoryUsageSnapshotting.scala:70:79: "comitted" is a misspelling of "committed"
```