### PR TITLE
correct missprint in akka getting started guide #26020

### DIFF
--- a/akka-docs/src/test/scala/tutorial_2/IotApp.scala
+++ b/akka-docs/src/test/scala/tutorial_2/IotApp.scala
@@ -17,7 +17,7 @@ object IotApp {
 
     try {
       // Create top level supervisor
-      val supervisor = system.actorOf(IotSupervisor.props(), "iot-supervisor")
+      val supervisor = system.actorOf(IotSupervisor.props, "iot-supervisor")
       // Exit the system after ENTER is pressed
       StdIn.readLine()
     } finally {


### PR DESCRIPTION
I fixed missprint in the code of IotApp from Akka Getting Started Guide, Issue #26020
https://github.com/akka/akka/blob/v2.5.18/akka-docs/src/test/scala/tutorial_2/IotApp.scala
val supervisor = system.actorOf(IotSupervisor.props(), "iot-supervisor")
line 20, after IotSupervisor.props there should be no parentheses, because props does not take parameters.