### PR TITLE
upgrade to latest ScalaTest

### DIFF
--- a/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/ActorTestKitTest.java
+++ b/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/ActorTestKitTest.java
@@ -8,7 +8,7 @@ import akka.Done;
 import akka.actor.typed.javadsl.Behaviors;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;

--- a/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/BehaviorTestKitTest.java
+++ b/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/BehaviorTestKitTest.java
@@ -14,7 +14,7 @@ import akka.actor.typed.javadsl.Behaviors;
 import akka.event.Logging;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/TestProbeTest.java
+++ b/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/TestProbeTest.java
@@ -12,7 +12,7 @@ import akka.actor.testkit.typed.scaladsl.TestProbeSpec;
 import akka.actor.testkit.typed.scaladsl.TestProbeSpec.*;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import static org.junit.Assert.*;
 

--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java
@@ -13,7 +13,7 @@ import akka.actor.testkit.typed.javadsl.ActorTestKit;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import org.junit.AfterClass;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.util.Success;
 import scala.util.Try;
 

--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/ManualTimerExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/ManualTimerExampleTest.java
@@ -10,7 +10,7 @@ import akka.actor.typed.Behavior;
 import akka.actor.testkit.typed.javadsl.ManualTime;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import org.junit.ClassRule;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import java.time.Duration;
 
 import akka.actor.typed.javadsl.Behaviors;

--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/SyncTestingExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/SyncTestingExampleTest.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 // #imports
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class SyncTestingExampleTest extends JUnitSuite {
 

--- a/akka-actor-tests/src/test/java/akka/actor/AbstractFSMActorTest.java
+++ b/akka-actor-tests/src/test/java/akka/actor/AbstractFSMActorTest.java
@@ -12,7 +12,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class AbstractFSMActorTest extends JUnitSuite {
 

--- a/akka-actor-tests/src/test/java/akka/actor/ActorCreationTest.java
+++ b/akka-actor-tests/src/test/java/akka/actor/ActorCreationTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 import akka.japi.Creator;
 import akka.japi.pf.ReceiveBuilder;
 
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class ActorCreationTest extends JUnitSuite {
 

--- a/akka-actor-tests/src/test/java/akka/actor/ActorSelectionTest.java
+++ b/akka-actor-tests/src/test/java/akka/actor/ActorSelectionTest.java
@@ -8,7 +8,7 @@ import akka.testkit.AkkaJUnitActorSystemResource;
 import akka.testkit.AkkaSpec;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import java.time.Duration;
 
 import java.util.concurrent.CompletionStage;

--- a/akka-actor-tests/src/test/java/akka/actor/ActorSystemTest.java
+++ b/akka-actor-tests/src/test/java/akka/actor/ActorSystemTest.java
@@ -8,7 +8,7 @@ import akka.testkit.AkkaJUnitActorSystemResource;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.concurrent.CompletionStage;
 

--- a/akka-actor-tests/src/test/java/akka/actor/InboxJavaAPITest.java
+++ b/akka-actor-tests/src/test/java/akka/actor/InboxJavaAPITest.java
@@ -10,7 +10,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import akka.testkit.AkkaJUnitActorSystemResource;
 import akka.testkit.AkkaSpec;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class InboxJavaAPITest extends JUnitSuite {
 

--- a/akka-actor-tests/src/test/java/akka/actor/JavaAPI.java
+++ b/akka-actor-tests/src/test/java/akka/actor/JavaAPI.java
@@ -20,7 +20,7 @@ import akka.testkit.TestProbe;
 
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.Option;
 
 import java.util.Optional;

--- a/akka-actor-tests/src/test/java/akka/actor/JavaExtension.java
+++ b/akka-actor-tests/src/test/java/akka/actor/JavaExtension.java
@@ -8,7 +8,7 @@ import akka.testkit.AkkaJUnitActorSystemResource;
 import org.junit.*;
 import akka.testkit.AkkaSpec;
 import com.typesafe.config.ConfigFactory;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import static org.junit.Assert.*;
 

--- a/akka-actor-tests/src/test/java/akka/actor/StashJavaAPI.java
+++ b/akka-actor-tests/src/test/java/akka/actor/StashJavaAPI.java
@@ -9,7 +9,7 @@ import akka.testkit.TestProbe;
 
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class StashJavaAPI extends JUnitSuite {
 

--- a/akka-actor-tests/src/test/java/akka/actor/setup/ActorSystemSetupTest.java
+++ b/akka-actor-tests/src/test/java/akka/actor/setup/ActorSystemSetupTest.java
@@ -7,7 +7,7 @@ package akka.actor.setup;
 import akka.actor.setup.ActorSystemSetup;
 import akka.actor.setup.Setup;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Optional;
 

--- a/akka-actor-tests/src/test/java/akka/dispatch/JavaFutureTests.java
+++ b/akka-actor-tests/src/test/java/akka/dispatch/JavaFutureTests.java
@@ -9,7 +9,7 @@ import akka.actor.ActorSystem;
 
 import akka.japi.*;
 import org.junit.ClassRule;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.Function1;
 import scala.concurrent.Await;
 import scala.concurrent.Future;

--- a/akka-actor-tests/src/test/java/akka/event/LoggingAdapterTest.java
+++ b/akka-actor-tests/src/test/java/akka/event/LoggingAdapterTest.java
@@ -18,7 +18,7 @@ import com.typesafe.config.ConfigFactory;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.*;
 import java.time.Duration;

--- a/akka-actor-tests/src/test/java/akka/japi/JavaAPITestBase.java
+++ b/akka-actor-tests/src/test/java/akka/japi/JavaAPITestBase.java
@@ -9,7 +9,7 @@ import akka.event.LoggingAdapter;
 import akka.event.NoLogging;
 import akka.serialization.JavaSerializer;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.concurrent.Callable;
 

--- a/akka-actor-tests/src/test/java/akka/japi/MatchBuilderTest.java
+++ b/akka-actor-tests/src/test/java/akka/japi/MatchBuilderTest.java
@@ -9,7 +9,7 @@ import akka.japi.pf.Match;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.MatchError;
 
 import static org.junit.Assert.*;

--- a/akka-actor-tests/src/test/java/akka/japi/pf/PFBuilderTest.java
+++ b/akka-actor-tests/src/test/java/akka/japi/pf/PFBuilderTest.java
@@ -5,7 +5,7 @@
 package akka.japi.pf;
 
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.PartialFunction;
 
 import static org.junit.Assert.*;

--- a/akka-actor-tests/src/test/java/akka/japi/pf/ReceiveBuilderTest.java
+++ b/akka-actor-tests/src/test/java/akka/japi/pf/ReceiveBuilderTest.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import org.junit.Before;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import akka.actor.AbstractActor.Receive;
 

--- a/akka-actor-tests/src/test/java/akka/pattern/CircuitBreakerTest.java
+++ b/akka-actor-tests/src/test/java/akka/pattern/CircuitBreakerTest.java
@@ -10,7 +10,7 @@ import akka.testkit.AkkaSpec;
 import akka.util.JavaDurationConverters;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.compat.java8.FutureConverters;
 import scala.concurrent.Await;
 

--- a/akka-actor-tests/src/test/java/akka/pattern/PatternsTest.java
+++ b/akka-actor-tests/src/test/java/akka/pattern/PatternsTest.java
@@ -12,7 +12,7 @@ import akka.testkit.TestProbe;
 import akka.util.Timeout;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;

--- a/akka-actor-tests/src/test/java/akka/util/ByteStringTest.java
+++ b/akka-actor-tests/src/test/java/akka/util/ByteStringTest.java
@@ -5,7 +5,7 @@
 package akka.util;
 
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import static junit.framework.TestCase.assertEquals;
 

--- a/akka-actor-tests/src/test/java/akka/util/JavaDuration.java
+++ b/akka-actor-tests/src/test/java/akka/util/JavaDuration.java
@@ -5,7 +5,7 @@
 package akka.util;
 
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 
 public class JavaDuration extends JUnitSuite {

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Await
 import akka.pattern.ask
 import scala.concurrent.duration._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.junit.JUnitSuiteLike
+import org.scalatestplus.junit.JUnitSuiteLike
 
 object ActorWithStashSpec {
 

--- a/akka-actor-tests/src/test/scala/akka/actor/ExtensionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ExtensionSpec.scala
@@ -10,7 +10,7 @@ import akka.testkit.EventFilter
 import akka.testkit.TestKit._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{ Matchers, WordSpec }
-import org.scalatest.junit.JUnitSuiteLike
+import org.scalatestplus.junit.JUnitSuiteLike
 
 import scala.util.control.NoStackTrace
 

--- a/akka-actor-tests/src/test/scala/akka/actor/JavaAPISpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/JavaAPISpec.scala
@@ -4,6 +4,6 @@
 
 package akka.actor
 
-import org.scalatest.junit.JUnitSuiteLike
+import org.scalatestplus.junit.JUnitSuiteLike
 
 class JavaAPISpec extends JavaAPI with JUnitSuiteLike

--- a/akka-actor-tests/src/test/scala/akka/japi/JavaAPITest.scala
+++ b/akka-actor-tests/src/test/scala/akka/japi/JavaAPITest.scala
@@ -4,6 +4,6 @@
 
 package akka.japi
 
-import org.scalatest.junit.JUnitSuiteLike
+import org.scalatestplus.junit.JUnitSuiteLike
 
 class JavaAPITest extends JavaAPITestBase with JUnitSuiteLike

--- a/akka-actor-tests/src/test/scala/akka/util/JavaDurationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/JavaDurationSpec.scala
@@ -4,6 +4,6 @@
 
 package akka.util
 
-import org.scalatest.junit.JUnitSuiteLike
+import org.scalatestplus.junit.JUnitSuiteLike
 
 class JavaDurationSpec extends JavaDuration with JUnitSuiteLike

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/ActorSystemTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/ActorSystemTest.java
@@ -6,7 +6,7 @@
 package akka.actor.typed;
 
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.concurrent.CompletionStage;
 

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/ExtensionsTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/ExtensionsTest.java
@@ -8,7 +8,7 @@ import akka.actor.setup.ActorSystemSetup;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.function.Function;
 

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorContextAskTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorContextAskTest.java
@@ -12,7 +12,7 @@ import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.util.Timeout;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorContextPipeToSelfTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorContextPipeToSelfTest.java
@@ -11,7 +11,7 @@ import akka.actor.typed.Props;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorLoggingTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorLoggingTest.java
@@ -13,7 +13,7 @@ import akka.testkit.CustomEventFilter;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.util.HashMap;

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/AdapterTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/AdapterTest.java
@@ -6,7 +6,7 @@ package akka.actor.typed.javadsl;
 
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import scala.concurrent.duration.FiniteDuration;
 

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/BehaviorBuilderTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/BehaviorBuilderTest.java
@@ -8,7 +8,7 @@ import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import akka.actor.typed.Behavior;
 import akka.actor.typed.Terminated;

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/InterceptTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/InterceptTest.java
@@ -10,7 +10,7 @@ import akka.actor.typed.*;
 import akka.testkit.AkkaSpec;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class InterceptTest extends JUnitSuite {
 

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ReceiveBuilderTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ReceiveBuilderTest.java
@@ -9,7 +9,7 @@ import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import akka.actor.typed.Behavior;
 

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/WatchTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/WatchTest.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit;
 import akka.Done;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import org.junit.ClassRule;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import org.junit.Test;
 
 import akka.actor.typed.*;

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/BubblingSampleTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/BubblingSampleTest.java
@@ -9,7 +9,7 @@ import akka.actor.typed.internal.adapter.ActorSystemAdapter;
 import akka.testkit.javadsl.EventFilter;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.concurrent.TimeUnit;
 

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/DispatchersDocTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/DispatchersDocTest.java
@@ -6,7 +6,7 @@ package jdocs.akka.typed;
 
 import akka.actor.typed.Behavior;
 import akka.actor.typed.javadsl.*;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import akka.actor.typed.DispatcherSelector;
 
 public class DispatchersDocTest {

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java
@@ -11,7 +11,7 @@ import akka.actor.typed.Props;
 import akka.actor.typed.javadsl.*;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.FiniteDuration;
 

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/StashDocTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/StashDocTest.java
@@ -16,7 +16,7 @@ import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingUntypedTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingUntypedTest.java
@@ -15,7 +15,7 @@ import akka.actor.typed.javadsl.Adapter;
 import akka.testkit.javadsl.TestKit;
 import akka.testkit.TestProbe;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 
 import static akka.actor.typed.javadsl.Behaviors.same;

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/UntypedWatchingTypedTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/UntypedWatchingTypedTest.java
@@ -16,7 +16,7 @@ import akka.actor.typed.javadsl.Adapter;
 import akka.testkit.TestProbe;
 import akka.testkit.javadsl.TestKit;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 
 import static akka.actor.typed.javadsl.Behaviors.same;

--- a/akka-camel/src/test/java/akka/camel/ConsumerJavaTest.java
+++ b/akka-camel/src/test/java/akka/camel/ConsumerJavaTest.java
@@ -9,7 +9,7 @@ import akka.testkit.AkkaSpec;
 import akka.testkit.javadsl.EventFilter;
 import akka.testkit.javadsl.TestKit;
 import org.junit.ClassRule;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.util.Timeout;

--- a/akka-camel/src/test/java/akka/camel/CustomRouteTest.java
+++ b/akka-camel/src/test/java/akka/camel/CustomRouteTest.java
@@ -11,7 +11,7 @@ import akka.camel.javaapi.UntypedProducerActor;
 import akka.testkit.AkkaJUnitActorSystemResource;
 import akka.util.Timeout;
 import org.junit.*;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.duration.Duration;

--- a/akka-camel/src/test/java/akka/camel/MessageJavaTest.java
+++ b/akka-camel/src/test/java/akka/camel/MessageJavaTest.java
@@ -11,7 +11,7 @@ import org.apache.camel.NoTypeConversionAvailableException;
 import org.apache.camel.converter.stream.InputStreamCache;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.io.InputStream;
 import java.util.*;

--- a/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/javadsl/ClusterShardingPersistenceTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/javadsl/ClusterShardingPersistenceTest.java
@@ -19,7 +19,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.concurrent.CompletionStage;
 

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleTest.java
@@ -15,7 +15,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import static jdocs.akka.cluster.sharding.typed.HelloWorldPersistentEntityExample.*;
 import static org.junit.Assert.assertEquals;

--- a/akka-cluster-tools/src/test/java/akka/cluster/client/ClusterClientTest.java
+++ b/akka-cluster-tools/src/test/java/akka/cluster/client/ClusterClientTest.java
@@ -13,7 +13,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import akka.testkit.AkkaJUnitActorSystemResource;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class ClusterClientTest extends JUnitSuite {
 

--- a/akka-cluster-tools/src/test/java/akka/cluster/pubsub/DistributedPubSubMediatorTest.java
+++ b/akka-cluster-tools/src/test/java/akka/cluster/pubsub/DistributedPubSubMediatorTest.java
@@ -17,7 +17,7 @@ import akka.actor.Props;
 import akka.actor.AbstractActor;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class DistributedPubSubMediatorTest extends JUnitSuite {
 

--- a/akka-cluster-typed/src/test/java/akka/cluster/ddata/typed/javadsl/ReplicatorTest.java
+++ b/akka-cluster-typed/src/test/java/akka/cluster/ddata/typed/javadsl/ReplicatorTest.java
@@ -9,7 +9,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 // #sample
 import java.util.Optional;

--- a/akka-cluster-typed/src/test/java/akka/cluster/typed/ClusterApiTest.java
+++ b/akka-cluster-typed/src/test/java/akka/cluster/typed/ClusterApiTest.java
@@ -10,7 +10,7 @@ import akka.actor.testkit.typed.javadsl.TestProbe;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 

--- a/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/ReceptionistExampleTest.java
+++ b/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/ReceptionistExampleTest.java
@@ -18,7 +18,7 @@ import akka.cluster.ClusterEvent;
 import akka.cluster.typed.Cluster;
 import akka.cluster.typed.Subscribe;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 

--- a/akka-contrib/src/test/java/akka/contrib/pattern/ReliableProxyTest.java
+++ b/akka-contrib/src/test/java/akka/contrib/pattern/ReliableProxyTest.java
@@ -12,7 +12,7 @@ import akka.testkit.AkkaJUnitActorSystemResource;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 import akka.testkit.TestProbe;
 

--- a/akka-contrib/src/test/java/akka/contrib/throttle/TimerBasedThrottlerTest.java
+++ b/akka-contrib/src/test/java/akka/contrib/throttle/TimerBasedThrottlerTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 import com.typesafe.config.ConfigFactory;
 import akka.actor.ActorRef;

--- a/akka-docs/src/test/java/jdocs/AbstractJavaTest.java
+++ b/akka-docs/src/test/java/jdocs/AbstractJavaTest.java
@@ -4,7 +4,7 @@
 
 package jdocs;
 
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 /** Base class for all runnable example tests written in Java */
 public abstract class AbstractJavaTest extends JUnitSuite {}

--- a/akka-docs/src/test/java/jdocs/tutorial_1/ActorHierarchyExperiments.java
+++ b/akka-docs/src/test/java/jdocs/tutorial_1/ActorHierarchyExperiments.java
@@ -11,7 +11,7 @@ import akka.testkit.javadsl.TestKit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 // #print-refs
 import akka.actor.AbstractActor;

--- a/akka-docs/src/test/java/jdocs/tutorial_3/DeviceTest.java
+++ b/akka-docs/src/test/java/jdocs/tutorial_3/DeviceTest.java
@@ -11,7 +11,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import akka.actor.ActorSystem;
 import akka.actor.ActorRef;

--- a/akka-docs/src/test/java/jdocs/tutorial_4/DeviceGroupTest.java
+++ b/akka-docs/src/test/java/jdocs/tutorial_4/DeviceGroupTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class DeviceGroupTest extends JUnitSuite {
 

--- a/akka-docs/src/test/java/jdocs/tutorial_4/DeviceTest.java
+++ b/akka-docs/src/test/java/jdocs/tutorial_4/DeviceTest.java
@@ -13,7 +13,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Optional;
 

--- a/akka-docs/src/test/java/jdocs/tutorial_5/DeviceGroupQueryTest.java
+++ b/akka-docs/src/test/java/jdocs/tutorial_5/DeviceGroupQueryTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.util.HashMap;

--- a/akka-docs/src/test/java/jdocs/tutorial_5/DeviceGroupTest.java
+++ b/akka-docs/src/test/java/jdocs/tutorial_5/DeviceGroupTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class DeviceGroupTest extends JUnitSuite {
 

--- a/akka-docs/src/test/java/jdocs/tutorial_5/DeviceTest.java
+++ b/akka-docs/src/test/java/jdocs/tutorial_5/DeviceTest.java
@@ -15,7 +15,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class DeviceTest extends JUnitSuite {
 

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_1/ActorHierarchyExperiments.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_1/ActorHierarchyExperiments.java
@@ -8,7 +8,7 @@ import akka.actor.typed.PreRestart;
 import akka.actor.typed.SupervisorStrategy;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.typed.PostStop;

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_3/DeviceTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_3/DeviceTest.java
@@ -23,7 +23,7 @@ import static com.lightbend.akka.sample.DeviceProtocol.*;
 public class DeviceTest {
 //#device-read-test
 */
-public class DeviceTest extends org.scalatest.junit.JUnitSuite {
+public class DeviceTest extends org.scalatestplus.junit.JUnitSuite {
   // #device-read-test
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceGroupTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceGroupTest.java
@@ -9,7 +9,7 @@ import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceManagerTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceManagerTest.java
@@ -9,7 +9,7 @@ import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import static jdocs.typed.tutorial_4.DeviceManagerProtocol.*;
 import static org.junit.Assert.assertNotEquals;

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_4/DeviceTest.java
@@ -9,7 +9,7 @@ import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Optional;
 

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceGroupQueryTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceGroupQueryTest.java
@@ -9,7 +9,7 @@ import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.time.Duration;
 import java.util.HashMap;

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceGroupTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceGroupTest.java
@@ -9,7 +9,7 @@ import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceManagerTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceManagerTest.java
@@ -9,7 +9,7 @@ import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import static jdocs.typed.tutorial_5.DeviceManagerProtocol.*;
 import static org.junit.Assert.assertNotEquals;

--- a/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceTest.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_5/DeviceTest.java
@@ -9,7 +9,7 @@ import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Optional;
 

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/EventSourcedActorFailureTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/EventSourcedActorFailureTest.java
@@ -15,7 +15,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.time.Duration;
 

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/NullEmptyStateTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/NullEmptyStateTest.java
@@ -14,7 +14,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class NullEmptyStateTest extends JUnitSuite {
 

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -32,7 +32,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import scala.Function0;
 
 import java.io.Serializable;

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PrimitiveStateTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PrimitiveStateTest.java
@@ -14,7 +14,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class PrimitiveStateTest extends JUnitSuite {
 

--- a/akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFSMTest.java
+++ b/akka-persistence/src/test/java/akka/persistence/fsm/AbstractPersistentFSMTest.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 
 import akka.persistence.fsm.PersistentFSM.CurrentState;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import static akka.persistence.fsm.PersistentFSM.FSMState;
 

--- a/akka-stream-tests-tck/src/test/scala/akka/stream/tck/AkkaIdentityProcessorVerification.scala
+++ b/akka-stream-tests-tck/src/test/scala/akka/stream/tck/AkkaIdentityProcessorVerification.scala
@@ -11,7 +11,7 @@ import akka.stream.testkit.TestPublisher
 import org.reactivestreams.{ Subscriber, Subscription, Processor, Publisher }
 import org.reactivestreams.tck.IdentityProcessorVerification
 import org.reactivestreams.tck.TestEnvironment
-import org.scalatest.testng.TestNGSuiteLike
+import org.scalatestplus.testng.TestNGSuiteLike
 import org.testng.annotations.AfterClass
 
 abstract class AkkaIdentityProcessorVerification[T](env: TestEnvironment, publisherShutdownTimeout: Long)

--- a/akka-stream-tests-tck/src/test/scala/akka/stream/tck/AkkaPublisherVerification.scala
+++ b/akka-stream-tests-tck/src/test/scala/akka/stream/tck/AkkaPublisherVerification.scala
@@ -10,7 +10,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.testkit.TestPublisher
 import org.reactivestreams.Publisher
 import org.reactivestreams.tck.{ PublisherVerification, TestEnvironment }
-import org.scalatest.testng.TestNGSuiteLike
+import org.scalatestplus.testng.TestNGSuiteLike
 
 abstract class AkkaPublisherVerification[T](val env: TestEnvironment, publisherShutdownTimeout: Long)
   extends PublisherVerification[T](env, publisherShutdownTimeout)

--- a/akka-stream-tests-tck/src/test/scala/akka/stream/tck/AkkaSubscriberVerification.scala
+++ b/akka-stream-tests-tck/src/test/scala/akka/stream/tck/AkkaSubscriberVerification.scala
@@ -10,7 +10,7 @@ import akka.stream.ActorMaterializer
 import org.reactivestreams.tck.SubscriberBlackboxVerification
 import org.reactivestreams.tck.SubscriberWhiteboxVerification
 import org.reactivestreams.tck.TestEnvironment
-import org.scalatest.testng.TestNGSuiteLike
+import org.scalatestplus.testng.TestNGSuiteLike
 
 abstract class AkkaSubscriberBlackboxVerification[T](env: TestEnvironment)
   extends SubscriberBlackboxVerification[T](env) with TestNGSuiteLike

--- a/akka-stream-tests-tck/src/test/scala/akka/stream/tck/SinkholeSubscriberTest.scala
+++ b/akka-stream-tests-tck/src/test/scala/akka/stream/tck/SinkholeSubscriberTest.scala
@@ -8,7 +8,7 @@ import akka.Done
 import akka.stream.impl.SinkholeSubscriber
 import org.reactivestreams.tck.{ TestEnvironment, SubscriberWhiteboxVerification }
 import org.reactivestreams.tck.SubscriberWhiteboxVerification.{ SubscriberPuppet, WhiteboxSubscriberProbe }
-import org.scalatest.testng.{ TestNGSuiteLike }
+import org.scalatestplus.testng.{ TestNGSuiteLike }
 import java.lang.{ Integer ⇒ JInt }
 import scala.concurrent.Promise
 import org.reactivestreams.{ Subscription, Subscriber }

--- a/akka-stream-tests/src/test/java/akka/stream/StreamTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/StreamTest.java
@@ -7,7 +7,7 @@ package akka.stream;
 import akka.stream.testkit.javadsl.StreamTestKit;
 import org.junit.After;
 import org.junit.Before;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import akka.actor.ActorSystem;
 import akka.testkit.AkkaJUnitActorSystemResource;

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
         case Some((2, n)) if n >= 12 ⇒ "1.14.0" // does not work for 2.11
         case _                       ⇒ "1.13.2"
       }),
-    scalaTestVersion := "3.0.6-SNAP5",
+    scalaTestVersion := "3.0.6-SNAP6",
     java8CompatVersion := {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, n)) if n >= 13 ⇒ "0.9.0"


### PR DESCRIPTION
stuff moved to a new package. you wouldn't expect that in a point
release, but they put type aliases in place so Scala users wouldn't
notice. but the change is visible to Java code.

the upgrade is not strictly necessary, but it would be convenient
for the Scala 2.13 community build to have this merged, so I don't
have to maintain these changes in our Akka fork