### PR TITLE
Update tutorial_1.md

### DIFF
--- a/akka-docs/src/main/paradox/guide/tutorial_1.md
+++ b/akka-docs/src/main/paradox/guide/tutorial_1.md
@@ -37,7 +37,11 @@ We create child, or non-top-level, actors by invoking `context.actorOf()` from a
 The easiest way to see the actor hierarchy in action is to print `ActorRef` instances. In this small experiment, we create an actor, print its reference, create a child of this actor, and print the child's reference. We start with the Hello World project, if you have not downloaded it, download the Quickstart project from the @scala[[Lightbend Tech Hub](http://developer.lightbend.com/start/?group=akka&project=akka-quickstart-scala)]@java[[Lightbend Tech Hub](http://developer.lightbend.com/start/?group=akka&project=akka-quickstart-java)].
 
 
-In your Hello World project, navigate to the `com.lightbend.akka.sample` package and create a new @scala[Scala file called `ActorHierarchyExperiments.scala`]@java[Java file called `ActorHierarchyExperiments.java`] here. Copy and paste the code from the snippet below to this new source file. Save your file and run `sbt "runMain com.lightbend.akka.sample.ActorHierarchyExperiments"` to observe the output.
+In your Hello World project, navigate to the `com.lightbend.akka.sample` package and create a new @scala[Scala file called `ActorHierarchyExperiments.scala`]@java[Java file called `ActorHierarchyExperiments.java`] here. Copy and paste the code from the snippet below to this new source file. Edit the file 'build.sbt' and add the following to the list of libraryDependencies:-
+
+"org.scalatest" % "scalatest_2.10" % "2.2.1"
+
+run `sbt "runMain com.lightbend.akka.sample.ActorHierarchyExperiments"` to observe the output.
 
 Scala
 :   @@snip [ActorHierarchyExperiments.scala]($code$/scala/tutorial_1/ActorHierarchyExperiments.scala) { #print-refs }


### PR DESCRIPTION
Add the dependency for 

"org.scalatest" % "scalatest_2.10" % "2.2.1"

into build.sbt.

If this is not done then you get the following error when trying to complile:-

[error] C:\Users\User\Downloads\AKKA\akka-quickstart-java\src\main\java\com\lightbend\akka\sample\ActorHierarchyExperiments.java:14:1: package org.scalatest.junit does not exist
[error] import org.scalatest.junit.JUnitSuite;
[error] C:\Users\User\Downloads\AKKA\akka-quickstart-java\src\main\java\com\lightbend\akka\sample\ActorHierarchyExperiments.java:137:1: cannot find symbol
[error]   symbol: class JUnitSuite
[error] class ActorHierarchyExperimentsTest extends JUnitSuite {
[error] (Compile / compileIncremental) javac returned non-zero exit code
[error] Total time: 2 s, completed 4 Sep 2018, 15:38:31

