### PR TITLE
WIP: API prototype of using annotations for command and event handlers

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/PersistentBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/PersistentBehavior.scala
@@ -32,7 +32,7 @@ abstract class PersistentBehavior[Command, Event, State >: Null] private[akka] (
    *
    * Return effects from your handlers in order to instruct persistence on how to act on the incoming message (i.e. persist events).
    */
-  protected final def Effect: EffectFactories[Command, Event, State] = EffectFactory.asInstanceOf[EffectFactories[Command, Event, State]]
+  protected final def Effect: EffectFactories[Event, State] = EffectFactory.asInstanceOf[EffectFactories[Event, State]]
 
   /**
    * Implement by returning the initial empty state object.

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/AccountExample20.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/AccountExample20.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.akka.persistence.typed;
+
+import akka.persistence.typed.PersistenceId;
+import akka.persistence.typed.javadsl.CommandHandler;
+import akka.persistence.typed.javadsl.Effect;
+import akka.persistence.typed.javadsl.Effects;
+import akka.persistence.typed.javadsl.EventHandler;
+import akka.persistence.typed.javadsl.PersistentBehavior;
+
+public class AccountExample20 {
+
+  interface AccountCommand {}
+  public static class CreateAccount implements AccountCommand {}
+  public static class Deposit implements AccountCommand {
+    public final double amount;
+
+    public Deposit(double amount) {
+      this.amount = amount;
+    }
+  }
+  public static class Withdraw implements AccountCommand {
+    public final double amount;
+
+    public Withdraw(double amount) {
+      this.amount = amount;
+    }
+  }
+  public static class CloseAccount implements AccountCommand {}
+
+  interface AccountEvent {}
+  public static class AccountCreated implements AccountEvent {}
+  public static class Deposited implements AccountEvent {
+    public final double amount;
+
+    Deposited(double amount) {
+      this.amount = amount;
+    }
+  }
+  public static class Withdrawn implements AccountEvent {
+    public final double amount;
+
+    Withdrawn(double amount) {
+      this.amount = amount;
+    }
+  }
+  public static class AccountClosed implements AccountEvent {}
+
+  interface Account {}
+  public static class EmptyAccount implements Account {
+    @CmdHandler
+    public Effect<AccountEvent, Account> create(CreateAccount cmd) {
+      return Effects.persist(new AccountCreated());
+    }
+
+    @EvtHandler
+    public Account created(AccountCreated evt) {
+      return new OpenedAccount(0.0);
+    }
+  }
+  public static class OpenedAccount implements Account {
+    public final double balance;
+
+    OpenedAccount(double balance) {
+      this.balance = balance;
+    }
+
+    @CmdHandler
+    public Effect<AccountEvent, Account> deposit(Deposit cmd) {
+      return Effects.persist(new Deposited(cmd.amount));
+    }
+
+    @CmdHandler
+    public Effect<AccountEvent, Account> withdraw(Withdraw cmd) {
+      if ((balance - cmd.amount) < 0.0) {
+        return Effects.unhandled(); // TODO replies are missing in this example
+      } else {
+        // Type inference doesn't work well here, Effects.<AccountEvent, Account> persist(
+        return Effects.<AccountEvent, Account> persist(new Withdrawn(cmd.amount))
+            .andThen(acc2 -> {
+              // we know this cast is safe, but somewhat ugly
+              OpenedAccount openAccount = (OpenedAccount) acc2;
+              // do some side-effect using balance
+              System.out.println(openAccount.balance);
+            });
+      }
+    }
+
+    @CmdHandler
+    public Effect<AccountEvent, Account> close(CloseAccount cmd) {
+      if (balance == 0.0)
+        return Effects.persist(new AccountClosed());
+      else
+        return Effects.unhandled();
+    }
+
+    @EvtHandler
+    public Account deposited(Deposited evt) {
+      return new OpenedAccount(balance + evt.amount);
+    }
+
+    @EvtHandler
+    public Account withdrawn(Withdrawn evt) {
+      return new OpenedAccount(balance - evt.amount);
+    }
+
+    @EvtHandler
+    public Account closed(AccountClosed evt) {
+      return new ClosedAccount();
+    }
+  }
+  public static class ClosedAccount implements Account {
+
+    @CmdHandler
+    public Effect<AccountEvent, Account> anyCommand(AccountCommand cmd) {
+      // not necessary to have this handler, default is also unhandled, unless we want to warn about missing handlers
+      return Effects.unhandled();
+    }
+
+  }
+
+  public static class AccountEntity extends PersistentBehavior<AccountCommand, AccountEvent, Account> {
+
+    public AccountEntity(String accountNumber) {
+      super(new PersistenceId("Account|" + accountNumber));
+    }
+
+    @Override
+    public Account emptyState() {
+      return new EmptyAccount();
+    }
+
+    @Override
+    public CommandHandler<AccountCommand, AccountEvent, Account> commandHandler() {
+      // FIXME this will not be needed when using annotations
+      return null;
+    }
+
+    @Override
+    public EventHandler<Account, AccountEvent> eventHandler() {
+      // FIXME this will not be needed when using annotations
+      return null;
+    }
+  }
+
+
+}

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/AccountExample21.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/AccountExample21.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.akka.persistence.typed;
+
+import akka.persistence.typed.PersistenceId;
+import akka.persistence.typed.javadsl.CommandHandler;
+import akka.persistence.typed.javadsl.Effect;
+import akka.persistence.typed.javadsl.EventHandler;
+import akka.persistence.typed.javadsl.PersistentBehavior;
+
+public class AccountExample21 {
+
+  interface AccountCommand {}
+  public static class CreateAccount implements AccountCommand {}
+  public static class Deposit implements AccountCommand {
+    public final double amount;
+
+    public Deposit(double amount) {
+      this.amount = amount;
+    }
+  }
+  public static class Withdraw implements AccountCommand {
+    public final double amount;
+
+    public Withdraw(double amount) {
+      this.amount = amount;
+    }
+  }
+  public static class CloseAccount implements AccountCommand {}
+
+  interface AccountEvent {}
+  public static class AccountCreated implements AccountEvent {}
+  public static class Deposited implements AccountEvent {
+    public final double amount;
+
+    Deposited(double amount) {
+      this.amount = amount;
+    }
+  }
+  public static class Withdrawn implements AccountEvent {
+    public final double amount;
+
+    Withdrawn(double amount) {
+      this.amount = amount;
+    }
+  }
+  public static class AccountClosed implements AccountEvent {}
+
+  interface Account {}
+  public static class OpenedAccount implements Account {
+    public final double balance;
+
+    OpenedAccount(double balance) {
+      this.balance = balance;
+    }
+  }
+  public static class ClosedAccount implements Account {
+  }
+
+  public static class AccountEntity extends PersistentBehavior<AccountCommand, AccountEvent, Account> {
+
+    public AccountEntity(String accountNumber) {
+      super(new PersistenceId("Account|" + accountNumber));
+    }
+
+    @Override
+    public Account emptyState() {
+      return null; // starting with null state instead of EmptyAccount
+    }
+
+    @CmdHandler
+    public Effect<AccountEvent, Account> handleCommand(CreateAccount cmd) {
+      // note that no state parameter, can be used for null initial state
+      return Effect().persist(new AccountCreated());
+    }
+
+    @CmdHandler
+    public Effect<AccountEvent, Account> handleCommand(ClosedAccount state, AccountCommand cmd) {
+      // not necessary to have this handler, default is also unhandled, unless we want to warn about missing handlers
+      return Effect().unhandled();
+    }
+
+    @CmdHandler
+    public Effect<AccountEvent, Account> handleCommand(OpenedAccount state, Deposit cmd) {
+      return Effect().persist(new Deposited(cmd.amount));
+    }
+
+    @CmdHandler
+    public Effect<AccountEvent, Account> handleCommand(OpenedAccount state, Withdraw cmd) {
+      if ((state.balance - cmd.amount) < 0.0) {
+        return Effect().unhandled(); // TODO replies are missing in this example
+      } else {
+        // Type inference doesn't work well here, Effects.<AccountEvent, Account> persist(
+        return Effect().persist(new Withdrawn(cmd.amount))
+            .andThen(acc2 -> {
+              // we know this cast is safe, but somewhat ugly
+              OpenedAccount openAccount = (OpenedAccount) acc2;
+              // do some side-effect using balance
+              System.out.println(openAccount.balance);
+            });
+      }
+    }
+
+    @CmdHandler
+    public Effect<AccountEvent, Account> handleCommand(OpenedAccount state, CloseAccount cmd) {
+      if (state.balance == 0.0)
+        return Effect().persist(new AccountClosed());
+      else
+        return Effect().unhandled();
+    }
+
+    @EvtHandler
+    public Account handleEvent(OpenedAccount state, Deposited evt) {
+      return new OpenedAccount(state.balance + evt.amount);
+    }
+
+    @EvtHandler
+    public Account handleEvent(OpenedAccount state, Withdrawn evt) {
+      return new OpenedAccount(state.balance - evt.amount);
+    }
+
+    @EvtHandler
+    public Account handleEvent(OpenedAccount state, AccountClosed evt) {
+      return new ClosedAccount();
+    }
+
+    @Override
+    public CommandHandler<AccountCommand, AccountEvent, Account> commandHandler() {
+      // FIXME this will not be needed when using annotations
+      return null;
+    }
+
+    @Override
+    public EventHandler<Account, AccountEvent> eventHandler() {
+      // FIXME this will not be needed when using annotations
+      return null;
+    }
+  }
+
+
+}

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/CmdHandler.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/CmdHandler.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.akka.persistence.typed;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD})
+public @interface CmdHandler { // FIXME rename to CommandHandler, but we already have that name
+}

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/EvtHandler.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/EvtHandler.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.akka.persistence.typed;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD})
+public @interface EvtHandler { // FIXME rename to EventHandler, but we already have that name
+}


### PR DESCRIPTION
We are selecting the method based on two dimensions, current state and incoming command/event.
The methods can be defined in the state as shown in AccountExample20.
There might be cases where one want to define same handlers for all state classes, and that should be possible by placing it up the state hierarchy.

I think we should also support handlers outside of the state classes. Then the handler methods takes two parameters, state and command/event. That should be possible to mix with handlers in the state, e.g. if you want event handlers to be in state but command handlers outside.
That is illustrated in AccountExample21. That can also be used for the initial null state, if that is used. Also illustrated in that example.

There will probably be cases of somewhat confusing ambiguity and for those we have to pick a rule or disallow ambiguous definitions.

One thing that we will not be able to support well is selecting method on other things than state class, for example if enums are used inside the state instead of different state classes. For example how the AuctionEntity was written. The builders have a predicate function for that purpose.

One drawback I personally find with the annotation approach is that there is no single entry point and therefore difficult to get an overview of all defined handlers, but that is probably just me.

Is this feasible to implement? Can we do it at compilation time, or do we have to do it at runtime?