### PR TITLE
fixed deprecated method in getting started guide

### DIFF
--- a/akka-docs/src/test/scala/tutorial_4/DeviceSpec.scala
+++ b/akka-docs/src/test/scala/tutorial_4/DeviceSpec.scala
@@ -27,10 +27,10 @@ class DeviceSpec extends AkkaSpec {
       val deviceActor = system.actorOf(Device.props("group", "device"))
 
       deviceActor.tell(DeviceManager.RequestTrackDevice("wrongGroup", "device"), probe.ref)
-      probe.expectNoMsg(500.milliseconds)
+      probe.expectNoMessage(500.milliseconds)
 
       deviceActor.tell(DeviceManager.RequestTrackDevice("group", "Wrongdevice"), probe.ref)
-      probe.expectNoMsg(500.milliseconds)
+      probe.expectNoMessage(500.milliseconds)
     }
     //#device-registration-tests
 


### PR DESCRIPTION
Fixed method in akka's getting started guide.
sbt says: method expectNoMsg in trait TestKitBase is deprecated (since 2.5.5): Use expectNoMessage instead, so i've made a little fix.
This pull request is related to issue #26082 