### PR TITLE
Add a "discard" method on akka.Done/akka.Unused

### DIFF
--- a/akka-actor/src/main/scala/akka/Done.scala
+++ b/akka-actor/src/main/scala/akka/Done.scala
@@ -12,7 +12,16 @@ import akka.annotation.DoNotInherit
  * but there is no actual value completed. More clearly signals intent
  * than `Unit` and is available both from Scala and Java (which `Unit` is not).
  */
-@DoNotInherit sealed abstract class Done extends Serializable
+@DoNotInherit sealed abstract class Done extends Serializable {
+  /**
+   * Discard the value of Done.
+   * <p>
+   * <p>This is useful when using the -Ywarn-value-discard option of the scala compiler.
+   *
+   * @see https://docs.scala-lang.org/overviews/compiler-options/index.html#Warning_Settings
+   */
+  def discard(): Unit = ()
+}
 
 case object Done extends Done {
   /**

--- a/akka-actor/src/main/scala/akka/NotUsed.scala
+++ b/akka-actor/src/main/scala/akka/NotUsed.scala
@@ -10,7 +10,16 @@ package akka
  * used from the other language. An example use-case is the materialized value of an Akka Stream for cases
  * where no result shall be returned from materialization.
  */
-sealed abstract class NotUsed
+sealed abstract class NotUsed {
+  /**
+   * Discard the value of NotUsed.
+   * <p>
+   * <p>This is useful when using the -Ywarn-value-discard option of the scala compiler.
+   *
+   * @see https://docs.scala-lang.org/overviews/compiler-options/index.html#Warning_Settings
+   */
+  def discard(): Unit = ()
+}
 
 case object NotUsed extends NotUsed {
   /**


### PR DESCRIPTION
This allow for discarding their values, which is useful when using the `-Ywarn-value-discard` option of the scala compiler.

See https://docs.scala-lang.org/overviews/compiler-options/index.html#Warning_Settings