### PR TITLE
Give `expectMsg` some more time in CoordinatedShutdownShardingSpec

### DIFF
--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/CoordinatedShutdownShardingSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/CoordinatedShutdownShardingSpec.scala
@@ -81,7 +81,7 @@ class CoordinatedShutdownShardingSpec extends AkkaSpec(CoordinatedShutdownShardi
       sys1.log.warning(s"Pinging entities... ping $i msg 1")
       val p1 = TestProbe()(sys2)
       region2.tell(1, p1.ref)
-      p1.expectMsg(1.seconds, 1)
+      p1.expectMsg(1)
       sys1.log.warning(s"Pinging entities... ping $i msg 2")
       val p2 = TestProbe()(sys2)
       region2.tell(2, p2.ref)

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/CoordinatedShutdownShardingSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/CoordinatedShutdownShardingSpec.scala
@@ -73,25 +73,17 @@ class CoordinatedShutdownShardingSpec extends AkkaSpec(CoordinatedShutdownShardi
 
   // Using region 2 as it is not shutdown in either test
   def pingEntities(): Unit = {
-    sys1.log.warning("Pinging entities...")
-    var i = 0
     awaitAssert({
-      i += 1
-
-      sys1.log.warning(s"Pinging entities... ping $i msg 1")
       val p1 = TestProbe()(sys2)
       region2.tell(1, p1.ref)
       p1.expectMsg(1)
-      sys1.log.warning(s"Pinging entities... ping $i msg 2")
       val p2 = TestProbe()(sys2)
       region2.tell(2, p2.ref)
-      p2.expectMsg(1.seconds, 2)
-      sys1.log.warning(s"Pinging entities... ping $i msg 3")
+      p2.expectMsg(2)
       val p3 = TestProbe()(sys2)
       region2.tell(3, p3.ref)
-      p3.expectMsg(1.seconds, 3)
+      p3.expectMsg(3)
     }, 20.seconds)
-    sys1.log.warning("Successfully pinged entities")
   }
 
   "Sharding and CoordinatedShutdown" must {

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/CoordinatedShutdownShardingSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/CoordinatedShutdownShardingSpec.scala
@@ -20,7 +20,10 @@ import akka.testkit.WithLogCapturing
 object CoordinatedShutdownShardingSpec {
   val config =
     """
-    akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+    // at least while resolving #26214
+    akka.loglevel = DEBUG
+    akka.loggers = ["akka.testkit.TestEventListener"]
+
     akka.actor.provider = "cluster"
     akka.remote.netty.tcp.port = 0
     akka.remote.artery.canonical.port = 0
@@ -75,12 +78,15 @@ class CoordinatedShutdownShardingSpec extends AkkaSpec(CoordinatedShutdownShardi
   def pingEntities(): Unit = {
     awaitAssert({
       val p1 = TestProbe()(sys2)
+      log.debug(s"Sending 1 to ${p1.ref.path}")
       region2.tell(1, p1.ref)
       p1.expectMsg(1)
       val p2 = TestProbe()(sys2)
+      log.debug(s"Sending 2 to ${p2.ref.path}")
       region2.tell(2, p2.ref)
       p2.expectMsg(2)
       val p3 = TestProbe()(sys2)
+      log.debug(s"Sending 3 to ${p3.ref.path}")
       region2.tell(3, p3.ref)
       p3.expectMsg(3)
     }, 20.seconds)

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/CoordinatedShutdownShardingSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/CoordinatedShutdownShardingSpec.scala
@@ -73,17 +73,25 @@ class CoordinatedShutdownShardingSpec extends AkkaSpec(CoordinatedShutdownShardi
 
   // Using region 2 as it is not shutdown in either test
   def pingEntities(): Unit = {
+    sys1.log.warning("Pinging entities...")
+    var i = 0
     awaitAssert({
+      i += 1
+
+      sys1.log.warning(s"Pinging entities... ping $i msg 1")
       val p1 = TestProbe()(sys2)
       region2.tell(1, p1.ref)
       p1.expectMsg(1.seconds, 1)
+      sys1.log.warning(s"Pinging entities... ping $i msg 2")
       val p2 = TestProbe()(sys2)
       region2.tell(2, p2.ref)
       p2.expectMsg(1.seconds, 2)
+      sys1.log.warning(s"Pinging entities... ping $i msg 3")
       val p3 = TestProbe()(sys2)
       region2.tell(3, p3.ref)
       p3.expectMsg(1.seconds, 3)
     }, 20.seconds)
+    sys1.log.warning("Successfully pinged entities")
   }
 
   "Sharding and CoordinatedShutdown" must {

--- a/akka-testkit/src/main/scala/akka/testkit/TestActors.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestActors.scala
@@ -4,7 +4,7 @@
 
 package akka.testkit
 
-import akka.actor.{ Props, Actor, ActorRef }
+import akka.actor.{ Actor, ActorLogging, ActorRef, Props }
 
 /**
  * A collection of common actor patterns used in tests.
@@ -14,9 +14,13 @@ object TestActors {
   /**
    * EchoActor sends back received messages (unmodified).
    */
-  class EchoActor extends Actor {
+  class EchoActor extends Actor with ActorLogging {
+    log.debug("Echo actor starting at [{}]", self.path)
+
     override def receive = {
-      case message ⇒ sender() ! message
+      case message ⇒
+        log.debug("Echo actor at [{}] echo'ing [{}]", self.path, message)
+        sender() ! message
     }
   }
 


### PR DESCRIPTION
The 1-second deadline was missed on jenkins, https://jenkins.akka.io:8498/blue/rest/organizations/jenkins/pipelines/akka-nightly/runs/6161/log/?start=0

Refs #26214