### PR TITLE
WIP: auto confirmations, #25482

### DIFF
--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
@@ -4,6 +4,9 @@
 
 package akka.cluster.sharding.typed.scaladsl
 
+import scala.concurrent.Future
+
+import akka.Done
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
@@ -13,6 +16,7 @@ import akka.cluster.typed.Cluster
 import akka.cluster.typed.Join
 import akka.persistence.typed.scaladsl.{ Effect, PersistentBehaviors }
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.persistence.typed.AutoConfirmation
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{ WordSpec, WordSpecLike }
 
@@ -40,6 +44,7 @@ object ClusterShardingPersistenceSpec {
 
   sealed trait Command
   final case class Add(s: String) extends Command
+  final case class AddWithConfirmation(s: String)(override val replyTo: ActorRef[Done]) extends Command with AutoConfirmation
   final case class Get(replyTo: ActorRef[String]) extends Command
   final case object StopPlz extends Command
 
@@ -48,7 +53,8 @@ object ClusterShardingPersistenceSpec {
       entityId,
       emptyState = "",
       commandHandler = (state, cmd) ⇒ cmd match {
-        case Add(s) ⇒ Effect.persist(s)
+        case Add(s)                 ⇒ Effect.persist(s)
+        case AddWithConfirmation(s) ⇒ Effect.persist(s)
         case Get(replyTo) ⇒
           replyTo ! s"$entityId:$state"
           Effect.none
@@ -69,13 +75,13 @@ class ClusterShardingPersistenceSpec extends ScalaTestWithActorTestKit(ClusterSh
 
     Cluster(system).manager ! Join(Cluster(system).selfMember.address)
 
-    "start persistent actor" in {
-      ClusterSharding(system).start(ShardedEntity(
-        entityId ⇒ persistentActor(entityId),
-        typeKey,
-        StopPlz
-      ))
+    ClusterSharding(system).start(ShardedEntity(
+      entityId ⇒ persistentActor(entityId),
+      typeKey,
+      StopPlz
+    ))
 
+    "start persistent actor" in {
       val p = TestProbe[String]()
 
       val ref = ClusterSharding(system).entityRefFor(typeKey, "123")
@@ -84,6 +90,20 @@ class ClusterShardingPersistenceSpec extends ScalaTestWithActorTestKit(ClusterSh
       ref ! Add("c")
       ref ! Get(p.ref)
       p.expectMessage("123:a|b|c")
+    }
+
+    "support ask with AutoConfirmation" in {
+      val p = TestProbe[String]()
+
+      val ref = ClusterSharding(system).entityRefFor(typeKey, "456")
+      val done1 = ref ? AddWithConfirmation("a")
+      done1.futureValue should ===(Done)
+
+      val done2: Future[Done] = ref ? AddWithConfirmation("b")
+      done2.futureValue should ===(Done)
+
+      ref ! Get(p.ref)
+      p.expectMessage("456:a|b")
     }
   }
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/AutoConfirmation.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/AutoConfirmation.scala
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed
+
+import akka.Done
+import akka.actor.typed.ActorRef
+
+/**
+ * A `Done` response message is automatically sent when commands implement this trait.
+ * The reply is sent after events in the returned effects have been persisted.
+ * The reply is only sent if the effects contains events to be persisted. For example
+ * stashing a command and returning `Effect.none` will not send a reply until the
+ * command is unstashed and actually handled.
+ * The reply is sent to the given [[AutoConfirmation#replyTo]] `ActorRef`, which can be the `replyTo`
+ * for an `ask` request.
+ */
+trait AutoConfirmation {
+
+  def replyTo: ActorRef[Done]
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/SideEffect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/SideEffect.scala
@@ -25,6 +25,9 @@ final private[akka] case class Callback[State](effect: State ⇒ Unit) extends S
 @InternalApi
 private[akka] case object Stop extends SideEffect[Nothing]
 
+@InternalApi
+final private[akka] case class AutoConfirmationSideEffect[State](cmd: AutoConfirmation) extends SideEffect[State]
+
 object SideEffect {
   /**
    * Create a ChainedEffect that can be run after Effects


### PR DESCRIPTION
* Note that this is supposed to be used as an opt-in where
  explicit replies are considered to be adding too much boilerplate.
* Not sure if it solves the problem of forgetting it. You still have
  to remember to add it to the command classes. I think that is
  solved best with a clear error message for AskTimeoutException,
  which has already been done.
* I also thought about if all actors could support this, for
  the sake of consistency. My conclusion was that they can't
  because there is no good signal for when the command has been
  fully completed. For example it might be stashed, which should
  not result in a confirmation (yet).

I'm not convinced that we should have this. It's convenience for one special case, although common. It reduces boilerplate, but I don't think it's making the learning experience easier. Users have to learn how to send replies for other cases anyway.