### PR TITLE
Use type alias for readability

### DIFF
--- a/akka-docs/src/test/scala/docs/stream/FlowDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/FlowDocSpec.scala
@@ -160,45 +160,49 @@ class FlowDocSpec extends AkkaSpec with CompileOnlySpec {
     })
 
     //#flow-mat-combine
+    type SourceMat = Promise[Option[Int]]
+    type FlowMat = Cancellable
+    type SinkMat = Future[Int]
+
     // An source that can be signalled explicitly from the outside
-    val source: Source[Int, Promise[Option[Int]]] = Source.maybe[Int]
+    val source: Source[Int, SourceMat] = Source.maybe[Int]
 
     // A flow that internally throttles elements to 1/second, and returns a Cancellable
     // which can be used to shut down the stream
-    val flow: Flow[Int, Int, Cancellable] = throttler
+    val flow: Flow[Int, Int, FlowMat] = throttler
 
     // A sink that returns the first element of a stream in the returned Future
-    val sink: Sink[Int, Future[Int]] = Sink.head[Int]
+    val sink: Sink[Int, SinkMat] = Sink.head[Int]
 
     // By default, the materialized value of the leftmost stage is preserved
-    val r1: RunnableGraph[Promise[Option[Int]]] = source.via(flow).to(sink)
+    val r1: RunnableGraph[SourceMat] = source.via(flow).to(sink)
 
     // Simple selection of materialized values by using Keep.right
-    val r2: RunnableGraph[Cancellable] = source.viaMat(flow)(Keep.right).to(sink)
-    val r3: RunnableGraph[Future[Int]] = source.via(flow).toMat(sink)(Keep.right)
+    val r2: RunnableGraph[FlowMat] = source.viaMat(flow)(Keep.right).to(sink)
+    val r3: RunnableGraph[SinkMat] = source.via(flow).toMat(sink)(Keep.right)
 
     // Using runWith will always give the materialized values of the stages added
     // by runWith() itself
-    val r4: Future[Int] = source.via(flow).runWith(sink)
-    val r5: Promise[Option[Int]] = flow.to(sink).runWith(source)
-    val r6: (Promise[Option[Int]], Future[Int]) = flow.runWith(source, sink)
+    val r4: SinkMat = source.via(flow).runWith(sink)
+    val r5: SourceMat = flow.to(sink).runWith(source)
+    val r6: (SourceMat, SinkMat) = flow.runWith(source, sink)
 
     // Using more complex combinations
-    val r7: RunnableGraph[(Promise[Option[Int]], Cancellable)] =
+    val r7: RunnableGraph[(SourceMat, FlowMat)] =
       source.viaMat(flow)(Keep.both).to(sink)
 
-    val r8: RunnableGraph[(Promise[Option[Int]], Future[Int])] =
+    val r8: RunnableGraph[(SourceMat, SinkMat)] =
       source.via(flow).toMat(sink)(Keep.both)
 
-    val r9: RunnableGraph[((Promise[Option[Int]], Cancellable), Future[Int])] =
+    val r9: RunnableGraph[((SourceMat, FlowMat), SinkMat)] =
       source.viaMat(flow)(Keep.both).toMat(sink)(Keep.both)
 
-    val r10: RunnableGraph[(Cancellable, Future[Int])] =
+    val r10: RunnableGraph[(FlowMat, SinkMat)] =
       source.viaMat(flow)(Keep.right).toMat(sink)(Keep.both)
 
     // It is also possible to map over the materialized values. In r9 we had a
     // doubly nested pair, but we want to flatten it out
-    val r11: RunnableGraph[(Promise[Option[Int]], Cancellable, Future[Int])] =
+    val r11: RunnableGraph[(SourceMat, FlowMat, SinkMat)] =
       r9.mapMaterializedValue {
         case ((promise, cancellable), future) ⇒
           (promise, cancellable, future)
@@ -213,7 +217,7 @@ class FlowDocSpec extends AkkaSpec with CompileOnlySpec {
     future.map(_ + 3)
 
     // The result of r11 can be also achieved by using the Graph API
-    val r12: RunnableGraph[(Promise[Option[Int]], Cancellable, Future[Int])] =
+    val r12: RunnableGraph[(SourceMat, FlowMat, SinkMat)] =
       RunnableGraph.fromGraph(GraphDSL.create(source, flow, sink)((_, _, _)) { implicit builder ⇒ (src, f, dst) ⇒
         import GraphDSL.Implicits._
         src ~> f ~> dst


### PR DESCRIPTION
Instead of [presenting materialisation](https://doc.akka.io/docs/akka/current/stream/stream-flows-and-basics.html#stream-materialization) with code like:

```scala

// Simple selection of materialized values by using Keep.right
val r2: RunnableGraph[Cancellable] = source.viaMat(flow)(Keep.right).to(sink)
val r3: RunnableGraph[Future[Int]] = source.via(flow).toMat(sink)(Keep.right)
```

this PR introduces three `type` aliases:

```scala
type SourceMat = Promise[Option[Int]]
type FlowMat = Cancellable
type SinkMat = Future[Int]
```

so code snippets are a bit more clear:

```scala
// Simple selection of materialized values by using Keep.right
val r2: RunnableGraph[FlowMat] = source.viaMat(flow)(Keep.right).to(sink)
val r3: RunnableGraph[SinkMat] = source.via(flow).toMat(sink)(Keep.right)
```

Note: I haven't tried porting this improvement to Java. Any ideas on how or if this should be done for Java are more than welcome.