### PR TITLE
WIP: Effects outside javadsl PersistentBehavior (no good)

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/PersistentBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/PersistentBehavior.scala
@@ -32,7 +32,7 @@ abstract class PersistentBehavior[Command, Event, State >: Null] private[akka] (
    *
    * Return effects from your handlers in order to instruct persistence on how to act on the incoming message (i.e. persist events).
    */
-  protected final def Effect: EffectFactories[Command, Event, State] = EffectFactory.asInstanceOf[EffectFactories[Command, Event, State]]
+  protected final def Effect: EffectFactories[Event, State] = EffectFactories.asInstanceOf[EffectFactories[Event, State]]
 
   /**
    * Implement by returning the initial empty state object.


### PR DESCRIPTION
* illustrates problems with type inference if Effects (and builder) is used
  outside PersistentBehavior (e.g. in State)