### PR TITLE
Allow interceptors to intercept post stop 

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/InterceptorImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/InterceptorImpl.scala
@@ -95,6 +95,8 @@ private[akka] final class InterceptorImpl[O, I](val interceptor: BehaviorInterce
                 def apply(ctx: TypedActorContext[_], signal: Signal): Behavior[I] = Behavior.same
               })
           }
+        case _ ⇒
+          interceptor.aroundSignal(ctx, signal, signalTarget)
       }
       Behavior.same
 


### PR DESCRIPTION
Fixes #26285

Previously when `Behaviors.stop(callback-behavior)` was called, this completely replaced any interceptor, and the result was that the post-stop was not intercepted, this broke `withTimers` as it is an interceptor and wants to cancel the timers on `PostStop`