### PR TITLE
added example for cycle operator

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/Source/cycle.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/cycle.md
@@ -28,3 +28,20 @@ terminated with an exception.
 
 @@@
 
+
+## Examples
+
+Scala
+:  @@snip [cycle.scala](/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala) { #cycle }
+
+Java
+:  @@snip [cycle.java](/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java) { #cycle }
+
+
+When iterator is empty the stream will be terminated with _IllegalArgumentException_
+
+Scala
+:  @@snip [cycleError.scala](/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala) { #cycle-error }
+
+Java
+:  @@snip [cycle.java](/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java) { #cycle-error }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
@@ -330,12 +330,23 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
 
     "continuously generate the same sequence" in {
       val expected = Seq(1, 2, 3, 1, 2, 3, 1, 2, 3)
-      Source.cycle(() ⇒ List(1, 2, 3).iterator).grouped(9).runWith(Sink.head).futureValue should ===(expected)
+      //#cycle
+      Source.cycle(() ⇒ List(1, 2, 3).iterator)
+        .grouped(9)
+        .runWith(Sink.head)
+        // This will produce the Seq(1, 2, 3, 1, 2, 3, 1, 2, 3)
+        //#cycle
+        .futureValue should ===(expected)
     }
 
     "throw an exception in case of empty iterator" in {
+      //#cycle-error
       val empty = Iterator.empty
-      assert(Source.cycle(() ⇒ empty).runWith(Sink.head).failed.futureValue.isInstanceOf[IllegalArgumentException])
+      Source.cycle(() ⇒ empty)
+        .runWith(Sink.head)
+        // This will return a failed future with an `IllegalArgumentException`
+        //#cycle-error
+        .failed.futureValue shouldBe an[IllegalArgumentException]
     }
   }
 


### PR DESCRIPTION
25468: added examples for `Stream # cycle` operator.