### PR TITLE
TLSSpec on Java 11

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/UdpConnectedIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpConnectedIntegrationSpec.scala
@@ -5,13 +5,13 @@
 package akka.io
 
 import java.net.InetSocketAddress
-import akka.testkit.{ TestProbe, ImplicitSender, AkkaSpec }
-import akka.util.ByteString
+
+import akka.testkit.{ AkkaSpec, ImplicitSender, TestProbe }
+import akka.util.{ ByteString, JavaVersion }
 import akka.actor.ActorRef
 import akka.testkit.SocketUtil._
 
 class UdpConnectedIntegrationSpec extends AkkaSpec("""
-    akka.loglevel = INFO
     akka.actor.serialize-creators = on
     """) with ImplicitSender {
 

--- a/akka-actor/src/main/scala/akka/util/JavaVersion.scala
+++ b/akka-actor/src/main/scala/akka/util/JavaVersion.scala
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi object JavaVersion {
+
+  val majorVersion = {
+    // FIXME replace with Runtime.version() when we no longer support Java 8
+    // See Oracle section 1.5.3 at:
+    // https://docs.oracle.com/javase/8/docs/technotes/guides/versioning/spec/versioning2.html
+    val version = System.getProperty("java.specification.version").split('.')
+
+    val majorString =
+      if (version(0) == "1") version(1) // Java 8 will be 1.8
+      else version(0) // later will be 9, 10, 11 etc
+
+    majorString.toInt
+  }
+}

--- a/akka-actor/src/main/scala/akka/util/Unsafe.java
+++ b/akka-actor/src/main/scala/akka/util/Unsafe.java
@@ -14,7 +14,7 @@ public final class Unsafe {
     public static final sun.misc.Unsafe instance;
 
     private static final long stringValueFieldOffset;
-    private static final boolean isJavaVersion9Plus;
+    private static final boolean isJavaVersion9Plus = JavaVersion.majorVersion() > 8;
 
     static {
         try {
@@ -29,15 +29,6 @@ public final class Unsafe {
             if (found == null) throw new IllegalStateException("Can't find instance of sun.misc.Unsafe");
             else instance = found;
             stringValueFieldOffset = instance.objectFieldOffset(String.class.getDeclaredField("value"));
-
-            // See Oracle section 1.5.3 at:
-            // https://docs.oracle.com/javase/8/docs/technotes/guides/versioning/spec/versioning2.html
-            final int[] version = Arrays.
-                stream(System.getProperty("java.specification.version").split("\\.")).
-                mapToInt(Integer::parseInt).
-                toArray();
-            final int javaVersion = version[0] == 1 ? version[1] : version[0];
-            isJavaVersion9Plus = javaVersion > 8;
         } catch (Throwable t) {
             throw new ExceptionInInitializerError(t);
         }


### PR DESCRIPTION
Error label from Java changed.

On top of PR #25792 since I needed the Java version thingie I added there.

Fixes #25739