### PR TITLE
Harden PrimitiveStateSpec: Expect termination before starting next actor

### DIFF
--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
@@ -57,7 +57,7 @@ class PrimitiveStateSpec extends ScalaTestWithActorTestKit(PrimitiveStateSpec.co
       probe.expectTerminated(ref1)
 
       val ref2 = testKit.spawn(b)
-      // eventHandler from reply
+      // eventHandler from replay
       probe.expectMessage("eventHandler:0:1")
       probe.expectMessage("eventHandler:1:2")
       probe.expectMessage("onRecoveryCompleted:3")

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
@@ -54,6 +54,8 @@ class PrimitiveStateSpec extends ScalaTestWithActorTestKit(PrimitiveStateSpec.co
       probe.expectMessage("eventHandler:1:2")
 
       ref1 ! -1
+      probe.expectTerminated(ref1)
+
       val ref2 = testKit.spawn(b)
       // eventHandler from reply
       probe.expectMessage("eventHandler:0:1")


### PR DESCRIPTION
Event handelr is called before persist so without this we may start
before the event is persisted. Expecting termination means that the
-1 is received so we know the persist is complete.

Fixes #25958