### PR TITLE
=stream Avoid boxing Attributes in java Optional

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/ActorRefBackpressureSinkStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorRefBackpressureSinkStage.scala
@@ -32,7 +32,7 @@ import akka.stream.stage._
     new GraphStageLogic(shape) with InHandler {
       implicit def self: ActorRef = stageActor.ref
 
-      val maxBuffer = inheritedAttributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16)).max
+      val maxBuffer = inheritedAttributes.get[InputBuffer](InputBuffer(16, 16)).max
       require(maxBuffer > 0, "Buffer size must be greater than 0")
 
       val buffer: util.Deque[In] = new util.ArrayDeque[In]()

--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -333,7 +333,7 @@ import scala.util.{ Failure, Success, Try }
     val stageLogic = new GraphStageLogic(shape) with InHandler with SinkQueueWithCancel[T] {
       type Received[E] = Try[Option[E]]
 
-      val maxBuffer = inheritedAttributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16)).max
+      val maxBuffer = inheritedAttributes.get[InputBuffer](InputBuffer(16, 16)).max
       require(maxBuffer > 0, "Buffer size must be greater than 0")
 
       var buffer: Buffer[Received[T]] = _

--- a/akka-stream/src/main/scala/akka/stream/impl/io/IOSources.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/IOSources.scala
@@ -59,7 +59,7 @@ private[akka] final class FileSource(path: Path, chunkSize: Int, startPosition: 
     val logic = new GraphStageLogic(shape) with OutHandler {
       handler ⇒
       val buffer = ByteBuffer.allocate(chunkSize)
-      val maxReadAhead = inheritedAttributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16)).max
+      val maxReadAhead = inheritedAttributes.get[InputBuffer](InputBuffer(16, 16)).max
       var channel: FileChannel = _
       var position = startPosition
       var chunkCallback: Try[Int] ⇒ Unit = _

--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
@@ -46,7 +46,7 @@ private[stream] object InputStreamSinkStage {
   override val shape: SinkShape[ByteString] = SinkShape.of(in)
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, InputStream) = {
-    val maxBuffer = inheritedAttributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16)).max
+    val maxBuffer = inheritedAttributes.get[InputBuffer](InputBuffer(16, 16)).max
     require(maxBuffer > 0, "Buffer size must be greater than 0")
 
     val dataQueue = new LinkedBlockingDeque[StreamToAdapterMessage](maxBuffer + 2)

--- a/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSourceStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSourceStage.scala
@@ -37,7 +37,7 @@ final private[stream] class OutputStreamSourceStage(writeTimeout: FiniteDuration
   override val shape: SourceShape[ByteString] = SourceShape.of(out)
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, OutputStream) = {
-    val maxBuffer = inheritedAttributes.getAttribute(classOf[InputBuffer], InputBuffer(16, 16)).max
+    val maxBuffer = inheritedAttributes.get[InputBuffer](InputBuffer(16, 16)).max
 
     require(maxBuffer > 0, "Buffer size must be greater than 0")
 


### PR DESCRIPTION
In internal implementation we are using the `Java API` method to get `Attributes`.

This cause Linking error on the Scala.Js side ( https://github.com/akka-js/akka.js/issues/89 ) and most notably a  superfluous boxing/unboxing (to/from java Optional).