### PR TITLE
Fix compiler warnings in akka-remote, akka-actor-typed.

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/Effect.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/Effect.scala
@@ -7,6 +7,7 @@ package akka.actor.testkit.typed
 import akka.actor.typed.{ ActorRef, Behavior, Props }
 import akka.annotation.{ DoNotInherit, InternalApi }
 import akka.util.JavaDurationConverters._
+import akka.util.unused
 
 import scala.compat.java8.FunctionConverters._
 import scala.concurrent.duration.FiniteDuration
@@ -114,18 +115,18 @@ object Effect {
   private[akka] final class SpawnedAnonymousAdapter[T](val ref: ActorRef[T])
     extends Effect with Product with Serializable {
 
-    override def equals(other: Any) = other match {
+    override def equals(other: Any): Boolean = other match {
       case _: SpawnedAnonymousAdapter[_] ⇒ true
       case _                             ⇒ false
     }
     override def hashCode: Int = Nil.##
     override def toString: String = "SpawnedAnonymousAdapter"
 
-    override def productPrefix = "SpawnedAnonymousAdapter"
-    override def productIterator = Iterator.empty
-    override def productArity = 0
+    override def productPrefix: String = "SpawnedAnonymousAdapter"
+    override def productIterator: Iterator[_] = Iterator.empty
+    override def productArity: Int = 0
     override def productElement(n: Int) = throw new NoSuchElementException
-    override def canEqual(o: Any) = o.isInstanceOf[SpawnedAnonymousAdapter[_]]
+    override def canEqual(o: Any): Boolean = o.isInstanceOf[SpawnedAnonymousAdapter[_]]
   }
 
   /**
@@ -134,7 +135,7 @@ object Effect {
   @InternalApi
   private[akka] object SpawnedAnonymousAdapter {
     def apply[T]() = new SpawnedAnonymousAdapter[T](null)
-    def unapply[T](s: SpawnedAnonymousAdapter[T]): Boolean = true
+    def unapply[T](@unused s: SpawnedAnonymousAdapter[T]): Boolean = true
   }
 
   /**

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
@@ -157,22 +157,12 @@ final class ActorTestKit private[akka] (delegate: akka.actor.testkit.typed.scala
    * @tparam M the type of messages the probe should accept
    */
   def createTestProbe[M](): TestProbe[M] = TestProbe.create(system)
-  /**
-   * Shortcut for creating a new test probe for the testkit actor system
-   * @tparam M the type of messages the probe should accept
-   */
-  def createTestProbe[M](clazz: Class[M]): TestProbe[M] = TestProbe.create(clazz, system)
 
   /**
    * Shortcut for creating a new named test probe for the testkit actor system
    * @tparam M the type of messages the probe should accept
    */
   def createTestProbe[M](name: String): TestProbe[M] = TestProbe.create(name, system)
-  /**
-   * Shortcut for creating a new named test probe for the testkit actor system
-   * @tparam M the type of messages the probe should accept
-   */
-  def createTestProbe[M](name: String, clazz: Class[M]): TestProbe[M] = TestProbe.create(name, clazz, system)
 
   // Note that if more methods are added here they should also be added to TestKitJunitResource
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
@@ -157,12 +157,22 @@ final class ActorTestKit private[akka] (delegate: akka.actor.testkit.typed.scala
    * @tparam M the type of messages the probe should accept
    */
   def createTestProbe[M](): TestProbe[M] = TestProbe.create(system)
+  /**
+   * Shortcut for creating a new test probe for the testkit actor system
+   * @tparam M the type of messages the probe should accept
+   */
+  def createTestProbe[M](clazz: Class[M]): TestProbe[M] = TestProbe.create(clazz, system)
 
   /**
    * Shortcut for creating a new named test probe for the testkit actor system
    * @tparam M the type of messages the probe should accept
    */
   def createTestProbe[M](name: String): TestProbe[M] = TestProbe.create(name, system)
+  /**
+   * Shortcut for creating a new named test probe for the testkit actor system
+   * @tparam M the type of messages the probe should accept
+   */
+  def createTestProbe[M](name: String, clazz: Class[M]): TestProbe[M] = TestProbe.create(name, clazz, system)
 
   // Note that if more methods are added here they should also be added to TestKitJunitResource
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestKitJunitResource.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestKitJunitResource.scala
@@ -101,14 +101,7 @@ final class TestKitJunitResource(_kit: ActorTestKit) extends ExternalResource {
    * See corresponding method on [[ActorTestKit]]
    */
   def createTestProbe[M](): TestProbe[M] = testKit.createTestProbe[M]()
-  /**
-   * See corresponding method on [[ActorTestKit]]
-   */
-  def createTestProbe[M](clazz: Class[M]): TestProbe[M] = testKit.createTestProbe(clazz)
-  /**
-   * See corresponding method on [[ActorTestKit]]
-   */
-  def createTestProbe[M](name: String, clazz: Class[M]): TestProbe[M] = testKit.createTestProbe(name, clazz)
+
   /**
    * See corresponding method on [[ActorTestKit]]
    */

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestKitJunitResource.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestKitJunitResource.scala
@@ -101,7 +101,14 @@ final class TestKitJunitResource(_kit: ActorTestKit) extends ExternalResource {
    * See corresponding method on [[ActorTestKit]]
    */
   def createTestProbe[M](): TestProbe[M] = testKit.createTestProbe[M]()
-
+  /**
+   * See corresponding method on [[ActorTestKit]]
+   */
+  def createTestProbe[M](clazz: Class[M]): TestProbe[M] = testKit.createTestProbe(clazz)
+  /**
+   * See corresponding method on [[ActorTestKit]]
+   */
+  def createTestProbe[M](name: String, clazz: Class[M]): TestProbe[M] = testKit.createTestProbe(name, clazz)
   /**
    * See corresponding method on [[ActorTestKit]]
    */

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
@@ -10,15 +10,15 @@ import java.util.{ List ⇒ JList }
 
 import akka.actor.typed.{ ActorRef, ActorSystem }
 import akka.annotation.DoNotInherit
+import akka.annotation.InternalApi
 import akka.actor.testkit.typed.internal.TestProbeImpl
 import akka.actor.testkit.typed.{ FishingOutcome, TestKitSettings }
 import akka.actor.testkit.typed.scaladsl.TestDuration
 import akka.util.JavaDurationConverters._
+
 import scala.collection.immutable
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
-
-import akka.annotation.InternalApi
 
 object FishingOutcomes {
   /**

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
@@ -15,6 +15,7 @@ import akka.actor.testkit.typed.internal.TestProbeImpl
 import akka.actor.testkit.typed.{ FishingOutcome, TestKitSettings }
 import akka.actor.testkit.typed.scaladsl.TestDuration
 import akka.util.JavaDurationConverters._
+import akka.util.unused
 
 import scala.collection.immutable
 import scala.collection.JavaConverters._
@@ -47,9 +48,14 @@ object TestProbe {
   def create[M](system: ActorSystem[_]): TestProbe[M] =
     create(name = "testProbe", system)
 
+  def create[M](@unused clazz: Class[M], system: ActorSystem[_]): TestProbe[M] =
+    create(system)
+
   def create[M](name: String, system: ActorSystem[_]): TestProbe[M] =
     new TestProbeImpl[M](name, system)
 
+  def create[M](name: String, @unused clazz: Class[M], system: ActorSystem[_]): TestProbe[M] =
+    new TestProbeImpl[M](name, system)
 }
 
 /**

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
@@ -47,14 +47,9 @@ object TestProbe {
   def create[M](system: ActorSystem[_]): TestProbe[M] =
     create(name = "testProbe", system)
 
-  def create[M](clazz: Class[M], system: ActorSystem[_]): TestProbe[M] =
-    create(system)
-
   def create[M](name: String, system: ActorSystem[_]): TestProbe[M] =
     new TestProbeImpl[M](name, system)
 
-  def create[M](name: String, clazz: Class[M], system: ActorSystem[_]): TestProbe[M] =
-    new TestProbeImpl[M](name, system)
 }
 
 /**

--- a/akka-actor-tests/src/test/scala/akka/actor/HotSwapSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/HotSwapSpec.scala
@@ -19,7 +19,7 @@ class HotSwapSpec extends AkkaSpec with ImplicitSender {
     "be able to become in its constructor" in {
       val a = system.actorOf(Props(new Becomer {
         context.become { case always ⇒ sender() ! always }
-        def receive = { case always ⇒ sender() ! "FAILURE" }
+        def receive = { case _ ⇒ sender() ! "FAILURE" }
       }))
       a ! "pigdog"
       expectMsg("pigdog")
@@ -28,7 +28,7 @@ class HotSwapSpec extends AkkaSpec with ImplicitSender {
     "be able to become multiple times in its constructor" in {
       val a = system.actorOf(Props(new Becomer {
         for (i ← 1 to 4) context.become({ case always ⇒ sender() ! i + ":" + always })
-        def receive = { case always ⇒ sender() ! "FAILURE" }
+        def receive = { case _ ⇒ sender() ! "FAILURE" }
       }))
       a ! "pigdog"
       expectMsg("4:pigdog")
@@ -48,7 +48,7 @@ class HotSwapSpec extends AkkaSpec with ImplicitSender {
     "be able to become, with stacking, multiple times in its constructor" in {
       val a = system.actorOf(Props(new Becomer {
         for (i ← 1 to 4) context.become({ case always ⇒ sender() ! i + ":" + always; context.unbecome() }, false)
-        def receive = { case always ⇒ sender() ! "FAILURE" }
+        def receive = { case _ ⇒ sender() ! "FAILURE" }
       }))
       a ! "pigdog"
       a ! "pigdog"

--- a/akka-actor-tests/src/test/scala/akka/util/ReflectSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ReflectSpec.scala
@@ -12,8 +12,8 @@ object ReflectSpec {
   final class A
   final class B
 
-  class One(a: A)
-  class Two(a: A, b: B)
+  class One(@unused a: A)
+  class Two(@unused a: A, @unused b: B)
 
   class MultipleOne(a: A, b: B) {
     def this(a: A) { this(a, null) }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
@@ -99,7 +99,7 @@ abstract class Props private[akka] () extends Product with Serializable {
     @tailrec def select(d: Props, acc: List[Props]): List[Props] =
       d match {
         case EmptyProps ⇒ acc.reverse
-        case t: T       ⇒ select(d.next, (d withNext EmptyProps) :: acc)
+        case _: T       ⇒ select(d.next, (d withNext EmptyProps) :: acc)
         case _          ⇒ select(d.next, acc)
       }
     select(this, Nil)
@@ -114,7 +114,7 @@ abstract class Props private[akka] () extends Product with Serializable {
     @tailrec def select(d: Props, acc: List[Props]): List[Props] =
       d match {
         case EmptyProps ⇒ acc
-        case t: T       ⇒ select(d.next, acc)
+        case _: T       ⇒ select(d.next, acc)
         case _          ⇒ select(d.next, d :: acc)
       }
     @tailrec def link(l: List[Props], acc: Props): Props =

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
@@ -135,9 +135,9 @@ import akka.util.OptionVal
   }
 
   override def unhandled(msg: Any): Unit = msg match {
-    case t @ Terminated(ref) ⇒ throw DeathPactException(ref)
-    case msg: Signal         ⇒ // that's ok
-    case other               ⇒ super.unhandled(other)
+    case Terminated(ref) ⇒ throw DeathPactException(ref)
+    case _: Signal       ⇒ // that's ok
+    case other           ⇒ super.unhandled(other)
   }
 
   override val supervisorStrategy = untyped.OneForOneStrategy(loggingEnabled = false) {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala
@@ -60,8 +60,8 @@ private[akka] object ActorRefAdapter {
         sysmsg.Watch(
           toUntyped(watchee),
           toUntyped(watcher)))
-      case internal.Unwatch(watchee, watcher)          ⇒ untyped.sendSystemMessage(sysmsg.Unwatch(toUntyped(watchee), toUntyped(watcher)))
-      case internal.DeathWatchNotification(ref, cause) ⇒ untyped.sendSystemMessage(sysmsg.DeathWatchNotification(toUntyped(ref), true, false))
-      case internal.NoMessage                          ⇒ // just to suppress the warning
+      case internal.Unwatch(watchee, watcher)      ⇒ untyped.sendSystemMessage(sysmsg.Unwatch(toUntyped(watchee), toUntyped(watcher)))
+      case internal.DeathWatchNotification(ref, _) ⇒ untyped.sendSystemMessage(sysmsg.DeathWatchNotification(toUntyped(ref), true, false))
+      case internal.NoMessage                      ⇒ // just to suppress the warning
     }
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
@@ -13,6 +13,7 @@ import akka.actor.typed.scaladsl
 import akka.annotation.ApiMayChange
 import akka.japi.function.{ Function2 ⇒ JapiFunction2 }
 import akka.japi.pf.PFBuilder
+import akka.util.unused
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
@@ -156,7 +157,7 @@ object Behaviors {
    * @param type the supertype of all messages accepted by this behavior
    * @return the behavior builder
    */
-  def receive[T](`type`: Class[T]): BehaviorBuilder[T] = BehaviorBuilder.create[T]
+  def receive[T](@unused `type`: Class[T]): BehaviorBuilder[T] = BehaviorBuilder.create[T]
 
   /**
    * Construct an actor behavior that can react to lifecycle signals only.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
@@ -6,14 +6,14 @@ package akka.actor.typed.scaladsl
 
 import java.util.concurrent.TimeoutException
 
+import scala.concurrent.Future
+
 import akka.actor.{ Address, RootActorPath, Scheduler }
 import akka.actor.typed.ActorRef
 import akka.actor.typed.internal.{ adapter ⇒ adapt }
 import akka.annotation.InternalApi
 import akka.pattern.PromiseActorRef
-import akka.util.Timeout
-import scala.concurrent.Future
-
+import akka.util.{ Timeout, unused }
 import akka.actor.typed.RecipientRef
 import akka.actor.typed.internal.InternalRecipientRef
 
@@ -54,7 +54,7 @@ object AskPattern {
      * val f: Future[Reply] = target ? replyTo => (Request("hello", replyTo))
      * }}}
      */
-    def ?[U](replyTo: ActorRef[U] ⇒ T)(implicit timeout: Timeout, scheduler: Scheduler): Future[U] = {
+    def ?[U](replyTo: ActorRef[U] ⇒ T)(implicit timeout: Timeout, @unused scheduler: Scheduler): Future[U] = {
       // We do not currently use the implicit scheduler, but want to require it
       // because it might be needed when we move to a 'native' typed runtime, see #24219
       ref match {

--- a/akka-actor/src/main/scala/akka/actor/dsl/Inbox.scala
+++ b/akka-actor/src/main/scala/akka/actor/dsl/Inbox.scala
@@ -97,7 +97,7 @@ trait Inbox { this: ActorDSL.type ⇒
       case g: Get ⇒
         if (messages.isEmpty) enqueueQuery(g)
         else sender() ! messages.dequeue()
-      case s @ Select(_, predicate, _) ⇒
+      case s: Select ⇒
         if (messages.isEmpty) enqueueQuery(s)
         else {
           currentSelect = s

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleTest.java
@@ -53,7 +53,7 @@ public class HelloWorldEventSourcedEntityExampleTest extends JUnitSuite {
   @Test
   public void sayHello() {
     EntityRef<HelloWorld.Command> world = sharding().entityRefFor(HelloWorld.ENTITY_TYPE_KEY, "1");
-    TestProbe<HelloWorld.Greeting> probe = testKit.createTestProbe(HelloWorld.Greeting.class);
+    TestProbe<HelloWorld.Greeting> probe = testKit.createTestProbe();
     world.tell(new HelloWorld.Greet("Alice", probe.getRef()));
     HelloWorld.Greeting greeting1 = probe.expectMessageClass(HelloWorld.Greeting.class);
     assertEquals("Alice", greeting1.whom);

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleTest.java
@@ -53,7 +53,7 @@ public class HelloWorldEventSourcedEntityExampleTest extends JUnitSuite {
   @Test
   public void sayHello() {
     EntityRef<HelloWorld.Command> world = sharding().entityRefFor(HelloWorld.ENTITY_TYPE_KEY, "1");
-    TestProbe<HelloWorld.Greeting> probe = testKit.createTestProbe();
+    TestProbe<HelloWorld.Greeting> probe = testKit.createTestProbe(HelloWorld.Greeting.class);
     world.tell(new HelloWorld.Greet("Alice", probe.getRef()));
     HelloWorld.Greeting greeting1 = probe.expectMessageClass(HelloWorld.Greeting.class);
     assertEquals("Alice", greeting1.whom);

--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -220,7 +220,7 @@ private[remote] class ReliableDeliverySupervisor(
     settings.SysResendTimeout, settings.SysResendTimeout, self, AttemptSysMsgRedelivery)
 
   override val supervisorStrategy = OneForOneStrategy(loggingEnabled = false) {
-    case e @ (_: AssociationProblem) ⇒ Escalate
+    case _: AssociationProblem ⇒ Escalate
     case NonFatal(e) ⇒
       val causedBy = if (e.getCause == null) "" else s"Caused by: [${e.getCause.getMessage}]"
       log.warning(
@@ -359,10 +359,10 @@ private[remote] class ReliableDeliverySupervisor(
         // Resending will be triggered by the incoming GotUid message after the connection finished
         goToActive()
       } else goToIdle()
-    case AttemptSysMsgRedelivery               ⇒ // Ignore
-    case s @ Send(msg: SystemMessage, _, _, _) ⇒ tryBuffer(s.copy(seqOpt = Some(nextSeq())))
-    case s: Send                               ⇒ context.system.deadLetters ! s
-    case EndpointWriter.FlushAndStop           ⇒ context.stop(self)
+    case AttemptSysMsgRedelivery             ⇒ // Ignore
+    case s @ Send(_: SystemMessage, _, _, _) ⇒ tryBuffer(s.copy(seqOpt = Some(nextSeq())))
+    case s: Send                             ⇒ context.system.deadLetters ! s
+    case EndpointWriter.FlushAndStop         ⇒ context.stop(self)
     case EndpointWriter.StopReading(w, replyTo) ⇒
       replyTo ! EndpointWriter.StoppedReading(w)
       sender() ! EndpointWriter.StoppedReading(w)

--- a/akka-remote/src/main/scala/akka/remote/MessageSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/MessageSerializer.scala
@@ -10,6 +10,7 @@ import akka.actor.ExtendedActorSystem
 import akka.annotation.InternalApi
 import akka.remote.artery.{ EnvelopeBuffer, HeaderBuilder, OutboundEnvelope }
 import akka.serialization._
+import akka.util.unused
 
 import scala.util.control.NonFatal
 
@@ -83,8 +84,13 @@ private[akka] object MessageSerializer {
     } finally Serialization.currentTransportInformation.value = oldInfo
   }
 
-  def deserializeForArtery(system: ExtendedActorSystem, originUid: Long, serialization: Serialization,
-                           serializer: Int, classManifest: String, envelope: EnvelopeBuffer): AnyRef = {
+  def deserializeForArtery(
+    @unused system:    ExtendedActorSystem,
+    @unused originUid: Long,
+    serialization:     Serialization,
+    serializer:        Int,
+    classManifest:     String,
+    envelope:          EnvelopeBuffer): AnyRef = {
     serialization.deserializeByteBuffer(envelope.byteBuffer, serializer, classManifest)
   }
 }

--- a/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
@@ -212,7 +212,7 @@ private[akka] class RemoteSystemDaemon(
 
   private def doCreateActor(message: DaemonMsg, props: Props, deploy: Deploy, path: String, supervisor: ActorRef) = {
     path match {
-      case ActorPathExtractor(address, elems) if elems.nonEmpty && elems.head == "remote" ⇒
+      case ActorPathExtractor(_, elems) if elems.nonEmpty && elems.head == "remote" ⇒
         // TODO RK currently the extracted “address” is just ignored, is that okay?
         // TODO RK canonicalize path so as not to duplicate it always #1446
         val subpath = elems.drop(1)

--- a/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
@@ -8,10 +8,11 @@ import akka.AkkaException
 import akka.Done
 import akka.actor._
 import akka.event.LoggingAdapter
+
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.control.NoStackTrace
-import akka.util.OptionVal
+import akka.util.{ OptionVal, unused }
 
 /**
  * RemoteTransportException represents a general failure within a RemoteTransport,
@@ -79,7 +80,7 @@ private[akka] abstract class RemoteTransport(val system: ExtendedActorSystem, va
    * @param cmd Command message to send to the transports.
    * @return A Future that indicates when the message was successfully handled or dropped.
    */
-  def managementCommand(cmd: Any): Future[Boolean] = { Future.successful(false) }
+  def managementCommand(@unused cmd: Any): Future[Boolean] = { Future.successful(false) }
 
   /**
    * A Logger that can be used to log issues that may occur

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -24,7 +24,6 @@ import scala.util.Success
 import scala.util.Try
 import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
-
 import akka.Done
 import akka.NotUsed
 import akka.actor.Actor
@@ -56,8 +55,7 @@ import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
-import akka.util.OptionVal
-import akka.util.WildcardIndex
+import akka.util.{ OptionVal, WildcardIndex, unused }
 
 /**
  * INTERNAL API
@@ -243,8 +241,11 @@ private[remote] object FlushOnShutdown {
 /**
  * INTERNAL API
  */
-private[remote] class FlushOnShutdown(done: Promise[Done], timeout: FiniteDuration,
-                                      inboundContext: InboundContext, associations: Set[Association]) extends Actor {
+private[remote] class FlushOnShutdown(
+  done:                   Promise[Done],
+  timeout:                FiniteDuration,
+  @unused inboundContext: InboundContext,
+  associations:           Set[Association]) extends Actor {
 
   var remaining = Map.empty[UniqueAddress, Int]
 

--- a/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
@@ -6,6 +6,10 @@ package akka.remote.artery
 
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.duration._
+import scala.concurrent.{ Future, Promise }
+import scala.util.control.NonFatal
+
 import akka.Done
 import akka.actor.{ EmptyLocalActorRef, _ }
 import akka.event.Logging
@@ -17,11 +21,7 @@ import akka.remote.{ MessageSerializer, OversizedPayloadException, RemoteActorRe
 import akka.serialization.{ Serialization, SerializationExtension, Serializers }
 import akka.stream._
 import akka.stream.stage._
-import akka.util.{ OptionVal, Unsafe }
-
-import scala.concurrent.duration._
-import scala.concurrent.{ Future, Promise }
-import scala.util.control.NonFatal
+import akka.util.{ OptionVal, Unsafe, unused }
 import akka.remote.artery.OutboundHandshake.HandshakeReq
 
 /**
@@ -43,7 +43,7 @@ private[remote] class Encoder(
   system:               ExtendedActorSystem,
   outboundEnvelopePool: ObjectPool[ReusableOutboundEnvelope],
   bufferPool:           EnvelopeBufferPool,
-  streamId:             Int,
+  @unused streamId:     Int,
   debugLogSend:         Boolean,
   version:              Byte)
   extends GraphStageWithMaterializedValue[FlowShape[OutboundEnvelope, EnvelopeBuffer], Encoder.OutboundCompressionAccess] {
@@ -59,7 +59,6 @@ private[remote] class Encoder(
       private val headerBuilder = HeaderBuilder.out()
       headerBuilder.setVersion(version)
       headerBuilder.setUid(uniqueLocalAddress.uid)
-      private val localAddress = uniqueLocalAddress.address
 
       // lazy init of SerializationExtension to avoid loading serializers before ActorRefProvider has been initialized
       private var _serialization: OptionVal[Serialization] = OptionVal.None
@@ -331,7 +330,6 @@ private[remote] class Decoder(
 
       override val compressions = inboundCompressions
 
-      private val localAddress = inboundContext.localAddress.address
       private val headerBuilder = HeaderBuilder.in(compressions)
       private val actorRefResolver: ActorRefResolveCacheWithAddress =
         new ActorRefResolveCacheWithAddress(system.provider.asInstanceOf[RemoteActorRefProvider], uniqueLocalAddress)
@@ -575,9 +573,9 @@ private[remote] class Decoder(
  * INTERNAL API
  */
 private[remote] class Deserializer(
-  inboundContext: InboundContext,
-  system:         ExtendedActorSystem,
-  bufferPool:     EnvelopeBufferPool) extends GraphStage[FlowShape[InboundEnvelope, InboundEnvelope]] {
+  @unused inboundContext: InboundContext,
+  system:                 ExtendedActorSystem,
+  bufferPool:             EnvelopeBufferPool) extends GraphStage[FlowShape[InboundEnvelope, InboundEnvelope]] {
 
   val in: Inlet[InboundEnvelope] = Inlet("Artery.Deserializer.in")
   val out: Outlet[InboundEnvelope] = Outlet("Artery.Deserializer.out")

--- a/akka-remote/src/main/scala/akka/remote/artery/Handshake.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Handshake.scala
@@ -4,20 +4,19 @@
 
 package akka.remote.artery
 
-import akka.actor.ActorSystem
-
 import scala.concurrent.duration._
+import scala.concurrent.Future
 import scala.util.control.NoStackTrace
+
+import akka.actor.ActorSystem
 import akka.remote.UniqueAddress
 import akka.stream.Attributes
 import akka.stream.FlowShape
 import akka.stream.Inlet
 import akka.stream.Outlet
 import akka.stream.stage._
-import akka.util.OptionVal
+import akka.util.{ OptionVal, unused }
 import akka.Done
-
-import scala.concurrent.Future
 import akka.actor.Address
 
 /**
@@ -50,7 +49,7 @@ private[remote] object OutboundHandshake {
  * INTERNAL API
  */
 private[remote] class OutboundHandshake(
-  system:                  ActorSystem,
+  @unused system:          ActorSystem,
   outboundContext:         OutboundContext,
   outboundEnvelopePool:    ObjectPool[ReusableOutboundEnvelope],
   timeout:                 FiniteDuration,
@@ -129,7 +128,7 @@ private[remote] class OutboundHandshake(
               // when it receives the HandshakeRsp reply
               implicit val ec = materializer.executionContext
               uniqueRemoteAddress.foreach {
-                getAsyncCallback[UniqueAddress] { a ⇒
+                getAsyncCallback[UniqueAddress] { _ ⇒
                   if (handshakeState != Completed) {
                     handshakeCompleted()
                     if (isAvailable(out))

--- a/akka-remote/src/main/scala/akka/remote/artery/MessageDispatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/MessageDispatcher.scala
@@ -41,7 +41,6 @@ private[remote] class MessageDispatcher(
     }
 
     val sender: ActorRef = senderOption.getOrElse(system.deadLetters)
-    val originalReceiver = recipient.path
 
     recipient match {
 

--- a/akka-remote/src/main/scala/akka/remote/artery/RemoteInstrument.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/RemoteInstrument.scala
@@ -4,12 +4,13 @@
 
 package akka.remote.artery
 
-import akka.actor.{ ActorRef, ExtendedActorSystem }
-import akka.event.{ Logging, LoggingAdapter }
-import akka.util.OptionVal
 import java.nio.ByteBuffer
+
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
+import akka.actor.{ ActorRef, ExtendedActorSystem }
+import akka.event.{ Logging, LoggingAdapter }
+import akka.util.{ OptionVal, unused }
 
 /**
  * INTERNAL API
@@ -287,7 +288,7 @@ private[remote] object RemoteInstruments {
   def getKey(kl: Int): Byte = (kl >>> 26).toByte
   def getLength(kl: Int): Int = kl & lengthMask
 
-  def create(system: ExtendedActorSystem, log: LoggingAdapter): Vector[RemoteInstrument] = {
+  def create(system: ExtendedActorSystem, @unused log: LoggingAdapter): Vector[RemoteInstrument] = {
     val c = system.settings.config
     val path = "akka.remote.artery.advanced.instruments"
     import scala.collection.JavaConverters._

--- a/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
@@ -91,7 +91,6 @@ import akka.util.OptionVal
       private var incarnation = outboundContext.associationState.incarnation
       private val unacknowledged = new ArrayDeque[OutboundEnvelope]
       private var resending = new ArrayDeque[OutboundEnvelope]
-      private var resendingFromSeqNo = -1L
       private var stopping = false
 
       private val giveUpAfterNanos = outboundContext.settings.Advanced.GiveUpSystemMessageAfter.toNanos
@@ -288,7 +287,6 @@ import akka.util.OptionVal
         incarnation = outboundContext.associationState.incarnation
         unacknowledged.clear()
         resending.clear()
-        resendingFromSeqNo = -1L
         cancelTimer(resendInterval)
       }
 

--- a/akka-remote/src/main/scala/akka/remote/artery/aeron/AeronSource.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/aeron/AeronSource.scala
@@ -34,7 +34,7 @@ private[remote] object AeronSource {
     () ⇒
       {
         handler.reset
-        val fragmentsRead = sub.poll(handler.fragmentsHandler, 1)
+        sub.poll(handler.fragmentsHandler, 1)
         val msg = handler.messageReceived
         handler.reset() // for GC
         if (msg ne null) {

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala
@@ -14,7 +14,7 @@ import akka.actor.Address
 import akka.event.Logging
 import akka.event.LoggingAdapter
 import akka.remote.artery._
-import akka.util.OptionVal
+import akka.util.{ OptionVal, unused }
 import org.agrona.collections.Long2ObjectHashMap
 
 /**
@@ -376,7 +376,7 @@ private[remote] abstract class InboundCompression[T >: Null](
    * Add `n` occurrence for the given key and call `heavyHittedDetected` if element has become a heavy hitter.
    * Empty keys are omitted.
    */
-  def increment(remoteAddress: Address, value: T, n: Long): Unit = {
+  def increment(@unused remoteAddress: Address, value: T, n: Long): Unit = {
     val count = cms.addObjectAndEstimateCount(value, n)
     addAndCheckIfheavyHitterDetected(value, count)
     alive = true

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/TopHeavyHitters.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/TopHeavyHitters.scala
@@ -169,7 +169,7 @@ private[remote] final class TopHeavyHitters[T >: Null](val max: Int)(implicit cl
           true
         } else {
           // The entry exists, let's update it.
-          updateExistingHeavyHitter(actualIdx, hashCode, item, count)
+          updateExistingHeavyHitter(actualIdx, count)
           // not a "new" heavy hitter, since we only replaced it (so it was signaled as new once before)
           false
         }
@@ -220,7 +220,7 @@ private[remote] final class TopHeavyHitters[T >: Null](val max: Int)(implicit cl
    * Replace existing heavy hitter – give it a new `count` value. This will also restore the heap property, so this
    * might make a previously lowest hitter no longer be one.
    */
-  private def updateExistingHeavyHitter(foundHashIndex: Int, hashCode: HashCodeVal, item: T, count: Long): Unit = {
+  private def updateExistingHeavyHitter(foundHashIndex: Int, count: Long): Unit = {
     if (weights(foundHashIndex) > count)
       throw new IllegalArgumentException(s"Weights can be only incremented or kept the same, not decremented. " +
         s"Previous weight was [${weights(foundHashIndex)}], attempted to modify it to [$count].")

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/SSLEngineProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/SSLEngineProvider.scala
@@ -24,8 +24,6 @@ import akka.event.LogMarker
 import akka.event.Logging
 import akka.event.MarkerLoggingAdapter
 import akka.japi.Util.immutableSeq
-import akka.stream.IgnoreComplete
-import akka.stream.TLSClosing
 import akka.stream.TLSRole
 import com.typesafe.config.Config
 import javax.net.ssl.KeyManager
@@ -158,8 +156,7 @@ class SslTransportException(message: String, cause: Throwable) extends RuntimeEx
     sslContext: SSLContext,
     role:       TLSRole,
     hostname:   String,
-    port:       Int,
-    closing:    TLSClosing = IgnoreComplete): SSLEngine = {
+    port:       Int): SSLEngine = {
 
     val engine = sslContext.createSSLEngine(hostname, port)
 

--- a/akka-remote/src/main/scala/akka/remote/routing/RemoteRouterConfig.scala
+++ b/akka-remote/src/main/scala/akka/remote/routing/RemoteRouterConfig.scala
@@ -69,9 +69,9 @@ final case class RemoteRouterConfig(local: Pool, nodes: Iterable[Address]) exten
   override def resizer: Option[Resizer] = local.resizer
 
   override def withFallback(other: RouterConfig): RouterConfig = other match {
-    case RemoteRouterConfig(local: RemoteRouterConfig, nodes) ⇒ throw new IllegalStateException(
+    case RemoteRouterConfig(_: RemoteRouterConfig, _) ⇒ throw new IllegalStateException(
       "RemoteRouterConfig is not allowed to wrap a RemoteRouterConfig")
-    case RemoteRouterConfig(local: Pool, nodes) ⇒
+    case RemoteRouterConfig(local: Pool, _) ⇒
       copy(local = this.local.withFallback(local).asInstanceOf[Pool])
     case _ ⇒ copy(local = this.local.withFallback(other).asInstanceOf[Pool])
   }

--- a/akka-remote/src/main/scala/akka/remote/serialization/ActorRefResolveCache.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/ActorRefResolveCache.scala
@@ -13,7 +13,7 @@ import akka.actor.ExtensionId
 import akka.actor.ExtensionIdProvider
 import akka.remote.RemoteActorRefProvider
 import akka.remote.artery.LruBoundedCache
-import akka.util.Unsafe
+import akka.util.{ Unsafe, unused }
 
 /**
  * INTERNAL API: Thread local cache per actor system
@@ -45,7 +45,7 @@ private[akka] class ActorRefResolveThreadLocalCache(val system: ExtendedActorSys
     override def initialValue: ActorRefResolveCache = new ActorRefResolveCache(provider)
   }
 
-  def threadLocalCache(provider: RemoteActorRefProvider): ActorRefResolveCache =
+  def threadLocalCache(@unused provider: RemoteActorRefProvider): ActorRefResolveCache =
     current.get
 
 }

--- a/akka-remote/src/main/scala/akka/remote/serialization/DaemonMsgCreateSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/DaemonMsgCreateSerializer.scala
@@ -6,11 +6,11 @@ package akka.remote.serialization
 
 import akka.serialization.{ BaseSerializer, SerializationExtension, SerializerWithStringManifest }
 import akka.protobuf.ByteString
-import com.typesafe.config.{ Config, ConfigFactory }
 import akka.actor.{ Deploy, ExtendedActorSystem, NoScopeGiven, Props, Scope }
 import akka.remote.DaemonMsgCreate
 import akka.remote.WireFormats.{ DaemonMsgCreateData, DeployData, PropsData }
 import akka.routing.{ NoRouter, RouterConfig }
+import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.reflect.ClassTag
 import util.{ Failure, Success }
@@ -176,8 +176,6 @@ private[akka] final class DaemonMsgCreateSerializer(val system: ExtendedActorSys
       path = proto.getPath,
       supervisor = deserializeActorRef(system, proto.getSupervisor))
   }
-
-  private def oldSerialize(any: Any): ByteString = ByteString.copyFrom(serialization.serialize(any.asInstanceOf[AnyRef]).get)
 
   private def serialize(any: Any): (Int, Boolean, String, Array[Byte]) = {
     val m = any.asInstanceOf[AnyRef]

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
@@ -554,7 +554,7 @@ private[transport] class ProtocolStateActor(
   }
 
   onTermination {
-    case StopEvent(reason, _, OutboundUnassociated(remoteAddress, statusPromise, transport)) ⇒
+    case StopEvent(reason, _, OutboundUnassociated(_, statusPromise, _)) ⇒
       statusPromise.tryFailure(reason match {
         case FSM.Failure(info: DisassociateInfo) ⇒ disassociateException(info)
         case _                                   ⇒ new AkkaProtocolException("Transport disassociated before handshake finished")
@@ -611,7 +611,7 @@ private[transport] class ProtocolStateActor(
     case FSM.Failure(ForbiddenUidReason)  ⇒ // no logging
     case FSM.Failure(TimeoutReason(errorMessage)) ⇒
       log.info(errorMessage)
-    case other ⇒ super.logTermination(reason)
+    case _ ⇒ super.logTermination(reason)
   }
 
   private def listenForListenerRegistration(readHandlerPromise: Promise[HandleEventListener]): Unit =

--- a/akka-remote/src/main/scala/akka/remote/transport/TestTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/TestTransport.scala
@@ -4,16 +4,17 @@
 
 package akka.remote.transport
 
+import java.util.concurrent.{ CopyOnWriteArrayList, ConcurrentHashMap }
+
 import TestTransport._
 import akka.actor._
 import akka.remote.transport.AssociationHandle._
 import akka.remote.transport.Transport._
 import akka.util.ByteString
 import com.typesafe.config.Config
-import java.util.concurrent.{ CopyOnWriteArrayList, ConcurrentHashMap }
+
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future, Promise }
-
 import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
@@ -218,7 +219,7 @@ object TestTransport {
      *   The constant the future will be completed with.
      */
     def pushConstant(c: B): Unit = push {
-      (x) ⇒ Future.successful(c)
+      _ ⇒ Future.successful(c)
     }
 
     /**
@@ -228,7 +229,7 @@ object TestTransport {
      *   The throwable the failed future will contain.
      */
     def pushError(e: Throwable): Unit = push {
-      (x) ⇒ Future.failed(e)
+      _ ⇒ Future.failed(e)
     }
 
     /**
@@ -243,7 +244,7 @@ object TestTransport {
       val originalBehavior = currentBehavior
 
       push(
-        (params: A) ⇒ for (delayed ← controlPromise.future; original ← originalBehavior(params)) yield original)
+        (params: A) ⇒ for (_ ← controlPromise.future; original ← originalBehavior(params)) yield original)
 
       controlPromise
     }

--- a/akka-remote/src/main/scala/akka/remote/transport/TestTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/TestTransport.scala
@@ -6,12 +6,12 @@ package akka.remote.transport
 
 import java.util.concurrent.{ CopyOnWriteArrayList, ConcurrentHashMap }
 
-import TestTransport._
 import akka.actor._
 import akka.remote.transport.AssociationHandle._
 import akka.remote.transport.Transport._
 import akka.util.ByteString
 import com.typesafe.config.Config
+import TestTransport._
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future, Promise }
@@ -38,8 +38,6 @@ class TestTransport(
       conf.getBytes("maximum-payload-bytes").toInt,
       conf.getString("scheme-identifier"))
   }
-
-  import akka.remote.transport.TestTransport._
 
   override def isResponsibleFor(address: Address): Boolean = true
 
@@ -244,7 +242,7 @@ object TestTransport {
       val originalBehavior = currentBehavior
 
       push(
-        (params: A) ⇒ for (_ ← controlPromise.future; original ← originalBehavior(params)) yield original)
+        (params: A) ⇒ controlPromise.future.flatMap(_ ⇒ originalBehavior(params)))
 
       controlPromise
     }

--- a/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
@@ -496,7 +496,7 @@ private[transport] class ThrottledAssociation(
       inboundThrottleMode = mode
       sender() ! SetThrottleAck
       stay()
-    case Event(Disassociated(info), _) ⇒
+    case Event(Disassociated(_), _) ⇒
       stop() // not notifying the upstream handler is intentional: we are relying on heartbeating
     case Event(FailWith(reason), _) ⇒
       if (upstreamListener ne null) upstreamListener notify Disassociated(reason)
@@ -513,7 +513,7 @@ private[transport] class ThrottledAssociation(
     } catch {
       // This layer should not care about malformed packets. Also, this also useful for testing, because
       // arbitrary payload could be passed in
-      case NonFatal(e) ⇒ None
+      case NonFatal(_) ⇒ None
     }
   }
 

--- a/akka-remote/src/main/scala/akka/remote/transport/Transport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/Transport.scala
@@ -5,12 +5,12 @@
 package akka.remote.transport
 
 import scala.concurrent.{ Future, Promise }
+import scala.util.control.NoStackTrace
+
 import akka.actor.{ ActorRef, Address, NoSerializationVerificationNeeded }
-import akka.util.ByteString
+import akka.util.{ ByteString, unused }
 import akka.remote.transport.AssociationHandle.HandleEventListener
 import akka.AkkaException
-
-import scala.util.control.NoStackTrace
 import akka.actor.DeadLetterSuppression
 import akka.event.LoggingAdapter
 
@@ -143,7 +143,7 @@ trait Transport {
    * @param cmd Command message to the transport
    * @return Future that succeeds when the command was handled or dropped
    */
-  def managementCommand(cmd: Any): Future[Boolean] = { Future.successful(false) }
+  def managementCommand(@unused cmd: Any): Future[Boolean] = { Future.successful(false) }
 
 }
 

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyHelpers.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyHelpers.scala
@@ -6,7 +6,10 @@ package akka.remote.transport.netty
 
 import akka.AkkaException
 import java.nio.channels.ClosedChannelException
+
+import akka.util.unused
 import org.jboss.netty.channel._
+
 import scala.util.control.NonFatal
 
 /**
@@ -14,17 +17,17 @@ import scala.util.control.NonFatal
  */
 private[netty] trait NettyHelpers {
 
-  protected def onConnect(ctx: ChannelHandlerContext, e: ChannelStateEvent): Unit = ()
+  protected def onConnect(@unused ctx: ChannelHandlerContext, @unused e: ChannelStateEvent): Unit = ()
 
-  protected def onDisconnect(ctx: ChannelHandlerContext, e: ChannelStateEvent): Unit = ()
+  protected def onDisconnect(@unused ctx: ChannelHandlerContext, @unused e: ChannelStateEvent): Unit = ()
 
-  protected def onOpen(ctx: ChannelHandlerContext, e: ChannelStateEvent): Unit = ()
+  protected def onOpen(@unused ctx: ChannelHandlerContext, @unused e: ChannelStateEvent): Unit = ()
 
-  protected def onMessage(ctx: ChannelHandlerContext, e: MessageEvent): Unit = ()
+  protected def onMessage(@unused ctx: ChannelHandlerContext, @unused e: MessageEvent): Unit = ()
 
-  protected def onException(ctx: ChannelHandlerContext, e: ExceptionEvent): Unit = ()
+  protected def onException(@unused ctx: ChannelHandlerContext, @unused e: ExceptionEvent): Unit = ()
 
-  final protected def transformException(ctx: ChannelHandlerContext, ev: ExceptionEvent): Unit = {
+  final protected def transformException(@unused ctx: ChannelHandlerContext, ev: ExceptionEvent): Unit = {
     val cause = if (ev.getCause ne null) ev.getCause else new AkkaException("Unknown cause")
     cause match {
       case _: ClosedChannelException ⇒ // Ignore

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -505,7 +505,7 @@ class NettyTransport(val settings: NettyTransportSettings, val system: ExtendedA
       } catch {
         case NonFatal(e) ⇒ {
           log.error("failed to bind to {}, shutting down Netty transport", address)
-          try { shutdown() } catch { case NonFatal(e) ⇒ } // ignore possible exception during shutdown
+          try { shutdown() } catch { case NonFatal(_) ⇒ } // ignore possible exception during shutdown
           throw e
         }
       }

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/SSLEngineProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/SSLEngineProvider.scala
@@ -20,8 +20,6 @@ import akka.event.Logging
 import akka.event.MarkerLoggingAdapter
 import akka.remote.RemoteTransportException
 import akka.remote.artery.tcp.SecureRandomFactory
-import akka.stream.IgnoreComplete
-import akka.stream.TLSClosing
 import akka.stream.TLSRole
 import javax.net.ssl.KeyManager
 import javax.net.ssl.KeyManagerFactory
@@ -108,10 +106,7 @@ import javax.net.ssl.TrustManagerFactory
     createSSLEngine(sslContext, role)
   }
 
-  private def createSSLEngine(
-    sslContext: SSLContext,
-    role:       TLSRole,
-    closing:    TLSClosing = IgnoreComplete): SSLEngine = {
+  private def createSSLEngine(sslContext: SSLContext, role: TLSRole): SSLEngine = {
 
     val engine = sslContext.createSSLEngine()
 

--- a/akka-remote/src/test/scala/akka/remote/transport/SwitchableLoggedBehaviorSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/SwitchableLoggedBehaviorSpec.scala
@@ -85,7 +85,7 @@ class SwitchableLoggedBehaviorSpec extends AkkaSpec with DefaultTimeout {
       Await.result(behavior(()), timeout.duration) should ===(3)
     }
 
-    "enable delayed completition" in {
+    "enable delayed completion" in {
       val behavior = defaultBehavior
       val controlPromise = behavior.pushDelayed
       val f = behavior(())
@@ -96,7 +96,7 @@ class SwitchableLoggedBehaviorSpec extends AkkaSpec with DefaultTimeout {
       awaitCond(f.isCompleted)
     }
 
-    "log calls and parametrers" in {
+    "log calls and parameters" in {
       val logPromise = Promise[Int]()
       val behavior = new SwitchableLoggedBehavior[Int, Int]((i) ⇒ Future.successful(3), (i) ⇒ logPromise.success(i))
 

--- a/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
@@ -8,8 +8,6 @@ import java.util.concurrent.ThreadFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
-import com.typesafe.config.Config
-
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
@@ -19,6 +17,8 @@ import scala.util.Try
 import akka.actor.Cancellable
 import akka.actor.Scheduler
 import akka.event.LoggingAdapter
+import akka.util.unused
+import com.typesafe.config.Config
 
 /**
  * For testing: scheduler that does not look at the clock, but must be
@@ -30,7 +30,7 @@ import akka.event.LoggingAdapter
  * easier, but these tests might fail to catch race conditions that only
  * happen when tasks are scheduled in parallel in 'real time'.
  */
-class ExplicitlyTriggeredScheduler(config: Config, log: LoggingAdapter, tf: ThreadFactory) extends Scheduler {
+class ExplicitlyTriggeredScheduler(@unused config: Config, log: LoggingAdapter, @unused tf: ThreadFactory) extends Scheduler {
 
   private case class Item(time: Long, interval: Option[FiniteDuration], runnable: Runnable)
 


### PR DESCRIPTION
[#26138](https://github.com/akka/akka/issues/26138) 
[#26088](https://github.com/akka/akka/issues/26088)

**akka-actor-typed**
Before: [warn] 14 warnings found
After: [warn] one warning found (a deprecation)

**akka-remote**
Before: [warn] 80 warnings found
After: [warn] 14 warnings found (for the moment, these last ones should remain)
