### PR TITLE
Support joining 2.5.9 or earlier, compat InitJoinAck, #25491

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -99,7 +99,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
   // ClusterJmx is initialized as the last thing in the constructor
   private var clusterJmx: Option[ClusterJmx] = None
 
-  logInfo("Starting up...")
+  logInfo("Starting up, Akka version [{}] ...", system.settings.ConfigVersion)
 
   val failureDetector: FailureDetectorRegistry[Address] = {
     val createFailureDetector = () ⇒

--- a/akka-cluster/src/main/scala/akka/cluster/JoinConfigCompatChecker.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/JoinConfigCompatChecker.scala
@@ -145,7 +145,10 @@ object JoinConfigCompatChecker {
 
     // composite checker
     new JoinConfigCompatChecker {
-      override val requiredKeys: im.Seq[String] = checkers.flatMap(_.requiredKeys).to[im.Seq]
+      override val requiredKeys: im.Seq[String] = {
+        // Always include akka.version (used in join logging)
+        "akka.version" +: checkers.flatMap(_.requiredKeys).to[im.Seq]
+      }
       override def check(toValidate: Config, clusterConfig: Config): ConfigValidation =
         checkers.foldLeft(Valid: ConfigValidation) { (acc, checker) ⇒
           acc ++ checker.check(toValidate, clusterConfig)

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -12,11 +12,11 @@ import akka.cluster._
 import akka.cluster.protobuf.msg.{ ClusterMessages ⇒ cm }
 import akka.serialization._
 import akka.protobuf.{ ByteString, MessageLite }
-
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.Deadline
+
 import akka.annotation.InternalApi
 import akka.cluster.InternalClusterAction._
 import akka.cluster.routing.{ ClusterRouterPool, ClusterRouterPoolSettings }
@@ -87,7 +87,7 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Se
     case ClusterUserAction.Leave(address)                        ⇒ addressToProtoByteArray(address)
     case ClusterUserAction.Down(address)                         ⇒ addressToProtoByteArray(address)
     case InternalClusterAction.InitJoin(config)                  ⇒ initJoinToProto(config).toByteArray
-    case InternalClusterAction.InitJoinAck(address, configCheck) ⇒ initJoinAckToProto(address, configCheck).toByteArray
+    case InternalClusterAction.InitJoinAck(address, configCheck) ⇒ initJoinAckToByteArray(address, configCheck)
     case InternalClusterAction.InitJoinNack(address)             ⇒ addressToProtoByteArray(address)
     case InternalClusterAction.ExitingConfirmed(node)            ⇒ uniqueAddressToProtoByteArray(node)
     case rp: ClusterRouterPool                                   ⇒ clusterRouterPoolToProtoByteArray(rp)
@@ -330,6 +330,13 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Se
       .build()
   }
 
+  private def initJoinAckToByteArray(address: Address, configCheck: ConfigCheck): Array[Byte] = {
+    if (configCheck == ConfigCheckUnsupportedByJoiningNode)
+      addressToProtoByteArray(address) // plain Address in 2.5.9 or earlier
+    else
+      initJoinAckToProto(address, configCheck).toByteArray
+  }
+
   private def initJoinAckToProto(address: Address, configCheck: ConfigCheck): cm.InitJoinAck = {
 
     val configCheckBuilder = cm.ConfigCheck.newBuilder()
@@ -344,7 +351,12 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Se
         configCheckBuilder
           .setType(cm.ConfigCheck.Type.CompatibleConfig)
           .setClusterConfig(conf.root.render(ConfigRenderOptions.concise))
+
+      case ConfigCheckUnsupportedByJoiningNode ⇒
+        // handled as Address in initJoinAckToByteArray
+        throw new IllegalStateException("Unexpected ConfigCheckNotSupportedByJoiningNode")
     }
+
     cm.InitJoinAck.newBuilder().
       setAddress(addressToProto(address)).
       setConfigCheck(configCheckBuilder.build()).

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -354,7 +354,7 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Se
 
       case ConfigCheckUnsupportedByJoiningNode ⇒
         // handled as Address in initJoinAckToByteArray
-        throw new IllegalStateException("Unexpected ConfigCheckNotSupportedByJoiningNode")
+        throw new IllegalStateException("Unexpected ConfigCheckUnsupportedByJoiningNode")
     }
 
     cm.InitJoinAck.newBuilder().

--- a/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
@@ -96,16 +96,26 @@ class ClusterMessageSerializerSpec extends AkkaSpec(
       deserialized shouldBe an[InternalClusterAction.InitJoin]
     }
 
-    "be compatible with wire format of version 2.5.9 (using serialized address for InitJoinAck)" in {
+    "deserialize from wire format of version 2.5.9 (using serialized address for InitJoinAck)" in {
       // we must use the old singleton class name so that the other side will see an InitJoin
       // but discard the config as it does not know about the config check
       val initJoinAck = InternalClusterAction.InitJoinAck(
         Address("akka.tcp", "cluster", "127.0.0.1", 2552),
         InternalClusterAction.UncheckedConfig)
-      val serializedinInitJoinAckPre2510 = serializer.addressToProto(initJoinAck.address).build().toByteArray
+      val serializedInitJoinAckPre2510 = serializer.addressToProto(initJoinAck.address).build().toByteArray
 
-      val deserialized = serializer.fromBinary(serializedinInitJoinAckPre2510, ClusterMessageSerializer.InitJoinAckManifest)
+      val deserialized = serializer.fromBinary(serializedInitJoinAckPre2510, ClusterMessageSerializer.InitJoinAckManifest)
       deserialized shouldEqual initJoinAck
+    }
+
+    "serialize to wire format of version 2.5.9 (using serialized address for InitJoinAck)" in {
+      val initJoinAck = InternalClusterAction.InitJoinAck(
+        Address("akka.tcp", "cluster", "127.0.0.1", 2552),
+        InternalClusterAction.ConfigCheckUnsupportedByJoiningNode)
+      val bytes = serializer.toBinary(initJoinAck)
+
+      val expectedSerializedInitJoinAckPre2510 = serializer.addressToProto(initJoinAck.address).build().toByteArray
+      bytes.toList should ===(expectedSerializedInitJoinAckPre2510.toList)
     }
 
     "be compatible with wire format of version 2.5.3 (using use-role instead of use-roles)" in {


### PR DESCRIPTION
* Detect that joining node is 2.5.9 or earlier by empty ConfigCheck
  config in InitJoin message. Then send back Address, which was the
  old representation of InitJoinAck
* Include akka.version in logging to facilitate troubleshooting

See problem description in ticket.

Refs #25491