### PR TITLE
Artery tests: use config to determine TCP/UDP free port + use the correct host

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeRetrySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeRetrySpec.scala
@@ -13,10 +13,6 @@ import akka.testkit.TestActors
 import com.typesafe.config.ConfigFactory
 
 object HandshakeRetrySpec {
-
-  // need the port before systemB is started
-  val portB = SocketUtil.temporaryLocalPort(udp = true)
-
   val commonConfig = ConfigFactory.parseString(s"""
      akka.remote.artery.advanced.handshake-timeout = 10s
      akka.remote.artery.advanced.image-liveness-timeout = 7s
@@ -25,14 +21,15 @@ object HandshakeRetrySpec {
 }
 
 class HandshakeRetrySpec extends ArteryMultiNodeSpec(HandshakeRetrySpec.commonConfig) with ImplicitSender {
-  import HandshakeRetrySpec._
+
+  val portB = freePort()
 
   "Artery handshake" must {
 
     "be retried during handshake-timeout (no message loss)" in {
       def sel = system.actorSelection(s"akka://systemB@localhost:$portB/user/echo")
       sel ! "hello"
-      expectNoMsg(1.second)
+      expectNoMessage(1.second)
 
       val systemB = newRemoteSystem(
         name = Some("systemB"),

--- a/akka-remote/src/test/scala/akka/remote/artery/LateConnectSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/LateConnectSpec.scala
@@ -25,7 +25,7 @@ object LateConnectSpec {
 
 class LateConnectSpec extends ArteryMultiNodeSpec(LateConnectSpec.config) with ImplicitSender {
 
-  val portB = SocketUtil.temporaryLocalPort(udp = true)
+  val portB = freePort()
   lazy val systemB = newRemoteSystem(
     name = Some("systemB"),
     extraConfig = Some(s"akka.remote.artery.canonical.port = $portB"))

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteActorSelectionSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteActorSelectionSpec.scala
@@ -5,7 +5,7 @@
 package akka.remote.artery
 
 import akka.actor.{ Actor, ActorIdentity, ActorLogging, ActorRef, ActorRefScope, ActorSelection, Identify, PoisonPill, Props, Terminated }
-import akka.testkit.{ ImplicitSender, SocketUtil, TestActors }
+import akka.testkit.{ ImplicitSender, TestActors }
 
 import scala.concurrent.duration._
 import akka.testkit.JavaSerializable
@@ -37,10 +37,10 @@ class RemoteActorSelectionSpec extends ArteryMultiNodeSpec with ImplicitSender {
     // TODO fails with not receiving the localGrandchild value, seems to go to dead letters
     "select actors across node boundaries" ignore {
 
-      val remotePort = SocketUtil.temporaryLocalPort(udp = true)
+      val remotePort = freePort()
       val remoteSysName = "remote-" + system.name
 
-      val localPort = SocketUtil.temporaryLocalPort(udp = true)
+      val localPort = freePort()
       val localSysName = "local-" + system.name
 
       def config(port: Int) =
@@ -58,7 +58,7 @@ class RemoteActorSelectionSpec extends ArteryMultiNodeSpec with ImplicitSender {
         extraConfig = Some(config(localPort)),
         name = Some(localSysName))
 
-      val remoteSystem = newRemoteSystem(
+      newRemoteSystem(
         extraConfig = Some(config(remotePort)),
         name = Some(remoteSysName))
 
@@ -149,9 +149,9 @@ class RemoteActorSelectionSpec extends ArteryMultiNodeSpec with ImplicitSender {
       child2 ! 55
       expectMsg(55)
       // msg to old ActorRef (different uid) should not get through
-      child2.path.uid should not be (remoteChild.path.uid)
+      child2.path.uid should not be remoteChild.path.uid
       remoteChild ! 56
-      expectNoMsg(1.second)
+      expectNoMessage(1.second)
       localSystem.actorSelection(localSystem / "looker2" / "child") ! 57
       expectMsg(57)
     }

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteConnectionSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteConnectionSpec.scala
@@ -30,13 +30,13 @@ class RemoteConnectionSpec extends ArteryMultiNodeSpec("akka.remote.retry-gate-c
       // try to talk to it before it is up
       val selection = localSystem.actorSelection(s"akka://$nextGeneratedSystemName@localhost:$remotePort/user/echo")
       selection.tell("ping", localProbe.ref)
-      localProbe.expectNoMsg(1.seconds)
+      localProbe.expectNoMessage(1.seconds)
 
       // then start the remote system and try again
       val remoteSystem = newRemoteSystem(extraConfig = Some(s"akka.remote.artery.canonical.port=$remotePort"))
 
       muteSystem(remoteSystem)
-      localProbe.expectNoMsg(2.seconds)
+      localProbe.expectNoMessage(2.seconds)
       remoteSystem.actorOf(TestActors.echoActorProps, "echo")
 
       within(5.seconds) {
@@ -51,23 +51,24 @@ class RemoteConnectionSpec extends ArteryMultiNodeSpec("akka.remote.retry-gate-c
       val localSystem = newRemoteSystem()
 
       val localPort = port(localSystem)
+      val localHost = address(localSystem).host.get
       muteSystem(localSystem)
 
       val localProbe = new TestProbe(localSystem)
       localSystem.actorOf(TestActors.echoActorProps, "echo")
 
-      val remotePort = temporaryServerAddress(udp = true).getPort
+      val remotePort = temporaryServerAddress(localHost, udp = true).getPort
 
       // try to talk to remote before it is up
       val selection = localSystem.actorSelection(s"akka://$nextGeneratedSystemName@localhost:$remotePort/user/echo")
       selection.tell("ping", localProbe.ref)
-      localProbe.expectNoMsg(1.seconds)
+      localProbe.expectNoMessage(1.seconds)
 
       // then when it is up, talk from other system
       val remoteSystem = newRemoteSystem(extraConfig = Some(s"akka.remote.artery.canonical.port=$remotePort"))
 
       muteSystem(remoteSystem)
-      localProbe.expectNoMsg(2.seconds)
+      localProbe.expectNoMessage(2.seconds)
       val otherProbe = new TestProbe(remoteSystem)
       val otherSender = otherProbe.ref
       val thisSelection = remoteSystem.actorSelection(s"akka://${localSystem.name}@localhost:$localPort/user/echo")

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteConnectionSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteConnectionSpec.scala
@@ -5,7 +5,6 @@
 package akka.remote.artery
 
 import akka.actor.ActorSystem
-import akka.testkit.SocketUtil._
 import akka.testkit.{ EventFilter, ImplicitSender, TestActors, TestEvent, TestProbe }
 
 import scala.concurrent.duration._
@@ -25,7 +24,7 @@ class RemoteConnectionSpec extends ArteryMultiNodeSpec("akka.remote.retry-gate-c
       muteSystem(localSystem)
       val localProbe = new TestProbe(localSystem)
 
-      val remotePort = temporaryLocalPort(udp = true)
+      val remotePort = freePort()
 
       // try to talk to it before it is up
       val selection = localSystem.actorSelection(s"akka://$nextGeneratedSystemName@localhost:$remotePort/user/echo")
@@ -51,13 +50,12 @@ class RemoteConnectionSpec extends ArteryMultiNodeSpec("akka.remote.retry-gate-c
       val localSystem = newRemoteSystem()
 
       val localPort = port(localSystem)
-      val localHost = address(localSystem).host.get
       muteSystem(localSystem)
 
       val localProbe = new TestProbe(localSystem)
       localSystem.actorOf(TestActors.echoActorProps, "echo")
 
-      val remotePort = temporaryServerAddress(localHost, udp = true).getPort
+      val remotePort = freePort()
 
       // try to talk to remote before it is up
       val selection = localSystem.actorSelection(s"akka://$nextGeneratedSystemName@localhost:$remotePort/user/echo")

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteDeathWatchSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteDeathWatchSpec.scala
@@ -14,7 +14,7 @@ import akka.remote.QuarantinedEvent
 import akka.remote.RARP
 
 object RemoteDeathWatchSpec {
-  val otherPort = SocketUtil.temporaryLocalPort(udp = true)
+  val otherPort = ArteryMultiNodeSpec.freePort(ConfigFactory.load())
 
   val config = ConfigFactory.parseString(s"""
     akka {

--- a/akka-remote/src/test/scala/akka/remote/artery/compress/HandshakeShouldDropCompressionTableSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/compress/HandshakeShouldDropCompressionTableSpec.scala
@@ -18,9 +18,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 object HandshakeShouldDropCompressionTableSpec {
-  // need the port before systemB is started
-  val portB = SocketUtil.temporaryLocalPort(udp = true)
-
   val commonConfig = ConfigFactory.parseString(s"""
      akka {
        remote.artery.advanced.handshake-timeout = 10s
@@ -39,10 +36,10 @@ object HandshakeShouldDropCompressionTableSpec {
 
 class HandshakeShouldDropCompressionTableSpec extends ArteryMultiNodeSpec(HandshakeShouldDropCompressionTableSpec.commonConfig)
   with ImplicitSender with BeforeAndAfter {
-  import HandshakeShouldDropCompressionTableSpec._
 
   implicit val t = Timeout(3.seconds)
   var systemB: ActorSystem = null
+  val portB = freePort()
 
   before {
     systemB = newRemoteSystem(

--- a/akka-testkit/src/test/scala/akka/testkit/WithLogCapturing.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/WithLogCapturing.scala
@@ -65,19 +65,19 @@ trait WithLogCapturing extends SuiteMixin { this: TestSuite ⇒
 }
 
 /**
- * An adaption of TestEventListener that never prints debug logs itself. Use together with [[akka.http.impl.util.WithLogCapturing]].
+ * An adaption of TestEventListener that never prints debug logs itself. Use together with [[akka.testkit.WithLogCapturing]].
  * It allows to enable noisy DEBUG logging for tests and silence pre/post test DEBUG output completely while still showing
  * test-specific DEBUG output selectively
  */
 class DebugLogSilencingTestEventListener extends TestEventListener {
   override def print(event: Any): Unit = event match {
-    case d: Debug ⇒ // ignore
+    case _: Debug ⇒ // ignore
     case _        ⇒ super.print(event)
   }
 }
 
 /**
- * An adaption of TestEventListener that does not print out any logs. Use together with [[akka.http.impl.util.WithLogCapturing]].
+ * An adaption of TestEventListener that does not print out any logs. Use together with [[akka.testkit.WithLogCapturing]].
  * It allows to enable noisy logging for tests and silence pre/post test log output completely while still showing
  * test-specific log output selectively on failures.
  */


### PR DESCRIPTION
* Select a free port on the same interface for the second actor system
rather than the random one

Fixes #26130