### PR TITLE
Add forgotten `expectNoMessage` method in StreamTestKit

### DIFF
--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -144,6 +144,14 @@ object TestPublisher {
     }
 
     /**
+      * Expect no messages.
+      */
+    def expectNoMessage(): Self = executeAfterSubscription {
+      probe.expectNoMessage()
+      self
+    }
+
+    /**
      * Expect no messages for a given duration.
      */
     def expectNoMessage(max: FiniteDuration): Self = executeAfterSubscription {

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -144,8 +144,8 @@ object TestPublisher {
     }
 
     /**
-      * Expect no messages.
-      */
+     * Expect no messages.
+     */
     def expectNoMessage(): Self = executeAfterSubscription {
       probe.expectNoMessage()
       self


### PR DESCRIPTION
As discovered during https://github.com/akka/akka-http/pull/2292#discussion_r239473817 the parameterless version of `expectNoMessage` in StreamTestKit is missing.