### PR TITLE
Log more details for TCP connection errors

### DIFF
--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -460,8 +460,19 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
       newInstance._cause = Some(cause)
       newInstance
     }
+
     @InternalApi
-    private[akka] def causedByString = _cause.map(c ⇒ s" because of ${c.getMessage}").getOrElse("")
+    private[akka] def causedByString = _cause.map(t ⇒ {
+      val msg =
+        if (t.getCause == null)
+          t.getMessage
+        else if (t.getCause.getCause == null)
+          s"${t.getMessage}, caused by: ${t.getCause}"
+        else
+          s"${t.getMessage}, caused by: ${t.getCause}, caused by: ${t.getCause.getCause}"
+
+      s" because of ${t.getClass.getName}: $msg"
+    }).getOrElse("")
 
     override def toString: String = s"CommandFailed($cmd)$causedByString"
   }


### PR DESCRIPTION
Notably the name of the exception was suppressed, and when you only the
'message' part of a `java.lang.UnknownHostException` it is not very obvious
what is wrong.

Inspired by #25438