### PR TITLE
Make the OO example use classes for all the behaviors for Java

### DIFF
--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OOIntroTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OOIntroTest.java
@@ -116,7 +116,7 @@ public class OOIntroTest {
               ActorRef<SessionEvent> client = getSession.replyTo;
               ActorRef<SessionCommand> ses =
                   context.spawn(
-                      session(context.getSelf(), getSession.screenName, client),
+                      new SessionBehavior(context.getSelf(), getSession.screenName, client),
                       URLEncoder.encode(getSession.screenName, StandardCharsets.UTF_8.name()));
               // narrow to only expose PostMessage
               client.tell(new SessionGranted(ses.narrow()));
@@ -137,55 +137,80 @@ public class OOIntroTest {
       }
     }
 
-    public static Behavior<ChatRoom.SessionCommand> session(
-        ActorRef<RoomCommand> room, String screenName, ActorRef<SessionEvent> client) {
-      return Behaviors.receive(ChatRoom.SessionCommand.class)
-          .onMessage(
-              PostMessage.class,
-              (context, post) -> {
-                // from client, publish to others via the room
-                room.tell(new PublishSessionMessage(screenName, post.message));
-                return Behaviors.same();
-              })
-          .onMessage(
-              NotifyClient.class,
-              (context, notification) -> {
-                // published from the room
-                client.tell(notification.message);
-                return Behaviors.same();
-              })
-          .build();
+    public static class SessionBehavior extends AbstractBehavior<ChatRoom.SessionCommand> {
+
+      private final ActorRef<RoomCommand> room;
+      private final String screenName;
+      private final ActorRef<SessionEvent> client;
+
+      public SessionBehavior(
+          ActorRef<RoomCommand> room, String screenName, ActorRef<SessionEvent> client) {
+        this.room = room;
+        this.screenName = screenName;
+        this.client = client;
+      }
+
+      @Override
+      public Receive<SessionCommand> createReceive() {
+        return newReceiveBuilder()
+            .onMessage(
+                PostMessage.class,
+                post -> {
+                  // from client, publish to others via the room
+                  room.tell(new PublishSessionMessage(screenName, post.message));
+                  return Behaviors.same();
+                })
+            .onMessage(
+                NotifyClient.class,
+                notification -> {
+                  // published from the room
+                  client.tell(notification.message);
+                  return Behaviors.same();
+                })
+            .build();
+      }
     }
     // #chatroom-behavior
   }
   // #chatroom-actor
 
   // #chatroom-gabbler
-  public abstract static class Gabbler {
-    private Gabbler() {}
+  public static class Gabbler extends AbstractBehavior<ChatRoom.SessionEvent> {
 
-    public static Behavior<ChatRoom.SessionEvent> behavior() {
-      return Behaviors.receive(ChatRoom.SessionEvent.class)
+    private ActorContext<ChatRoom.SessionEvent> context;
+
+    public Gabbler(ActorContext<ChatRoom.SessionEvent> context) {
+      this.context = context;
+    }
+
+    @Override
+    public Receive<ChatRoom.SessionEvent> createReceive() {
+      ReceiveBuilder<ChatRoom.SessionEvent> builder = newReceiveBuilder();
+      return builder
           .onMessage(
               ChatRoom.SessionDenied.class,
-              (context, message) -> {
+              message -> {
                 System.out.println("cannot start chat room session: " + message.reason);
                 return Behaviors.stopped();
               })
           .onMessage(
               ChatRoom.SessionGranted.class,
-              (context, message) -> {
+              message -> {
                 message.handle.tell(new ChatRoom.PostMessage("Hello World!"));
                 return Behaviors.same();
               })
           .onMessage(
               ChatRoom.MessagePosted.class,
-              (context, message) -> {
+              message -> {
                 System.out.println(
                     "message has been posted by '" + message.screenName + "': " + message.message);
                 return Behaviors.stopped();
               })
           .build();
+    }
+
+    public static Behavior<ChatRoom.SessionEvent> behavior() {
+      return Behaviors.setup(Gabbler::new);
     }
   }
   // #chatroom-gabbler
@@ -212,5 +237,9 @@ public class OOIntroTest {
 
     final ActorSystem<Void> system = ActorSystem.create(main, "ChatRoomDemo");
     // #chatroom-main
+  }
+
+  public static void main(String[] args) throws Exception {
+    runChatRoom();
   }
 }

--- a/akka-docs/src/main/paradox/typed/actors.md
+++ b/akka-docs/src/main/paradox/typed/actors.md
@@ -402,9 +402,8 @@ problematic, so passing an @scala[`ActorRef[PublishSessionMessage]`]@java[`Actor
 
 #### Trying it out
 
-In order to see this chat room in action we need to write a client Actor that can use it, for this 
-stateless actor it doesn't make much sense to use the `AbstractBehavior` so let's just reuse the
-functional style gabbler from the sample above:
+In order to see this chat room in action we need to write a client Actor that can use it
+@scala[, for this stateless actor it doesn't make much sense to use the `AbstractBehavior` so let's just reuse the functional style gabbler from the sample above]:
 
 Scala
 :  @@snip [OOIntroSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/OOIntroSpec.scala) {  #chatroom-gabbler }


### PR DESCRIPTION
Where as it is valid that stateless actors don't benefit I see
java users using the OO style for everything