### PR TITLE
Deprecated the after pattern supporting methods which accept a v…

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/Patterns.scala
+++ b/akka-actor/src/main/scala/akka/pattern/Patterns.scala
@@ -431,6 +431,7 @@ object Patterns {
    * Returns a [[scala.concurrent.Future]] that will be completed with the success or failure of the provided Callable
    * after the specified duration.
    */
+  @deprecated("Use the overload one which accepts a Callable of Future instead.", since = "2.5.22")
   def after[T](duration: FiniteDuration, scheduler: Scheduler, context: ExecutionContext, value: Future[T]): Future[T] =
     scalaAfter(duration, scheduler)(value)(context)
 
@@ -438,6 +439,7 @@ object Patterns {
    * Returns a [[java.util.concurrent.CompletionStage]] that will be completed with the success or failure of the provided value
    * after the specified duration.
    */
+  @deprecated("Use the overloaded one which accepts a Callable of CompletionStage instead.", since = "2.5.22")
   def after[T](duration: java.time.Duration,
                scheduler: Scheduler,
                context: ExecutionContext,
@@ -871,7 +873,8 @@ object PatternsCS {
    * Returns a [[java.util.concurrent.CompletionStage]] that will be completed with the success or failure of the provided value
    * after the specified duration.
    */
-  @deprecated("Use the overloaded one which accepts java.time.Duration instead.", since = "2.5.12")
+  @deprecated("Use Patterns.after which accepts java.time.Duration and Callable of CompletionStage instead.",
+              since = "2.5.22")
   def after[T](duration: FiniteDuration,
                scheduler: Scheduler,
                context: ExecutionContext,
@@ -882,7 +885,8 @@ object PatternsCS {
    * Returns a [[java.util.concurrent.CompletionStage]] that will be completed with the success or failure of the provided value
    * after the specified duration.
    */
-  @deprecated("Use Patterns.after instead.", since = "2.5.19")
+  @deprecated("Use Patterns.after which accepts java.time.Duration and Callable of CompletionStage instead.",
+              since = "2.5.22")
   def after[T](duration: java.time.Duration,
                scheduler: Scheduler,
                context: ExecutionContext,

--- a/akka-docs/src/test/java/jdocs/future/FutureDocTest.java
+++ b/akka-docs/src/test/java/jdocs/future/FutureDocTest.java
@@ -637,7 +637,6 @@ public class FutureDocTest extends AbstractJavaTest {
   public void useOnOnComplete() throws Exception {
     {
       Future<String> future = Futures.successful("foo");
-
       // #onComplete
       final ExecutionContext ec = system.dispatcher();
 

--- a/akka-docs/src/test/java/jdocs/stream/StreamTestKitDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/StreamTestKitDocTest.java
@@ -205,7 +205,7 @@ public class StreamTestKitDocTest extends AbstractJavaTest {
                         Duration.ofMillis(10),
                         system.scheduler(),
                         system.dispatcher(),
-                        CompletableFuture.completedFuture(sleep)));
+                        () -> CompletableFuture.completedFuture(sleep)));
 
     final Pair<TestPublisher.Probe<Integer>, TestSubscriber.Probe<Integer>> pubAndSub =
         TestSource.<Integer>probe(system)


### PR DESCRIPTION
Refs https://github.com/akka/akka/issues/15547

I would like to deprecate the `Callable` one for scaladsl and change the `call by value` of `Future` to `call by name` based in 3.0.