### PR TITLE
+doc Adding a fiddle example for Akka Typed

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
@@ -4,11 +4,13 @@
 
 package docs.akka.typed
 
+//#fiddle_code
 //#imports
 import akka.NotUsed
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, DispatcherSelector, Terminated }
 //#imports
+//#fiddle_code
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import java.net.URLEncoder
@@ -19,6 +21,8 @@ import scala.concurrent.duration._
 import akka.actor.typed.TypedAkkaSpecWithShutdown
 
 object IntroSpec {
+  //format: OFF
+  //#fiddle_code
 
   //#hello-world-actor
   object HelloWorld {
@@ -26,7 +30,12 @@ object IntroSpec {
     final case class Greeted(whom: String, from: ActorRef[Greet])
 
     val greeter: Behavior[Greet] = Behaviors.receive { (ctx, msg) ⇒
+  //#fiddle_code
       ctx.log.info("Hello {}!", msg.whom)
+  //#fiddle_code
+  //#hello-world-actor
+      println(s"Hello ${msg.whom}!")
+  //#hello-world-actor
       msg.replyTo ! Greeted(msg.whom, ctx.self)
       Behaviors.same
     }
@@ -39,7 +48,12 @@ object IntroSpec {
     def bot(greetingCounter: Int, max: Int): Behavior[HelloWorld.Greeted] =
       Behaviors.receive { (ctx, msg) ⇒
         val n = greetingCounter + 1
+  //#fiddle_code
         ctx.log.info("Greeting {} for {}", n, msg.whom)
+  //#fiddle_code
+  //#hello-world-bot
+        println(s"Greeting ${n} for ${msg.whom}")
+  //#hello-world-bot
         if (n == max) {
           Behaviors.stopped
         } else {
@@ -67,6 +81,8 @@ object IntroSpec {
       }
   }
   //#hello-world-main
+  //#fiddle_code
+  //format: ON
 
   object CustomDispatchersExample {
     import HelloWorldMain.Start
@@ -161,6 +177,7 @@ class IntroSpec extends ActorTestKit with TypedAkkaSpecWithShutdown {
 
   "Hello world" must {
     "say hello" in {
+      //#fiddle_code
       //#hello-world
 
       val system: ActorSystem[HelloWorldMain.Start] =
@@ -170,6 +187,7 @@ class IntroSpec extends ActorTestKit with TypedAkkaSpecWithShutdown {
       system ! HelloWorldMain.Start("Akka")
 
       //#hello-world
+      //#fiddle_code
 
       Thread.sleep(500) // it will not fail if too short
       ActorTestKit.shutdown(system)

--- a/akka-docs/src/main/paradox/assets/js/scalafiddle.js
+++ b/akka-docs/src/main/paradox/assets/js/scalafiddle.js
@@ -1,8 +1,8 @@
 window.scalaFiddleTemplates = {
   "Akka": {
-    pre: "// $FiddleDependency org.akka-js %%% akkajsactor % 1.2.5.11 \n" +
-    "// $FiddleDependency org.akka-js %%% akkajsactorstream % 1.2.5.11 \n" +
-    "// $FiddleDependency org.akka-js %%% akkajsactortyped % 1.2.5.11 \n",
+    pre: "// $FiddleDependency org.akka-js %%% akkajsactor % 1.2.5.14 \n" +
+    "// $FiddleDependency org.akka-js %%% akkajsactorstream % 1.2.5.14 \n" +
+    "// $FiddleDependency org.akka-js %%% akkajsactortyped % 1.2.5.14 \n",
     post: ""
   }
 }

--- a/akka-docs/src/main/paradox/typed/actors.md
+++ b/akka-docs/src/main/paradox/typed/actors.md
@@ -126,6 +126,15 @@ The console output may look like this:
 [INFO] [03/13/2018 15:50:05.816] [hello-akka.actor.default-dispatcher-6] [akka://hello/user/Akka] Greeting 3 for Akka
 ```
 
+@@@ div { .group-scala }
+
+#### Here is another example that you can edit and run in the browser:
+
+@@fiddle [IntroSpec.scala]($akka$/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala) { #fiddle_code template=Akka layout=v75 minheight=400px }
+
+@@@
+
+
 ## A More Complex Example
 
 The next example is more realistic and demonstrates some important patterns:

--- a/build.sbt
+++ b/build.sbt
@@ -230,7 +230,8 @@ lazy val docs = akkaModule("akka-docs")
       "snip.code.base_dir" -> (sourceDirectory in Test).value.getAbsolutePath,
       "snip.akka.base_dir" -> (baseDirectory in ThisBuild).value.getAbsolutePath,
       "signature.akka.base_dir" -> (baseDirectory in ThisBuild).value.getAbsolutePath,
-      "fiddle.code.base_dir" -> (sourceDirectory in Test).value.getAbsolutePath
+      "fiddle.code.base_dir" -> (sourceDirectory in Test).value.getAbsolutePath,
+      "fiddle.akka.base_dir" -> (baseDirectory in ThisBuild).value.getAbsolutePath,
     ),
     paradoxGroups := Map("Language" -> Seq("Scala", "Java")),
     resolvers += Resolver.jcenterRepo,


### PR DESCRIPTION
Finally the API was stable enough to get a working example with an older version of akka-typed :-)

I have had to keep the `format off` to align comments for snippet inclusion.