### PR TITLE
Fix: DNS TTL uses seconds while caching usese millis

### DIFF
--- a/akka-actor/src/main/mima-filters/2.5.17.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.17.backwards.excludes
@@ -1,0 +1,8 @@
+# #25848 - TTL seconds used when TTL milliseconds expected
+# Change of a field name with ApiMayChange
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.UnknownRecord.ttl")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.ARecord.ttl")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.CNameRecord.ttl")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.AAAARecord.ttl")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.ResourceRecord.ttl")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.SRVRecord.ttl")

--- a/akka-actor/src/main/scala/akka/io/dns/DnsResourceRecords.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/DnsResourceRecords.scala
@@ -14,7 +14,7 @@ import akka.util.{ ByteIterator, ByteString, ByteStringBuilder }
 import scala.annotation.switch
 
 @ApiMayChange
-sealed abstract class ResourceRecord(val name: String, val ttlSeconds: Int, val recType: Short, val recClass: Short)
+sealed abstract class ResourceRecord(val name: String, val ttlInSeconds: Int, val recType: Short, val recClass: Short)
   extends NoSerializationVerificationNeeded {
 
   /**
@@ -29,8 +29,8 @@ sealed abstract class ResourceRecord(val name: String, val ttlSeconds: Int, val 
 }
 
 @ApiMayChange
-final case class ARecord(override val name: String, override val ttlSeconds: Int,
-                         ip: InetAddress) extends ResourceRecord(name, ttlSeconds, RecordType.A.code, RecordClass.IN.code) {
+final case class ARecord(override val name: String, override val ttlInSeconds: Int,
+                         ip: InetAddress) extends ResourceRecord(name, ttlInSeconds, RecordType.A.code, RecordClass.IN.code) {
 
   /**
    * INTERNAL API
@@ -49,16 +49,16 @@ final case class ARecord(override val name: String, override val ttlSeconds: Int
  */
 @InternalApi
 private[dns] object ARecord {
-  def parseBody(name: String, ttlSeconds: Int, length: Short, it: ByteIterator): ARecord = {
+  def parseBody(name: String, ttlInSeconds: Int, length: Short, it: ByteIterator): ARecord = {
     val addr = Array.ofDim[Byte](4)
     it.getBytes(addr)
-    ARecord(name, ttlSeconds, InetAddress.getByAddress(addr).asInstanceOf[Inet4Address])
+    ARecord(name, ttlInSeconds, InetAddress.getByAddress(addr).asInstanceOf[Inet4Address])
   }
 }
 
 @ApiMayChange
-final case class AAAARecord(override val name: String, override val ttlSeconds: Int,
-                            ip: Inet6Address) extends ResourceRecord(name, ttlSeconds, RecordType.AAAA.code, RecordClass.IN.code) {
+final case class AAAARecord(override val name: String, override val ttlInSeconds: Int,
+                            ip: Inet6Address) extends ResourceRecord(name, ttlInSeconds, RecordType.AAAA.code, RecordClass.IN.code) {
 
   /**
    * INTERNAL API
@@ -82,16 +82,16 @@ private[dns] object AAAARecord {
    * INTERNAL API
    */
   @InternalApi
-  def parseBody(name: String, ttlSeconds: Int, length: Short, it: ByteIterator): AAAARecord = {
+  def parseBody(name: String, ttlInSeconds: Int, length: Short, it: ByteIterator): AAAARecord = {
     val addr = Array.ofDim[Byte](16)
     it.getBytes(addr)
-    AAAARecord(name, ttlSeconds, InetAddress.getByAddress(addr).asInstanceOf[Inet6Address])
+    AAAARecord(name, ttlInSeconds, InetAddress.getByAddress(addr).asInstanceOf[Inet6Address])
   }
 }
 
 @ApiMayChange
-final case class CNameRecord(override val name: String, override val ttlSeconds: Int,
-                             canonicalName: String) extends ResourceRecord(name, ttlSeconds, RecordType.CNAME.code, RecordClass.IN.code) {
+final case class CNameRecord(override val name: String, override val ttlInSeconds: Int,
+                             canonicalName: String) extends ResourceRecord(name, ttlInSeconds, RecordType.CNAME.code, RecordClass.IN.code) {
   /**
    * INTERNAL API
    */
@@ -109,14 +109,14 @@ private[dns] object CNameRecord {
    * INTERNAL API
    */
   @InternalApi
-  def parseBody(name: String, ttlSeconds: Int, length: Short, it: ByteIterator, msg: ByteString): CNameRecord = {
-    CNameRecord(name, ttlSeconds, DomainName.parse(it, msg))
+  def parseBody(name: String, ttlInSeconds: Int, length: Short, it: ByteIterator, msg: ByteString): CNameRecord = {
+    CNameRecord(name, ttlInSeconds, DomainName.parse(it, msg))
   }
 }
 
 @ApiMayChange
-final case class SRVRecord(override val name: String, override val ttlSeconds: Int,
-                           priority: Int, weight: Int, port: Int, target: String) extends ResourceRecord(name, ttlSeconds, RecordType.SRV.code, RecordClass.IN.code) {
+final case class SRVRecord(override val name: String, override val ttlInSeconds: Int,
+                           priority: Int, weight: Int, port: Int, target: String) extends ResourceRecord(name, ttlInSeconds, RecordType.SRV.code, RecordClass.IN.code) {
   /**
    * INTERNAL API
    */
@@ -139,18 +139,18 @@ private[dns] object SRVRecord {
    * INTERNAL API
    */
   @InternalApi
-  def parseBody(name: String, ttlSeconds: Int, length: Short, it: ByteIterator, msg: ByteString): SRVRecord = {
+  def parseBody(name: String, ttlInSeconds: Int, length: Short, it: ByteIterator, msg: ByteString): SRVRecord = {
     val priority = it.getShort
     val weight = it.getShort
     val port = it.getShort
-    SRVRecord(name, ttlSeconds, priority, weight, port, DomainName.parse(it, msg))
+    SRVRecord(name, ttlInSeconds, priority, weight, port, DomainName.parse(it, msg))
   }
 }
 
 @ApiMayChange
-final case class UnknownRecord(override val name: String, override val ttlSeconds: Int,
+final case class UnknownRecord(override val name: String, override val ttlInSeconds: Int,
                                override val recType: Short, override val recClass: Short,
-                               data: ByteString) extends ResourceRecord(name, ttlSeconds, recType, recClass) {
+                               data: ByteString) extends ResourceRecord(name, ttlInSeconds, recType, recClass) {
   /**
    * INTERNAL API
    */
@@ -171,8 +171,8 @@ private[dns] object UnknownRecord {
    * INTERNAL API
    */
   @InternalApi
-  def parseBody(name: String, ttlSeconds: Int, recType: Short, recClass: Short, length: Short, it: ByteIterator): UnknownRecord =
-    UnknownRecord(name, ttlSeconds, recType, recClass, it.toByteString)
+  def parseBody(name: String, ttlInSeconds: Int, recType: Short, recClass: Short, length: Short, it: ByteIterator): UnknownRecord =
+    UnknownRecord(name, ttlInSeconds, recType, recClass, it.toByteString)
 }
 
 /**

--- a/akka-actor/src/main/scala/akka/io/dns/DnsResourceRecords.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/DnsResourceRecords.scala
@@ -49,10 +49,10 @@ final case class ARecord(override val name: String, override val ttlSeconds: Int
  */
 @InternalApi
 private[dns] object ARecord {
-  def parseBody(name: String, ttl: Int, length: Short, it: ByteIterator): ARecord = {
+  def parseBody(name: String, ttlSeconds: Int, length: Short, it: ByteIterator): ARecord = {
     val addr = Array.ofDim[Byte](4)
     it.getBytes(addr)
-    ARecord(name, ttl, InetAddress.getByAddress(addr).asInstanceOf[Inet4Address])
+    ARecord(name, ttlSeconds, InetAddress.getByAddress(addr).asInstanceOf[Inet4Address])
   }
 }
 
@@ -82,10 +82,10 @@ private[dns] object AAAARecord {
    * INTERNAL API
    */
   @InternalApi
-  def parseBody(name: String, ttl: Int, length: Short, it: ByteIterator): AAAARecord = {
+  def parseBody(name: String, ttlSeconds: Int, length: Short, it: ByteIterator): AAAARecord = {
     val addr = Array.ofDim[Byte](16)
     it.getBytes(addr)
-    AAAARecord(name, ttl, InetAddress.getByAddress(addr).asInstanceOf[Inet6Address])
+    AAAARecord(name, ttlSeconds, InetAddress.getByAddress(addr).asInstanceOf[Inet6Address])
   }
 }
 
@@ -109,8 +109,8 @@ private[dns] object CNameRecord {
    * INTERNAL API
    */
   @InternalApi
-  def parseBody(name: String, ttl: Int, length: Short, it: ByteIterator, msg: ByteString): CNameRecord = {
-    CNameRecord(name, ttl, DomainName.parse(it, msg))
+  def parseBody(name: String, ttlSeconds: Int, length: Short, it: ByteIterator, msg: ByteString): CNameRecord = {
+    CNameRecord(name, ttlSeconds, DomainName.parse(it, msg))
   }
 }
 
@@ -139,11 +139,11 @@ private[dns] object SRVRecord {
    * INTERNAL API
    */
   @InternalApi
-  def parseBody(name: String, ttl: Int, length: Short, it: ByteIterator, msg: ByteString): SRVRecord = {
+  def parseBody(name: String, ttlSeconds: Int, length: Short, it: ByteIterator, msg: ByteString): SRVRecord = {
     val priority = it.getShort
     val weight = it.getShort
     val port = it.getShort
-    SRVRecord(name, ttl, priority, weight, port, DomainName.parse(it, msg))
+    SRVRecord(name, ttlSeconds, priority, weight, port, DomainName.parse(it, msg))
   }
 }
 
@@ -171,8 +171,8 @@ private[dns] object UnknownRecord {
    * INTERNAL API
    */
   @InternalApi
-  def parseBody(name: String, ttl: Int, recType: Short, recClass: Short, length: Short, it: ByteIterator): UnknownRecord =
-    UnknownRecord(name, ttl, recType, recClass, it.toByteString)
+  def parseBody(name: String, ttlSeconds: Int, recType: Short, recClass: Short, length: Short, it: ByteIterator): UnknownRecord =
+    UnknownRecord(name, ttlSeconds, recType, recClass, it.toByteString)
 }
 
 /**

--- a/akka-actor/src/main/scala/akka/io/dns/DnsResourceRecords.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/DnsResourceRecords.scala
@@ -14,7 +14,7 @@ import akka.util.{ ByteIterator, ByteString, ByteStringBuilder }
 import scala.annotation.switch
 
 @ApiMayChange
-sealed abstract class ResourceRecord(val name: String, val ttl: Int, val recType: Short, val recClass: Short)
+sealed abstract class ResourceRecord(val name: String, val ttlSeconds: Int, val recType: Short, val recClass: Short)
   extends NoSerializationVerificationNeeded {
 
   /**
@@ -29,8 +29,8 @@ sealed abstract class ResourceRecord(val name: String, val ttl: Int, val recType
 }
 
 @ApiMayChange
-final case class ARecord(override val name: String, override val ttl: Int,
-                         ip: InetAddress) extends ResourceRecord(name, ttl, RecordType.A.code, RecordClass.IN.code) {
+final case class ARecord(override val name: String, override val ttlSeconds: Int,
+                         ip: InetAddress) extends ResourceRecord(name, ttlSeconds, RecordType.A.code, RecordClass.IN.code) {
 
   /**
    * INTERNAL API
@@ -57,8 +57,8 @@ private[dns] object ARecord {
 }
 
 @ApiMayChange
-final case class AAAARecord(override val name: String, override val ttl: Int,
-                            ip: Inet6Address) extends ResourceRecord(name, ttl, RecordType.AAAA.code, RecordClass.IN.code) {
+final case class AAAARecord(override val name: String, override val ttlSeconds: Int,
+                            ip: Inet6Address) extends ResourceRecord(name, ttlSeconds, RecordType.AAAA.code, RecordClass.IN.code) {
 
   /**
    * INTERNAL API
@@ -90,8 +90,8 @@ private[dns] object AAAARecord {
 }
 
 @ApiMayChange
-final case class CNameRecord(override val name: String, override val ttl: Int,
-                             canonicalName: String) extends ResourceRecord(name, ttl, RecordType.CNAME.code, RecordClass.IN.code) {
+final case class CNameRecord(override val name: String, override val ttlSeconds: Int,
+                             canonicalName: String) extends ResourceRecord(name, ttlSeconds, RecordType.CNAME.code, RecordClass.IN.code) {
   /**
    * INTERNAL API
    */
@@ -115,8 +115,8 @@ private[dns] object CNameRecord {
 }
 
 @ApiMayChange
-final case class SRVRecord(override val name: String, override val ttl: Int,
-                           priority: Int, weight: Int, port: Int, target: String) extends ResourceRecord(name, ttl, RecordType.SRV.code, RecordClass.IN.code) {
+final case class SRVRecord(override val name: String, override val ttlSeconds: Int,
+                           priority: Int, weight: Int, port: Int, target: String) extends ResourceRecord(name, ttlSeconds, RecordType.SRV.code, RecordClass.IN.code) {
   /**
    * INTERNAL API
    */
@@ -148,9 +148,9 @@ private[dns] object SRVRecord {
 }
 
 @ApiMayChange
-final case class UnknownRecord(override val name: String, override val ttl: Int,
+final case class UnknownRecord(override val name: String, override val ttlSeconds: Int,
                                override val recType: Short, override val recClass: Short,
-                               data: ByteString) extends ResourceRecord(name, ttl, recType, recClass) {
+                               data: ByteString) extends ResourceRecord(name, ttlSeconds, recType, recClass) {
   /**
    * INTERNAL API
    */

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsCache.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsCache.scala
@@ -55,10 +55,10 @@ import scala.annotation.tailrec
   }
 
   @tailrec
-  private[io] final def put(key: (String, QueryType), records: Answer, ttlMillis: Long): Unit = {
+  private[io] final def put(key: (String, QueryType), records: Answer, ttlInMillis: Long): Unit = {
     val c = cache.get()
-    if (!cache.compareAndSet(c, c.put(key, records, ttlMillis)))
-      put(key, records, ttlMillis)
+    if (!cache.compareAndSet(c, c.put(key, records, ttlInMillis)))
+      put(key, records, ttlInMillis)
   }
 
   @tailrec

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
@@ -116,12 +116,12 @@ private[io] final class AsyncDnsResolver(
         ipv4Recs.flatMap(ipv4Records ⇒ {
           // TODO, do we want config to specify a max for this?
           if (ipv4Records.rrs.nonEmpty) {
-            val minTtl4 = ipv4Records.rrs.minBy(_.ttlSeconds).ttlSeconds
+            val minTtl4 = ipv4Records.rrs.minBy(_.ttlInSeconds).ttlInSeconds
             cache.put((name, Ipv4Type), ipv4Records, minTtl4 * 1000)
           }
           ipv6Recs.map(ipv6Records ⇒ {
             if (ipv6Records.rrs.nonEmpty) {
-              val minTtl6 = ipv6Records.rrs.minBy(_.ttlSeconds).ttlSeconds
+              val minTtl6 = ipv6Records.rrs.minBy(_.ttlInSeconds).ttlInSeconds
               cache.put((name, Ipv6Type), ipv6Records, minTtl6 * 1000)
             }
             ipv4Records.rrs ++ ipv6Records.rrs
@@ -136,8 +136,8 @@ private[io] final class AsyncDnsResolver(
             sendQuestion(resolver, SrvQuestion(nextId(), caseFoldedName))
               .map(answer ⇒ {
                 if (answer.rrs.nonEmpty) {
-                  val minTtlSeconds = answer.rrs.minBy(_.ttlSeconds).ttlSeconds
-                  cache.put((name, SrvType), answer, minTtlSeconds * 1000) // cache uses ttl in millis
+                  val minttlInSeconds = answer.rrs.minBy(_.ttlInSeconds).ttlInSeconds
+                  cache.put((name, SrvType), answer, minttlInSeconds * 1000) // cache uses ttl in millis
                 }
                 DnsProtocol.Resolved(name, answer.rrs, answer.additionalRecs)
               })

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
@@ -117,12 +117,12 @@ private[io] final class AsyncDnsResolver(
           // TODO, do we want config to specify a max for this?
           if (ipv4Records.rrs.nonEmpty) {
             val minTtl4 = ipv4Records.rrs.minBy(_.ttlSeconds).ttlSeconds
-            cache.put((name, Ipv4Type), ipv4Records, minTtl4*1000)
+            cache.put((name, Ipv4Type), ipv4Records, minTtl4 * 1000)
           }
           ipv6Recs.map(ipv6Records ⇒ {
             if (ipv6Records.rrs.nonEmpty) {
               val minTtl6 = ipv6Records.rrs.minBy(_.ttlSeconds).ttlSeconds
-              cache.put((name, Ipv6Type), ipv6Records, minTtl6*1000)
+              cache.put((name, Ipv6Type), ipv6Records, minTtl6 * 1000)
             }
             ipv4Records.rrs ++ ipv6Records.rrs
           }).map(recs ⇒ DnsProtocol.Resolved(name, recs))
@@ -137,7 +137,7 @@ private[io] final class AsyncDnsResolver(
               .map(answer ⇒ {
                 if (answer.rrs.nonEmpty) {
                   val minTtlSeconds = answer.rrs.minBy(_.ttlSeconds).ttlSeconds
-                  cache.put((name, SrvType), answer, minTtlSeconds*1000) // cache uses ttl in millis
+                  cache.put((name, SrvType), answer, minTtlSeconds * 1000) // cache uses ttl in millis
                 }
                 DnsProtocol.Resolved(name, answer.rrs, answer.additionalRecs)
               })


### PR DESCRIPTION
DNS records use an `Int` with seconds as unit to specify the TTL of the record. The internal caching to implement that TTL used `AsyncDnsCache` which expects _millis_.