### PR TITLE
Add forgotten `expectNoMessage` method in TestSubscriber

### DIFF
--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -602,6 +602,17 @@ object TestSubscriber {
     /**
      * Fluent DSL
      *
+     * Same as `expectNoMessage(remaining)`, but correctly treating the timeFactor.
+     * NOTE! Timeout value is automatically multiplied by timeFactor.
+     */
+    def expectNoMessage(): Self = {
+      probe.expectNoMessage()
+      self
+    }
+
+    /**
+     * Fluent DSL
+     *
      * Assert that no message is received for the specified time.
      */
     def expectNoMessage(remaining: FiniteDuration): Self = {


### PR DESCRIPTION
Follow up of #26070 where the missing method was added only to the `StreamTestKit`.
`TestSubscriber` needs to have this overloaded method as well