### PR TITLE
build: make sure ignore files are searched for in base directory

### DIFF
--- a/project/JavaFormatter.scala
+++ b/project/JavaFormatter.scala
@@ -6,15 +6,14 @@ import akka.ProjectFileIgnoreSupport
 import com.lightbend.sbt.JavaFormatterPlugin
 import sbt.{AutoPlugin, PluginTrigger, Plugins}
 
-object JavaFormatter extends AutoPlugin with ProjectFileIgnoreSupport {
+object JavaFormatter extends AutoPlugin {
 
   override def trigger = PluginTrigger.AllRequirements
 
   override def requires: Plugins = JavaFormatterPlugin
 
-  final override protected val ignoreConfigFileName: String = ".sbt-java-formatter.conf"
-
-  final override protected val descriptor: String = "sbt-java-formatter"
+  private val ignoreConfigFileName: String = ".sbt-java-formatter.conf"
+  private val descriptor: String = "sbt-java-formatter"
 
   import JavaFormatterPlugin.autoImport._
   import sbt.Keys._
@@ -24,7 +23,8 @@ object JavaFormatter extends AutoPlugin with ProjectFileIgnoreSupport {
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     //below is for sbt java formatter
     (excludeFilter in format) := {
-      val simpleFileFilter = new SimpleFileFilter(file => isIgnoredByFileOrPackages(file))
+      val ignoreSupport = new ProjectFileIgnoreSupport((baseDirectory in ThisBuild).value / ignoreConfigFileName, descriptor)
+      val simpleFileFilter = new SimpleFileFilter(file => ignoreSupport.isIgnoredByFileOrPackages(file))
       simpleFileFilter || (excludeFilter in format).value
     }
   )

--- a/project/ProjectFileIgnoreSupport.scala
+++ b/project/ProjectFileIgnoreSupport.scala
@@ -7,37 +7,41 @@ package akka
 import java.io.File
 
 import com.typesafe.config.ConfigFactory
+import sbt.AutoPlugin
+import sbt.Def
 import sbt.file
 import sbt.internal.sbtscalafix.Compat
 
-trait ProjectFileIgnoreSupport {
-  protected val stdoutLogger = Compat.ConsoleLogger(System.out)
+class ProjectFileIgnoreSupport(ignoreConfigFile: File, descriptor: String) {
+  private val stdoutLogger = Compat.ConsoleLogger(System.out)
 
-  protected def ignoreConfigFileName: String
+  private lazy val ignoreConfig = {
+    require(ignoreConfigFile.exists(), s"Expected ignore configuration for $descriptor at ${ignoreConfigFile.getAbsolutePath} but was missing")
+    ConfigFactory.parseFile(ignoreConfigFile)
+  }
 
-  protected def descriptor: String
-
-  lazy val ignoredFiles: Set[String] = {
+  private lazy val ignoredFiles: Set[String] = {
     import scala.collection.JavaConverters._
-    val config = ConfigFactory.parseFile(file(ignoreConfigFileName))
-    stdoutLogger.debug(s"Loading ignored-files from $ignoreConfigFileName:[${config.origin().url().toURI.getPath}]")
-    config
+    stdoutLogger.debug(s"Loading ignored-files from $ignoreConfigFile:[${ignoreConfig.origin().url().toURI.getPath}]")
+    ignoreConfig
       .getStringList("ignored-files")
       .asScala
       .toSet
   }
 
-  lazy val ignoredPackages: Set[String] = {
+  private lazy val ignoredPackages: Set[String] = {
     import scala.collection.JavaConverters._
-    val config = ConfigFactory.parseFile(file(ignoreConfigFileName))
-    stdoutLogger.debug(s"Loading ignored-packages from $ignoreConfigFileName:[${config.origin().url().toURI.getPath}]")
-    config
+    stdoutLogger.debug(s"Loading ignored-packages from $ignoreConfigFile:[${ignoreConfig.origin().url().toURI.getPath}]")
+    ignoreConfig
       .getStringList("ignored-packages")
       .asScala
       .toSet
   }
 
-  protected def isIgnoredByFile(file: File): Boolean = {
+  def isIgnoredByFileOrPackages(file: File): Boolean =
+    isIgnoredByFile(file) || isIgnoredByPackages(file)
+
+  private def isIgnoredByFile(file: File): Boolean = {
     val ignoredByFile = ignoredFiles(file.getName)
     if (ignoredByFile) {
       stdoutLogger.debug(s"$descriptor ignored file with file name:${file.getName} file:[${file.toPath}]")
@@ -45,7 +49,7 @@ trait ProjectFileIgnoreSupport {
     ignoredByFile
   }
 
-  protected def isIgnoredByPackages(file: File): Boolean = {
+  private def isIgnoredByPackages(file: File): Boolean = {
     val ignoredByPackages = ignoredPackages.exists(pkg => {
       getPackageName(file.toURI.toString) match {
         case Some(packageName) =>
@@ -60,11 +64,7 @@ trait ProjectFileIgnoreSupport {
     ignoredByPackages
   }
 
-  protected def isIgnoredByFileOrPackages(file: File): Boolean = {
-    isIgnoredByFile(file) || isIgnoredByPackages(file)
-  }
-
-  protected def getPackageName(fileName: String): Option[String] = {
+  private def getPackageName(fileName: String): Option[String] = {
     def getPackageName0(fileType: String): String = {
       import java.io.{File => JFile}
       fileName.split(JFile.separatorChar)

--- a/project/ScalafixSupport.scala
+++ b/project/ScalafixSupport.scala
@@ -3,22 +3,24 @@
  */
 
 package sbt
+import Keys.baseDirectory
 
 import akka.ProjectFileIgnoreSupport
 import sbt.Keys.unmanagedSources
 
-trait ScalafixSupport extends ProjectFileIgnoreSupport {
-
-  final override protected val ignoreConfigFileName: String = ".scalafix.conf"
-
-  final override protected val descriptor: String = "scalafix"
+trait ScalafixSupport {
+  private val ignoreConfigFileName: String = ".scalafix.conf"
+  private val descriptor: String = "scalafix"
 
   protected def ignore(configKey: ConfigKey): Def.Setting[Task[Seq[File]]] = {
     import scalafix.sbt.ScalafixPlugin.autoImport._
-    
-    unmanagedSources.in(configKey, scalafix) :=
+
+    unmanagedSources.in(configKey, scalafix) := {
+      val ignoreSupport = new ProjectFileIgnoreSupport((baseDirectory in ThisBuild).value / ignoreConfigFileName, descriptor)
+
       unmanagedSources.in(configKey, scalafix).value
-        .filterNot(file => isIgnoredByFileOrPackages(file))
+        .filterNot(file => ignoreSupport.isIgnoredByFileOrPackages(file))
+    }
   }
 
 


### PR DESCRIPTION
Previously, the paths were just relative paths and depended on the working
directory of the sbt process. However, that's unreliable when the akka
sources are included in another build as in the akka-http nightlies.

Fixes https://github.com/akka/akka-http/issues/2387.