### PR TITLE
PersistentEntity to glue together Sharding and PersistentBehavior better

### DIFF
--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/PersistentEntity.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/PersistentEntity.scala
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding.typed.javadsl
+
+import java.util.Optional
+
+import scala.compat.java8.OptionConverters._
+
+import akka.actor.typed.BackoffSupervisorStrategy
+import akka.actor.typed.Behavior
+import akka.persistence.typed.PersistenceId
+import akka.persistence.typed.javadsl.PersistentBehavior
+
+/**
+ * Any [[Behavior]] can be used as a sharded entity actor, but the combination of sharding and persistent
+ * actors is very common and therefore this `PersistentEntity` class is provided as convenience.
+ *
+ * It is a [[PersistentBehavior]] and is implemented in the same way. It selects the `persistenceId`
+ * automatically from the [[EntityTypeKey]] and `entityId` constructor parameters by using
+ * [[EntityTypeKey.persistenceIdFrom]].
+ */
+abstract class PersistentEntity[Command, Event, State >: Null] private (
+  val entityTypeKey: EntityTypeKey[Command],
+  persistenceId:     PersistenceId, supervisorStrategy: Optional[BackoffSupervisorStrategy])
+  extends PersistentBehavior[Command, Event, State](persistenceId, supervisorStrategy) {
+
+  def this(entityTypeKey: EntityTypeKey[Command], entityId: String) = {
+    this(entityTypeKey, persistenceId = entityTypeKey.persistenceIdFrom(entityId), Optional.empty[BackoffSupervisorStrategy])
+  }
+
+  def this(entityTypeKey: EntityTypeKey[Command], entityId: String, backoffSupervisorStrategy: BackoffSupervisorStrategy) = {
+    this(entityTypeKey, persistenceId = entityTypeKey.persistenceIdFrom(entityId), Optional.ofNullable(backoffSupervisorStrategy))
+  }
+
+}

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/PersistentEntity.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/PersistentEntity.scala
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding.typed.scaladsl
+
+import akka.actor.typed.Behavior
+import akka.persistence.typed.scaladsl.Effect
+import akka.persistence.typed.scaladsl.PersistentBehavior
+
+object PersistentEntity {
+
+  /**
+   * Create a `Behavior` for a persistent actor that is used with Cluster Sharding.
+   *
+   * Any [[Behavior]] can be used as a sharded entity actor, but the combination of sharding and persistent
+   * actors is very common and therefore this `PersistentEntity` is provided as convenience.
+   *
+   * It is a [[PersistentBehavior]] and is implemented in the same way. It selects the `persistenceId`
+   * automatically from the [[EntityTypeKey]] and `entityId` constructor parameters by using
+   * [[EntityTypeKey.persistenceIdFrom]].
+   */
+  def apply[Command, Event, State](
+    entityTypeKey:  EntityTypeKey[Command],
+    entityId:       String,
+    emptyState:     State,
+    commandHandler: (State, Command) ⇒ Effect[Event, State],
+    eventHandler:   (State, Event) ⇒ State): PersistentBehavior[Command, Event, State] =
+    PersistentBehavior(entityTypeKey.persistenceIdFrom(entityId), emptyState, commandHandler, eventHandler)
+}

--- a/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/MultiDcClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/MultiDcClusterShardingSpec.scala
@@ -7,7 +7,7 @@ package akka.cluster.sharding.typed
 import akka.actor.typed.{ ActorRef, Props }
 import akka.cluster.sharding.typed.scaladsl.EntityTypeKey
 import akka.cluster.sharding.typed.scaladsl.ClusterSharding
-import akka.cluster.sharding.typed.scaladsl.ShardedEntity
+import akka.cluster.sharding.typed.scaladsl.Entity
 import akka.cluster.typed.{ MultiDcClusterActors, MultiNodeTypedClusterSpec }
 import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
 import akka.actor.testkit.typed.scaladsl.TestProbe
@@ -69,9 +69,9 @@ abstract class MultiDcClusterShardingSpec extends MultiNodeSpec(MultiDcClusterSh
     "start sharding" in {
       val sharding = ClusterSharding(typedSystem)
       val shardRegion: ActorRef[ShardingEnvelope[PingProtocol]] = sharding.start(
-        ShardedEntity(
-          _ ⇒ multiDcPinger,
+        Entity(
           typeKey,
+          _ ⇒ multiDcPinger,
           NoMore))
       val probe = TestProbe[Pong]
       shardRegion ! ShardingEnvelope(entityId, Ping(probe.ref))
@@ -99,9 +99,9 @@ abstract class MultiDcClusterShardingSpec extends MultiNodeSpec(MultiDcClusterSh
   "be able to message cross dc via proxy" in {
     runOn(first, second) {
       val proxy: ActorRef[ShardingEnvelope[PingProtocol]] = ClusterSharding(typedSystem).start(
-        ShardedEntity(
-          _ ⇒ multiDcPinger,
+        Entity(
           typeKey,
+          _ ⇒ multiDcPinger,
           NoMore)
           .withSettings(ClusterShardingSettings(typedSystem).withDataCenter("dc2")))
       val probe = TestProbe[Pong]

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExample.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExample.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.akka.cluster.sharding.typed;
+
+import akka.actor.typed.ActorRef;
+import akka.actor.typed.ActorSystem;
+import akka.actor.typed.javadsl.ActorContext;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+
+//#persistent-entity-import
+import akka.cluster.sharding.typed.javadsl.EntityTypeKey;
+import akka.cluster.sharding.typed.javadsl.PersistentEntity;
+import akka.persistence.typed.javadsl.CommandHandler;
+import akka.persistence.typed.javadsl.Effect;
+import akka.persistence.typed.javadsl.EventHandler;
+//#persistent-entity-import
+
+//#persistent-entity-usage-import
+import akka.cluster.sharding.typed.javadsl.ClusterSharding;
+import akka.cluster.sharding.typed.javadsl.EntityRef;
+import akka.cluster.sharding.typed.javadsl.Entity;
+import akka.util.Timeout;
+//#persistent-entity-usage-import
+
+public class HelloWorldPersistentEntityExample {
+
+  //#persistent-entity-usage
+
+  public static class HelloWorldService {
+    private final ActorSystem<?> system;
+    private final ClusterSharding sharding;
+    private final Timeout askTimeout = Timeout.create(Duration.ofSeconds(5));
+
+    // registration at startup
+    public HelloWorldService(ActorSystem<?> system) {
+      this.system = system;
+      sharding = ClusterSharding.get(system);
+
+      sharding.start(
+        Entity.ofPersistentEntity(
+          HelloWorld.ENTITY_TYPE_KEY,
+          ctx -> new HelloWorld(ctx.getActorContext(), ctx.getEntityId()),
+          HelloWorld.Passivate.INSTANCE));
+    }
+
+    // usage example
+    public CompletionStage<Integer> sayHello(String worldId, String whom) {
+      EntityRef<HelloWorld.Command> entityRef =
+        sharding.entityRefFor(HelloWorld.ENTITY_TYPE_KEY, worldId);
+      CompletionStage<HelloWorld.Greeting> result =
+          entityRef.ask(replyTo -> new HelloWorld.Greet(whom, replyTo), askTimeout);
+      return result.thenApply(greeting -> greeting.numberOfPeople);
+    }
+  }
+  //#persistent-entity-usage
+
+  //#persistent-entity
+
+  public static class HelloWorld extends PersistentEntity<HelloWorld.Command, HelloWorld.Greeted, HelloWorld.KnownPeople> {
+
+    // Command
+    interface Command {
+    }
+
+    public static final class Greet implements Command {
+      public final String whom;
+      public final ActorRef<Greeting> replyTo;
+
+      public Greet(String whom, ActorRef<Greeting> replyTo) {
+        this.whom = whom;
+        this.replyTo = replyTo;
+      }
+    }
+
+    enum Passivate implements Command {
+      INSTANCE
+    }
+
+    // Response
+    public static final class Greeting {
+      public final String whom;
+      public final int numberOfPeople;
+
+      public Greeting(String whom, int numberOfPeople) {
+        this.whom = whom;
+        this.numberOfPeople = numberOfPeople;
+      }
+    }
+
+    // Event
+    public static final class Greeted {
+      public final String whom;
+
+      public Greeted(String whom) {
+        this.whom = whom;
+      }
+    }
+
+    // State
+    static final class KnownPeople {
+      private Set<String> names = Collections.emptySet();
+
+      KnownPeople() {
+      }
+
+      private KnownPeople(Set<String> names) {
+        this.names = names;
+      }
+
+      KnownPeople add(String name) {
+        Set<String> newNames = new HashSet<>(names);
+        newNames.add(name);
+        return new KnownPeople(newNames);
+      }
+
+      int numberOfPeople() {
+        return names.size();
+      }
+    }
+
+    public static final EntityTypeKey<Command> ENTITY_TYPE_KEY =
+      EntityTypeKey.create(Command.class, "HelloWorld");
+
+    public HelloWorld(ActorContext<Command> ctx, String entityId) {
+      super(ENTITY_TYPE_KEY, entityId);
+    }
+
+    @Override
+    public KnownPeople emptyState() {
+      return new KnownPeople();
+    }
+
+    @Override
+    public CommandHandler<Command, Greeted, KnownPeople> commandHandler() {
+      return commandHandlerBuilder(KnownPeople.class)
+        .matchCommand(Greet.class, this::greet)
+        .matchCommand(Greet.class, this::passivate)
+        .build();
+    }
+
+    private Effect<Greeted, KnownPeople> passivate(KnownPeople state, Command cmd) {
+      return Effect().stop();
+    }
+
+    private Effect<Greeted, KnownPeople> greet(KnownPeople state, Greet cmd) {
+      return Effect().persist(new Greeted(cmd.whom))
+        .andThen(newState -> cmd.replyTo.tell(new Greeting(cmd.whom, newState.numberOfPeople())));
+    }
+
+    @Override
+    public EventHandler<KnownPeople, Greeted> eventHandler() {
+      return (state, evt) -> state.add(evt.whom);
+    }
+
+  }
+  //#persistent-entity
+}

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExampleTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExampleTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.akka.cluster.sharding.typed;
+
+import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
+import akka.actor.testkit.typed.javadsl.TestProbe;
+import akka.cluster.sharding.typed.javadsl.ClusterSharding;
+import akka.cluster.sharding.typed.javadsl.EntityRef;
+import akka.cluster.sharding.typed.javadsl.Entity;
+import akka.cluster.typed.Cluster;
+import akka.cluster.typed.Join;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
+
+import static jdocs.akka.cluster.sharding.typed.HelloWorldPersistentEntityExample.*;
+import static org.junit.Assert.assertEquals;
+
+public class HelloWorldPersistentEntityExampleTest extends JUnitSuite {
+
+  public static final Config config = ConfigFactory.parseString(
+          "akka.actor.provider = cluster \n" +
+          "akka.remote.netty.tcp.port = 0 \n" +
+          "akka.remote.artery.canonical.port = 0 \n" +
+          "akka.remote.artery.canonical.hostname = 127.0.0.1 \n" +
+          "akka.persistence.journal.plugin = \"akka.persistence.journal.inmem\" \n");
+
+  @ClassRule
+  public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
+
+  private ClusterSharding _sharding = null;
+
+  private ClusterSharding sharding() {
+    if (_sharding == null) {
+      // initialize first time only
+      Cluster cluster = Cluster.get(testKit.system());
+      cluster.manager().tell(new Join(cluster.selfMember().address()));
+
+      ClusterSharding sharding = ClusterSharding.get(testKit.system());
+      sharding.start(
+        Entity.ofPersistentEntity(
+          HelloWorld.ENTITY_TYPE_KEY,
+          ctx -> new HelloWorld(ctx.getActorContext(), ctx.getEntityId()),
+          HelloWorld.Passivate.INSTANCE));
+      _sharding = sharding;
+    }
+    return _sharding;
+  }
+
+  @Test
+  public void sayHello() {
+    EntityRef<HelloWorld.Command> world = sharding().entityRefFor(HelloWorld.ENTITY_TYPE_KEY, "1");
+    TestProbe<HelloWorld.Greeting> probe = testKit.createTestProbe(HelloWorld.Greeting.class);
+    world.tell(new HelloWorld.Greet("Alice", probe.getRef()));
+    HelloWorld.Greeting greeting1 = probe.expectMessageClass(HelloWorld.Greeting.class);
+    assertEquals("Alice", greeting1.whom);
+    assertEquals(1, greeting1.numberOfPeople);
+
+    world.tell(new HelloWorld.Greet("Bob", probe.getRef()));
+    HelloWorld.Greeting greeting2 = probe.expectMessageClass(HelloWorld.Greeting.class);
+    assertEquals("Bob", greeting2.whom);
+    assertEquals(2, greeting2.numberOfPeople);
+  }
+
+}

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java
@@ -16,7 +16,7 @@ import akka.cluster.sharding.typed.ShardingEnvelope;
 import akka.cluster.sharding.typed.javadsl.ClusterSharding;
 import akka.cluster.sharding.typed.javadsl.EntityTypeKey;
 import akka.cluster.sharding.typed.javadsl.EntityRef;
-import akka.cluster.sharding.typed.javadsl.ShardedEntity;
+import akka.cluster.sharding.typed.javadsl.Entity;
 
 //#import
 
@@ -103,9 +103,9 @@ public class ShardingCompileOnlyTest {
     EntityTypeKey<CounterCommand> typeKey = EntityTypeKey.create(CounterCommand.class, "Counter");
 
     sharding.start(
-      ShardedEntity.create(
-        (shard, entityId) -> counter2(shard, entityId),
+      Entity.of(
         typeKey,
+        ctx -> counter2(ctx.getShard(), ctx.getEntityId()),
         new GoodByeCounter()));
     //#counter-passivate-start
   }
@@ -124,9 +124,9 @@ public class ShardingCompileOnlyTest {
     EntityTypeKey<CounterCommand> typeKey = EntityTypeKey.create(CounterCommand.class, "Counter");
 
     ActorRef<ShardingEnvelope<CounterCommand>> shardRegion = sharding.start(
-      ShardedEntity.create(
-        entityId -> counter(entityId,0),
+      Entity.of(
         typeKey,
+        ctx -> counter(ctx.getEntityId(),0),
         new GoodByeCounter()));
     //#start
 
@@ -148,9 +148,9 @@ public class ShardingCompileOnlyTest {
     EntityTypeKey<BlogCommand> blogTypeKey = EntityTypeKey.create(BlogCommand.class, "BlogPost");
 
     sharding.start(
-      ShardedEntity.create(
-        BlogBehavior::behavior,
+      Entity.of(
         blogTypeKey,
+        ctx -> BlogBehavior.behavior(ctx.getEntityId()),
         new PassivatePost()));
     //#persistence
   }

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExample.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExample.scala
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.akka.cluster.sharding.typed
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+
+object HelloWorldPersistentEntityExample {
+
+  //#persistent-entity-usage
+  import akka.cluster.sharding.typed.scaladsl.ClusterSharding
+  import akka.cluster.sharding.typed.scaladsl.Entity
+  import akka.util.Timeout
+
+  class HelloWorldService(system: ActorSystem[_]) {
+    import system.executionContext
+
+    // registration at startup
+    private val sharding = ClusterSharding(system)
+
+    sharding.start(Entity(
+      typeKey = HelloWorld.entityTypeKey,
+      createBehavior = entityContext ⇒ HelloWorld.persistentEntity(entityContext.entityId),
+      stopMessage = HelloWorld.Passivate))
+
+    private implicit val askTimeout: Timeout = Timeout(5.seconds)
+
+    def greet(worldId: String, whom: String): Future[Int] = {
+      val entityRef = sharding.entityRefFor(HelloWorld.entityTypeKey, worldId)
+      val greeting = entityRef ? HelloWorld.Greet(whom)
+      greeting.map(_.numberOfPeople)
+    }
+
+  }
+  //#persistent-entity-usage
+
+  //#persistent-entity
+  import akka.actor.typed.Behavior
+  import akka.cluster.sharding.typed.scaladsl.EntityTypeKey
+  import akka.cluster.sharding.typed.scaladsl.PersistentEntity
+  import akka.persistence.typed.scaladsl.Effect
+
+  object HelloWorld {
+
+    // Command
+    trait Command
+    final case class Greet(whom: String)(val replyTo: ActorRef[Greeting]) extends Command
+    case object Passivate extends Command
+    // Response
+    final case class Greeting(whom: String, numberOfPeople: Int)
+
+    // Event
+    final case class Greeted(whom: String)
+
+    // State
+    private final case class KnownPeople(names: Set[String]) {
+      def add(name: String): KnownPeople = copy(names = names + name)
+
+      def numberOfPeople: Int = names.size
+    }
+
+    private val commandHandler: (KnownPeople, Command) ⇒ Effect[Greeted, KnownPeople] = {
+      (_, cmd) ⇒
+        cmd match {
+          case cmd: Greet ⇒ greet(cmd)
+          case Passivate  ⇒ passivate()
+        }
+    }
+
+    private def greet(cmd: Greet): Effect[Greeted, KnownPeople] =
+      Effect.persist(Greeted(cmd.whom))
+        .thenRun(state ⇒ cmd.replyTo ! Greeting(cmd.whom, state.numberOfPeople))
+
+    private def passivate(): Effect[Greeted, KnownPeople] =
+      Effect.stop
+
+    private val eventHandler: (KnownPeople, Greeted) ⇒ KnownPeople = {
+      (state, evt) ⇒ state.add(evt.whom)
+    }
+
+    val entityTypeKey: EntityTypeKey[Command] =
+      EntityTypeKey[Command]("HelloWorld")
+
+    def persistentEntity(entityId: String): Behavior[Command] = PersistentEntity(
+      entityTypeKey = entityTypeKey,
+      entityId = entityId,
+      emptyState = KnownPeople(Set.empty),
+      commandHandler,
+      eventHandler
+    )
+
+  }
+  //#persistent-entity
+
+}

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExampleSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExampleSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.akka.cluster.sharding.typed
+
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.cluster.sharding.typed.scaladsl.ClusterSharding
+import akka.cluster.sharding.typed.scaladsl.Entity
+import akka.cluster.typed.Cluster
+import akka.cluster.typed.Join
+import com.typesafe.config.ConfigFactory
+import org.scalatest.WordSpecLike
+
+object HelloWorldPersistentEntityExampleSpec {
+  val config = ConfigFactory.parseString(
+    """
+      akka.actor.provider = cluster
+
+      akka.remote.netty.tcp.port = 0
+      akka.remote.artery.canonical.port = 0
+      akka.remote.artery.canonical.hostname = 127.0.0.1
+
+      akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+    """)
+}
+
+class HelloWorldPersistentEntityExampleSpec extends ScalaTestWithActorTestKit(HelloWorldPersistentEntityExampleSpec.config) with WordSpecLike {
+  import HelloWorldPersistentEntityExample.HelloWorld
+  import HelloWorldPersistentEntityExample.HelloWorld._
+
+  val sharding = ClusterSharding(system)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    Cluster(system).manager ! Join(Cluster(system).selfMember.address)
+
+    sharding.start(Entity(
+      HelloWorld.entityTypeKey,
+      ctx ⇒ HelloWorld.persistentEntity(ctx.entityId),
+      HelloWorld.Passivate
+    ))
+  }
+
+  "HelloWorld example" must {
+
+    "sayHello" in {
+      val probe = createTestProbe[Greeting]()
+      val ref = ClusterSharding(system).entityRefFor(HelloWorld.entityTypeKey, "1")
+      ref ! Greet("Alice")(probe.ref)
+      probe.expectMessage(Greeting("Alice", 1))
+      ref ! Greet("Bob")(probe.ref)
+      probe.expectMessage(Greeting("Bob", 2))
+    }
+
+  }
+}

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ShardingCompileOnlySpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ShardingCompileOnlySpec.scala
@@ -6,9 +6,9 @@ package docs.akka.cluster.sharding.typed
 
 import scala.concurrent.duration._
 
-import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, Props }
+import akka.actor.typed.{ ActorRef, ActorSystem, Behavior }
 import akka.actor.typed.scaladsl.Behaviors
-import akka.cluster.sharding.typed.scaladsl.ShardedEntity
+import akka.cluster.sharding.typed.scaladsl.Entity
 import docs.akka.persistence.typed.BlogPostExample
 import docs.akka.persistence.typed.BlogPostExample.{ BlogCommand, PassivatePost }
 
@@ -17,7 +17,6 @@ object ShardingCompileOnlySpec {
   val system = ActorSystem(Behaviors.empty, "Sharding")
 
   //#sharding-extension
-  import akka.cluster.sharding.typed.ClusterShardingSettings
   import akka.cluster.sharding.typed.ShardingEnvelope
   import akka.cluster.sharding.typed.scaladsl.ClusterSharding
   import akka.cluster.sharding.typed.scaladsl.EntityTypeKey
@@ -50,9 +49,9 @@ object ShardingCompileOnlySpec {
   //#start
   val TypeKey = EntityTypeKey[CounterCommand]("Counter")
 
-  val shardRegion: ActorRef[ShardingEnvelope[CounterCommand]] = sharding.start(ShardedEntity(
-    create = entityId ⇒ counter(entityId, 0),
+  val shardRegion: ActorRef[ShardingEnvelope[CounterCommand]] = sharding.start(Entity(
     typeKey = TypeKey,
+    createBehavior = ctx ⇒ counter(ctx.entityId, 0),
     stopMessage = GoodByeCounter))
   //#start
 
@@ -69,9 +68,9 @@ object ShardingCompileOnlySpec {
   //#persistence
   val BlogTypeKey = EntityTypeKey[BlogCommand]("BlogPost")
 
-  ClusterSharding(system).start(ShardedEntity(
-    create = entityId ⇒ behavior(entityId),
+  ClusterSharding(system).start(Entity(
     typeKey = BlogTypeKey,
+    createBehavior = ctx ⇒ behavior(ctx.entityId),
     stopMessage = PassivatePost))
   //#persistence
 
@@ -103,9 +102,9 @@ object ShardingCompileOnlySpec {
     }
   }
 
-  sharding.start(ShardedEntity(
-    create = (shard, entityId) ⇒ counter2(shard, entityId),
+  sharding.start(Entity(
     typeKey = TypeKey,
+    createBehavior = ctx ⇒ counter2(ctx.shard, ctx.entityId),
     stopMessage = GoodByeCounter))
   //#counter-passivate
 

--- a/akka-docs/src/main/paradox/typed/interaction-patterns.md
+++ b/akka-docs/src/main/paradox/typed/interaction-patterns.md
@@ -169,8 +169,8 @@ The response adapting function is running in the receiving actor and can safely 
  * When `ask` times out, the receiving actor does not know and may still process it to completion, or even start processing it after the fact
  * Finding a good value for the timeout, especially when `ask` is triggers chained `ask`s in the receiving actor. You want a short timeout to be responsive and answer back to the requester, but at the same time you do not want to have many false positives 
 
-
-## Request-Response with ask from outside the ActorSystem
+<a id="outside-ask"></a>
+## Request-Response with ask from outside an Actor
 
 Some times you need to interact with actors from outside of the actor system, this can be done with fire-and-forget as described above or through another version of `ask` that returns a @scala[`Future[Response]`]@java[`CompletionStage<Response>`] that is either completed with a successful response or failed with a `TimeoutException` if there was no response within the specified timeout.
  

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -130,8 +130,19 @@ Scala
 Java
 :  @@snip [PersistentActorCompileOnyTest.java](/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java) { #behavior }
 
-The `PersistentBehavior` can then be run as with any plain typed actor as described in [typed actors documentation](actors-typed.md).
+## Cluster Sharding and persistence
 
+In a use case where the number of persistent actors needed are higher than what would fit in the memory of one node or
+where resilience is important so that if a node crashes the persistent actors are quickly started on a new node and can
+resume operations @ref:[Cluster Sharding](cluster-sharding.md) is an excellent fit to spread persistent actors over a
+cluster and address them by id.
+
+The `PersistentBehavior` can then be run as with any plain typed actor as described in [actors documentation](actors-typed.md),
+but since Akka Persistence is based on the single-writer principle the persistent actors are typically used together
+with Cluster Sharding. For a particular `persistenceId` only one persistent actor instance should be active at one time.
+If multiple instances were to persist events at the same time, the events would be interleaved and might not be
+interpreted correctly on replay. Cluster Sharding ensures that there is only one active entity for each id. The
+@ref:[Cluster Sharding example](cluster-sharding.md#persistence-example) illustrates this common combination.
 
 ## Accessing the ActorContext
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Effect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Effect.scala
@@ -14,6 +14,11 @@ import akka.persistence.typed.ExpectingReply
 
 object EffectFactory extends EffectFactories[Nothing, Nothing, Nothing]
 
+/**
+ * Factory methods for creating [[Effect]] directives.
+ *
+ * Not for user extension
+ */
 @DoNotInherit sealed class EffectFactories[Command, Event, State] {
   /**
    * Persist a single event

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/PersistentBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/PersistentBehavior.scala
@@ -7,7 +7,6 @@ package akka.persistence.typed.scaladsl
 import akka.Done
 import akka.actor.typed.BackoffSupervisorStrategy
 import akka.actor.typed.Behavior.DeferredBehavior
-import akka.annotation.InternalApi
 import akka.persistence._
 import akka.persistence.typed.EventAdapter
 import akka.persistence.typed.internal._
@@ -85,9 +84,14 @@ object PersistentBehavior {
 }
 
 /**
- * Not intended for user extension.
+ * Further customization of the `PersistentBehavior` can be done with the methods defined here.
+ *
+ * Not for user extension
  */
 @DoNotInherit trait PersistentBehavior[Command, Event, State] extends DeferredBehavior[Command] {
+
+  def persistenceId: PersistenceId
+
   /**
    * The `callback` function is called to notify the actor that the recovery process
    * is finished.


### PR DESCRIPTION
* for example you don't have to worry about the persistenceId, only EntityTypeKey and entityId

PersistentEntityCompileOnlyTest illustrates how it's used.