### PR TITLE
Persistence Query: InmemReadJournal

### DIFF
--- a/akka-persistence-query/src/main/resources/reference.conf
+++ b/akka-persistence-query/src/main/resources/reference.conf
@@ -27,3 +27,17 @@ akka.persistence.query.journal.leveldb {
   max-buffer-size = 100
 }
 #//#query-leveldb
+
+#//#query-inmem
+# Configuration for the InmemReadJournal
+akka.persistence.query.journal.inmem {
+  # Implementation class of the Inmem ReadJournalProvider
+  class = "akka.persistence.query.journal.inmem.InmemReadJournalProvider"
+
+  # Absolute path to the write journal plugin configuration entry that this 
+  # query journal will connect to. That must be a InmemJournal
+  # If undefined (or "") it will connect to the default journal as specified by the
+  # akka.persistence.journal.plugin property.
+  write-plugin = ""
+}
+#//#query-inmem

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/inmem/InmemReadJournalProvider.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/inmem/InmemReadJournalProvider.scala
@@ -1,6 +1,6 @@
 /**
-  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
-  */
+ * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 
 package akka.persistence.query.journal.inmem
 

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/inmem/InmemReadJournalProvider.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/inmem/InmemReadJournalProvider.scala
@@ -1,0 +1,19 @@
+/**
+  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+  */
+
+package akka.persistence.query.journal.inmem
+
+import akka.actor.ExtendedActorSystem
+import akka.persistence.query.ReadJournalProvider
+import com.typesafe.config.Config
+
+class InmemReadJournalProvider(system: ExtendedActorSystem, config: Config) extends ReadJournalProvider {
+
+  override val scaladslReadJournal: scaladsl.InmemReadJournal =
+    new scaladsl.InmemReadJournal(system, config)
+
+  override val javadslReadJournal: javadsl.InmemReadJournal =
+    new javadsl.InmemReadJournal(scaladslReadJournal)
+
+}

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/inmem/javadsl/InmemReadJournal.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/inmem/javadsl/InmemReadJournal.scala
@@ -1,150 +1,151 @@
 /**
-  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
-  */
+ * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.persistence.query.journal.inmem.javadsl
 
 import akka.NotUsed
-import akka.persistence.query.{EventEnvelope, Offset}
+import akka.persistence.query.{ EventEnvelope, Offset }
 import akka.persistence.query.javadsl._
 import akka.stream.javadsl.Source
 
 /**
-  * Java API: [[akka.persistence.query.javadsl.ReadJournal]] implementation for Inmem (for testing purposes only)
-  *
-  * It is retrieved with:
-  * {{{
-  * InmemReadJournal queries =
-  *   PersistenceQuery.get(system).getReadJournalFor(InmemReadJournal.class, InmemReadJournal.Identifier());
-  * }}}
-  *
-  * Corresponding Scala API is in [[akka.persistence.query.journal.inmem.javadsl.InmemReadJournal]].
-  *
-  * Configuration settings can be defined in the configuration section with the
-  * absolute path corresponding to the identifier, which is `"akka.persistence.query.journal.inmem"`
-  * for the default [[InmemReadJournal#Identifier]]. See `reference.conf`.
-  *
-  */
+ * Java API: [[akka.persistence.query.javadsl.ReadJournal]] implementation for Inmem (for testing purposes only)
+ *
+ * It is retrieved with:
+ * {{{
+ * InmemReadJournal queries =
+ *   PersistenceQuery.get(system).getReadJournalFor(InmemReadJournal.class, InmemReadJournal.Identifier());
+ * }}}
+ *
+ * Corresponding Scala API is in [[akka.persistence.query.journal.inmem.javadsl.InmemReadJournal]].
+ *
+ * Configuration settings can be defined in the configuration section with the
+ * absolute path corresponding to the identifier, which is `"akka.persistence.query.journal.inmem"`
+ * for the default [[InmemReadJournal#Identifier]]. See `reference.conf`.
+ *
+ */
 class InmemReadJournal(scaladslReadJournal: akka.persistence.query.journal.inmem.scaladsl.InmemReadJournal)
   extends ReadJournal
-    with PersistenceIdsQuery with CurrentPersistenceIdsQuery
-    with EventsByPersistenceIdQuery with CurrentEventsByPersistenceIdQuery
-    with EventsByTagQuery with CurrentEventsByTagQuery {
+  with PersistenceIdsQuery with CurrentPersistenceIdsQuery
+  with EventsByPersistenceIdQuery with CurrentEventsByPersistenceIdQuery
+  with EventsByTagQuery with CurrentEventsByTagQuery {
 
   /**
-    * `persistenceIds` is used for retrieving all `persistenceIds` of all
-    * persistent actors.
-    *
-    * The returned event stream is unordered and you can expect different order for multiple
-    * executions of the query.
-    *
-    * The stream is not completed when it reaches the end of the currently used `persistenceIds`,
-    * but it continues to push new `persistenceIds` when new persistent actors are created.
-    * Corresponding query that is completed when it reaches the end of the currently
-    * currently used `persistenceIds` is provided by [[#currentPersistenceIds]].
-    *
-    * The Inmem write journal is notifying the query side as soon as new `persistenceIds` are
-    * created and there is no periodic polling or batching involved in this query.
-    *
-    * The stream is completed with failure if there is a failure in executing the query in the
-    * backend journal.
-    */
+   * `persistenceIds` is used for retrieving all `persistenceIds` of all
+   * persistent actors.
+   *
+   * The returned event stream is unordered and you can expect different order for multiple
+   * executions of the query.
+   *
+   * The stream is not completed when it reaches the end of the currently used `persistenceIds`,
+   * but it continues to push new `persistenceIds` when new persistent actors are created.
+   * Corresponding query that is completed when it reaches the end of the currently
+   * currently used `persistenceIds` is provided by [[#currentPersistenceIds]].
+   *
+   * The Inmem write journal is notifying the query side as soon as new `persistenceIds` are
+   * created and there is no periodic polling or batching involved in this query.
+   *
+   * The stream is completed with failure if there is a failure in executing the query in the
+   * backend journal.
+   */
   override def persistenceIds(): Source[String, NotUsed] =
     scaladslReadJournal.persistenceIds().asJava
 
   /**
-    * Same type of query as [[#persistenceIds]] but the stream
-    * is completed immediately when it reaches the end of the "result set". Persistent
-    * actors that are created after the query is completed are not included in the stream.
-    */
+   * Same type of query as [[#persistenceIds]] but the stream
+   * is completed immediately when it reaches the end of the "result set". Persistent
+   * actors that are created after the query is completed are not included in the stream.
+   */
   override def currentPersistenceIds(): Source[String, NotUsed] =
     scaladslReadJournal.currentPersistenceIds().asJava
 
   /**
-    * `eventsByPersistenceId` is used for retrieving events for a specific
-    * `PersistentActor` identified by `persistenceId`.
-    *
-    * You can retrieve a subset of all events by specifying `fromSequenceNr` and `toSequenceNr`
-    * or use `0L` and `Long.MaxValue` respectively to retrieve all events. Note that
-    * the corresponding sequence number of each event is provided in the
-    * [[akka.persistence.query.EventEnvelope]], which makes it possible to resume the
-    * stream at a later point from a given sequence number.
-    *
-    * The returned event stream is ordered by sequence number, i.e. the same order as the
-    * `PersistentActor` persisted the events. The same prefix of stream elements (in same order)
-    *  are returned for multiple executions of the query, except for when events have been deleted.
-    *
-    * The stream is not completed when it reaches the end of the currently stored events,
-    * but it continues to push new events when new events are persisted.
-    * Corresponding query that is completed when it reaches the end of the currently
-    * stored events is provided by [[#currentEventsByPersistenceId]].
-    *
-    * The Inmem write journal is notifying the query side as soon as events are persisted, but for
-    * efficiency reasons the query side retrieves the events in batches that sometimes can
-    * be delayed up to the configured `refresh-interval`.
-    *
-    * The stream is completed with failure if there is a failure in executing the query in the
-    * backend journal.
-    */
+   * `eventsByPersistenceId` is used for retrieving events for a specific
+   * `PersistentActor` identified by `persistenceId`.
+   *
+   * You can retrieve a subset of all events by specifying `fromSequenceNr` and `toSequenceNr`
+   * or use `0L` and `Long.MaxValue` respectively to retrieve all events. Note that
+   * the corresponding sequence number of each event is provided in the
+   * [[akka.persistence.query.EventEnvelope]], which makes it possible to resume the
+   * stream at a later point from a given sequence number.
+   *
+   * The returned event stream is ordered by sequence number, i.e. the same order as the
+   * `PersistentActor` persisted the events. The same prefix of stream elements (in same order)
+   *  are returned for multiple executions of the query, except for when events have been deleted.
+   *
+   * The stream is not completed when it reaches the end of the currently stored events,
+   * but it continues to push new events when new events are persisted.
+   * Corresponding query that is completed when it reaches the end of the currently
+   * stored events is provided by [[#currentEventsByPersistenceId]].
+   *
+   * The Inmem write journal is notifying the query side as soon as events are persisted, but for
+   * efficiency reasons the query side retrieves the events in batches that sometimes can
+   * be delayed up to the configured `refresh-interval`.
+   *
+   * The stream is completed with failure if there is a failure in executing the query in the
+   * backend journal.
+   */
   override def eventsByPersistenceId(persistenceId: String, fromSequenceNr: Long,
                                      toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
     scaladslReadJournal.eventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
 
   /**
-    * Same type of query as [[#eventsByPersistenceId]] but the event stream
-    * is completed immediately when it reaches the end of the "result set". Events that are
-    * stored after the query is completed are not included in the event stream.
-    */
+   * Same type of query as [[#eventsByPersistenceId]] but the event stream
+   * is completed immediately when it reaches the end of the "result set". Events that are
+   * stored after the query is completed are not included in the event stream.
+   */
   override def currentEventsByPersistenceId(persistenceId: String, fromSequenceNr: Long,
                                             toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
     scaladslReadJournal.currentEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
 
   /**
-    * `eventsByTag` is used for retrieving events that were marked with
-    * a given tag, e.g. all events of an Aggregate Root type.
-    *
-    * To tag events you create an [[akka.persistence.journal.EventAdapter]] that wraps the events
-    * in a [[akka.persistence.journal.Tagged]] with the given `tags`.
-    *
-    * You can retrieve a subset of all events by specifying `offset`, or use `0L` to retrieve all
-    * events with a given tag. The `offset` corresponds to an ordered sequence number for
-    * the specific tag. Note that the corresponding offset of each event is provided in the
-    * [[akka.persistence.query.EventEnvelope]], which makes it possible to resume the
-    * stream at a later point from a given offset.
-    *
-    * In addition to the `offset` the `EventEnvelope` also provides `persistenceId` and `sequenceNr`
-    * for each event. The `sequenceNr` is the sequence number for the persistent actor with the
-    * `persistenceId` that persisted the event. The `persistenceId` + `sequenceNr` is an unique
-    * identifier for the event.
-    *
-    * The `offset` is exclusive, i.e. the event with the exact same sequence number will not be included
-    * in the returned stream. This means that you can use the offset that is returned in `EventEnvelope`
-    * as the `offset` parameter in a subsequent query.
-    *
-    * The returned event stream is ordered by the offset (tag sequence number), which corresponds
-    * to the same order as the write journal stored the events. The same stream elements (in same order)
-    * are returned for multiple executions of the query. Deleted events are not deleted from the
-    * tagged event stream.
-    *
-    * The stream is not completed when it reaches the end of the currently stored events,
-    * but it continues to push new events when new events are persisted.
-    * Corresponding query that is completed when it reaches the end of the currently
-    * stored events is provided by [[#currentEventsByTag]].
-    *
-    * The Inmem write journal is notifying the query side as soon as tagged events are persisted, but for
-    * efficiency reasons the query side retrieves the events in batches that sometimes can
-    * be delayed up to the configured `refresh-interval`.
-    *
-    * The stream is completed with failure if there is a failure in executing the query in the
-    * backend journal.
-    */
+   * `eventsByTag` is used for retrieving events that were marked with
+   * a given tag, e.g. all events of an Aggregate Root type.
+   *
+   * To tag events you create an [[akka.persistence.journal.EventAdapter]] that wraps the events
+   * in a [[akka.persistence.journal.Tagged]] with the given `tags`.
+   *
+   * You can retrieve a subset of all events by specifying `offset`, or use `0L` to retrieve all
+   * events with a given tag. The `offset` corresponds to an ordered sequence number for
+   * the specific tag. Note that the corresponding offset of each event is provided in the
+   * [[akka.persistence.query.EventEnvelope]], which makes it possible to resume the
+   * stream at a later point from a given offset.
+   *
+   * In addition to the `offset` the `EventEnvelope` also provides `persistenceId` and `sequenceNr`
+   * for each event. The `sequenceNr` is the sequence number for the persistent actor with the
+   * `persistenceId` that persisted the event. The `persistenceId` + `sequenceNr` is an unique
+   * identifier for the event.
+   *
+   * The `offset` is exclusive, i.e. the event with the exact same sequence number will not be included
+   * in the returned stream. This means that you can use the offset that is returned in `EventEnvelope`
+   * as the `offset` parameter in a subsequent query.
+   *
+   * The returned event stream is ordered by the offset (tag sequence number), which corresponds
+   * to the same order as the write journal stored the events. The same stream elements (in same order)
+   * are returned for multiple executions of the query. Deleted events are not deleted from the
+   * tagged event stream.
+   *
+   * The stream is not completed when it reaches the end of the currently stored events,
+   * but it continues to push new events when new events are persisted.
+   * Corresponding query that is completed when it reaches the end of the currently
+   * stored events is provided by [[#currentEventsByTag]].
+   *
+   * The Inmem write journal is notifying the query side as soon as tagged events are persisted, but for
+   * efficiency reasons the query side retrieves the events in batches that sometimes can
+   * be delayed up to the configured `refresh-interval`.
+   *
+   * The stream is completed with failure if there is a failure in executing the query in the
+   * backend journal.
+   */
   override def eventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] =
     scaladslReadJournal.eventsByTag(tag, offset).asJava
 
   /**
-    * Same type of query as [[#eventsByTag]] but the event stream
-    * is completed immediately when it reaches the end of the "result set". Events that are
-    * stored after the query is completed are not included in the event stream.
-    */
+   * Same type of query as [[#eventsByTag]] but the event stream
+   * is completed immediately when it reaches the end of the "result set". Events that are
+   * stored after the query is completed are not included in the event stream.
+   */
   override def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] =
     scaladslReadJournal.currentEventsByTag(tag, offset).asJava
 
@@ -152,12 +153,12 @@ class InmemReadJournal(scaladslReadJournal: akka.persistence.query.journal.inmem
 
 object InmemReadJournal {
   /**
-    * The default identifier for [[InmemReadJournal]] to be used with
-    * [[akka.persistence.query.PersistenceQuery#getReadJournalFor]].
-    *
-    * The value is `"akka.persistence.query.journal.inmem"` and corresponds
-    * to the absolute path to the read journal configuration entry.
-    */
+   * The default identifier for [[InmemReadJournal]] to be used with
+   * [[akka.persistence.query.PersistenceQuery#getReadJournalFor]].
+   *
+   * The value is `"akka.persistence.query.journal.inmem"` and corresponds
+   * to the absolute path to the read journal configuration entry.
+   */
   final val Identifier = akka.persistence.query.journal.inmem.scaladsl.InmemReadJournal.Identifier
 }
 

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/inmem/javadsl/InmemReadJournal.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/inmem/javadsl/InmemReadJournal.scala
@@ -1,0 +1,163 @@
+/**
+  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+  */
+package akka.persistence.query.journal.inmem.javadsl
+
+import akka.NotUsed
+import akka.persistence.query.{EventEnvelope, Offset}
+import akka.persistence.query.javadsl._
+import akka.stream.javadsl.Source
+
+/**
+  * Java API: [[akka.persistence.query.javadsl.ReadJournal]] implementation for Inmem (for testing purposes only)
+  *
+  * It is retrieved with:
+  * {{{
+  * InmemReadJournal queries =
+  *   PersistenceQuery.get(system).getReadJournalFor(InmemReadJournal.class, InmemReadJournal.Identifier());
+  * }}}
+  *
+  * Corresponding Scala API is in [[akka.persistence.query.journal.inmem.javadsl.InmemReadJournal]].
+  *
+  * Configuration settings can be defined in the configuration section with the
+  * absolute path corresponding to the identifier, which is `"akka.persistence.query.journal.inmem"`
+  * for the default [[InmemReadJournal#Identifier]]. See `reference.conf`.
+  *
+  */
+class InmemReadJournal(scaladslReadJournal: akka.persistence.query.journal.inmem.scaladsl.InmemReadJournal)
+  extends ReadJournal
+    with PersistenceIdsQuery with CurrentPersistenceIdsQuery
+    with EventsByPersistenceIdQuery with CurrentEventsByPersistenceIdQuery
+    with EventsByTagQuery with CurrentEventsByTagQuery {
+
+  /**
+    * `persistenceIds` is used for retrieving all `persistenceIds` of all
+    * persistent actors.
+    *
+    * The returned event stream is unordered and you can expect different order for multiple
+    * executions of the query.
+    *
+    * The stream is not completed when it reaches the end of the currently used `persistenceIds`,
+    * but it continues to push new `persistenceIds` when new persistent actors are created.
+    * Corresponding query that is completed when it reaches the end of the currently
+    * currently used `persistenceIds` is provided by [[#currentPersistenceIds]].
+    *
+    * The Inmem write journal is notifying the query side as soon as new `persistenceIds` are
+    * created and there is no periodic polling or batching involved in this query.
+    *
+    * The stream is completed with failure if there is a failure in executing the query in the
+    * backend journal.
+    */
+  override def persistenceIds(): Source[String, NotUsed] =
+    scaladslReadJournal.persistenceIds().asJava
+
+  /**
+    * Same type of query as [[#persistenceIds]] but the stream
+    * is completed immediately when it reaches the end of the "result set". Persistent
+    * actors that are created after the query is completed are not included in the stream.
+    */
+  override def currentPersistenceIds(): Source[String, NotUsed] =
+    scaladslReadJournal.currentPersistenceIds().asJava
+
+  /**
+    * `eventsByPersistenceId` is used for retrieving events for a specific
+    * `PersistentActor` identified by `persistenceId`.
+    *
+    * You can retrieve a subset of all events by specifying `fromSequenceNr` and `toSequenceNr`
+    * or use `0L` and `Long.MaxValue` respectively to retrieve all events. Note that
+    * the corresponding sequence number of each event is provided in the
+    * [[akka.persistence.query.EventEnvelope]], which makes it possible to resume the
+    * stream at a later point from a given sequence number.
+    *
+    * The returned event stream is ordered by sequence number, i.e. the same order as the
+    * `PersistentActor` persisted the events. The same prefix of stream elements (in same order)
+    *  are returned for multiple executions of the query, except for when events have been deleted.
+    *
+    * The stream is not completed when it reaches the end of the currently stored events,
+    * but it continues to push new events when new events are persisted.
+    * Corresponding query that is completed when it reaches the end of the currently
+    * stored events is provided by [[#currentEventsByPersistenceId]].
+    *
+    * The Inmem write journal is notifying the query side as soon as events are persisted, but for
+    * efficiency reasons the query side retrieves the events in batches that sometimes can
+    * be delayed up to the configured `refresh-interval`.
+    *
+    * The stream is completed with failure if there is a failure in executing the query in the
+    * backend journal.
+    */
+  override def eventsByPersistenceId(persistenceId: String, fromSequenceNr: Long,
+                                     toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
+    scaladslReadJournal.eventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
+
+  /**
+    * Same type of query as [[#eventsByPersistenceId]] but the event stream
+    * is completed immediately when it reaches the end of the "result set". Events that are
+    * stored after the query is completed are not included in the event stream.
+    */
+  override def currentEventsByPersistenceId(persistenceId: String, fromSequenceNr: Long,
+                                            toSequenceNr: Long): Source[EventEnvelope, NotUsed] =
+    scaladslReadJournal.currentEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
+
+  /**
+    * `eventsByTag` is used for retrieving events that were marked with
+    * a given tag, e.g. all events of an Aggregate Root type.
+    *
+    * To tag events you create an [[akka.persistence.journal.EventAdapter]] that wraps the events
+    * in a [[akka.persistence.journal.Tagged]] with the given `tags`.
+    *
+    * You can retrieve a subset of all events by specifying `offset`, or use `0L` to retrieve all
+    * events with a given tag. The `offset` corresponds to an ordered sequence number for
+    * the specific tag. Note that the corresponding offset of each event is provided in the
+    * [[akka.persistence.query.EventEnvelope]], which makes it possible to resume the
+    * stream at a later point from a given offset.
+    *
+    * In addition to the `offset` the `EventEnvelope` also provides `persistenceId` and `sequenceNr`
+    * for each event. The `sequenceNr` is the sequence number for the persistent actor with the
+    * `persistenceId` that persisted the event. The `persistenceId` + `sequenceNr` is an unique
+    * identifier for the event.
+    *
+    * The `offset` is exclusive, i.e. the event with the exact same sequence number will not be included
+    * in the returned stream. This means that you can use the offset that is returned in `EventEnvelope`
+    * as the `offset` parameter in a subsequent query.
+    *
+    * The returned event stream is ordered by the offset (tag sequence number), which corresponds
+    * to the same order as the write journal stored the events. The same stream elements (in same order)
+    * are returned for multiple executions of the query. Deleted events are not deleted from the
+    * tagged event stream.
+    *
+    * The stream is not completed when it reaches the end of the currently stored events,
+    * but it continues to push new events when new events are persisted.
+    * Corresponding query that is completed when it reaches the end of the currently
+    * stored events is provided by [[#currentEventsByTag]].
+    *
+    * The Inmem write journal is notifying the query side as soon as tagged events are persisted, but for
+    * efficiency reasons the query side retrieves the events in batches that sometimes can
+    * be delayed up to the configured `refresh-interval`.
+    *
+    * The stream is completed with failure if there is a failure in executing the query in the
+    * backend journal.
+    */
+  override def eventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] =
+    scaladslReadJournal.eventsByTag(tag, offset).asJava
+
+  /**
+    * Same type of query as [[#eventsByTag]] but the event stream
+    * is completed immediately when it reaches the end of the "result set". Events that are
+    * stored after the query is completed are not included in the event stream.
+    */
+  override def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] =
+    scaladslReadJournal.currentEventsByTag(tag, offset).asJava
+
+}
+
+object InmemReadJournal {
+  /**
+    * The default identifier for [[InmemReadJournal]] to be used with
+    * [[akka.persistence.query.PersistenceQuery#getReadJournalFor]].
+    *
+    * The value is `"akka.persistence.query.journal.inmem"` and corresponds
+    * to the absolute path to the read journal configuration entry.
+    */
+  final val Identifier = akka.persistence.query.journal.inmem.scaladsl.InmemReadJournal.Identifier
+}
+

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/inmem/scaladsl/InmemReadJournal.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/inmem/scaladsl/InmemReadJournal.scala
@@ -1,0 +1,444 @@
+package akka.persistence.query.journal.inmem.scaladsl
+
+import java.util.concurrent.{CompletionStage, TimeUnit}
+
+import akka.{Done, NotUsed}
+import akka.pattern.ask
+import akka.actor.{Actor, ActorLogging, ExtendedActorSystem, Props}
+import akka.event.Logging
+import akka.persistence.journal.Tagged
+import akka.persistence.{Persistence, PersistentRepr}
+import akka.persistence.journal.inmem.InmemJournal
+import akka.persistence.query._
+import akka.persistence.query.journal.inmem.scaladsl.MessageReceiver.{LiveSubscription, SubscribeCurrent, SubscribeLive}
+import akka.persistence.query.scaladsl._
+import akka.stream._
+import akka.stream.scaladsl.SourceQueueWithComplete
+import akka.stream.scaladsl.{Concat, Flow, GraphDSL, Keep, RunnableGraph, Sink, Source, Zip}
+import akka.stream.stage.{GraphStage, GraphStageLogic, OutHandler}
+import akka.util.Timeout
+import com.typesafe.config.Config
+import org.reactivestreams.{Publisher, Subscriber}
+
+import scala.collection.mutable
+import scala.collection.{immutable => im}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+
+object MessageReceiver {
+  trait Get
+  case object GetAllCurrent /* response is: Seq[PersistentRepr] */ extends Get
+  final case class GetAllCurrentTagged(tag: String) /* response is: Seq[(PersistentRepr, Offset)] */ extends Get
+
+
+  final case class LiveSubscription(source: Source[PersistentRepr, NotUsed])
+  final case object SubscribeLive // response is: LiveSubscription */
+  final case object SubscribeCurrent // response is: LiveSubscription */
+}
+
+class MessageReceiver(implicit mat: Materializer) extends Actor with ActorLogging {
+  implicit def executionContext:ExecutionContext = context.dispatcher
+
+  private var allMessages: mutable.Buffer[PersistentRepr] = mutable.Buffer.empty
+  private var taggedMessages: mutable.Map[String, mutable.Buffer[PersistentRepr]] = mutable.Map.empty
+
+  private def createCurrentSource: Source[PersistentRepr, NotUsed] = {
+    val currentDataSnapshot = allMessages.toStream
+    val current = Source(currentDataSnapshot)
+    current
+  }
+
+  private def createNewAndCurrentLiveSource: (SourceQueueWithComplete[PersistentRepr], Source[PersistentRepr, NotUsed]) = {
+    /* This first loop runs immediately, and publishes into a Backpressured-publisher */
+    val live = Source.queue[PersistentRepr](10, OverflowStrategies.Backpressure)
+    /* the source we return is a combination of current and live data sources */
+    val current = createCurrentSource
+    val combo = Source.combineMat(current, live)(Concat(_))(Keep.right)
+
+    val runnable = combo.toMat(Sink.asPublisher(false))(Keep.both)
+
+    val (sourceQ, pub) = runnable.run
+
+    val livePub = Source.fromPublisher(pub)
+        .watchTermination() {
+      case (notUsed, fDone) =>
+        /* propagate completion, especially early termination of the downstream graph, to the upstream graph */
+        fDone
+            .map { _ =>
+              log.debug("completing {} due to downstream being terminated", sourceQ)
+              sourceQ.complete()
+            }
+            .onFailure {
+              case ex: Throwable =>
+                sourceQ.fail(ex)
+            }
+
+        notUsed
+    }
+
+    (sourceQ, livePub)
+  }
+
+  private var activePublishedQueues: mutable.Buffer[SourceQueueWithComplete[PersistentRepr]] = mutable.Buffer.empty
+
+  private def startNewAndCurrentLiveSource: Source[PersistentRepr, NotUsed] = {
+    val (sourceQ, source) = createNewAndCurrentLiveSource
+    activePublishedQueues.append(sourceQ)
+    source
+  }
+
+  private def publishMessageSynchronously(m: PersistentRepr): Unit = {
+    if (activePublishedQueues.nonEmpty) {
+      try {
+        val fFutureOfferResults = activePublishedQueues
+          .map { q =>
+            val f = try {
+              q.offer(m)
+            } catch {
+              case ex: Throwable =>
+                Future.successful(QueueOfferResult.Failure(ex))
+            }
+
+            f.map(r => (m, q, r))
+              .recoverWith { case ex: Throwable =>
+                Future.successful((m, q, QueueOfferResult.Failure(ex)))
+              }
+          }
+
+
+        val fOfferResults = try {
+          Future.sequence(fFutureOfferResults)
+        } catch {
+          case t: Throwable =>
+            throw t
+        }
+
+        val enqueueResults = try {
+          Await.result(fOfferResults, Duration.Inf) // we voluntarily wait indefinitely until it no longer backpressures
+          //.map { r => println(s"enqueue result=${r} "); r }
+        } catch {
+          case t: Throwable =>
+            throw t
+        }
+
+        val queuesToPurge = enqueueResults
+          .flatMap {
+            case (m, q, QueueOfferResult.Enqueued) =>
+              None
+            case (m, q, QueueOfferResult.Dropped) =>
+              q.fail(new IllegalStateException("downstream queues should not drop items, killing live Source"))
+              Some(q)
+            case (m, q, QueueOfferResult.Failure(cause)) =>
+              q.fail(new IllegalStateException("downstream queue failed, killing live Source", cause))
+              Some(q)
+            case (m, q, QueueOfferResult.QueueClosed) =>
+              Some(q) // we reached an end and this is okay
+          }.toSet
+
+        if (queuesToPurge.nonEmpty) {
+          val newPublishedQueues = activePublishedQueues.filterNot(queuesToPurge.contains)
+          activePublishedQueues = newPublishedQueues
+        }
+      }
+      catch {
+        case t: Throwable =>
+          log.error(t, "failing to propagate {}", m)
+      }
+    }
+  }
+
+  /**
+    * Scala API: This defines the initial actor behavior, it must return a partial function
+    * with the actor logic.
+    */
+  def receive = {
+    case InmemJournal.SpooledMessages(messages) =>
+      allMessages = allMessages ++ messages
+      messages.foreach(publishMessageSynchronously)
+
+    case InmemJournal.DeleteSpooledMessages(persistenceId, toSequenceNr) =>
+      val kept = allMessages.filterNot { repr => (repr.persistenceId == persistenceId) && (repr.sequenceNr <= toSequenceNr) }
+      allMessages = kept
+      sender() ! Done
+
+    case MessageReceiver.GetAllCurrent =>
+      sender() ! allMessages.toArray.toSeq
+
+    case MessageReceiver.GetAllCurrentTagged(tag) =>
+
+      val perTag: Seq[(PersistentRepr, Offset)] = allMessages
+        .map(repr => (repr, repr.payload))
+        .collect { case (repr, Tagged(realPayload, tags)) if tags.contains(tag) => repr }
+        .toArray
+        .zipWithIndex
+        .map { case (repr, idx) => (repr, Sequence(idx + 1)) }
+
+
+      sender() ! perTag
+
+    case MessageReceiver.SubscribeLive =>
+      val newSrc = startNewAndCurrentLiveSource
+      sender() ! MessageReceiver.LiveSubscription(newSrc)
+
+    case MessageReceiver.SubscribeCurrent =>
+      val newSrc = createCurrentSource
+      sender() ! MessageReceiver.LiveSubscription(newSrc)
+  }
+}
+
+/**
+  * Scala API [[akka.persistence.query.scaladsl.ReadJournal]] implementation for Inmem (for testing purposes only)
+  *
+  * It is retrieved with:
+  * {{{
+  * val queries = PersistenceQuery(system).readJournalFor[InmemReadJournal](InmemReadJournal.Identifier)
+  * }}}
+  *
+  * Corresponding Java API is in [[akka.persistence.query.journal.inmem.javadsl.InmemReadJournal]].
+  *
+  * Configuration settings can be defined in the configuration section with the
+  * absolute path corresponding to the identifier, which is `"akka.persistence.query.journal.inmem"`
+  * for the default [[InmemReadJournal#Identifier]]. See `reference.conf`.
+  */
+class InmemReadJournal(system: ExtendedActorSystem, config: Config) extends ReadJournal
+  with PersistenceIdsQuery with CurrentPersistenceIdsQuery
+  with EventsByPersistenceIdQuery with CurrentEventsByPersistenceIdQuery
+  with EventsByTagQuery with CurrentEventsByTagQuery {
+
+  implicit def timeout: Timeout = Timeout(FiniteDuration(1, TimeUnit.MINUTES))
+
+  implicit def executionContext: ExecutionContext = system.dispatcher
+
+  implicit val mat: ActorMaterializer = ActorMaterializer()(system)
+
+  private val journalRef = Persistence(system).journalFor("akka.persistence.journal.inmem")
+  private val receiver = system.actorOf(Props(new MessageReceiver), "inmem-journal-recv")
+
+  journalRef ! InmemJournal.SetDownstreamReceiver(receiver)
+  /* from this point on, receiver receives a copy of 'persisted' events */
+
+  private def getAllCurrentRepr(filterPredicate: (PersistentRepr, Offset) => Boolean = (_,_) => true): Future[Seq[(PersistentRepr, Offset)]] =
+    (receiver ? MessageReceiver.GetAllCurrent)
+      .map { case pack: Seq[PersistentRepr @unchecked] =>
+        pack
+          .filter { item => filterPredicate(item, NoOffset) }
+          .map(item => (item, NoOffset))
+      }
+
+  private def getAllTaggedRepr(tag: String, filterPredicate: (PersistentRepr, Offset) => Boolean = (_,_) => true): Future[Seq[(PersistentRepr, Offset)]] = {
+    val filtered =
+      (receiver ? MessageReceiver.GetAllCurrentTagged(tag))
+        .map { case pack: Seq[(PersistentRepr, Offset)@unchecked] =>
+          pack
+            .filter { case (item, offset) => filterPredicate(item, offset) }
+        }
+    /* now strip the "Tagged" structure, as the current API doesn't provide for conjunction of tags */
+
+    filtered.map { pack =>
+      pack
+        .map { case (repr, idx) => (repr, repr.payload, idx) }
+        .collect {
+          case (repr, Tagged(realPayload, tags), idx) =>
+            (repr.withPayload(realPayload), idx)
+        }
+    }
+  }
+
+  private def currentRepr(f: Future[Iterable[(PersistentRepr, Offset)]]): Source[EventEnvelope, NotUsed] =
+    Source.fromFuture(f).flatMapConcat {
+      iterable =>
+        Source.fromIterator {
+          () =>
+            iterable.map {
+              case (repr, offset) =>
+                val event = repr.payload // FIXME: not entirely sure?
+                EventEnvelope(offset, repr.persistenceId, repr.sequenceNr, event)
+            }.toIterator
+        }
+    }
+
+  private val streamLogLevels =       Attributes.logLevels(onElement = Logging.InfoLevel, onFailure = Logging.ErrorLevel, onFinish = Logging.InfoLevel)
+
+  private def newLiveMessageSource: Source[PersistentRepr, NotUsed] = {
+    val f = Source.fromFuture((receiver ? SubscribeLive).mapTo[LiveSubscription].map(_.source))
+      .withAttributes(streamLogLevels)
+
+    val f2 = f.flatMapConcat(identity)
+
+    f2
+      .withAttributes(streamLogLevels)
+  }
+
+  private def newCurrentMessageSource: Source[PersistentRepr, NotUsed] = {
+    val f = Source.fromFuture((receiver ? SubscribeCurrent).mapTo[LiveSubscription].map(_.source))
+      .withAttributes(streamLogLevels)
+
+    val f2 = f.flatMapConcat(identity)
+
+
+    f2
+      .withAttributes(streamLogLevels)
+  }
+
+  /**
+    * Query all `PersistentActor` identifiers, i.e. as defined by the
+    * `persistenceId` of the `PersistentActor`.
+    *
+    * The stream is not completed when it reaches the end of the currently used `persistenceIds`,
+    * but it continues to push new `persistenceIds` when new persistent actors are created.
+    * Corresponding query that is completed when it reaches the end of the currently
+    * currently used `persistenceIds` is provided by [[CurrentPersistenceIdsQuery#currentPersistenceIds]].
+    */
+  override def persistenceIds(): Source[String, NotUsed] = {
+    reprSourceToPersistenceIds(newLiveMessageSource)
+  }
+
+  /**
+    * Same type of query as [[PersistenceIdsQuery#persistenceIds]] but the stream
+    * is completed immediately when it reaches the end of the "result set". Persistent
+    * actors that are created after the query is completed are not included in the stream.
+    */
+  override def currentPersistenceIds(): Source[String, NotUsed] = {
+    reprSourceToPersistenceIds(newCurrentMessageSource)
+  }
+
+  private def reprSourceToPersistenceIds(src: Source[PersistentRepr, NotUsed]): Source[String, NotUsed] = {
+    src
+      .scan( (Set.empty[String], None:Option[String]) ) {
+        case ((known, _), repr) if known.contains(repr.persistenceId) =>
+          (known, None)
+        case ((known, _), repr) /* if !known.contains(repr.persistenceId) */ =>
+          (known, Some(repr.persistenceId))
+      }
+      .collect { case (_, Some(newPersistenceId)) =>
+        newPersistenceId
+      }
+  }
+
+  /**
+    * Query events for a specific `PersistentActor` identified by `persistenceId`.
+    *
+    * You can retrieve a subset of all events by specifying `fromSequenceNr` and `toSequenceNr`
+    * or use `0L` and `Long.MaxValue` respectively to retrieve all events.
+    *
+    * The returned event stream should be ordered by sequence number.
+    *
+    * The stream is not completed when it reaches the end of the currently stored events,
+    * but it continues to push new events when new events are persisted.
+    * Corresponding query that is completed when it reaches the end of the currently
+    * stored events is provided by [[CurrentEventsByPersistenceIdQuery#currentEventsByPersistenceId]].
+    */
+  override def eventsByPersistenceId(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long): Source[EventEnvelope, NotUsed] = {
+    reprSourceByPersistenceId(newLiveMessageSource)(persistenceId, fromSequenceNr, toSequenceNr)
+  }
+
+  /**
+    * Same type of query as [[EventsByPersistenceIdQuery#eventsByPersistenceId]]
+    * but the event stream is completed immediately when it reaches the end of
+    * the "result set". Events that are stored after the query is completed are
+    * not included in the event stream.
+    */
+  override def currentEventsByPersistenceId(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long): Source[EventEnvelope, NotUsed] = {
+    reprSourceByPersistenceId(newCurrentMessageSource)(persistenceId, fromSequenceNr, toSequenceNr)
+  }
+
+  private def reprSourceByPersistenceId(src: Source[PersistentRepr, NotUsed])(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long): Source[EventEnvelope, NotUsed] = {
+    if (fromSequenceNr > toSequenceNr) {
+      Source.empty
+    } else {
+      src
+        .filter(_.persistenceId == persistenceId)
+        .filter(_.sequenceNr >= fromSequenceNr)
+        .takeWhile(_.sequenceNr <= toSequenceNr)
+        .takeWhile(_.sequenceNr < toSequenceNr, inclusive = true) /* we stop as soon as _.sequenceNr == toSequenceNr and we want to return that one, too */
+        .map(repr => (repr, repr.payload))
+        .map {
+          case (repr, Tagged(realPayload, tags)) =>
+            (repr, realPayload) // strip tags
+          case (repr, realPayload) =>
+            (repr, realPayload) // it's actually okay
+        }
+        .zipWithIndex // starts counting at 0L, offsets start at 1L
+        .map { case ((repr, event), offset) =>
+          EventEnvelope(Sequence(offset + 1L), repr.persistenceId, repr.sequenceNr, event)
+        }
+        .withAttributes(streamLogLevels)
+    }
+  }
+
+  /**
+    * Query events that have a specific tag. A tag can for example correspond to an
+    * aggregate root type (in DDD terminology).
+    *
+    * The consumer can keep track of its current position in the event stream by storing the
+    * `offset` and restart the query from a given `offset` after a crash/restart.
+    *
+    * The exact meaning of the `offset` depends on the journal and must be documented by the
+    * read journal plugin. It may be a sequential id number that uniquely identifies the
+    * position of each event within the event stream. Distributed data stores cannot easily
+    * support those semantics and they may use a weaker meaning. For example it may be a
+    * timestamp (taken when the event was created or stored). Timestamps are not unique and
+    * not strictly ordered, since clocks on different machines may not be synchronized.
+    *
+    * The returned event stream should be ordered by `offset` if possible, but this can also be
+    * difficult to fulfill for a distributed data store. The order must be documented by the
+    * read journal plugin.
+    *
+    * The stream is not completed when it reaches the end of the currently stored events,
+    * but it continues to push new events when new events are persisted.
+    * Corresponding query that is completed when it reaches the end of the currently
+    * stored events is provided by [[CurrentEventsByTagQuery#currentEventsByTag]].
+    */
+  override def eventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] = {
+    reprSourceByTag(newLiveMessageSource, tag, offset)
+  }
+
+  /**
+    * Same type of query as [[EventsByTagQuery#eventsByTag]] but the event stream
+    * is completed immediately when it reaches the end of the "result set". Events that are
+    * stored after the query is completed are not included in the event stream.
+    */
+  override def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] = {
+    reprSourceByTag(newCurrentMessageSource, tag, offset)
+  }
+
+  private def reprSourceByTag(src: Source[PersistentRepr, NotUsed], tag: String, offset: Offset): Source[EventEnvelope, NotUsed] = {
+    def truePredicate(x: (PersistentRepr, Any), eventOffset: Long): Boolean = true
+    def acceptAfterMinOffset(minOffset: Long)(x: (PersistentRepr, Any), eventOffset: Long): Boolean = eventOffset > minOffset
+
+    val filterPredicate = offset match {
+      case NoOffset => truePredicate _
+      case Sequence(minOffset) => acceptAfterMinOffset(minOffset) _
+      case _ => throw new IllegalArgumentException(s"Unsupported offset ${offset} must be a Sequence or NoOffset")
+    }
+
+    src
+      .map(repr => (repr, repr.payload))
+      .collect {
+        case (repr, Tagged(realPayload, tags)) if tags.contains(tag) =>
+          (repr, realPayload) // strip tags
+        /* we drop untagged events or tagged events that don't contain our tag*/
+      }
+      .zipWithIndex // counts at 0L, offsets count at 1L
+      .filter { case (x, eventOffset) => filterPredicate(x, eventOffset + 1L) }
+      .map { case ((repr, event), eventOffset) =>
+        EventEnvelope(Sequence(eventOffset + 1L), repr.persistenceId, repr.sequenceNr, event)
+      }
+
+  }
+
+
+}
+
+object InmemReadJournal {
+  /**
+    * The default identifier for [[InmemReadJournal]] to be used with
+    * [[akka.persistence.query.PersistenceQuery#readJournalFor]].
+    *
+    * The value is `"akka.persistence.query.journal.inmem"` and corresponds
+    * to the absolute path to the read journal configuration entry.
+    */
+  final val Identifier = "akka.persistence.query.journal.inmem"
+
+}

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/journal/inmem/scaladsl/InmemReadJournal.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/journal/inmem/scaladsl/InmemReadJournal.scala
@@ -1,36 +1,40 @@
+/*
+ * Written by Cyrille Chepelov <cyrille@chepelov.org>
+ *
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.persistence.query.journal.inmem.scaladsl
 
-import java.util.concurrent.{CompletionStage, TimeUnit}
+import java.util.concurrent.{ CompletionStage, TimeUnit }
 
-import akka.{Done, NotUsed}
+import akka.{ Done, NotUsed }
 import akka.pattern.ask
-import akka.actor.{Actor, ActorLogging, ExtendedActorSystem, Props}
+import akka.actor.{ Actor, ActorLogging, ExtendedActorSystem, Props }
 import akka.event.Logging
 import akka.persistence.journal.Tagged
-import akka.persistence.{Persistence, PersistentRepr}
+import akka.persistence.{ Persistence, PersistentRepr }
 import akka.persistence.journal.inmem.InmemJournal
 import akka.persistence.query._
-import akka.persistence.query.journal.inmem.scaladsl.MessageReceiver.{LiveSubscription, SubscribeCurrent, SubscribeLive}
+import akka.persistence.query.journal.inmem.scaladsl.MessageReceiver.{ LiveSubscription, SubscribeCurrent, SubscribeLive }
 import akka.persistence.query.scaladsl._
 import akka.stream._
 import akka.stream.scaladsl.SourceQueueWithComplete
-import akka.stream.scaladsl.{Concat, Flow, GraphDSL, Keep, RunnableGraph, Sink, Source, Zip}
-import akka.stream.stage.{GraphStage, GraphStageLogic, OutHandler}
+import akka.stream.scaladsl.{ Concat, Flow, GraphDSL, Keep, RunnableGraph, Sink, Source, Zip }
+import akka.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
 import akka.util.Timeout
 import com.typesafe.config.Config
-import org.reactivestreams.{Publisher, Subscriber}
+import org.reactivestreams.{ Publisher, Subscriber }
 
 import scala.collection.mutable
-import scala.collection.{immutable => im}
-import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.concurrent.duration.{Duration, FiniteDuration}
-
+import scala.collection.{ immutable ⇒ im }
+import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 object MessageReceiver {
   trait Get
   case object GetAllCurrent /* response is: Seq[PersistentRepr] */ extends Get
   final case class GetAllCurrentTagged(tag: String) /* response is: Seq[(PersistentRepr, Offset)] */ extends Get
-
 
   final case class LiveSubscription(source: Source[PersistentRepr, NotUsed])
   final case object SubscribeLive // response is: LiveSubscription */
@@ -38,7 +42,7 @@ object MessageReceiver {
 }
 
 class MessageReceiver(implicit mat: Materializer) extends Actor with ActorLogging {
-  implicit def executionContext:ExecutionContext = context.dispatcher
+  implicit def executionContext: ExecutionContext = context.dispatcher
 
   private var allMessages: mutable.Buffer[PersistentRepr] = mutable.Buffer.empty
   private var taggedMessages: mutable.Map[String, mutable.Buffer[PersistentRepr]] = mutable.Map.empty
@@ -61,21 +65,21 @@ class MessageReceiver(implicit mat: Materializer) extends Actor with ActorLoggin
     val (sourceQ, pub) = runnable.run
 
     val livePub = Source.fromPublisher(pub)
-        .watchTermination() {
-      case (notUsed, fDone) =>
-        /* propagate completion, especially early termination of the downstream graph, to the upstream graph */
-        fDone
-            .map { _ =>
+      .watchTermination() {
+        case (notUsed, fDone) ⇒
+          /* propagate completion, especially early termination of the downstream graph, to the upstream graph */
+          fDone
+            .map { _ ⇒
               log.debug("completing {} due to downstream being terminated", sourceQ)
               sourceQ.complete()
             }
             .onFailure {
-              case ex: Throwable =>
+              case ex: Throwable ⇒
                 sourceQ.fail(ex)
             }
 
-        notUsed
-    }
+          notUsed
+      }
 
     (sourceQ, livePub)
   }
@@ -92,25 +96,25 @@ class MessageReceiver(implicit mat: Materializer) extends Actor with ActorLoggin
     if (activePublishedQueues.nonEmpty) {
       try {
         val fFutureOfferResults = activePublishedQueues
-          .map { q =>
+          .map { q ⇒
             val f = try {
               q.offer(m)
             } catch {
-              case ex: Throwable =>
+              case ex: Throwable ⇒
                 Future.successful(QueueOfferResult.Failure(ex))
             }
 
-            f.map(r => (m, q, r))
-              .recoverWith { case ex: Throwable =>
-                Future.successful((m, q, QueueOfferResult.Failure(ex)))
+            f.map(r ⇒ (m, q, r))
+              .recoverWith {
+                case ex: Throwable ⇒
+                  Future.successful((m, q, QueueOfferResult.Failure(ex)))
               }
           }
-
 
         val fOfferResults = try {
           Future.sequence(fFutureOfferResults)
         } catch {
-          case t: Throwable =>
+          case t: Throwable ⇒
             throw t
         }
 
@@ -118,21 +122,21 @@ class MessageReceiver(implicit mat: Materializer) extends Actor with ActorLoggin
           Await.result(fOfferResults, Duration.Inf) // we voluntarily wait indefinitely until it no longer backpressures
           //.map { r => println(s"enqueue result=${r} "); r }
         } catch {
-          case t: Throwable =>
+          case t: Throwable ⇒
             throw t
         }
 
         val queuesToPurge = enqueueResults
           .flatMap {
-            case (m, q, QueueOfferResult.Enqueued) =>
+            case (m, q, QueueOfferResult.Enqueued) ⇒
               None
-            case (m, q, QueueOfferResult.Dropped) =>
+            case (m, q, QueueOfferResult.Dropped) ⇒
               q.fail(new IllegalStateException("downstream queues should not drop items, killing live Source"))
               Some(q)
-            case (m, q, QueueOfferResult.Failure(cause)) =>
+            case (m, q, QueueOfferResult.Failure(cause)) ⇒
               q.fail(new IllegalStateException("downstream queue failed, killing live Source", cause))
               Some(q)
-            case (m, q, QueueOfferResult.QueueClosed) =>
+            case (m, q, QueueOfferResult.QueueClosed) ⇒
               Some(q) // we reached an end and this is okay
           }.toSet
 
@@ -140,67 +144,65 @@ class MessageReceiver(implicit mat: Materializer) extends Actor with ActorLoggin
           val newPublishedQueues = activePublishedQueues.filterNot(queuesToPurge.contains)
           activePublishedQueues = newPublishedQueues
         }
-      }
-      catch {
-        case t: Throwable =>
+      } catch {
+        case t: Throwable ⇒
           log.error(t, "failing to propagate {}", m)
       }
     }
   }
 
   /**
-    * Scala API: This defines the initial actor behavior, it must return a partial function
-    * with the actor logic.
-    */
+   * Scala API: This defines the initial actor behavior, it must return a partial function
+   * with the actor logic.
+   */
   def receive = {
-    case InmemJournal.SpooledMessages(messages) =>
+    case InmemJournal.SpooledMessages(messages) ⇒
       allMessages = allMessages ++ messages
       messages.foreach(publishMessageSynchronously)
 
-    case InmemJournal.DeleteSpooledMessages(persistenceId, toSequenceNr) =>
-      val kept = allMessages.filterNot { repr => (repr.persistenceId == persistenceId) && (repr.sequenceNr <= toSequenceNr) }
+    case InmemJournal.DeleteSpooledMessages(persistenceId, toSequenceNr) ⇒
+      val kept = allMessages.filterNot { repr ⇒ (repr.persistenceId == persistenceId) && (repr.sequenceNr <= toSequenceNr) }
       allMessages = kept
       sender() ! Done
 
-    case MessageReceiver.GetAllCurrent =>
+    case MessageReceiver.GetAllCurrent ⇒
       sender() ! allMessages.toArray.toSeq
 
-    case MessageReceiver.GetAllCurrentTagged(tag) =>
+    case MessageReceiver.GetAllCurrentTagged(tag) ⇒
 
       val perTag: Seq[(PersistentRepr, Offset)] = allMessages
-        .map(repr => (repr, repr.payload))
-        .collect { case (repr, Tagged(realPayload, tags)) if tags.contains(tag) => repr }
+        .map(repr ⇒ (repr, repr.payload))
+        .collect { case (repr, Tagged(realPayload, tags)) if tags.contains(tag) ⇒ repr }
         .toArray
         .zipWithIndex
-        .map { case (repr, idx) => (repr, Sequence(idx + 1)) }
-
+        .map { case (repr, idx) ⇒ (repr, Sequence(idx + 1)) }
 
       sender() ! perTag
 
-    case MessageReceiver.SubscribeLive =>
+    case MessageReceiver.SubscribeLive ⇒
       val newSrc = startNewAndCurrentLiveSource
       sender() ! MessageReceiver.LiveSubscription(newSrc)
 
-    case MessageReceiver.SubscribeCurrent =>
+    case MessageReceiver.SubscribeCurrent ⇒
       val newSrc = createCurrentSource
       sender() ! MessageReceiver.LiveSubscription(newSrc)
   }
 }
 
 /**
-  * Scala API [[akka.persistence.query.scaladsl.ReadJournal]] implementation for Inmem (for testing purposes only)
-  *
-  * It is retrieved with:
-  * {{{
-  * val queries = PersistenceQuery(system).readJournalFor[InmemReadJournal](InmemReadJournal.Identifier)
-  * }}}
-  *
-  * Corresponding Java API is in [[akka.persistence.query.journal.inmem.javadsl.InmemReadJournal]].
-  *
-  * Configuration settings can be defined in the configuration section with the
-  * absolute path corresponding to the identifier, which is `"akka.persistence.query.journal.inmem"`
-  * for the default [[InmemReadJournal#Identifier]]. See `reference.conf`.
-  */
+ * Scala API [[akka.persistence.query.scaladsl.ReadJournal]] implementation for Inmem (for testing purposes only)
+ *
+ * It is retrieved with:
+ * {{{
+ * val queries = PersistenceQuery(system).readJournalFor[InmemReadJournal](InmemReadJournal.Identifier)
+ * }}}
+ *
+ * Corresponding Java API is in [[akka.persistence.query.journal.inmem.javadsl.InmemReadJournal]].
+ *
+ * Configuration settings can be defined in the configuration section with the
+ * absolute path corresponding to the identifier, which is `"akka.persistence.query.journal.inmem"`
+ * for the default [[InmemReadJournal#Identifier]]. See `reference.conf`.
+ */
 class InmemReadJournal(system: ExtendedActorSystem, config: Config) extends ReadJournal
   with PersistenceIdsQuery with CurrentPersistenceIdsQuery
   with EventsByPersistenceIdQuery with CurrentEventsByPersistenceIdQuery
@@ -261,84 +263,74 @@ class InmemReadJournal(system: ExtendedActorSystem, config: Config) extends Read
   private val streamLogLevels =       Attributes.logLevels(onElement = Logging.InfoLevel, onFailure = Logging.ErrorLevel, onFinish = Logging.InfoLevel)
 
   private def newLiveMessageSource: Source[PersistentRepr, NotUsed] = {
-    val f = Source.fromFuture((receiver ? SubscribeLive).mapTo[LiveSubscription].map(_.source))
-      .withAttributes(streamLogLevels)
-
-    val f2 = f.flatMapConcat(identity)
-
-    f2
-      .withAttributes(streamLogLevels)
+    Source.fromFuture((receiver ? SubscribeLive).mapTo[LiveSubscription].map(_.source))
+      .flatMapConcat(identity)
   }
 
   private def newCurrentMessageSource: Source[PersistentRepr, NotUsed] = {
-    val f = Source.fromFuture((receiver ? SubscribeCurrent).mapTo[LiveSubscription].map(_.source))
-      .withAttributes(streamLogLevels)
-
-    val f2 = f.flatMapConcat(identity)
-
-
-    f2
-      .withAttributes(streamLogLevels)
+    Source.fromFuture((receiver ? SubscribeCurrent).mapTo[LiveSubscription].map(_.source))
+      .flatMapConcat(identity)
   }
 
   /**
-    * Query all `PersistentActor` identifiers, i.e. as defined by the
-    * `persistenceId` of the `PersistentActor`.
-    *
-    * The stream is not completed when it reaches the end of the currently used `persistenceIds`,
-    * but it continues to push new `persistenceIds` when new persistent actors are created.
-    * Corresponding query that is completed when it reaches the end of the currently
-    * currently used `persistenceIds` is provided by [[CurrentPersistenceIdsQuery#currentPersistenceIds]].
-    */
+   * Query all `PersistentActor` identifiers, i.e. as defined by the
+   * `persistenceId` of the `PersistentActor`.
+   *
+   * The stream is not completed when it reaches the end of the currently used `persistenceIds`,
+   * but it continues to push new `persistenceIds` when new persistent actors are created.
+   * Corresponding query that is completed when it reaches the end of the currently
+   * currently used `persistenceIds` is provided by [[CurrentPersistenceIdsQuery#currentPersistenceIds]].
+   */
   override def persistenceIds(): Source[String, NotUsed] = {
     reprSourceToPersistenceIds(newLiveMessageSource)
   }
 
   /**
-    * Same type of query as [[PersistenceIdsQuery#persistenceIds]] but the stream
-    * is completed immediately when it reaches the end of the "result set". Persistent
-    * actors that are created after the query is completed are not included in the stream.
-    */
+   * Same type of query as [[PersistenceIdsQuery#persistenceIds]] but the stream
+   * is completed immediately when it reaches the end of the "result set". Persistent
+   * actors that are created after the query is completed are not included in the stream.
+   */
   override def currentPersistenceIds(): Source[String, NotUsed] = {
     reprSourceToPersistenceIds(newCurrentMessageSource)
   }
 
   private def reprSourceToPersistenceIds(src: Source[PersistentRepr, NotUsed]): Source[String, NotUsed] = {
     src
-      .scan( (Set.empty[String], None:Option[String]) ) {
-        case ((known, _), repr) if known.contains(repr.persistenceId) =>
+      .scan((Set.empty[String], None: Option[String])) {
+        case ((known, _), repr) if known.contains(repr.persistenceId) ⇒
           (known, None)
-        case ((known, _), repr) /* if !known.contains(repr.persistenceId) */ =>
+        case ((known, _), repr) /* if !known.contains(repr.persistenceId) */ ⇒
           (known, Some(repr.persistenceId))
       }
-      .collect { case (_, Some(newPersistenceId)) =>
-        newPersistenceId
+      .collect {
+        case (_, Some(newPersistenceId)) ⇒
+          newPersistenceId
       }
   }
 
   /**
-    * Query events for a specific `PersistentActor` identified by `persistenceId`.
-    *
-    * You can retrieve a subset of all events by specifying `fromSequenceNr` and `toSequenceNr`
-    * or use `0L` and `Long.MaxValue` respectively to retrieve all events.
-    *
-    * The returned event stream should be ordered by sequence number.
-    *
-    * The stream is not completed when it reaches the end of the currently stored events,
-    * but it continues to push new events when new events are persisted.
-    * Corresponding query that is completed when it reaches the end of the currently
-    * stored events is provided by [[CurrentEventsByPersistenceIdQuery#currentEventsByPersistenceId]].
-    */
+   * Query events for a specific `PersistentActor` identified by `persistenceId`.
+   *
+   * You can retrieve a subset of all events by specifying `fromSequenceNr` and `toSequenceNr`
+   * or use `0L` and `Long.MaxValue` respectively to retrieve all events.
+   *
+   * The returned event stream should be ordered by sequence number.
+   *
+   * The stream is not completed when it reaches the end of the currently stored events,
+   * but it continues to push new events when new events are persisted.
+   * Corresponding query that is completed when it reaches the end of the currently
+   * stored events is provided by [[CurrentEventsByPersistenceIdQuery#currentEventsByPersistenceId]].
+   */
   override def eventsByPersistenceId(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long): Source[EventEnvelope, NotUsed] = {
     reprSourceByPersistenceId(newLiveMessageSource)(persistenceId, fromSequenceNr, toSequenceNr)
   }
 
   /**
-    * Same type of query as [[EventsByPersistenceIdQuery#eventsByPersistenceId]]
-    * but the event stream is completed immediately when it reaches the end of
-    * the "result set". Events that are stored after the query is completed are
-    * not included in the event stream.
-    */
+   * Same type of query as [[EventsByPersistenceIdQuery#eventsByPersistenceId]]
+   * but the event stream is completed immediately when it reaches the end of
+   * the "result set". Events that are stored after the query is completed are
+   * not included in the event stream.
+   */
   override def currentEventsByPersistenceId(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long): Source[EventEnvelope, NotUsed] = {
     reprSourceByPersistenceId(newCurrentMessageSource)(persistenceId, fromSequenceNr, toSequenceNr)
   }
@@ -352,53 +344,53 @@ class InmemReadJournal(system: ExtendedActorSystem, config: Config) extends Read
         .filter(_.sequenceNr >= fromSequenceNr)
         .takeWhile(_.sequenceNr <= toSequenceNr)
         .takeWhile(_.sequenceNr < toSequenceNr, inclusive = true) /* we stop as soon as _.sequenceNr == toSequenceNr and we want to return that one, too */
-        .map(repr => (repr, repr.payload))
+        .map(repr ⇒ (repr, repr.payload))
         .map {
-          case (repr, Tagged(realPayload, tags)) =>
+          case (repr, Tagged(realPayload, tags)) ⇒
             (repr, realPayload) // strip tags
-          case (repr, realPayload) =>
+          case (repr, realPayload) ⇒
             (repr, realPayload) // it's actually okay
         }
         .zipWithIndex // starts counting at 0L, offsets start at 1L
-        .map { case ((repr, event), offset) =>
-          EventEnvelope(Sequence(offset + 1L), repr.persistenceId, repr.sequenceNr, event)
+        .map {
+          case ((repr, event), offset) ⇒
+            EventEnvelope(Sequence(offset + 1L), repr.persistenceId, repr.sequenceNr, event)
         }
-        .withAttributes(streamLogLevels)
     }
   }
 
   /**
-    * Query events that have a specific tag. A tag can for example correspond to an
-    * aggregate root type (in DDD terminology).
-    *
-    * The consumer can keep track of its current position in the event stream by storing the
-    * `offset` and restart the query from a given `offset` after a crash/restart.
-    *
-    * The exact meaning of the `offset` depends on the journal and must be documented by the
-    * read journal plugin. It may be a sequential id number that uniquely identifies the
-    * position of each event within the event stream. Distributed data stores cannot easily
-    * support those semantics and they may use a weaker meaning. For example it may be a
-    * timestamp (taken when the event was created or stored). Timestamps are not unique and
-    * not strictly ordered, since clocks on different machines may not be synchronized.
-    *
-    * The returned event stream should be ordered by `offset` if possible, but this can also be
-    * difficult to fulfill for a distributed data store. The order must be documented by the
-    * read journal plugin.
-    *
-    * The stream is not completed when it reaches the end of the currently stored events,
-    * but it continues to push new events when new events are persisted.
-    * Corresponding query that is completed when it reaches the end of the currently
-    * stored events is provided by [[CurrentEventsByTagQuery#currentEventsByTag]].
-    */
+   * Query events that have a specific tag. A tag can for example correspond to an
+   * aggregate root type (in DDD terminology).
+   *
+   * The consumer can keep track of its current position in the event stream by storing the
+   * `offset` and restart the query from a given `offset` after a crash/restart.
+   *
+   * The exact meaning of the `offset` depends on the journal and must be documented by the
+   * read journal plugin. It may be a sequential id number that uniquely identifies the
+   * position of each event within the event stream. Distributed data stores cannot easily
+   * support those semantics and they may use a weaker meaning. For example it may be a
+   * timestamp (taken when the event was created or stored). Timestamps are not unique and
+   * not strictly ordered, since clocks on different machines may not be synchronized.
+   *
+   * The returned event stream should be ordered by `offset` if possible, but this can also be
+   * difficult to fulfill for a distributed data store. The order must be documented by the
+   * read journal plugin.
+   *
+   * The stream is not completed when it reaches the end of the currently stored events,
+   * but it continues to push new events when new events are persisted.
+   * Corresponding query that is completed when it reaches the end of the currently
+   * stored events is provided by [[CurrentEventsByTagQuery#currentEventsByTag]].
+   */
   override def eventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] = {
     reprSourceByTag(newLiveMessageSource, tag, offset)
   }
 
   /**
-    * Same type of query as [[EventsByTagQuery#eventsByTag]] but the event stream
-    * is completed immediately when it reaches the end of the "result set". Events that are
-    * stored after the query is completed are not included in the event stream.
-    */
+   * Same type of query as [[EventsByTagQuery#eventsByTag]] but the event stream
+   * is completed immediately when it reaches the end of the "result set". Events that are
+   * stored after the query is completed are not included in the event stream.
+   */
   override def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] = {
     reprSourceByTag(newCurrentMessageSource, tag, offset)
   }
@@ -408,37 +400,37 @@ class InmemReadJournal(system: ExtendedActorSystem, config: Config) extends Read
     def acceptAfterMinOffset(minOffset: Long)(x: (PersistentRepr, Any), eventOffset: Long): Boolean = eventOffset > minOffset
 
     val filterPredicate = offset match {
-      case NoOffset => truePredicate _
-      case Sequence(minOffset) => acceptAfterMinOffset(minOffset) _
-      case _ => throw new IllegalArgumentException(s"Unsupported offset ${offset} must be a Sequence or NoOffset")
+      case NoOffset            ⇒ truePredicate _
+      case Sequence(minOffset) ⇒ acceptAfterMinOffset(minOffset) _
+      case _                   ⇒ throw new IllegalArgumentException(s"Unsupported offset ${offset} must be a Sequence or NoOffset")
     }
 
     src
-      .map(repr => (repr, repr.payload))
+      .map(repr ⇒ (repr, repr.payload))
       .collect {
-        case (repr, Tagged(realPayload, tags)) if tags.contains(tag) =>
+        case (repr, Tagged(realPayload, tags)) if tags.contains(tag) ⇒
           (repr, realPayload) // strip tags
         /* we drop untagged events or tagged events that don't contain our tag*/
       }
       .zipWithIndex // counts at 0L, offsets count at 1L
-      .filter { case (x, eventOffset) => filterPredicate(x, eventOffset + 1L) }
-      .map { case ((repr, event), eventOffset) =>
-        EventEnvelope(Sequence(eventOffset + 1L), repr.persistenceId, repr.sequenceNr, event)
+      .filter { case (x, eventOffset) ⇒ filterPredicate(x, eventOffset + 1L) }
+      .map {
+        case ((repr, event), eventOffset) ⇒
+          EventEnvelope(Sequence(eventOffset + 1L), repr.persistenceId, repr.sequenceNr, event)
       }
 
   }
-
 
 }
 
 object InmemReadJournal {
   /**
-    * The default identifier for [[InmemReadJournal]] to be used with
-    * [[akka.persistence.query.PersistenceQuery#readJournalFor]].
-    *
-    * The value is `"akka.persistence.query.journal.inmem"` and corresponds
-    * to the absolute path to the read journal configuration entry.
-    */
+   * The default identifier for [[InmemReadJournal]] to be used with
+   * [[akka.persistence.query.PersistenceQuery#readJournalFor]].
+   *
+   * The value is `"akka.persistence.query.journal.inmem"` and corresponds
+   * to the absolute path to the read journal configuration entry.
+   */
   final val Identifier = "akka.persistence.query.journal.inmem"
 
 }

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/AllPersistenceIdsSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/AllPersistenceIdsSpec.scala
@@ -4,11 +4,11 @@
 
 package akka.persistence.query.journal
 
-import akka.persistence.query.scaladsl.{CurrentPersistenceIdsQuery, PersistenceIdsQuery, ReadJournal}
+import akka.persistence.query.scaladsl.{ CurrentPersistenceIdsQuery, PersistenceIdsQuery, ReadJournal }
 import akka.stream.ActorMaterializer
 import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.{AkkaSpec, ImplicitSender}
-import com.typesafe.config.{Config, ConfigFactory}
+import akka.testkit.{ AkkaSpec, ImplicitSender }
+import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.concurrent.duration._
 

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/AllPersistenceIdsSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/AllPersistenceIdsSpec.scala
@@ -2,35 +2,31 @@
  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package akka.persistence.query.journal.leveldb
+package akka.persistence.query.journal
+
+import akka.persistence.query.scaladsl.{CurrentPersistenceIdsQuery, PersistenceIdsQuery, ReadJournal}
+import akka.stream.ActorMaterializer
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.{AkkaSpec, ImplicitSender}
+import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.concurrent.duration._
 
-import akka.persistence.query.PersistenceQuery
-import akka.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal
-import akka.persistence.query.scaladsl.PersistenceIdsQuery
-import akka.stream.ActorMaterializer
-import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.AkkaSpec
-import akka.testkit.ImplicitSender
-
 object AllPersistenceIdsSpec {
-  val config = """
+  def config: Config = ConfigFactory.parseString("""
     akka.loglevel = INFO
-    akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
-    akka.persistence.journal.leveldb.dir = "target/journal-AllPersistenceIdsSpec"
     akka.test.single-expect-default = 10s
-    """
+    """)
 }
 
-class AllPersistenceIdsSpec extends AkkaSpec(AllPersistenceIdsSpec.config)
-  with Cleanup with ImplicitSender {
+abstract class AllPersistenceIdsSpec(backendName: String, config: Config) extends AkkaSpec(config)
+  with ImplicitSender {
 
   implicit val mat = ActorMaterializer()(system)
 
-  val queries = PersistenceQuery(system).readJournalFor[LeveldbReadJournal](LeveldbReadJournal.Identifier)
+  def queries: ReadJournal with CurrentPersistenceIdsQuery with PersistenceIdsQuery
 
-  "Leveldb query AllPersistenceIds" must {
+  s"$backendName query AllPersistenceIds" must {
 
     "implement standard AllPersistenceIdsQuery" in {
       queries.isInstanceOf[PersistenceIdsQuery] should ===(true)

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/EventsByPersistenceIdSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/EventsByPersistenceIdSpec.scala
@@ -8,8 +8,8 @@ import akka.actor.ActorRef
 import akka.persistence.query.scaladsl._
 import akka.stream.ActorMaterializer
 import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.{AkkaSpec, ImplicitSender}
-import com.typesafe.config.{Config, ConfigFactory}
+import akka.testkit.{ AkkaSpec, ImplicitSender }
+import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.concurrent.duration._
 
@@ -66,7 +66,7 @@ abstract class EventsByPersistenceIdSpec(backendName: String, config: Config) ex
       val src = queries.currentEventsByPersistenceId("b", 0L, 2L)
       val x = src.map(_.event).runWith(TestSink.probe[Any])
 
-        x
+      x
         .request(5)
         .expectNext("b-1", "b-2")
         .expectComplete()
@@ -164,7 +164,6 @@ abstract class EventsByPersistenceIdSpec(backendName: String, config: Config) ex
 
       probe.expectNext("c-4")
     }
-
 
     "find new events up to a sequence number" in {
       val ref = setup("d")

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/EventsByTagSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/EventsByTagSpec.scala
@@ -1,16 +1,16 @@
 /**
-  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
-  */
+ * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 
 package akka.persistence.query.journal
 
-import akka.persistence.journal.{Tagged, WriteEventAdapter}
+import akka.persistence.journal.{ Tagged, WriteEventAdapter }
 import akka.persistence.query.scaladsl._
-import akka.persistence.query.{EventEnvelope, NoOffset, Sequence}
+import akka.persistence.query.{ EventEnvelope, NoOffset, Sequence }
 import akka.stream.ActorMaterializer
 import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.{AkkaSpec, ImplicitSender}
-import com.typesafe.config.{Config, ConfigFactory}
+import akka.testkit.{ AkkaSpec, ImplicitSender }
+import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.concurrent.duration._
 
@@ -43,7 +43,6 @@ abstract class EventsByTagSpec(backendName: String, config: Config) extends Akka
   implicit val mat = ActorMaterializer()(system)
 
   def queries: ReadJournal with EventsByTagQuery with CurrentEventsByTagQuery
-
 
   s"$backendName query EventsByTag" must {
     "implement standard EventsByTagQuery" in {

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/TestActor.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/TestActor.scala
@@ -4,8 +4,8 @@
 
 package akka.persistence.query.journal
 
-import akka.actor.{ActorRef, Props}
-import akka.persistence.{DeleteMessagesSuccess, PersistentActor}
+import akka.actor.{ ActorRef, Props }
+import akka.persistence.{ DeleteMessagesSuccess, PersistentActor }
 
 import scala.collection.mutable
 

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/TestActor.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/TestActor.scala
@@ -2,10 +2,12 @@
  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package akka.persistence.query.journal.leveldb
+package akka.persistence.query.journal
 
-import akka.persistence.PersistentActor
-import akka.actor.Props
+import akka.actor.{ActorRef, Props}
+import akka.persistence.{DeleteMessagesSuccess, PersistentActor}
+
+import scala.collection.mutable
 
 object TestActor {
   def props(persistenceId: String): Props =

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/inmem/InmemAllPersistenceIdsSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/inmem/InmemAllPersistenceIdsSpec.scala
@@ -1,13 +1,13 @@
 /**
-  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
-  */
+ * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 
 package akka.persistence.query.journal.inmem
 
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.journal.AllPersistenceIdsSpec
 import akka.persistence.query.journal.inmem.scaladsl.InmemReadJournal
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
 object InmemAllPersistenceIdsSpec {
   def config: Config = ConfigFactory.parseString(

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/inmem/InmemAllPersistenceIdsSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/inmem/InmemAllPersistenceIdsSpec.scala
@@ -1,0 +1,21 @@
+/**
+  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+  */
+
+package akka.persistence.query.journal.inmem
+
+import akka.persistence.query.PersistenceQuery
+import akka.persistence.query.journal.AllPersistenceIdsSpec
+import akka.persistence.query.journal.inmem.scaladsl.InmemReadJournal
+import com.typesafe.config.{Config, ConfigFactory}
+
+object InmemAllPersistenceIdsSpec {
+  def config: Config = ConfigFactory.parseString(
+    """
+    akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+    """).withFallback(AllPersistenceIdsSpec.config)
+}
+
+class InmemAllPersistenceIdsSpec extends AllPersistenceIdsSpec("Inmem", InmemAllPersistenceIdsSpec.config) {
+  override val queries = PersistenceQuery(system).readJournalFor[InmemReadJournal](InmemReadJournal.Identifier)
+}

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/inmem/InmemEventsByPersistenceIdSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/inmem/InmemEventsByPersistenceIdSpec.scala
@@ -1,0 +1,22 @@
+/**
+  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+  */
+
+package akka.persistence.query.journal.inmem
+
+import akka.persistence.query.PersistenceQuery
+import akka.persistence.query.journal.inmem.scaladsl.InmemReadJournal
+import akka.persistence.query.journal.{AllPersistenceIdsSpec, EventsByPersistenceIdSpec}
+import com.typesafe.config.{Config, ConfigFactory}
+
+object InmemEventsByPersistenceIdSpec {
+  def config: Config = ConfigFactory.parseString(
+    """
+    akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+    """).withFallback(AllPersistenceIdsSpec.config)
+}
+
+class InmemEventsByPersistenceIdSpec extends EventsByPersistenceIdSpec("Inmem", InmemEventsByPersistenceIdSpec.config) {
+
+  override val queries = PersistenceQuery(system).readJournalFor[InmemReadJournal](InmemReadJournal.Identifier)
+}

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/inmem/InmemEventsByPersistenceIdSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/inmem/InmemEventsByPersistenceIdSpec.scala
@@ -1,13 +1,13 @@
 /**
-  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
-  */
+ * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 
 package akka.persistence.query.journal.inmem
 
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.journal.inmem.scaladsl.InmemReadJournal
-import akka.persistence.query.journal.{AllPersistenceIdsSpec, EventsByPersistenceIdSpec}
-import com.typesafe.config.{Config, ConfigFactory}
+import akka.persistence.query.journal.{ AllPersistenceIdsSpec, EventsByPersistenceIdSpec }
+import com.typesafe.config.{ Config, ConfigFactory }
 
 object InmemEventsByPersistenceIdSpec {
   def config: Config = ConfigFactory.parseString(

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/inmem/InmemEventsByTagSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/inmem/InmemEventsByTagSpec.scala
@@ -1,13 +1,13 @@
 /**
-  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
-  */
+ * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 
 package akka.persistence.query.journal.inmem
 
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.journal.EventsByTagSpec
 import akka.persistence.query.journal.inmem.scaladsl.InmemReadJournal
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
 object InmemEventsByTagSpec {
   def config: Config = ConfigFactory.parseString(
@@ -25,6 +25,6 @@ object InmemEventsByTagSpec {
 
 }
 
-class InmemEventsByTagSpec extends EventsByTagSpec("Inmem", InmemEventsByTagSpec.config)  {
+class InmemEventsByTagSpec extends EventsByTagSpec("Inmem", InmemEventsByTagSpec.config) {
   override val queries = PersistenceQuery(system).readJournalFor[InmemReadJournal](InmemReadJournal.Identifier)
 }

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/inmem/InmemEventsByTagSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/inmem/InmemEventsByTagSpec.scala
@@ -1,0 +1,30 @@
+/**
+  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+  */
+
+package akka.persistence.query.journal.inmem
+
+import akka.persistence.query.PersistenceQuery
+import akka.persistence.query.journal.EventsByTagSpec
+import akka.persistence.query.journal.inmem.scaladsl.InmemReadJournal
+import com.typesafe.config.{Config, ConfigFactory}
+
+object InmemEventsByTagSpec {
+  def config: Config = ConfigFactory.parseString(
+    """
+    akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+    akka.persistence.journal.inmem {
+      event-adapters {
+        color-tagger  = akka.persistence.query.journal.ColorTagger
+      }
+      event-adapter-bindings = {
+        "java.lang.String" = color-tagger
+      }
+    }
+    """).withFallback(EventsByTagSpec.config)
+
+}
+
+class InmemEventsByTagSpec extends EventsByTagSpec("Inmem", InmemEventsByTagSpec.config)  {
+  override val queries = PersistenceQuery(system).readJournalFor[InmemReadJournal](InmemReadJournal.Identifier)
+}

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/LeveldbAllPersistenceIdsSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/LeveldbAllPersistenceIdsSpec.scala
@@ -1,0 +1,21 @@
+/**
+  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+  */
+
+package akka.persistence.query.journal.leveldb
+
+import akka.persistence.query.PersistenceQuery
+import akka.persistence.query.journal.AllPersistenceIdsSpec
+import akka.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal
+import com.typesafe.config.{Config, ConfigFactory}
+
+object LeveldbAllPersistenceIdsSpec {
+  def config: Config = ConfigFactory.parseString(
+    """
+    akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
+    """).withFallback(AllPersistenceIdsSpec.config)
+}
+
+class LeveldbAllPersistenceIdsSpec extends AllPersistenceIdsSpec("Leveldb", LeveldbAllPersistenceIdsSpec.config) with Cleanup {
+  override val queries = PersistenceQuery(system).readJournalFor[LeveldbReadJournal](LeveldbReadJournal.Identifier)
+}

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/LeveldbAllPersistenceIdsSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/LeveldbAllPersistenceIdsSpec.scala
@@ -1,13 +1,13 @@
 /**
-  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
-  */
+ * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 
 package akka.persistence.query.journal.leveldb
 
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.journal.AllPersistenceIdsSpec
 import akka.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
 object LeveldbAllPersistenceIdsSpec {
   def config: Config = ConfigFactory.parseString(

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/LeveldbEventsByPersistenceIdSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/LeveldbEventsByPersistenceIdSpec.scala
@@ -1,0 +1,25 @@
+/**
+  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+  */
+
+package akka.persistence.query.journal.leveldb
+
+import akka.persistence.query.PersistenceQuery
+import akka.persistence.query.journal.EventsByPersistenceIdSpec
+import akka.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal
+import com.typesafe.config.{Config, ConfigFactory}
+
+object LeveldbEventsByPersistenceIdSpec {
+  def config: Config = ConfigFactory.parseString(
+    """
+    akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
+    akka.persistence.journal.leveldb.dir = "target/journal-LeveldbEventsByPersistenceIdSpec"
+    akka.persistence.query.journal.leveldb.refresh-interval = 1s
+    """).withFallback(EventsByPersistenceIdSpec.config)
+}
+
+class LeveldbEventsByPersistenceIdSpec extends EventsByPersistenceIdSpec("Leveldb", LeveldbEventsByPersistenceIdSpec.config)
+  with Cleanup {
+
+  override val queries = PersistenceQuery(system).readJournalFor[LeveldbReadJournal](LeveldbReadJournal.Identifier)
+}

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/LeveldbEventsByPersistenceIdSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/LeveldbEventsByPersistenceIdSpec.scala
@@ -1,13 +1,13 @@
 /**
-  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
-  */
+ * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 
 package akka.persistence.query.journal.leveldb
 
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.journal.EventsByPersistenceIdSpec
 import akka.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
 object LeveldbEventsByPersistenceIdSpec {
   def config: Config = ConfigFactory.parseString(

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/LeveldbEventsByTagSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/LeveldbEventsByTagSpec.scala
@@ -1,0 +1,34 @@
+/**
+  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+  */
+
+package akka.persistence.query.journal.leveldb
+
+import akka.persistence.query.PersistenceQuery
+import akka.persistence.query.journal.EventsByTagSpec
+import akka.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal
+import com.typesafe.config.{Config, ConfigFactory}
+
+object LeveldbEventsByTagSpec {
+  def config: Config = ConfigFactory.parseString(
+    """
+    akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
+    akka.persistence.journal.leveldb {
+      dir = "target/journal-LeveldbEventsByTagSpec"
+      event-adapters {
+        color-tagger  = akka.persistence.query.journal.ColorTagger
+      }
+      event-adapter-bindings = {
+        "java.lang.String" = color-tagger
+      }
+    }
+    akka.persistence.query.journal.leveldb.refresh-interval = 1s
+    """).withFallback(EventsByTagSpec.config)
+
+}
+
+class LeveldbEventsByTagSpec extends EventsByTagSpec("Leveldb", LeveldbEventsByTagSpec.config)
+  with Cleanup {
+
+  override val queries = PersistenceQuery(system).readJournalFor[LeveldbReadJournal](LeveldbReadJournal.Identifier)
+}

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/LeveldbEventsByTagSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/LeveldbEventsByTagSpec.scala
@@ -1,13 +1,13 @@
 /**
-  * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
-  */
+ * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 
 package akka.persistence.query.journal.leveldb
 
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.journal.EventsByTagSpec
 import akka.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
 object LeveldbEventsByTagSpec {
   def config: Config = ConfigFactory.parseString(

--- a/akka-persistence/src/main/scala/akka/persistence/journal/inmem/InmemJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/inmem/InmemJournal.scala
@@ -4,12 +4,34 @@
 
 package akka.persistence.journal.inmem
 
+import akka.actor.ActorRef
+import akka.pattern.ask
+
 import scala.collection.immutable
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 import akka.persistence.journal.AsyncWriteJournal
 import akka.persistence.PersistentRepr
 import akka.persistence.AtomicWrite
+import akka.util.Timeout
+
+import scala.concurrent.duration._
+
+/**
+  * INTERNAL API — used to implement Persistence Query for testing purposes only.
+ */
+private[persistence] object InmemJournal {
+
+  final case class SetDownstreamReceiver(target: ActorRef)
+  case object RemoveDownstreamReceiver
+
+  case object Ping // replies akka.Done
+  case object SpoolExistingMessages
+
+  final case class SpooledMessages(messages: Iterable[PersistentRepr])
+
+  final case class DeleteSpooledMessages(persistenceId: String, toSequenceNr: Long) // replies akka.Done
+}
 
 /**
  * INTERNAL API.
@@ -17,6 +39,8 @@ import akka.persistence.AtomicWrite
  * In-memory journal for testing purposes only.
  */
 private[persistence] class InmemJournal extends AsyncWriteJournal with InmemMessages {
+  import InmemJournal._
+
   override def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = {
     for (w ← messages; p ← w.payload)
       add(p)
@@ -36,14 +60,66 @@ private[persistence] class InmemJournal extends AsyncWriteJournal with InmemMess
   }
 
   def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] = {
+    implicit def executionContext: ExecutionContext = context.dispatcher
+
     val toSeqNr = math.min(toSequenceNr, highestSequenceNr(persistenceId))
     var snr = 1L
     while (snr <= toSeqNr) {
       delete(persistenceId, snr)
       snr += 1
     }
-    Future.successful(())
+
+    for {
+      downstream <- sendDownstreamDeletion(persistenceId, toSeqNr)
+    } yield {
+      ()
+    }
   }
+
+  /* support for diverting messages to a downstream receiver: */
+
+  private var _downstreamReceiver: Option[ActorRef] = None
+
+  protected def sendDownstream(messages: => Iterable[PersistentRepr]): Unit =
+    _downstreamReceiver.foreach(_ ! SpooledMessages(messages))
+
+  protected def sendDownstreamDeletion(persistenceId: String, toSequenceNr: Long): Future[Unit] = {
+    implicit val timeout: Timeout = Timeout(21474835L, SECONDS) // FIXME
+    implicit def executionContext: ExecutionContext = context.dispatcher
+
+    _downstreamReceiver match {
+      case Some(target) => (target ? DeleteSpooledMessages(persistenceId, toSequenceNr)).map(_ => ())
+      case None => Future.successful()
+    }
+  }
+
+  override def receivePluginInternal: Receive = super.receivePluginInternal orElse {
+    case SetDownstreamReceiver(target) =>
+      _downstreamReceiver = Some(target)
+
+    case RemoveDownstreamReceiver =>
+      _downstreamReceiver = None
+
+    case SpoolExistingMessages =>
+      sendDownstream(messages.values.reduce(_ ++ _).sortBy(_.sequenceNr))
+
+    case Ping =>
+      sender() ! akka.Done // this is just an "ordering" marker as
+  }
+
+  override def add(p: PersistentRepr): Unit = {
+    super.add(p)
+    sendDownstream(p :: Nil)
+  }
+
+  override def update(pid: String, snr: Long)(f: PersistentRepr => PersistentRepr): Unit = {
+    _downstreamReceiver match {
+      case Some(tap) => throw new UnsupportedOperationException("cannot update messages in active tap mode") // smell: Refused Bequest
+      case None => super.update(pid, snr)(f)
+    }
+  }
+
+  override def delete(pid: String, snr: Long): Unit = super.delete(pid, snr)
 }
 
 /**


### PR DESCRIPTION
InmemJournal, whose purpose is testing, lacked a facility to read events like other journals (Leveldb, SQL/JDBC, Cassandra etc.)

This PR provides a stab at implementing such a reader. 