### PR TITLE
adds service name parser (copied from akka-management)

### DIFF
--- a/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
@@ -129,7 +129,7 @@ object ServiceDiscovery {
  * For example `portName` could be used to distinguish between
  * Akka remoting ports and HTTP ports.
  *
-  * @throws IllegalArgumentException if [[serviceName]] is 'null' or an empty String
+ * @throws IllegalArgumentException if [[serviceName]] is 'null' or an empty String
  */
 @ApiMayChange
 final class Lookup(

--- a/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
@@ -195,40 +195,39 @@ case object Lookup {
    */
   def create(serviceName: String): Lookup = new Lookup(serviceName, None, None)
 
-
   private val SrvQuery = """^_(.+?)\._(.+?)\.(.+?)$""".r
 
   private val DomainName = "^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,6}$".r
 
   /**
-    * Create a service Lookup from a string with format:
-    * _portName._protocol.serviceName.
-    * (as specified by https://www.ietf.org/rfc/rfc2782.txt)
-    *
-    * If the passed string conforms with this format, a SRV Lookup is returned.
-    * The serviceName part must be a valid domain name.
-    *
-    * The string is parsed and dismembered to build a Lookup as following:
-    * Lookup(serviceName).withPortName(portName).withProtocol(protocol)
-    *
-    * If the string doesn't not conform with the SRV format, a simple A/AAAA Lookup is returned
-    * using the whole string as service name.
-    */
+   * Create a service Lookup from a string with format:
+   * _portName._protocol.serviceName.
+   * (as specified by https://www.ietf.org/rfc/rfc2782.txt)
+   *
+   * If the passed string conforms with this format, a SRV Lookup is returned.
+   * The serviceName part must be a valid domain name.
+   *
+   * The string is parsed and dismembered to build a Lookup as following:
+   * Lookup(serviceName).withPortName(portName).withProtocol(protocol)
+   *
+   * If the string doesn't not conform with the SRV format, a simple A/AAAA Lookup is returned
+   * using the whole string as service name.
+   */
   def fromString(str: String): Lookup =
     str match {
-      case SrvQuery(portName, protocol, serviceName) if validDomainName(serviceName) =>
+      case SrvQuery(portName, protocol, serviceName) if validDomainName(serviceName) ⇒
         Lookup(serviceName).withPortName(portName).withProtocol(protocol)
 
-      case _ => Lookup(str)
+      case _ ⇒ Lookup(str)
     }
 
   /**
-    * Returns true if passed string conforms with SRV format. Otherwise returns false.
-    */
+   * Returns true if passed string conforms with SRV format. Otherwise returns false.
+   */
   def isValidSrv(srv: String): Boolean =
     srv match {
-      case SrvQuery(_, _, serviceName) =>  validDomainName(serviceName) 
-      case _ => false
+      case SrvQuery(_, _, serviceName) ⇒ validDomainName(serviceName)
+      case _                           ⇒ false
     }
 
   private def validDomainName(name: String): Boolean =

--- a/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
@@ -214,6 +214,8 @@ case object Lookup {
    * The string is parsed and dismembered to build a Lookup as following:
    * Lookup(serviceName).withPortName(portName).withProtocol(protocol)
    *
+   *
+   * @throws NullPointerException If the passed string is null
    * @throws IllegalArgumentException If the string doesn't not conform with the SRV format
    */
   def parseSrv(str: String): Lookup =
@@ -221,7 +223,8 @@ case object Lookup {
       case SrvQuery(portName, protocol, serviceName) if validDomainName(serviceName) ⇒
         Lookup(serviceName).withPortName(portName).withProtocol(protocol)
 
-      case _ ⇒ throw new IllegalArgumentException(s"Unable to create Lookup from passed SRV string, invalid format: $str")
+      case null ⇒ throw new NullPointerException("Unable to create Lookup from passed SRV string. Passed value is 'null'")
+      case _    ⇒ throw new IllegalArgumentException(s"Unable to create Lookup from passed SRV string, invalid format: $str")
     }
 
   /**

--- a/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
@@ -129,6 +129,7 @@ object ServiceDiscovery {
  * For example `portName` could be used to distinguish between
  * Akka remoting ports and HTTP ports.
  *
+  * @throws IllegalArgumentException if [[serviceName]] is 'null' or an empty String
  */
 @ApiMayChange
 final class Lookup(
@@ -136,8 +137,8 @@ final class Lookup(
   val portName:    Option[String],
   val protocol:    Option[String]) {
 
-  require(serviceName != null, "serviceName cannot be null")
-  require(serviceName.trim.nonEmpty, "serviceName cannot be empty")
+  require(serviceName != null, "'serviceName' cannot be null")
+  require(serviceName.trim.nonEmpty, "'serviceName' cannot be empty")
 
   /**
    * Which port for a service e.g. Akka remoting or HTTP.
@@ -221,7 +222,7 @@ case object Lookup {
       case SrvQuery(portName, protocol, serviceName) if validDomainName(serviceName) ⇒
         Lookup(serviceName).withPortName(portName).withProtocol(protocol)
 
-      case _ ⇒ throw new IllegalArgumentException(s"Invalid SRV string $str")
+      case _ ⇒ throw new IllegalArgumentException(s"Unable to create Lookup from passed SRV string, invalid format: $str.")
     }
 
   /**

--- a/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
@@ -4,7 +4,6 @@
 
 package akka.discovery
 
-import java.lang.invoke.MethodHandles
 import java.net.InetAddress
 import java.util.Optional
 import java.util.concurrent.CompletionStage

--- a/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
@@ -227,7 +227,7 @@ case object Lookup {
     */
   def isValidSrv(srv: String): Boolean =
     srv match {
-      case SrvQuery(_, _, serviceName) if validDomainName(serviceName) => true
+      case SrvQuery(_, _, serviceName) =>  validDomainName(serviceName) 
       case _ => false
     }
 

--- a/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
@@ -221,7 +221,7 @@ case object Lookup {
       case SrvQuery(portName, protocol, serviceName) if validDomainName(serviceName) ⇒
         Lookup(serviceName).withPortName(portName).withProtocol(protocol)
 
-      case _ ⇒ throw new IllegalArgumentException(s"Unable to create Lookup from passed SRV string, invalid format: $str.")
+      case _ ⇒ throw new IllegalArgumentException(s"Unable to create Lookup from passed SRV string, invalid format: $str")
     }
 
   /**

--- a/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery

--- a/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -37,7 +37,7 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
     }
 
     "throw an IllegalArgumentException when passing a 'null' SRV String" in {
-      assertThrows[IllegalArgumentException] {
+      assertThrows[NullPointerException] {
         Lookup.parseSrv(null)
       }
     }

--- a/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -71,5 +71,17 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
       }
     }
 
+    "return false for empty SRV String" in {
+      Lookup.isValidSrv("") shouldBe false
+    }
+
+    "return false for 'null' SRV String" in {
+      Lookup.isValidSrv(null) shouldBe false
+    }
+
+    "return true for a SRV with valid domain name" in {
+      Lookup.isValidSrv("_portName._protocol.serviceName.local") shouldBe true
+    }
+
   }
 }

--- a/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.discovery
+
+import org.scalatest.{ Matchers, OptionValues, WordSpec }
+
+class LookupSpec extends WordSpec with Matchers with OptionValues {
+
+  // SRV strings with invalid domain names
+  // should fail to build lookups
+  val srvWithInvalidDomainNames = List(
+    "_portName._protocol.service_name.local",
+    "_portName._protocol.servicename,local",
+    "_portName._protocol.servicename.local-",
+    "_portName._protocol.-servicename.local"
+  )
+
+  // No SRV that should result in simple A/AAAA lookups
+  val noSrvLookups = List(
+    "portName.protocol.serviceName.local",
+    "serviceName.local",
+    "_portName.serviceName",
+    "_serviceName.local",
+    "_serviceName,local",
+    "-serviceName.local",
+    "serviceName.local-"
+  )
+
+  "Lookup.fromString" should {
+
+    "generate a SRV Lookup from a SRV String" in {
+      val name = "_portName._protocol.serviceName.local"
+      val lookup = Lookup.fromString(name)
+      lookup.serviceName shouldBe "serviceName.local"
+      lookup.portName.value shouldBe "portName"
+      lookup.protocol.value shouldBe "protocol"
+    }
+
+    "generate a A/AAAA from any non-conforming SRV String" in {
+      (noSrvLookups ++ srvWithInvalidDomainNames).foreach { str =>
+        withClue(s"parsing '$str'") {
+          val lookup = Lookup.fromString(str)
+          lookup.serviceName shouldBe str
+          lookup.portName shouldBe empty
+          lookup.protocol shouldBe empty
+        }
+      }
+    }
+
+  }
+
+  "Lookup.isValidSrv" should {
+
+    "return true for any conforming SRV String" in {
+      Lookup.isValidSrv("_portName._protocol.serviceName.local") shouldBe true
+    }
+
+    "return false for any non-conforming SRV String" in {
+      noSrvLookups.foreach { str =>
+        withClue(s"checking '$str'") {
+          Lookup.isValidSrv(str) shouldBe false
+        }
+      }
+    }
+
+    "return false for if domain part in SRV String is an invalid domain name" in {
+      srvWithInvalidDomainNames.foreach { str =>
+        withClue(s"checking '$str'") {
+          Lookup.isValidSrv(str) shouldBe false
+        }
+      }
+    }
+
+  }
+}

--- a/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -26,23 +26,44 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
     "-serviceName.local",
     "serviceName.local-")
 
-  "Lookup.fromString" should {
+  "Lookup.parseSrv" should {
 
     "generate a SRV Lookup from a SRV String" in {
       val name = "_portName._protocol.serviceName.local"
-      val lookup = Lookup.fromString(name)
+      val lookup = Lookup.parseSrv(name)
       lookup.serviceName shouldBe "serviceName.local"
       lookup.portName.value shouldBe "portName"
       lookup.protocol.value shouldBe "protocol"
     }
 
-    "generate a A/AAAA from any non-conforming SRV String" in {
-      (noSrvLookups ++ srvWithInvalidDomainNames).foreach { str ⇒
+    "throw an IllegalArgumentException when passing null SRV String" in {
+      assertThrows[IllegalArgumentException] {
+        Lookup.parseSrv(null)
+      }
+    }
+
+    "throw an IllegalArgumentException when passing an empty SRV String" in {
+      assertThrows[IllegalArgumentException] {
+        Lookup.parseSrv("")
+      }
+    }
+
+    "throw an IllegalArgumentException for any non-conforming SRV String" in {
+      noSrvLookups.foreach { str ⇒
         withClue(s"parsing '$str'") {
-          val lookup = Lookup.fromString(str)
-          lookup.serviceName shouldBe str
-          lookup.portName shouldBe empty
-          lookup.protocol shouldBe empty
+          assertThrows[IllegalArgumentException] {
+            Lookup.parseSrv(str)
+          }
+        }
+      }
+    }
+
+    "throw an IllegalArgumentException for any SRV with invalid domain names" in {
+      srvWithInvalidDomainNames.foreach { str ⇒
+        withClue(s"parsing '$str'") {
+          assertThrows[IllegalArgumentException] {
+            Lookup.parseSrv(str)
+          }
         }
       }
     }

--- a/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.discovery
@@ -37,7 +37,7 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
     }
 
     "generate a A/AAAA from any non-conforming SRV String" in {
-      (noSrvLookups ++ srvWithInvalidDomainNames).foreach { str =>
+      (noSrvLookups ++ srvWithInvalidDomainNames).foreach { str ⇒
         withClue(s"parsing '$str'") {
           val lookup = Lookup.fromString(str)
           lookup.serviceName shouldBe str
@@ -56,7 +56,7 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
     }
 
     "return false for any non-conforming SRV String" in {
-      noSrvLookups.foreach { str =>
+      noSrvLookups.foreach { str ⇒
         withClue(s"checking '$str'") {
           Lookup.isValidSrv(str) shouldBe false
         }
@@ -64,7 +64,7 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
     }
 
     "return false for if domain part in SRV String is an invalid domain name" in {
-      srvWithInvalidDomainNames.foreach { str =>
+      srvWithInvalidDomainNames.foreach { str ⇒
         withClue(s"checking '$str'") {
           Lookup.isValidSrv(str) shouldBe false
         }

--- a/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -14,8 +14,7 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
     "_portName._protocol.service_name.local",
     "_portName._protocol.servicename,local",
     "_portName._protocol.servicename.local-",
-    "_portName._protocol.-servicename.local"
-  )
+    "_portName._protocol.-servicename.local")
 
   // No SRV that should result in simple A/AAAA lookups
   val noSrvLookups = List(
@@ -25,8 +24,7 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
     "_serviceName.local",
     "_serviceName,local",
     "-serviceName.local",
-    "serviceName.local-"
-  )
+    "serviceName.local-")
 
   "Lookup.fromString" should {
 

--- a/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/LookupSpec.scala
@@ -36,7 +36,7 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
       lookup.protocol.value shouldBe "protocol"
     }
 
-    "throw an IllegalArgumentException when passing null SRV String" in {
+    "throw an IllegalArgumentException when passing a 'null' SRV String" in {
       assertThrows[IllegalArgumentException] {
         Lookup.parseSrv(null)
       }
@@ -84,7 +84,7 @@ class LookupSpec extends WordSpec with Matchers with OptionValues {
       }
     }
 
-    "return false for if domain part in SRV String is an invalid domain name" in {
+    "return false if domain part in SRV String is an invalid domain name" in {
       srvWithInvalidDomainNames.foreach { str ⇒
         withClue(s"checking '$str'") {
           Lookup.isValidSrv(str) shouldBe false


### PR DESCRIPTION
This adds the Service Name parser that was added to Akka Management but wasn't moved to Akka when ServiceDiscovery was moved. 

@jroper I decided to keep that old implementation and not port/bring to Akka the one you added in [lagom/akka-discovery-service-locator](https://github.com/lagom/akka-discovery-service-locator/blob/master/service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/ServiceNameParser.scala#L13).

The reason is that the SRV format is a very well-known and used format backed by a specification [see rfc2782](https://www.ietf.org/rfc/rfc2782.txt). It's used by Kubernetes API and by DNS, and probably by others. 

Akka Discovery users are expected to do the lookup themselves and therefore if they don't use that format, they can parse their string the way they want and fill port-name and port-protocol the way they want. We could also argue that SVR parser is also not needed, but I find it a nice convenience.


