### PR TITLE
needed tweak for Scala 2.12 community build on JDK 11

### DIFF
--- a/project/Jdk9.scala
+++ b/project/Jdk9.scala
@@ -31,8 +31,8 @@ object Jdk9 extends AutoPlugin {
       (Compile / sourceDirectory).value / SCALA_SOURCE_DIRECTORY,
       (Compile / sourceDirectory).value / JAVA_SOURCE_DIRECTORY
     ))),
-    scalacOptions := AkkaBuild.DefaultScalacOptions ++ notOnJdk8(notOnScala211(scalaBinaryVersion.value, Seq("-release", "9"))),
-    javacOptions := AkkaBuild.DefaultJavacOptions ++ notOnJdk8(notOnScala211(scalaBinaryVersion.value, Seq("--release", "9")))
+    scalacOptions := AkkaBuild.DefaultScalacOptions ++ notOnJdk8(notOnScala211(scalaBinaryVersion.value, Seq("-release", "11"))),
+    javacOptions := AkkaBuild.DefaultJavacOptions ++ notOnJdk8(notOnScala211(scalaBinaryVersion.value, Seq("--release", "11")))
   )
 
   val compileSettings = Seq(


### PR DESCRIPTION
context: https://github.com/scala/community-builds/pull/832

I don't actually understand the nature of the problem here, but 9 and 10 are dead so `-release 11` seems desirable anyway