### PR TITLE
Add Java DSL Flow#mapError version without PartialFunction (#24992)

### DIFF
--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
@@ -1093,7 +1093,7 @@ public class FlowTest extends StreamTest {
 
     source
         .via(flow)
-        .runWith(TestSink.probe(system), materializer)
+        .runWith(TestSink.probe(system), system)
         .request(2)
         .expectNext(head)
         .expectError(boom);
@@ -1107,7 +1107,7 @@ public class FlowTest extends StreamTest {
             .mapError(NoSuchElementException.class, IllegalArgumentException::new);
 
     final Throwable actual =
-        source.via(flow).runWith(TestSink.probe(system), materializer).request(1).expectError();
+        source.via(flow).runWith(TestSink.probe(system), system).request(1).expectError();
     org.junit.Assert.assertTrue(actual instanceof IndexOutOfBoundsException);
   }
 
@@ -1123,7 +1123,7 @@ public class FlowTest extends StreamTest {
 
     source
         .via(flow)
-        .runWith(TestSink.probe(system), materializer)
+        .runWith(TestSink.probe(system), system)
         .request(2)
         .expectNext(head)
         .expectError(boom);

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
@@ -13,6 +13,7 @@ import akka.japi.function.*;
 import akka.japi.pf.PFBuilder;
 import akka.stream.*;
 import akka.stream.scaladsl.FlowSpec;
+import akka.stream.testkit.javadsl.TestSink;
 import akka.util.ConstantFun;
 import akka.stream.javadsl.GraphDSL.Builder;
 import akka.stream.stage.*;
@@ -1078,6 +1079,36 @@ public class FlowTest extends StreamTest {
     probe.expectMsgEquals(55);
     probe.expectMsgEquals(0);
     future.toCompletableFuture().get(3, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void mustBeAbleToMapErrorClass() {
+    final String head = "foo";
+    final Source<Optional<String>, NotUsed> source =
+        Source.from(Arrays.asList(Optional.of(head), Optional.empty()));
+    final IllegalArgumentException boom = new IllegalArgumentException("boom");
+    final Flow<Optional<String>, String, NotUsed> flow =
+        Flow.<Optional<String>, String>fromFunction(Optional::get)
+            .mapError(NoSuchElementException.class, (NoSuchElementException e) -> boom);
+
+    source
+        .via(flow)
+        .runWith(TestSink.probe(system), materializer)
+        .request(2)
+        .expectNext(head)
+        .expectError(boom);
+  }
+
+  @Test
+  public void mustBeAbleToMapErrorClassExactly() {
+    final Source<String, NotUsed> source = Source.single("foo");
+    final Flow<String, Character, NotUsed> flow =
+        Flow.<String, Character>fromFunction(str -> str.charAt(-1))
+            .mapError(NoSuchElementException.class, IllegalArgumentException::new);
+
+    final Throwable actual =
+        source.via(flow).runWith(TestSink.probe(system), materializer).request(1).expectError();
+    org.junit.Assert.assertTrue(actual instanceof IndexOutOfBoundsException);
   }
 
   @Test

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowTest.java
@@ -1112,6 +1112,24 @@ public class FlowTest extends StreamTest {
   }
 
   @Test
+  public void mustBeAbleToMapErrorSuperClass() {
+    final String head = "foo";
+    final Source<Optional<String>, NotUsed> source =
+        Source.from(Arrays.asList(Optional.of(head), Optional.empty()));
+    final IllegalArgumentException boom = new IllegalArgumentException("boom");
+    final Flow<Optional<String>, String, NotUsed> flow =
+        Flow.<Optional<String>, String>fromFunction(Optional::get)
+            .mapError(RuntimeException.class, (RuntimeException e) -> boom);
+
+    source
+        .via(flow)
+        .runWith(TestSink.probe(system), materializer)
+        .request(2)
+        .expectNext(head)
+        .expectError(boom);
+  }
+
+  @Test
   public void mustBeAbleToMaterializeIdentityWithJavaFlow() throws Exception {
     final TestKit probe = new TestKit(system);
     final List<String> input = Arrays.asList("A", "B", "C");

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1576,7 +1576,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    */
   def mapError[E <: Throwable](clazz: Class[E], f: function.Function[E, Throwable]): javadsl.Flow[In, Out, Mat] =
     mapError {
-      case err if clazz.isInstance(err) ⇒ f(clazz.cast(err))
+      case err if clazz.isInstance(err) => f(clazz.cast(err))
     }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1556,6 +1556,32 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     new Flow(delegate.mapError(pf))
 
   /**
+   * Java API
+   *
+   * While similar to [[recover]] this operator can be used to transform an error signal to a different one *without* logging
+   * it as an error in the process. So in that sense it is NOT exactly equivalent to `recover(t => throw t2)` since recover
+   * would log the `t2` error.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This operator can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Similarly to [[recover]] throwing an exception inside `mapError` _will_ be logged.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   */
+  def mapError[E <: Throwable](clazz: Class[E], f: function.Function[E, Throwable]): javadsl.Flow[In, Out, Mat] =
+    mapError {
+      case err if clazz.isInstance(err) ⇒ f(clazz.cast(err))
+    }
+
+  /**
    * RecoverWith allows to switch to alternative Source on flow failure. It will stay in effect after
    * a failure has been recovered so that each time there is a failure it is fed into the `pf` and a new
    * Source may be materialized.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1556,8 +1556,6 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     new Flow(delegate.mapError(pf))
 
   /**
-   * Java API
-   *
    * While similar to [[recover]] this operator can be used to transform an error signal to a different one *without* logging
    * it as an error in the process. So in that sense it is NOT exactly equivalent to `recover(t => throw t2)` since recover
    * would log the `t2` error.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -1868,7 +1868,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    */
   def mapError[E <: Throwable](clazz: Class[E], f: function.Function[E, Throwable]): javadsl.Source[Out, Mat] =
     mapError {
-      case err if clazz.isInstance(err) ⇒ f(clazz.cast(err))
+      case err if clazz.isInstance(err) => f(clazz.cast(err))
     }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -1848,6 +1848,30 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
     new Source(delegate.mapError(pf))
 
   /**
+   * While similar to [[recover]] this operator can be used to transform an error signal to a different one *without* logging
+   * it as an error in the process. So in that sense it is NOT exactly equivalent to `recover(t => throw t2)` since recover
+   * would log the `t2` error.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This operator can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Similarly to [[recover]] throwing an exception inside `mapError` _will_ be logged.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   */
+  def mapError[E <: Throwable](clazz: Class[E], f: function.Function[E, Throwable]): javadsl.Source[Out, Mat] =
+    mapError {
+      case err if clazz.isInstance(err) ⇒ f(clazz.cast(err))
+    }
+
+  /**
    * RecoverWith allows to switch to alternative Source on flow failure. It will stay in effect after
    * a failure has been recovered so that each time there is a failure it is fed into the `pf` and a new
    * Source may be materialized.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -1027,6 +1027,30 @@ class SubFlow[In, Out, Mat](
     new SubFlow(delegate.mapError(pf))
 
   /**
+   * While similar to [[recover]] this operator can be used to transform an error signal to a different one *without* logging
+   * it as an error in the process. So in that sense it is NOT exactly equivalent to `recover(t => throw t2)` since recover
+   * would log the `t2` error.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This operator can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Similarly to [[recover]] throwing an exception inside `mapError` _will_ be logged.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   */
+  def mapError[E <: Throwable](clazz: Class[E], f: function.Function[E, Throwable]): javadsl.SubFlow[In, Out, Mat @uncheckedVariance] =
+    mapError {
+      case err if clazz.isInstance(err) ⇒ f(clazz.cast(err))
+    }
+
+  /**
    * Terminate processing (and cancel the upstream publisher) after the given
    * number of elements. Due to input buffering some elements may have been
    * requested from upstream publishers that will then not be processed downstream

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -1045,9 +1045,11 @@ class SubFlow[In, Out, Mat](
    * '''Cancels when''' downstream cancels
    *
    */
-  def mapError[E <: Throwable](clazz: Class[E], f: function.Function[E, Throwable]): javadsl.SubFlow[In, Out, Mat @uncheckedVariance] =
+  def mapError[E <: Throwable](
+      clazz: Class[E],
+      f: function.Function[E, Throwable]): javadsl.SubFlow[In, Out, Mat @uncheckedVariance] =
     mapError {
-      case err if clazz.isInstance(err) ⇒ f(clazz.cast(err))
+      case err if clazz.isInstance(err) => f(clazz.cast(err))
     }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -1028,7 +1028,7 @@ class SubSource[Out, Mat](
    */
   def mapError[E <: Throwable](clazz: Class[E], f: function.Function[E, Throwable]): javadsl.SubSource[Out, Mat] =
     mapError {
-      case err if clazz.isInstance(err) ⇒ f(clazz.cast(err))
+      case err if clazz.isInstance(err) => f(clazz.cast(err))
     }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -1008,6 +1008,30 @@ class SubSource[Out, Mat](
     new SubSource(delegate.mapError(pf))
 
   /**
+   * While similar to [[recover]] this operator can be used to transform an error signal to a different one *without* logging
+   * it as an error in the process. So in that sense it is NOT exactly equivalent to `recover(t => throw t2)` since recover
+   * would log the `t2` error.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This operator can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Similarly to [[recover]] throwing an exception inside `mapError` _will_ be logged.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and pf returns an element
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   */
+  def mapError[E <: Throwable](clazz: Class[E], f: function.Function[E, Throwable]): javadsl.SubSource[Out, Mat] =
+    mapError {
+      case err if clazz.isInstance(err) ⇒ f(clazz.cast(err))
+    }
+
+  /**
    * Terminate processing (and cancel the upstream publisher) after the given
    * number of elements. Due to input buffering some elements may have been
    * requested from upstream publishers that will then not be processed downstream


### PR DESCRIPTION
Add an overloaded version of the Flow#mapError (Java DSL) which does not use a Scala PartialFunction.

Resolves a part of #24992