### PR TITLE
Slf4jLogger expects also null as a marker to support Warning4 events

### DIFF
--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -833,6 +833,7 @@ object Logging {
 
   /** INTERNAL API, Marker interface for LogEvents containing Markers, which can be set for example on an slf4j logger */
   sealed trait LogEventWithMarker extends LogEvent {
+    /** Marker attribute is nullable due to backward binary compatibility in the class `Warning4` */
     def marker: LogMarker
     /** Appends the marker to the Debug/Info/Warning/Error toString representations */
     override def toString = {

--- a/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
@@ -113,6 +113,7 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
     event match {
       case m: LogEventWithMarker ⇒
         m.marker match {
+          case null                        ⇒ null
           case slf4jMarker: Slf4jLogMarker ⇒ slf4jMarker.marker
           case marker                      ⇒ MarkerFactory.getMarker(marker.name)
         }

--- a/akka-slf4j/src/test/scala/akka/event/slf4j/Slf4jLoggerSpec.scala
+++ b/akka-slf4j/src/test/scala/akka/event/slf4j/Slf4jLoggerSpec.scala
@@ -155,6 +155,14 @@ class Slf4jLoggerSpec extends AkkaSpec(Slf4jLoggerSpec.config) with BeforeAndAft
       s should include("msg=[Message with custom MDC values]")
     }
 
+    "support null marker" in {
+      producer ! StringWithMarker("security-wise interesting message", null)
+
+      awaitCond(outputString.contains("----"), 5 seconds)
+      val s = outputString
+      s should include("msg=[security-wise interesting message]")
+    }
+
     "Support null values in custom MDC" in {
       producer ! StringWithMDC("Message with null custom MDC values", Map("ticketNumber" → 3671, "ticketDesc" → null))
 


### PR DESCRIPTION
Fixes #26042 

The binary compatible fix not changing the signature (see the discussion).

I've also implemented a binary incompatible fix [here](https://github.com/KarelCemus/akka/commit/652ca013fd671ab8f00792d79b5375a2a987cf77). Should I open another PR? What would be a target branch?