### PR TITLE
Introduce Behavior#unsafeCast (asInstanceOf alt)

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
@@ -399,10 +399,10 @@ object Behavior {
       case SameBehavior | UnhandledBehavior ⇒
         throw new IllegalArgumentException(s"cannot execute with [$behavior] as behavior")
       case d: DeferredBehavior[_] ⇒ throw new IllegalArgumentException(s"deferred [$d] should not be passed to interpreter")
-      case IgnoreBehavior         ⇒ SameBehavior.asInstanceOf[Behavior[T]]
+      case IgnoreBehavior         ⇒ Behavior.same[T]
       case s: StoppedBehavior[T]  ⇒ s
       case f: FailedBehavior      ⇒ f
-      case EmptyBehavior          ⇒ UnhandledBehavior.asInstanceOf[Behavior[T]]
+      case EmptyBehavior          ⇒ Behavior.unhandled[T]
       case ext: ExtensibleBehavior[T] ⇒
         val possiblyDeferredResult = msg match {
           case signal: Signal ⇒ ext.receiveSignal(ctx, signal)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/InterceptorImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/InterceptorImpl.scala
@@ -79,7 +79,7 @@ private[akka] final class InterceptorImpl[O, I](val interceptor: BehaviorInterce
   private def deduplicate(interceptedResult: Behavior[I], ctx: ActorContext[O]): Behavior[O] = {
     val started = Behavior.start(interceptedResult, ctx.asInstanceOf[ActorContext[I]])
     if (started == UnhandledBehavior || started == SameBehavior || !Behavior.isAlive(started)) {
-      started.asInstanceOf[Behavior[O]]
+      started.unsafeCast[O]
     } else {
       // returned behavior could be nested in setups, so we need to start before we deduplicate
       val duplicateInterceptExists = Behavior.existsInStack(started) {
@@ -87,7 +87,7 @@ private[akka] final class InterceptorImpl[O, I](val interceptor: BehaviorInterce
         case _ ⇒ false
       }
 
-      if (duplicateInterceptExists) started.asInstanceOf[Behavior[O]]
+      if (duplicateInterceptExists) started.unsafeCast[O]
       else new InterceptorImpl[O, I](interceptor, started)
     }
   }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/WithMdcBehaviorInterceptor.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/WithMdcBehaviorInterceptor.scala
@@ -51,7 +51,7 @@ import scala.collection.immutable.HashMap
       next match {
         case i: InterceptorImpl[T, T] if i.interceptor.isSame(this.asInstanceOf[BehaviorInterceptor[Any, Any]]) ⇒
           // eliminate that interceptor
-          loop(i.nestedBehavior.asInstanceOf[Behavior[T]])
+          loop(i.nestedBehavior)
 
         case w: WrappingBehavior[T, T] ⇒
           val nested = w.nestedBehavior
@@ -63,7 +63,7 @@ import scala.collection.immutable.HashMap
       }
     }
 
-    loop(target.start(ctx)).asInstanceOf[Behavior[T]]
+    loop(target.start(ctx))
   }
 
   // in the normal case, a new withMDC replaces the previous one


### PR DESCRIPTION
Also:
* Introduce StoppedBehavior#cast, as a local, safe alternative.
* Remove some unnecessary casts in WithMdcBehaviorInterceptor
* Reuse Behavior.same & Behavior.unhandled