### PR TITLE
use receiveOne instead of receiveMessageType, #25914

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
@@ -153,7 +153,7 @@ private[akka] final class TestProbeImpl[M](name: String, system: ActorSystem[_])
   override def expectMessage[T <: M](max: JDuration, hint: String, obj: T): T =
     expectMessage(max.asScala, hint, obj)
 
-  private def expectMessage_internal[T <: M](max: Duration, obj: T, hint: Option[String] = None): T = {
+  private def expectMessage_internal[T <: M](max: FiniteDuration, obj: T, hint: Option[String] = None): T = {
     val o = receiveOne_internal(max)
     val hintOrEmptyString = hint.map(": " + _).getOrElse("")
     o match {
@@ -163,13 +163,15 @@ private[akka] final class TestProbeImpl[M](name: String, system: ActorSystem[_])
     }
   }
 
-  override def receiveOne(): M = receiveOne(remainingOrDefault)
+  override def receiveMessage(): M = receiveMessage_internal(remainingOrDefault)
 
-  override def receiveOne(max: JDuration): M = receiveOne(max.asScala)
+  override def receiveMessage(max: JDuration): M = receiveMessage(max.asScala)
 
-  def receiveOne(max: FiniteDuration): M =
-    receiveOne_internal(max.dilated).
-      getOrElse(assertFail(s"Timeout ($max) during receiveOne while waiting for message."))
+  override def receiveMessage(max: FiniteDuration): M = receiveMessage_internal(max.dilated)
+
+  def receiveMessage_internal(max: FiniteDuration): M =
+    receiveOne_internal(max).
+      getOrElse(assertFail(s"Timeout ($max) during receiveMessage while waiting for message."))
 
   /**
    * Receive one message from the internal queue of the TestActor. If the given
@@ -177,14 +179,12 @@ private[akka] final class TestProbeImpl[M](name: String, system: ActorSystem[_])
    *
    * This method does NOT automatically scale its Duration parameter!
    */
-  private def receiveOne_internal(max: Duration): Option[M] = {
+  private def receiveOne_internal(max: FiniteDuration): Option[M] = {
     val message = Option(
       if (max == Duration.Zero) {
         queue.pollFirst
-      } else if (max.isFinite) {
-        queue.pollFirst(max.length, max.unit)
       } else {
-        queue.takeFirst
+        queue.pollFirst(max.length, max.unit)
       }
     )
     lastWasNoMessage = false

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
@@ -230,19 +230,19 @@ private[akka] final class TestProbeImpl[M](name: String, system: ActorSystem[_])
     }
   }
 
-  override def receiveN(n: Int): immutable.Seq[M] =
-    receiveN_internal(n, remainingOrDefault)
+  override def receiveMessages(n: Int): immutable.Seq[M] =
+    receiveMessages_internal(n, remainingOrDefault)
 
-  override def receiveN(n: Int, max: FiniteDuration): immutable.Seq[M] =
-    receiveN_internal(n, max.dilated)
+  override def receiveMessages(n: Int, max: FiniteDuration): immutable.Seq[M] =
+    receiveMessages_internal(n, max.dilated)
 
-  override def receiveMessages(n: Int): JList[M] =
-    receiveN_internal(n, getRemainingOrDefault.asScala).asJava
+  override def receiveSeveralMessages(n: Int): JList[M] =
+    receiveMessages_internal(n, getRemainingOrDefault.asScala).asJava
 
-  override def receiveMessages(n: Int, max: JDuration): JList[M] =
-    receiveN_internal(n, max.asScala.dilated).asJava
+  override def receiveSeveralMessages(n: Int, max: JDuration): JList[M] =
+    receiveMessages_internal(n, max.asScala.dilated).asJava
 
-  private def receiveN_internal(n: Int, max: FiniteDuration): immutable.Seq[M] = {
+  private def receiveMessages_internal(n: Int, max: FiniteDuration): immutable.Seq[M] = {
     val stop = max + now
     for (x ← 1 to n) yield {
       val timeout = stop - now

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
@@ -181,16 +181,16 @@ abstract class TestProbe[M] {
   def receiveMessage(max: Duration): M
 
   /**
-   * Same as `receiveMessages(n, remaining)` but using the default timeout as deadline.
+   * Same as `receiveSeveralMessages(n, remaining)` but using the default timeout as deadline.
    */
-  def receiveMessages(n: Int): JList[M]
+  def receiveSeveralMessages(n: Int): JList[M]
 
   /**
    * Receive `n` messages in a row before the given deadline.
    *
    * Note that the timeout is scaled using the configuration entry "akka.actor.testkit.typed.timefactor".
    */
-  def receiveMessages(n: Int, max: Duration): JList[M]
+  def receiveSeveralMessages(n: Int, max: Duration): JList[M]
 
   /**
    * Java API: Allows for flexible matching of multiple messages within a timeout, the fisher function is fed each incoming

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
@@ -172,13 +172,13 @@ abstract class TestProbe[M] {
   /**
    * Receive one message of type `M` within the default timeout as deadline.
    */
-  def receiveOne(): M
+  def receiveMessage(): M
 
   /**
    * Receive one message of type `M`. Wait time is bounded by the `max` duration,
    * with an [[AssertionError]] raised in case of timeout.
    */
-  def receiveOne(max: Duration): M
+  def receiveMessage(max: Duration): M
 
   /**
    * Same as `receiveMessages(n, remaining)` but using the default timeout as deadline.

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/TestProbe.scala
@@ -151,13 +151,13 @@ object TestProbe {
   /**
    * Receive one message of type `M` within the default timeout as deadline.
    */
-  def receiveOne(): M
+  def receiveMessage(): M
 
   /**
    * Receive one message of type `M`. Wait time is bounded by the `max` duration,
    * with an [[AssertionError]] raised in case of timeout.
    */
-  def receiveOne(max: FiniteDuration): M
+  def receiveMessage(max: FiniteDuration): M
 
   /**
    * Same as `receiveN(n, remaining)` but using the default timeout as deadline.

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/TestProbe.scala
@@ -160,16 +160,16 @@ object TestProbe {
   def receiveMessage(max: FiniteDuration): M
 
   /**
-   * Same as `receiveN(n, remaining)` but using the default timeout as deadline.
+   * Same as `receiveMessages(n, remaining)` but using the default timeout as deadline.
    */
-  def receiveN(n: Int): immutable.Seq[M]
+  def receiveMessages(n: Int): immutable.Seq[M]
 
   /**
    * Receive `n` messages in a row before the given deadline.
    *
    * Note that the timeout is scaled using the configuration entry "akka.actor.testkit.typed.timefactor".
    */
-  def receiveN(n: Int, max: FiniteDuration): immutable.Seq[M]
+  def receiveMessages(n: Int, max: FiniteDuration): immutable.Seq[M]
 
   /**
    * Allows for flexible matching of multiple messages within a timeout, the fisher function is fed each incoming

--- a/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/TestProbeTest.java
+++ b/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/TestProbeTest.java
@@ -21,7 +21,7 @@ public class TestProbeTest extends JUnitSuite {
   @ClassRule public static TestKitJunitResource testKit = new TestKitJunitResource();
 
   @Test
-  public void testReceiveOne() {
+  public void testReceiveMessage() {
     TestProbe<EventT> probe = TestProbe.create(testKit.system());
 
     List<EventT> eventsT = akka.japi.Util.javaArrayList(TestProbeSpec.eventsT(10));
@@ -29,14 +29,14 @@ public class TestProbeTest extends JUnitSuite {
     eventsT.forEach(
         e -> {
           probe.getRef().tell(e);
-          assertEquals(probe.receiveOne(), e);
+          assertEquals(probe.receiveMessage(), e);
         });
 
     probe.expectNoMessage();
   }
 
   @Test
-  public void testReceiveOneMaxDuration() {
+  public void testReceiveMessageMaxDuration() {
     TestProbe<EventT> probe = TestProbe.create(testKit.system());
 
     List<EventT> eventsT = akka.japi.Util.javaArrayList(TestProbeSpec.eventsT(2));
@@ -44,16 +44,16 @@ public class TestProbeTest extends JUnitSuite {
     eventsT.forEach(
         e -> {
           probe.getRef().tell(e);
-          assertEquals(probe.receiveOne(Duration.ofMillis(100)), e);
+          assertEquals(probe.receiveMessage(Duration.ofMillis(100)), e);
         });
 
     probe.expectNoMessage();
   }
 
   @Test(expected = AssertionError.class)
-  public void testReceiveOneFailOnTimeout() {
+  public void testReceiveMessageFailOnTimeout() {
     TestProbe<EventT> probe = TestProbe.create(testKit.system());
-    probe.receiveOne(Duration.ofMillis(100));
+    probe.receiveMessage(Duration.ofMillis(100));
   }
 
   @Test

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestProbeSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestProbeSpec.scala
@@ -123,25 +123,25 @@ class TestProbeSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       }
     }
 
-    "allow receiving N messages" in {
+    "allow receiving several messages" in {
       val probe = TestProbe[String]()
 
       probe.ref ! "one"
       probe.ref ! "two"
       probe.ref ! "three"
 
-      val result = probe.receiveN(3)
+      val result = probe.receiveMessages(3)
 
       result should ===(List("one", "two", "three"))
     }
 
-    "time out when not receiving N messages" in {
+    "time out when not receiving several messages" in {
       val probe = TestProbe[String]()
 
       probe.ref ! "one"
 
       intercept[AssertionError] {
-        probe.receiveN(3, 50.millis)
+        probe.receiveMessages(3, 50.millis)
       }
     }
 

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestProbeSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestProbeSpec.scala
@@ -149,14 +149,14 @@ class TestProbeSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val probe = createTestProbe[EventT]()
       eventsT(10).forall { e ⇒
         probe.ref ! e
-        probe.receiveOne == e
+        probe.receiveMessage == e
       } should ===(true)
 
       probe.expectNoMessage()
     }
 
     "timeout if expected single message is not received by a provided timeout" in {
-      intercept[AssertionError](createTestProbe[EventT]().receiveOne(100.millis))
+      intercept[AssertionError](createTestProbe[EventT]().receiveMessage(100.millis))
     }
 
     "support watch and stop of probe" in {
@@ -189,7 +189,7 @@ class TestProbeTimeoutSpec extends ScalaTestWithActorTestKit(TestProbeSpec.timeo
   "The test probe" must {
 
     "timeout if expected single message is not received by the default timeout" in {
-      intercept[AssertionError](createTestProbe[EventT]().receiveOne())
+      intercept[AssertionError](createTestProbe[EventT]().receiveMessage())
     }
   }
 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
@@ -500,7 +500,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
           Behaviors.same
       }.decorate)
       actor ! "create"
-      val children = probe.expectMessageType[Children]
+      val children = probe.receiveOne()
       actor ! "A"
       probe.expectMessage(Seq.empty)
       actor ! "all"
@@ -575,7 +575,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
       }.decorate)
       val adapterName = "hello"
       actor ! adapterName
-      val adapter = probe.expectMessageType[ActorRef[String]]
+      val adapter = probe.receiveOne()
       adapter.path.name should include(adapterName)
       adapter ! "message"
       messages.expectMessage(actor → "received message")

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
@@ -500,7 +500,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
           Behaviors.same
       }.decorate)
       actor ! "create"
-      val children = probe.receiveOne()
+      val children = probe.receiveMessage()
       actor ! "A"
       probe.expectMessage(Seq.empty)
       actor ! "all"
@@ -575,7 +575,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
       }.decorate)
       val adapterName = "hello"
       actor ! adapterName
-      val adapter = probe.receiveOne()
+      val adapter = probe.receiveMessage()
       adapter.path.name should include(adapterName)
       adapter ! "message"
       messages.expectMessage(actor → "received message")

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SpawnProtocolSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SpawnProtocolSpec.scala
@@ -34,7 +34,7 @@ class SpawnProtocolSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val parentReply = TestProbe[ActorRef[Message]]()
       val parent = spawn(SpawnProtocol.behavior, "parent")
       parent ! SpawnProtocol.Spawn(target, "child", Props.empty, parentReply.ref)
-      val child = parentReply.expectMessageType[ActorRef[Message]]
+      val child = parentReply.receiveOne()
       child.path.name should ===("child")
       child.path.parent.name should ===("parent")
 
@@ -57,11 +57,11 @@ class SpawnProtocolSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       try {
         val guardianReply = TestProbe[ActorRef[Message]]()(sys)
         sys ! SpawnProtocol.Spawn(target, "child1", Props.empty, guardianReply.ref)
-        val child1 = guardianReply.expectMessageType[ActorRef[Message]]
+        val child1 = guardianReply.receiveOne()
         child1.path.elements.mkString("/", "/", "") should ===("/user/child1")
 
         sys ! SpawnProtocol.Spawn(target, "child2", Props.empty, guardianReply.ref)
-        val child2 = guardianReply.expectMessageType[ActorRef[Message]]
+        val child2 = guardianReply.receiveOne()
         child2.path.elements.mkString("/", "/", "") should ===("/user/child2")
       } finally {
         ActorTestKit.shutdown(sys)
@@ -73,21 +73,21 @@ class SpawnProtocolSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val parent = spawn(SpawnProtocol.behavior, "parent3")
 
       parent ! SpawnProtocol.Spawn(target, "child", Props.empty, parentReply.ref)
-      val child0 = parentReply.expectMessageType[ActorRef[Message]]
+      val child0 = parentReply.receiveOne()
       child0.path.name should ===("child")
 
       parent ! SpawnProtocol.Spawn(target, "child", Props.empty, parentReply.ref)
-      val child1 = parentReply.expectMessageType[ActorRef[Message]]
+      val child1 = parentReply.receiveOne()
       child1.path.name should ===("child-1")
 
       // take the generated name
       parent ! SpawnProtocol.Spawn(target, "child-2", Props.empty, parentReply.ref)
-      val child2 = parentReply.expectMessageType[ActorRef[Message]]
+      val child2 = parentReply.receiveOne()
       child2.path.name should ===("child-2")
 
       // "child" is taken, and also "child-1" and "child-2"
       parent ! SpawnProtocol.Spawn(target, "child", Props.empty, parentReply.ref)
-      val child3 = parentReply.expectMessageType[ActorRef[Message]]
+      val child3 = parentReply.receiveOne()
       child3.path.name should ===("child-3")
     }
   }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SpawnProtocolSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SpawnProtocolSpec.scala
@@ -34,7 +34,7 @@ class SpawnProtocolSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val parentReply = TestProbe[ActorRef[Message]]()
       val parent = spawn(SpawnProtocol.behavior, "parent")
       parent ! SpawnProtocol.Spawn(target, "child", Props.empty, parentReply.ref)
-      val child = parentReply.receiveOne()
+      val child = parentReply.receiveMessage()
       child.path.name should ===("child")
       child.path.parent.name should ===("parent")
 
@@ -57,11 +57,11 @@ class SpawnProtocolSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       try {
         val guardianReply = TestProbe[ActorRef[Message]]()(sys)
         sys ! SpawnProtocol.Spawn(target, "child1", Props.empty, guardianReply.ref)
-        val child1 = guardianReply.receiveOne()
+        val child1 = guardianReply.receiveMessage()
         child1.path.elements.mkString("/", "/", "") should ===("/user/child1")
 
         sys ! SpawnProtocol.Spawn(target, "child2", Props.empty, guardianReply.ref)
-        val child2 = guardianReply.receiveOne()
+        val child2 = guardianReply.receiveMessage()
         child2.path.elements.mkString("/", "/", "") should ===("/user/child2")
       } finally {
         ActorTestKit.shutdown(sys)
@@ -73,21 +73,21 @@ class SpawnProtocolSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val parent = spawn(SpawnProtocol.behavior, "parent3")
 
       parent ! SpawnProtocol.Spawn(target, "child", Props.empty, parentReply.ref)
-      val child0 = parentReply.receiveOne()
+      val child0 = parentReply.receiveMessage()
       child0.path.name should ===("child")
 
       parent ! SpawnProtocol.Spawn(target, "child", Props.empty, parentReply.ref)
-      val child1 = parentReply.receiveOne()
+      val child1 = parentReply.receiveMessage()
       child1.path.name should ===("child-1")
 
       // take the generated name
       parent ! SpawnProtocol.Spawn(target, "child-2", Props.empty, parentReply.ref)
-      val child2 = parentReply.receiveOne()
+      val child2 = parentReply.receiveMessage()
       child2.path.name should ===("child-2")
 
       // "child" is taken, and also "child-1" and "child-2"
       parent ! SpawnProtocol.Spawn(target, "child", Props.empty, parentReply.ref)
-      val child3 = parentReply.receiveOne()
+      val child3 = parentReply.receiveMessage()
       child3.path.name should ===("child-3")
     }
   }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
@@ -307,7 +307,7 @@ class TimerSpec extends ScalaTestWithActorTestKit(
 
       val probe = TestProbe[Array[StackTraceElement]]()
       spawn(next(0, probe.ref))
-      val elements = probe.receiveOne()
+      val elements = probe.receiveMessage()
       if (elements.count(_.getClassName == "TimerInterceptor") > 1)
         fail(s"Stack contains TimerInterceptor more than once: \n${elements.mkString("\n\t")}")
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
@@ -307,7 +307,7 @@ class TimerSpec extends ScalaTestWithActorTestKit(
 
       val probe = TestProbe[Array[StackTraceElement]]()
       spawn(next(0, probe.ref))
-      val elements = probe.expectMessageType[Array[StackTraceElement]]
+      val elements = probe.receiveOne()
       if (elements.count(_.getClassName == "TimerInterceptor") > 1)
         fail(s"Stack contains TimerInterceptor more than once: \n${elements.mkString("\n\t")}")
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/LocalReceptionistSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/LocalReceptionistSpec.scala
@@ -117,7 +117,7 @@ class LocalReceptionistSpec extends ScalaTestWithActorTestKit with WordSpecLike 
     "be present in the system" in {
       val probe = TestProbe[Receptionist.Listing]()
       system.receptionist ! Find(ServiceKeyA, probe.ref)
-      val listing: Listing = probe.receiveOne()
+      val listing: Listing = probe.receiveMessage()
       listing.isForKey(ServiceKeyA) should ===(true)
       listing.serviceInstances(ServiceKeyA) should be(Set())
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/LocalReceptionistSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/LocalReceptionistSpec.scala
@@ -117,7 +117,7 @@ class LocalReceptionistSpec extends ScalaTestWithActorTestKit with WordSpecLike 
     "be present in the system" in {
       val probe = TestProbe[Receptionist.Listing]()
       system.receptionist ! Find(ServiceKeyA, probe.ref)
-      val listing: Listing = probe.expectMessageType[Listing]
+      val listing: Listing = probe.receiveOne()
       listing.isForKey(ServiceKeyA) should ===(true)
       listing.serviceInstances(ServiceKeyA) should be(Set())
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
@@ -66,7 +66,7 @@ class ActorContextAskSpec extends ScalaTestWithActorTestKit(ActorContextAskSpec.
 
       spawn(snitch, "snitch", Props.empty.withDispatcherFromConfig("snitch-dispatcher"))
 
-      val pong = probe.receiveOne()
+      val pong = probe.receiveMessage()
 
       pong.selfName should ===("snitch1")
       pong.threadName should startWith("ActorContextAskSpec-snitch-dispatcher")

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
@@ -66,7 +66,7 @@ class ActorContextAskSpec extends ScalaTestWithActorTestKit(ActorContextAskSpec.
 
       spawn(snitch, "snitch", Props.empty.withDispatcherFromConfig("snitch-dispatcher"))
 
-      val pong = probe.expectMessageType[Pong]
+      val pong = probe.receiveOne()
 
       pong.selfName should ===("snitch1")
       pong.threadName should startWith("ActorContextAskSpec-snitch-dispatcher")

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
@@ -71,12 +71,12 @@ class MessageAdapterSpec extends ScalaTestWithActorTestKit(MessageAdapterSpec.co
 
       spawn(snitch, "snitch", Props.empty.withDispatcherFromConfig("snitch-dispatcher"))
 
-      val response1 = probe.expectMessageType[AnotherPong]
+      val response1 = probe.receiveOne()
       response1.selfName should ===("snitch")
       response1.threadName should startWith("MessageAdapterSpec-snitch-dispatcher")
 
       // and from the spawnMessageAdapter
-      val response2 = probe.expectMessageType[AnotherPong]
+      val response2 = probe.receiveOne()
       response2.selfName should ===("snitch")
       response2.threadName should startWith("MessageAdapterSpec-snitch-dispatcher")
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
@@ -71,12 +71,12 @@ class MessageAdapterSpec extends ScalaTestWithActorTestKit(MessageAdapterSpec.co
 
       spawn(snitch, "snitch", Props.empty.withDispatcherFromConfig("snitch-dispatcher"))
 
-      val response1 = probe.receiveOne()
+      val response1 = probe.receiveMessage()
       response1.selfName should ===("snitch")
       response1.threadName should startWith("MessageAdapterSpec-snitch-dispatcher")
 
       // and from the spawnMessageAdapter
-      val response2 = probe.receiveOne()
+      val response2 = probe.receiveMessage()
       response2.selfName should ===("snitch")
       response2.threadName should startWith("MessageAdapterSpec-snitch-dispatcher")
     }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/DispatchersDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/DispatchersDocSpec.scala
@@ -65,15 +65,15 @@ class DispatchersDocSpec extends ScalaTestWithActorTestKit(DispatchersDocSpec.co
 
       val withDefault = (actor ? Spawn(giveMeYourDispatcher, "default", Props.empty)).futureValue
       withDefault ! WhichDispatcher(probe.ref)
-      probe.receiveOne().id shouldEqual "akka.actor.default-dispatcher"
+      probe.receiveMessage().id shouldEqual "akka.actor.default-dispatcher"
 
       val withBlocking = (actor ? Spawn(giveMeYourDispatcher, "default", DispatcherSelector.blocking())).futureValue
       withBlocking ! WhichDispatcher(probe.ref)
-      probe.receiveOne().id shouldEqual "akka.actor.default-blocking-io-dispatcher"
+      probe.receiveMessage().id shouldEqual "akka.actor.default-blocking-io-dispatcher"
 
       val withCustom = (actor ? Spawn(giveMeYourDispatcher, "default", DispatcherSelector.fromConfig("your-dispatcher"))).futureValue
       withCustom ! WhichDispatcher(probe.ref)
-      probe.receiveOne().id shouldEqual "your-dispatcher"
+      probe.receiveMessage().id shouldEqual "your-dispatcher"
     }
   }
 }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/DispatchersDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/DispatchersDocSpec.scala
@@ -65,15 +65,15 @@ class DispatchersDocSpec extends ScalaTestWithActorTestKit(DispatchersDocSpec.co
 
       val withDefault = (actor ? Spawn(giveMeYourDispatcher, "default", Props.empty)).futureValue
       withDefault ! WhichDispatcher(probe.ref)
-      probe.expectMessageType[Dispatcher].id shouldEqual "akka.actor.default-dispatcher"
+      probe.receiveOne().id shouldEqual "akka.actor.default-dispatcher"
 
       val withBlocking = (actor ? Spawn(giveMeYourDispatcher, "default", DispatcherSelector.blocking())).futureValue
       withBlocking ! WhichDispatcher(probe.ref)
-      probe.expectMessageType[Dispatcher].id shouldEqual "akka.actor.default-blocking-io-dispatcher"
+      probe.receiveOne().id shouldEqual "akka.actor.default-blocking-io-dispatcher"
 
       val withCustom = (actor ? Spawn(giveMeYourDispatcher, "default", DispatcherSelector.fromConfig("your-dispatcher"))).futureValue
       withCustom ! WhichDispatcher(probe.ref)
-      probe.expectMessageType[Dispatcher].id shouldEqual "your-dispatcher"
+      probe.receiveOne().id shouldEqual "your-dispatcher"
     }
   }
 }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
@@ -74,7 +74,7 @@ class InteractionPatternsSpec extends ScalaTestWithActorTestKit with WordSpecLik
       otherActor ! Request("give me cookies", context.self)
       // #request-response-send
 
-      probe.expectMessageType[Response]
+      probe.receiveOne()
     }
 
     "contain a sample for adapted response" in {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
@@ -74,7 +74,7 @@ class InteractionPatternsSpec extends ScalaTestWithActorTestKit with WordSpecLik
       otherActor ! Request("give me cookies", context.self)
       // #request-response-send
 
-      probe.receiveOne()
+      probe.receiveMessage()
     }
 
     "contain a sample for adapted response" in {

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleTest.java
@@ -55,12 +55,12 @@ public class HelloWorldEventSourcedEntityExampleTest extends JUnitSuite {
     EntityRef<HelloWorld.Command> world = sharding().entityRefFor(HelloWorld.ENTITY_TYPE_KEY, "1");
     TestProbe<HelloWorld.Greeting> probe = testKit.createTestProbe(HelloWorld.Greeting.class);
     world.tell(new HelloWorld.Greet("Alice", probe.getRef()));
-    HelloWorld.Greeting greeting1 = probe.expectMessageClass(HelloWorld.Greeting.class);
+    HelloWorld.Greeting greeting1 = probe.receiveOne();
     assertEquals("Alice", greeting1.whom);
     assertEquals(1, greeting1.numberOfPeople);
 
     world.tell(new HelloWorld.Greet("Bob", probe.getRef()));
-    HelloWorld.Greeting greeting2 = probe.expectMessageClass(HelloWorld.Greeting.class);
+    HelloWorld.Greeting greeting2 = probe.receiveOne();
     assertEquals("Bob", greeting2.whom);
     assertEquals(2, greeting2.numberOfPeople);
   }

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleTest.java
@@ -55,12 +55,12 @@ public class HelloWorldEventSourcedEntityExampleTest extends JUnitSuite {
     EntityRef<HelloWorld.Command> world = sharding().entityRefFor(HelloWorld.ENTITY_TYPE_KEY, "1");
     TestProbe<HelloWorld.Greeting> probe = testKit.createTestProbe(HelloWorld.Greeting.class);
     world.tell(new HelloWorld.Greet("Alice", probe.getRef()));
-    HelloWorld.Greeting greeting1 = probe.receiveOne();
+    HelloWorld.Greeting greeting1 = probe.receiveMessage();
     assertEquals("Alice", greeting1.whom);
     assertEquals(1, greeting1.numberOfPeople);
 
     world.tell(new HelloWorld.Greet("Bob", probe.getRef()));
-    HelloWorld.Greeting greeting2 = probe.receiveOne();
+    HelloWorld.Greeting greeting2 = probe.receiveMessage();
     assertEquals("Bob", greeting2.whom);
     assertEquals(2, greeting2.numberOfPeople);
   }

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
@@ -133,7 +133,7 @@ class ClusterShardingPersistenceSpec extends ScalaTestWithActorTestKit(ClusterSh
     val untypedRegion = UntypedClusterSharding(system.toUntyped)
     regionStateProbe.awaitAssert {
       untypedRegion.shardRegion(typeKey.name).tell(GetShardRegionState, regionStateProbe.ref.toUntyped)
-      regionStateProbe.expectMessageType[CurrentShardRegionState].shards.foreach { shardState ⇒
+      regionStateProbe.receiveOne().shards.foreach { shardState ⇒
         shardState.entityIds should not contain entityId
       }
     }

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
@@ -133,7 +133,7 @@ class ClusterShardingPersistenceSpec extends ScalaTestWithActorTestKit(ClusterSh
     val untypedRegion = UntypedClusterSharding(system.toUntyped)
     regionStateProbe.awaitAssert {
       untypedRegion.shardRegion(typeKey.name).tell(GetShardRegionState, regionStateProbe.ref.toUntyped)
-      regionStateProbe.receiveOne().shards.foreach { shardState ⇒
+      regionStateProbe.receiveMessage().shards.foreach { shardState ⇒
         shardState.entityIds should not contain entityId
       }
     }

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -426,7 +426,7 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
       (1 to numberOfEntities).foreach { n ⇒
         shardingRef1 ! ShardingEnvelope(s"test$n", WhoAreYou(probe1.ref))
       }
-      val replies1 = probe1.receiveN(numberOfEntities, 10.seconds)
+      val replies1 = probe1.receiveMessages(numberOfEntities, 10.seconds)
 
       Cluster(system2).manager ! Leave(Cluster(system2).selfMember.address)
 
@@ -439,7 +439,7 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
       (1 to numberOfEntities).foreach { n ⇒
         shardingRef1 ! ShardingEnvelope(s"test$n", WhoAreYou(probe2.ref))
       }
-      val replies2 = probe2.receiveN(numberOfEntities, 10.seconds)
+      val replies2 = probe2.receiveMessages(numberOfEntities, 10.seconds)
       replies2 should !==(replies1) // different addresses
     }
   }

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -323,10 +323,10 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
       val p = TestProbe[String]()
 
       charlieRef ! WhoAreYou(p.ref)
-      p.expectMessageType[String] should startWith("I'm charlie")
+      p.receiveOne() should startWith("I'm charlie")
 
       charlieRef tell WhoAreYou(p.ref)
-      p.expectMessageType[String] should startWith("I'm charlie")
+      p.receiveOne() should startWith("I'm charlie")
 
       charlieRef ! StopPlz()
     }
@@ -366,7 +366,7 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
           }
         })
 
-      p.expectMessageType[TheReply].s should startWith("I'm alice")
+      p.receiveOne().s should startWith("I'm alice")
 
       aliceRef ! StopPlz()
     }

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -323,10 +323,10 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
       val p = TestProbe[String]()
 
       charlieRef ! WhoAreYou(p.ref)
-      p.receiveOne() should startWith("I'm charlie")
+      p.receiveMessage() should startWith("I'm charlie")
 
       charlieRef tell WhoAreYou(p.ref)
-      p.receiveOne() should startWith("I'm charlie")
+      p.receiveMessage() should startWith("I'm charlie")
 
       charlieRef ! StopPlz()
     }
@@ -366,7 +366,7 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
           }
         })
 
-      p.receiveOne().s should startWith("I'm alice")
+      p.receiveMessage().s should startWith("I'm alice")
 
       aliceRef ! StopPlz()
     }

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingStateSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingStateSpec.scala
@@ -53,7 +53,7 @@ class ClusterShardingStateSpec extends ScalaTestWithActorTestKit(ClusterSharding
 
       //#get-region-state
       ClusterSharding(system).shardState ! GetShardRegionState(typeKey, probe.ref)
-      val state = probe.expectMessageType[CurrentShardRegionState]
+      val state = probe.receiveOne()
       //#get-region-state
       state.shards should be(Set(ShardState(shardExtractor.shardId("id1"), Set("id1"))))
     }

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingStateSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingStateSpec.scala
@@ -53,7 +53,7 @@ class ClusterShardingStateSpec extends ScalaTestWithActorTestKit(ClusterSharding
 
       //#get-region-state
       ClusterSharding(system).shardState ! GetShardRegionState(typeKey, probe.ref)
-      val state = probe.receiveOne()
+      val state = probe.receiveMessage()
       //#get-region-state
       state.shards should be(Set(ShardState(shardExtractor.shardId("id1"), Set("id1"))))
     }

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
@@ -50,8 +50,8 @@ class ClusterApiSpec extends ScalaTestWithActorTestKit(ClusterApiSpec.config) wi
       try {
         val clusterNode2 = Cluster(adaptedSystem2)
 
-        val node1Probe = TestProbe[AnyRef]()(system)
-        val node2Probe = TestProbe[AnyRef]()(adaptedSystem2)
+        val node1Probe = TestProbe[ClusterDomainEvent]()(system)
+        val node2Probe = TestProbe[ClusterDomainEvent]()(adaptedSystem2)
 
         // initial cached selfMember
         clusterNode1.selfMember.status should ===(MemberStatus.Removed)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
@@ -116,8 +116,8 @@ class ClusterSingletonApiSpec extends ScalaTestWithActorTestKit(ClusterSingleton
       clusterNode1.manager ! Join(clusterNode1.selfMember.address)
       clusterNode2.manager ! Join(clusterNode1.selfMember.address)
 
-      node1UpProbe.receiveOne()
-      node2UpProbe.receiveOne()
+      node1UpProbe.receiveMessage()
+      node2UpProbe.receiveMessage()
 
       val cs1: ClusterSingleton = ClusterSingleton(system)
       val cs2 = ClusterSingleton(adaptedSystem2)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
@@ -116,8 +116,8 @@ class ClusterSingletonApiSpec extends ScalaTestWithActorTestKit(ClusterSingleton
       clusterNode1.manager ! Join(clusterNode1.selfMember.address)
       clusterNode2.manager ! Join(clusterNode1.selfMember.address)
 
-      node1UpProbe.expectMessageType[SelfUp]
-      node2UpProbe.expectMessageType[SelfUp]
+      node1UpProbe.receiveOne()
+      node2UpProbe.receiveOne()
 
       val cs1: ClusterSingleton = ClusterSingleton(system)
       val cs2 = ClusterSingleton(adaptedSystem2)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPoisonPillSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPoisonPillSpec.scala
@@ -37,7 +37,7 @@ class ClusterSingletonPoisonPillSpec extends ScalaTestWithActorTestKit(ClusterSi
       val probe = TestProbe[ActorRef[Any]]
       val singleton = ClusterSingleton(system).init(SingletonActor(ClusterSingletonPoisonPillSpec.sneakyBehavior, "sneaky"))
       singleton ! GetSelf(probe.ref)
-      val singletonRef = probe.receiveOne()
+      val singletonRef = probe.receiveMessage()
       singletonRef ! PoisonPill
       probe.expectTerminated(singletonRef, 1.second)
     }

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPoisonPillSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPoisonPillSpec.scala
@@ -37,7 +37,7 @@ class ClusterSingletonPoisonPillSpec extends ScalaTestWithActorTestKit(ClusterSi
       val probe = TestProbe[ActorRef[Any]]
       val singleton = ClusterSingleton(system).init(SingletonActor(ClusterSingletonPoisonPillSpec.sneakyBehavior, "sneaky"))
       singleton ! GetSelf(probe.ref)
-      val singletonRef = probe.expectMessageType[ActorRef[Any]]
+      val singletonRef = probe.receiveOne()
       singletonRef ! PoisonPill
       probe.expectTerminated(singletonRef, 1.second)
     }

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
@@ -110,7 +110,7 @@ class RemoteContextAskSpec extends ScalaTestWithActorTestKit(RemoteContextAskSpe
       // wait until the service is seen on the first node
       val remoteRef = node1Probe.expectMessageType[Receptionist.Listing].serviceInstances(pingPongKey).head
 
-      spawn(Behaviors.setup[AnyRef] { (ctx) ⇒
+      spawn(Behaviors.setup[AnyRef] { ctx ⇒
         implicit val timeout: Timeout = 3.seconds
 
         ctx.ask(remoteRef)(Ping) {
@@ -118,7 +118,7 @@ class RemoteContextAskSpec extends ScalaTestWithActorTestKit(RemoteContextAskSpe
           case Failure(ex)   ⇒ ex
         }
 
-        Behaviors.receive { (_, msg) ⇒
+        Behaviors.receiveMessage { msg ⇒
           node1Probe.ref ! msg
           Behaviors.same
         }

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_3/DeviceTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_3/DeviceTest.java
@@ -33,7 +33,7 @@ public class DeviceTest extends org.scalatest.junit.JUnitSuite {
     TestProbe<RespondTemperature> probe = testKit.createTestProbe(RespondTemperature.class);
     ActorRef<DeviceMessage> deviceActor = testKit.spawn(Device.createBehavior("group", "device"));
     deviceActor.tell(new ReadTemperature(42L, probe.getRef()));
-    RespondTemperature response = probe.expectMessageClass(RespondTemperature.class);
+    RespondTemperature response = probe.receiveOne();
     assertEquals(42L, response.requestId);
     assertEquals(Optional.empty(), response.value);
   }
@@ -47,18 +47,18 @@ public class DeviceTest extends org.scalatest.junit.JUnitSuite {
     ActorRef<DeviceMessage> deviceActor = testKit.spawn(Device.createBehavior("group", "device"));
 
     deviceActor.tell(new RecordTemperature(1L, 24.0, recordProbe.getRef()));
-    assertEquals(1L, recordProbe.expectMessageClass(TemperatureRecorded.class).requestId);
+    assertEquals(1L, recordProbe.receiveOne().requestId);
 
     deviceActor.tell(new ReadTemperature(2L, readProbe.getRef()));
-    RespondTemperature response1 = readProbe.expectMessageClass(RespondTemperature.class);
+    RespondTemperature response1 = readProbe.receiveOne();
     assertEquals(2L, response1.requestId);
     assertEquals(Optional.of(24.0), response1.value);
 
     deviceActor.tell(new RecordTemperature(3L, 55.0, recordProbe.getRef()));
-    assertEquals(3L, recordProbe.expectMessageClass(TemperatureRecorded.class).requestId);
+    assertEquals(3L, recordProbe.receiveOne().requestId);
 
     deviceActor.tell(new ReadTemperature(4L, readProbe.getRef()));
-    RespondTemperature response2 = readProbe.expectMessageClass(RespondTemperature.class);
+    RespondTemperature response2 = readProbe.receiveOne();
     assertEquals(4L, response2.requestId);
     assertEquals(Optional.of(55.0), response2.value);
   }

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_3/DeviceTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_3/DeviceTest.java
@@ -33,7 +33,7 @@ public class DeviceTest extends org.scalatest.junit.JUnitSuite {
     TestProbe<RespondTemperature> probe = testKit.createTestProbe(RespondTemperature.class);
     ActorRef<DeviceMessage> deviceActor = testKit.spawn(Device.createBehavior("group", "device"));
     deviceActor.tell(new ReadTemperature(42L, probe.getRef()));
-    RespondTemperature response = probe.receiveOne();
+    RespondTemperature response = probe.receiveMessage();
     assertEquals(42L, response.requestId);
     assertEquals(Optional.empty(), response.value);
   }
@@ -47,18 +47,18 @@ public class DeviceTest extends org.scalatest.junit.JUnitSuite {
     ActorRef<DeviceMessage> deviceActor = testKit.spawn(Device.createBehavior("group", "device"));
 
     deviceActor.tell(new RecordTemperature(1L, 24.0, recordProbe.getRef()));
-    assertEquals(1L, recordProbe.receiveOne().requestId);
+    assertEquals(1L, recordProbe.receiveMessage().requestId);
 
     deviceActor.tell(new ReadTemperature(2L, readProbe.getRef()));
-    RespondTemperature response1 = readProbe.receiveOne();
+    RespondTemperature response1 = readProbe.receiveMessage();
     assertEquals(2L, response1.requestId);
     assertEquals(Optional.of(24.0), response1.value);
 
     deviceActor.tell(new RecordTemperature(3L, 55.0, recordProbe.getRef()));
-    assertEquals(3L, recordProbe.receiveOne().requestId);
+    assertEquals(3L, recordProbe.receiveMessage().requestId);
 
     deviceActor.tell(new ReadTemperature(4L, readProbe.getRef()));
-    RespondTemperature response2 = readProbe.receiveOne();
+    RespondTemperature response2 = readProbe.receiveMessage();
     assertEquals(4L, response2.requestId);
     assertEquals(Optional.of(55.0), response2.value);
   }

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceGroupTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceGroupTest.java
@@ -30,19 +30,19 @@ public class DeviceGroupTest extends JUnitSuite {
     ActorRef<DeviceGroupMessage> groupActor = testKit.spawn(DeviceGroup.createBehavior("group"));
 
     groupActor.tell(new RequestTrackDevice("group", "device", probe.getRef()));
-    DeviceRegistered registered1 = probe.receiveOne();
+    DeviceRegistered registered1 = probe.receiveMessage();
 
     // another deviceId
     groupActor.tell(new RequestTrackDevice("group", "device3", probe.getRef()));
-    DeviceRegistered registered2 = probe.receiveOne();
+    DeviceRegistered registered2 = probe.receiveMessage();
     assertNotEquals(registered1.device, registered2.device);
 
     // Check that the device actors are working
     TestProbe<TemperatureRecorded> recordProbe = testKit.createTestProbe(TemperatureRecorded.class);
     registered1.device.tell(new RecordTemperature(0L, 1.0, recordProbe.getRef()));
-    assertEquals(0L, recordProbe.receiveOne().requestId);
+    assertEquals(0L, recordProbe.receiveMessage().requestId);
     registered2.device.tell(new RecordTemperature(1L, 2.0, recordProbe.getRef()));
-    assertEquals(1L, recordProbe.receiveOne().requestId);
+    assertEquals(1L, recordProbe.receiveMessage().requestId);
   }
 
   @Test
@@ -61,11 +61,11 @@ public class DeviceGroupTest extends JUnitSuite {
     ActorRef<DeviceGroupMessage> groupActor = testKit.spawn(DeviceGroup.createBehavior("group"));
 
     groupActor.tell(new RequestTrackDevice("group", "device", probe.getRef()));
-    DeviceRegistered registered1 = probe.receiveOne();
+    DeviceRegistered registered1 = probe.receiveMessage();
 
     // registering same again should be idempotent
     groupActor.tell(new RequestTrackDevice("group", "device", probe.getRef()));
-    DeviceRegistered registered2 = probe.receiveOne();
+    DeviceRegistered registered2 = probe.receiveMessage();
     assertEquals(registered1.device, registered2.device);
   }
   // #device-group-test3
@@ -77,15 +77,15 @@ public class DeviceGroupTest extends JUnitSuite {
     ActorRef<DeviceGroupMessage> groupActor = testKit.spawn(DeviceGroup.createBehavior("group"));
 
     groupActor.tell(new RequestTrackDevice("group", "device1", registeredProbe.getRef()));
-    registeredProbe.receiveOne();
+    registeredProbe.receiveMessage();
 
     groupActor.tell(new RequestTrackDevice("group", "device2", registeredProbe.getRef()));
-    registeredProbe.receiveOne();
+    registeredProbe.receiveMessage();
 
     TestProbe<ReplyDeviceList> deviceListProbe = testKit.createTestProbe(ReplyDeviceList.class);
 
     groupActor.tell(new RequestDeviceList(0L, "group", deviceListProbe.getRef()));
-    ReplyDeviceList reply = deviceListProbe.receiveOne();
+    ReplyDeviceList reply = deviceListProbe.receiveMessage();
     assertEquals(0L, reply.requestId);
     assertEquals(Stream.of("device1", "device2").collect(Collectors.toSet()), reply.ids);
   }
@@ -96,17 +96,17 @@ public class DeviceGroupTest extends JUnitSuite {
     ActorRef<DeviceGroupMessage> groupActor = testKit.spawn(DeviceGroup.createBehavior("group"));
 
     groupActor.tell(new RequestTrackDevice("group", "device1", registeredProbe.getRef()));
-    DeviceRegistered registered1 = registeredProbe.receiveOne();
+    DeviceRegistered registered1 = registeredProbe.receiveMessage();
 
     groupActor.tell(new RequestTrackDevice("group", "device2", registeredProbe.getRef()));
-    DeviceRegistered registered2 = registeredProbe.receiveOne();
+    DeviceRegistered registered2 = registeredProbe.receiveMessage();
 
     ActorRef<DeviceMessage> toShutDown = registered1.device;
 
     TestProbe<ReplyDeviceList> deviceListProbe = testKit.createTestProbe(ReplyDeviceList.class);
 
     groupActor.tell(new RequestDeviceList(0L, "group", deviceListProbe.getRef()));
-    ReplyDeviceList reply = deviceListProbe.receiveOne();
+    ReplyDeviceList reply = deviceListProbe.receiveMessage();
     assertEquals(0L, reply.requestId);
     assertEquals(Stream.of("device1", "device2").collect(Collectors.toSet()), reply.ids);
 
@@ -118,7 +118,7 @@ public class DeviceGroupTest extends JUnitSuite {
     registeredProbe.awaitAssert(
         () -> {
           groupActor.tell(new RequestDeviceList(1L, "group", deviceListProbe.getRef()));
-          ReplyDeviceList r = deviceListProbe.receiveOne();
+          ReplyDeviceList r = deviceListProbe.receiveMessage();
           assertEquals(1L, r.requestId);
           assertEquals(Stream.of("device2").collect(Collectors.toSet()), r.ids);
           return null;

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceGroupTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package jdocs.typed.tutorial_4;
@@ -21,28 +21,29 @@ import static jdocs.typed.tutorial_4.DeviceProtocol.*;
 
 public class DeviceGroupTest extends JUnitSuite {
 
-  @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();
+  @ClassRule
+  public static final TestKitJunitResource testKit = new TestKitJunitResource();
 
-  // #device-group-test-registration
+  //#device-group-test-registration
   @Test
   public void testReplyToRegistrationRequests() {
     TestProbe<DeviceRegistered> probe = testKit.createTestProbe(DeviceRegistered.class);
     ActorRef<DeviceGroupMessage> groupActor = testKit.spawn(DeviceGroup.createBehavior("group"));
 
     groupActor.tell(new RequestTrackDevice("group", "device", probe.getRef()));
-    DeviceRegistered registered1 = probe.expectMessageClass(DeviceRegistered.class);
+    DeviceRegistered registered1 = probe.receiveOne();
 
     // another deviceId
     groupActor.tell(new RequestTrackDevice("group", "device3", probe.getRef()));
-    DeviceRegistered registered2 = probe.expectMessageClass(DeviceRegistered.class);
+    DeviceRegistered registered2 = probe.receiveOne();
     assertNotEquals(registered1.device, registered2.device);
 
     // Check that the device actors are working
     TestProbe<TemperatureRecorded> recordProbe = testKit.createTestProbe(TemperatureRecorded.class);
     registered1.device.tell(new RecordTemperature(0L, 1.0, recordProbe.getRef()));
-    assertEquals(0L, recordProbe.expectMessageClass(TemperatureRecorded.class).requestId);
+    assertEquals(0L, recordProbe.receiveOne().requestId);
     registered2.device.tell(new RecordTemperature(1L, 2.0, recordProbe.getRef()));
-    assertEquals(1L, recordProbe.expectMessageClass(TemperatureRecorded.class).requestId);
+    assertEquals(1L, recordProbe.receiveOne().requestId);
   }
 
   @Test
@@ -52,40 +53,40 @@ public class DeviceGroupTest extends JUnitSuite {
     groupActor.tell(new RequestTrackDevice("wrongGroup", "device1", probe.getRef()));
     probe.expectNoMessage();
   }
-  // #device-group-test-registration
+  //#device-group-test-registration
 
-  // #device-group-test3
+  //#device-group-test3
   @Test
   public void testReturnSameActorForSameDeviceId() {
     TestProbe<DeviceRegistered> probe = testKit.createTestProbe(DeviceRegistered.class);
     ActorRef<DeviceGroupMessage> groupActor = testKit.spawn(DeviceGroup.createBehavior("group"));
 
     groupActor.tell(new RequestTrackDevice("group", "device", probe.getRef()));
-    DeviceRegistered registered1 = probe.expectMessageClass(DeviceRegistered.class);
+    DeviceRegistered registered1 = probe.receiveOne();
 
     // registering same again should be idempotent
     groupActor.tell(new RequestTrackDevice("group", "device", probe.getRef()));
-    DeviceRegistered registered2 = probe.expectMessageClass(DeviceRegistered.class);
+    DeviceRegistered registered2 = probe.receiveOne();
     assertEquals(registered1.device, registered2.device);
   }
-  // #device-group-test3
+  //#device-group-test3
 
-  // #device-group-list-terminate-test
+  //#device-group-list-terminate-test
   @Test
   public void testListActiveDevices() {
     TestProbe<DeviceRegistered> registeredProbe = testKit.createTestProbe(DeviceRegistered.class);
     ActorRef<DeviceGroupMessage> groupActor = testKit.spawn(DeviceGroup.createBehavior("group"));
 
     groupActor.tell(new RequestTrackDevice("group", "device1", registeredProbe.getRef()));
-    registeredProbe.expectMessageClass(DeviceRegistered.class);
+    registeredProbe.receiveOne();
 
     groupActor.tell(new RequestTrackDevice("group", "device2", registeredProbe.getRef()));
-    registeredProbe.expectMessageClass(DeviceRegistered.class);
+    registeredProbe.receiveOne();
 
     TestProbe<ReplyDeviceList> deviceListProbe = testKit.createTestProbe(ReplyDeviceList.class);
 
     groupActor.tell(new RequestDeviceList(0L, "group", deviceListProbe.getRef()));
-    ReplyDeviceList reply = deviceListProbe.expectMessageClass(ReplyDeviceList.class);
+    ReplyDeviceList reply = deviceListProbe.receiveOne();
     assertEquals(0L, reply.requestId);
     assertEquals(Stream.of("device1", "device2").collect(Collectors.toSet()), reply.ids);
   }
@@ -96,17 +97,17 @@ public class DeviceGroupTest extends JUnitSuite {
     ActorRef<DeviceGroupMessage> groupActor = testKit.spawn(DeviceGroup.createBehavior("group"));
 
     groupActor.tell(new RequestTrackDevice("group", "device1", registeredProbe.getRef()));
-    DeviceRegistered registered1 = registeredProbe.expectMessageClass(DeviceRegistered.class);
+    DeviceRegistered registered1 = registeredProbe.receiveOne();
 
     groupActor.tell(new RequestTrackDevice("group", "device2", registeredProbe.getRef()));
-    DeviceRegistered registered2 = registeredProbe.expectMessageClass(DeviceRegistered.class);
+    DeviceRegistered registered2 = registeredProbe.receiveOne();
 
     ActorRef<DeviceMessage> toShutDown = registered1.device;
 
     TestProbe<ReplyDeviceList> deviceListProbe = testKit.createTestProbe(ReplyDeviceList.class);
 
     groupActor.tell(new RequestDeviceList(0L, "group", deviceListProbe.getRef()));
-    ReplyDeviceList reply = deviceListProbe.expectMessageClass(ReplyDeviceList.class);
+    ReplyDeviceList reply = deviceListProbe.receiveOne();
     assertEquals(0L, reply.requestId);
     assertEquals(Stream.of("device1", "device2").collect(Collectors.toSet()), reply.ids);
 
@@ -115,14 +116,13 @@ public class DeviceGroupTest extends JUnitSuite {
 
     // using awaitAssert to retry because it might take longer for the groupActor
     // to see the Terminated, that order is undefined
-    registeredProbe.awaitAssert(
-        () -> {
-          groupActor.tell(new RequestDeviceList(1L, "group", deviceListProbe.getRef()));
-          ReplyDeviceList r = deviceListProbe.expectMessageClass(ReplyDeviceList.class);
-          assertEquals(1L, r.requestId);
-          assertEquals(Stream.of("device2").collect(Collectors.toSet()), r.ids);
-          return null;
-        });
+    registeredProbe.awaitAssert(() -> {
+      groupActor.tell(new RequestDeviceList(1L, "group", deviceListProbe.getRef()));
+      ReplyDeviceList r = deviceListProbe.receiveOne();
+      assertEquals(1L, r.requestId);
+      assertEquals(Stream.of("device2").collect(Collectors.toSet()), r.ids);
+      return null;
+    });
   }
-  // #device-group-list-terminate-test
+  //#device-group-list-terminate-test
 }

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceGroupTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package jdocs.typed.tutorial_4;
@@ -21,10 +21,9 @@ import static jdocs.typed.tutorial_4.DeviceProtocol.*;
 
 public class DeviceGroupTest extends JUnitSuite {
 
-  @ClassRule
-  public static final TestKitJunitResource testKit = new TestKitJunitResource();
+  @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();
 
-  //#device-group-test-registration
+  // #device-group-test-registration
   @Test
   public void testReplyToRegistrationRequests() {
     TestProbe<DeviceRegistered> probe = testKit.createTestProbe(DeviceRegistered.class);
@@ -53,9 +52,9 @@ public class DeviceGroupTest extends JUnitSuite {
     groupActor.tell(new RequestTrackDevice("wrongGroup", "device1", probe.getRef()));
     probe.expectNoMessage();
   }
-  //#device-group-test-registration
+  // #device-group-test-registration
 
-  //#device-group-test3
+  // #device-group-test3
   @Test
   public void testReturnSameActorForSameDeviceId() {
     TestProbe<DeviceRegistered> probe = testKit.createTestProbe(DeviceRegistered.class);
@@ -69,9 +68,9 @@ public class DeviceGroupTest extends JUnitSuite {
     DeviceRegistered registered2 = probe.receiveOne();
     assertEquals(registered1.device, registered2.device);
   }
-  //#device-group-test3
+  // #device-group-test3
 
-  //#device-group-list-terminate-test
+  // #device-group-list-terminate-test
   @Test
   public void testListActiveDevices() {
     TestProbe<DeviceRegistered> registeredProbe = testKit.createTestProbe(DeviceRegistered.class);
@@ -116,13 +115,14 @@ public class DeviceGroupTest extends JUnitSuite {
 
     // using awaitAssert to retry because it might take longer for the groupActor
     // to see the Terminated, that order is undefined
-    registeredProbe.awaitAssert(() -> {
-      groupActor.tell(new RequestDeviceList(1L, "group", deviceListProbe.getRef()));
-      ReplyDeviceList r = deviceListProbe.receiveOne();
-      assertEquals(1L, r.requestId);
-      assertEquals(Stream.of("device2").collect(Collectors.toSet()), r.ids);
-      return null;
-    });
+    registeredProbe.awaitAssert(
+        () -> {
+          groupActor.tell(new RequestDeviceList(1L, "group", deviceListProbe.getRef()));
+          ReplyDeviceList r = deviceListProbe.receiveOne();
+          assertEquals(1L, r.requestId);
+          assertEquals(Stream.of("device2").collect(Collectors.toSet()), r.ids);
+          return null;
+        });
   }
-  //#device-group-list-terminate-test
+  // #device-group-list-terminate-test
 }

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceManagerTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceManagerTest.java
@@ -24,11 +24,11 @@ public class DeviceManagerTest extends JUnitSuite {
     ActorRef<DeviceManagerMessage> managerActor = testKit.spawn(DeviceManager.createBehavior());
 
     managerActor.tell(new RequestTrackDevice("group1", "device", probe.getRef()));
-    DeviceRegistered registered1 = probe.expectMessageClass(DeviceRegistered.class);
+    DeviceRegistered registered1 = probe.receiveOne();
 
     // another group
     managerActor.tell(new RequestTrackDevice("group2", "device", probe.getRef()));
-    DeviceRegistered registered2 = probe.expectMessageClass(DeviceRegistered.class);
+    DeviceRegistered registered2 = probe.receiveOne();
     assertNotEquals(registered1.device, registered2.device);
   }
 }

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceManagerTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceManagerTest.java
@@ -24,11 +24,11 @@ public class DeviceManagerTest extends JUnitSuite {
     ActorRef<DeviceManagerMessage> managerActor = testKit.spawn(DeviceManager.createBehavior());
 
     managerActor.tell(new RequestTrackDevice("group1", "device", probe.getRef()));
-    DeviceRegistered registered1 = probe.receiveOne();
+    DeviceRegistered registered1 = probe.receiveMessage();
 
     // another group
     managerActor.tell(new RequestTrackDevice("group2", "device", probe.getRef()));
-    DeviceRegistered registered2 = probe.receiveOne();
+    DeviceRegistered registered2 = probe.receiveMessage();
     assertNotEquals(registered1.device, registered2.device);
   }
 }

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceTest.java
@@ -26,7 +26,7 @@ public class DeviceTest extends JUnitSuite {
     TestProbe<RespondTemperature> probe = testKit.createTestProbe(RespondTemperature.class);
     ActorRef<DeviceMessage> deviceActor = testKit.spawn(Device.createBehavior("group", "device"));
     deviceActor.tell(new ReadTemperature(42L, probe.getRef()));
-    RespondTemperature response = probe.receiveOne();
+    RespondTemperature response = probe.receiveMessage();
     assertEquals(42L, response.requestId);
     assertEquals(Optional.empty(), response.value);
   }
@@ -40,18 +40,18 @@ public class DeviceTest extends JUnitSuite {
     ActorRef<DeviceMessage> deviceActor = testKit.spawn(Device.createBehavior("group", "device"));
 
     deviceActor.tell(new RecordTemperature(1L, 24.0, recordProbe.getRef()));
-    assertEquals(1L, recordProbe.receiveOne().requestId);
+    assertEquals(1L, recordProbe.receiveMessage().requestId);
 
     deviceActor.tell(new ReadTemperature(2L, readProbe.getRef()));
-    RespondTemperature response1 = readProbe.receiveOne();
+    RespondTemperature response1 = readProbe.receiveMessage();
     assertEquals(2L, response1.requestId);
     assertEquals(Optional.of(24.0), response1.value);
 
     deviceActor.tell(new RecordTemperature(3L, 55.0, recordProbe.getRef()));
-    assertEquals(3L, recordProbe.receiveOne().requestId);
+    assertEquals(3L, recordProbe.receiveMessage().requestId);
 
     deviceActor.tell(new ReadTemperature(4L, readProbe.getRef()));
-    RespondTemperature response2 = readProbe.receiveOne();
+    RespondTemperature response2 = readProbe.receiveMessage();
     assertEquals(4L, response2.requestId);
     assertEquals(Optional.of(55.0), response2.value);
   }

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceTest.java
@@ -26,7 +26,7 @@ public class DeviceTest extends JUnitSuite {
     TestProbe<RespondTemperature> probe = testKit.createTestProbe(RespondTemperature.class);
     ActorRef<DeviceMessage> deviceActor = testKit.spawn(Device.createBehavior("group", "device"));
     deviceActor.tell(new ReadTemperature(42L, probe.getRef()));
-    RespondTemperature response = probe.expectMessageClass(RespondTemperature.class);
+    RespondTemperature response = probe.receiveOne();
     assertEquals(42L, response.requestId);
     assertEquals(Optional.empty(), response.value);
   }
@@ -40,18 +40,18 @@ public class DeviceTest extends JUnitSuite {
     ActorRef<DeviceMessage> deviceActor = testKit.spawn(Device.createBehavior("group", "device"));
 
     deviceActor.tell(new RecordTemperature(1L, 24.0, recordProbe.getRef()));
-    assertEquals(1L, recordProbe.expectMessageClass(TemperatureRecorded.class).requestId);
+    assertEquals(1L, recordProbe.receiveOne().requestId);
 
     deviceActor.tell(new ReadTemperature(2L, readProbe.getRef()));
-    RespondTemperature response1 = readProbe.expectMessageClass(RespondTemperature.class);
+    RespondTemperature response1 = readProbe.receiveOne();
     assertEquals(2L, response1.requestId);
     assertEquals(Optional.of(24.0), response1.value);
 
     deviceActor.tell(new RecordTemperature(3L, 55.0, recordProbe.getRef()));
-    assertEquals(3L, recordProbe.expectMessageClass(TemperatureRecorded.class).requestId);
+    assertEquals(3L, recordProbe.receiveOne().requestId);
 
     deviceActor.tell(new ReadTemperature(4L, readProbe.getRef()));
-    RespondTemperature response2 = readProbe.expectMessageClass(RespondTemperature.class);
+    RespondTemperature response2 = readProbe.receiveOne();
     assertEquals(4L, response2.requestId);
     assertEquals(Optional.of(55.0), response2.value);
   }

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceGroupQueryTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceGroupQueryTest.java
@@ -52,7 +52,7 @@ public class DeviceGroupQueryTest extends JUnitSuite {
         new DeviceGroupQuery.WrappedRespondTemperature(
             new RespondTemperature(0L, "device2", Optional.of(2.0))));
 
-    RespondAllTemperatures response = requester.expectMessageClass(RespondAllTemperatures.class);
+    RespondAllTemperatures response = requester.receiveOne();
     assertEquals(1L, response.requestId);
 
     Map<String, TemperatureReading> expectedTemperatures = new HashMap<>();
@@ -91,7 +91,7 @@ public class DeviceGroupQueryTest extends JUnitSuite {
         new DeviceGroupQuery.WrappedRespondTemperature(
             new RespondTemperature(0L, "device2", Optional.of(2.0))));
 
-    RespondAllTemperatures response = requester.expectMessageClass(RespondAllTemperatures.class);
+    RespondAllTemperatures response = requester.receiveOne();
     assertEquals(1L, response.requestId);
 
     Map<String, TemperatureReading> expectedTemperatures = new HashMap<>();
@@ -128,7 +128,7 @@ public class DeviceGroupQueryTest extends JUnitSuite {
 
     device2.stop();
 
-    RespondAllTemperatures response = requester.expectMessageClass(RespondAllTemperatures.class);
+    RespondAllTemperatures response = requester.receiveOne();
     assertEquals(1L, response.requestId);
 
     Map<String, TemperatureReading> expectedTemperatures = new HashMap<>();
@@ -169,7 +169,7 @@ public class DeviceGroupQueryTest extends JUnitSuite {
 
     device2.stop();
 
-    RespondAllTemperatures response = requester.expectMessageClass(RespondAllTemperatures.class);
+    RespondAllTemperatures response = requester.receiveOne();
     assertEquals(1L, response.requestId);
 
     Map<String, TemperatureReading> expectedTemperatures = new HashMap<>();
@@ -206,7 +206,7 @@ public class DeviceGroupQueryTest extends JUnitSuite {
 
     // no reply from device2
 
-    RespondAllTemperatures response = requester.expectMessageClass(RespondAllTemperatures.class);
+    RespondAllTemperatures response = requester.receiveOne();
     assertEquals(1L, response.requestId);
 
     Map<String, TemperatureReading> expectedTemperatures = new HashMap<>();

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceGroupQueryTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceGroupQueryTest.java
@@ -52,7 +52,7 @@ public class DeviceGroupQueryTest extends JUnitSuite {
         new DeviceGroupQuery.WrappedRespondTemperature(
             new RespondTemperature(0L, "device2", Optional.of(2.0))));
 
-    RespondAllTemperatures response = requester.receiveOne();
+    RespondAllTemperatures response = requester.receiveMessage();
     assertEquals(1L, response.requestId);
 
     Map<String, TemperatureReading> expectedTemperatures = new HashMap<>();
@@ -91,7 +91,7 @@ public class DeviceGroupQueryTest extends JUnitSuite {
         new DeviceGroupQuery.WrappedRespondTemperature(
             new RespondTemperature(0L, "device2", Optional.of(2.0))));
 
-    RespondAllTemperatures response = requester.receiveOne();
+    RespondAllTemperatures response = requester.receiveMessage();
     assertEquals(1L, response.requestId);
 
     Map<String, TemperatureReading> expectedTemperatures = new HashMap<>();
@@ -128,7 +128,7 @@ public class DeviceGroupQueryTest extends JUnitSuite {
 
     device2.stop();
 
-    RespondAllTemperatures response = requester.receiveOne();
+    RespondAllTemperatures response = requester.receiveMessage();
     assertEquals(1L, response.requestId);
 
     Map<String, TemperatureReading> expectedTemperatures = new HashMap<>();
@@ -169,7 +169,7 @@ public class DeviceGroupQueryTest extends JUnitSuite {
 
     device2.stop();
 
-    RespondAllTemperatures response = requester.receiveOne();
+    RespondAllTemperatures response = requester.receiveMessage();
     assertEquals(1L, response.requestId);
 
     Map<String, TemperatureReading> expectedTemperatures = new HashMap<>();
@@ -206,7 +206,7 @@ public class DeviceGroupQueryTest extends JUnitSuite {
 
     // no reply from device2
 
-    RespondAllTemperatures response = requester.receiveOne();
+    RespondAllTemperatures response = requester.receiveMessage();
     assertEquals(1L, response.requestId);
 
     Map<String, TemperatureReading> expectedTemperatures = new HashMap<>();

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceGroupTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceGroupTest.java
@@ -31,19 +31,19 @@ public class DeviceGroupTest extends JUnitSuite {
     ActorRef<DeviceGroupMessage> groupActor = testKit.spawn(DeviceGroup.createBehavior("group"));
 
     groupActor.tell(new RequestTrackDevice("group", "device", probe.getRef()));
-    DeviceRegistered registered1 = probe.receiveOne();
+    DeviceRegistered registered1 = probe.receiveMessage();
 
     // another deviceId
     groupActor.tell(new RequestTrackDevice("group", "device3", probe.getRef()));
-    DeviceRegistered registered2 = probe.receiveOne();
+    DeviceRegistered registered2 = probe.receiveMessage();
     assertNotEquals(registered1.device, registered2.device);
 
     // Check that the device actors are working
     TestProbe<TemperatureRecorded> recordProbe = testKit.createTestProbe(TemperatureRecorded.class);
     registered1.device.tell(new RecordTemperature(0L, 1.0, recordProbe.getRef()));
-    assertEquals(0L, recordProbe.receiveOne().requestId);
+    assertEquals(0L, recordProbe.receiveMessage().requestId);
     registered2.device.tell(new RecordTemperature(1L, 2.0, recordProbe.getRef()));
-    assertEquals(1L, recordProbe.receiveOne().requestId);
+    assertEquals(1L, recordProbe.receiveMessage().requestId);
   }
 
   @Test
@@ -60,11 +60,11 @@ public class DeviceGroupTest extends JUnitSuite {
     ActorRef<DeviceGroupMessage> groupActor = testKit.spawn(DeviceGroup.createBehavior("group"));
 
     groupActor.tell(new RequestTrackDevice("group", "device", probe.getRef()));
-    DeviceRegistered registered1 = probe.receiveOne();
+    DeviceRegistered registered1 = probe.receiveMessage();
 
     // registering same again should be idempotent
     groupActor.tell(new RequestTrackDevice("group", "device", probe.getRef()));
-    DeviceRegistered registered2 = probe.receiveOne();
+    DeviceRegistered registered2 = probe.receiveMessage();
     assertEquals(registered1.device, registered2.device);
   }
 
@@ -74,15 +74,15 @@ public class DeviceGroupTest extends JUnitSuite {
     ActorRef<DeviceGroupMessage> groupActor = testKit.spawn(DeviceGroup.createBehavior("group"));
 
     groupActor.tell(new RequestTrackDevice("group", "device1", registeredProbe.getRef()));
-    registeredProbe.receiveOne();
+    registeredProbe.receiveMessage();
 
     groupActor.tell(new RequestTrackDevice("group", "device2", registeredProbe.getRef()));
-    registeredProbe.receiveOne();
+    registeredProbe.receiveMessage();
 
     TestProbe<ReplyDeviceList> deviceListProbe = testKit.createTestProbe(ReplyDeviceList.class);
 
     groupActor.tell(new RequestDeviceList(0L, "group", deviceListProbe.getRef()));
-    ReplyDeviceList reply = deviceListProbe.receiveOne();
+    ReplyDeviceList reply = deviceListProbe.receiveMessage();
     assertEquals(0L, reply.requestId);
     assertEquals(Stream.of("device1", "device2").collect(Collectors.toSet()), reply.ids);
   }
@@ -93,17 +93,17 @@ public class DeviceGroupTest extends JUnitSuite {
     ActorRef<DeviceGroupMessage> groupActor = testKit.spawn(DeviceGroup.createBehavior("group"));
 
     groupActor.tell(new RequestTrackDevice("group", "device1", registeredProbe.getRef()));
-    DeviceRegistered registered1 = registeredProbe.receiveOne();
+    DeviceRegistered registered1 = registeredProbe.receiveMessage();
 
     groupActor.tell(new RequestTrackDevice("group", "device2", registeredProbe.getRef()));
-    registeredProbe.receiveOne();
+    registeredProbe.receiveMessage();
 
     ActorRef<DeviceMessage> toShutDown = registered1.device;
 
     TestProbe<ReplyDeviceList> deviceListProbe = testKit.createTestProbe(ReplyDeviceList.class);
 
     groupActor.tell(new RequestDeviceList(0L, "group", deviceListProbe.getRef()));
-    ReplyDeviceList reply = deviceListProbe.receiveOne();
+    ReplyDeviceList reply = deviceListProbe.receiveMessage();
     assertEquals(0L, reply.requestId);
     assertEquals(Stream.of("device1", "device2").collect(Collectors.toSet()), reply.ids);
 
@@ -115,7 +115,7 @@ public class DeviceGroupTest extends JUnitSuite {
     registeredProbe.awaitAssert(
         () -> {
           groupActor.tell(new RequestDeviceList(1L, "group", deviceListProbe.getRef()));
-          ReplyDeviceList r = deviceListProbe.receiveOne();
+          ReplyDeviceList r = deviceListProbe.receiveMessage();
           assertEquals(1L, r.requestId);
           assertEquals(Stream.of("device2").collect(Collectors.toSet()), r.ids);
           return null;
@@ -129,26 +129,26 @@ public class DeviceGroupTest extends JUnitSuite {
     ActorRef<DeviceGroupMessage> groupActor = testKit.spawn(DeviceGroup.createBehavior("group"));
 
     groupActor.tell(new RequestTrackDevice("group", "device1", registeredProbe.getRef()));
-    ActorRef<DeviceMessage> deviceActor1 = registeredProbe.receiveOne().device;
+    ActorRef<DeviceMessage> deviceActor1 = registeredProbe.receiveMessage().device;
 
     groupActor.tell(new RequestTrackDevice("group", "device2", registeredProbe.getRef()));
-    ActorRef<DeviceMessage> deviceActor2 = registeredProbe.receiveOne().device;
+    ActorRef<DeviceMessage> deviceActor2 = registeredProbe.receiveMessage().device;
 
     groupActor.tell(new RequestTrackDevice("group", "device3", registeredProbe.getRef()));
-    ActorRef<DeviceMessage> deviceActor3 = registeredProbe.receiveOne().device;
+    ActorRef<DeviceMessage> deviceActor3 = registeredProbe.receiveMessage().device;
 
     // Check that the device actors are working
     TestProbe<TemperatureRecorded> recordProbe = testKit.createTestProbe(TemperatureRecorded.class);
     deviceActor1.tell(new RecordTemperature(0L, 1.0, recordProbe.getRef()));
-    assertEquals(0L, recordProbe.receiveOne().requestId);
+    assertEquals(0L, recordProbe.receiveMessage().requestId);
     deviceActor2.tell(new RecordTemperature(1L, 2.0, recordProbe.getRef()));
-    assertEquals(1L, recordProbe.receiveOne().requestId);
+    assertEquals(1L, recordProbe.receiveMessage().requestId);
     // No temperature for device 3
 
     TestProbe<RespondAllTemperatures> allTempProbe =
         testKit.createTestProbe(RespondAllTemperatures.class);
     groupActor.tell(new RequestAllTemperatures(0L, "group", allTempProbe.getRef()));
-    RespondAllTemperatures response = allTempProbe.receiveOne();
+    RespondAllTemperatures response = allTempProbe.receiveMessage();
     assertEquals(0L, response.requestId);
 
     Map<String, TemperatureReading> expectedTemperatures = new HashMap<>();

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceGroupTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package jdocs.typed.tutorial_5;
@@ -23,8 +23,7 @@ import static org.junit.Assert.assertNotEquals;
 
 public class DeviceGroupTest extends JUnitSuite {
 
-  @ClassRule
-  public static final TestKitJunitResource testKit = new TestKitJunitResource();
+  @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();
 
   @Test
   public void testReplyToRegistrationRequests() {
@@ -113,16 +112,17 @@ public class DeviceGroupTest extends JUnitSuite {
 
     // using awaitAssert to retry because it might take longer for the groupActor
     // to see the Terminated, that order is undefined
-    registeredProbe.awaitAssert(() -> {
-      groupActor.tell(new RequestDeviceList(1L, "group", deviceListProbe.getRef()));
-      ReplyDeviceList r = deviceListProbe.receiveOne();
-      assertEquals(1L, r.requestId);
-      assertEquals(Stream.of("device2").collect(Collectors.toSet()), r.ids);
-      return null;
-    });
+    registeredProbe.awaitAssert(
+        () -> {
+          groupActor.tell(new RequestDeviceList(1L, "group", deviceListProbe.getRef()));
+          ReplyDeviceList r = deviceListProbe.receiveOne();
+          assertEquals(1L, r.requestId);
+          assertEquals(Stream.of("device2").collect(Collectors.toSet()), r.ids);
+          return null;
+        });
   }
 
-    //#group-query-integration-test
+  // #group-query-integration-test
   @Test
   public void testCollectTemperaturesFromAllActiveDevices() {
     TestProbe<DeviceRegistered> registeredProbe = testKit.createTestProbe(DeviceRegistered.class);
@@ -145,7 +145,8 @@ public class DeviceGroupTest extends JUnitSuite {
     assertEquals(1L, recordProbe.receiveOne().requestId);
     // No temperature for device 3
 
-    TestProbe<RespondAllTemperatures> allTempProbe = testKit.createTestProbe(RespondAllTemperatures.class);
+    TestProbe<RespondAllTemperatures> allTempProbe =
+        testKit.createTestProbe(RespondAllTemperatures.class);
     groupActor.tell(new RequestAllTemperatures(0L, "group", allTempProbe.getRef()));
     RespondAllTemperatures response = allTempProbe.receiveOne();
     assertEquals(0L, response.requestId);
@@ -157,5 +158,5 @@ public class DeviceGroupTest extends JUnitSuite {
 
     assertEquals(expectedTemperatures, response.temperatures);
   }
-  //#group-query-integration-test
+  // #group-query-integration-test
 }

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceManagerTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceManagerTest.java
@@ -24,11 +24,11 @@ public class DeviceManagerTest extends JUnitSuite {
     ActorRef<DeviceManagerMessage> managerActor = testKit.spawn(DeviceManager.createBehavior());
 
     managerActor.tell(new RequestTrackDevice("group1", "device", probe.getRef()));
-    DeviceRegistered registered1 = probe.expectMessageClass(DeviceRegistered.class);
+    DeviceRegistered registered1 = probe.receiveOne();
 
     // another group
     managerActor.tell(new RequestTrackDevice("group2", "device", probe.getRef()));
-    DeviceRegistered registered2 = probe.expectMessageClass(DeviceRegistered.class);
+    DeviceRegistered registered2 = probe.receiveOne();
     assertNotEquals(registered1.device, registered2.device);
   }
 }

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceManagerTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceManagerTest.java
@@ -24,11 +24,11 @@ public class DeviceManagerTest extends JUnitSuite {
     ActorRef<DeviceManagerMessage> managerActor = testKit.spawn(DeviceManager.createBehavior());
 
     managerActor.tell(new RequestTrackDevice("group1", "device", probe.getRef()));
-    DeviceRegistered registered1 = probe.receiveOne();
+    DeviceRegistered registered1 = probe.receiveMessage();
 
     // another group
     managerActor.tell(new RequestTrackDevice("group2", "device", probe.getRef()));
-    DeviceRegistered registered2 = probe.receiveOne();
+    DeviceRegistered registered2 = probe.receiveMessage();
     assertNotEquals(registered1.device, registered2.device);
   }
 }

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceTest.java
@@ -13,7 +13,6 @@ import org.scalatest.junit.JUnitSuite;
 
 import java.util.Optional;
 
-import static jdocs.typed.tutorial_5.DeviceManagerProtocol.*;
 import static jdocs.typed.tutorial_5.DeviceProtocol.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -27,7 +26,7 @@ public class DeviceTest extends JUnitSuite {
     TestProbe<RespondTemperature> probe = testKit.createTestProbe(RespondTemperature.class);
     ActorRef<DeviceMessage> deviceActor = testKit.spawn(Device.createBehavior("group", "device"));
     deviceActor.tell(new ReadTemperature(42L, probe.getRef()));
-    RespondTemperature response = probe.receiveOne();
+    RespondTemperature response = probe.receiveMessage();
     assertEquals(42L, response.requestId);
     assertEquals(Optional.empty(), response.value);
   }
@@ -39,18 +38,18 @@ public class DeviceTest extends JUnitSuite {
     ActorRef<DeviceMessage> deviceActor = testKit.spawn(Device.createBehavior("group", "device"));
 
     deviceActor.tell(new RecordTemperature(1L, 24.0, recordProbe.getRef()));
-    assertEquals(1L, recordProbe.receiveOne().requestId);
+    assertEquals(1L, recordProbe.receiveMessage().requestId);
 
     deviceActor.tell(new ReadTemperature(2L, readProbe.getRef()));
-    RespondTemperature response1 = readProbe.receiveOne();
+    RespondTemperature response1 = readProbe.receiveMessage();
     assertEquals(2L, response1.requestId);
     assertEquals(Optional.of(24.0), response1.value);
 
     deviceActor.tell(new RecordTemperature(3L, 55.0, recordProbe.getRef()));
-    assertEquals(3L, recordProbe.receiveOne().requestId);
+    assertEquals(3L, recordProbe.receiveMessage().requestId);
 
     deviceActor.tell(new ReadTemperature(4L, readProbe.getRef()));
-    RespondTemperature response2 = readProbe.receiveOne();
+    RespondTemperature response2 = readProbe.receiveMessage();
     assertEquals(4L, response2.requestId);
     assertEquals(Optional.of(55.0), response2.value);
   }

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceTest.java
@@ -27,7 +27,7 @@ public class DeviceTest extends JUnitSuite {
     TestProbe<RespondTemperature> probe = testKit.createTestProbe(RespondTemperature.class);
     ActorRef<DeviceMessage> deviceActor = testKit.spawn(Device.createBehavior("group", "device"));
     deviceActor.tell(new ReadTemperature(42L, probe.getRef()));
-    RespondTemperature response = probe.expectMessageClass(RespondTemperature.class);
+    RespondTemperature response = probe.receiveOne();
     assertEquals(42L, response.requestId);
     assertEquals(Optional.empty(), response.value);
   }
@@ -39,18 +39,18 @@ public class DeviceTest extends JUnitSuite {
     ActorRef<DeviceMessage> deviceActor = testKit.spawn(Device.createBehavior("group", "device"));
 
     deviceActor.tell(new RecordTemperature(1L, 24.0, recordProbe.getRef()));
-    assertEquals(1L, recordProbe.expectMessageClass(TemperatureRecorded.class).requestId);
+    assertEquals(1L, recordProbe.receiveOne().requestId);
 
     deviceActor.tell(new ReadTemperature(2L, readProbe.getRef()));
-    RespondTemperature response1 = readProbe.expectMessageClass(RespondTemperature.class);
+    RespondTemperature response1 = readProbe.receiveOne();
     assertEquals(2L, response1.requestId);
     assertEquals(Optional.of(24.0), response1.value);
 
     deviceActor.tell(new RecordTemperature(3L, 55.0, recordProbe.getRef()));
-    assertEquals(3L, recordProbe.expectMessageClass(TemperatureRecorded.class).requestId);
+    assertEquals(3L, recordProbe.receiveOne().requestId);
 
     deviceActor.tell(new ReadTemperature(4L, readProbe.getRef()));
-    RespondTemperature response2 = readProbe.expectMessageClass(RespondTemperature.class);
+    RespondTemperature response2 = readProbe.receiveOne();
     assertEquals(4L, response2.requestId);
     assertEquals(Optional.of(55.0), response2.value);
   }

--- a/akka-docs/src/test/scala/typed/tutorial_3/DeviceSpec.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_3/DeviceSpec.scala
@@ -18,7 +18,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val deviceActor = spawn(Device("group", "device"))
 
       deviceActor ! Device.ReadTemperature(requestId = 42, probe.ref)
-      val response = probe.receiveOne()
+      val response = probe.receiveMessage()
       response.requestId should ===(42)
       response.value should ===(None)
     }
@@ -34,7 +34,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       recordProbe.expectMessage(Device.TemperatureRecorded(requestId = 1))
 
       deviceActor ! Device.ReadTemperature(requestId = 2, readProbe.ref)
-      val response1 = readProbe.receiveOne()
+      val response1 = readProbe.receiveMessage()
       response1.requestId should ===(2)
       response1.value should ===(Some(24.0))
 
@@ -42,7 +42,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       recordProbe.expectMessage(Device.TemperatureRecorded(requestId = 3))
 
       deviceActor ! Device.ReadTemperature(requestId = 4, readProbe.ref)
-      val response2 = readProbe.receiveOne()
+      val response2 = readProbe.receiveMessage()
       response2.requestId should ===(4)
       response2.value should ===(Some(55.0))
     }

--- a/akka-docs/src/test/scala/typed/tutorial_3/DeviceSpec.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_3/DeviceSpec.scala
@@ -18,7 +18,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val deviceActor = spawn(Device("group", "device"))
 
       deviceActor ! Device.ReadTemperature(requestId = 42, probe.ref)
-      val response = probe.expectMessageType[Device.RespondTemperature]
+      val response = probe.receiveOne()
       response.requestId should ===(42)
       response.value should ===(None)
     }
@@ -34,7 +34,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       recordProbe.expectMessage(Device.TemperatureRecorded(requestId = 1))
 
       deviceActor ! Device.ReadTemperature(requestId = 2, readProbe.ref)
-      val response1 = readProbe.expectMessageType[RespondTemperature]
+      val response1 = readProbe.receiveOne()
       response1.requestId should ===(2)
       response1.value should ===(Some(24.0))
 
@@ -42,7 +42,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       recordProbe.expectMessage(Device.TemperatureRecorded(requestId = 3))
 
       deviceActor ! Device.ReadTemperature(requestId = 4, readProbe.ref)
-      val response2 = readProbe.expectMessageType[RespondTemperature]
+      val response2 = readProbe.receiveOne()
       response2.requestId should ===(4)
       response2.value should ===(Some(55.0))
     }

--- a/akka-docs/src/test/scala/typed/tutorial_4/DeviceGroupSpec.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_4/DeviceGroupSpec.scala
@@ -21,12 +21,12 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", probe.ref)
-      val registered1 = probe.expectMessageType[DeviceRegistered]
+      val registered1 = probe.receiveOne()
       val deviceActor1 = registered1.device
 
       // another deviceId
       groupActor ! RequestTrackDevice("group", "device2", probe.ref)
-      val registered2 = probe.expectMessageType[DeviceRegistered]
+      val registered2 = probe.receiveOne()
       val deviceActor2 = registered2.device
       deviceActor1 should !==(deviceActor2)
 
@@ -53,11 +53,11 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", probe.ref)
-      val registered1 = probe.expectMessageType[DeviceRegistered]
+      val registered1 = probe.receiveOne()
 
       // registering same again should be idempotent
       groupActor ! RequestTrackDevice("group", "device1", probe.ref)
-      val registered2 = probe.expectMessageType[DeviceRegistered]
+      val registered2 = probe.receiveOne()
 
       registered1.device should ===(registered2.device)
     }
@@ -69,10 +69,10 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", registeredProbe.ref)
-      registeredProbe.expectMessageType[DeviceRegistered]
+      registeredProbe.receiveOne()
 
       groupActor ! RequestTrackDevice("group", "device2", registeredProbe.ref)
-      registeredProbe.expectMessageType[DeviceRegistered]
+      registeredProbe.receiveOne()
 
       val deviceListProbe = createTestProbe[ReplyDeviceList]()
       groupActor ! RequestDeviceList(requestId = 0, groupId = "group", deviceListProbe.ref)
@@ -84,11 +84,11 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", registeredProbe.ref)
-      val registered1 = registeredProbe.expectMessageType[DeviceRegistered]
+      val registered1 = registeredProbe.receiveOne()
       val toShutDown = registered1.device
 
       groupActor ! RequestTrackDevice("group", "device2", registeredProbe.ref)
-      registeredProbe.expectMessageType[DeviceRegistered]
+      registeredProbe.receiveOne()
 
       val deviceListProbe = createTestProbe[ReplyDeviceList]()
       groupActor ! RequestDeviceList(requestId = 0, groupId = "group", deviceListProbe.ref)

--- a/akka-docs/src/test/scala/typed/tutorial_4/DeviceGroupSpec.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_4/DeviceGroupSpec.scala
@@ -21,12 +21,12 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", probe.ref)
-      val registered1 = probe.receiveOne()
+      val registered1 = probe.receiveMessage()
       val deviceActor1 = registered1.device
 
       // another deviceId
       groupActor ! RequestTrackDevice("group", "device2", probe.ref)
-      val registered2 = probe.receiveOne()
+      val registered2 = probe.receiveMessage()
       val deviceActor2 = registered2.device
       deviceActor1 should !==(deviceActor2)
 
@@ -53,11 +53,11 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", probe.ref)
-      val registered1 = probe.receiveOne()
+      val registered1 = probe.receiveMessage()
 
       // registering same again should be idempotent
       groupActor ! RequestTrackDevice("group", "device1", probe.ref)
-      val registered2 = probe.receiveOne()
+      val registered2 = probe.receiveMessage()
 
       registered1.device should ===(registered2.device)
     }
@@ -69,10 +69,10 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", registeredProbe.ref)
-      registeredProbe.receiveOne()
+      registeredProbe.receiveMessage()
 
       groupActor ! RequestTrackDevice("group", "device2", registeredProbe.ref)
-      registeredProbe.receiveOne()
+      registeredProbe.receiveMessage()
 
       val deviceListProbe = createTestProbe[ReplyDeviceList]()
       groupActor ! RequestDeviceList(requestId = 0, groupId = "group", deviceListProbe.ref)
@@ -84,11 +84,11 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", registeredProbe.ref)
-      val registered1 = registeredProbe.receiveOne()
+      val registered1 = registeredProbe.receiveMessage()
       val toShutDown = registered1.device
 
       groupActor ! RequestTrackDevice("group", "device2", registeredProbe.ref)
-      registeredProbe.receiveOne()
+      registeredProbe.receiveMessage()
 
       val deviceListProbe = createTestProbe[ReplyDeviceList]()
       groupActor ! RequestDeviceList(requestId = 0, groupId = "group", deviceListProbe.ref)

--- a/akka-docs/src/test/scala/typed/tutorial_4/DeviceManagerSpec.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_4/DeviceManagerSpec.scala
@@ -17,11 +17,11 @@ class DeviceManagerSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val managerActor = spawn(DeviceManager())
 
       managerActor ! RequestTrackDevice("group1", "device", probe.ref)
-      val registered1 = probe.receiveOne()
+      val registered1 = probe.receiveMessage()
 
       // another group
       managerActor ! RequestTrackDevice("group2", "device", probe.ref)
-      val registered2 = probe.receiveOne()
+      val registered2 = probe.receiveMessage()
 
       registered1.device should !==(registered2.device)
     }

--- a/akka-docs/src/test/scala/typed/tutorial_4/DeviceManagerSpec.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_4/DeviceManagerSpec.scala
@@ -17,11 +17,11 @@ class DeviceManagerSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val managerActor = spawn(DeviceManager())
 
       managerActor ! RequestTrackDevice("group1", "device", probe.ref)
-      val registered1 = probe.expectMessageType[DeviceRegistered]
+      val registered1 = probe.receiveOne()
 
       // another group
       managerActor ! RequestTrackDevice("group2", "device", probe.ref)
-      val registered2 = probe.expectMessageType[DeviceRegistered]
+      val registered2 = probe.receiveOne()
 
       registered1.device should !==(registered2.device)
     }

--- a/akka-docs/src/test/scala/typed/tutorial_4/DeviceSpec.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_4/DeviceSpec.scala
@@ -18,7 +18,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val deviceActor = spawn(Device("group", "device"))
 
       deviceActor ! Device.ReadTemperature(requestId = 42, probe.ref)
-      val response = probe.receiveOne()
+      val response = probe.receiveMessage()
       response.requestId should ===(42)
       response.value should ===(None)
     }
@@ -34,7 +34,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       recordProbe.expectMessage(Device.TemperatureRecorded(requestId = 1))
 
       deviceActor ! Device.ReadTemperature(requestId = 2, readProbe.ref)
-      val response1 = readProbe.receiveOne()
+      val response1 = readProbe.receiveMessage()
       response1.requestId should ===(2)
       response1.value should ===(Some(24.0))
 
@@ -42,7 +42,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       recordProbe.expectMessage(Device.TemperatureRecorded(requestId = 3))
 
       deviceActor ! Device.ReadTemperature(requestId = 4, readProbe.ref)
-      val response2 = readProbe.receiveOne()
+      val response2 = readProbe.receiveMessage()
       response2.requestId should ===(4)
       response2.value should ===(Some(55.0))
     }

--- a/akka-docs/src/test/scala/typed/tutorial_4/DeviceSpec.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_4/DeviceSpec.scala
@@ -18,7 +18,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val deviceActor = spawn(Device("group", "device"))
 
       deviceActor ! Device.ReadTemperature(requestId = 42, probe.ref)
-      val response = probe.expectMessageType[Device.RespondTemperature]
+      val response = probe.receiveOne()
       response.requestId should ===(42)
       response.value should ===(None)
     }
@@ -34,7 +34,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       recordProbe.expectMessage(Device.TemperatureRecorded(requestId = 1))
 
       deviceActor ! Device.ReadTemperature(requestId = 2, readProbe.ref)
-      val response1 = readProbe.expectMessageType[RespondTemperature]
+      val response1 = readProbe.receiveOne()
       response1.requestId should ===(2)
       response1.value should ===(Some(24.0))
 
@@ -42,7 +42,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       recordProbe.expectMessage(Device.TemperatureRecorded(requestId = 3))
 
       deviceActor ! Device.ReadTemperature(requestId = 4, readProbe.ref)
-      val response2 = readProbe.expectMessageType[RespondTemperature]
+      val response2 = readProbe.receiveOne()
       response2.requestId should ===(4)
       response2.value should ===(Some(55.0))
     }

--- a/akka-docs/src/test/scala/typed/tutorial_5/DeviceGroupSpec.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_5/DeviceGroupSpec.scala
@@ -21,12 +21,12 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", probe.ref)
-      val registered1 = probe.receiveOne()
+      val registered1 = probe.receiveMessage()
       val deviceActor1 = registered1.device
 
       // another deviceId
       groupActor ! RequestTrackDevice("group", "device2", probe.ref)
-      val registered2 = probe.receiveOne()
+      val registered2 = probe.receiveMessage()
       val deviceActor2 = registered2.device
       deviceActor1 should !==(deviceActor2)
 
@@ -53,11 +53,11 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", probe.ref)
-      val registered1 = probe.receiveOne()
+      val registered1 = probe.receiveMessage()
 
       // registering same again should be idempotent
       groupActor ! RequestTrackDevice("group", "device1", probe.ref)
-      val registered2 = probe.receiveOne()
+      val registered2 = probe.receiveMessage()
 
       registered1.device should ===(registered2.device)
     }
@@ -69,10 +69,10 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", registeredProbe.ref)
-      registeredProbe.receiveOne()
+      registeredProbe.receiveMessage()
 
       groupActor ! RequestTrackDevice("group", "device2", registeredProbe.ref)
-      registeredProbe.receiveOne()
+      registeredProbe.receiveMessage()
 
       val deviceListProbe = createTestProbe[ReplyDeviceList]()
       groupActor ! RequestDeviceList(requestId = 0, groupId = "group", deviceListProbe.ref)
@@ -84,11 +84,11 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", registeredProbe.ref)
-      val registered1 = registeredProbe.receiveOne()
+      val registered1 = registeredProbe.receiveMessage()
       val toShutDown = registered1.device
 
       groupActor ! RequestTrackDevice("group", "device2", registeredProbe.ref)
-      registeredProbe.receiveOne()
+      registeredProbe.receiveMessage()
 
       val deviceListProbe = createTestProbe[ReplyDeviceList]()
       groupActor ! RequestDeviceList(requestId = 0, groupId = "group", deviceListProbe.ref)
@@ -112,13 +112,13 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", registeredProbe.ref)
-      val deviceActor1 = registeredProbe.receiveOne().device
+      val deviceActor1 = registeredProbe.receiveMessage().device
 
       groupActor ! RequestTrackDevice("group", "device2", registeredProbe.ref)
-      val deviceActor2 = registeredProbe.receiveOne().device
+      val deviceActor2 = registeredProbe.receiveMessage().device
 
       groupActor ! RequestTrackDevice("group", "device3", registeredProbe.ref)
-      registeredProbe.receiveOne()
+      registeredProbe.receiveMessage()
 
       // Check that the device actors are working
       val recordProbe = createTestProbe[TemperatureRecorded]()

--- a/akka-docs/src/test/scala/typed/tutorial_5/DeviceGroupSpec.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_5/DeviceGroupSpec.scala
@@ -21,12 +21,12 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", probe.ref)
-      val registered1 = probe.expectMessageType[DeviceRegistered]
+      val registered1 = probe.receiveOne()
       val deviceActor1 = registered1.device
 
       // another deviceId
       groupActor ! RequestTrackDevice("group", "device2", probe.ref)
-      val registered2 = probe.expectMessageType[DeviceRegistered]
+      val registered2 = probe.receiveOne()
       val deviceActor2 = registered2.device
       deviceActor1 should !==(deviceActor2)
 
@@ -53,11 +53,11 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", probe.ref)
-      val registered1 = probe.expectMessageType[DeviceRegistered]
+      val registered1 = probe.receiveOne()
 
       // registering same again should be idempotent
       groupActor ! RequestTrackDevice("group", "device1", probe.ref)
-      val registered2 = probe.expectMessageType[DeviceRegistered]
+      val registered2 = probe.receiveOne()
 
       registered1.device should ===(registered2.device)
     }
@@ -69,10 +69,10 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", registeredProbe.ref)
-      registeredProbe.expectMessageType[DeviceRegistered]
+      registeredProbe.receiveOne()
 
       groupActor ! RequestTrackDevice("group", "device2", registeredProbe.ref)
-      registeredProbe.expectMessageType[DeviceRegistered]
+      registeredProbe.receiveOne()
 
       val deviceListProbe = createTestProbe[ReplyDeviceList]()
       groupActor ! RequestDeviceList(requestId = 0, groupId = "group", deviceListProbe.ref)
@@ -84,11 +84,11 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", registeredProbe.ref)
-      val registered1 = registeredProbe.expectMessageType[DeviceRegistered]
+      val registered1 = registeredProbe.receiveOne()
       val toShutDown = registered1.device
 
       groupActor ! RequestTrackDevice("group", "device2", registeredProbe.ref)
-      registeredProbe.expectMessageType[DeviceRegistered]
+      registeredProbe.receiveOne()
 
       val deviceListProbe = createTestProbe[ReplyDeviceList]()
       groupActor ! RequestDeviceList(requestId = 0, groupId = "group", deviceListProbe.ref)
@@ -112,13 +112,13 @@ class DeviceGroupSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val groupActor = spawn(DeviceGroup("group"))
 
       groupActor ! RequestTrackDevice("group", "device1", registeredProbe.ref)
-      val deviceActor1 = registeredProbe.expectMessageType[DeviceRegistered].device
+      val deviceActor1 = registeredProbe.receiveOne().device
 
       groupActor ! RequestTrackDevice("group", "device2", registeredProbe.ref)
-      val deviceActor2 = registeredProbe.expectMessageType[DeviceRegistered].device
+      val deviceActor2 = registeredProbe.receiveOne().device
 
       groupActor ! RequestTrackDevice("group", "device3", registeredProbe.ref)
-      registeredProbe.expectMessageType[DeviceRegistered]
+      registeredProbe.receiveOne()
 
       // Check that the device actors are working
       val recordProbe = createTestProbe[TemperatureRecorded]()

--- a/akka-docs/src/test/scala/typed/tutorial_5/DeviceManagerSpec.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_5/DeviceManagerSpec.scala
@@ -17,11 +17,11 @@ class DeviceManagerSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val managerActor = spawn(DeviceManager())
 
       managerActor ! RequestTrackDevice("group1", "device", probe.ref)
-      val registered1 = probe.receiveOne()
+      val registered1 = probe.receiveMessage()
 
       // another group
       managerActor ! RequestTrackDevice("group2", "device", probe.ref)
-      val registered2 = probe.receiveOne()
+      val registered2 = probe.receiveMessage()
 
       registered1.device should !==(registered2.device)
     }

--- a/akka-docs/src/test/scala/typed/tutorial_5/DeviceManagerSpec.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_5/DeviceManagerSpec.scala
@@ -17,11 +17,11 @@ class DeviceManagerSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val managerActor = spawn(DeviceManager())
 
       managerActor ! RequestTrackDevice("group1", "device", probe.ref)
-      val registered1 = probe.expectMessageType[DeviceRegistered]
+      val registered1 = probe.receiveOne()
 
       // another group
       managerActor ! RequestTrackDevice("group2", "device", probe.ref)
-      val registered2 = probe.expectMessageType[DeviceRegistered]
+      val registered2 = probe.receiveOne()
 
       registered1.device should !==(registered2.device)
     }

--- a/akka-docs/src/test/scala/typed/tutorial_5/DeviceSpec.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_5/DeviceSpec.scala
@@ -18,7 +18,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val deviceActor = spawn(Device("group", "device"))
 
       deviceActor ! Device.ReadTemperature(requestId = 42, probe.ref)
-      val response = probe.receiveOne()
+      val response = probe.receiveMessage()
       response.requestId should ===(42)
       response.value should ===(None)
     }
@@ -34,7 +34,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       recordProbe.expectMessage(Device.TemperatureRecorded(requestId = 1))
 
       deviceActor ! Device.ReadTemperature(requestId = 2, readProbe.ref)
-      val response1 = readProbe.receiveOne()
+      val response1 = readProbe.receiveMessage()
       response1.requestId should ===(2)
       response1.value should ===(Some(24.0))
 
@@ -42,7 +42,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       recordProbe.expectMessage(Device.TemperatureRecorded(requestId = 3))
 
       deviceActor ! Device.ReadTemperature(requestId = 4, readProbe.ref)
-      val response2 = readProbe.receiveOne()
+      val response2 = readProbe.receiveMessage()
       response2.requestId should ===(4)
       response2.value should ===(Some(55.0))
     }

--- a/akka-docs/src/test/scala/typed/tutorial_5/DeviceSpec.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_5/DeviceSpec.scala
@@ -18,7 +18,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val deviceActor = spawn(Device("group", "device"))
 
       deviceActor ! Device.ReadTemperature(requestId = 42, probe.ref)
-      val response = probe.expectMessageType[Device.RespondTemperature]
+      val response = probe.receiveOne()
       response.requestId should ===(42)
       response.value should ===(None)
     }
@@ -34,7 +34,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       recordProbe.expectMessage(Device.TemperatureRecorded(requestId = 1))
 
       deviceActor ! Device.ReadTemperature(requestId = 2, readProbe.ref)
-      val response1 = readProbe.expectMessageType[RespondTemperature]
+      val response1 = readProbe.receiveOne()
       response1.requestId should ===(2)
       response1.value should ===(Some(24.0))
 
@@ -42,7 +42,7 @@ class DeviceSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       recordProbe.expectMessage(Device.TemperatureRecorded(requestId = 3))
 
       deviceActor ! Device.ReadTemperature(requestId = 4, readProbe.ref)
-      val response2 = readProbe.expectMessageType[RespondTemperature]
+      val response2 = readProbe.receiveOne()
       response2.requestId should ===(4)
       response2.value should ===(Some(55.0))
     }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
@@ -86,7 +86,7 @@ class ManyRecoveriesSpec extends ScalaTestWithActorTestKit(s"""
 
       latch.countDown()
 
-      forN(100)(_ ⇒ probe.expectMessageType[String]) should
+      forN(100)(_ ⇒ probe.receiveOne()) should
         be(forN(100)(i ⇒ s"a$i-B"))
     }
   }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
@@ -86,7 +86,7 @@ class ManyRecoveriesSpec extends ScalaTestWithActorTestKit(s"""
 
       latch.countDown()
 
-      forN(100)(_ ⇒ probe.receiveOne()) should
+      forN(100)(_ ⇒ probe.receiveMessage()) should
         be(forN(100)(i ⇒ s"a$i-B"))
     }
   }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
@@ -205,7 +205,7 @@ class RecoveryPermitterSpec extends ScalaTestWithActorTestKit(s"""
       p3.expectMessage(Recovered)
       // stop it
       parent ! StopActor
-      val persistentActor = stopProbe.receiveOne()
+      val persistentActor = stopProbe.receiveMessage()
       stopProbe.expectTerminated(persistentActor, 1.second)
 
       requestPermit(p4)

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
@@ -205,7 +205,7 @@ class RecoveryPermitterSpec extends ScalaTestWithActorTestKit(s"""
       p3.expectMessage(Recovered)
       // stop it
       parent ! StopActor
-      val persistentActor = stopProbe.expectMessageType[ActorRef[Command]]
+      val persistentActor = stopProbe.receiveOne()
       stopProbe.expectTerminated(persistentActor, 1.second)
 
       requestPermit(p4)


### PR DESCRIPTION
* when the type is the same as the probe's type

Refs #25914