### PR TITLE
Read port/weight/priority as unsigned shorts for SRVRecords

### DIFF
--- a/akka-actor-tests/src/test/bind/etc/db.foo.test
+++ b/akka-actor-tests/src/test/bind/etc/db.foo.test
@@ -72,8 +72,8 @@ many in AAAA 2001:985:965:1:ba27:ebff:fe5f:9d2d
 many in AAAA 2001:985:965:1:ba27:ebff:fe5f:9d2e
 many in AAAA 2001:985:965:1:ba27:ebff:fe5f:9d2f
 
-service.tcp   86400 IN    SRV 10       60     5060 a-single
-service.tcp   86400 IN    SRV 10       40     5070 a-double
+service.tcp   86400 IN    SRV 10       65534    5060 a-single
+service.tcp   86400 IN    SRV 65533    40       65535 a-double
 
 cname-in IN CNAME  a-double
 cname-ext IN CNAME  a-single.bar.example.

--- a/akka-actor-tests/src/test/scala/akka/io/dns/AsyncDnsResolverIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/AsyncDnsResolverIntegrationSpec.scala
@@ -35,7 +35,7 @@ class AsyncDnsResolverIntegrationSpec extends AkkaSpec(
 
   "Resolver" must {
     if (!dockerAvailable()) {
-      system.log.info("Test not run as docker is not available")
+      system.log.error("Test not run as docker is not available")
       pending
     }
 

--- a/akka-actor-tests/src/test/scala/akka/io/dns/AsyncDnsResolverIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/AsyncDnsResolverIntegrationSpec.scala
@@ -34,8 +34,10 @@ class AsyncDnsResolverIntegrationSpec extends AkkaSpec(
   val hostPort = AsyncDnsResolverIntegrationSpec.dockerDnsServerPort
 
   "Resolver" must {
-    if (!dockerAvailable())
+    if (!dockerAvailable()) {
+      system.log.info("Test not run as docker is not available")
       pending
+    }
 
     "resolve single A record" in {
       val name = "a-single.foo.test"
@@ -122,8 +124,8 @@ class AsyncDnsResolverIntegrationSpec extends AkkaSpec(
 
       answer.name shouldEqual name
       answer.records.collect { case r: SRVRecord ⇒ r }.toSet shouldEqual Set(
-        SRVRecord("service.tcp.foo.test", 86400, 10, 60, 5060, "a-single.foo.test"),
-        SRVRecord("service.tcp.foo.test", 86400, 10, 40, 5070, "a-double.foo.test")
+        SRVRecord("service.tcp.foo.test", 86400, 10, 65534, 5060, "a-single.foo.test"),
+        SRVRecord("service.tcp.foo.test", 86400, 65533, 40, 65535, "a-double.foo.test")
       )
     }
 

--- a/akka-actor/src/main/mima-filters/2.5.17.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.17.backwards.excludes
@@ -6,3 +6,12 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.CNameRecord.ttl"
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.AAAARecord.ttl")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.ResourceRecord.ttl")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.SRVRecord.ttl")
+
+# Removal of internal methods #25760
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.UnknownRecord.write")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.ARecord.write")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.CNameRecord.write")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.AAAARecord.write")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.ResourceRecord.write")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.SRVRecord.write")
+

--- a/akka-actor/src/main/scala/akka/io/dns/internal/DnsMessage.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/DnsMessage.scala
@@ -111,14 +111,12 @@ private[internal] case class Message(
     ret.putShort(id)
       .putShort(flags.flags)
       .putShort(questions.size)
-      .putShort(answerRecs.size)
-      .putShort(authorityRecs.size)
-      .putShort(additionalRecs.size)
+      // We only send questions, never answers with resource records in
+      .putShort(0)
+      .putShort(0)
+      .putShort(0)
 
     questions.foreach(_.write(ret))
-    answerRecs.foreach(_.write(ret))
-    authorityRecs.foreach(_.write(ret))
-    additionalRecs.foreach(_.write(ret))
   }
 }
 


### PR DESCRIPTION
* Delete writing code for resource records. Isn't used/tested.

I originally wrote tests that serialised/deserialised but there are bugs in the write side and didn't see any point fixing them as we never write resource records (originally from outside source). 

Fixes https://github.com/akka/akka/issues/25760