### PR TITLE
Upgrade to ssl-config 0.3.5, from 0.3.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   lazy val scalaCheckVersion = settingKey[String]("The version of ScalaCheck to use.")
   lazy val java8CompatVersion = settingKey[String]("The version of scala-java8-compat to use.")
   val junitVersion = "4.12"
-  val sslConfigVersion = "0.3.4"
+  val sslConfigVersion = "0.3.5"
   val slf4jVersion = "1.7.25"
   val scalaXmlVersion = "1.0.6"
   val aeronVersion = "1.11.2"


### PR DESCRIPTION
These are the additional binary API changes introduced:

    [error]  * class com.typesafe.sslconfig.ssl.FakeKeyStore is declared final in current version
    [error]    filter with: ProblemFilters.exclude[FinalClassProblem]("com.typesafe.sslconfig.ssl.FakeKeyStore")

    [error]  * method GeneratedKeyStore()java.lang.String in class com.typesafe.sslconfig.ssl.FakeKeyStore does not have a correspondent in current version
    [error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("com.typesafe.sslconfig.ssl.FakeKeyStore.GeneratedKeyStore")

    [error]  * method SignatureAlgorithmOID()sun.security.util.ObjectIdentifier in class com.typesafe.sslconfig.ssl.FakeKeyStore does not have a correspondent in current version
    [error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("com.typesafe.sslconfig.ssl.FakeKeyStore.SignatureAlgorithmOID")

    [error]  * method SignatureAlgorithmName()java.lang.String in class com.typesafe.sslconfig.ssl.FakeKeyStore does not have a correspondent in current version
    [error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("com.typesafe.sslconfig.ssl.FakeKeyStore.SignatureAlgorithmName")