### PR TITLE
Hardening of typed./ClusterShardingSpec, #25794

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
@@ -6,6 +6,7 @@ package akka.actor.testkit.typed.javadsl
 
 import java.time.Duration
 import java.util.function.Supplier
+import java.util.{ List ⇒ JList }
 
 import akka.actor.typed.{ ActorRef, ActorSystem }
 import akka.annotation.DoNotInherit
@@ -13,6 +14,7 @@ import akka.actor.testkit.typed.internal.TestProbeImpl
 import akka.actor.testkit.typed.{ FishingOutcome, TestKitSettings }
 import akka.actor.testkit.typed.scaladsl.TestDuration
 import akka.util.JavaDurationConverters._
+import scala.collection.immutable
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
 
@@ -217,6 +219,22 @@ abstract class TestProbe[M] {
    * INTERNAL API
    */
   @InternalApi protected def expectMessageClass_internal[C](max: FiniteDuration, c: Class[C]): C
+
+  /**
+   * Same as `receiveN(n, remaining)` but correctly taking into account
+   * the timeFactor.
+   */
+  def receiveMessages(n: Int): JList[M] = receiveN_internal(n, getRemainingOrDefault.asScala).asJava
+
+  /**
+   * Receive `n` messages in a row before the given deadline.
+   */
+  def receiveMessages(n: Int, max: Duration): JList[M] = receiveN_internal(n, max.asScala.dilated).asJava
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi protected def receiveN_internal(n: Int, max: FiniteDuration): immutable.Seq[M]
 
   /**
    * Java API: Allows for flexible matching of multiple messages within a timeout, the fisher function is fed each incoming

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/TestProbe.scala
@@ -154,6 +154,19 @@ object TestProbe {
   protected def expectMessageClass_internal[C](max: FiniteDuration, c: Class[C]): C
 
   /**
+   * Same as `receiveN(n, remaining)` but correctly taking into account
+   * the timeFactor.
+   */
+  def receiveN(n: Int): immutable.Seq[M] = receiveN_internal(n, remainingOrDefault)
+
+  /**
+   * Receive `n` messages in a row before the given deadline.
+   */
+  def receiveN(n: Int, max: FiniteDuration): immutable.Seq[M] = receiveN_internal(n, max.dilated)
+
+  protected def receiveN_internal(n: Int, max: FiniteDuration): immutable.Seq[M]
+
+  /**
    * Allows for flexible matching of multiple messages within a timeout, the fisher function is fed each incoming
    * message, and returns one of the following effects to decide on what happens next:
    *

--- a/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/TestProbeTest.java
+++ b/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/TestProbeTest.java
@@ -8,6 +8,7 @@ import akka.actor.typed.ActorRef;
 import akka.actor.typed.ActorSystem;
 
 import java.time.Duration;
+import java.util.List;
 
 public class TestProbeTest {
 
@@ -46,6 +47,9 @@ public class TestProbeTest {
       // ... something ...
       return "result";
     });
+
+    List<String> messages1 = probe.receiveMessages(3);
+    List<String> messages2 = probe.receiveMessages(3, Duration.ofSeconds(5));
 
   }
 }

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestProbeSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestProbeSpec.scala
@@ -120,6 +120,28 @@ class TestProbeSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       }
     }
 
+    "allow receiving N messages" in {
+      val probe = TestProbe[String]()
+
+      probe.ref ! "one"
+      probe.ref ! "two"
+      probe.ref ! "three"
+
+      val result = probe.receiveN(3)
+
+      result should ===(List("one", "two", "three"))
+    }
+
+    "time out when not receiving N messages" in {
+      val probe = TestProbe[String]()
+
+      probe.ref ! "one"
+
+      intercept[AssertionError] {
+        probe.receiveN(3, 50.millis)
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
* The replies didn't change after the leaving
* I see two reason why it could have failed
  * The test is sending the same messages as the very first thing
    earlier in the test and then sharding might not now about the
    two nodes and therefore allocated all to one node
  * All messages are hashed to the same node/shard

Refs #25794

Also added `receiveN` to the testkit.