### PR TITLE
Parse akka.remote.log-frame-size-exceeding as bytes

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -28,7 +28,7 @@ final class RemoteSettings(val config: Config) {
 
   val LogFrameSizeExceeding: Option[Int] = {
     if (config.getString("akka.remote.log-frame-size-exceeding").toLowerCase == "off") None
-    else Some(getInt("akka.remote.log-frame-size-exceeding"))
+    else Some(getBytes("akka.remote.log-frame-size-exceeding").toInt)
   }
 
   val UntrustedMode: Boolean = getBoolean("akka.remote.untrusted-mode")

--- a/akka-remote/src/test/scala/akka/remote/RemoteSettingsSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteSettingsSpec.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.remote
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{ Matchers, WordSpec }
+
+class RemoteSettingsSpec extends WordSpec with Matchers {
+
+  "Remote settings" must {
+    "default akka.remote.log-frame-size-exceeding to off" in {
+      new RemoteSettings(ConfigFactory.load()).LogFrameSizeExceeding shouldEqual None
+    }
+
+    "parse akka.remote.log-frame-size-exceeding  value as bytes" in {
+      new RemoteSettings(ConfigFactory.parseString("akka.remote.log-frame-size-exceeding = 100b").withFallback(ConfigFactory.load())).LogFrameSizeExceeding shouldEqual Some(100)
+    }
+  }
+
+}


### PR DESCRIPTION
Missed in PR validation as only used in multi jvm tests