### PR TITLE
Simplify ClusterDeathWatchSpec

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
@@ -173,8 +173,10 @@ abstract class ClusterDeathWatchSpec
       }
       enterBarrier("remote-watch")
 
-      // second and third are already removed
-      awaitClusterUp(first, fourth, fifth)
+      runOn(fifth) {
+        cluster.join(first)
+      }
+      enterBarrier("fifth-joined")
 
       runOn(first) {
         // fifth is member, so the node is handled by the ClusterRemoteWatcher,


### PR DESCRIPTION
awaitClusterUp does more than necessary here, leading to confusing logging.

Should make #19383 easier to diagnose further