### PR TITLE
Adjust OSGi imports for sslconfig 0.3.6

### DIFF
--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -92,7 +92,7 @@ object OSGi {
       packages = Seq(
         "akka.stream.*",
         "com.typesafe.sslconfig.akka.*"),
-      imports = Seq(scalaJava8CompatImport(), scalaParsingCombinatorImport(), sslConfigCoreImport(), sslConfigCoreSslImport(), sslConfigCoreUtilImport()))
+      imports = Seq(scalaJava8CompatImport(), scalaParsingCombinatorImport(), sslConfigCoreSslImport(), sslConfigCoreUtilImport()))
 
   val streamTestkit = exports(Seq("akka.stream.testkit.*"))
 
@@ -127,9 +127,8 @@ object OSGi {
   }
   def scalaJava8CompatImport(packageName: String = "scala.compat.java8.*") = versionedImport(packageName, "0.7.0", "1.0.0")
   def scalaParsingCombinatorImport(packageName: String = "scala.util.parsing.combinator.*") = versionedImport(packageName, "1.1.0", "1.2.0")
-  def sslConfigCoreImport(packageName: String = "com.typesafe.sslconfig") = versionedImport(packageName, "0.2.3", "1.0.0")
-  def sslConfigCoreSslImport(packageName: String = "com.typesafe.sslconfig.ssl.*") = versionedImport(packageName, "0.2.3", "1.0.0")
-  def sslConfigCoreUtilImport(packageName: String = "com.typesafe.sslconfig.util.*") = versionedImport(packageName, "0.2.3", "1.0.0")
+  def sslConfigCoreSslImport(packageName: String = "com.typesafe.sslconfig.ssl.*") = versionedImport(packageName, "0.3.6", "1.0.0")
+  def sslConfigCoreUtilImport(packageName: String = "com.typesafe.sslconfig.util.*") = versionedImport(packageName, "0.3.6", "1.0.0")
   def kamonImport(packageName: String = "kamon.sigar.*") = optionalResolution(versionedImport(packageName, "1.6.5", "1.6.6"))
   def sigarImport(packageName: String = "org.hyperic.*") = optionalResolution(versionedImport(packageName, "1.6.5", "1.6.6"))
   def optionalResolution(packageName: String) = "%s;resolution:=optional".format(packageName)


### PR DESCRIPTION
Between sslconfig 0.2.3 and 0.3.6, the com.typesafe.config package was
dropped from the OSGi bundle's exports, so we can no longer import
it. This patch adjusts the imports appropriately.

Signed-off-by: Stephen Kitt <skitt@redhat.com>