### PR TITLE
Additional records support for async dns

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsResolverSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsResolverSpec.scala
@@ -8,14 +8,15 @@ import java.net.{ Inet6Address, InetAddress }
 
 import akka.actor.Status.Failure
 import akka.actor.{ ActorRef, ExtendedActorSystem, Props }
-import akka.io.dns.{ AAAARecord, ARecord, DnsSettings }
+import akka.io.dns.{ AAAARecord, ARecord, DnsSettings, SRVRecord }
 import akka.testkit.{ AkkaSpec, ImplicitSender, TestProbe }
 import com.typesafe.config.ConfigFactory
 import akka.io.dns.DnsProtocol._
 import akka.io.dns.internal.AsyncDnsResolver.ResolveFailedException
 import akka.io.dns.internal.DnsClient.{ Answer, Question4, Question6, SrvQuestion }
+import scala.concurrent.duration._
 
-import scala.collection.immutable
+import scala.collection.{ immutable ⇒ im }
 
 class AsyncDnsResolverSpec extends AkkaSpec(
   """
@@ -30,9 +31,9 @@ class AsyncDnsResolverSpec extends AkkaSpec(
       val r = resolver(List(dnsClient1.ref, dnsClient2.ref))
       r ! Resolve("cats.com", Ip(ipv4 = true, ipv6 = false))
       dnsClient1.expectMsg(Question4(1, "cats.com"))
-      dnsClient1.reply(Answer(1, immutable.Seq()))
+      dnsClient1.reply(Answer(1, im.Seq.empty))
       dnsClient2.expectNoMessage()
-      expectMsg(Resolved("cats.com", immutable.Seq()))
+      expectMsg(Resolved("cats.com", im.Seq.empty))
     }
 
     "move to next client if first fails" in {
@@ -44,8 +45,8 @@ class AsyncDnsResolverSpec extends AkkaSpec(
       dnsClient1.expectMsg(Question4(1, "cats.com"))
       dnsClient1.reply(Failure(new RuntimeException("Nope")))
       dnsClient2.expectMsg(Question4(2, "cats.com"))
-      dnsClient2.reply(Answer(2, immutable.Seq()))
-      expectMsg(Resolved("cats.com", immutable.Seq()))
+      dnsClient2.reply(Answer(2, im.Seq.empty))
+      expectMsg(Resolved("cats.com", im.Seq.empty))
     }
 
     "move to next client if first times out" in {
@@ -56,8 +57,8 @@ class AsyncDnsResolverSpec extends AkkaSpec(
       // first will get ask timeout
       dnsClient1.expectMsg(Question4(1, "cats.com"))
       dnsClient2.expectMsg(Question4(2, "cats.com"))
-      dnsClient2.reply(Answer(2, immutable.Seq()))
-      expectMsg(Resolved("cats.com", immutable.Seq()))
+      dnsClient2.reply(Answer(2, im.Seq.empty))
+      expectMsg(Resolved("cats.com", im.Seq.empty))
     }
 
     "gets both A and AAAA records if requested" in {
@@ -66,11 +67,11 @@ class AsyncDnsResolverSpec extends AkkaSpec(
       r ! Resolve("cats.com", Ip(ipv4 = true, ipv6 = true))
       dnsClient1.expectMsg(Question4(1, "cats.com"))
       val ipv4Record = ARecord("cats.com", 100, InetAddress.getByName("127.0.0.1"))
-      dnsClient1.reply(Answer(1, immutable.Seq(ipv4Record)))
+      dnsClient1.reply(Answer(1, im.Seq(ipv4Record)))
       dnsClient1.expectMsg(Question6(2, "cats.com"))
       val ipv6Record = AAAARecord("cats.com", 100, InetAddress.getByName("::1").asInstanceOf[Inet6Address])
-      dnsClient1.reply(Answer(2, immutable.Seq(ipv6Record)))
-      expectMsg(Resolved("cats.com", immutable.Seq(ipv4Record, ipv6Record)))
+      dnsClient1.reply(Answer(2, im.Seq(ipv6Record)))
+      expectMsg(Resolved("cats.com", im.Seq(ipv4Record, ipv6Record)))
     }
 
     "fails if all dns clients timeout" in {
@@ -89,34 +90,50 @@ class AsyncDnsResolverSpec extends AkkaSpec(
       val r = resolver(List(dnsClient1.ref, dnsClient2.ref))
       r ! Resolve("cats.com", Srv)
       dnsClient1.expectMsg(SrvQuestion(1, "cats.com"))
-      dnsClient1.reply(Answer(1, immutable.Seq()))
+      dnsClient1.reply(Answer(1, im.Seq.empty))
       dnsClient2.expectNoMessage()
-      expectMsg(Resolved("cats.com", immutable.Seq()))
+      expectMsg(Resolved("cats.com", im.Seq.empty))
     }
 
-    "not hang when resolving raw IP address" in {
-      import scala.concurrent.duration._
+    "response immediately IP address" in {
       val name = "127.0.0.1"
       val dnsClient1 = TestProbe()
       val r = resolver(List(dnsClient1.ref))
       r ! Resolve(name)
       dnsClient1.expectNoMessage(50.millis)
       val answer = expectMsgType[Resolved]
-      answer.results.collect { case r: ARecord ⇒ r }.toSet shouldEqual Set(
+      answer.records.collect { case r: ARecord ⇒ r }.toSet shouldEqual Set(
         ARecord("127.0.0.1", Int.MaxValue, InetAddress.getByName("127.0.0.1"))
       )
     }
-    "not hang when resolving raw IPv6 address" in {
-      import scala.concurrent.duration._
+
+    "response immediately for IPv6 address" in {
       val name = "1:2:3:0:0:0:0:0"
       val dnsClient1 = TestProbe()
       val r = resolver(List(dnsClient1.ref))
       r ! Resolve(name)
       dnsClient1.expectNoMessage(50.millis)
       val answer = expectMsgType[Resolved]
-      answer.results.collect { case r: ARecord ⇒ r }.toSet shouldEqual Set(
+      answer.records.collect { case r: ARecord ⇒ r }.toSet shouldEqual Set(
         ARecord("1:2:3:0:0:0:0:0", Int.MaxValue, InetAddress.getByName("1:2:3:0:0:0:0:0"))
       )
+    }
+
+    "return additional records for SRV requests" in {
+      val dnsClient1 = TestProbe()
+      val dnsClient2 = TestProbe()
+      val r = resolver(List(dnsClient1.ref, dnsClient2.ref))
+      r ! Resolve("cats.com", Srv)
+      dnsClient1.expectMsg(SrvQuestion(1, "cats.com"))
+      val srvRecs = im.Seq(SRVRecord("cats.com", 5000, 1, 1, 1, "a.cats.com"))
+      val aRecs = im.Seq(ARecord("a.cats.com", 1, InetAddress.getByName("127.0.0.1")))
+      dnsClient1.reply(Answer(1, srvRecs, aRecs))
+      dnsClient2.expectNoMessage(50.millis)
+      expectMsg(Resolved("cats.com", srvRecs, aRecs))
+
+      // cached the second time, don't have the probe reply
+      r ! Resolve("cats.com", Srv)
+      expectMsg(Resolved("cats.com", srvRecs, aRecs))
     }
   }
 

--- a/akka-actor/src/main/scala/akka/io/dns/DnsProtocol.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/DnsProtocol.scala
@@ -9,7 +9,7 @@ import java.util
 import akka.actor.NoSerializationVerificationNeeded
 import akka.annotation.ApiMayChange
 
-import scala.collection.immutable
+import scala.collection.{ immutable ⇒ im }
 import scala.collection.JavaConverters._
 
 /**
@@ -61,11 +61,15 @@ object DnsProtocol {
   }
 
   @ApiMayChange
-  final case class Resolved(name: String, results: immutable.Seq[ResourceRecord]) extends NoSerializationVerificationNeeded {
+  final case class Resolved(name: String, records: im.Seq[ResourceRecord], additionalRecords: im.Seq[ResourceRecord] = im.Seq.empty) extends NoSerializationVerificationNeeded {
     /**
      * Java API
      */
-    def getResults(): util.List[ResourceRecord] = results.asJava
+    def getRecords(): util.List[ResourceRecord] = records.asJava
+    /**
+     * Java API
+     */
+    def getAdditionalRecords(): util.List[ResourceRecord] = additionalRecords.asJava
   }
 
 }

--- a/akka-actor/src/main/scala/akka/io/dns/DnsProtocol.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/DnsProtocol.scala
@@ -60,16 +60,34 @@ object DnsProtocol {
     def create(name: String, requestType: RequestType): Resolve = Resolve(name, requestType)
   }
 
+  /**
+   * @param name of the record
+   * @param records resource records for the query
+   * @param additionalRecords records that relate to the query but are not strictly answers
+   */
   @ApiMayChange
-  final case class Resolved(name: String, records: im.Seq[ResourceRecord], additionalRecords: im.Seq[ResourceRecord] = im.Seq.empty) extends NoSerializationVerificationNeeded {
+  final case class Resolved(name: String, records: im.Seq[ResourceRecord], additionalRecords: im.Seq[ResourceRecord]) extends NoSerializationVerificationNeeded {
     /**
      * Java API
+     *
+     * Records for the query
      */
     def getRecords(): util.List[ResourceRecord] = records.asJava
     /**
      * Java API
+     *
+     * Records that relate to the query but are not strickly answers e.g. A records for the records returned for an SRV query.
+     *
      */
     def getAdditionalRecords(): util.List[ResourceRecord] = additionalRecords.asJava
+  }
+
+  @ApiMayChange
+  object Resolved {
+
+    @ApiMayChange
+    def apply(name: String, records: im.Seq[ResourceRecord]): Resolved =
+      new Resolved(name, records, Nil)
   }
 
 }

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
@@ -74,7 +74,7 @@ private[io] final class AsyncDnsManager(val ext: DnsExt) extends Actor
       val adapted = DnsProtocol.Resolve(name)
       val reply = (resolver ? adapted).mapTo[DnsProtocol.Resolved]
         .map { asyncResolved ⇒
-          val ips = asyncResolved.results.collect { case a: ARecord ⇒ a.ip }
+          val ips = asyncResolved.records.collect { case a: ARecord ⇒ a.ip }
           Dns.Resolved(asyncResolved.name, ips)
         }
       reply pipeTo sender

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
@@ -133,7 +133,6 @@ private[io] final class AsyncDnsResolver(
             sendQuestion(resolver, SrvQuestion(nextId(), caseFoldedName))
               .map(r ⇒ {
                 if (r.rrs.nonEmpty) {
-                  println("Caching")
                   val minTtl = r.rrs.minBy(_.ttl).ttl
                   cache.put((name, SrvType), r, minTtl)
                 }

--- a/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
@@ -12,7 +12,7 @@ import akka.annotation.InternalApi
 import akka.io.dns.{ RecordClass, RecordType, ResourceRecord }
 import akka.io.{ IO, Udp }
 
-import scala.collection.immutable
+import scala.collection.{ immutable ⇒ im }
 import scala.util.Try
 
 /**
@@ -25,7 +25,7 @@ import scala.util.Try
   final case class SrvQuestion(id: Short, name: String) extends DnsQuestion
   final case class Question4(id: Short, name: String) extends DnsQuestion
   final case class Question6(id: Short, name: String) extends DnsQuestion
-  final case class Answer(id: Short, rrs: immutable.Seq[ResourceRecord]) extends NoSerializationVerificationNeeded
+  final case class Answer(id: Short, rrs: im.Seq[ResourceRecord], additionalRecs: im.Seq[ResourceRecord] = im.Seq.empty) extends NoSerializationVerificationNeeded
   final case class DropRequest(id: Short)
 }
 
@@ -56,7 +56,7 @@ import scala.util.Try
   }
 
   private def message(name: String, id: Short, recordType: RecordType): Message = {
-    Message(id, MessageFlags(), immutable.Seq(Question(name, recordType, RecordClass.IN)))
+    Message(id, MessageFlags(), im.Seq(Question(name, recordType, RecordClass.IN)))
   }
 
   def ready(socket: ActorRef): Receive = {
@@ -103,8 +103,8 @@ import scala.util.Try
       log.debug(s"Received message from [{}]: [{}]", remote, data)
       val msg = Message.parse(data)
       log.debug(s"Decoded: $msg")
-      val recs = if (msg.flags.responseCode == ResponseCode.SUCCESS) msg.answerRecs else immutable.Seq.empty
-      val response = Answer(msg.id, recs)
+      val (recs, additionalRecs) = if (msg.flags.responseCode == ResponseCode.SUCCESS) (msg.answerRecs, msg.additionalRecs) else (im.Seq.empty, im.Seq.empty)
+      val response = Answer(msg.id, recs, additionalRecs)
       inflightRequests.get(response.id) match {
         case Some(reply) ⇒
           reply ! response

--- a/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
@@ -25,7 +25,7 @@ import scala.util.Try
   final case class SrvQuestion(id: Short, name: String) extends DnsQuestion
   final case class Question4(id: Short, name: String) extends DnsQuestion
   final case class Question6(id: Short, name: String) extends DnsQuestion
-  final case class Answer(id: Short, rrs: im.Seq[ResourceRecord], additionalRecs: im.Seq[ResourceRecord] = im.Seq.empty) extends NoSerializationVerificationNeeded
+  final case class Answer(id: Short, rrs: im.Seq[ResourceRecord], additionalRecs: im.Seq[ResourceRecord] = Nil) extends NoSerializationVerificationNeeded
   final case class DropRequest(id: Short)
 }
 
@@ -103,7 +103,7 @@ import scala.util.Try
       log.debug(s"Received message from [{}]: [{}]", remote, data)
       val msg = Message.parse(data)
       log.debug(s"Decoded: $msg")
-      val (recs, additionalRecs) = if (msg.flags.responseCode == ResponseCode.SUCCESS) (msg.answerRecs, msg.additionalRecs) else (im.Seq.empty, im.Seq.empty)
+      val (recs, additionalRecs) = if (msg.flags.responseCode == ResponseCode.SUCCESS) (msg.answerRecs, msg.additionalRecs) else (Nil, Nil)
       val response = Answer(msg.id, recs, additionalRecs)
       inflightRequests.get(response.id) match {
         case Some(reply) ⇒


### PR DESCRIPTION
- Currently just used for SRV A/AAAA records
- Cache SRV records
- Rename Resolved.results to Resolved.records

This is required to make SRV records useful for cluster bootstrap as the additional records can be used to see match the self ip against the discovered record from the srv request