### PR TITLE
Warn about async-dns lack of support for search domains

### DIFF
--- a/akka-actor/src/main/scala/akka/io/dns/DnsSettings.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/DnsSettings.scala
@@ -68,7 +68,7 @@ object DnsSettings {
 
   /**
    * INTERNAL API
-   * Find out the default search domains that Java would use normally, e.g. when using InetAddress to resolve domains.
+   * Find out the default search lists that Java would use normally, e.g. when using InetAddress to resolve domains.
    *
    * The default nameservers are attempted to be obtained from: jndi-dns and from `sun.net.dnsResolverConfiguration`
    * as a fallback (which is expected to fail though when running on JDK9+ due to the module encapsulation of sun packages).

--- a/akka-docs/src/main/paradox/io-dns.md
+++ b/akka-docs/src/main/paradox/io-dns.md
@@ -2,7 +2,9 @@
 
 @@@ warning
 
-`async-dns` does not currently support TCP fallback and so DNS repsonses may be truncated. See [#25460](https://github.com/akka/akka/issues/25460)
+`async-dns` does not support:
+* [Local hosts file](https://github.com/akka/akka/issues/25846) e.g. `/etc/hosts` on Unix systems
+* [Search domains](https://github.com/akka/akka/issues/25825) e.g. in `/etc/resolve.conf` on Unix systems
 
 @@@
 


### PR DESCRIPTION
Removes the TCP warning as that is now implemented