### PR TITLE
WIP: Down myself when other has quarantined, #24764

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/DowningWhenOtherHasQuarantinedThisActorSystemSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/DowningWhenOtherHasQuarantinedThisActorSystemSpec.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster
+
+import scala.concurrent.duration._
+
+import akka.remote.OtherHasQuarantinedThisActorSystemEvent
+import akka.remote.artery.ArterySettings
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.remote.transport.ThrottlerTransportAdapter
+import akka.testkit.LongRunningTest
+import com.typesafe.config.ConfigFactory
+
+object DowningWhenOtherHasQuarantinedThisActorSystemSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+
+  commonConfig(debugConfig(on = false).
+    withFallback(MultiNodeClusterSpec.clusterConfig)
+    .withFallback(ConfigFactory.parseString("""
+        akka.remote.artery.enabled = on
+        """)))
+
+  nodeConfig(first, third) {
+    ConfigFactory.parseString("akka.cluster.auto-down-unreachable-after = 2s")
+  }
+
+  testTransport(on = true)
+}
+
+class DowningWhenOtherHasQuarantinedThisActorSystemMultiJvmNode1 extends DowningWhenOtherHasQuarantinedThisActorSystemSpec
+class DowningWhenOtherHasQuarantinedThisActorSystemMultiJvmNode2 extends DowningWhenOtherHasQuarantinedThisActorSystemSpec
+class DowningWhenOtherHasQuarantinedThisActorSystemMultiJvmNode3 extends DowningWhenOtherHasQuarantinedThisActorSystemSpec
+
+abstract class DowningWhenOtherHasQuarantinedThisActorSystemSpec extends MultiNodeSpec(DowningWhenOtherHasQuarantinedThisActorSystemSpec)
+  with MultiNodeClusterSpec {
+  import DowningWhenOtherHasQuarantinedThisActorSystemSpec._
+
+  "Cluster node downed by other" must {
+
+    if (!ArterySettings(system.settings.config.getConfig("akka.remote.artery")).Enabled) {
+      // this feature only works in Artery, because classic remoting will not accept connections from
+      // a quarantined node, and that is too high risk of introducing regressions if changing that
+      pending
+    }
+
+    "join cluster" taggedAs LongRunningTest in {
+      awaitClusterUp(first, second, third)
+      enterBarrier("after-1")
+    }
+
+    "down itself" taggedAs LongRunningTest in {
+      runOn(first) {
+        testConductor.blackhole(first, second, ThrottlerTransportAdapter.Direction.Both).await
+        testConductor.blackhole(third, second, ThrottlerTransportAdapter.Direction.Both).await
+      }
+      enterBarrier("blackhole")
+
+      within(10.seconds) {
+        runOn(first) {
+          awaitAssert {
+            cluster.state.unreachable.map(_.address) should ===(Set(address(second)))
+          }
+          awaitAssert {
+            // second downed and removed
+            cluster.state.members.map(_.address) should ===(Set(address(first), address(third)))
+          }
+        }
+        runOn(second) {
+          awaitAssert {
+            cluster.state.unreachable.map(_.address) should ===(Set(address(first), address(third)))
+          }
+        }
+      }
+      enterBarrier("down-second")
+
+      runOn(first) {
+        testConductor.passThrough(first, second, ThrottlerTransportAdapter.Direction.Both).await
+        testConductor.passThrough(third, second, ThrottlerTransportAdapter.Direction.Both).await
+      }
+      enterBarrier("pass-through")
+
+      runOn(second) {
+        // shutting down itself
+        awaitCond(cluster.isTerminated)
+      }
+
+      enterBarrier("after-2")
+    }
+
+    "FIXME illustrate trouble" taggedAs LongRunningTest in {
+      runOn(first) {
+        system.eventStream.subscribe(testActor, classOf[OtherHasQuarantinedThisActorSystemEvent])
+      }
+      enterBarrier("subscribing")
+
+      runOn(third) {
+        // The ActorSystem continues running and will reply with Quarantined when receiving heartbeats from first,
+        // which result in that first is downing itself, which is undesired.
+        // Normally the ActorSystem will be terminated (or exit JVM) but there could be race conditions during
+        // shutdown that would result in same issue.
+        cluster.shutdown()
+      }
+
+      runOn(first) {
+        // FIXME this is failing, OtherHasQuarantinedThisActorSystemEvent is published
+        expectNoMessage(10.seconds)
+      }
+
+      enterBarrier("after-2")
+    }
+
+  }
+}

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteRestartedQuarantinedSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteRestartedQuarantinedSpec.scala
@@ -58,7 +58,7 @@ abstract class RemoteRestartedQuarantinedSpec
 
   import RemoteRestartedQuarantinedSpec._
 
-  override def initialParticipants = 2
+  override def initialParticipants = roles.size
 
   def identifyWithUid(role: RoleName, actorName: String): (Int, ActorRef) = {
     system.actorSelection(node(role) / "user" / actorName) ! "identify"
@@ -113,7 +113,7 @@ abstract class RemoteRestartedQuarantinedSpec
         }
 
         expectMsgPF(10 seconds) {
-          case ThisActorSystemQuarantinedEvent(local, remote) ⇒
+          case ThisActorSystemQuarantinedEvent(_, _) ⇒
         }
 
         enterBarrier("still-quarantined")

--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -517,6 +517,7 @@ private[remote] class EndpointManager(conf: Config, log: LoggingAdapter) extends
         }
         disassiciationInfo.foreach {
           case AssociationHandle.Quarantined ⇒
+            println(s"# publish ThisActorSystemQuarantinedEvent") // FIXME
             context.system.eventStream.publish(ThisActorSystemQuarantinedEvent(localAddress, remoteAddress))
           case _ ⇒ // do nothing
         }

--- a/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
@@ -121,10 +121,22 @@ final case class GracefulShutdownQuarantinedEvent(uniqueAddress: UniqueAddress, 
       s"messages to this UID will be delivered to dead letters. Reason: $reason "
 }
 
+/**
+ * Used in Classic remoting, in Artery remoting [[OtherHasQuarantinedThisActorSystemEvent]] is used instead.
+ */
 @SerialVersionUID(1L)
 final case class ThisActorSystemQuarantinedEvent(localAddress: Address, remoteAddress: Address) extends RemotingLifecycleEvent {
   override def logLevel: LogLevel = Logging.WarningLevel
-  override val toString: String = s"The remote system ${remoteAddress} has quarantined this system ${localAddress}."
+  override val toString: String = s"The remote system [$remoteAddress] has quarantined this system [$localAddress]."
+}
+
+/**
+ * Used in Artery remoting instead of [[ThisActorSystemQuarantinedEvent]] to include full unique addresses.
+ */
+@SerialVersionUID(1L)
+final case class OtherHasQuarantinedThisActorSystemEvent(localAddress: UniqueAddress, remoteAddress: UniqueAddress) extends RemotingLifecycleEvent {
+  override def logLevel: LogLevel = Logging.WarningLevel
+  override val toString: String = s"The remote system [$remoteAddress] has quarantined this system [$localAddress]."
 }
 
 /**

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -33,10 +33,10 @@ import akka.actor._
 import akka.event.Logging
 import akka.event.LoggingAdapter
 import akka.remote.AddressUidExtension
+import akka.remote.OtherHasQuarantinedThisActorSystemEvent
 import akka.remote.RemoteActorRef
 import akka.remote.RemoteActorRefProvider
 import akka.remote.RemoteTransport
-import akka.remote.ThisActorSystemQuarantinedEvent
 import akka.remote.UniqueAddress
 import akka.remote.artery.Decoder.InboundCompressionAccess
 import akka.remote.artery.Encoder.OutboundCompressionAccess
@@ -577,7 +577,7 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
               // and can result in forming two separate clusters (cluster split).
               // Instead, the downing strategy should act on ThisActorSystemQuarantinedEvent, e.g.
               // use it as a STONITH signal.
-              val lifecycleEvent = ThisActorSystemQuarantinedEvent(localAddress.address, from.address)
+              val lifecycleEvent = OtherHasQuarantinedThisActorSystemEvent(localAddress, from)
               system.eventStream.publish(lifecycleEvent)
 
             case _ ⇒ // not interesting


### PR DESCRIPTION
This is more difficult than one might first think. This is not completed and illustrates a problem that must be solved if we decide to do this at all.

* When node A quarantines node B it sends Quarantined message to B,
  which will be publised to the eventStream as OtherHasQuarantinedThisActorSystemEvent
  at B
* If there was a network partition B might not receive the above message, and might continue
  and attempt to send messages to A (e.g. heartbeat messages). Then A will send back Quarantined,
  which will be publised to the eventStream as OtherHasQuarantinedThisActorSystemEvent at B
* ClusterDaemon subscribes to OtherHasQuarantinedThisActorSystemEvent and downs itself.
* However, there can be situations of false self downing as illustrated in the test.

Refs #24764