### PR TITLE
Import `akka.actor` as `untyped` but not `a`.

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -10,7 +10,7 @@ import akka.actor.typed.internal.ActorRefImpl
 import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, DispatcherSelector, Dispatchers, Extension, ExtensionId, Logger, Props, Settings, Terminated }
 import akka.annotation.InternalApi
 import akka.util.Timeout
-import akka.{ actor ⇒ a }
+import akka.{ actor ⇒ untyped }
 import com.typesafe.config.ConfigFactory
 import scala.compat.java8.FutureConverters
 import scala.concurrent._
@@ -24,7 +24,7 @@ import akka.actor.typed.internal.InternalRecipientRef
 @InternalApi private[akka] final class ActorSystemStub(val name: String)
   extends ActorSystem[Nothing] with ActorRef[Nothing] with ActorRefImpl[Nothing] with InternalRecipientRef[Nothing] {
 
-  override val path: a.ActorPath = a.RootActorPath(a.Address("akka", name)) / "user"
+  override val path: untyped.ActorPath = untyped.RootActorPath(untyped.Address("akka", name)) / "user"
 
   override val settings: Settings = new Settings(getClass.getClassLoader, ConfigFactory.empty, name)
 
@@ -51,11 +51,11 @@ import akka.actor.typed.internal.InternalRecipientRef
     def shutdown(): Unit = ()
   }
 
-  override def dynamicAccess: a.DynamicAccess = new a.ReflectiveDynamicAccess(getClass.getClassLoader)
+  override def dynamicAccess: untyped.DynamicAccess = new untyped.ReflectiveDynamicAccess(getClass.getClassLoader)
 
   override def logConfiguration(): Unit = log.info(settings.toString)
 
-  override def scheduler: a.Scheduler = throw new UnsupportedOperationException("no scheduler")
+  override def scheduler: untyped.Scheduler = throw new UnsupportedOperationException("no scheduler")
 
   private val terminationPromise = Promise[Terminated]
   override def terminate(): Future[akka.actor.typed.Terminated] = {

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/DebugRef.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/DebugRef.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import akka.actor.typed.ActorRef
 import akka.actor.typed.internal.{ ActorRefImpl, SystemMessage }
 import akka.annotation.InternalApi
-import akka.{ actor ⇒ a }
+import akka.{ actor ⇒ untyped }
 import scala.annotation.tailrec
 
 import akka.actor.ActorRefProvider
@@ -18,7 +18,7 @@ import akka.actor.typed.internal.InternalRecipientRef
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] final class DebugRef[T](override val path: a.ActorPath, override val isLocal: Boolean)
+@InternalApi private[akka] final class DebugRef[T](override val path: untyped.ActorPath, override val isLocal: Boolean)
   extends ActorRef[T] with ActorRefImpl[T] with InternalRecipientRef[T] {
 
   private val q = new ConcurrentLinkedQueue[Either[SystemMessage, T]]

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -85,7 +85,7 @@ class AskSpec extends ScalaTestWithActorTestKit("""
       val noSuchActor: ActorRef[Msg] = system match {
         case adaptedSys: ActorSystemAdapter[_] ⇒
           import akka.actor.typed.scaladsl.adapter._
-          adaptedSys.untyped.provider.resolveActorRef("/foo/bar")
+          adaptedSys.untypedSystem.provider.resolveActorRef("/foo/bar")
         case _ ⇒
           fail("this test must only run in an adapted actor system")
       }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorRef.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorRef.scala
@@ -5,7 +5,7 @@
 package akka.actor.typed
 
 import akka.annotation.DoNotInherit
-import akka.{ actor ⇒ a }
+import akka.{ actor ⇒ untyped }
 import scala.annotation.unchecked.uncheckedVariance
 
 import akka.actor.typed.internal.InternalRecipientRef
@@ -48,7 +48,7 @@ trait ActorRef[-T] extends RecipientRef[T] with java.lang.Comparable[ActorRef[_]
    * and more than one Actor instance can exist with the same path at different
    * points in time, but not concurrently.
    */
-  def path: a.ActorPath
+  def path: untyped.ActorPath
 
   @throws(classOf[java.io.ObjectStreamException])
   private def writeReplace(): AnyRef = SerializedActorRef[T](this)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
@@ -9,7 +9,7 @@ package adapter
 import akka.actor.ExtendedActorSystem
 import akka.annotation.InternalApi
 import akka.util.OptionVal
-import akka.{ ConfigurationException, actor ⇒ a }
+import akka.{ ConfigurationException, actor ⇒ untyped }
 
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
@@ -17,31 +17,31 @@ import scala.concurrent.duration._
 /**
  * INTERNAL API. Wrapping an [[akka.actor.ActorContext]] as an [[TypedActorContext]].
  */
-@InternalApi private[akka] final class ActorContextAdapter[T](val untyped: a.ActorContext) extends ActorContextImpl[T] {
+@InternalApi private[akka] final class ActorContextAdapter[T](val untypedContext: untyped.ActorContext) extends ActorContextImpl[T] {
 
   import ActorRefAdapter.toUntyped
 
   // lazily initialized
   private var actorLogger: OptionVal[Logger] = OptionVal.None
 
-  final override val self = ActorRefAdapter(untyped.self)
-  final override val system = ActorSystemAdapter(untyped.system)
-  override def children = untyped.children.map(ActorRefAdapter(_))
-  override def child(name: String) = untyped.child(name).map(ActorRefAdapter(_))
-  override def spawnAnonymous[U](behavior: Behavior[U], props: Props = Props.empty) =
-    ActorContextAdapter.spawnAnonymous(untyped, behavior, props)
-  override def spawn[U](behavior: Behavior[U], name: String, props: Props = Props.empty) =
-    ActorContextAdapter.spawn(untyped, behavior, name, props)
+  final override val self = ActorRefAdapter(untypedContext.self)
+  final override val system = ActorSystemAdapter(untypedContext.system)
+  override def children: Iterable[ActorRef[Nothing]] = untypedContext.children.map(ActorRefAdapter(_))
+  override def child(name: String): Option[ActorRef[Nothing]] = untypedContext.child(name).map(ActorRefAdapter(_))
+  override def spawnAnonymous[U](behavior: Behavior[U], props: Props = Props.empty): ActorRef[U] =
+    ActorContextAdapter.spawnAnonymous(untypedContext, behavior, props)
+  override def spawn[U](behavior: Behavior[U], name: String, props: Props = Props.empty): ActorRef[U] =
+    ActorContextAdapter.spawn(untypedContext, behavior, name, props)
   override def stop[U](child: ActorRef[U]): Unit =
     if (child.path.parent == self.path) { // only if a direct child
       toUntyped(child) match {
         case f: akka.actor.FunctionRef ⇒
-          val cell = untyped.asInstanceOf[akka.actor.ActorCell]
+          val cell = untypedContext.asInstanceOf[akka.actor.ActorCell]
           cell.removeFunctionRef(f)
         case c ⇒
-          untyped.child(child.path.name) match {
+          untypedContext.child(child.path.name) match {
             case Some(`c`) ⇒
-              untyped.stop(c)
+              untypedContext.stop(c)
             case _ ⇒
             // child that was already stopped
           }
@@ -59,27 +59,27 @@ import scala.concurrent.duration._
           "an explicit stop message that the actor accepts.")
     }
 
-  override def watch[U](other: ActorRef[U]) = { untyped.watch(toUntyped(other)) }
-  override def watchWith[U](other: ActorRef[U], msg: T) = { untyped.watchWith(toUntyped(other), msg) }
-  override def unwatch[U](other: ActorRef[U]) = { untyped.unwatch(toUntyped(other)) }
+  override def watch[U](other: ActorRef[U]): Unit = { untypedContext.watch(toUntyped(other)) }
+  override def watchWith[U](other: ActorRef[U], msg: T): Unit = { untypedContext.watchWith(toUntyped(other), msg) }
+  override def unwatch[U](other: ActorRef[U]): Unit = { untypedContext.unwatch(toUntyped(other)) }
   var receiveTimeoutMsg: T = null.asInstanceOf[T]
-  override def setReceiveTimeout(d: FiniteDuration, msg: T) = {
+  override def setReceiveTimeout(d: FiniteDuration, msg: T): Unit = {
     receiveTimeoutMsg = msg
-    untyped.setReceiveTimeout(d)
+    untypedContext.setReceiveTimeout(d)
   }
   override def cancelReceiveTimeout(): Unit = {
     receiveTimeoutMsg = null.asInstanceOf[T]
-    untyped.setReceiveTimeout(Duration.Undefined)
+    untypedContext.setReceiveTimeout(Duration.Undefined)
   }
-  override def executionContext: ExecutionContextExecutor = untyped.dispatcher
-  override def scheduleOnce[U](delay: FiniteDuration, target: ActorRef[U], msg: U): a.Cancellable = {
-    import untyped.dispatcher
-    untyped.system.scheduler.scheduleOnce(delay, toUntyped(target), msg)
+  override def executionContext: ExecutionContextExecutor = untypedContext.dispatcher
+  override def scheduleOnce[U](delay: FiniteDuration, target: ActorRef[U], msg: U): untyped.Cancellable = {
+    import untypedContext.dispatcher
+    untypedContext.system.scheduler.scheduleOnce(delay, toUntyped(target), msg)
   }
   override private[akka] def internalSpawnMessageAdapter[U](f: U ⇒ T, _name: String): ActorRef[U] = {
-    val cell = untyped.asInstanceOf[akka.actor.ActorCell]
+    val cell = untypedContext.asInstanceOf[akka.actor.ActorCell]
     // apply the function inside the actor by wrapping the msg and f, handled by ActorAdapter
-    val ref = cell.addFunctionRef((_, msg) ⇒ untyped.self ! AdaptMessage[U, T](msg.asInstanceOf[U], f), _name)
+    val ref = cell.addFunctionRef((_, msg) ⇒ untypedContext.self ! AdaptMessage[U, T](msg.asInstanceOf[U], f), _name)
     ActorRefAdapter[U](ref)
   }
 
@@ -88,8 +88,8 @@ import scala.concurrent.duration._
       case OptionVal.Some(logger) ⇒ logger
       case OptionVal.None ⇒
         val logSource = self.path.toString
-        val logClass = classOf[Behavior[_]] // FIXME figure out a better class somehow
-        val system = untyped.system.asInstanceOf[ExtendedActorSystem]
+        val logClass = classOf[Behavior[_]] // FIXME figure out untyped better class somehow
+        val system = untypedContext.system.asInstanceOf[ExtendedActorSystem]
         val logger = new LoggerAdapterImpl(system.eventStream, logClass, logSource, system.logFilter)
         actorLogger = OptionVal.Some(logger)
         logger
@@ -102,46 +102,46 @@ import scala.concurrent.duration._
  */
 @InternalApi private[typed] object ActorContextAdapter {
 
-  private def toUntypedImp[U](ctx: TypedActorContext[_]): a.ActorContext =
-    ctx match {
-      case adapter: ActorContextAdapter[_] ⇒ adapter.untyped
+  private def toUntypedImp[U](context: TypedActorContext[_]): untyped.ActorContext =
+    context match {
+      case adapter: ActorContextAdapter[_] ⇒ adapter.untypedContext
       case _ ⇒
         throw new UnsupportedOperationException("only adapted untyped ActorContext permissible " +
-          s"($ctx of class ${ctx.getClass.getName})")
+          s"($context of class ${context.getClass.getName})")
     }
 
-  def toUntyped2[U](ctx: TypedActorContext[_]): a.ActorContext = toUntypedImp(ctx)
+  def toUntyped2[U](context: TypedActorContext[_]): untyped.ActorContext = toUntypedImp(context)
 
-  def toUntyped[U](ctx: scaladsl.ActorContext[_]): a.ActorContext =
-    ctx match {
+  def toUntyped[U](context: scaladsl.ActorContext[_]): untyped.ActorContext =
+    context match {
       case c: TypedActorContext[_] ⇒ toUntypedImp(c)
       case _ ⇒
         throw new UnsupportedOperationException("unknown ActorContext type " +
-          s"($ctx of class ${ctx.getClass.getName})")
+          s"($context of class ${context.getClass.getName})")
     }
 
-  def toUntyped[U](ctx: javadsl.ActorContext[_]): a.ActorContext =
-    ctx match {
+  def toUntyped[U](context: javadsl.ActorContext[_]): untyped.ActorContext =
+    context match {
       case c: TypedActorContext[_] ⇒ toUntypedImp(c)
       case _ ⇒
         throw new UnsupportedOperationException("unknown ActorContext type " +
-          s"($ctx of class ${ctx.getClass.getName})")
+          s"($context of class ${context.getClass.getName})")
     }
 
-  def spawnAnonymous[T](ctx: akka.actor.ActorContext, behavior: Behavior[T], props: Props): ActorRef[T] = {
+  def spawnAnonymous[T](context: akka.actor.ActorContext, behavior: Behavior[T], props: Props): ActorRef[T] = {
     try {
       Behavior.validateAsInitial(behavior)
-      ActorRefAdapter(ctx.actorOf(PropsAdapter(() ⇒ behavior, props)))
+      ActorRefAdapter(context.actorOf(PropsAdapter(() ⇒ behavior, props)))
     } catch {
       case ex: ConfigurationException if ex.getMessage.startsWith("configuration requested remote deployment") ⇒
         throw new ConfigurationException("Remote deployment not allowed for typed actors", ex)
     }
   }
 
-  def spawn[T](ctx: akka.actor.ActorContext, behavior: Behavior[T], name: String, props: Props): ActorRef[T] = {
+  def spawn[T](context: akka.actor.ActorContext, behavior: Behavior[T], name: String, props: Props): ActorRef[T] = {
     try {
       Behavior.validateAsInitial(behavior)
-      ActorRefAdapter(ctx.actorOf(PropsAdapter(() ⇒ behavior, props), name))
+      ActorRefAdapter(context.actorOf(PropsAdapter(() ⇒ behavior, props), name))
     } catch {
       case ex: ConfigurationException if ex.getMessage.startsWith("configuration requested remote deployment") ⇒
         throw new ConfigurationException("Remote deployment not allowed for typed actors", ex)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala
@@ -8,60 +8,60 @@ package adapter
 
 import akka.actor.ActorRefProvider
 import akka.actor.InvalidMessageException
-import akka.{ actor ⇒ a }
+import akka.{ actor ⇒ untyped }
 import akka.annotation.InternalApi
 import akka.dispatch.sysmsg
 
 /**
  * INTERNAL API
  */
-@InternalApi private[typed] class ActorRefAdapter[-T](val untyped: a.InternalActorRef)
+@InternalApi private[typed] class ActorRefAdapter[-T](val untypedRef: untyped.InternalActorRef)
   extends ActorRef[T] with internal.ActorRefImpl[T] with internal.InternalRecipientRef[T] {
 
-  override def path: a.ActorPath = untyped.path
+  override def path: untyped.ActorPath = untypedRef.path
 
   override def tell(msg: T): Unit = {
     if (msg == null) throw new InvalidMessageException("[null] is not an allowed message")
-    untyped ! msg
+    untypedRef ! msg
   }
 
   // impl ActorRefImpl
-  override def isLocal: Boolean = untyped.isLocal
+  override def isLocal: Boolean = untypedRef.isLocal
   // impl ActorRefImpl
   override def sendSystem(signal: internal.SystemMessage): Unit =
-    ActorRefAdapter.sendSystemMessage(untyped, signal)
+    ActorRefAdapter.sendSystemMessage(untypedRef, signal)
 
   // impl InternalRecipientRef
-  override def provider: ActorRefProvider = untyped.provider
+  override def provider: ActorRefProvider = untypedRef.provider
   // impl InternalRecipientRef
-  def isTerminated: Boolean = untyped.isTerminated
+  def isTerminated: Boolean = untypedRef.isTerminated
 
   @throws(classOf[java.io.ObjectStreamException])
   private def writeReplace(): AnyRef = SerializedActorRef[T](this)
 }
 
 private[akka] object ActorRefAdapter {
-  def apply[T](untyped: a.ActorRef): ActorRef[T] = new ActorRefAdapter(untyped.asInstanceOf[a.InternalActorRef])
+  def apply[T](ref: untyped.ActorRef): ActorRef[T] = new ActorRefAdapter(ref.asInstanceOf[untyped.InternalActorRef])
 
   def toUntyped[U](ref: ActorRef[U]): akka.actor.InternalActorRef =
     ref match {
-      case adapter: ActorRefAdapter[_]   ⇒ adapter.untyped
-      case system: ActorSystemAdapter[_] ⇒ system.untyped.guardian
+      case adapter: ActorRefAdapter[_]   ⇒ adapter.untypedRef
+      case system: ActorSystemAdapter[_] ⇒ system.untypedSystem.guardian
       case _ ⇒
         throw new UnsupportedOperationException("only adapted untyped ActorRefs permissible " +
           s"($ref of class ${ref.getClass.getName})")
     }
 
-  def sendSystemMessage(untyped: akka.actor.InternalActorRef, signal: internal.SystemMessage): Unit =
+  def sendSystemMessage(untypedRef: akka.actor.InternalActorRef, signal: internal.SystemMessage): Unit =
     signal match {
       case internal.Create()    ⇒ throw new IllegalStateException("WAT? No, seriously.")
-      case internal.Terminate() ⇒ untyped.stop()
-      case internal.Watch(watchee, watcher) ⇒ untyped.sendSystemMessage(
+      case internal.Terminate() ⇒ untypedRef.stop()
+      case internal.Watch(watchee, watcher) ⇒ untypedRef.sendSystemMessage(
         sysmsg.Watch(
           toUntyped(watchee),
           toUntyped(watcher)))
-      case internal.Unwatch(watchee, watcher)      ⇒ untyped.sendSystemMessage(sysmsg.Unwatch(toUntyped(watchee), toUntyped(watcher)))
-      case internal.DeathWatchNotification(ref, _) ⇒ untyped.sendSystemMessage(sysmsg.DeathWatchNotification(toUntyped(ref), true, false))
+      case internal.Unwatch(watchee, watcher)      ⇒ untypedRef.sendSystemMessage(sysmsg.Unwatch(toUntyped(watchee), toUntyped(watcher)))
+      case internal.DeathWatchNotification(ref, _) ⇒ untypedRef.sendSystemMessage(sysmsg.DeathWatchNotification(toUntyped(ref), true, false))
       case internal.NoMessage                      ⇒ // just to suppress the warning
     }
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -11,7 +11,7 @@ import java.util.concurrent.CompletionStage
 import akka.actor
 import akka.actor.ExtendedActorSystem
 import akka.actor.InvalidMessageException
-import akka.{ actor ⇒ a }
+import akka.{ actor ⇒ untyped }
 import scala.concurrent.ExecutionContextExecutor
 
 import akka.util.Timeout
@@ -29,83 +29,83 @@ import akka.actor.ActorRefProvider
  * a longer time; in all other cases the wrapper will just be spawned for a single call in
  * most circumstances.
  */
-@InternalApi private[akka] class ActorSystemAdapter[-T](val untyped: a.ActorSystemImpl)
+@InternalApi private[akka] class ActorSystemAdapter[-T](val untypedSystem: untyped.ActorSystemImpl)
   extends ActorSystem[T] with ActorRef[T] with internal.ActorRefImpl[T] with internal.InternalRecipientRef[T] with ExtensionsImpl {
 
-  untyped.assertInitialized()
+  untypedSystem.assertInitialized()
 
   import ActorRefAdapter.sendSystemMessage
 
   // Members declared in akka.actor.typed.ActorRef
   override def tell(msg: T): Unit = {
     if (msg == null) throw InvalidMessageException("[null] is not an allowed message")
-    untyped.guardian ! msg
+    untypedSystem.guardian ! msg
   }
 
   // impl ActorRefImpl
   override def isLocal: Boolean = true
   // impl ActorRefImpl
-  override def sendSystem(signal: internal.SystemMessage): Unit = sendSystemMessage(untyped.guardian, signal)
+  override def sendSystem(signal: internal.SystemMessage): Unit = sendSystemMessage(untypedSystem.guardian, signal)
 
   // impl InternalRecipientRef
-  override def provider: ActorRefProvider = untyped.provider
+  override def provider: ActorRefProvider = untypedSystem.provider
   // impl InternalRecipientRef
   def isTerminated: Boolean = whenTerminated.isCompleted
 
-  final override val path: a.ActorPath = a.RootActorPath(a.Address("akka", untyped.name)) / "user"
+  final override val path: untyped.ActorPath = untyped.RootActorPath(untyped.Address("akka", untypedSystem.name)) / "user"
 
-  override def toString: String = untyped.toString
+  override def toString: String = untypedSystem.toString
 
   // Members declared in akka.actor.typed.ActorSystem
-  override def deadLetters[U]: ActorRef[U] = ActorRefAdapter(untyped.deadLetters)
+  override def deadLetters[U]: ActorRef[U] = ActorRefAdapter(untypedSystem.deadLetters)
   override def dispatchers: Dispatchers = new Dispatchers {
     override def lookup(selector: DispatcherSelector): ExecutionContextExecutor =
       selector match {
-        case DispatcherDefault(_)         ⇒ untyped.dispatcher
-        case DispatcherFromConfig(str, _) ⇒ untyped.dispatchers.lookup(str)
+        case DispatcherDefault(_)         ⇒ untypedSystem.dispatcher
+        case DispatcherFromConfig(str, _) ⇒ untypedSystem.dispatchers.lookup(str)
       }
     override def shutdown(): Unit = () // there was no shutdown in untyped Akka
   }
-  override def dynamicAccess: a.DynamicAccess = untyped.dynamicAccess
-  implicit override def executionContext: scala.concurrent.ExecutionContextExecutor = untyped.dispatcher
-  override val log: Logger = new LoggerAdapterImpl(untyped.eventStream, getClass, name, untyped.logFilter)
-  override def logConfiguration(): Unit = untyped.logConfiguration()
-  override def name: String = untyped.name
-  override def scheduler: akka.actor.Scheduler = untyped.scheduler
-  override def settings: Settings = new Settings(untyped.settings)
-  override def startTime: Long = untyped.startTime
-  override def threadFactory: java.util.concurrent.ThreadFactory = untyped.threadFactory
-  override def uptime: Long = untyped.uptime
-  override def printTree: String = untyped.printTree
+  override def dynamicAccess: untyped.DynamicAccess = untypedSystem.dynamicAccess
+  implicit override def executionContext: scala.concurrent.ExecutionContextExecutor = untypedSystem.dispatcher
+  override val log: Logger = new LoggerAdapterImpl(untypedSystem.eventStream, getClass, name, untypedSystem.logFilter)
+  override def logConfiguration(): Unit = untypedSystem.logConfiguration()
+  override def name: String = untypedSystem.name
+  override def scheduler: akka.actor.Scheduler = untypedSystem.scheduler
+  override def settings: Settings = new Settings(untypedSystem.settings)
+  override def startTime: Long = untypedSystem.startTime
+  override def threadFactory: java.util.concurrent.ThreadFactory = untypedSystem.threadFactory
+  override def uptime: Long = untypedSystem.uptime
+  override def printTree: String = untypedSystem.printTree
 
   import akka.dispatch.ExecutionContexts.sameThreadExecutionContext
 
   override def terminate(): scala.concurrent.Future[akka.actor.typed.Terminated] =
-    untyped.terminate().map(t ⇒ Terminated(ActorRefAdapter(t.actor)))(sameThreadExecutionContext)
+    untypedSystem.terminate().map(t ⇒ Terminated(ActorRefAdapter(t.actor)))(sameThreadExecutionContext)
   override lazy val whenTerminated: scala.concurrent.Future[akka.actor.typed.Terminated] =
-    untyped.whenTerminated.map(t ⇒ Terminated(ActorRefAdapter(t.actor)))(sameThreadExecutionContext)
+    untypedSystem.whenTerminated.map(t ⇒ Terminated(ActorRefAdapter(t.actor)))(sameThreadExecutionContext)
   override lazy val getWhenTerminated: CompletionStage[akka.actor.typed.Terminated] =
     FutureConverters.toJava(whenTerminated)
 
   def systemActorOf[U](behavior: Behavior[U], name: String, props: Props)(implicit timeout: Timeout): Future[ActorRef[U]] = {
-    val ref = untyped.systemActorOf(PropsAdapter(() ⇒ behavior, props), name)
+    val ref = untypedSystem.systemActorOf(PropsAdapter(() ⇒ behavior, props), name)
     Future.successful(ActorRefAdapter(ref))
   }
 
 }
 
 private[akka] object ActorSystemAdapter {
-  def apply(untyped: a.ActorSystem): ActorSystem[Nothing] = AdapterExtension(untyped).adapter
+  def apply(system: untyped.ActorSystem): ActorSystem[Nothing] = AdapterExtension(system).adapter
 
   // to make sure we do never create more than one adapter for the same actor system
-  class AdapterExtension(system: a.ExtendedActorSystem) extends a.Extension {
-    val adapter = new ActorSystemAdapter(system.asInstanceOf[a.ActorSystemImpl])
+  class AdapterExtension(system: untyped.ExtendedActorSystem) extends untyped.Extension {
+    val adapter = new ActorSystemAdapter(system.asInstanceOf[untyped.ActorSystemImpl])
   }
 
-  object AdapterExtension extends a.ExtensionId[AdapterExtension] with a.ExtensionIdProvider {
-    override def get(system: a.ActorSystem): AdapterExtension = super.get(system)
+  object AdapterExtension extends untyped.ExtensionId[AdapterExtension] with untyped.ExtensionIdProvider {
+    override def get(system: untyped.ActorSystem): AdapterExtension = super.get(system)
     override def lookup() = AdapterExtension
-    override def createExtension(system: a.ExtendedActorSystem): AdapterExtension =
+    override def createExtension(system: untyped.ExtendedActorSystem): AdapterExtension =
       new AdapterExtension(system)
   }
 
@@ -116,19 +116,19 @@ private[akka] object ActorSystemAdapter {
    *
    * When on the classpath typed extensions will be loaded for untyped ActorSystems as well.
    */
-  class LoadTypedExtensions(system: a.ExtendedActorSystem) extends a.Extension {
+  class LoadTypedExtensions(system: untyped.ExtendedActorSystem) extends untyped.Extension {
     ActorSystemAdapter.AdapterExtension(system).adapter.loadExtensions()
   }
 
-  object LoadTypedExtensions extends a.ExtensionId[LoadTypedExtensions] with a.ExtensionIdProvider {
+  object LoadTypedExtensions extends untyped.ExtensionId[LoadTypedExtensions] with untyped.ExtensionIdProvider {
     override def lookup(): actor.ExtensionId[_ <: actor.Extension] = this
     override def createExtension(system: ExtendedActorSystem): LoadTypedExtensions =
       new LoadTypedExtensions(system)
   }
 
-  def toUntyped[U](sys: ActorSystem[_]): a.ActorSystem =
+  def toUntyped[U](sys: ActorSystem[_]): untyped.ActorSystem =
     sys match {
-      case adapter: ActorSystemAdapter[_] ⇒ adapter.untyped
+      case adapter: ActorSystemAdapter[_] ⇒ adapter.untypedSystem
       case _ ⇒ throw new UnsupportedOperationException("only adapted untyped ActorSystem permissible " +
         s"($sys of class ${sys.getClass.getName})")
     }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -31,7 +31,7 @@ abstract class Receptionist extends Extension {
 
   private def hasCluster: Boolean = {
     // FIXME: replace with better indicator that cluster is enabled
-    val provider = system.settings.untyped.ProviderClass
+    val provider = system.settings.untypedSettings.ProviderClass
     provider == "akka.cluster.ClusterActorRefProvider"
   }
 

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/AdaptedClusterImpl.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/AdaptedClusterImpl.scala
@@ -7,7 +7,7 @@ package akka.cluster.typed.internal
 import akka.actor.typed.Props
 import akka.annotation.InternalApi
 import akka.cluster.ClusterEvent.MemberEvent
-import akka.cluster.{ ClusterEvent, Member, MemberStatus, UniqueAddress }
+import akka.cluster.{ ClusterEvent, Member, MemberStatus }
 import akka.actor.typed.{ ActorRef, ActorSystem, Terminated }
 import akka.cluster.typed._
 import akka.actor.typed.internal.adapter.ActorSystemAdapter

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/StashManagement.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/StashManagement.scala
@@ -4,7 +4,7 @@
 
 package akka.persistence.typed.internal
 
-import akka.{ actor ⇒ a }
+import akka.{ actor ⇒ untyped }
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.{ ActorContext, StashBuffer }
 import akka.actor.{ DeadLetter, StashOverflowException }
@@ -33,7 +33,7 @@ private[akka] trait StashManagement[C, E, S] {
       case e: StashOverflowException ⇒
         setup.internalStashOverflowStrategy match {
           case DiscardToDeadLetterStrategy ⇒
-            val noSenderBecauseAkkaTyped: a.ActorRef = a.ActorRef.noSender
+            val noSenderBecauseAkkaTyped: untyped.ActorRef = untyped.ActorRef.noSender
             context.system.deadLetters.tell(DeadLetter(msg, noSenderBecauseAkkaTyped, context.self.toUntyped))
 
           case ReplyToStrategy(_) ⇒


### PR DESCRIPTION
I know we import the `actor` as `a` and named other things as `untyped` but for me, this is a little confusing.
I would like to import `actor` as `untyped` and name something like `untyped:a.ActorRef` to `ref:untyped.ActorRef` or `delegate:untyped:ActorRef`, or even import the `actor.ActorRef` as `UntypedActorRef`.

For now, I think it's clean.