### PR TITLE
Cleanup typed test output

### DIFF
--- a/akka-actor-typed-tests/src/test/resources/application.conf
+++ b/akka-actor-typed-tests/src/test/resources/application.conf
@@ -1,2 +1,0 @@
-akka.loglevel=warning
-akka.log-dead-letters=off

--- a/akka-actor-typed-tests/src/test/resources/application.conf
+++ b/akka-actor-typed-tests/src/test/resources/application.conf
@@ -1,0 +1,2 @@
+akka.loglevel=warning
+akka.log-dead-letters=off

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -79,9 +79,6 @@ class StubbedSupervisionSpec extends WordSpec with Matchers {
 
   import SupervisionSpec._
 
-  def mkTestkit(behv: Behavior[Command]): BehaviorTestKit[Command] =
-    BehaviorTestKit(behv)
-
   "A restarter (stubbed)" must {
     "receive message" in {
       val inbox = TestInbox[Event]("evt")
@@ -235,7 +232,7 @@ class StubbedSupervisionSpec extends WordSpec with Matchers {
         inbox.ref ! Started
         targetBehavior(inbox.ref)
       }).onFailure[Exc1](SupervisorStrategy.restart)
-      mkTestkit(behv)
+      BehaviorTestKit(behv)
       // it's supposed to be created immediately (not waiting for first message)
       inbox.receiveMessage() should ===(Started)
     }
@@ -711,7 +708,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit(
         .onFailure[Exception](SupervisorStrategy.restart)
 
       EventFilter[ActorInitializationException](occurrences = 1).intercept {
-        val ref = spawn(behv)
+        spawn(behv)
         probe.expectMessage(Started) // first one before failure
       }
     }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala
@@ -4,6 +4,7 @@
 
 package docs.akka.typed.coexistence
 
+import akka.actor.ActorLogging
 import akka.actor.typed._
 import akka.actor.typed.scaladsl.Behaviors
 import akka.testkit.TestKit
@@ -25,7 +26,7 @@ object UntypedWatchingTypedSpec {
   }
 
   //#untyped-watch
-  class Untyped extends untyped.Actor {
+  class Untyped extends untyped.Actor with ActorLogging {
     // context.spawn is an implicit extension method
     val second: ActorRef[Typed.Command] =
       context.spawn(Typed.behavior, "second")
@@ -40,11 +41,11 @@ object UntypedWatchingTypedSpec {
 
     override def receive = {
       case Typed.Pong ⇒
-        println(s"$self got Pong from ${sender()}")
+        log.info(s"$self got Pong from ${sender()}")
         // context.stop is an implicit extension method
         context.stop(second)
       case untyped.Terminated(ref) ⇒
-        println(s"$self observed termination of $ref")
+        log.info(s"$self observed termination of $ref")
         context.stop(self)
     }
   }
@@ -60,7 +61,7 @@ object UntypedWatchingTypedSpec {
       Behaviors.receive { (ctx, msg) ⇒
         msg match {
           case Ping(replyTo) ⇒
-            println(s"${ctx.self} got Ping from $replyTo")
+            ctx.log.info(s"${ctx.self} got Ping from $replyTo")
             // replyTo is an untyped actor that has been converted for coexistence
             replyTo ! Pong
             Behaviors.same


### PR DESCRIPTION
Fixes #25597

Most of the typed actor tests more quiet now. Two exceptions: weird warning log entry of `null` in AdapterSpec that I didn't figure out and the Java tests, there is currently only Java API for event filtering of errors from Java and I didn't want to scope this PR out to change that (created #25668 to track it)