### PR TITLE
Cross run MiMa when releasing

### DIFF
--- a/project/scripts/release
+++ b/project/scripts/release
@@ -304,7 +304,7 @@ echolog "Successfully created local release"
 # check binary compatibility for dry run
 if [ ! $no_mima ] && [ $dry_run ]; then
   echodry "Running migration manager report..."
-  sbt mimaReportBinaryIssues
+  sbt +mimaReportBinaryIssues
   echodry "Finished migration manager report"
 fi
 


### PR DESCRIPTION
This ensures the binary compatibility will run for all Scala 
versions that are used to do the release.