### PR TITLE
Add dedicated exception when try to stop self with ActorContext#stop in Akka typed.

### DIFF
--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/AdapterTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/AdapterTest.java
@@ -83,6 +83,13 @@ public class AdapterTest extends JUnitSuite {
         Adapter.watch(context, child);
         Adapter.stop(context, child);
         return same();
+      } else if (message.equals("stop-self")){
+        try {
+          context.stop(context.getSelf());
+        } catch (Exception e){
+          probe.tell(e,akka.actor.ActorRef.noSender());
+        }
+        return same();
       } else {
         return unhandled();
       }
@@ -337,5 +344,14 @@ public class AdapterTest extends JUnitSuite {
     ActorRef<String> typedRef = Adapter.spawnAnonymous(system, Typed1.create(ignore, probe.getRef()));
     typedRef.tell("stop-child");
     probe.expectMsg("terminated");
+  }
+
+  @Test
+  public void stopSelfWillCauseError() {
+    TestKit probe = new TestKit(system);
+    akka.actor.ActorRef ignore = system.actorOf(akka.actor.Props.empty());
+    ActorRef<String> typedRef = Adapter.spawnAnonymous(system, Typed1.create(ignore, probe.getRef()));
+    typedRef.tell("stop-self");
+    probe.expectMsgClass(IllegalArgumentException.class);
   }
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
@@ -24,8 +24,8 @@ import scala.concurrent.duration._
   // lazily initialized
   private var actorLogger: OptionVal[Logger] = OptionVal.None
 
-  override def self = ActorRefAdapter(untyped.self)
-  override val system = ActorSystemAdapter(untyped.system)
+  final override val self = ActorRefAdapter(untyped.self)
+  final override val system = ActorSystemAdapter(untyped.system)
   override def children = untyped.children.map(ActorRefAdapter(_))
   override def child(name: String) = untyped.child(name).map(ActorRefAdapter(_))
   override def spawnAnonymous[U](behavior: Behavior[U], props: Props = Props.empty) =
@@ -46,6 +46,12 @@ import scala.concurrent.duration._
             // child that was already stopped
           }
       }
+    } else if (self == child) {
+      throw new IllegalArgumentException(
+        "Only direct children of an actor can be stopped through the actor context, " +
+          s"but you tried to stop [$self] by passing its ActorRef to the `stop` method. " +
+          "Stopping self has to be expressed as explicitly returning a Stop Behavior " +
+          "with `Behaviors.stopped`.")
     } else {
       throw new IllegalArgumentException(
         "Only direct children of an actor can be stopped through the actor context, " +


### PR DESCRIPTION
I explored the source code when I was reading the https://doc.akka.io/docs/akka/current/typed/guide/tutorial_1.html#the-actor-lifecycle，
and found this should be improved a little.