### PR TITLE
unidoc genjavadoc doesn't work with sbt 1.2.7 yet

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
+# We need to fix javadoc generation to be able to update to 1.2.7, see https://github.com/akka/akka/issues/26100
 sbt.version=1.2.6

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.2.6


### PR DESCRIPTION
* when using JDK 9
* sbt -Dakka.genjavadoc.enabled=true unidoc

@raboof You changed it back in https://github.com/akka/akka/pull/26112 but I don't think CallerSensitive itself is fixing it, at least it doesn't work for me on JDK 9.

The JDK 11 Jenkins job you referred to is not running `sbt -Dakka.genjavadoc.enabled=true unidoc`