### PR TITLE
[ttk] Add access to logged events in BehaviorTestKit #25905

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/CapturedLogEvent.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/CapturedLogEvent.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.testkit.typed
+
+import java.util.Optional
+
+import akka.actor.typed.LogMarker
+import akka.event.Logging.LogLevel
+import akka.util.OptionVal
+import akka.util.OptionVal.{ None, Some }
+
+import scala.collection.JavaConverters._
+import scala.compat.java8.OptionConverters._
+import scala.{ None ⇒ SNone, Option ⇒ SOption, Some ⇒ SSome }
+
+/**
+ * Representation of a Log Event issued by a [[akka.actor.typed.Behavior]]
+ */
+final case class CapturedLogEvent private[akka] (logLevel: LogLevel, message: String,
+                                                 private val cause:  OptionVal[Throwable],
+                                                 private val marker: OptionVal[LogMarker],
+                                                 mdc:                Map[String, Any]) {
+
+  /**
+   * Constructor for Java code
+   */
+  def this(logLevel: LogLevel, message: String, errorCause: Optional[Throwable], marker: Optional[LogMarker], mdc: java.util.Map[String, Any]) {
+    this(logLevel, message, errorCause.asScala.map(Some(_)).getOrElse(None), marker.asScala.map(Some(_)).getOrElse(None), mdc.asScala.toMap)
+  }
+
+  def getMdc: java.util.Map[String, Any] = mdc.asJava
+
+  //This is needed as OptionVal is private for the akka package
+  def errorCause: SOption[Throwable] = cause match {
+    case Some(ex) ⇒ SSome(ex)
+    case _        ⇒ SNone
+  }
+
+  def getErrorCause: Optional[Throwable] = errorCause.asJava
+
+  //This is needed as OptionVal is private for the akka package
+  def logMarker: SOption[LogMarker] = marker match {
+    case Some(logMarker) ⇒ SSome(logMarker)
+    case _               ⇒ SNone
+  }
+
+  def getLogMarker: Optional[LogMarker] = logMarker.asJava
+}
+
+object CapturedLogEvent {
+
+  /**
+   * This auxiliary constructor uses Scala's Option instead, so it will create extra allocations. This, however, should
+   * not be critical as it is only used in the [[akka.actor.testkit.typed.scaladsl.BehaviorTestKit]]
+   */
+  def apply(
+    logLevel:   LogLevel,
+    message:    String,
+    errorCause: SOption[Throwable] = SNone,
+    logMarker:  SOption[LogMarker] = SNone,
+    mdc:        Map[String, Any]   = Map.empty): CapturedLogEvent = {
+    new CapturedLogEvent(logLevel, message, errorCause.map(Some(_)).getOrElse(None), logMarker.map(Some(_)).getOrElse(None), mdc)
+  }
+}

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/CapturedLogEvent.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/CapturedLogEvent.scala
@@ -7,60 +7,67 @@ package akka.actor.testkit.typed
 import java.util.Optional
 
 import akka.actor.typed.LogMarker
+import akka.annotation.InternalApi
 import akka.event.Logging.LogLevel
 import akka.util.OptionVal
-import akka.util.OptionVal.{ None, Some }
 
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
-import scala.{ None ⇒ SNone, Option ⇒ SOption, Some ⇒ SSome }
 
 /**
  * Representation of a Log Event issued by a [[akka.actor.typed.Behavior]]
  */
-final case class CapturedLogEvent private[akka] (logLevel: LogLevel, message: String,
-                                                 private val cause:  OptionVal[Throwable],
-                                                 private val marker: OptionVal[LogMarker],
-                                                 mdc:                Map[String, Any]) {
+final case class CapturedLogEvent(
+  logLevel: LogLevel,
+  message:  String,
+  cause:    Option[Throwable],
+  marker:   Option[LogMarker],
+  mdc:      Map[String, Any]) {
 
   /**
-   * Constructor for Java code
+   * Constructor for Java API
    */
   def this(logLevel: LogLevel, message: String, errorCause: Optional[Throwable], marker: Optional[LogMarker], mdc: java.util.Map[String, Any]) {
-    this(logLevel, message, errorCause.asScala.map(Some(_)).getOrElse(None), marker.asScala.map(Some(_)).getOrElse(None), mdc.asScala.toMap)
+    this(logLevel, message, errorCause.asScala, marker.asScala, mdc.asScala.toMap)
   }
 
   def getMdc: java.util.Map[String, Any] = mdc.asJava
 
-  //This is needed as OptionVal is private for the akka package
-  def errorCause: SOption[Throwable] = cause match {
-    case Some(ex) ⇒ SSome(ex)
-    case _        ⇒ SNone
-  }
+  def getErrorCause: Optional[Throwable] = cause.asJava
 
-  def getErrorCause: Optional[Throwable] = errorCause.asJava
-
-  //This is needed as OptionVal is private for the akka package
-  def logMarker: SOption[LogMarker] = marker match {
-    case Some(logMarker) ⇒ SSome(logMarker)
-    case _               ⇒ SNone
-  }
-
-  def getLogMarker: Optional[LogMarker] = logMarker.asJava
+  def getLogMarker: Optional[LogMarker] = marker.asJava
 }
 
 object CapturedLogEvent {
 
   /**
-   * This auxiliary constructor uses Scala's Option instead, so it will create extra allocations. This, however, should
-   * not be critical as it is only used in the [[akka.actor.testkit.typed.scaladsl.BehaviorTestKit]]
+   * Helper method to convert [[OptionVal]] to [[Option]]
    */
+  private def toOption[A](optionVal: OptionVal[A]): Option[A] = optionVal match {
+    case OptionVal.Some(x) ⇒ Some(x)
+    case _                 ⇒ None
+  }
+
   def apply(
+    logLevel: LogLevel,
+    message:  String,
+    cause:    Option[Throwable] = None,
+    marker:   Option[LogMarker] = None,
+    mdc:      Map[String, Any]  = Map.empty): CapturedLogEvent = {
+    new CapturedLogEvent(logLevel, message, cause, marker, mdc)
+  }
+
+  /**
+   * Auxiliary constructor that receives Akka's internal [[OptionVal]] as parameters and converts them to Scala's [[Option]].
+   * INTERNAL API
+   */
+  @InternalApi
+  private[akka] def apply(
     logLevel:   LogLevel,
     message:    String,
-    errorCause: SOption[Throwable] = SNone,
-    logMarker:  SOption[LogMarker] = SNone,
-    mdc:        Map[String, Any]   = Map.empty): CapturedLogEvent = {
-    new CapturedLogEvent(logLevel, message, errorCause.map(Some(_)).getOrElse(None), logMarker.map(Some(_)).getOrElse(None), mdc)
+    errorCause: OptionVal[Throwable],
+    logMarker:  OptionVal[LogMarker],
+    mdc:        Map[String, Any]): CapturedLogEvent = {
+    new CapturedLogEvent(logLevel, message, toOption(errorCause), toOption(logMarker), mdc)
   }
 }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -7,10 +7,9 @@ package akka.actor.testkit.typed.internal
 import java.util
 
 import akka.actor.ActorPath
-
-import akka.actor.typed.{ Behavior, PostStop, Signal, ActorRef }
+import akka.actor.typed.{ ActorRef, Behavior, PostStop, Signal }
 import akka.annotation.InternalApi
-import akka.actor.testkit.typed.Effect
+import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
 import akka.actor.testkit.typed.Effect._
 
 import scala.annotation.tailrec
@@ -138,4 +137,10 @@ private[akka] final class BehaviorTestKitImpl[T](_path: ActorPath, _initialBehav
   }
 
   override def hasEffects(): Boolean = !context.effectQueue.isEmpty
+
+  override def getAllLogEntries(): util.List[CapturedLogEvent] = logEntries().asJava
+
+  override def logEntries(): Seq[CapturedLogEvent] = context.logEntries
+
+  override def clearLog(): Unit = context.clearLog()
 }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -140,7 +140,7 @@ private[akka] final class BehaviorTestKitImpl[T](_path: ActorPath, _initialBehav
 
   override def getAllLogEntries(): util.List[CapturedLogEvent] = logEntries().asJava
 
-  override def logEntries(): Seq[CapturedLogEvent] = context.logEntries
+  override def logEntries(): immutable.Seq[CapturedLogEvent] = context.logEntries
 
   override def clearLog(): Unit = context.clearLog()
 }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
@@ -7,16 +7,15 @@ package akka.actor.testkit.typed.internal
 import akka.actor.typed._
 import akka.actor.typed.internal._
 import akka.actor.typed.internal.adapter.AbstractLogger
+import akka.actor.testkit.typed.CapturedLogEvent
 import akka.actor.testkit.typed.scaladsl.TestInbox
 import akka.actor.{ ActorPath, InvalidMessageException }
 import akka.annotation.InternalApi
 import akka.event.Logging
-import akka.event.Logging.LogLevel
 import akka.util.{ Helpers, OptionVal }
 import akka.{ actor ⇒ untyped }
 import java.util.concurrent.ThreadLocalRandom.{ current ⇒ rnd }
 
-import scala.collection.JavaConverters._
 import scala.collection.immutable.TreeMap
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.FiniteDuration
@@ -49,13 +48,6 @@ private[akka] final class FunctionRef[-T](
   override def provider: ActorRefProvider = throw new UnsupportedOperationException("no provider")
   // impl InternalRecipientRef
   def isTerminated: Boolean = false
-}
-
-final case class CapturedLogEvent(logLevel: LogLevel, message: String,
-                                  cause:  OptionVal[Throwable],
-                                  marker: OptionVal[LogMarker],
-                                  mdc:    Map[String, Any]) {
-  def getMdc: java.util.Map[String, Any] = mdc.asJava
 }
 
 /**

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
@@ -4,10 +4,10 @@
 
 package akka.actor.testkit.typed.javadsl
 
-import akka.actor.typed.{ Behavior, Signal, ActorRef }
-import akka.annotation.DoNotInherit
-import akka.actor.testkit.typed.Effect
 import akka.actor.testkit.typed.internal.BehaviorTestKitImpl
+import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
+import akka.actor.typed.{ ActorRef, Behavior, Signal }
+import akka.annotation.DoNotInherit
 
 import java.util.concurrent.ThreadLocalRandom
 
@@ -127,4 +127,14 @@ abstract class BehaviorTestKit[T] {
    * Send the signal to the beheavior and record any [[Effect]]s
    */
   def signal(signal: Signal): Unit
+
+  /**
+   * Returns all the [[CapturedLogEvent]] issued by this behavior(s)
+   */
+  def getAllLogEntries(): java.util.List[CapturedLogEvent]
+
+  /**
+   * Clear the log entries
+   */
+  def clearLog(): Unit
 }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
@@ -4,10 +4,10 @@
 
 package akka.actor.testkit.typed.scaladsl
 
-import akka.actor.typed.{ Behavior, Signal, ActorRef }
-import akka.annotation.DoNotInherit
-import akka.actor.testkit.typed.Effect
 import akka.actor.testkit.typed.internal.BehaviorTestKitImpl
+import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
+import akka.actor.typed.{ ActorRef, Behavior, Signal }
+import akka.annotation.DoNotInherit
 
 import java.util.concurrent.ThreadLocalRandom
 
@@ -41,7 +41,7 @@ trait BehaviorTestKit[T] {
   private[akka] def context: akka.actor.typed.ActorContext[T]
 
   /**
-   * Requests the oldest [[Effect]] or [[akka.actor.testkit.typed.scaladsl.Effects.NoEffects]] if no effects
+   * Requests the oldest [[Effect]] or [[akka.actor.testkit.typed.Effect.NoEffects]] if no effects
    * have taken place. The effect is consumed, subsequent calls won't
    * will not include this effect.
    */
@@ -129,7 +129,17 @@ trait BehaviorTestKit[T] {
   def runOne(): Unit
 
   /**
-   * Send the signal to the beheavior and record any [[Effect]]s
+   * Send the signal to the behavior and record any [[Effect]]s
    */
   def signal(signal: Signal): Unit
+
+  /**
+   * Returns all the [[CapturedLogEvent]] issued by this behavior(s)
+   */
+  def logEntries(): Seq[CapturedLogEvent]
+
+  /**
+   * Clear the log entries
+   */
+  def clearLog(): Unit
 }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
@@ -136,7 +136,7 @@ trait BehaviorTestKit[T] {
   /**
    * Returns all the [[CapturedLogEvent]] issued by this behavior(s)
    */
-  def logEntries(): Seq[CapturedLogEvent]
+  def logEntries(): immutable.Seq[CapturedLogEvent]
 
   /**
    * Clear the log entries

--- a/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/BehaviorTestKitTest.java
+++ b/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/BehaviorTestKitTest.java
@@ -5,18 +5,22 @@
 package akka.actor.testkit.typed.javadsl;
 
 import akka.Done;
+import akka.actor.testkit.typed.CapturedLogEvent;
 import akka.actor.testkit.typed.Effect;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
 import akka.actor.typed.Props;
 import akka.actor.typed.javadsl.Behaviors;
+import akka.event.Logging;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
@@ -111,6 +115,14 @@ public class BehaviorTestKitTest extends JUnitSuite {
     }
   }
 
+  public static class Log implements Command {
+    private final String what;
+
+    public Log(String what) {
+      this.what = what;
+    }
+  }
+
   public interface Action {
   }
 
@@ -171,6 +183,10 @@ public class BehaviorTestKitTest extends JUnitSuite {
       message.replyTo.tell(Done.getInstance());
       return Behaviors.same();
     })
+    .onMessage(Log.class, (context, message) -> {
+      context.getLog().info(message.what);
+      return Behaviors.same();
+    })
     .build();
 
 
@@ -192,6 +208,26 @@ public class BehaviorTestKitTest extends JUnitSuite {
   public void allowsExpectingNoEffectByType() {
     BehaviorTestKit<Command> test = BehaviorTestKit.create(behavior);
     test.expectEffectClass(Effect.NoEffects.class);
+  }
+
+  @Test
+  public void allowRetrieveAllLogs() {
+    BehaviorTestKit<Command> test = BehaviorTestKit.create(behavior);
+    String what = "Hello!";
+    test.run(new Log(what));
+    final List<CapturedLogEvent> allLogEntries = test.getAllLogEntries();
+    assertEquals(1, allLogEntries.size());
+    assertEquals(new CapturedLogEvent(Logging.InfoLevel(), what, Optional.empty(), Optional.empty(), new HashMap<>()), allLogEntries.get(0));
+  }
+
+  @Test
+  public void allowClearLogs() {
+    BehaviorTestKit<Command> test = BehaviorTestKit.create(behavior);
+    String what = "Hello!";
+    test.run(new Log(what));
+    assertEquals(1, test.getAllLogEntries().size());
+    test.clearLog();
+    assertEquals(0, test.getAllLogEntries().size());
   }
 
   @Test

--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/SyncTestingExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/SyncTestingExampleTest.java
@@ -5,14 +5,21 @@
 package jdocs.akka.actor.testkit.typed.javadsl;
 
 //#imports
+import akka.actor.testkit.typed.CapturedLogEvent;
 import akka.actor.testkit.typed.javadsl.BehaviorTestKit;
 import akka.actor.testkit.typed.javadsl.Effects;
 import akka.actor.testkit.typed.javadsl.TestInbox;
 import akka.actor.typed.*;
 import akka.actor.typed.javadsl.*;
+import akka.event.Logging;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
 //#imports
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 import org.scalatest.junit.JUnitSuite;
+
 
 public class SyncTestingExampleTest extends JUnitSuite {
 
@@ -43,6 +50,13 @@ public class SyncTestingExampleTest extends JUnitSuite {
       this.who = who;
     }
   }
+  public static class LogAndSayHello implements Command {
+    private final ActorRef<String> who;
+
+    public LogAndSayHello(ActorRef<String> who) {
+      this.who = who;
+    }
+  }
 
   public static Behavior<Command> myBehavior = Behaviors.receive(Command.class)
     .onMessage(CreateAChild.class, (context, message) -> {
@@ -62,10 +76,17 @@ public class SyncTestingExampleTest extends JUnitSuite {
       ActorRef<String> child = context.spawnAnonymous(childActor);
       child.tell("hello stranger");
       return Behaviors.same();
-    }).onMessage(SayHello.class, (context, message) -> {
+    })
+    .onMessage(SayHello.class, (context, message) -> {
       message.who.tell("hello");
       return Behaviors.same();
-    }).build();
+    })
+    .onMessage(LogAndSayHello.class, (context, message) -> {
+      context.getLog().info("Saying hello to {}", message.who.path().name());
+      message.who.tell("hello");
+      return Behaviors.same();
+    })
+    .build();
   //#under-test
 
 
@@ -116,5 +137,20 @@ public class SyncTestingExampleTest extends JUnitSuite {
      TestInbox<String> childInbox = testKit.childInbox("$a");
      childInbox.expectMessage("hello stranger");
      //#test-child-message-anonymous
+  }
+
+  @Test
+  public void testCheckLogging() {
+    //#test-check-logging
+    BehaviorTestKit<Command> test = BehaviorTestKit.create(myBehavior);
+    TestInbox<String> inbox = TestInbox.create("Inboxer");
+    test.run(new LogAndSayHello(inbox.getRef()));
+
+    List<CapturedLogEvent> allLogEntries = test.getAllLogEntries();
+    assertEquals(1, allLogEntries.size());
+    CapturedLogEvent expectedLogEvent = new CapturedLogEvent(Logging.InfoLevel(),"Saying hello to Inboxer",
+            Optional.empty(), Optional.empty(), new HashMap<>());
+    assertEquals(expectedLogEvent, allLogEntries.get(0));
+    //#test-check-logging
   }
 }

--- a/akka-docs/src/main/paradox/typed/testing.md
+++ b/akka-docs/src/main/paradox/typed/testing.md
@@ -126,6 +126,18 @@ The `BehaviorTestkit` keeps track other effects you can verify, look at the sub-
  * Unwatched
  * Scheduled
 
+### Checking for Log Messages
+
+The `BehaviorTestkit` also keeps track of everything that is being logged. Here, you can see an example on how to check
+if the behavior logged certain messages:
+
+Scala
+:  @@snip [SyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/SyncTestingExampleSpec.scala) { #test-check-logging }
+
+Java
+:  @@snip [SyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/SyncTestingExampleTest.java) { #test-check-logging }
+
+
 See the other public methods and API documentation on `BehaviorTestkit` for other types of verification.
 
 ## Asynchronous testing


### PR DESCRIPTION
`BehaviorTestKit` now has methods to:
 - Access to logged events
 - Clear all log events

Added section in docs explaining how to check for logs.

Note about the implementation: `CapturedLogEvent` was effectively private to akka. It uses `OptionVal` internally, this makes it impossible to be used from outside akka. To overcome this, I added some methods to translate it to the corresponding `Option` and `Optional`.