### PR TITLE
Fix compiler warnings in akka-cluster* #26087

### DIFF
--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/internal/ReplicatorBehavior.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/internal/ReplicatorBehavior.scala
@@ -183,7 +183,7 @@ import akka.actor.typed.Terminated
           }
         }
           .receiveSignal {
-            case (ctx, Terminated(ref: ActorRef[JReplicator.Changed[ReplicatedData]] @unchecked)) ⇒
+            case (_, Terminated(ref: ActorRef[JReplicator.Changed[ReplicatedData]] @unchecked)) ⇒
               stopSubscribeAdapter(ref)
           }
       }

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/DistributedData.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/DistributedData.scala
@@ -11,7 +11,6 @@ import akka.actor.typed.ActorRef
 import akka.actor.ExtendedActorSystem
 import akka.actor.typed.Props
 import akka.cluster.{ ddata ⇒ dd }
-import akka.cluster.typed.{ Cluster ⇒ ClusterT }
 import akka.cluster.ddata.SelfUniqueAddress
 
 object DistributedData extends ExtensionId[DistributedData] {

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/AdaptedClusterImpl.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/AdaptedClusterImpl.scala
@@ -104,7 +104,7 @@ private[akka] object AdapterClusterImpl {
     }.narrow[ClusterStateSubscription]
   }
 
-  private def managerBehavior(adaptedCluster: akka.cluster.Cluster) = Behaviors.receive[ClusterCommand]((ctx, msg) ⇒
+  private def managerBehavior(adaptedCluster: akka.cluster.Cluster) = Behaviors.receive[ClusterCommand]((_, msg) ⇒
     msg match {
       case Join(address) ⇒
         adaptedCluster.join(address)

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
@@ -302,7 +302,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
           }
       }
 
-      Behaviors.receive[Command] { (ctx, msg) ⇒
+      Behaviors.receive[Command] { (_, msg) ⇒
         msg match {
           // support two heterogenous types of messages without union types
           case cmd: InternalCommand ⇒ onInternalCommand(cmd)

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/Registry.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/Registry.scala
@@ -91,7 +91,7 @@ import scala.concurrent.duration.Deadline
 
   def pruneTombstones(): ShardedServiceRegistry = {
     copy(tombstones = tombstones.filter {
-      case (ref, deadline) ⇒ deadline.hasTimeLeft
+      case (_, deadline) ⇒ deadline.hasTimeLeft
     })
   }
 

--- a/akka-cluster/src/main/mima-filters/2.5.19.backwards.excludes
+++ b/akka-cluster/src/main/mima-filters/2.5.19.backwards.excludes
@@ -1,0 +1,4 @@
+# #26087 Fix compiler warnings in akka-cluster and akka-cluster-typed
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterDaemon.this")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.ClusterDaemon.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterRemoteWatcher#DelayedQuarantine.this")

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -168,7 +168,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
 
   // create supervisor for daemons under path "/system/cluster"
   private val clusterDaemons: ActorRef = {
-    system.systemActorOf(Props(classOf[ClusterDaemon], settings, joinConfigCompatChecker).
+    system.systemActorOf(Props(classOf[ClusterDaemon], joinConfigCompatChecker).
       withDispatcher(UseDispatcher).withDeploy(Deploy.local), name = "cluster")
   }
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -179,7 +179,7 @@ private[cluster] object InternalClusterAction {
  * Supervisor managing the different Cluster daemons.
  */
 @InternalApi
-private[cluster] final class ClusterDaemon(settings: ClusterSettings, joinConfigCompatChecker: JoinConfigCompatChecker) extends Actor with ActorLogging
+private[cluster] final class ClusterDaemon(joinConfigCompatChecker: JoinConfigCompatChecker) extends Actor with ActorLogging
   with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
   import InternalClusterAction._
   // Important - don't use Cluster(context.system) in constructor because that would

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala
@@ -56,7 +56,7 @@ private[akka] class ClusterReadView(cluster: Cluster) extends Closeable {
       def receive = {
         case e: ClusterDomainEvent ⇒
           e match {
-            case SeenChanged(convergence, seenBy) ⇒
+            case SeenChanged(_, seenBy) ⇒
               _state = _state.copy(seenBy = seenBy)
             case ReachabilityChanged(reachability) ⇒
               _reachability = reachability

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
@@ -31,6 +31,9 @@ private[cluster] object ClusterRemoteWatcher {
     heartbeatExpectedResponseAfter: FiniteDuration): Props =
     Props(classOf[ClusterRemoteWatcher], failureDetector, heartbeatInterval, unreachableReaperInterval,
       heartbeatExpectedResponseAfter).withDeploy(Deploy.local)
+
+  private final case class DelayedQuarantine(m: Member, previousStatus: MemberStatus) extends NoSerializationVerificationNeeded
+
 }
 
 /**
@@ -55,11 +58,11 @@ private[cluster] class ClusterRemoteWatcher(
     unreachableReaperInterval,
     heartbeatExpectedResponseAfter) {
 
+  import ClusterRemoteWatcher.DelayedQuarantine
+
   private val arteryEnabled = RARP(context.system).provider.remoteSettings.Artery.Enabled
   val cluster = Cluster(context.system)
   import cluster.selfAddress
-
-  private final case class DelayedQuarantine(m: Member, previousStatus: MemberStatus) extends NoSerializationVerificationNeeded
 
   private var pendingDelayedQuarantine: Set[UniqueAddress] = Set.empty
 

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -262,7 +262,7 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem) extends Se
 
       InternalClusterAction.InitJoinAck(addressFromProto(i.getAddress), configCheck)
     } catch {
-      case ex: akka.protobuf.InvalidProtocolBufferException ⇒
+      case _: akka.protobuf.InvalidProtocolBufferException ⇒
         // nodes previous to 2.5.9 sends just an address
         InternalClusterAction.InitJoinAck(addressFromBinary(bytes), UncheckedConfig)
     }

--- a/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
@@ -90,7 +90,7 @@ final case class ClusterRouterGroupSettings(
     throw new IllegalArgumentException("routeesPaths must be defined")
 
   routeesPaths.foreach {
-    case RelativeActorPath(elements) ⇒ // good
+    case RelativeActorPath(_) ⇒ // good
     case p ⇒
       throw new IllegalArgumentException(s"routeesPaths [$p] is not a valid actor path without address information")
   }
@@ -421,7 +421,7 @@ private[akka] class ClusterRouterGroupActor(val settings: ClusterRouterGroupSett
       if (unusedNodes.nonEmpty) {
         Some((unusedNodes.head, settings.routeesPaths.head))
       } else {
-        val (address, used) = usedRouteePaths.minBy { case (address, used) ⇒ used.size }
+        val (address, used) = usedRouteePaths.minBy { case (_, used) ⇒ used.size }
         // pick next of the unused paths
         settings.routeesPaths.collectFirst { case p if !used.contains(p) ⇒ (address, p) }
       }


### PR DESCRIPTION
#26087

Fixed: all but the deprecations
**akka-cluster**
Before:
[warn] there were 7 deprecation warnings in total; re-run with -deprecation for details
[warn] 11 warnings found

After:
[warn] there were 7 deprecation warnings in total; re-run with -deprecation for details
[warn] 5 warnings found

**akka-cluster-typed**
Before:
[warn] there was one deprecation warning (since 2.4.5); re-run with -deprecation for details
[warn] 6 warnings found

After:
[warn] there was one deprecation warning (since 2.4.5); re-run with -deprecation for details
[warn] one warning found