### PR TITLE
Wrap exception from unstash, #26148

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
@@ -39,7 +39,7 @@ object ActorSpecMessages {
 
   case class StopRef[T](ref: ActorRef[T]) extends Command
 
-  case class GotSignal(signal: Signal) extends Event
+  case class ReceivedSignal(signal: Signal) extends Event
 
   case class GotChildSignal(signal: Signal) extends Event
 
@@ -130,7 +130,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
           throw new TestException("Boom")
       } receiveSignal {
         case (_, signal) ⇒
-          probe.ref ! GotSignal(signal)
+          probe.ref ! ReceivedSignal(signal)
           Behaviors.same
       }).decorate
 
@@ -139,7 +139,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
       EventFilter[TestException](occurrences = 1).intercept {
         actor ! Fail
       }
-      probe.expectMessage(GotSignal(PreRestart))
+      probe.expectMessage(ReceivedSignal(PreRestart))
     }
 
     "signal post stop after voluntary termination" in {
@@ -150,13 +150,13 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
           case (_, Stop) ⇒ Behaviors.stopped
         } receiveSignal {
           case (_, signal) ⇒
-            probe.ref ! GotSignal(signal)
+            probe.ref ! ReceivedSignal(signal)
             Behaviors.same
         }).decorate
 
       val actor = spawn(behavior)
       actor ! Stop
-      probe.expectMessage(GotSignal(PostStop))
+      probe.expectMessage(ReceivedSignal(PostStop))
     }
 
     "restart and stop a child actor" in {
@@ -186,7 +186,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
             Behavior.same
         } receiveSignal {
           case (_, signal) ⇒
-            probe.ref ! GotSignal(signal)
+            probe.ref ! ReceivedSignal(signal)
             Behavior.stopped
         }).decorate
       })
@@ -217,7 +217,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
             Behaviors.same
         } receiveSignal {
           case (_, signal) ⇒
-            probe.ref ! GotSignal(signal)
+            probe.ref ! ReceivedSignal(signal)
             Behavior.stopped
         }
       }).decorate
@@ -285,7 +285,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
           throw new TestException("boom")
       } receiveSignal {
         case (_, PostStop) ⇒
-          probe.ref ! GotSignal(PostStop)
+          probe.ref ! ReceivedSignal(PostStop)
           Behavior.same
       }).decorate
       val actorToWatch = spawn(behavior)
@@ -297,7 +297,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
             Behavior.same
         } receiveSignal {
           case (_, signal) ⇒
-            probe.ref ! GotSignal(signal)
+            probe.ref ! ReceivedSignal(signal)
             Behavior.same
         }
       ).decorate)
@@ -308,7 +308,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
       EventFilter[TestException](occurrences = 1).intercept {
         actorToWatch ! Fail
       }
-      probe.expectMessage(GotSignal(PostStop))
+      probe.expectMessage(ReceivedSignal(PostStop))
       probe.expectTerminated(actorToWatch, timeout.duration)
     }
 
@@ -352,7 +352,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
               Behaviors.same
           } receiveSignal {
             case (_, signal) ⇒
-              probe.ref ! GotSignal(signal)
+              probe.ref ! ReceivedSignal(signal)
               Behaviors.same
           }
         }).decorate
@@ -379,7 +379,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
               Behaviors.same
           } receiveSignal {
             case (_, signal) ⇒
-              probe.ref ! GotSignal(signal)
+              probe.ref ! ReceivedSignal(signal)
               Behaviors.same
           }
         }).decorate
@@ -414,7 +414,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
               Behaviors.same
           } receiveSignal {
             case (_, signal) ⇒
-              probe.ref ! GotSignal(signal)
+              probe.ref ! ReceivedSignal(signal)
               Behaviors.same
           }
         }).decorate
@@ -451,12 +451,12 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
               } receiveSignal {
                 case (_, Terminated(_)) ⇒ Behaviors.unhandled
                 case (_, signal) ⇒
-                  probe.ref ! GotSignal(signal)
+                  probe.ref ! ReceivedSignal(signal)
                   Behaviors.same
               }
           } receiveSignal {
             case (_, signal) ⇒
-              probe.ref ! GotSignal(signal)
+              probe.ref ! ReceivedSignal(signal)
               Behaviors.same
           }
         }).decorate
@@ -467,7 +467,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit(
       EventFilter[DeathPactException](occurrences = 1).intercept {
         childRef ! Stop
         probe.expectMessage(GotChildSignal(PostStop))
-        probe.expectMessage(GotSignal(PostStop))
+        probe.expectMessage(ReceivedSignal(PostStop))
         probe.expectTerminated(actor, timeout.duration)
       }
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
@@ -48,7 +48,7 @@ object BehaviorSpec {
   case object Stop extends Command
 
   sealed trait Event
-  case class GotSignal(signal: Signal) extends Event
+  case class ReceivedSignal(signal: Signal) extends Event
   case class Self(self: ActorRef[Command]) extends Event
   case object Missed extends Event
   case object Ignored extends Event
@@ -100,7 +100,7 @@ object BehaviorSpec {
     implicit class Check(val setup: Setup) {
       def check(signal: Signal): Setup = {
         setup.testKit.signal(signal)
-        setup.inbox.receiveAll() should ===(GotSignal(signal) :: Nil)
+        setup.inbox.receiveAll() should ===(ReceivedSignal(signal) :: Nil)
         checkAux(signal, setup.aux)
         setup
       }
@@ -166,7 +166,7 @@ object BehaviorSpec {
       case (_, _)    ⇒ SBehaviors.unhandled
     } receiveSignal {
       case (_, signal) ⇒
-        monitor ! GotSignal(signal)
+        monitor ! ReceivedSignal(signal)
         SBehaviors.same
     }
   }
@@ -372,7 +372,7 @@ class ReceiveBehaviorSpec extends Messages with BecomeWithLifecycle with Stoppab
       case (_, _: AuxPing) ⇒ SBehaviors.unhandled
     } receiveSignal {
       case (_, signal) ⇒
-        monitor ! GotSignal(signal)
+        monitor ! ReceivedSignal(signal)
         SBehaviors.same
     }
   }
@@ -409,7 +409,7 @@ class ImmutableWithSignalScalaBehaviorSpec extends Messages with BecomeWithLifec
         }
     } receiveSignal {
       case (_, sig) ⇒
-        monitor ! GotSignal(sig)
+        monitor ! ReceivedSignal(sig)
         SBehaviors.same
     }
 }
@@ -559,7 +559,7 @@ class ImmutableWithSignalJavaBehaviorSpec extends Messages with BecomeWithLifecy
         case _: AuxPing ⇒ SBehaviors.unhandled
       }),
       fs((_, sig) ⇒ {
-        monitor ! GotSignal(sig)
+        monitor ! ReceivedSignal(sig)
         SBehaviors.same
       }))
 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -613,6 +613,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit(
         childProbe.expectMessage(GotSignal(PostStop)) // child2
       }
 
+      parentProbe.expectMessage(GotSignal(PreRestart))
       ref ! GetState
       parentProbe.expectMessageType[State].children.keySet should ===(Set.empty)
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashSpec.scala
@@ -5,11 +5,17 @@
 package akka.actor.typed
 package scaladsl
 
+import scala.concurrent.duration._
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+import akka.actor.testkit.typed.TestException
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.testkit.EventFilter
 import org.scalatest.WordSpecLike
 
-object StashSpec {
+object AbstractStashSpec {
   sealed trait Command
   final case class Msg(s: String) extends Command
   final case class Unstashed(cmd: Command) extends Command
@@ -25,7 +31,7 @@ object StashSpec {
       val buffer = StashBuffer[Command](capacity = 10)
 
       def active(processed: Vector[String]): Behavior[Command] =
-        Behaviors.receive { (context, cmd) ⇒
+        Behaviors.receive { (_, cmd) ⇒
           cmd match {
             case message: Msg ⇒
               active(processed :+ message.s)
@@ -176,20 +182,20 @@ object StashSpec {
 
 }
 
-class ImmutableStashSpec extends StashSpec {
-  import StashSpec._
+class ImmutableStashSpec extends AbstractStashSpec {
+  import AbstractStashSpec._
   def testQualifier: String = "immutable behavior"
   def behaviorUnderTest: Behavior[Command] = immutableStash
 }
 
-class MutableStashSpec extends StashSpec {
-  import StashSpec._
+class MutableStashSpec extends AbstractStashSpec {
+  import AbstractStashSpec._
   def testQualifier: String = "mutable behavior"
   def behaviorUnderTest: Behavior[Command] = Behaviors.setup(context ⇒ new MutableStash(context))
 }
 
-abstract class StashSpec extends ScalaTestWithActorTestKit with WordSpecLike {
-  import StashSpec._
+abstract class AbstractStashSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+  import AbstractStashSpec._
 
   def testQualifier: String
   def behaviorUnderTest: Behavior[Command]
@@ -237,6 +243,355 @@ abstract class StashSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       actor ! Msg("g") // might arrive in the middle of the unstashing
       actor ! GetProcessed(probe.ref) // this is also stashed until all unstashed
       probe.expectMessage(Vector("a", "b", "c", "d", "e", "f", "g"))
+    }
+
+  }
+
+}
+
+class UnstashingSpec extends ScalaTestWithActorTestKit("""
+  akka.loggers = ["akka.testkit.TestEventListener"]
+  """) with WordSpecLike {
+
+  // needed for EventFilter
+  private implicit val untypedSys: akka.actor.ActorSystem = {
+    import akka.actor.typed.scaladsl.adapter._
+    system.toUntyped
+  }
+
+  private def slowStoppingChild(latch: CountDownLatch): Behavior[String] =
+    Behaviors.receiveSignal {
+      case (_, PostStop) ⇒
+        println(s"# child waiting for latch") // FIXME
+        latch.await(10, TimeUnit.SECONDS)
+        println(s"# child passed latch") // FIXME
+        Behaviors.same
+    }
+
+  private def stashingBehavior(
+    probe:                 ActorRef[String],
+    withSlowStoppingChild: Option[CountDownLatch] = None) = {
+    Behaviors.setup[String] { ctx ⇒
+      println(s"# stashingBehavior setup") // FIXME
+
+      withSlowStoppingChild.foreach(latch ⇒ ctx.spawnAnonymous(slowStoppingChild(latch)))
+
+      val stash = StashBuffer[String](10)
+
+      def unstashing(n: Int): Behavior[String] =
+        Behaviors.receiveMessage[String] {
+          case "stash" ⇒
+            probe.ref ! s"unstashing-$n"
+            unstashing(n + 1)
+          case "stash-fail" ⇒
+            probe.ref ! s"stash-fail-$n"
+            throw TestException("unstash-fail")
+          case "get-current" ⇒
+            probe.ref ! s"current-$n"
+            Behaviors.same
+          case "get-stash-size" ⇒
+            probe.ref ! s"stash-size-${stash.size}"
+            Behaviors.same
+          case "unstash" ⇒
+            // when testing resume
+            stash.unstashAll(ctx, Behaviors.same)
+        }.receiveSignal {
+          case (_, PreRestart) ⇒
+            probe.ref ! s"pre-restart-$n"
+            Behaviors.same
+          case (_, PostStop) ⇒
+            probe.ref ! s"post-stop-$n"
+            Behaviors.same
+        }
+
+      Behaviors.receiveMessage[String] {
+        case msg if msg.startsWith("stash") ⇒
+          stash.stash(msg)
+          Behavior.same
+        case "unstash" ⇒
+          stash.unstashAll(ctx, unstashing(0))
+        case "get-current" ⇒
+          probe.ref ! s"current-00"
+          Behaviors.same
+        case "get-stash-size" ⇒
+          probe.ref ! s"stash-size-${stash.size}"
+          Behaviors.same
+      }
+    }
+  }
+
+  "Unstashing" must {
+
+    "work with initial Behaviors.same" in {
+      val probe = TestProbe[String]()
+      // unstashing is inside setup
+      val ref = spawn(Behaviors.receive[String] {
+        case (ctx, "unstash") ⇒
+          val stash = StashBuffer[String](10)
+          stash.stash("one")
+          stash.unstashAll(ctx, Behavior.same)
+
+        case (_, msg) ⇒
+          probe.ref ! msg
+          Behaviors.same
+      })
+
+      ref ! "unstash"
+      probe.expectMessage("one")
+    }
+
+    "work with intermediate Behaviors.same" in {
+      val probe = TestProbe[String]()
+      // unstashing is inside setup
+      val ref = spawn(Behaviors.receivePartial[String] {
+        case (ctx, "unstash") ⇒
+          val stash = StashBuffer[String](10)
+          stash.stash("one")
+          stash.stash("two")
+          stash.unstashAll(ctx, Behaviors.receiveMessage { msg ⇒
+            probe.ref ! msg
+            Behaviors.same
+          })
+      })
+
+      ref ! "unstash"
+      probe.expectMessage("one")
+      probe.expectMessage("two")
+      ref ! "three"
+      probe.expectMessage("three")
+    }
+
+    "work with supervised initial Behaviors.same" in {
+      val probe = TestProbe[String]()
+      // unstashing is inside setup
+      val ref = spawn(Behaviors.supervise(Behaviors.receivePartial[String] {
+        case (ctx, "unstash") ⇒
+          val stash = StashBuffer[String](10)
+          stash.stash("one")
+          stash.unstashAll(ctx, Behavior.same)
+
+        case (_, msg) ⇒
+          probe.ref ! msg
+          Behaviors.same
+      }).onFailure[TestException](SupervisorStrategy.stop))
+
+      ref ! "unstash"
+      probe.expectMessage("one")
+      ref ! "two"
+      probe.expectMessage("two")
+    }
+
+    "work with supervised intermediate Behaviors.same" in {
+      val probe = TestProbe[String]()
+      // unstashing is inside setup
+      val ref = spawn(Behaviors.supervise(Behaviors.receivePartial[String] {
+        case (ctx, "unstash") ⇒
+          val stash = StashBuffer[String](10)
+          stash.stash("one")
+          stash.stash("two")
+          // FIXME #26148: do we need then ctx param in unstashAll?
+          stash.unstashAll(ctx, Behaviors.receiveMessage { msg ⇒
+            probe.ref ! msg
+            Behaviors.same
+          })
+      }).onFailure[TestException](SupervisorStrategy.stop))
+
+      ref ! "unstash"
+      probe.expectMessage("one")
+      probe.expectMessage("two")
+      ref ! "three"
+      probe.expectMessage("three")
+    }
+
+    def testPostStop(
+      probe: TestProbe[String],
+      ref:   ActorRef[String]
+    ): Unit = {
+      ref ! "stash"
+      ref ! "stash"
+      ref ! "stash-fail"
+      ref ! "stash"
+      EventFilter[TestException](start = "unstash-fail", occurrences = 1)
+        .intercept {
+          ref ! "unstash"
+          probe.expectMessage("unstashing-0")
+          probe.expectMessage("unstashing-1")
+          probe.expectMessage("stash-fail-2")
+          probe.expectMessage("post-stop-2")
+        }
+    }
+
+    "signal PostStop to the latest unstashed behavior on failure" in {
+      val probe = TestProbe[String]()
+      val ref = spawn(stashingBehavior(probe.ref))
+      testPostStop(probe, ref)
+    }
+
+    "signal PostStop to the latest unstashed behavior on failure with stop supervision" in {
+      val probe = TestProbe[String]()
+      val ref =
+        spawn(Behaviors.supervise(stashingBehavior(probe.ref))
+          .onFailure[TestException](SupervisorStrategy.stop))
+      testPostStop(probe, ref)
+    }
+
+    def testPreRestart(
+      probe:      TestProbe[String],
+      childLatch: Option[CountDownLatch],
+      ref:        ActorRef[String]
+    ): Unit = {
+      ref ! "stash"
+      ref ! "stash"
+      ref ! "stash-fail"
+      ref ! "stash"
+      EventFilter[TestException](
+        start = "Supervisor RestartSupervisor saw failure: unstash-fail",
+        occurrences = 1
+      ).intercept {
+        ref ! "unstash"
+        // when childLatch is defined this be stashed in the internal stash of the RestartSupervisor
+        // because it's waiting for child to stop
+        ref ! "get-current"
+
+        probe.expectMessage("unstashing-0")
+        probe.expectMessage("unstashing-1")
+        probe.expectMessage("stash-fail-2")
+        probe.expectMessage("pre-restart-2")
+
+        childLatch.foreach(_.countDown())
+        probe.expectMessage("current-00")
+
+        ref ! "get-stash-size"
+        probe.expectMessage("stash-size-0")
+      }
+    }
+
+    "signal PreRestart to the latest unstashed behavior on failure with restart supervision" in {
+      val probe = TestProbe[String]()
+      val ref =
+        spawn(Behaviors.supervise(stashingBehavior(probe.ref))
+          .onFailure[TestException](SupervisorStrategy.restart))
+
+      testPreRestart(probe, None, ref)
+      // one more time to ensure that the restart strategy is kept
+      testPreRestart(probe, None, ref)
+
+      Thread.sleep(2000)
+      println(s"# DONE -----------") // FIXME
+    }
+
+    "signal PreRestart to the latest unstashed behavior on failure with restart supervision and slow stopping child" in {
+      val probe = TestProbe[String]()
+      val childLatch = new CountDownLatch(1)
+      val ref =
+        spawn(Behaviors.supervise(stashingBehavior(probe.ref, Some(childLatch)))
+          .onFailure[TestException](SupervisorStrategy.restart))
+
+      testPreRestart(probe, Some(childLatch), ref)
+
+      Thread.sleep(2000)
+      println(s"# DONE -----------") // FIXME
+    }
+
+    "signal PreRestart to the latest unstashed behavior on failure with backoff supervision" in {
+      val probe = TestProbe[String]()
+      val ref =
+        spawn(Behaviors.supervise(stashingBehavior(probe.ref))
+          .onFailure[TestException](SupervisorStrategy.restartWithBackoff(100.millis, 100.millis, 0.0)))
+
+      testPreRestart(probe, None, ref)
+
+      // FIXME 26148 Note ClassCastException: akka.actor.typed.internal.RestartSupervisor$ResetRestartCount cannot
+      // be cast to java.lang.String
+      // which is because the original backoff strategy isn't installed after the RestartSupervisor has unstashAll
+      Thread.sleep(2000)
+      println(s"# STEP1 -----------") // FIXME
+
+      // one more time to ensure that the backoff strategy is kept
+      testPreRestart(probe, None, ref)
+
+      Thread.sleep(5000)
+      println(s"# DONE -----------") // FIXME
+    }
+
+    "signal PreRestart to the latest unstashed behavior on failure with backoff supervision and slow stopping child" in {
+      val probe = TestProbe[String]()
+      val childLatch = new CountDownLatch(1)
+      val ref =
+        spawn(Behaviors.supervise(stashingBehavior(probe.ref, Some(childLatch)))
+          .onFailure[TestException](SupervisorStrategy.restartWithBackoff(100.millis, 100.millis, 0.0)))
+
+      testPreRestart(probe, Some(childLatch), ref)
+
+      Thread.sleep(5000)
+      println(s"# DONE -----------") // FIXME
+    }
+
+    "handle resume correctly on failure unstashing" in {
+      val probe = TestProbe[String]()
+      val ref =
+        spawn(Behaviors.supervise(stashingBehavior(probe.ref))
+          .onFailure[TestException](SupervisorStrategy.resume))
+
+      ref ! "stash"
+      ref ! "stash"
+      ref ! "stash-fail"
+      ref ! "stash"
+      ref ! "stash"
+      ref ! "stash"
+      ref ! "stash-fail"
+      ref ! "stash"
+      EventFilter[TestException](start = "Supervisor ResumeSupervisor saw failure: unstash-fail", occurrences = 1).intercept {
+        ref ! "unstash"
+        ref ! "get-current"
+
+        probe.expectMessage("unstashing-0")
+        probe.expectMessage("unstashing-1")
+        probe.expectMessage("stash-fail-2")
+        probe.expectMessage("current-2")
+        ref ! "get-stash-size"
+        probe.expectMessage("stash-size-5")
+      }
+
+      ref ! "unstash"
+      ref ! "get-current"
+      probe.expectMessage("unstashing-2")
+      probe.expectMessage("unstashing-3")
+      probe.expectMessage("unstashing-4")
+      probe.expectMessage("stash-fail-5")
+      probe.expectMessage("current-5")
+      ref ! "get-stash-size"
+      probe.expectMessage("stash-size-1")
+
+      ref ! "unstash"
+      ref ! "get-current"
+      probe.expectMessage("unstashing-5")
+      probe.expectMessage("current-6")
+
+      ref ! "get-stash-size"
+      probe.expectMessage("stash-size-0")
+    }
+
+    "be possible in combination with setup" in {
+      val probe = TestProbe[String]()
+      val ref = spawn(Behaviors.setup[String] { _ ⇒
+        val stash = StashBuffer[String](10)
+        stash.stash("one")
+
+        // unstashing is inside setup
+        Behaviors.receiveMessage {
+          case "unstash" ⇒
+            Behaviors.setup { ctx ⇒
+              stash.unstashAll(ctx, Behavior.same)
+            }
+          case msg ⇒
+            probe.ref ! msg
+            Behavior.same
+        }
+      })
+
+      ref ! "unstash"
+      probe.expectMessage("one")
     }
 
   }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
@@ -424,27 +424,5 @@ object Behavior {
     }
   }
 
-  /**
-   * INTERNAL API
-   *
-   * Execute the behavior with the given messages (or signals).
-   * The returned [[Behavior]] from each processed message is used for the next message.
-   */
-  @InternalApi private[akka] def interpretMessages[T](behavior: Behavior[T], ctx: TypedActorContext[T], messages: Iterator[T]): Behavior[T] = {
-    @tailrec def interpretOne(b: Behavior[T]): Behavior[T] = {
-      val b2 = Behavior.start(b, ctx)
-      if (!Behavior.isAlive(b2) || !messages.hasNext) b2
-      else {
-        val nextB = messages.next() match {
-          case sig: Signal ⇒ Behavior.interpretSignal(b2, ctx, sig)
-          case msg         ⇒ Behavior.interpretMessage(b2, ctx, msg)
-        }
-        interpretOne(Behavior.canonicalize(nextB, b, ctx)) // recursive
-      }
-    }
-
-    interpretOne(Behavior.start(behavior, ctx))
-  }
-
 }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
@@ -7,7 +7,12 @@ package akka.actor.typed.internal
 import java.util.function.Consumer
 import java.util.function.{ Function ⇒ JFunction }
 
+import scala.annotation.tailrec
+import scala.util.control.NonFatal
+
 import akka.actor.typed.Behavior
+import akka.actor.typed.Signal
+import akka.actor.typed.TypedActorContext
 import akka.actor.typed.javadsl
 import akka.actor.typed.scaladsl
 import akka.annotation.InternalApi
@@ -86,7 +91,7 @@ import akka.util.ConstantFun
     }
   }
 
-  override def forEach(f: Consumer[T]): Unit = foreach(f.accept(_))
+  override def forEach(f: Consumer[T]): Unit = foreach(f.accept)
 
   override def unstashAll(ctx: scaladsl.ActorContext[T], behavior: Behavior[T]): Behavior[T] =
     unstash(ctx, behavior, size, ConstantFun.scalaIdentityFunction[T])
@@ -96,11 +101,36 @@ import akka.util.ConstantFun
 
   override def unstash(ctx: scaladsl.ActorContext[T], behavior: Behavior[T],
                        numberOfMessages: Int, wrap: T ⇒ T): Behavior[T] = {
-    val iter = new Iterator[T] {
-      override def hasNext: Boolean = StashBufferImpl.this.nonEmpty
-      override def next(): T = wrap(StashBufferImpl.this.dropHead())
-    }.take(numberOfMessages)
-    Behavior.interpretMessages[T](behavior, ctx, iter)
+    if (isEmpty)
+      behavior // optimization
+    else {
+      val iter = new Iterator[T] {
+        override def hasNext: Boolean = StashBufferImpl.this.nonEmpty
+        override def next(): T = wrap(StashBufferImpl.this.dropHead())
+      }.take(numberOfMessages)
+      interpretUnstashedMessages(behavior, ctx, iter)
+    }
+  }
+
+  private def interpretUnstashedMessages(behavior: Behavior[T], ctx: TypedActorContext[T], messages: Iterator[T]): Behavior[T] = {
+    @tailrec def interpretOne(b: Behavior[T]): Behavior[T] = {
+      val b2 = Behavior.start(b, ctx)
+      if (!Behavior.isAlive(b2) || !messages.hasNext) b2
+      else {
+        val nextB = try {
+          messages.next() match {
+            case sig: Signal ⇒ Behavior.interpretSignal(b2, ctx, sig)
+            case msg         ⇒ Behavior.interpretMessage(b2, ctx, msg)
+          }
+        } catch {
+          case NonFatal(e) ⇒ throw UnstashException(e, b2)
+        }
+
+        interpretOne(Behavior.canonicalize(nextB, b, ctx)) // recursive
+      }
+    }
+
+    interpretOne(Behavior.start(behavior, ctx))
   }
 
   override def unstash(ctx: javadsl.ActorContext[T], behavior: Behavior[T],
@@ -111,3 +141,23 @@ import akka.util.ConstantFun
     s"StashBuffer($size/$capacity)"
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object UnstashException {
+  def unwrap(t: Throwable): Throwable = t match {
+    case UnstashException(e, _) ⇒ e
+    case _                      ⇒ t
+  }
+
+}
+
+/**
+ * INTERNAL API:
+ *
+ * When unstashing the exception is wrapped in UnstashException because supervisor strategy
+ * and ActorAdapter need the behavior that thrown to emit the PreRestart and PostStop to the right
+ * behavior and install the latest for resume strategy.
+ */
+@InternalApi private[akka] final case class UnstashException[T](cause: Throwable, behavior: Behavior[T])
+  extends RuntimeException(s"[$cause] when unstashing in [$behavior]", cause)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
@@ -126,7 +126,7 @@ import akka.util.ConstantFun
           case NonFatal(e) ⇒ throw UnstashException(e, b2)
         }
 
-        interpretOne(Behavior.canonicalize(nextB, b, ctx)) // recursive
+        interpretOne(Behavior.canonicalize(nextB, b2, ctx)) // recursive
       }
     }
 
@@ -155,9 +155,9 @@ import akka.util.ConstantFun
 /**
  * INTERNAL API:
  *
- * When unstashing the exception is wrapped in UnstashException because supervisor strategy
- * and ActorAdapter need the behavior that thrown to emit the PreRestart and PostStop to the right
- * behavior and install the latest for resume strategy.
+ * When unstashing, the exception is wrapped in UnstashException because supervisor strategy
+ * and ActorAdapter need the behavior that threw. It will use the behavior in the `UnstashException`
+ * to emit the PreRestart and PostStop to the right behavior and install the latest behavior for resume strategy.
  */
 @InternalApi private[akka] final case class UnstashException[T](cause: Throwable, behavior: Behavior[T])
   extends RuntimeException(s"[$cause] when unstashing in [$behavior]", cause)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
@@ -49,9 +49,8 @@ private abstract class AbstractSupervisor[O, I, Thr <: Throwable](strategy: Supe
 
   private val throwableClass = implicitly[ClassTag[Thr]].runtimeClass
 
-  protected def isInstanceOfTheThrowableClass(t: Throwable): Boolean = {
+  protected def isInstanceOfTheThrowableClass(t: Throwable): Boolean =
     throwableClass.isAssignableFrom(UnstashException.unwrap(t).getClass)
-  }
 
   override def isSame(other: BehaviorInterceptor[Any, Any]): Boolean = {
     other match {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
@@ -49,6 +49,10 @@ private abstract class AbstractSupervisor[O, I, Thr <: Throwable](strategy: Supe
 
   private val throwableClass = implicitly[ClassTag[Thr]].runtimeClass
 
+  protected def isInstanceOfTheThrowableClass(t: Throwable): Boolean = {
+    throwableClass.isAssignableFrom(UnstashException.unwrap(t).getClass)
+  }
+
   override def isSame(other: BehaviorInterceptor[Any, Any]): Boolean = {
     other match {
       case as: AbstractSupervisor[_, _, Thr] if throwableClass == as.throwableClass ⇒ true
@@ -70,7 +74,8 @@ private abstract class AbstractSupervisor[O, I, Thr <: Throwable](strategy: Supe
 
   def log(ctx: TypedActorContext[_], t: Throwable): Unit = {
     if (strategy.loggingEnabled) {
-      ctx.asScala.log.error(t, "Supervisor {} saw failure: {}", this, t.getMessage)
+      val unwrapped = UnstashException.unwrap(t)
+      ctx.asScala.log.error(unwrapped, "Supervisor {} saw failure: {}", this, unwrapped.getMessage)
     }
   }
 
@@ -98,7 +103,7 @@ private abstract class SimpleSupervisor[T, Thr <: Throwable: ClassTag](ss: Super
   }
 
   protected def handleException(@unused ctx: TypedActorContext[T]): Catcher[Behavior[T]] = {
-    case NonFatal(t: Thr) ⇒
+    case NonFatal(t) if isInstanceOfTheThrowableClass(t) ⇒
       Behavior.failed(t)
   }
 
@@ -113,8 +118,9 @@ private abstract class SimpleSupervisor[T, Thr <: Throwable: ClassTag](ss: Super
 
 private class StopSupervisor[T, Thr <: Throwable: ClassTag](@unused initial: Behavior[T], strategy: Stop)
   extends SimpleSupervisor[T, Thr](strategy) {
+
   override def handleException(ctx: TypedActorContext[T]): Catcher[Behavior[T]] = {
-    case NonFatal(t: Thr) ⇒
+    case NonFatal(t) if isInstanceOfTheThrowableClass(t) ⇒
       log(ctx, t)
       Behavior.failed(t)
   }
@@ -122,9 +128,12 @@ private class StopSupervisor[T, Thr <: Throwable: ClassTag](@unused initial: Beh
 
 private class ResumeSupervisor[T, Thr <: Throwable: ClassTag](ss: Resume) extends SimpleSupervisor[T, Thr](ss) {
   override protected def handleException(ctx: TypedActorContext[T]): Catcher[Behavior[T]] = {
-    case NonFatal(t: Thr) ⇒
+    case NonFatal(t) if isInstanceOfTheThrowableClass(t) ⇒
       log(ctx, t)
-      Behaviors.same
+      t match {
+        case e: UnstashException[T] @unchecked ⇒ e.behavior
+        case _                                 ⇒ Behaviors.same
+      }
   }
 }
 
@@ -239,7 +248,7 @@ private class RestartSupervisor[O, T, Thr <: Throwable: ClassTag](initial: Behav
   }
 
   override protected def handleExceptionOnStart(ctx: TypedActorContext[O], @unused target: PreStartTarget[T]): Catcher[Behavior[T]] = {
-    case NonFatal(t: Thr) ⇒
+    case NonFatal(t) if isInstanceOfTheThrowableClass(t) ⇒
       strategy match {
         case _: Restart ⇒
           // if unlimited restarts then don't restart if starting fails as it would likely be an infinite restart loop
@@ -255,14 +264,20 @@ private class RestartSupervisor[O, T, Thr <: Throwable: ClassTag](initial: Behav
   }
 
   override protected def handleSignalException(ctx: TypedActorContext[O], target: SignalTarget[T]): Catcher[Behavior[T]] = {
-    handleException(ctx, () ⇒ target(ctx, PreRestart))
+    handleException(ctx, signalRestart = {
+      case e: UnstashException[O] @unchecked ⇒ Behavior.interpretSignal(e.behavior, ctx, PreRestart)
+      case _                                 ⇒ target(ctx, PreRestart)
+    })
   }
   override protected def handleReceiveException(ctx: TypedActorContext[O], target: ReceiveTarget[T]): Catcher[Behavior[T]] = {
-    handleException(ctx, () ⇒ target.signalRestart(ctx))
+    handleException(ctx, signalRestart = {
+      case e: UnstashException[O] @unchecked ⇒ Behavior.interpretSignal(e.behavior, ctx, PreRestart)
+      case _                                 ⇒ target.signalRestart(ctx)
+    })
   }
 
-  private def handleException(ctx: TypedActorContext[O], signalRestart: () ⇒ Unit): Catcher[Behavior[T]] = {
-    case NonFatal(t: Thr) ⇒
+  private def handleException(ctx: TypedActorContext[O], signalRestart: Throwable ⇒ Unit): Catcher[Behavior[T]] = {
+    case NonFatal(t) if isInstanceOfTheThrowableClass(t) ⇒
       if (strategy.maxRestarts != -1 && restartCount >= strategy.maxRestarts && deadlineHasTimeLeft) {
         strategy match {
           case _: Restart ⇒ throw t
@@ -272,7 +287,7 @@ private class RestartSupervisor[O, T, Thr <: Throwable: ClassTag](initial: Behav
         }
 
       } else {
-        try signalRestart() catch {
+        try signalRestart(t) catch {
           case NonFatal(ex) ⇒ ctx.asScala.log.error(ex, "failure during PreRestart")
         }
 
@@ -326,9 +341,10 @@ private class RestartSupervisor[O, T, Thr <: Throwable: ClassTag](initial: Behav
           stashBuffer.unstashAll(ctx.asScala.asInstanceOf[scaladsl.ActorContext[Any]], newBehavior.unsafeCast)
       }
       nextBehavior.narrow
-    } catch handleException(ctx, signalRestart = () ⇒ ())
-    // FIXME signal Restart is not done if unstashAll throws, unstash of each message may return a new behavior and
-    //      it's the failing one that should receive the signal
+    } catch handleException(ctx, signalRestart = {
+      case e: UnstashException[O] @unchecked ⇒ Behavior.interpretSignal(e.behavior, ctx, PreRestart)
+      case _                                 ⇒ ()
+    })
   }
 
   private def stopChildren(ctx: TypedActorContext[_], children: Set[ActorRef[Nothing]]): Unit = {


### PR DESCRIPTION
* When unstashing the exception is wrapped in `UnstashException` because supervisor strategy and ActorAdapter need the behavior that thrown to emit the PreRestart and PostStop to the right behavior and install the latest for resume strategy.

Refs #26148