### PR TITLE
Support mutable state by stashing commands while storing snapshot, #25740

### DIFF
--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -87,8 +87,8 @@ akka.cluster.sharding {
   # The shard deletes persistent events (messages and snapshots) after doing snapshot
   # keeping this number of old persistent batches.
   # Batch is of size `snapshot-after`.
-  # When set to 0 after snapshot is successfully done all messages with equal or lower sequence number will be deleted.
-  # Default value of 2 leaves last maximum 2*`snapshot-after` messages and 3 snapshots (2 old ones + fresh snapshot)
+  # When set to 0 after snapshot is successfully done all events with equal or lower sequence number will be deleted.
+  # Default value of 2 leaves last maximum 2*`snapshot-after` events and 3 snapshots (2 old ones + latest snapshot)
   keep-nr-of-batches = 2
 
   # Setting for the default shard allocation strategy

--- a/akka-docs/src/main/paradox/persistence.md
+++ b/akka-docs/src/main/paradox/persistence.md
@@ -649,7 +649,7 @@ where `metadata` is of type `SnapshotMetadata`:
 
 @@snip [SnapshotProtocol.scala](/akka-persistence/src/main/scala/akka/persistence/SnapshotProtocol.scala) { #snapshot-metadata }
 
-During recovery, the persistent actor is offered a previously saved snapshot via a `SnapshotOffer` message from
+During recovery, the persistent actor is offered the latest saved snapshot via a `SnapshotOffer` message from
 which it can initialize internal state.
 
 Scala
@@ -679,7 +679,7 @@ saved snapshot matches the specified `SnapshotSelectionCriteria` will replay all
 In order to use snapshots, a default snapshot-store (`akka.persistence.snapshot-store.plugin`) must be configured,
 or the @scala[`PersistentActor`]@java[persistent actor] can pick a snapshot store explicitly by overriding @scala[`def snapshotPluginId: String`]@java[`String snapshotPluginId()`].
 
-Since it is acceptable for some applications to not use any snapshotting, it is legal to not configure a snapshot store.
+Because some use cases may not benefit from or need snapshots, it is perfectly valid not to not configure a snapshot store.
 However, Akka will log a warning message when this situation is detected and then continue to operate until
 an actor tries to store a snapshot, at which point the operation will fail (by replying with an `SaveSnapshotFailure` for example).
 

--- a/akka-docs/src/main/paradox/typed/persistence-snapshot.md
+++ b/akka-docs/src/main/paradox/typed/persistence-snapshot.md
@@ -1,0 +1,64 @@
+# Persistence - snapshotting
+
+## Snapshots
+
+As you model your domain using @ref:[persistent actors](persistence.md), you may notice that some actors may be
+prone to accumulating extremely long event logs and experiencing long recovery times. Sometimes, the right approach
+may be to split out into a set of shorter lived actors. However, when this is not an option, you can use snapshots
+to reduce recovery times drastically.
+
+Persistent actors can save snapshots of internal state every N events or when a given predicated of the state
+is fulfilled.
+
+Scala
+:  @@snip [BasicPersistentActorCompileOnly.scala](/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala) { #snapshottingEveryN }
+
+Java
+:  @@snip [BasicPersistentBehaviorTest.java](/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java) { #snapshottingEveryN }
+
+
+Scala
+:  @@snip [BasicPersistentActorCompileOnly.scala](/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala) { #snapshottingPredicate }
+
+Java
+:  @@snip [BasicPersistentBehaviorTest.java](/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java) { #snapshottingPredicate }
+
+When a snapshot is triggered incoming commands are stashed until the snapshot has been saved. This means that
+the state can safely be mutable although the serialization and storage of the state is performed asynchronously,
+since the state instance will not be updated by new events until after the snapshot has been saved.
+
+During recovery, the persistent actor is using the previously saved snapshot to initialize the state and then events
+after the snapshot are replayed using the event handler to recover the persistent actor to its current (i.e. latest)
+state.
+
+If not specified, they default to @scala[`SnapshotSelectionCriteria.Latest`]@java[`SnapshotSelectionCriteria.latest()`]
+which selects the latest (youngest) snapshot. It's possible to override the selection of which snapshot to use for
+recovery like this:
+
+Scala
+:  @@snip [BasicPersistentActorCompileOnly.scala](/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala) { #snapshotSelection }
+
+TODO include corresponding example in Java
+
+To disable snapshot-based recovery, applications can use @scala[`SnapshotSelectionCriteria.None`]@java[`SnapshotSelectionCriteria.none()`].
+A recovery where no saved snapshot matches the specified `SnapshotSelectionCriteria` will replay all journaled
+events. This can be useful if snapshot serialization format has changed in an incompatible way. It should typically
+not be used when events have been deleted.
+
+In order to use snapshots, a default snapshot-store (`akka.persistence.snapshot-store.plugin`) must be configured,
+or the @scala[`PersistentActor`]@java[persistent actor] can pick a snapshot store explicitly by overriding @scala[`def snapshotPluginId: String`]@java[`String snapshotPluginId()`].
+
+Since it is acceptable for some applications to not use any snapshotting, it is legal to not configure a snapshot store.
+However, Akka will log a warning message when this situation is detected and then continue to operate until
+an actor tries to store a snapshot, at which point the operation will fail.
+
+## Snapshot failures
+
+Saving snapshots can either succeed or fail – this information is reported back to the persistent actor via
+the `onSnapshot` callback. Snapshot failures are by default logged but don't cause the actor to stop or
+restart.
+
+If there is a problem with recovering the state of the actor from the journal when the actor is
+started, `onRecoveryFailure` is called (logging the error by default), and the actor will be stopped.
+Note that failure to load snapshot is also treated like this, but you can disable loading of snapshots
+if you for example know that serialization format has changed in an incompatible way..

--- a/akka-docs/src/main/paradox/typed/persistence-snapshot.md
+++ b/akka-docs/src/main/paradox/typed/persistence-snapshot.md
@@ -23,11 +23,11 @@ Scala
 Java
 :  @@snip [BasicPersistentBehaviorTest.java](/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java) { #snapshottingPredicate }
 
-When a snapshot is triggered incoming commands are stashed until the snapshot has been saved. This means that
-the state can safely be mutable although the serialization and storage of the state is performed asynchronously,
-since the state instance will not be updated by new events until after the snapshot has been saved.
+When a snapshot is triggered, incoming commands are stashed until the snapshot has been saved. This means that
+the state can safely be mutable although the serialization and storage of the state is performed asynchronously.
+The state instance will not be updated by new events until after the snapshot has been saved.
 
-During recovery, the persistent actor is using the previously saved snapshot to initialize the state and then events
+During recovery, the persistent actor is using the latest saved snapshot to initialize the state. Thereafter the events
 after the snapshot are replayed using the event handler to recover the persistent actor to its current (i.e. latest)
 state.
 
@@ -38,7 +38,7 @@ recovery like this:
 Scala
 :  @@snip [BasicPersistentActorCompileOnly.scala](/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala) { #snapshotSelection }
 
-TODO include corresponding example in Java
+TODO #26273 include corresponding example in Java
 
 To disable snapshot-based recovery, applications can use @scala[`SnapshotSelectionCriteria.None`]@java[`SnapshotSelectionCriteria.none()`].
 A recovery where no saved snapshot matches the specified `SnapshotSelectionCriteria` will replay all journaled
@@ -48,14 +48,14 @@ not be used when events have been deleted.
 In order to use snapshots, a default snapshot-store (`akka.persistence.snapshot-store.plugin`) must be configured,
 or the @scala[`PersistentActor`]@java[persistent actor] can pick a snapshot store explicitly by overriding @scala[`def snapshotPluginId: String`]@java[`String snapshotPluginId()`].
 
-Since it is acceptable for some applications to not use any snapshotting, it is legal to not configure a snapshot store.
+Because some use cases may not benefit from or need snapshots, it is perfectly valid not to not configure a snapshot store.
 However, Akka will log a warning message when this situation is detected and then continue to operate until
 an actor tries to store a snapshot, at which point the operation will fail.
 
 ## Snapshot failures
 
 Saving snapshots can either succeed or fail – this information is reported back to the persistent actor via
-the `onSnapshot` callback. Snapshot failures are by default logged but don't cause the actor to stop or
+the `onSnapshot` callback. Snapshot failures are, by default, logged but do not cause the actor to stop or
 restart.
 
 If there is a problem with recovering the state of the actor from the journal when the actor is

--- a/akka-docs/src/main/paradox/typed/persistence-snapshot.md
+++ b/akka-docs/src/main/paradox/typed/persistence-snapshot.md
@@ -61,4 +61,4 @@ restart.
 If there is a problem with recovering the state of the actor from the journal when the actor is
 started, `onRecoveryFailure` is called (logging the error by default), and the actor will be stopped.
 Note that failure to load snapshot is also treated like this, but you can disable loading of snapshots
-if you for example know that serialization format has changed in an incompatible way..
+if you for example know that serialization format has changed in an incompatible way.

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -87,8 +87,8 @@ mutable the event handler may update the state instance and return the same inst
 
 The same event handler is also used when the entity is started up to recover its state from the stored events.
 
-It is not recommended to perform side effects in the event handler, as those are also executed during recovery of
-an persistent actor
+The event handler should only update the state and it mustn't perform side effects, as those would also be
+executed during recovery of the persistent actor.
 
 ### Completing the example
 

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -3,6 +3,7 @@
 @@@ index
 
 * [Persistence - coding style](persistence-style.md)
+* [Persistence - snapshotting](persistence-snapshot.md)
 
 @@@
 
@@ -81,11 +82,13 @@ are executed sequentially after successful execution of the persist statement (o
 
 When an event has been persisted successfully the new state is created by applying the event to the current state with the `eventHandler`.
 
-The event handler returns the new state, which must be immutable so you return a new instance of the state.
+The state is typically immutable and then the event handler returns a new instance of the state. If the state is
+mutable the event handler may update the state instance and return the same instance.
+
 The same event handler is also used when the entity is started up to recover its state from the stored events.
 
-It is not recommended to perform side effects
-in the event handler, as those are also executed during recovery of an persistent actor
+It is not recommended to perform side effects in the event handler, as those are also executed during recovery of
+an persistent actor
 
 ### Completing the example
 
@@ -342,6 +345,8 @@ Java
 
 The `onRecoveryCompleted` takes @scala[an `ActorContext` and] the current `State`,
 and doesn't return anything.
+
+@ref[Snapshots)[persistence-snapshot.md] can be used for optimizing recovery times.
 
 ## Tagging
 

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -82,12 +82,13 @@ are executed sequentially after successful execution of the persist statement (o
 
 When an event has been persisted successfully the new state is created by applying the event to the current state with the `eventHandler`.
 
-The state is typically immutable and then the event handler returns a new instance of the state. If the state is
-mutable the event handler may update the state instance and return the same instance.
+The state is typically defined as an immutable class and then the event handler returns a new instance of the state.
+You may choose to use a mutable class for the state, and then the event handler may update the state instance and
+return the same instance. Both immutable and mutable state is supported.
 
 The same event handler is also used when the entity is started up to recover its state from the stored events.
 
-The event handler should only update the state and it mustn't perform side effects, as those would also be
+The event handler should only update the state and never perform side effects, as those would also be
 executed during recovery of the persistent actor.
 
 ### Completing the example

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
@@ -120,6 +120,7 @@ private[akka] object MDC {
   val ReplayingEvents   = "replay-evts"
   val RunningCmds       = "running-cmnds"
   val PersistingEvents  = "persist-evts"
+  val StoringSnapshot  = "storing-snapshot"
   // format: ON
 
   def create(persistenceId: PersistenceId, phaseName: String): Map[String, Any] = {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/JournalInteractions.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/JournalInteractions.scala
@@ -112,7 +112,7 @@ private[akka] trait JournalInteractions[C, E, S] {
 
   protected def internalSaveSnapshot(state: Running.RunningState[S]): Unit = {
     if (state.state == null)
-      throw new IllegalStateException("null state is not allowed as snapshot")
+      throw new IllegalStateException("A snapshot must not be a null state.")
     else
       setup.snapshotStore.tell(SnapshotProtocol.SaveSnapshot(
         SnapshotMetadata(setup.persistenceId.id, state.seqNr),

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/JournalInteractions.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/JournalInteractions.scala
@@ -111,8 +111,9 @@ private[akka] trait JournalInteractions[C, E, S] {
   }
 
   protected def internalSaveSnapshot(state: Running.RunningState[S]): Unit = {
-    // don't store null state
-    if (state.state != null)
+    if (state.state == null)
+      throw new IllegalStateException("null state is not allowed as snapshot")
+    else
       setup.snapshotStore.tell(SnapshotProtocol.SaveSnapshot(
         SnapshotMetadata(setup.persistenceId.id, state.seqNr),
         state.state), setup.selfUntyped)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -313,7 +313,7 @@ private[akka] object Running {
         case SaveSnapshotFailure(meta, ex) ⇒
           setup.onSnapshot(meta, Failure(ex))
 
-        // FIXME not implemented
+        // FIXME #24698 not implemented yet
         case DeleteSnapshotFailure(_, _)  ⇒ ???
         case DeleteSnapshotSuccess(_)     ⇒ ???
         case DeleteSnapshotsFailure(_, _) ⇒ ???

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -81,6 +81,7 @@ private[akka] object Running {
 
   private val runningCmdsMdc = MDC.create(setup.persistenceId, MDC.RunningCmds)
   private val persistingEventsMdc = MDC.create(setup.persistenceId, MDC.PersistingEvents)
+  private val storingSnapshotMdc = MDC.create(setup.persistenceId, MDC.StoringSnapshot)
 
   def handlingCommands(state: RunningState[S]): Behavior[InternalProtocol] = {
 
@@ -171,8 +172,10 @@ private[akka] object Running {
 
     Behaviors.receiveMessage[InternalProtocol] {
       case IncomingCommand(c: C @unchecked) ⇒ onCommand(state, c)
-      case SnapshotterResponse(r)           ⇒ onSnapshotterResponse(r, Behaviors.same)
-      case _                                ⇒ Behaviors.unhandled
+      case SnapshotterResponse(r) ⇒
+        setup.log.warning("Unexpected SnapshotterResponse {}", r)
+        Behaviors.unhandled
+      case _ ⇒ Behaviors.unhandled
     }.receiveSignal {
       case (_, PoisonPill) ⇒
         if (isInternalStashEmpty && !isUnstashAllInProgress) Behaviors.stopped
@@ -205,11 +208,13 @@ private[akka] object Running {
 
     override def onMessage(msg: InternalProtocol): Behavior[InternalProtocol] = {
       msg match {
-        case in: IncomingCommand[C @unchecked] ⇒ onCommand(in)
-        case SnapshotterResponse(r)            ⇒ onSnapshotterResponse(r, this)
         case JournalResponse(r)                ⇒ onJournalResponse(r)
-        case RecoveryTickEvent(_)              ⇒ Behaviors.unhandled
-        case RecoveryPermitGranted             ⇒ Behaviors.unhandled
+        case in: IncomingCommand[C @unchecked] ⇒ onCommand(in)
+        case SnapshotterResponse(r) ⇒
+          setup.log.warning("Unexpected SnapshotterResponse {}", r)
+          Behaviors.unhandled
+        case RecoveryTickEvent(_)  ⇒ Behaviors.unhandled
+        case RecoveryPermitGranted ⇒ Behaviors.unhandled
       }
     }
 
@@ -235,10 +240,11 @@ private[akka] object Running {
         // only once all things are applied we can revert back
         if (eventCounter < numberOfEvents) this
         else {
-          if (shouldSnapshotAfterPersist)
+          if (shouldSnapshotAfterPersist && state.state != null) {
             internalSaveSnapshot(state)
-
-          tryUnstashOne(applySideEffects(sideEffects, state))
+            storingSnapshot(state, sideEffects)
+          } else
+            tryUnstashOne(applySideEffects(sideEffects, state))
         }
       }
 
@@ -281,27 +287,57 @@ private[akka] object Running {
 
   }
 
-  private def onSnapshotterResponse(
-    response: SnapshotProtocol.Response,
-    outer:    Behavior[InternalProtocol]): Behavior[InternalProtocol] = {
-    response match {
-      case SaveSnapshotSuccess(meta) ⇒
-        setup.onSnapshot(meta, Success(Done))
-        outer
-      case SaveSnapshotFailure(meta, ex) ⇒
-        setup.onSnapshot(meta, Failure(ex))
-        outer
+  // ===============================================
 
-      // FIXME not implemented
-      case DeleteSnapshotFailure(_, _)  ⇒ ???
-      case DeleteSnapshotSuccess(_)     ⇒ ???
-      case DeleteSnapshotsFailure(_, _) ⇒ ???
-      case DeleteSnapshotsSuccess(_)    ⇒ ???
+  def storingSnapshot(
+    state:       RunningState[S],
+    sideEffects: immutable.Seq[SideEffect[S]]
+  ): Behavior[InternalProtocol] = {
+    setup.setMdc(storingSnapshotMdc)
 
-      // ignore LoadSnapshot messages
+    def onCommand(cmd: IncomingCommand[C]): Behavior[InternalProtocol] = {
+      if (state.receivedPoisonPill) {
+        if (setup.settings.logOnStashing) setup.log.debug(
+          "Discarding message [{}], because actor is to be stopped", cmd)
+        Behaviors.unhandled
+      } else {
+        stashUser(cmd)
+        storingSnapshot(state, sideEffects)
+      }
+    }
+
+    def onSnapshotterResponse(response: SnapshotProtocol.Response): Unit = {
+      response match {
+        case SaveSnapshotSuccess(meta) ⇒
+          setup.onSnapshot(meta, Success(Done))
+        case SaveSnapshotFailure(meta, ex) ⇒
+          setup.onSnapshot(meta, Failure(ex))
+
+        // FIXME not implemented
+        case DeleteSnapshotFailure(_, _)  ⇒ ???
+        case DeleteSnapshotSuccess(_)     ⇒ ???
+        case DeleteSnapshotsFailure(_, _) ⇒ ???
+        case DeleteSnapshotsSuccess(_)    ⇒ ???
+
+        // ignore LoadSnapshot messages
+        case _                            ⇒
+      }
+    }
+
+    Behaviors.receiveMessage[InternalProtocol] {
+      case cmd: IncomingCommand[C] @unchecked ⇒
+        onCommand(cmd)
+      case SnapshotterResponse(r) ⇒
+        onSnapshotterResponse(r)
+        tryUnstashOne(applySideEffects(sideEffects, state))
       case _ ⇒
         Behaviors.unhandled
+    }.receiveSignal {
+      case (_, PoisonPill) ⇒
+        // wait for snapshot response before stopping
+        storingSnapshot(state.copy(receivedPoisonPill = true), sideEffects)
     }
+
   }
 
   // --------------------------
@@ -345,3 +381,4 @@ private[akka] object Running {
   }
 
 }
+

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
@@ -227,6 +227,48 @@ public class BasicPersistentBehaviorTest {
               };
             });
     // #wrapPersistentBehavior
+
+    public static class BookingCompleted implements Event {}
+
+    public static class Snapshotting extends EventSourcedBehavior<Command, Event, State> {
+      public Snapshotting(PersistenceId persistenceId) {
+        super(persistenceId);
+      }
+
+      @Override
+      public State emptyState() {
+        return new State();
+      }
+
+      @Override
+      public CommandHandler<Command, Event, State> commandHandler() {
+        return (state, command) -> {
+          throw new RuntimeException("TODO: process the command & return an Effect");
+        };
+      }
+
+      @Override
+      public EventHandler<State, Event> eventHandler() {
+        return (state, event) -> {
+          throw new RuntimeException("TODO: process the event return the next state");
+        };
+      }
+
+      // #snapshottingEveryN
+      @Override // override snapshotEvery in EventSourcedBehavior
+      public long snapshotEvery() {
+        return 100;
+      }
+      // #snapshottingEveryN
+
+      // #snapshottingPredicate
+      @Override // override shouldSnapshot in EventSourcedBehavior
+      public boolean shouldSnapshot(State state, Event event, long sequenceNr) {
+        return event instanceof BookingCompleted;
+      }
+      // #snapshottingPredicate
+
+    }
   }
 
   interface WithActorContext {

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotMutableStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotMutableStateSpec.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.scaladsl
+
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+
+import akka.actor.testkit.typed.TestKitSettings
+import akka.actor.testkit.typed.scaladsl._
+import akka.actor.typed.ActorRef
+import akka.actor.typed.Behavior
+import akka.persistence.SelectedSnapshot
+import akka.persistence.SnapshotMetadata
+import akka.persistence.SnapshotSelectionCriteria
+import akka.persistence.snapshot.SnapshotStore
+import akka.persistence.typed.PersistenceId
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.WordSpecLike
+
+object SnapshotMutableStateSpec {
+
+  class SlowInMemorySnapshotStore extends SnapshotStore {
+
+    private var state = Map.empty[String, (Any, SnapshotMetadata)]
+
+    def loadAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
+      Future.successful(state.get(persistenceId).map {
+        case (snap, meta) ⇒ SelectedSnapshot(meta, snap)
+      })
+    }
+
+    def saveAsync(metadata: SnapshotMetadata, snapshot: Any): Future[Unit] = {
+      val value1 = snapshot.asInstanceOf[MutableState].value
+      Thread.sleep(50)
+      val value2 = snapshot.asInstanceOf[MutableState].value
+      if (value1 != value2)
+        Future.failed(new IllegalStateException(s"State changed from $value1 to $value2"))
+      else {
+        state = state.updated(metadata.persistenceId, (snapshot, metadata))
+        Future.successful(())
+      }
+    }
+
+    def deleteAsync(metadata: SnapshotMetadata) = ???
+    def deleteAsync(persistenceId: String, criteria: SnapshotSelectionCriteria) = ???
+  }
+
+  def conf: Config = ConfigFactory.parseString(
+    s"""
+    akka.loglevel = INFO
+    akka.persistence.journal.leveldb.dir = "target/typed-persistence-${UUID.randomUUID().toString}"
+    akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
+    akka.persistence.snapshot-store.plugin = "slow-snapshot-store"
+
+    slow-snapshot-store.class = "${classOf[SlowInMemorySnapshotStore].getName}"
+    """)
+
+  sealed trait Command
+  final case object Increment extends Command
+  final case class GetValue(replyTo: ActorRef[Int]) extends Command
+
+  sealed trait Event
+  case object Incremented extends Event
+
+  final class MutableState(var value: Int)
+
+  def counter(
+    persistenceId: PersistenceId,
+    snapshotProbe: ActorRef[String]): EventSourcedBehavior[Command, Event, MutableState] = {
+    EventSourcedBehavior[Command, Event, MutableState](
+      persistenceId,
+      emptyState = new MutableState(0),
+      commandHandler = (state, cmd) ⇒ cmd match {
+        case Increment ⇒
+          Effect.persist(Incremented)
+
+        case GetValue(replyTo) ⇒
+          replyTo ! state.value
+          Effect.none
+      },
+      eventHandler = (state, evt) ⇒ evt match {
+        case Incremented ⇒
+          state.value += 1
+          state
+      }).onSnapshot {
+        case (meta, Success(_)) ⇒ snapshotProbe ! s"snapshot-success-${meta.sequenceNr}"
+        case (meta, Failure(_)) ⇒ snapshotProbe ! s"snapshot-failure-${meta.sequenceNr}"
+      }
+  }
+
+}
+
+class SnapshotMutableStateSpec extends ScalaTestWithActorTestKit(SnapshotMutableStateSpec.conf) with WordSpecLike {
+
+  import SnapshotMutableStateSpec._
+
+  private implicit val testSettings = TestKitSettings(system)
+
+  val pidCounter = new AtomicInteger(0)
+  private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")
+
+  "A typed persistent actor with mutable state" must {
+
+    "support mutable state by stashing commands while storing snapshot" in {
+      val pid = nextPid()
+      val snapshotProbe = TestProbe[String]()
+      val snapshotState3: Behavior[Command] =
+        counter(pid, snapshotProbe.ref).snapshotWhen { (state, _, _) ⇒ state.value == 3 }
+      val c = spawn(snapshotState3)
+
+      (1 to 5).foreach { _ ⇒
+        c ! Increment
+      }
+      snapshotProbe.expectMessage(s"snapshot-success-3")
+
+      val replyProbe = TestProbe[Int]()
+      c ! GetValue(replyProbe.ref)
+      replyProbe.expectMessage(5)
+    }
+  }
+}

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
@@ -166,4 +166,49 @@ object BasicPersistentBehaviorCompileOnly {
     }
   // #actor-context
 
+  //#snapshottingEveryN
+  val snapshottingEveryN = EventSourcedBehavior[Command, Event, State](
+    persistenceId = PersistenceId("abc"),
+    emptyState = State(),
+    commandHandler =
+      (state, cmd) ⇒
+        throw new RuntimeException("TODO: process the command & return an Effect"),
+    eventHandler =
+      (state, evt) ⇒
+        throw new RuntimeException("TODO: process the event return the next state")
+  ).snapshotEvery(100)
+  //#snapshottingEveryN
+
+  final case class BookingCompleted(orderNr: String) extends Event
+  //#snapshottingPredicate
+  val snapshottingPredicate = EventSourcedBehavior[Command, Event, State](
+    persistenceId = PersistenceId("abc"),
+    emptyState = State(),
+    commandHandler =
+      (state, cmd) ⇒
+        throw new RuntimeException("TODO: process the command & return an Effect"),
+    eventHandler =
+      (state, evt) ⇒
+        throw new RuntimeException("TODO: process the event return the next state")
+  ).snapshotWhen {
+      case (state, BookingCompleted(_), sequenceNumber) ⇒ true
+      case (state, event, sequenceNumber)               ⇒ false
+    }
+  //#snapshottingPredicate
+
+  //#snapshotSelection
+  import akka.persistence.SnapshotSelectionCriteria
+
+  val snapshotSelection = EventSourcedBehavior[Command, Event, State](
+    persistenceId = PersistenceId("abc"),
+    emptyState = State(),
+    commandHandler =
+      (state, cmd) ⇒
+        throw new RuntimeException("TODO: process the command & return an Effect"),
+    eventHandler =
+      (state, evt) ⇒
+        throw new RuntimeException("TODO: process the event return the next state")
+  ).withSnapshotSelectionCriteria(SnapshotSelectionCriteria.None)
+  //#snapshotSelection
+
 }


### PR DESCRIPTION
Stashing while storing snapshot is easy to reason about. We could consider optimization opt-in for immutable state later if it turns out to be important to support completely async snapshotting. 

Refs #25740