### PR TITLE
Don't apply 'discipline' flags to compilation run for documentation

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -83,7 +83,7 @@ object AkkaBuild {
 
   private def allWarnings: Boolean = System.getProperty("akka.allwarnings", "false").toBoolean
 
-  final val DefaultScalacOptions = Seq("-encoding", "UTF-8", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint", "-Ywarn-unused")
+  final val DefaultScalacOptions = Seq("-encoding", "UTF-8", "-feature", "-unchecked", "-Xlog-reflective-calls")
 
   // -XDignore.symbol.file suppresses sun.misc.Unsafe warnings
   final val DefaultJavacOptions = Seq("-encoding", "UTF-8", "-Xlint:unchecked", "-XDignore.symbol.file")
@@ -93,12 +93,6 @@ object AkkaBuild {
     Protobuf.settings ++ Seq[Setting[_]](
       // compile options
       scalacOptions in Compile ++= DefaultScalacOptions,
-      // On 2.13, adding -Ywarn-unused breaks 'sbt ++2.13.0-M5 akka-actor/doc'
-      // https://github.com/akka/akka/issues/26119
-      scalacOptions in Compile --= (CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 13)) => Seq("-Ywarn-unused")
-        case _             => Seq.empty
-      }),
       // Makes sure that, even when compiling with a jdk version greater than 8, the resulting jar will not refer to
       // methods not found in jdk8. To test whether this has the desired effect, compile akka-remote and check the
       // invocation of 'ByteBuffer.clear()' in EnvelopeBuffer.class with 'javap -c': it should refer to
@@ -114,8 +108,7 @@ object AkkaBuild {
             Seq("-release", "8", "-javabootclasspath", CrossJava.Keys.fullJavaHomes.value("8") + "/jre/lib/rt.jar")),
       scalacOptions in Compile ++= (if (allWarnings) Seq("-deprecation") else Nil),
       scalacOptions in Test := (scalacOptions in Test).value.filterNot(opt ⇒
-        opt == "-Xlog-reflective-calls" || opt.contains("genjavadoc")) ++ Seq(
-        "-Ywarn-unused"),
+        opt == "-Xlog-reflective-calls" || opt.contains("genjavadoc")),
       javacOptions in compile ++= DefaultJavacOptions ++ (
         if (System.getProperty("java.version").startsWith("1."))
           Seq()

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -39,6 +39,12 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
       Compile / scalacOptions ++= disciplineScalacOptions,
       Compile / scalacOptions --= undisciplineScalacOptions,
       Compile / console / scalacOptions --= Seq("-deprecation", "-Xfatal-warnings", "-Xlint", "-Ywarn-unused:imports"),
+      // -Ywarn-unused:_ breaks 'sbt ++2.13.0-M5 akka-actor/doc'
+      // https://github.com/akka/akka/issues/26119
+      Compile / doc / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 13)) => Seq("-Ywarn-unused:_,-explicits")
+        case _ => Nil
+      }),
       Compile / scalacOptions --= (CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 13)) =>
           Seq(
@@ -48,9 +54,6 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
             "-Ywarn-nullary-unit",
             "-Ypartial-unification",
             "-Yno-adapted-args",
-            // -Ywarn-unused:_ breaks 'sbt ++2.13.0-M5 akka-actor/doc'
-            // https://github.com/akka/akka/issues/26119
-            "-Ywarn-unused:_",
           )
         case Some((2, 12)) =>
           Nil
@@ -69,10 +72,7 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
     "-Yno-adapted-args",
     "-Xfatal-warnings")
 
-  /** Optimistic, this is desired over time.
-    * -Xlint and -Ywarn-unused: are included in commonScalaOptions.
-    * If eventually all modules use this plugin, we could migrate them here.
-    */
+  /** These options are desired, but some are excluded for the time being*/
   val disciplineScalacOptions = Seq(
     // start: must currently remove, version regardless
     "-Xfatal-warnings",
@@ -81,6 +81,7 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
     "-Ywarn-numeric-widen",
     // end
     "-Xfuture",
+    "-Xlint",
     "-Ywarn-dead-code",
     "-Ywarn-inaccessible",
     "-Ywarn-infer-any",

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -39,12 +39,11 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
       Compile / scalacOptions ++= disciplineScalacOptions,
       Compile / scalacOptions --= undisciplineScalacOptions,
       Compile / console / scalacOptions --= Seq("-deprecation", "-Xfatal-warnings", "-Xlint", "-Ywarn-unused:imports"),
-      // -Ywarn-unused:_ breaks 'sbt ++2.13.0-M5 akka-actor/doc'
+      // Discipline is not needed for the docs compilation run (which uses
+      // different compiler phases from the regular run), and in particular
+      // '-Ywarn-unused:explicits' breaks 'sbt ++2.13.0-M5 akka-actor/doc'
       // https://github.com/akka/akka/issues/26119
-      Compile / doc / scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 13)) => Seq("-Ywarn-unused:_,-explicits")
-        case _ => Nil
-      }),
+      Compile / doc / scalacOptions --= disciplineScalacOptions,
       Compile / scalacOptions --= (CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 13)) =>
           Seq(

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -41,7 +41,17 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
       Compile / console / scalacOptions --= Seq("-deprecation", "-Xfatal-warnings", "-Xlint", "-Ywarn-unused:imports"),
       Compile / scalacOptions --= (CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 13)) =>
-          Seq("-Ywarn-inaccessible", "-Ywarn-infer-any", "-Ywarn-nullary-override", "-Ywarn-nullary-unit", "-Ypartial-unification", "-Yno-adapted-args")
+          Seq(
+            "-Ywarn-inaccessible",
+            "-Ywarn-infer-any",
+            "-Ywarn-nullary-override",
+            "-Ywarn-nullary-unit",
+            "-Ypartial-unification",
+            "-Yno-adapted-args",
+            // -Ywarn-unused:_ breaks 'sbt ++2.13.0-M5 akka-actor/doc'
+            // https://github.com/akka/akka/issues/26119
+            "-Ywarn-unused:_",
+          )
         case Some((2, 12)) =>
           Nil
         case Some((2, 11)) =>


### PR DESCRIPTION
This is not needed, and in particular caused problems with `-Ywarn-unused:_` on scala 2.13.0-M5 (#26119)