### PR TITLE
Improve accepted JSON values in JsonObjectParser

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/JsonFramingBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/JsonFramingBenchmark.scala
@@ -29,6 +29,8 @@ class JsonFramingBenchmark {
          |{"fname":"Hank","name":"Smith","age":42,"id":1337,"boardMember":false}""".stripMargin
     )
 
+  val json5by5 = for (i ← 0.until(json5.length, 5)) yield json5.slice(i, i + 5).compact
+
   val jsonLong =
     ByteString(
       s"""{"fname":"Frank","name":"Smith","age":42,"id":1337,"boardMember":false,"description":"${"a" * 1000000}"}"""
@@ -51,6 +53,34 @@ class JsonFramingBenchmark {
     bracket.poll().get
     bracket.poll().get
     bracket.poll().get
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(25)
+  def counting_offer_5x5: ByteString = {
+    /* this test validates that we don't create too much internal buffer misalignment-caused loss of performance.
+     */
+
+    for (i ← 0 until 5) {
+      bracket.offer(json5)
+    }
+
+    for (i ← 0 until 24) {
+      bracket.poll().get
+    }
+    bracket.poll().get // 25
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(5)
+  def counting_offer_5by5bytes: ByteString = {
+    /* this test validates how we JsonObjectParser when the incoming data does not come by object boundaries */
+    json5by5.foreach(bracket.offer)
+
+    for (i ← 0 until 4) {
+      bracket.poll().get
+    }
+    bracket.poll().get // 5
   }
 
   @Benchmark

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/JsonFramingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/JsonFramingSpec.scala
@@ -495,13 +495,14 @@ class JsonFramingSpec extends AkkaSpec {
               |   }
               |}
               | """.stripMargin))
-          buffer.poll().get.utf8String shouldBe """{  "name": "john",
-                                                      |   "age": 101,
-                                                      |   "address": {
-                                                      |     "street": "Straight Street",
-                                                      |     "postcode": 1234
-                                                      |   }
-                                                      |}""".stripMargin
+          buffer.poll().get.utf8String shouldBe
+            """{  "name": "john",
+              |   "age": 101,
+              |   "address": {
+              |     "street": "Straight Street",
+              |     "postcode": 1234
+              |   }
+              |}""".stripMargin
         }
 
         "successfully parse single field having multiple level of nested object" in {
@@ -519,16 +520,17 @@ class JsonFramingSpec extends AkkaSpec {
               |   }
               |}
               | """.stripMargin))
-          buffer.poll().get.utf8String shouldBe """{  "name": "john",
-                                                      |   "age": 101,
-                                                      |   "address": {
-                                                      |     "street": {
-                                                      |       "name": "Straight",
-                                                      |       "type": "Avenue"
-                                                      |     },
-                                                      |     "postcode": 1234
-                                                      |   }
-                                                      |}""".stripMargin
+          buffer.poll().get.utf8String shouldBe
+            """{  "name": "john",
+              |   "age": 101,
+              |   "address": {
+              |     "street": {
+              |       "name": "Straight",
+              |       "type": "Avenue"
+              |     },
+              |     "postcode": 1234
+              |   }
+              |}""".stripMargin
         }
 
         "successfully parse an escaped backslash followed by a double quote" in {
@@ -541,9 +543,10 @@ class JsonFramingSpec extends AkkaSpec {
               | """.stripMargin
           ))
 
-          buffer.poll().get.utf8String shouldBe """{
-                                          | "key": "\\"
-                                          | }""".stripMargin
+          buffer.poll().get.utf8String shouldBe
+            """{
+              | "key": "\\"
+              | }""".stripMargin
         }
 
         "successfully parse a string that contains an escaped quote" in {
@@ -556,9 +559,10 @@ class JsonFramingSpec extends AkkaSpec {
               | """.stripMargin
           ))
 
-          buffer.poll().get.utf8String shouldBe """{
-                                                  | "key": "\""
-                                                  | }""".stripMargin
+          buffer.poll().get.utf8String shouldBe
+            """{
+              | "key": "\""
+              | }""".stripMargin
         }
 
         "successfully parse a string that contains escape sequence" in {
@@ -571,9 +575,10 @@ class JsonFramingSpec extends AkkaSpec {
               | """.stripMargin
           ))
 
-          buffer.poll().get.utf8String shouldBe """{
-                                                  | "key": "\\\""
-                                                  | }""".stripMargin
+          buffer.poll().get.utf8String shouldBe
+            """{
+              | "key": "\\\""
+              | }""".stripMargin
         }
       }
 
@@ -591,14 +596,15 @@ class JsonFramingSpec extends AkkaSpec {
               |   ]
               |}
               | """.stripMargin))
-          buffer.poll().get.utf8String shouldBe """{  "name": "john",
-                                                      |   "things": [
-                                                      |     1,
-                                                      |     "hey",
-                                                      |     3,
-                                                      |     "there"
-                                                      |   ]
-                                                      |}""".stripMargin
+          buffer.poll().get.utf8String shouldBe
+            """{  "name": "john",
+              |   "things": [
+              |     1,
+              |     "hey",
+              |     3,
+              |     "there"
+              |   ]
+              |}""".stripMargin
         }
       }
 
@@ -631,28 +637,29 @@ class JsonFramingSpec extends AkkaSpec {
               |}
               | """.stripMargin))
 
-          buffer.poll().get.utf8String shouldBe """{
-                                                      |  "name": "john",
-                                                      |  "addresses": [
-                                                      |    {
-                                                      |      "street": "3 Hopson Street",
-                                                      |      "postcode": "ABC-123",
-                                                      |      "tags": ["work", "office"],
-                                                      |      "contactTime": [
-                                                      |        {"time": "0900-1800", "timezone", "UTC"}
-                                                      |      ]
-                                                      |    },
-                                                      |    {
-                                                      |      "street": "12 Adielie Road",
-                                                      |      "postcode": "ZZY-888",
-                                                      |      "tags": ["home"],
-                                                      |      "contactTime": [
-                                                      |        {"time": "0800-0830", "timezone", "UTC"},
-                                                      |        {"time": "1800-2000", "timezone", "UTC"}
-                                                      |      ]
-                                                      |    }
-                                                      |  ]
-                                                      |}""".stripMargin
+          buffer.poll().get.utf8String shouldBe
+            """{
+              |  "name": "john",
+              |  "addresses": [
+              |    {
+              |      "street": "3 Hopson Street",
+              |      "postcode": "ABC-123",
+              |      "tags": ["work", "office"],
+              |      "contactTime": [
+              |        {"time": "0900-1800", "timezone", "UTC"}
+              |      ]
+              |    },
+              |    {
+              |      "street": "12 Adielie Road",
+              |      "postcode": "ZZY-888",
+              |      "tags": ["home"],
+              |      "contactTime": [
+              |        {"time": "0800-0830", "timezone", "UTC"},
+              |        {"time": "1800-2000", "timezone", "UTC"}
+              |      ]
+              |    }
+              |  ]
+              |}""".stripMargin
         }
       }
 
@@ -726,18 +733,30 @@ class JsonFramingSpec extends AkkaSpec {
         buffer.offer(ByteString("}"))
         buffer.poll().get.utf8String shouldBe """{ "name": "john"}"""
       }
+    }
 
-      "invalid json is supplied" should {
-        "fail if it's broken from the start" in {
+    "invalid json is supplied" which {
+      "is broken from the start" should {
+        "noticeably fail" in {
           val buffer = new JsonObjectParser()
           buffer.offer(ByteString("""THIS IS NOT VALID { "name": "john"}"""))
+          a[FramingException] shouldBe thrownBy {
+            buffer.poll()
+          }
+        }
+      }
+
+      "is broken at the end" should {
+        "noticeably fail" in {
+          val buffer = new JsonObjectParser()
+          buffer.offer(ByteString("""{ "name": "john"} THIS IS NOT VALID"""))
           a[FramingException] shouldBe thrownBy { buffer.poll() }
         }
 
-        "fail if it's broken at the end" in {
+        "noticeably fail before emitting the last valid element" in {
           val buffer = new JsonObjectParser()
-          buffer.offer(ByteString("""{ "name": "john"} THIS IS NOT VALID"""))
-          buffer.poll() // first emitting the valid element
+          buffer.offer(ByteString("""{ "name": "paul"}, { "name": "john"} THIS IS NOT VALID"""))
+          buffer.poll() // this is '{ "name": "paul"}' and this should pass
           a[FramingException] shouldBe thrownBy { buffer.poll() }
         }
       }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/JsonFramingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/JsonFramingSpec.scala
@@ -937,6 +937,10 @@ class JsonFramingSpec extends AkkaSpec {
   }
 
   "running tests used for benchmarking" should {
+    /* This code is repackaged (copied) from the benchmarking code, in order to clarify the (formerly implicit)
+    specific behavior the benchmarking code was relying on.
+     */
+
     "work fine with a single object" in {
       val json =
         ByteString(

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/JsonFramingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/JsonFramingSpec.scala
@@ -276,8 +276,6 @@ class JsonFramingSpec extends AkkaSpec {
       result.futureValue shouldBe Seq("""[ [ 1, 2], [ 3, 4 ] ]""", """[ 5, [ 6, 7 ], 8 ]""")
     }
 
-
-
     "emit single json element from string" in {
       val input =
         """| { "name": "john" }

--- a/akka-stream/src/main/mima-filters/2.5.18.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.18.backwards.excludes
@@ -1,4 +1,3 @@
-# #25949 adding loglevel for overflow strategy
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.DelayOverflowStrategy.isBackpressure")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.OverflowStrategy.withLogLevel")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.OverflowStrategy.logLevel")
@@ -50,3 +49,4 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.OverflowStrategi
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.OverflowStrategies#DropNew.productIterator")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.OverflowStrategies#DropNew.productPrefix")
 ProblemFilters.exclude[FinalMethodProblem]("akka.stream.OverflowStrategies#DropNew.toString")
+

--- a/akka-stream/src/main/mima-filters/2.5.19.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.19.backwards.excludes
@@ -1,0 +1,10 @@
+# JsonObjectParser (which is Internal API)'s own internals
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.Comma")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.Backslash")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.DoubleQuote")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.CurlyBraceEnd")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.SquareBraceEnd")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.CurlyBraceStart")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.SquareBraceStart")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.JsonObjectParser.isWhitespace")
+

--- a/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes
@@ -70,3 +70,4 @@ ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObje
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.SquareBraceEnd")
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.CurlyBraceStart")
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.SquareBraceStart")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.JsonObjectParser.isWhitespace")

--- a/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes
@@ -61,13 +61,3 @@ ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowO
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.zipLatest")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.zipLatestWithGraph")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.zipLatestWith")
-
-# JsonObjectParser (which is Internal API)'s own internals
-ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.Comma")
-ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.Backslash")
-ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.DoubleQuote")
-ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.CurlyBraceEnd")
-ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.SquareBraceEnd")
-ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.CurlyBraceStart")
-ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.SquareBraceStart")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.JsonObjectParser.isWhitespace")

--- a/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes
@@ -61,3 +61,12 @@ ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowO
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.zipLatest")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.zipLatestWithGraph")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.zipLatestWith")
+
+# JsonObjectParser (which is Internal API)'s own internals
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.Comma")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.Backslash")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.DoubleQuote")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.CurlyBraceEnd")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.SquareBraceEnd")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.CurlyBraceStart")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.impl.JsonObjectParser.SquareBraceStart")

--- a/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
@@ -76,8 +76,6 @@ import scala.reflect.ClassTag
         val input = pp.buffer(pp.pos)
         val nextState = (evaluateNextCharacter(input): @inline) // must mutate pp.pos OR (inclusive) return a different state
 
-        //println(s"pos=${pp.pos} bufsize=${buffer.size} remsteps=${remainingSteps} sd=${stackDepth} complete=${pp.completedObject} state=${debugState(pp, nextState)}")
-
         if (nextState eq this) {
           /* same-type tailrec: inline */
           seekNextEventInternal(maxSeekPos)
@@ -681,10 +679,7 @@ import scala.reflect.ClassTag
       val foundObject = seekObject()
 
       if (foundObject && (pos > 0)) {
-        val r = emitItem()
-        // println("emit=",r.map(_.utf8String))
-        r
-
+        emitItem()
       } else {
         None
       }
@@ -718,8 +713,6 @@ import scala.reflect.ClassTag
   }
 
   @noinline private def takeNextBufferInternal(): Boolean = {
-    // println("enlarge: before = ", state.debugState(state))
-
     val headNext = nextBuffers.removeHead()
 
     val taken = headNext
@@ -733,8 +726,6 @@ import scala.reflect.ClassTag
     pos = 0
     trimFront = 0
     buffer = taken
-
-    // println("enlarge: after = ", state.debugState(state))
 
     buffer.nonEmpty
 
@@ -751,7 +742,6 @@ import scala.reflect.ClassTag
   /** @return true if an entire valid JSON object was found, false otherwise */
   @tailrec
   private def seekObject(): Boolean = {
-    // println("start of seek= ", state.debugState(state))
     completedObject = false
 
     val maxSeekPos = Math.min(buffer.length, maximumObjectLength)

--- a/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
@@ -580,8 +580,12 @@ import scala.annotation.{ switch, tailrec }
       (pos: @switch) match {
         case -1 | 0 ⇒ None
         case _ ⇒
-          val (emit, buf) = buffer.splitAt(pos)
-          buffer = buf.compact
+          val emit = buffer.take(pos)
+          val buf = buffer.drop(pos)
+          buffer = buf /* We don't compact; meaning we'll keep the underlying memory "as is" until the polled objects
+
+                          have all been consumed. Presumably, a JSON parse operation is to happen soon and these
+                          ByteStrings will become irrelevant and GC'd */
           pos = 0
 
           val tf = trimFront

--- a/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
@@ -191,13 +191,7 @@ import scala.reflect.ClassTag
 
     sealed abstract class TopLevelLeafContainerState extends InnerLeafContainerState with TopLevelContainerState
 
-    private case object UnknownState extends ParserState with NeitherTakingOrSkippingState with ParserStateMachinery {
-
-      final override def evaluateNextCharacter(input: Byte)(implicit pp: JsonObjectParser): ParserState =
-        throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] — unknown state")
-    }
-
-    private case object InitialState extends ParserState with SkippingState with ParserStateMachinery {
+    case object InitialState extends ParserState with SkippingState with ParserStateMachinery {
 
       final override def evaluateNextCharacter(input: Byte)(implicit pp: JsonObjectParser): ParserState = {
         if (input == SquareBraceStart) {

--- a/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
@@ -15,14 +15,14 @@ import scala.annotation.{ switch }
  */
 @InternalApi private[akka] object JsonObjectParser {
 
-  final val SquareBraceStart = '['.toByte
-  final val SquareBraceEnd = ']'.toByte
-  final val CurlyBraceStart = '{'.toByte
-  final val CurlyBraceEnd = '}'.toByte
-  final val Colon = ':'.toByte
-  final val DoubleQuote = '"'.toByte
-  final val Backslash = '\\'.toByte
-  final val Comma = ','.toByte
+  final val SquareBraceStart = 91 // '['.toByte
+  final val SquareBraceEnd = 93 // ']'.toByte
+  final val CurlyBraceStart = 123 // '{'.toByte
+  final val CurlyBraceEnd = 125 // '}'.toByte
+  final val Colon = 58 // ':'.toByte
+  final val DoubleQuote = 34 // '"'.toByte
+  final val Backslash = 92 // '\\'.toByte
+  final val Comma = 44 // ','.toByte
 
   final val LineBreak = 10 // '\n'
   final val LineBreak2 = 13 // '\r'

--- a/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
@@ -59,22 +59,17 @@ import scala.annotation.{switch}
         if (input == SquareBraceStart) {
           pp.skip()
           pp.state = MainArrayBeforeElement
-          println("—I1—")
         } else if (isWhitespace(input)) {
           pp.skip()
-          println("—I2—")
         } else if (input == DoubleQuote) {
           pp.take()
           pp.state = InOuterString(NotArrayAfterElement, pp)
-          println("—I2—")
         } else if (input == CurlyBraceStart) {
           pp.take()
           pp.state = pp.enterContainer(InOuterObject, NotArrayAfterElement)
-          println("—I3—")
         } else if (!isWhitespace(input)) {
           pp.take()
           pp.state = InOuterNaked(NotArrayAfterElement, pp)
-          println("—I4—")
         } else {
           throw new FramingException(s"Invalid JSON encountered at position [$pp.pos] of [$pp.buffer]")
         }
@@ -90,29 +85,23 @@ import scala.annotation.{switch}
       override def proceed(input: Byte, pp: JsonObjectParser): Unit = input match {
           case _ if isWhitespace(input) =>
             pp.skip()
-            println("—ABE 1—")
           case Comma =>
             throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}]")
           case SquareBraceEnd =>
             pp.skip()
             pp.state = AfterMainArray
-            println("—ABE 2—")
           case SquareBraceStart =>
             pp.take()
             pp.state = pp.enterContainer(InOuterArray, MainArrayAfterElement)
-            println("—ABE 3—")
           case DoubleQuote =>
             pp.take()
             pp.state = InOuterString(MainArrayAfterElement, pp)
-            println("—ABE 4—")
           case CurlyBraceStart =>
             pp.take()
             pp.state = pp.enterContainer(InOuterObject, MainArrayAfterElement)
-            println("—ABE 5—")
           case _ if !isWhitespace(input) =>
             pp.take()
             pp.state = InOuterNaked(MainArrayAfterElement, pp)
-            println("—ABE 6—")
           case _ =>
             throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}]")
         }
@@ -125,7 +114,6 @@ import scala.annotation.{switch}
       override def proceed(input: Byte, pp: JsonObjectParser): Unit = (input: @switch) match {
           case _ if isWhitespace(input) =>
             pp.skip()
-            println("—AA 1—")
           case _ =>
             throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] after closed JSON-style array")
         }
@@ -140,15 +128,12 @@ import scala.annotation.{switch}
       override def proceed(input: Byte, pp: JsonObjectParser): Unit = input match {
         case _ if isWhitespace(input) =>
           pp.skip()
-          println("—AAE 1—")
         case Comma =>
           pp.skip()
           pp.state = MainArrayBeforeElement
-          println("—AAE 2—")
         case SquareBraceEnd =>
           pp.skip()
           pp.state = AfterMainArray
-          println("—AAE 3—")
         case _ =>
           throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] after JSON-style array element")
       }
@@ -246,7 +231,6 @@ import scala.annotation.{switch}
         val nextState = pp.stateAfterNakedValue
         pp.stateAfterNakedValue = UnknownState
 
-        println(s"—IN 1— ⇒ $nextState")
         pp.state = nextState
         exitAction(pp)
         nextState.proceed(input, pp)
@@ -261,7 +245,6 @@ import scala.annotation.{switch}
 
         case _ if !isWhitespace(input) =>
           pp.take()
-          println("—IN 3—")
       }
     }
 
@@ -276,35 +259,28 @@ import scala.annotation.{switch}
       final override def proceed(input: Byte, pp: JsonObjectParser): Unit = input match {
         case _ if isWhitespace(input) =>
           pp.take()
-          println("— IO 1 —")
 
         case _ if input == containerEnd =>
           /* this is our end! */
           pp.take()
-          println("— IO 2 —")
           exitAction(pp)
 
         case DoubleQuote =>
           pp.take()
           pp.state = InString(this, pp)
-          println("— IO 3 —")
 
         case  Comma | Colon =>
           /* in a real JSON parser we'd check whether the colon and commas appear at appropriate places. Here
           we do without: we're just framing JSON and this is good enough */
           pp.take()
-          println("— IO 4 —")
 
         case CurlyBraceStart =>
           pp.take()
           pp.state = pp.enterContainer(InObject, this)
-          println("— IO 5 —")
 
         case SquareBraceStart =>
           pp.take()
           pp.state = pp.enterContainer(InArray, this)
-          println("— IO 6 —")
-
 
         case _ =>
           pp.take()
@@ -340,16 +316,13 @@ import scala.annotation.{switch}
         case Comma =>
           pp.skip()
           pp.state = CommaSeparatedBeforeElement
-          println("—NAAE 1—")
 
         case LineBreak =>
           pp.skip()
           pp.state = LinebreakSeparatedBeforeElement
-          println("—NAAE 2—")
 
         case _ if isWhitespace(input) =>
           pp.skip()
-          println("— NAAE 3—")
 
         case _ =>
           throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] — junk after value in linebreak or comma-separated stream")
@@ -366,11 +339,9 @@ import scala.annotation.{switch}
         case _ if input == separator =>
           pp.skip()
           pp.state = beforeNextItem
-          println("—SSAE 1—")
 
         case _ if isWhitespace(input) =>
           pp.skip()
-          println("—SSAE 2—")
 
         case _ =>
           throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] — junk after value in $separatorName-separated stream")
@@ -385,31 +356,25 @@ import scala.annotation.{switch}
         case DoubleQuote =>
           pp.take()
           pp.state = InOuterString(afterState, pp)
-          println("—SSBE 1—")
 
         case SquareBraceStart =>
           pp.take()
           pp.state = pp.enterContainer(InOuterArray, afterState)
-          println("—SSBE 2—")
 
         case CurlyBraceStart =>
           pp.take()
           pp.state = pp.enterContainer(InOuterObject, afterState)
-          println("—SSBE 3—")
 
         case _ if input == afterState.separator =>
           pp.skip()
           /* note: effectively, empty lines are tolerated, ignored and skipped. Throw a FramingError if desired otherwise */
-          println("—SSBE 4—")
 
         case _ if isWhitespace(input) =>
           pp.skip()
-          println("—SSBE 5—")
 
         case _ if !isWhitespace(input) =>
           pp.take()
           pp.state = InOuterNaked(afterState, pp)
-          println("—SSBE 6—")
       }
     }
 
@@ -469,9 +434,7 @@ import scala.annotation.{switch}
       def previous: ContainerStackLevel = {
         throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] — can't unpack")
       }
-
       def level: Int = 0
-
     }
 
     final case class Regular(pp: JsonObjectParser, current: ParserState, next: ParserState, previous: ContainerStackLevel) extends ContainerStackLevel {
@@ -480,10 +443,7 @@ import scala.annotation.{switch}
 
       override def toString: String = s"Regular(_, ${current}, ${next}) → ${previous}"
     }
-
-
   }
-
 }
 
 /**
@@ -580,7 +540,6 @@ import scala.annotation.{switch}
             if (trimmed.isEmpty) None
             else Some(trimmed)
           }
-          println("result=" + result.map(_.utf8String))
           result
       }
   }
@@ -591,12 +550,8 @@ import scala.annotation.{switch}
 
     val bufSize = buffer.size
     while (pos != -1 && (pos < bufSize && pos < maximumObjectLength) && !completedObject) {
-      val input = buffer(pos)
-      println(s"input=${input}: >${input.toChar}< this=(pos: $pos, state=${state} sofar='${debugCurrentSelection}' level=${containerStack.level} containerStack=${containerStack})")
       state.proceed(buffer(pos), this)
     }
-
-    println(s"done proceeding; pos=${pos} bufSize=$bufSize complete=$completedObject")
 
     if (pos >= maximumObjectLength)
       throw new FramingException(s"""JSON element exceeded maximumObjectLength ($maximumObjectLength bytes)!""")

--- a/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
@@ -8,7 +8,7 @@ import akka.annotation.InternalApi
 import akka.stream.scaladsl.Framing.FramingException
 import akka.util.ByteString
 
-import scala.annotation.{switch}
+import scala.annotation.{ switch }
 
 /**
  * INTERNAL API: Use [[akka.stream.scaladsl.JsonFraming]] instead.
@@ -36,7 +36,6 @@ import scala.annotation.{switch}
     case Tab        ⇒ true
     case _          ⇒ false
   }
-
 
   private sealed trait ParserState {
     def proceed(input: Byte, pp: JsonObjectParser): Unit
@@ -77,34 +76,34 @@ import scala.annotation.{switch}
     }
 
     /**
-      * We are in this state whenever we're inside a JSON Array-style stream, before any element
-      */
+     * We are in this state whenever we're inside a JSON Array-style stream, before any element
+     */
     private object MainArrayBeforeElement extends ParserState {
       override def toString: String = "MainArrayBeforeElement"
 
       override def proceed(input: Byte, pp: JsonObjectParser): Unit = input match {
-          case _ if isWhitespace(input) =>
-            pp.skip()
-          case Comma =>
-            throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}]")
-          case SquareBraceEnd =>
-            pp.skip()
-            pp.state = AfterMainArray
-          case SquareBraceStart =>
-            pp.take()
-            pp.state = pp.enterContainer(InOuterArray, MainArrayAfterElement)
-          case DoubleQuote =>
-            pp.take()
-            pp.state = InOuterString(MainArrayAfterElement, pp)
-          case CurlyBraceStart =>
-            pp.take()
-            pp.state = pp.enterContainer(InOuterObject, MainArrayAfterElement)
-          case _ if !isWhitespace(input) =>
-            pp.take()
-            pp.state = InOuterNaked(MainArrayAfterElement, pp)
-          case _ =>
-            throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}]")
-        }
+        case _ if isWhitespace(input) ⇒
+          pp.skip()
+        case Comma ⇒
+          throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}]")
+        case SquareBraceEnd ⇒
+          pp.skip()
+          pp.state = AfterMainArray
+        case SquareBraceStart ⇒
+          pp.take()
+          pp.state = pp.enterContainer(InOuterArray, MainArrayAfterElement)
+        case DoubleQuote ⇒
+          pp.take()
+          pp.state = InOuterString(MainArrayAfterElement, pp)
+        case CurlyBraceStart ⇒
+          pp.take()
+          pp.state = pp.enterContainer(InOuterObject, MainArrayAfterElement)
+        case _ if !isWhitespace(input) ⇒
+          pp.take()
+          pp.state = InOuterNaked(MainArrayAfterElement, pp)
+        case _ ⇒
+          throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}]")
+      }
 
     }
 
@@ -112,11 +111,11 @@ import scala.annotation.{switch}
       override def toString: String = "AfterMainArray"
 
       override def proceed(input: Byte, pp: JsonObjectParser): Unit = (input: @switch) match {
-          case _ if isWhitespace(input) =>
-            pp.skip()
-          case _ =>
-            throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] after closed JSON-style array")
-        }
+        case _ if isWhitespace(input) ⇒
+          pp.skip()
+        case _ ⇒
+          throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] after closed JSON-style array")
+      }
     }
 
     private object MainArrayAfterElement extends ParserState {
@@ -126,15 +125,15 @@ import scala.annotation.{switch}
       exit action that happened just before we ended up here.
        */
       override def proceed(input: Byte, pp: JsonObjectParser): Unit = input match {
-        case _ if isWhitespace(input) =>
+        case _ if isWhitespace(input) ⇒
           pp.skip()
-        case Comma =>
+        case Comma ⇒
           pp.skip()
           pp.state = MainArrayBeforeElement
-        case SquareBraceEnd =>
+        case SquareBraceEnd ⇒
           pp.skip()
           pp.state = AfterMainArray
-        case _ =>
+        case _ ⇒
           throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] after JSON-style array element")
       }
     }
@@ -159,30 +158,29 @@ import scala.annotation.{switch}
       }
     }
 
-    private trait HasExitAction { this: ParserState =>
+    private trait HasExitAction { this: ParserState ⇒
       def exitAction(pp: JsonObjectParser): Unit
     }
 
-    private trait HasEmptyExitAction extends HasExitAction { this: ParserState =>
-      final def exitAction(pp: JsonObjectParser): Unit = { }
+    private trait HasEmptyExitAction extends HasExitAction { this: ParserState ⇒
+      final def exitAction(pp: JsonObjectParser): Unit = {}
     }
-    private trait CompleteObjectOnExitAction extends HasExitAction { this: ParserState =>
+    private trait CompleteObjectOnExitAction extends HasExitAction { this: ParserState ⇒
       final def exitAction(pp: JsonObjectParser): Unit = pp.objectDone()
     }
 
-    private trait LeaveContainerOnExit extends HasExitAction { this: ParserState =>
+    private trait LeaveContainerOnExit extends HasExitAction { this: ParserState ⇒
       final def exitAction(pp: JsonObjectParser): Unit = {
         pp.state = pp.leaveContainer()
       }
     }
 
-    private trait CompleteObjectAndLeaveContainerOnExit extends HasExitAction { this: ParserState =>
+    private trait CompleteObjectAndLeaveContainerOnExit extends HasExitAction { this: ParserState ⇒
       final def exitAction(pp: JsonObjectParser): Unit = {
         pp.objectDone()
         pp.state = pp.leaveContainer()
       }
     }
-
 
     private abstract class InStringBase extends LeafParserState with HasExitAction {
       def exitAction(pp: JsonObjectParser): Unit
@@ -194,20 +192,20 @@ import scala.annotation.{switch}
       }
 
       final override def proceed(input: Byte, pp: JsonObjectParser): Unit = input match {
-        case Backslash =>
+        case Backslash ⇒
           pp.take()
           pp.state = AfterBackslash(this, pp)
 
-        case DoubleQuote =>
+        case DoubleQuote ⇒
           pp.take()
           pp.state = pp.stateAfterStringValue
           pp.stateAfterStringValue = UnknownState
           exitAction(pp)
 
-        case LineBreak | LineBreak2 =>
+        case LineBreak | LineBreak2 ⇒
           throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] — line break in string")
 
-        case _ =>
+        case _ ⇒
           pp.take()
       }
 
@@ -237,52 +235,52 @@ import scala.annotation.{switch}
       }
 
       final override def proceed(input: Byte, pp: JsonObjectParser): Unit = input match {
-        case Comma | SquareBraceEnd | CurlyBraceEnd | LineBreak =>
+        case Comma | SquareBraceEnd | CurlyBraceEnd | LineBreak ⇒
           finish(input, pp)
 
-        case _ if isWhitespace(input) =>
+        case _ if isWhitespace(input) ⇒
           finish(input, pp)
 
-        case _ if !isWhitespace(input) =>
+        case _ if !isWhitespace(input) ⇒
           pp.take()
       }
     }
 
-    private object InNaked extends InNakedBase with HasEmptyExitAction{
+    private object InNaked extends InNakedBase with HasEmptyExitAction {
       override def toString: String = "InNaked"
     }
     private object InOuterNaked extends InNakedBase with CompleteObjectOnExitAction {
       override def toString: String = "InOuterNaked"
     }
 
-    private abstract class InContainerBase(containerEnd: Int)  extends ParserState with HasExitAction {
+    private abstract class InContainerBase(containerEnd: Int) extends ParserState with HasExitAction {
       final override def proceed(input: Byte, pp: JsonObjectParser): Unit = input match {
-        case _ if isWhitespace(input) =>
+        case _ if isWhitespace(input) ⇒
           pp.take()
 
-        case _ if input == containerEnd =>
+        case _ if input == containerEnd ⇒
           /* this is our end! */
           pp.take()
           exitAction(pp)
 
-        case DoubleQuote =>
+        case DoubleQuote ⇒
           pp.take()
           pp.state = InString(this, pp)
 
-        case  Comma | Colon =>
+        case Comma | Colon ⇒
           /* in a real JSON parser we'd check whether the colon and commas appear at appropriate places. Here
           we do without: we're just framing JSON and this is good enough */
           pp.take()
 
-        case CurlyBraceStart =>
+        case CurlyBraceStart ⇒
           pp.take()
           pp.state = pp.enterContainer(InObject, this)
 
-        case SquareBraceStart =>
+        case SquareBraceStart ⇒
           pp.take()
           pp.state = pp.enterContainer(InArray, this)
 
-        case _ =>
+        case _ ⇒
           pp.take()
           pp.state = InNaked(this, pp)
 
@@ -291,13 +289,12 @@ import scala.annotation.{switch}
       }
     }
 
-    private object InArray extends InContainerBase(SquareBraceEnd) with LeaveContainerOnExit{
+    private object InArray extends InContainerBase(SquareBraceEnd) with LeaveContainerOnExit {
       override def toString: String = "InArray"
     }
     private object InOuterArray extends InContainerBase(SquareBraceEnd) with CompleteObjectAndLeaveContainerOnExit {
       override def toString: String = "InOuterArray"
     }
-
 
     private object InObject extends InContainerBase(CurlyBraceEnd) with LeaveContainerOnExit {
       override def toString: String = "InObject"
@@ -305,7 +302,7 @@ import scala.annotation.{switch}
     private object InOuterObject extends InContainerBase(CurlyBraceEnd) with CompleteObjectAndLeaveContainerOnExit {
       override def toString: String = "InOuterObject"
     }
-    
+
     private object NotArrayAfterElement extends ParserState {
       override def toString: String = "NotArrayAfter"
 
@@ -313,18 +310,18 @@ import scala.annotation.{switch}
       separator is being used. We'll never revisit this state or InitialState once we meet a separator
        */
       override def proceed(input: Byte, pp: JsonObjectParser): Unit = input match {
-        case Comma =>
+        case Comma ⇒
           pp.skip()
           pp.state = CommaSeparatedBeforeElement
 
-        case LineBreak =>
+        case LineBreak ⇒
           pp.skip()
           pp.state = LinebreakSeparatedBeforeElement
 
-        case _ if isWhitespace(input) =>
+        case _ if isWhitespace(input) ⇒
           pp.skip()
 
-        case _ =>
+        case _ ⇒
           throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] — junk after value in linebreak or comma-separated stream")
       }
     }
@@ -336,14 +333,14 @@ import scala.annotation.{switch}
       def beforeNextItem: ParserState
 
       final override def proceed(input: Byte, pp: JsonObjectParser): Unit = (input: @switch) match {
-        case _ if input == separator =>
+        case _ if input == separator ⇒
           pp.skip()
           pp.state = beforeNextItem
 
-        case _ if isWhitespace(input) =>
+        case _ if isWhitespace(input) ⇒
           pp.skip()
 
-        case _ =>
+        case _ ⇒
           throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] — junk after value in $separatorName-separated stream")
 
       }
@@ -353,26 +350,26 @@ import scala.annotation.{switch}
       def afterState: SeparatorSeparatedAfterElement
 
       final override def proceed(input: Byte, pp: JsonObjectParser): Unit = input match {
-        case DoubleQuote =>
+        case DoubleQuote ⇒
           pp.take()
           pp.state = InOuterString(afterState, pp)
 
-        case SquareBraceStart =>
+        case SquareBraceStart ⇒
           pp.take()
           pp.state = pp.enterContainer(InOuterArray, afterState)
 
-        case CurlyBraceStart =>
+        case CurlyBraceStart ⇒
           pp.take()
           pp.state = pp.enterContainer(InOuterObject, afterState)
 
-        case _ if input == afterState.separator =>
+        case _ if input == afterState.separator ⇒
           pp.skip()
-          /* note: effectively, empty lines are tolerated, ignored and skipped. Throw a FramingError if desired otherwise */
+        /* note: effectively, empty lines are tolerated, ignored and skipped. Throw a FramingError if desired otherwise */
 
-        case _ if isWhitespace(input) =>
+        case _ if isWhitespace(input) ⇒
           pp.skip()
 
-        case _ if !isWhitespace(input) =>
+        case _ if !isWhitespace(input) ⇒
           pp.take()
           pp.state = InOuterNaked(afterState, pp)
       }
@@ -410,7 +407,6 @@ import scala.annotation.{switch}
       override def beforeNextItem: ParserState = CommaSeparatedBeforeElement
     }
 
-
   }
 
   private sealed class ContainerStackLevel(_pp: JsonObjectParser, _current: ParserState, _stateAtExit: ParserState,
@@ -424,13 +420,13 @@ import scala.annotation.{switch}
     val pp: JsonObjectParser = _pp
 
     def level: Int = previous match {
-      case null => 0
-      case p => 1 + p.level
+      case null ⇒ 0
+      case p    ⇒ 1 + p.level
     }
 
     override def toString: String = previous match {
-      case null => s"Root($pp)"
-      case _ => s"Regular(_, ${current}, ${stateAtExit}) → ${previous}"
+      case null ⇒ s"Root($pp)"
+      case _    ⇒ s"Regular(_, ${current}, ${stateAtExit}) → ${previous}"
     }
   }
 
@@ -441,11 +437,11 @@ import scala.annotation.{switch}
       /* this slightly ugly routine re-uses ContainerStackLevels in order to avoid allocating during stream processing */
 
       previous.next match {
-        case null =>
+        case null ⇒
           val n = new ContainerStackLevel(pp, current, stateAtExit, previous)
           previous.next = n
           n
-        case reuse =>
+        case reuse ⇒
           reuse.current = current
           reuse.stateAtExit = stateAtExit
           reuse.previous = previous
@@ -491,7 +487,6 @@ import scala.annotation.{switch}
     nextState
   }
 
-
   def skip(): Unit = {
     pos += 1
     if (charsInObject == 0) trimFront += 1
@@ -508,7 +503,6 @@ import scala.annotation.{switch}
 
   def debugCurrentSelection: String =
     buffer.take(pos).drop(trimFront).take(charsInObject).utf8String
-
 
   /**
    * Appends input ByteString to internal byte string buffer.
@@ -544,8 +538,7 @@ import scala.annotation.{switch}
             val trimmed = emit.take(cio)
             if (trimmed.isEmpty) None
             else Some(trimmed)
-          }
-          else {
+          } else {
             val trimmed = emit.drop(tf).take(cio)
             if (trimmed.isEmpty) None
             else Some(trimmed)

--- a/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
@@ -168,13 +168,40 @@ import scala.annotation.switch
       pos += 1
       charsInObject += 1
       println("—S4—")
-    } else if (input == DoubleQuote) {
-      if (!isStartOfEscapeSequence) inStringExpression = !inStringExpression
+    } else if ((input == DoubleQuote) && isStartOfEscapeSequence && inStringExpression) {
       isStartOfEscapeSequence = false
       pos += 1
       charsInObject += 1
-      println("—S5—")
-    } else if (input == CurlyBraceStart && !inStringExpression && !inNakedExpression) {
+      println("—S5 A—")
+    } else if ((input == DoubleQuote) && (!isStartOfEscapeSequence) && (!inStringExpression) && !pastExpression && !inNakedExpression)  {
+      // we can start that whether we are insideObject or outsideObject
+      inStringExpression = true
+      pos += 1
+      charsInObject += 1
+      println("—S5 B—")
+    } else if ((input == DoubleQuote) && (!isStartOfEscapeSequence) && inStringExpression) {
+      inStringExpression = false
+      pos += 1
+      charsInObject += 1
+      if (outsideObject) {
+        pastExpression = true
+        // if we're insideObject, we're not pastExpression here; in fact we may find additional strings soon.
+      }
+      println("—S5 C—")
+
+      /* note:
+      - DoubleQuote && !inStringExpression && inNakedExpression is malformed
+      - DoubleQuote && !inStringExpression && pastExpression is malformed
+      - DoubleQuote && isStartOfEscapeSequence && !inStringExpression is malformed
+       */
+
+    } else if ((input != DoubleQuote) && inStringExpression) {
+      // we're in the string, let's accumulate
+      pos += 1
+      charsInObject += 1
+      println("—Sx2—")
+    }
+    else if (input == CurlyBraceStart && !inStringExpression && !inNakedExpression) {
       isStartOfEscapeSequence = false
       depth += 1
       pos += 1

--- a/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
@@ -191,15 +191,13 @@ import scala.reflect.ClassTag
 
     sealed abstract class TopLevelLeafContainerState extends InnerLeafContainerState with TopLevelContainerState
 
-    object UnknownState extends ParserState with NeitherTakingOrSkippingState with ParserStateMachinery {
-      override def toString: String = "Unknown"
+    private case object UnknownState extends ParserState with NeitherTakingOrSkippingState with ParserStateMachinery {
 
       final override def evaluateNextCharacter(input: Byte)(implicit pp: JsonObjectParser): ParserState =
         throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] — unknown state")
     }
 
-    object InitialState extends ParserState with SkippingState with ParserStateMachinery {
-      override def toString: String = "Initial"
+    private case object InitialState extends ParserState with SkippingState with ParserStateMachinery {
 
       final override def evaluateNextCharacter(input: Byte)(implicit pp: JsonObjectParser): ParserState = {
         if (input == SquareBraceStart) {
@@ -224,8 +222,7 @@ import scala.reflect.ClassTag
     /**
      * We are in this state whenever we're inside a JSON Array-style stream, before any element
      */
-    private object MainArrayBeforeElement extends ParserState with SkippingState with ParserStateMachinery {
-      override def toString: String = "MainArrayBeforeElement"
+    private case object MainArrayBeforeElement extends ParserState with SkippingState with ParserStateMachinery {
 
       final override def evaluateNextCharacter(input: Byte)(implicit pp: JsonObjectParser): ParserState = {
         if (isWhitespace(input)) {
@@ -253,8 +250,7 @@ import scala.reflect.ClassTag
 
     }
 
-    private object AfterMainArray extends ParserState with SkippingState with ParserStateMachinery {
-      override def toString: String = "AfterMainArray"
+    private case object AfterMainArray extends ParserState with SkippingState with ParserStateMachinery {
 
       final override def evaluateNextCharacter(input: Byte)(implicit pp: JsonObjectParser): ParserState with SkippingState =
         if (isWhitespace(input)) {
@@ -265,8 +261,7 @@ import scala.reflect.ClassTag
         }
     }
 
-    private object MainArrayAfterElement extends NonContainerState with SkippingState with ParserStateMachinery {
-      override def toString: String = "MainArrayAfterElement"
+    private case object MainArrayAfterElement extends NonContainerState with SkippingState with ParserStateMachinery {
 
       /* note: we don't mark the object complete as it's been done, if necessary, as part of the
       exit action that happened just before we ended up here.
@@ -287,8 +282,7 @@ import scala.reflect.ClassTag
       }
     }
 
-    private object AfterBackslash extends ContainerState with ParserStateMachinery {
-      override def toString: String = "AfterBackslash"
+    private case object AfterBackslash extends ContainerState with ParserStateMachinery {
 
       final override def evaluateNextCharacter(input: Byte)(implicit pp: JsonObjectParser): ParserState = {
         take()
@@ -324,13 +318,9 @@ import scala.reflect.ClassTag
       }
     }
 
-    private object InString extends InnerLeafContainerState with InStringBase with ParserStateMachinery {
-      override def toString: String = "InString"
-    }
+    private case object InString extends InnerLeafContainerState with InStringBase with ParserStateMachinery
 
-    private object InOuterString extends TopLevelLeafContainerState with InStringBase with ParserStateMachinery {
-      override def toString: String = "InOuterString"
-    }
+    private case object InOuterString extends TopLevelLeafContainerState with InStringBase with ParserStateMachinery
 
     private sealed trait InNakedBase {
       this: ContainerState ⇒
@@ -347,13 +337,9 @@ import scala.reflect.ClassTag
       }
     }
 
-    private object InNaked extends InnerLeafContainerState with InNakedBase with ParserStateMachinery {
-      override def toString: String = "InNaked"
-    }
+    private case object InNaked extends InnerLeafContainerState with InNakedBase with ParserStateMachinery
 
-    private object InOuterNaked extends TopLevelLeafContainerState with InNakedBase with ParserStateMachinery {
-      override def toString: String = "InOuterNaked"
-    }
+    private case object InOuterNaked extends TopLevelLeafContainerState with InNakedBase with ParserStateMachinery
 
     private sealed abstract class InContainerBase(containerEnd: Int) extends ContainerState {
       final override def evaluateNextCharacter(input: Byte)(implicit pp: JsonObjectParser): ParserState = {
@@ -400,24 +386,15 @@ import scala.reflect.ClassTag
       }
     }
 
-    private object InArray extends BranchContainer(SquareBraceEnd) with ParserStateMachinery {
-      override def toString: String = "InArray"
-    }
+    private case object InArray extends BranchContainer(SquareBraceEnd) with ParserStateMachinery
 
-    private object InOuterArray extends RootContainer(SquareBraceEnd) with ParserStateMachinery {
-      override def toString: String = "InOuterArray"
-    }
+    private case object InOuterArray extends RootContainer(SquareBraceEnd) with ParserStateMachinery
 
-    private object InObject extends BranchContainer(CurlyBraceEnd) with ParserStateMachinery {
-      override def toString: String = "InObject"
-    }
+    private case object InObject extends BranchContainer(CurlyBraceEnd) with ParserStateMachinery
 
-    private object InOuterObject extends RootContainer(CurlyBraceEnd) with ParserStateMachinery {
-      override def toString: String = "InOuterObject"
-    }
+    private case object InOuterObject extends RootContainer(CurlyBraceEnd) with ParserStateMachinery
 
-    private object NotArrayAfterElement extends NonContainerState with ParserStateMachinery {
-      override def toString: String = "NotArrayAfter"
+    private case object NotArrayAfterElement extends NonContainerState with ParserStateMachinery {
 
       /* in this state we know we are not in a JSON array-formatted stream, but we don't yet know yet what kind of
       separator is being used. We'll never revisit this state or InitialState once we meet a separator
@@ -500,24 +477,17 @@ import scala.reflect.ClassTag
       }
     }
 
-    private object LinebreakSeparatedBeforeElement extends SeparatorSeparatedBeforeElement(LinebreakSeparatedAfterElement) with ParserStateMachinery {
-      override def toString: String = "LinebreakSeparatedBeforeElement"
-    }
+    private case object LinebreakSeparatedBeforeElement extends SeparatorSeparatedBeforeElement(LinebreakSeparatedAfterElement) with ParserStateMachinery
 
-    private object LinebreakSeparatedAfterElement extends SeparatorSeparatedAfterElement(LineBreak) with ParserStateMachinery {
-      override def toString: String = "LinebreakSeparatedAfterElement"
-
+    private case object LinebreakSeparatedAfterElement extends SeparatorSeparatedAfterElement(LineBreak) with ParserStateMachinery {
       override def separatorName: String = "linebreak"
 
       override def beforeNextItem: ParserState with SkippingState = LinebreakSeparatedBeforeElement
     }
 
-    private object CommaSeparatedBeforeElement extends SeparatorSeparatedBeforeElement(CommaSeparatedAfterElement) with ParserStateMachinery {
-      override def toString: String = "CommaSeparatedBeforeElement"
-    }
+    private case object CommaSeparatedBeforeElement extends SeparatorSeparatedBeforeElement(CommaSeparatedAfterElement) with ParserStateMachinery
 
-    private object CommaSeparatedAfterElement extends SeparatorSeparatedAfterElement(Comma) with ParserStateMachinery {
-      override def toString: String = "CommaSeparatedAfterElement"
+    private case object CommaSeparatedAfterElement extends SeparatorSeparatedAfterElement(Comma) with ParserStateMachinery {
 
       override def separatorName: String = "comma"
 

--- a/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
@@ -6,7 +6,7 @@ package akka.stream.impl
 
 import akka.annotation.InternalApi
 import akka.stream.scaladsl.Framing.FramingException
-import akka.util.ByteString
+import akka.util.{ ByteString, CompactByteString }
 
 import scala.annotation.{ switch, tailrec }
 
@@ -46,14 +46,18 @@ import scala.annotation.{ switch, tailrec }
     @inline
     protected def proceed(input: Byte, pp: JsonObjectParser): ParserState
 
-    final def seekNextEvent(pp: JsonObjectParser, maxSeekPos: Int, buffer: ByteString): Boolean = {
-      val remainingSteps = maxSeekPos - pp.pos
+    final def seekNextEventCompact(pp: JsonObjectParser, maxSeekPos: Int, buffer: ByteString.ByteString1C): Boolean = {
+      seekNextEventInternal(pp, maxSeekPos, buffer)
+    }
+    final def seekNextEventOther(pp: JsonObjectParser, maxSeekPos: Int, buffer: ByteString): Boolean = {
+      seekNextEventInternal(pp, maxSeekPos, buffer)
+    }
 
-      def keepSeeking(pp: JsonObjectParser, remainingSteps: Int): Boolean = (!pp.completedObject) && (remainingSteps > 0)
+    private final def seekNextEventInternal(pp: JsonObjectParser, maxSeekPos: Int, buffer: ByteString): Boolean = {
 
       @tailrec
-      def seekInternal(remainingSteps: Int): Boolean = {
-        if (keepSeeking(pp, remainingSteps)) {
+      def seekInternal(maxPos: Int): Boolean = {
+        if ((!pp.completedObject) && (pp.pos < maxPos)) {
 
           // val oldPos = pp.pos
           val nextState = proceed(buffer(pp.pos), pp) // must mutate pp.pos OR (inclusive) return a different state
@@ -64,7 +68,7 @@ import scala.annotation.{ switch, tailrec }
           if (nextState eq this) {
             /* same-type tailrec: inline */
             // if (consumed != 1) throw new IllegalStateException("assumption violate: if we keep the same state then we MUST advance the position")
-            seekInternal(remainingSteps - 1)
+            seekInternal(maxPos)
           } else {
             // consumed may be 0 or 1 (we'll recompute the steps to the end anyway)
 
@@ -76,7 +80,15 @@ import scala.annotation.{ switch, tailrec }
         }
       }
 
-      seekInternal(remainingSteps)
+      if (pp.pos >= 0) {
+        if (maxSeekPos < buffer.length) {
+          seekInternal(maxSeekPos)
+        } else {
+          seekInternal(buffer.length)
+        }
+      } else {
+        false // out of bounds
+      }
     }
   }
 
@@ -607,8 +619,15 @@ import scala.annotation.{ switch, tailrec }
   }
 
   private def internalSeekObject(maxSeekPos: Int): Boolean = {
-    while (state.seekNextEvent(this, maxSeekPos, buffer)) {
-      // keep going
+    buffer match {
+      case compact: ByteString.ByteString1C ⇒
+        while (state.seekNextEventCompact(this, maxSeekPos, compact)) {
+          // keep going
+        }
+      case _ ⇒
+        while (state.seekNextEventOther(this, maxSeekPos, buffer)) {
+          // keep going
+        }
     }
 
     if (pos >= maximumObjectLength)

--- a/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
@@ -321,6 +321,16 @@ import scala.annotation.{ switch }
         case _ if isWhitespace(input) ⇒
           pp.skip()
 
+        /* This is a tolerance; since there is no ambiguity, we can consider a next object immediately after
+          the previous, even without a Comma or Linebreak separator. Akka Stream 2.5.16 has historically supported that.
+
+          We can't extend the same tolerance to arrays, as any stream whose first non-whitespace character is a SquareBraceStart
+          will be considered to be a JSON Array stream
+           */
+        case CurlyBraceStart ⇒
+          pp.take()
+          pp.enterContainer(InOuterObject, NotArrayAfterElement)
+
         case _ ⇒
           throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] — junk after value in linebreak or comma-separated stream")
       }
@@ -339,6 +349,16 @@ import scala.annotation.{ switch }
 
         case _ if isWhitespace(input) ⇒
           pp.skip()
+
+        /* This is a tolerance; since there is no ambiguity, we can consider a next object immediately after
+        the previous, even without a Comma or Linebreak separator. Akka Stream 2.5.16 has historically supported that.
+
+        We can't extend the same tolerance to arrays, as any stream whose first non-whitespace character is a SquareBraceStart
+        will be considered to be a JSON Array stream
+         */
+        case CurlyBraceStart ⇒
+          pp.take()
+          pp.enterContainer(InOuterObject, this)
 
         case _ ⇒
           throw new FramingException(s"Invalid JSON encountered at position [${pp.pos}] of [${pp.buffer}] — junk after value in $separatorName-separated stream")

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
@@ -136,7 +136,9 @@ object Framing {
   def simpleFramingProtocolEncoder(maximumMessageLength: Int): Flow[ByteString, ByteString, NotUsed] =
     Flow[ByteString].via(new SimpleFramingProtocolEncoder(maximumMessageLength))
 
-  class FramingException(msg: String) extends RuntimeException(msg)
+  class FramingException(msg: String, inner: Throwable) extends RuntimeException(msg, inner) {
+    def this(msg: String) = this(msg, null)
+  }
 
   private final val bigEndianDecoder: (ByteIterator, Int) ⇒ Int = (bs, length) ⇒ {
     var count = length


### PR DESCRIPTION
This PR fixes #25673 by making the JsonObjectParser framing engine able to also accept:

- arrays of scalar Json values (strings, booleans, numbers)
- linebreak or comma-separated scalar Json values 

The tests are expanded to reflect this improvement.

In terms of implementation, the increased complexity led me to extract the state machine logic (formerly in ```def proceed```) into independent private state objects (which are stored within the companion in order to avoid creating tons of instances at each new stream). The JsonObjectParser will now behave very differently according to the following keys:
  - if the first non-whitespace character is a ```[```, then the parser assumes the "JSON Array" encoding and will enforce a single value per item, separated by commas, and optionally terminated with a single ```]``` (it will not complain if that is missing).
  - otherwise, it runs in "separator-separated mode". This mode is subdivided in comma or linebreak-separated mode, depending in which separator is found after the first value. 

Furthermore, it was discovered as part of running the JMH Benchmark that the previous implementation of JsonObjectParser was able to accept streams of unseparated JSON *Object* values, i.e. it did correctly frame the following stream:
```json
  {"foo":1}{"foo":2}{"foo":3}
```
even though there is neither a comma or a line break between objects.
The tests are further expanded to reflect this. All three of "yet undetermined separator-separated", "comma-separated" and "linebreak-separated" modes accept the above sequence.

In terms of performance, at at **-wi 5 -i 5** iterations:

**Before**, (https://github.com/akka/akka/commit/16438fcb860f932aec4187c27053884dcf2d9fe5)
```text
Benchmark                                     Mode  Cnt        Score        Error  Units
JsonFramingBenchmark.counting_1              thrpt    5  2084711,811 ± 207865,821  ops/s
JsonFramingBenchmark.counting_long_document  thrpt    5      186,252 ±    116,947  ops/s
JsonFramingBenchmark.counting_offer_5        thrpt    5  2306649,473 ± 471682,266  ops/s
```
**After**:
```text
Benchmark                                     Mode  Cnt        Score        Error  Units
JsonFramingBenchmark.counting_1              thrpt    5  3418384,183 ± 481082,430  ops/s
JsonFramingBenchmark.counting_long_document  thrpt    5      728,951 ±     30,755  ops/s
JsonFramingBenchmark.counting_offer_5        thrpt    5  2772735,430 ± 321462,765  ops/s
```

When running at a high amount of iterations, it seems something strange kicks in (running with **-wi 30 -i 30**):
**Before**
```text
JsonFramingBenchmark.counting_1              thrpt   30  2565875,250 ± 24452,637  ops/s
JsonFramingBenchmark.counting_long_document  thrpt   30      190,048 ±     2,777  ops/s
JsonFramingBenchmark.counting_offer_5        thrpt   30  2188289,936 ± 32093,784  ops/s
```

**After**
```text
Benchmark                                     Mode  Cnt        Score       Error  Units
JsonFramingBenchmark.counting_1              thrpt   30  2409937,623 ± 10269,970  ops/s
JsonFramingBenchmark.counting_long_document  thrpt   30      700,063 ±    15,331  ops/s
JsonFramingBenchmark.counting_offer_5        thrpt   30  2078812,214 ± 45579,564  ops/s
```
There is a noticeable drop in throughput for ```counting_1``` and ```counting_offer_5``` after the 20th warm-up iteration. It is unclear to me whether JsonObjectParser, thermal CPU throttling or the test fixture itself is the culprit (the nominal CPU frequency appeared to stay put at 3509 MHz throughout the test runs)
```text
# JMH version: 1.21
# VM version: JDK 1.8.0_171, OpenJDK 64-Bit Server VM, 25.171-b11
# scala 2.12.6
```
