### PR TITLE
Add Source.lazyInitAsync

### DIFF
--- a/akka-docs/src/main/categories/flow-operators.md
+++ b/akka-docs/src/main/categories/flow-operators.md
@@ -1,0 +1,1 @@
+These built-in flows are available from @scala[`akka.stream.scaladsl.Flow`] @java[`akka.stream.javadsl.Flow`]:

--- a/akka-docs/src/main/paradox/stream/operators/Flow/fromSinkAndSource.md
+++ b/akka-docs/src/main/paradox/stream/operators/Flow/fromSinkAndSource.md
@@ -2,7 +2,7 @@
 
 Creates a `Flow` from a `Sink` and a `Source` where the Flow's input will be sent to the `Sink` and the `Flow` 's output will come from the Source.
 
-@ref[Flow operators composed of Sinks and Sources](../index.md#flow-operators-composed-of-sinks-and-sources)
+@ref[Flow operators](../index.md#flow-operators)
 
 @@@div { .group-scala }
 

--- a/akka-docs/src/main/paradox/stream/operators/Flow/fromSinkAndSourceCoupled.md
+++ b/akka-docs/src/main/paradox/stream/operators/Flow/fromSinkAndSourceCoupled.md
@@ -2,7 +2,7 @@
 
 Allows coupling termination (cancellation, completion, erroring) of Sinks and Sources while creating a Flow between them.
 
-@ref[Flow operators composed of Sinks and Sources](../index.md#flow-operators-composed-of-sinks-and-sources)
+@ref[Flow operators](../index.md#flow-operators)
 
 @@@div { .group-scala }
 

--- a/akka-docs/src/main/paradox/stream/operators/Flow/lazyInitAsync.md
+++ b/akka-docs/src/main/paradox/stream/operators/Flow/lazyInitAsync.md
@@ -2,7 +2,7 @@
 
 Creates a real `Flow` upon receiving the first element by calling relevant `flowFactory` given as an argument.
 
-@ref[Simple operators](../index.md#simple-operators)
+@ref[Flow operators](../index.md#flow-operators)
 
 @@@div { .group-scala }
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/lazyInitAsync.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/lazyInitAsync.md
@@ -1,8 +1,10 @@
-# lazyInitAsync
+# Source.lazyInitAsync
 
 Defers creation and materialization of a `Source` until there is demand.
 
 @ref[Source operators](../index.md#source-operators)
+
+@@@div { .group-scala }
 
 ## Signature
 
@@ -12,7 +14,13 @@ Defers creation and materialization of a `Source` until there is demand.
 
 ## Description
 
-Defers creation and materialization of a `Source` until there is demand.
+Creates a real `Source` upon the first demand by calling the given `sourcefactory`.
+The real `Source` will not be created if there is no demand.
+
+The materialized value of the `Source` is a @scala[`Future[Option[M]]`]@java[`CompletionStage<Optional<M>>`] that is 
+completed with @scala[`Some(mat)`]@java[`Optional.of(mat)`] when the real source gets materialized or with @scala[`None`]
+@java[an empty optional] when there is no demand prior to cancellation. If the source materialization (including the call of the `sourcefactory`) 
+fails then the future is completed with the failure.
 
 
 @@@div { .callout }

--- a/akka-docs/src/main/paradox/stream/operators/Source/lazyInitAsync.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/lazyInitAsync.md
@@ -1,0 +1,25 @@
+# lazyInitAsync
+
+Defers creation and materialization of a `Source` until there is demand.
+
+@ref[Source operators](../index.md#source-operators)
+
+## Signature
+
+@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #lazyInitAsync }
+
+@@@
+
+## Description
+
+Defers creation and materialization of a `Source` until there is demand.
+
+
+@@@div { .callout }
+
+**emits** depends on the wrapped `Source`
+
+**completes** depends on the wrapped `Source`
+
+@@@
+

--- a/akka-docs/src/main/paradox/stream/operators/index.md
+++ b/akka-docs/src/main/paradox/stream/operators/index.md
@@ -22,6 +22,7 @@ These built-in sources are available from @scala[`akka.stream.scaladsl.Source`] 
 |Source|<a name="fromsourcecompletionstage"></a>@ref[fromSourceCompletionStage](Source/fromSourceCompletionStage.md)|Streams the elements of an asynchronous source once its given *completion* operator completes.|
 |Source|<a name="lazily"></a>@ref[lazily](Source/lazily.md)|Defers creation and materialization of a `Source` until there is demand.|
 |Source|<a name="lazilyasync"></a>@ref[lazilyAsync](Source/lazilyAsync.md)|Defers creation and materialization of a `CompletionStage` until there is demand.|
+|Source|<a name="lazyinitasync"></a>@ref[lazyInitAsync](Source/lazyInitAsync.md)|Creates a real `Source` upon receiving the first demand. |
 |Source|<a name="maybe"></a>@ref[maybe](Source/maybe.md)|Materialize a @scala[`Promise[Option[T]]`] @java[`CompletionStage`] that if completed with a @scala[`Some[T]`] @java[`Optional`] will emit that *T* and then complete the stream, or if completed with @scala[`None`] @java[`empty Optional`] complete the stream right away.|
 |Source|<a name="queue"></a>@ref[queue](Source/queue.md)|Materialize a `SourceQueue` onto which elements can be pushed for emitting from the source. |
 |Source|<a name="range"></a>@ref[range](Source/range.md)|Emit each integer in a range, with an option to take bigger steps than 1.|
@@ -304,6 +305,7 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 * [failed](Source/failed.md)
 * [lazily](Source/lazily.md)
 * [lazilyAsync](Source/lazilyAsync.md)
+* [lazyInitAsync](Source/lazyInitAsync.md)
 * [asSubscriber](Source/asSubscriber.md)
 * [actorRef](Source/actorRef.md)
 * [zipN](Source/zipN.md)

--- a/akka-docs/src/main/paradox/stream/operators/index.md
+++ b/akka-docs/src/main/paradox/stream/operators/index.md
@@ -59,7 +59,7 @@ These built-in sinks are available from @scala[`akka.stream.scaladsl.Sink`] @jav
 |Sink|<a name="ignore"></a>@ref[ignore](Sink/ignore.md)|Consume all elements but discards them.|
 |Sink|<a name="last"></a>@ref[last](Sink/last.md)|Materializes into a @scala[`Future`] @java[`CompletionStage`] which will complete with the last value emitted when the stream completes.|
 |Sink|<a name="lastoption"></a>@ref[lastOption](Sink/lastOption.md)|Materialize a @scala[`Future[Option[T]]`] @java[`CompletionStage<Optional<T>>`] which completes with the last value emitted wrapped in an @scala[`Some`] @java[`Optional`] when the stream completes.|
-|Sink|<a name="lazyinitasync"></a>@ref[lazyInitAsync](Sink/lazyInitAsync.md)|Defers creation and materialization of `Sink` until receiving an element. |
+|Sink|<a name="lazyinitasync"></a>@ref[lazyInitAsync](Sink/lazyInitAsync.md)|Creates a real `Sink` upon receiving the first element. |
 |Sink|<a name="oncomplete"></a>@ref[onComplete](Sink/onComplete.md)|Invoke a callback when the stream has completed or failed.|
 |Sink|<a name="prematerialize"></a>@ref[preMaterialize](Sink/preMaterialize.md)|Materializes this Sink, immediately returning (1) its materialized value, and (2) a new Sink that can be consume elements 'into' the pre-materialized one.|
 |Sink|<a name="queue"></a>@ref[queue](Sink/queue.md)|Materialize a `SinkQueue` that can be pulled to trigger demand through the sink.|
@@ -165,7 +165,7 @@ These built-in flows are available from @scala[`akka.stream.scaladsl.Flow`] @jav
 |--|--|--|
 |Flow|<a name="fromsinkandsource"></a>@ref[fromSinkAndSource](Flow/fromSinkAndSource.md)|Creates a `Flow` from a `Sink` and a `Source` where the Flow's input will be sent to the `Sink` and the `Flow` 's output will come from the Source.|
 |Flow|<a name="fromsinkandsourcecoupled"></a>@ref[fromSinkAndSourceCoupled](Flow/fromSinkAndSourceCoupled.md)|Allows coupling termination (cancellation, completion, erroring) of Sinks and Sources while creating a Flow between them.|
-|Flow|<a name="lazyinitasync"></a>@ref[lazyInitAsync](Flow/lazyInitAsync.md)|Defers creation and materialization of a `Flow` until receiving an element.|
+|Flow|<a name="lazyinitasync"></a>@ref[lazyInitAsync](Flow/lazyInitAsync.md)|Creates a real `Flow` upon receiving the first element by calling relevant `flowFactory` given as an argument.|
 
 ## Asynchronous operators
 

--- a/akka-docs/src/main/paradox/stream/operators/index.md
+++ b/akka-docs/src/main/paradox/stream/operators/index.md
@@ -22,7 +22,7 @@ These built-in sources are available from @scala[`akka.stream.scaladsl.Source`] 
 |Source|<a name="fromsourcecompletionstage"></a>@ref[fromSourceCompletionStage](Source/fromSourceCompletionStage.md)|Streams the elements of an asynchronous source once its given *completion* operator completes.|
 |Source|<a name="lazily"></a>@ref[lazily](Source/lazily.md)|Defers creation and materialization of a `Source` until there is demand.|
 |Source|<a name="lazilyasync"></a>@ref[lazilyAsync](Source/lazilyAsync.md)|Defers creation and materialization of a `CompletionStage` until there is demand.|
-|Source|<a name="lazyinitasync"></a>@ref[lazyInitAsync](Source/lazyInitAsync.md)|Creates a real `Source` upon receiving the first demand. |
+|Source|<a name="lazyinitasync"></a>@ref[lazyInitAsync](Source/lazyInitAsync.md)|Defers creation and materialization of a `Source` until there is demand.|
 |Source|<a name="maybe"></a>@ref[maybe](Source/maybe.md)|Materialize a @scala[`Promise[Option[T]]`] @java[`CompletionStage`] that if completed with a @scala[`Some[T]`] @java[`Optional`] will emit that *T* and then complete the stream, or if completed with @scala[`None`] @java[`empty Optional`] complete the stream right away.|
 |Source|<a name="queue"></a>@ref[queue](Source/queue.md)|Materialize a `SourceQueue` onto which elements can be pushed for emitting from the source. |
 |Source|<a name="range"></a>@ref[range](Source/range.md)|Emit each integer in a range, with an option to take bigger steps than 1.|
@@ -59,7 +59,7 @@ These built-in sinks are available from @scala[`akka.stream.scaladsl.Sink`] @jav
 |Sink|<a name="ignore"></a>@ref[ignore](Sink/ignore.md)|Consume all elements but discards them.|
 |Sink|<a name="last"></a>@ref[last](Sink/last.md)|Materializes into a @scala[`Future`] @java[`CompletionStage`] which will complete with the last value emitted when the stream completes.|
 |Sink|<a name="lastoption"></a>@ref[lastOption](Sink/lastOption.md)|Materialize a @scala[`Future[Option[T]]`] @java[`CompletionStage<Optional<T>>`] which completes with the last value emitted wrapped in an @scala[`Some`] @java[`Optional`] when the stream completes.|
-|Sink|<a name="lazyinitasync"></a>@ref[lazyInitAsync](Sink/lazyInitAsync.md)|Creates a real `Sink` upon receiving the first element. |
+|Sink|<a name="lazyinitasync"></a>@ref[lazyInitAsync](Sink/lazyInitAsync.md)|Defers creation and materialization of `Sink` until receiving an element. |
 |Sink|<a name="oncomplete"></a>@ref[onComplete](Sink/onComplete.md)|Invoke a callback when the stream has completed or failed.|
 |Sink|<a name="prematerialize"></a>@ref[preMaterialize](Sink/preMaterialize.md)|Materializes this Sink, immediately returning (1) its materialized value, and (2) a new Sink that can be consume elements 'into' the pre-materialized one.|
 |Sink|<a name="queue"></a>@ref[queue](Sink/queue.md)|Materialize a `SinkQueue` that can be pulled to trigger demand through the sink.|
@@ -137,7 +137,6 @@ depending on being backpressured by downstream or not.
 |Source/Flow|<a name="foldasync"></a>@ref[foldAsync](Source-or-Flow/foldAsync.md)|Just like `fold` but receives a function that results in a @scala[`Future`] @java[`CompletionStage`] to the next value.|
 |Source/Flow|<a name="grouped"></a>@ref[grouped](Source-or-Flow/grouped.md)|Accumulate incoming events until the specified number of elements have been accumulated and then pass the collection of elements downstream.|
 |Source/Flow|<a name="intersperse"></a>@ref[intersperse](Source-or-Flow/intersperse.md)|Intersperse stream with provided element similar to `List.mkString`.|
-|Flow|<a name="lazyinitasync"></a>@ref[lazyInitAsync](Flow/lazyInitAsync.md)|Creates a real `Flow` upon receiving the first element by calling relevant `flowFactory` given as an argument.|
 |Source/Flow|<a name="limit"></a>@ref[limit](Source-or-Flow/limit.md)|Limit number of element from upstream to given `max` number.|
 |Source/Flow|<a name="limitweighted"></a>@ref[limitWeighted](Source-or-Flow/limitWeighted.md)|Ensure stream boundedness by evaluating the cost of incoming elements using a cost function.|
 |Source/Flow|<a name="log"></a>@ref[log](Source-or-Flow/log.md)|Log elements flowing through the stream as well as completion and erroring.|
@@ -158,14 +157,15 @@ depending on being backpressured by downstream or not.
 |Source/Flow|<a name="watch"></a>@ref[watch](Source-or-Flow/watch.md)|Watch a specific `ActorRef` and signal a failure downstream once the actor terminates.|
 |Source/Flow|<a name="wiretap"></a>@ref[wireTap](Source-or-Flow/wireTap.md)|Attaches the given `Sink` to this `Flow` as a wire tap, meaning that elements that pass through will also be sent to the wire-tap `Sink`, without the latter affecting the mainline flow.|
 
-## Flow operators composed of Sinks and Sources
+## Flow operators
 
-
+These built-in flows are available from @scala[`akka.stream.scaladsl.Flow`] @java[`akka.stream.javadsl.Flow`]:
 
 | |Operator|Description|
 |--|--|--|
 |Flow|<a name="fromsinkandsource"></a>@ref[fromSinkAndSource](Flow/fromSinkAndSource.md)|Creates a `Flow` from a `Sink` and a `Source` where the Flow's input will be sent to the `Sink` and the `Flow` 's output will come from the Source.|
 |Flow|<a name="fromsinkandsourcecoupled"></a>@ref[fromSinkAndSourceCoupled](Flow/fromSinkAndSourceCoupled.md)|Allows coupling termination (cancellation, completion, erroring) of Sinks and Sources while creating a Flow between them.|
+|Flow|<a name="lazyinitasync"></a>@ref[lazyInitAsync](Flow/lazyInitAsync.md)|Defers creation and materialization of a `Flow` until receiving an element.|
 
 ## Asynchronous operators
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LazyInitAsyncSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LazyInitAsyncSourceSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.scaladsl
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import akka.Done
+import akka.stream.impl.LazySource
+import akka.stream.stage.{GraphStage, GraphStageLogic}
+import akka.stream.testkit.Utils.TE
+import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.stream.testkit.{StreamSpec, TestPublisher, TestSubscriber}
+import akka.stream.{ActorMaterializer, Attributes, Outlet, SourceShape}
+import akka.testkit.DefaultTimeout
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
+
+class LazyInitAsyncSourceSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
+
+  implicit val materializer = ActorMaterializer()
+
+  "A lazy source" should {
+    "work like a normal source, happy path" in assertAllStagesStopped {
+      val result = Source.lazyInitAsync(() ⇒ Future.successful(Source(List(1, 2, 3)))).runWith(Sink.seq)
+
+      result.futureValue should ===(Seq(1, 2, 3))
+    }
+
+//    "never construct the source when there was no demand" in assertAllStagesStopped {
+//      val probe = TestSubscriber.probe[Int]()
+//      val constructed = new AtomicBoolean(false)
+//      val result = Source.fromGraph(LazySource { () ⇒ constructed.set(true); Source(List(1, 2, 3)) }).runWith(Sink.fromSubscriber(probe))
+//      probe.cancel()
+//
+//      constructed.get() should ===(false)
+//    }
+//
+//    "fail the materialized value when downstream cancels without ever consuming any element" in assertAllStagesStopped {
+//      val matF = Source.fromGraph(LazySource(() ⇒ Source(List(1, 2, 3))))
+//        .toMat(Sink.cancelled)(Keep.left)
+//        .run()
+//
+//      intercept[RuntimeException] {
+//        matF.futureValue
+//      }
+//    }
+//
+//    "stop consuming when downstream has cancelled" in assertAllStagesStopped {
+//      val outProbe = TestSubscriber.probe[Int]()
+//      val inProbe = TestPublisher.probe[Int]()
+//
+//      Source.fromGraph(LazySource(() ⇒ Source.fromPublisher(inProbe))).runWith(Sink.fromSubscriber(outProbe))
+//
+//      outProbe.request(1)
+//      inProbe.expectRequest()
+//      inProbe.sendNext(27)
+//      outProbe.expectNext(27)
+//      outProbe.cancel()
+//      inProbe.expectCancellation()
+//    }
+//
+//    "materialize when the source has been created" in assertAllStagesStopped {
+//      val probe = TestSubscriber.probe[Int]()
+//
+//      val matF: Future[Done] = Source.fromGraph(LazySource { () ⇒
+//        Source(List(1, 2, 3)).mapMaterializedValue(_ ⇒ Done)
+//      }).to(Sink.fromSubscriber(probe))
+//        .run()
+//
+//      matF.value shouldEqual None
+//      probe.request(1)
+//      probe.expectNext(1)
+//      matF.futureValue should ===(Done)
+//
+//      probe.cancel()
+//    }
+//
+//    "fail stage when upstream fails" in assertAllStagesStopped {
+//      val outProbe = TestSubscriber.probe[Int]()
+//      val inProbe = TestPublisher.probe[Int]()
+//
+//      Source.fromGraph(LazySource(() ⇒ Source.fromPublisher(inProbe))).runWith(Sink.fromSubscriber(outProbe))
+//
+//      outProbe.request(1)
+//      inProbe.expectRequest()
+//      inProbe.sendNext(27)
+//      outProbe.expectNext(27)
+//      inProbe.sendError(TE("OMG Who set that on fire!?!"))
+//      outProbe.expectError() shouldEqual TE("OMG Who set that on fire!?!")
+//    }
+//
+//    "fail correctly when materialization of inner source fails" in assertAllStagesStopped {
+//      val matFail = TE("fail!")
+//      object FailingInnerMat extends GraphStage[SourceShape[String]] {
+//        val out = Outlet[String]("out")
+//        val shape = SourceShape(out)
+//        override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+//          throw matFail
+//        }
+//      }
+//
+//      val result = Source.lazily(() ⇒ Source.fromGraph(FailingInnerMat)).to(Sink.ignore).run()
+//
+//      result.failed.futureValue should ===(matFail)
+//
+//    }
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/LazySourceAsync.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/LazySourceAsync.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.impl
+
+import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
+import akka.stream._
+import akka.stream.impl.Stages.DefaultAttributes
+import akka.stream.scaladsl.{Keep, Source}
+import akka.stream.stage._
+
+import scala.concurrent.{Future, Promise}
+import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
+
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] final class LazySourceAsync[T, M](sourceFactory: () ⇒ Future[Source[T, M]]) extends GraphStageWithMaterializedValue[SourceShape[T], Future[Option[M]]] {
+  val out = Outlet[T]("LazySourceAsync.out")
+  override val shape = SourceShape(out)
+
+  override protected def initialAttributes = DefaultAttributes.lazySource
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Option[M]]) = {
+    val matPromise = Promise[Option[M]]()
+    val logic = new GraphStageLogic(shape) with OutHandler {
+
+      override def onDownstreamFinish(): Unit = {
+        matPromise.success(None)
+        super.onDownstreamFinish()
+      }
+
+      override def onPull(): Unit = {
+
+        val cb: AsyncCallback[Try[Source[T, M]]] =
+          getAsyncCallback {
+            case Success(source) ⇒
+              // check if the stage is still in need for the lazy source
+              // (there could have been an onDownstreamFinish in the meantime that has completed the promise)
+              if (!matPromise.isCompleted) {
+                try {
+                  val mat = switchTo(source)
+                  matPromise.success(Some(mat))
+                } catch {
+                  case NonFatal(e) ⇒
+                    matPromise.failure(e)
+                    failStage(e)
+                }
+              }
+            case Failure(e) ⇒
+              matPromise.tryFailure(e)
+              failStage(e)
+          }
+
+        try {
+          sourceFactory().onComplete(cb.invoke)(ExecutionContexts.sameThreadExecutionContext)
+        } catch {
+          case NonFatal(e) ⇒
+            matPromise.failure(e)
+            failStage(e)
+        }
+
+      }
+
+      setHandler(out, this)
+
+      private def switchTo(source: Source[T, M]): M = {
+
+        val subSink = new SubSinkInlet[T]("LazySourceAsync")
+        subSink.pull()
+
+        setHandler(out, new OutHandler {
+          override def onPull(): Unit = {
+            subSink.pull()
+          }
+
+          override def onDownstreamFinish(): Unit = {
+            subSink.cancel()
+            completeStage()
+          }
+        })
+
+        subSink.setHandler(new InHandler {
+          override def onPush(): Unit = {
+            push(out, subSink.grab())
+          }
+        })
+
+        try {
+          subFusingMaterializer.materialize(source.toMat(subSink.sink)(Keep.left), inheritedAttributes)
+        } catch {
+          case NonFatal(ex) ⇒
+            subSink.cancel()
+            throw ex
+        }
+      }
+
+    }
+
+    (logic, matPromise.future)
+  }
+
+  override def toString = "LazySourceAsync"
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/LazySourceAsync.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/LazySourceAsync.scala
@@ -8,13 +8,12 @@ import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts
 import akka.stream._
 import akka.stream.impl.Stages.DefaultAttributes
-import akka.stream.scaladsl.{Keep, Source}
+import akka.stream.scaladsl.{ Keep, Source }
 import akka.stream.stage._
 
-import scala.concurrent.{Future, Promise}
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.{ Future, Promise }
+import scala.util.{ Failure, Success, Try }
 import scala.util.control.NonFatal
-
 
 /**
  * INTERNAL API

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -438,6 +438,20 @@ object Source {
     lazily(() ⇒ fromFuture(create()))
 
   /**
+    * Creates a real `Source` upon receiving the first demand. Internal `Source` will not be created if there is no
+    * demand because of cancellation.
+    *
+    * If upstream completes before an element was received then the `Future` is completed with `None`.
+    * If upstream fails before an element was received, `sinkFactory` throws an exception, or materialization of the internal
+    * sink fails then the `Future` is completed with the exception.
+    * Otherwise the `Future` is completed with the materialized value of the internal sink.
+    */
+  def lazyInitAsync[T, M](sourceFactory: () ⇒ Future[Source[T, M]]): Source[T, Future[Option[M]]] =
+    Source.fromGraph(new LazySourceAsync[T, M](_ ⇒ sourceFactory()))
+
+
+
+  /**
    * Creates a `Source` that is materialized as a [[org.reactivestreams.Subscriber]]
    */
   def asSubscriber[T]: Source[T, Subscriber[T]] =

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -438,18 +438,16 @@ object Source {
     lazily(() ⇒ fromFuture(create()))
 
   /**
-    * Creates a real `Source` upon receiving the first demand. Internal `Source` will not be created if there is no
-    * demand because of cancellation.
-    *
-    * If upstream completes before an element was received then the `Future` is completed with `None`.
-    * If upstream fails before an element was received, `sinkFactory` throws an exception, or materialization of the internal
-    * sink fails then the `Future` is completed with the exception.
-    * Otherwise the `Future` is completed with the materialized value of the internal sink.
-    */
+   * Creates a real `Source` upon receiving the first demand. Internal `Source` will not be created if downstream
+   * finishes without any demand.
+   *
+   * If downstream finishes without any demand the materialized `Future` is completed with `None`.
+   * If the future of the real source or the materialization of the real source fails then the
+   * materialized `Future` is completed with the exception.
+   * Otherwise the `Future` is completed with `Some` of the materialized value of the internal source.
+   */
   def lazyInitAsync[T, M](sourceFactory: () ⇒ Future[Source[T, M]]): Source[T, Future[Option[M]]] =
-    Source.fromGraph(new LazySourceAsync[T, M](_ ⇒ sourceFactory()))
-
-
+    Source.fromGraph(new LazySourceAsync[T, M](sourceFactory))
 
   /**
    * Creates a `Source` that is materialized as a [[org.reactivestreams.Subscriber]]

--- a/project/StreamOperatorsIndexGenerator.scala
+++ b/project/StreamOperatorsIndexGenerator.scala
@@ -25,7 +25,7 @@ object StreamOperatorsIndexGenerator extends AutoPlugin {
     "Additional Sink and Source converters",
     "File IO Sinks and Sources",
     "Simple operators",
-    "Flow operators composed of Sinks and Sources",
+    "Flow operators",
     "Asynchronous operators",
     "Timer driven operators",
     "Backpressure aware operators",
@@ -74,6 +74,10 @@ object StreamOperatorsIndexGenerator extends AutoPlugin {
     "orElseGraph",
     "divertToGraph",
     "zipWithGraph"
+  )
+
+  val distinguishSourceAndFlow = Set(
+    "lazyInitAsync"
   )
 
   // FIXME document these methods as well
@@ -176,7 +180,7 @@ object StreamOperatorsIndexGenerator extends AutoPlugin {
 
     val groupedDefs =
       defs.map {
-        case (element @ ("Source" | "Flow"), method) if sourceAndFlow.contains(method) =>
+        case (element @ ("Source" | "Flow"), method) if sourceAndFlow.contains(method) && !distinguishSourceAndFlow.contains(method) =>
           ("Source/Flow", method, s"Source-or-Flow/$method.md")
         case (element, method) =>
           (element, method, s"$element/$method.md")


### PR DESCRIPTION
Allow to create a source lazily and asynchronously. There already is `Sink.lazyInitAsync` and `Flow.lazyInitAsync` but `Source.lazyInitAsync` is missing.