### PR TITLE
Create one SBT general task to run locally before pushing a PR #26157

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -509,13 +509,13 @@ def akkaModule(name: String): Project =
   - the assumption is the user has already run tests, hence the test:compile. */
 def commandValue(p: Project, externalTest: Option[Project] = None) = {
   val test = externalTest.getOrElse(p)
-  s";${p.id}/clean;${test.id}/test:compile;${p.id}/mimaReportBinaryIssues;${docs.id}/paradox"
+  s"${test.id}/test:compile;${p.id}/mimaReportBinaryIssues;${docs.id}/paradox"
 }
-addCommandAlias("actorAll", commandValue(actor, Some(actorTests)))
-addCommandAlias("remoteAll", commandValue(remote, Some(remoteTests)))
-addCommandAlias("clusterAll", commandValue(cluster))
-addCommandAlias("distributedDataAll", commandValue(distributedData))
-addCommandAlias("clusterShardingAll", commandValue(clusterSharding))
-addCommandAlias("persistenceAll", commandValue(persistence))
-addCommandAlias("streamAll", commandValue(stream, Some(streamTests)))
-addCommandAlias("discoveryAll", commandValue(discovery))
+addCommandAlias("allActor", commandValue(actor, Some(actorTests)))
+addCommandAlias("allRemote", commandValue(remote, Some(remoteTests)))
+addCommandAlias("allCluster", commandValue(cluster))
+addCommandAlias("allDistributedData", commandValue(distributedData))
+addCommandAlias("allClusterSharding", commandValue(clusterSharding))
+addCommandAlias("allPersistence", commandValue(persistence))
+addCommandAlias("allStream", commandValue(stream, Some(streamTests)))
+addCommandAlias("allDiscovery", commandValue(discovery))

--- a/build.sbt
+++ b/build.sbt
@@ -502,3 +502,20 @@ def akkaModule(name: String): Project =
     .settings(akka.AkkaBuild.defaultSettings)
     .settings(akka.Formatting.formatSettings)
     .enablePlugins(BootstrapGenjavadoc)
+
+/* Command aliases one can run locally against a module
+  - where three or more tasks should be checked for faster turnaround
+  - to avoid another push and CI cycle should mima or paradox fail.
+  - the assumption is the user has already run tests, hence the test:compile. */
+def commandValue(p: Project, externalTest: Option[Project] = None) = {
+  val test = externalTest.getOrElse(p)
+  s";${p.id}/clean;${test.id}/test:compile;${p.id}/mimaReportBinaryIssues;${docs.id}/paradox"
+}
+addCommandAlias("actorAll", commandValue(actor, Some(actorTests)))
+addCommandAlias("remoteAll", commandValue(remote, Some(remoteTests)))
+addCommandAlias("clusterAll", commandValue(cluster))
+addCommandAlias("distributedDataAll", commandValue(distributedData))
+addCommandAlias("clusterShardingAll", commandValue(clusterSharding))
+addCommandAlias("persistenceAll", commandValue(persistence))
+addCommandAlias("streamAll", commandValue(stream, Some(streamTests)))
+addCommandAlias("discoveryAll", commandValue(discovery))

--- a/build.sbt
+++ b/build.sbt
@@ -509,7 +509,8 @@ def akkaModule(name: String): Project =
   - the assumption is the user has already run tests, hence the test:compile. */
 def commandValue(p: Project, externalTest: Option[Project] = None) = {
   val test = externalTest.getOrElse(p)
-  s"${test.id}/test:compile;${p.id}/mimaReportBinaryIssues;${docs.id}/paradox"
+  val optionalMima = if (p.id.endsWith("-typed")) "" else s";${p.id}/mimaReportBinaryIssues"
+  s";${test.id}/test:compile$optionalMima;${docs.id}/paradox"
 }
 addCommandAlias("allActor", commandValue(actor, Some(actorTests)))
 addCommandAlias("allRemote", commandValue(remote, Some(remoteTests)))
@@ -519,3 +520,10 @@ addCommandAlias("allClusterSharding", commandValue(clusterSharding))
 addCommandAlias("allPersistence", commandValue(persistence))
 addCommandAlias("allStream", commandValue(stream, Some(streamTests)))
 addCommandAlias("allDiscovery", commandValue(discovery))
+addCommandAlias("allTyped", Seq(
+  commandValue(actorTyped, Some(actorTypedTests)),
+  commandValue(actorTestkitTyped),
+  commandValue(clusterTyped),
+  commandValue(clusterShardingTyped),
+  commandValue(persistenceTyped),
+  commandValue(streamTyped)).mkString)


### PR DESCRIPTION
#26157

For a starting point, this offers the ability to locally run several pre-push tasks locally.
Originally I had it also running the relevant tests but changed it to just the `test:compile` for speed because the user would already have run the tests necessary.  See the full list of tasks in the diff.