### PR TITLE
POC for safe ActorExecutionContext that runs thunks inside of the actor, refs #24375

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/pattern/ActorExecutionContextSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/ActorExecutionContextSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.pattern
+
+import java.util.concurrent.ThreadLocalRandom
+
+import akka.actor.Actor
+import akka.actor.NoSerializationVerificationNeeded
+import akka.actor.Props
+import akka.testkit.AkkaSpec
+import akka.testkit.TestProbe
+
+import scala.concurrent.duration._
+import scala.concurrent.Future
+
+class ActorExecutionContextSpec extends AkkaSpec {
+  "The ActorExecutionContext pattern" must {
+    "run thunks inside the actor context" in {
+      case class Inc(by: Int) extends NoSerializationVerificationNeeded
+
+      class ValueActor extends Actor with ActorExecutionContext {
+        private[this] var _counter: Int = 0
+
+        def receive: Receive = {
+          case "get" ⇒ sender() ! _counter
+          case Inc(by) ⇒
+            akka.pattern.after(ThreadLocalRandom.current().nextInt(10).millis, system.scheduler) {
+              Future(_counter += by)
+            }
+          case "ping" ⇒
+            Future {
+              sender() ! s"result from $self"
+            }
+        }
+      }
+
+      val probe = TestProbe()
+      val actor = system.actorOf(Props(new ValueActor))
+      (1 to 100).foreach(i ⇒ probe.send(actor, Inc(i)))
+
+      Thread.sleep(200)
+
+      probe.send(actor, "get")
+      // actual concurrency would disrupt the counter but doesn't with ActorExecutionContext
+      probe.expectMsg(5050)
+    }
+  }
+}

--- a/akka-actor/src/main/scala/akka/pattern/ActorExecutionContext.scala
+++ b/akka-actor/src/main/scala/akka/pattern/ActorExecutionContext.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.pattern
+
+import akka.actor.Actor
+import akka.actor.ActorCell
+import akka.actor.NoSerializationVerificationNeeded
+import akka.dispatch.Envelope
+import akka.pattern.ActorExecutionContext.ExecuteThunk
+
+import scala.concurrent.ExecutionContext
+import scala.util.Try
+
+trait ActorExecutionContext extends Actor {
+  // called `dispatcher` explicitly to clash with a potential `import context.dispatcher`
+  implicit def dispatcher: ExecutionContext =
+    new ExecutionContext {
+      val _originalEnvelope = currentMessage
+      override def execute(runnable: Runnable): Unit =
+        self ! ExecuteThunk(_originalEnvelope, runnable)
+
+      override def reportFailure(cause: Throwable): Unit = ???
+    }
+
+  abstract override protected[akka] def aroundReceive(receive: Receive, msg: Any): Unit =
+    msg match {
+      case ExecuteThunk(envelope, runnable) ⇒
+        val oldMsg = currentMessage
+        setCurrentMessage(envelope)
+        Try(runnable.run()) // FIXME: what to do if thunk fails?
+        setCurrentMessage(oldMsg)
+
+      case x ⇒ super.aroundReceive(receive, msg)
+    }
+
+  private def currentMessage: Envelope = context.asInstanceOf[ActorCell].currentMessage
+  private def setCurrentMessage(newMessage: Envelope): Unit = context.asInstanceOf[ActorCell].currentMessage = newMessage
+}
+
+private[akka] object ActorExecutionContext {
+  final case class ExecuteThunk(originalEnvelope: Envelope, runnable: Runnable) extends NoSerializationVerificationNeeded
+}


### PR DESCRIPTION
This is a stub for discussion the idea as once suggested in #24375. It even keeps `sender()` working.

There are a few potential caveats:

 * it's still quite simple to define another ExecutionContext that would take precedence over the one inherited from `ActorExecutionContext` (though, `import context.dispatcher` is detected as a conflict because of the same name)
 * Not-yet-executed thunks are lost when the actor is stopped (which must be this way, but might still be surprising). We could add a DeadLetter listener that would log a warning when that happens.
 * In #24375, I noted:

   > One concern (mentioned by @patriknw) would be that this way an actor would create more entry-points into actor processing instead of the single receive message which could lead to spaghetti code.

   Not sure if that's a real problem because I don't think "entry-points into actor processing" are the real problem but code executing from the Actor's lexical scope but not in the Actor's context which exactly is fixed by this pattern.

Upside:

 * As this is would be an opt-in feature for the foreseeable future, you can teach people about it and make the caveats clear.

(In some way this is quite revolutionary but I wonder how many headaches could be avoided using this pattern...)