### PR TITLE
fix format of verbose logging of cluster events

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala
@@ -105,7 +105,7 @@ private[akka] class ClusterReadView(cluster: Cluster) extends Closeable {
             case _: SeenChanged ⇒ // ignore
             case event ⇒
               if (cluster.settings.LogInfoVerbose)
-                logInfo(" - event {}", event)
+                logInfo("event {}", event)
           }
 
         case s: CurrentClusterState ⇒ _state = s

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterLogSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterLogSpec.scala
@@ -31,9 +31,9 @@ abstract class ClusterLogSpec(config: Config) extends AkkaSpec(config) with Impl
 
   protected val selfAddress: Address = system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
 
-  protected val upLogMessage = " - event MemberUp"
+  protected val upLogMessage = "event MemberUp"
 
-  protected val downLogMessage = " - event MemberDowned"
+  protected val downLogMessage = "event MemberDowned"
 
   protected val cluster = Cluster(system)
 


### PR DESCRIPTION
The output was with one too many `-`, like
```
Cluster Node [...] -  - event ReachabilityChanged()
```