### PR TITLE
Cleanup Typed TestProbe implementation

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/TestProbe.scala
@@ -4,14 +4,16 @@
 
 package akka.actor.testkit.typed.scaladsl
 
-import akka.actor.typed.{ ActorRef, ActorSystem }
-import akka.annotation.DoNotInherit
-import akka.actor.testkit.typed.internal.TestProbeImpl
-import akka.actor.testkit.typed.{ FishingOutcome, TestKitSettings }
-
+import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
-import scala.collection.immutable
+
+import akka.actor.testkit.typed.FishingOutcome
+import akka.actor.testkit.typed.TestKitSettings
+import akka.actor.testkit.typed.internal.TestProbeImpl
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.annotation.DoNotInherit
 
 object FishingOutcomes {
   /**
@@ -84,8 +86,8 @@ object TestProbe {
    * take maximum wait times are available in a version which implicitly uses
    * the remaining time governed by the innermost enclosing `within` block.
    *
-   * Note that the timeout is scaled using Duration.dilated, which uses the
-   * configuration entry "akka.actor.testkit.typed.timefactor", while the min Duration is not.
+   * Note that the max timeout is scaled using the configuration entry "akka.actor.testkit.typed.timefactor",
+   * while the min Duration is not.
    *
    * {{{
    * val ret = within(50 millis) {
@@ -94,15 +96,12 @@ object TestProbe {
    * }
    * }}}
    */
-  def within[T](min: FiniteDuration, max: FiniteDuration)(f: ⇒ T): T =
-    within_internal(min, max, f)
+  def within[T](min: FiniteDuration, max: FiniteDuration)(f: ⇒ T): T
+
   /**
    * Same as calling `within(0 seconds, max)(f)`.
    */
-  def within[T](max: FiniteDuration)(f: ⇒ T): T =
-    within_internal(Duration.Zero, max, f)
-
-  protected def within_internal[T](min: FiniteDuration, max: FiniteDuration, f: ⇒ T): T
+  def within[T](max: FiniteDuration)(f: ⇒ T): T
 
   /**
    * Same as `expectMessage(remainingOrDefault, obj)`, but using the default timeout as deadline.
@@ -134,24 +133,20 @@ object TestProbe {
   def expectNoMessage(max: FiniteDuration): Unit
 
   /**
-   * Assert that no message is received. Waits for the default period configured as `akka.actor.testkit.typed.expect-no-message-default`
-   * That value is dilated.
+   * Assert that no message is received. Waits for the default period configured as `akka.actor.testkit.typed.expect-no-message-default`.
+   * That timeout is scaled using the configuration entry "akka.actor.testkit.typed.timefactor".
    */
   def expectNoMessage(): Unit
 
   /**
    * Same as `expectMessageType[T](remainingOrDefault)`, but using the default timeout as deadline.
    */
-  def expectMessageType[T <: M](implicit t: ClassTag[T]): T =
-    expectMessageClass_internal(remainingOrDefault, t.runtimeClass.asInstanceOf[Class[T]])
+  def expectMessageType[T <: M](implicit t: ClassTag[T]): T
 
   /**
    * Expect a message of type T to arrive within `max` or fail. `max` is dilated.
    */
-  def expectMessageType[T <: M](max: FiniteDuration)(implicit t: ClassTag[T]): T =
-    expectMessageClass_internal(max.dilated, t.runtimeClass.asInstanceOf[Class[T]])
-
-  protected def expectMessageClass_internal[C](max: FiniteDuration, c: Class[C]): C
+  def expectMessageType[T <: M](max: FiniteDuration)(implicit t: ClassTag[T]): T
 
   /**
    * Receive one message of type `M` within the default timeout as deadline.
@@ -167,14 +162,14 @@ object TestProbe {
   /**
    * Same as `receiveN(n, remaining)` but using the default timeout as deadline.
    */
-  def receiveN(n: Int): immutable.Seq[M] = receiveN_internal(n, remainingOrDefault)
+  def receiveN(n: Int): immutable.Seq[M]
 
   /**
    * Receive `n` messages in a row before the given deadline.
+   *
+   * Note that the timeout is scaled using the configuration entry "akka.actor.testkit.typed.timefactor".
    */
-  def receiveN(n: Int, max: FiniteDuration): immutable.Seq[M] = receiveN_internal(n, max.dilated)
-
-  protected def receiveN_internal(n: Int, max: FiniteDuration): immutable.Seq[M]
+  def receiveN(n: Int, max: FiniteDuration): immutable.Seq[M]
 
   /**
    * Allows for flexible matching of multiple messages within a timeout, the fisher function is fed each incoming
@@ -190,20 +185,16 @@ object TestProbe {
    * is decorated with some fishing details and the test is failed (making it convenient to use this method with a
    * partial function).
    *
-   * @param max Max total time without the fisher function returning `CompleteFishing` before failing
-   *            The timeout is dilated.
+   * @param max Max total time without the fisher function returning `CompleteFishing` before failing.
+   *            The timeout is scaled using the configuration entry "akka.actor.testkit.typed.timefactor".
    * @return The messages accepted in the order they arrived
    */
-  def fishForMessage(max: FiniteDuration, hint: String)(fisher: M ⇒ FishingOutcome): immutable.Seq[M] =
-    fishForMessage_internal(max, hint, fisher)
+  def fishForMessage(max: FiniteDuration, hint: String)(fisher: M ⇒ FishingOutcome): immutable.Seq[M]
 
   /**
    * Same as the other `fishForMessage` but with no hint
    */
-  def fishForMessage(max: FiniteDuration)(fisher: M ⇒ FishingOutcome): immutable.Seq[M] =
-    fishForMessage(max, "")(fisher)
-
-  protected def fishForMessage_internal(max: FiniteDuration, hint: String, fisher: M ⇒ FishingOutcome): immutable.Seq[M]
+  def fishForMessage(max: FiniteDuration)(fisher: M ⇒ FishingOutcome): immutable.Seq[M]
 
   /**
    * Expect the given actor to be stopped or stop within the given timeout or
@@ -212,18 +203,35 @@ object TestProbe {
   def expectTerminated[U](actorRef: ActorRef[U], max: FiniteDuration): Unit
 
   /**
+   * Expect the given actor to be stopped or stop within the default timeout.
+   */
+  def expectTerminated[U](actorRef: ActorRef[U]): Unit
+
+  /**
    * Evaluate the given assert every `interval` until it does not throw an exception and return the
    * result.
    *
    * If the `max` timeout expires the last exception is thrown.
    *
-   * If no timeout is given, take it from the innermost enclosing `within`
-   * block.
-   *
-   * Note that the timeout is scaled using Duration.dilated,
-   * which uses the configuration entry "akka.test.timefactor".
+   * Note that the timeout is scaled using the configuration entry "akka.actor.testkit.typed.timefactor".
    */
-  def awaitAssert[A](a: ⇒ A, max: Duration = Duration.Undefined, interval: Duration = 100.millis): A
+  def awaitAssert[A](a: ⇒ A, max: FiniteDuration, interval: FiniteDuration): A
+
+  /**
+   * Evaluate the given assert every 100 ms until it does not throw an exception and return the
+   * result.
+   *
+   * If the `max` timeout expires the last exception is thrown.
+   */
+  def awaitAssert[A](a: ⇒ A, max: FiniteDuration): A
+
+  /**
+   * Evaluate the given assert every 100 ms until it does not throw an exception and return the
+   * result.
+   *
+   * If the default timeout expires the last exception is thrown.
+   */
+  def awaitAssert[A](a: ⇒ A): A
 
   /**
    * Stops the [[TestProbe.ref]], which is useful when testing watch and termination.

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/package.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/package.scala
@@ -10,7 +10,7 @@ package object scaladsl {
 
   /**
    * Scala API. Scale timeouts (durations) during tests with the configured
-   * 'akka.test.timefactor'.
+   * 'akka.actor.testkit.typed.timefactor'.
    * Implicit class providing `dilated` method.
    *
    * {{{


### PR DESCRIPTION
* use a consistent api/impl technique
* _internal methods are not dilating
* add expectTerminated with default timeout
* FiniteDuration in awaitAssert

My original intention was only to add the missing expectTerminated overload but...