### PR TITLE
harden ClusterShardingPersistenceSpec by using onPostStop, #26230

### DIFF
--- a/akka-actor/src/main/scala/akka/util/ConstantFun.scala
+++ b/akka-actor/src/main/scala/akka/util/ConstantFun.scala
@@ -44,6 +44,8 @@ import akka.japi.{ Pair ⇒ JPair }
 
   val oneInt = (_: Any) ⇒ 1
 
+  val unitToUnit = () ⇒ ()
+
   private val _nullFun = (_: Any) ⇒ null
 
   private val conforms = (a: Any) ⇒ a

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
@@ -87,16 +87,26 @@ abstract class EventSourcedBehavior[Command, Event, State >: Null] private[akka]
     EventHandlerBuilder.builder[State, Event]()
 
   /**
-   * The `callback` function is called to notify the actor that the recovery process
+   * The callback is invoked to notify the actor that the recovery process
    * is finished.
    */
   def onRecoveryCompleted(state: State): Unit = ()
 
   /**
-   * The `callback` function is called to notify the actor that the recovery process
+   * The callback is invoked to notify the actor that the recovery process
    * has failed
    */
   def onRecoveryFailure(failure: Throwable): Unit = ()
+
+  /**
+   * The callback is invoked to notify that the actor has stopped.
+   */
+  def onPostStop(): Unit = ()
+
+  /**
+   * The callback is invoked to notify that the actor is restarted.
+   */
+  def onPreRestart(): Unit = ()
 
   /**
    * Override to get notified when a snapshot is finished.
@@ -160,6 +170,8 @@ abstract class EventSourcedBehavior[Command, Event, State >: Null] private[akka]
       eventHandler()(_, _),
       getClass)
       .onRecoveryCompleted(onRecoveryCompleted)
+      .onPostStop(() ⇒ onPostStop())
+      .onPreRestart(() ⇒ onPreRestart())
       .snapshotWhen(snapshotWhen)
       .withTagger(tagger)
       .onSnapshot((meta, result) ⇒ {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/EventSourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/EventSourcedBehavior.scala
@@ -108,6 +108,16 @@ object EventSourcedBehavior {
   def onRecoveryFailure(callback: Throwable ⇒ Unit): EventSourcedBehavior[Command, Event, State]
 
   /**
+   * The `callback` function is called to notify that the actor has stopped.
+   */
+  def onPostStop(callback: () ⇒ Unit): EventSourcedBehavior[Command, Event, State]
+
+  /**
+   * The `callback` function is called to notify that the actor is restarted.
+   */
+  def onPreRestart(callback: () ⇒ Unit): EventSourcedBehavior[Command, Event, State]
+
+  /**
    * The `callback` function is called to notify when a snapshot is complete.
    */
   def onSnapshot(callback: (SnapshotMetadata, Try[Done]) ⇒ Unit): EventSourcedBehavior[Command, Event, State]

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -459,6 +459,23 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
   }
 
   @Test
+  public void postStop() {
+    TestProbe<String> probe = testKit.createTestProbe();
+    Behavior<Command> counter =
+        Behaviors.setup(
+            ctx ->
+                new CounterBehavior(new PersistenceId("c5"), ctx) {
+                  @Override
+                  public void onPostStop() {
+                    probe.ref().tell("stopped");
+                  }
+                });
+    ActorRef<Command> c = testKit.spawn(counter);
+    c.tell(StopThenLog.INSTANCE);
+    probe.expectMessage("stopped");
+  }
+
+  @Test
   public void tapPersistentActor() {
     TestProbe<Object> interceptProbe = testKit.createTestProbe();
     TestProbe<Signal> signalProbe = testKit.createTestProbe();


### PR DESCRIPTION
Also adding onPostStop and onPreRestart hooks to EventSourcedBehavior

Refs #26230
Refs #26404

Debug logging revealed that it was a race condition between sending the Passivate to the shard and processing of next command.

```
[DEBUG] [02/18/2019 13:43:09.777] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-23] [akka://ClusterShardingPersistenceSpec@127.0.0.1:60240/system/sharding/test] Request shard [51] home. Coordinator [Some(Actor[akka://ClusterShardingPersistenceSpec/system/sharding/testCoordinator/singleton/coordinator#50385039])]
[DEBUG] [02/18/2019 13:43:09.778] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-22] [akka://ClusterShardingPersistenceSpec@127.0.0.1:60240/system/sharding/replicator] Received Update for key [testCoordinatorState]
[DEBUG] [02/18/2019 13:43:09.779] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-23] [akka://ClusterShardingPersistenceSpec@127.0.0.1:60240/system/sharding/testCoordinator/singleton/coordinator] The coordinator state was successfully updated with ShardHomeAllocated(51,Actor[akka://ClusterShardingPersistenceSpec/system/sharding/test#1485895496])
[DEBUG] [02/18/2019 13:43:09.779] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-23] [akka://ClusterShardingPersistenceSpec@127.0.0.1:60240/system/sharding/testCoordinator/singleton/coordinator] Shard [51] allocated at [Actor[akka://ClusterShardingPersistenceSpec/system/sharding/test#1485895496]]
[DEBUG] [02/18/2019 13:43:09.779] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-22] [akka://ClusterShardingPersistenceSpec@127.0.0.1:60240/system/sharding/test] Host Shard [51] 
[DEBUG] [02/18/2019 13:43:09.780] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-22] [akka://ClusterShardingPersistenceSpec@127.0.0.1:60240/system/sharding/test] Starting shard [51] in region
[DEBUG] [02/18/2019 13:43:09.781] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-22] [akka://ClusterShardingPersistenceSpec@127.0.0.1:60240/system/sharding/test] Shard [51] located at [Actor[akka://ClusterShardingPersistenceSpec/system/sharding/test#1485895496]]
[DEBUG] [02/18/2019 13:43:09.781] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-22] [akka://ClusterShardingPersistenceSpec@127.0.0.1:60240/system/sharding/test] Shard was initialized 51
[DEBUG] [02/18/2019 13:43:09.781] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-22] [akka://ClusterShardingPersistenceSpec@127.0.0.1:60240/system/sharding/test] Deliver [1] buffered messages for shard [51]
[DEBUG] [02/18/2019 13:43:09.782] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-23] [akka://ClusterShardingPersistenceSpec@127.0.0.1:60240/system/sharding/test/51] Starting entity [3] in shard [51]
[DEBUG] [02/18/2019 13:43:09.786] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-2] [akka://ClusterShardingPersistenceSpec/system/sharding/test/51/3][persistenceId:test|3][phase:get-permit] Initializing snapshot recovery: Recovery(SnapshotSelectionCriteria(9223372036854775807,9223372036854775807,0,0),9223372036854775807,9223372036854775807)
[DEBUG] [02/18/2019 13:43:09.788] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-23] [akka://ClusterShardingPersistenceSpec/system/sharding/test/51/3][persistenceId:test|3][phase:replay-evts] Replaying messages: from: 1, to: 9223372036854775807
[DEBUG] [02/18/2019 13:43:09.789] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-23] [akka://ClusterShardingPersistenceSpec/system/sharding/test/51/3][persistenceId:test|3][phase:replay-evts] Recovery successful, recovered until sequenceNr: [0]
[DEBUG] [02/18/2019 13:43:09.790] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-23] [akka://ClusterShardingPersistenceSpec/system/sharding/test/51/3][persistenceId:test|3][phase:replay-evts] Returning recovery permit, reason: replay completed successfully
[DEBUG] [02/18/2019 13:43:09.790] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-23] [akka://ClusterShardingPersistenceSpec/system/sharding/test/51/3] onRecoveryCompleted: []

>>> 1
[DEBUG] [02/18/2019 13:43:09.792] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-23] [akka://ClusterShardingPersistenceSpec/system/sharding/test/51/3][persistenceId:test|3][phase:running-cmnds] Handled command [akka.cluster.sharding.typed.scaladsl.ClusterShardingPersistenceSpec$PassivateAndPersist], resulting effect: [Persist(1)], side effects: [1]
[DEBUG] [02/18/2019 13:43:09.793] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-14] [akka://ClusterShardingPersistenceSpec/system/sharding/test/51/3][persistenceId:test|3][phase:persist-evts] Received Journal response: WriteMessagesSuccessful
[DEBUG] [02/18/2019 13:43:09.794] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-14] [akka://ClusterShardingPersistenceSpec/system/sharding/test/51/3][persistenceId:test|3][phase:persist-evts] Received Journal response: WriteMessageSuccess(PersistentImpl(1,1,test|3,,false,null,cffad868-592e-4a2f-ae10-d7676b5bec62),3)
[DEBUG] [02/18/2019 13:43:09.795] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-2] [akka://ClusterShardingPersistenceSpec/system/sharding/test/51/3][persistenceId:test|3][phase:running-cmnds] 

>>> 2
Handled command [akka.cluster.sharding.typed.scaladsl.ClusterShardingPersistenceSpec$PassivateAndPersist], resulting effect: [Persist(2)], side effects: [1]

>>>
[DEBUG] [02/18/2019 13:43:09.795] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-14] [akka://ClusterShardingPersistenceSpec@127.0.0.1:60240/system/sharding/test/51] Passivation already in progress for Actor[akka://ClusterShardingPersistenceSpec/system/sharding/test/51/3#367017175]. Not sending stopMessage back to entity.
[DEBUG] [02/18/2019 13:43:09.798] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-2] [akka://ClusterShardingPersistenceSpec/system/sharding/test/51/3][persistenceId:test|3][phase:persist-evts] Received Journal response: WriteMessagesSuccessful
[DEBUG] [02/18/2019 13:43:09.798] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-2] [akka://ClusterShardingPersistenceSpec/system/sharding/test/51/3][persistenceId:test|3][phase:persist-evts] Received Journal response: WriteMessageSuccess(PersistentImpl(2,2,test|3,,false,null,cffad868-592e-4a2f-ae10-d7676b5bec62),3)
[DEBUG] [02/18/2019 13:43:09.806] [ClusterShardingPersistenceSpec-akka.actor.default-dispatcher-23] [akka://ClusterShardingPersistenceSpec@127.0.0.1:60240/system/sharding/test/51] Entity stopped after passivation [3]
[info] - must handle PoisonPill after persist effect *** FAILED *** (10 seconds, 33 milliseconds)
[info]   java.lang.AssertionError: timeout (10 seconds) during expectMessage while waiting for recoveryCompleted:1
```