### PR TITLE
Spike trying to make scalatest suite type agnostic

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitBase.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitBase.scala
@@ -23,7 +23,7 @@ object ActorTestKitBase {
  * A base class for the [[ActorTestKit]], making it possible to have testing framework (e.g. ScalaTest)
  * manage the lifecycle of the testkit.
  *
- * An implementation for ScalaTest is [[ActorTestKitWordSpec]].
+ * An implementation for ScalaTest is [[ActorTestKitScalaTestSpec]].
  *
  * Another abstract class that is testing framework specific should extend this class and
  * automatically shut down the `testKit` when the test completes or fails by implementing [[ActorTestKitBase#afterAll]].

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitScalaTestSpec.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitScalaTestSpec.scala
@@ -14,7 +14,8 @@ import org.scalatest.time.Span
 
 /**
  * A ScalaTest base class for the [[ActorTestKit]], making it possible to have ScalaTest manage the lifecycle of the testkit.
- * The testkit will be automatically shut down when the test completes or fails.
+ * The testkit will be automatically shut down when the test completes or fails using ScalaTest's BeforeAndAfterAll trait. If
+ * a spec overrides afterAll it must call super.afterAll.
  *
  * Note that ScalaTest is not provided as a transitive dependency of the testkit module but must be added explicitly
  * to your project to use this.
@@ -47,7 +48,10 @@ abstract class ActorTestKitScalaTestSpec(testKit: ActorTestKit) extends ActorTes
   implicit val patience: PatienceConfig =
     PatienceConfig(testKit.testKitSettings.DefaultTimeout.duration, Span(100, org.scalatest.time.Millis))
 
-  // FIXME document to call super if override
+  /**
+    * Shuts down the ActorTestKit. If override be sure to call super.afterAll
+    * or shut down the testkit explicitly with `testKit.shutdownTestKit()`.
+    */
   override protected def afterAll(): Unit = {
     super.afterAll()
     testKit.shutdownTestKit()

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitScalaTestSpec.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitScalaTestSpec.scala
@@ -7,9 +7,7 @@ package akka.actor.testkit.typed.scaladsl
 import akka.actor.testkit.typed.TestKitSettings
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.Matchers
-import org.scalatest.WordSpecLike
+import org.scalatest._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.Span
@@ -20,13 +18,9 @@ import org.scalatest.time.Span
  *
  * Note that ScalaTest is not provided as a transitive dependency of the testkit module but must be added explicitly
  * to your project to use this.
- *
- * This is a `WordSpec`, other ScalaTest styles can be implemented in a similar abstract class like this one.
- * For example `with FlatSpecLike with BeforeAndAfterAll` and implementing the `afterAll` method by calling
- * `testKit.shutdownTestKit()`.
  */
-abstract class ActorTestKitWordSpec(testKit: ActorTestKit) extends ActorTestKitBase(testKit)
-  with WordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures with Eventually {
+abstract class ActorTestKitScalaTestSpec(testKit: ActorTestKit) extends ActorTestKitBase(testKit)
+  with TestSuite with Matchers with BeforeAndAfterAll with ScalaFutures with Eventually {
 
   def this() = this(ActorTestKit(ActorTestKitBase.testNameFromCallStack()))
 
@@ -52,5 +46,11 @@ abstract class ActorTestKitWordSpec(testKit: ActorTestKit) extends ActorTestKitB
    */
   implicit val patience: PatienceConfig =
     PatienceConfig(testKit.testKitSettings.DefaultTimeout.duration, Span(100, org.scalatest.time.Millis))
+
+  // FIXME document to call super if override
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    testKit.shutdownTestKit()
+  }
 }
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitScalaTestSpec.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitScalaTestSpec.scala
@@ -49,9 +49,9 @@ abstract class ActorTestKitScalaTestSpec(testKit: ActorTestKit) extends ActorTes
     PatienceConfig(testKit.testKitSettings.DefaultTimeout.duration, Span(100, org.scalatest.time.Millis))
 
   /**
-    * Shuts down the ActorTestKit. If override be sure to call super.afterAll
-    * or shut down the testkit explicitly with `testKit.shutdownTestKit()`.
-    */
+   * Shuts down the ActorTestKit. If override be sure to call super.afterAll
+   * or shut down the testkit explicitly with `testKit.shutdownTestKit()`.
+   */
   override protected def afterAll(): Unit = {
     super.afterAll()
     testKit.shutdownTestKit()

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.Matchers
 import org.scalatest.WordSpec
 import org.scalatest.WordSpecLike
 
-class ActorTestKitSpec extends ActorTestKitWordSpec {
+class ActorTestKitSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   "the Scala testkit" should {
 
@@ -69,7 +69,7 @@ class ActorTestKitSpec extends ActorTestKitWordSpec {
 }
 
 // derivative classes should also work fine (esp the naming part
-abstract class MyBaseSpec extends ActorTestKitWordSpec with WordSpecLike with Matchers
+abstract class MyBaseSpec extends ActorTestKitScalaTestSpec with Matchers with WordSpecLike
 
 class MyConcreteDerivateSpec extends MyBaseSpec {
   "A derivative test" should {

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestProbeSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestProbeSpec.scala
@@ -5,10 +5,10 @@
 package akka.actor.testkit.typed.scaladsl
 
 import scala.concurrent.duration._
-
 import akka.actor.typed.scaladsl.Behaviors
+import org.scalatest.WordSpecLike
 
-class TestProbeSpec extends ActorTestKitWordSpec {
+class TestProbeSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   def compileOnlyApiTest(): Unit = {
     val probe = TestProbe[AnyRef]()

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ManualTimerExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ManualTimerExampleSpec.scala
@@ -6,13 +6,13 @@ package docs.akka.actor.testkit.typed.scaladsl
 
 //#manual-scheduling-simple
 import scala.concurrent.duration._
-
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.testkit.typed.scaladsl.ManualTime
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.scaladsl.Behaviors
+import org.scalatest.WordSpecLike
 
-class ManualTimerExampleSpec extends ActorTestKitWordSpec(ManualTime.config) {
+class ManualTimerExampleSpec extends ActorTestKitScalaTestSpec(ManualTime.config) with WordSpecLike {
 
   val manualTime: ManualTime = ManualTime()
 

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ScalaTestIntegrationExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ScalaTestIntegrationExampleSpec.scala
@@ -5,9 +5,10 @@
 package docs.akka.actor.testkit.typed.scaladsl
 
 //#scalatest-integration
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
-class ScalaTestIntegrationExampleSpec extends ActorTestKitWordSpec {
+class ScalaTestIntegrationExampleSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   "Something" must {
     "behave correctly" in {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
@@ -7,11 +7,12 @@ package akka.actor.typed
 import akka.actor.InvalidMessageException
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.testkit.typed.scaladsl.TestProbe
+
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
-
 import akka.actor.testkit.typed.TestException
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 object ActorSpecMessages {
 
@@ -61,7 +62,7 @@ object ActorSpecMessages {
 
 }
 
-abstract class ActorContextSpec extends ActorTestKitWordSpec {
+abstract class ActorContextSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   import ActorSpecMessages._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -13,11 +13,12 @@ import akka.testkit.EventFilter
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
+
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, TimeoutException }
 import scala.util.Success
-
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 object AskSpec {
   sealed trait Msg
@@ -25,8 +26,8 @@ object AskSpec {
   final case class Stop(replyTo: ActorRef[Unit]) extends Msg
 }
 
-class AskSpec extends ActorTestKitWordSpec(
-  "akka.loggers = [ akka.testkit.TestEventListener ]") {
+class AskSpec extends ActorTestKitScalaTestSpec(
+  "akka.loggers = [ akka.testkit.TestEventListener ]") with WordSpecLike {
 
   import AskSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
@@ -12,7 +12,7 @@ import akka.japi.pf.{ FI, PFBuilder }
 import java.util.function.{ Function ⇒ F1 }
 
 import akka.Done
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.testkit.typed.scaladsl.{ BehaviorTestKit, TestInbox }
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.Matchers
@@ -342,7 +342,7 @@ object BehaviorSpec {
 
 import BehaviorSpec._
 
-class FullBehaviorSpec extends ActorTestKitWordSpec with Messages with BecomeWithLifecycle with Stoppable {
+class FullBehaviorSpec extends ActorTestKitScalaTestSpec with Messages with BecomeWithLifecycle with Stoppable {
   override def behavior(monitor: ActorRef[Event]): (Behavior[Command], Aux) = mkFull(monitor) → null
 }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
@@ -8,12 +8,10 @@ import akka.testkit.EventFilter
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.scaladsl._
-import scala.util.control.NoStackTrace
 
+import scala.util.control.NoStackTrace
 import akka.actor.ActorInitializationException
-import com.typesafe.config.ConfigFactory
-import org.scalatest.Matchers
-import org.scalatest.WordSpec
+import org.scalatest.{ Matchers, WordSpec, WordSpecLike }
 
 object DeferredSpec {
   sealed trait Command
@@ -31,10 +29,10 @@ object DeferredSpec {
     })
 }
 
-class DeferredSpec extends ActorTestKitWordSpec(
+class DeferredSpec extends ActorTestKitScalaTestSpec(
   """
     akka.loggers = [akka.testkit.TestEventListener]
-    """) {
+    """) with WordSpecLike {
 
   import DeferredSpec._
   implicit val testSettings = TestKitSettings(system)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ExtensionsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ExtensionsSpec.scala
@@ -7,11 +7,12 @@ package akka.actor.typed
 import java.util.concurrent.atomic.AtomicInteger
 
 import com.typesafe.config.{ Config, ConfigFactory }
-import scala.concurrent.Future
 
+import scala.concurrent.Future
 import akka.actor.BootstrapSetup
 import akka.actor.setup.ActorSystemSetup
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 class DummyExtension1 extends Extension
 object DummyExtension1 extends ExtensionId[DummyExtension1] {
@@ -60,7 +61,7 @@ akka.actor.typed {
    """).resolve()
 }
 
-class ExtensionsSpec extends ActorTestKitWordSpec {
+class ExtensionsSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   "The extensions subsystem" must {
     "return the same instance for the same id" in

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/InterceptSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/InterceptSpec.scala
@@ -13,13 +13,13 @@ import org.scalatest.WordSpecLike
 import scala.concurrent.duration._
 
 import akka.actor.ActorInitializationException
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import com.typesafe.config.ConfigFactory
 
-class InterceptSpec extends ActorTestKitWordSpec(
+class InterceptSpec extends ActorTestKitScalaTestSpec(
   """
       akka.loggers = [akka.testkit.TestEventListener]
-    """) {
+    """) with WordSpecLike {
   import BehaviorInterceptor._
 
   // FIXME eventfilter support in typed testkit

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MonitorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MonitorSpec.scala
@@ -4,11 +4,12 @@
 
 package akka.actor.typed
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.scaladsl.Behaviors
+import org.scalatest.WordSpecLike
 
-class MonitorSpec extends ActorTestKitWordSpec {
+class MonitorSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   "The monitor behavior" should {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SpawnProtocolSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SpawnProtocolSpec.scala
@@ -5,13 +5,11 @@
 package akka.actor.typed
 
 import scala.concurrent.duration._
-
 import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.scaladsl._
 import akka.actor.typed.scaladsl.Behaviors
 import akka.util.Timeout
-import org.scalatest.Matchers
-import org.scalatest.WordSpec
+import org.scalatest.{ Matchers, WordSpec, WordSpecLike }
 
 object SpawnProtocolSpec {
   sealed trait Message
@@ -26,7 +24,7 @@ object SpawnProtocolSpec {
     }
 }
 
-class SpawnProtocolSpec extends ActorTestKitWordSpec {
+class SpawnProtocolSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   import SpawnProtocolSpec._
   implicit val testSettings = TestKitSettings(system)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -13,7 +13,7 @@ import akka.actor.typed.scaladsl.Behaviors._
 import akka.testkit.EventFilter
 import akka.actor.testkit.typed.scaladsl._
 import akka.actor.testkit.typed._
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.{ Matchers, WordSpec, WordSpecLike }
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
@@ -242,10 +242,10 @@ class StubbedSupervisionSpec extends WordSpec with Matchers {
   }
 }
 
-class SupervisionSpec extends ActorTestKitWordSpec(
+class SupervisionSpec extends ActorTestKitScalaTestSpec(
   """
     akka.loggers = [akka.testkit.TestEventListener]
-    """) {
+    """) with WordSpecLike {
 
   import SupervisionSpec._
   import BehaviorInterceptor._

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
@@ -10,13 +10,13 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
-
 import akka.actor.testkit.typed.scaladsl._
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.TimerScheduler
 import akka.testkit.TimingTest
+import org.scalatest.WordSpecLike
 
-class TimerSpec extends ActorTestKitWordSpec {
+class TimerSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   sealed trait Command
   case class Tick(n: Int) extends Command

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
@@ -10,12 +10,13 @@ import akka.actor.typed.scaladsl.MutableBehavior
 import akka.actor.typed.scaladsl.adapter._
 import akka.testkit.EventFilter
 import akka.actor.testkit.typed.scaladsl.TestProbe
+
 import scala.concurrent._
 import scala.concurrent.duration._
-
 import akka.actor.testkit.typed.TestException
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import com.typesafe.config.ConfigFactory
+import org.scalatest.WordSpecLike
 
 object WatchSpec {
   val config = ConfigFactory.parseString("""akka.loggers = ["akka.testkit.TestEventListener"]""")
@@ -41,7 +42,7 @@ object WatchSpec {
   case class StartWatchingWith(watchee: ActorRef[Stop.type], msg: CustomTerminationMessage) extends Message
 }
 
-class WatchSpec extends ActorTestKitWordSpec(WatchSpec.config) {
+class WatchSpec extends ActorTestKitScalaTestSpec(WatchSpec.config) with WordSpecLike {
   // FIXME why systemActor? spawn?
   import testKit.systemActor
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WidenSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WidenSpec.scala
@@ -6,11 +6,12 @@ package akka.actor.typed
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.scaladsl.Behaviors
+import org.scalatest.WordSpecLike
 
-class WidenSpec extends ActorTestKitWordSpec {
+class WidenSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   "Widen" should {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorRefSerializationSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorRefSerializationSpec.scala
@@ -8,8 +8,9 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.ActorRef
 import akka.serialization.{ JavaSerializer, SerializationExtension }
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import com.typesafe.config.ConfigFactory
+import org.scalatest.WordSpecLike
 
 object ActorRefSerializationSpec {
   def config = ConfigFactory.parseString(
@@ -25,7 +26,7 @@ object ActorRefSerializationSpec {
   case class MessageWrappingActorRef(s: String, ref: ActorRef[Unit]) extends java.io.Serializable
 }
 
-class ActorRefSerializationSpec extends ActorTestKitWordSpec(ActorRefSerializationSpec.config) {
+class ActorRefSerializationSpec extends ActorTestKitScalaTestSpec(ActorRefSerializationSpec.config) with WordSpecLike {
 
   val serialization = SerializationExtension(system.toUntyped)
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/LocalReceptionistSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/LocalReceptionistSpec.scala
@@ -5,8 +5,7 @@
 package akka.actor.typed.internal.receptionist
 
 import scala.concurrent.Future
-
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.testkit.typed.scaladsl.BehaviorTestKit
 import akka.actor.testkit.typed.scaladsl.TestInbox
 import akka.actor.testkit.typed.scaladsl.TestProbe
@@ -16,8 +15,7 @@ import akka.actor.typed.receptionist.Receptionist._
 import akka.actor.typed.receptionist.ServiceKey
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.scaladsl.Behaviors
-import org.scalatest.Matchers
-import org.scalatest.WordSpec
+import org.scalatest.{ Matchers, WordSpec, WordSpecLike }
 
 object LocalReceptionistSpec {
   trait ServiceA
@@ -38,7 +36,7 @@ object LocalReceptionistSpec {
 
 }
 
-class LocalReceptionistSpec extends ActorTestKitWordSpec {
+class LocalReceptionistSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
   import LocalReceptionistSpec._
 
   abstract class TestSetup {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/ServiceKeySerializationSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/ServiceKeySerializationSpec.scala
@@ -8,9 +8,10 @@ import akka.actor.typed.internal.ActorRefSerializationSpec
 import akka.actor.typed.receptionist.ServiceKey
 import akka.actor.typed.scaladsl.adapter._
 import akka.serialization.SerializationExtension
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
-class ServiceKeySerializationSpec extends ActorTestKitWordSpec(ActorRefSerializationSpec.config) {
+class ServiceKeySerializationSpec extends ActorTestKitScalaTestSpec(ActorRefSerializationSpec.config) with WordSpecLike {
 
   val serialization = SerializationExtension(system.toUntyped)
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
@@ -9,12 +9,13 @@ import akka.actor.typed.{ ActorRef, PostStop, Props }
 import akka.testkit.EventFilter
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import com.typesafe.config.ConfigFactory
+
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success }
-
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 object ActorContextAskSpec {
   val config = ConfigFactory.parseString(
@@ -31,7 +32,7 @@ object ActorContextAskSpec {
     """)
 }
 
-class ActorContextAskSpec extends ActorTestKitWordSpec(ActorContextAskSpec.config) {
+class ActorContextAskSpec extends ActorTestKitScalaTestSpec(ActorContextAskSpec.config) with WordSpecLike {
 
   implicit val untyped = system.toUntyped // FIXME no typed event filter yet
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
@@ -6,18 +6,19 @@ package akka.actor.typed.scaladsl
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.testkit.typed.TestException
 import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.{ Behavior, LogMarker }
 import akka.event.Logging
 import akka.event.Logging.{ LogEventWithCause, LogEventWithMarker }
 import akka.testkit.EventFilter
+import org.scalatest.WordSpecLike
 
-class ActorLoggingSpec extends ActorTestKitWordSpec("""
+class ActorLoggingSpec extends ActorTestKitScalaTestSpec("""
     akka.loglevel = DEBUG # test verifies debug
     akka.loggers = ["akka.testkit.TestEventListener"]
-    """) {
+    """) with WordSpecLike {
 
   val marker = LogMarker("marker")
   val cause = new TestException("böö")

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/GracefulStopSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/GracefulStopSpec.scala
@@ -7,10 +7,11 @@ package scaladsl
 
 import akka.Done
 import akka.NotUsed
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import org.scalatest.WordSpecLike
 
-final class GracefulStopSpec extends ActorTestKitWordSpec {
+final class GracefulStopSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   "Graceful stop" must {
 
@@ -19,13 +20,13 @@ final class GracefulStopSpec extends ActorTestKitWordSpec {
 
       val behavior =
         Behaviors.setup[akka.NotUsed] { context ⇒
-          val c1 = context.spawn[NotUsed](Behaviors.receiveSignal {
+          context.spawn[NotUsed](Behaviors.receiveSignal {
             case (_, PostStop) ⇒
               probe.ref ! "child-done"
               Behaviors.stopped
           }, "child1")
 
-          val c2 = context.spawn[NotUsed](Behaviors.receiveSignal {
+          context.spawn[NotUsed](Behaviors.receiveSignal {
             case (_, PostStop) ⇒
               probe.ref ! "child-done"
               Behaviors.stopped
@@ -33,7 +34,7 @@ final class GracefulStopSpec extends ActorTestKitWordSpec {
 
           Behaviors.stopped {
             Behaviors.receiveSignal {
-              case (ctx, PostStop) ⇒
+              case (_, PostStop) ⇒
                 // cleanup function body
                 probe.ref ! "parent-done"
                 Behaviors.same
@@ -51,11 +52,11 @@ final class GracefulStopSpec extends ActorTestKitWordSpec {
       val probe = TestProbe[Done]("probe")
 
       val behavior =
-        Behaviors.setup[akka.NotUsed] { context ⇒
+        Behaviors.setup[akka.NotUsed] { _ ⇒
           // do not spawn any children
           Behaviors.stopped {
             Behaviors.receiveSignal {
-              case (ctx, PostStop) ⇒
+              case (_, PostStop) ⇒
                 // cleanup function body
                 probe.ref ! Done
                 Behaviors.same

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.actor.typed.scaladsl
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.testkit.typed.TestException
 import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.ActorRef
@@ -14,6 +14,7 @@ import akka.actor.typed.Props
 import akka.testkit.EventFilter
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import com.typesafe.config.ConfigFactory
+import org.scalatest.WordSpecLike
 
 object MessageAdapterSpec {
   val config = ConfigFactory.parseString(
@@ -31,7 +32,7 @@ object MessageAdapterSpec {
     """)
 }
 
-class MessageAdapterSpec extends ActorTestKitWordSpec(MessageAdapterSpec.config) {
+class MessageAdapterSpec extends ActorTestKitScalaTestSpec(MessageAdapterSpec.config) with WordSpecLike {
 
   implicit val untyped = system.toUntyped // FIXME no typed event filter yet
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/OnSignalSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/OnSignalSpec.scala
@@ -6,10 +6,11 @@ package akka.actor.typed
 package scaladsl
 
 import akka.Done
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import org.scalatest.WordSpecLike
 
-final class OnSignalSpec extends ActorTestKitWordSpec {
+final class OnSignalSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   "An Actor.OnSignal behavior" must {
     "must correctly install the signal handler" in {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ReceivePartialSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ReceivePartialSpec.scala
@@ -5,13 +5,17 @@
 package akka.actor.typed
 package scaladsl
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import org.scalatest.WordSpecLike
 
-class ReceivePartialSpec extends ActorTestKitWordSpec {
+import scala.concurrent.duration._
+
+class ReceivePartialSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
+
+  implicit val ec = system.executionContext
 
   "An immutable partial" must {
-
     "correctly install the receiveMessage handler" in {
       val probe = TestProbe[Command]("probe")
       val behavior =

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashSpec.scala
@@ -5,8 +5,9 @@
 package akka.actor.typed
 package scaladsl
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import org.scalatest.WordSpecLike
 
 object StashSpec {
   sealed trait Command
@@ -187,7 +188,7 @@ class MutableStashSpec extends StashSpec {
   def behaviorUnderTest: Behavior[Command] = Behaviors.setup(ctx ⇒ new MutableStash(ctx))
 }
 
-abstract class StashSpec extends ActorTestKitWordSpec {
+abstract class StashSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
   import StashSpec._
 
   def testQualifier: String

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StopSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StopSpec.scala
@@ -5,17 +5,17 @@
 package akka.actor.typed.scaladsl
 
 import scala.concurrent.Promise
-
 import akka.Done
 import akka.actor.testkit.typed.TE
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.typed
 import akka.actor.typed.Behavior
 import akka.actor.typed.BehaviorInterceptor
 import akka.actor.typed.PostStop
 import akka.actor.typed.Signal
+import org.scalatest.WordSpecLike
 
-class StopSpec extends ActorTestKitWordSpec {
+class StopSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
   import BehaviorInterceptor._
 
   "Stopping an actor" should {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/DispatchersDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/DispatchersDocSpec.scala
@@ -11,8 +11,9 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ ActorRef, Behavior, DispatcherSelector, Props, SpawnProtocol }
 import akka.dispatch.Dispatcher
 import DispatchersDocSpec._
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import com.typesafe.config.ConfigFactory
+import org.scalatest.WordSpecLike
 
 object DispatchersDocSpec {
 
@@ -55,7 +56,7 @@ object DispatchersDocSpec {
 
 }
 
-class DispatchersDocSpec extends ActorTestKitWordSpec(DispatchersDocSpec.config) {
+class DispatchersDocSpec extends ActorTestKitScalaTestSpec(DispatchersDocSpec.config) with WordSpecLike {
 
   "Actor Dispatchers" should {
     "support default and blocking dispatcher" in {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/FSMDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/FSMDocSpec.scala
@@ -7,10 +7,11 @@ package docs.akka.typed
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ ActorRef, Behavior }
+
 import scala.collection.immutable
 import scala.concurrent.duration._
-
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 object FSMDocSpec {
 
@@ -66,7 +67,7 @@ object FSMDocSpec {
   //#test-code
 }
 
-class FSMDocSpec extends ActorTestKitWordSpec {
+class FSMDocSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   import FSMDocSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/FaultToleranceDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/FaultToleranceDocSpec.scala
@@ -6,13 +6,14 @@ package docs.akka.typed
 
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ DeathPactException, SupervisorStrategy }
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
-class FaultToleranceDocSpec extends ActorTestKitWordSpec(
+class FaultToleranceDocSpec extends ActorTestKitScalaTestSpec(
   """
       # silenced to not put noise in test logs
       akka.loglevel = OFF
-    """) {
+    """) with WordSpecLike {
 
   "Bubbling of failures" must {
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/GracefulStopDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/GracefulStopDocSpec.scala
@@ -7,12 +7,14 @@ package docs.akka.typed
 //#imports
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ ActorSystem, Logger, PostStop }
+import org.scalatest.WordSpecLike
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
 //#imports
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
 object GracefulStopDocSpec {
 
@@ -67,7 +69,7 @@ object GracefulStopDocSpec {
 
 }
 
-class GracefulStopDocSpec extends ActorTestKitWordSpec {
+class GracefulStopDocSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   import GracefulStopDocSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
@@ -11,13 +11,14 @@ import akka.actor.typed.{ ActorRef, ActorSystem, Behavior }
 import akka.actor.typed.scaladsl.{ Behaviors, TimerScheduler }
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.util.Timeout
+
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
-
-class InteractionPatternsSpec extends ActorTestKitWordSpec {
+class InteractionPatternsSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   "The interaction patterns docs" must {
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
@@ -8,10 +8,11 @@ package docs.akka.typed
 import akka.NotUsed
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, DispatcherSelector, Terminated }
+import org.scalatest.WordSpecLike
 //#imports
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import scala.concurrent.Await
@@ -154,7 +155,7 @@ object IntroSpec {
 
 }
 
-class IntroSpec extends ActorTestKitWordSpec {
+class IntroSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   import IntroSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/MutableIntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/MutableIntroSpec.scala
@@ -10,10 +10,11 @@ import java.nio.charset.StandardCharsets
 
 import akka.actor.typed._
 import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, MutableBehavior }
+
 import scala.concurrent.duration._
 import scala.concurrent.Await
-
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 //#imports
 
 object MutableIntroSpec {
@@ -86,7 +87,7 @@ object MutableIntroSpec {
 
 }
 
-class MutableIntroSpec extends ActorTestKitWordSpec {
+class MutableIntroSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   import MutableIntroSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
@@ -7,10 +7,10 @@ package docs.akka.typed
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
-
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import docs.akka.typed.IntroSpec.HelloWorld
+import org.scalatest.WordSpecLike
 
 //#imports1
 import akka.actor.typed.Behavior
@@ -43,7 +43,7 @@ object SpawnProtocolDocSpec {
   //#main
 }
 
-class SpawnProtocolDocSpec extends ActorTestKitWordSpec {
+class SpawnProtocolDocSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   import SpawnProtocolDocSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala
@@ -91,6 +91,7 @@ class UntypedWatchingTypedSpec extends WordSpec {
       val system = akka.actor.ActorSystem("UntypedToTypedSystem")
       val typedSystem: ActorSystem[Nothing] = system.toTyped
       //#convert-untyped
+      typedSystem.scheduler // remove compile warning
       TestKit.shutdownActorSystem(system)
     }
   }

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -835,6 +835,7 @@ private[akka] class ActorSystemImpl(
           "Please report at https://github.com/akka/akka/issues."
       )
   private lazy val _start: this.type = try {
+
     registerOnTermination(stopScheduler())
     // the provider is expected to start default loggers, LocalActorRefProvider does this
     provider.init(this)
@@ -968,9 +969,6 @@ private[akka] class ActorSystemImpl(
         }
       }
     }
-
-    // eager initialization of CoordinatedShutdown
-    CoordinatedShutdown(this)
 
     loadExtensions("akka.library-extensions", throwOnLoadFail = true)
     loadExtensions("akka.extensions", throwOnLoadFail = false)

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ShardingSerializerSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ShardingSerializerSpec.scala
@@ -9,7 +9,7 @@ import akka.cluster.sharding.typed.internal.ShardingSerializer
 import akka.serialization.SerializationExtension
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
-class ShardingSerializerSpec extends ActorTestKitScalaTestSpec with WordSpecLike{
+class ShardingSerializerSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   "The typed ShardingSerializer" must {
 

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ShardingSerializerSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ShardingSerializerSpec.scala
@@ -7,9 +7,9 @@ package akka.cluster.sharding.typed
 import akka.actor.typed.internal.adapter.ActorSystemAdapter
 import akka.cluster.sharding.typed.internal.ShardingSerializer
 import akka.serialization.SerializationExtension
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
-class ShardingSerializerSpec extends ActorTestKitWordSpec {
+class ShardingSerializerSpec extends ActorTestKitScalaTestSpec with WordSpecLike{
 
   "The typed ShardingSerializer" must {
 

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ShardingSerializerSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ShardingSerializerSpec.scala
@@ -8,6 +8,7 @@ import akka.actor.typed.internal.adapter.ActorSystemAdapter
 import akka.cluster.sharding.typed.internal.ShardingSerializer
 import akka.serialization.SerializationExtension
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 class ShardingSerializerSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
@@ -14,6 +14,7 @@ import akka.cluster.typed.Join
 import akka.persistence.typed.scaladsl.{ Effect, PersistentBehaviors }
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import com.typesafe.config.ConfigFactory
+import org.scalatest.{ WordSpec, WordSpecLike }
 
 object ClusterShardingPersistenceSpec {
   val config = ConfigFactory.parseString(
@@ -59,7 +60,7 @@ object ClusterShardingPersistenceSpec {
 
 }
 
-class ClusterShardingPersistenceSpec extends ActorTestKitScalaTestSpec(ClusterShardingPersistenceSpec.config) {
+class ClusterShardingPersistenceSpec extends ActorTestKitScalaTestSpec(ClusterShardingPersistenceSpec.config) with WordSpecLike {
   import ClusterShardingPersistenceSpec._
 
   val sharding = ClusterSharding(system)

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.cluster.sharding.typed.scaladsl
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
 import akka.actor.typed.Props
@@ -59,7 +59,7 @@ object ClusterShardingPersistenceSpec {
 
 }
 
-class ClusterShardingPersistenceSpec extends ActorTestKitWordSpec(ClusterShardingPersistenceSpec.config) {
+class ClusterShardingPersistenceSpec extends ActorTestKitScalaTestSpec(ClusterShardingPersistenceSpec.config) {
   import ClusterShardingPersistenceSpec._
 
   val sharding = ClusterSharding(system)

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -7,7 +7,6 @@ package akka.cluster.sharding.typed.scaladsl
 import java.nio.charset.StandardCharsets
 
 import scala.concurrent.duration._
-
 import akka.actor.ExtendedActorSystem
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
@@ -26,6 +25,7 @@ import akka.serialization.SerializerWithStringManifest
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
+import org.scalatest.WordSpecLike
 import org.scalatest.time.Span
 
 object ClusterShardingSpec {
@@ -121,7 +121,7 @@ object ClusterShardingSpec {
 
 }
 
-class ClusterShardingSpec extends ActorTestKitScalaTestSpec(ClusterShardingSpec.config) {
+class ClusterShardingSpec extends ActorTestKitScalaTestSpec(ClusterShardingSpec.config) with WordSpecLike {
   import ClusterShardingSpec._
 
   val sharding = ClusterSharding(system)

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 
 import akka.actor.ExtendedActorSystem
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorRefResolver
 import akka.actor.typed.ActorSystem
@@ -121,7 +121,7 @@ object ClusterShardingSpec {
 
 }
 
-class ClusterShardingSpec extends ActorTestKitWordSpec(ClusterShardingSpec.config) {
+class ClusterShardingSpec extends ActorTestKitScalaTestSpec(ClusterShardingSpec.config) {
   import ClusterShardingSpec._
 
   val sharding = ClusterSharding(system)

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerStartupSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerStartupSpec.scala
@@ -5,27 +5,18 @@
 package akka.cluster.singleton
 
 import language.postfixOps
-import scala.collection.immutable
 import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 import akka.actor.Actor
-import akka.actor.ActorLogging
 import akka.actor.ActorRef
-import akka.actor.Address
 import akka.actor.Props
 import akka.actor.PoisonPill
-import akka.actor.RootActorPath
 import akka.cluster.Cluster
-import akka.cluster.ClusterEvent._
-import akka.cluster.Member
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
 import akka.remote.testkit.MultiNodeSpec
 import akka.remote.testkit.STMultiNodeSpec
 import akka.testkit._
-import akka.testkit.TestEvent._
-import akka.actor.Terminated
-import akka.actor.ActorSelection
 import akka.cluster.MemberStatus
 
 object ClusterSingletonManagerStartupSpec extends MultiNodeConfig {

--- a/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
@@ -16,6 +16,7 @@ import akka.actor.testkit.typed.scaladsl._
 import akka.actor.testkit.typed.TestKitSettings
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
+import org.scalatest.WordSpecLike
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -115,7 +116,7 @@ object ReplicatorSpec {
 
 }
 
-class ReplicatorSpec extends ActorTestKitScalaTestSpec(ReplicatorSpec.config) {
+class ReplicatorSpec extends ActorTestKitScalaTestSpec(ReplicatorSpec.config) with WordSpecLike {
 
   import ReplicatorSpec._
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
@@ -115,7 +115,7 @@ object ReplicatorSpec {
 
 }
 
-class ReplicatorSpec extends ActorTestKitWordSpec(ReplicatorSpec.config) {
+class ReplicatorSpec extends ActorTestKitScalaTestSpec(ReplicatorSpec.config) {
 
   import ReplicatorSpec._
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
@@ -11,7 +11,7 @@ import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import com.typesafe.config.ConfigFactory
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
 object ClusterApiSpec {
   val config = ConfigFactory.parseString(
@@ -34,7 +34,7 @@ object ClusterApiSpec {
     """)
 }
 
-class ClusterApiSpec extends ActorTestKitWordSpec(ClusterApiSpec.config) {
+class ClusterApiSpec extends ActorTestKitScalaTestSpec(ClusterApiSpec.config) {
 
   val testSettings = TestKitSettings(system)
   val clusterNode1 = Cluster(system)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
@@ -12,6 +12,7 @@ import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import com.typesafe.config.ConfigFactory
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 object ClusterApiSpec {
   val config = ConfigFactory.parseString(
@@ -34,7 +35,7 @@ object ClusterApiSpec {
     """)
 }
 
-class ClusterApiSpec extends ActorTestKitScalaTestSpec(ClusterApiSpec.config) {
+class ClusterApiSpec extends ActorTestKitScalaTestSpec(ClusterApiSpec.config) with WordSpecLike {
 
   val testSettings = TestKitSettings(system)
   val clusterNode1 = Cluster(system)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
@@ -17,7 +17,7 @@ import com.typesafe.config.ConfigFactory
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
 object ClusterSingletonApiSpec {
 
@@ -88,7 +88,7 @@ object ClusterSingletonApiSpec {
   }
 }
 
-class ClusterSingletonApiSpec extends ActorTestKitWordSpec(ClusterSingletonApiSpec.config) {
+class ClusterSingletonApiSpec extends ActorTestKitScalaTestSpec(ClusterSingletonApiSpec.config) {
   import ClusterSingletonApiSpec._
 
   implicit val testSettings = TestKitSettings(system)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
@@ -14,10 +14,11 @@ import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.{ ActorRef, ActorRefResolver, Props }
 import akka.serialization.SerializerWithStringManifest
 import com.typesafe.config.ConfigFactory
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
-
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 object ClusterSingletonApiSpec {
 
@@ -88,7 +89,7 @@ object ClusterSingletonApiSpec {
   }
 }
 
-class ClusterSingletonApiSpec extends ActorTestKitScalaTestSpec(ClusterSingletonApiSpec.config) {
+class ClusterSingletonApiSpec extends ActorTestKitScalaTestSpec(ClusterSingletonApiSpec.config) with WordSpecLike {
   import ClusterSingletonApiSpec._
 
   implicit val testSettings = TestKitSettings(system)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.cluster.typed
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.typed.{ ActorRef, Behavior, Props }
 import akka.persistence.typed.scaladsl.{ Effect, PersistentBehaviors }
 import akka.actor.testkit.typed.scaladsl.TestProbe
@@ -49,7 +49,7 @@ object ClusterSingletonPersistenceSpec {
 
 }
 
-class ClusterSingletonPersistenceSpec extends ActorTestKitWordSpec(ClusterSingletonPersistenceSpec.config) {
+class ClusterSingletonPersistenceSpec extends ActorTestKitScalaTestSpec(ClusterSingletonPersistenceSpec.config) {
   import ClusterSingletonPersistenceSpec._
   import akka.actor.typed.scaladsl.adapter._
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
@@ -9,6 +9,7 @@ import akka.actor.typed.{ ActorRef, Behavior, Props }
 import akka.persistence.typed.scaladsl.{ Effect, PersistentBehaviors }
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import com.typesafe.config.ConfigFactory
+import org.scalatest.WordSpecLike
 
 object ClusterSingletonPersistenceSpec {
   val config = ConfigFactory.parseString(
@@ -49,7 +50,7 @@ object ClusterSingletonPersistenceSpec {
 
 }
 
-class ClusterSingletonPersistenceSpec extends ActorTestKitScalaTestSpec(ClusterSingletonPersistenceSpec.config) {
+class ClusterSingletonPersistenceSpec extends ActorTestKitScalaTestSpec(ClusterSingletonPersistenceSpec.config) with WordSpecLike {
   import ClusterSingletonPersistenceSpec._
   import akka.actor.typed.scaladsl.adapter._
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
@@ -19,7 +19,7 @@ import com.typesafe.config.ConfigFactory
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
 class RemoteContextAskSpecSerializer(system: ExtendedActorSystem) extends SerializerWithStringManifest {
   override def identifier = 41
@@ -83,7 +83,7 @@ object RemoteContextAskSpec {
 
 }
 
-class RemoteContextAskSpec extends ActorTestKitWordSpec(RemoteContextAskSpec.config) {
+class RemoteContextAskSpec extends ActorTestKitScalaTestSpec(RemoteContextAskSpec.config) {
 
   import RemoteContextAskSpec._
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
@@ -16,10 +16,11 @@ import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.scaladsl.adapter._
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
+
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
-
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 class RemoteContextAskSpecSerializer(system: ExtendedActorSystem) extends SerializerWithStringManifest {
   override def identifier = 41
@@ -83,7 +84,7 @@ object RemoteContextAskSpec {
 
 }
 
-class RemoteContextAskSpec extends ActorTestKitScalaTestSpec(RemoteContextAskSpec.config) {
+class RemoteContextAskSpec extends ActorTestKitScalaTestSpec(RemoteContextAskSpec.config) with WordSpecLike {
 
   import RemoteContextAskSpec._
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteDeployNotAllowedSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteDeployNotAllowedSpec.scala
@@ -11,7 +11,7 @@ import com.typesafe.config.ConfigFactory
 import scala.concurrent.duration._
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
 object RemoteDeployNotAllowedSpec {
   def config = ConfigFactory.parseString(
@@ -44,7 +44,7 @@ object RemoteDeployNotAllowedSpec {
     """).withFallback(config)
 }
 
-class RemoteDeployNotAllowedSpec extends ActorTestKitWordSpec(RemoteDeployNotAllowedSpec.config) {
+class RemoteDeployNotAllowedSpec extends ActorTestKitScalaTestSpec(RemoteDeployNotAllowedSpec.config) {
 
   "Typed cluster" must {
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteDeployNotAllowedSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteDeployNotAllowedSpec.scala
@@ -8,10 +8,11 @@ import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import com.typesafe.config.ConfigFactory
-import scala.concurrent.duration._
 
+import scala.concurrent.duration._
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.{ WordSpec, WordSpecLike }
 
 object RemoteDeployNotAllowedSpec {
   def config = ConfigFactory.parseString(
@@ -44,7 +45,7 @@ object RemoteDeployNotAllowedSpec {
     """).withFallback(config)
 }
 
-class RemoteDeployNotAllowedSpec extends ActorTestKitScalaTestSpec(RemoteDeployNotAllowedSpec.config) {
+class RemoteDeployNotAllowedSpec extends ActorTestKitScalaTestSpec(RemoteDeployNotAllowedSpec.config) with WordSpecLike {
 
   "Typed cluster" must {
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializerSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializerSpec.scala
@@ -11,7 +11,7 @@ import akka.cluster.typed.internal.receptionist.ClusterReceptionist
 import akka.serialization.SerializationExtension
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
-class AkkaClusterTypedSerializerSpec extends ActorTestKitScalaTestSpec with WordSpecLike{
+class AkkaClusterTypedSerializerSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   val ref = spawn(Behavior.empty[String])
   val untypedSystem = system.toUntyped

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializerSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializerSpec.scala
@@ -9,9 +9,9 @@ import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.Behavior
 import akka.cluster.typed.internal.receptionist.ClusterReceptionist
 import akka.serialization.SerializationExtension
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
-class AkkaClusterTypedSerializerSpec extends ActorTestKitWordSpec {
+class AkkaClusterTypedSerializerSpec extends ActorTestKitScalaTestSpec with WordSpecLike{
 
   val ref = spawn(Behavior.empty[String])
   val untypedSystem = system.toUntyped

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializerSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializerSpec.scala
@@ -10,6 +10,7 @@ import akka.actor.typed.Behavior
 import akka.cluster.typed.internal.receptionist.ClusterReceptionist
 import akka.serialization.SerializationExtension
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 class AkkaClusterTypedSerializerSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
@@ -10,10 +10,11 @@ import akka.persistence.typed.scaladsl.PersistentBehaviors.CommandHandler
 import akka.persistence.typed.scaladsl.{ Effect, PersistentBehavior, PersistentBehaviors }
 import akka.testkit.TestLatch
 import akka.actor.testkit.typed.scaladsl.TestProbe
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
-
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 object ManyRecoveriesSpec {
 
@@ -58,7 +59,7 @@ class ManyRecoveriesSpec extends ActorTestKitScalaTestSpec(s"""
     akka.persistence.max-concurrent-recoveries = 3
     akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
     akka.actor.warn-about-java-serializer-usage = off
-    """) {
+    """) with WordSpecLike {
 
   import ManyRecoveriesSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
@@ -13,7 +13,7 @@ import akka.actor.testkit.typed.scaladsl.TestProbe
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
 object ManyRecoveriesSpec {
 
@@ -47,7 +47,7 @@ object ManyRecoveriesSpec {
     (1 to n).map(mapper).toSet
 }
 
-class ManyRecoveriesSpec extends ActorTestKitWordSpec(s"""
+class ManyRecoveriesSpec extends ActorTestKitScalaTestSpec(s"""
     akka.actor.default-dispatcher {
       type = Dispatcher
       executor = "thread-pool-executor"

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/EventsourcedStashReferenceManagementTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/EventsourcedStashReferenceManagementTest.scala
@@ -10,9 +10,9 @@ import akka.persistence.typed.internal.EventsourcedBehavior.InternalProtocol
 import akka.persistence.typed.internal.EventsourcedBehavior.InternalProtocol.{ IncomingCommand, RecoveryPermitGranted }
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import scala.concurrent.duration._
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
-class EventsourcedStashReferenceManagementTest extends ActorTestKitWordSpec {
+class EventsourcedStashReferenceManagementTest extends ActorTestKitScalaTestSpec with WordSpecLike{
 
   case class Impl() extends EventsourcedStashReferenceManagement
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/EventsourcedStashReferenceManagementTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/EventsourcedStashReferenceManagementTest.scala
@@ -9,8 +9,10 @@ import akka.actor.typed.{ Behavior, Signal }
 import akka.persistence.typed.internal.EventsourcedBehavior.InternalProtocol
 import akka.persistence.typed.internal.EventsourcedBehavior.InternalProtocol.{ IncomingCommand, RecoveryPermitGranted }
 import akka.actor.testkit.typed.scaladsl.TestProbe
+
 import scala.concurrent.duration._
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 class EventsourcedStashReferenceManagementTest extends ActorTestKitScalaTestSpec with WordSpecLike {
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/EventsourcedStashReferenceManagementTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/EventsourcedStashReferenceManagementTest.scala
@@ -12,7 +12,7 @@ import akka.actor.testkit.typed.scaladsl.TestProbe
 import scala.concurrent.duration._
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
-class EventsourcedStashReferenceManagementTest extends ActorTestKitScalaTestSpec with WordSpecLike{
+class EventsourcedStashReferenceManagementTest extends ActorTestKitScalaTestSpec with WordSpecLike {
 
   case class Impl() extends EventsourcedStashReferenceManagement
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
@@ -14,10 +14,11 @@ import akka.persistence.RecoveryPermitter.{ RecoveryPermitGranted, RequestRecove
 import akka.persistence.typed.scaladsl.PersistentBehaviors.CommandHandler
 import akka.persistence.typed.scaladsl.{ Effect, PersistentBehaviors }
 import akka.testkit.EventFilter
+
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
-
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 object RecoveryPermitterSpec {
 
@@ -67,7 +68,7 @@ class RecoveryPermitterSpec extends ActorTestKitScalaTestSpec(s"""
       akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
       akka.actor.warn-about-java-serializer-usage = off
       akka.loggers = ["akka.testkit.TestEventListener"]
-      """) {
+      """) with WordSpecLike {
 
   import RecoveryPermitterSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
@@ -17,7 +17,7 @@ import akka.testkit.EventFilter
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
 object RecoveryPermitterSpec {
 
@@ -62,7 +62,7 @@ object RecoveryPermitterSpec {
     }
 }
 
-class RecoveryPermitterSpec extends ActorTestKitWordSpec(s"""
+class RecoveryPermitterSpec extends ActorTestKitScalaTestSpec(s"""
       akka.persistence.max-concurrent-recoveries = 3
       akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
       akka.actor.warn-about-java-serializer-usage = off

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
@@ -11,6 +11,7 @@ import akka.actor.typed.scaladsl.adapter.{ TypedActorRefOps, TypedActorSystemOps
 import akka.event.Logging
 import akka.persistence.typed.scaladsl.PersistentBehaviors.CommandHandler
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import org.scalatest.WordSpecLike
 
 object OptionalSnapshotStoreSpec {
 
@@ -50,7 +51,7 @@ class OptionalSnapshotStoreSpec extends ActorTestKitScalaTestSpec(s"""
 
     # snapshot store plugin is NOT defined, things should still work
     akka.persistence.snapshot-store.local.dir = "target/snapshots-${classOf[OptionalSnapshotStoreSpec].getName}/"
-    """) {
+    """) with WordSpecLike {
 
   import OptionalSnapshotStoreSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
@@ -6,7 +6,7 @@ package akka.persistence.typed.scaladsl
 
 import java.util.UUID
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 import akka.actor.typed.scaladsl.adapter.{ TypedActorRefOps, TypedActorSystemOps }
 import akka.event.Logging
 import akka.persistence.typed.scaladsl.PersistentBehaviors.CommandHandler
@@ -41,7 +41,7 @@ object OptionalSnapshotStoreSpec {
 
 }
 
-class OptionalSnapshotStoreSpec extends ActorTestKitWordSpec(s"""
+class OptionalSnapshotStoreSpec extends ActorTestKitScalaTestSpec(s"""
     akka.persistence.publish-plugin-commands = on
     akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
     akka.persistence.journal.leveldb.dir = "target/journal-${classOf[OptionalSnapshotStoreSpec].getName}"

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
@@ -12,9 +12,10 @@ import akka.persistence.typed.scaladsl.PersistentBehaviors.CommandHandler
 import akka.actor.testkit.typed.TE
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import com.typesafe.config.ConfigFactory
-import scala.concurrent.duration._
 
+import scala.concurrent.duration._
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 object PerformanceSpec {
 
@@ -99,7 +100,7 @@ class PerformanceSpec extends ActorTestKitScalaTestSpec(ConfigFactory.parseStrin
       akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
       akka.persistence.snapshot-store.local.dir = "target/snapshots-PerformanceSpec/"
       akka.test.single-expect-default = 10s
-      """).withFallback(ConfigFactory.parseString(PerformanceSpec.config))) {
+      """).withFallback(ConfigFactory.parseString(PerformanceSpec.config))) with WordSpecLike {
 
   import PerformanceSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
@@ -14,7 +14,7 @@ import akka.actor.testkit.typed.scaladsl.TestProbe
 import com.typesafe.config.ConfigFactory
 import scala.concurrent.duration._
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
 object PerformanceSpec {
 
@@ -89,7 +89,7 @@ object PerformanceSpec {
     }
 }
 
-class PerformanceSpec extends ActorTestKitWordSpec(ConfigFactory.parseString(s"""
+class PerformanceSpec extends ActorTestKitScalaTestSpec(ConfigFactory.parseString(s"""
       akka.actor.serialize-creators = off
       akka.actor.serialize-messages = off
       akka.actor.warn-about-java-serializer-usage = off

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorFailureSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorFailureSpec.scala
@@ -61,7 +61,7 @@ object PersistentBehaviorFailureSpec {
     """).withFallback(ConfigFactory.load("reference.conf")).resolve()
 }
 
-class PersistentBehaviorFailureSpec extends ActorTestKitWordSpec(PersistentBehaviorFailureSpec.conf) {
+class PersistentBehaviorFailureSpec extends ActorTestKitScalaTestSpec(PersistentBehaviorFailureSpec.conf) {
 
   import PersistentBehaviorSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorFailureSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorFailureSpec.scala
@@ -13,6 +13,7 @@ import akka.persistence.AtomicWrite
 import akka.persistence.journal.inmem.InmemJournal
 import akka.persistence.typed.EventRejectedException
 import com.typesafe.config.ConfigFactory
+import org.scalatest.WordSpecLike
 
 import scala.collection.immutable
 import scala.concurrent.Future
@@ -61,15 +62,13 @@ object PersistentBehaviorFailureSpec {
     """).withFallback(ConfigFactory.load("reference.conf")).resolve()
 }
 
-class PersistentBehaviorFailureSpec extends ActorTestKitScalaTestSpec(PersistentBehaviorFailureSpec.conf) {
-
-  import PersistentBehaviorSpec._
+class PersistentBehaviorFailureSpec extends ActorTestKitScalaTestSpec(PersistentBehaviorFailureSpec.conf) with WordSpecLike {
 
   implicit val testSettings = TestKitSettings(system)
 
   def failingPersistentActor(pid: String, probe: ActorRef[String]): Behavior[String] = PersistentBehaviors.receive[String, String, String](
     pid, "",
-    (ctx, state, cmd) ⇒ {
+    (_, _, cmd) ⇒ {
       probe.tell("persisting")
       Effect.persist(cmd)
     },

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorSpec.scala
@@ -20,11 +20,13 @@ import akka.stream.scaladsl.Sink
 import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.scaladsl._
 import com.typesafe.config.{ Config, ConfigFactory }
+
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.{ Success, Try }
 import akka.persistence.journal.inmem.InmemJournal
+import org.scalatest.WordSpecLike
 
 object PersistentBehaviorSpec {
 
@@ -211,7 +213,7 @@ object PersistentBehaviorSpec {
 
 }
 
-class PersistentBehaviorSpec extends ActorTestKitScalaTestSpec(PersistentBehaviorSpec.conf) {
+class PersistentBehaviorSpec extends ActorTestKitScalaTestSpec(PersistentBehaviorSpec.conf) with WordSpecLike {
 
   import PersistentBehaviorSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentBehaviorSpec.scala
@@ -211,7 +211,7 @@ object PersistentBehaviorSpec {
 
 }
 
-class PersistentBehaviorSpec extends ActorTestKitWordSpec(PersistentBehaviorSpec.conf) {
+class PersistentBehaviorSpec extends ActorTestKitScalaTestSpec(PersistentBehaviorSpec.conf) {
 
   import PersistentBehaviorSpec._
 

--- a/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorFlowSpec.scala
+++ b/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorFlowSpec.scala
@@ -11,7 +11,7 @@ import akka.actor.typed.ActorRef
 import akka.actor.typed.scaladsl.Behaviors
 import scala.concurrent.duration._
 
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
 //#imports
 import akka.actor.typed.DispatcherSelector
@@ -25,7 +25,7 @@ object ActorFlowSpec {
   final case class Reply(s: String)
 }
 
-class ActorFlowSpec extends ActorTestKitWordSpec {
+class ActorFlowSpec extends ActorTestKitScalaTestSpec with WordSpecLike{
   import ActorFlowSpec._
 
   implicit val mat = ActorMaterializer()

--- a/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorFlowSpec.scala
+++ b/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorFlowSpec.scala
@@ -9,9 +9,10 @@ import akka.stream.typed.scaladsl.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.actor.typed.ActorRef
 import akka.actor.typed.scaladsl.Behaviors
-import scala.concurrent.duration._
 
+import scala.concurrent.duration._
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 //#imports
 import akka.actor.typed.DispatcherSelector

--- a/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorFlowSpec.scala
+++ b/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorFlowSpec.scala
@@ -25,7 +25,7 @@ object ActorFlowSpec {
   final case class Reply(s: String)
 }
 
-class ActorFlowSpec extends ActorTestKitScalaTestSpec with WordSpecLike{
+class ActorFlowSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
   import ActorFlowSpec._
 
   implicit val mat = ActorMaterializer()

--- a/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorSourceSinkSpec.scala
+++ b/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorSourceSinkSpec.scala
@@ -11,6 +11,7 @@ import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.actor.testkit.typed.scaladsl._
+import org.scalatest.WordSpecLike
 
 object ActorSourceSinkSpec {
 

--- a/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorSourceSinkSpec.scala
+++ b/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorSourceSinkSpec.scala
@@ -21,7 +21,7 @@ object ActorSourceSinkSpec {
   case object Failed extends AckProto
 }
 
-class ActorSourceSinkSpec extends ActorTestKitScalaTestSpec with WordSpecLike{
+class ActorSourceSinkSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
   import ActorSourceSinkSpec._
 
   implicit val mat = ActorMaterializer()

--- a/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorSourceSinkSpec.scala
+++ b/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorSourceSinkSpec.scala
@@ -21,7 +21,7 @@ object ActorSourceSinkSpec {
   case object Failed extends AckProto
 }
 
-class ActorSourceSinkSpec extends ActorTestKitWordSpec {
+class ActorSourceSinkSpec extends ActorTestKitScalaTestSpec with WordSpecLike{
   import ActorSourceSinkSpec._
 
   implicit val mat = ActorMaterializer()

--- a/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/CustomGuardianAndMaterializerSpec.scala
+++ b/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/CustomGuardianAndMaterializerSpec.scala
@@ -5,12 +5,12 @@
 package akka.stream.typed.scaladsl
 
 import scala.concurrent.Future
-
 import akka.actor.typed.ActorRef
 import akka.actor.typed.scaladsl.Behaviors
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
+import org.scalatest.WordSpecLike
 
 object CustomGuardianAndMaterializerSpec {
 

--- a/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/CustomGuardianAndMaterializerSpec.scala
+++ b/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/CustomGuardianAndMaterializerSpec.scala
@@ -21,7 +21,7 @@ object CustomGuardianAndMaterializerSpec {
   case object Failed extends GuardianProtocol
 }
 
-class CustomGuardianAndMaterializerSpec extends ActorTestKitScalaTestSpec with WordSpecLike{
+class CustomGuardianAndMaterializerSpec extends ActorTestKitScalaTestSpec with WordSpecLike {
   import CustomGuardianAndMaterializerSpec._
 
   val guardian = Behaviors.receive[GuardianProtocol] {

--- a/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/CustomGuardianAndMaterializerSpec.scala
+++ b/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/CustomGuardianAndMaterializerSpec.scala
@@ -10,7 +10,7 @@ import akka.actor.typed.ActorRef
 import akka.actor.typed.scaladsl.Behaviors
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
-import akka.actor.testkit.typed.scaladsl.ActorTestKitWordSpec
+import akka.actor.testkit.typed.scaladsl.ActorTestKitScalaTestSpec
 
 object CustomGuardianAndMaterializerSpec {
 
@@ -21,7 +21,7 @@ object CustomGuardianAndMaterializerSpec {
   case object Failed extends GuardianProtocol
 }
 
-class CustomGuardianAndMaterializerSpec extends ActorTestKitWordSpec {
+class CustomGuardianAndMaterializerSpec extends ActorTestKitScalaTestSpec with WordSpecLike{
   import CustomGuardianAndMaterializerSpec._
 
   val guardian = Behaviors.receive[GuardianProtocol] {


### PR DESCRIPTION
Spiked trying to create this base class work with any of the SpecLike traits from ScalaTest

Most of the changes are to the tests that use it, will point out the buts to look at