### PR TITLE
fix cluster routing docs

### DIFF
--- a/akka-docs/src/main/paradox/cluster-routing.md
+++ b/akka-docs/src/main/paradox/cluster-routing.md
@@ -77,7 +77,7 @@ Scala
 Java
 :  @@snip [StatsService.java](/akka-docs/src/test/java/jdocs/cluster/StatsService.java) { #router-lookup-in-code }
 
-See [configuration](#cluster-configuration) section for further descriptions of the settings.
+See @ref:[reference configuration](general/configuration.md#config-akka-cluster) for further descriptions of the settings.
 
 ### Router Example with Group of Routees
 
@@ -185,7 +185,7 @@ Scala
 Java
 :  @@snip [StatsService.java](/akka-docs/src/test/java/jdocs/cluster/StatsService.java) { #router-deploy-in-code }
 
-See [configuration](#cluster-configuration) section for further descriptions of the settings.
+See @ref:[reference configuration](general/configuration.md#config-akka-cluster) for further descriptions of the settings.
 
 ### Router Example with Pool of Remote Deployed Routees
 

--- a/akka-docs/src/main/paradox/index-cluster.md
+++ b/akka-docs/src/main/paradox/index-cluster.md
@@ -6,6 +6,7 @@
 
 * [common/cluster](common/cluster.md)
 * [cluster-usage](cluster-usage.md)
+* [cluster-routing](cluster-routing.md)
 * [cluster-singleton](cluster-singleton.md)
 * [distributed-pub-sub](distributed-pub-sub.md)
 * [cluster-client](cluster-client.md)


### PR DESCRIPTION
* broke when it was moved to separate page