### PR TITLE
Optimize compact during framing

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/FramingBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FramingBenchmark.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream
+
+import java.util.concurrent.{Semaphore, TimeUnit}
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{Framing, Sink, Source}
+import akka.util.ByteString
+import com.typesafe.config.{Config, ConfigFactory}
+import org.openjdk.jmh.annotations._
+import org.reactivestreams.{Publisher, Subscriber, Subscription}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+class FramingBenchmark {
+
+  val config: Config = ConfigFactory.parseString(
+    """
+      akka {
+        log-config-on-start = off
+        log-dead-letters-during-shutdown = off
+        stdout-loglevel = "OFF"
+        loglevel = "OFF"
+        actor.default-dispatcher {
+          #executor = "thread-pool-executor"
+          throughput = 1024
+        }
+        actor.default-mailbox {
+          mailbox-type = "akka.dispatch.SingleConsumerOnlyUnboundedMailbox"
+        }
+        test {
+          timefactor =  1.0
+          filter-leeway = 3s
+          single-expect-default = 3s
+          default-timeout = 5s
+          calling-thread-dispatcher {
+            type = akka.testkit.CallingThreadDispatcherConfigurator
+          }
+        }
+      }""".stripMargin
+  ).withFallback(ConfigFactory.load())
+
+  implicit val system: ActorSystem = ActorSystem("test", config)
+
+  var materializer: ActorMaterializer = _
+
+  // Safe to be benchmark scoped because the flows we construct in this bench are stateless
+  var flow: Source[ByteString, NotUsed] = _
+
+  @Param(Array("32", "64", "128"))
+  var framePerSeq = 0
+
+  @Setup
+  def setup(): Unit = {
+    materializer = ActorMaterializer()
+
+    val frame = ByteString(List.range(0, framePerSeq, 1).map(_ => "a" * 128 + "\n").mkString)
+
+    // Important to use a synchronous, zero overhead source, otherwise the slowness of the source
+    // might bias the benchmark, since the stream always adjusts the rate to the slowest stage.
+    val syncTestPublisher = new Publisher[ByteString] {
+      override def subscribe(s: Subscriber[_ >: ByteString]): Unit = {
+        val sub: Subscription = new Subscription {
+          var counter = 0 // Piggyback on caller thread, no need for volatile
+
+          override def request(n: Long): Unit = {
+            var i = n
+            while (i > 0) {
+              s.onNext(frame)
+              counter += 1
+              if (counter == 100000) {
+                s.onComplete()
+                return
+              }
+              i -= 1
+            }
+          }
+
+          override def cancel(): Unit = ()
+        }
+
+        s.onSubscribe(sub)
+      }
+    }
+
+    flow = Source.fromPublisher(syncTestPublisher)
+      .via(Framing.delimiter(ByteString("\n"), Int.MaxValue))
+  }
+
+  @TearDown
+  def shutdown(): Unit = {
+    Await.result(system.terminate(), 5.seconds)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(100000)
+  def framing(): Unit = {
+    val lock = new Semaphore(1)
+    lock.acquire()
+    flow.runWith(Sink.onComplete(_ ⇒ lock.release()))(materializer)
+    lock.acquire()
+  }
+
+}

--- a/akka-bench-jmh/src/main/scala/akka/stream/FramingBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FramingBenchmark.scala
@@ -4,15 +4,15 @@
 
 package akka.stream
 
-import java.util.concurrent.{Semaphore, TimeUnit}
+import java.util.concurrent.{ Semaphore, TimeUnit }
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.{Framing, Sink, Source}
+import akka.stream.scaladsl.{ Framing, Sink, Source }
 import akka.util.ByteString
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 import org.openjdk.jmh.annotations._
-import org.reactivestreams.{Publisher, Subscriber, Subscription}
+import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -62,7 +62,7 @@ class FramingBenchmark {
   def setup(): Unit = {
     materializer = ActorMaterializer()
 
-    val frame = ByteString(List.range(0, framePerSeq, 1).map(_ => "a" * 128 + "\n").mkString)
+    val frame = ByteString(List.range(0, framePerSeq, 1).map(_ ⇒ "a" * 128 + "\n").mkString)
 
     // Important to use a synchronous, zero overhead source, otherwise the slowness of the source
     // might bias the benchmark, since the stream always adjusts the rate to the slowest stage.


### PR DESCRIPTION
Currently `Framing.delimiter` can pass a significant amount of time allocating byte arrays instead of parsing on a high load.
This is caused by the use of the method `compact` each time we found a frame.
In some case, we can get multiples frames in one `ByteString` [[Ref](https://github.com/amannocci/streamy/issues/38)] and in these cases compacting every time is inefficient.
A solution can be to parse every frame and then compact to let GC do is work.
I have done a small improvement and a JMH to test this solution.
I have obtained some interesting results:

Master branch:
```bash
[info] Benchmark                   (framePerSeq)   Mode  Cnt      Score      Error  Units
[info] FramingBenchmark.framing               32  thrpt    5  93675.026 ± 1381.528  ops/s
[info] FramingBenchmark.framing               64  thrpt    5  34122.613 ±  540.357  ops/s
[info] FramingBenchmark.framing              128  thrpt    5  11310.841 ±  146.387  ops/s
```

PR branch:
```bash
[info] Benchmark                   (framePerSeq)   Mode  Cnt       Score      Error  Units
[info] FramingBenchmark.framing               32  thrpt    5  232453.491 ± 1542.536  ops/s
[info] FramingBenchmark.framing               64  thrpt    5  119805.343 ± 1235.092  ops/s
[info] FramingBenchmark.framing              128  thrpt    5   57768.423 ±  448.558  ops/s
```

Tell me what you thing about it.
