### PR TITLE
Undeprecate the config, add a note in cluster singleton

### DIFF
--- a/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
@@ -44,6 +44,8 @@ object ClusterSingletonManagerSettings {
    */
   def apply(system: ActorSystem): ClusterSingletonManagerSettings =
     apply(system.settings.config.getConfig("akka.cluster.singleton"))
+      // note that this setting has some additional logic inside the ClusterSingletonManager
+      // falling back to DowningProvider.downRemovalMargin if it is off/Zero
       .withRemovalMargin(Cluster(system).settings.DownRemovalMargin)
 
   /**

--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -47,10 +47,6 @@ akka {
     # If a downing-provider-class is configured this setting is ignored.
     auto-down-unreachable-after = off
 
-    # DEPRECATED: Specific to akka.cluster.AutoDown (which is discouraged to be used in production)
-    #             should not be used anywhere else, instead Cluster.downingProvider.downRemovalMargin
-    #             should be used as it allows the downing provider to decide removal margins.
-    # 
     # Time margin after which shards or singletons that belonged to a downed/removed
     # partition are created in surviving partition. The purpose of this margin is that
     # in case of a network partition the persistent actors in the non-surviving partitions


### PR DESCRIPTION
After discussing this we realized the config property itself should in fact not be deprecated and should be left for the `DowningProvider` to return as `downRemovalMargin`.