### PR TITLE
Bumps ssl-config 0.3.6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   lazy val scalaCheckVersion = settingKey[String]("The version of ScalaCheck to use.")
   lazy val java8CompatVersion = settingKey[String]("The version of scala-java8-compat to use.")
   val junitVersion = "4.12"
-  val sslConfigVersion = "0.3.5"
+  val sslConfigVersion = "0.3.6"
   val slf4jVersion = "1.7.25"
   val scalaXmlVersion = "1.0.6"
   val aeronVersion = "1.11.2"


### PR DESCRIPTION
`0.3.5` defaulted to `PKCS12` format for the auto-generated key stores. The `ssl-config` library doesn't support setting the trustStore password which is required in `PKCS12` format to read the trusted certificates. As a consequence generated stores could not be used as truststores.

Related to https://github.com/playframework/playframework/pull/8691 and https://github.com/lagom/lagom/pull/1619