### PR TITLE
Avoid samples getting left truncated 

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.5")
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.10")
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.11")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.12")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.1") // for advanced PR validation features


### PR DESCRIPTION
Refs #241

Makes sure the code at least isn't truncated, this isn't the complete solution because indentation is completely borked. I propose we merge this to get the truncation fixed but spend some more time on getting that indentation right. (Ping @2m )

Code sample after fix:
<img width="1137" alt="screen shot 2018-09-07 at 09 48 17" src="https://user-images.githubusercontent.com/666915/45205739-574e2880-b283-11e8-87a7-3d47233e2aa3.png">
