### PR TITLE
Fix compiler warnings akka-actor

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
@@ -396,16 +396,14 @@ abstract class ActorModelSpec(config: String) extends AkkaSpec(config) with Defa
                   val mq = dispatcher.messageQueue
 
                   System.err.println("Teammates left: " + team.size + " stopLatch: " + stopLatch.getCount + " inhab:" + dispatcher.inhabitants)
-                  team.toArray sorted new Ordering[AnyRef] {
-                    def compare(l: AnyRef, r: AnyRef) = (l, r) match {
-                      case (ll: ActorCell, rr: ActorCell) ⇒ ll.self.path compareTo rr.self.path
-                      case (ll: AnyRef, rr: AnyRef)       ⇒ ll.hashCode compareTo rr.hashCode
-                    }
-                  } foreach {
-                    case cell: ActorCell ⇒
+
+                  import scala.collection.JavaConverters._
+                  team.asScala.toList
+                    .sortBy(_.self.path)
+                    .foreach { cell: ActorCell ⇒
                       System.err.println(" - " + cell.self.path + " " + cell.isTerminated + " " + cell.mailbox.currentStatus + " "
                         + cell.mailbox.numberOfMessages + " " + cell.mailbox.systemDrain(SystemMessageList.LNil).size)
-                  }
+                    }
 
                   System.err.println("Mailbox: " + mq.numberOfMessages + " " + mq.hasMessages)
                   Iterator.continually(mq.dequeue) takeWhile (_ ne null) foreach System.err.println

--- a/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
@@ -196,8 +196,6 @@ class AskSpec extends AkkaSpec {
       val echo = system.actorOf(Props(new Actor {
         def receive = {
           case x ⇒
-            val name = sender.path.name
-            val parent = sender.path.parent
             context.actorSelection(sender().path / "missing") ! x
         }
       }), "select-echo6")

--- a/akka-actor-tests/src/test/scala/akka/pattern/BackoffOnRestartSupervisorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/BackoffOnRestartSupervisorSpec.scala
@@ -206,7 +206,7 @@ class BackoffOnRestartSupervisorSpec extends AkkaSpec with ImplicitSender {
       filterException[TestActor.TestException] {
         probe.watch(supervisor)
         // Throw three times rapidly
-        for (i ← 1 to 3) {
+        for (_ ← 1 to 3) {
           supervisor ! "THROW"
           probe.expectMsg("STARTED")
         }

--- a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
@@ -658,7 +658,7 @@ class CircuitBreakerSpec extends AkkaSpec with BeforeAndAfter with MockitoSugar 
     "reset failure count after success" in {
       val breaker = CircuitBreakerSpec.multiFailureCb()
       breaker().withCircuitBreaker(Future(sayHi))
-      for (n ← 1 to 4) breaker().withCircuitBreaker(Future(throwException))
+      for (_ ← 1 to 4) breaker().withCircuitBreaker(Future(throwException))
       awaitCond(breaker().currentFailureCount == 4, awaitTimeout)
       breaker().withCircuitBreaker(Future(sayHi))
       awaitCond(breaker().currentFailureCount == 0, awaitTimeout)

--- a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerStressSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerStressSpec.scala
@@ -42,7 +42,7 @@ object CircuitBreakerStressSpec {
       case JobDone ⇒
         doneCount += 1
         breaker.withCircuitBreaker(job).pipeTo(self)
-      case Failure(ex: CircuitBreakerOpenException) ⇒
+      case Failure(_: CircuitBreakerOpenException) ⇒
         circCount += 1
         breaker.withCircuitBreaker(job).pipeTo(self)
       case Failure(_: TimeoutException) ⇒

--- a/akka-actor-tests/src/test/scala/akka/routing/ConfiguredLocalRoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ConfiguredLocalRoutingSpec.scala
@@ -161,11 +161,11 @@ class ConfiguredLocalRoutingSpec extends AkkaSpec(ConfiguredLocalRoutingSpec.con
     }
 
     "not get confused when trying to wildcard-configure children" in {
-      val router = system.actorOf(FromConfig.props(routeeProps = Props(classOf[SendRefAtStartup], testActor)), "weird")
+      system.actorOf(FromConfig.props(routeeProps = Props(classOf[SendRefAtStartup], testActor)), "weird")
       val recv = Set() ++ (for (_ ← 1 to 3) yield expectMsgType[ActorRef])
       val expc = Set('a', 'b', 'c') map (i ⇒ system.actorFor("/user/weird/$" + i))
       recv should ===(expc)
-      expectNoMsg(1 second)
+      expectNoMessage(1 second)
     }
 
     "support custom router" in {

--- a/akka-actor-tests/src/test/scala/akka/routing/ConsistentHashingRouterSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ConsistentHashingRouterSpec.scala
@@ -78,7 +78,7 @@ class ConsistentHashingRouterSpec extends AkkaSpec(ConsistentHashingRouterSpec.c
 
     "select destination with defined hashMapping" in {
       def hashMapping: ConsistentHashMapping = {
-        case Msg2(key, data) ⇒ key
+        case Msg2(key, _) ⇒ key
       }
       val router2 = system.actorOf(ConsistentHashingPool(nrOfInstances = 1, hashMapping = hashMapping).
         props(Props[Echo]), "router2")

--- a/akka-actor-tests/src/test/scala/akka/routing/RandomSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RandomSpec.scala
@@ -36,7 +36,7 @@ class RandomSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
       actor ! "hello"
 
       within(2 seconds) {
-        for (i ← 1 to 5) expectMsg("world")
+        for (_ ← 1 to 5) expectMsg("world")
       }
 
       system.stop(actor)
@@ -63,8 +63,8 @@ class RandomSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
           }
         })), name = "random")
 
-      for (i ← 0 until iterationCount) {
-        for (k ← 0 until connectionCount) {
+      for (_ ← 0 until iterationCount) {
+        for (_ ← 0 until connectionCount) {
           val id = Await.result((actor ? "hit").mapTo[Int], timeout.duration)
           replies = replies + (id → (replies(id) + 1))
         }

--- a/akka-actor-tests/src/test/scala/akka/routing/ResizerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ResizerSpec.scala
@@ -198,13 +198,13 @@ class ResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultTimeout with 
       routeeSize(router) should ===(resizer.lowerBound)
 
       def loop(loops: Int, d: FiniteDuration) = {
-        for (m ← 0 until loops) {
+        for (_ ← 0 until loops) {
           router ! d
           // sending in too quickly will result in skipped resize due to many resizeInProgress conflicts
           Thread.sleep(20.millis.dilated.toMillis)
         }
         within((d * loops / resizer.lowerBound) + 2.seconds.dilated) {
-          for (m ← 0 until loops) expectMsg("done")
+          for (_ ← 0 until loops) expectMsg("done")
         }
       }
 
@@ -236,7 +236,7 @@ class ResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultTimeout with 
         })))
 
       // put some pressure on the router
-      for (m ← 0 until 15) {
+      for (_ ← 0 until 15) {
         router ! 150
         Thread.sleep((20 millis).dilated.toMillis)
       }

--- a/akka-actor-tests/src/test/scala/akka/routing/ScatterGatherFirstCompletedSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ScatterGatherFirstCompletedSpec.scala
@@ -28,7 +28,7 @@ object ScatterGatherFirstCompletedSpec {
         case Stop(None)                     ⇒ context.stop(self)
         case Stop(Some(_id)) if (_id == id) ⇒ context.stop(self)
         case _id: Int if (_id == id)        ⇒
-        case x ⇒ {
+        case _ ⇒ {
           Thread sleep 100 * id
           sender() ! id
         }

--- a/akka-actor-tests/src/test/scala/akka/routing/SmallestMailboxSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/SmallestMailboxSpec.scala
@@ -26,7 +26,7 @@ class SmallestMailboxSpec extends AkkaSpec("akka.actor.serialize-messages = off"
           case (msg: Int, receivedLatch: TestLatch) ⇒
             usedActors.put(msg, self.path.toString)
             receivedLatch.countDown()
-          case s: String ⇒
+          case _: String ⇒
         }
       })))
 

--- a/akka-actor-tests/src/test/scala/akka/routing/TailChoppingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/TailChoppingSpec.scala
@@ -20,7 +20,7 @@ object TailChoppingSpec {
       def receive = {
         case "stop"  ⇒ context.stop(self)
         case "times" ⇒ sender() ! times
-        case x ⇒
+        case _ ⇒
           times += 1
           Thread sleep sleepTime.toMillis
           sender ! "ack"
@@ -99,7 +99,7 @@ class TailChoppingSpec extends AkkaSpec with DefaultTimeout with ImplicitSender 
 
       probe.send(routedActor, "")
       probe.expectMsgPF() {
-        case Failure(timeoutEx: AskTimeoutException) ⇒
+        case Failure(_: AskTimeoutException) ⇒
       }
 
       allShouldEqual(1, actor1, actor2)(ref ⇒ Await.result(ref ? "times", timeout.duration))

--- a/akka-actor-tests/src/test/scala/akka/util/BoundedBlockingQueueSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/BoundedBlockingQueueSpec.scala
@@ -143,7 +143,7 @@ class BoundedBlockingQueueSpec
 
   "take" must {
     "call the backing queue if not empty" in {
-      val TestContext(queue, events, _, _, _, backingQueue) = newBoundedBlockingQueue(1)
+      val TestContext(queue, events, _, _, _, _) = newBoundedBlockingQueue(1)
       queue.put("Hello")
       queue.take()
 
@@ -151,7 +151,7 @@ class BoundedBlockingQueueSpec
     }
 
     "signal notFull when taking an element" in {
-      val TestContext(queue, events, _, _, _, backingQueue) = newBoundedBlockingQueue(1)
+      val TestContext(queue, events, _, _, _, _) = newBoundedBlockingQueue(1)
       queue.put("Hello")
       queue.take()
       events should contain(signalNotFull)
@@ -259,7 +259,7 @@ class BoundedBlockingQueueSpec
     }
 
     "return false if the timeout is exceeded" in {
-      val TestContext(queue, events, _, notFull, _, _) = newBoundedBlockingQueue(1)
+      val TestContext(queue, events, _, _, _, _) = newBoundedBlockingQueue(1)
       queue.put("Hello")
       queue.offer("World", 100, TimeUnit.MILLISECONDS) should equal(false)
       events shouldNot contain(offer("World"))
@@ -315,7 +315,7 @@ class BoundedBlockingQueueSpec
     }
 
     "return the first element inserted" in {
-      val TestContext(queue, events, _, _, _, _) = newBoundedBlockingQueue(2)
+      val TestContext(queue, _, _, _, _, _) = newBoundedBlockingQueue(2)
       queue.put("Hello")
       queue.put("World")
       queue.poll() should equal("Hello")
@@ -360,14 +360,14 @@ class BoundedBlockingQueueSpec
     }
 
     "immediately poll the backing queue" in {
-      val TestContext(queue, events, notEmpty, _, _, _) = newBoundedBlockingQueue(1)
+      val TestContext(queue, events, _, _, _, _) = newBoundedBlockingQueue(1)
 
       queue.poll(100, TimeUnit.MILLISECONDS)
       events should contain(poll)
     }
 
     "return null if the timeout is exceeded" in {
-      val TestContext(queue, events, notEmpty, _, _, _) = newBoundedBlockingQueue(1)
+      val TestContext(queue, _, notEmpty, _, _, _) = newBoundedBlockingQueue(1)
 
       queue.poll(100, TimeUnit.MILLISECONDS) should equal(null)
     }
@@ -402,7 +402,7 @@ class BoundedBlockingQueueSpec
     }
 
     "return true if the element was removed" in {
-      val TestContext(queue, events, _, _, _, _) = newBoundedBlockingQueue(2)
+      val TestContext(queue, _, _, _, _, _) = newBoundedBlockingQueue(2)
       queue.put("Hello")
       queue.remove("Hello") should equal(true)
     }
@@ -428,7 +428,7 @@ class BoundedBlockingQueueSpec
     }
 
     "return true if the backing queue contains the element" in {
-      val TestContext(queue, events, _, _, _, backingQueue) = newBoundedBlockingQueue(2)
+      val TestContext(queue, _, _, _, _, backingQueue) = newBoundedBlockingQueue(2)
       backingQueue.offer("Hello")
       queue.contains("Hello") should equal(true)
     }
@@ -757,7 +757,7 @@ trait QueueSetupHelper {
       }
     }
 
-    def manualTimeControl(on: Boolean): Unit =
+    def manualTimeControl(@unused on: Boolean): Unit =
       waiting = Some(Manual())
 
     override def signalAll(): Unit = condition.signalAll()
@@ -774,7 +774,7 @@ trait QueueSetupHelper {
         try {
           this.await()
         } catch {
-          case e: InterruptedException ⇒
+          case _: InterruptedException ⇒
         }
         waitTime
       }

--- a/akka-actor-tests/src/test/scala/akka/util/TypedMultiMapSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/TypedMultiMapSpec.scala
@@ -59,12 +59,12 @@ class TypedMultiMapSpec extends WordSpec with Matchers with TypeCheckedTripleEqu
     }
 
     "reject invalid insertions" in {
-      val m1 = TypedMultiMap.empty[AbstractKey, KV]
+      TypedMultiMap.empty[AbstractKey, KV]
       "m1.inserted(Key(1))(MyValue(42L))" shouldNot compile
     }
 
     "reject invalid removals" in {
-      val m1 = TypedMultiMap.empty[AbstractKey, KV]
+      TypedMultiMap.empty[AbstractKey, KV]
       "m1.removed(Key(1))(MyValue(42L))" shouldNot compile
     }
 

--- a/akka-actor-tests/src/test/scala/akka/util/TypedMultiMapSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/TypedMultiMapSpec.scala
@@ -59,13 +59,10 @@ class TypedMultiMapSpec extends WordSpec with Matchers with TypeCheckedTripleEqu
     }
 
     "reject invalid insertions" in {
-      /*   TypedMultiMap.empty[AbstractKey, KV].inserted(Key(1))(MyValue(42L))
-      "m1.inserted(Key(1))(MyValue(42L))" shouldNot compile*/
       "TypedMultiMap.empty[AbstractKey, KV].inserted(Key(1))(MyValue(42L))" shouldNot compile
     }
 
     "reject invalid removals" in {
-      // val m1 = TypedMultiMap.empty[AbstractKey, KV]
       "TypedMultiMap.empty[AbstractKey, KV].removed(Key(1))(MyValue(42L))" shouldNot compile
     }
 

--- a/akka-actor-tests/src/test/scala/akka/util/TypedMultiMapSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/TypedMultiMapSpec.scala
@@ -59,13 +59,14 @@ class TypedMultiMapSpec extends WordSpec with Matchers with TypeCheckedTripleEqu
     }
 
     "reject invalid insertions" in {
-      TypedMultiMap.empty[AbstractKey, KV]
-      "m1.inserted(Key(1))(MyValue(42L))" shouldNot compile
+      /*   TypedMultiMap.empty[AbstractKey, KV].inserted(Key(1))(MyValue(42L))
+      "m1.inserted(Key(1))(MyValue(42L))" shouldNot compile*/
+      "TypedMultiMap.empty[AbstractKey, KV].inserted(Key(1))(MyValue(42L))" shouldNot compile
     }
 
     "reject invalid removals" in {
-      TypedMultiMap.empty[AbstractKey, KV]
-      "m1.removed(Key(1))(MyValue(42L))" shouldNot compile
+      // val m1 = TypedMultiMap.empty[AbstractKey, KV]
+      "TypedMultiMap.empty[AbstractKey, KV].removed(Key(1))(MyValue(42L))" shouldNot compile
     }
 
   }

--- a/akka-actor/src/main/scala/akka/Main.scala
+++ b/akka-actor/src/main/scala/akka/Main.scala
@@ -31,7 +31,7 @@ object Main {
       try {
         val appClass = system.asInstanceOf[ExtendedActorSystem].dynamicAccess.getClassFor[Actor](args(0)).get
         val app = system.actorOf(Props(appClass), "app")
-        val terminator = system.actorOf(Props(classOf[Terminator], app), "app-terminator")
+        system.actorOf(Props(classOf[Terminator], app), "app-terminator")
       } catch {
         case NonFatal(e) ⇒ system.terminate(); throw e
       }

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -6,13 +6,13 @@ package akka.actor
 
 import akka.AkkaException
 import akka.event.LoggingAdapter
-
 import java.util.Optional
+
 import scala.annotation.tailrec
 import scala.beans.BeanProperty
 import scala.util.control.NoStackTrace
-
 import akka.annotation.InternalApi
+import akka.util.unused
 
 /**
  * INTERNAL API
@@ -342,7 +342,7 @@ trait ActorLogging { this: Actor ⇒
 trait DiagnosticActorLogging extends Actor {
   import akka.event.Logging._
   val log = akka.event.Logging(this)
-  def mdc(currentMessage: Any): MDC = emptyMDC
+  def mdc(@unused currentMessage: Any): MDC = emptyMDC
 
   override protected[akka] def aroundReceive(receive: Actor.Receive, msg: Any): Unit = try {
     log.mdc(mdc(msg))
@@ -592,7 +592,7 @@ trait Actor {
    */
   @throws(classOf[Exception]) // when changing this you MUST also change ActorDocTest
   //#lifecycle-hooks
-  def preRestart(reason: Throwable, message: Option[Any]): Unit = {
+  def preRestart(@unused reason: Throwable, @unused message: Option[Any]): Unit = {
     context.children foreach { child ⇒
       context.unwatch(child)
       context.stop(child)
@@ -610,7 +610,7 @@ trait Actor {
    */
   @throws(classOf[Exception]) // when changing this you MUST also change ActorDocTest
   //#lifecycle-hooks
-  def postRestart(reason: Throwable): Unit = {
+  def postRestart(@unused reason: Throwable): Unit = {
     preStart()
   }
   //#lifecycle-hooks

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -4,20 +4,20 @@
 
 package akka.actor
 
-import akka.actor.dungeon.ChildrenContainer
-import akka.dispatch.Envelope
-import akka.dispatch.sysmsg._
-import akka.event.Logging.{ Debug, Error, LogEvent }
-import akka.japi.Procedure
 import java.io.{ NotSerializableException, ObjectOutputStream }
+import java.util.concurrent.ThreadLocalRandom
 
 import scala.annotation.{ switch, tailrec }
 import scala.collection.immutable
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.Duration
-import java.util.concurrent.ThreadLocalRandom
-
 import scala.util.control.NonFatal
+
+import akka.actor.dungeon.ChildrenContainer
+import akka.dispatch.Envelope
+import akka.dispatch.sysmsg._
+import akka.event.Logging.{ Debug, Error, LogEvent }
+import akka.japi.Procedure
 import akka.dispatch.MessageDispatcher
 import akka.util.Reflect
 import akka.annotation.InternalApi
@@ -553,8 +553,8 @@ private[akka] class ActorCell(
       if (influenceReceiveTimeout)
         cancelReceiveTimeout()
       messageHandle.message match {
-        case msg: AutoReceivedMessage ⇒ autoReceiveMessage(messageHandle)
-        case msg                      ⇒ receiveMessage(msg)
+        case _: AutoReceivedMessage ⇒ autoReceiveMessage(messageHandle)
+        case msg                    ⇒ receiveMessage(msg)
       }
       currentMessage = null // reset current message after successful invocation
     } catch handleNonFatalOrInterruptedException { e ⇒
@@ -675,7 +675,7 @@ private[akka] class ActorCell(
     if (!isTerminating) {
       // Supervise is the first thing we get from a new child, so store away the UID for later use in handleFailure()
       initChild(child) match {
-        case Some(crs) ⇒
+        case Some(_) ⇒
           handleSupervise(child, async)
           if (system.settings.DebugLifecycle) publish(Debug(self.path.toString, clazz(actor), "now supervising " + child))
         case None ⇒ publish(Error(self.path.toString, clazz(actor), "received Supervise from unregistered child " + child + ", this will not end well"))

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -12,14 +12,13 @@ import scala.collection.immutable
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
-
 import akka.actor.dungeon.ChildrenContainer
 import akka.dispatch.Envelope
 import akka.dispatch.sysmsg._
 import akka.event.Logging.{ Debug, Error, LogEvent }
 import akka.japi.Procedure
 import akka.dispatch.MessageDispatcher
-import akka.util.Reflect
+import akka.util.{ Reflect, unused }
 import akka.annotation.InternalApi
 
 /**
@@ -230,7 +229,7 @@ trait ActorContext extends ActorRefFactory {
   /**
    * ActorContexts shouldn't be Serializable
    */
-  final protected def writeObject(o: ObjectOutputStream): Unit =
+  final protected def writeObject(@unused o: ObjectOutputStream): Unit =
     throw new NotSerializableException("ActorContext is not serializable!")
 }
 

--- a/akka-actor/src/main/scala/akka/actor/ActorPath.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorPath.scala
@@ -281,7 +281,7 @@ final case class RootActorPath(address: Address, name: String = "/") extends Act
 
   override def compareTo(other: ActorPath): Int = other match {
     case r: RootActorPath  ⇒ toString compareTo r.toString // FIXME make this cheaper by comparing address and name in isolation
-    case c: ChildActorPath ⇒ 1
+    case _: ChildActorPath ⇒ 1
   }
 
   /**
@@ -315,7 +315,7 @@ final class ChildActorPath private[akka] (val parent: ActorPath, val name: Strin
   override def elements: immutable.Iterable[String] = {
     @tailrec
     def rec(p: ActorPath, acc: List[String]): immutable.Iterable[String] = p match {
-      case r: RootActorPath ⇒ acc
+      case _: RootActorPath ⇒ acc
       case _                ⇒ rec(p.parent, p.name :: acc)
     }
     rec(this, Nil)

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -791,7 +791,7 @@ private[akka] class LocalActorRefProvider private[akka] (
           // routers use context.actorOf() to create the routees, which does not allow us to pass
           // these through, but obtain them here for early verification
           val routeeDispatcher = system.dispatchers.lookup(p.dispatcher)
-          val routeeMailbox = system.mailboxes.getMailboxType(routeeProps, routeeDispatcher.configurator.config)
+          system.mailboxes.getMailboxType(routeeProps, routeeDispatcher.configurator.config)
 
           new RoutedActorRef(system, routerProps, routerDispatcher, routerMailbox, routeeProps, supervisor, path).initialize(async)
         } catch {

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -972,7 +972,7 @@ private[akka] class ActorSystemImpl(
           } finally {
             inProcessOfRegistration.countDown //Always notify listeners of the inProcess signal
           }
-          case other ⇒ registerExtension(ext) //Someone else is in process of registering an extension for this Extension, retry
+          case _ ⇒ registerExtension(ext) //Someone else is in process of registering an extension for this Extension, retry
         }
       case existing ⇒ existing.asInstanceOf[T]
     }
@@ -994,7 +994,7 @@ private[akka] class ActorSystemImpl(
         dynamicAccess.getObjectFor[AnyRef](fqcn) recoverWith { case _ ⇒ dynamicAccess.createInstanceFor[AnyRef](fqcn, Nil) } match {
           case Success(p: ExtensionIdProvider) ⇒ registerExtension(p.lookup())
           case Success(p: ExtensionId[_])      ⇒ registerExtension(p)
-          case Success(other) ⇒
+          case Success(_) ⇒
             if (!throwOnLoadFail) log.error("[{}] is not an 'ExtensionIdProvider' or 'ExtensionId', skipping...", fqcn)
             else throw new RuntimeException(s"[$fqcn] is not an 'ExtensionIdProvider' or 'ExtensionId'")
           case Failure(problem) ⇒

--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -203,7 +203,7 @@ private[akka] class Deployer(val settings: ActorSystem.Settings, val dynamicAcce
         case e: NoSuchMethodException ⇒
           dynamicAccess.createInstanceFor[RouterConfig](fqn, args2).recover({
             case e @ (_: IllegalArgumentException | _: ConfigException) ⇒ throw e
-            case e2 ⇒ throwCannotInstantiateRouter(args2, e)
+            case _ ⇒ throwCannotInstantiateRouter(args2, e)
           }).get
         case e ⇒ throwCannotInstantiateRouter(args2, e)
       }).get

--- a/akka-actor/src/main/scala/akka/actor/FSM.scala
+++ b/akka-actor/src/main/scala/akka/actor/FSM.scala
@@ -7,12 +7,12 @@ package akka.actor
 import language.implicitConversions
 import scala.concurrent.duration.Duration
 import scala.collection.mutable
-import akka.routing.{ Deafen, Listen, Listeners }
-
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
+
+import akka.routing.{ Deafen, Listen, Listeners }
 import akka.annotation.InternalApi
-import akka.util.JavaDurationConverters
+import akka.util.{ JavaDurationConverters, unused }
 
 object FSM {
 
@@ -607,7 +607,7 @@ trait FSM[S, D] extends Actor with Listeners with ActorLogging {
    * unhandled event handler
    */
   private val handleEventDefault: StateFunction = {
-    case Event(value, stateData) ⇒
+    case Event(value, _) ⇒
       log.warning("unhandled event " + value + " in state " + stateName)
       stay
   }
@@ -678,7 +678,7 @@ trait FSM[S, D] extends Actor with Listeners with ActorLogging {
     processEvent(event, source)
   }
 
-  private[akka] def processEvent(event: Event, source: AnyRef): Unit = {
+  private[akka] def processEvent(event: Event, @unused source: AnyRef): Unit = {
     val stateFunc = stateFunctions(currentState.stateName)
     val nextState = if (stateFunc isDefinedAt event) {
       stateFunc(event)

--- a/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
@@ -6,13 +6,15 @@ package akka.actor
 
 import java.util.{ LinkedList ⇒ JLinkedList }
 import java.util.concurrent.locks.ReentrantLock
+
 import scala.annotation.tailrec
 import scala.collection.immutable
 import akka.actor.dungeon.ChildrenContainer
 import akka.event.Logging.Warning
-import akka.util.Unsafe
+import akka.util.{ Unsafe, unused }
 import akka.dispatch._
 import akka.dispatch.sysmsg._
+
 import scala.util.control.NonFatal
 
 /**
@@ -77,7 +79,7 @@ private[akka] class RepointableActorRef(
         supervisor.sendSystemMessage(Supervise(this, async))
         if (!async) point(false)
         this
-      case other ⇒ throw new IllegalStateException("initialize called more than once!")
+      case _ ⇒ throw new IllegalStateException("initialize called more than once!")
     }
 
   /**
@@ -115,7 +117,7 @@ private[akka] class RepointableActorRef(
    * This is called by activate() to obtain the cell which is to replace the
    * unstarted cell. The cell must be fully functional.
    */
-  def newCell(old: UnstartedCell): Cell =
+  def newCell(@unused old: UnstartedCell): Cell =
     new ActorCell(system, this, props, dispatcher, supervisor).init(sendSupervise = false, mailboxType)
 
   def start(): Unit = ()

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
@@ -22,6 +22,9 @@ private[akka] trait Children { this: ActorCell ⇒
 
   import ChildrenContainer._
 
+  @volatile
+  private var _childrenRefsDoNotCallMeDirectly: ChildrenContainer = EmptyChildrenContainer
+
   def childrenRefs: ChildrenContainer =
     Unsafe.instance.getObjectVolatile(this, AbstractActorCell.childrenOffset).asInstanceOf[ChildrenContainer]
 
@@ -45,6 +48,7 @@ private[akka] trait Children { this: ActorCell ⇒
   private[akka] def attachChild(props: Props, name: String, systemService: Boolean): ActorRef =
     makeChild(this, props, checkName(name), async = true, systemService = systemService)
 
+  @volatile private var _functionRefsDoNotCallMeDirectly = Map.empty[String, FunctionRef]
   private def functionRefs: Map[String, FunctionRef] =
     Unsafe.instance.getObjectVolatile(this, AbstractActorCell.functionRefsOffset).asInstanceOf[Map[String, FunctionRef]]
 
@@ -95,6 +99,7 @@ private[akka] trait Children { this: ActorCell ⇒
     refs.valuesIterator.foreach(_.stop())
   }
 
+  @volatile private var _nextNameDoNotCallMeDirectly = 0L
   final protected def randomName(sb: java.lang.StringBuilder): String = {
     val num = Unsafe.instance.getAndAddLong(this, AbstractActorCell.nextNameOffset, 1)
     Helpers.base64(num, sb)

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
@@ -4,6 +4,8 @@
 
 package akka.actor.dungeon
 
+import java.util.Optional
+
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 import scala.collection.immutable
@@ -11,7 +13,6 @@ import scala.collection.immutable
 import akka.actor._
 import akka.serialization.{ Serialization, SerializationExtension, Serializers }
 import akka.util.{ Helpers, Unsafe }
-import java.util.Optional
 
 private[akka] object Children {
   val GetNobody = () ⇒ Nobody
@@ -20,9 +21,6 @@ private[akka] object Children {
 private[akka] trait Children { this: ActorCell ⇒
 
   import ChildrenContainer._
-
-  @volatile
-  private var _childrenRefsDoNotCallMeDirectly: ChildrenContainer = EmptyChildrenContainer
 
   def childrenRefs: ChildrenContainer =
     Unsafe.instance.getObjectVolatile(this, AbstractActorCell.childrenOffset).asInstanceOf[ChildrenContainer]
@@ -47,7 +45,6 @@ private[akka] trait Children { this: ActorCell ⇒
   private[akka] def attachChild(props: Props, name: String, systemService: Boolean): ActorRef =
     makeChild(this, props, checkName(name), async = true, systemService = systemService)
 
-  @volatile private var _functionRefsDoNotCallMeDirectly = Map.empty[String, FunctionRef]
   private def functionRefs: Map[String, FunctionRef] =
     Unsafe.instance.getObjectVolatile(this, AbstractActorCell.functionRefsOffset).asInstanceOf[Map[String, FunctionRef]]
 
@@ -98,7 +95,6 @@ private[akka] trait Children { this: ActorCell ⇒
     refs.valuesIterator.foreach(_.stop())
   }
 
-  @volatile private var _nextNameDoNotCallMeDirectly = 0L
   final protected def randomName(sb: java.lang.StringBuilder): String = {
     val num = Unsafe.instance.getAndAddLong(this, AbstractActorCell.nextNameOffset, 1)
     Helpers.base64(num, sb)
@@ -184,7 +180,8 @@ private[akka] trait Children { this: ActorCell ⇒
     childrenRefs.stats foreach {
       case ChildRestartStats(child: InternalActorRef, _, _) ⇒
         child.resume(if (perp == child) causedByFailure else null)
-      case _ ⇒ // if child not InternalActorRef ignore
+      case stats ⇒
+        throw new IllegalStateException(s"Unexpected child ActorRef: ${stats.child}")
     }
 
   def getChildByName(name: String): Option[ChildStats] = childrenRefs.getByName(name)

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
@@ -184,6 +184,7 @@ private[akka] trait Children { this: ActorCell ⇒
     childrenRefs.stats foreach {
       case ChildRestartStats(child: InternalActorRef, _, _) ⇒
         child.resume(if (perp == child) causedByFailure else null)
+      case _ ⇒ // if child not InternalActorRef ignore
     }
 
   def getChildByName(name: String): Option[ChildStats] = childrenRefs.getByName(name)

--- a/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
@@ -4,10 +4,11 @@
 
 package akka.actor.dungeon
 
-import akka.dispatch.sysmsg.{ Unwatch, Watch, DeathWatchNotification }
-import akka.event.Logging.{ Warning, Debug }
-import akka.actor.{ InternalActorRef, Address, Terminated, Actor, ActorRefScope, ActorCell, ActorRef, MinimalActorRef }
+import akka.dispatch.sysmsg.{ DeathWatchNotification, Unwatch, Watch }
+import akka.event.Logging.{ Debug, Warning }
+import akka.actor.{ Actor, ActorCell, ActorRef, ActorRefScope, Address, InternalActorRef, MinimalActorRef, Terminated }
 import akka.event.AddressTerminatedTopic
+import akka.util.unused
 
 private[akka] trait DeathWatch { this: ActorCell ⇒
 
@@ -159,7 +160,7 @@ private[akka] trait DeathWatch { this: ActorCell ⇒
       }
     }
 
-  protected def unwatchWatchedActors(actor: Actor): Unit =
+  protected def unwatchWatchedActors(@unused actor: Actor): Unit =
     if (!watching.isEmpty) {
       maintainAddressTerminatedSubscription() {
         try {

--- a/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
@@ -288,10 +288,10 @@ private[akka] trait FaultHandling { this: ActorCell ⇒
      * then we are continuing the previously suspended recreate/create/terminate action
      */
     status match {
-      case Some(c @ ChildrenContainer.Recreation(cause)) ⇒ finishRecreate(cause, actor)
-      case Some(c @ ChildrenContainer.Creation()) ⇒ finishCreate()
-      case Some(ChildrenContainer.Termination) ⇒ finishTerminate()
-      case _ ⇒
+      case Some(ChildrenContainer.Recreation(cause)) ⇒ finishRecreate(cause, actor)
+      case Some(ChildrenContainer.Creation())        ⇒ finishCreate()
+      case Some(ChildrenContainer.Termination)       ⇒ finishTerminate()
+      case _                                         ⇒
     }
   }
 

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -12,7 +12,7 @@ import akka.dispatch.affinity.AffinityPoolConfigurator
 import akka.dispatch.sysmsg._
 import akka.event.EventStream
 import akka.event.Logging.{ Debug, Error, LogEventException }
-import akka.util.{ Index, Unsafe }
+import akka.util.{ Index, Unsafe, unused }
 import com.typesafe.config.Config
 
 import scala.annotation.tailrec
@@ -309,7 +309,7 @@ abstract class MessageDispatcher(val configurator: MessageDispatcherConfigurator
 /**
  * An ExecutorServiceConfigurator is a class that given some prerequisites and a configuration can create instances of ExecutorService
  */
-abstract class ExecutorServiceConfigurator(config: Config, prerequisites: DispatcherPrerequisites) extends ExecutorServiceFactoryProvider
+abstract class ExecutorServiceConfigurator(@unused config: Config, @unused prerequisites: DispatcherPrerequisites) extends ExecutorServiceFactoryProvider
 
 /**
  * Base class to be used for hooking in new dispatchers into Dispatchers.
@@ -354,7 +354,7 @@ class ThreadPoolExecutorConfigurator(config: Config, prerequisites: DispatcherPr
 
   val threadPoolConfig: ThreadPoolConfig = createThreadPoolConfigBuilder(config, prerequisites).config
 
-  protected def createThreadPoolConfigBuilder(config: Config, prerequisites: DispatcherPrerequisites): ThreadPoolConfigBuilder = {
+  protected def createThreadPoolConfigBuilder(config: Config, @unused prerequisites: DispatcherPrerequisites): ThreadPoolConfigBuilder = {
     import akka.util.Helpers.ConfigOps
     val builder =
       ThreadPoolConfigBuilder(ThreadPoolConfig())

--- a/akka-actor/src/main/scala/akka/dispatch/BalancingDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/BalancingDispatcher.scala
@@ -97,7 +97,7 @@ private[akka] class BalancingDispatcher(
           && i.hasNext
           && (executorService.executor match {
             case lm: LoadMetrics ⇒ lm.atFullThrottle == false
-            case other           ⇒ true
+            case _               ⇒ true
           })
           && !registerForExecution(i.next.mailbox, false, false))
           scheduleOne(i)

--- a/akka-actor/src/main/scala/akka/dispatch/CachingConfig.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/CachingConfig.scala
@@ -51,11 +51,11 @@ private[akka] class CachingConfig(_config: Config) extends Config {
   private def getPathEntry(path: String): PathEntry = entryMap.get(path) match {
     case null ⇒
       val ne = Try { config.hasPath(path) } match {
-        case Failure(e)     ⇒ invalidPathEntry
+        case Failure(_)     ⇒ invalidPathEntry
         case Success(false) ⇒ nonExistingPathEntry
         case _ ⇒
           Try { config.getValue(path) } match {
-            case Failure(e) ⇒
+            case Failure(_) ⇒
               emptyPathEntry
             case Success(v) ⇒
               if (v.valueType() == ConfigValueType.STRING)

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
@@ -115,7 +115,7 @@ class Dispatcher(
           executorService execute mbox
           true
         } catch {
-          case e: RejectedExecutionException ⇒
+          case _: RejectedExecutionException ⇒
             try {
               executorService execute mbox
               true

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
@@ -286,7 +286,7 @@ class PinnedDispatcherConfigurator(config: Config, prerequisites: DispatcherPrer
 
   private val threadPoolConfig: ThreadPoolConfig = configureExecutor() match {
     case e: ThreadPoolExecutorConfigurator ⇒ e.threadPoolConfig
-    case other ⇒
+    case _ ⇒
       prerequisites.eventStream.publish(
         Warning(
           "PinnedDispatcherConfigurator",

--- a/akka-actor/src/main/scala/akka/dispatch/ForkJoinExecutorConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ForkJoinExecutorConfigurator.scala
@@ -42,7 +42,7 @@ object ForkJoinExecutorConfigurator {
     override def getRawResult(): Unit = ()
     override def setRawResult(unit: Unit): Unit = ()
     final override def exec(): Boolean = try { runnable.run(); true } catch {
-      case ie: InterruptedException ⇒
+      case _: InterruptedException ⇒
         Thread.currentThread.interrupt()
         false
       case anything: Throwable ⇒
@@ -61,7 +61,7 @@ class ForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherPrer
 
   def validate(t: ThreadFactory): ForkJoinPool.ForkJoinWorkerThreadFactory = t match {
     case correct: ForkJoinPool.ForkJoinWorkerThreadFactory ⇒ correct
-    case x ⇒ throw new IllegalStateException("The prerequisites for the ForkJoinExecutorConfigurator is a ForkJoinPool.ForkJoinWorkerThreadFactory!")
+    case _ ⇒ throw new IllegalStateException("The prerequisites for the ForkJoinExecutorConfigurator is a ForkJoinPool.ForkJoinWorkerThreadFactory!")
   }
 
   class ForkJoinExecutorServiceFactory(
@@ -83,7 +83,7 @@ class ForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherPrer
     val asyncMode = config.getString("task-peeking-mode") match {
       case "FIFO" ⇒ true
       case "LIFO" ⇒ false
-      case unsupported ⇒ throw new IllegalArgumentException("Cannot instantiate ForkJoinExecutorServiceFactory. " +
+      case _ ⇒ throw new IllegalArgumentException("Cannot instantiate ForkJoinExecutorServiceFactory. " +
         """"task-peeking-mode" in "fork-join-executor" section could only set to "FIFO" or "LIFO".""")
     }
 

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -4,16 +4,20 @@
 
 package akka.dispatch
 
-import scala.runtime.{ BoxedUnit, AbstractPartialFunction }
-import akka.japi.{ Function ⇒ JFunc, Option ⇒ JOption, Procedure }
-import scala.concurrent.{ Future, Promise, ExecutionContext, ExecutionContextExecutor, ExecutionContextExecutorService }
+import scala.runtime.{ AbstractPartialFunction, BoxedUnit }
+import akka.japi.{ Procedure, Function ⇒ JFunc, Option ⇒ JOption }
+
+import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, ExecutionContextExecutorService, Future, Promise }
 import java.lang.{ Iterable ⇒ JIterable }
 import java.util.{ LinkedList ⇒ JLinkedList }
-import java.util.concurrent.{ Executor, ExecutorService, Callable }
-import scala.util.{ Try, Success, Failure }
+import java.util.concurrent.{ Callable, Executor, ExecutorService }
+
+import scala.util.{ Failure, Success, Try }
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.CompletableFuture
+
 import akka.compat
+import akka.util.unused
 
 /**
  * ExecutionContexts is the Java API for ExecutionContexts
@@ -187,20 +191,20 @@ object japi {
       internal(t)
       BoxedUnit.UNIT
     }
-    protected def internal(result: T): Unit = ()
+    protected def internal(@unused result: T): Unit = ()
   }
 
   @deprecated("Do not use this directly, use 'Recover'", "2.0")
   class RecoverBridge[+T] extends AbstractPartialFunction[Throwable, T] {
     override final def isDefinedAt(t: Throwable): Boolean = true
     override final def apply(t: Throwable): T = internal(t)
-    protected def internal(result: Throwable): T = null.asInstanceOf[T]
+    protected def internal(@unused result: Throwable): T = null.asInstanceOf[T]
   }
 
   @deprecated("Do not use this directly, use subclasses of this", "2.0")
   class BooleanFunctionBridge[-T] extends scala.Function1[T, Boolean] {
     override final def apply(t: T): Boolean = internal(t)
-    protected def internal(result: T): Boolean = false
+    protected def internal(@unused result: T): Boolean = false
   }
 
   @deprecated("Do not use this directly, use subclasses of this", "2.0")
@@ -210,7 +214,7 @@ object japi {
     final def apply$mcLF$sp(f: Float): BoxedUnit = { internal(f.asInstanceOf[T]); BoxedUnit.UNIT }
     final def apply$mcLD$sp(d: Double): BoxedUnit = { internal(d.asInstanceOf[T]); BoxedUnit.UNIT }
     override final def apply(t: T): BoxedUnit = { internal(t); BoxedUnit.UNIT }
-    protected def internal(result: T): Unit = ()
+    protected def internal(@unused result: T): Unit = ()
   }
 }
 
@@ -365,5 +369,5 @@ abstract class Mapper[-T, +R] extends scala.runtime.AbstractFunction1[T, R] {
    * Throws UnsupportedOperation by default.
    */
   @throws(classOf[Throwable])
-  def checkedApply(parameter: T): R = throw new UnsupportedOperationException("Mapper.checkedApply has not been implemented")
+  def checkedApply(@unused parameter: T): R = throw new UnsupportedOperationException("Mapper.checkedApply has not been implemented")
 }

--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -233,7 +233,7 @@ private[akka] abstract class Mailbox(val messageQueue: MessageQueue)
   override final def getRawResult(): Unit = ()
   override final def setRawResult(unit: Unit): Unit = ()
   final override def exec(): Boolean = try { run(); false } catch {
-    case ie: InterruptedException ⇒
+    case _: InterruptedException ⇒
       Thread.currentThread.interrupt()
       false
     case anything: Throwable ⇒

--- a/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
@@ -152,7 +152,7 @@ private[akka] class Mailboxes(
     } else if (hasRequiredType(actorClass)) {
       try verifyRequirements(lookupByQueueType(getRequiredType(actorClass)))
       catch {
-        case NonFatal(thr) if (hasMailboxRequirement) ⇒ verifyRequirements(lookupByQueueType(mailboxRequirement))
+        case NonFatal(_) if (hasMailboxRequirement) ⇒ verifyRequirements(lookupByQueueType(mailboxRequirement))
       }
     } else if (hasMailboxRequirement) {
       verifyRequirements(lookupByQueueType(mailboxRequirement))

--- a/akka-actor/src/main/scala/akka/dispatch/affinity/AffinityPool.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/affinity/AffinityPool.scala
@@ -325,7 +325,7 @@ private[akka] final class AffinityPoolConfigurator(config: Config, prerequisites
   private val queueSelectorFactory: QueueSelectorFactory =
     prerequisites.dynamicAccess.createInstanceFor[QueueSelectorFactory](queueSelectorFactoryFQCN, immutable.Seq(classOf[Config] → config))
       .recover({
-        case exception ⇒ throw new IllegalArgumentException(
+        case _ ⇒ throw new IllegalArgumentException(
           s"Cannot instantiate QueueSelectorFactory(queueSelector = $queueSelectorFactoryFQCN), make sure it has an accessible constructor which accepts a Config parameter")
       }).get
 

--- a/akka-actor/src/main/scala/akka/event/ActorClassificationUnsubscriber.scala
+++ b/akka-actor/src/main/scala/akka/event/ActorClassificationUnsubscriber.scala
@@ -8,6 +8,8 @@ import akka.actor._
 import akka.event.Logging.simpleName
 import java.util.concurrent.atomic.AtomicInteger
 
+import akka.util.unused
+
 /**
  * INTERNAL API
  *
@@ -65,7 +67,7 @@ private[akka] object ActorClassificationUnsubscriber {
   final case class Register(actor: ActorRef, seq: Int)
   final case class Unregister(actor: ActorRef, seq: Int)
 
-  def start(system: ActorSystem, bus: ManagedActorClassification, debug: Boolean = false) = {
+  def start(system: ActorSystem, bus: ManagedActorClassification, @unused debug: Boolean = false) = {
     val debug = system.settings.config.getBoolean("akka.actor.debug.event-stream")
     system.asInstanceOf[ExtendedActorSystem]
       .systemActorOf(props(bus, debug), "actorClassificationUnsubscriber-" + unsubscribersCount.incrementAndGet())

--- a/akka-actor/src/main/scala/akka/event/ActorClassificationUnsubscriber.scala
+++ b/akka-actor/src/main/scala/akka/event/ActorClassificationUnsubscriber.scala
@@ -32,7 +32,8 @@ protected[akka] class ActorClassificationUnsubscriber(bus: ManagedActorClassific
       atSeq = nextSeq
       unstashAll()
 
-    case _: Register ⇒ stash()
+    case _: Register ⇒
+      stash()
 
     case Unregister(actor, seq) if seq == nextSeq ⇒
       if (debug) context.system.eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"unregistered watch of $actor in $bus"))
@@ -40,7 +41,8 @@ protected[akka] class ActorClassificationUnsubscriber(bus: ManagedActorClassific
       atSeq = nextSeq
       unstashAll()
 
-    case _: Unregister ⇒ stash()
+    case _: Unregister ⇒
+      stash()
 
     case Terminated(actor) ⇒
       if (debug) context.system.eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"actor $actor has terminated, unsubscribing it from $bus"))

--- a/akka-actor/src/main/scala/akka/event/ActorClassificationUnsubscriber.scala
+++ b/akka-actor/src/main/scala/akka/event/ActorClassificationUnsubscriber.scala
@@ -32,8 +32,7 @@ protected[akka] class ActorClassificationUnsubscriber(bus: ManagedActorClassific
       atSeq = nextSeq
       unstashAll()
 
-    case reg: Register ⇒
-      stash()
+    case _: Register ⇒ stash()
 
     case Unregister(actor, seq) if seq == nextSeq ⇒
       if (debug) context.system.eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"unregistered watch of $actor in $bus"))
@@ -41,8 +40,7 @@ protected[akka] class ActorClassificationUnsubscriber(bus: ManagedActorClassific
       atSeq = nextSeq
       unstashAll()
 
-    case unreg: Unregister ⇒
-      stash()
+    case _: Unregister ⇒ stash()
 
     case Terminated(actor) ⇒
       if (debug) context.system.eventStream.publish(Logging.Debug(simpleName(getClass), getClass, s"actor $actor has terminated, unsubscribing it from $bus"))

--- a/akka-actor/src/main/scala/akka/event/LoggerMailbox.scala
+++ b/akka-actor/src/main/scala/akka/event/LoggerMailbox.scala
@@ -12,13 +12,14 @@ import akka.actor.ActorSystem
 import akka.actor.ActorRef
 import akka.dispatch.ProducesMessageQueue
 import akka.event.Logging.LogEvent
+import akka.util.unused
 
 trait LoggerMessageQueueSemantics
 
 /**
  * INTERNAL API
  */
-private[akka] class LoggerMailboxType(settings: ActorSystem.Settings, config: Config) extends MailboxType
+private[akka] class LoggerMailboxType(@unused settings: ActorSystem.Settings, @unused config: Config) extends MailboxType
   with ProducesMessageQueue[LoggerMailbox] {
 
   override def create(owner: Option[ActorRef], system: Option[ActorSystem]) = (owner, system) match {
@@ -30,7 +31,7 @@ private[akka] class LoggerMailboxType(settings: ActorSystem.Settings, config: Co
 /**
  * INTERNAL API
  */
-private[akka] class LoggerMailbox(owner: ActorRef, system: ActorSystem)
+private[akka] class LoggerMailbox(@unused owner: ActorRef, system: ActorSystem)
   extends UnboundedMailbox.MessageQueue with LoggerMessageQueueSemantics {
 
   override def cleanUp(owner: ActorRef, deadLetters: MessageQueue): Unit = {

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -417,10 +417,9 @@ object Logging {
   /**
    * INTERNAL API
    */
-  private[akka] class LogExt(system: ExtendedActorSystem) extends Extension {
+  private[akka] class LogExt(@unused system: ExtendedActorSystem) extends Extension {
     private val loggerId = new AtomicInteger
     def id() = loggerId.incrementAndGet()
-    def name(clazz: Class[_ <: Actor]): String = "log" + system + "-" + id + "-" + clazz
   }
 
   /**
@@ -487,8 +486,7 @@ object Logging {
     case WarningLevel ⇒ classOf[Warning]
     case InfoLevel    ⇒ classOf[Info]
     case DebugLevel   ⇒ classOf[Debug]
-    case unsupported  ⇒ throw new LoggerInitializationException(s"Unsupported Logger type $unsupported.")
-
+    case level        ⇒ throw new IllegalArgumentException(s"Unsupported log level [$level]")
   }
 
   // these type ascriptions/casts are necessary to avoid CCEs during construction while retaining correct type
@@ -725,7 +723,7 @@ object Logging {
       case WarningLevel ⇒ Warning(logSource, logClass, message)
       case InfoLevel    ⇒ Info(logSource, logClass, message)
       case DebugLevel   ⇒ Debug(logSource, logClass, message)
-      case other        ⇒ throw new LoggerInitializationException(s"Unknown Logger $other.")
+      case level        ⇒ throw new IllegalArgumentException(s"Unsupported log level [$level]")
     }
 
     def apply(level: LogLevel, logSource: String, logClass: Class[_], message: Any, mdc: MDC): LogEvent = level match {
@@ -733,7 +731,7 @@ object Logging {
       case WarningLevel ⇒ Warning(logSource, logClass, message, mdc)
       case InfoLevel    ⇒ Info(logSource, logClass, message, mdc)
       case DebugLevel   ⇒ Debug(logSource, logClass, message, mdc)
-      case other        ⇒ throw new LoggerInitializationException(s"Unknown Logger $other.")
+      case level        ⇒ throw new IllegalArgumentException(s"Unsupported log level [$level]")
     }
 
     def apply(level: LogLevel, logSource: String, logClass: Class[_], message: Any, mdc: MDC, marker: LogMarker): LogEvent = level match {
@@ -741,7 +739,7 @@ object Logging {
       case WarningLevel ⇒ Warning(logSource, logClass, message, mdc, marker)
       case InfoLevel    ⇒ Info(logSource, logClass, message, mdc, marker)
       case DebugLevel   ⇒ Debug(logSource, logClass, message, mdc, marker)
-      case other        ⇒ throw new LoggerInitializationException(s"Unknown Logger $other.")
+      case level        ⇒ throw new IllegalArgumentException(s"Unsupported log level [$level]")
     }
 
   }
@@ -1293,7 +1291,7 @@ trait LoggingAdapter {
     case Logging.WarningLevel ⇒ if (isWarningEnabled) notifyWarning(message)
     case Logging.InfoLevel    ⇒ if (isInfoEnabled) notifyInfo(message)
     case Logging.DebugLevel   ⇒ if (isDebugEnabled) notifyDebug(message)
-    case unsupported          ⇒ throw new ConfigurationException(s"Log level '$unsupported' in config is not supported.")
+    case level                ⇒ throw new IllegalArgumentException(s"Unsupported log level [$level]")
   }
 
   /**

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -1293,9 +1293,7 @@ trait LoggingAdapter {
     case Logging.WarningLevel ⇒ if (isWarningEnabled) notifyWarning(message)
     case Logging.InfoLevel    ⇒ if (isInfoEnabled) notifyInfo(message)
     case Logging.DebugLevel   ⇒ if (isDebugEnabled) notifyDebug(message)
-    case unsupported ⇒ if (isEnabled(unsupported)) {
-      throw new ConfigurationException(s"Log level '$unsupported' in config is not supported.")
-    }
+    case unsupported          ⇒ throw new ConfigurationException(s"Log level '$unsupported' in config is not supported.")
   }
 
   /**

--- a/akka-actor/src/main/scala/akka/event/jul/JavaLogger.scala
+++ b/akka-actor/src/main/scala/akka/event/jul/JavaLogger.scala
@@ -14,6 +14,7 @@ import akka.event.EventStream
 import akka.event.LoggerMessageQueueSemantics
 import akka.event.Logging._
 import akka.event.LoggingFilter
+import akka.util.unused
 
 /**
  * `java.util.logging` logger.
@@ -88,7 +89,7 @@ object Logger {
  * backend configuration to filter log events before publishing
  * the log events to the `eventStream`.
  */
-class JavaLoggingFilter(settings: ActorSystem.Settings, eventStream: EventStream) extends LoggingFilter {
+class JavaLoggingFilter(@unused settings: ActorSystem.Settings, eventStream: EventStream) extends LoggingFilter {
   import Logger.mapLevel
 
   def isErrorEnabled(logClass: Class[_], logSource: String) =

--- a/akka-actor/src/main/scala/akka/io/DirectByteBufferPool.scala
+++ b/akka-actor/src/main/scala/akka/io/DirectByteBufferPool.scala
@@ -90,9 +90,9 @@ private[akka] object DirectByteBufferPool {
             val cleaner = cleanerMethod.invoke(bb)
             cleanMethod.invoke(cleaner)
           }
-        catch { case NonFatal(e) ⇒ /* ok, best effort attempt to cleanup failed */ }
+        catch { case NonFatal(_) ⇒ /* ok, best effort attempt to cleanup failed */ }
       }
-    } catch { case NonFatal(e) ⇒ _ ⇒ () /* reflection failed, use no-op fallback */ }
+    } catch { case NonFatal(_) ⇒ _ ⇒ () /* reflection failed, use no-op fallback */ }
 
   /**
    * DirectByteBuffers are garbage collected by using a phantom reference and a

--- a/akka-actor/src/main/scala/akka/io/Dns.scala
+++ b/akka-actor/src/main/scala/akka/io/Dns.scala
@@ -20,7 +20,7 @@ abstract class Dns {
    * Lookup if a DNS resolved is cached. The exact behavior of caching will depend on
    * the akka.actor.io.dns.resolver that is configured.
    */
-  def cached(name: String): Option[Dns.Resolved] = None
+  def cached(name: String): Option[Dns.Resolved] = name match { case _ ⇒ None } // avoid compiler warning
 
   /**
    * If an entry is cached return it immediately. If it is not then

--- a/akka-actor/src/main/scala/akka/io/Dns.scala
+++ b/akka-actor/src/main/scala/akka/io/Dns.scala
@@ -20,7 +20,7 @@ abstract class Dns {
    * Lookup if a DNS resolved is cached. The exact behavior of caching will depend on
    * the akka.actor.io.dns.resolver that is configured.
    */
-  def cached(name: String): Option[Dns.Resolved] = name match { case _ ⇒ None } // avoid compiler warning
+  def cached(name: String): Option[Dns.Resolved] = None
 
   /**
    * If an entry is cached return it immediately. If it is not then

--- a/akka-actor/src/main/scala/akka/io/Dns.scala
+++ b/akka-actor/src/main/scala/akka/io/Dns.scala
@@ -12,6 +12,9 @@ import akka.annotation.InternalApi
 import akka.routing.ConsistentHashingRouter.ConsistentHashable
 import com.typesafe.config.Config
 import java.util.function.{ Function ⇒ JFunction }
+
+import akka.util.unused
+
 import scala.collection.{ breakOut, immutable }
 
 abstract class Dns {
@@ -20,7 +23,7 @@ abstract class Dns {
    * Lookup if a DNS resolved is cached. The exact behavior of caching will depend on
    * the akka.actor.io.dns.resolver that is configured.
    */
-  def cached(name: String): Option[Dns.Resolved] = None
+  def cached(@unused name: String): Option[Dns.Resolved] = None
 
   /**
    * If an entry is cached return it immediately. If it is not then

--- a/akka-actor/src/main/scala/akka/io/Inet.scala
+++ b/akka-actor/src/main/scala/akka/io/Inet.scala
@@ -4,10 +4,12 @@
 
 package akka.io
 
-import java.nio.channels.{ DatagramChannel }
+import java.nio.channels.DatagramChannel
 import java.net.DatagramSocket
 import java.net.ServerSocket
 import java.net.Socket
+
+import akka.util.unused
 
 object Inet {
 
@@ -20,23 +22,23 @@ object Inet {
     /**
      * Action to be taken for this option before bind() is called
      */
-    def beforeDatagramBind(ds: DatagramSocket): Unit = ()
+    def beforeDatagramBind(@unused ds: DatagramSocket): Unit = ()
 
     /**
      * Action to be taken for this option before bind() is called
      */
-    def beforeServerSocketBind(ss: ServerSocket): Unit = ()
+    def beforeServerSocketBind(@unused ss: ServerSocket): Unit = ()
 
     /**
      * Action to be taken for this option before calling connect()
      */
-    def beforeConnect(s: Socket): Unit = ()
+    def beforeConnect(@unused s: Socket): Unit = ()
 
     /**
      * Action to be taken for this option after connect returned (i.e. on
      * the slave socket for servers).
      */
-    def afterConnect(s: Socket): Unit = ()
+    def afterConnect(@unused s: Socket): Unit = ()
   }
 
   /**
@@ -50,19 +52,19 @@ object Inet {
      * Action to be taken for this option after connect returned (i.e. on
      * the slave socket for servers).
      */
-    def afterBind(s: DatagramSocket): Unit = ()
+    def afterBind(@unused s: DatagramSocket): Unit = ()
 
     /**
      * Action to be taken for this option after connect returned (i.e. on
      * the slave socket for servers).
      */
-    def afterBind(s: ServerSocket): Unit = ()
+    def afterBind(@unused s: ServerSocket): Unit = ()
 
     /**
      * Action to be taken for this option after connect returned (i.e. on
      * the slave socket for servers).
      */
-    def afterConnect(s: DatagramSocket): Unit = ()
+    def afterConnect(@unused s: DatagramSocket): Unit = ()
 
   }
 

--- a/akka-actor/src/main/scala/akka/io/Inet.scala
+++ b/akka-actor/src/main/scala/akka/io/Inet.scala
@@ -20,23 +20,24 @@ object Inet {
     /**
      * Action to be taken for this option before bind() is called
      */
-    def beforeDatagramBind(ds: DatagramSocket): Unit = ()
+    def beforeDatagramBind(ds: DatagramSocket): Unit = ds match { case _ ⇒ () } // avoid compiler warning
 
     /**
      * Action to be taken for this option before bind() is called
      */
-    def beforeServerSocketBind(ss: ServerSocket): Unit = ()
+    def beforeServerSocketBind(ss: ServerSocket): Unit = ss match { case _ ⇒ () } // avoid compiler warning
 
     /**
      * Action to be taken for this option before calling connect()
      */
-    def beforeConnect(s: Socket): Unit = ()
+    def beforeConnect(s: Socket): Unit = s match { case _ ⇒ () } // avoid compiler warning
 
     /**
      * Action to be taken for this option after connect returned (i.e. on
      * the slave socket for servers).
      */
-    def afterConnect(s: Socket): Unit = ()
+    def afterConnect(s: Socket): Unit = s match { case _ ⇒ () } // avoid compiler warning
+
   }
 
   /**
@@ -50,19 +51,19 @@ object Inet {
      * Action to be taken for this option after connect returned (i.e. on
      * the slave socket for servers).
      */
-    def afterBind(s: DatagramSocket): Unit = ()
+    def afterBind(s: DatagramSocket): Unit = s match { case _ ⇒ () } // avoid compiler warning
 
     /**
      * Action to be taken for this option after connect returned (i.e. on
      * the slave socket for servers).
      */
-    def afterBind(s: ServerSocket): Unit = ()
+    def afterBind(s: ServerSocket): Unit = s match { case _ ⇒ () } // avoid compiler warning
 
     /**
      * Action to be taken for this option after connect returned (i.e. on
      * the slave socket for servers).
      */
-    def afterConnect(s: DatagramSocket): Unit = ()
+    def afterConnect(s: DatagramSocket): Unit = s match { case _ ⇒ () } // avoid compiler warning
 
   }
 

--- a/akka-actor/src/main/scala/akka/io/Inet.scala
+++ b/akka-actor/src/main/scala/akka/io/Inet.scala
@@ -20,24 +20,23 @@ object Inet {
     /**
      * Action to be taken for this option before bind() is called
      */
-    def beforeDatagramBind(ds: DatagramSocket): Unit = ds match { case _ ⇒ () } // avoid compiler warning
+    def beforeDatagramBind(ds: DatagramSocket): Unit = ()
 
     /**
      * Action to be taken for this option before bind() is called
      */
-    def beforeServerSocketBind(ss: ServerSocket): Unit = ss match { case _ ⇒ () } // avoid compiler warning
+    def beforeServerSocketBind(ss: ServerSocket): Unit = ()
 
     /**
      * Action to be taken for this option before calling connect()
      */
-    def beforeConnect(s: Socket): Unit = s match { case _ ⇒ () } // avoid compiler warning
+    def beforeConnect(s: Socket): Unit = ()
 
     /**
      * Action to be taken for this option after connect returned (i.e. on
      * the slave socket for servers).
      */
-    def afterConnect(s: Socket): Unit = s match { case _ ⇒ () } // avoid compiler warning
-
+    def afterConnect(s: Socket): Unit = ()
   }
 
   /**
@@ -51,19 +50,19 @@ object Inet {
      * Action to be taken for this option after connect returned (i.e. on
      * the slave socket for servers).
      */
-    def afterBind(s: DatagramSocket): Unit = s match { case _ ⇒ () } // avoid compiler warning
+    def afterBind(s: DatagramSocket): Unit = ()
 
     /**
      * Action to be taken for this option after connect returned (i.e. on
      * the slave socket for servers).
      */
-    def afterBind(s: ServerSocket): Unit = s match { case _ ⇒ () } // avoid compiler warning
+    def afterBind(s: ServerSocket): Unit = ()
 
     /**
      * Action to be taken for this option after connect returned (i.e. on
      * the slave socket for servers).
      */
-    def afterConnect(s: DatagramSocket): Unit = s match { case _ ⇒ () } // avoid compiler warning
+    def afterConnect(s: DatagramSocket): Unit = ()
 
   }
 

--- a/akka-actor/src/main/scala/akka/io/InetAddressDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/InetAddressDnsResolver.scala
@@ -96,7 +96,7 @@ class InetAddressDnsResolver(cache: SimpleDnsCache, config: Config) extends Acto
             if (positiveCachePolicy != Never) cache.put(answer, positiveCachePolicy)
             answer
           } catch {
-            case e: UnknownHostException ⇒
+            case _: UnknownHostException ⇒
               val answer = Dns.Resolved(name, immutable.Seq.empty, immutable.Seq.empty)
               if (negativeCachePolicy != Never) cache.put(answer, negativeCachePolicy)
               answer

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -577,11 +577,11 @@ class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
     val MaxDirectBufferPoolSize: Int = getInt("direct-buffer-pool-limit")
     val RegisterTimeout: Duration = getString("register-timeout") match {
       case "infinite" ⇒ Duration.Undefined
-      case x          ⇒ _config.getMillisDuration("register-timeout")
+      case _          ⇒ _config.getMillisDuration("register-timeout")
     }
     val ReceivedMessageSizeLimit: Int = getString("max-received-message-size") match {
       case "unlimited" ⇒ Int.MaxValue
-      case x           ⇒ getIntBytes("max-received-message-size")
+      case _           ⇒ getIntBytes("max-received-message-size")
     }
     val ManagementDispatcher: String = getString("management-dispatcher")
     val FileIODispatcher: String = getString("file-io-dispatcher")

--- a/akka-actor/src/main/scala/akka/io/UdpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnection.scala
@@ -8,8 +8,10 @@ import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.channels.DatagramChannel
 import java.nio.channels.SelectionKey._
+
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
+
 import akka.actor.{ Actor, ActorLogging, ActorRef }
 import akka.dispatch.{ UnboundedMessageQueueSemantics, RequiresMessageQueue }
 import akka.util.ByteString
@@ -55,7 +57,6 @@ private[io] class UdpConnection(
   }
 
   def doConnect(address: InetSocketAddress): Unit = {
-    // FIXME: why is address not used? If not needed then function should not have the param
     reportConnectFailure {
       channel = DatagramChannel.open
       channel.configureBlocking(false)

--- a/akka-actor/src/main/scala/akka/io/UdpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnection.scala
@@ -55,6 +55,7 @@ private[io] class UdpConnection(
   }
 
   def doConnect(address: InetSocketAddress): Unit = {
+    // FIXME: why is address not used? If not needed then function should not have the param
     reportConnectFailure {
       channel = DatagramChannel.open
       channel.configureBlocking(false)

--- a/akka-actor/src/main/scala/akka/io/UdpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnection.scala
@@ -11,10 +11,9 @@ import java.nio.channels.SelectionKey._
 
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
-
 import akka.actor.{ Actor, ActorLogging, ActorRef }
-import akka.dispatch.{ UnboundedMessageQueueSemantics, RequiresMessageQueue }
-import akka.util.ByteString
+import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
+import akka.util.{ ByteString, unused }
 import akka.io.SelectionHandler._
 import akka.io.UdpConnected._
 
@@ -56,7 +55,7 @@ private[io] class UdpConnection(
       }
   }
 
-  def doConnect(address: InetSocketAddress): Unit = {
+  def doConnect(@unused address: InetSocketAddress): Unit = {
     reportConnectFailure {
       channel = DatagramChannel.open
       channel.configureBlocking(false)

--- a/akka-actor/src/main/scala/akka/io/dns/DnsResourceRecords.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/DnsResourceRecords.scala
@@ -10,7 +10,7 @@ import akka.actor.NoSerializationVerificationNeeded
 import akka.annotation.{ ApiMayChange, InternalApi }
 import CachePolicy._
 import akka.io.dns.internal.{ DomainName, _ }
-import akka.util.{ ByteIterator, ByteString }
+import akka.util.{ ByteIterator, ByteString, unused }
 
 import scala.annotation.switch
 import scala.concurrent.duration._
@@ -30,7 +30,7 @@ final case class ARecord(override val name: String, override val ttl: Ttl,
  */
 @InternalApi
 private[dns] object ARecord {
-  def parseBody(name: String, ttl: Ttl, length: Short, it: ByteIterator): ARecord = {
+  def parseBody(name: String, ttl: Ttl, @unused length: Short, it: ByteIterator): ARecord = {
     val addr = Array.ofDim[Byte](4)
     it.getBytes(addr)
     ARecord(name, ttl, InetAddress.getByAddress(addr).asInstanceOf[Inet4Address])
@@ -52,7 +52,7 @@ private[dns] object AAAARecord {
    * INTERNAL API
    */
   @InternalApi
-  def parseBody(name: String, ttl: Ttl, length: Short, it: ByteIterator): AAAARecord = {
+  def parseBody(name: String, ttl: Ttl, @unused length: Short, it: ByteIterator): AAAARecord = {
     val addr = Array.ofDim[Byte](16)
     it.getBytes(addr)
     AAAARecord(name, ttl, InetAddress.getByAddress(addr).asInstanceOf[Inet6Address])
@@ -70,7 +70,7 @@ private[dns] object CNameRecord {
    * INTERNAL API
    */
   @InternalApi
-  def parseBody(name: String, ttl: Ttl, length: Short, it: ByteIterator, msg: ByteString): CNameRecord = {
+  def parseBody(name: String, ttl: Ttl, @unused length: Short, it: ByteIterator, msg: ByteString): CNameRecord = {
     CNameRecord(name, ttl, DomainName.parse(it, msg))
   }
 }
@@ -89,7 +89,7 @@ private[dns] object SRVRecord {
    * INTERNAL API
    */
   @InternalApi
-  def parseBody(name: String, ttl: Ttl, length: Short, it: ByteIterator, msg: ByteString): SRVRecord = {
+  def parseBody(name: String, ttl: Ttl, @unused length: Short, it: ByteIterator, msg: ByteString): SRVRecord = {
     val priority = it.getShort.toInt & 0xFFFF
     val weight = it.getShort.toInt & 0xFFFF
     val port = it.getShort.toInt & 0xFFFF
@@ -112,7 +112,7 @@ private[dns] object UnknownRecord {
    * INTERNAL API
    */
   @InternalApi
-  def parseBody(name: String, ttl: Ttl, recType: Short, recClass: Short, length: Short, it: ByteIterator): UnknownRecord =
+  def parseBody(name: String, ttl: Ttl, recType: Short, recClass: Short, @unused length: Short, it: ByteIterator): UnknownRecord =
     UnknownRecord(name, ttl, recType, recClass, it.toByteString)
 }
 

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsCache.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsCache.scala
@@ -9,15 +9,13 @@ import java.util.concurrent.atomic.AtomicReference
 import akka.annotation.InternalApi
 import akka.io.{ Dns, PeriodicCacheCleanup }
 import akka.io.dns.CachePolicy.CachePolicy
-
-import scala.collection.immutable
 import akka.io.SimpleDnsCache._
 import akka.io.dns.internal.AsyncDnsResolver.{ Ipv4Type, Ipv6Type, QueryType }
 import akka.io.dns.internal.DnsClient.Answer
 import akka.io.dns.{ AAAARecord, ARecord }
 
 import scala.annotation.tailrec
-import scala.concurrent.duration._
+import scala.collection.immutable
 
 /**
  * Internal API

--- a/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
@@ -43,7 +43,7 @@ import scala.concurrent.duration._
   val udp = IO(Udp)
   val tcp = IO(Tcp)
 
-  var inflightRequests: Map[Short, (ActorRef, Message)] = Map.empty
+  private[internal] var inflightRequests: Map[Short, (ActorRef, Message)] = Map.empty
 
   lazy val tcpDnsClient: ActorRef = createTcpClient()
 

--- a/akka-actor/src/main/scala/akka/io/dns/internal/DnsMessage.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/DnsMessage.scala
@@ -135,10 +135,10 @@ private[internal] object Message {
     val nsCount = it.getShort
     val arCount = it.getShort
 
-    val qs = (0 until qdCount) map { _ ⇒ Try(Question.parse(it, msg)) }
-    val ans = (0 until anCount) map { _ ⇒ Try(ResourceRecord.parse(it, msg)) }
-    val nss = (0 until nsCount) map { _ ⇒ Try(ResourceRecord.parse(it, msg)) }
-    val ars = (0 until arCount) map { _ ⇒ Try(ResourceRecord.parse(it, msg)) }
+    val qs = (0 until qdCount).map { _ ⇒ Try(Question.parse(it, msg)) }
+    val ans = (0 until anCount).map { _ ⇒ Try(ResourceRecord.parse(it, msg)) }
+    val nss = (0 until nsCount).map { _ ⇒ Try(ResourceRecord.parse(it, msg)) }
+    val ars = (0 until arCount).map { _ ⇒ Try(ResourceRecord.parse(it, msg)) }
 
     import scala.language.implicitConversions
     implicit def flattener[T](tried: Try[T]): GenTraversableOnce[T] =

--- a/akka-actor/src/main/scala/akka/io/dns/internal/DnsMessage.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/DnsMessage.scala
@@ -135,10 +135,10 @@ private[internal] object Message {
     val nsCount = it.getShort
     val arCount = it.getShort
 
-    val qs = (0 until qdCount) map { i ⇒ Try(Question.parse(it, msg)) }
-    val ans = (0 until anCount) map { i ⇒ Try(ResourceRecord.parse(it, msg)) }
-    val nss = (0 until nsCount) map { i ⇒ Try(ResourceRecord.parse(it, msg)) }
-    val ars = (0 until arCount) map { i ⇒ Try(ResourceRecord.parse(it, msg)) }
+    val qs = (0 until qdCount) map { _ ⇒ Try(Question.parse(it, msg)) }
+    val ans = (0 until anCount) map { _ ⇒ Try(ResourceRecord.parse(it, msg)) }
+    val nss = (0 until nsCount) map { _ ⇒ Try(ResourceRecord.parse(it, msg)) }
+    val ars = (0 until arCount) map { _ ⇒ Try(ResourceRecord.parse(it, msg)) }
 
     import scala.language.implicitConversions
     implicit def flattener[T](tried: Try[T]): GenTraversableOnce[T] =

--- a/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
@@ -722,10 +722,10 @@ class CircuitBreaker(
         val f = materialize(body)
 
         f.onComplete {
-          case s: Success[_] ⇒
+          case _: Success[_] ⇒
             notifyCallSuccessListeners(start)
             callSucceeds()
-          case Failure(ex) ⇒
+          case Failure(_) ⇒
             notifyCallFailureListeners(start)
             callFails()
         }

--- a/akka-actor/src/main/scala/akka/pattern/PipeToSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/PipeToSupport.scala
@@ -5,12 +5,14 @@
 package akka.pattern
 
 import language.implicitConversions
-import scala.concurrent.{ Future, ExecutionContext }
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
-import akka.actor.{ Status, ActorRef, Actor }
+import akka.actor.{ Actor, ActorRef, Status }
 import akka.actor.ActorSelection
 import java.util.concurrent.CompletionStage
 import java.util.function.BiConsumer
+
+import akka.util.unused
 
 trait PipeToSupport {
 
@@ -39,7 +41,7 @@ trait PipeToSupport {
     }
   }
 
-  final class PipeableCompletionStage[T](val future: CompletionStage[T])(implicit executionContext: ExecutionContext) {
+  final class PipeableCompletionStage[T](val future: CompletionStage[T])(implicit @unused executionContext: ExecutionContext) {
     def pipeTo(recipient: ActorRef)(implicit sender: ActorRef = Actor.noSender): CompletionStage[T] = {
       future whenComplete new BiConsumer[T, Throwable] {
         override def accept(t: T, ex: Throwable): Unit = {

--- a/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
+++ b/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
@@ -219,7 +219,7 @@ final case class ConsistentHashingRoutingLogic(
       message match {
         case _ if hashMapping.isDefinedAt(message) ⇒ target(hashMapping(message))
         case hashable: ConsistentHashable          ⇒ target(hashable.consistentHashKey)
-        case other ⇒
+        case _ ⇒
           log.warning(
             "Message [{}] must be handled by hashMapping, or implement [{}] or be wrapped in [{}]",
             message.getClass.getName, classOf[ConsistentHashable].getName,
@@ -424,7 +424,7 @@ private[akka] final case class ConsistentRoutee(routee: Routee, selfAddress: Add
   private def toStringWithfullAddress(path: ActorPath): String = {
     path.address match {
       case Address(_, _, None, None) ⇒ path.toStringWithAddress(selfAddress)
-      case a                         ⇒ path.toString
+      case _                         ⇒ path.toString
     }
   }
 }

--- a/akka-actor/src/main/scala/akka/routing/OptimalSizeExploringResizer.scala
+++ b/akka-actor/src/main/scala/akka/routing/OptimalSizeExploringResizer.scala
@@ -194,7 +194,7 @@ case class DefaultOptimalSizeExploringResizer(
             cell.mailbox.numberOfMessages + (if (cell.currentMessage != null) 1 else 0)
           case cell ⇒ cell.numberOfMessages
         }
-      case x ⇒ 0
+      case _ ⇒ 0
     }
 
     val totalQueueLength = messagesInRoutees.sum

--- a/akka-actor/src/main/scala/akka/routing/Resizer.scala
+++ b/akka-actor/src/main/scala/akka/routing/Resizer.scala
@@ -205,7 +205,7 @@ case class DefaultResizer(
               case threshold  ⇒ cell.numberOfMessages >= threshold
             }
         }
-      case x ⇒
+      case _ ⇒
         false
     }
   }

--- a/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
+++ b/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
@@ -5,7 +5,6 @@
 package akka.routing
 
 import scala.collection.immutable
-
 import akka.ConfigurationException
 import akka.actor.ActorContext
 import akka.actor.ActorPath
@@ -17,6 +16,7 @@ import akka.actor.Terminated
 import akka.dispatch.Dispatchers
 import akka.actor.ActorSystem
 import akka.japi.Util.immutableSeq
+import akka.util.unused
 
 /**
  * This trait represents a router factory: it produces the actual router actor
@@ -59,7 +59,7 @@ trait RouterConfig extends Serializable {
    * Management messages not handled by the "head" actor are
    * delegated to this controller actor.
    */
-  def routingLogicController(routingLogic: RoutingLogic): Option[Props] = routingLogic match { case _ ⇒ None } // avoiding compiler warning
+  def routingLogicController(@unused routingLogic: RoutingLogic): Option[Props] = None
 
   /**
    * Is the message handled by the router head actor or the
@@ -79,12 +79,12 @@ trait RouterConfig extends Serializable {
   /**
    * Overridable merge strategy, by default completely prefers `this` (i.e. no merge).
    */
-  def withFallback(other: RouterConfig): RouterConfig = other match { case _ ⇒ this } // avoiding compiler warning
+  def withFallback(@unused other: RouterConfig): RouterConfig = this
 
   /**
    * Check that everything is there which is needed. Called in constructor of RoutedActorRef to fail early.
    */
-  def verifyConfig(path: ActorPath): Unit = path match { case _ ⇒ () } // avoiding compiler warning
+  def verifyConfig(@unused path: ActorPath): Unit = ()
 
   /**
    * INTERNAL API

--- a/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
+++ b/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
@@ -5,6 +5,7 @@
 package akka.routing
 
 import scala.collection.immutable
+
 import akka.ConfigurationException
 import akka.actor.ActorContext
 import akka.actor.ActorPath
@@ -58,7 +59,7 @@ trait RouterConfig extends Serializable {
    * Management messages not handled by the "head" actor are
    * delegated to this controller actor.
    */
-  def routingLogicController(routingLogic: RoutingLogic): Option[Props] = None
+  def routingLogicController(routingLogic: RoutingLogic): Option[Props] = routingLogic match { case _ ⇒ None } // avoiding compiler warning
 
   /**
    * Is the message handled by the router head actor or the
@@ -78,12 +79,12 @@ trait RouterConfig extends Serializable {
   /**
    * Overridable merge strategy, by default completely prefers `this` (i.e. no merge).
    */
-  def withFallback(other: RouterConfig): RouterConfig = this
+  def withFallback(other: RouterConfig): RouterConfig = other match { case _ ⇒ this } // avoiding compiler warning
 
   /**
    * Check that everything is there which is needed. Called in constructor of RoutedActorRef to fail early.
    */
-  def verifyConfig(path: ActorPath): Unit = ()
+  def verifyConfig(path: ActorPath): Unit = path match { case _ ⇒ () } // avoiding compiler warning
 
   /**
    * INTERNAL API
@@ -240,7 +241,7 @@ trait Pool extends RouterConfig {
   private[akka] override def createRouterActor(): RouterActor =
     resizer match {
       case None    ⇒ new RouterPoolActor(supervisorStrategy)
-      case Some(r) ⇒ new ResizablePoolActor(supervisorStrategy)
+      case Some(_) ⇒ new ResizablePoolActor(supervisorStrategy)
     }
 
 }

--- a/akka-actor/src/main/scala/akka/serialization/Serialization.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serialization.scala
@@ -234,7 +234,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
                     val classManifestOption: Option[Class[_]] = Some(classManifest)
                     updateCache(cache, manifest, classManifestOption)
                     s1.fromBinary(bytes, classManifestOption)
-                  case Failure(e) ⇒
+                  case Failure(_) ⇒
                     throw new NotSerializableException(
                       s"Cannot find manifest class [$manifest] for serializer with id [${serializer.identifier}].")
                 }

--- a/akka-actor/src/main/scala/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/ByteString.scala
@@ -752,7 +752,8 @@ sealed abstract class ByteString extends IndexedSeq[Byte] with IndexedSeqOptimiz
    * @return the number of bytes actually copied
    */
   // *must* be overridden by derived classes.
-  def copyToBuffer(buffer: ByteBuffer): Int = throw new UnsupportedOperationException("Method copyToBuffer is not implemented in ByteString")
+  def copyToBuffer(buffer: ByteBuffer): Int = throw new UnsupportedOperationException(
+    s"Method copyToBuffer is not implemented in ByteString, failed for buffer $buffer")
 
   /**
    * Create a new ByteString with all contents compacted into a single,

--- a/akka-actor/src/main/scala/akka/util/ClassLoaderObjectInputStream.scala
+++ b/akka-actor/src/main/scala/akka/util/ClassLoaderObjectInputStream.scala
@@ -16,6 +16,6 @@ import java.io.{ InputStream, ObjectInputStream, ObjectStreamClass }
 class ClassLoaderObjectInputStream(classLoader: ClassLoader, is: InputStream) extends ObjectInputStream(is) {
   override protected def resolveClass(objectStreamClass: ObjectStreamClass): Class[_] =
     try Class.forName(objectStreamClass.getName, false, classLoader) catch {
-      case cnfe: ClassNotFoundException ⇒ super.resolveClass(objectStreamClass)
+      case _: ClassNotFoundException ⇒ super.resolveClass(objectStreamClass)
     }
 }

--- a/akka-actor/src/main/scala/akka/util/LineNumbers.scala
+++ b/akka-actor/src/main/scala/akka/util/LineNumbers.scala
@@ -179,7 +179,7 @@ object LineNumbers {
     } finally {
       try dis.close() catch {
         case ex: InterruptedException ⇒ throw ex
-        case NonFatal(ex)             ⇒ // ignore
+        case NonFatal(_)              ⇒ // ignore
       }
     }
   }

--- a/akka-actor/src/main/scala/akka/util/ManifestInfo.scala
+++ b/akka-actor/src/main/scala/akka/util/ManifestInfo.scala
@@ -59,7 +59,7 @@ object ManifestInfo extends ExtensionId[ManifestInfo] with ExtensionIdProvider {
           numbers(numbersPos) = segments(segmentPos).toInt
           segmentPos += 1
         } catch {
-          case e: NumberFormatException ⇒
+          case _: NumberFormatException ⇒
             // This means that we have a trailing part on the version string and
             // less than 3 numbers, so we assume that this is a "newer" version
             numbers(numbersPos) = Integer.MAX_VALUE

--- a/akka-actor/src/main/scala/akka/util/Reflect.scala
+++ b/akka-actor/src/main/scala/akka/util/Reflect.scala
@@ -33,7 +33,7 @@ private[akka] object Reflect {
       val m = c.getMethod("getCallerClass", Array(classOf[Int]): _*)
       Some((i: Int) ⇒ m.invoke(null, Array[AnyRef](i.asInstanceOf[java.lang.Integer]): _*).asInstanceOf[Class[_]])
     } catch {
-      case NonFatal(e) ⇒ None
+      case NonFatal(_) ⇒ None
     }
   }
 
@@ -43,7 +43,7 @@ private[akka] object Reflect {
    * @return a new instance from the default constructor of the given class
    */
   private[akka] def instantiate[T](clazz: Class[T]): T = try clazz.newInstance catch {
-    case iae: IllegalAccessException ⇒
+    case _: IllegalAccessException ⇒
       val ctor = clazz.getDeclaredConstructor()
       ctor.setAccessible(true)
       ctor.newInstance()

--- a/akka-actor/src/main/scala/akka/util/Unused.scala
+++ b/akka-actor/src/main/scala/akka/util/Unused.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+import akka.annotation.InternalApi
+
+/**
+ * Marker for explicit or implicit parameter known to be unused, yet
+ * still necessary from a binary compatibility perspective
+ * or other reason. Useful in combination with
+ * `-Ywarn-unused:explicits,implicits` compiler options.
+ *
+ * INTERNAL API
+ */
+@InternalApi private[akka] class unused extends deprecated("unused", "")

--- a/akka-testkit/src/main/scala/akka/testkit/TestActorRef.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestActorRef.scala
@@ -32,7 +32,7 @@ class TestActorRef[T <: Actor](
     private val disregard = _supervisor match {
       case l: LocalActorRef ⇒ l.underlying.reserveChild(name)
       case r: RepointableActorRef ⇒ r.underlying match {
-        case u: UnstartedCell ⇒ throw new IllegalStateException("cannot attach a TestActor to an unstarted top-level actor, ensure that it is started by sending a message and observing the reply")
+        case _: UnstartedCell ⇒ throw new IllegalStateException("cannot attach a TestActor to an unstarted top-level actor, ensure that it is started by sending a message and observing the reply")
         case c: ActorCell     ⇒ c.reserveChild(name)
         case o                ⇒ _system.log.error("trying to attach child {} to unknown type of supervisor cell {}, this is not going to end well", name, o.getClass)
       }

--- a/akka-testkit/src/main/scala/akka/testkit/TestBarrier.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestBarrier.scala
@@ -32,7 +32,7 @@ class TestBarrier(count: Int) {
     try {
       barrier.await(timeout.dilated.toNanos, TimeUnit.NANOSECONDS)
     } catch {
-      case e: TimeoutException ⇒
+      case _: TimeoutException ⇒
         throw new TestBarrierTimeoutException("Timeout of %s and time factor of %s"
           format (timeout.toString, TestKitExtension(system).TestTimeFactor))
     }

--- a/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
@@ -521,7 +521,7 @@ class TestEventListener extends Logging.DefaultLogger {
     case m ⇒ print(Debug(context.system.name, this.getClass, m))
   }
 
-  def filter(event: LogEvent): Boolean = filters exists (f ⇒ try { f(event) } catch { case e: Exception ⇒ false })
+  def filter(event: LogEvent): Boolean = filters exists (f ⇒ try { f(event) } catch { case _: Exception ⇒ false })
 
   def addFilter(filter: EventFilter): Unit = filters ::= filter
 

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -62,7 +62,7 @@ object TestActor {
     override def sender: ActorRef = throw IllegalActorStateException("last receive did not dequeue a message")
   }
 
-  val FALSE = (x: Any) ⇒ false
+  val FALSE = (_: Any) ⇒ false
 
   /** INTERNAL API */
   private[TestActor] class DelegatingSupervisorStrategy extends SupervisorStrategy {
@@ -734,7 +734,7 @@ trait TestKitBase {
           case RealMessage(o, _) if (f isDefinedAt o) ⇒
             msg = lastMessage
             doit(f(o) :: acc, count + 1)
-          case RealMessage(o, _) ⇒
+          case RealMessage(_, _) ⇒
             queue.offerFirst(lastMessage)
             lastMessage = msg
             acc.reverse

--- a/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
@@ -489,7 +489,7 @@ class TestKit(system: ActorSystem) {
    * given object. Wait time is bounded by the given duration, with an
    * AssertionFailure being thrown in case of timeout.
    */
-  def expectMsg[T](max: java.time.Duration, obj: T, hint: String): T = expectMsg(max.asScala, obj)
+  def expectMsg[T](max: java.time.Duration, obj: T, hint: String): T = expectMsg(max, obj, hint)
 
   /**
    * Receive one message from the test actor and assert that the given


### PR DESCRIPTION
Around 50% of fixes for [# 26089](https://github.com/akka/akka/issues/26089)

**akka-actor**
Before: 132 warnings found
After: 27 warnings found - these will remain for the moment; some for binary compatibility, etc.

**akka-actor-tests**
Before: 207 warnings found
After: 170, it was mind-numbing, we can clean more up later.

**Idea from**
https://github.com/scalaz/scalaz/pull/1670

**Related to**
https://github.com/scala/bug/issues/10287

**Also note**
https://github.com/scala/scala/pull/5402#issuecomment-279384281
https://github.com/scala/scala/commit/109f03e56c37c215b6d910d52e491f209658cc3a