### PR TITLE
Fix SelectionHandler sequenceNumber overflow,  #25546

### DIFF
--- a/akka-actor/src/main/scala/akka/io/SelectionHandler.scala
+++ b/akka-actor/src/main/scala/akka/io/SelectionHandler.scala
@@ -258,7 +258,7 @@ private[io] class SelectionHandler(settings: SelectionHandlerSettings) extends A
   import SelectionHandler._
   import settings._
 
-  private[this] var sequenceNumber = 0
+  private[this] var sequenceNumber = 0L // should be Long to prevent overflow
   private[this] var childCount = 0
   private[this] val registry = {
     val dispatcher = context.system.dispatchers.lookup(SelectorDispatcher)


### PR DESCRIPTION
Resolves #25546 
Using Long at rate 10000 children per second it will take 58 million years to overflow the  `sequenceNumber`.