### PR TITLE
Cover the unsafe string access optimizations with direct tests

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/AsciiStringCopySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/AsciiStringCopySpec.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+class AsciiStringCopySpec extends WordSpec with Matchers {
+
+  "The copyUSAsciiStrToBytes optimization" must {
+
+    "copy string internal representation successfully" in {
+      val ascii = "abcdefghijklmnopqrstuvxyz"
+      val byteArray = new Array[Byte](ascii.length)
+      Unsafe.copyUSAsciiStrToBytes(ascii, byteArray)
+      new String(byteArray) should ===(ascii)
+    }
+  }
+
+  "The fast hash optimization" must {
+
+    "hash strings successfully" in {
+      Unsafe.fastHash("abcdefghijklmnopqrstuvxyz")
+    }
+
+  }
+
+}

--- a/akka-actor-tests/src/test/scala/akka/util/AsciiStringCopySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/AsciiStringCopySpec.scala
@@ -3,6 +3,8 @@
  */
 
 package akka.util
+import java.nio.charset.StandardCharsets
+
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
 
@@ -14,7 +16,7 @@ class AsciiStringCopySpec extends WordSpec with Matchers {
       val ascii = "abcdefghijklmnopqrstuvxyz"
       val byteArray = new Array[Byte](ascii.length)
       Unsafe.copyUSAsciiStrToBytes(ascii, byteArray)
-      new String(byteArray) should ===(ascii)
+      new String(byteArray, StandardCharsets.US_ASCII) should ===(ascii)
     }
   }
 


### PR DESCRIPTION
Follow up on #26286 so that we notice quicker if new JDKs change internal representation somehow.