### PR TITLE
remove ccompat import in CollectionSinkSpec, #26305

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/CollectionSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/CollectionSinkSpec.scala
@@ -6,7 +6,6 @@ package akka.stream.scaladsl
 
 import akka.stream.testkit.{ StreamSpec, TestPublisher }
 import akka.stream.{ AbruptTerminationException, ActorMaterializer, ActorMaterializerSettings }
-import akka.util.ccompat._
 
 import scala.collection.immutable
 import scala.concurrent.{ Await, Future }


### PR DESCRIPTION
This doesn't compile with Akka 2.5.21, but seems fine in master. I guess it was fixed by https://github.com/akka/akka/pull/26350

Refs #26305