### PR TITLE
Add setup operator

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/Sink/setup.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/setup.md
@@ -1,0 +1,17 @@
+# Sink.setup
+
+Defer the creation of a `Sink` until materialization and access `ActorMaterializer` and `Attributes`
+
+@ref[Sink operators](../index.md#sink-operators)
+
+@@@ div { .group-scala }
+
+## Signature
+
+@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #setup }
+@@@
+
+## Description
+
+Typically used when access to materializer is needed to run a different stream during the construction of a sink.
+Can also be used to access the underlying `ActorSystem` from `ActorMaterializer`.

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/setup.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/setup.md
@@ -1,0 +1,19 @@
+# Source/Flow.setup
+
+Defer the creation of a `Source/Flow` until materialization and access `ActorMaterializer` and `Attributes`
+
+@ref[Simple operators](../index.md#simple-operators)
+
+@@@ div { .group-scala }
+
+## Signature
+
+@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #setup }
+@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #setup }
+
+@@@
+
+## Description
+
+Typically used when access to materializer is needed to run a different stream during the construction of a source/flow.
+Can also be used to access the underlying `ActorSystem` from `ActorMaterializer`.

--- a/akka-docs/src/main/paradox/stream/operators/index.md
+++ b/akka-docs/src/main/paradox/stream/operators/index.md
@@ -64,6 +64,7 @@ These built-in sinks are available from @scala[`akka.stream.scaladsl.Sink`] @jav
 |Sink|<a name="queue"></a>@ref[queue](Sink/queue.md)|Materialize a `SinkQueue` that can be pulled to trigger demand through the sink.|
 |Sink|<a name="reduce"></a>@ref[reduce](Sink/reduce.md)|Apply a reduction function on the incoming elements and pass the result to the next invocation.|
 |Sink|<a name="seq"></a>@ref[seq](Sink/seq.md)|Collect values emitted from the stream into a collection.|
+|Sink|<a name="setup"></a>@ref[setup](Sink/setup.md)|Defer the creation of a `Sink` until materialization and access `ActorMaterializer` and `Attributes`|
 |Sink|<a name="takelast"></a>@ref[takeLast](Sink/takeLast.md)|Collect the last `n` values emitted from the stream into a collection.|
 
 ## Additional Sink and Source converters
@@ -150,6 +151,7 @@ depending on being backpressured by downstream or not.
 |Source/Flow|<a name="reduce"></a>@ref[reduce](Source-or-Flow/reduce.md)|Start with first element and then apply the current and next value to the given function, when upstream complete the current value is emitted downstream.|
 |Source/Flow|<a name="scan"></a>@ref[scan](Source-or-Flow/scan.md)|Emit its current value, which starts at `zero`, and then apply the current and next value to the given function, emitting the next current value.|
 |Source/Flow|<a name="scanasync"></a>@ref[scanAsync](Source-or-Flow/scanAsync.md)|Just like `scan` but receives a function that results in a @scala[`Future`] @java[`CompletionStage`] to the next value.|
+|Source/Flow|<a name="setup"></a>@ref[setup](Source-or-Flow/setup.md)|Defer the creation of a `Source/Flow` until materialization and access `ActorMaterializer` and `Attributes`|
 |Source/Flow|<a name="sliding"></a>@ref[sliding](Source-or-Flow/sliding.md)|Provide a sliding window over the incoming stream and pass the windows as groups of elements downstream.|
 |Source/Flow|<a name="statefulmapconcat"></a>@ref[statefulMapConcat](Source-or-Flow/statefulMapConcat.md)|Transform each element into zero or more elements that are individually passed downstream.|
 |Source/Flow|<a name="take"></a>@ref[take](Source-or-Flow/take.md)|Pass `n` incoming elements downstream and then complete|
@@ -291,6 +293,7 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 * [fromPublisher](Source/fromPublisher.md)
 * [fromIterator](Source/fromIterator.md)
 * [cycle](Source/cycle.md)
+* [setup](Source-or-Flow/setup.md)
 * [fromFuture](Source/fromFuture.md)
 * [fromCompletionStage](Source/fromCompletionStage.md)
 * [fromFutureSource](Source/fromFutureSource.md)
@@ -391,6 +394,7 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 * [fromSinkAndSourceCoupled](Flow/fromSinkAndSourceCoupled.md)
 * [lazyInitAsync](Flow/lazyInitAsync.md)
 * [preMaterialize](Sink/preMaterialize.md)
+* [setup](Sink/setup.md)
 * [fromSubscriber](Sink/fromSubscriber.md)
 * [cancelled](Sink/cancelled.md)
 * [head](Sink/head.md)

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/SetupTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/SetupTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.javadsl;
+
+import akka.NotUsed;
+import akka.japi.Pair;
+import akka.stream.StreamTest;
+import akka.testkit.AkkaJUnitActorSystemResource;
+import akka.testkit.AkkaSpec;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class SetupTest extends StreamTest {
+  public SetupTest() {
+    super(actorSystemResource);
+  }
+
+  @ClassRule
+  public static AkkaJUnitActorSystemResource actorSystemResource =
+      new AkkaJUnitActorSystemResource("SetupTest", AkkaSpec.testConf());
+
+  @Test
+  public void shouldExposeMaterializerAndAttributesToSource() throws Exception {
+    final Source<Pair<Boolean, Boolean>, CompletionStage<NotUsed>> source =
+        Source.setup(
+            (mat, attr) ->
+                Source.single(Pair.create(mat.isShutdown(), attr.attributeList().isEmpty())));
+
+    assertEquals(
+        Pair.create(false, false),
+        source.runWith(Sink.head(), materializer).toCompletableFuture().get(5, TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void shouldExposeMaterializerAndAttributesToFlow() throws Exception {
+    final Flow<Object, Pair<Boolean, Boolean>, CompletionStage<NotUsed>> flow =
+        Flow.setup(
+            (mat, attr) ->
+                Flow.fromSinkAndSource(
+                    Sink.ignore(),
+                    Source.single(Pair.create(mat.isShutdown(), attr.attributeList().isEmpty()))));
+
+    assertEquals(
+        Pair.create(false, false),
+        Source.empty()
+            .via(flow)
+            .runWith(Sink.head(), materializer)
+            .toCompletableFuture()
+            .get(5, TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void shouldExposeMaterializerAndAttributesToSink() throws Exception {
+    Sink<Object, CompletionStage<CompletionStage<Pair<Boolean, Boolean>>>> sink =
+        Sink.setup(
+            (mat, attr) ->
+                Sink.fold(
+                    Pair.create(mat.isShutdown(), attr.attributeList().isEmpty()), Keep.left()));
+
+    assertEquals(
+        Pair.create(false, false),
+        Source.empty()
+            .runWith(sink, materializer)
+            .thenCompose(c -> c)
+            .toCompletableFuture()
+            .get(5, TimeUnit.SECONDS));
+  }
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/DslFactoriesConsistencySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/DslFactoriesConsistencySpec.scala
@@ -47,7 +47,7 @@ class DslFactoriesConsistencySpec extends WordSpec with Matchers {
       (classOf[scala.Function0[_]],                        classOf[java.util.concurrent.Callable[_]]) ::
       (classOf[scala.Function1[_, Unit]],                  classOf[akka.japi.function.Procedure[_]]) ::
       (classOf[scala.Function1[_, _]],                     classOf[akka.japi.function.Function[_, _]]) ::
-      (classOf[scala.Function1[_, _]],                     classOf[java.util.function.BiFunction[_, _, _]]) :: // setup
+      (classOf[scala.Function2[_, _, _]],                  classOf[java.util.function.BiFunction[_, _, _]]) :: // setup
       (classOf[scala.Function1[scala.Function1[_, _], _]], classOf[akka.japi.function.Function2[_, _, _]]) ::
       (classOf[akka.stream.scaladsl.Source[_, _]],         classOf[akka.stream.javadsl.Source[_, _]]) ::
       (classOf[akka.stream.scaladsl.Sink[_, _]],           classOf[akka.stream.javadsl.Sink[_, _]]) ::

--- a/akka-stream-tests/src/test/scala/akka/stream/DslFactoriesConsistencySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/DslFactoriesConsistencySpec.scala
@@ -47,6 +47,7 @@ class DslFactoriesConsistencySpec extends WordSpec with Matchers {
       (classOf[scala.Function0[_]],                        classOf[java.util.concurrent.Callable[_]]) ::
       (classOf[scala.Function1[_, Unit]],                  classOf[akka.japi.function.Procedure[_]]) ::
       (classOf[scala.Function1[_, _]],                     classOf[akka.japi.function.Function[_, _]]) ::
+      (classOf[scala.Function1[_, _]],                     classOf[java.util.function.BiFunction[_, _, _]]) :: // setup
       (classOf[scala.Function1[scala.Function1[_, _], _]], classOf[akka.japi.function.Function2[_, _, _]]) ::
       (classOf[akka.stream.scaladsl.Source[_, _]],         classOf[akka.stream.javadsl.Source[_, _]]) ::
       (classOf[akka.stream.scaladsl.Sink[_, _]],           classOf[akka.stream.javadsl.Sink[_, _]]) ::

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
@@ -42,19 +42,23 @@ class SetupSpec extends StreamSpec {
     }
 
     "propagate attributes" in {
-      val source = Source.setup { (_, attr) ⇒
-        Source.single(attr.nameLifted)
-      }.named("my-name")
+      val source = Source
+        .setup { (_, attr) ⇒
+          Source.single(attr.nameLifted)
+        }
+        .named("my-name")
 
       source.runWith(Sink.head).futureValue shouldBe Some("my-name")
     }
 
     "propagate attributes when nested" in {
-      val source = Source.setup { (_, _) ⇒
-        Source.setup { (_, attr) ⇒
-          Source.single(attr.nameLifted)
+      val source = Source
+        .setup { (_, _) ⇒
+          Source.setup { (_, attr) ⇒
+            Source.single(attr.nameLifted)
+          }
         }
-      }.named("my-name")
+        .named("my-name")
 
       source.runWith(Sink.head).futureValue shouldBe Some("my-name")
     }
@@ -112,19 +116,23 @@ class SetupSpec extends StreamSpec {
     }
 
     "propagate attributes" in {
-      val flow = Flow.setup { (_, attr) ⇒
-        Flow.fromSinkAndSource(Sink.ignore, Source.single(attr.nameLifted))
-      }.named("my-name")
+      val flow = Flow
+        .setup { (_, attr) ⇒
+          Flow.fromSinkAndSource(Sink.ignore, Source.single(attr.nameLifted))
+        }
+        .named("my-name")
 
       Source.empty.via(flow).runWith(Sink.head).futureValue shouldBe Some("my-name")
     }
 
     "propagate attributes when nested" in {
-      val flow = Flow.setup { (_, _) ⇒
-        Flow.setup { (_, attr) ⇒
-          Flow.fromSinkAndSource(Sink.ignore, Source.single(attr.nameLifted))
+      val flow = Flow
+        .setup { (_, _) ⇒
+          Flow.setup { (_, attr) ⇒
+            Flow.fromSinkAndSource(Sink.ignore, Source.single(attr.nameLifted))
+          }
         }
-      }.named("my-name")
+        .named("my-name")
 
       Source.empty.via(flow).runWith(Sink.head).futureValue shouldBe Some("my-name")
     }
@@ -180,19 +188,23 @@ class SetupSpec extends StreamSpec {
     }
 
     "propagate attributes" in {
-      val sink = Sink.setup { (_, attr) ⇒
-        Sink.fold(attr.nameLifted)(Keep.left)
-      }.named("my-name")
+      val sink = Sink
+        .setup { (_, attr) ⇒
+          Sink.fold(attr.nameLifted)(Keep.left)
+        }
+        .named("my-name")
 
       Source.empty.runWith(sink).flatMap(identity).futureValue shouldBe Some("my-name")
     }
 
     "propagate attributes when nested" in {
-      val sink = Sink.setup { (_, _) ⇒
-        Sink.setup { (_, attr) ⇒
-          Sink.fold(attr.nameLifted)(Keep.left)
+      val sink = Sink
+        .setup { (_, _) ⇒
+          Sink.setup { (_, attr) ⇒
+            Sink.fold(attr.nameLifted)(Keep.left)
+          }
         }
-      }.named("my-name")
+        .named("my-name")
 
       Source.empty.runWith(sink).flatMap(identity).flatMap(identity).futureValue shouldBe Some("my-name")
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
@@ -16,7 +16,7 @@ class SetupSpec extends StreamSpec {
   "Source.setup" should {
 
     "expose materializer" in {
-      val source = Source.setup { mat ⇒ _ ⇒
+      val source = Source.setup { (mat, _) ⇒
         Source.single(mat.isShutdown)
       }
 
@@ -24,7 +24,7 @@ class SetupSpec extends StreamSpec {
     }
 
     "expose attributes" in {
-      val source = Source.setup { _ ⇒ attr ⇒
+      val source = Source.setup { (_, attr) ⇒
         Source.single(attr.attributeList)
       }
 
@@ -32,7 +32,7 @@ class SetupSpec extends StreamSpec {
     }
 
     "propagate materialized value" in {
-      val source = Source.setup { _ ⇒ _ ⇒
+      val source = Source.setup { (_, _) ⇒
         Source.maybe[NotUsed]
       }
 
@@ -42,7 +42,7 @@ class SetupSpec extends StreamSpec {
     }
 
     "propagate attributes" in {
-      val source = Source.setup { _ ⇒ attr ⇒
+      val source = Source.setup { (_, attr) ⇒
         Source.single(attr.nameLifted)
       }.named("my-name")
 
@@ -50,8 +50,8 @@ class SetupSpec extends StreamSpec {
     }
 
     "propagate attributes when nested" in {
-      val source = Source.setup { _ ⇒ _ ⇒
-        Source.setup { _ ⇒ attr ⇒
+      val source = Source.setup { (_, _) ⇒
+        Source.setup { (_, attr) ⇒
           Source.single(attr.nameLifted)
         }
       }.named("my-name")
@@ -61,7 +61,7 @@ class SetupSpec extends StreamSpec {
 
     "handle factory failure" in {
       val error = new Error("boom")
-      val source = Source.setup { _ ⇒ _ ⇒
+      val source = Source.setup { (_, _) ⇒
         throw error
       }
 
@@ -72,7 +72,7 @@ class SetupSpec extends StreamSpec {
 
     "handle materialization failure" in {
       val error = new Error("boom")
-      val source = Source.setup { _ ⇒ _ ⇒
+      val source = Source.setup { (_, _) ⇒
         Source.empty.mapMaterializedValue(_ ⇒ throw error)
       }
 
@@ -86,7 +86,7 @@ class SetupSpec extends StreamSpec {
   "Flow.setup" should {
 
     "expose materializer" in {
-      val flow = Flow.setup { mat ⇒ _ ⇒
+      val flow = Flow.setup { (mat, _) ⇒
         Flow.fromSinkAndSource(Sink.ignore, Source.single(mat.isShutdown))
       }
 
@@ -94,7 +94,7 @@ class SetupSpec extends StreamSpec {
     }
 
     "expose attributes" in {
-      val flow = Flow.setup { _ ⇒ attr ⇒
+      val flow = Flow.setup { (_, attr) ⇒
         Flow.fromSinkAndSource(Sink.ignore, Source.single(attr.attributeList))
       }
 
@@ -102,7 +102,7 @@ class SetupSpec extends StreamSpec {
     }
 
     "propagate materialized value" in {
-      val flow = Flow.setup { _ ⇒ _ ⇒
+      val flow = Flow.setup { (_, _) ⇒
         Flow.fromSinkAndSourceMat(Sink.ignore, Source.maybe[NotUsed])(Keep.right)
       }
 
@@ -112,7 +112,7 @@ class SetupSpec extends StreamSpec {
     }
 
     "propagate attributes" in {
-      val flow = Flow.setup { _ ⇒ attr ⇒
+      val flow = Flow.setup { (_, attr) ⇒
         Flow.fromSinkAndSource(Sink.ignore, Source.single(attr.nameLifted))
       }.named("my-name")
 
@@ -120,8 +120,8 @@ class SetupSpec extends StreamSpec {
     }
 
     "propagate attributes when nested" in {
-      val flow = Flow.setup { _ ⇒ _ ⇒
-        Flow.setup { _ ⇒ attr ⇒
+      val flow = Flow.setup { (_, _) ⇒
+        Flow.setup { (_, attr) ⇒
           Flow.fromSinkAndSource(Sink.ignore, Source.single(attr.nameLifted))
         }
       }.named("my-name")
@@ -131,7 +131,7 @@ class SetupSpec extends StreamSpec {
 
     "handle factory failure" in {
       val error = new Error("boom")
-      val flow = Flow.setup { _ ⇒ _ ⇒
+      val flow = Flow.setup { (_, _) ⇒
         throw error
       }
 
@@ -142,7 +142,7 @@ class SetupSpec extends StreamSpec {
 
     "handle materialization failure" in {
       val error = new Error("boom")
-      val flow = Flow.setup { _ ⇒ _ ⇒
+      val flow = Flow.setup { (_, _) ⇒
         Flow[NotUsed].mapMaterializedValue(_ ⇒ throw error)
       }
 
@@ -156,7 +156,7 @@ class SetupSpec extends StreamSpec {
   "Sink.setup" should {
 
     "expose materializer" in {
-      val sink = Sink.setup { mat ⇒ _ ⇒
+      val sink = Sink.setup { (mat, _) ⇒
         Sink.fold(mat.isShutdown)(Keep.left)
       }
 
@@ -164,7 +164,7 @@ class SetupSpec extends StreamSpec {
     }
 
     "expose attributes" in {
-      val sink = Sink.setup { _ ⇒ attr ⇒
+      val sink = Sink.setup { (_, attr) ⇒
         Sink.fold(attr.attributeList)(Keep.left)
       }
 
@@ -172,7 +172,7 @@ class SetupSpec extends StreamSpec {
     }
 
     "propagate materialized value" in {
-      val sink = Sink.setup { _ ⇒ _ ⇒
+      val sink = Sink.setup { (_, _) ⇒
         Sink.fold(NotUsed)(Keep.left)
       }
 
@@ -180,7 +180,7 @@ class SetupSpec extends StreamSpec {
     }
 
     "propagate attributes" in {
-      val sink = Sink.setup { _ ⇒ attr ⇒
+      val sink = Sink.setup { (_, attr) ⇒
         Sink.fold(attr.nameLifted)(Keep.left)
       }.named("my-name")
 
@@ -188,8 +188,8 @@ class SetupSpec extends StreamSpec {
     }
 
     "propagate attributes when nested" in {
-      val sink = Sink.setup { _ ⇒ _ ⇒
-        Sink.setup { _ ⇒ attr ⇒
+      val sink = Sink.setup { (_, _) ⇒
+        Sink.setup { (_, attr) ⇒
           Sink.fold(attr.nameLifted)(Keep.left)
         }
       }.named("my-name")
@@ -199,7 +199,7 @@ class SetupSpec extends StreamSpec {
 
     "handle factory failure" in {
       val error = new Error("boom")
-      val sink = Sink.setup { _ ⇒ _ ⇒
+      val sink = Sink.setup { (_, _) ⇒
         throw error
       }
 
@@ -208,7 +208,7 @@ class SetupSpec extends StreamSpec {
 
     "handle materialization failure" in {
       val error = new Error("boom")
-      val sink = Sink.setup { _ ⇒ _ ⇒
+      val sink = Sink.setup { (_, _) ⇒
         Sink.ignore.mapMaterializedValue(_ ⇒ throw error)
       }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.scaladsl
+
+import akka.NotUsed
+import akka.stream.ActorMaterializer
+import akka.stream.testkit.StreamSpec
+
+class SetupSpec extends StreamSpec {
+
+  implicit val materializer = ActorMaterializer()
+  import system.dispatcher
+
+  "Source.setup" should {
+
+    "expose materializer" in {
+      val source = Source.setup { mat ⇒ _ ⇒
+        Source.single(mat.isShutdown)
+      }
+
+      source.runWith(Sink.head).futureValue shouldBe false
+    }
+
+    "expose attributes" in {
+      val source = Source.setup { _ ⇒ attr ⇒
+        Source.single(attr.attributeList)
+      }
+
+      source.runWith(Sink.head).futureValue should not be empty
+    }
+
+    "propagate materialized value" in {
+      val source = Source.setup { _ ⇒ _ ⇒
+        Source.maybe[NotUsed]
+      }
+
+      val (completion, element) = source.toMat(Sink.head)(Keep.both).run()
+      completion.futureValue.trySuccess(Some(NotUsed))
+      element.futureValue shouldBe NotUsed
+    }
+
+    "propagate attributes" in {
+      val source = Source.setup { _ ⇒ attr ⇒
+        Source.single(attr.nameLifted)
+      }.named("my-name")
+
+      source.runWith(Sink.head).futureValue shouldBe Some("my-name")
+    }
+
+    "propagate attributes when nested" in {
+      val source = Source.setup { _ ⇒ _ ⇒
+        Source.setup { _ ⇒ attr ⇒
+          Source.single(attr.nameLifted)
+        }
+      }.named("my-name")
+
+      source.runWith(Sink.head).futureValue shouldBe Some("my-name")
+    }
+
+  }
+
+  "Flow.setup" should {
+
+    "expose materializer" in {
+      val flow = Flow.setup { mat ⇒ _ ⇒
+        Flow.fromSinkAndSource(Sink.ignore, Source.single(mat.isShutdown))
+      }
+
+      Source.empty.via(flow).runWith(Sink.head).futureValue shouldBe false
+    }
+
+    "expose attributes" in {
+      val flow = Flow.setup { _ ⇒ attr ⇒
+        Flow.fromSinkAndSource(Sink.ignore, Source.single(attr.attributeList))
+      }
+
+      Source.empty.via(flow).runWith(Sink.head).futureValue should not be empty
+    }
+
+    "propagate materialized value" in {
+      val flow = Flow.setup { _ ⇒ _ ⇒
+        Flow.fromSinkAndSourceMat(Sink.ignore, Source.maybe[NotUsed])(Keep.right)
+      }
+
+      val (completion, element) = Source.empty.viaMat(flow)(Keep.right).toMat(Sink.head)(Keep.both).run()
+      completion.futureValue.trySuccess(Some(NotUsed))
+      element.futureValue shouldBe NotUsed
+    }
+
+    "propagate attributes" in {
+      val flow = Flow.setup { _ ⇒ attr ⇒
+        Flow.fromSinkAndSource(Sink.ignore, Source.single(attr.nameLifted))
+      }.named("my-name")
+
+      Source.empty.via(flow).runWith(Sink.head).futureValue shouldBe Some("my-name")
+    }
+
+    "propagate attributes when nested" in {
+      val flow = Flow.setup { _ ⇒ _ ⇒
+        Flow.setup { _ ⇒ attr ⇒
+          Flow.fromSinkAndSource(Sink.ignore, Source.single(attr.nameLifted))
+        }
+      }.named("my-name")
+
+      Source.empty.via(flow).runWith(Sink.head).futureValue shouldBe Some("my-name")
+    }
+
+  }
+
+  "Sink.setup" should {
+
+    "expose materializer" in {
+      val sink = Sink.setup { mat ⇒ _ ⇒
+        Sink.fold(mat.isShutdown)(Keep.left)
+      }
+
+      Source.empty.runWith(sink).flatMap(identity).futureValue shouldBe false
+    }
+
+    "expose attributes" in {
+      val sink = Sink.setup { _ ⇒ attr ⇒
+        Sink.fold(attr.attributeList)(Keep.left)
+      }
+
+      Source.empty.runWith(sink).flatMap(identity).futureValue should not be empty
+    }
+
+    "propagate materialized value" in {
+      val sink = Sink.setup { _ ⇒ _ ⇒
+        Sink.fold(NotUsed)(Keep.left)
+      }
+
+      Source.empty.runWith(sink).flatMap(identity).futureValue shouldBe NotUsed
+    }
+
+    "propagate attributes" in {
+      val sink = Sink.setup { _ ⇒ attr ⇒
+        Sink.fold(attr.nameLifted)(Keep.left)
+      }.named("my-name")
+
+      Source.empty.runWith(sink).flatMap(identity).futureValue shouldBe Some("my-name")
+    }
+
+    "propagate attributes when nested" in {
+      val sink = Sink.setup { _ ⇒ _ ⇒
+        Sink.setup { _ ⇒ attr ⇒
+          Sink.fold(attr.nameLifted)(Keep.left)
+        }
+      }.named("my-name")
+
+      Source.empty.runWith(sink).flatMap(identity).flatMap(identity).futureValue shouldBe Some("my-name")
+    }
+
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/SetupStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SetupStage.scala
@@ -136,10 +136,11 @@ private object SetupStage {
       subOutlet.fail(ex)
   }
 
-  def delegateToOutlet[T](push: T ⇒ Unit,
-                          complete: () ⇒ Unit,
-                          fail: Throwable ⇒ Unit,
-                          subInlet: GraphStageLogic#SubSinkInlet[T]) = new InHandler {
+  def delegateToOutlet[T](
+      push: T ⇒ Unit,
+      complete: () ⇒ Unit,
+      fail: Throwable ⇒ Unit,
+      subInlet: GraphStageLogic#SubSinkInlet[T]) = new InHandler {
     override def onPush(): Unit =
       push(subInlet.grab())
     override def onUpstreamFinish(): Unit =

--- a/akka-stream/src/main/scala/akka/stream/impl/SetupStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SetupStage.scala
@@ -14,7 +14,7 @@ import scala.util.control.NonFatal
 
 /** Internal Api */
 @InternalApi private[stream] final class SetupSinkStage[T, M](factory: ActorMaterializer ⇒ Attributes ⇒ Sink[T, M])
-  extends GraphStageWithMaterializedValue[SinkShape[T], Future[M]] {
+    extends GraphStageWithMaterializedValue[SinkShape[T], Future[M]] {
 
   private val in = Inlet[T]("SetupSinkStage.in")
   override val shape = SinkShape(in)
@@ -48,8 +48,9 @@ import scala.util.control.NonFatal
 }
 
 /** Internal Api */
-@InternalApi private[stream] final class SetupFlowStage[T, U, M](factory: ActorMaterializer ⇒ Attributes ⇒ Flow[T, U, M])
-  extends GraphStageWithMaterializedValue[FlowShape[T, U], Future[M]] {
+@InternalApi private[stream] final class SetupFlowStage[T, U, M](
+    factory: ActorMaterializer ⇒ Attributes ⇒ Flow[T, U, M])
+    extends GraphStageWithMaterializedValue[FlowShape[T, U], Future[M]] {
 
   private val in = Inlet[T]("SetupFlowStage.in")
   private val out = Outlet[U]("SetupFlowStage.out")
@@ -93,7 +94,7 @@ import scala.util.control.NonFatal
 
 /** Internal Api */
 @InternalApi private[stream] final class SetupSourceStage[T, M](factory: ActorMaterializer ⇒ Attributes ⇒ Source[T, M])
-  extends GraphStageWithMaterializedValue[SourceShape[T], Future[M]] {
+    extends GraphStageWithMaterializedValue[SourceShape[T], Future[M]] {
 
   private val out = Outlet[T]("SetupSourceStage.out")
   override val shape = SourceShape(out)
@@ -114,10 +115,7 @@ import scala.util.control.NonFatal
       try {
         val source = factory(ActorMaterializerHelper.downcast(materializer))(attributes)
 
-        val mat = source
-          .withAttributes(attributes)
-          .to(Sink.fromGraph(subInlet.sink))
-          .run()(subFusingMaterializer)
+        val mat = source.withAttributes(attributes).to(Sink.fromGraph(subInlet.sink)).run()(subFusingMaterializer)
         matPromise.success(mat)
       } catch {
         case NonFatal(ex) ⇒
@@ -138,11 +136,10 @@ private object SetupStage {
       subOutlet.fail(ex)
   }
 
-  def delegateToOutlet[T](
-    push:     T ⇒ Unit,
-    complete: () ⇒ Unit,
-    fail:     Throwable ⇒ Unit,
-    subInlet: GraphStageLogic#SubSinkInlet[T]) = new InHandler {
+  def delegateToOutlet[T](push: T ⇒ Unit,
+                          complete: () ⇒ Unit,
+                          fail: Throwable ⇒ Unit,
+                          subInlet: GraphStageLogic#SubSinkInlet[T]) = new InHandler {
     override def onPush(): Unit =
       push(subInlet.grab())
     override def onUpstreamFinish(): Unit =

--- a/akka-stream/src/main/scala/akka/stream/impl/SetupStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SetupStage.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.impl
+
+import akka.annotation.InternalApi
+import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import akka.stream._
+import akka.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, InHandler, OutHandler }
+
+import scala.concurrent.{ Future, Promise }
+
+/** Internal Api */
+@InternalApi private[stream] final class SetupSinkStage[T, M](factory: ActorMaterializer ⇒ Attributes ⇒ Sink[T, M])
+  extends GraphStageWithMaterializedValue[SinkShape[T], Future[M]] {
+
+  private val in = Inlet[T]("SetupSinkStage.in")
+  override val shape = SinkShape(in)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[M]) = {
+    val matPromise = Promise[M]
+    (createStageLogic(matPromise), matPromise.future)
+  }
+
+  private def createStageLogic(matPromise: Promise[M]) = new GraphStageLogic(shape) {
+    import SetupStage._
+
+    val subOutlet = new SubSourceOutlet[T]("SetupSinkStage")
+    subOutlet.setHandler(delegateToInlet(() ⇒ pull(in), () ⇒ cancel(in)))
+    setHandler(in, delegateToSubOutlet(() ⇒ grab(in), subOutlet))
+
+    override def preStart(): Unit = {
+      val sink = factory(ActorMaterializerHelper.downcast(materializer))(attributes)
+
+      val mat = Source.fromGraph(subOutlet.source).runWith(sink.withAttributes(attributes))(subFusingMaterializer)
+      matPromise.success(mat)
+    }
+  }
+
+}
+
+/** Internal Api */
+@InternalApi private[stream] final class SetupFlowStage[T, U, M](factory: ActorMaterializer ⇒ Attributes ⇒ Flow[T, U, M])
+  extends GraphStageWithMaterializedValue[FlowShape[T, U], Future[M]] {
+
+  private val in = Inlet[T]("SetupFlowStage.in")
+  private val out = Outlet[U]("SetupFlowStage.out")
+  override val shape = FlowShape(in, out)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[M]) = {
+    val matPromise = Promise[M]
+    (createStageLogic(matPromise), matPromise.future)
+  }
+
+  private def createStageLogic(matPromise: Promise[M]) = new GraphStageLogic(shape) {
+    import SetupStage._
+
+    val subInlet = new SubSinkInlet[U]("SetupFlowStage")
+    val subOutlet = new SubSourceOutlet[T]("SetupFlowStage")
+
+    subInlet.setHandler(delegateToOutlet(push(out, _: U), () ⇒ complete(out), fail(out, _), subInlet))
+    subOutlet.setHandler(delegateToInlet(() ⇒ pull(in), () ⇒ cancel(in)))
+
+    setHandler(in, delegateToSubOutlet(() ⇒ grab(in), subOutlet))
+    setHandler(out, delegateToSubInlet(subInlet))
+
+    override def preStart(): Unit = {
+      val flow = factory(ActorMaterializerHelper.downcast(materializer))(attributes)
+
+      val mat = Source
+        .fromGraph(subOutlet.source)
+        .viaMat(flow.withAttributes(attributes))(Keep.right)
+        .to(Sink.fromGraph(subInlet.sink))
+        .run()(subFusingMaterializer)
+      matPromise.success(mat)
+    }
+  }
+}
+
+/** Internal Api */
+@InternalApi private[stream] final class SetupSourceStage[T, M](factory: ActorMaterializer ⇒ Attributes ⇒ Source[T, M])
+  extends GraphStageWithMaterializedValue[SourceShape[T], Future[M]] {
+
+  private val out = Outlet[T]("SetupSourceStage.out")
+  override val shape = SourceShape(out)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[M]) = {
+    val matPromise = Promise[M]
+    (createStageLogic(matPromise), matPromise.future)
+  }
+
+  private def createStageLogic(matPromise: Promise[M]) = new GraphStageLogic(shape) {
+    import SetupStage._
+
+    val subInlet = new SubSinkInlet[T]("SetupSourceStage")
+    subInlet.setHandler(delegateToOutlet(push(out, _: T), () ⇒ complete(out), fail(out, _), subInlet))
+    setHandler(out, delegateToSubInlet(subInlet))
+
+    override def preStart(): Unit = {
+      val source = factory(ActorMaterializerHelper.downcast(materializer))(attributes)
+
+      val mat = source
+        .withAttributes(attributes)
+        .to(Sink.fromGraph(subInlet.sink))
+        .run()(subFusingMaterializer)
+      matPromise.success(mat)
+    }
+  }
+}
+
+private object SetupStage {
+  def delegateToSubOutlet[T](grab: () ⇒ T, subOutlet: GraphStageLogic#SubSourceOutlet[T]) = new InHandler {
+    override def onPush(): Unit =
+      subOutlet.push(grab())
+    override def onUpstreamFinish(): Unit =
+      subOutlet.complete()
+    override def onUpstreamFailure(ex: Throwable): Unit =
+      subOutlet.fail(ex)
+  }
+
+  def delegateToOutlet[T](
+    push:     T ⇒ Unit,
+    complete: () ⇒ Unit,
+    fail:     Throwable ⇒ Unit,
+    subInlet: GraphStageLogic#SubSinkInlet[T]) = new InHandler {
+    override def onPush(): Unit =
+      push(subInlet.grab())
+    override def onUpstreamFinish(): Unit =
+      complete()
+    override def onUpstreamFailure(ex: Throwable): Unit =
+      fail(ex)
+  }
+
+  def delegateToSubInlet[T](subInlet: GraphStageLogic#SubSinkInlet[T]) = new OutHandler {
+    override def onPull(): Unit =
+      subInlet.pull()
+    override def onDownstreamFinish(): Unit =
+      subInlet.cancel()
+  }
+
+  def delegateToInlet(pull: () ⇒ Unit, cancel: () ⇒ Unit) = new OutHandler {
+    override def onPull(): Unit =
+      pull()
+    override def onDownstreamFinish(): Unit =
+      cancel()
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -69,7 +69,7 @@ object Flow {
    */
   def setup[I, O, M](
       factory: BiFunction[ActorMaterializer, Attributes, Flow[I, O, M]]): Flow[I, O, CompletionStage[M]] =
-    scaladsl.Flow.setup(mat ⇒ attr ⇒ factory(mat, attr).asScala).mapMaterializedValue(_.toJava).asJava
+    scaladsl.Flow.setup((mat, attr) ⇒ factory(mat, attr).asScala).mapMaterializedValue(_.toJava).asJava
 
   /**
    * Creates a `Flow` from a `Sink` and a `Source` where the Flow's input

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -67,7 +67,8 @@ object Flow {
    * exposes [[ActorMaterializer]] which is going to be used during materialization and
    * [[Attributes]] of the [[Flow]] returned by this method.
    */
-  def setup[I, O, M](factory: BiFunction[ActorMaterializer, Attributes, Flow[I, O, M]]): Flow[I, O, CompletionStage[M]] =
+  def setup[I, O, M](
+      factory: BiFunction[ActorMaterializer, Attributes, Flow[I, O, M]]): Flow[I, O, CompletionStage[M]] =
     scaladsl.Flow.setup(mat ⇒ attr ⇒ factory(mat, attr).asScala).mapMaterializedValue(_.toJava).asJava
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -293,7 +293,7 @@ object Sink {
    * [[Attributes]] of the [[Sink]] returned by this method.
    */
   def setup[T, M](factory: BiFunction[ActorMaterializer, Attributes, Sink[T, M]]): Sink[T, CompletionStage[M]] =
-    scaladsl.Sink.setup(mat ⇒ attr ⇒ factory(mat, attr).asScala).mapMaterializedValue(_.toJava).asJava
+    scaladsl.Sink.setup((mat, attr) ⇒ factory(mat, attr).asScala).mapMaterializedValue(_.toJava).asJava
 
   /**
    * Combine several sinks with fan-out strategy like `Broadcast` or `Balance` and returns `Sink`.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -18,6 +18,8 @@ import scala.compat.java8.OptionConverters._
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 import java.util.concurrent.CompletionStage
+import java.util.function.BiFunction
+
 import scala.collection.immutable
 import scala.annotation.unchecked.uncheckedVariance
 import scala.compat.java8.FutureConverters._
@@ -284,6 +286,14 @@ object Sink {
       case s: Sink[T, M] => s
       case other         => new Sink(scaladsl.Sink.fromGraph(other))
     }
+
+  /**
+   * Defers the creation of a [[Sink]] until materialization. The `factory` function
+   * exposes [[ActorMaterializer]] which is going to be used during materialization and
+   * [[Attributes]] of the [[Sink]] returned by this method.
+   */
+  def setup[T, M](factory: BiFunction[ActorMaterializer, Attributes, Sink[T, M]]): Sink[T, CompletionStage[M]] =
+    scaladsl.Sink.setup(mat ⇒ attr ⇒ factory(mat, attr).asScala).mapMaterializedValue(_.toJava).asJava
 
   /**
    * Combine several sinks with fan-out strategy like `Broadcast` or `Balance` and returns `Sink`.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -365,7 +365,7 @@ object Source {
    * [[Attributes]] of the [[Source]] returned by this method.
    */
   def setup[T, M](factory: BiFunction[ActorMaterializer, Attributes, Source[T, M]]): Source[T, CompletionStage[M]] =
-    scaladsl.Source.setup(mat ⇒ attr ⇒ factory(mat, attr).asScala).mapMaterializedValue(_.toJava).asJava
+    scaladsl.Source.setup((mat, attr) ⇒ factory(mat, attr).asScala).mapMaterializedValue(_.toJava).asJava
 
   /**
    * Combines several sources with fan-in strategy like `Merge` or `Concat` and returns `Source`.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -26,7 +26,7 @@ import scala.concurrent.{ Future, Promise }
 import scala.compat.java8.OptionConverters._
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.CompletableFuture
-import java.util.function.Supplier
+import java.util.function.{ BiFunction, Supplier }
 
 import akka.util.unused
 import com.github.ghik.silencer.silent
@@ -358,6 +358,14 @@ object Source {
       case s if s eq scaladsl.Source.empty => empty().asInstanceOf[Source[T, M]]
       case other                           => new Source(scaladsl.Source.fromGraph(other))
     }
+
+  /**
+   * Defers the creation of a [[Source]] until materialization. The `factory` function
+   * exposes [[ActorMaterializer]] which is going to be used during materialization and
+   * [[Attributes]] of the [[Source]] returned by this method.
+   */
+  def setup[T, M](factory: BiFunction[ActorMaterializer, Attributes, Source[T, M]]): Source[T, CompletionStage[M]] =
+    scaladsl.Source.setup(mat ⇒ attr ⇒ factory(mat, attr).asScala).mapMaterializedValue(_.toJava).asJava
 
   /**
    * Combines several sources with fan-in strategy like `Merge` or `Concat` and returns `Source`.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -7,7 +7,16 @@ package akka.stream.scaladsl
 import akka.event.LoggingAdapter
 import akka.stream._
 import akka.Done
-import akka.stream.impl._
+import akka.stream.impl.{
+  fusing,
+  LinearTraversalBuilder,
+  ProcessorModule,
+  SetupFlowStage,
+  SubFlowImpl,
+  Throttle,
+  Timers,
+  TraversalBuilder
+}
 import akka.stream.impl.fusing._
 import akka.stream.stage._
 import akka.util.{ ConstantFun, Timeout }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -393,7 +393,7 @@ object Flow {
    * exposes [[ActorMaterializer]] which is going to be used during materialization and
    * [[Attributes]] of the [[Flow]] returned by this method.
    */
-  def setup[T, U, M](factory: ActorMaterializer ⇒ Attributes ⇒ Flow[T, U, M]): Flow[T, U, Future[M]] =
+  def setup[T, U, M](factory: (ActorMaterializer, Attributes) ⇒ Flow[T, U, M]): Flow[T, U, Future[M]] =
     Flow.fromGraph(new SetupFlowStage(factory))
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -7,15 +7,7 @@ package akka.stream.scaladsl
 import akka.event.LoggingAdapter
 import akka.stream._
 import akka.Done
-import akka.stream.impl.{
-  fusing,
-  LinearTraversalBuilder,
-  ProcessorModule,
-  SubFlowImpl,
-  Throttle,
-  Timers,
-  TraversalBuilder
-}
+import akka.stream.impl._
 import akka.stream.impl.fusing._
 import akka.stream.stage._
 import akka.util.{ ConstantFun, Timeout }
@@ -386,6 +378,14 @@ object Flow {
 
       case _ => new Flow(LinearTraversalBuilder.fromBuilder(g.traversalBuilder, g.shape, Keep.right), g.shape)
     }
+
+  /**
+   * Defers the creation of a [[Flow]] until materialization. The `factory` function
+   * exposes [[ActorMaterializer]] which is going to be used during materialization and
+   * [[Attributes]] of the [[Flow]] returned by this method.
+   */
+  def setup[T, U, M](factory: ActorMaterializer ⇒ Attributes ⇒ Flow[T, U, M]): Flow[T, U, Future[M]] =
+    Flow.fromGraph(new SetupFlowStage(factory))
 
   /**
    * Creates a `Flow` from a `Sink` and a `Source` where the Flow's input

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -146,6 +146,14 @@ object Sink {
     }
 
   /**
+   * Defers the creation of a [[Sink]] until materialization. The `factory` function
+   * exposes [[ActorMaterializer]] which is going to be used during materialization and
+   * [[Attributes]] of the [[Sink]] returned by this method.
+   */
+  def setup[T, M](factory: ActorMaterializer ⇒ Attributes ⇒ Sink[T, M]): Sink[T, Future[M]] =
+    Sink.fromGraph(new SetupSinkStage(factory))
+
+  /**
    * Helper to create [[Sink]] from `Subscriber`.
    */
   def fromSubscriber[T](subscriber: Subscriber[T]): Sink[T, NotUsed] =

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -150,7 +150,7 @@ object Sink {
    * exposes [[ActorMaterializer]] which is going to be used during materialization and
    * [[Attributes]] of the [[Sink]] returned by this method.
    */
-  def setup[T, M](factory: ActorMaterializer ⇒ Attributes ⇒ Sink[T, M]): Sink[T, Future[M]] =
+  def setup[T, M](factory: (ActorMaterializer, Attributes) ⇒ Sink[T, M]): Sink[T, Future[M]] =
     Sink.fromGraph(new SetupSinkStage(factory))
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -296,6 +296,14 @@ object Source {
   }
 
   /**
+   * Defers the creation of a [[Source]] until materialization. The `factory` function
+   * exposes [[ActorMaterializer]] which is going to be used during materialization and
+   * [[Attributes]] of the [[Source]] returned by this method.
+   */
+  def setup[T, M](factory: ActorMaterializer ⇒ Attributes ⇒ Source[T, M]): Source[T, Future[M]] =
+    Source.fromGraph(new SetupSourceStage(factory))
+
+  /**
    * Helper to create [[Source]] from `Iterable`.
    * Example usage: `Source(Seq(1,2,3))`
    *

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -300,7 +300,7 @@ object Source {
    * exposes [[ActorMaterializer]] which is going to be used during materialization and
    * [[Attributes]] of the [[Source]] returned by this method.
    */
-  def setup[T, M](factory: ActorMaterializer ⇒ Attributes ⇒ Source[T, M]): Source[T, Future[M]] =
+  def setup[T, M](factory: (ActorMaterializer, Attributes) ⇒ Source[T, M]): Source[T, Future[M]] =
     Source.fromGraph(new SetupSourceStage(factory))
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -389,7 +389,8 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
    */
   private[akka] def interpreter: GraphInterpreter =
     if (_interpreter == null)
-      throw new IllegalStateException("not yet initialized: only setHandler is allowed in GraphStageLogic constructor. To access materializer use Source/Flow/Sink.setup factory")
+      throw new IllegalStateException(
+        "not yet initialized: only setHandler is allowed in GraphStageLogic constructor. To access materializer use Source/Flow/Sink.setup factory")
     else _interpreter
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -77,7 +77,7 @@ abstract class GraphStageWithMaterializedValue[+S <: Shape, +M] extends Graph[S,
  *
  * Extend this `AbstractGraphStageWithMaterializedValue` if you want to provide a materialized value,
  * represented by the type parameter `M`. If your GraphStage does not need to provide a materialized
- * value you can instead extende [[GraphStage]] which materializes a [[NotUsed]] value.
+ * value you can instead extend [[GraphStage]] which materializes a [[NotUsed]] value.
  *
  * A GraphStage consists of a [[Shape]] which describes its input and output ports and a factory function that
  * creates a [[GraphStageLogic]] which implements the processing logic that ties the ports together.
@@ -389,11 +389,15 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
    */
   private[akka] def interpreter: GraphInterpreter =
     if (_interpreter == null)
-      throw new IllegalStateException("not yet initialized: only setHandler is allowed in GraphStageLogic constructor")
+      throw new IllegalStateException("not yet initialized: only setHandler is allowed in GraphStageLogic constructor. To access materializer use Source/Flow/Sink.setup factory")
     else _interpreter
 
   /**
    * The [[akka.stream.Materializer]] that has set this GraphStage in motion.
+   *
+   * Can not be used from a `GraphStage` constructor. Access to materializer is provided by the
+   * [[akka.stream.scaladsl.Source.setup]], [[akka.stream.scaladsl.Flow.setup]] and [[akka.stream.scaladsl.Sink.setup]]
+   * and their corresponding Java API factories.
    */
   protected def materializer: Materializer = interpreter.materializer
 


### PR DESCRIPTION
Adds a `Source/Flow/Sink.setup` operator that allows to get a hold to `ActorMaterializer` and `Attributes` while constructing operators using the linear DSL.

Very useful when operators use akka-http or need access to Attributes to resolve other resources.

This has been sitting in a couple of Alpakka connectors for a while now, with a couple of bug fixes here and there.

Fixes #26192