### PR TITLE
second fix 2.13 compilation error, SortedSet, #26382

### DIFF
--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerDownedSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerDownedSpec.scala
@@ -5,7 +5,6 @@
 package akka.cluster.singleton
 
 import scala.concurrent.duration._
-
 import akka.actor.Actor
 import akka.actor.ActorRef
 import akka.actor.PoisonPill
@@ -18,6 +17,7 @@ import akka.remote.testkit.MultiNodeSpec
 import akka.remote.testkit.STMultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter
 import akka.testkit._
+import akka.util.ccompat.imm._
 import com.typesafe.config.ConfigFactory
 
 object ClusterSingletonManagerDownedSpec extends MultiNodeConfig {


### PR DESCRIPTION
Previous PR https://github.com/akka/akka/pull/26391 passed PR validation although it has compilation error. https://jenkins.akka.io:8498/job/pr-validator-per-commit-jenkins/14750/consoleText

```
[error] /localhome/jenkinsakka/workspace/pr-validator-per-commit-jenkins/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerDownedSpec.scala:90:33: value unsorted is not a member of scala.collection.immutable.SortedSet[akka.cluster.Member]
[error]           cluster.state.members.unsorted.map(_.status) should ===(Set(MemberStatus.Up))
[error]                                 ^
```

We must investigate why.

Refs #26382