### PR TITLE
don't show receiveSignal from ExtensibleBehavior in Receive

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
@@ -36,7 +36,7 @@ import akka.actor.typed.scaladsl.{ ActorContext ⇒ SAC }
  */
 @ApiMayChange
 @DoNotInherit
-sealed abstract class Behavior[T] { behavior ⇒
+abstract class Behavior[T] { behavior ⇒
   /**
    * Narrow the type of this Behavior, which is always a safe operation. This
    * method is necessary to implement the contravariant nature of Behavior

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
@@ -253,7 +253,7 @@ object Behaviors {
    * signal reception behavior. It's returned by for example [[Behaviors.receiveMessage]].
    */
   @DoNotInherit
-  trait Receive[T] extends ExtensibleBehavior[T] {
+  trait Receive[T] extends Behavior[T] {
     def receiveSignal(onSignal: PartialFunction[(ActorContext[T], Signal), Behavior[T]]): Behavior[T]
   }
 


### PR DESCRIPTION
The intended API is `Behaviors.receiveMessage(...).receiveSignal { case ... }`
but in code completion of the `Receive` two `receiveSignal` shows up, the one
from ExtensibleBehavior is confusing.

Removing sealed form Behavior isn't so nice, but what else can we do?