### PR TITLE
Import service discovery from akka-management 

### DIFF
--- a/akka-discovery/src/main/resources/reference.conf
+++ b/akka-discovery/src/main/resources/reference.conf
@@ -1,0 +1,67 @@
+######################################################
+# Akka Discovery Config                              #
+######################################################
+
+akka.discovery {
+
+  # Users MUST configure this value to set the default discovery mechanism.
+  #
+  # The value can be an implementation config path name, such as "akka-dns",
+  # which would attempt to resolve as `akka.discovery.akka-dns` which is expected
+  # to contain a `class` setting. As fallback, the root `akka-dns` setting scope
+  # would be used. If none of those contained a `class` setting, then the value is
+  # assumed to be a class name, and an attempt is made to intanciate it.
+  method = "<method>"
+
+  # Config based service discovery
+  config {
+    class = akka.discovery.config.ConfigServiceDiscovery
+
+    # Location of the services
+    services-path = "akka.discovery.config.services"
+
+    # A map of services to resolve from configuration.
+    # See docs for more examples.
+    # A list of endpoints with host/port where port is optional e.g.
+    # services {
+    #  service1 {
+    #    endpoints = [
+    #      {
+    #        host = "cat.com"
+    #        port = 1233
+    #      },
+    #      {
+    #        host = "dog.com"
+    #      }
+    #    ]
+    #  },
+    #  service2 {
+    #    endpoints = [
+    #    {
+    #        host = "fish.com"
+    #        port = 1233
+    #      }
+    #    ]
+    #  }
+    # }
+    services = {
+
+    }
+  }
+
+  # Aggregate multiple service discovery mechaisms
+  aggregate {
+    class = akka.discovery.aggregate.AggregateServiceDiscovery
+
+    # List of service discovery mechanisms to try in order. E.g DNS then fall back to config
+    # ["akka-dns" , "akka-confg" ]
+    discovery-mechanisms = []
+
+  }
+
+  # DNS based service discovery
+  akka-dns {
+    class = akka.discovery.dns.DnsServiceDiscovery
+  }
+}
+

--- a/akka-discovery/src/main/scala/akka/discovery/Discovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/Discovery.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.discovery
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.function.{ Function ⇒ JFunction }
+
+import akka.actor._
+
+import scala.util.{ Failure, Success }
+
+final class Discovery(implicit system: ExtendedActorSystem) extends Extension {
+
+  private val implementations = new ConcurrentHashMap[String, ServiceDiscovery]
+  private val factory = new JFunction[String, ServiceDiscovery] {
+    override def apply(method: String): ServiceDiscovery = createServiceDiscovery(method)
+  }
+
+  private lazy val _defaultImplMethod =
+    system.settings.config.getString("akka.discovery.method") match {
+      case "<method>" ⇒
+        throw new IllegalArgumentException(
+          "No default service discovery implementation configured in " +
+            "`akka.discovery.method`. Make sure to configure this setting to your preferred implementation such as " +
+            "'akka-dns' in your application.conf (from the akka-discovery-dns module).")
+      case method ⇒ method
+    }
+
+  private lazy val _simpleImpl = loadServiceDiscovery(_defaultImplMethod)
+
+  /**
+   * Default [[ServiceDiscovery]] as configured in `akka.discovery.method`.
+   */
+  @throws[IllegalArgumentException]
+  def discovery: ServiceDiscovery = _simpleImpl
+
+  /**
+   * Create a [[ServiceDiscovery]] from configuration property.
+   * The given `method` parameter is used to find configuration property
+   * "akka.discovery.[method].class" or "[method].class". `method` can also
+   * be a fully class name.
+   *
+   * The `SimpleServiceDiscovery` instance for a given `method` will be created
+   * once and subsequent requests for the same `method` will return the same instance.
+   */
+  def loadServiceDiscovery(method: String): ServiceDiscovery = {
+    implementations.computeIfAbsent(method, factory)
+  }
+
+  private def createServiceDiscovery(method: String): ServiceDiscovery = {
+    val config = system.settings.config
+    val dynamic = system.dynamicAccess
+
+    def classNameFromConfig(path: String): String =
+      if (config.hasPath(path)) config.getString(path)
+      else "<nope>"
+
+    def create(clazzName: String) = {
+      dynamic
+        .createInstanceFor[ServiceDiscovery](clazzName, (classOf[ExtendedActorSystem] → system) :: Nil)
+        .recoverWith {
+          case _: ClassNotFoundException | _: NoSuchMethodException ⇒
+            dynamic.createInstanceFor[ServiceDiscovery](clazzName, (classOf[ActorSystem] → system) :: Nil)
+        }
+        .recoverWith {
+          case _: ClassNotFoundException | _: NoSuchMethodException ⇒
+            dynamic.createInstanceFor[ServiceDiscovery](clazzName, Nil)
+        }
+    }
+
+    val configName = "akka.discovery." + method + ".class"
+    val instanceTry = create(classNameFromConfig(configName)).recoverWith {
+      case _: ClassNotFoundException | _: NoSuchMethodException ⇒
+        create(classNameFromConfig(method + ".class"))
+    }.recoverWith {
+      case _: ClassNotFoundException | _: NoSuchMethodException ⇒
+        create(method) // so perhaps, it is a classname?
+    }
+
+    instanceTry match {
+      case Failure(e @ (_: ClassNotFoundException | _: NoSuchMethodException)) ⇒
+        throw new IllegalArgumentException(
+          s"Illegal [$configName] value or incompatible class! " +
+            "The implementation class MUST extend akka.discovery.SimpleServiceDiscovery and take an " +
+            "ExtendedActorSystem as constructor argument.", e)
+      case Failure(e)        ⇒ throw e
+      case Success(instance) ⇒ instance
+    }
+
+  }
+
+}
+
+object Discovery extends ExtensionId[Discovery] with ExtensionIdProvider {
+  override def apply(system: ActorSystem): Discovery = super.apply(system)
+
+  override def lookup: Discovery.type = Discovery
+
+  override def get(system: ActorSystem): Discovery = super.get(system)
+
+  override def createExtension(system: ExtendedActorSystem): Discovery = new Discovery()(system)
+
+}

--- a/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.discovery
+
+import java.net.InetAddress
+import java.util.Optional
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.TimeUnit
+
+import akka.actor.DeadLetterSuppression
+import akka.annotation.ApiMayChange
+
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
+
+/**
+ * Implement to provide basic service discovery mechanism.
+ */
+@ApiMayChange
+object ServiceDiscovery {
+
+  /** Result of a successful resolve request */
+  final case class Resolved(serviceName: String, addresses: immutable.Seq[ResolvedTarget])
+    extends DeadLetterSuppression {
+
+    def getAddresses: java.util.List[ResolvedTarget] = {
+      import scala.collection.JavaConverters._
+      addresses.asJava
+    }
+  }
+
+  object ResolvedTarget {
+    // Simply compare the bytes of the address.
+    // This may not work in exotic cases such as IPv4 addresses encoded as IPv6 addresses.
+    private implicit val inetAddressOrdering: Ordering[InetAddress] =
+      Ordering.by[InetAddress, Iterable[Byte]](_.getAddress)
+
+    implicit val addressOrdering: Ordering[ResolvedTarget] = Ordering.by { t ⇒
+      (t.address, t.host, t.port)
+    }
+
+    def apply(host: String, port: Option[Int]): ResolvedTarget =
+      ResolvedTarget(host, port, Try(InetAddress.getByName(host)).toOption)
+  }
+
+  /**
+   * Resolved target host, with optional port and the IP address.
+   * @param host the hostname or the IP address of the target
+   * @param port optional port number
+   * @param address optional IP address of the target. This is used during cluster bootstap when available.
+   */
+  final case class ResolvedTarget(
+    host:    String,
+    port:    Option[Int],
+    address: Option[InetAddress]
+  ) {
+    def getPort: Optional[Int] = {
+      import scala.compat.java8.OptionConverters._
+      port.asJava
+    }
+
+    def getAddress: Optional[InetAddress] = {
+      import scala.compat.java8.OptionConverters._
+      address.asJava
+    }
+  }
+
+}
+
+/**
+ * A service lookup. It is up to each mechanism to decide
+ * what to do with the optional portName and protocol fields.
+ * For example `portName` could be used to distinguish between
+ * Akka remoting ports and HTTP ports.
+ *
+ */
+@ApiMayChange
+case class Lookup(serviceName: String, portName: Option[String], protocol: Option[String]) {
+
+  /**
+   * Which port for a service e.g. Akka remoting or HTTP.
+   * Maps to "service" for an SRV records.
+   */
+  def withPortName(value: String): Lookup = copy(portName = Some(value))
+
+  /**
+   * Which protocol e.g. TCP or UDP.
+   * Maps to "protocol" for SRV records.
+   */
+  def withProtocol(value: String): Lookup = copy(protocol = Some(value))
+}
+
+case object Lookup {
+
+  /**
+   * Create a simple service Lookup with only a serviceName.
+   * Use withPortName and withProtocol to provide optional portName
+   * and protocol
+   */
+  def apply(serviceName: String): Lookup = new Lookup(serviceName, None, None)
+
+  /**
+   * Java API
+   *
+   * Create a simple service Lookup with only a serviceName.
+   * Use withPortName and withProtocol to provide optional portName
+   * and protocol
+   */
+  def create(serviceName: String): Lookup = new Lookup(serviceName, None, None)
+}
+
+/**
+ * Implement to provide basic service discovery mechanism.
+ *
+ * "Simple" because it's only the basic "lookup" methods, no ability to "keep monitoring a namespace for changes" etc.
+ */
+@ApiMayChange
+abstract class ServiceDiscovery {
+
+  import ServiceDiscovery._
+
+  /**
+   * Scala API: Perform lookup using underlying discovery implementation.
+   *
+   * @param lookup       A service discovery lookup.
+   * @param resolveTimeout Timeout. Up to the discovery-mechanism to adhere to his
+   */
+  def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved]
+
+  /**
+   * Scala API: Perform lookup using underlying discovery implementation.
+   *
+   * Convenience for when only a name is required.
+   */
+  def lookup(serviceName: String, resolveTimeout: FiniteDuration): Future[Resolved] =
+    lookup(Lookup(serviceName), resolveTimeout)
+
+  /**
+   * Java API: Perform basic lookup using underlying discovery implementation.
+   *
+   * While the implementation may provide other settings and ways to configure timeouts,
+   * the passed `resolveTimeout` should never be exceeded, as it signals the application's
+   * eagerness to wait for a result for this specific lookup.
+   *
+   * The returned future SHOULD be failed once resolveTimeout has passed.
+   *
+   */
+  def lookup(query: Lookup, resolveTimeout: java.time.Duration): CompletionStage[Resolved] = {
+    import scala.compat.java8.FutureConverters._
+    lookup(query, FiniteDuration(resolveTimeout.toMillis, TimeUnit.MILLISECONDS)).toJava
+  }
+
+  /**
+   * Java API
+   *
+   * @param serviceName           A name, see discovery-mechanism's docs for how this is interpreted
+   * @param resolveTimeout Timeout. Up to the discovery-mechanism to adhere to his
+   */
+  def lookup(serviceName: String, resolveTimeout: java.time.Duration): CompletionStage[Resolved] =
+    lookup(Lookup(serviceName), resolveTimeout)
+
+}

--- a/akka-discovery/src/main/scala/akka/discovery/aggregate/AggregateServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/aggregate/AggregateServiceDiscovery.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.discovery.aggregate
+
+import akka.actor.ExtendedActorSystem
+import akka.discovery.ServiceDiscovery.Resolved
+import akka.discovery.aggregate.AggregateServiceDiscovery.Mechanisms
+import akka.discovery.{ Lookup, Discovery, ServiceDiscovery }
+import akka.event.Logging
+import akka.util.Helpers.Requiring
+import com.typesafe.config.Config
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NonFatal
+
+final class AggregateSimpleServiceDiscoverySettings(config: Config) {
+
+  val discoveryMechanisms = config
+    .getStringList("discovery-mechanisms")
+    .asScala
+    .toList
+    .requiring(_.nonEmpty, "At least one discovery mechanism should be specified")
+
+}
+
+object AggregateServiceDiscovery {
+  type Mechanisms = List[(String, ServiceDiscovery)]
+}
+
+final class AggregateServiceDiscovery(system: ExtendedActorSystem) extends ServiceDiscovery {
+
+  private val log = Logging(system, getClass)
+
+  private val settings =
+    new AggregateSimpleServiceDiscoverySettings(system.settings.config.getConfig("akka.discovery.aggregate"))
+
+  private val mechanisms = {
+    val serviceDiscovery = Discovery(system)
+    settings.discoveryMechanisms.map(mech ⇒ (mech, serviceDiscovery.loadServiceDiscovery(mech)))
+  }
+  private implicit val ec = system.dispatcher
+
+  /**
+   * Each discovery mechanism is given the resolveTimeout rather than reducing it each time between mechanisms.
+   */
+  override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] =
+    resolve(mechanisms, lookup, resolveTimeout)
+
+  private def resolve(sds: Mechanisms, query: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = {
+    sds match {
+      case (mechanism, next) :: Nil ⇒
+        log.debug("Looking up [{}] with [{}]", query, mechanism)
+        next.lookup(query, resolveTimeout)
+      case (mechanism, next) :: tail ⇒
+        log.debug("Looking up [{}] with [{}]", query, mechanism)
+        // If nothing comes back then try the next one
+        next
+          .lookup(query, resolveTimeout)
+          .flatMap { resolved ⇒
+            if (resolved.addresses.isEmpty) {
+              log.debug("Mechanism [{}] returned no ResolvedTargets, trying next", query)
+              resolve(tail, query, resolveTimeout)
+            } else
+              Future.successful(resolved)
+          }
+          .recoverWith {
+            case NonFatal(t) ⇒
+              log.error(t, "[{}] Service discovery failed. Trying next discovery mechanism", mechanism)
+              resolve(tail, query, resolveTimeout)
+          }
+      case Nil ⇒
+        // this is checked in `discoveryMechanisms`, but silence compiler warning
+        throw new IllegalStateException("At least one discovery mechanism should be specified")
+    }
+  }
+}

--- a/akka-discovery/src/main/scala/akka/discovery/config/ConfigServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/config/ConfigServiceDiscovery.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.discovery.config
+
+import akka.actor.ExtendedActorSystem
+import akka.discovery.{ Lookup, ServiceDiscovery }
+import akka.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.event.Logging
+import com.typesafe.config.Config
+
+import scala.collection.JavaConverters._
+import scala.collection.{ breakOut, immutable }
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+object ConfigServicesParser {
+  def parse(config: Config): Map[String, Resolved] = {
+    val byService = config
+      .root()
+      .entrySet()
+      .asScala
+      .map { en ⇒
+        (en.getKey, config.getConfig(en.getKey))
+      }
+      .toMap
+
+    byService.map {
+      case (serviceName, full) ⇒
+        val endpoints = full.getConfigList("endpoints").asScala
+        val resolvedTargets: immutable.Seq[ResolvedTarget] = endpoints.map { c ⇒
+          val host = c.getString("host")
+          val port = if (c.hasPath("port")) Some(c.getInt("port")) else None
+          ResolvedTarget(host = host, port = port, address = None)
+        }(breakOut)
+        (serviceName, Resolved(serviceName, resolvedTargets))
+    }
+  }
+}
+
+class ConfigServiceDiscovery(system: ExtendedActorSystem) extends ServiceDiscovery {
+
+  private val log = Logging(system, getClass)
+
+  private val resolvedServices = ConfigServicesParser.parse(
+    system.settings.config.getConfig(system.settings.config.getString("akka.discovery.config.services-path"))
+  )
+
+  log.debug("Config discovery serving: {}", resolvedServices)
+
+  override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = {
+    // TODO or fail or change the Resolved type to an ADT?
+    Future
+      .successful(resolvedServices.getOrElse(lookup.serviceName, Resolved(lookup.serviceName, immutable.Seq.empty)))
+  }
+
+}

--- a/akka-discovery/src/main/scala/akka/discovery/dns/DnsServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/dns/DnsServiceDiscovery.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.discovery.dns
+
+import java.net.InetAddress
+
+import akka.AkkaVersion
+import akka.actor.ActorSystem
+import akka.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.event.Logging
+import akka.io.{ Dns, IO }
+import akka.pattern.ask
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import akka.discovery._
+import akka.io.dns.DnsProtocol.{ Ip, Srv }
+import akka.io.dns.{ AAAARecord, ARecord, DnsProtocol, SRVRecord }
+
+import scala.collection.{ immutable ⇒ im }
+
+object DnsServiceDiscovery {
+  def srvRecordsToResolved(srvRequest: String, resolved: DnsProtocol.Resolved): Resolved = {
+    val ips: Map[String, im.Seq[InetAddress]] =
+      resolved.additionalRecords.foldLeft(Map.empty[String, im.Seq[InetAddress]]) {
+        case (acc, a: ARecord) ⇒
+          acc.updated(a.name, a.ip +: acc.getOrElse(a.name, Nil))
+        case (acc, a: AAAARecord) ⇒
+          acc.updated(a.name, a.ip +: acc.getOrElse(a.name, Nil))
+        case (acc, _) ⇒
+          acc
+      }
+
+    val addresses = resolved.records.flatMap {
+      case srv: SRVRecord ⇒
+        val addresses = ips.getOrElse(srv.target, Nil).map(ip ⇒ ResolvedTarget(srv.target, Some(srv.port), Some(ip)))
+        if (addresses.isEmpty) {
+          im.Seq(ResolvedTarget(srv.target, Some(srv.port), None))
+        } else {
+          addresses
+        }
+      case other ⇒ im.Seq.empty[ResolvedTarget]
+    }
+
+    Resolved(srvRequest, addresses)
+  }
+
+}
+
+/**
+ * Looks for A records for a given service.
+ */
+class DnsServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
+
+  import DnsServiceDiscovery._
+
+  // TODO: Switch to creating an async resolver directly
+  // Required for async dns, 15 for additional records
+  require(
+    system.settings.config.getString("akka.io.dns.resolver") == "async-dns",
+    "Akka discovery DNS requires akka.io.dns.resolver to be set to async-dns")
+
+  import ServiceDiscovery._
+
+  private val log = Logging(system, getClass)
+  private val dns = IO(Dns)(system)
+
+  import system.dispatcher
+
+  private def cleanIpString(ipString: String): String =
+    if (ipString.startsWith("/")) ipString.tail else ipString
+
+  override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = {
+    lookup match {
+      case Lookup(name, Some(portName), Some(protocol)) ⇒
+        val srvRequest = s"_$portName._$protocol.$name"
+        log.debug("Lookup [{}] translated to SRV query [{}] as contains portName and protocol", lookup, srvRequest)
+        dns.ask(DnsProtocol.Resolve(srvRequest, Srv))(resolveTimeout).map {
+          case resolved: DnsProtocol.Resolved ⇒
+            log.debug("Resolved Dns.Resolved: {}", resolved)
+            srvRecordsToResolved(srvRequest, resolved)
+          case resolved ⇒
+            log.warning("Resolved UNEXPECTED (resolving to Nil): {}", resolved.getClass)
+            Resolved(srvRequest, Nil)
+        }
+      case _ ⇒
+        log.debug("Lookup[{}] translated to A/AAAA lookup as does not have portName and protocol", lookup)
+        dns.ask(DnsProtocol.Resolve(lookup.serviceName, Ip()))(resolveTimeout).map {
+          case resolved: DnsProtocol.Resolved ⇒
+            log.debug("Resolved Dns.Resolved: {}", resolved)
+            val addresses = resolved.records.collect {
+              case a: ARecord    ⇒ ResolvedTarget(cleanIpString(a.ip.getHostAddress), None, Some(a.ip))
+              case a: AAAARecord ⇒ ResolvedTarget(cleanIpString(a.ip.getHostAddress), None, Some(a.ip))
+            }
+            Resolved(lookup.serviceName, addresses)
+          case resolved ⇒
+            log.warning("Resolved UNEXPECTED (resolving to Nil): {}", resolved.getClass)
+            Resolved(lookup.serviceName, Nil)
+
+        }
+    }
+  }
+
+}

--- a/akka-discovery/src/test/java/jdoc/akka/discovery/CompileOnlyTest.java
+++ b/akka-discovery/src/test/java/jdoc/akka/discovery/CompileOnlyTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdoc.akka.discovery;
+
+import akka.actor.ActorSystem;
+import akka.discovery.Lookup;
+import akka.discovery.Discovery;
+import akka.discovery.ServiceDiscovery;
+
+import java.time.Duration;
+
+public class CompileOnlyTest {
+    public static void example() {
+        //#loading
+        ActorSystem as = ActorSystem.create();
+        ServiceDiscovery serviceDiscovery = Discovery.get(as).discovery();
+        //#loading
+
+        //#simple
+        serviceDiscovery.lookup(Lookup.create("akka.io"), Duration.ofSeconds(1));
+        // convenience for a Lookup with only a serviceName
+        serviceDiscovery.lookup("akka.io", Duration.ofSeconds(1));
+        //#simple
+
+        //#full
+        serviceDiscovery.lookup(Lookup.create("akka.io").withPortName("remoting").withProtocol("tcp"), Duration.ofSeconds(1));
+        //#full
+
+    }
+}

--- a/akka-discovery/src/test/scala/akka/discovery/DiscoveryConfigurationSpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/DiscoveryConfigurationSpec.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.discovery
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import akka.actor.ActorSystem
+import akka.discovery.ServiceDiscovery.Resolved
+import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+class DiscoveryConfigurationSpec extends WordSpec with Matchers {
+
+  "ServiceDiscovery" should {
+    "throw when no default discovery configured" in {
+      val sys = ActorSystem("DiscoveryConfigurationSpec")
+      try {
+        val ex = intercept[Exception] {
+          Discovery(sys).discovery
+        }
+        ex.getMessage should include("No default service discovery implementation configured")
+      } finally TestKit.shutdownActorSystem(sys)
+    }
+
+    "select implementation from config by classname" in {
+      val className = classOf[FakeTestDiscovery].getCanonicalName
+
+      val sys = ActorSystem("DiscoveryConfigurationSpec", ConfigFactory.parseString(s"""
+          akka.discovery.method = $className
+        """).withFallback(ConfigFactory.load()))
+
+      try Discovery(sys).discovery.getClass.getCanonicalName should ===(className)
+      finally TestKit.shutdownActorSystem(sys)
+    }
+
+    "select implementation from config by config name (inside akka.discovery namespace)" in {
+      val className = classOf[FakeTestDiscovery].getCanonicalName
+
+      val sys = ActorSystem("DiscoveryConfigurationSpec", ConfigFactory.parseString(s"""
+            akka.discovery {
+              method = akka-mock-inside
+
+              akka-mock-inside {
+                class = $className
+              }
+            }
+        """).withFallback(ConfigFactory.load()))
+
+      try Discovery(sys).discovery.getClass.getCanonicalName should ===(className)
+      finally TestKit.shutdownActorSystem(sys)
+    }
+
+    "select implementation from config by config name (outside akka.discovery namespace)" in {
+      val className = classOf[FakeTestDiscovery].getCanonicalName
+
+      val sys = ActorSystem("DiscoveryConfigurationSpec", ConfigFactory.parseString(s"""
+            akka.discovery {
+              method = com.akka-mock-outside
+            }
+
+            com.akka-mock-outside {
+              class = $className
+            }
+        """).withFallback(ConfigFactory.load()))
+
+      try Discovery(sys).discovery.getClass.getCanonicalName should ===(className)
+      finally TestKit.shutdownActorSystem(sys)
+    }
+
+    "select implementation from full class name" in {
+      val className = classOf[FakeTestDiscovery].getCanonicalName
+
+      val sys = ActorSystem("DiscoveryConfigurationSpec", ConfigFactory.parseString(s"""
+            akka.discovery {
+              method = "$className"
+            }
+        """).withFallback(ConfigFactory.load()))
+
+      try Discovery(sys).discovery.getClass.getCanonicalName should ===(className)
+      finally TestKit.shutdownActorSystem(sys)
+    }
+
+    "load another implementation from config by config name" in {
+      val className1 = classOf[FakeTestDiscovery].getCanonicalName
+      val className2 = classOf[FakeTestDiscovery2].getCanonicalName
+
+      val sys = ActorSystem("DiscoveryConfigurationSpec", ConfigFactory.parseString(s"""
+            akka.discovery {
+              method = mock1
+
+              mock1 {
+                class = $className1
+              }
+              mock2 {
+                class = $className2
+              }
+            }
+        """).withFallback(ConfigFactory.load()))
+
+      try {
+        Discovery(sys).discovery.getClass.getCanonicalName should ===(className1)
+        Discovery(sys).loadServiceDiscovery("mock2").getClass.getCanonicalName should ===(className2)
+      } finally TestKit.shutdownActorSystem(sys)
+    }
+
+    "return same instance for same method" in {
+      val className1 = classOf[FakeTestDiscovery].getCanonicalName
+      val className2 = classOf[FakeTestDiscovery2].getCanonicalName
+
+      val sys = ActorSystem("DiscoveryConfigurationSpec", ConfigFactory.parseString(s"""
+            akka.discovery {
+              method = mock1
+
+              mock1 {
+                class = $className1
+              }
+              mock2 {
+                class = $className2
+              }
+            }
+        """).withFallback(ConfigFactory.load()))
+
+      try {
+        Discovery(sys).loadServiceDiscovery("mock2") should be theSameInstanceAs Discovery(sys)
+          .loadServiceDiscovery("mock2")
+
+        Discovery(sys).discovery should be theSameInstanceAs Discovery(sys).loadServiceDiscovery("mock1")
+      } finally TestKit.shutdownActorSystem(sys)
+    }
+
+    "throw a specific discovery method exception" in {
+      val className = classOf[ExceptionThrowingDiscovery].getCanonicalName
+
+      val sys = ActorSystem("DiscoveryConfigurationSpec", ConfigFactory.parseString(s"""
+            akka.discovery {
+              method = "$className"
+            }
+        """).withFallback(ConfigFactory.load()))
+
+      try {
+        an[DiscoveryException] should be thrownBy Discovery(sys).discovery
+      } finally TestKit.shutdownActorSystem(sys)
+    }
+
+    "throw an illegal argument exception for not existing method" in {
+      val className = "className"
+
+      val sys = ActorSystem("DiscoveryConfigurationSpec", ConfigFactory.parseString(s"""
+            akka.discovery {
+              method = "$className"
+            }
+        """).withFallback(ConfigFactory.load()))
+
+      try {
+        an[IllegalArgumentException] should be thrownBy Discovery(sys).discovery
+      } finally TestKit.shutdownActorSystem(sys)
+    }
+
+  }
+
+}
+
+class FakeTestDiscovery extends ServiceDiscovery {
+
+  override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = ???
+}
+
+class FakeTestDiscovery2 extends FakeTestDiscovery
+
+class DiscoveryException(message: String) extends Exception
+
+class ExceptionThrowingDiscovery extends ServiceDiscovery {
+
+  def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = ???
+
+  throw new DiscoveryException("Test Exception")
+
+}

--- a/akka-discovery/src/test/scala/akka/discovery/aggregate/AggregateServiceDiscoverySpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/aggregate/AggregateServiceDiscoverySpec.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.discovery.aggregate
+
+import akka.actor.{ ActorSystem, ExtendedActorSystem }
+import akka.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.discovery.{ Lookup, Discovery, ServiceDiscovery }
+import akka.testkit.TestKit
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.collection.immutable
+
+class StubbedServiceDiscovery(system: ExtendedActorSystem) extends ServiceDiscovery {
+
+  override def lookup(query: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] = {
+    if (query.serviceName == "stubbed") {
+      Future.successful(Resolved(
+        query.serviceName,
+        immutable.Seq(
+          ResolvedTarget(host = "stubbed1", port = Some(1234), address = None)
+        )))
+    } else if (query.serviceName == "fail") {
+      Future.failed(new RuntimeException("No resolving for you!"))
+    } else {
+      Future.successful(Resolved(query.serviceName, immutable.Seq.empty))
+    }
+  }
+}
+
+object AggregateServiceDiscoverySpec {
+  val config: Config = ConfigFactory.parseString("""
+      akka {
+        loglevel = DEBUG
+        discovery {
+          method = aggregate
+
+          aggregate {
+            discovery-mechanisms = ["stubbed1", "config"]
+          }
+        }
+      }
+
+      akka.discovery.stubbed1 {
+        class = akka.discovery.aggregate.StubbedServiceDiscovery
+      }
+
+      akka.discovery.config.services = {
+        config1 = {
+          endpoints = [
+            {
+              host = "cat"
+              port = 1233
+            },
+            {
+              host = "dog"
+              port = 1234
+            }
+          ]
+        },
+        fail = {
+          endpoints = [
+            {
+              host = "from-config"
+            }
+          ]
+        }
+      }
+    """)
+}
+
+class AggregateServiceDiscoverySpec
+  extends TestKit(ActorSystem("AggregateSimpleDiscoverySpec", AggregateServiceDiscoverySpec.config))
+  with WordSpecLike
+  with Matchers
+  with BeforeAndAfterAll
+  with ScalaFutures {
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  val discovery: ServiceDiscovery = Discovery(system).discovery
+
+  "Aggregate service discovery" must {
+
+    "only call first one if returns results" in {
+      val results = discovery.lookup("stubbed", 100.millis).futureValue
+      results shouldEqual Resolved(
+        "stubbed",
+        immutable.Seq(
+          ResolvedTarget(host = "stubbed1", port = Some(1234), address = None)
+        ))
+    }
+
+    "move onto the next if no resolved targets" in {
+      val results = discovery.lookup("config1", 100.millis).futureValue
+      results shouldEqual Resolved(
+        "config1",
+        immutable.Seq(
+          ResolvedTarget(host = "cat", port = Some(1233), address = None),
+          ResolvedTarget(host = "dog", port = Some(1234), address = None)
+        ))
+    }
+
+    "move onto next if fails" in {
+      val results = discovery.lookup("fail", 100.millis).futureValue
+      // Stub fails then result comes from config
+      results shouldEqual Resolved(
+        "fail",
+        immutable.Seq(
+          ResolvedTarget(host = "from-config", port = None, address = None)
+        ))
+    }
+  }
+
+}

--- a/akka-discovery/src/test/scala/akka/discovery/config/ConfigServiceDiscoverySpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/config/ConfigServiceDiscoverySpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.discovery.config
+
+import akka.actor.ActorSystem
+import akka.discovery.Discovery
+import akka.discovery.ServiceDiscovery.ResolvedTarget
+import akka.testkit.TestKit
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+
+import scala.concurrent.duration._
+import scala.collection.immutable
+
+object ConfigServiceDiscoverySpec {
+
+  val config: Config = ConfigFactory.parseString("""
+akka {
+  loglevel = DEBUG
+  discovery {
+    method = config
+    config {
+      services = {
+        service1 = {
+          endpoints = [
+            {
+              host = "cat"
+              port = 1233
+            },
+            {
+              host = "dog"
+            }
+          ]
+        },
+        service2 = {
+          endpoints = []
+        }
+      }
+    }
+  }
+}
+    """)
+
+}
+
+class ConfigServiceDiscoverySpec
+  extends TestKit(ActorSystem("ConfigSimpleDiscoverySpec", ConfigServiceDiscoverySpec.config))
+  with WordSpecLike
+  with Matchers
+  with BeforeAndAfterAll
+  with ScalaFutures {
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  val discovery = Discovery(system).discovery
+
+  "Config discovery" must {
+    "load from config" in {
+      val result = discovery.lookup("service1", 100.millis).futureValue
+      result.serviceName shouldEqual "service1"
+      result.addresses shouldEqual immutable.Seq(
+        ResolvedTarget(host = "cat", port = Some(1233), address = None),
+        ResolvedTarget(host = "dog", port = None, address = None)
+      )
+    }
+
+    "return no resolved targets if not in config" in {
+      val result = discovery.lookup("dontexist", 100.millis).futureValue
+      result.serviceName shouldEqual "dontexist"
+      result.addresses shouldEqual immutable.Seq.empty
+    }
+  }
+}

--- a/akka-discovery/src/test/scala/akka/discovery/config/ConfigServicesParserSpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/config/ConfigServicesParserSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.discovery.config
+
+import akka.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.discovery.config.ConfigServicesParserSpec._
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.{ Matchers, WordSpec }
+
+import scala.collection.immutable
+
+object ConfigServicesParserSpec {
+  val exampleConfig: Config = ConfigFactory.parseString("""
+      services {
+        service1 {
+          endpoints = [
+            {
+              host = "cat"
+              port = 1233
+            },
+            {
+              host = "dog"
+            }
+          ]
+        },
+        service2 {
+          endpoints = []
+        }
+      }
+    """.stripMargin)
+}
+
+class ConfigServicesParserSpec extends WordSpec with Matchers {
+
+  "Config parsing" must {
+    "parse" in {
+      val config = exampleConfig.getConfig("services")
+
+      val result = ConfigServicesParser.parse(config)
+
+      result("service1") shouldEqual Resolved(
+        "service1",
+        immutable.Seq(
+          ResolvedTarget(host = "cat", port = Some(1233), address = None),
+          ResolvedTarget(host = "dog", port = None, address = None)
+        ))
+      result("service2") shouldEqual Resolved("service2", immutable.Seq())
+    }
+  }
+}

--- a/akka-discovery/src/test/scala/akka/discovery/dns/DnsDiscoverySpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/dns/DnsDiscoverySpec.scala
@@ -1,0 +1,139 @@
+package akka.discovery.dns
+
+import akka.actor.ActorSystem
+import akka.discovery.ServiceDiscovery.ResolvedTarget
+import akka.discovery.{Discovery, Lookup }
+import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+import scala.concurrent.duration._
+
+/*
+Testing is done via subbing out the DnsClient. To test against a real dns server
+install bind and add this to /etc/named.conf
+
+zone "akka.test" IN {
+  type master;
+  file "akka.test.zone";
+};
+
+zone "akka.test2" IN {
+  type master;
+  file "akka.test2.zone";
+};
+
+Then add the two zone files to /var/named/ akka.test.zone and akka.test2.zone
+
+akka.test.zone:
+=================
+
+$TTL 86400
+
+@ IN SOA akka.test root.akka.test (
+  2017010302
+  3600
+  900
+  604800
+  86400
+)
+
+@      IN NS test
+test     IN A  192.168.1.19
+a-single IN A  192.168.1.20
+a-double IN A  192.168.1.21
+a-double IN A  192.168.1.22
+aaaa-single IN AAAA fd4d:36b2:3eca:a2d8:0:0:0:1
+aaaa-double IN AAAA fd4d:36b2:3eca:a2d8:0:0:0:2
+aaaa-double IN AAAA fd4d:36b2:3eca:a2d8:0:0:0:3
+a-aaaa IN AAAA fd4d:36b2:3eca:a2d8:0:0:0:4
+a-aaaa IN AAAA fd4d:36b2:3eca:a2d8:0:0:0:5
+a-aaaa IN A  192.168.1.23
+a-aaaa IN A  192.168.1.24
+
+_service._tcp   86400 IN    SRV 10       60     5060 a-single
+_service._tcp   86400 IN    SRV 10       40     5070 a-double
+
+cname-in IN CNAME  a-double
+cname-ext IN CNAME  a-single.akka.test2.
+
+akka.test.zone:
+=================
+
+$TTL 86400
+
+@ IN SOA akka.test2 root.akka.test2 (
+  2017010302
+  3600
+  900
+  604800
+  86400
+)
+
+@      IN NS test2
+test2     IN A  192.168.2.19
+a-single IN A  192.168.2.20
+
+
+
+ */
+
+object DnsDiscoverySpec {
+
+  val config = ConfigFactory.parseString("""
+     //#configure-dns
+     akka {
+       discovery.method = akka-dns
+       io.dns.resolver = async-dns
+     }
+     //#configure-dns
+     akka {
+       loglevel = DEBUG
+       io.dns.async-dns.nameservers = ["localhost"]
+     }
+    """)
+
+}
+
+class DnsDiscoverySpec
+  extends TestKit(ActorSystem("DnsDiscoverySpec", DnsDiscoverySpec.config))
+    with WordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures {
+
+  "Dns Discovery" must {
+
+    // Requires DNS server, see above, FIXME use the dns testing infra from dns
+    pending
+
+    "work with SRV records" in {
+      val discovery = Discovery(system).discovery
+      val name = "_service._tcp.akka.test."
+      val result =
+        discovery
+          .lookup(Lookup("akka.test.").withPortName("service").withProtocol("tcp"), resolveTimeout = 500.milliseconds)
+          .futureValue
+      result.addresses.toSet shouldEqual Set(
+        ResolvedTarget("a-single.akka.test", Some(5060)),
+        ResolvedTarget("a-double.akka.test", Some(5070))
+      )
+      result.serviceName shouldEqual name
+    }
+
+    "work with IP records" in {
+      val discovery = Discovery(system).discovery
+      val name = "a-single.akka.test"
+      val result = discovery.lookup(name, resolveTimeout = 500.milliseconds).futureValue
+      result.serviceName shouldEqual name
+      result.addresses.toSet shouldEqual Set(
+        ResolvedTarget("192.168.1.20", None)
+      )
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+}

--- a/akka-discovery/src/test/scala/akka/discovery/dns/DnsServiceDiscoverySpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/dns/DnsServiceDiscoverySpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.discovery.dns
+
+import java.net.{ Inet6Address, InetAddress }
+
+import akka.discovery.ServiceDiscovery
+import akka.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.io.dns.{ AAAARecord, ARecord, DnsProtocol, SRVRecord }
+import org.scalatest.{ Matchers, WordSpec }
+
+import scala.collection.{ immutable ⇒ im }
+
+class DnsServiceDiscoverySpec extends WordSpec with Matchers {
+  "srvRecordsToResolved" must {
+    "fill in ips from A records" in {
+      val resolved = DnsProtocol.Resolved("cats.com", im.Seq(new SRVRecord("cats.com", 1, 2, 3, 4, "kittens.com")),
+        im.Seq(
+          new ARecord("kittens.com", 1, InetAddress.getByName("127.0.0.2")),
+          new ARecord("kittens.com", 1, InetAddress.getByName("127.0.0.3")),
+          new ARecord("donkeys.com", 1, InetAddress.getByName("127.0.0.4"))
+        ))
+
+      val result: ServiceDiscovery.Resolved =
+        DnsServiceDiscovery.srvRecordsToResolved("cats.com", resolved)
+
+      result.serviceName shouldEqual "cats.com"
+      result.addresses.toSet shouldEqual Set(
+        ResolvedTarget("kittens.com", Some(4), Some(InetAddress.getByName("127.0.0.2"))),
+        ResolvedTarget("kittens.com", Some(4), Some(InetAddress.getByName("127.0.0.3")))
+      )
+    }
+
+    // Naughty DNS server
+    "use SRV targetand port if no additional records" in {
+      val resolved = DnsProtocol.Resolved("cats.com", im.Seq(new SRVRecord("cats.com", 1, 2, 3, 8080, "kittens.com")),
+        im.Seq(new ARecord("donkeys.com", 1, InetAddress.getByName("127.0.0.4"))))
+
+      val result =
+        DnsServiceDiscovery.srvRecordsToResolved("cats.com", resolved)
+
+      result shouldEqual Resolved("cats.com", im.Seq(ResolvedTarget("kittens.com", Some(8080), None)))
+    }
+
+    "fill in ips from AAAA records" in {
+      val resolved = DnsProtocol.Resolved("cats.com", im.Seq(new SRVRecord("cats1.com", 1, 2, 3, 4, "kittens.com")),
+        im.Seq(
+          new AAAARecord("kittens.com", 2, InetAddress.getByName("::1").asInstanceOf[Inet6Address]),
+          new AAAARecord("kittens.com", 2, InetAddress.getByName("::2").asInstanceOf[Inet6Address]),
+          new AAAARecord("donkeys.com", 2, InetAddress.getByName("::3").asInstanceOf[Inet6Address])
+        ))
+
+      val result: ServiceDiscovery.Resolved =
+        DnsServiceDiscovery.srvRecordsToResolved("cats.com", resolved)
+
+      result.serviceName shouldEqual "cats.com"
+      result.addresses.toSet shouldEqual Set(
+        ResolvedTarget("kittens.com", Some(4), Some(InetAddress.getByName("::1"))),
+        ResolvedTarget("kittens.com", Some(4), Some(InetAddress.getByName("::2")))
+      )
+    }
+  }
+}

--- a/akka-discovery/src/test/scala/doc/akka/discovery/CompileOnlySpec.scala
+++ b/akka-discovery/src/test/scala/doc/akka/discovery/CompileOnlySpec.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package doc.akka.discovery
+
+import akka.actor.ActorSystem
+import akka.discovery.{ Lookup, Discovery }
+
+import scala.concurrent.duration._
+
+object CompileOnlySpec {
+
+  //#loading
+  val system = ActorSystem()
+  val serviceDiscovery = Discovery(system).discovery
+  //#loading
+
+  //#simple
+  serviceDiscovery.lookup(Lookup("akka.io"), 1.second)
+  // Convenience for a Lookup with only a serviceName
+  serviceDiscovery.lookup("akka.io", 1.second)
+  //#simple
+
+  //#full
+  serviceDiscovery.lookup(Lookup("akka.io").withPortName("remoting").withProtocol("tcp"), 1.second)
+  //#full
+
+}

--- a/akka-docs/src/main/paradox/discovery/index.md
+++ b/akka-docs/src/main/paradox/discovery/index.md
@@ -1,0 +1,209 @@
+# Discovery
+
+@@@ warning
+
+This module is currently marked as @ref:[may change](../common/may-change.md)
+This means that API or semantics can
+change without warning or deprecation period and it is not recommended to use
+this module in production.
+
+@@@
+
+Akka Discovery provides an interface around various ways of locating services, such as DNS
+or using configuration or key-value stores like zookeeper, consul. The built in methods are:
+
+* Configuration
+* DNS
+* Aggregate
+
+In addition `akka-management` contains methods for:
+
+* Kubernetes API
+* AWS
+* Consul
+* Marathon API
+
+Discovery used to be part of `akka-management` but has become an Akka module as of 2.5.19 of Akka and version 0.20
+of `akka-management`.
+
+## Dependency
+
+@@dependency[sbt,Gradle,Maven] {
+  group="com.typesafe.akka"
+  artifact="akka-discovery_2.12"
+  version="$akka.version$"
+}
+
+## What is Service Discovery
+
+Akka's Discovery talks specifically about discovering hosts and ports that relate to some
+logical name.
+
+Discovery is done in a method agnostic way:
+
+Scala
+:  @@snip [CompileOnlySpec.scala](/akka-discovery/src/test/scala/doc/akka/discovery/CompileOnlySpec.scala) { #loading }
+
+Java
+:  @@snip [CompileOnlyTest.java](/akka-discovery/src/test/java/jdoc/akka/discovery/CompileOnlyTest.java) { #loading }
+
+A `Lookup` contains a mandatory `serviceName` and an optional `portName` and `protocol`. How these are interpreted is discovery 
+method dependent e.g.DNS does an A/AAAA record query if any of the fields are missing and an SRV query for a full look up:
+
+Scala
+:  @@snip [CompileOnlySpec.scala](/akka-discovery/src/test/scala/doc/akka/discovery/CompileOnlySpec.scala) { #simple }
+
+Java
+:  @@snip [CompileOnlyTest.java](/akka-discovery/src/test/java/jdoc/akka/discovery/CompileOnlyTest.java) { #simple }
+
+
+`portName` and `protocol` are optional and their meaning is interpreted by the method.
+
+Scala
+:  @@snip [CompileOnlySpec.scala](/akka-discovery/src/test/scala/doc/akka/discovery/CompileOnlySpec.scala) { #full }
+
+Java
+:  @@snip [CompileOnlyTest.java](/akka-discovery/src/test/java/jdoc/akka/discovery/CompileOnlyTest.java) { #full }
+
+Port can be used when a service opens multiple ports e.g. a HTTP port and an Akka remoting port.
+
+## Discovery Method: DNS
+
+DNS discovery maps `Lookup` queries as follows:
+
+* `serviceName`, `portName` and `protocol` set: SRV query in the form: `_port._protocol._name` Where the `_`s are added.
+* Any query  missing any of the fields is mapped to a A/AAAA query for the `serviceName`
+
+The mapping between Akka service discovery terminology and SRV terminology:
+
+* SRV service = port
+* SRV name = serviceName
+* SRV protocol = protocol
+
+Configure it to be used as discovery implementation in your `application.conf` and `async-dns` to be uses
+as the Akka DNS resolver:
+
+@@snip[application.conf](/akka-discovery/src/test/scala/akka/discovery/dns/DnsDiscoverySpec.scala){ #configure-dns }
+
+From there on, you can use the generic API that hides the fact which discovery method is being used by calling::
+
+Scala
+:   ```scala
+    import akka.discovery.ServiceDiscovery
+    val system = ActorSystem("Example")
+    // ...
+    val discovery = ServiceDiscovery(system).discovery
+    val result: Future[Resolved] = discovery.lookup("service-name", resolveTimeout = 500 milliseconds)
+    ```
+
+Java
+:   ```java
+    import akka.discovery.ServiceDiscovery;
+    ActorSystem system = ActorSystem.create("Example");
+    // ...
+    SimpleServiceDiscovery discovery = ServiceDiscovery.get(system).discovery();
+    Future<SimpleServiceDiscovery.Resolved> result = discovery.lookup("service-name", Duration.create("500 millis"));
+    ```
+
+### How it works
+
+DNS discovery will use either A/AAAA records or SRV records depending on whether a `Simple` or `Full` lookup is issued..
+The advantage of SRV records is that they can include a port.
+
+#### SRV records
+
+Lookups with all the fields set become SRV queries. For example:
+
+```
+dig srv service.tcp.akka.test
+
+; <<>> DiG 9.11.3-RedHat-9.11.3-6.fc28 <<>> srv service.tcp.akka.test
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 60023
+;; flags: qr aa rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 1, ADDITIONAL: 5
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 4096
+; COOKIE: 5ab8dd4622e632f6190f54de5b28bb8fb1b930a5333c3862 (good)
+;; QUESTION SECTION:
+;service.tcp.akka.test.         IN      SRV
+
+;; ANSWER SECTION:
+service.tcp.akka.test.  86400   IN      SRV     10 60 5060 a-single.akka.test.
+service.tcp.akka.test.  86400   IN      SRV     10 40 5070 a-double.akka.test.
+
+```
+
+In this case `service.tcp.akka.test` resolves to `a-single.akka.test` on port `5060`
+and `a-double.akka.test` on port `5070`. Currently discovery does not support the weightings.
+
+#### A/AAAA records
+
+Lookups with any fields missing become A/AAAA record queries. For example:
+
+```
+dig a-double.akka.test
+
+; <<>> DiG 9.11.3-RedHat-9.11.3-6.fc28 <<>> a-double.akka.test
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 11983
+;; flags: qr aa rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 1, ADDITIONAL: 2
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 4096
+; COOKIE: 16e9815d9ca2514d2f3879265b28bad05ff7b4a82721edd0 (good)
+;; QUESTION SECTION:
+;a-double.akka.test.            IN      A
+
+;; ANSWER SECTION:
+a-double.akka.test.     86400   IN      A       192.168.1.21
+a-double.akka.test.     86400   IN      A       192.168.1.22
+
+```
+
+In this case `a-double.akka.test` would resolve to `192.168.1.21` and `192.168.1.22`.
+
+## Discovery Method: Configuration
+
+Configuration currently ignores all fields apart from service name.
+
+For simple use cases configuration can be used for service discovery. The advantage of using Akka Discovery with
+configuration rather than your own configuration values is that applications can be migrated to a more
+sophisticated discovery mechanism without any code changes.
+
+
+Configure it to be used as discovery method in your `application.conf`
+
+```
+akka {
+  discovery.method = config
+}
+```
+
+By default the services discoverable are defined in `akka.discovery.config.services` and have the following format:
+
+```
+akka.discovery.config.services = {
+  service1 = {
+    endpoints = [
+      {
+        host = "cat"
+        port = 1233
+      },
+      {
+        host = "dog"
+        port = 1234
+      }
+    ]
+  },
+  service2 = {
+    endpoints = []
+  }
+}
+```
+
+Where the above block defines two services, `service1` and `service2`.
+Each service can have multiple endpoints.
+

--- a/akka-docs/src/main/paradox/index.md
+++ b/akka-docs/src/main/paradox/index.md
@@ -18,5 +18,6 @@
 * [howto](howto.md)
 * [project/index](project/index.md)
 * [additional/index](additional/index.md)
+* [discovery](discovery/index.md)
 
 @@@

--- a/build.sbt
+++ b/build.sbt
@@ -474,6 +474,14 @@ lazy val actorTypedTests = akkaModule("akka-actor-typed-tests")
   .disablePlugins(MimaPlugin)
   .enablePlugins(NoPublish)
 
+lazy val discovery = akkaModule("akka-discovery")
+  .dependsOn(
+    actor,
+    testkit % "test->test"
+  )
+  .settings(Dependencies.discovery)
+  .settings(AkkaBuild.mayChangeSettings)
+  .settings(AutomaticModuleName.settings("akka.discovery"))
 
 def akkaModule(name: String): Project =
   Project(id = name, base = file(name))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -148,6 +148,8 @@ object Dependencies {
 
   val actor = l ++= Seq(config, java8Compat.value)
 
+  val discovery = l ++= Seq(Test.junit, Test.scalatest.value)
+
   val testkit = l ++= Seq(Test.junit, Test.scalatest.value) ++ Test.metricsAll
 
   val actorTests = l ++= Seq(


### PR DESCRIPTION
* Rename extension to Discovery to go with akka-discovery name
* Rename interafce to ServiceDisovery
* Import config, aggregate and dns

Documentation can still be improved. Captured some things in #25931