### PR TITLE
Simple JDK 11 fixes

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/CapacityLimitSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/CapacityLimitSpec.scala
@@ -17,7 +17,7 @@ class CapacityLimitSpec extends AkkaSpec("""
 
   "The TCP transport implementation" should {
 
-    "reply with CommandFailed to a Bind or Connect command if max-channels capacity has been reached" in new TestSetup {
+    "reply with CommandFailed to a Bind or Connect command if max-channels capacity has been reached" in new TestSetup(runClientInExtraSystem = false) {
       establishNewClientConnection()
 
       // we now have three channels registered: a listener, a server connection and a client connection

--- a/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpecSupport.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpecSupport.scala
@@ -11,10 +11,19 @@ import akka.actor.ActorRef
 import akka.io.Inet.SocketOption
 import akka.testkit.SocketUtil._
 import Tcp._
+import akka.actor.ActorSystem
+import akka.dispatch.ExecutionContexts
 
 trait TcpIntegrationSpecSupport { _: AkkaSpec ⇒
 
-  class TestSetup(shouldBindServer: Boolean = true) {
+  class TestSetup(shouldBindServer: Boolean = true, runClientInExtraSystem: Boolean = true) {
+    val clientSystem =
+      if (runClientInExtraSystem) {
+        val res = ActorSystem("TcpIntegrationSpec-client", system.settings.config)
+        // terminate clientSystem after server system
+        system.whenTerminated.onComplete { _ ⇒ res.terminate() }(ExecutionContexts.sameThreadExecutionContext)
+        res
+      } else system
     val bindHandler = TestProbe()
     val endpoint = temporaryServerAddress()
 
@@ -27,10 +36,10 @@ trait TcpIntegrationSpecSupport { _: AkkaSpec ⇒
     }
 
     def establishNewClientConnection(): (TestProbe, ActorRef, TestProbe, ActorRef) = {
-      val connectCommander = TestProbe()
-      connectCommander.send(IO(Tcp), Connect(endpoint, options = connectOptions))
+      val connectCommander = TestProbe()(clientSystem)
+      connectCommander.send(IO(Tcp)(clientSystem), Connect(endpoint, options = connectOptions))
       val Connected(`endpoint`, localAddress) = connectCommander.expectMsgType[Connected]
-      val clientHandler = TestProbe()
+      val clientHandler = TestProbe()(clientSystem)
       connectCommander.sender() ! Register(clientHandler.ref)
 
       val Connected(`localAddress`, `endpoint`) = bindHandler.expectMsgType[Connected]

--- a/akka-actor-tests/src/test/scala/akka/io/dns/AsyncDnsResolverIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/AsyncDnsResolverIntegrationSpec.scala
@@ -10,6 +10,7 @@ import akka.io.dns.DnsProtocol.{ Ip, RequestType, Srv }
 import akka.io.{ Dns, IO }
 import CachePolicy.Ttl
 import akka.pattern.ask
+import akka.testkit.WithLogCapturing
 import akka.testkit.{ AkkaSpec, SocketUtil }
 import akka.util.Timeout
 
@@ -25,10 +26,11 @@ test starts and tear it down when it finishes.
 class AsyncDnsResolverIntegrationSpec extends AkkaSpec(
   s"""
     akka.loglevel = DEBUG
+    akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
     akka.io.dns.resolver = async-dns
     akka.io.dns.async-dns.nameservers = ["localhost:${AsyncDnsResolverIntegrationSpec.dockerDnsServerPort}"]
 //    akka.io.dns.async-dns.nameservers = default
-  """) with DockerBindDnsService {
+  """) with DockerBindDnsService with WithLogCapturing {
   val duration = 10.seconds
   implicit val timeout = Timeout(duration)
 

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsManagerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsManagerSpec.scala
@@ -10,6 +10,7 @@ import akka.io.Dns
 import akka.io.dns.AAAARecord
 import akka.io.dns.DnsProtocol.{ Resolve, Resolved }
 import akka.io.dns.CachePolicy.Ttl
+import akka.testkit.WithLogCapturing
 import akka.testkit.{ AkkaSpec, ImplicitSender }
 
 import scala.collection.immutable.Seq
@@ -17,9 +18,10 @@ import scala.collection.immutable.Seq
 class AsyncDnsManagerSpec extends AkkaSpec(
   """
     akka.loglevel = DEBUG
+    akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
     akka.io.dns.resolver = async-dns
     akka.io.dns.async-dns.nameservers = default
-  """) with ImplicitSender {
+  """) with ImplicitSender with WithLogCapturing {
 
   val dns = Dns(system).manager
 

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsResolverSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsResolverSpec.scala
@@ -15,14 +15,17 @@ import akka.io.dns.internal.DnsClient.{ Answer, Question4, Question6, SrvQuestio
 import akka.io.dns.{ AAAARecord, ARecord, DnsSettings, SRVRecord }
 import akka.testkit.{ AkkaSpec, ImplicitSender, TestProbe }
 import com.typesafe.config.ConfigFactory
+import akka.testkit.WithLogCapturing
 
+import scala.concurrent.duration._
 import scala.collection.{ immutable ⇒ im }
 import scala.concurrent.duration._
 
 class AsyncDnsResolverSpec extends AkkaSpec(
   """
-    akka.loglevel = INFO
-  """) with ImplicitSender {
+    akka.loglevel = DEBUG
+    akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+  """) with ImplicitSender with WithLogCapturing {
 
   "Async DNS Resolver" must {
 

--- a/akka-actor/src/main/scala/akka/util/JavaVersion.scala
+++ b/akka-actor/src/main/scala/akka/util/JavaVersion.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object JavaVersion {
+
+  val majorVersion: Int = {
+    // FIXME replace with Runtime.version() when we no longer support Java 8
+    // See Oracle section 1.5.3 at:
+    // https://docs.oracle.com/javase/8/docs/technotes/guides/versioning/spec/versioning2.html
+    val version = System.getProperty("java.specification.version").split('.')
+
+    val majorString =
+      if (version(0) == "1") version(1) // Java 8 will be 1.8
+      else version(0) // later will be 9, 10, 11 etc
+
+    majorString.toInt
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -153,7 +153,7 @@ object Dependencies {
   val actorTests = l ++= Seq(
     Test.junit, Test.scalatest.value, Test.commonsCodec, Test.commonsMath,
     Test.mockito, Test.scalacheck.value, Test.jimfs,
-    Test.dockerClient
+    Test.dockerClient, Provided.activation // dockerClient needs javax.activation.DataSource in JDK 11+
   )
 
   val actorTestkitTyped = l ++= Seq(Provided.junit, Provided.scalatest.value)


### PR DESCRIPTION
These are the small and and simple parts of fixes for JDK 11, split out from #25923 for easier digestion.

Refs #25733.