### PR TITLE
Source.actorRef with buffer stats (#25402)

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/Source/actorRef.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/actorRef.md
@@ -24,3 +24,11 @@ elements or failing the stream; the strategy is chosen by the user.
 
 @@@
 
+The created actor can be asked about the inner buffer state too. 
+
+Scala
+:   @@snip [SourceOperators.scala]($code$/scala/docs/stream/operators/SourceOperators.scala) { #sourceActorRefBufferSize }
+
+Java
+:   @@snip [ActorRefSource.java]($code$/java/jdocs/stream/operators/ActorRefSource.java) { #sourceActorRefBufferSize }
+

--- a/akka-docs/src/test/java/jdocs/stream/operators/ActorRefSource.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/ActorRefSource.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.stream.operators;
+
+//#sourceActorRefBufferSize
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.stream.*;
+import static akka.pattern.PatternsCS.ask;
+
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.util.Timeout;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+//#sourceActorRefBufferSize
+
+class ActorRefSource {
+
+  void example() {
+    //#sourceActorRefBufferSize
+    ActorSystem system = ActorSystem.create("ExampleSystem");
+    ActorMaterializer mat = ActorMaterializer.create(system);
+    Timeout t = Timeout.create(Duration.ofSeconds(5));
+
+    ActorRef ref = Source.actorRef(1000, OverflowStrategy.fail()).to(Sink.ignore()).run(mat);
+    CompletableFuture<Object> future1 = ask(ref, GetBufferStatus.getInstance(), t).toCompletableFuture();
+    future1.thenRun(() -> {
+      BufferStatus status = (BufferStatus) future1.join();
+      System.out.println("Buffer status: " + status.getUsed() + "/" + status.getCapacity());
+    });
+    //#sourceActorRefBufferSize
+  }
+}

--- a/akka-docs/src/test/scala/docs/stream/operators/SourceOperators.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/SourceOperators.scala
@@ -25,4 +25,27 @@ object SourceOperators {
     val done: Future[Done] = source.runWith(sink) //10
     //#sourceFromFuture
   }
+
+  def actorRef = {
+    //#sourceActorRefBufferSize
+    import akka.stream.OverflowStrategy
+    import akka.stream.scaladsl._
+    import akka.actor.{ ActorRef, ActorSystem }
+    import akka.stream.ActorMaterializer
+    import akka.pattern.ask
+    import akka.stream.{ BufferStatus, GetBufferStatus }
+    import scala.concurrent.Future
+    import concurrent.duration._
+    import akka.util.Timeout
+
+    implicit val system: ActorSystem = ActorSystem()
+    implicit val materializer: ActorMaterializer = ActorMaterializer()
+    implicit val executionContext = system.dispatcher
+    implicit val timeout = Timeout(5.seconds)
+
+    val ref: ActorRef = Source.actorRef(1000, OverflowStrategy.fail).to(Sink.ignore).run
+    val ans: Future[BufferStatus] = (ref ? GetBufferStatus).mapTo[BufferStatus]
+    ans.foreach(bs ⇒ println(s"Buffer status: ${bs.used}/${bs.capacity}"))
+    //#sourceActorRefBufferSize
+  }
 }

--- a/akka-stream/src/main/scala/akka/stream/BufferStatus.scala
+++ b/akka-stream/src/main/scala/akka/stream/BufferStatus.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream
+
+import akka.annotation.DoNotInherit
+
+class BufferStatus(val used: Int, val capacity: Int) {
+  def getUsed() = used
+  def getCapacity() = capacity
+}
+
+@DoNotInherit sealed abstract class GetBufferStatus
+
+case object GetBufferStatus extends GetBufferStatus {
+  /**
+   * Java API: the singleton instance
+   */
+  def getInstance(): GetBufferStatus = this
+}


### PR DESCRIPTION
Hy!

A small PR with a small QOL improvement. It can be useful for the early stages of development, under loadtests, and can be used in production as metrics.

fixes #25402 