### PR TITLE
WIP Make postStop accept a callback instead of a behavior

### DIFF
--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorCompile.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorCompile.java
@@ -62,7 +62,7 @@ public class ActorCompile {
           });
   Behavior<MyMsg> actor9 = widened(actor7, pf -> pf.match(MyMsgA.class, x -> x));
   Behavior<MyMsg> actor10 =
-      Behaviors.receive((context, message) -> stopped(actor4), (context, signal) -> same());
+      Behaviors.receive((context, message) -> stopped(() -> System.out.println("Stopping")));
 
   ActorSystem<MyMsg> system = ActorSystem.create(actor1, "Sys");
 

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/GracefulStopDocTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/GracefulStopDocTest.java
@@ -60,13 +60,8 @@ public class GracefulStopDocTest {
                   context.getSystem().log().info("Initiating graceful shutdown...");
 
                   // perform graceful stop, executing cleanup before final system termination
-                  // behavior executing cleanup is passed as a parameter to Actor.stopped
-                  return Behaviors.stopped(
-                      Behaviors.receiveSignal(
-                          (_ctx, PostStop) -> {
-                            context.getSystem().log().info("Cleanup!");
-                            return Behaviors.same();
-                          }));
+                  // callback executing cleanup is passed as a parameter to Actor.stopped
+                  return Behaviors.stopped(() -> context.getSystem().log().info("Cleanup!"));
                 })
             .onSignal(
                 PostStop.class,

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/GracefulStopSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/GracefulStopSpec.scala
@@ -32,13 +32,9 @@ final class GracefulStopSpec extends ScalaTestWithActorTestKit with WordSpecLike
               Behaviors.stopped
           }, "child2")
 
-          Behaviors.stopped {
-            Behaviors.receiveSignal {
-              case (_, PostStop) ⇒
-                // cleanup function body
-                probe.ref ! "parent-done"
-                Behaviors.same
-            }
+          Behaviors.stopped { () ⇒
+            // cleanup function body
+            probe.ref ! "parent-done"
           }
         }
 
@@ -54,13 +50,9 @@ final class GracefulStopSpec extends ScalaTestWithActorTestKit with WordSpecLike
       val behavior =
         Behaviors.setup[akka.NotUsed] { _ ⇒
           // do not spawn any children
-          Behaviors.stopped {
-            Behaviors.receiveSignal {
-              case (_, PostStop) ⇒
-                // cleanup function body
-                probe.ref ! Done
-                Behaviors.same
-            }
+          Behaviors.stopped { () ⇒
+            // cleanup function body
+            probe.ref ! Done
           }
         }
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/GracefulStopDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/GracefulStopDocSpec.scala
@@ -37,13 +37,9 @@ object GracefulStopDocSpec {
         case GracefulShutdown ⇒
           context.log.info("Initiating graceful shutdown...")
           // perform graceful stop, executing cleanup before final system termination
-          // behavior executing cleanup is passed as a parameter to Actor.stopped
-          Behaviors.stopped {
-            Behaviors.receiveSignal {
-              case (context, PostStop) ⇒
-                cleanup(context.system.log)
-                Behaviors.same
-            }
+          // callback executing cleanup is passed as a parameter to Actor.stopped
+          Behaviors.stopped { () ⇒
+            cleanup(context.system.log)
           }
       }
     }.receiveSignal {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
@@ -74,6 +74,20 @@ object Behaviors {
    * shall terminate voluntarily. If this actor has created child actors then
    * these will be stopped as part of the shutdown procedure.
    *
+   * When the PostStop signal that results from stopping this actor is received the
+   * provided `postStop` runnable is invoked. All other messages and signals will effectively be
+   * ignored.
+   */
+  def stopped[T](postStop: Runnable): Behavior[T] = Behavior.stopped(receiveSignal((ctx, signal) ⇒ {
+    postStop.run();
+    return same[T];
+  }))
+
+  /**
+   * Return this behavior from message processing to signal that this actor
+   * shall terminate voluntarily. If this actor has created child actors then
+   * these will be stopped as part of the shutdown procedure.
+   *
    * The PostStop signal that results from stopping this actor will be passed to the
    * given `postStop` behavior. All other messages and signals will effectively be
    * ignored.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
@@ -62,6 +62,21 @@ object Behaviors {
    * shall terminate voluntarily. If this actor has created child actors then
    * these will be stopped as part of the shutdown procedure.
    *
+   * The when the PostStop signal that results from stopping this actor is received
+   * the given `postStop` callback will be invoked. All other messages and signals will effectively be
+   * ignored.
+   */
+  def stopped[T](postStop: () ⇒ Unit): Behavior[T] = Behavior.stopped(receiveSignal {
+    case (_, PostStop) ⇒
+      postStop()
+      Behaviors.same
+  })
+
+  /**
+   * Return this behavior from message processing to signal that this actor
+   * shall terminate voluntarily. If this actor has created child actors then
+   * these will be stopped as part of the shutdown procedure.
+   *
    * The PostStop signal that results from stopping this actor will be passed to the
    * given `postStop` behavior. All other messages and signals will effectively be
    * ignored.


### PR DESCRIPTION
I'd probably want to completely remove the one that takes a behavior, as that is more of an implementation detail than something that is interesting to users.