### PR TITLE
WIP:  Unstashing via behavior to handle exceptions, #26148

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
@@ -295,9 +295,10 @@ object Behavior {
     def unstash(previousBehavior: Behavior[T], ctx: TypedActorContext[T]): Behavior[T] = {
       @tailrec def interpretOne(b: Behavior[T]): Behavior[T] = {
         val b2 = Behavior.start(b, ctx)
-        if (!Behavior.isAlive(b2) || !stashIterator.hasNext) b2
+        if (!Behavior.isAlive(b2) || stashIterator.isEmpty) b2
         else {
           val nextMessage = stashIterator.next()
+          println(s"# unstash interpretOne [$nextMessage] b2 [$b2]") // FIXME
           val nextB = interpret(b2, ctx, nextMessage)
           // must make sure that we don't have Same if starting fails
           _currentBehavior = Behavior.canonicalize(nextB, _currentBehavior, ctx)
@@ -320,6 +321,9 @@ object Behavior {
           Behavior.unhandled
       }
     }
+
+    override def toString: String =
+      s"UnstashingBehavior($currentBehavior, ${stashIterator.nonEmpty})"
 
   }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/InterceptorImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/InterceptorImpl.scala
@@ -75,6 +75,7 @@ private[akka] final class InterceptorImpl[O, I](val interceptor: BehaviorInterce
 
   private val catchFromUnstashing: Catcher[Behavior[I]] = {
     case NonFatal(e) ⇒
+      println(s"# interceptor catchFromUnstashing [${e.getMessage}] nestedBehavior [$nestedBehavior]") // FIXME
       // unstashing is aborted on failure
       nestedBehavior match {
         case u: UnstashingBehavior[I] ⇒

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
@@ -8,6 +8,7 @@ import java.util.function.Consumer
 import java.util.function.{ Function ⇒ JFunction }
 
 import akka.actor.typed.Behavior
+import akka.actor.typed.Behavior.UnstashingBehavior
 import akka.actor.typed.javadsl
 import akka.actor.typed.scaladsl
 import akka.annotation.InternalApi
@@ -100,7 +101,7 @@ import akka.util.ConstantFun
       override def hasNext: Boolean = StashBufferImpl.this.nonEmpty
       override def next(): T = wrap(StashBufferImpl.this.dropHead())
     }.take(numberOfMessages)
-    Behavior.interpretMessages[T](behavior, ctx, iter)
+    new UnstashingBehavior[T](behavior, iter)
   }
 
   override def unstash(ctx: javadsl.ActorContext[T], behavior: Behavior[T],

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
@@ -12,7 +12,6 @@ import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
 import scala.util.control.Exception.Catcher
 import scala.util.control.NonFatal
-
 import akka.actor.DeadLetterSuppression
 import akka.actor.typed.BehaviorInterceptor.PreStartTarget
 import akka.actor.typed.BehaviorInterceptor.ReceiveTarget
@@ -327,8 +326,6 @@ private class RestartSupervisor[O, T, Thr <: Throwable: ClassTag](initial: Behav
       }
       nextBehavior.narrow
     } catch handleException(ctx, signalRestart = () ⇒ ())
-    // FIXME signal Restart is not done if unstashAll throws, unstash of each message may return a new behavior and
-    //      it's the failing one that should receive the signal
   }
 
   private def stopChildren(ctx: TypedActorContext[_], children: Set[ActorRef[Nothing]]): Unit = {


### PR DESCRIPTION
Continued from https://github.com/akka/akka/pull/26361 by adding more tests and fixing a few things, but the tests illustrates more problems (see inline comments) and therefore I took a step back and implemented it with the wrapping of the exception instead in https://github.com/akka/akka/pull/26396 which seems much more straightforward than putting more responsibilities onto the interceptors.

Opening this PR for comparison of the approaches.

Refs #26148