### PR TITLE
Allow OptionVal to hold boxed primitives

### DIFF
--- a/akka-actor/src/main/scala/akka/util/OptionVal.scala
+++ b/akka-actor/src/main/scala/akka/util/OptionVal.scala
@@ -9,12 +9,14 @@ package akka.util
  */
 private[akka] object OptionVal {
 
-  def apply[A >: Null](x: A): OptionVal[A] = new OptionVal(x)
+  def apply[A](x: A): OptionVal[A] = new OptionVal(x)
 
   object Some {
-    def apply[A >: Null](x: A): OptionVal[A] = new OptionVal(x)
-    def unapply[A >: Null](x: OptionVal[A]): OptionVal[A] = x
+    def apply[A](x: A): OptionVal[A] = new OptionVal(x)
+    def unapply[A](x: OptionVal[A]): OptionVal[A] = x
   }
+
+  def none[A]: OptionVal[A] = None.asInstanceOf[OptionVal[A]]
 
   /**
    * Represents non-existent values, `null` values.
@@ -31,7 +33,7 @@ private[akka] object OptionVal {
  * because it has name based extractor using methods `isEmpty` and `get`.
  * See https://hseeberger.wordpress.com/2013/10/04/name-based-extractors-in-scala-2-11/
  */
-private[akka] final class OptionVal[+A >: Null](val x: A) extends AnyVal {
+private[akka] final class OptionVal[+A](val x: A) extends AnyVal {
 
   /**
    * Returns true if the option is `OptionVal.None`, false otherwise.


### PR DESCRIPTION
Previously OptionVal was restricted to types that have Null as their
bottom type, that is reference types (that extend AnyRef/Object), rather
than also allowing primitives (that extend AnyVal).

By removing this restrictions any type is a valid type argument.

The effect this will have is that primitives will be box, because we
need a way to represent the None case (using the null value).