### PR TITLE
Typo in futures.md

### DIFF
--- a/akka-docs/src/main/paradox/futures.md
+++ b/akka-docs/src/main/paradox/futures.md
@@ -28,7 +28,7 @@ See also @ref:[Java 8 Compatibility](java8-compat.md) for Java compatibility.
 ## Execution Contexts
 
 In order to execute callbacks and operations, Futures need something called an `ExecutionContext`,
-which is very similar to a `java.util.concurrent.Executor`. if you have an `ActorSystem` in scope,
+which is very similar to a `java.util.concurrent.Executor`. If you have an `ActorSystem` in scope,
 it will use its default dispatcher as the `ExecutionContext`, or you can use the factory methods provided
 by the @scala[`ExecutionContext` companion object]@java[`ExecutionContexts` class] to wrap `Executors` and `ExecutorServices`, or even create your own.
 


### PR DESCRIPTION
Small letter at the start of the sentence.