### PR TITLE
Clarify Javadoc now needs jdk9+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,7 +274,7 @@ If you'd like to check if your links and formatting look good in JavaDoc (and no
 sbt -Dakka.genjavadoc.enabled=true javaunidoc:doc
 ```
 
-Which will generate JavaDoc style docs in `./target/javaunidoc/index.html`.
+Which will generate JavaDoc style docs in `./target/javaunidoc/index.html`. This requires a jdk version 9 or later.
 
 ## External dependencies
 


### PR DESCRIPTION
Because jdk8 does not have the option to ignore the errors in the
genjavadoc-generated java code.