### PR TITLE
increase outbound-control-queue-size

### DIFF
--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -942,17 +942,18 @@ akka {
 
         # Size of the send queue for outgoing control messages, such as system messages.
         # If this limit is reached the remote system is declared to be dead and its UID
-        # marked as quarantined.
-        # The trade-off of using a larger queue size is that it consumes more memory,
-        # since the queue is based on preallocated array with fixed size.
-        outbound-control-queue-size = 3072
+        # marked as quarantined. Note that there is one such queue per outbound association.
+        # It is a linked queue so it will not use more memory than needed but by increasing
+        # too much you may risk OutOfMemoryError in the worst case.
+        outbound-control-queue-size = 20000
 
         # Size of the send queue for outgoing large messages. Messages will be dropped if
         # the queue becomes full. This may happen if you send a burst of many messages
         # without end-to-end flow control. Note that there is one such queue per
-        # outbound association. The trade-off of using a larger queue size is that
-        # it consumes more memory, since the queue is based on preallocated array with
-        # fixed size.
+        # outbound association.
+        # It is a linked queue so it will not use more memory than needed but by increasing
+        # too much you may risk OutOfMemoryError, especially since the message payload
+        # of these messages may be large.
         outbound-large-message-queue-size = 256
 
         # This setting defines the maximum number of unacknowledged system messages


### PR DESCRIPTION
* since it's a linked queue nowadays it's fine to have a higher limit
* using 20000, since that is also the default of the system messages buffer