### PR TITLE
#25733 close channels from SelectionHandler to make sure they are properly flushed from Selector

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpec.scala
@@ -6,19 +6,23 @@ package akka.io
 
 import akka.actor.{ ActorRef, PoisonPill }
 import akka.io.Tcp._
-import akka.testkit.{ TestProbe, AkkaSpec }
+import akka.testkit.{ AkkaSpec, TestProbe }
 import akka.util.ByteString
 import java.io.IOException
-import java.net.{ ServerSocket, InetSocketAddress }
-import org.scalatest.concurrent.Timeouts
-import scala.concurrent.duration._
+import java.net.{ InetSocketAddress, ServerSocket }
 
+import akka.testkit.WithLogCapturing
+import org.scalatest.concurrent.Timeouts
+
+import scala.concurrent.duration._
 import scala.language.postfixOps
 
 class TcpIntegrationSpec extends AkkaSpec("""
-    akka.loglevel = INFO
+    akka.loglevel = debug
+    akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+    akka.io.tcp.trace-logging = on
     akka.actor.serialize-creators = on
-    """) with TcpIntegrationSpecSupport with Timeouts {
+    """) with TcpIntegrationSpecSupport with Timeouts with WithLogCapturing {
 
   def verifyActorTermination(actor: ActorRef): Unit = {
     watch(actor)
@@ -152,6 +156,13 @@ class TcpIntegrationSpec extends AkkaSpec("""
 
       override def bindOptions = List(SO.SendBufferSize(1024))
       override def connectOptions = List(SO.ReceiveBufferSize(1024))
+
+      serverHandler.send(serverConnection, Close)
+      serverHandler.expectMsg(Closed)
+      clientHandler.expectMsg(PeerClosed)
+
+      verifyActorTermination(clientConnection)
+      verifyActorTermination(serverConnection)
     }
 
     "don't report Connected when endpoint isn't responding" in {

--- a/akka-actor/src/main/mima-filters/2.5.18.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.18.backwards.excludes
@@ -46,4 +46,12 @@ ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.io.dns.UnknownRecord
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.dns.UnknownRecord.ttlInSeconds")
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.io.dns.UnknownRecord.ttl")
 
+# Changes to internal implementation classes
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.TcpConnection.stopWith")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.TcpConnection.closedMessage_=")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.TcpConnection.closedMessage")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.TcpConnection.abort")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.ChannelRegistration.cancel")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.io.ChannelRegistration.cancelAndClose")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.SelectionHandler#ChannelRegistryImpl.this")
 

--- a/akka-actor/src/main/scala/akka/io/TcpOutgoingConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpOutgoingConnection.scala
@@ -39,7 +39,8 @@ private[io] class TcpOutgoingConnection(
   channelRegistry.register(channel, 0)
   timeout foreach context.setReceiveTimeout //Initiate connection timeout if supplied
 
-  private def stop(cause: Throwable): Unit = stopWith(CloseInformation(Set(commander), connect.failureMessage.withCause(cause)))
+  private def stop(cause: Throwable): Unit =
+    stopWith(CloseInformation(Set(commander), connect.failureMessage.withCause(cause)), shouldAbort = true)
 
   private def reportConnectFailure(thunk: ⇒ Unit): Unit = {
     try {
@@ -53,6 +54,7 @@ private[io] class TcpOutgoingConnection(
 
   def receive: Receive = {
     case registration: ChannelRegistration ⇒
+      setRegistration(registration)
       reportConnectFailure {
         if (remoteAddress.isUnresolved) {
           log.debug("Resolving {} before connecting", remoteAddress.getHostName)

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -19,6 +19,7 @@ import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit._
 import akka.testkit.{ EventFilter, TestKit, TestLatch, TestProbe }
 import akka.testkit.SocketUtil.temporaryServerAddress
+import akka.testkit.WithLogCapturing
 import akka.util.ByteString
 import akka.{ Done, NotUsed }
 import com.typesafe.config.ConfigFactory
@@ -31,9 +32,11 @@ import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 import scala.util.control.NonFatal
 
 class TcpSpec extends StreamSpec("""
-    akka.loglevel = info
+    akka.loglevel = debug
+    akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+    akka.io.tcp.trace-logging = true
     akka.stream.materializer.subscription-timeout.timeout = 2s
-  """) with TcpHelper {
+  """) with TcpHelper with WithLogCapturing {
 
   "Outgoing TCP stream" must {
 


### PR DESCRIPTION
This makes sure that we report connection closure only after it has really happened. This is important on JDK 11 (and before on Windows) where a channel is only closed after it is cancelled and flushed from its selector.

Tests in akka-actor-tests are now fixed. Something is still broken in akka-stream.

Fixes #25733, #25913.