### PR TITLE
Reachability.allObservers wrong after filterRecords, #25950

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/Reachability.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Reachability.scala
@@ -276,7 +276,7 @@ private[cluster] class Reachability private (
     }
   }
 
-  def allObservers: Set[UniqueAddress] = versions.keySet
+  def allObservers: Set[UniqueAddress] = records.iterator.map(_.observer).toSet
 
   def recordsFrom(observer: UniqueAddress): immutable.IndexedSeq[Record] = {
     observerRows(observer) match {

--- a/akka-cluster/src/test/scala/akka/cluster/ReachabilityPerfSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ReachabilityPerfSpec.scala
@@ -27,8 +27,8 @@ class ReachabilityPerfSpec extends WordSpec with Matchers {
     }
 
   private def addUnreachable(base: Reachability, count: Int): Reachability = {
-    val observers = base.allObservers.take(count)
-    val subjects = Stream.continually(base.allObservers).flatten.iterator
+    val observers = base.versions.keySet.take(count)
+    val subjects = Stream.continually(base.versions.keySet).flatten.iterator
     observers.foldLeft(base) {
       case (r, o) ⇒
         (1 to 5).foldLeft(r) { case (r, _) ⇒ r.unreachable(o, subjects.next()) }
@@ -38,7 +38,7 @@ class ReachabilityPerfSpec extends WordSpec with Matchers {
   val reachability1 = createReachabilityOfSize(Reachability.empty, nodesSize)
   val reachability2 = createReachabilityOfSize(reachability1, nodesSize)
   val reachability3 = addUnreachable(reachability1, nodesSize / 2)
-  val allowed = reachability1.allObservers
+  val allowed = reachability1.versions.keySet
 
   private def checkThunkFor(r1: Reachability, r2: Reachability, thunk: (Reachability, Reachability) ⇒ Unit, times: Int): Unit = {
     for (i ← 1 to times) {

--- a/akka-cluster/src/test/scala/akka/cluster/ReachabilitySpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ReachabilitySpec.scala
@@ -235,5 +235,17 @@ class ReachabilitySpec extends WordSpec with Matchers {
       r2.versions.keySet should ===(Set(nodeD))
     }
 
+    "be able to filter records" in {
+      val r = Reachability.empty
+        .unreachable(nodeC, nodeB)
+        .unreachable(nodeB, nodeA)
+        .unreachable(nodeB, nodeC)
+
+      val filtered1 = r.filterRecords(record ⇒ record.observer != nodeC)
+      filtered1.isReachable(nodeB) should ===(true)
+      filtered1.isReachable(nodeA) should ===(false)
+      filtered1.allObservers should ===(Set(nodeB))
+    }
+
   }
 }


### PR DESCRIPTION
`allObservers` isn't used anywhere apart from tests so this should be a safe change

Refs #25950