### PR TITLE
Sets correct return type for withAttributes on Source/FlowWithContext

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWithContextLogSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWithContextLogSpec.scala
@@ -62,12 +62,11 @@ class FlowWithContextLogSpec extends StreamSpec("""
           onFinish = Logging.DebugLevel,
           onFailure = Logging.DebugLevel)
 
-        val logging = FlowWithContext[Message, Long].log("my-log3")
+        val logging = FlowWithContext[Message, Long].log("my-log3").withAttributes(disableElementLogging)
         Source(List(Message("a", 1L), Message("b", 2L)))
           .startContextPropagation(m ⇒ m.offset)
           .via(logging)
           .endContextPropagation
-          .withAttributes(disableElementLogging)
           .runWith(Sink.ignore)
 
         logProbe.expectMsg(Logging.Debug(LogSrc, LogClazz, "[my-log3] Upstream finished."))
@@ -98,6 +97,22 @@ class FlowWithContextLogSpec extends StreamSpec("""
 
         logProbe.expectMsg(Logging.Debug(LogSrc, LogClazz, "[my-log5] Element: a"))
         logProbe.expectMsg(Logging.Debug(LogSrc, LogClazz, "[my-log5] Upstream finished."))
+      }
+
+      "allow disabling element logging" in {
+        val disableElementLogging = Attributes.logLevels(
+          onElement = LogLevels.Off,
+          onFinish = Logging.DebugLevel,
+          onFailure = Logging.DebugLevel)
+
+        Source(List(Message("a", 1L), Message("b", 2L)))
+          .startContextPropagation(m ⇒ m.offset)
+          .log("my-log6")
+          .withAttributes(disableElementLogging)
+          .endContextPropagation
+          .runWith(Sink.ignore)
+
+        logProbe.expectMsg(Logging.Debug(LogSrc, LogClazz, "[my-log6] Upstream finished."))
       }
 
     }

--- a/akka-stream/src/main/mima-filters/2.5.21.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.21.backwards.excludes
@@ -2,3 +2,6 @@
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowWithContextOps.log")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowWithContextOps.log$default$2")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowWithContextOps.log$default$3")
+
+# Sets correct return type for withAttributes on Source/FlowWithContext #26411
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.GraphDelegate.withAttributes")

--- a/akka-stream/src/main/scala/akka/stream/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/Graph.scala
@@ -80,5 +80,4 @@ trait Graph[+S <: Shape, +M] {
 private[stream] abstract class GraphDelegate[+S <: Shape, +Mat](delegate: Graph[S, Mat]) extends Graph[S, Mat] {
   final override def shape: S = delegate.shape
   final override private[stream] def traversalBuilder: TraversalBuilder = delegate.traversalBuilder
-  final override def withAttributes(attr: Attributes): Graph[S, Mat] = delegate.withAttributes(attr)
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FlowWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FlowWithContext.scala
@@ -58,6 +58,14 @@ final class FlowWithContext[-In, -CtxIn, +Out, +CtxOut, +Mat](delegate: scaladsl
   }
 
   /**
+   * Context-preserving variant of [[akka.stream.javadsl.Flow.withAttributes]].
+   *
+   * @see [[akka.stream.javadsl.Flow.withAttributes]]
+   */
+  override def withAttributes(attr: Attributes): FlowWithContext[In, CtxIn, Out, CtxOut, Mat] =
+    viaScala(_.withAttributes(attr))
+
+  /**
    * Creates a regular flow of pairs (data, context).
    */
   def asFlow(): Flow[Pair[In, CtxIn], Pair[Out, CtxOut], Mat] @uncheckedVariance =

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SourceWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SourceWithContext.scala
@@ -41,6 +41,14 @@ final class SourceWithContext[+Out, +Ctx, +Mat](delegate: scaladsl.SourceWithCon
     viaScala(_.via(akka.stream.scaladsl.Flow[(Out, Ctx)].map { case (o, c) ⇒ Pair(o, c) }.via(viaFlow).map(_.toScala)))
 
   /**
+   * Context-preserving variant of [[akka.stream.javadsl.Source.withAttributes]].
+   *
+   * @see [[akka.stream.javadsl.Source.withAttributes]]
+   */
+  override def withAttributes(attr: Attributes): SourceWithContext[Out, Ctx, Mat] =
+    viaScala(_.withAttributes(attr))
+
+  /**
    * Stops automatic context propagation from here and converts this to a regular
    * stream of a pair of (data, context).
    */

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContext.scala
@@ -51,6 +51,14 @@ final class FlowWithContext[-In, -CtxIn, +Out, +CtxOut, +Mat](
   override def viaMat[Out2, Ctx2, Mat2, Mat3](flow: Graph[FlowShape[(Out, CtxOut), (Out2, Ctx2)], Mat2])(combine: (Mat, Mat2) ⇒ Mat3): FlowWithContext[In, CtxIn, Out2, Ctx2, Mat3] =
     FlowWithContext.from(delegate.viaMat(flow)(combine))
 
+  /**
+   * Context-preserving variant of [[akka.stream.scaladsl.Flow.withAttributes]].
+   *
+   * @see [[akka.stream.scaladsl.Flow.withAttributes]]
+   */
+  override def withAttributes(attr: Attributes): FlowWithContext[In, CtxIn, Out, CtxOut, Mat] =
+    new FlowWithContext(delegate.withAttributes(attr))
+
   def asFlow: Flow[(In, CtxIn), (Out, CtxOut), Mat] = delegate
 
   def asJava[JIn <: In, JCtxIn <: CtxIn, JOut >: Out, JCtxOut >: CtxOut, JMat >: Mat]: javadsl.FlowWithContext[JIn, JCtxIn, JOut, JCtxOut, JMat] =

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/SourceWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/SourceWithContext.scala
@@ -32,6 +32,14 @@ final class SourceWithContext[+Out, +Ctx, +Mat] private[stream] (
     new SourceWithContext(delegate.viaMat(flow)(combine))
 
   /**
+   * Context-preserving variant of [[akka.stream.scaladsl.Source.withAttributes]].
+   *
+   * @see [[akka.stream.scaladsl.Source.withAttributes]]
+   */
+  override def withAttributes(attr: Attributes): SourceWithContext[Out, Ctx, Mat] =
+    new SourceWithContext(delegate.withAttributes(attr))
+
+  /**
    * Stops automatic context propagation from here and converts this to a regular
    * stream of a pair of (data, context).
    */


### PR DESCRIPTION
`withAttributes` in `GraphDelegate` had a too generic return type.
Moved the function to the specific classe.

It is not possible to have the function in `FlowWithContextOps`, as it works using `via` on an empty subflow.
And `withAttributes` doesn't work on empty flow.

Updated the existing tests to use the function.