### PR TITLE
Fix TestProbeImpl#receiveN_internal with the receiveOne change

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
@@ -194,8 +194,10 @@ private[akka] final class TestProbeImpl[M](name: String, system: ActorSystem[_])
     for (x ← 1 to n) yield {
       val timeout = stop - now
       val o = receiveOne(timeout)
-      assert(o != null, s"timeout ($max) while expecting $n messages (got ${x - 1})")
-      o
+      o match {
+        case Some(m) ⇒ m
+        case None    ⇒ assertFail(s"timeout ($max) while expecting $n messages (got ${x - 1})")
+      }
     }
   }
 


### PR DESCRIPTION
Semantic conflict between the changes in #25863 and #25801 not being tested together.

Fixes #26005