### PR TITLE
POC Make Behavior#intercept pattern matching on tags but not types.

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
@@ -114,7 +114,7 @@ object Behavior {
     final val StoppedBehavior = 5
     final val ExtensibleBehavior = 6
     final val WrappingBehavior = 7
-    final val InterceptorImpl = 1000
+    final val InterceptorImpl = -1
   }
 
   final implicit class BehaviorDecorators[T](val behavior: Behavior[T]) extends AnyVal {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/InterceptorImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/InterceptorImpl.scala
@@ -35,6 +35,7 @@ private[akka] object InterceptorImpl {
 @InternalApi
 private[akka] final class InterceptorImpl[O, I](val interceptor: BehaviorInterceptor[O, I], val nestedBehavior: Behavior[I])
   extends ExtensibleBehavior[O] with WrappingBehavior[O, I] {
+  override private[akka] def tag: Int = Behavior.Tags.InterceptorImpl
 
   import BehaviorInterceptor._
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/WrappingBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/WrappingBehavior.scala
@@ -4,7 +4,7 @@
 
 package akka.actor.typed.internal
 
-import akka.actor.typed.Behavior
+import akka.actor.typed.{ Behavior, BehaviorTag }
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
 
@@ -20,7 +20,10 @@ import akka.annotation.InternalApi
  */
 @DoNotInherit
 @InternalApi
-private[akka] trait WrappingBehavior[O, I] {
+private[akka] trait WrappingBehavior[O, I] extends BehaviorTag {
+
+  override private[akka] def tag: Int = Behavior.Tags.WrappingBehavior
+
   /**
    * @return The behavior that is wrapped by this behavior
    */


### PR DESCRIPTION
I think pattern matching on tags will reduce the overhead of emulation on the untyped actor, but this kind of thing changes a lot to the source code, maybe not worth it, so just a POC.

```
   FRAME SAME
    ALOAD 1
    INVOKEVIRTUAL akka/actor/typed/Behavior.tag ()I
    ISTORE 5
    ILOAD 5
    LOOKUPSWITCH
      0: L3
      1: L4
      2: L5
      3: L6
      4: L5
      5: L7
      6: L8
      1000: L8
      default: L9
```