### PR TITLE
Fix 2.11 compilation

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/CapturedLogEvent.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/CapturedLogEvent.scala
@@ -50,11 +50,8 @@ object CapturedLogEvent {
 
   def apply(
     logLevel: LogLevel,
-    message:  String,
-    cause:    Option[Throwable] = None,
-    marker:   Option[LogMarker] = None,
-    mdc:      Map[String, Any]  = Map.empty): CapturedLogEvent = {
-    new CapturedLogEvent(logLevel, message, cause, marker, mdc)
+    message:  String): CapturedLogEvent = {
+    CapturedLogEvent(logLevel, message, None, None, Map.empty[String, Any])
   }
 
   /**


### PR DESCRIPTION
And avoid default params in a public api

For 2.11

```
[error] /localhome/jenkinsakka/workspace/akka-nightly-2.11/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/CapturedLogEvent.scala:20:18: method apply is defined twice
[error]   conflicting symbols both originated in file '/localhome/jenkinsakka/workspace/akka-nightly-2.11/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/CapturedLogEvent.scala'
[error] final case class CapturedLogEvent(
[error]                  ^
[error] one error found
```