### PR TITLE
Updates header for `akka.compat.Future`

### DIFF
--- a/akka-actor/src/main/scala-2.11/akka/compat/Future.scala
+++ b/akka-actor/src/main/scala-2.11/akka/compat/Future.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.compat


### PR DESCRIPTION
This is only visible when explicitly building for Scala 2.11.x. 

Better to get it integrated so it doesn't get added in unrelated PRs.