### PR TITLE
Fix excludes for docs publish in release script

### DIFF
--- a/project/scripts/release
+++ b/project/scripts/release
@@ -371,7 +371,7 @@ if [ $dry_run ]; then
 else
   important ssh ${release_server} "cd ${release_path}/docs/akka; git add .; git commit -m 'before publishing version $version'; true"
   important sbt "deployRsync ${release_server}"
-  important rsync -rlpvz --chmod=Dg+ws,Fg+w --exclude ${release_dir}/downloads --exclude ${release_dir}/docs ${release_dir}/ ${publish_path}/
+  important rsync -rlpvz --chmod=Dg+ws,Fg+w --exclude downloads --exclude docs ${release_dir}/ ${publish_path}/
   #important ssh ${release_server} cp -v ${release_path}/docs/akka/${version}/_static/warnOldDocs.js ${release_path}/docs/akka
   #important ssh ${release_server} ln -snvf ../../warnOldDocs.js ${release_path}/docs/akka/${version}/_static/warnOldDocs.js
   important ssh ${release_server} "cd ${release_path}/docs/akka; git add .; git commit -m 'publish version $version'"


### PR DESCRIPTION
They should be relative to the from path so this was rsyncing the
docs twice, once via SBT and once when doing the api docs