### PR TITLE
Make the stop message in sharding optional, #25642

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/PoisonPill.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/PoisonPill.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.internal
+
+import akka.actor.typed.ActorContext
+import akka.actor.typed.Behavior
+import akka.actor.typed.BehaviorInterceptor
+import akka.actor.typed.Signal
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] sealed abstract class PoisonPill extends Signal
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] case object PoisonPill extends PoisonPill {
+  def instance: PoisonPill = this
+}
+
+/**
+ * INTERNAL API
+ *
+ * Returns `Behaviors.stopped` for [[PoisonPill]] signals unless it has been handled by the target `Behavior`.
+ * Used by Cluster Sharding to automatically stop entities without defining a stop message in the
+ * application protocol. Persistent actors handle `PoisonPill` and run side effects after persist
+ * and process stashed messages before stopping.
+ */
+@InternalApi private[akka] final class PoisonPillInterceptor[M] extends BehaviorInterceptor[M, M] {
+  override def aroundReceive(ctx: ActorContext[M], msg: M, target: BehaviorInterceptor.ReceiveTarget[M]): Behavior[M] =
+    target(ctx, msg)
+
+  override def aroundSignal(ctx: ActorContext[M], signal: Signal, target: BehaviorInterceptor.SignalTarget[M]): Behavior[M] = {
+    signal match {
+      case p: PoisonPill ⇒
+        val next = target(ctx, p)
+        if (Behavior.isUnhandled(next)) Behavior.stopped
+        else next
+      case _ ⇒ target(ctx, signal)
+    }
+  }
+
+  override def isSame(other: BehaviorInterceptor[Any, Any]): Boolean =
+    // only one interceptor per behavior stack is needed
+    other.isInstanceOf[PoisonPillInterceptor[_]]
+}

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -133,7 +133,7 @@ import akka.util.Timeout
   private val shardCommandActors: ConcurrentHashMap[String, ActorRef[scaladsl.ClusterSharding.ShardCommand]] = new ConcurrentHashMap
 
   // scaladsl impl
-  override def start[M, E](entity: scaladsl.Entity[M, E]): ActorRef[E] = {
+  override def init[M, E](entity: scaladsl.Entity[M, E]): ActorRef[E] = {
     val settings = entity.settings match {
       case None    ⇒ ClusterShardingSettings(system)
       case Some(s) ⇒ s
@@ -144,14 +144,14 @@ import akka.util.Timeout
       case Some(e) ⇒ e
     }).asInstanceOf[ShardingMessageExtractor[E, M]]
 
-    internalStart(entity.createBehavior, entity.entityProps, entity.typeKey,
+    internalInit(entity.createBehavior, entity.entityProps, entity.typeKey,
       entity.stopMessage, settings, extractor, entity.allocationStrategy)
   }
 
   // javadsl impl
-  override def start[M, E](entity: javadsl.Entity[M, E]): ActorRef[E] = {
+  override def init[M, E](entity: javadsl.Entity[M, E]): ActorRef[E] = {
     import scala.compat.java8.OptionConverters._
-    start(new scaladsl.Entity(
+    init(new scaladsl.Entity(
       createBehavior = (ctx: EntityContext) ⇒ Behaviors.setup[M] { actorContext ⇒
         entity.createBehavior(
           new javadsl.EntityContext[M](ctx.entityId, ctx.shard, actorContext.asJava))
@@ -165,7 +165,7 @@ import akka.util.Timeout
     ))
   }
 
-  private def internalStart[M, E](
+  private def internalInit[M, E](
     behavior:           EntityContext ⇒ Behavior[M],
     entityProps:        Props,
     typeKey:            scaladsl.EntityTypeKey[M],
@@ -241,7 +241,7 @@ import akka.util.Timeout
 
     typeNames.putIfAbsent(typeKey.name, messageClassName) match {
       case spawnedMessageClassName: String if messageClassName != spawnedMessageClassName ⇒
-        throw new IllegalArgumentException(s"[${typeKey.name}] already started for [$spawnedMessageClassName]")
+        throw new IllegalArgumentException(s"[${typeKey.name}] already initialized for [$spawnedMessageClassName]")
       case _ ⇒ ()
     }
 

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ClusterSharding.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ClusterSharding.scala
@@ -7,7 +7,6 @@ package javadsl
 
 import java.util.Optional
 import java.util.concurrent.CompletionStage
-import java.util.function.BiFunction
 
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
@@ -72,7 +71,7 @@ object ClusterSharding {
  * to route the message with the entity id to the final destination.
  *
  * This extension is supposed to be used by first, typically at system startup on each node
- * in the cluster, registering the supported entity types with the [[ClusterSharding#spawn]]
+ * in the cluster, registering the supported entity types with the [[ClusterSharding#init]]
  * method, which returns the `ShardRegion` actor reference for a named entity type.
  * Messages to the entities are always sent via that `ActorRef`, i.e. the local `ShardRegion`.
  * Messages can also be sent via the [[EntityRef]] retrieved with [[ClusterSharding#entityRefFor]],
@@ -176,7 +175,7 @@ abstract class ClusterSharding {
    * @tparam M The type of message the entity accepts
    * @tparam E A possible envelope around the message the entity accepts
    */
-  def start[M, E](entity: Entity[M, E]): ActorRef[E]
+  def init[M, E](entity: Entity[M, E]): ActorRef[E]
 
   /**
    * Create an `ActorRef`-like reference to a specific sharded entity.
@@ -199,7 +198,7 @@ abstract class ClusterSharding {
 object Entity {
 
   /**
-   * Defines how the entity should be created. Used in [[ClusterSharding#start]]. More optional
+   * Defines how the entity should be created. Used in [[ClusterSharding#init]]. More optional
    * settings can be defined using the `with` methods of the returned [[Entity]].
    *
    * Any [[Behavior]] can be used as a sharded entity actor, but the combination of sharding and persistent actors
@@ -217,7 +216,7 @@ object Entity {
   }
 
   /**
-   * Defines how the [[PersistentEntity]] should be created. Used in [[ClusterSharding#start]]. Any [[Behavior]] can
+   * Defines how the [[PersistentEntity]] should be created. Used in [[ClusterSharding#init]]. Any [[Behavior]] can
    * be used as a sharded entity actor, but the combination of sharding and persistent actors is very common
    * and therefore this factory is provided as convenience.
    *
@@ -246,7 +245,7 @@ object Entity {
 }
 
 /**
- * Defines how the entity should be created. Used in [[ClusterSharding#start]].
+ * Defines how the entity should be created. Used in [[ClusterSharding#init]].
  */
 final class Entity[M, E] private[akka] (
   val createBehavior:     JFunction[EntityContext[M], Behavior[M]],

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/PersistentEntity.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/PersistentEntity.scala
@@ -23,15 +23,18 @@ import akka.persistence.typed.javadsl.PersistentBehavior
  */
 abstract class PersistentEntity[Command, Event, State >: Null] private (
   val entityTypeKey: EntityTypeKey[Command],
+  val entityId:      String,
   persistenceId:     PersistenceId, supervisorStrategy: Optional[BackoffSupervisorStrategy])
   extends PersistentBehavior[Command, Event, State](persistenceId, supervisorStrategy) {
 
   def this(entityTypeKey: EntityTypeKey[Command], entityId: String) = {
-    this(entityTypeKey, persistenceId = entityTypeKey.persistenceIdFrom(entityId), Optional.empty[BackoffSupervisorStrategy])
+    this(entityTypeKey, entityId,
+      persistenceId = entityTypeKey.persistenceIdFrom(entityId), Optional.empty[BackoffSupervisorStrategy])
   }
 
   def this(entityTypeKey: EntityTypeKey[Command], entityId: String, backoffSupervisorStrategy: BackoffSupervisorStrategy) = {
-    this(entityTypeKey, persistenceId = entityTypeKey.persistenceIdFrom(entityId), Optional.ofNullable(backoffSupervisorStrategy))
+    this(entityTypeKey, entityId,
+      persistenceId = entityTypeKey.persistenceIdFrom(entityId), Optional.ofNullable(backoffSupervisorStrategy))
   }
 
 }

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/ClusterSharding.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/ClusterSharding.scala
@@ -19,7 +19,6 @@ import akka.actor.typed.ExtensionSetup
 import akka.actor.typed.RecipientRef
 import akka.actor.typed.Props
 import akka.actor.typed.internal.InternalRecipientRef
-import akka.actor.typed.scaladsl.ActorContext
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
 import akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
@@ -27,7 +26,6 @@ import akka.cluster.sharding.typed.internal.ClusterShardingImpl
 import akka.cluster.sharding.typed.internal.EntityTypeKeyImpl
 import akka.cluster.sharding.ShardRegion.{ StartEntity â‡’ UntypedStartEntity }
 import akka.persistence.typed.PersistenceId
-import akka.persistence.typed.scaladsl.PersistentBehavior
 
 object ClusterSharding extends ExtensionId[ClusterSharding] {
 
@@ -74,7 +72,7 @@ object ClusterSharding extends ExtensionId[ClusterSharding] {
  * to route the message with the entity id to the final destination.
  *
  * This extension is supposed to be used by first, typically at system startup on each node
- * in the cluster, registering the supported entity types with the [[ClusterSharding#spawn]]
+ * in the cluster, registering the supported entity types with the [[ClusterSharding#init]]
  * method, which returns the `ShardRegion` actor reference for a named entity type.
  * Messages to the entities are always sent via that `ActorRef`, i.e. the local `ShardRegion`.
  * Messages can also be sent via the [[EntityRef]] retrieved with [[ClusterSharding#entityRefFor]],
@@ -178,7 +176,7 @@ trait ClusterSharding extends Extension { javadslSelf: javadsl.ClusterSharding â
    * @tparam M The type of message the entity accepts
    * @tparam E A possible envelope around the message the entity accepts
    */
-  def start[M, E](entity: Entity[M, E]): ActorRef[E]
+  def init[M, E](entity: Entity[M, E]): ActorRef[E]
 
   /**
    * Create an `ActorRef`-like reference to a specific sharded entity.
@@ -206,12 +204,12 @@ trait ClusterSharding extends Extension { javadslSelf: javadsl.ClusterSharding â
 object Entity {
 
   /**
-   * Defines how the entity should be created. Used in [[ClusterSharding#start]]. More optional
+   * Defines how the entity should be created. Used in [[ClusterSharding#init]]. More optional
    * settings can be defined using the `with` methods of the returned [[Entity]].
    *
    * Any [[Behavior]] can be used as a sharded entity actor, but the combination of sharding and persistent actors
    * is very common and therefore [[PersistentEntity]] is provided as a convenience for creating such
-   * [[PersistentBehavior]].
+   * `PersistentBehavior`.
    *
    * @param typeKey A key that uniquely identifies the type of entity in this cluster
    * @param createBehavior Create the behavior for an entity given a [[EntityContext]] (includes entityId)
@@ -224,7 +222,7 @@ object Entity {
 }
 
 /**
- * Defines how the entity should be created. Used in [[ClusterSharding#start]].
+ * Defines how the entity should be created. Used in [[ClusterSharding#init]].
  */
 final class Entity[M, E] private[akka] (
   val createBehavior:     EntityContext â‡’ Behavior[M],

--- a/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/MultiDcClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/MultiDcClusterShardingSpec.scala
@@ -67,14 +67,14 @@ abstract class MultiDcClusterShardingSpec extends MultiNodeSpec(MultiDcClusterSh
       formCluster(first, second, third, fourth)
     }
 
-    "start sharding" in {
+    "init sharding" in {
       val sharding = ClusterSharding(typedSystem)
-      val shardRegion: ActorRef[ShardingEnvelope[PingProtocol]] = sharding.start(
+      val shardRegion: ActorRef[ShardingEnvelope[PingProtocol]] = sharding.init(
         Entity(typeKey, _ ⇒ multiDcPinger))
       val probe = TestProbe[Pong]
       shardRegion ! ShardingEnvelope(entityId, Ping(probe.ref))
       probe.expectMessage(max = 10.seconds, Pong(cluster.selfMember.dataCenter))
-      enterBarrier("sharding-started")
+      enterBarrier("sharding-initialized")
     }
 
     "be able to message via entity ref" in {
@@ -96,7 +96,7 @@ abstract class MultiDcClusterShardingSpec extends MultiNodeSpec(MultiDcClusterSh
 
   "be able to message cross dc via proxy" in {
     runOn(first, second) {
-      val proxy: ActorRef[ShardingEnvelope[PingProtocol]] = ClusterSharding(typedSystem).start(
+      val proxy: ActorRef[ShardingEnvelope[PingProtocol]] = ClusterSharding(typedSystem).init(
         Entity(
           typeKey,
           _ ⇒ multiDcPinger)

--- a/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/MultiDcClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/MultiDcClusterShardingSpec.scala
@@ -70,10 +70,7 @@ abstract class MultiDcClusterShardingSpec extends MultiNodeSpec(MultiDcClusterSh
     "start sharding" in {
       val sharding = ClusterSharding(typedSystem)
       val shardRegion: ActorRef[ShardingEnvelope[PingProtocol]] = sharding.start(
-        Entity(
-          typeKey,
-          _ ⇒ multiDcPinger,
-          NoMore))
+        Entity(typeKey, _ ⇒ multiDcPinger))
       val probe = TestProbe[Pong]
       shardRegion ! ShardingEnvelope(entityId, Ping(probe.ref))
       probe.expectMessage(max = 10.seconds, Pong(cluster.selfMember.dataCenter))
@@ -102,8 +99,7 @@ abstract class MultiDcClusterShardingSpec extends MultiNodeSpec(MultiDcClusterSh
       val proxy: ActorRef[ShardingEnvelope[PingProtocol]] = ClusterSharding(typedSystem).start(
         Entity(
           typeKey,
-          _ ⇒ multiDcPinger,
-          NoMore)
+          _ ⇒ multiDcPinger)
           .withSettings(ClusterShardingSettings(typedSystem).withDataCenter("dc2")))
       val probe = TestProbe[Pong]
       proxy ! ShardingEnvelope(entityId, Ping(probe.ref))

--- a/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/javadsl/ClusterShardingPersistenceTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/javadsl/ClusterShardingPersistenceTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding.typed.javadsl;
+
+import akka.Done;
+import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
+import akka.actor.testkit.typed.javadsl.TestProbe;
+import akka.actor.typed.ActorRef;
+import akka.cluster.typed.Cluster;
+import akka.cluster.typed.Join;
+import akka.persistence.typed.ExpectingReply;
+import akka.persistence.typed.javadsl.CommandHandler;
+import akka.persistence.typed.javadsl.Effect;
+import akka.persistence.typed.javadsl.EventHandler;
+import akka.util.Timeout;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
+
+import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClusterShardingPersistenceTest extends JUnitSuite {
+
+  public static final Config config = ConfigFactory.parseString(
+          "akka.actor.provider = cluster \n" +
+          "akka.remote.netty.tcp.port = 0 \n" +
+          "akka.remote.artery.canonical.port = 0 \n" +
+          "akka.remote.artery.canonical.hostname = 127.0.0.1 \n" +
+          "akka.persistence.journal.plugin = \"akka.persistence.journal.inmem\" \n");
+
+  @ClassRule
+  public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
+
+  interface Command {}
+  static class Add implements Command {
+    public final String s;
+
+    Add(String s) {
+      this.s = s;
+    }
+  }
+  static class AddWithConfirmation implements Command, ExpectingReply<Done> {
+    final String s;
+    private final ActorRef<Done> replyTo;
+
+    AddWithConfirmation(String s, ActorRef<Done> replyTo) {
+      this.s = s;
+      this.replyTo = replyTo;
+    }
+
+    @Override
+    public ActorRef<Done> replyTo() {
+      return replyTo;
+    }
+  }
+  static class Get implements Command {
+    final ActorRef<String> replyTo;
+
+    Get(ActorRef<String> replyTo) {
+      this.replyTo = replyTo;
+    }
+  }
+  static enum StopPlz implements Command {
+    INSTANCE
+  }
+
+
+
+  static class TestPersistentEntity extends PersistentEntity<Command, String, String> {
+
+    public static final EntityTypeKey<Command> ENTITY_TYPE_KEY =
+      EntityTypeKey.create(Command.class, "HelloWorld");
+
+    public TestPersistentEntity(String entityId) {
+      super(ENTITY_TYPE_KEY, entityId);
+    }
+
+    @Override
+    public String emptyState() {
+      return "";
+    }
+
+    @Override
+    public CommandHandler<Command, String, String> commandHandler() {
+      return commandHandlerBuilder(String.class)
+        .matchCommand(Add.class, this::add)
+        .matchCommand(AddWithConfirmation.class, this::addWithConfirmation)
+        .matchCommand(Get.class, this::getState)
+        .build();
+    }
+
+    private Effect<String, String> add(String state, Add cmd) {
+      return Effect().persist(cmd.s);
+    }
+
+    private Effect<String, String> addWithConfirmation(String state, AddWithConfirmation cmd) {
+      return Effect().persist(cmd.s)
+        .thenReply(cmd, newState -> Done.getInstance());
+    }
+
+    private Effect<String, String> getState(String state, Get cmd) {
+      cmd.replyTo.tell(entityId() + ":" + state);
+      return Effect().none();
+    }
+
+    @Override
+    public EventHandler<String, String> eventHandler() {
+      return eventHandlerBuilder()
+        .matchEvent(String.class, this::applyEvent)
+        .build();
+    }
+
+    private String applyEvent(String state, String evt) {
+      if (state.equals(""))
+        return evt;
+      else
+        return state + "|" + evt;
+    }
+  }
+
+  private ClusterSharding _sharding = null;
+
+  private ClusterSharding sharding() {
+    if (_sharding == null) {
+      // initialize first time only
+      Cluster cluster = Cluster.get(testKit.system());
+      cluster.manager().tell(new Join(cluster.selfMember().address()));
+
+      ClusterSharding sharding = ClusterSharding.get(testKit.system());
+
+      sharding.start(Entity.ofPersistentEntity(TestPersistentEntity.ENTITY_TYPE_KEY,
+        entityContext -> new TestPersistentEntity(entityContext.getEntityId()))
+      .withStopMessage(StopPlz.INSTANCE));
+
+      _sharding = sharding;
+    }
+    return _sharding;
+  }
+
+  @Test
+  public void startPersistentActor() {
+    TestProbe<String> p = testKit.createTestProbe();
+    EntityRef<Command> ref = sharding().entityRefFor(TestPersistentEntity.ENTITY_TYPE_KEY, "123");
+    ref.tell(new Add("a"));
+    ref.tell(new Add("b"));
+    ref.tell(new Add("c"));
+    ref.tell(new Get(p.getRef()));
+    p.expectMessage("123:a|b|c");
+  }
+
+  @Test
+  public void askWithThenReply() {
+    TestProbe<Done> p1 = testKit.createTestProbe();
+    EntityRef<Command> ref = sharding().entityRefFor(TestPersistentEntity.ENTITY_TYPE_KEY, "456");
+    Timeout askTimeout = Timeout.create(p1.getRemainingOrDefault());
+    CompletionStage<Done> done1 =ref.ask(replyTo -> new AddWithConfirmation("a", replyTo), askTimeout);
+    done1.thenAccept(d -> p1.getRef().tell(d));
+    p1.expectMessage(Done.getInstance());
+
+    CompletionStage<Done> done2 =ref.ask(replyTo -> new AddWithConfirmation("b", replyTo), askTimeout);
+    done1.thenAccept(d -> p1.getRef().tell(d));
+    p1.expectMessage(Done.getInstance());
+
+    TestProbe<String> p2 = testKit.createTestProbe();
+    ref.tell(new Get(p2.getRef()));
+    p2.expectMessage("456:a|b");
+  }
+
+}

--- a/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/javadsl/ClusterShardingPersistenceTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/javadsl/ClusterShardingPersistenceTest.java
@@ -21,7 +21,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
-import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 
 import static org.junit.Assert.assertEquals;
@@ -135,7 +134,7 @@ public class ClusterShardingPersistenceTest extends JUnitSuite {
 
       ClusterSharding sharding = ClusterSharding.get(testKit.system());
 
-      sharding.start(Entity.ofPersistentEntity(TestPersistentEntity.ENTITY_TYPE_KEY,
+      sharding.init(Entity.ofPersistentEntity(TestPersistentEntity.ENTITY_TYPE_KEY,
         entityContext -> new TestPersistentEntity(entityContext.getEntityId()))
       .withStopMessage(StopPlz.INSTANCE));
 

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExample.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExample.java
@@ -42,7 +42,7 @@ public class HelloWorldPersistentEntityExample {
       this.system = system;
       sharding = ClusterSharding.get(system);
 
-      sharding.start(
+      sharding.init(
         Entity.ofPersistentEntity(
           HelloWorld.ENTITY_TYPE_KEY,
           ctx -> new HelloWorld(ctx.getActorContext(), ctx.getEntityId())));

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExample.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExample.java
@@ -45,8 +45,7 @@ public class HelloWorldPersistentEntityExample {
       sharding.start(
         Entity.ofPersistentEntity(
           HelloWorld.ENTITY_TYPE_KEY,
-          ctx -> new HelloWorld(ctx.getActorContext(), ctx.getEntityId()),
-          HelloWorld.Passivate.INSTANCE));
+          ctx -> new HelloWorld(ctx.getActorContext(), ctx.getEntityId())));
     }
 
     // usage example
@@ -76,10 +75,6 @@ public class HelloWorldPersistentEntityExample {
         this.whom = whom;
         this.replyTo = replyTo;
       }
-    }
-
-    enum Passivate implements Command {
-      INSTANCE
     }
 
     // Response
@@ -140,12 +135,7 @@ public class HelloWorldPersistentEntityExample {
     public CommandHandler<Command, Greeted, KnownPeople> commandHandler() {
       return commandHandlerBuilder(KnownPeople.class)
         .matchCommand(Greet.class, this::greet)
-        .matchCommand(Greet.class, this::passivate)
         .build();
-    }
-
-    private Effect<Greeted, KnownPeople> passivate(KnownPeople state, Command cmd) {
-      return Effect().stop();
     }
 
     private Effect<Greeted, KnownPeople> greet(KnownPeople state, Greet cmd) {

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExampleTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExampleTest.java
@@ -41,7 +41,7 @@ public class HelloWorldPersistentEntityExampleTest extends JUnitSuite {
       cluster.manager().tell(new Join(cluster.selfMember().address()));
 
       ClusterSharding sharding = ClusterSharding.get(testKit.system());
-      sharding.start(
+      sharding.init(
         Entity.ofPersistentEntity(
           HelloWorld.ENTITY_TYPE_KEY,
           ctx -> new HelloWorld(ctx.getActorContext(), ctx.getEntityId())));

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExampleTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExampleTest.java
@@ -44,8 +44,7 @@ public class HelloWorldPersistentEntityExampleTest extends JUnitSuite {
       sharding.start(
         Entity.ofPersistentEntity(
           HelloWorld.ENTITY_TYPE_KEY,
-          ctx -> new HelloWorld(ctx.getActorContext(), ctx.getEntityId()),
-          HelloWorld.Passivate.INSTANCE));
+          ctx -> new HelloWorld(ctx.getActorContext(), ctx.getEntityId())));
       _sharding = sharding;
     }
     return _sharding;

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java
@@ -89,22 +89,22 @@ public class ShardingCompileOnlyTest {
   }
   //#counter-passivate
 
-  public static void startPassivateExample() {
+  public static void initPassivateExample() {
     ActorSystem system = ActorSystem.create(
         Behaviors.empty(), "ShardingExample"
     );
     ClusterSharding sharding = ClusterSharding.get(system);
 
-    //#counter-passivate-start
+    //#counter-passivate-init
     
     EntityTypeKey<CounterCommand> typeKey = EntityTypeKey.create(CounterCommand.class, "Counter");
 
-    sharding.start(
+    sharding.init(
       Entity.of(
         typeKey,
         ctx -> counter2(ctx.getShard(), ctx.getEntityId()))
         .withStopMessage(new GoodByeCounter()));
-    //#counter-passivate-start
+    //#counter-passivate-init
   }
 
   public static void example() {
@@ -117,14 +117,14 @@ public class ShardingCompileOnlyTest {
     ClusterSharding sharding = ClusterSharding.get(system);
     //#sharding-extension
 
-    //#start
+    //#init
     EntityTypeKey<CounterCommand> typeKey = EntityTypeKey.create(CounterCommand.class, "Counter");
 
-    ActorRef<ShardingEnvelope<CounterCommand>> shardRegion = sharding.start(
+    ActorRef<ShardingEnvelope<CounterCommand>> shardRegion = sharding.init(
       Entity.of(
         typeKey,
         ctx -> counter(ctx.getEntityId(),0)));
-    //#start
+    //#init
 
     //#send
     EntityRef<CounterCommand> counterOne = sharding.entityRefFor(typeKey, "counter-`");
@@ -143,7 +143,7 @@ public class ShardingCompileOnlyTest {
     //#persistence
     EntityTypeKey<BlogCommand> blogTypeKey = EntityTypeKey.create(BlogCommand.class, "BlogPost");
 
-    sharding.start(
+    sharding.init(
       Entity.of(
         blogTypeKey,
         ctx -> BlogBehavior.behavior(ctx.getEntityId())));

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java
@@ -22,14 +22,12 @@ import akka.cluster.sharding.typed.javadsl.Entity;
 
 import jdocs.akka.persistence.typed.BlogPostExample.BlogCommand;
 import jdocs.akka.persistence.typed.BlogPostExample.BlogBehavior;
-import jdocs.akka.persistence.typed.BlogPostExample.PassivatePost;
 
 public class ShardingCompileOnlyTest {
 
   //#counter-messages
   interface CounterCommand {}
   public static class Increment implements CounterCommand { }
-  public static class GoodByeCounter implements CounterCommand { }
 
   public static class GetValue implements CounterCommand {
     private final ActorRef<Integer> replyTo;
@@ -50,15 +48,14 @@ public class ShardingCompileOnlyTest {
         msg.replyTo.tell(value);
         return Behaviors.same();
       })
-      .onMessage(GoodByeCounter.class, (ctx, msg) -> {
-        return Behaviors.stopped();
-      })
       .build();
   }
   //#counter
 
   //#counter-passivate
   public static class Idle implements CounterCommand { }
+
+  public static class GoodByeCounter implements CounterCommand { }
 
   public static Behavior<CounterCommand> counter2(ActorRef<ClusterSharding.ShardCommand> shard, String entityId) {
     return Behaviors.setup(ctx -> {
@@ -105,8 +102,8 @@ public class ShardingCompileOnlyTest {
     sharding.start(
       Entity.of(
         typeKey,
-        ctx -> counter2(ctx.getShard(), ctx.getEntityId()),
-        new GoodByeCounter()));
+        ctx -> counter2(ctx.getShard(), ctx.getEntityId()))
+        .withStopMessage(new GoodByeCounter()));
     //#counter-passivate-start
   }
 
@@ -126,8 +123,7 @@ public class ShardingCompileOnlyTest {
     ActorRef<ShardingEnvelope<CounterCommand>> shardRegion = sharding.start(
       Entity.of(
         typeKey,
-        ctx -> counter(ctx.getEntityId(),0),
-        new GoodByeCounter()));
+        ctx -> counter(ctx.getEntityId(),0)));
     //#start
 
     //#send
@@ -150,8 +146,7 @@ public class ShardingCompileOnlyTest {
     sharding.start(
       Entity.of(
         blogTypeKey,
-        ctx -> BlogBehavior.behavior(ctx.getEntityId()),
-        new PassivatePost()));
+        ctx -> BlogBehavior.behavior(ctx.getEntityId())));
     //#persistence
   }
 }

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
@@ -139,7 +139,7 @@ class ClusterShardingPersistenceSpec extends ScalaTestWithActorTestKit(ClusterSh
 
   "Typed cluster sharding with persistent actor" must {
 
-    ClusterSharding(system).start(Entity(
+    ClusterSharding(system).init(Entity(
       typeKey,
       ctx ⇒ persistentEntity(ctx.entityId, ctx.shard)))
 

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
@@ -4,13 +4,27 @@
 
 package akka.cluster.sharding.typed.scaladsl
 
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.Promise
 
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
+import akka.actor.typed.internal.PoisonPill
+import akka.actor.typed.scaladsl.Behaviors
+import akka.cluster.sharding.ShardRegion.CurrentShardRegionState
+import akka.cluster.sharding.ShardRegion.GetShardRegionState
+import akka.cluster.sharding.typed.scaladsl.ClusterSharding.Passivate
+import akka.cluster.sharding.typed.scaladsl.ClusterSharding.ShardCommand
+import akka.cluster.sharding.{ ClusterSharding ⇒ UntypedClusterSharding }
 import akka.cluster.typed.Cluster
 import akka.cluster.typed.Join
 import akka.persistence.typed.ExpectingReply
@@ -21,8 +35,10 @@ import org.scalatest.WordSpecLike
 object ClusterShardingPersistenceSpec {
   val config = ConfigFactory.parseString(
     """
-      akka.actor.provider = cluster
+      akka.loglevel = DEBUG
+      #akka.persistence.typed.log-stashing = on
 
+      akka.actor.provider = cluster
       akka.remote.netty.tcp.port = 0
       akka.remote.artery.canonical.port = 0
       akka.remote.artery.canonical.hostname = 127.0.0.1
@@ -33,61 +49,119 @@ object ClusterShardingPersistenceSpec {
   sealed trait Command
   final case class Add(s: String) extends Command
   final case class AddWithConfirmation(s: String)(override val replyTo: ActorRef[Done]) extends Command with ExpectingReply[Done]
+  final case class PassivateAndPersist(s: String)(override val replyTo: ActorRef[Done]) extends Command with ExpectingReply[Done]
   final case class Get(replyTo: ActorRef[String]) extends Command
-  final case object StopPlz extends Command
+  final case class Echo(msg: String, replyTo: ActorRef[String]) extends Command
+  final case class Block(latch: CountDownLatch) extends Command
 
   val typeKey = EntityTypeKey[Command]("test")
 
-  def persistentEntity(entityId: String): Behavior[Command] =
-    PersistentEntity[Command, String, String](
-      entityTypeKey = typeKey,
-      entityId = entityId,
-      emptyState = "",
-      commandHandler = (state, cmd) ⇒ cmd match {
-        case Add(s) ⇒
-          Effect.persist(s)
+  val recoveryCompletedProbes = new ConcurrentHashMap[String, ActorRef[String]]
 
-        case cmd @ AddWithConfirmation(s) ⇒
-          Effect.persist(s)
-            .thenReply(cmd)(newState ⇒ Done)
+  // Need this to be able to send the PoisonPill from the outside, simulating rebalance before recovery and such.
+  // Promise completed by the actor when it's started.
+  val entityActorRefs = new ConcurrentHashMap[String, Promise[ActorRef[Any]]]
 
-        case Get(replyTo) ⇒
-          replyTo ! s"$entityId:$state"
-          Effect.none
-        case StopPlz ⇒ Effect.stop()
-      },
-      eventHandler = (state, evt) ⇒ if (state.isEmpty) evt else state + "|" + evt)
+  def persistentEntity(entityId: String, shard: ActorRef[ShardCommand]): Behavior[Command] = {
+    Behaviors.setup { ctx ⇒
+
+      entityActorRefs.get(entityId) match {
+        case null    ⇒
+        case promise ⇒ promise.trySuccess(ctx.self.upcast)
+      }
+
+      PersistentEntity[Command, String, String](
+        entityTypeKey = typeKey,
+        entityId = entityId,
+        emptyState = "",
+        commandHandler = (state, cmd) ⇒ cmd match {
+          case Add(s) ⇒
+            Effect.persist(s)
+
+          case cmd @ AddWithConfirmation(s) ⇒
+            Effect.persist(s)
+              .thenReply(cmd)(newState ⇒ Done)
+
+          case Get(replyTo) ⇒
+            replyTo ! s"$entityId:$state"
+            Effect.none
+
+          case cmd @ PassivateAndPersist(s) ⇒
+            shard ! Passivate(ctx.self)
+            Effect.persist(s)
+              .thenReply(cmd)(newState ⇒ Done)
+
+          case Echo(msg, replyTo) ⇒
+            Effect.none.thenRun(_ ⇒ replyTo ! msg)
+
+          case Block(latch) ⇒
+            latch.await(5, TimeUnit.SECONDS)
+            Effect.none
+        },
+        eventHandler = (state, evt) ⇒ if (state.isEmpty) evt else state + "|" + evt)
+        .onRecoveryCompleted { state ⇒
+          ctx.log.debug("onRecoveryCompleted: [{}]", state)
+          recoveryCompletedProbes.get(entityId) match {
+            case null ⇒ ctx.log.debug("no recoveryCompletedProbe for [{}]", entityId)
+            case p    ⇒ p ! s"recoveryCompleted:$state"
+          }
+        }
+    }
+  }
 
 }
 
 class ClusterShardingPersistenceSpec extends ScalaTestWithActorTestKit(ClusterShardingPersistenceSpec.config) with WordSpecLike {
   import ClusterShardingPersistenceSpec._
 
+  private var _entityId = 0
+  def nextEntityId(): String = {
+    _entityId += 1
+    _entityId.toString
+  }
+
+  private def awaitEntityTerminatedAndRemoved(ref: ActorRef[_], entityId: String): Unit = {
+    val p = TestProbe[Any]()
+    p.expectTerminated(ref, p.remainingOrDefault)
+
+    // also make sure that the entity is removed from the Shard before continuing
+    // FIXME rewrite this with Typed API when region queries are supported
+    import akka.actor.typed.scaladsl.adapter._
+    val regionStateProbe = TestProbe[CurrentShardRegionState]()
+    val untypedRegion = UntypedClusterSharding(system.toUntyped)
+    regionStateProbe.awaitAssert {
+      untypedRegion.shardRegion(typeKey.name).tell(GetShardRegionState, regionStateProbe.ref.toUntyped)
+      regionStateProbe.expectMessageType[CurrentShardRegionState].shards.foreach { shardState ⇒
+        shardState.entityIds should not contain entityId
+      }
+    }
+  }
+
   "Typed cluster sharding with persistent actor" must {
 
     ClusterSharding(system).start(Entity(
       typeKey,
-      ctx ⇒ persistentEntity(ctx.entityId),
-      StopPlz
-    ))
+      ctx ⇒ persistentEntity(ctx.entityId, ctx.shard)))
 
     Cluster(system).manager ! Join(Cluster(system).selfMember.address)
 
     "start persistent actor" in {
+      val entityId = nextEntityId()
       val p = TestProbe[String]()
 
-      val ref = ClusterSharding(system).entityRefFor(typeKey, "123")
+      val ref = ClusterSharding(system).entityRefFor(typeKey, entityId)
       ref ! Add("a")
       ref ! Add("b")
       ref ! Add("c")
       ref ! Get(p.ref)
-      p.expectMessage("123:a|b|c")
+      p.expectMessage("1:a|b|c")
     }
 
     "support ask with thenReply" in {
+      val entityId = nextEntityId()
       val p = TestProbe[String]()
 
-      val ref = ClusterSharding(system).entityRefFor(typeKey, "456")
+      val ref = ClusterSharding(system).entityRefFor(typeKey, entityId)
       val done1 = ref ? AddWithConfirmation("a")
       done1.futureValue should ===(Done)
 
@@ -95,7 +169,244 @@ class ClusterShardingPersistenceSpec extends ScalaTestWithActorTestKit(ClusterSh
       done2.futureValue should ===(Done)
 
       ref ! Get(p.ref)
-      p.expectMessage("456:a|b")
+      p.expectMessage("2:a|b")
     }
+
+    "handle PoisonPill after persist effect" in {
+      val entityId = nextEntityId()
+      val recoveryProbe = TestProbe[String]()
+      recoveryCompletedProbes.put(entityId, recoveryProbe.ref)
+
+      val p1 = TestProbe[Done]()
+      val ref = ClusterSharding(system).entityRefFor(typeKey, entityId)
+      (1 to 10).foreach { n ⇒
+        ref ! PassivateAndPersist(n.toString)(p1.ref)
+        // recoveryCompleted each time, verifies that it was actually stopped
+        recoveryProbe.expectMessage("recoveryCompleted:" + (1 until n).map(_.toString).mkString("|"))
+        p1.expectMessage(Done)
+      }
+
+      val p2 = TestProbe[String]()
+      ref ! Get(p2.ref)
+      p2.expectMessage(entityId + ":" + (1 to 10).map(_.toString).mkString("|"))
+    }
+
+    "handle PoisonPill after several stashed commands that persist" in {
+      val entityId = nextEntityId()
+      val actorRefPromise = Promise[ActorRef[Any]]()
+      entityActorRefs.put(entityId, actorRefPromise)
+
+      val addProbe = TestProbe[Done]()
+      val recoveryProbe = TestProbe[String]()
+      recoveryCompletedProbes.put(entityId, recoveryProbe.ref)
+
+      val entityRef = ClusterSharding(system).entityRefFor(typeKey, entityId)
+      // this will wakeup the entity, and complete the entityActorRefPromise
+      entityRef ! AddWithConfirmation("a")(addProbe.ref)
+      addProbe.expectMessage(Done)
+      recoveryProbe.expectMessage("recoveryCompleted:")
+      // now we know that it's in EventSourcedRunning with no stashed commands
+
+      val actorRef = actorRefPromise.future.futureValue
+
+      // not sending via the EntityRef because that would make the test racy
+      // these are stashed, since before the PoisonPill
+      val latch = new CountDownLatch(1)
+      actorRef ! Block(latch)
+      actorRef ! AddWithConfirmation("b")(addProbe.ref)
+      actorRef ! AddWithConfirmation("c")(addProbe.ref)
+
+      actorRef ! PoisonPill
+
+      // those messages should be ignored since they happen after the PoisonPill,
+      actorRef ! AddWithConfirmation("d")(addProbe.ref)
+      actorRef ! AddWithConfirmation("e")(addProbe.ref)
+
+      // now we have enqueued the message sequence and start processing them
+      latch.countDown()
+
+      addProbe.expectMessage(Done)
+      addProbe.expectMessage(Done)
+
+      // wake up again
+      awaitEntityTerminatedAndRemoved(actorRef, entityId)
+      val p2 = TestProbe[String]()
+      entityRef ! AddWithConfirmation("f")(addProbe.ref)
+      entityRef ! Get(p2.ref)
+      recoveryProbe.expectMessage("recoveryCompleted:a|b|c")
+      p2.expectMessage(entityId + ":a|b|c|f")
+    }
+
+    "handle PoisonPill after several stashed commands that DON'T persist" in {
+      val entityId = nextEntityId()
+      val actorRefPromise = Promise[ActorRef[Any]]()
+      entityActorRefs.put(entityId, actorRefPromise)
+
+      val addProbe = TestProbe[Done]()
+      val echoProbe = TestProbe[String]()
+      val recoveryProbe = TestProbe[String]()
+      recoveryCompletedProbes.put(entityId, recoveryProbe.ref)
+
+      val entityRef = ClusterSharding(system).entityRefFor(typeKey, entityId)
+      // this will wakeup the entity, and complete the entityActorRefPromise
+      entityRef ! AddWithConfirmation("a")(addProbe.ref)
+      addProbe.expectMessage(Done)
+      recoveryProbe.expectMessage("recoveryCompleted:")
+      // now we know that it's in EventSourcedRunning with no stashed commands
+
+      val actorRef = actorRefPromise.future.futureValue
+      // not sending via the EntityRef because that would make the test racy
+      // these are stashed, since before the PoisonPill
+      val latch = new CountDownLatch(1)
+      actorRef ! Block(latch)
+      actorRef ! AddWithConfirmation("b")(addProbe.ref)
+      actorRef ! AddWithConfirmation("c")(addProbe.ref)
+      actorRef ! Echo("echo-1", echoProbe.ref)
+
+      actorRef ! PoisonPill
+
+      // those messages should be ignored since they happen after the PoisonPill,
+      actorRef ! Echo("echo-2", echoProbe.ref)
+      actorRef ! AddWithConfirmation("d")(addProbe.ref)
+      actorRef ! AddWithConfirmation("e")(addProbe.ref)
+      actorRef ! Echo("echo-3", echoProbe.ref)
+
+      // now we have enqueued the message sequence and start processing them
+      latch.countDown()
+
+      echoProbe.expectMessage("echo-1")
+      addProbe.expectMessage(Done)
+      addProbe.expectMessage(Done)
+
+      // wake up again
+      awaitEntityTerminatedAndRemoved(actorRef, entityId)
+      val p2 = TestProbe[String]()
+      entityRef ! Echo("echo-4", echoProbe.ref)
+      echoProbe.expectMessage("echo-4")
+      entityRef ! AddWithConfirmation("f")(addProbe.ref)
+      entityRef ! Get(p2.ref)
+      recoveryProbe.expectMessage("recoveryCompleted:a|b|c")
+      p2.expectMessage(entityId + ":a|b|c|f")
+    }
+
+    "handle PoisonPill when stash empty" in {
+      val entityId = nextEntityId()
+      val actorRefPromise = Promise[ActorRef[Any]]()
+      entityActorRefs.put(entityId, actorRefPromise)
+
+      val addProbe = TestProbe[Done]()
+      val recoveryProbe = TestProbe[String]()
+      recoveryCompletedProbes.put(entityId, recoveryProbe.ref)
+
+      val entityRef = ClusterSharding(system).entityRefFor(typeKey, entityId)
+      // this will wakeup the entity, and complete the entityActorRefPromise
+      entityRef ! AddWithConfirmation("a")(addProbe.ref)
+      addProbe.expectMessage(Done)
+      recoveryProbe.expectMessage("recoveryCompleted:")
+      // now we know that it's in EventSourcedRunning with no stashed commands
+
+      val actorRef = actorRefPromise.future.futureValue
+      // not sending via the EntityRef because that would make the test racy
+      val latch = new CountDownLatch(1)
+      actorRef ! Block(latch)
+      actorRef ! PoisonPill
+      // those messages should be ignored since they happen after the PoisonPill,
+      actorRef ! AddWithConfirmation("b")(addProbe.ref)
+
+      // now we have enqueued the message sequence and start processing them
+      latch.countDown()
+
+      // wake up again
+      awaitEntityTerminatedAndRemoved(actorRef, entityId)
+      val p2 = TestProbe[String]()
+      entityRef ! AddWithConfirmation("c")(addProbe.ref)
+      entityRef ! Get(p2.ref)
+      recoveryProbe.expectMessage("recoveryCompleted:a")
+      p2.expectMessage(entityId + ":a|c")
+    }
+
+    "handle PoisonPill before recovery completed without stashed commands" in {
+      val entityId = nextEntityId()
+      val actorRefPromise = Promise[ActorRef[Any]]()
+      entityActorRefs.put(entityId, actorRefPromise)
+
+      val recoveryProbe = TestProbe[String]()
+      recoveryCompletedProbes.put(entityId, recoveryProbe.ref)
+
+      val entityRef = ClusterSharding(system).entityRefFor(typeKey, entityId)
+      val ignoreFirstEchoProbe = TestProbe[String]()
+      val echoProbe = TestProbe[String]()
+      // first echo will wakeup the entity, and complete the entityActorRefPromise
+      // ignore the first echo reply since it may be racy with the PoisonPill
+      entityRef ! Echo("echo-1", ignoreFirstEchoProbe.ref)
+
+      // not using actorRefPromise.future.futureValue because it's polling (slow) and want to run this before
+      // recovery completed, to exercise that scenario
+      implicit val ec: ExecutionContext = testKit.system.executionContext
+      val poisonSent = actorRefPromise.future.map { actorRef ⇒
+        // not sending via the EntityRef because that would make the test racy
+        actorRef ! PoisonPill
+        actorRef
+      }
+      val actorRef = poisonSent.futureValue
+
+      recoveryProbe.expectMessage("recoveryCompleted:")
+
+      // wake up again
+      awaitEntityTerminatedAndRemoved(actorRef, entityId)
+      entityRef ! Echo("echo-2", echoProbe.ref)
+      echoProbe.expectMessage("echo-2")
+      recoveryProbe.expectMessage("recoveryCompleted:")
+    }
+
+    "handle PoisonPill before recovery completed with stashed commands" in {
+      val entityId = nextEntityId()
+      val actorRefPromise = Promise[ActorRef[Any]]()
+      entityActorRefs.put(entityId, actorRefPromise)
+
+      val recoveryProbe = TestProbe[String]()
+      recoveryCompletedProbes.put(entityId, recoveryProbe.ref)
+
+      val entityRef = ClusterSharding(system).entityRefFor(typeKey, entityId)
+      val addProbe = TestProbe[Done]()
+      val ignoreFirstEchoProbe = TestProbe[String]()
+      val echoProbe = TestProbe[String]()
+      // first echo will wakeup the entity, and complete the entityActorRefPromise
+      // ignore the first echo reply since it may be racy with the PoisonPill
+      entityRef ! Echo("echo-1", ignoreFirstEchoProbe.ref)
+
+      // not using actorRefPromise.future.futureValue because it's polling (slow) and want to run this before
+      // recovery completed, to exercise that scenario
+      implicit val ec: ExecutionContext = testKit.system.executionContext
+      val poisonSent = actorRefPromise.future.map { actorRef ⇒
+        // not sending via the EntityRef because that would make the test racy
+        // these are stashed, since before the PoisonPill
+        actorRef ! Echo("echo-2", echoProbe.ref)
+        actorRef ! AddWithConfirmation("a")(addProbe.ref)
+        actorRef ! AddWithConfirmation("b")(addProbe.ref)
+        actorRef ! Echo("echo-3", echoProbe.ref)
+
+        actorRef ! PoisonPill
+
+        // those messages should be ignored since they happen after the PoisonPill,
+        actorRef ! Echo("echo-4", echoProbe.ref)
+        actorRef ! AddWithConfirmation("c")(addProbe.ref)
+        actorRef
+      }
+      val actorRef = poisonSent.futureValue
+
+      recoveryProbe.expectMessage("recoveryCompleted:")
+      echoProbe.expectMessage("echo-2")
+      echoProbe.expectMessage("echo-3")
+      addProbe.expectMessage(Done)
+      addProbe.expectMessage(Done)
+
+      // wake up again
+      awaitEntityTerminatedAndRemoved(actorRef, entityId)
+      entityRef ! Echo("echo-5", echoProbe.ref)
+      echoProbe.expectMessage("echo-5")
+      recoveryProbe.expectMessage("recoveryCompleted:a|b")
+    }
+
   }
 }

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -188,17 +188,17 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
       Behaviors.same
   }
 
-  private val shardingRef1: ActorRef[ShardingEnvelope[TestProtocol]] = sharding.start(Entity(
+  private val shardingRef1: ActorRef[ShardingEnvelope[TestProtocol]] = sharding.init(Entity(
     typeKey,
     ctx ⇒ behavior(ctx.shard))
     .withStopMessage(StopPlz()))
 
-  private val shardingRef2 = sharding2.start(Entity(
+  private val shardingRef2 = sharding2.init(Entity(
     typeKey,
     ctx ⇒ behavior(ctx.shard))
     .withStopMessage(StopPlz()))
 
-  private val shardingRef3: ActorRef[IdTestProtocol] = sharding.start(Entity(
+  private val shardingRef3: ActorRef[IdTestProtocol] = sharding.init(Entity(
     typeKey2,
     ctx ⇒ behaviorWithId(ctx.shard))
     .withMessageExtractor(ShardingMessageExtractor.noEnvelope[IdTestProtocol](10, IdStopPlz()) {
@@ -209,7 +209,7 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
     .withStopMessage(IdStopPlz())
   )
 
-  private val shardingRef4 = sharding2.start(Entity(
+  private val shardingRef4 = sharding2.init(Entity(
     typeKey2,
     ctx ⇒ behaviorWithId(ctx.shard))
     .withMessageExtractor(
@@ -268,7 +268,7 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
       val p = TestProbe[String]()
       val typeKey3 = EntityTypeKey[TestProtocol]("passivate-test")
 
-      val shardingRef3: ActorRef[ShardingEnvelope[TestProtocol]] = sharding.start(Entity(
+      val shardingRef3: ActorRef[ShardingEnvelope[TestProtocol]] = sharding.init(Entity(
         typeKey3,
         ctx ⇒ behavior(ctx.shard, Some(stopProbe.ref)))
         .withStopMessage(StopPlz()))
@@ -289,7 +289,7 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
       val p = TestProbe[String]()
       val typeKey4 = EntityTypeKey[TestProtocol]("passivate-test-poison")
 
-      val shardingRef4: ActorRef[ShardingEnvelope[TestProtocol]] = sharding.start(Entity(
+      val shardingRef4: ActorRef[ShardingEnvelope[TestProtocol]] = sharding.init(Entity(
         typeKey4,
         ctx ⇒ behavior(ctx.shard, Some(stopProbe.ref))))
       // no StopPlz stopMessage
@@ -305,16 +305,16 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
       p.expectMessage("Hello!")
     }
 
-    "fail if starting sharding for already used typeName, but with a different type" in {
-      // sharding has been already started with EntityTypeKey[TestProtocol]("envelope-shard")
+    "fail if init sharding for already used typeName, but with a different type" in {
+      // sharding has been already initialized with EntityTypeKey[TestProtocol]("envelope-shard")
       val ex = intercept[Exception] {
-        sharding.start(Entity(
+        sharding.init(Entity(
           EntityTypeKey[IdTestProtocol]("envelope-shard"),
           ctx ⇒ behaviorWithId(ctx.shard))
           .withStopMessage(IdStopPlz()))
       }
 
-      ex.getMessage should include("already started")
+      ex.getMessage should include("already initialized")
     }
 
     "EntityRef - tell" in {
@@ -374,7 +374,7 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
     "EntityRef - AskTimeoutException" in {
       val ignorantKey = EntityTypeKey[TestProtocol]("ignorant")
 
-      sharding.start(Entity(
+      sharding.init(Entity(
         ignorantKey,
         _ ⇒ Behaviors.ignore[TestProtocol])
         .withStopMessage(StopPlz()))

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -18,6 +18,7 @@ import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorRefResolver
 import akka.actor.typed.ActorSystem
+import akka.actor.typed.PostStop
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
 import akka.cluster.MemberStatus
@@ -148,14 +149,14 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
   }
 
   private val typeKey = EntityTypeKey[TestProtocol]("envelope-shard")
-  private def behavior(shard: ActorRef[ClusterSharding.ShardCommand], stopProbe: Option[ActorRef[Done]] = None) =
+  private def behavior(shard: ActorRef[ClusterSharding.ShardCommand], stopProbe: Option[ActorRef[String]] = None) =
     Behaviors.receive[TestProtocol] {
       case (ctx, PassivatePlz()) ⇒
         shard ! ClusterSharding.Passivate(ctx.self)
         Behaviors.same
 
       case (_, StopPlz()) ⇒
-        stopProbe.foreach(_ ! Done)
+        stopProbe.foreach(_ ! "StopPlz")
         Behaviors.stopped
 
       case (ctx, WhoAreYou(replyTo)) ⇒
@@ -165,6 +166,10 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
 
       case (_, ReplyPlz(toMe)) ⇒
         toMe ! "Hello!"
+        Behaviors.same
+    }.receiveSignal {
+      case (_, PostStop) ⇒
+        stopProbe.foreach(_ ! "PostStop")
         Behaviors.same
     }
 
@@ -185,35 +190,35 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
 
   private val shardingRef1: ActorRef[ShardingEnvelope[TestProtocol]] = sharding.start(Entity(
     typeKey,
-    ctx ⇒ behavior(ctx.shard),
-    StopPlz()))
+    ctx ⇒ behavior(ctx.shard))
+    .withStopMessage(StopPlz()))
 
   private val shardingRef2 = sharding2.start(Entity(
     typeKey,
-    ctx ⇒ behavior(ctx.shard),
-    StopPlz()))
+    ctx ⇒ behavior(ctx.shard))
+    .withStopMessage(StopPlz()))
 
   private val shardingRef3: ActorRef[IdTestProtocol] = sharding.start(Entity(
     typeKey2,
-    ctx ⇒ behaviorWithId(ctx.shard),
-    IdStopPlz())
+    ctx ⇒ behaviorWithId(ctx.shard))
     .withMessageExtractor(ShardingMessageExtractor.noEnvelope[IdTestProtocol](10, IdStopPlz()) {
       case IdReplyPlz(id, _)  ⇒ id
       case IdWhoAreYou(id, _) ⇒ id
       case other              ⇒ throw new IllegalArgumentException(s"Unexpected message $other")
     })
+    .withStopMessage(IdStopPlz())
   )
 
   private val shardingRef4 = sharding2.start(Entity(
     typeKey2,
-    ctx ⇒ behaviorWithId(ctx.shard),
-    IdStopPlz())
+    ctx ⇒ behaviorWithId(ctx.shard))
     .withMessageExtractor(
       ShardingMessageExtractor.noEnvelope[IdTestProtocol](10, IdStopPlz()) {
         case IdReplyPlz(id, _)  ⇒ id
         case IdWhoAreYou(id, _) ⇒ id
         case other              ⇒ throw new IllegalArgumentException(s"Unexpected message $other")
       })
+    .withStopMessage(IdStopPlz())
   )
 
   def totalEntityCount1(): Int = {
@@ -258,23 +263,45 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
       }
     }
 
-    "be able to passivate" in {
-      val stopProbe = TestProbe[Done]()
+    "be able to passivate with custom stop message" in {
+      val stopProbe = TestProbe[String]()
       val p = TestProbe[String]()
       val typeKey3 = EntityTypeKey[TestProtocol]("passivate-test")
 
       val shardingRef3: ActorRef[ShardingEnvelope[TestProtocol]] = sharding.start(Entity(
         typeKey3,
-        ctx ⇒ behavior(ctx.shard, Some(stopProbe.ref)),
-        StopPlz()))
+        ctx ⇒ behavior(ctx.shard, Some(stopProbe.ref)))
+        .withStopMessage(StopPlz()))
 
       shardingRef3 ! ShardingEnvelope(s"test1", ReplyPlz(p.ref))
       p.expectMessage("Hello!")
 
       shardingRef3 ! ShardingEnvelope(s"test1", PassivatePlz())
-      stopProbe.expectMessage(Done)
+      stopProbe.expectMessage("StopPlz")
+      stopProbe.expectMessage("PostStop")
 
       shardingRef3 ! ShardingEnvelope(s"test1", ReplyPlz(p.ref))
+      p.expectMessage("Hello!")
+    }
+
+    "be able to passivate with PoisonPill" in {
+      val stopProbe = TestProbe[String]()
+      val p = TestProbe[String]()
+      val typeKey4 = EntityTypeKey[TestProtocol]("passivate-test-poison")
+
+      val shardingRef4: ActorRef[ShardingEnvelope[TestProtocol]] = sharding.start(Entity(
+        typeKey4,
+        ctx ⇒ behavior(ctx.shard, Some(stopProbe.ref))))
+      // no StopPlz stopMessage
+
+      shardingRef4 ! ShardingEnvelope(s"test4", ReplyPlz(p.ref))
+      p.expectMessage("Hello!")
+
+      shardingRef4 ! ShardingEnvelope(s"test4", PassivatePlz())
+      // no StopPlz
+      stopProbe.expectMessage("PostStop")
+
+      shardingRef4 ! ShardingEnvelope(s"test4", ReplyPlz(p.ref))
       p.expectMessage("Hello!")
     }
 
@@ -283,8 +310,8 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
       val ex = intercept[Exception] {
         sharding.start(Entity(
           EntityTypeKey[IdTestProtocol]("envelope-shard"),
-          ctx ⇒ behaviorWithId(ctx.shard),
-          IdStopPlz()))
+          ctx ⇒ behaviorWithId(ctx.shard))
+          .withStopMessage(IdStopPlz()))
       }
 
       ex.getMessage should include("already started")
@@ -349,8 +376,8 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
 
       sharding.start(Entity(
         ignorantKey,
-        _ ⇒ Behaviors.ignore[TestProtocol],
-        StopPlz()))
+        _ ⇒ Behaviors.ignore[TestProtocol])
+        .withStopMessage(StopPlz()))
 
       val ref = sharding.entityRefFor(ignorantKey, "sloppy")
 

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExample.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExample.scala
@@ -23,7 +23,7 @@ object HelloWorldPersistentEntityExample {
     // registration at startup
     private val sharding = ClusterSharding(system)
 
-    sharding.start(Entity(
+    sharding.init(Entity(
       typeKey = HelloWorld.entityTypeKey,
       createBehavior = entityContext ⇒ HelloWorld.persistentEntity(entityContext.entityId)))
 

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExample.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExample.scala
@@ -25,8 +25,7 @@ object HelloWorldPersistentEntityExample {
 
     sharding.start(Entity(
       typeKey = HelloWorld.entityTypeKey,
-      createBehavior = entityContext ⇒ HelloWorld.persistentEntity(entityContext.entityId),
-      stopMessage = HelloWorld.Passivate))
+      createBehavior = entityContext ⇒ HelloWorld.persistentEntity(entityContext.entityId)))
 
     private implicit val askTimeout: Timeout = Timeout(5.seconds)
 
@@ -50,7 +49,6 @@ object HelloWorldPersistentEntityExample {
     // Command
     trait Command
     final case class Greet(whom: String)(val replyTo: ActorRef[Greeting]) extends Command
-    case object Passivate extends Command
     // Response
     final case class Greeting(whom: String, numberOfPeople: Int)
 
@@ -68,16 +66,12 @@ object HelloWorldPersistentEntityExample {
       (_, cmd) ⇒
         cmd match {
           case cmd: Greet ⇒ greet(cmd)
-          case Passivate  ⇒ passivate()
         }
     }
 
     private def greet(cmd: Greet): Effect[Greeted, KnownPeople] =
       Effect.persist(Greeted(cmd.whom))
         .thenRun(state ⇒ cmd.replyTo ! Greeting(cmd.whom, state.numberOfPeople))
-
-    private def passivate(): Effect[Greeted, KnownPeople] =
-      Effect.stop()
 
     private val eventHandler: (KnownPeople, Greeted) ⇒ KnownPeople = {
       (state, evt) ⇒ state.add(evt.whom)

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExampleSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExampleSpec.scala
@@ -35,7 +35,7 @@ class HelloWorldPersistentEntityExampleSpec extends ScalaTestWithActorTestKit(He
     super.beforeAll()
     Cluster(system).manager ! Join(Cluster(system).selfMember.address)
 
-    sharding.start(Entity(
+    sharding.init(Entity(
       HelloWorld.entityTypeKey,
       ctx ⇒ HelloWorld.persistentEntity(ctx.entityId)))
   }

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExampleSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldPersistentEntityExampleSpec.scala
@@ -37,9 +37,7 @@ class HelloWorldPersistentEntityExampleSpec extends ScalaTestWithActorTestKit(He
 
     sharding.start(Entity(
       HelloWorld.entityTypeKey,
-      ctx ⇒ HelloWorld.persistentEntity(ctx.entityId),
-      HelloWorld.Passivate
-    ))
+      ctx ⇒ HelloWorld.persistentEntity(ctx.entityId)))
   }
 
   "HelloWorld example" must {

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ShardingCompileOnlySpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ShardingCompileOnlySpec.scala
@@ -43,13 +43,13 @@ object ShardingCompileOnlySpec {
     }
   //#counter
 
-  //#start
+  //#init
   val TypeKey = EntityTypeKey[CounterCommand]("Counter")
 
-  val shardRegion: ActorRef[ShardingEnvelope[CounterCommand]] = sharding.start(Entity(
+  val shardRegion: ActorRef[ShardingEnvelope[CounterCommand]] = sharding.init(Entity(
     typeKey = TypeKey,
     createBehavior = ctx ⇒ counter(ctx.entityId, 0)))
-  //#start
+  //#init
 
   //#send
   // With an EntityRef
@@ -64,7 +64,7 @@ object ShardingCompileOnlySpec {
   //#persistence
   val BlogTypeKey = EntityTypeKey[BlogCommand]("BlogPost")
 
-  ClusterSharding(system).start(Entity(
+  ClusterSharding(system).init(Entity(
     typeKey = BlogTypeKey,
     createBehavior = ctx ⇒ behavior(ctx.entityId)))
   //#persistence
@@ -98,7 +98,7 @@ object ShardingCompileOnlySpec {
     }
   }
 
-  sharding.start(Entity(
+  sharding.init(Entity(
     typeKey = TypeKey,
     createBehavior = ctx ⇒ counter2(ctx.shard, ctx.entityId))
     .withStopMessage(GoodByeCounter))

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -105,10 +105,11 @@ If a message is already enqueued to the entity when it stops itself the enqueued
 in the mailbox will be dropped. To support graceful passivation without losing such
 messages the entity actor can send `ClusterSharding.Passivate` to to the
 @scala[`ActorRef[ShardCommand]`]@java[`ActorRef<ShardCommand>`] that was passed in to
-the factory method when creating the entity. The specified `handOffStopMessage` message
-will be sent back to the entity, which is then supposed to stop itself. Incoming messages
-will be buffered by the `Shard` between reception of `Passivate` and termination of the
-entity. Such buffered messages are thereafter delivered to a new incarnation of the entity.
+the factory method when creating the entity. The optional `stopMessage` message
+will be sent back to the entity, which is then supposed to stop itself, otherwise it will
+be stopped automatically. Incoming messages will be buffered by the `Shard` between reception
+of `Passivate` and termination of the entity. Such buffered messages are thereafter delivered
+to a new incarnation of the entity.
 
 Scala
 :  @@snip [ShardingCompileOnlySpec.scala](/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ShardingCompileOnlySpec.scala) { #counter-messages #counter-passivate }
@@ -116,6 +117,10 @@ Scala
 Java
 :  @@snip [ShardingCompileOnlyTest.java](/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java) { #counter-messages #counter-passivate #counter-passivate-start }
 
+Note that in the above example the `stopMessage` is specified as `GoodByeCounter`. That message will be sent to
+the entity when it's supposed to stop itself due to rebalance or passivation. If the `stopMessage` is not defined
+it will be stopped automatically without receiving a specific message. It can be useful to define a custom stop
+message if the entity needs to perform some asynchronous cleanup or interactions before stopping.
 
 ### Automatic Passivation
 
@@ -123,5 +128,5 @@ The entities can be configured to be automatically passivated if they haven't re
 a message for a while using the `akka.cluster.sharding.passivate-idle-entity-after` setting,
 or by explicitly setting `ClusterShardingSettings.passivateIdleEntityAfter` to a suitable
 time to keep the actor alive. Note that only messages sent through sharding are counted, so direct messages
-to the `ActorRef` of the actor or messages that it sends to itself are not counted as activity. 
+to the `ActorRef` of the actor or messages that it sends to itself are not counted as activity.
 By default automatic passivation is disabled.

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -45,10 +45,10 @@ Java
 Each Entity type has a key that is then used to retrieve an EntityRef for a given entity identifier.
 
 Scala
-:  @@snip [ShardingCompileOnlySpec.scala](/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ShardingCompileOnlySpec.scala) { #start }
+:  @@snip [ShardingCompileOnlySpec.scala](/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ShardingCompileOnlySpec.scala) { #init }
 
 Java
-:  @@snip [ShardingCompileOnlyTest.java](/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java) { #start }
+:  @@snip [ShardingCompileOnlyTest.java](/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java) { #init }
 
 Messages to a specific entity are then sent via an EntityRef.
 It is also possible to wrap methods in a `ShardingEnvelop` or define extractor functions and send messages directly to the shard region.
@@ -115,7 +115,7 @@ Scala
 :  @@snip [ShardingCompileOnlySpec.scala](/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ShardingCompileOnlySpec.scala) { #counter-messages #counter-passivate }
 
 Java
-:  @@snip [ShardingCompileOnlyTest.java](/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java) { #counter-messages #counter-passivate #counter-passivate-start }
+:  @@snip [ShardingCompileOnlyTest.java](/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java) { #counter-messages #counter-passivate #counter-passivate-init }
 
 Note that in the above example the `stopMessage` is specified as `GoodByeCounter`. That message will be sent to
 the entity when it's supposed to stop itself due to rebalance or passivation. If the `stopMessage` is not defined

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedStashManagement.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventsourcedStashManagement.scala
@@ -24,6 +24,8 @@ private[akka] trait EventsourcedStashManagement[C, E, S] {
 
   private def stashBuffer: StashBuffer[InternalProtocol] = setup.internalStash
 
+  protected def isStashEmpty: Boolean = stashBuffer.isEmpty
+
   protected def stash(msg: InternalProtocol): Unit = {
     if (setup.settings.logOnStashing) setup.log.debug("Stashing message: [{}]", msg)
 

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BlogPostExample.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BlogPostExample.java
@@ -133,8 +133,6 @@ public class BlogPostExample {
       this.replyTo = replyTo;
     }
   }
-  public static class PassivatePost implements BlogCommand {
-  }
   public static class PostContent implements BlogCommand {
     final String postId;
     final String title;
@@ -204,8 +202,7 @@ public class BlogPostExample {
 
     private CommandHandlerBuilder<BlogCommand, BlogEvent, BlogState, BlogState> commonCommandHandler() {
       return commandHandlerBuilder(BlogState.class)
-          .matchCommand(AddPost.class, (state, cmd) -> Effect().unhandled())
-          .matchCommand(PassivatePost.class, (state, cmd) -> Effect().stop());
+          .matchCommand(AddPost.class, (state, cmd) -> Effect().unhandled());
     }
     //#post-added-command-handler
 

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/NullBlogState.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/NullBlogState.java
@@ -105,9 +105,6 @@ public class NullBlogState {
       this.replyTo = replyTo;
     }
   }
-  public static class PassivatePost implements BlogCommand {
-
-  }
   public static class PostContent implements BlogCommand {
     final String postId;
     final String title;
@@ -128,8 +125,7 @@ public class NullBlogState {
             PostAdded event = new PostAdded(cmd.content.postId, cmd.content);
             return Effect().persist(event)
                 .thenRun(() -> cmd.replyTo.tell(new AddPostDone(cmd.content.postId)));
-          })
-          .matchCommand(PassivatePost.class, cmd -> Effect().stop());
+          });
     }
 
     private CommandHandlerBuilder<BlogCommand, BlogEvent, BlogState, BlogState> postCommandHandler() {
@@ -147,8 +143,7 @@ public class NullBlogState {
             cmd.replyTo.tell(state.postContent);
             return Effect().none();
           })
-          .matchCommand(AddPost.class, (state, cmd) -> Effect().unhandled())
-          .matchCommand(PassivatePost.class, cmd -> Effect().stop());
+          .matchCommand(AddPost.class, (state, cmd) -> Effect().unhandled());
     }
 
     public BlogBehavior(PersistenceId persistenceId) {

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/OptionalBlogState.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/OptionalBlogState.java
@@ -105,9 +105,6 @@ public class OptionalBlogState {
       this.replyTo = replyTo;
     }
   }
-  public static class PassivatePost implements BlogCommand {
-
-  }
   public static class PostContent implements BlogCommand {
     final String postId;
     final String title;
@@ -128,8 +125,7 @@ public class OptionalBlogState {
             PostAdded event = new PostAdded(cmd.content.postId, cmd.content);
             return Effect().persist(event)
                 .thenRun(() -> cmd.replyTo.tell(new AddPostDone(cmd.content.postId)));
-          })
-          .matchCommand(PassivatePost.class, cmd -> Effect().stop());
+          });
     }
 
     private CommandHandlerBuilder<BlogCommand, BlogEvent, Optional<BlogState>, Optional<BlogState>> postCommandHandler() {
@@ -147,8 +143,7 @@ public class OptionalBlogState {
             cmd.replyTo.tell(state.get().postContent);
             return Effect().none();
           })
-          .matchCommand(AddPost.class, (state, cmd) -> Effect().unhandled())
-          .matchCommand(PassivatePost.class, cmd -> Effect().stop());
+          .matchCommand(AddPost.class, (state, cmd) -> Effect().unhandled());
     }
 
     public BlogBehavior(PersistenceId persistenceId) {

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BlogPostExample.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BlogPostExample.scala
@@ -51,7 +51,6 @@ object BlogPostExample {
   final case class GetPost(replyTo: ActorRef[PostContent]) extends BlogCommand
   final case class ChangeBody(newBody: String, replyTo: ActorRef[Done]) extends BlogCommand
   final case class Publish(replyTo: ActorRef[Done]) extends BlogCommand
-  final case object PassivatePost extends BlogCommand
   final case class PostContent(postId: String, title: String, body: String)
   //#commands
 
@@ -69,9 +68,8 @@ object BlogPostExample {
     state match {
 
       case BlankState ⇒ command match {
-        case cmd: AddPost  ⇒ addPost(cmd)
-        case PassivatePost ⇒ Effect.stop()
-        case _             ⇒ Effect.unhandled
+        case cmd: AddPost ⇒ addPost(cmd)
+        case _            ⇒ Effect.unhandled
       }
 
       case draftState: DraftState ⇒ command match {
@@ -79,12 +77,10 @@ object BlogPostExample {
         case Publish(replyTo) ⇒ publish(draftState, replyTo)
         case GetPost(replyTo) ⇒ getPost(draftState, replyTo)
         case _: AddPost       ⇒ Effect.unhandled
-        case PassivatePost    ⇒ Effect.stop()
       }
 
       case publishedState: PublishedState ⇒ command match {
         case GetPost(replyTo) ⇒ getPost(publishedState, replyTo)
-        case PassivatePost    ⇒ Effect.stop()
         case _                ⇒ Effect.unhandled
       }
     }


### PR DESCRIPTION
* It's mostly technical concern that is blurring the business logic in the entity
* Async interactions before stopping is often not needed
* Implemented with an internal PoisonPill signal that is added by sharding,
* Persistent actors handle PoisonPill and run side effects after persist
  and process stashed messages before stopping.

Refs #25642

cc @TimMoore @renatocaval This was the remaining wart in the Sharding API.