### PR TITLE
Use supervision in all places of Source.fromIterator, #25574

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowIteratorSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowIteratorSpec.scala
@@ -39,9 +39,7 @@ class FlowIterableSpec extends AbstractFlowIteratorSpec {
     sub.request(1)
     c.expectNext(1)
     c.expectNoMsg(100.millis)
-    EventFilter[IllegalStateException](message = "not two", occurrences = 1).intercept {
-      sub.request(2)
-    }
+    sub.request(2)
     c.expectError().getMessage should be("not two")
     sub.request(2)
     c.expectNoMsg(100.millis)


### PR DESCRIPTION
* it was noticed in Source.fromIterator depending on where the
  iterator throwed exception
* fromIterator, as many other things, is implemented with
  statefulMapConcat
* supervision was only used for exceptions in onPush and not
  in onPull, added it there also

Refs #25574