### PR TITLE
Zip/Unzip support up to 22 ports

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphUnzipWithSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphUnzipWithSpec.scala
@@ -295,7 +295,7 @@ class GraphUnzipWithSpec extends StreamSpec {
       probe5.expectNext("2")
       probe10.expectNext(5)
       probe15.expectNext("7")
-      probe21.expectNext("9")
+      probe21.expectNext("10")
 
       probe0.expectComplete()
       probe5.expectComplete()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphUnzipWithSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphUnzipWithSpec.scala
@@ -225,16 +225,16 @@ class GraphUnzipWithSpec extends StreamSpec {
       probe2.expectComplete()
     }
 
-    "work with up to 20 outputs" in {
+    "work with up to 22 outputs" in {
       val probe0 = TestSubscriber.manualProbe[Int]()
       val probe5 = TestSubscriber.manualProbe[String]()
       val probe10 = TestSubscriber.manualProbe[Int]()
       val probe15 = TestSubscriber.manualProbe[String]()
-      val probe19 = TestSubscriber.manualProbe[String]()
+      val probe21 = TestSubscriber.manualProbe[String]()
 
       RunnableGraph.fromGraph(GraphDSL.create() { implicit b ⇒
 
-        val split20 = (a: (List[Int])) ⇒
+        val split22 = (a: (List[Int])) ⇒
           (a(0), a(0).toString,
             a(1), a(1).toString,
             a(2), a(2).toString,
@@ -244,12 +244,13 @@ class GraphUnzipWithSpec extends StreamSpec {
             a(6), a(6).toString,
             a(7), a(7).toString,
             a(8), a(8).toString,
-            a(9), a(9).toString)
+            a(9), a(9).toString,
+            a(10), a(10).toString)
 
         // odd input ports will be Int, even input ports will be String
-        val unzip = b.add(UnzipWith(split20))
+        val unzip = b.add(UnzipWith(split22))
 
-        Source.single((0 to 19).toList) ~> unzip.in
+        Source.single((0 to 21).toList) ~> unzip.in
 
         def createSink[T](o: Outlet[T]) =
           o ~> Flow[T].buffer(1, OverflowStrategy.backpressure) ~> Sink.fromSubscriber(TestSubscriber.manualProbe[T]())
@@ -276,8 +277,10 @@ class GraphUnzipWithSpec extends StreamSpec {
         createSink(unzip.out16)
         createSink(unzip.out17)
         createSink(unzip.out18)
+        createSink(unzip.out19)
+        createSink(unzip.out20)
 
-        unzip.out19 ~> Sink.fromSubscriber(probe19)
+        unzip.out21 ~> Sink.fromSubscriber(probe21)
 
         ClosedShape
       }).run()
@@ -286,19 +289,19 @@ class GraphUnzipWithSpec extends StreamSpec {
       probe5.expectSubscription().request(1)
       probe10.expectSubscription().request(1)
       probe15.expectSubscription().request(1)
-      probe19.expectSubscription().request(1)
+      probe21.expectSubscription().request(1)
 
       probe0.expectNext(0)
       probe5.expectNext("2")
       probe10.expectNext(5)
       probe15.expectNext("7")
-      probe19.expectNext("9")
+      probe21.expectNext("9")
 
       probe0.expectComplete()
       probe5.expectComplete()
       probe10.expectComplete()
       probe15.expectComplete()
-      probe19.expectComplete()
+      probe21.expectComplete()
     }
 
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphZipWithSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphZipWithSpec.scala
@@ -143,13 +143,14 @@ class GraphZipWithSpec extends TwoStreamsSetup {
 
       RunnableGraph.fromGraph(GraphDSL.create() { implicit b ⇒
 
-        val sum19 = (v1: Int, v2: String, v3: Int, v4: String, v5: Int, v6: String, v7: Int, v8: String, v9: Int, v10: String,
-          v11: Int, v12: String, v13: Int, v14: String, v15: Int, v16: String, v17: Int, v18: String, v19: Int) ⇒
+        val sum22 = (v1: Int, v2: String, v3: Int, v4: String, v5: Int, v6: String, v7: Int, v8: String, v9: Int, v10: String,
+          v11: Int, v12: String, v13: Int, v14: String, v15: Int, v16: String, v17: Int, v18: String, v19: Int, v20: String, v21: Int, v22: String) ⇒
           v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10 +
-            v11 + v12 + v13 + v14 + v15 + v16 + v17 + v18 + v19
+            v11 + v12 + v13 + v14 + v15 + v16 + v17 + v18 +
+            v19 + v20 + v21 + v22
 
         // odd input ports will be Int, even input ports will be String
-        val zip = b.add(ZipWith(sum19))
+        val zip = b.add(ZipWith(sum22))
 
         Source.single(1) ~> zip.in0
         Source.single(2).map(_.toString) ~> zip.in1
@@ -170,6 +171,9 @@ class GraphZipWithSpec extends TwoStreamsSetup {
         Source.single(17) ~> zip.in16
         Source.single(18).map(_.toString) ~> zip.in17
         Source.single(19) ~> zip.in18
+        Source.single(20).map(_.toString) ~> zip.in19
+        Source.single(21) ~> zip.in20
+        Source.single(22).map(_.toString) ~> zip.in21
 
         zip.out ~> Sink.fromSubscriber(probe)
 
@@ -179,7 +183,7 @@ class GraphZipWithSpec extends TwoStreamsSetup {
       val subscription = probe.expectSubscription()
 
       subscription.request(1)
-      probe.expectNext((1 to 19).mkString(""))
+      probe.expectNext((1 to 22).mkString(""))
 
       probe.expectComplete()
 

--- a/akka-stream/src/main/boilerplate/akka/stream/javadsl/UnzipWith.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/javadsl/UnzipWith.scala.template
@@ -32,7 +32,7 @@ object UnzipWith {
     scaladsl.UnzipWith[In, A, B]((in: In) => f.apply(in) match { case Pair(a, b) => (a, b) })
 
 
-  [3..20#/** Create a new `UnzipWith` specialized for 1 outputs.
+  [3..22#/** Create a new `UnzipWith` specialized for 1 outputs.
    *
    * @param f unzipping-function from the input value to the output values
    */

--- a/akka-stream/src/main/boilerplate/akka/stream/javadsl/ZipWith.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/javadsl/ZipWith.scala.template
@@ -30,7 +30,7 @@ object ZipWith {
   def create[A, B, Out](f: function.Function2[A, B, Out]): Graph[FanInShape2[A, B, Out], NotUsed] =
     scaladsl.ZipWith(f.apply _)
 
-  [3..20#/** Create a new `ZipWith` specialized for 1 inputs.
+  [3..22#/** Create a new `ZipWith` specialized for 1 inputs.
    *
    * @param f zipping-function from the input values to the output value
    * @param attributes optional attributes for this vertex

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/UnzipWithApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/UnzipWithApply.scala.template
@@ -14,7 +14,7 @@ object UnzipWithApply {
     def create(unzipper: Function1[In, Out]): T
   }
 
-  [2..20#trait UnzipWithCreator1[In, [#A1#]] extends UnzipWithCreator[In, Tuple1[[#A1#]], UnzipWith1[In, [#A1#]]] {
+  [2..22#trait UnzipWithCreator1[In, [#A1#]] extends UnzipWithCreator[In, Tuple1[[#A1#]], UnzipWith1[In, [#A1#]]] {
     override def create(unzipper: In ⇒ ([#A1#])): UnzipWith1[In, [#A1#]] = {
       new UnzipWith1(unzipper)
     }
@@ -29,7 +29,7 @@ trait UnzipWithApply {
   import UnzipWithApply._
 
 
-  [2..20#/**
+  [2..22#/**
    * Create a new `UnzipWith` specialized for 1 outputs.
    *
    * @param unzipper unzipping-function from the input value to 1 output values
@@ -41,7 +41,7 @@ trait UnzipWithApply {
   ]
 }
 
-[2..20#/** `UnzipWith` specialized for 1 outputs */
+[2..22#/** `UnzipWith` specialized for 1 outputs */
 class UnzipWith1[In, [#A1#]](val unzipper: In ⇒ ([#A1#])) extends GraphStage[FanOutShape1[In, [#A1#]]] {
   override def initialAttributes = Attributes.name("UnzipWith1")
   override val shape: FanOutShape1[In, [#A1#]] = new FanOutShape1[In, [#A1#]]("UnzipWith1")

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipWithApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipWithApply.scala.template
@@ -9,7 +9,7 @@ import akka.stream.stage._
 
 trait ZipWithApply {
 
-  [2..20#/**
+  [2..22#/**
    * Create a new `ZipWith` specialized for 1 inputs.
    *
    * @param zipper zipping-function from the input values to the output value
@@ -22,7 +22,7 @@ trait ZipWithApply {
 
 }
 
-[2..20#/** `ZipWith` specialized for 1 inputs */
+[2..22#/** `ZipWith` specialized for 1 inputs */
 class ZipWith1[[#A1#], O] (val zipper: ([#A1#]) ⇒ O) extends GraphStage[FanInShape1[[#A1#], O]] {
   override def initialAttributes = Attributes.name("ZipWith1")
   override val shape: FanInShape1[[#A1#], O] = new FanInShape1[[#A1#], O]("ZipWith1")

--- a/akka-stream/src/main/mima-filters/2.5.17.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.17.backwards.excludes
@@ -1,0 +1,3 @@
+# #25742 zip/unzip 22 parameters support
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.ZipWithApply.apply")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.UnzipWithApply.apply")


### PR DESCRIPTION
As discussed with @patriknw and @johanandren, here's a PR that corrects the small inconsistency in terms of number of ports for Zip and Unzip graphstages