### PR TITLE
Subtypes of state in typed persistence runThen Java API 

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Effect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Effect.scala
@@ -120,9 +120,15 @@ import akka.persistence.typed.internal._
   self: EffectImpl[Event, State] ⇒
   /**
    * Run the given callback. Callbacks are run sequentially.
+   *
+   * @tparam NewState The type of the state after the event is persisted, when not specified will be the same as `State`
+   *                  but if a known subtype of `State` is expected that can be specified instead (preferrably by
+   *                  explicitly typing the lambda parameter like so: `thenRun((SubState state) -> { ... })`).
+   *                  If the state is not of the expected type an [[java.lang.ClassCastException]] is thrown.
+   *
    */
-  final def thenRun(callback: function.Procedure[State]): Effect[Event, State] =
-    CompositeEffect(this, SideEffect[State](s ⇒ callback.apply(s)))
+  final def thenRun[NewState <: State](callback: function.Procedure[NewState]): Effect[Event, State] =
+    CompositeEffect(this, SideEffect[State](s ⇒ callback.apply(s.asInstanceOf[NewState])))
 
   /**
    * Run the given callback. Callbacks are run sequentially.

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -583,7 +583,8 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
 
     @Override
     public CommandHandler<String, String, Object> commandHandler() {
-      return commandHandlerBuilder(Object.class)
+      return newCommandHandlerBuilder()
+          .forAnyState()
           .matchCommand(
               msg -> msg.equals("expect wrong type"),
               (context) ->
@@ -603,7 +604,9 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
 
     @Override
     public EventHandler<Object, String> eventHandler() {
-      return eventHandlerBuilder().matchAny((event, state) -> state); // keep Integer state
+      return newEventHandlerBuilder()
+          .forAnyState()
+          .matchAny((event, state) -> state); // keep Integer state
     }
   }
 

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -9,6 +9,7 @@ import akka.actor.typed.*;
 import akka.actor.typed.javadsl.ActorContext;
 import akka.actor.typed.javadsl.Adapter;
 import akka.actor.typed.javadsl.Behaviors;
+import akka.event.Logging;
 import akka.japi.Pair;
 import akka.persistence.SnapshotMetadata;
 import akka.persistence.query.EventEnvelope;
@@ -32,6 +33,7 @@ import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
+import scala.Function0;
 
 import java.io.Serializable;
 import java.time.Duration;
@@ -614,14 +616,14 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
 
     probe.expectMessage("started!"); // workaround for #26256
 
-    // FIXME this is a not a good Java API
-    new ErrorFilter(ClassCastException.class, null, null, false, false, 1)
+    new EventFilter(Logging.Error.class, Adapter.toUntyped(testKit.system()))
+        .occurrences(1)
         .intercept(
             () -> {
               c.tell("expect wrong type");
               return null;
-            },
-            Adapter.toUntyped(testKit.system()));
+            });
+
     probe.expectTerminated(c);
   }
 }

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -591,7 +591,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     public CommandHandler<String, String, Object> commandHandler() {
       return newCommandHandlerBuilder()
           .forAnyState()
-          .matchCommand(
+          .onCommand(
               msg -> msg.equals("expect wrong type"),
               (context) ->
                   Effect()
@@ -612,7 +612,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     public EventHandler<Object, String> eventHandler() {
       return newEventHandlerBuilder()
           .forAnyState()
-          .matchAny((event, state) -> state); // keep Integer state
+          .onAnyEvent((event, state) -> state); // keep Integer state
     }
   }
 

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -464,6 +464,12 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     TestProbe<Signal> signalProbe = testKit.createTestProbe();
     BehaviorInterceptor<Command, Command> tap =
         new BehaviorInterceptor<Command, Command>() {
+
+          @Override
+          public Class<? extends Command> interceptMessageType() {
+            return Command.class;
+          }
+
           @Override
           public Behavior<Command> aroundReceive(
               TypedActorContext<Command> ctx, Command msg, ReceiveTarget<Command> target) {
@@ -621,6 +627,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
 
     new EventFilter(Logging.Error.class, Adapter.toUntyped(testKit.system()))
         .occurrences(1)
+        .message("java.lang.Integer cannot be cast to java.lang.String")
         .intercept(
             () -> {
               c.tell("expect wrong type");


### PR DESCRIPTION
Fixes half of #25737

The Scala part I'll do separately because the suggestion in the issue didn't work out, while this is good to go IMO.