### PR TITLE
!str remove {Source,Flow}WithContext.statefulMapConcat, fixes #26330

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceWithContextSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceWithContextSpec.scala
@@ -107,23 +107,5 @@ class SourceWithContextSpec extends StreamSpec {
         .expectNext((Seq("a-1", "a-2"), Seq(1L, 1L)), (Seq("a-3", "a-4"), Seq(1L, 1L)))
         .expectComplete()
     }
-
-    "pass through context via statefulMapConcat" in {
-      val statefulFunction: () ⇒ String ⇒ collection.immutable.Iterable[String] = () ⇒ {
-        var counter = 0
-        str ⇒ {
-          counter = counter + 1
-          (1 to counter).map(_ ⇒ str)
-        }
-      }
-      Source(Vector(Message("a", 1L), Message("z", 2L)))
-        .asSourceWithContext(_.offset)
-        .map(_.data)
-        .statefulMapConcat(statefulFunction)
-        .runWith(TestSink.probe[(String, Long)])
-        .request(3)
-        .expectNext(("a", 1L), ("z", 2L), ("z", 2L))
-        .expectComplete()
-    }
   }
 }

--- a/akka-stream/src/main/mima-filters/2.5.21.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.21.backwards.excludes
@@ -24,3 +24,10 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.GraphDelegate.wi
 
 # rename `from` to `fromTuples` in WithContext Scala dsl #26370
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.FlowWithContext.from")
+
+# Remove statefulMapConcat from @ApiMayChange {Source,Flow}WithContext #26330
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.javadsl.FlowWithContext.statefulMapConcat")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.javadsl.SourceWithContext.statefulMapConcat")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.FlowWithContext.statefulMapConcat")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.SourceWithContext.statefulMapConcat")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.FlowWithContextOps.statefulMapConcat")

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FlowWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FlowWithContext.scala
@@ -180,40 +180,6 @@ final class FlowWithContext[-In, -CtxIn, +Out, +CtxOut, +Mat](delegate: scaladsl
     viaScala(_.sliding(n, step).map(_.asJava).mapContext(_.asJava))
 
   /**
-   * Context-preserving variant of [[akka.stream.javadsl.Flow.statefulMapConcat]].
-   *
-   * The context of the input element will be associated with each of the output elements calculated from
-   * this input element.
-   *
-   * Example:
-   *
-   * ```
-   * def dup(element: String) = Seq(element, element)
-   *
-   * Input:
-   *
-   * ("a", 1)
-   * ("b", 2)
-   *
-   * inputElements.statefulMapConcat(() => dup)
-   *
-   * Output:
-   *
-   * ("a", 1)
-   * ("a", 1)
-   * ("b", 2)
-   * ("b", 2)
-   * ```
-   *
-   * @see [[akka.stream.javadsl.Flow.statefulMapConcat]]
-   */
-  def statefulMapConcat[Out2](f: function.Creator[function.Function[Out, java.lang.Iterable[Out2]]]): FlowWithContext[In, CtxIn, Out2, CtxOut, Mat] =
-    viaScala(_.statefulMapConcat { () ⇒
-      val fun = f.create()
-      elem ⇒ Util.immutableSeq(fun(elem))
-    })
-
-  /**
    * Context-preserving variant of [[akka.stream.javadsl.Flow.log]].
    *
    * @see [[akka.stream.javadsl.Flow.log]]

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SourceWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SourceWithContext.scala
@@ -170,40 +170,6 @@ final class SourceWithContext[+Out, +Ctx, +Mat](delegate: scaladsl.SourceWithCon
     viaScala(_.sliding(n, step).map(_.asJava).mapContext(_.asJava))
 
   /**
-   * Context-preserving variant of [[akka.stream.javadsl.Source.statefulMapConcat]].
-   *
-   * The context of the input element will be associated with each of the output elements calculated from
-   * this input element.
-   *
-   * Example:
-   *
-   * ```
-   * def dup(element: String) = Seq(element, element)
-   *
-   * Input:
-   *
-   * ("a", 1)
-   * ("b", 2)
-   *
-   * inputElements.statefulMapConcat(() => dup)
-   *
-   * Output:
-   *
-   * ("a", 1)
-   * ("a", 1)
-   * ("b", 2)
-   * ("b", 2)
-   * ```
-   *
-   * @see [[akka.stream.javadsl.Source.statefulMapConcat]]
-   */
-  def statefulMapConcat[Out2](f: function.Creator[function.Function[Out, java.lang.Iterable[Out2]]]): SourceWithContext[Out2, Ctx, Mat] =
-    viaScala(_.statefulMapConcat { () ⇒
-      val fun = f.create()
-      elem ⇒ Util.immutableSeq(fun(elem))
-    })
-
-  /**
    * Context-preserving variant of [[akka.stream.javadsl.Source.log]].
    *
    * @see [[akka.stream.javadsl.Source.log]]


### PR DESCRIPTION
statefulMapConcat will by design confound processing of single elements.
However, in the WithContext APIs the user only has access to the elements
but not to the contexts so the association is likely to be wrong in the end.

So, for now, we follow our basic rule not to include potentially order-changing
operations in the WithContext APIs and remove statefulMapConcat. Users that
need something like that should drop to the regular tuple passing APIs and
manage context propagation manually.

Fixes #26330.

/cc @RayRoestenburg 