### PR TITLE
Fix ShardRegion.changeMembers, #25509

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -480,22 +480,14 @@ private[akka] class ShardRegion(
   def receiveClusterEvent(evt: ClusterDomainEvent): Unit = evt match {
     case MemberUp(m) ⇒
       if (matchingRole(m))
-        changeMembers {
-          // replace, it's possible that the upNumber is changed
-          membersByAge = membersByAge.filterNot(_.uniqueAddress == m.uniqueAddress)
-          membersByAge += m
-          membersByAge
-        }
+        // replace, it's possible that the upNumber is changed
+        changeMembers(membersByAge.filterNot(_.uniqueAddress == m.uniqueAddress) + m)
 
     case MemberRemoved(m, _) ⇒
       if (m.uniqueAddress == cluster.selfUniqueAddress)
         context.stop(self)
       else if (matchingRole(m))
-        changeMembers {
-          // filter, it's possible that the upNumber is changed
-          membersByAge = membersByAge.filterNot(_.uniqueAddress == m.uniqueAddress)
-          membersByAge
-        }
+        changeMembers(membersByAge.filterNot(_.uniqueAddress == m.uniqueAddress))
 
     case _: MemberEvent ⇒ // these are expected, no need to warn about them
 


### PR DESCRIPTION
The reason it was working anyway was that it's also watching the coordinator and setting it back to None also when Terminated

Refs #25509