### PR TITLE
WIP: experiment with mutable state and builders inside state class

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventHandler.scala
@@ -83,6 +83,19 @@ final class EventHandlerBuilder[State >: Null, Event]() {
   }
 
   /**
+   * Match any event.
+   *
+   * Use this when then `State` is not needed in the `handler`, otherwise there is an overloaded method that pass
+   * the state in a `BiFunction`.
+   */
+  def matchAny(f: JFunction[Event, State]): EventHandler[State, Event] = {
+    matchAny(new BiFunction[State, Event, State] {
+      override def apply(state: State, event: Event): State = f(event)
+    })
+    build()
+  }
+
+  /**
    * Compose this builder with another builder. The handlers in this builder will be tried first followed
    * by the handlers in `other`.
    */

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/PersistentBehavior10.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/PersistentBehavior10.scala
@@ -1,0 +1,188 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.javadsl
+
+import java.util.function.Predicate
+import java.util.{ Collections, Optional }
+
+import akka.actor.typed
+import akka.actor.typed.{ BackoffSupervisorStrategy, Behavior }
+import akka.actor.typed.Behavior.DeferredBehavior
+import akka.annotation.{ ApiMayChange, InternalApi }
+import akka.persistence.SnapshotMetadata
+import akka.persistence.typed.{ EventAdapter, _ }
+import akka.persistence.typed.internal._
+import scala.util.{ Failure, Success }
+
+/** Java API */
+@ApiMayChange
+abstract class PersistentBehavior10[Command, Event, State >: Null, ImmutableSnapshot] private (val persistenceId: PersistenceId, supervisorStrategy: Option[BackoffSupervisorStrategy]) extends DeferredBehavior[Command] {
+
+  def this(persistenceId: PersistenceId) = {
+    this(persistenceId, None)
+  }
+
+  def this(persistenceId: PersistenceId, backoffSupervisorStrategy: BackoffSupervisorStrategy) = {
+    this(persistenceId, Some(backoffSupervisorStrategy))
+  }
+
+  /**
+   * Factory of effects.
+   *
+   * Return effects from your handlers in order to instruct persistence on how to act on the incoming message (i.e. persist events).
+   */
+  protected final def Effect: EffectFactories[Command, Event, State] = EffectFactory.asInstanceOf[EffectFactories[Command, Event, State]]
+
+  /**
+   * Implement by returning the initial empty state object.
+   * This object will be passed into this behaviors handlers, until a new state replaces it.
+   *
+   * Also known as "zero state" or "neutral state".
+   */
+  protected def emptyState: State
+
+  /**
+   * Implement by handling incoming commands and return an `Effect()` to persist or signal other effects
+   * of the command handling such as stopping the behavior or others.
+   *
+   * The command handlers are only invoked when the actor is running (i.e. not replaying).
+   * While the actor is persisting events, the incoming messages are stashed and only
+   * delivered to the handler once persisting them has completed.
+   */
+  protected def commandHandler(): CommandHandler[Command, Event, State]
+
+  /**
+   * Implement by applying the event to the current state in order to return a new state.
+   *
+   * The event handlers are invoked during recovery as well as running operation of this behavior,
+   * in order to keep updating the state state.
+   *
+   * For that reason it is strongly discouraged to perform side-effects in this handler;
+   * Side effects should be executed in `andThen` or `recoveryCompleted` blocks.
+   */
+  protected def eventHandler(): EventHandler[State, Event]
+
+  /**
+   * The snapshot must be immutable because it is serialized asynchronously by another thread.
+   * If the `State` is immutable it can be returned as is, otherwise an immutable representation
+   * or a deep copy that is not modified later must be returned.
+   */
+  protected def toSnapshot(state: State): ImmutableSnapshot
+
+  protected def fromSnapshot(snapshot: ImmutableSnapshot): State
+
+  /**
+   * @param stateClass The handlers defined by this builder are used when the state is an instance of the `stateClass`
+   * @return A new, mutable, command handler builder
+   */
+  protected final def commandHandlerBuilder[S <: State](stateClass: Class[S]): CommandHandlerBuilder[Command, Event, S, State] =
+    CommandHandlerBuilder.builder[Command, Event, S, State](stateClass)
+
+  /**
+   * @param statePredicate The handlers defined by this builder are used when the `statePredicate` is `true`,
+   *                       *                       useful for example when state type is an Optional
+   * @return A new, mutable, command handler builder
+   */
+  protected final def commandHandlerBuilder(statePredicate: Predicate[State]): CommandHandlerBuilder[Command, Event, State, State] =
+    CommandHandlerBuilder.builder[Command, Event, State](statePredicate)
+
+  /**
+   * @return A new, mutable, event handler builder
+   */
+  protected final def eventHandlerBuilder(): EventHandlerBuilder[State, Event] =
+    EventHandlerBuilder.builder[State, Event]()
+
+  /**
+   * The `callback` function is called to notify the actor that the recovery process
+   * is finished.
+   */
+  def onRecoveryCompleted(state: State): Unit = ()
+
+  /**
+   * Override to get notified when a snapshot is finished.
+   *
+   * @param result None if successful otherwise contains the exception thrown when snapshotting
+   */
+  def onSnapshot(meta: SnapshotMetadata, result: Optional[Throwable]): Unit = ()
+
+  /**
+   * Override and define that snapshot should be saved every N events.
+   *
+   * If this is overridden `shouldSnapshot` is not used.
+   *
+   * @return number of events between snapshots, should be greater than 0
+   * @see [[PersistentBehavior10#shouldSnapshot]]
+   */
+  def snapshotEvery(): Long = 0L
+
+  /**
+   * Initiates a snapshot if the given function returns true.
+   * When persisting multiple events at once the snapshot is triggered after all the events have
+   * been persisted.
+   *
+   * receives the State, Event and the sequenceNr used for the Event
+   *
+   * @return `true` if snapshot should be saved for the given event
+   * @see [[PersistentBehavior#snapshotEvery]]
+   */
+  def shouldSnapshot(state: State, event: Event, sequenceNr: Long): Boolean = false
+
+  /**
+   * The `tagger` function should give event tags, which will be used in persistence query
+   */
+  def tagsFor(event: Event): java.util.Set[String] = Collections.emptySet()
+
+  def eventAdapter(): EventAdapter[Event, _] = NoOpEventAdapter.instance[Event]
+
+  /**
+   * INTERNAL API: DeferredBehavior init
+   */
+  @InternalApi override def apply(context: typed.ActorContext[Command]): Behavior[Command] = {
+
+    val snapshotWhen: (State, Event, Long) ⇒ Boolean = { (state, event, seqNr) ⇒
+      val n = snapshotEvery()
+      if (n > 0)
+        seqNr % n == 0
+      else
+        shouldSnapshot(state, event, seqNr)
+    }
+
+    val tagger: Event ⇒ Set[String] = { event ⇒
+      import scala.collection.JavaConverters._
+      val tags = tagsFor(event)
+      if (tags.isEmpty) Set.empty
+      else tags.asScala.toSet
+    }
+
+    val behavior = scaladsl.PersistentBehavior[Command, Event, State](
+      persistenceId,
+      emptyState,
+      (state, cmd) ⇒ commandHandler()(state, cmd).asInstanceOf[EffectImpl[Event, State]],
+      eventHandler()(_, _))
+      .onRecoveryCompleted(onRecoveryCompleted)
+      .snapshotWhen(snapshotWhen)
+      .withTagger(tagger)
+      .onSnapshot((meta, result) ⇒ {
+        result match {
+          case Success(_) ⇒
+            context.asScala.log.debug("Save snapshot successful, snapshot metadata: [{}]", meta)
+          case Failure(e) ⇒
+            context.asScala.log.error(e, "Save snapshot failed, snapshot metadata: [{}]", meta)
+        }
+
+        onSnapshot(meta, result match {
+          case Success(_) ⇒ Optional.empty()
+          case Failure(t) ⇒ Optional.of(t)
+        })
+      }).eventAdapter(eventAdapter())
+
+    if (supervisorStrategy.isDefined)
+      behavior.onPersistFailure(supervisorStrategy.get)
+    else
+      behavior
+  }
+
+}
+

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/AccountExample10.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/AccountExample10.java
@@ -1,0 +1,222 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.akka.persistence.typed;
+
+import akka.actor.typed.Behavior;
+import akka.actor.typed.javadsl.ActorContext;
+import akka.actor.typed.javadsl.Behaviors;
+import akka.persistence.typed.PersistenceId;
+import akka.persistence.typed.javadsl.CommandHandler;
+import akka.persistence.typed.javadsl.CommandHandlerBuilder;
+import akka.persistence.typed.javadsl.EventHandler;
+import akka.persistence.typed.javadsl.EventHandlerBuilder;
+import akka.persistence.typed.javadsl.PersistentBehavior10;
+
+public class AccountExample10 extends PersistentBehavior10<AccountExample10.AccountCommand, AccountExample10.AccountEvent, AccountExample10.Account, AccountExample10.AccountSnapshot> {
+
+  interface AccountCommand {}
+  public static class CreateAccount implements AccountCommand {}
+  public static class Deposit implements AccountCommand {
+    public final double amount;
+
+    public Deposit(double amount) {
+      this.amount = amount;
+    }
+  }
+  public static class Withdraw implements AccountCommand {
+    public final double amount;
+
+    public Withdraw(double amount) {
+      this.amount = amount;
+    }
+  }
+  public static class CloseAccount implements AccountCommand {}
+
+  interface AccountEvent {}
+  public static class AccountCreated implements AccountEvent {}
+  public static class Deposited implements AccountEvent {
+    public final double amount;
+
+    Deposited(double amount) {
+      this.amount = amount;
+    }
+  }
+  public static class Withdrawn implements AccountEvent {
+    public final double amount;
+
+    Withdrawn(double amount) {
+      this.amount = amount;
+    }
+  }
+  public static class AccountClosed implements AccountEvent {}
+
+  interface Account {
+
+    Account applyEvent(AccountEvent event);
+
+    AccountSnapshot toSnapshot();
+
+    static Account fromSnapshot(AccountSnapshot snapshot) {
+      switch (snapshot.lifecycle) {
+        case EMPTY: return new EmptyAccount();
+        case OPEN: return new OpenedAccount(snapshot.balance);
+        case CLOSED: return new ClosedAccount();
+        default: throw new IllegalStateException();
+      }
+    }
+  }
+  public static class EmptyAccount implements Account {
+    @Override
+    public Account applyEvent(AccountEvent event) {
+      if (event instanceof AccountCreated)
+        return new OpenedAccount(0.0);
+      else throw new IllegalStateException();
+    }
+
+    @Override
+    public AccountSnapshot toSnapshot() {
+      return new AccountSnapshot(0.0, AccountLifecycle.EMPTY);
+    }
+  }
+
+  public static class OpenedAccount implements Account {
+    private double balance;
+
+    private final EventHandler<Account, AccountEvent> eventHandler =
+        EventHandlerBuilder.<Account, AccountEvent>builder()
+            .matchEvent(Deposited.class, evt -> {
+              setBalance(getBalance() + evt.amount);
+              return OpenedAccount.this;
+            })
+            .matchEvent(AccountClosed.class, evt -> {
+                return new ClosedAccount();
+            })
+            .matchAny(evt -> {
+              throw new IllegalStateException();
+            });
+
+    OpenedAccount(double balance) {
+      this.balance = balance;
+    }
+
+    public double getBalance() {
+      return balance;
+    }
+
+    private void setBalance(double balance) {
+      this.balance = balance;
+    }
+
+    @Override
+    public Account applyEvent(AccountEvent event) {
+      return eventHandler.apply(this, event);
+    }
+
+    @Override
+    public AccountSnapshot toSnapshot() {
+      return new AccountSnapshot(balance, AccountLifecycle.OPEN);
+    }
+  }
+
+  public static class ClosedAccount implements Account {
+    @Override
+    public Account applyEvent(AccountEvent event) {
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public AccountSnapshot toSnapshot() {
+      return new AccountSnapshot(0.0, AccountLifecycle.CLOSED);
+    }
+  }
+
+  public static Behavior<AccountCommand> behavior(String accountNumber) {
+    return Behaviors.setup(context -> new AccountExample10(context, accountNumber));
+  }
+
+  enum AccountLifecycle {
+    EMPTY, OPEN, CLOSED
+  }
+
+  public static class AccountSnapshot {
+    public final double balance;
+    public final AccountLifecycle lifecycle;
+
+    AccountSnapshot(double balance, AccountLifecycle lifecycle) {
+      this.balance = balance;
+      this.lifecycle = lifecycle;
+    }
+  }
+
+  public AccountExample10(ActorContext<AccountCommand> context, String accountNumber) {
+    super(new PersistenceId(accountNumber));
+  }
+
+  @Override
+  public Account emptyState() {
+    return new EmptyAccount();
+  }
+
+  @Override
+  public AccountSnapshot toSnapshot(Account state) {
+    return state.toSnapshot();
+  }
+
+  @Override
+  public Account fromSnapshot(AccountSnapshot snapshot) {
+    return Account.fromSnapshot(snapshot);
+  }
+
+  private CommandHandlerBuilder<AccountCommand, AccountEvent, EmptyAccount, Account> initialHandler() {
+    return commandHandlerBuilder(EmptyAccount.class)
+      .matchCommand(CreateAccount.class, (__, cmd) -> Effect().persist(new AccountCreated()));
+  }
+
+  private CommandHandlerBuilder<AccountCommand, AccountEvent, OpenedAccount, Account> openedAccountHandler() {
+    return commandHandlerBuilder(OpenedAccount.class)
+      .matchCommand(Deposit.class, (__, cmd) -> Effect().persist(new Deposited(cmd.amount)))
+      .matchCommand(Withdraw.class, (acc, cmd) -> {
+        if ((acc.getBalance() - cmd.amount) < 0.0) {
+          return Effect().unhandled(); // TODO replies are missing in this example
+        } else {
+          return Effect().persist(new Withdrawn(cmd.amount))
+            .andThen(acc2 -> { // FIXME in scaladsl it's named thenRun, change javadsl also?
+              // we know this cast is safe, but somewhat ugly
+              OpenedAccount openAccount = (OpenedAccount) acc2;
+              // do some side-effect using balance
+              System.out.println(openAccount.getBalance());
+            });
+        }
+      })
+      .matchCommand(CloseAccount.class, (acc, cmd) -> {
+        if (acc.getBalance() == 0.0)
+          return Effect().persist(new AccountClosed());
+        else
+          return Effect().unhandled();
+        });
+  }
+
+  private CommandHandlerBuilder<AccountCommand, AccountEvent, ClosedAccount, Account> closedHandler() {
+    return commandHandlerBuilder(ClosedAccount.class)
+        .matchCommand(AccountCommand.class, (__, ___) -> Effect().unhandled());
+  }
+
+  @Override
+  public CommandHandler<AccountCommand, AccountEvent, Account> commandHandler() {
+    return initialHandler()
+      .orElse(openedAccountHandler())
+      .orElse(closedHandler())
+      .build();
+  }
+
+  @Override
+  public EventHandler<Account, AccountEvent> eventHandler() {
+    return Account::applyEvent;
+  }
+
+
+
+
+}


### PR DESCRIPTION
* The builders work fine when defined outside the State, but if we
  want to support a ADT style where the actual logic of how to apply
  the events is defined in the concrete State classes. Due to lack
  of pattern matching in Java we would have to use builders for matching
  on the events, but creating a new builder for each invokation seems
  very wasteful and contradicts the idea that a builder is created once
  to construct the function, which is then invoked many times.
* By allowing mutable State classes the builder can be used inside
  the state class.
* That requires a way to convert to/from immutable snapshot.