### PR TITLE
Rename MutableBehavior to AbstractBehavior, #25750

### DIFF
--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ReceiveBuilderTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ReceiveBuilderTest.java
@@ -18,7 +18,7 @@ public class ReceiveBuilderTest extends JUnitSuite {
 
   @Test
   public void testMutableCounter() {
-    Behavior<BehaviorBuilderTest.CounterMessage> mutable = Behaviors.setup(ctx -> new MutableBehavior<BehaviorBuilderTest.CounterMessage>() {
+    Behavior<BehaviorBuilderTest.CounterMessage> mutable = Behaviors.setup(ctx -> new AbstractBehavior<BehaviorBuilderTest.CounterMessage>() {
       int currentValue = 0;
 
       private Behavior<BehaviorBuilderTest.CounterMessage> receiveIncrease(BehaviorBuilderTest.Increase msg) {
@@ -32,7 +32,7 @@ public class ReceiveBuilderTest extends JUnitSuite {
       }
 
       @Override
-      public Behaviors.Receive<BehaviorBuilderTest.CounterMessage> createReceive() {
+      public Receive<BehaviorBuilderTest.CounterMessage> createReceive() {
         return receiveBuilder()
           .onMessage(BehaviorBuilderTest.Increase.class, this::receiveIncrease)
           .onMessage(BehaviorBuilderTest.Get.class, this::receiveGet)
@@ -41,16 +41,16 @@ public class ReceiveBuilderTest extends JUnitSuite {
     });
   }
 
-  private static class MyMutableBehavior extends MutableBehavior<BehaviorBuilderTest.CounterMessage> {
+  private static class MyAbstractBehavior extends AbstractBehavior<BehaviorBuilderTest.CounterMessage> {
     private int value;
 
-    public MyMutableBehavior(int initialValue) {
+    public MyAbstractBehavior(int initialValue) {
       super();
       this.value = initialValue;
     }
 
     @Override
-    public Behaviors.Receive<BehaviorBuilderTest.CounterMessage> createReceive() {
+    public Receive<BehaviorBuilderTest.CounterMessage> createReceive() {
       assertEquals(42, value);
       return receiveBuilder().build();
     }
@@ -58,7 +58,7 @@ public class ReceiveBuilderTest extends JUnitSuite {
 
   @Test
   public void testInitializationOrder() throws Exception {
-    MyMutableBehavior mutable = new MyMutableBehavior(42);
+    MyAbstractBehavior mutable = new MyAbstractBehavior(42);
     assertEquals(Behaviors.unhandled(), mutable.receive(null, new BehaviorBuilderTest.Increase()));
   }
 }

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java
@@ -170,7 +170,7 @@ public class InteractionPatternsTest extends JUnitSuite {
       }
     }
 
-    public static class Translator extends MutableBehavior<Command> {
+    public static class Translator extends AbstractBehavior<Command> {
       private final ActorContext<Command> ctx;
       private final ActorRef<Backend.Request> backend;
       private final ActorRef<Backend.Response> backendResponseAdapter;
@@ -194,7 +194,7 @@ public class InteractionPatternsTest extends JUnitSuite {
       }
 
       @Override
-      public Behaviors.Receive<Command> createReceive() {
+      public Receive<Command> createReceive() {
         return receiveBuilder()
           .onMessage(Translate.class, cmd -> {
             taskIdCounter += 1;
@@ -522,7 +522,7 @@ public class InteractionPatternsTest extends JUnitSuite {
   }
 
   // per session actor behavior
-  class PrepareToLeaveHome extends MutableBehavior<Object> {
+  class PrepareToLeaveHome extends AbstractBehavior<Object> {
     private final String whoIsLeaving;
     private final ActorRef<ReadyToLeaveHome> respondTo;
     private final ActorRef<GetKeys> keyCabinet;
@@ -537,7 +537,7 @@ public class InteractionPatternsTest extends JUnitSuite {
     }
 
     @Override
-    public Behaviors.Receive<Object> createReceive() {
+    public Receive<Object> createReceive() {
       return receiveBuilder()
         .onMessage(Wallet.class, (wallet) -> {
           this.wallet = Optional.of(wallet);

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OOIntroTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OOIntroTest.java
@@ -10,17 +10,17 @@ import akka.actor.typed.ActorRef;
 import akka.actor.typed.ActorSystem;
 import akka.actor.typed.Behavior;
 import akka.actor.typed.Terminated;
-import akka.actor.typed.javadsl.Behaviors;
-import akka.actor.typed.javadsl.Behaviors.Receive;
+import akka.actor.typed.javadsl.AbstractBehavior;
 import akka.actor.typed.javadsl.ActorContext;
-import akka.actor.typed.javadsl.MutableBehavior;
+import akka.actor.typed.javadsl.Behaviors;
+import akka.actor.typed.javadsl.Receive;
 //#imports
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MutableIntroTest {
+public class OOIntroTest {
 
   //#chatroom-actor
   public static class ChatRoom {
@@ -89,7 +89,7 @@ public class MutableIntroTest {
       return Behaviors.setup(ChatRoomBehavior::new);
     }
 
-    public static class ChatRoomBehavior extends MutableBehavior<RoomCommand> {
+    public static class ChatRoomBehavior extends AbstractBehavior<RoomCommand> {
       final ActorContext<RoomCommand> ctx;
       final List<ActorRef<SessionCommand>> sessions = new ArrayList<>();
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
@@ -5,7 +5,7 @@
 package akka.actor.typed
 
 import akka.actor.typed.scaladsl.{ Behaviors ⇒ SBehaviors }
-import akka.actor.typed.scaladsl.{ MutableBehavior ⇒ SMutableBehavior }
+import akka.actor.typed.scaladsl.{ AbstractBehavior ⇒ SAbstractBehavior }
 import akka.actor.typed.javadsl.{ ActorContext ⇒ JActorContext, Behaviors ⇒ JBehaviors }
 import akka.japi.function.{ Function ⇒ F1e, Function2 ⇒ F2, Procedure2 ⇒ P2 }
 import akka.japi.pf.{ FI, PFBuilder }
@@ -451,7 +451,7 @@ class MutableScalaBehaviorSpec extends Messages with Become with Stoppable {
 
   def behv(monitor: ActorRef[Event]): Behavior[Command] =
     SBehaviors.setup[Command] { ctx ⇒
-      new SMutableBehavior[Command] {
+      new SAbstractBehavior[Command] {
         private var state: State = StateA
 
         override def onMessage(msg: Command): Behavior[Command] = {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -8,7 +8,7 @@ import java.io.IOException
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
 
 import akka.actor.ActorInitializationException
-import akka.actor.typed.scaladsl.{ Behaviors, MutableBehavior }
+import akka.actor.typed.scaladsl.{ Behaviors, AbstractBehavior }
 import akka.actor.typed.scaladsl.Behaviors._
 import akka.testkit.EventFilter
 import akka.actor.testkit.typed.scaladsl._
@@ -64,7 +64,7 @@ object SupervisionSpec {
         Behaviors.same
     }
 
-  class FailingConstructor(monitor: ActorRef[Event]) extends MutableBehavior[Command] {
+  class FailingConstructor(monitor: ActorRef[Event]) extends AbstractBehavior[Command] {
     monitor ! Started
     throw new RuntimeException("simulated exc from constructor") with NoStackTrace
 
@@ -257,7 +257,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit(
 
   class FailingConstructorTestSetup(failCount: Int) {
     val failCounter = new AtomicInteger(0)
-    class FailingConstructor(monitor: ActorRef[Event]) extends MutableBehavior[Command] {
+    class FailingConstructor(monitor: ActorRef[Event]) extends AbstractBehavior[Command] {
       monitor ! Started
       if (failCounter.getAndIncrement() < failCount) {
         throw TE("simulated exc from constructor")
@@ -732,7 +732,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit(
       }
     }
 
-    "fail when exception from MutableBehavior constructor" in new FailingConstructorTestSetup(failCount = 1) {
+    "fail when exception from AbstractBehavior constructor" in new FailingConstructorTestSetup(failCount = 1) {
       val probe = TestProbe[Event]("evt")
       val behv = supervise(setup[Command](_ ⇒ new FailingConstructor(probe.ref)))
         .onFailure[Exception](SupervisorStrategy.restart)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
@@ -6,7 +6,7 @@ package akka.actor.typed
 
 import akka.Done
 import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.scaladsl.MutableBehavior
+import akka.actor.typed.scaladsl.AbstractBehavior
 import akka.actor.typed.scaladsl.adapter._
 import akka.testkit.EventFilter
 import akka.actor.testkit.typed.scaladsl.TestProbe
@@ -28,7 +28,7 @@ object WatchSpec {
       case (_, Stop) ⇒ Behaviors.stopped
     }
 
-  val mutableTerminatorBehavior = new MutableBehavior[Stop.type] {
+  val mutableTerminatorBehavior = new AbstractBehavior[Stop.type] {
     override def onMessage(msg: Stop.type) = msg match {
       case Stop ⇒ Behaviors.stopped
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashSpec.scala
@@ -120,7 +120,7 @@ object StashSpec {
       active(Vector.empty)
     }
 
-  class MutableStash(ctx: ActorContext[Command]) extends MutableBehavior[Command] {
+  class MutableStash(ctx: ActorContext[Command]) extends AbstractBehavior[Command] {
 
     private val buffer = StashBuffer.apply[Command](capacity = 10)
     private var stashing = false

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/OOIntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/OOIntroSpec.scala
@@ -9,7 +9,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 import akka.actor.typed._
-import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, MutableBehavior }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, AbstractBehavior }
 
 import scala.concurrent.duration._
 import scala.concurrent.Await
@@ -17,7 +17,7 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import org.scalatest.WordSpecLike
 //#imports
 
-object MutableIntroSpec {
+object OOIntroSpec {
 
   //#chatroom-actor
   object ChatRoom {
@@ -46,7 +46,7 @@ object MutableIntroSpec {
     def behavior(): Behavior[RoomCommand] =
       Behaviors.setup[RoomCommand](ctx ⇒ new ChatRoomBehavior(ctx))
 
-    class ChatRoomBehavior(ctx: ActorContext[RoomCommand]) extends MutableBehavior[RoomCommand] {
+    class ChatRoomBehavior(ctx: ActorContext[RoomCommand]) extends AbstractBehavior[RoomCommand] {
       private var sessions: List[ActorRef[SessionCommand]] = List.empty
 
       override def onMessage(msg: RoomCommand): Behavior[RoomCommand] = {
@@ -87,9 +87,9 @@ object MutableIntroSpec {
 
 }
 
-class MutableIntroSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class OOIntroSpec extends ScalaTestWithActorTestKit with WordSpecLike {
 
-  import MutableIntroSpec._
+  import OOIntroSpec._
 
   "A chat room" must {
     "chat" in {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AbstractBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AbstractBehavior.scala
@@ -5,21 +5,24 @@
 package akka.actor.typed.javadsl
 
 import akka.actor.typed.{ Behavior, ExtensibleBehavior, Signal }
-import akka.actor.typed.javadsl.Behaviors.Receive
 import akka.util.OptionVal
 
 /**
- * Mutable behavior can be implemented by extending this class and implement the
- * abstract method [[MutableBehavior#onMessage]] and optionally override
- * [[MutableBehavior#onSignal]].
+ * An actor `Behavior` can be implemented by extending this class and implement the
+ * abstract method [[AbstractBehavior#createReceive]]. Mutable state can be defined
+ * as instance variables of the class.
  *
- * Instances of this behavior should be created via [[Behaviors#setup]] and if
+ * This is an Object-oriented style of defining a `Behavior`. A more functional style
+ * alternative is provided by the factory methods in [[Behaviors]], for example
+ * [[Behaviors.receiveMessage]].
+ *
+ * Instances of this behavior should be created via [[Behaviors.setup]] and if
  * the [[ActorContext]] is needed it can be passed as a constructor parameter
  * from the factory function.
  *
- * @see [[Behaviors#setup]]
+ * @see [[Behaviors.setup]]
  */
-abstract class MutableBehavior[T] extends ExtensibleBehavior[T] {
+abstract class AbstractBehavior[T] extends ExtensibleBehavior[T] {
   private var _receive: OptionVal[Receive[T]] = OptionVal.None
   private def receive: Receive[T] = _receive match {
     case OptionVal.None ⇒
@@ -37,7 +40,15 @@ abstract class MutableBehavior[T] extends ExtensibleBehavior[T] {
   override final def receiveSignal(ctx: akka.actor.typed.ActorContext[T], msg: Signal): Behavior[T] =
     receive.receiveSignal(ctx, msg)
 
+  /**
+   * Implement this to define how messages and signals are processed. Use the
+   * [[AbstractBehavior.receiveBuilder]] to define the message dispatch.
+   */
   def createReceive: Receive[T]
 
+  /**
+   * Create a [[ReceiveBuilder]] to define the message dispatch of the `Behavior`.
+   * Typically used from [[AbstractBehavior.createReceive]].
+   */
   def receiveBuilder: ReceiveBuilder[T] = ReceiveBuilder.create
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ActorContext.scala
@@ -234,7 +234,7 @@ trait ActorContext[T] extends akka.actor.typed.ActorContext[T] {
    *
    * A message adapter (and the returned `ActorRef`) has the same lifecycle as
    * this actor. It's recommended to register the adapters in a top level
-   * `Behaviors.setup` or constructor of `MutableBehavior` but it's possible to
+   * `Behaviors.setup` or constructor of `AbstractBehavior` but it's possible to
    * register them later also if needed. Message adapters don't have to be stopped since
    * they consume no resources other than an entry in an internal `Map` and the number
    * of adapters are bounded since it's only possible to have one per message class.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
@@ -7,10 +7,10 @@ package akka.actor.typed.javadsl
 import java.util.Collections
 import java.util.function.{ Function ⇒ JFunction }
 
-import akka.actor.typed.{ ActorRef, Behavior, BehaviorInterceptor, ExtensibleBehavior, Signal, SupervisorStrategy }
+import akka.actor.typed.{ ActorRef, Behavior, BehaviorInterceptor, Signal, SupervisorStrategy }
 import akka.actor.typed.internal.{ BehaviorImpl, Supervisor, TimerSchedulerImpl, WithMdcBehaviorInterceptor }
 import akka.actor.typed.scaladsl
-import akka.annotation.{ ApiMayChange, DoNotInherit }
+import akka.annotation.ApiMayChange
 import akka.japi.function.{ Function2 ⇒ JapiFunction2 }
 import akka.japi.pf.PFBuilder
 
@@ -97,11 +97,10 @@ object Behaviors {
    * [[ActorContext]] that allows access to the system, spawning and watching
    * other actors, etc.
    *
-   * This constructor is called immutable because the behavior instance doesn't
-   * have or close over any mutable state. Processing the next message
-   * results in a new behavior that can potentially be different from this one.
-   * State is updated by returning a new behavior that holds the new immutable
-   * state.
+   * Compared to using [[AbstractBehavior]] this factory is a more functional style
+   * of defining the `Behavior`. Processing the next message results in a new behavior
+   * that can potentially be different from this one. State is maintained by returning
+   * a new behavior that holds the new immutable state.
    */
   def receive[T](onMessage: JapiFunction2[ActorContext[T], T, Behavior[T]]): Behavior[T] =
     new BehaviorImpl.ReceiveBehavior((ctx, msg) ⇒ onMessage.apply(ctx.asJava, msg))
@@ -117,11 +116,10 @@ object Behaviors {
    * [[ActorContext]] that allows access to the system, spawning and watching
    * other actors, etc.
    *
-   * This constructor is called immutable because the behavior instance doesn't
-   * have or close over any mutable state. Processing the next message
-   * results in a new behavior that can potentially be different from this one.
-   * State is updated by returning a new behavior that holds the new immutable
-   * state.
+   * Compared to using [[AbstractBehavior]] this factory is a more functional style
+   * of defining the `Behavior`. Processing the next message results in a new behavior
+   * that can potentially be different from this one. State is maintained by returning
+   * a new behavior that holds the new immutable state.
    */
   def receiveMessage[T](onMessage: akka.japi.Function[T, Behavior[T]]): Behavior[T] =
     new BehaviorImpl.ReceiveBehavior((_, msg) ⇒ onMessage.apply(msg))
@@ -133,11 +131,10 @@ object Behaviors {
    * [[ActorContext]] that allows access to the system, spawning and watching
    * other actors, etc.
    *
-   * This constructor is called immutable because the behavior instance doesn't
-   * have or close over any mutable state. Processing the next message
-   * results in a new behavior that can potentially be different from this one.
-   * State is updated by returning a new behavior that holds the new immutable
-   * state.
+   * Compared to using [[AbstractBehavior]] this factory is a more functional style
+   * of defining the `Behavior`. Processing the next message results in a new behavior
+   * that can potentially be different from this one. State is maintained by returning
+   * a new behavior that holds the new immutable state.
    */
   def receive[T](
     onMessage: JapiFunction2[ActorContext[T], T, Behavior[T]],
@@ -151,10 +148,10 @@ object Behaviors {
    * Constructs an actor behavior builder that can build a behavior that can react to both
    * incoming messages and lifecycle signals.
    *
-   * This constructor is called immutable because the behavior instance does not
-   * need and in fact should not use (close over) mutable variables, but instead
-   * return a potentially different behavior encapsulating any state changes.
-   * If no change is desired, use {@link #same}.
+   * Compared to using [[AbstractBehavior]] this factory is a more functional style
+   * of defining the `Behavior`. Processing the next message results in a new behavior
+   * that can potentially be different from this one. State is maintained by returning
+   * a new behavior that holds the new immutable state.
    *
    * @param type the supertype of all messages accepted by this behavior
    * @return the behavior builder
@@ -273,10 +270,6 @@ object Behaviors {
    */
   def withTimers[T](factory: akka.japi.function.Function[TimerScheduler[T], Behavior[T]]): Behavior[T] =
     TimerSchedulerImpl.withTimers(timers ⇒ factory.apply(timers))
-
-  /** A specialized "receive" behavior that is implemented using message matching builders. */
-  @DoNotInherit
-  trait Receive[T] extends ExtensibleBehavior[T]
 
   /**
    * Per message MDC (Mapped Diagnostic Context) logging.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Receive.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Receive.scala
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.javadsl
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.ExtensibleBehavior
+import akka.actor.typed.Signal
+import akka.annotation.DoNotInherit
+
+/**
+ * A specialized "receive" behavior that is implemented using message matching builders,
+ * such as [[ReceiveBuilder]], from [[AbstractBehavior]].
+ */
+@DoNotInherit
+abstract class Receive[T] extends ExtensibleBehavior[T] {
+  // Note that this class may be opened for extensions to support other builder patterns,
+  // or message dispatch without builders.
+
+  /**
+   * Process an incoming message and return the next behavior.
+   *
+   * The returned behavior can in addition to normal behaviors be one of the
+   * canned special objects:
+   *
+   *  * returning `stopped` will terminate this Behavior
+   *  * returning `same` designates to reuse the current Behavior
+   *  * returning `unhandled` keeps the same Behavior and signals that the message was not yet handled
+   *
+   */
+  @throws(classOf[Exception])
+  def receiveMessage(msg: T): Behavior[T]
+
+  /**
+   * Process an incoming [[akka.actor.typed.Signal]] and return the next behavior. This means
+   * that all lifecycle hooks, ReceiveTimeout, Terminated and Failed messages
+   * can initiate a behavior change.
+   *
+   * The returned behavior can in addition to normal behaviors be one of the
+   * canned special objects:
+   *
+   *  * returning `stopped` will terminate this Behavior
+   *  * returning `same` designates to reuse the current Behavior
+   *  * returning `unhandled` keeps the same Behavior and signals that the message was not yet handled
+   */
+  @throws(classOf[Exception])
+  def receiveSignal(sig: Signal): Behavior[T]
+
+  @throws(classOf[Exception])
+  override final def receive(ctx: akka.actor.typed.ActorContext[T], msg: T): Behavior[T] =
+    receiveMessage(msg)
+
+  @throws(classOf[Exception])
+  override final def receiveSignal(ctx: akka.actor.typed.ActorContext[T], sig: Signal): Behavior[T] =
+    receiveSignal(sig)
+
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AbstractBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AbstractBehavior.scala
@@ -7,20 +7,22 @@ package akka.actor.typed.scaladsl
 import akka.actor.typed.{ Behavior, ExtensibleBehavior, Signal }
 
 /**
- * Mutable behavior can be implemented by extending this class and implement the
- * abstract method [[MutableBehavior#onMessage]] and optionally override
- * [[MutableBehavior#onSignal]].
+ * An actor `Behavior` can be implemented by extending this class and implement the
+ * abstract method [[AbstractBehavior#onMessage]] and optionally override
+ * [[AbstractBehavior#onSignal]]. Mutable state can be defined as instance variables
+ * of the class.
  *
- * Instances of this behavior should be created via [[Behaviors#setup]] and if
+ * This is an Object-oriented style of defining a `Behavior`. A more functional style
+ * alternative is provided by the factory methods in [[Behaviors]], for example
+ * [[Behaviors.receiveMessage]].
+ *
+ * Instances of this behavior should be created via [[Behaviors.setup]] and if
  * the [[ActorContext]] is needed it can be passed as a constructor parameter
  * from the factory function.
  *
- * @see [[Behaviors#setup]]
+ * @see [[Behaviors.setup]]
  */
-abstract class MutableBehavior[T] extends ExtensibleBehavior[T] {
-  @throws(classOf[Exception])
-  override final def receive(ctx: akka.actor.typed.ActorContext[T], msg: T): Behavior[T] =
-    onMessage(msg)
+abstract class AbstractBehavior[T] extends ExtensibleBehavior[T] {
 
   /**
    * Implement this method to process an incoming message and return the next behavior.
@@ -35,10 +37,6 @@ abstract class MutableBehavior[T] extends ExtensibleBehavior[T] {
    */
   @throws(classOf[Exception])
   def onMessage(msg: T): Behavior[T]
-
-  @throws(classOf[Exception])
-  override final def receiveSignal(ctx: akka.actor.typed.ActorContext[T], msg: Signal): Behavior[T] =
-    onSignal.applyOrElse(msg, { case _ ⇒ Behavior.unhandled }: PartialFunction[Signal, Behavior[T]])
 
   /**
    * Override this method to process an incoming [[akka.actor.typed.Signal]] and return the next behavior.
@@ -55,4 +53,12 @@ abstract class MutableBehavior[T] extends ExtensibleBehavior[T] {
    */
   @throws(classOf[Exception])
   def onSignal: PartialFunction[Signal, Behavior[T]] = PartialFunction.empty
+
+  @throws(classOf[Exception])
+  override final def receive(ctx: akka.actor.typed.ActorContext[T], msg: T): Behavior[T] =
+    onMessage(msg)
+
+  @throws(classOf[Exception])
+  override final def receiveSignal(ctx: akka.actor.typed.ActorContext[T], msg: Signal): Behavior[T] =
+    onSignal.applyOrElse(msg, { case _ ⇒ Behavior.unhandled }: PartialFunction[Signal, Behavior[T]])
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
@@ -238,7 +238,7 @@ trait ActorContext[T] extends akka.actor.typed.ActorContext[T] { this: akka.acto
    *
    * A message adapter (and the returned `ActorRef`) has the same lifecycle as
    * this actor. It's recommended to register the adapters in a top level
-   * `Behaviors.setup` or constructor of `MutableBehavior` but it's possible to
+   * `Behaviors.setup` or constructor of `AbstractBehavior` but it's possible to
    * register them later also if needed. Message adapters don't have to be stopped since
    * they consume no resources other than an entry in an internal `Map` and the number
    * of adapters are bounded since it's only possible to have one per message class.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
@@ -85,9 +85,10 @@ object Behaviors {
    * [[ActorContext]] that allows access to the system, spawning and watching
    * other actors, etc.
    *
-   * This constructor is called immutable because the behavior instance does not
-   * need and in fact should not use (close over) mutable variables, but instead
-   * return a potentially different behavior encapsulating any state changes.
+   * Compared to using [[AbstractBehavior]] this factory is a more functional style
+   * of defining the `Behavior`. Processing the next message results in a new behavior
+   * that can potentially be different from this one. State is maintained by returning
+   * a new behavior that holds the new immutable state.
    */
   def receive[T](onMessage: (ActorContext[T], T) ⇒ Behavior[T]): Receive[T] =
     new ReceiveImpl(onMessage)
@@ -103,15 +104,16 @@ object Behaviors {
    * [[ActorContext]] that allows access to the system, spawning and watching
    * other actors, etc.
    *
-   * This constructor is called immutable because the behavior instance does not
-   * need and in fact should not use (close over) mutable variables, but instead
-   * return a potentially different behavior encapsulating any state changes.
+   * Compared to using [[AbstractBehavior]] this factory is a more functional style
+   * of defining the `Behavior`. Processing the next message results in a new behavior
+   * that can potentially be different from this one. State is maintained by returning
+   * a new behavior that holds the new immutable state.
    */
   def receiveMessage[T](onMessage: T ⇒ Behavior[T]): Receive[T] =
     new ReceiveMessageImpl(onMessage)
 
   /**
-   * Construct an immutable actor behavior from a partial message handler which treats undefined messages as unhandled.
+   * Construct an actor `Behavior` from a partial message handler which treats undefined messages as unhandled.
    *
    * Behaviors can also be composed with [[Behavior#orElse]].
    */
@@ -121,7 +123,7 @@ object Behaviors {
     }
 
   /**
-   * Construct an immutable actor behavior from a partial message handler which treats undefined messages as unhandled.
+   * Construct an actor `Behavior` from a partial message handler which treats undefined messages as unhandled.
    *
    * Behaviors can also be composed with [[Behavior#orElse]].
    */
@@ -131,7 +133,7 @@ object Behaviors {
     }
 
   /**
-   * Construct an actor behavior that can react to lifecycle signals only.
+   * Construct an actor `Behavior` that can react to lifecycle signals only.
    */
   def receiveSignal[T](handler: PartialFunction[(ActorContext[T], Signal), Behavior[T]]): Behavior[T] =
     receive[T]((_, _) ⇒ same).receiveSignal(handler)
@@ -247,18 +249,13 @@ object Behaviors {
   def withMdc[T](staticMdc: Map[String, Any], mdcForMessage: T ⇒ Map[String, Any])(behavior: Behavior[T]): Behavior[T] =
     WithMdcBehaviorInterceptor[T](staticMdc, mdcForMessage, behavior)
 
-  // TODO
-  // final case class Selective[T](timeout: FiniteDuration, selector: PartialFunction[T, Behavior[T]], onTimeout: () ⇒ Behavior[T])
-
   /**
-   * Immutable behavior that exposes additional fluent DSL methods
-   * to further change the message or signal reception behavior.
+   * `Behavior` that exposes additional fluent DSL methods to further change the message or
+   * signal reception behavior. It's returned by for example [[Behaviors.receiveMessage]].
    */
   @DoNotInherit
   trait Receive[T] extends ExtensibleBehavior[T] {
     def receiveSignal(onSignal: PartialFunction[(ActorContext[T], Signal), Behavior[T]]): Behavior[T]
-
-    // TODO orElse can be defined here
   }
 
   @InternalApi

--- a/akka-bench-jmh/src/main/scala/akka/actor/typed/TypedBenchmarkActors.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/typed/TypedBenchmarkActors.scala
@@ -7,7 +7,7 @@ package akka.actor.typed
 import java.util.concurrent.{ CountDownLatch, TimeUnit }
 
 import akka.Done
-import akka.actor.typed.scaladsl.{ Behaviors, MutableBehavior }
+import akka.actor.typed.scaladsl.{ Behaviors, AbstractBehavior }
 import akka.actor.typed.scaladsl.{ ActorContext ⇒ SActorContext }
 
 import scala.concurrent.duration._

--- a/akka-cluster-typed/src/test/java/akka/cluster/ddata/typed/javadsl/ReplicatorTest.java
+++ b/akka-cluster-typed/src/test/java/akka/cluster/ddata/typed/javadsl/ReplicatorTest.java
@@ -25,8 +25,9 @@ import akka.actor.typed.Behavior;
 import akka.cluster.ddata.typed.javadsl.Replicator.Command;
 import akka.actor.typed.javadsl.Behaviors;
 import akka.actor.typed.javadsl.Adapter;
-import akka.actor.typed.javadsl.MutableBehavior;
+import akka.actor.typed.javadsl.AbstractBehavior;
 import akka.actor.typed.javadsl.ActorContext;
+import akka.actor.typed.javadsl.Receive;
 
 // #sample
 
@@ -83,7 +84,7 @@ public class ReplicatorTest extends JUnitSuite {
 
   static final Key<GCounter> Key = GCounterKey.create("counter");
 
-  static class Counter extends MutableBehavior<ClientCommand> {
+  static class Counter extends AbstractBehavior<ClientCommand> {
     private final ActorRef<Replicator.Command> replicator;
     private final Cluster node;
     final ActorRef<Replicator.UpdateResponse<GCounter>> updateResponseAdapter;
@@ -132,7 +133,7 @@ public class ReplicatorTest extends JUnitSuite {
     // #sample
 
     @Override
-    public Behaviors.Receive<ClientCommand> createReceive() {
+    public Receive<ClientCommand> createReceive() {
       return receiveBuilder()
         .onMessage(Increment.class, this::onIncrement)
         .onMessage(InternalUpdateResponse.class, msg -> Behaviors.same())

--- a/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/ReceptionistExampleTest.java
+++ b/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/ReceptionistExampleTest.java
@@ -10,7 +10,8 @@ import akka.actor.typed.ActorSystem;
 import akka.actor.typed.Behavior;
 import akka.actor.typed.javadsl.ActorContext;
 import akka.actor.typed.javadsl.Behaviors;
-import akka.actor.typed.javadsl.MutableBehavior;
+import akka.actor.typed.javadsl.AbstractBehavior;
+import akka.actor.typed.javadsl.Receive;
 import akka.actor.typed.receptionist.Receptionist;
 import akka.actor.typed.receptionist.ServiceKey;
 import akka.cluster.ClusterEvent;
@@ -32,7 +33,7 @@ public class ReceptionistExampleTest extends JUnitSuite {
 
   static class RandomRouter {
 
-    private static class RouterBehavior<T> extends MutableBehavior<Object> {
+    private static class RouterBehavior<T> extends AbstractBehavior<Object> {
       private final Class<T> messageClass;
       private final ServiceKey<T> serviceKey;
       private final List<ActorRef<T>> routees = new ArrayList<>();
@@ -44,7 +45,7 @@ public class ReceptionistExampleTest extends JUnitSuite {
       }
 
       @Override
-      public Behaviors.Receive<Object> createReceive() {
+      public Receive<Object> createReceive() {
         return receiveBuilder()
           .onMessage(Receptionist.Listing.class, listing -> listing.isForKey(serviceKey), (listing) -> {
             routees.clear();
@@ -74,7 +75,7 @@ public class ReceptionistExampleTest extends JUnitSuite {
       }
     }
 
-    private static class ClusterRouterBehavior<T> extends MutableBehavior<Object> {
+    private static class ClusterRouterBehavior<T> extends AbstractBehavior<Object> {
       private final Class<T> messageClass;
       private final ServiceKey<T> serviceKey;
       private final List<ActorRef<T>> routees = new ArrayList<>();
@@ -110,7 +111,7 @@ public class ReceptionistExampleTest extends JUnitSuite {
       }
 
       @Override
-      public Behaviors.Receive<Object> createReceive() {
+      public Receive<Object> createReceive() {
         return receiveBuilder()
           .onMessage(Receptionist.Listing.class, listing -> listing.isForKey(serviceKey), listing -> {
             routees.clear();

--- a/akka-docs/src/main/paradox/typed/interaction-patterns.md
+++ b/akka-docs/src/main/paradox/typed/interaction-patterns.md
@@ -119,7 +119,7 @@ their registration order, i.e. the last registered first.
 
 A message adapter (and the returned `ActorRef`) has the same lifecycle as
 the receiving actor. It's recommended to register the adapters in a top level
-`Behaviors.setup` or constructor of `MutableBehavior` but it's possible to
+`Behaviors.setup` or constructor of `AbstractBehavior` but it's possible to
 register them later also if needed.
 
 The adapter function is running in the receiving actor and can safely access state of it, but if it throws an exception the actor is stopped.

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedRunning.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedRunning.scala
@@ -7,7 +7,7 @@ package akka.persistence.typed.internal
 import akka.Done
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.scaladsl.MutableBehavior
+import akka.actor.typed.scaladsl.AbstractBehavior
 import akka.annotation.InternalApi
 import akka.persistence.JournalProtocol._
 import akka.persistence._
@@ -179,7 +179,7 @@ private[akka] object EventsourcedRunning {
     numberOfEvents:             Int,
     shouldSnapshotAfterPersist: Boolean,
     var sideEffects:            immutable.Seq[SideEffect[S]])
-    extends MutableBehavior[EventsourcedBehavior.InternalProtocol] {
+    extends AbstractBehavior[EventsourcedBehavior.InternalProtocol] {
 
     private var eventCounter = 0
 


### PR DESCRIPTION
* Also cleanup javadsl Receive, which is only used from AbstractBehavior
* Clarify further in docs that the functional vs OO style is a matter of taste

Refs #25750