### PR TITLE
Refactor PersistentActorJavaDslTest

### DIFF
--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -472,20 +472,20 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
   public void tapPersistentActor() {
     TestProbe<Object> interceptProbe = testKit.createTestProbe();
     TestProbe<Signal> signalProbe = testKit.createTestProbe();
-    BehaviorInterceptor<Object, Object> tap = new BehaviorInterceptor<Object, Object>() {
+    BehaviorInterceptor<Command, Command> tap = new BehaviorInterceptor<Command, Command>() {
       @Override
-      public Behavior<Object> aroundReceive(ActorContext<Object> ctx, Object msg, ReceiveTarget<Object> target) {
+      public Behavior<Command> aroundReceive(ActorContext<Command> ctx, Command msg, ReceiveTarget<Command> target) {
         interceptProbe.ref().tell(msg);
         return target.apply(ctx, msg);
       }
 
       @Override
-      public Behavior<Object> aroundSignal(ActorContext<Object> ctx, Signal signal, SignalTarget<Object> target) {
+      public Behavior<Command> aroundSignal(ActorContext<Command> ctx, Signal signal, SignalTarget<Command> target) {
         signalProbe.ref().tell(signal);
         return target.apply(ctx, signal);
       }
     };
-    ActorRef<Command> c = testKit.spawn(Behaviors.intercept(tap, ((Behavior)counter(new PersistenceId("tap1")))));
+    ActorRef<Command> c = testKit.spawn(Behaviors.intercept(tap, counter(new PersistenceId("tap1"))));
     c.tell(Increment.instance);
     interceptProbe.expectMessage(Increment.instance);
     signalProbe.expectNoMessage();

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -48,9 +48,6 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
   public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
 
 
-  static final Incremented timeoutEvent = new Incremented(100);
-  static final Incremented terminatedEvent = new Incremented(10);
-
   private LeveldbReadJournal queries = PersistenceQuery.get(Adapter.toUntyped(testKit.system()))
     .getReadJournalFor(LeveldbReadJournal.class, LeveldbReadJournal.Identifier());
 
@@ -254,7 +251,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     }
 
     private Effect<Incremented, State> timeout(State state, Timeout command) {
-      return Effect().persist(timeoutEvent);
+      return Effect().persist(new Incremented(100));
     }
 
     private Effect<Incremented, State> emptyEventsListAndThenLog(State state, EmptyEventsListAndThenLog command) {
@@ -348,7 +345,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     c.tell(Increment.INSTANCE);
     c.tell(IncrementLater.INSTANCE);
     eventHandlerProbe.expectMessage(Pair.create(State.EMPTY, new Incremented(1)));
-    eventHandlerProbe.expectMessage(Pair.create(new State(1, Collections.singletonList(0)), terminatedEvent));
+    eventHandlerProbe.expectMessage(Pair.create(new State(1, Collections.singletonList(0)), new Incremented(10)));
   }
 
   @Test
@@ -365,7 +362,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     );
     ActorRef<Command> c = testKit.spawn(counter);
     c.tell(Increment100OnTimeout.INSTANCE);
-    eventHandlerProbe.expectMessage(Pair.create(State.EMPTY, timeoutEvent));
+    eventHandlerProbe.expectMessage(Pair.create(State.EMPTY, new Incremented(100)));
   }
 
   @Test


### PR DESCRIPTION
As I was exploring the Java typed persistence API through this test, I made a few changes to the structure to simplify it and make some more idiomatic or recommended Java patterns.

I can split this into separate pull requests for the `BehaviorInterceptor` change and the other changes if the Akka team prefers.