### PR TITLE
WIP: Prototype of pre intercepting with another Behavior

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/PreSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/PreSpec.scala
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed
+
+import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.typed.scaladsl.Behaviors
+import org.scalatest.concurrent.ScalaFutures
+
+object PreSpec {
+  final case class Msg(hello: String, replyTo: ActorRef[String])
+  case object MyPoisonPill
+}
+
+class PreSpec extends ActorTestKit
+  with TypedAkkaSpecWithShutdown with ScalaFutures {
+  override def name = "WidenSpec"
+
+  import PreSpec._
+
+  "Pre" must {
+    "be useful for implementing PoisonPill" in {
+
+      def inner(count: Int): Behavior[Msg] = Behaviors.receiveMessage {
+        case Msg(hello, replyTo) ⇒
+          replyTo ! s"$hello-$count"
+          inner(count + 1)
+      }
+
+      val poisonInterceptor: Behavior[Any] = Behaviors.receiveMessagePartial[Any] {
+        case MyPoisonPill ⇒ Behaviors.stopped
+      }
+
+      // FIXME can we simplify this widen - narrow dance
+      val decorated: Behavior[Msg] =
+        Behaviors.pre(poisonInterceptor, inner(0).widen[Any] { case m: Msg ⇒ m }).narrow
+
+      val ref = spawn(decorated)
+      val probe = TestProbe[String]()
+      ref ! Msg("hello", probe.ref)
+      probe.expectMessage("hello-0")
+      ref ! Msg("hello", probe.ref)
+      probe.expectMessage("hello-1")
+
+      ref.upcast[Any] ! MyPoisonPill
+
+      probe.expectTerminated(ref, probe.remainingOrDefault)
+    }
+
+  }
+}

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WidenSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WidenSpec.scala
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed
+
+import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.typed.scaladsl.Behaviors
+import org.scalatest.concurrent.ScalaFutures
+
+object WidenSpec {
+  final case class Msg1(hello: String, replyTo: ActorRef[String])
+  final case class Msg2(hello: String, replyTo: ActorRef[String])
+}
+
+class WidenSpec extends ActorTestKit
+  with TypedAkkaSpecWithShutdown with ScalaFutures {
+  override def name = "WidenSpec"
+
+  import WidenSpec._
+
+  "Widen" must {
+    "be useful for transforming and filtering messages" in {
+
+      def inner(count: Int): Behavior[Msg2] = Behaviors.receiveMessage {
+        case Msg2(hello, replyTo) ⇒
+          replyTo ! s"$hello-$count"
+          inner(count + 1)
+      }
+
+      def outer: Behavior[Msg1] = inner(0).widen[Msg1] {
+        case Msg1(hello, replyTo) if hello != "unsupported" ⇒ Msg2(hello, replyTo)
+      }
+
+      val ref = spawn(outer)
+      val probe = TestProbe[String]()
+      ref ! Msg1("hello", probe.ref)
+      probe.expectMessage("hello-0")
+      ref ! Msg1("unsupported", probe.ref)
+      probe.expectNoMessage()
+      ref ! Msg1("hello", probe.ref)
+      probe.expectMessage("hello-1")
+    }
+
+  }
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
@@ -161,6 +161,9 @@ object Behaviors {
     onSignal:  (ActorContext[T], Signal) ⇒ Unit): Behavior[T] =
     BehaviorImpl.tap(onMessage, onSignal, behavior)
 
+  def pre[T](preBehavior: Behavior[T], behavior: Behavior[T]): Behavior[T] =
+    BehaviorImpl.pre(preBehavior, behavior)
+
   /**
    * Behavior decorator that copies all received message to the designated
    * monitor [[akka.actor.typed.ActorRef]] before invoking the wrapped behavior. The


### PR DESCRIPTION
I was thinking about how to solve the automatic handoffStopMessage as discussed in https://github.com/akka/akka/issues/25480

Might be useful for implementing automatic handOffStopMessage
(like PoisonPill) in ClusterSharding. If the handOffStopMessage
is not given we could decorate like this automatically.

If we think this could work we would also have to have something that plays nice with the stashing in the persistence implementation.

