### PR TITLE
Add direction & throttler mode accessors to improve Java interop

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
@@ -165,6 +165,31 @@ object ThrottlerTransportAdapter {
      */
     def getInstance = this
   }
+
+  /**
+   * Java API: get the Direction.Send instance
+   */
+  def sendDirection() = Direction.Send
+
+  /**
+   * Java API: get the Direction.Receive instance
+   */
+  def receiveDirection() = Direction.Receive
+
+  /**
+   * Java API: get the Direction.Both instance
+   */
+  def bothDirection() = Direction.Both
+
+  /**
+   * Java API: get the ThrottleMode.Blackhole instance
+   */
+  def blackholeThrottleMode() = Blackhole
+
+  /**
+   * Java API: get the ThrottleMode.Unthrottled instance
+   */
+  def unthrottledThrottleMode() = Unthrottled
 }
 
 class ThrottlerTransportAdapter(_wrappedTransport: Transport, _system: ExtendedActorSystem) extends ActorTransportAdapter(_wrappedTransport, _system) {

--- a/akka-remote/src/test/java/akka/remote/transport/ThrottlerTransportAdapterTest.java
+++ b/akka-remote/src/test/java/akka/remote/transport/ThrottlerTransportAdapterTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.remote.transport;
+
+// compile only; verify java interop
+public class ThrottlerTransportAdapterTest {
+
+    public void compileThrottlerTransportAdapterDirections() {
+        acceptDirection(ThrottlerTransportAdapter.bothDirection());
+        acceptDirection(ThrottlerTransportAdapter.receiveDirection());
+        acceptDirection(ThrottlerTransportAdapter.sendDirection());
+    }
+
+    public void compleThrottleMode() {
+        acceptThrottleMode(ThrottlerTransportAdapter.unthrottledThrottleMode());
+        acceptThrottleMode(ThrottlerTransportAdapter.blackholeThrottleMode());
+        acceptThrottleMode(new ThrottlerTransportAdapter.TokenBucket(0, 0.0, 0, 0));
+    }
+
+    void acceptDirection(ThrottlerTransportAdapter.Direction dir) {}
+
+    void acceptThrottleMode(ThrottlerTransportAdapter.ThrottleMode mode) {}
+
+}


### PR DESCRIPTION
#25429
added acessors to ThrottlerTransportAdapter object, 
added compile only java tests. 
 