### PR TITLE
Introduce RecipientRef interface for ActorRef and EntityRef, #24463

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/DebugRef.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/DebugRef.scala
@@ -10,14 +10,16 @@ import akka.actor.typed.ActorRef
 import akka.actor.typed.internal.{ ActorRefImpl, SystemMessage }
 import akka.annotation.InternalApi
 import akka.{ actor ⇒ a }
-
 import scala.annotation.tailrec
+
+import akka.actor.ActorRefProvider
+import akka.actor.typed.internal.InternalRecipientRef
 
 /**
  * INTERNAL API
  */
 @InternalApi private[akka] final class DebugRef[T](override val path: a.ActorPath, override val isLocal: Boolean)
-  extends ActorRef[T] with ActorRefImpl[T] {
+  extends ActorRef[T] with ActorRefImpl[T] with InternalRecipientRef[T] {
 
   private val q = new ConcurrentLinkedQueue[Either[SystemMessage, T]]
 
@@ -58,4 +60,9 @@ import scala.annotation.tailrec
       }
     rec(Nil)
   }
+
+  // impl InternalRecipientRef, ask not supported
+  override def provider: ActorRefProvider = throw new UnsupportedOperationException("no provider")
+  // impl InternalRecipientRef
+  def isTerminated: Boolean = false
 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
@@ -47,9 +47,9 @@ class ActorContextAskSpec extends ScalaTestWithActorTestKit(ActorContextAskSpec.
         Behaviors.same
       }, "ping-pong", Props.empty.withDispatcherFromConfig("ping-pong-dispatcher"))
 
-      val probe = TestProbe[AnyRef]()
+      val probe = TestProbe[Pong]()
 
-      val snitch = Behaviors.setup[Pong] { (ctx) ⇒
+      val snitch = Behaviors.setup[Pong] { ctx ⇒
 
         // Timeout comes from TypedAkkaSpec
 
@@ -58,10 +58,9 @@ class ActorContextAskSpec extends ScalaTestWithActorTestKit(ActorContextAskSpec.
           case Failure(ex)   ⇒ throw ex
         }
 
-        Behaviors.receive {
-          case (ctx, pong: Pong) ⇒
-            probe.ref ! pong
-            Behaviors.same
+        Behaviors.receiveMessage { pong ⇒
+          probe.ref ! pong
+          Behaviors.same
         }
       }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorRef.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorRef.scala
@@ -6,10 +6,11 @@ package akka.actor.typed
 
 import akka.annotation.InternalApi
 import akka.{ actor ⇒ a }
-
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.Future
 import scala.util.Success
+
+import akka.actor.typed.internal.InternalRecipientRef
 
 /**
  * An ActorRef is the identity or address of an Actor instance. It is valid
@@ -20,7 +21,7 @@ import scala.util.Success
  * [[akka.event.EventStream]] on a best effort basis
  * (i.e. this delivery is not reliable).
  */
-trait ActorRef[-T] extends java.lang.Comparable[ActorRef[_]] with java.io.Serializable {
+trait ActorRef[-T] extends RecipientRef[T] with java.lang.Comparable[ActorRef[_]] with java.io.Serializable { this: InternalRecipientRef[T] ⇒
   /**
    * Send a message to the Actor referenced by this ActorRef using *at-most-once*
    * messaging semantics.
@@ -100,5 +101,29 @@ private[akka] final case class SerializedActorRef[T] private (address: String) {
     case someSystem ⇒
       val resolver = ActorRefResolver(someSystem.toTyped)
       resolver.resolveActorRef(address)
+  }
+}
+
+/**
+ * FIXME doc
+ * - not serializable
+ * - not watchable
+ */
+trait RecipientRef[-T] { this: InternalRecipientRef[T] ⇒
+  /**
+   * Send a message to the destination referenced by this `RecipientRef` using *at-most-once*
+   * messaging semantics.
+   */
+  def tell(msg: T): Unit
+}
+
+object RecipientRef {
+
+  implicit final class RecipientRefOps[-T](val ref: RecipientRef[T]) extends AnyVal {
+    /**
+     * Send a message to the destination referenced by this `RecipientRef` using *at-most-once*
+     * messaging semantics.
+     */
+    def !(msg: T): Unit = ref.tell(msg)
   }
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -9,14 +9,14 @@ import java.util.concurrent.{ CompletionStage, ThreadFactory }
 
 import akka.actor.setup.ActorSystemSetup
 import com.typesafe.config.{ Config, ConfigFactory }
-
 import scala.concurrent.{ ExecutionContextExecutor, Future }
+
 import akka.actor.typed.internal.adapter.{ ActorSystemAdapter, PropsAdapter }
 import akka.util.Timeout
 import akka.annotation.DoNotInherit
 import akka.annotation.ApiMayChange
-
 import akka.actor.BootstrapSetup
+import akka.actor.typed.internal.InternalRecipientRef
 import akka.actor.typed.internal.adapter.GuardianActorAdapter
 import akka.actor.typed.receptionist.Receptionist
 
@@ -31,7 +31,7 @@ import akka.actor.typed.receptionist.Receptionist
  */
 @DoNotInherit
 @ApiMayChange
-abstract class ActorSystem[-T] extends ActorRef[T] with Extensions {
+abstract class ActorSystem[-T] extends ActorRef[T] with Extensions { this: InternalRecipientRef[T] ⇒
   /**
    * The name of this actor system, used to distinguish multiple ones within
    * the same JVM & class loader.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
@@ -82,16 +82,16 @@ import akka.util.JavaDurationConverters._
     spawnAnonymous(behavior, Props.empty)
 
   // Scala API impl
-  override def ask[Req, Res](otherActor: ActorRef[Req])(createRequest: ActorRef[Res] ⇒ Req)(mapResponse: Try[Res] ⇒ T)(implicit responseTimeout: Timeout, classTag: ClassTag[Res]): Unit = {
+  override def ask[Req, Res](target: RecipientRef[Req])(createRequest: ActorRef[Res] ⇒ Req)(mapResponse: Try[Res] ⇒ T)(implicit responseTimeout: Timeout, classTag: ClassTag[Res]): Unit = {
     import akka.actor.typed.scaladsl.AskPattern._
-    (otherActor ? createRequest)(responseTimeout, system.scheduler).onComplete(res ⇒
+    (target ? createRequest)(responseTimeout, system.scheduler).onComplete(res ⇒
       self.asInstanceOf[ActorRef[AnyRef]] ! new AskResponse(res, mapResponse)
     )
   }
 
   // Java API impl
-  def ask[Req, Res](resClass: Class[Res], otherActor: ActorRef[Req], responseTimeout: Timeout, createRequest: function.Function[ActorRef[Res], Req], applyToResponse: BiFunction[Res, Throwable, T]): Unit = {
-    this.ask(otherActor)(createRequest.apply) {
+  def ask[Req, Res](resClass: Class[Res], target: RecipientRef[Req], responseTimeout: Timeout, createRequest: function.Function[ActorRef[Res], Req], applyToResponse: BiFunction[Res, Throwable, T]): Unit = {
+    this.ask(target)(createRequest.apply) {
       case Success(message) ⇒ applyToResponse.apply(message, null)
       case Failure(ex)      ⇒ applyToResponse.apply(null.asInstanceOf[Res], ex)
     }(responseTimeout, ClassTag[Res](resClass))

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorRefImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorRefImpl.scala
@@ -13,7 +13,7 @@ import scala.annotation.unchecked.uncheckedVariance
  * available in the package object, enabling `ref.toImpl` (or `ref.toImplN`
  * for `ActorRef[Nothing]`—Scala refuses to infer `Nothing` as a type parameter).
  */
-private[akka] trait ActorRefImpl[-T] extends ActorRef[T] {
+private[akka] trait ActorRefImpl[-T] extends ActorRef[T] { this: InternalRecipientRef[T] ⇒
   def sendSystem(signal: SystemMessage): Unit
   def isLocal: Boolean
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/InternalRecipientRef.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/InternalRecipientRef.scala
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.internal
+
+import akka.actor.ActorRefProvider
+import akka.actor.typed.RecipientRef
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] trait InternalRecipientRef[-T] extends RecipientRef[T] {
+
+  /**
+   * Get a reference to the actor ref provider which created this ref.
+   */
+  def provider: ActorRefProvider
+
+  /**
+   * @return `true` if the actor is locally known to be terminated, `false` if alive or uncertain.
+   */
+  def isTerminated: Boolean
+
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala
@@ -6,6 +6,7 @@ package akka.actor.typed
 package internal
 package adapter
 
+import akka.actor.ActorRefProvider
 import akka.actor.InvalidMessageException
 import akka.{ actor ⇒ a }
 import akka.annotation.InternalApi
@@ -15,7 +16,7 @@ import akka.dispatch.sysmsg
  * INTERNAL API
  */
 @InternalApi private[typed] class ActorRefAdapter[-T](val untyped: a.InternalActorRef)
-  extends ActorRef[T] with internal.ActorRefImpl[T] {
+  extends ActorRef[T] with internal.ActorRefImpl[T] with internal.InternalRecipientRef[T] {
 
   override def path: a.ActorPath = untyped.path
 
@@ -23,9 +24,17 @@ import akka.dispatch.sysmsg
     if (msg == null) throw new InvalidMessageException("[null] is not an allowed message")
     untyped ! msg
   }
+
+  // impl ActorRefImpl
   override def isLocal: Boolean = untyped.isLocal
+  // impl ActorRefImpl
   override def sendSystem(signal: internal.SystemMessage): Unit =
     ActorRefAdapter.sendSystemMessage(untyped, signal)
+
+  // impl InternalRecipientRef
+  override def provider: ActorRefProvider = untyped.provider
+  // impl InternalRecipientRef
+  def isTerminated: Boolean = untyped.isTerminated
 
   @throws(classOf[java.io.ObjectStreamException])
   private def writeReplace(): AnyRef = SerializedActorRef[T](this)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ActorContext.scala
@@ -260,7 +260,7 @@ trait ActorContext[T] extends akka.actor.typed.ActorContext[T] {
    *
    * @param createRequest A function that creates a message for the other actor, containing the provided `ActorRef[Res]` that
    *                      the other actor can send a message back through.
-   * @param applyToResponse Transforms the response from the `otherActor` into a message this actor understands.
+   * @param applyToResponse Transforms the response from the `target` into a message this actor understands.
    *                        Will be invoked with either the response message or an AskTimeoutException failed or
    *                        potentially another exception if the remote actor is untyped and sent a
    *                        [[akka.actor.Status.Failure]] as response. The returned message of type `T` is then
@@ -274,7 +274,7 @@ trait ActorContext[T] extends akka.actor.typed.ActorContext[T] {
    */
   def ask[Req, Res](
     resClass:        Class[Res],
-    otherActor:      ActorRef[Req],
+    target:          RecipientRef[Req],
     responseTimeout: Timeout,
     createRequest:   java.util.function.Function[ActorRef[Res], Req],
     applyToResponse: BiFunction[Res, Throwable, T]): Unit

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
@@ -265,7 +265,7 @@ trait ActorContext[T] extends akka.actor.typed.ActorContext[T] { this: akka.acto
    *
    * @param createRequest A function that creates a message for the other actor, containing the provided `ActorRef[Res]` that
    *                      the other actor can send a message back through.
-   * @param mapResponse Transforms the response from the `otherActor` into a message this actor understands.
+   * @param mapResponse Transforms the response from the `target` into a message this actor understands.
    *                              Should be a pure function but is executed inside the actor when the response arrives
    *                              so can safely touch the actor internals. If this function throws an exception it is
    *                              just as if the normal message receiving logic would throw.
@@ -273,6 +273,6 @@ trait ActorContext[T] extends akka.actor.typed.ActorContext[T] { this: akka.acto
    * @tparam Req The request protocol, what the other actor accepts
    * @tparam Res The response protocol, what the other actor sends back
    */
-  def ask[Req, Res](otherActor: ActorRef[Req])(createRequest: ActorRef[Res] ⇒ Req)(mapResponse: Try[Res] ⇒ T)(implicit responseTimeout: Timeout, classTag: ClassTag[Res]): Unit
+  def ask[Req, Res](target: RecipientRef[Req])(createRequest: ActorRef[Res] ⇒ Req)(mapResponse: Try[Res] ⇒ T)(implicit responseTimeout: Timeout, classTag: ClassTag[Res]): Unit
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
@@ -6,14 +6,16 @@ package akka.actor.typed.scaladsl
 
 import java.util.concurrent.TimeoutException
 
-import akka.actor.{ Address, InternalActorRef, RootActorPath, Scheduler }
+import akka.actor.{ Address, RootActorPath, Scheduler }
 import akka.actor.typed.ActorRef
 import akka.actor.typed.internal.{ adapter ⇒ adapt }
 import akka.annotation.InternalApi
 import akka.pattern.PromiseActorRef
 import akka.util.Timeout
-
 import scala.concurrent.Future
+
+import akka.actor.typed.RecipientRef
+import akka.actor.typed.internal.InternalRecipientRef
 
 /**
  * The ask-pattern implements the initiator side of a request–reply protocol.
@@ -26,7 +28,7 @@ object AskPattern {
   /**
    * See [[?]]
    */
-  implicit final class Askable[T](val ref: ActorRef[T]) extends AnyVal {
+  implicit final class Askable[T](val ref: RecipientRef[T]) extends AnyVal {
     /**
      * The ask-pattern implements the initiator side of a request–reply protocol.
      * The `?` operator is pronounced as "ask".
@@ -49,36 +51,38 @@ object AskPattern {
      * implicit val scheduler = system.scheduler
      * implicit val timeout = Timeout(3.seconds)
      * val target: ActorRef[Request] = ...
-     * val f: Future[Reply] = target ? ref => (Request("hello", ref))
+     * val f: Future[Reply] = target ? replyTo => (Request("hello", replyTo))
      * }}}
      */
-    def ?[U](f: ActorRef[U] ⇒ T)(implicit timeout: Timeout, scheduler: Scheduler): Future[U] = {
+    def ?[U](replyTo: ActorRef[U] ⇒ T)(implicit timeout: Timeout, scheduler: Scheduler): Future[U] = {
       // We do not currently use the implicit scheduler, but want to require it
       // because it might be needed when we move to a 'native' typed runtime, see #24219
       ref match {
-        case a: adapt.ActorRefAdapter[_]    ⇒ askUntyped(ref, a.untyped, timeout, f)
-        case a: adapt.ActorSystemAdapter[_] ⇒ askUntyped(ref, a.untyped.guardian, timeout, f)
-        case a                              ⇒ throw new IllegalStateException("Only expect actor references to be ActorRefAdapter or ActorSystemAdapter until native system is implemented: " + a.getClass)
+        case a: InternalRecipientRef[_] ⇒ askUntyped(a, timeout, replyTo)
+        case a ⇒ throw new IllegalStateException(
+          "Only expect references to be RecipientRef, ActorRefAdapter or ActorSystemAdapter until " +
+            "native system is implemented: " + a.getClass)
       }
     }
   }
 
   private val onTimeout: String ⇒ Throwable = msg ⇒ new TimeoutException(msg)
 
-  private final class PromiseRef[U](target: ActorRef[_], untyped: InternalActorRef, timeout: Timeout) {
+  private final class PromiseRef[U](target: InternalRecipientRef[_], timeout: Timeout) {
 
     // Note: _promiseRef mustn't have a type pattern, since it can be null
     private[this] val (_ref: ActorRef[U], _future: Future[U], _promiseRef) =
-      if (untyped.isTerminated)
+      if (target.isTerminated)
         (
-          adapt.ActorRefAdapter[U](untyped.provider.deadLetters),
+          adapt.ActorRefAdapter[U](target.provider.deadLetters),
           Future.failed[U](new TimeoutException(s"Recipient[$target] had already been terminated.")), null)
       else if (timeout.duration.length <= 0)
         (
-          adapt.ActorRefAdapter[U](untyped.provider.deadLetters),
+          adapt.ActorRefAdapter[U](target.provider.deadLetters),
           Future.failed[U](new IllegalArgumentException(s"Timeout length must be positive, question not sent to [$target]")), null)
       else {
-        val a = PromiseActorRef(untyped.provider, timeout, target, "unknown", onTimeout = onTimeout)
+        // messageClassName "unknown' is set later, after applying the message factory
+        val a = PromiseActorRef(target.provider, timeout, target, "unknown", onTimeout = onTimeout)
         val b = adapt.ActorRefAdapter[U](a)
         (b, a.result.future.asInstanceOf[Future[U]], a)
       }
@@ -88,8 +92,8 @@ object AskPattern {
     val promiseRef: PromiseActorRef = _promiseRef
   }
 
-  private def askUntyped[T, U](target: ActorRef[T], untyped: InternalActorRef, timeout: Timeout, f: ActorRef[U] ⇒ T): Future[U] = {
-    val p = new PromiseRef[U](target, untyped, timeout)
+  private def askUntyped[T, U](target: InternalRecipientRef[T], timeout: Timeout, f: ActorRef[U] ⇒ T): Future[U] = {
+    val p = new PromiseRef[U](target, timeout)
     val m = f(p.ref)
     if (p.promiseRef ne null) p.promiseRef.messageClassName = m.getClass.getName
     target ! m

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/adapter/package.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/adapter/package.scala
@@ -99,6 +99,19 @@ package object adapter {
   }
 
   /**
+   * Extension methods added to [[akka.actor.ActorRef]].
+   */
+  implicit class UntypedActorRefOps(val ref: akka.actor.ActorRef) extends AnyVal {
+
+    /**
+     * Adapt the untyped `ActorRef` to typed `ActorRef[T]`. There is also an
+     * automatic implicit conversion for this, but this more explicit variant might
+     * sometimes be preferred.
+     */
+    def toTyped[T]: ActorRef[T] = ActorRefAdapter(ref)
+  }
+
+  /**
    * Implicit conversion from untyped [[akka.actor.ActorRef]] to typed [[akka.actor.typed.ActorRef]].
    */
   implicit def actorRefAdapter[T](ref: akka.actor.ActorRef): ActorRef[T] = ActorRefAdapter(ref)

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ClusterSharding.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ClusterSharding.scala
@@ -12,7 +12,9 @@ import java.util.function.BiFunction
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
+import akka.actor.typed.RecipientRef
 import akka.actor.typed.Props
+import akka.actor.typed.internal.InternalRecipientRef
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
 import akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
@@ -333,7 +335,7 @@ object EntityTypeKey {
  *
  * Not for user extension.
  */
-@DoNotInherit abstract class EntityRef[M] { scaladslSelf: scaladsl.EntityRef[M] ⇒
+@DoNotInherit abstract class EntityRef[M] extends RecipientRef[M] { scaladslSelf: scaladsl.EntityRef[M] with InternalRecipientRef[M] ⇒
 
   /**
    * Send a message to the entity referenced by this EntityRef using *at-most-once*
@@ -344,6 +346,9 @@ object EntityTypeKey {
   /**
    * Allows to "ask" the [[EntityRef]] for a reply.
    * See [[akka.actor.typed.javadsl.AskPattern]] for a complete write-up of this pattern
+   *
+   * Note that if you are inside of an actor you should prefer [[akka.actor.typed.javadsl.ActorContext.ask]]
+   * as that provides better safety.
    */
   def ask[U](message: JFunction[ActorRef[U], M], timeout: Timeout): CompletionStage[U]
 

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/ClusterSharding.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/ClusterSharding.scala
@@ -16,7 +16,9 @@ import akka.actor.typed.Behavior
 import akka.actor.typed.Extension
 import akka.actor.typed.ExtensionId
 import akka.actor.typed.ExtensionSetup
+import akka.actor.typed.RecipientRef
 import akka.actor.typed.Props
+import akka.actor.typed.internal.InternalRecipientRef
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
 import akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
@@ -330,7 +332,7 @@ object EntityTypeKey {
  * [[ActorRef]] and watch it in case such notification is desired.
  * Not for user extension.
  */
-@DoNotInherit trait EntityRef[M] {
+@DoNotInherit trait EntityRef[M] extends RecipientRef[M] { this: InternalRecipientRef[M] ⇒
 
   /**
    * Send a message to the entity referenced by this EntityRef using *at-most-once*
@@ -360,6 +362,9 @@ object EntityTypeKey {
    * Allows to "ask" the [[EntityRef]] for a reply.
    * See [[akka.actor.typed.scaladsl.AskPattern]] for a complete write-up of this pattern
    *
+   * Note that if you are inside of an actor you should prefer [[akka.actor.typed.scaladsl.ActorContext.ask]]
+   * as that provides better safety.
+   *
    * Example usage:
    * {{{
    * case class Request(msg: String, replyTo: ActorRef[Reply])
@@ -377,6 +382,9 @@ object EntityTypeKey {
   /**
    * Allows to "ask" the [[EntityRef]] for a reply.
    * See [[akka.actor.typed.scaladsl.AskPattern]] for a complete write-up of this pattern
+   *
+   * Note that if you are inside of an actor you should prefer [[akka.actor.typed.scaladsl.ActorContext.ask]]
+   * as that provides better safety.
    *
    * Example usage:
    * {{{


### PR DESCRIPTION
* to make it possible to use ActorContext.ask also with EntityRef
  destinations
* this abstraction will probably be useful for other things, where a
  full ActorRef is not required
* a MessageChannel only has to support tell (and ask), while a full ActorRef
  is watchable (destination has a lifecycle) and location transparent (serializable)

wdyt?

Refs #24463