### PR TITLE
Add completeAfterIdleTimeout

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -2588,6 +2588,21 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     idleTimeout(timeout.asScala)
 
   /**
+    * Terminate processing (and cancel the upstream publisher) if the time between two processed
+    * elements exceeds the provided timeout.
+    *
+    * '''Emits when''' upstream emits an element
+    *
+    * '''Backpressures when''' downstream backpressures
+    *
+    * '''Completes when''' upstream completes
+    *
+    * '''Cancels when''' downstream cancels or timeout elapses between two emitted elements
+    */
+  def completeAfterIdleTimeout(timeout: java.time.Duration): javadsl.Flow[In, Out, Mat] =
+    new Flow(delegate.completeAfterIdleTimeout(timeout.asScala))
+
+  /**
    * If the time between the emission of an element and the following downstream demand exceeds the provided timeout,
    * the stream is failed with a [[java.util.concurrent.TimeoutException]]. The timeout is checked periodically,
    * so the resolution of the check is one period (equals to timeout value).

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2756,6 +2756,21 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
     completionTimeout(timeout.asScala)
 
   /**
+    * Terminate processing (and cancel the upstream publisher) if the time between two processed
+    * elements exceeds the provided timeout.
+    *
+    * '''Emits when''' upstream emits an element
+    *
+    * '''Backpressures when''' downstream backpressures
+    *
+    * '''Completes when''' upstream completes
+    *
+    * '''Cancels when''' downstream cancels or timeout elapses between two emitted elements
+    */
+  def completeAfterIdleTimeout(timeout: java.time.Duration): javadsl.Source[Out, Mat] =
+    new Source(delegate.completeAfterIdleTimeout(timeout.asScala))
+
+  /**
    * If the time between two processed elements exceeds the provided timeout, the stream is failed
    * with a [[java.util.concurrent.TimeoutException]]. The timeout is checked periodically,
    * so the resolution of the check is one period (equals to timeout value).

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -2069,6 +2069,20 @@ trait FlowOps[+Out, +Mat] {
   def idleTimeout(timeout: FiniteDuration): Repr[Out] = via(new Timers.Idle[Out](timeout))
 
   /**
+    * Terminate processing (and cancel the upstream publisher) if the time between two processed
+    * elements exceeds the provided timeout.
+    *
+    * '''Emits when''' upstream emits an element
+    *
+    * '''Backpressures when''' downstream backpressures
+    *
+    * '''Completes when''' upstream completes
+    *
+    * '''Cancels when''' downstream cancels or timeout elapses between two emitted elements
+    */
+  def completeAfterIdleTimeout(timeout: FiniteDuration): Repr[Out] = via(new Timers.CompleteAfterIdle[Out](timeout))
+
+  /**
    * If the time between the emission of an element and the following downstream demand exceeds the provided timeout,
    * the stream is failed with a [[scala.concurrent.TimeoutException]]. The timeout is checked periodically,
    * so the resolution of the check is one period (equals to timeout value).


### PR DESCRIPTION
Adds a feature to akka-streams so you can configure a stream to gracefully complete after a period of inactivity.

The use case that I had when I created this was to end processing a stream with multiple merged sources, I had to be sure I consumed all the useful messages from each source (and some sources could have more useful messages than others) so a simple `takeWhile()` wouldn't suffice as I don't want to stop processing when a single source is fully processed.
The solution here would be `.filter().completeAfterIdleTimeout()` so basically this stream would be completed after all the sources had stopped providing useful messages