### PR TITLE
26160: added `Source.empty` in Java API

### DIFF
--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java
@@ -771,6 +771,14 @@ public class SourceTest extends StreamTest {
   }
 
   @Test
+  public void createEmptySource() throws Exception {
+      List<Integer> actual = Source.empty(Integer.class)
+              .runWith(Sink.seq(), materializer)
+              .toCompletableFuture().get();
+      assertThat(actual, is(Collections.emptyList()));
+  }
+
+  @Test
   public void cycleSourceMustGenerateSameSequenceInRepeatedFashion() throws Exception {
     //#cycle
     final Source<Integer, NotUsed> source = Source.cycle(() -> Arrays.asList(1, 2, 3).iterator());
@@ -781,7 +789,7 @@ public class SourceTest extends StreamTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void cycleSourceMustThr() throws Throwable {
+  public void cycleSourceMustThrow() throws Throwable {
 
     try {
       //#cycle-error

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -41,6 +41,11 @@ object Source {
   def empty[O](): Source[O, NotUsed] = _empty.asInstanceOf[Source[O, NotUsed]]
 
   /**
+   * Create a `Source` with no elements. The result is the same as calling `Source.<O>empty()`
+   */
+  def empty[T](clazz: Class[T]): Source[T, NotUsed] = empty[T]()
+
+  /**
    * Create a `Source` which materializes a [[java.util.concurrent.CompletableFuture]] which controls what element
    * will be emitted by the Source.
    * If the materialized promise is completed with a filled Optional, that value will be produced downstream,


### PR DESCRIPTION
added `Source.empty` which take Class as a parameter and produce empty source (in Java API)