### PR TITLE
Adding the CVE ID to RNG advisory

### DIFF
--- a/akka-docs/src/main/paradox/security/2018-08-29-aes-rng.md
+++ b/akka-docs/src/main/paradox/security/2018-08-29-aes-rng.md
@@ -1,5 +1,9 @@
 # Broken random number generators AES128CounterSecureRNG / AES256CounterSecureRNG, Fixed in Akka 2.5.16
 
+### CVE ID
+
+CVE-2018-16115
+
 ### Date
 
 29 August 2018

--- a/akka-docs/src/main/paradox/security/2018-08-29-aes-rng.md
+++ b/akka-docs/src/main/paradox/security/2018-08-29-aes-rng.md
@@ -36,7 +36,7 @@ Please subscribe to the [akka-security](https://groups.google.com/forum/#!forum/
 
 ### Severity
 
-The [CVSS](https://en.wikipedia.org/wiki/CVSS) score of this vulnerability is 5.9 (Medium), based on vector [AV:A/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N/E:U/RL:O/RC:C](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N/E:U/RL:O/RC:C).
+The [CVSS](https://en.wikipedia.org/wiki/CVSS) score of this vulnerability is 5.9 (Medium), based on vector [AV:A/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N/E:U/RL:O/RC:C](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:A/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N/E:U/RL:O/RC:C).
 
 Rationale for the score:
 


### PR DESCRIPTION
Didn't have this when releasing 2.5.16