### PR TITLE
Make copyUSAsciiStrToBytes more robust w.r.t. JDK for Java9+ #26286

### DIFF
--- a/akka-actor/src/main/scala/akka/util/Unsafe.java
+++ b/akka-actor/src/main/scala/akka/util/Unsafe.java
@@ -46,7 +46,7 @@ public final class Unsafe {
     public static void copyUSAsciiStrToBytes(String str, byte[] bytes) {
         if (isJavaVersion9Plus) {
             final byte[] chars = (byte[]) instance.getObject(str, stringValueFieldOffset);
-            System.arraycopy(chars, 0, bytes, 0, chars.length);
+            System.arraycopy(chars, 0, bytes, 0, str.length());
         } else {
             final char[] chars = (char[]) instance.getObject(str, stringValueFieldOffset);
             int i = 0;
@@ -63,7 +63,7 @@ public final class Unsafe {
 
         if (isJavaVersion9Plus) {
             final byte[] chars = (byte[]) instance.getObject(str, stringValueFieldOffset);
-            while (i < chars.length) {
+            while (i < str.length()) {
                 long x = s0 ^ (long)chars[i++]; // Mix character into PRNG state
                 long y = s1;
 
@@ -76,7 +76,7 @@ public final class Unsafe {
             }
         } else {
             final char[] chars = (char[]) instance.getObject(str, stringValueFieldOffset);
-            while (i < chars.length) {
+            while (i < str.length()) {
                 long x = s0 ^ (long)chars[i++]; // Mix character into PRNG state
                 long y = s1;
 

--- a/akka-actor/src/main/scala/akka/util/Unsafe.java
+++ b/akka-actor/src/main/scala/akka/util/Unsafe.java
@@ -46,7 +46,7 @@ public final class Unsafe {
     public static void copyUSAsciiStrToBytes(String str, byte[] bytes) {
         if (isJavaVersion9Plus) {
             final byte[] chars = (byte[]) instance.getObject(str, stringValueFieldOffset);
-            System.arraycopy(chars, 0, bytes, 0, chars.length);
+            System.arraycopy(chars, 0, bytes, 0, str.length());
         } else {
             final char[] chars = (char[]) instance.getObject(str, stringValueFieldOffset);
             int i = 0;


### PR DESCRIPTION
Resolves #26286 by applying same change for Java9+ as was done for Java8 in PR #25165