### PR TITLE
Rename akka.actor.typed.ActorContext #25734

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/Effect.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/Effect.scala
@@ -7,6 +7,7 @@ package akka.actor.testkit.typed
 import akka.actor.typed.{ ActorRef, Behavior, Props }
 import akka.annotation.{ DoNotInherit, InternalApi }
 import akka.util.JavaDurationConverters._
+import akka.util.unused
 
 import scala.compat.java8.FunctionConverters._
 import scala.concurrent.duration.FiniteDuration
@@ -114,18 +115,18 @@ object Effect {
   private[akka] final class SpawnedAnonymousAdapter[T](val ref: ActorRef[T])
     extends Effect with Product with Serializable {
 
-    override def equals(other: Any) = other match {
+    override def equals(other: Any): Boolean = other match {
       case _: SpawnedAnonymousAdapter[_] ⇒ true
       case _                             ⇒ false
     }
     override def hashCode: Int = Nil.##
     override def toString: String = "SpawnedAnonymousAdapter"
 
-    override def productPrefix = "SpawnedAnonymousAdapter"
-    override def productIterator = Iterator.empty
-    override def productArity = 0
+    override def productPrefix: String = "SpawnedAnonymousAdapter"
+    override def productIterator: Iterator[_] = Iterator.empty
+    override def productArity: Int = 0
     override def productElement(n: Int) = throw new NoSuchElementException
-    override def canEqual(o: Any) = o.isInstanceOf[SpawnedAnonymousAdapter[_]]
+    override def canEqual(o: Any): Boolean = o.isInstanceOf[SpawnedAnonymousAdapter[_]]
   }
 
   /**
@@ -134,7 +135,7 @@ object Effect {
   @InternalApi
   private[akka] object SpawnedAnonymousAdapter {
     def apply[T]() = new SpawnedAnonymousAdapter[T](null)
-    def unapply[T](s: SpawnedAnonymousAdapter[T]): Boolean = true
+    def unapply[T](@unused s: SpawnedAnonymousAdapter[T]): Boolean = true
   }
 
   /**

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
@@ -126,7 +126,7 @@ private[akka] final class FunctionRef[-T](
 /**
  * INTERNAL API
  *
- * An [[ActorContext]] for synchronous execution of a [[Behavior]] that
+ * A [[TypedActorContext]] for synchronous execution of a [[Behavior]] that
  * provides only stubs for the effects an Actor can perform and replaces
  * created child Actors by a synchronous Inbox (see `Inbox.sync`).
  */

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
@@ -10,15 +10,16 @@ import java.util.{ List ⇒ JList }
 
 import akka.actor.typed.{ ActorRef, ActorSystem }
 import akka.annotation.DoNotInherit
+import akka.annotation.InternalApi
 import akka.actor.testkit.typed.internal.TestProbeImpl
 import akka.actor.testkit.typed.{ FishingOutcome, TestKitSettings }
 import akka.actor.testkit.typed.scaladsl.TestDuration
 import akka.util.JavaDurationConverters._
+import akka.util.unused
+
 import scala.collection.immutable
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
-
-import akka.annotation.InternalApi
 
 object FishingOutcomes {
   /**
@@ -47,13 +48,13 @@ object TestProbe {
   def create[M](system: ActorSystem[_]): TestProbe[M] =
     create(name = "testProbe", system)
 
-  def create[M](clazz: Class[M], system: ActorSystem[_]): TestProbe[M] =
+  def create[M](@unused clazz: Class[M], system: ActorSystem[_]): TestProbe[M] =
     create(system)
 
   def create[M](name: String, system: ActorSystem[_]): TestProbe[M] =
     new TestProbeImpl[M](name, system)
 
-  def create[M](name: String, clazz: Class[M], system: ActorSystem[_]): TestProbe[M] =
+  def create[M](name: String, @unused clazz: Class[M], system: ActorSystem[_]): TestProbe[M] =
     new TestProbeImpl[M](name, system)
 }
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
@@ -6,9 +6,8 @@ package akka.actor.testkit.typed.scaladsl
 
 import akka.actor.testkit.typed.internal.BehaviorTestKitImpl
 import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
-import akka.actor.typed.{ ActorRef, Behavior, Signal }
+import akka.actor.typed.{ ActorRef, Behavior, Signal, TypedActorContext }
 import akka.annotation.DoNotInherit
-
 import java.util.concurrent.ThreadLocalRandom
 
 import scala.collection.immutable
@@ -38,7 +37,7 @@ object BehaviorTestKit {
 trait BehaviorTestKit[T] {
 
   // FIXME it is weird that this is public but it is used in BehaviorSpec, could we avoid that?
-  private[akka] def context: akka.actor.typed.TypedActorContext[T]
+  private[akka] def context: TypedActorContext[T]
 
   /**
    * Requests the oldest [[Effect]] or [[akka.actor.testkit.typed.Effect.NoEffects]] if no effects

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
@@ -38,7 +38,7 @@ object BehaviorTestKit {
 trait BehaviorTestKit[T] {
 
   // FIXME it is weird that this is public but it is used in BehaviorSpec, could we avoid that?
-  private[akka] def context: akka.actor.typed.ActorContext[T]
+  private[akka] def context: akka.actor.typed.TypedActorContext[T]
 
   /**
    * Requests the oldest [[Effect]] or [[akka.actor.testkit.typed.Effect.NoEffects]] if no effects

--- a/akka-actor-tests/src/test/scala/akka/actor/HotSwapSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/HotSwapSpec.scala
@@ -19,7 +19,7 @@ class HotSwapSpec extends AkkaSpec with ImplicitSender {
     "be able to become in its constructor" in {
       val a = system.actorOf(Props(new Becomer {
         context.become { case always ⇒ sender() ! always }
-        def receive = { case always ⇒ sender() ! "FAILURE" }
+        def receive = { case _ ⇒ sender() ! "FAILURE" }
       }))
       a ! "pigdog"
       expectMsg("pigdog")
@@ -28,7 +28,7 @@ class HotSwapSpec extends AkkaSpec with ImplicitSender {
     "be able to become multiple times in its constructor" in {
       val a = system.actorOf(Props(new Becomer {
         for (i ← 1 to 4) context.become({ case always ⇒ sender() ! i + ":" + always })
-        def receive = { case always ⇒ sender() ! "FAILURE" }
+        def receive = { case _ ⇒ sender() ! "FAILURE" }
       }))
       a ! "pigdog"
       expectMsg("4:pigdog")
@@ -48,7 +48,7 @@ class HotSwapSpec extends AkkaSpec with ImplicitSender {
     "be able to become, with stacking, multiple times in its constructor" in {
       val a = system.actorOf(Props(new Becomer {
         for (i ← 1 to 4) context.become({ case always ⇒ sender() ! i + ":" + always; context.unbecome() }, false)
-        def receive = { case always ⇒ sender() ! "FAILURE" }
+        def receive = { case _ ⇒ sender() ! "FAILURE" }
       }))
       a ! "pigdog"
       a ! "pigdog"

--- a/akka-actor-tests/src/test/scala/akka/util/ReflectSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ReflectSpec.scala
@@ -12,8 +12,8 @@ object ReflectSpec {
   final class A
   final class B
 
-  class One(a: A)
-  class Two(a: A, b: B)
+  class One(@unused a: A)
+  class Two(@unused a: A, @unused b: B)
 
   class MultipleOne(a: A, b: B) {
     def this(a: A) { this(a, null) }

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorCompile.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorCompile.java
@@ -5,7 +5,7 @@
 package akka.actor.typed.javadsl;
 
 import akka.actor.typed.*;
-import akka.actor.typed.ActorContext;
+import akka.actor.typed.TypedActorContext;
 
 import java.time.Duration;
 
@@ -39,12 +39,12 @@ public class ActorCompile {
   Behavior<MyMsg> actor5 = ignore();
   Behavior<MyMsg> actor6 = intercept(new BehaviorInterceptor<MyMsg, MyMsg>() {
     @Override
-    public Behavior<MyMsg> aroundReceive(ActorContext<MyMsg> context, MyMsg message, ReceiveTarget<MyMsg> target) {
+    public Behavior<MyMsg> aroundReceive(TypedActorContext<MyMsg> context, MyMsg message, ReceiveTarget<MyMsg> target) {
       return target.apply(context, message);
     }
 
     @Override
-    public Behavior<MyMsg> aroundSignal(ActorContext<MyMsg> context, Signal signal, SignalTarget<MyMsg> target) {
+    public Behavior<MyMsg> aroundSignal(TypedActorContext<MyMsg> context, Signal signal, SignalTarget<MyMsg> target) {
       return target.apply(context, signal);
     }
   }, actor5);
@@ -84,12 +84,12 @@ public class ActorCompile {
   static class MyBehavior extends ExtensibleBehavior<MyMsg> {
 
     @Override
-    public Behavior<MyMsg> receiveSignal(ActorContext<MyMsg> context, Signal message) throws Exception {
+    public Behavior<MyMsg> receiveSignal(TypedActorContext<MyMsg> context, Signal message) throws Exception {
       return this;
     }
 
     @Override
-    public Behavior<MyMsg> receive(ActorContext<MyMsg> context, MyMsg message) throws Exception {
+    public Behavior<MyMsg> receive(TypedActorContext<MyMsg> context, MyMsg message) throws Exception {
       ActorRef<String> adapter = context.asJava().messageAdapter(String.class, s -> new MyMsgB(s.toUpperCase()));
       return this;
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
@@ -636,9 +636,9 @@ class InterceptActorContextSpec extends ActorContextSpec {
   import BehaviorInterceptor._
 
   def tap[T] = new BehaviorInterceptor[T, T] {
-    override def aroundReceive(context: ActorContext[T], message: T, target: ReceiveTarget[T]): Behavior[T] =
+    override def aroundReceive(context: TypedActorContext[T], message: T, target: ReceiveTarget[T]): Behavior[T] =
       target(context, message)
-    override def aroundSignal(context: ActorContext[T], signal: Signal, target: SignalTarget[T]): Behavior[T] =
+    override def aroundSignal(context: TypedActorContext[T], signal: Signal, target: SignalTarget[T]): Behavior[T] =
       target(context, signal)
   }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
@@ -20,30 +20,30 @@ import org.scalatest.WordSpecLike
 
 object BehaviorSpec {
   sealed trait Command {
-    def expectedResponse(context: ActorContext[Command]): Seq[Event] = Nil
+    def expectedResponse(context: TypedActorContext[Command]): Seq[Event] = Nil
   }
   case object GetSelf extends Command {
-    override def expectedResponse(context: ActorContext[Command]): Seq[Event] = Self(context.asScala.self) :: Nil
+    override def expectedResponse(context: TypedActorContext[Command]): Seq[Event] = Self(context.asScala.self) :: Nil
   }
   // Behavior under test must return Unhandled
   case object Miss extends Command {
-    override def expectedResponse(context: ActorContext[Command]): Seq[Event] = Missed :: Nil
+    override def expectedResponse(context: TypedActorContext[Command]): Seq[Event] = Missed :: Nil
   }
   // Behavior under test must return same
   case object Ignore extends Command {
-    override def expectedResponse(context: ActorContext[Command]): Seq[Event] = Ignored :: Nil
+    override def expectedResponse(context: TypedActorContext[Command]): Seq[Event] = Ignored :: Nil
   }
   case object Ping extends Command {
-    override def expectedResponse(context: ActorContext[Command]): Seq[Event] = Pong :: Nil
+    override def expectedResponse(context: TypedActorContext[Command]): Seq[Event] = Pong :: Nil
   }
   case object Swap extends Command {
-    override def expectedResponse(context: ActorContext[Command]): Seq[Event] = Swapped :: Nil
+    override def expectedResponse(context: TypedActorContext[Command]): Seq[Event] = Swapped :: Nil
   }
   case class GetState()(s: State) extends Command {
-    override def expectedResponse(context: ActorContext[Command]): Seq[Event] = s :: Nil
+    override def expectedResponse(context: TypedActorContext[Command]): Seq[Event] = s :: Nil
   }
   case class AuxPing(id: Int) extends Command {
-    override def expectedResponse(context: ActorContext[Command]): Seq[Event] = Pong :: Nil
+    override def expectedResponse(context: TypedActorContext[Command]): Seq[Event] = Pong :: Nil
   }
   case object Stop extends Command
 
@@ -512,12 +512,12 @@ class InterceptScalaBehaviorSpec extends ImmutableWithSignalScalaBehaviorSpec wi
   override def behavior(monitor: ActorRef[Event]): (Behavior[Command], Aux) = {
     val inbox = TestInbox[Either[Signal, Command]]("tapListener")
     val tap = new BehaviorInterceptor[Command, Command] {
-      override def aroundReceive(context: ActorContext[Command], message: Command, target: ReceiveTarget[Command]): Behavior[Command] = {
+      override def aroundReceive(context: TypedActorContext[Command], message: Command, target: ReceiveTarget[Command]): Behavior[Command] = {
         inbox.ref ! Right(message)
         target(context, message)
       }
 
-      override def aroundSignal(context: ActorContext[Command], signal: Signal, target: SignalTarget[Command]): Behavior[Command] = {
+      override def aroundSignal(context: TypedActorContext[Command], signal: Signal, target: SignalTarget[Command]): Behavior[Command] = {
         inbox.ref ! Left(signal)
         target(context, signal)
       }
@@ -625,12 +625,12 @@ class TapJavaBehaviorSpec extends ImmutableWithSignalJavaBehaviorSpec with Reuse
   override def behavior(monitor: ActorRef[Event]): (Behavior[Command], Aux) = {
     val inbox = TestInbox[Either[Signal, Command]]("tapListener")
     val tap = new BehaviorInterceptor[Command, Command] {
-      override def aroundReceive(context: ActorContext[Command], message: Command, target: ReceiveTarget[Command]): Behavior[Command] = {
+      override def aroundReceive(context: TypedActorContext[Command], message: Command, target: ReceiveTarget[Command]): Behavior[Command] = {
         inbox.ref ! Right(message)
         target(context, message)
       }
 
-      override def aroundSignal(context: ActorContext[Command], signal: Signal, target: SignalTarget[Command]): Behavior[Command] = {
+      override def aroundSignal(context: TypedActorContext[Command], signal: Signal, target: SignalTarget[Command]): Behavior[Command] = {
         inbox.ref ! Left(signal)
         target(context, signal)
       }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/InterceptSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/InterceptSpec.scala
@@ -32,14 +32,14 @@ class InterceptSpec extends ScalaTestWithActorTestKit(
   implicit val untypedSystem = system.toUntyped
 
   private def snitchingInterceptor(probe: ActorRef[String]) = new BehaviorInterceptor[String, String] {
-    override def aroundReceive(context: ActorContext[String], message: String, target: ReceiveTarget[String]): Behavior[String] = {
+    override def aroundReceive(context: TypedActorContext[String], message: String, target: ReceiveTarget[String]): Behavior[String] = {
       probe ! ("before " + message)
       val b = target(context, message)
       probe ! ("after " + message)
       b
     }
 
-    override def aroundSignal(context: ActorContext[String], signal: Signal, target: SignalTarget[String]): Behavior[String] = {
+    override def aroundSignal(context: TypedActorContext[String], signal: Signal, target: SignalTarget[String]): Behavior[String] = {
       target(context, signal)
     }
 
@@ -176,14 +176,14 @@ class InterceptSpec extends ScalaTestWithActorTestKit(
     "allow an interceptor to replace started behavior" in {
       val interceptor = new BehaviorInterceptor[String, String] {
 
-        override def aroundStart(context: ActorContext[String], target: PreStartTarget[String]): Behavior[String] = {
+        override def aroundStart(context: TypedActorContext[String], target: PreStartTarget[String]): Behavior[String] = {
           Behaviors.stopped
         }
 
-        def aroundReceive(context: ActorContext[String], message: String, target: ReceiveTarget[String]): Behavior[String] =
+        def aroundReceive(context: TypedActorContext[String], message: String, target: ReceiveTarget[String]): Behavior[String] =
           target(context, message)
 
-        def aroundSignal(context: ActorContext[String], signal: Signal, target: SignalTarget[String]): Behavior[String] =
+        def aroundSignal(context: TypedActorContext[String], signal: Signal, target: SignalTarget[String]): Behavior[String] =
           target(context, signal)
       }
 
@@ -282,14 +282,14 @@ class InterceptSpec extends ScalaTestWithActorTestKit(
     }
 
     val poisonInterceptor = new BehaviorInterceptor[Any, Msg] {
-      override def aroundReceive(context: ActorContext[Any], message: Any, target: ReceiveTarget[Msg]): Behavior[Msg] =
+      override def aroundReceive(context: TypedActorContext[Any], message: Any, target: ReceiveTarget[Msg]): Behavior[Msg] =
         message match {
           case MyPoisonPill ⇒ Behaviors.stopped
           case m: Msg       ⇒ target(context, m)
           case _            ⇒ Behaviors.unhandled
         }
 
-      override def aroundSignal(context: ActorContext[Any], signal: Signal, target: SignalTarget[Msg]): Behavior[Msg] =
+      override def aroundSignal(context: TypedActorContext[Any], signal: Signal, target: SignalTarget[Msg]): Behavior[Msg] =
         target.apply(context, signal)
 
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -804,10 +804,10 @@ class SupervisionSpec extends ScalaTestWithActorTestKit(
       // irrelevant for test case but needed to use intercept in the pyramid of doom below
       val whateverInterceptor = new BehaviorInterceptor[String, String] {
         // identity intercept
-        override def aroundReceive(context: ActorContext[String], message: String, target: ReceiveTarget[String]): Behavior[String] =
+        override def aroundReceive(context: TypedActorContext[String], message: String, target: ReceiveTarget[String]): Behavior[String] =
           target(context, message)
 
-        override def aroundSignal(context: ActorContext[String], signal: Signal, target: SignalTarget[String]): Behavior[String] =
+        override def aroundSignal(context: TypedActorContext[String], signal: Signal, target: SignalTarget[String]): Behavior[String] =
           target(context, signal)
       }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StopSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StopSpec.scala
@@ -38,11 +38,11 @@ class StopSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val ref = spawn(Behaviors.setup[AnyRef] { _ ⇒
         Behaviors.intercept(
           new BehaviorInterceptor[AnyRef, AnyRef] {
-            override def aroundReceive(context: typed.ActorContext[AnyRef], message: AnyRef, target: ReceiveTarget[AnyRef]): Behavior[AnyRef] = {
+            override def aroundReceive(context: typed.TypedActorContext[AnyRef], message: AnyRef, target: ReceiveTarget[AnyRef]): Behavior[AnyRef] = {
               target(context, message)
             }
 
-            override def aroundSignal(context: typed.ActorContext[AnyRef], signal: Signal, target: SignalTarget[AnyRef]): Behavior[AnyRef] = {
+            override def aroundSignal(context: typed.TypedActorContext[AnyRef], signal: Signal, target: SignalTarget[AnyRef]): Behavior[AnyRef] = {
               target(context, signal)
             }
           }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -51,7 +51,7 @@ abstract class ActorSystem[-T] extends ActorRef[T] with Extensions { this: Inter
   /**
    * A [[akka.actor.typed.Logger]] that can be used to emit log messages
    * without specifying a more detailed source. Typically it is desirable to
-   * use the dedicated `Logger` available from each Actor’s [[ActorContext]]
+   * use the dedicated `Logger` available from each Actor’s [[TypedActorContext]]
    * as that ties the log entries to the actor.
    */
   def log: Logger

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/BehaviorInterceptor.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/BehaviorInterceptor.scala
@@ -23,7 +23,7 @@ abstract class BehaviorInterceptor[O, I] {
    * @return The returned behavior will be the "started" behavior of the actor used to accept
    *         the next message or signal.
    */
-  def aroundStart(ctx: ActorContext[O], target: PreStartTarget[I]): Behavior[I] =
+  def aroundStart(ctx: TypedActorContext[O], target: PreStartTarget[I]): Behavior[I] =
     target.start(ctx)
 
   /**
@@ -33,7 +33,7 @@ abstract class BehaviorInterceptor[O, I] {
    *
    * @return The behavior for next message or signal
    */
-  def aroundReceive(ctx: ActorContext[O], msg: O, target: ReceiveTarget[I]): Behavior[I]
+  def aroundReceive(ctx: TypedActorContext[O], msg: O, target: ReceiveTarget[I]): Behavior[I]
 
   /**
    * Intercept a signal sent to the running actor. Pass the signal on to the next behavior
@@ -41,7 +41,7 @@ abstract class BehaviorInterceptor[O, I] {
    *
    * @return The behavior for next message or signal
    */
-  def aroundSignal(ctx: ActorContext[O], signal: Signal, target: SignalTarget[I]): Behavior[I]
+  def aroundSignal(ctx: TypedActorContext[O], signal: Signal, target: SignalTarget[I]): Behavior[I]
 
   /**
    * @return `true` if this behavior logically the same as another behavior interceptor and can therefore be eliminated
@@ -61,7 +61,7 @@ object BehaviorInterceptor {
    */
   @DoNotInherit
   trait PreStartTarget[T] {
-    def start(ctx: ActorContext[_]): Behavior[T]
+    def start(ctx: TypedActorContext[_]): Behavior[T]
   }
 
   /**
@@ -71,7 +71,7 @@ object BehaviorInterceptor {
    */
   @DoNotInherit
   trait ReceiveTarget[T] {
-    def apply(ctx: ActorContext[_], msg: T): Behavior[T]
+    def apply(ctx: TypedActorContext[_], msg: T): Behavior[T]
 
     /**
      * INTERNAL API
@@ -82,7 +82,7 @@ object BehaviorInterceptor {
      * is taking place.
      */
     @InternalApi
-    private[akka] def signalRestart(ctx: ActorContext[_]): Unit
+    private[akka] def signalRestart(ctx: TypedActorContext[_]): Unit
   }
 
   /**
@@ -92,7 +92,7 @@ object BehaviorInterceptor {
    */
   @DoNotInherit
   trait SignalTarget[T] {
-    def apply(ctx: ActorContext[_], signal: Signal): Behavior[T]
+    def apply(ctx: TypedActorContext[_], signal: Signal): Behavior[T]
   }
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
@@ -99,7 +99,7 @@ abstract class Props private[akka] () extends Product with Serializable {
     @tailrec def select(d: Props, acc: List[Props]): List[Props] =
       d match {
         case EmptyProps ⇒ acc.reverse
-        case t: T       ⇒ select(d.next, (d withNext EmptyProps) :: acc)
+        case _: T       ⇒ select(d.next, (d withNext EmptyProps) :: acc)
         case _          ⇒ select(d.next, acc)
       }
     select(this, Nil)
@@ -114,7 +114,7 @@ abstract class Props private[akka] () extends Product with Serializable {
     @tailrec def select(d: Props, acc: List[Props]): List[Props] =
       d match {
         case EmptyProps ⇒ acc
-        case t: T       ⇒ select(d.next, acc)
+        case _: T       ⇒ select(d.next, acc)
         case _          ⇒ select(d.next, d :: acc)
       }
     @tailrec def link(l: List[Props], acc: Props): Props =

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/TypedActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/TypedActorContext.scala
@@ -15,7 +15,7 @@ import akka.annotation.ApiMayChange
  */
 @DoNotInherit
 @ApiMayChange
-trait ActorContext[T] {
+trait TypedActorContext[T] {
   // this should be a pure interface, i.e. only abstract methods
 
   /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
@@ -25,7 +25,7 @@ import akka.util.JavaDurationConverters._
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] trait ActorContextImpl[T] extends ActorContext[T] with javadsl.ActorContext[T] with scaladsl.ActorContext[T] {
+@InternalApi private[akka] trait ActorContextImpl[T] extends TypedActorContext[T] with javadsl.ActorContext[T] with scaladsl.ActorContext[T] {
 
   private var messageAdapterRef: OptionVal[ActorRef[Any]] = OptionVal.None
   private var _messageAdapters: List[(Class[_], Any ⇒ T)] = Nil

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/BehaviorImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/BehaviorImpl.scala
@@ -7,7 +7,7 @@ package internal
 
 import akka.util.{ LineNumbers }
 import akka.annotation.InternalApi
-import akka.actor.typed.{ ActorContext ⇒ AC }
+import akka.actor.typed.{ TypedActorContext ⇒ AC }
 import akka.actor.typed.scaladsl.{ ActorContext ⇒ SAC }
 
 /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/InterceptorImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/InterceptorImpl.scala
@@ -7,7 +7,7 @@ package akka.actor.typed.internal
 import akka.actor.typed
 import akka.actor.typed.Behavior.{ SameBehavior, UnhandledBehavior }
 import akka.actor.typed.internal.TimerSchedulerImpl.TimerMsg
-import akka.actor.typed.{ ActorContext, ActorRef, Behavior, BehaviorInterceptor, ExtensibleBehavior, PreRestart, Signal }
+import akka.actor.typed.{ TypedActorContext, ActorRef, Behavior, BehaviorInterceptor, ExtensibleBehavior, PreRestart, Signal }
 import akka.annotation.InternalApi
 import akka.util.LineNumbers
 
@@ -39,26 +39,26 @@ private[akka] final class InterceptorImpl[O, I](val interceptor: BehaviorInterce
   import BehaviorInterceptor._
 
   private val preStartTarget: PreStartTarget[I] = new PreStartTarget[I] {
-    override def start(ctx: ActorContext[_]): Behavior[I] = {
-      Behavior.start[I](nestedBehavior, ctx.asInstanceOf[ActorContext[I]])
+    override def start(ctx: TypedActorContext[_]): Behavior[I] = {
+      Behavior.start[I](nestedBehavior, ctx.asInstanceOf[TypedActorContext[I]])
     }
   }
 
   private val receiveTarget: ReceiveTarget[I] = new ReceiveTarget[I] {
-    override def apply(ctx: ActorContext[_], msg: I): Behavior[I] =
-      Behavior.interpretMessage(nestedBehavior, ctx.asInstanceOf[ActorContext[I]], msg)
+    override def apply(ctx: TypedActorContext[_], msg: I): Behavior[I] =
+      Behavior.interpretMessage(nestedBehavior, ctx.asInstanceOf[TypedActorContext[I]], msg)
 
-    override def signalRestart(ctx: ActorContext[_]): Unit =
-      Behavior.interpretSignal(nestedBehavior, ctx.asInstanceOf[ActorContext[I]], PreRestart)
+    override def signalRestart(ctx: TypedActorContext[_]): Unit =
+      Behavior.interpretSignal(nestedBehavior, ctx.asInstanceOf[TypedActorContext[I]], PreRestart)
   }
 
   private val signalTarget = new SignalTarget[I] {
-    override def apply(ctx: ActorContext[_], signal: Signal): Behavior[I] =
-      Behavior.interpretSignal(nestedBehavior, ctx.asInstanceOf[ActorContext[I]], signal)
+    override def apply(ctx: TypedActorContext[_], signal: Signal): Behavior[I] =
+      Behavior.interpretSignal(nestedBehavior, ctx.asInstanceOf[TypedActorContext[I]], signal)
   }
 
   // invoked pre-start to start/de-duplicate the initial behavior stack
-  def preStart(ctx: typed.ActorContext[O]): Behavior[O] = {
+  def preStart(ctx: typed.TypedActorContext[O]): Behavior[O] = {
     val started = interceptor.aroundStart(ctx, preStartTarget)
     deduplicate(started, ctx)
   }
@@ -66,18 +66,18 @@ private[akka] final class InterceptorImpl[O, I](val interceptor: BehaviorInterce
   override def replaceNested(newNested: Behavior[I]): Behavior[O] =
     new InterceptorImpl(interceptor, newNested)
 
-  override def receive(ctx: typed.ActorContext[O], msg: O): Behavior[O] = {
+  override def receive(ctx: typed.TypedActorContext[O], msg: O): Behavior[O] = {
     val interceptedResult = interceptor.aroundReceive(ctx, msg, receiveTarget)
     deduplicate(interceptedResult, ctx)
   }
 
-  override def receiveSignal(ctx: typed.ActorContext[O], signal: Signal): Behavior[O] = {
+  override def receiveSignal(ctx: typed.TypedActorContext[O], signal: Signal): Behavior[O] = {
     val interceptedResult = interceptor.aroundSignal(ctx, signal, signalTarget)
     deduplicate(interceptedResult, ctx)
   }
 
-  private def deduplicate(interceptedResult: Behavior[I], ctx: ActorContext[O]): Behavior[O] = {
-    val started = Behavior.start(interceptedResult, ctx.asInstanceOf[ActorContext[I]])
+  private def deduplicate(interceptedResult: Behavior[I], ctx: TypedActorContext[O]): Behavior[O] = {
+    val started = Behavior.start(interceptedResult, ctx.asInstanceOf[TypedActorContext[I]])
     if (started == UnhandledBehavior || started == SameBehavior || !Behavior.isAlive(started)) {
       started.unsafeCast[O]
     } else {
@@ -104,12 +104,12 @@ private[akka] final class InterceptorImpl[O, I](val interceptor: BehaviorInterce
 private[akka] final case class MonitorInterceptor[T](actorRef: ActorRef[T]) extends BehaviorInterceptor[T, T] {
   import BehaviorInterceptor._
 
-  override def aroundReceive(ctx: ActorContext[T], msg: T, target: ReceiveTarget[T]): Behavior[T] = {
+  override def aroundReceive(ctx: TypedActorContext[T], msg: T, target: ReceiveTarget[T]): Behavior[T] = {
     actorRef ! msg
     target(ctx, msg)
   }
 
-  override def aroundSignal(ctx: ActorContext[T], signal: Signal, target: SignalTarget[T]): Behavior[T] = {
+  override def aroundSignal(ctx: TypedActorContext[T], signal: Signal, target: SignalTarget[T]): Behavior[T] = {
     target(ctx, signal)
   }
 
@@ -150,7 +150,7 @@ private[akka] final case class WidenedInterceptor[O, I](matcher: PartialFunction
     case _ ⇒ false
   }
 
-  def aroundReceive(ctx: ActorContext[O], msg: O, target: ReceiveTarget[I]): Behavior[I] = {
+  def aroundReceive(ctx: TypedActorContext[O], msg: O, target: ReceiveTarget[I]): Behavior[I] = {
     // widen would wrap the TimerMessage, which would be wrong, see issue #25318
     msg match {
       case t: TimerMsg ⇒ throw new IllegalArgumentException(
@@ -164,7 +164,7 @@ private[akka] final case class WidenedInterceptor[O, I](matcher: PartialFunction
     }
   }
 
-  def aroundSignal(ctx: ActorContext[O], signal: Signal, target: SignalTarget[I]): Behavior[I] =
+  def aroundSignal(ctx: TypedActorContext[O], signal: Signal, target: SignalTarget[I]): Behavior[I] =
     target(ctx, signal)
 
   override def toString: String = s"Widen(${LineNumbers(matcher)})"

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/PoisonPill.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/PoisonPill.scala
@@ -4,7 +4,7 @@
 
 package akka.actor.typed.internal
 
-import akka.actor.typed.ActorContext
+import akka.actor.typed.TypedActorContext
 import akka.actor.typed.Behavior
 import akka.actor.typed.BehaviorInterceptor
 import akka.actor.typed.Signal
@@ -31,10 +31,10 @@ import akka.annotation.InternalApi
  * and process stashed messages before stopping.
  */
 @InternalApi private[akka] final class PoisonPillInterceptor[M] extends BehaviorInterceptor[M, M] {
-  override def aroundReceive(ctx: ActorContext[M], msg: M, target: BehaviorInterceptor.ReceiveTarget[M]): Behavior[M] =
+  override def aroundReceive(ctx: TypedActorContext[M], msg: M, target: BehaviorInterceptor.ReceiveTarget[M]): Behavior[M] =
     target(ctx, msg)
 
-  override def aroundSignal(ctx: ActorContext[M], signal: Signal, target: BehaviorInterceptor.SignalTarget[M]): Behavior[M] = {
+  override def aroundSignal(ctx: TypedActorContext[M], signal: Signal, target: BehaviorInterceptor.SignalTarget[M]): Behavior[M] = {
     signal match {
       case p: PoisonPill ⇒
         val next = target(ctx, p)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
@@ -147,7 +147,7 @@ private class RestartSupervisor[T, Thr <: Throwable](initial: Behavior[T], strat
     val timeLeft = deadlineHasTimeLeft
     val newDeadline = if (deadline.isDefined && timeLeft) deadline else OptionVal.Some(Deadline.now + strategy.withinTimeRange)
     restarts = if (timeLeft) restarts + 1 else 1
-    deadline = newDeadlineq
+    deadline = newDeadline
   }
 
   private def handleException(ctx: TypedActorContext[T], signalRestart: () ⇒ Unit): Catcher[Behavior[T]] = {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
@@ -147,7 +147,7 @@ private class RestartSupervisor[T, Thr <: Throwable](initial: Behavior[T], strat
     val timeLeft = deadlineHasTimeLeft
     val newDeadline = if (deadline.isDefined && timeLeft) deadline else OptionVal.Some(Deadline.now + strategy.withinTimeRange)
     restarts = if (timeLeft) restarts + 1 else 1
-    deadline = newDeadline
+    deadline = newDeadlineq
   }
 
   private def handleException(ctx: TypedActorContext[T], signalRestart: () ⇒ Unit): Catcher[Behavior[T]] = {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
@@ -156,7 +156,7 @@ private final class TimerInterceptor[T](timerSchedulerImpl: TimerSchedulerImpl[T
   import TimerSchedulerImpl._
   import BehaviorInterceptor._
 
-  override def aroundReceive(ctx: typed.ActorContext[T], msg: T, target: ReceiveTarget[T]): Behavior[T] = {
+  override def aroundReceive(ctx: typed.TypedActorContext[T], msg: T, target: ReceiveTarget[T]): Behavior[T] = {
     val maybeIntercepted = msg match {
       case msg: TimerMsg ⇒ timerSchedulerImpl.interceptTimerMsg(ctx.asScala.log, msg)
       case msg           ⇒ OptionVal.Some(msg)
@@ -168,7 +168,7 @@ private final class TimerInterceptor[T](timerSchedulerImpl: TimerSchedulerImpl[T
     }
   }
 
-  override def aroundSignal(ctx: typed.ActorContext[T], signal: Signal, target: SignalTarget[T]): Behavior[T] = {
+  override def aroundSignal(ctx: typed.TypedActorContext[T], signal: Signal, target: SignalTarget[T]): Behavior[T] = {
     signal match {
       case PreRestart | PostStop ⇒ timerSchedulerImpl.cancelAll()
       case _                     ⇒ // unhandled

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/WithMdcBehaviorInterceptor.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/WithMdcBehaviorInterceptor.scala
@@ -5,7 +5,7 @@
 package akka.actor.typed.internal
 
 import akka.actor.typed.internal.adapter.AbstractLogger
-import akka.actor.typed.{ ActorContext, Behavior, BehaviorInterceptor, Signal }
+import akka.actor.typed.{ TypedActorContext, Behavior, BehaviorInterceptor, Signal }
 import akka.annotation.InternalApi
 
 import scala.collection.immutable.HashMap
@@ -38,7 +38,7 @@ import scala.collection.immutable.HashMap
 
   import BehaviorInterceptor._
 
-  override def aroundStart(ctx: ActorContext[T], target: PreStartTarget[T]): Behavior[T] = {
+  override def aroundStart(ctx: TypedActorContext[T], target: PreStartTarget[T]): Behavior[T] = {
     // when declaring we expect the outermost to win
     // for example with
     // val behavior = ...
@@ -72,7 +72,7 @@ import scala.collection.immutable.HashMap
     case _                                ⇒ false
   }
 
-  override def aroundReceive(ctx: ActorContext[T], msg: T, target: ReceiveTarget[T]): Behavior[T] = {
+  override def aroundReceive(ctx: TypedActorContext[T], msg: T, target: ReceiveTarget[T]): Behavior[T] = {
     val mdc = merge(staticMdc, mdcForMessage(msg))
     ctx.asScala.log.asInstanceOf[AbstractLogger].mdc = mdc
     val next =
@@ -84,7 +84,7 @@ import scala.collection.immutable.HashMap
     next
   }
 
-  override def aroundSignal(ctx: ActorContext[T], signal: Signal, target: SignalTarget[T]): Behavior[T] = {
+  override def aroundSignal(ctx: TypedActorContext[T], signal: Signal, target: SignalTarget[T]): Behavior[T] = {
     ctx.asScala.log.asInstanceOf[AbstractLogger].mdc = staticMdc
     try {
       target(ctx, signal)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
@@ -135,9 +135,9 @@ import akka.util.OptionVal
   }
 
   override def unhandled(msg: Any): Unit = msg match {
-    case t @ Terminated(ref) ⇒ throw DeathPactException(ref)
-    case msg: Signal         ⇒ // that's ok
-    case other               ⇒ super.unhandled(other)
+    case Terminated(ref) ⇒ throw DeathPactException(ref)
+    case _: Signal       ⇒ // that's ok
+    case other           ⇒ super.unhandled(other)
   }
 
   override val supervisorStrategy = untyped.OneForOneStrategy(loggingEnabled = false) {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
 
 /**
- * INTERNAL API. Wrapping an [[akka.actor.ActorContext]] as an [[ActorContext]].
+ * INTERNAL API. Wrapping an [[akka.actor.ActorContext]] as an [[TypedActorContext]].
  */
 @InternalApi private[akka] final class ActorContextAdapter[T](val untyped: a.ActorContext) extends ActorContextImpl[T] {
 
@@ -102,7 +102,7 @@ import scala.concurrent.duration._
  */
 @InternalApi private[typed] object ActorContextAdapter {
 
-  private def toUntypedImp[U](ctx: ActorContext[_]): a.ActorContext =
+  private def toUntypedImp[U](ctx: TypedActorContext[_]): a.ActorContext =
     ctx match {
       case adapter: ActorContextAdapter[_] ⇒ adapter.untyped
       case _ ⇒
@@ -110,11 +110,11 @@ import scala.concurrent.duration._
           s"($ctx of class ${ctx.getClass.getName})")
     }
 
-  def toUntyped2[U](ctx: ActorContext[_]): a.ActorContext = toUntypedImp(ctx)
+  def toUntyped2[U](ctx: TypedActorContext[_]): a.ActorContext = toUntypedImp(ctx)
 
   def toUntyped[U](ctx: scaladsl.ActorContext[_]): a.ActorContext =
     ctx match {
-      case c: ActorContext[_] ⇒ toUntypedImp(c)
+      case c: TypedActorContext[_] ⇒ toUntypedImp(c)
       case _ ⇒
         throw new UnsupportedOperationException("unknown ActorContext type " +
           s"($ctx of class ${ctx.getClass.getName})")
@@ -122,7 +122,7 @@ import scala.concurrent.duration._
 
   def toUntyped[U](ctx: javadsl.ActorContext[_]): a.ActorContext =
     ctx match {
-      case c: ActorContext[_] ⇒ toUntypedImp(c)
+      case c: TypedActorContext[_] ⇒ toUntypedImp(c)
       case _ ⇒
         throw new UnsupportedOperationException("unknown ActorContext type " +
           s"($ctx of class ${ctx.getClass.getName})")

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala
@@ -60,8 +60,8 @@ private[akka] object ActorRefAdapter {
         sysmsg.Watch(
           toUntyped(watchee),
           toUntyped(watcher)))
-      case internal.Unwatch(watchee, watcher)          ⇒ untyped.sendSystemMessage(sysmsg.Unwatch(toUntyped(watchee), toUntyped(watcher)))
-      case internal.DeathWatchNotification(ref, cause) ⇒ untyped.sendSystemMessage(sysmsg.DeathWatchNotification(toUntyped(ref), true, false))
-      case internal.NoMessage                          ⇒ // just to suppress the warning
+      case internal.Unwatch(watchee, watcher)      ⇒ untyped.sendSystemMessage(sysmsg.Unwatch(toUntyped(watchee), toUntyped(watcher)))
+      case internal.DeathWatchNotification(ref, _) ⇒ untyped.sendSystemMessage(sysmsg.DeathWatchNotification(toUntyped(ref), true, false))
+      case internal.NoMessage                      ⇒ // just to suppress the warning
     }
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AbstractBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AbstractBehavior.scala
@@ -33,11 +33,11 @@ abstract class AbstractBehavior[T] extends ExtensibleBehavior[T] {
   }
 
   @throws(classOf[Exception])
-  override final def receive(ctx: akka.actor.typed.ActorContext[T], msg: T): Behavior[T] =
+  override final def receive(ctx: akka.actor.typed.TypedActorContext[T], msg: T): Behavior[T] =
     receive.receive(ctx, msg)
 
   @throws(classOf[Exception])
-  override final def receiveSignal(ctx: akka.actor.typed.ActorContext[T], msg: Signal): Behavior[T] =
+  override final def receiveSignal(ctx: akka.actor.typed.TypedActorContext[T], msg: Signal): Behavior[T] =
     receive.receiveSignal(ctx, msg)
 
   /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AbstractBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AbstractBehavior.scala
@@ -4,7 +4,7 @@
 
 package akka.actor.typed.javadsl
 
-import akka.actor.typed.{ Behavior, ExtensibleBehavior, Signal }
+import akka.actor.typed.{ Behavior, ExtensibleBehavior, Signal, TypedActorContext }
 import akka.util.OptionVal
 
 /**
@@ -33,11 +33,11 @@ abstract class AbstractBehavior[T] extends ExtensibleBehavior[T] {
   }
 
   @throws(classOf[Exception])
-  override final def receive(ctx: akka.actor.typed.TypedActorContext[T], msg: T): Behavior[T] =
+  override final def receive(ctx: TypedActorContext[T], msg: T): Behavior[T] =
     receive.receive(ctx, msg)
 
   @throws(classOf[Exception])
-  override final def receiveSignal(ctx: akka.actor.typed.TypedActorContext[T], msg: Signal): Behavior[T] =
+  override final def receiveSignal(ctx: TypedActorContext[T], msg: Signal): Behavior[T] =
     receive.receiveSignal(ctx, msg)
 
   /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ActorContext.scala
@@ -36,7 +36,7 @@ import scala.concurrent.ExecutionContextExecutor
  */
 @DoNotInherit
 @ApiMayChange
-trait ActorContext[T] extends akka.actor.typed.ActorContext[T] {
+trait ActorContext[T] extends akka.actor.typed.TypedActorContext[T] {
   // this must be a pure interface, i.e. only abstract methods
 
   /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ActorContext.scala
@@ -36,7 +36,7 @@ import scala.concurrent.ExecutionContextExecutor
  */
 @DoNotInherit
 @ApiMayChange
-trait ActorContext[T] extends akka.actor.typed.TypedActorContext[T] {
+trait ActorContext[T] extends TypedActorContext[T] {
   // this must be a pure interface, i.e. only abstract methods
 
   /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/BehaviorBuilder.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/BehaviorBuilder.scala
@@ -249,9 +249,9 @@ private class BuiltBehavior[T](
   private val signalHandlers:  List[Case[T, Signal]]
 ) extends ExtensibleBehavior[T] {
 
-  override def receive(ctx: typed.ActorContext[T], msg: T): Behavior[T] = receive[T](ctx.asJava, msg, messageHandlers)
+  override def receive(ctx: typed.TypedActorContext[T], msg: T): Behavior[T] = receive[T](ctx.asJava, msg, messageHandlers)
 
-  override def receiveSignal(ctx: typed.ActorContext[T], msg: Signal): Behavior[T] = receive[Signal](ctx.asJava, msg, signalHandlers)
+  override def receiveSignal(ctx: typed.TypedActorContext[T], msg: Signal): Behavior[T] = receive[Signal](ctx.asJava, msg, signalHandlers)
 
   @tailrec
   private def receive[M](ctx: ActorContext[T], msg: M, handlers: List[Case[T, M]]): Behavior[T] =

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
@@ -13,6 +13,7 @@ import akka.actor.typed.scaladsl
 import akka.annotation.ApiMayChange
 import akka.japi.function.{ Function2 ⇒ JapiFunction2 }
 import akka.japi.pf.PFBuilder
+import akka.util.unused
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
@@ -156,7 +157,7 @@ object Behaviors {
    * @param type the supertype of all messages accepted by this behavior
    * @return the behavior builder
    */
-  def receive[T](`type`: Class[T]): BehaviorBuilder[T] = BehaviorBuilder.create[T]
+  def receive[T](@unused `type`: Class[T]): BehaviorBuilder[T] = BehaviorBuilder.create[T]
 
   /**
    * Construct an actor behavior that can react to lifecycle signals only.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Receive.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Receive.scala
@@ -4,9 +4,7 @@
 
 package akka.actor.typed.javadsl
 
-import akka.actor.typed.Behavior
-import akka.actor.typed.ExtensibleBehavior
-import akka.actor.typed.Signal
+import akka.actor.typed.{ Behavior, ExtensibleBehavior, Signal, TypedActorContext }
 import akka.annotation.DoNotInherit
 
 /**
@@ -48,11 +46,11 @@ abstract class Receive[T] extends ExtensibleBehavior[T] {
   def receiveSignal(sig: Signal): Behavior[T]
 
   @throws(classOf[Exception])
-  override final def receive(ctx: akka.actor.typed.TypedActorContext[T], msg: T): Behavior[T] =
+  override final def receive(ctx: TypedActorContext[T], msg: T): Behavior[T] =
     receiveMessage(msg)
 
   @throws(classOf[Exception])
-  override final def receiveSignal(ctx: akka.actor.typed.TypedActorContext[T], sig: Signal): Behavior[T] =
+  override final def receiveSignal(ctx: TypedActorContext[T], sig: Signal): Behavior[T] =
     receiveSignal(sig)
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Receive.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Receive.scala
@@ -48,11 +48,11 @@ abstract class Receive[T] extends ExtensibleBehavior[T] {
   def receiveSignal(sig: Signal): Behavior[T]
 
   @throws(classOf[Exception])
-  override final def receive(ctx: akka.actor.typed.ActorContext[T], msg: T): Behavior[T] =
+  override final def receive(ctx: akka.actor.typed.TypedActorContext[T], msg: T): Behavior[T] =
     receiveMessage(msg)
 
   @throws(classOf[Exception])
-  override final def receiveSignal(ctx: akka.actor.typed.ActorContext[T], sig: Signal): Behavior[T] =
+  override final def receiveSignal(ctx: akka.actor.typed.TypedActorContext[T], sig: Signal): Behavior[T] =
     receiveSignal(sig)
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AbstractBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AbstractBehavior.scala
@@ -55,10 +55,10 @@ abstract class AbstractBehavior[T] extends ExtensibleBehavior[T] {
   def onSignal: PartialFunction[Signal, Behavior[T]] = PartialFunction.empty
 
   @throws(classOf[Exception])
-  override final def receive(ctx: akka.actor.typed.ActorContext[T], msg: T): Behavior[T] =
+  override final def receive(ctx: akka.actor.typed.TypedActorContext[T], msg: T): Behavior[T] =
     onMessage(msg)
 
   @throws(classOf[Exception])
-  override final def receiveSignal(ctx: akka.actor.typed.ActorContext[T], msg: Signal): Behavior[T] =
+  override final def receiveSignal(ctx: akka.actor.typed.TypedActorContext[T], msg: Signal): Behavior[T] =
     onSignal.applyOrElse(msg, { case _ ⇒ Behavior.unhandled }: PartialFunction[Signal, Behavior[T]])
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AbstractBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AbstractBehavior.scala
@@ -4,7 +4,7 @@
 
 package akka.actor.typed.scaladsl
 
-import akka.actor.typed.{ Behavior, ExtensibleBehavior, Signal }
+import akka.actor.typed.{ Behavior, ExtensibleBehavior, Signal, TypedActorContext }
 
 /**
  * An actor `Behavior` can be implemented by extending this class and implement the
@@ -55,10 +55,10 @@ abstract class AbstractBehavior[T] extends ExtensibleBehavior[T] {
   def onSignal: PartialFunction[Signal, Behavior[T]] = PartialFunction.empty
 
   @throws(classOf[Exception])
-  override final def receive(ctx: akka.actor.typed.TypedActorContext[T], msg: T): Behavior[T] =
+  override final def receive(ctx: TypedActorContext[T], msg: T): Behavior[T] =
     onMessage(msg)
 
   @throws(classOf[Exception])
-  override final def receiveSignal(ctx: akka.actor.typed.TypedActorContext[T], msg: Signal): Behavior[T] =
+  override final def receiveSignal(ctx: TypedActorContext[T], msg: Signal): Behavior[T] =
     onSignal.applyOrElse(msg, { case _ ⇒ Behavior.unhandled }: PartialFunction[Signal, Behavior[T]])
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
@@ -36,7 +36,7 @@ import akka.annotation.InternalApi
  */
 @DoNotInherit
 @ApiMayChange
-trait ActorContext[T] extends akka.actor.typed.ActorContext[T] { this: akka.actor.typed.javadsl.ActorContext[T] ⇒
+trait ActorContext[T] extends akka.actor.typed.TypedActorContext[T] { this: akka.actor.typed.javadsl.ActorContext[T] ⇒
 
   /**
    * Get the `javadsl` of this `ActorContext`.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
@@ -36,7 +36,7 @@ import akka.annotation.InternalApi
  */
 @DoNotInherit
 @ApiMayChange
-trait ActorContext[T] extends akka.actor.typed.TypedActorContext[T] { this: akka.actor.typed.javadsl.ActorContext[T] ⇒
+trait ActorContext[T] extends TypedActorContext[T] { this: akka.actor.typed.javadsl.ActorContext[T] ⇒
 
   /**
    * Get the `javadsl` of this `ActorContext`.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
@@ -6,14 +6,14 @@ package akka.actor.typed.scaladsl
 
 import java.util.concurrent.TimeoutException
 
+import scala.concurrent.Future
+
 import akka.actor.{ Address, RootActorPath, Scheduler }
 import akka.actor.typed.ActorRef
 import akka.actor.typed.internal.{ adapter ⇒ adapt }
 import akka.annotation.InternalApi
 import akka.pattern.PromiseActorRef
-import akka.util.Timeout
-import scala.concurrent.Future
-
+import akka.util.{ Timeout, unused }
 import akka.actor.typed.RecipientRef
 import akka.actor.typed.internal.InternalRecipientRef
 
@@ -54,7 +54,7 @@ object AskPattern {
      * val f: Future[Reply] = target ? replyTo => (Request("hello", replyTo))
      * }}}
      */
-    def ?[U](replyTo: ActorRef[U] ⇒ T)(implicit timeout: Timeout, scheduler: Scheduler): Future[U] = {
+    def ?[U](replyTo: ActorRef[U] ⇒ T)(implicit timeout: Timeout, @unused scheduler: Scheduler): Future[U] = {
       // We do not currently use the implicit scheduler, but want to require it
       // because it might be needed when we move to a 'native' typed runtime, see #24219
       ref match {

--- a/akka-actor/src/main/scala/akka/actor/dsl/Inbox.scala
+++ b/akka-actor/src/main/scala/akka/actor/dsl/Inbox.scala
@@ -97,7 +97,7 @@ trait Inbox { this: ActorDSL.type ⇒
       case g: Get ⇒
         if (messages.isEmpty) enqueueQuery(g)
         else sender() ! messages.dequeue()
-      case s @ Select(_, predicate, _) ⇒
+      case s: Select ⇒
         if (messages.isEmpty) enqueueQuery(s)
         else {
           currentSelect = s

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -16,7 +16,7 @@ import akka.actor.ActorRefProvider
 import akka.actor.ExtendedActorSystem
 import akka.actor.InternalActorRef
 import akka.actor.Scheduler
-import akka.actor.typed.ActorContext
+import akka.actor.typed.TypedActorContext
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -348,7 +348,7 @@ import akka.util.Timeout
   import akka.cluster.sharding.ShardRegion.{ Passivate ⇒ UntypedPassivate }
 
   def behavior(stopMessage: Any): Behavior[scaladsl.ClusterSharding.ShardCommand] = {
-    def sendUntypedPassivate(entity: ActorRef[_], ctx: ActorContext[_]): Unit = {
+    def sendUntypedPassivate(entity: ActorRef[_], ctx: TypedActorContext[_]): Unit = {
       val pathToShard = entity.toUntyped.path.elements.take(4).mkString("/")
       ctx.asScala.system.toUntyped.actorSelection(pathToShard).tell(UntypedPassivate(stopMessage), entity.toUntyped)
     }

--- a/akka-docs/src/main/paradox/typed/actor-lifecycle.md
+++ b/akka-docs/src/main/paradox/typed/actor-lifecycle.md
@@ -46,7 +46,8 @@ is a tool that mimics the old style of starting up actors.
 
 ### Spawning Children
 
-Child actors are spawned with @unidoc[akka.actor.typed.ActorContext]'s `spawn`. In the example below, when the root actor
+Child actors are spawned with @scala[@unidoc[akka.actor.typed.scaladsl.ActorContext]]@java[@unidoc[akka.actor.typed.javadsl.ActorContext]]'s `spawn`. 
+In the example below, when the root actor
 is started, it spawns a child actor described by the behavior `HelloWorld.greeter`. Additionally, when the root actor receives a
 `Start` message, it creates a child actor defined by the behavior `HelloWorldBot.bot`:
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -67,7 +67,7 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
 
   import EventSourcedBehaviorImpl.WriterIdentity
 
-  override def apply(context: typed.ActorContext[Command]): Behavior[Command] = {
+  override def apply(context: typed.TypedActorContext[Command]): Behavior[Command] = {
     Behaviors.supervise {
       Behaviors.setup[Command] { ctx ⇒
         val settings = EventSourcedSettings(ctx.system, journalPluginId.getOrElse(""), snapshotPluginId.getOrElse(""))
@@ -103,11 +103,11 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
         // not part of the protocol
         val onStopInterceptor = new BehaviorInterceptor[Any, Any] {
           import BehaviorInterceptor._
-          def aroundReceive(ctx: typed.ActorContext[Any], msg: Any, target: ReceiveTarget[Any]): Behavior[Any] = {
+          def aroundReceive(ctx: typed.TypedActorContext[Any], msg: Any, target: ReceiveTarget[Any]): Behavior[Any] = {
             target(ctx, msg)
           }
 
-          def aroundSignal(ctx: typed.ActorContext[Any], signal: Signal, target: SignalTarget[Any]): Behavior[Any] = {
+          def aroundSignal(ctx: typed.TypedActorContext[Any], signal: Signal, target: SignalTarget[Any]): Behavior[Any] = {
             if (signal == PostStop) {
               eventsourcedSetup.cancelRecoveryTimer()
               clearStashBuffer()

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
@@ -137,7 +137,7 @@ abstract class EventSourcedBehavior[Command, Event, State >: Null] private[akka]
   /**
    * INTERNAL API: DeferredBehavior init
    */
-  @InternalApi override def apply(context: typed.ActorContext[Command]): Behavior[Command] = {
+  @InternalApi override def apply(context: typed.TypedActorContext[Command]): Behavior[Command] = {
 
     val snapshotWhen: (State, Event, Long) ⇒ Boolean = { (state, event, seqNr) ⇒
       val n = snapshotEvery()

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -452,13 +452,13 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     TestProbe<Signal> signalProbe = testKit.createTestProbe();
     BehaviorInterceptor<Command, Command> tap = new BehaviorInterceptor<Command, Command>() {
       @Override
-      public Behavior<Command> aroundReceive(akka.actor.typed.ActorContext<Command> ctx, Command msg, ReceiveTarget<Command> target) {
+      public Behavior<Command> aroundReceive(akka.actor.typed.TypedActorContext<Command> ctx, Command msg, ReceiveTarget<Command> target) {
         interceptProbe.ref().tell(msg);
         return target.apply(ctx, msg);
       }
 
       @Override
-      public Behavior<Command> aroundSignal(akka.actor.typed.ActorContext<Command> ctx, Signal signal, SignalTarget<Command> target) {
+      public Behavior<Command> aroundSignal(akka.actor.typed.TypedActorContext<Command> ctx, Signal signal, SignalTarget<Command> target) {
         signalProbe.ref().tell(signal);
         return target.apply(ctx, signal);
       }

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -452,13 +452,13 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     TestProbe<Signal> signalProbe = testKit.createTestProbe();
     BehaviorInterceptor<Command, Command> tap = new BehaviorInterceptor<Command, Command>() {
       @Override
-      public Behavior<Command> aroundReceive(akka.actor.typed.TypedActorContext<Command> ctx, Command msg, ReceiveTarget<Command> target) {
+      public Behavior<Command> aroundReceive(TypedActorContext<Command> ctx, Command msg, ReceiveTarget<Command> target) {
         interceptProbe.ref().tell(msg);
         return target.apply(ctx, msg);
       }
 
       @Override
-      public Behavior<Command> aroundSignal(akka.actor.typed.TypedActorContext<Command> ctx, Signal signal, SignalTarget<Command> target) {
+      public Behavior<Command> aroundSignal(TypedActorContext<Command> ctx, Signal signal, SignalTarget<Command> target) {
         signalProbe.ref().tell(signal);
         return target.apply(ctx, signal);
       }

--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -220,7 +220,7 @@ private[remote] class ReliableDeliverySupervisor(
     settings.SysResendTimeout, settings.SysResendTimeout, self, AttemptSysMsgRedelivery)
 
   override val supervisorStrategy = OneForOneStrategy(loggingEnabled = false) {
-    case e @ (_: AssociationProblem) ⇒ Escalate
+    case _: AssociationProblem ⇒ Escalate
     case NonFatal(e) ⇒
       val causedBy = if (e.getCause == null) "" else s"Caused by: [${e.getCause.getMessage}]"
       log.warning(
@@ -359,10 +359,10 @@ private[remote] class ReliableDeliverySupervisor(
         // Resending will be triggered by the incoming GotUid message after the connection finished
         goToActive()
       } else goToIdle()
-    case AttemptSysMsgRedelivery               ⇒ // Ignore
-    case s @ Send(msg: SystemMessage, _, _, _) ⇒ tryBuffer(s.copy(seqOpt = Some(nextSeq())))
-    case s: Send                               ⇒ context.system.deadLetters ! s
-    case EndpointWriter.FlushAndStop           ⇒ context.stop(self)
+    case AttemptSysMsgRedelivery             ⇒ // Ignore
+    case s @ Send(_: SystemMessage, _, _, _) ⇒ tryBuffer(s.copy(seqOpt = Some(nextSeq())))
+    case s: Send                             ⇒ context.system.deadLetters ! s
+    case EndpointWriter.FlushAndStop         ⇒ context.stop(self)
     case EndpointWriter.StopReading(w, replyTo) ⇒
       replyTo ! EndpointWriter.StoppedReading(w)
       sender() ! EndpointWriter.StoppedReading(w)

--- a/akka-remote/src/main/scala/akka/remote/MessageSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/MessageSerializer.scala
@@ -10,6 +10,7 @@ import akka.actor.ExtendedActorSystem
 import akka.annotation.InternalApi
 import akka.remote.artery.{ EnvelopeBuffer, HeaderBuilder, OutboundEnvelope }
 import akka.serialization._
+import akka.util.unused
 
 import scala.util.control.NonFatal
 
@@ -83,8 +84,13 @@ private[akka] object MessageSerializer {
     } finally Serialization.currentTransportInformation.value = oldInfo
   }
 
-  def deserializeForArtery(system: ExtendedActorSystem, originUid: Long, serialization: Serialization,
-                           serializer: Int, classManifest: String, envelope: EnvelopeBuffer): AnyRef = {
+  def deserializeForArtery(
+    @unused system:    ExtendedActorSystem,
+    @unused originUid: Long,
+    serialization:     Serialization,
+    serializer:        Int,
+    classManifest:     String,
+    envelope:          EnvelopeBuffer): AnyRef = {
     serialization.deserializeByteBuffer(envelope.byteBuffer, serializer, classManifest)
   }
 }

--- a/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
@@ -212,7 +212,7 @@ private[akka] class RemoteSystemDaemon(
 
   private def doCreateActor(message: DaemonMsg, props: Props, deploy: Deploy, path: String, supervisor: ActorRef) = {
     path match {
-      case ActorPathExtractor(address, elems) if elems.nonEmpty && elems.head == "remote" ⇒
+      case ActorPathExtractor(_, elems) if elems.nonEmpty && elems.head == "remote" ⇒
         // TODO RK currently the extracted “address” is just ignored, is that okay?
         // TODO RK canonicalize path so as not to duplicate it always #1446
         val subpath = elems.drop(1)

--- a/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteTransport.scala
@@ -8,10 +8,11 @@ import akka.AkkaException
 import akka.Done
 import akka.actor._
 import akka.event.LoggingAdapter
+
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.control.NoStackTrace
-import akka.util.OptionVal
+import akka.util.{ OptionVal, unused }
 
 /**
  * RemoteTransportException represents a general failure within a RemoteTransport,
@@ -79,7 +80,7 @@ private[akka] abstract class RemoteTransport(val system: ExtendedActorSystem, va
    * @param cmd Command message to send to the transports.
    * @return A Future that indicates when the message was successfully handled or dropped.
    */
-  def managementCommand(cmd: Any): Future[Boolean] = { Future.successful(false) }
+  def managementCommand(@unused cmd: Any): Future[Boolean] = { Future.successful(false) }
 
   /**
    * A Logger that can be used to log issues that may occur

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -24,7 +24,6 @@ import scala.util.Success
 import scala.util.Try
 import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
-
 import akka.Done
 import akka.NotUsed
 import akka.actor.Actor
@@ -56,8 +55,7 @@ import akka.stream.SharedKillSwitch
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
-import akka.util.OptionVal
-import akka.util.WildcardIndex
+import akka.util.{ OptionVal, WildcardIndex, unused }
 
 /**
  * INTERNAL API
@@ -243,8 +241,11 @@ private[remote] object FlushOnShutdown {
 /**
  * INTERNAL API
  */
-private[remote] class FlushOnShutdown(done: Promise[Done], timeout: FiniteDuration,
-                                      inboundContext: InboundContext, associations: Set[Association]) extends Actor {
+private[remote] class FlushOnShutdown(
+  done:                   Promise[Done],
+  timeout:                FiniteDuration,
+  @unused inboundContext: InboundContext,
+  associations:           Set[Association]) extends Actor {
 
   var remaining = Map.empty[UniqueAddress, Int]
 

--- a/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
@@ -6,6 +6,10 @@ package akka.remote.artery
 
 import java.util.concurrent.TimeUnit
 
+import scala.concurrent.duration._
+import scala.concurrent.{ Future, Promise }
+import scala.util.control.NonFatal
+
 import akka.Done
 import akka.actor.{ EmptyLocalActorRef, _ }
 import akka.event.Logging
@@ -17,11 +21,7 @@ import akka.remote.{ MessageSerializer, OversizedPayloadException, RemoteActorRe
 import akka.serialization.{ Serialization, SerializationExtension, Serializers }
 import akka.stream._
 import akka.stream.stage._
-import akka.util.{ OptionVal, Unsafe }
-
-import scala.concurrent.duration._
-import scala.concurrent.{ Future, Promise }
-import scala.util.control.NonFatal
+import akka.util.{ OptionVal, Unsafe, unused }
 import akka.remote.artery.OutboundHandshake.HandshakeReq
 
 /**
@@ -43,7 +43,7 @@ private[remote] class Encoder(
   system:               ExtendedActorSystem,
   outboundEnvelopePool: ObjectPool[ReusableOutboundEnvelope],
   bufferPool:           EnvelopeBufferPool,
-  streamId:             Int,
+  @unused streamId:     Int,
   debugLogSend:         Boolean,
   version:              Byte)
   extends GraphStageWithMaterializedValue[FlowShape[OutboundEnvelope, EnvelopeBuffer], Encoder.OutboundCompressionAccess] {
@@ -59,7 +59,6 @@ private[remote] class Encoder(
       private val headerBuilder = HeaderBuilder.out()
       headerBuilder.setVersion(version)
       headerBuilder.setUid(uniqueLocalAddress.uid)
-      private val localAddress = uniqueLocalAddress.address
 
       // lazy init of SerializationExtension to avoid loading serializers before ActorRefProvider has been initialized
       private var _serialization: OptionVal[Serialization] = OptionVal.None
@@ -331,7 +330,6 @@ private[remote] class Decoder(
 
       override val compressions = inboundCompressions
 
-      private val localAddress = inboundContext.localAddress.address
       private val headerBuilder = HeaderBuilder.in(compressions)
       private val actorRefResolver: ActorRefResolveCacheWithAddress =
         new ActorRefResolveCacheWithAddress(system.provider.asInstanceOf[RemoteActorRefProvider], uniqueLocalAddress)
@@ -575,9 +573,9 @@ private[remote] class Decoder(
  * INTERNAL API
  */
 private[remote] class Deserializer(
-  inboundContext: InboundContext,
-  system:         ExtendedActorSystem,
-  bufferPool:     EnvelopeBufferPool) extends GraphStage[FlowShape[InboundEnvelope, InboundEnvelope]] {
+  @unused inboundContext: InboundContext,
+  system:                 ExtendedActorSystem,
+  bufferPool:             EnvelopeBufferPool) extends GraphStage[FlowShape[InboundEnvelope, InboundEnvelope]] {
 
   val in: Inlet[InboundEnvelope] = Inlet("Artery.Deserializer.in")
   val out: Outlet[InboundEnvelope] = Outlet("Artery.Deserializer.out")

--- a/akka-remote/src/main/scala/akka/remote/artery/Handshake.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Handshake.scala
@@ -4,20 +4,19 @@
 
 package akka.remote.artery
 
-import akka.actor.ActorSystem
-
 import scala.concurrent.duration._
+import scala.concurrent.Future
 import scala.util.control.NoStackTrace
+
+import akka.actor.ActorSystem
 import akka.remote.UniqueAddress
 import akka.stream.Attributes
 import akka.stream.FlowShape
 import akka.stream.Inlet
 import akka.stream.Outlet
 import akka.stream.stage._
-import akka.util.OptionVal
+import akka.util.{ OptionVal, unused }
 import akka.Done
-
-import scala.concurrent.Future
 import akka.actor.Address
 
 /**
@@ -50,7 +49,7 @@ private[remote] object OutboundHandshake {
  * INTERNAL API
  */
 private[remote] class OutboundHandshake(
-  system:                  ActorSystem,
+  @unused system:          ActorSystem,
   outboundContext:         OutboundContext,
   outboundEnvelopePool:    ObjectPool[ReusableOutboundEnvelope],
   timeout:                 FiniteDuration,
@@ -129,7 +128,7 @@ private[remote] class OutboundHandshake(
               // when it receives the HandshakeRsp reply
               implicit val ec = materializer.executionContext
               uniqueRemoteAddress.foreach {
-                getAsyncCallback[UniqueAddress] { a ⇒
+                getAsyncCallback[UniqueAddress] { _ ⇒
                   if (handshakeState != Completed) {
                     handshakeCompleted()
                     if (isAvailable(out))

--- a/akka-remote/src/main/scala/akka/remote/artery/MessageDispatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/MessageDispatcher.scala
@@ -41,7 +41,6 @@ private[remote] class MessageDispatcher(
     }
 
     val sender: ActorRef = senderOption.getOrElse(system.deadLetters)
-    val originalReceiver = recipient.path
 
     recipient match {
 

--- a/akka-remote/src/main/scala/akka/remote/artery/RemoteInstrument.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/RemoteInstrument.scala
@@ -4,12 +4,13 @@
 
 package akka.remote.artery
 
-import akka.actor.{ ActorRef, ExtendedActorSystem }
-import akka.event.{ Logging, LoggingAdapter }
-import akka.util.OptionVal
 import java.nio.ByteBuffer
+
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
+import akka.actor.{ ActorRef, ExtendedActorSystem }
+import akka.event.{ Logging, LoggingAdapter }
+import akka.util.{ OptionVal, unused }
 
 /**
  * INTERNAL API
@@ -287,7 +288,7 @@ private[remote] object RemoteInstruments {
   def getKey(kl: Int): Byte = (kl >>> 26).toByte
   def getLength(kl: Int): Int = kl & lengthMask
 
-  def create(system: ExtendedActorSystem, log: LoggingAdapter): Vector[RemoteInstrument] = {
+  def create(system: ExtendedActorSystem, @unused log: LoggingAdapter): Vector[RemoteInstrument] = {
     val c = system.settings.config
     val path = "akka.remote.artery.advanced.instruments"
     import scala.collection.JavaConverters._

--- a/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
@@ -91,7 +91,6 @@ import akka.util.OptionVal
       private var incarnation = outboundContext.associationState.incarnation
       private val unacknowledged = new ArrayDeque[OutboundEnvelope]
       private var resending = new ArrayDeque[OutboundEnvelope]
-      private var resendingFromSeqNo = -1L
       private var stopping = false
 
       private val giveUpAfterNanos = outboundContext.settings.Advanced.GiveUpSystemMessageAfter.toNanos
@@ -288,7 +287,6 @@ import akka.util.OptionVal
         incarnation = outboundContext.associationState.incarnation
         unacknowledged.clear()
         resending.clear()
-        resendingFromSeqNo = -1L
         cancelTimer(resendInterval)
       }
 

--- a/akka-remote/src/main/scala/akka/remote/artery/aeron/AeronSource.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/aeron/AeronSource.scala
@@ -34,7 +34,7 @@ private[remote] object AeronSource {
     () ⇒
       {
         handler.reset
-        val fragmentsRead = sub.poll(handler.fragmentsHandler, 1)
+        sub.poll(handler.fragmentsHandler, 1)
         val msg = handler.messageReceived
         handler.reset() // for GC
         if (msg ne null) {

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala
@@ -14,7 +14,7 @@ import akka.actor.Address
 import akka.event.Logging
 import akka.event.LoggingAdapter
 import akka.remote.artery._
-import akka.util.OptionVal
+import akka.util.{ OptionVal, unused }
 import org.agrona.collections.Long2ObjectHashMap
 
 /**
@@ -376,7 +376,7 @@ private[remote] abstract class InboundCompression[T >: Null](
    * Add `n` occurrence for the given key and call `heavyHittedDetected` if element has become a heavy hitter.
    * Empty keys are omitted.
    */
-  def increment(remoteAddress: Address, value: T, n: Long): Unit = {
+  def increment(@unused remoteAddress: Address, value: T, n: Long): Unit = {
     val count = cms.addObjectAndEstimateCount(value, n)
     addAndCheckIfheavyHitterDetected(value, count)
     alive = true

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/TopHeavyHitters.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/TopHeavyHitters.scala
@@ -169,7 +169,7 @@ private[remote] final class TopHeavyHitters[T >: Null](val max: Int)(implicit cl
           true
         } else {
           // The entry exists, let's update it.
-          updateExistingHeavyHitter(actualIdx, hashCode, item, count)
+          updateExistingHeavyHitter(actualIdx, count)
           // not a "new" heavy hitter, since we only replaced it (so it was signaled as new once before)
           false
         }
@@ -220,7 +220,7 @@ private[remote] final class TopHeavyHitters[T >: Null](val max: Int)(implicit cl
    * Replace existing heavy hitter – give it a new `count` value. This will also restore the heap property, so this
    * might make a previously lowest hitter no longer be one.
    */
-  private def updateExistingHeavyHitter(foundHashIndex: Int, hashCode: HashCodeVal, item: T, count: Long): Unit = {
+  private def updateExistingHeavyHitter(foundHashIndex: Int, count: Long): Unit = {
     if (weights(foundHashIndex) > count)
       throw new IllegalArgumentException(s"Weights can be only incremented or kept the same, not decremented. " +
         s"Previous weight was [${weights(foundHashIndex)}], attempted to modify it to [$count].")

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/SSLEngineProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/SSLEngineProvider.scala
@@ -24,8 +24,6 @@ import akka.event.LogMarker
 import akka.event.Logging
 import akka.event.MarkerLoggingAdapter
 import akka.japi.Util.immutableSeq
-import akka.stream.IgnoreComplete
-import akka.stream.TLSClosing
 import akka.stream.TLSRole
 import com.typesafe.config.Config
 import javax.net.ssl.KeyManager
@@ -158,8 +156,7 @@ class SslTransportException(message: String, cause: Throwable) extends RuntimeEx
     sslContext: SSLContext,
     role:       TLSRole,
     hostname:   String,
-    port:       Int,
-    closing:    TLSClosing = IgnoreComplete): SSLEngine = {
+    port:       Int): SSLEngine = {
 
     val engine = sslContext.createSSLEngine(hostname, port)
 

--- a/akka-remote/src/main/scala/akka/remote/routing/RemoteRouterConfig.scala
+++ b/akka-remote/src/main/scala/akka/remote/routing/RemoteRouterConfig.scala
@@ -69,9 +69,9 @@ final case class RemoteRouterConfig(local: Pool, nodes: Iterable[Address]) exten
   override def resizer: Option[Resizer] = local.resizer
 
   override def withFallback(other: RouterConfig): RouterConfig = other match {
-    case RemoteRouterConfig(local: RemoteRouterConfig, nodes) ⇒ throw new IllegalStateException(
+    case RemoteRouterConfig(_: RemoteRouterConfig, _) ⇒ throw new IllegalStateException(
       "RemoteRouterConfig is not allowed to wrap a RemoteRouterConfig")
-    case RemoteRouterConfig(local: Pool, nodes) ⇒
+    case RemoteRouterConfig(local: Pool, _) ⇒
       copy(local = this.local.withFallback(local).asInstanceOf[Pool])
     case _ ⇒ copy(local = this.local.withFallback(other).asInstanceOf[Pool])
   }

--- a/akka-remote/src/main/scala/akka/remote/serialization/ActorRefResolveCache.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/ActorRefResolveCache.scala
@@ -13,7 +13,7 @@ import akka.actor.ExtensionId
 import akka.actor.ExtensionIdProvider
 import akka.remote.RemoteActorRefProvider
 import akka.remote.artery.LruBoundedCache
-import akka.util.Unsafe
+import akka.util.{ Unsafe, unused }
 
 /**
  * INTERNAL API: Thread local cache per actor system
@@ -45,7 +45,7 @@ private[akka] class ActorRefResolveThreadLocalCache(val system: ExtendedActorSys
     override def initialValue: ActorRefResolveCache = new ActorRefResolveCache(provider)
   }
 
-  def threadLocalCache(provider: RemoteActorRefProvider): ActorRefResolveCache =
+  def threadLocalCache(@unused provider: RemoteActorRefProvider): ActorRefResolveCache =
     current.get
 
 }

--- a/akka-remote/src/main/scala/akka/remote/serialization/DaemonMsgCreateSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/DaemonMsgCreateSerializer.scala
@@ -6,11 +6,11 @@ package akka.remote.serialization
 
 import akka.serialization.{ BaseSerializer, SerializationExtension, SerializerWithStringManifest }
 import akka.protobuf.ByteString
-import com.typesafe.config.{ Config, ConfigFactory }
 import akka.actor.{ Deploy, ExtendedActorSystem, NoScopeGiven, Props, Scope }
 import akka.remote.DaemonMsgCreate
 import akka.remote.WireFormats.{ DaemonMsgCreateData, DeployData, PropsData }
 import akka.routing.{ NoRouter, RouterConfig }
+import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.reflect.ClassTag
 import util.{ Failure, Success }
@@ -176,8 +176,6 @@ private[akka] final class DaemonMsgCreateSerializer(val system: ExtendedActorSys
       path = proto.getPath,
       supervisor = deserializeActorRef(system, proto.getSupervisor))
   }
-
-  private def oldSerialize(any: Any): ByteString = ByteString.copyFrom(serialization.serialize(any.asInstanceOf[AnyRef]).get)
 
   private def serialize(any: Any): (Int, Boolean, String, Array[Byte]) = {
     val m = any.asInstanceOf[AnyRef]

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
@@ -554,7 +554,7 @@ private[transport] class ProtocolStateActor(
   }
 
   onTermination {
-    case StopEvent(reason, _, OutboundUnassociated(remoteAddress, statusPromise, transport)) ⇒
+    case StopEvent(reason, _, OutboundUnassociated(_, statusPromise, _)) ⇒
       statusPromise.tryFailure(reason match {
         case FSM.Failure(info: DisassociateInfo) ⇒ disassociateException(info)
         case _                                   ⇒ new AkkaProtocolException("Transport disassociated before handshake finished")
@@ -611,7 +611,7 @@ private[transport] class ProtocolStateActor(
     case FSM.Failure(ForbiddenUidReason)  ⇒ // no logging
     case FSM.Failure(TimeoutReason(errorMessage)) ⇒
       log.info(errorMessage)
-    case other ⇒ super.logTermination(reason)
+    case _ ⇒ super.logTermination(reason)
   }
 
   private def listenForListenerRegistration(readHandlerPromise: Promise[HandleEventListener]): Unit =

--- a/akka-remote/src/main/scala/akka/remote/transport/TestTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/TestTransport.scala
@@ -4,16 +4,17 @@
 
 package akka.remote.transport
 
-import TestTransport._
+import java.util.concurrent.{ CopyOnWriteArrayList, ConcurrentHashMap }
+
 import akka.actor._
 import akka.remote.transport.AssociationHandle._
 import akka.remote.transport.Transport._
 import akka.util.ByteString
 import com.typesafe.config.Config
-import java.util.concurrent.{ CopyOnWriteArrayList, ConcurrentHashMap }
+import TestTransport._
+
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future, Promise }
-
 import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
@@ -37,8 +38,6 @@ class TestTransport(
       conf.getBytes("maximum-payload-bytes").toInt,
       conf.getString("scheme-identifier"))
   }
-
-  import akka.remote.transport.TestTransport._
 
   override def isResponsibleFor(address: Address): Boolean = true
 
@@ -218,7 +217,7 @@ object TestTransport {
      *   The constant the future will be completed with.
      */
     def pushConstant(c: B): Unit = push {
-      (x) ⇒ Future.successful(c)
+      _ ⇒ Future.successful(c)
     }
 
     /**
@@ -228,7 +227,7 @@ object TestTransport {
      *   The throwable the failed future will contain.
      */
     def pushError(e: Throwable): Unit = push {
-      (x) ⇒ Future.failed(e)
+      _ ⇒ Future.failed(e)
     }
 
     /**
@@ -243,7 +242,7 @@ object TestTransport {
       val originalBehavior = currentBehavior
 
       push(
-        (params: A) ⇒ for (delayed ← controlPromise.future; original ← originalBehavior(params)) yield original)
+        (params: A) ⇒ controlPromise.future.flatMap(_ ⇒ originalBehavior(params)))
 
       controlPromise
     }

--- a/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
@@ -496,7 +496,7 @@ private[transport] class ThrottledAssociation(
       inboundThrottleMode = mode
       sender() ! SetThrottleAck
       stay()
-    case Event(Disassociated(info), _) ⇒
+    case Event(Disassociated(_), _) ⇒
       stop() // not notifying the upstream handler is intentional: we are relying on heartbeating
     case Event(FailWith(reason), _) ⇒
       if (upstreamListener ne null) upstreamListener notify Disassociated(reason)
@@ -513,7 +513,7 @@ private[transport] class ThrottledAssociation(
     } catch {
       // This layer should not care about malformed packets. Also, this also useful for testing, because
       // arbitrary payload could be passed in
-      case NonFatal(e) ⇒ None
+      case NonFatal(_) ⇒ None
     }
   }
 

--- a/akka-remote/src/main/scala/akka/remote/transport/Transport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/Transport.scala
@@ -5,12 +5,12 @@
 package akka.remote.transport
 
 import scala.concurrent.{ Future, Promise }
+import scala.util.control.NoStackTrace
+
 import akka.actor.{ ActorRef, Address, NoSerializationVerificationNeeded }
-import akka.util.ByteString
+import akka.util.{ ByteString, unused }
 import akka.remote.transport.AssociationHandle.HandleEventListener
 import akka.AkkaException
-
-import scala.util.control.NoStackTrace
 import akka.actor.DeadLetterSuppression
 import akka.event.LoggingAdapter
 
@@ -143,7 +143,7 @@ trait Transport {
    * @param cmd Command message to the transport
    * @return Future that succeeds when the command was handled or dropped
    */
-  def managementCommand(cmd: Any): Future[Boolean] = { Future.successful(false) }
+  def managementCommand(@unused cmd: Any): Future[Boolean] = { Future.successful(false) }
 
 }
 

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyHelpers.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyHelpers.scala
@@ -6,7 +6,10 @@ package akka.remote.transport.netty
 
 import akka.AkkaException
 import java.nio.channels.ClosedChannelException
+
+import akka.util.unused
 import org.jboss.netty.channel._
+
 import scala.util.control.NonFatal
 
 /**
@@ -14,17 +17,17 @@ import scala.util.control.NonFatal
  */
 private[netty] trait NettyHelpers {
 
-  protected def onConnect(ctx: ChannelHandlerContext, e: ChannelStateEvent): Unit = ()
+  protected def onConnect(@unused ctx: ChannelHandlerContext, @unused e: ChannelStateEvent): Unit = ()
 
-  protected def onDisconnect(ctx: ChannelHandlerContext, e: ChannelStateEvent): Unit = ()
+  protected def onDisconnect(@unused ctx: ChannelHandlerContext, @unused e: ChannelStateEvent): Unit = ()
 
-  protected def onOpen(ctx: ChannelHandlerContext, e: ChannelStateEvent): Unit = ()
+  protected def onOpen(@unused ctx: ChannelHandlerContext, @unused e: ChannelStateEvent): Unit = ()
 
-  protected def onMessage(ctx: ChannelHandlerContext, e: MessageEvent): Unit = ()
+  protected def onMessage(@unused ctx: ChannelHandlerContext, @unused e: MessageEvent): Unit = ()
 
-  protected def onException(ctx: ChannelHandlerContext, e: ExceptionEvent): Unit = ()
+  protected def onException(@unused ctx: ChannelHandlerContext, @unused e: ExceptionEvent): Unit = ()
 
-  final protected def transformException(ctx: ChannelHandlerContext, ev: ExceptionEvent): Unit = {
+  final protected def transformException(@unused ctx: ChannelHandlerContext, ev: ExceptionEvent): Unit = {
     val cause = if (ev.getCause ne null) ev.getCause else new AkkaException("Unknown cause")
     cause match {
       case _: ClosedChannelException ⇒ // Ignore

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -505,7 +505,7 @@ class NettyTransport(val settings: NettyTransportSettings, val system: ExtendedA
       } catch {
         case NonFatal(e) ⇒ {
           log.error("failed to bind to {}, shutting down Netty transport", address)
-          try { shutdown() } catch { case NonFatal(e) ⇒ } // ignore possible exception during shutdown
+          try { shutdown() } catch { case NonFatal(_) ⇒ } // ignore possible exception during shutdown
           throw e
         }
       }

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/SSLEngineProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/SSLEngineProvider.scala
@@ -20,8 +20,6 @@ import akka.event.Logging
 import akka.event.MarkerLoggingAdapter
 import akka.remote.RemoteTransportException
 import akka.remote.artery.tcp.SecureRandomFactory
-import akka.stream.IgnoreComplete
-import akka.stream.TLSClosing
 import akka.stream.TLSRole
 import javax.net.ssl.KeyManager
 import javax.net.ssl.KeyManagerFactory
@@ -108,10 +106,7 @@ import javax.net.ssl.TrustManagerFactory
     createSSLEngine(sslContext, role)
   }
 
-  private def createSSLEngine(
-    sslContext: SSLContext,
-    role:       TLSRole,
-    closing:    TLSClosing = IgnoreComplete): SSLEngine = {
+  private def createSSLEngine(sslContext: SSLContext, role: TLSRole): SSLEngine = {
 
     val engine = sslContext.createSSLEngine()
 

--- a/akka-remote/src/test/scala/akka/remote/transport/SwitchableLoggedBehaviorSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/transport/SwitchableLoggedBehaviorSpec.scala
@@ -85,7 +85,7 @@ class SwitchableLoggedBehaviorSpec extends AkkaSpec with DefaultTimeout {
       Await.result(behavior(()), timeout.duration) should ===(3)
     }
 
-    "enable delayed completition" in {
+    "enable delayed completion" in {
       val behavior = defaultBehavior
       val controlPromise = behavior.pushDelayed
       val f = behavior(())
@@ -96,7 +96,7 @@ class SwitchableLoggedBehaviorSpec extends AkkaSpec with DefaultTimeout {
       awaitCond(f.isCompleted)
     }
 
-    "log calls and parametrers" in {
+    "log calls and parameters" in {
       val logPromise = Promise[Int]()
       val behavior = new SwitchableLoggedBehavior[Int, Int]((i) ⇒ Future.successful(3), (i) ⇒ logPromise.success(i))
 

--- a/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
@@ -8,8 +8,6 @@ import java.util.concurrent.ThreadFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
-import com.typesafe.config.Config
-
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
@@ -19,6 +17,8 @@ import scala.util.Try
 import akka.actor.Cancellable
 import akka.actor.Scheduler
 import akka.event.LoggingAdapter
+import akka.util.unused
+import com.typesafe.config.Config
 
 /**
  * For testing: scheduler that does not look at the clock, but must be
@@ -30,7 +30,7 @@ import akka.event.LoggingAdapter
  * easier, but these tests might fail to catch race conditions that only
  * happen when tasks are scheduled in parallel in 'real time'.
  */
-class ExplicitlyTriggeredScheduler(config: Config, log: LoggingAdapter, tf: ThreadFactory) extends Scheduler {
+class ExplicitlyTriggeredScheduler(@unused config: Config, log: LoggingAdapter, @unused tf: ThreadFactory) extends Scheduler {
 
   private case class Item(time: Long, interval: Option[FiniteDuration], runnable: Runnable)
 


### PR DESCRIPTION
[#25734](https://github.com/akka/akka/issues/25734)

I looked at existing Akka naming conventions and nothing made sense until I saw TypedActor, which I like in the context (no pun intended) of the akka.actor.typed.ActorContext[] => TypedActorContext[] for simplicity. Which additionally coincides with conventions like ActorRefProvider, ClusterActorRefProvider, RemoteActorRefProvider and so forth.