### PR TITLE
updateFutureDoc executorService shutdown

### DIFF
--- a/akka-docs/src/test/scala/docs/future/FutureDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/future/FutureDocSpec.scala
@@ -145,7 +145,7 @@ class FutureDocSpec extends AkkaSpec {
 
     // Then shut your ExecutionContext down at some
     // appropriate place in your program/application
-    ec.shutdown()
+    yourExecutorServiceGoesHere.shutdown()
     //#diy-execution-context
   }
 


### PR DESCRIPTION
ec.shutdown is not compiling (no method Shutdown in ExecutorContext)
I think it should be yourExecutorServiceGoesHere.shutdown