### PR TITLE
Remove duplicate code in Cluster Sharding Typed HashCode*MessageExtractor [#26197]

### DIFF
--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ShardingMessageExtractor.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ShardingMessageExtractor.scala
@@ -4,6 +4,9 @@
 
 package akka.cluster.sharding.typed
 
+import akka.annotation.InternalApi
+import akka.cluster.sharding.ShardRegion.HashCodeMessageExtractor
+
 object ShardingMessageExtractor {
 
   /**
@@ -27,7 +30,6 @@ object ShardingMessageExtractor {
     new HashCodeNoEnvelopeMessageExtractor[M](numberOfShards) {
       def entityId(message: M) = extractEntityId(message)
     }
-
 }
 
 /**
@@ -75,7 +77,7 @@ final class HashCodeMessageExtractor[M](
   extends ShardingMessageExtractor[ShardingEnvelope[M], M] {
 
   override def entityId(envelope: ShardingEnvelope[M]): String = envelope.entityId
-  override def shardId(entityId: String): String = math.abs(entityId.hashCode % numberOfShards).toString
+  override def shardId(entityId: String): String = HashCodeMessageExtractor.shardId(entityId, numberOfShards)
   override def unwrapMessage(envelope: ShardingEnvelope[M]): M = envelope.message
 }
 
@@ -91,7 +93,7 @@ abstract class HashCodeNoEnvelopeMessageExtractor[M](
   val numberOfShards: Int)
   extends ShardingMessageExtractor[M, M] {
 
-  override def shardId(entityId: String): String = math.abs(entityId.hashCode % numberOfShards).toString
+  override def shardId(entityId: String): String = HashCodeMessageExtractor.shardId(entityId, numberOfShards)
   override final def unwrapMessage(message: M): M = message
 
   override def toString = s"HashCodeNoEnvelopeMessageExtractor($numberOfShards)"

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -123,11 +123,11 @@ object ShardRegion {
 
     /** INTERNAL API */
     @InternalApi
-    private[sharding] def shardId(entityId: String, numberOfShards: Int): String = {
+    private[sharding] def shardId(id: String, maxNumberOfShards: Int): String = {
       // It would be better to have abs(id.hashCode % maxNumberOfShards), see issue #25034
       // but to avoid getting different values when rolling upgrade we keep the old way,
       // and it doesn't have any serious consequences
-      math.abs(entityId.hashCode % numberOfShards).toString
+      (math.abs(id.hashCode) % maxNumberOfShards).toString
     }
   }
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -123,8 +123,12 @@ object ShardRegion {
 
     /** INTERNAL API */
     @InternalApi
-    private[sharding] def shardId(entityId: String, numberOfShards: Int): String =
+    private[sharding] def shardId(entityId: String, numberOfShards: Int): String = {
+      // It would be better to have abs(id.hashCode % maxNumberOfShards), see issue #25034
+      // but to avoid getting different values when rolling upgrade we keep the old way,
+      // and it doesn't have any serious consequences
       math.abs(entityId.hashCode % numberOfShards).toString
+    }
   }
 
   /**
@@ -143,9 +147,6 @@ object ShardRegion {
         case ShardRegion.StartEntity(entityId) ⇒ entityId
         case _                                 ⇒ entityId(message)
       }
-      // It would be better to have abs(id.hashCode % maxNumberOfShards), see issue #25034
-      // but to avoid getting different values when rolling upgrade we keep the old way,
-      // and it doesn't have any serious consequences
       HashCodeMessageExtractor.shardId(id, maxNumberOfShards)
     }
   }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -21,6 +21,7 @@ import scala.concurrent.Future
 import scala.reflect.ClassTag
 import scala.concurrent.Promise
 import akka.Done
+import akka.annotation.InternalApi
 import akka.cluster.ClusterSettings
 import akka.cluster.ClusterSettings.DataCenter
 
@@ -118,6 +119,14 @@ object ShardRegion {
     def shardId(message: Any): String
   }
 
+  object HashCodeMessageExtractor {
+
+    /** INTERNAL API */
+    @InternalApi
+    private[sharding] def shardId(entityId: String, numberOfShards: Int): String =
+      math.abs(entityId.hashCode % numberOfShards).toString
+  }
+
   /**
    * Convenience implementation of [[ShardRegion.MessageExtractor]] that
    * construct `shardId` based on the `hashCode` of the `entityId`. The number
@@ -131,13 +140,13 @@ object ShardRegion {
 
     override def shardId(message: Any): String = {
       val id = message match {
-        case ShardRegion.StartEntity(id) ⇒ id
-        case _                           ⇒ entityId(message)
+        case ShardRegion.StartEntity(entityId) ⇒ entityId
+        case _                                 ⇒ entityId(message)
       }
       // It would be better to have abs(id.hashCode % maxNumberOfShards), see issue #25034
       // but to avoid getting different values when rolling upgrade we keep the old way,
       // and it doesn't have any serious consequences
-      (math.abs(id.hashCode) % maxNumberOfShards).toString
+      HashCodeMessageExtractor.shardId(id, maxNumberOfShards)
     }
   }
 


### PR DESCRIPTION
[#26197](https://github.com/akka/akka/issues/26197)

This hash and number of shards function is duplicated in three places between sharding and typed sharding.