### PR TITLE
Minor documentation fixes

### DIFF
--- a/akka-docs/src/main/paradox/stream/stream-customize.md
+++ b/akka-docs/src/main/paradox/stream/stream-customize.md
@@ -498,7 +498,7 @@ or the downstreams. Even for operators that do not complete or fail in this mann
 ## Extending Flow Operators with Custom Operators
 
 The most general way of extending any `Source`, `Flow` or `SubFlow` (e.g. from `groupBy`) is
-demonstrated above: create a operator of flow-shape like the `Duplicator` example given above and use the `.via(...)`
+demonstrated above: create an operator of flow-shape like the `Duplicator` example given above and use the `.via(...)`
 operator to integrate it into your stream topology. This works with all `FlowOps` sub-types, including the
 ports that you connect with the graph DSL.
 

--- a/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
+++ b/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
@@ -63,15 +63,15 @@ can hand it back for further use to an underlying thread-pool.
 Linear processing pipelines can be expressed in Akka Streams using the following core abstractions:
 
 Source
-: A operator with *exactly one output*, emitting data elements whenever downstream operators are
+: An operator with *exactly one output*, emitting data elements whenever downstream operators are
 ready to receive them.
 
 Sink
-: A operator with *exactly one input*, requesting and accepting data elements possibly slowing down the upstream
-producer of elements
+: An operator with *exactly one input*, requesting and accepting data elements, possibly slowing down the upstream
+producer of elements.
 
 Flow
-: A operator which has *exactly one input and output*, which connects its upstream and downstream by
+: An operator which has *exactly one input and output*, which connects its upstream and downstream by
 transforming the data elements flowing through it.
 
 RunnableGraph


### PR DESCRIPTION
There were some indefinite errors introduced when wordings changed, e.g., "graph" or "processing stages" to "operators".
Also, I've added some missing punctuation.