### PR TITLE
log warning when dropping messages when Artery send queue is full, #23207

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/event/HiFrequencyLoggingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/HiFrequencyLoggingSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.event
+
+import akka.testkit._
+import akka.testkit.TimingTest
+import scala.concurrent.duration._
+
+class HiFrequencyLoggingSpec extends AkkaSpec("akka.loglevel = INFO") {
+  "HiFrequencyLogging" should {
+    val log = Logging(system, getClass)
+
+    "log as normal before reaching limit" in {
+      val hiFrequency = new HiFrequencyLogging(system, maxCalls = 100, within = 10.seconds)
+      EventFilter.info(pattern = "aaa.*", occurrences = 3) intercept {
+        hiFrequency.filter(discardInfo ⇒ log.info("aaa-1{}", discardInfo))
+        hiFrequency.filter(discardInfo ⇒ log.info("aaa-2{}", discardInfo))
+        hiFrequency.filter(discardInfo ⇒ log.info("aaa-3{}", discardInfo))
+      }
+    }
+
+    "discard log messages after reaching limit" in {
+      val hiFrequency = new HiFrequencyLogging(system, maxCalls = 2, within = 10.seconds)
+      EventFilter.info(pattern = "bbb.*", occurrences = 2) intercept {
+        hiFrequency.filter(discardInfo ⇒ log.info("bbb-1{}", discardInfo)) should ===(true)
+        hiFrequency.filter(discardInfo ⇒ log.info("bbb-2{}", discardInfo)) should ===(true)
+        hiFrequency.filter(discardInfo ⇒ log.info("bbb-3{}", discardInfo)) should ===(false)
+      }
+    }
+
+    "continue logging after reset" in {
+      val hiFrequency = new HiFrequencyLogging(system, maxCalls = 2, within = 10.seconds)
+      EventFilter.info(pattern = "ccc.*", occurrences = 2) intercept {
+        hiFrequency.filter(discardInfo ⇒ log.info("ccc-1{}", discardInfo)) should ===(true)
+        hiFrequency.filter(discardInfo ⇒ log.info("ccc-2{}", discardInfo)) should ===(true)
+        hiFrequency.filter(discardInfo ⇒ log.info("ccc-3{}", discardInfo)) should ===(false)
+        hiFrequency.filter(discardInfo ⇒ log.info("ccc-4{}", discardInfo)) should ===(false)
+        hiFrequency.filter(discardInfo ⇒ log.info("ccc-5{}", discardInfo)) should ===(false)
+      }
+      hiFrequency.reset()
+      EventFilter.info(message = "ccc-6 ([3] similar log messages were discarded in last [10000 ms])", occurrences = 1) intercept {
+        hiFrequency.filter(discardInfo ⇒ log.info("ccc-6{}", discardInfo)) should ===(true)
+      }
+      EventFilter.info(message = "ccc-7", occurrences = 1) intercept {
+        hiFrequency.filter(discardInfo ⇒ log.info("ccc-7{}", discardInfo)) should ===(true)
+      }
+    }
+
+    "log once per second (example)" taggedAs TimingTest in {
+      val hiFrequency = new HiFrequencyLogging(system, maxCalls = 1, within = 1.seconds)
+      EventFilter.info(pattern = "ddd.*", occurrences = 3) intercept {
+        (1 to 25).foreach { n ⇒
+          hiFrequency.filter(discardInfo ⇒ log.info("ddd-{}{}", n, discardInfo))
+          Thread.sleep(100)
+        }
+      }
+
+    }
+
+  }
+}

--- a/akka-actor/src/main/scala/akka/event/HiFrequencyLogging.scala
+++ b/akka-actor/src/main/scala/akka/event/HiFrequencyLogging.scala
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.event
+
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.concurrent.duration.FiniteDuration
+
+import akka.actor.ActorSystem
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ *
+ * Utility to filter log statements, e.g. log at most once every 10 seconds.
+ * Useful in places where there is a risk of overwhelming the logging system with too many log messages.
+ */
+@InternalApi private[akka] class HiFrequencyLogging(system: ActorSystem, maxCalls: Int, within: FiniteDuration) {
+
+  private val count = new AtomicLong
+  @volatile private var discarded = 0L
+
+  /**
+   * The `logStatement` will be called if the `maxCalls` limit has not been reached. The counter is
+   * reset after the `within` duration.
+   * @param logStatement function for the log statement to call if the limit has not been reached, the `String`
+   *                     parameter is additional information about number of discarded statements which
+   *                     can be included at the end of the log message
+   * @return `true` if the statement was run
+   */
+  def filter(logStatement: String ⇒ Unit): Boolean = {
+    val n = count.incrementAndGet()
+    if (n == 1L) {
+      // lazy scheduling for minimal resource consumption when not used
+      system.scheduler.scheduleOnce(within) {
+        reset()
+      }(system.dispatcher)
+
+      val d = discarded
+      val discardInfo =
+        if (d == 0) ""
+        else s" ([$d] similar log messages were discarded in last [${within.toMillis} ms])" // first time after a reset
+
+      logStatement(discardInfo)
+      true
+    } else if (n <= maxCalls) {
+      logStatement("")
+      true
+    } else {
+      // exceeded limit, don't log
+      false
+    }
+  }
+
+  def reset(): Unit =
+    discarded = math.max(0L, count.getAndSet(0) - maxCalls)
+
+}

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteDeliverySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteDeliverySpec.scala
@@ -13,9 +13,6 @@ import akka.actor.ActorRef
 import akka.actor.Props
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
-import akka.remote.testkit.STMultiNodeSpec
-import akka.testkit._
 import akka.actor.ActorIdentity
 import akka.actor.Identify
 


### PR DESCRIPTION
* including high frequency logging filter, once per 10 seconds

This is probably useful in more places.

Refs #23207