### PR TITLE
Fix doc links to cluster docker compose sample

### DIFF
--- a/akka-docs/src/main/paradox/additional/deploy.md
+++ b/akka-docs/src/main/paradox/additional/deploy.md
@@ -38,8 +38,8 @@ that you will need to take special care with the network configuration when usin
 described here: @ref:[Akka behind NAT or in a Docker container](../remoting.md#remote-configuration-nat)
 
 You can look at the
-@java[@extref[Cluster with docker-compse example project](samples:akka-samples-cluster-docker-compose-java)]
-@scala[@extref[Cluster with docker-compose example project](samples:akka-samples-cluster-docker-compose-scala)]
+@java[@extref[Cluster with docker-compse example project](samples:akka-sample-cluster-docker-compose-java)]
+@scala[@extref[Cluster with docker-compose example project](samples:akka-sample-cluster-docker-compose-scala)]
 to see what this looks like in practice.
 
 For the JVM to run well in a Docker container, there are some general (not Akka specific) parameters that might need tuning. You may want to look into using [`-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap`](https://dzone.com/articles/running-a-jvm-in-a-container-without-getting-kille) options for your JVM later than 8u131, which makes it understand c-group memory limits.

--- a/akka-docs/src/main/paradox/remoting-artery.md
+++ b/akka-docs/src/main/paradox/remoting-artery.md
@@ -936,6 +936,6 @@ akka {
 ```
 
 You can look at the
-@java[@extref[Cluster with docker-compse example project](samples:akka-samples-cluster-docker-compose-java)]
-@scala[@extref[Cluster with docker-compose example project](samples:akka-samples-cluster-docker-compose-scala)]
+@java[@extref[Cluster with docker-compse example project](samples:akka-sample-cluster-docker-compose-java)]
+@scala[@extref[Cluster with docker-compose example project](samples:akka-sample-cluster-docker-compose-scala)]
 to see what this looks like in practice.

--- a/akka-docs/src/main/paradox/remoting.md
+++ b/akka-docs/src/main/paradox/remoting.md
@@ -622,6 +622,6 @@ Keep in mind that local.address will most likely be in one of private network ra
 For further details see [RFC 1597](https://tools.ietf.org/html/rfc1597) and [RFC 1918](https://tools.ietf.org/html/rfc1918).
 
 You can look at the
-@java[@extref[Cluster with docker-compse example project](samples:akka-samples-cluster-docker-compose-java)]
-@scala[@extref[Cluster with docker-compose example project](samples:akka-samples-cluster-docker-compose-scala)]
+@java[@extref[Cluster with docker-compse example project](samples:akka-sample-cluster-docker-compose-java)]
+@scala[@extref[Cluster with docker-compose example project](samples:akka-sample-cluster-docker-compose-scala)]
 to see what this looks like in practice.


### PR DESCRIPTION
Fix for broken links to the Cluster in Docker sample. Not sure why the sample changed name (or if the links were wrong everywhere before), but changing them is quick and easy.