### PR TITLE
Update to sbt 1.2.8 (adding --ignore-source-errors for javadoc)

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -238,7 +238,7 @@ object AkkaBuild {
   lazy val docLintingSettings = Seq(
     javacOptions in compile ++= Seq("-Xdoclint:none"),
     javacOptions in test ++= Seq("-Xdoclint:none"),
-    javacOptions in doc ++= Seq("-Xdoclint:none"))
+    javacOptions in doc ++= Seq("-Xdoclint:none", "--ignore-source-errors"))
 
   def loadSystemProperties(fileName: String): Unit = {
     import scala.collection.JavaConverters._

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -115,7 +115,7 @@ object UnidocRoot extends AutoPlugin {
       .getOrElse(sbtunidoc.ScalaUnidocPlugin)
 
   val akkaSettings = UnidocRoot.CliOptions.genjavadocEnabled.ifTrue(
-    Seq(javacOptions in (JavaUnidoc, unidoc) := Seq("-Xdoclint:none", "--ignore-source-errors"))).getOrElse(Nil)
+    Seq(javacOptions in (JavaUnidoc, unidoc) := Seq("-Xdoclint:none", "--frames", "--ignore-source-errors"))).getOrElse(Nil)
 
   override lazy val projectSettings = {
     def unidocRootProjectFilter(ignoreProjects: Seq[ProjectReference]): ProjectFilter = 

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -115,7 +115,7 @@ object UnidocRoot extends AutoPlugin {
       .getOrElse(sbtunidoc.ScalaUnidocPlugin)
 
   val akkaSettings = UnidocRoot.CliOptions.genjavadocEnabled.ifTrue(
-    Seq(javacOptions in (JavaUnidoc, unidoc) := Seq("-Xdoclint:none"))).getOrElse(Nil)
+    Seq(javacOptions in (JavaUnidoc, unidoc) := Seq("-Xdoclint:none", "--ignore-source-errors"))).getOrElse(Nil)
 
   override lazy val projectSettings = {
     def unidocRootProjectFilter(ignoreProjects: Seq[ProjectReference]): ProjectFilter = 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 # We need to fix javadoc generation to be able to update to 1.2.7, see https://github.com/akka/akka/issues/26100
-sbt.version=1.2.6
+sbt.version=1.2.8


### PR DESCRIPTION
`--ignore-source-errors` makes 'sbt -Dakka.genjavadoc.enabled=true clean unidoc' ignore source errors.

The genjavadoc-generated code in `akka.stream.scaladsl.GraphDSL.Implicits.ReversePortsOps` in `scaladsl/GraphDSL.java` seems to be problematic, but since this is scaladsl anyway it seems reasonable to just exclude it from the javadoc.

Refs #26057, #26100