### PR TITLE
Cluster singleton should not use the deprecated DownRemovalMargin

### DIFF
--- a/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
@@ -44,7 +44,7 @@ object ClusterSingletonManagerSettings {
    */
   def apply(system: ActorSystem): ClusterSingletonManagerSettings =
     apply(system.settings.config.getConfig("akka.cluster.singleton"))
-      .withRemovalMargin(Cluster(system).settings.DownRemovalMargin)
+      .withRemovalMargin(Cluster(system).downingProvider.downRemovalMargin)
 
   /**
    * Create settings from a configuration with the same layout as

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/ClusterSingleton.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/ClusterSingleton.scala
@@ -159,7 +159,7 @@ object ClusterSingletonManagerSettings {
    */
   def apply(system: ActorSystem[_]): ClusterSingletonManagerSettings =
     apply(system.settings.config.getConfig("akka.cluster.singleton"))
-      .withRemovalMargin(akka.cluster.Cluster(system.toUntyped).settings.DownRemovalMargin)
+      .withRemovalMargin(akka.cluster.Cluster(system.toUntyped).downingProvider.downRemovalMargin)
 
   /**
    * Create settings from a configuration with the same layout as


### PR DESCRIPTION
The `DownRemovalMargin` in the config was deprecated a while ago, nowadays the margin should come from the downing provider through `Cluster().downingProvider.downRemovalMargin` which the downing provider impl is free to keep in its own config or use some other logic to decide.