### PR TITLE
Akka-typed-testkit: Provides a way of stopping actors

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestKitUtils.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestKitUtils.scala
@@ -21,6 +21,7 @@ private[akka] object ActorTestKitGuardian {
   final case class SpawnActor[T](name: String, behavior: Behavior[T], replyTo: ActorRef[ActorRef[T]], props: Props) extends TestKitCommand
   final case class SpawnActorAnonymous[T](behavior: Behavior[T], replyTo: ActorRef[ActorRef[T]], props: Props) extends TestKitCommand
   final case class StopActor[T](ref: ActorRef[T], replyTo: ActorRef[Ack.type]) extends TestKitCommand
+  final case class ActorStopped[T](replyTo: ActorRef[Ack.type]) extends TestKitCommand
 
   final case object Ack
 
@@ -32,7 +33,10 @@ private[akka] object ActorTestKitGuardian {
       reply ! context.spawnAnonymous(behavior, props)
       Behaviors.same
     case (context, StopActor(ref, reply)) ⇒
+      context.watchWith(ref, ActorStopped(reply))
       context.stop(ref)
+      Behaviors.same
+    case (_, ActorStopped(reply)) ⇒
       reply ! Ack
       Behaviors.same
   }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
@@ -152,9 +152,13 @@ final class ActorTestKit private[akka] (delegate: akka.actor.testkit.typed.scala
    */
   def spawn[T](behavior: Behavior[T], name: String, props: Props): ActorRef[T] = delegate.spawn(behavior, name, props)
   /**
-   * Stop actor under test. To make sure it stopped, use [[TestProbe#expectTerminated]] method.
+   * Stop the actor under test and wait until it terminates.
    */
   def stop[T](ref: ActorRef[T]): Unit = delegate.stop(ref)
+  /**
+   * Stop the actor under test and wait `max` until it terminates.
+   */
+  def stop[T](ref: ActorRef[T], max: Duration): Unit = delegate.stop(ref, max.asScala)
 
   /**
    * Shortcut for creating a new test probe for the testkit actor system

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
@@ -151,6 +151,10 @@ final class ActorTestKit private[akka] (delegate: akka.actor.testkit.typed.scala
    * for the spawned actor, note that spawning actors with the same name in multiple test cases will cause failures.
    */
   def spawn[T](behavior: Behavior[T], name: String, props: Props): ActorRef[T] = delegate.spawn(behavior, name, props)
+  /**
+   * Stop actor under test. To make sure it stopped, use [[TestProbe#expectTerminated]] method.
+   */
+  def stop[T](ref: ActorRef[T]): Unit = delegate.stop(ref)
 
   /**
    * Shortcut for creating a new test probe for the testkit actor system

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -174,6 +174,12 @@ final class ActorTestKit private[akka] (val name: String, val config: Config, se
     Await.result(internalSystem ? (ActorTestKitGuardian.SpawnActor(name, behavior, _, props)), timeout.duration)
 
   /**
+   * Stop the actor under test. To make sure it stopped, use [[TestProbe#expectTerminated]] method.
+   */
+  def stop[T](ref: ActorRef[T]): Unit =
+    Await.result(internalSystem ? { x: ActorRef[ActorTestKitGuardian.Ack.type] ⇒ ActorTestKitGuardian.StopActor(ref, x) }, timeout.duration)
+
+  /**
    * Shortcut for creating a new test probe for the testkit actor system
    * @tparam M the type of messages the probe should accept
    */

--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java
@@ -88,21 +88,18 @@ public class AsyncTestingExampleTest {
 
   @Test
   public void testStoppingActors() {
-    Duration termTime = Duration.ofSeconds(5);
     TestProbe<Pong> probe = testKit.createTestProbe();
     //#test-stop-actors
     ActorRef<Ping> pinger1 = testKit.spawn(echoActor, "pinger");
     pinger1.tell(new Ping("hello", probe.ref()));
     probe.expectMessage(new Pong("hello"));
     testKit.stop(pinger1);
-    probe.expectTerminated(pinger1, termTime);
 
     // Immediately creating an actor with the same name
     ActorRef<Ping> pinger2 = testKit.spawn(echoActor, "pinger");
     pinger2.tell(new Ping("hello", probe.ref()));
     probe.expectMessage(new Pong("hello"));
-    testKit.stop(pinger2);
-    probe.expectTerminated(pinger2, termTime);
+    testKit.stop(pinger2, Duration.ofSeconds(10));
     //#test-stop-actors
   }
 

--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java
@@ -12,6 +12,9 @@ import akka.actor.testkit.typed.javadsl.TestProbe;
 import org.junit.AfterClass;
 import org.junit.Test;
 
+import java.time.Duration;
+import java.util.Objects;
+
 import static org.junit.Assert.assertEquals;
 
 //#test-header
@@ -35,6 +38,19 @@ public class AsyncTestingExampleTest {
     public Pong(String message) {
       this.message = message;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof Pong)) return false;
+      Pong pong = (Pong) o;
+      return message.equals(pong.message);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(message);
+    }
   }
 
   Behavior<Ping> echoActor = Behaviors.receive((context, ping) -> {
@@ -45,7 +61,7 @@ public class AsyncTestingExampleTest {
 
   //#test-shutdown
   @AfterClass
-  public void cleanup() {
+  public static void cleanup() {
     testKit.shutdownTestKit();
   }
   //#test-shutdown
@@ -68,6 +84,25 @@ public class AsyncTestingExampleTest {
     TestProbe<Pong> probe = testKit.createTestProbe();
     pinger.tell(new Ping("hello", probe.ref()));
     probe.expectMessage(new Pong("hello"));
+  }
+
+  @Test
+  public void testStoppingActors() {
+    Duration termTime = Duration.ofSeconds(5);
+    TestProbe<Pong> probe = testKit.createTestProbe();
+
+    ActorRef<Ping> pinger1 = testKit.spawn(echoActor, "pinger");
+    pinger1.tell(new Ping("hello", probe.ref()));
+    probe.expectMessage(new Pong("hello"));
+    testKit.stop(pinger1);
+    probe.expectTerminated(pinger1, termTime);
+
+    // Immediately creating an actor with the same name
+    ActorRef<Ping> pinger2 = testKit.spawn(echoActor, "pinger");
+    pinger2.tell(new Ping("hello", probe.ref()));
+    probe.expectMessage(new Pong("hello"));
+    testKit.stop(pinger2);
+    probe.expectTerminated(pinger2, termTime);
   }
 
   @Test

--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java
@@ -90,7 +90,7 @@ public class AsyncTestingExampleTest {
   public void testStoppingActors() {
     Duration termTime = Duration.ofSeconds(5);
     TestProbe<Pong> probe = testKit.createTestProbe();
-
+    //#test-stop-actors
     ActorRef<Ping> pinger1 = testKit.spawn(echoActor, "pinger");
     pinger1.tell(new Ping("hello", probe.ref()));
     probe.expectMessage(new Pong("hello"));
@@ -103,6 +103,7 @@ public class AsyncTestingExampleTest {
     probe.expectMessage(new Pong("hello"));
     testKit.stop(pinger2);
     probe.expectTerminated(pinger2, termTime);
+    //#test-stop-actors
   }
 
   @Test

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala
@@ -53,21 +53,19 @@ class AsyncTestingExampleSpec extends WordSpec with BeforeAndAfterAll {
     }
 
     "be able to stop actors under test" in {
-      val termTime = 5.seconds
+      // Will fail with 'name not unique' exception if the first actor is not fully stopped
       val probe = testKit.createTestProbe[Pong]()
       //#test-stop-actors
       val pinger1 = testKit.spawn(echoActor, "pinger")
       pinger1 ! Ping("hello", probe.ref)
       probe.expectMessage(Pong("hello"))
-      testKit.stop(pinger1)
-      probe.expectTerminated(pinger1, termTime)
+      testKit.stop(pinger1) // Uses default timeout
 
       // Immediately creating an actor with the same name
       val pinger2 = testKit.spawn(echoActor, "pinger")
       pinger2 ! Ping("hello", probe.ref)
       probe.expectMessage(Pong("hello"))
-      testKit.stop(pinger2)
-      probe.expectTerminated(pinger2, termTime)
+      testKit.stop(pinger2, 10.seconds) // Custom timeout
       //#test-stop-actors
     }
   }

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala
@@ -55,7 +55,7 @@ class AsyncTestingExampleSpec extends WordSpec with BeforeAndAfterAll {
     "be able to stop actors under test" in {
       val termTime = 5.seconds
       val probe = testKit.createTestProbe[Pong]()
-
+      //#test-stop-actors
       val pinger1 = testKit.spawn(echoActor, "pinger")
       pinger1 ! Ping("hello", probe.ref)
       probe.expectMessage(Pong("hello"))
@@ -68,6 +68,7 @@ class AsyncTestingExampleSpec extends WordSpec with BeforeAndAfterAll {
       probe.expectMessage(Pong("hello"))
       testKit.stop(pinger2)
       probe.expectTerminated(pinger2, termTime)
+      //#test-stop-actors
     }
   }
 

--- a/akka-docs/src/main/paradox/typed/testing.md
+++ b/akka-docs/src/main/paradox/typed/testing.md
@@ -199,6 +199,15 @@ Scala
 Java
 :  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-spawn-anonymous }
 
+#### Stopping actors
+To make sure an actor is stopped, use `TestProbe#expectTerminated` method.
+
+Scala
+:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #test-stop-actors }
+
+Java
+:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-stop-actors }
+
 Note that you can add `import testKit._` to get access to the `spawn` and `createTestProbe` methods at the top level
 without prefixing them with `testKit`.
 

--- a/akka-docs/src/main/paradox/typed/testing.md
+++ b/akka-docs/src/main/paradox/typed/testing.md
@@ -199,8 +199,11 @@ Scala
 Java
 :  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-spawn-anonymous }
 
+Note that you can add `import testKit._` to get access to the `spawn` and `createTestProbe` methods at the top level
+without prefixing them with `testKit`.
+
 #### Stopping actors
-To make sure an actor is stopped, use `TestProbe#expectTerminated` method.
+The method will wait until the actor stops or throw an assertion error in case of a timeout.
 
 Scala
 :  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #test-stop-actors }
@@ -208,8 +211,6 @@ Scala
 Java
 :  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-stop-actors }
 
-Note that you can add `import testKit._` to get access to the `spawn` and `createTestProbe` methods at the top level
-without prefixing them with `testKit`.
 
 ### Test framework integration
 


### PR DESCRIPTION
This PR adds  the `stop()` method to the `ActorTestKit`. ~~To make sure the actor is stopped, one can use the `TestProbe#expectTerminated` method.~~ If accepted, I believe the #24165 could be closed.