### PR TITLE
Don't warn about old DNS protocol use

### DIFF
--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
@@ -70,7 +70,6 @@ private[io] final class AsyncDnsManager(val ext: DnsExt) extends Actor
     case Dns.Resolve(name) ⇒
       // adapt legacy protocol to new protocol
       log.debug("Resolution request for {} from {}", name, sender())
-      warnAboutOldProtocolUse(name)
       val adapted = DnsProtocol.Resolve(name)
       val reply = (resolver ? adapted).mapTo[DnsProtocol.Resolved]
         .map { asyncResolved ⇒
@@ -84,15 +83,6 @@ private[io] final class AsyncDnsManager(val ext: DnsExt) extends Actor
 
     case CacheCleanup ⇒
       cacheCleanup.foreach(_.cleanup())
-  }
-
-  private def warnAboutOldProtocolUse(name: String): Unit = {
-    val warnAtMostTimes = 10
-    if (oldProtocolWarningLoggedTimes < warnAtMostTimes) {
-      oldProtocolWarningLoggedTimes += 1
-      log.warning("Received Dns.Resolve({}) message while Async DNS resolver active. Please use the new API [akka.io.dns.DnsProtocol] to issue resolve requests. " +
-        "(This warning will be logged at most {} times)", name, warnAtMostTimes)
-    }
   }
 }
 


### PR DESCRIPTION
We use the old DNS protocol ourselves, and the old implementation (which is
still the default) does not support the new protocol. For now the old protocol
is fine and works with both the default and the async impl.