### PR TITLE
Small tweaks to all command aliases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,11 @@ target PR branch you can do so by setting the PR_TARGET_BRANCH environment varia
 PR_TARGET_BRANCH=origin/example sbt validatePullRequest
 ```
 
+If you dont want to run all tests and just want to check that everything is formatted/mima passes there
+are a set of `all*` commands aliases for running `test:compile` (also formats), `mimaReportBinaryIssues`, and `validateCompile` 
+(compiles `multi-jvm` if enabled for that project). See `build.sbt` or use completion to find the most appropriate one 
+e.g. `allCluster`, `allTyped`.
+
 ## Binary compatibility
 
 Binary compatibility rules and guarantees are described in depth in the [Binary Compatibility Rules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ target PR branch you can do so by setting the PR_TARGET_BRANCH environment varia
 PR_TARGET_BRANCH=origin/example sbt validatePullRequest
 ```
 
-If you dont want to run all tests and just want to check that everything is formatted/mima passes there
+If you have already run all tests and now just need to check that everything is formatted and or mima passes there
 are a set of `all*` commands aliases for running `test:compile` (also formats), `mimaReportBinaryIssues`, and `validateCompile` 
 (compiles `multi-jvm` if enabled for that project). See `build.sbt` or use completion to find the most appropriate one 
 e.g. `allCluster`, `allTyped`.

--- a/build.sbt
+++ b/build.sbt
@@ -514,9 +514,16 @@ def commandValue(p: Project, externalTest: Option[Project] = None) = {
 }
 addCommandAlias("allActor", commandValue(actor, Some(actorTests)))
 addCommandAlias("allRemote", commandValue(remote, Some(remoteTests)))
-addCommandAlias("allCluster", commandValue(cluster))
+addCommandAlias("allClusterCore", commandValue(cluster))
+addCommandAlias("allClusterMetrics", commandValue(clusterMetrics))
 addCommandAlias("allDistributedData", commandValue(distributedData))
 addCommandAlias("allClusterSharding", commandValue(clusterSharding))
+addCommandAlias("allClusterTools", commandValue(clusterTools))
+addCommandAlias("allCluster", Seq(
+  commandValue(cluster),
+  commandValue(distributedData),
+  commandValue(clusterSharding),
+  commandValue(clusterTools)).mkString)
 addCommandAlias("allPersistence", commandValue(persistence))
 addCommandAlias("allStream", commandValue(stream, Some(streamTests)))
 addCommandAlias("allDiscovery", commandValue(discovery))


### PR DESCRIPTION
* Adds other cluster all commands
* Makes allCluster do all cluster modules

My normally terrible intuition thinks `allCuster` should do all cluster related thing which is something I often want to do when working on core cluster as I don't find out I've broken something in a cluster module until PR validation..

WDYT @helena ?