### PR TITLE
actor: Potential systemQueuePut improvement

### DIFF
--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -210,6 +210,7 @@ private[akka] abstract class Mailbox(val messageQueue: MessageQueue)
       Unsafe.instance.getObjectVolatile(this, AbstractMailbox.systemMessageOffset).asInstanceOf[SystemMessage])
 
   protected final def systemQueuePut(_old: LatestFirstSystemMessageList, _new: LatestFirstSystemMessageList): Boolean =
+    (_old.head eq _new.head) ||
     // Note: calling .head is not actually existing on the bytecode level as the parameters _old and _new
     // are SystemMessage instances hidden during compile time behind the SystemMessageList value class.
     // Without calling .head the parameters would be boxed in SystemMessageList wrapper.


### PR DESCRIPTION
Not completely sure, if that's safe to do. ~5% performance win measured with ActorBenchmark.

It seems when no system messages need to be handled, systemQueuePut is
mostly called with both lists being empty. In that case, we try to
avoid the CAS overhead.

This changes behavior at least in two regards:
 * no volatile write memory access, so there's no barrier (but is that required, we read the value directly before in systemDrain which would at least trigger the volatile read semantics)
 * one less opportunity for competing threads to put a message into the
   queue and have that being delivered immediately, so the previous
   version could be seen as an extra poll (but would that be needed for
   anything?)