### PR TITLE
Disallow nested mixed widen usages 

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WidenSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WidenSpec.scala
@@ -6,12 +6,22 @@ package akka.actor.typed
 
 import java.util.concurrent.atomic.AtomicInteger
 
+import akka.actor.ActorInitializationException
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter._
+import akka.testkit.EventFilter
 import org.scalatest.WordSpecLike
 
-class WidenSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+import scala.concurrent.duration._
+
+class WidenSpec extends ScalaTestWithActorTestKit(
+  """
+    akka.loggers = [akka.testkit.TestEventListener]
+    """) with WordSpecLike {
+
+  implicit val untypedSystem = system.toUntyped
 
   def intToString(probe: ActorRef[String]): Behavior[Int] = {
     Behaviors.receiveMessage[String] { msg ⇒
@@ -36,11 +46,14 @@ class WidenSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val probe = TestProbe[String]()
       val ref = spawn(intToString(probe.ref))
 
-      ref ! 42
-      ref ! 13
-      ref ! 43
-      probe.expectMessage("42")
-      probe.expectMessage("43")
+      // non-convertible/filtered message 13 is logged as warning
+      EventFilter.warning(occurrences = 1).intercept {
+        ref ! 42
+        ref ! 13
+        ref ! 43
+        probe.expectMessage("42")
+        probe.expectMessage("43")
+      }
     }
 
     "not build up when the same widen is used many times (initially)" in {
@@ -103,6 +116,30 @@ class WidenSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       ref ! "43"
       probe.expectMessage("43")
       transformCount.get should ===(2)
+
+    }
+
+    "not allow mixing different widens in the same behavior stack" in {
+      val probe = TestProbe[String]()
+
+      def widen(behavior: Behavior[String]): Behavior[String] =
+        behavior.widen[String] {
+          case s ⇒ s.toLowerCase
+        }
+
+      EventFilter[ActorInitializationException](occurrences = 1).intercept {
+        val ref = spawn(
+          widen(
+            widen(
+              Behaviors.receiveMessage[String] { msg ⇒
+                Behaviors.same
+              }
+            )
+          )
+        )
+
+        probe.expectTerminated(ref, 3.seconds)
+      }
 
     }
   }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WidenSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WidenSpec.scala
@@ -46,7 +46,7 @@ class WidenSpec extends ScalaTestWithActorTestKit(
       val probe = TestProbe[String]()
       val ref = spawn(intToString(probe.ref))
 
-      // non-convertible/filtered message 13 is logged as warning
+      // TestEventListener logs unhandled as warnings, silence that
       EventFilter.warning(occurrences = 1).intercept {
         ref ! 42
         ref ! 13


### PR DESCRIPTION
Fixes #25604

I decided to leave the option of using the same instance of pf which is then deduplicated, since we know that is safe, even if that isn't how people normally use pfs.