### PR TITLE
RFC: reliable side effect delivery in Typed Persistent actors

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/ReliableSideEffectBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/ReliableSideEffectBehaviorImpl.scala
@@ -6,10 +6,10 @@
 
 package akka.persistence.typed
 
+import akka.Done
 import akka.actor.{ ActorPath, typed }
-import akka.actor.typed.{ BackoffSupervisorStrategy, Behavior, Signal, SupervisorStrategy, Terminated }
+import akka.actor.typed.{ BackoffSupervisorStrategy, Behavior, SupervisorStrategy, Terminated }
 import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
-import akka.persistence.typed._
 import akka.persistence.typed.internal._
 import akka.persistence.{ Recovery, SnapshotMetadata, SnapshotSelectionCriteria }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/ReliableSideEffectBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/ReliableSideEffectBehaviorImpl.scala
@@ -1,0 +1,316 @@
+/*
+ * written as a Proof of Concept by Cyrille Chepelov
+ *
+ * Based on code Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed
+
+import akka.actor.{ ActorPath, typed }
+import akka.actor.typed.{ BackoffSupervisorStrategy, Behavior, Signal, SupervisorStrategy, Terminated }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.persistence.typed._
+import akka.persistence.typed.internal._
+import akka.persistence.{ Recovery, SnapshotMetadata, SnapshotSelectionCriteria }
+
+import scala.collection.{ immutable ⇒ im }
+import akka.persistence.typed.scaladsl.{ Effect, PersistentBehavior, PersistentBehaviors }
+import akka.util.ConstantFun
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.{ Failure, Success, Try }
+import scala.language.existentials
+
+class NotificationDeliveryFailure(from: ActorPath, inner: Throwable) extends Exception(inner) {
+  override def getMessage: String = s"from actor ${from}"
+}
+class MultipleNotificationDeliveryFailures(from: ActorPath, throwables: Seq[Throwable]) extends Exception {
+  override def getMessage: String = s"from actor ${from}\n" + throwables.zipWithIndex.map {
+    case (ex, idx) ⇒ s"   Mdnf[${idx}] → ${ex.toString}"
+  }.mkString("\n")
+}
+
+case class ReliableSideEffectBehaviorImpl[Command, Event, State, Notification](persistenceId: String, emptyState: State,
+                                                                               commandHandler:      ReliableSideEffectBehaviors.CommandHandler[Command, Event, State],
+                                                                               eventHandler:        ReliableSideEffectBehaviors.EventHandler[State, Event, Notification],
+                                                                               notificationHandler: ReliableSideEffectBehaviors.NotificationHandler[State, Notification],
+
+                                                                               journalPluginId:     Option[String]                                                      = None,
+                                                                               snapshotPluginId:    Option[String]                                                      = None,
+                                                                               recoveryCompleted:   (ActorContext[Command], State) ⇒ Unit                               = ConstantFun.scalaAnyTwoToUnit,
+                                                                               tagger:              Event ⇒ Set[String]                                                 = (_: Event) ⇒ Set.empty[String],
+                                                                               eventAdapter:        EventAdapter[Event, _]                                              = NoOpEventAdapter.instance[Event],
+                                                                               snapshotCriteria:    Option[Either[Long, (State, Event, Long) ⇒ Boolean]]                = None,
+                                                                               recovery:            Recovery                                                            = Recovery(),
+                                                                               supervisionStrategy: SupervisorStrategy                                                  = SupervisorStrategy.stop,
+                                                                               afterSnapshot:       Option[(ActorContext[Command], SnapshotMetadata, Try[Done]) ⇒ Unit] = None)
+  extends ReliableSecondaryEffectBehavior[Command, Event, State, Notification] {
+
+  import ReliableSideEffectBehaviors._
+
+  private val EffectStop = Effect.stop[Event, State]
+
+  def wrapEffect(value: Effect[Event, State]): Effect[RseEvent[Event, Notification], RseState[State, Notification]] = value match {
+    case _ if value == Unhandled      ⇒ Effect.unhandled
+    case _ if value == PersistNothing ⇒ Effect.none
+
+    case impl: EffectImpl[Event, State] ⇒
+      val wrappedEvents = impl.events.map(WrappedEvent.apply[Event, Notification])
+
+      val wrappedSideEffects: im.Seq[SideEffect[RseState[State, Notification]]] = {
+        val implSideEffects = impl match {
+          case ce: CompositeEffect[Event, State] @unchecked ⇒
+            ce._sideEffects
+          case _ ⇒
+            Nil
+        }
+
+        implSideEffects.map {
+          case se: Callback[State] @unchecked ⇒
+            SideEffect[RseState[State, Notification]](state ⇒ se.effect(state.state))
+          case se if se == Stop ⇒
+            SideEffect.stop[RseState[State, Notification]]
+        }
+      }
+
+      val mainPersist: Effect[RseEvent[Event, Notification], RseState[State, Notification]] = wrappedEvents match {
+        case _ if wrappedEvents.isEmpty   ⇒ Effect.none
+        case _ if wrappedEvents.size == 1 ⇒ Effect.persist(wrappedEvents.head)
+        case _                            ⇒ Effect.persist(wrappedEvents)
+      }
+
+      if (wrappedSideEffects.isEmpty) mainPersist else
+        mainPersist match {
+          case mp: EffectImpl[RseEvent[Event, Notification], RseState[State, Notification]] @unchecked ⇒
+            new CompositeEffect(mp, wrappedSideEffects)
+        }
+  }
+
+  def tryFlushNotifications(ctx: ActorContext[RseCommand], intentsToBeFlushed: im.Seq[(Long, Notification)])(state: RseState[State, Notification]): Unit = {
+    import ctx.executionContext
+
+    val fNotificationResults = intentsToBeFlushed.map {
+      case (nfySeqNr, nfy) ⇒
+        val fNotified: Future[(Long, Try[Unit])] = notificationHandler(state.state, nfy)
+          // 2.12: .transform & go
+          .map(x ⇒ nfySeqNr → Success(x))
+          .recoverWith { case t: Throwable ⇒ Future.successful(nfySeqNr → Failure(t)) }
+
+        fNotified
+    }
+
+    val fResult = Future.sequence(fNotificationResults)
+    fResult.foreach { result ⇒
+      val completedNotifications = result.collect {
+        case (nfySeqNr, Success(_)) ⇒ nfySeqNr
+      }
+      if (completedNotifications.nonEmpty) {
+        ctx.self ! RemoveIntents(completedNotifications)
+      }
+
+      val failedNotifications = result.collect {
+        case (nfySeqNr, Failure(ex)) ⇒ ex
+      }
+      if (failedNotifications.nonEmpty) {
+        if (failedNotifications.tail.isEmpty) {
+          throw new NotificationDeliveryFailure(ctx.self.path, failedNotifications.head)
+        } else {
+          throw new MultipleNotificationDeliveryFailures(ctx.self.path, failedNotifications)
+        }
+      }
+    }
+
+  }
+
+  type IPB = PersistentBehavior[RseCommand, RseEvent[Event, Notification], RseState[State, Notification]]
+
+  private def wrappingTagger(e: RseEvent[Event, Notification]): Set[String] = e match {
+    case WrappedEvent(event) ⇒ this.tagger(event)
+    case _                   ⇒ Set.empty
+  }
+
+  override def apply(wrappedCtx: typed.ActorContext[Command]): Behavior[Command] = {
+    val rawInternal =
+      PersistentBehaviors.receive[RseCommand, RseEvent[Event, Notification], RseState[State, Notification]](
+        persistenceId = persistenceId,
+        emptyState = RseState(emptyState),
+        commandHandler = internalCommandHandler(wrappedCtx.asScala),
+        eventHandler = internalEventHandler)
+
+    val transformers: Seq[IPB ⇒ IPB] =
+      this.journalPluginId.map(s ⇒ (pb: IPB) ⇒ pb.withJournalPluginId(s)).getOrElse((pb: IPB) ⇒ pb) ::
+        this.snapshotPluginId.map(s ⇒ (pb: IPB) ⇒ pb.withSnapshotPluginId(s)).getOrElse((pb: IPB) ⇒ pb) ::
+        ((pb: IPB) ⇒ pb.withTagger(wrappingTagger)) ::
+        ((pb: IPB) ⇒ if (eventAdapter == NoOpEventAdapter.instance[Event]) pb
+        else {
+          /* the problem is, even if we know the type of the written payload, the internal eventAdapter does not
+            * know how to persist our wrapper… */
+          ???
+        }) ::
+        ((pb: IPB) ⇒ snapshotCriteria match {
+          case None              ⇒ pb
+          case Some(Left(every)) ⇒ pb.snapshotEvery(every)
+          case Some(Right(method)) ⇒
+            pb.snapshotWhen {
+              case (rseState, WrappedEvent(event), seqNumber) ⇒
+                /* FIXME : this may miss a beat when the wrapped method doesn't care for the event but does a simple
+                'modulo' operation on the seqNumber. E.g. "snapshotEvery" has been called. */
+                method(rseState.state, event, seqNumber)
+              case (rseState, otherEvent, seqNumber) ⇒
+                false
+            }
+        }) ::
+        ((pb: IPB) ⇒ pb.withSnapshotSelectionCriteria(recovery.fromSnapshot)) ::
+        ((pb: IPB) ⇒ afterSnapshot.map(onSnapshot ⇒ pb.onSnapshot(bounceOnSnapshot(wrappedCtx.asScala))).getOrElse(pb)) ::
+        ((pb: IPB) ⇒ pb.onRecoveryCompleted(internalRecoveryCompleted(wrappedCtx.asScala))) ::
+        Nil
+
+    val internal = transformers.foldLeft(rawInternal) { case (pb, xform) ⇒ xform(pb) }
+
+    val middle = Behaviors.setup[RseMiddleCommand] {
+      middleCtx ⇒
+        /* note: the role of the middle agent is simply to run the "flushintents" thing whenever there is a lull in
+        message traffic. it's really there because we can't access the context (to kick new "intent to flush") commands
+        as part of the eventHandler.
+         */
+
+        val internalRef = middleCtx.spawnAnonymous(internal)
+        middleCtx.watch(internalRef)
+
+        Behaviors.receiveMessage[RseMiddleCommand] {
+          case cw: CommandWrapper[Command] @unchecked ⇒
+            internalRef ! cw
+            middleCtx.setReceiveTimeout(0.milliseconds, StartFlushIntents)
+            Behaviors.same
+          case StartFlushIntents ⇒
+            internalRef ! StartFlushIntents
+            middleCtx.cancelReceiveTimeout()
+            Behaviors.same
+        }.receiveSignal {
+          case (ctx, t: Terminated) if t.ref == internalRef ⇒
+            t.failure.foreach { ex ⇒
+              throw ex
+            }
+            Behaviors.stopped
+        }
+
+    }
+    val middleRef = wrappedCtx.asScala.spawnAnonymous(middle)
+    wrappedCtx.asScala.watch(middleRef)
+
+    val outer =
+      Behaviors.receiveMessage[Command] { msg ⇒
+        middleRef ! CommandWrapper(msg)
+        Behaviors.same
+      }
+        .receiveSignal {
+          case (ctx, t: Terminated) if t.ref == middleRef ⇒
+            t.failure.foreach { ex ⇒
+              throw ex
+            }
+            Behaviors.stopped
+        }
+
+    outer
+  }
+
+  def internalCommandHandler(wrappedCtx: ActorContext[Command])(ctx: ActorContext[RseCommand], state: RseState[State, Notification], command: RseCommand): Effect[RseEvent[Event, Notification], RseState[State, Notification]] =
+    command match {
+      case cw: CommandWrapper[Command] ⇒
+        wrapEffect(commandHandler(wrappedCtx.asScala, state.state, cw.wrapped))
+
+      case StartFlushIntents ⇒
+        val eventSeqNrs = state.requestedNotifications.map { case (seqnr, nfy) ⇒ seqnr }
+
+        Effect
+          .persist(IntentToNotifyEvents[Event, Notification](eventSeqNrs))
+          .thenRun(state ⇒ ctx.self ! ExecuteFlushIntents(eventSeqNrs)) // if we fail at delivering this, we'll find the intents back at recovery time.
+
+      case ExecuteFlushIntents(intentSeqNrs) ⇒
+        val intentSeqNrsIndex = intentSeqNrs.toSet
+        val selectedNotifications = state.intendedNotifications.filter { case (seqNr, nfy) ⇒ intentSeqNrsIndex.contains(seqNr) }
+
+        if (selectedNotifications.nonEmpty) {
+          tryFlushNotifications(ctx, selectedNotifications)(state) /* if we fail at delivering the removals (e.g. we failed while executing the notification) then
+          we will find the intent to notify again ('more than once') at recovery time and will restart. */
+        }
+        Effect.none
+
+      case RemoveIntents(intentSeqNr) if intentSeqNr.isEmpty ⇒
+        Effect.none
+
+      case RemoveIntents(intentSeqNr) ⇒
+        Effect.persist(CompletedNotificationEvent[Event, Notification](intentSeqNr))
+    }
+
+  def internalEventHandler: (RseState[State, Notification], RseEvent[Event, Notification]) ⇒ RseState[State, Notification] = {
+    case (state, event: WrappedEvent[Event, Notification]) ⇒ {
+      val (innerState, newNotifications) = eventHandler(state.state, event.event)
+
+      val nstate = state.update(innerState).addNotifications(newNotifications)
+
+      if (nstate.requestedNotifications.nonEmpty) {
+        /* PROBLEM: we SHOULD be able to send ourself a message saying that we need to flush outgoing notifications! */
+        println("foo")
+      }
+      nstate
+    }
+
+    case (state, event: IntentToNotifyEvents[Event, Notification]) ⇒
+      state.markIntended(event.notificationNumbers)
+
+    case (state, event: CompletedNotificationEvent[Event, Notification]) ⇒
+      state.removeNotifications(event.notificationNumbers)
+
+  }
+
+  def internalRecoveryCompleted(wrappedCtx: ActorContext[Command])(context: ActorContext[RseCommand], state: RseState[State, Notification]): Unit = {
+
+    recoveryCompleted(wrappedCtx, state.state)
+
+    if (state.intendedNotifications.nonEmpty) {
+      /* ah, recovering and some intents to notify were not completed? Let's try again (and possibly, fail again. Hail Supervisionà. */
+      context.self ! ExecuteFlushIntents(state.intendedNotifications.map { case (nfySeqNr, nfy) ⇒ nfySeqNr })
+    }
+    if (state.requestedNotifications.nonEmpty) {
+      /* ah, recovering and some intents to notify were not started? Let's try again */
+      context.self ! StartFlushIntents
+    }
+  }
+
+  private def bounceOnSnapshot(wrappedCtx: ActorContext[Command])(innerCtw: ActorContext[RseCommand], snapshotMeta: SnapshotMetadata, result: Try[Done]): Unit = {
+    afterSnapshot.foreach(callback ⇒ callback(wrappedCtx, snapshotMeta, result))
+  }
+
+  override def onSnapshot(callback: (ActorContext[Command], SnapshotMetadata, Try[Done]) ⇒ Unit): ReliableSecondaryEffectBehavior[Command, Event, State, Notification] =
+    copy(afterSnapshot = Some(callback))
+
+  override def onRecoveryCompleted(callback: (ActorContext[Command], State) ⇒ Unit): ReliableSecondaryEffectBehavior[Command, Event, State, Notification] = {
+    copy(recoveryCompleted = callback)
+  }
+
+  override def snapshotWhen(predicate: (State, Event, Long) ⇒ Boolean): ReliableSecondaryEffectBehavior[Command, Event, State, Notification] =
+    copy(snapshotCriteria = Some(Right(predicate)))
+
+  override def snapshotEvery(numberOfEvents: Long): ReliableSecondaryEffectBehavior[Command, Event, State, Notification] =
+    copy(snapshotCriteria = Some(Left(numberOfEvents)))
+
+  override def withJournalPluginId(id: String): ReliableSecondaryEffectBehavior[Command, Event, State, Notification] =
+    copy(journalPluginId = Some(id))
+
+  override def withSnapshotPluginId(id: String): ReliableSecondaryEffectBehavior[Command, Event, State, Notification] =
+    copy(snapshotPluginId = Some(id))
+
+  override def withSnapshotSelectionCriteria(selection: SnapshotSelectionCriteria): ReliableSecondaryEffectBehavior[Command, Event, State, Notification] =
+    copy(recovery = Recovery(selection))
+
+  override def withTagger(tagger: Event ⇒ Set[String]): ReliableSecondaryEffectBehavior[Command, Event, State, Notification] =
+    copy(tagger = tagger)
+
+  override def eventAdapter(adapter: EventAdapter[Event, _]): ReliableSecondaryEffectBehavior[Command, Event, State, Notification] =
+    copy(eventAdapter = adapter)
+
+  override def onPersistFailure(backoffStrategy: BackoffSupervisorStrategy): ReliableSecondaryEffectBehavior[Command, Event, State, Notification] =
+    copy(supervisionStrategy = backoffStrategy)
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/ReliableSideEffectBehaviors.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/ReliableSideEffectBehaviors.scala
@@ -7,9 +7,9 @@
 package akka.persistence.typed
 
 import akka.actor.typed.scaladsl.ActorContext
-import akka.persistence.typed.scaladsl.{Effect, PersistentBehavior}
+import akka.persistence.typed.scaladsl.{ Effect, PersistentBehavior }
 
-import scala.collection.{immutable => im}
+import scala.collection.{ immutable ⇒ im }
 import scala.concurrent.Future
 
 object ReliableSideEffectBehaviors {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/ReliableSideEffectBehaviors.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/ReliableSideEffectBehaviors.scala
@@ -1,0 +1,108 @@
+/*
+ * written as a Proof of Concept by Cyrille Chepelov
+ *
+ * Based on code Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed
+
+import akka.actor.typed.scaladsl.ActorContext
+import akka.persistence.typed.scaladsl.{Effect, PersistentBehavior}
+
+import scala.collection.{immutable => im}
+import scala.concurrent.Future
+
+object ReliableSideEffectBehaviors {
+
+  sealed trait RseEvent[Event, Notification] extends Serializable
+  final case class WrappedEvent[Event, Notification](event: Event) extends RseEvent[Event, Notification]
+  final case class IntentToNotifyEvents[Event, Notification](notificationNumbers: im.Seq[Long]) extends RseEvent[Event, Notification]
+  final case class CompletedNotificationEvent[Event, Notification](notificationNumbers: im.Seq[Long]) extends RseEvent[Event, Notification]
+
+  final case class RseState[State, Notification](
+    state:                  State,
+    nextNotificationSeqNr:  Long,
+    requestedNotifications: im.IndexedSeq[(Long, Notification)],
+    intendedNotifications:  im.IndexedSeq[(Long, Notification)]) extends Product with Serializable {
+    def update(newState: State): RseState[State, Notification] = this.copy(state = newState)
+
+    def addNotifications(notification: im.Seq[Notification]): RseState[State, Notification] = {
+      val tagged = notification.to[Vector].zipWithIndex
+        .map { case (nfy, idx) ⇒ (nextNotificationSeqNr + idx, nfy) }
+
+      this.copy(nextNotificationSeqNr = nextNotificationSeqNr + tagged.size, requestedNotifications = requestedNotifications ++ tagged)
+    }
+
+    def markIntended(notificationSeqNrs: Iterable[Long]): RseState[State, Notification] = {
+      val toSelect = notificationSeqNrs.to[Set]
+      val (selected, remainingRequests) = requestedNotifications.partition { case (seqNr, nfy) ⇒ toSelect.contains(seqNr) }
+
+      copy(requestedNotifications = remainingRequests, intendedNotifications = intendedNotifications ++ selected)
+    }
+
+    def removeNotifications(notificationSeqNrs: Iterable[Long]): RseState[State, Notification] = {
+      val toRemove = notificationSeqNrs.to[Set]
+      val remainingRequests = requestedNotifications.filterNot { case (seqNr, nfy) ⇒ toRemove.contains(seqNr) }
+      val remainingIntents = intendedNotifications.filterNot { case (seqNr, nfy) ⇒ toRemove.contains(seqNr) }
+
+      /* avoid wrap-around when it is safe to do so: */
+      val fNextNotif = if ((nextNotificationSeqNr > 0x7000000000000000L) && remainingRequests.isEmpty && remainingIntents.isEmpty) {
+        0L
+      } else {
+        nextNotificationSeqNr
+      }
+
+      copy(nextNotificationSeqNr = fNextNotif, requestedNotifications = remainingRequests, intendedNotifications = remainingIntents)
+    }
+  }
+  object RseState {
+    def apply[State, Notification](state: State): RseState[State, Notification] =
+      new RseState[State, Notification](state, 0L, im.IndexedSeq.empty, im.IndexedSeq.empty)
+  }
+
+  sealed trait RseMiddleCommand
+  sealed trait RseCommand
+  private[akka] final case class CommandWrapper[Command](wrapped: Command) extends RseCommand with RseMiddleCommand
+  private[akka] sealed trait RseInternalCommand extends RseCommand
+  private[akka] final case object StartFlushIntents extends RseInternalCommand with RseMiddleCommand
+  private[akka] final case class ExecuteFlushIntents(intentSeqN: im.Seq[Long]) extends RseInternalCommand
+  private[akka] final case class RemoveIntents(intentSeqN: im.Seq[Long]) extends RseInternalCommand
+
+  /**
+   * Type alias for the command handler function for reacting on events having been persisted.
+   *
+   * The type alias is not used in API signatures because it's easier to see (in IDE) what is needed
+   * when full function type is used. When defining the handler as a separate function value it can
+   * be useful to use the alias for shorter type signature.
+   */
+  type CommandHandler[Command, Event, State] = (ActorContext[Command], State, Command) ⇒ Effect[Event, State]
+
+  /**
+   * Type alias for the event handler function defines how to act on commands.
+   *
+   * The type alias is not used in API signatures because it's easier to see (in IDE) what is needed
+   * when full function type is used. When defining the handler as a separate function value it can
+   * be useful to use the alias for shorter type signature.
+   */
+  type EventHandler[State, Event, Notification] = (State, Event) ⇒ (State, im.Seq[Notification])
+
+  /**
+   * Type alias for the notification handler defined how to carry out a notification
+   *
+   * The type alias is not used in API signatures because it's easier to see (in IDE) what is needed
+   * when full function type is used. When defining the handler as a separate function value it can
+   * be useful to use the alias for shorter type signature.
+   */
+  type NotificationHandler[State, Notification] = (State, Notification) ⇒ Future[Unit]
+
+  def receive[Command, Event, State, Notification](
+    persistenceId:       String,
+    emptyState:          State,
+    commandHandler:      (ActorContext[Command], State, Command) ⇒ Effect[Event, State],
+    eventHandler:        (State, Event) ⇒ (State, im.Seq[Notification]),
+    notificationHandler: (State, Notification) ⇒ Future[Unit]): ReliableSecondaryEffectBehavior[Command, Event, State, Notification] =
+    ReliableSideEffectBehaviorImpl[Command, Event, State, Notification](persistenceId, emptyState, commandHandler, eventHandler, notificationHandler)
+
+}
+
+trait ReliableSecondaryEffectBehavior[Command, Event, State, Notification] extends PersistentBehavior[Command, Event, State]

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ReliableSideEffectBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ReliableSideEffectBehaviorSpec.scala
@@ -7,17 +7,17 @@ package akka.persistence.typed
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.typed.scaladsl.AskPattern._
-import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
-import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 import akka.persistence.typed.scaladsl.Effect
 import akka.util.Timeout
 import akka.Done
-import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.{AsyncFlatSpec, BeforeAndAfterAll, Matchers}
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.{ AsyncFlatSpec, BeforeAndAfterAll, Matchers }
 
-import scala.collection.{immutable => im}
+import scala.collection.{ immutable ⇒ im }
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext, Future, TimeoutException}
+import scala.concurrent.{ Await, ExecutionContext, Future, TimeoutException }
 
 object ReliableSideEffectBehaviorSpec {
   sealed trait Protocol
@@ -190,13 +190,13 @@ class ReliableSideEffectBehaviorSpec extends AsyncFlatSpec with Matchers with Be
       counter = counter + 1
       system.systemActorOf(
         startRseb("def") {
-        case (state, nfy: AddedString) ⇒ Future {
-          receptacle ! ReceptacleProtocol.Add("+" + nfy.message)
-        }
-        case (state, nfy: RemovedString) ⇒ Future {
-          receptacle ! ReceptacleProtocol.Add("-" + nfy.message)
-        }
-      },
+          case (state, nfy: AddedString) ⇒ Future {
+            receptacle ! ReceptacleProtocol.Add("+" + nfy.message)
+          }
+          case (state, nfy: RemovedString) ⇒ Future {
+            receptacle ! ReceptacleProtocol.Add("-" + nfy.message)
+          }
+        },
         s"defActor-${counter}")
     }
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ReliableSideEffectBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ReliableSideEffectBehaviorSpec.scala
@@ -1,0 +1,398 @@
+/*
+ * written as a Proof of Concept by Cyrille Chepelov
+ *
+ */
+
+package akka.persistence.typed
+
+import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import akka.actor.typed.scaladsl.AskPattern._
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
+import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
+import akka.persistence.typed.scaladsl.Effect
+import akka.util.Timeout
+import akka.Done
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.{AsyncFlatSpec, BeforeAndAfterAll, Matchers}
+
+import scala.collection.{immutable => im}
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future, TimeoutException}
+
+object ReliableSideEffectBehaviorSpec {
+  sealed trait Protocol
+  sealed trait Commands extends Protocol
+  case class AppendString(message: String)(val replyTo: ActorRef[Done]) extends Commands
+  case class RemoveString(message: String)(val replyTo: ActorRef[Done]) extends Commands
+  case class ClearMessages()(val replyTo: ActorRef[Done]) extends Commands
+  case class Stop()(val replyTo: ActorRef[Done]) extends Commands
+
+  sealed trait Queries extends Protocol
+  final case class GetStrings()(val replyTo: ActorRef[Vector[String]]) extends Queries
+
+  final case class CauseGrief(message: String) extends Commands
+
+  final case class State(messages: Vector[String])
+  object State {
+    def empty: State = State(Vector.empty)
+  }
+
+  sealed trait Event extends Serializable
+  final case class AddedStringEvent(str: String) extends Event
+  final case class RemovedStringEvent(str: String) extends Event
+  case object ClearedEvent extends Event
+
+  sealed trait Notification
+  final case class AddedString(persistentId: String, message: String) extends Notification
+  final case class RemovedString(persistentId: String, message: String) extends Notification
+
+  private def commandHandler: (ActorContext[Protocol], State, Protocol) ⇒ Effect[Event, State] = {
+    case (ctx, state, cmd: Stop) ⇒
+      Effect.stop
+        .thenRun {
+          _ ⇒ cmd.replyTo ! Done
+        }
+
+    case (ctx, state, cmd: AppendString) ⇒
+      Effect.persist(AddedStringEvent(cmd.message))
+        .thenRun(state ⇒ cmd.replyTo ! Done)
+
+    case (ctx, state, cmd: RemoveString) ⇒
+      Effect.persist(RemovedStringEvent(cmd.message))
+        .thenRun(state ⇒ cmd.replyTo ! Done)
+    case (ctx, state, cmd: ClearMessages) ⇒
+      Effect.persist(ClearedEvent)
+        .thenRun(state ⇒ cmd.replyTo ! Done)
+
+    case (ctx, state, cmd: GetStrings) ⇒
+      cmd.replyTo ! state.messages
+      Effect.none
+
+    case (ctx, state, cmd: CauseGrief) ⇒
+      throw new Exception("Throwing exception as commanded: " + cmd.message)
+  }
+
+  private def eventHandler(persistentId: String): ReliableSideEffectBehaviors.EventHandler[State, Event, Notification] = {
+    case (state, AddedStringEvent(message)) ⇒
+      state.copy(messages = state.messages :+ message) -> (AddedString(persistentId, message) :: Nil)
+    case (state, RemovedStringEvent(message)) ⇒
+      state.copy(messages = state.messages.filterNot(_ == message)) -> (RemovedString(persistentId, message) :: Nil)
+    case (state, ClearedEvent) ⇒
+      State.empty -> state.messages.map(RemovedString(persistentId, _))
+  }
+
+  def startRseb(persistentId: String)(notificationHandler: (State, Notification) ⇒ Future[Unit]): ReliableSecondaryEffectBehavior[Protocol, Event, State, Notification] =
+    ReliableSideEffectBehaviors.receive(
+      persistentId,
+      State.empty,
+      commandHandler,
+      eventHandler(persistentId: String),
+      notificationHandler)
+
+  /* FIXME: we have not provided the Notification generation */
+
+  sealed trait ReceptacleProtocol
+  object ReceptacleProtocol {
+    final case class Add(message: String) extends ReceptacleProtocol
+    final case class Clear()(val replyTo: ActorRef[Done]) extends ReceptacleProtocol
+    final case class Get()(val replyTo: ActorRef[im.Seq[String]]) extends ReceptacleProtocol
+  }
+
+  def startReceptacle: Behavior[ReceptacleProtocol] = {
+    def next(content: Vector[String]): Behavior[ReceptacleProtocol] = Behaviors.receiveMessage[ReceptacleProtocol] {
+      case cmd: ReceptacleProtocol.Add ⇒
+        next(content :+ cmd.message)
+      case cmd: ReceptacleProtocol.Clear ⇒
+        cmd.replyTo ! Done
+        next(Vector.empty)
+      case q: ReceptacleProtocol.Get ⇒
+        q.replyTo ! content
+        Behaviors.same
+    }
+
+    next(Vector.empty)
+  }
+}
+
+class ReliableSideEffectBehaviorSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll with ActorTestKit {
+  override protected def afterAll(): Unit = {
+    shutdownTestKit()
+  }
+
+  import ReliableSideEffectBehaviorSpec._
+
+  override def config: Config = ConfigFactory.parseString(
+    s"""
+    akka.actor.default-dispatcher {
+      type = Dispatcher
+      executor = "thread-pool-executor"
+      thread-pool-executor {
+        fixed-pool-size = 5
+      }
+    }
+    akka.persistence.max-concurrent-recoveries = 3
+    akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+    akka.actor.warn-about-java-serializer-usage = off
+  """)
+
+  implicit override def executionContext: ExecutionContext = system.executionContext
+
+  "a ReliableSideEffectBehaviorSpec" should "demonstrate proper basic operation even without notifications" in {
+
+    var counter: Int = 0
+
+    def startActor = {
+      counter = counter + 1
+      system.systemActorOf(
+        startRseb("abc") { (state, nfy) ⇒ Future.successful(()) },
+        s"abcActor-${counter}")
+    }
+
+    val fStage1 = for {
+      rsebActor ← startActor
+      initial ← rsebActor ? GetStrings()
+      _ = initial shouldBe empty
+
+      _ ← rsebActor ? AppendString("abc")
+      _ ← rsebActor ? AppendString("def")
+      _ ← rsebActor ? AppendString("ghi")
+      _ ← rsebActor ? AppendString("klm")
+      _ ← rsebActor ? RemoveString("def")
+
+      result ← rsebActor ? GetStrings()
+
+      _ ← rsebActor ? Stop()
+
+    } yield {
+      result shouldEqual Vector("abc", "ghi", "klm")
+    }
+
+    val fStage2 = for {
+      _ ← fStage1
+      rsebActor ← startActor
+      result ← rsebActor ? GetStrings()
+    } yield {
+      result shouldEqual Vector("abc", "ghi", "klm")
+    }
+
+    fStage2
+    //Await.result(fStage2, implicitly[Timeout].duration)
+  }
+
+  it should "demonstrate proper notification delivery (in the absence of trouble)" in {
+
+    val fReceptacle = system.systemActorOf(startReceptacle, "receptacle")
+    val receptacle = Await.result(fReceptacle, implicitly[Timeout].duration)
+
+    var counter: Int = 0
+
+    def startActor = {
+      counter = counter + 1
+      system.systemActorOf(
+        startRseb("def") {
+        case (state, nfy: AddedString) ⇒ Future {
+          receptacle ! ReceptacleProtocol.Add("+" + nfy.message)
+        }
+        case (state, nfy: RemovedString) ⇒ Future {
+          receptacle ! ReceptacleProtocol.Add("-" + nfy.message)
+        }
+      },
+        s"defActor-${counter}")
+    }
+
+    val fStage1 = for {
+      rsebActor ← startActor
+      initial ← rsebActor ? GetStrings()
+      _ = initial shouldBe empty
+
+      _ ← rsebActor ? AppendString("abc")
+      _ ← rsebActor ? AppendString("def")
+      _ ← rsebActor ? AppendString("ghi")
+      _ ← rsebActor ? AppendString("klm")
+      _ ← rsebActor ? RemoveString("def")
+
+      result ← rsebActor ? GetStrings()
+
+      _ ← rsebActor ? Stop()
+
+      receivedNotifications ← receptacle ? ReceptacleProtocol.Get()
+
+    } yield {
+      result shouldEqual Vector("abc", "ghi", "klm")
+      receivedNotifications.to[Vector].sorted.mkString("\n") shouldEqual
+        """+abc
+          |+def
+          |+ghi
+          |+klm
+          |-def""".stripMargin
+      // note: we must sort the received notifications, as there is no reason that the notifications happen synchronously.
+    }
+
+    val fStage2 = for {
+      _ ← fStage1
+      rsebActor ← startActor
+      result ← rsebActor ? GetStrings()
+
+      receivedNotifications ← receptacle ? ReceptacleProtocol.Get()
+
+      _ ← rsebActor ? Stop()
+    } yield {
+      result shouldEqual Vector("abc", "ghi", "klm")
+
+      receivedNotifications.to[Vector].sorted.mkString("\n") shouldEqual
+        """+abc
+          |+def
+          |+ghi
+          |+klm
+          |-def""".stripMargin
+    }
+
+    val fStage3 = for {
+      _ ← fStage2
+      rsebActor ← startActor
+
+      _ ← rsebActor ? ClearMessages()
+      _ ← rsebActor ? AppendString("ABC")
+      _ ← rsebActor ? AppendString("DEF")
+      _ ← rsebActor ? AppendString("GHI")
+
+      result ← rsebActor ? GetStrings()
+      _ ← rsebActor ? Stop()
+
+      receivedNotifications ← receptacle ? ReceptacleProtocol.Get()
+    } yield {
+      result shouldEqual Vector("ABC", "DEF", "GHI")
+
+      receivedNotifications.to[Vector].sorted.mkString("\n") shouldEqual
+        """+ABC
+          |+DEF
+          |+GHI
+          |+abc
+          |+def
+          |+ghi
+          |+klm
+          |-abc
+          |-def
+          |-ghi
+          |-klm""".stripMargin
+    }
+
+    val fStage4 = for {
+      _ ← fStage3
+      _ ← receptacle ? ReceptacleProtocol.Clear()
+      cleared ← receptacle ? ReceptacleProtocol.Get()
+      _ = cleared shouldBe empty
+
+      rsebActor ← startActor
+
+      result ← rsebActor ? GetStrings()
+      _ ← rsebActor ? Stop()
+
+      receivedNotifications ← receptacle ? ReceptacleProtocol.Get()
+    } yield {
+      result shouldEqual Vector("ABC", "DEF", "GHI")
+
+      println(system.printTree)
+
+      /* since we've done a stop/replay cycle where the notification delivery machinery was more or less at rest,
+      * we should not reissue the notifications (regardless of snapshots) */
+      receivedNotifications.to[Vector].sorted.mkString("\n") shouldEqual
+        """""".stripMargin
+    }
+
+    //Await.result(fStage4, implicitly[Timeout].duration)
+    fStage4
+  }
+
+  /* TODO: now do test we successfully recover from a glitch during a notification */
+
+  it should "demonstrate proper notification delivery even if the actor dies & is restarted" in {
+
+    val fReceptacle = system.systemActorOf(startReceptacle, "receptacleGhi")
+
+    var counter: Int = 0
+
+    def startActor(receptacle: ActorRef[ReceptacleProtocol]) = {
+      counter = counter + 1
+
+      val bhv: Behavior[Protocol] = startRseb("ghi") {
+        case (state, nfy: AddedString) ⇒ Future {
+          receptacle ! ReceptacleProtocol.Add("+" + nfy.message)
+        }
+        case (state, nfy: RemovedString) ⇒ Future {
+          receptacle ! ReceptacleProtocol.Add("-" + nfy.message)
+        }
+      }
+      val supervised = Behaviors.supervise(bhv)
+        .onFailure(SupervisorStrategy.restart) // this is important
+
+      system.systemActorOf(
+        supervised,
+        s"ghiActor-${counter}")
+
+    }
+
+    val fStage1 = for {
+      receptacle ← fReceptacle
+      rsebActor ← startActor(receptacle)
+      initial ← rsebActor ? GetStrings()
+      _ = initial shouldBe empty
+
+      _ ← rsebActor ? AppendString("abc")
+      _ ← rsebActor ? AppendString("def")
+
+      _ = rsebActor ! CauseGrief("boo!") // this throws an exception in the command handler, and causes the actor to die and be respawned.
+
+      /* let the supervision take notice and retry: */
+      _ = try {
+        Await.result(rsebActor ? GetStrings(), 3.seconds)
+        Unit
+      } catch {
+        case ex: TimeoutException ⇒
+          Unit
+      }
+      /* and now we should be happy bunnies : */
+
+      _ ← rsebActor ? AppendString("ghi")
+      _ ← rsebActor ? AppendString("klm")
+      _ ← rsebActor ? RemoveString("def")
+
+      result ← rsebActor ? GetStrings()
+
+      _ ← rsebActor ? Stop()
+
+      receivedNotifications ← receptacle ? ReceptacleProtocol.Get()
+
+    } yield {
+      println(system.printTree)
+
+      result shouldEqual Vector("abc", "ghi", "klm")
+      /*
+        The point is that IT DOES NOT MATTER that we got trouble in the middle, supervision caused a recovery
+        and we successfully restarted with the same state as in the first tests.
+
+        Notification testing may be more tricky: we will have or not have
+       */
+
+      val notificationsCounts = receivedNotifications.groupBy(Predef.identity).mapValues(_.size)
+
+      notificationsCounts.keys.to[Vector].sorted.mkString("\n") shouldEqual
+        """+abc
+          |+def
+          |+ghi
+          |+klm
+          |-def""".stripMargin
+
+      // pre-crash notifications may be replayed (this is time-sensitive)
+      notificationsCounts("+abc") should be >= 1
+      notificationsCounts("+def") should be >= 1
+      // post-crash notifications shouldd be delivered only once
+      notificationsCounts("+ghi") shouldEqual 1
+      notificationsCounts("+klm") shouldEqual 1
+      notificationsCounts("-def") shouldEqual 1
+    }
+
+    fStage1
+
+  }
+}


### PR DESCRIPTION
This PR is a request for comment.

Currently, there is no guarantee that the callback provided in an effect's `.thenRun()` method is delivered. For instance, if the JVM dies precisely after achieving the durability of an event but before executing the side effects.
Or if the side effect dies in the course of execution for transient reasons (unable to connect to a message broker, etc).

An approach is to perform Persistence Query and ensure the "reliable side effect is generated there"; but this can be a pretty heavy machinery when the use case is to ensure another downstream aggregate root is notified of something. 

This code attempts a different approach with a different tradeoff. In this new proposed `ReliableSideEffectBehavior`, four types: `Command`, `State`, `Event` but also `Notification`. The notifications are side effects generated as part of evolving the state in response to an event.

A new `notificationHandler` is guaranteed to be called *at least once* per generated notification, even in case of *rapid unintended passivation* 

In terms of implementation, this is currently made the clumsy way by wrapping events into an EventWrapper that is also able to carry intents to deliver notifications and completion of notifications. As a result, this implementation trades a journal event stream listener with more events.

For the end user, `ReliableSideEffectBehavior` has the additional benefit of entirely avoiding the tagged events/journal pollng mechanism and simply work off whichever journal plugin is currently used.

I haven't attempted to map into the scaladsl/javadsl dichotomy as it's a bit premature at the RFC phase, and I'm unsure what adaptation Java would require.

Would appreciate any feedback.