### PR TITLE
build: detect adoptopenjdk java homes

### DIFF
--- a/project/CrossJava.scala
+++ b/project/CrossJava.scala
@@ -100,7 +100,7 @@ object CrossJava {
   }
 
   object JavaDiscoverConfig {
-    private val JavaHomeDir = """(java-|jdk-?)(1\.)?([0-9]+).*""".r
+    private val JavaHomeDir = """(java-|jdk-?|adoptopenjdk-)(1\.)?([0-9]+).*""".r
 
     class LinuxDiscoverConfig(base: File) extends JavaDiscoverConf {
       def javaHomes: Vector[(String, File)] =


### PR DESCRIPTION
The Ubuntu PPA for adoptopenjdk does not strictly follow the Ubuntu Java
naming correctly which can fail the akka build if no other JDK is installed.

rpardini/adoptopenjdk-deb-installer