### PR TITLE
[WIP] Create shaded module of JCTools and implement JCToolsMailbox to akka-actor

### DIFF
--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -547,14 +547,16 @@ akka {
       # FQCN of the MailboxType. The Class of the FQCN must have a public
       # constructor with
       # (akka.actor.ActorSystem.Settings, com.typesafe.config.Config) parameters.
-      mailbox-type = "akka.dispatch.UnboundedMailbox"
+      mailbox-type = "akka.dispatch.VirtuallyUnboundedJCToolsMailbox"
+
+      mailbox-initial-capacity = 16
 
       # If the mailbox is bounded then it uses this setting to determine its
       # capacity. The provided value must be positive.
       # NOTICE:
       # Up to version 2.1 the mailbox type was determined based on this setting;
       # this is no longer the case, the type must explicitly be a bounded mailbox.
-      mailbox-capacity = 1000
+      mailbox-capacity = 65536
 
       # If the mailbox is bounded then this is the timeout for enqueueing
       # in case the mailbox is full. Negative values signify infinite

--- a/akka-actor/src/main/scala/akka/dispatch/JcToolsMailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/JcToolsMailbox.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.dispatch
+
+import akka.actor.DeadLetter
+import akka.actor.InternalActorRef
+import akka.actor.{ ActorRef, ActorSystem }
+import com.typesafe.config.Config
+
+import scala.concurrent.duration.Duration
+import akka.jctools.queues.MpscGrowableArrayQueue
+
+import scala.annotation.tailrec
+
+case class VirtuallyUnboundedJCToolsMailbox(initialCapacity: Int, capacity: Int) extends MailboxType with ProducesMessageQueue[JCToolsMessageQueue] {
+  if (capacity < 0) throw new IllegalArgumentException("The capacity for JCToolsMailbox can not be negative")
+
+  def this(settings: ActorSystem.Settings, config: Config) =
+    this(config.getInt("mailbox-initial-capacity"), config.getInt("mailbox-capacity"))
+
+  final override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue =
+    new JCToolsMessageQueue(initialCapacity, capacity) with UnboundedMessageQueueSemantics
+}
+
+private[dispatch] abstract class JCToolsMessageQueue(initialCapacity: Int, capacity: Int) extends MpscGrowableArrayQueue[Envelope](initialCapacity, capacity) with MessageQueue {
+  final def pushTimeOut: Duration = Duration.Undefined
+
+  final def enqueue(receiver: ActorRef, handle: Envelope): Unit =
+    if (!offer(handle))
+      receiver.asInstanceOf[InternalActorRef].provider.deadLetters.tell(
+        DeadLetter(handle.message, handle.sender, receiver), handle.sender
+      )
+
+  final def dequeue(): Envelope = poll()
+
+  final def numberOfMessages: Int = size()
+
+  final def hasMessages: Boolean = !isEmpty()
+
+  @tailrec final def cleanUp(owner: ActorRef, deadLetters: MessageQueue): Unit = {
+    val envelope = dequeue()
+    if (envelope ne null) {
+      deadLetters.enqueue(owner, envelope)
+      cleanUp(owner, deadLetters)
+    }
+  }
+}

--- a/akka-bench-jmh/src/main/scala/akka/actor/JCToolsMailbox.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/JCToolsMailbox.scala
@@ -12,7 +12,7 @@ import akka.dispatch.MessageQueue
 import akka.dispatch.BoundedMessageQueueSemantics
 import scala.concurrent.duration.Duration
 import akka.dispatch.Envelope
-import org.jctools.queues.MpscGrowableArrayQueue
+import akka.jctools.queues.MpscGrowableArrayQueue
 import scala.annotation.tailrec
 
 case class JCToolsMailbox(val capacity: Int) extends MailboxType with ProducesMessageQueue[BoundedNodeMessageQueue] {

--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,7 @@ lazy val root = Project(
  ).enablePlugins(CopyrightHeaderForBuild)
 
 lazy val actor = akkaModule("akka-actor")
+  .dependsOn(jcTools)
   .settings(Dependencies.actor)
   .settings(OSGi.actor)
   .settings(AutomaticModuleName.settings("akka.actor"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -194,7 +194,7 @@ object Dependencies {
 
   val contrib = l ++= Seq(Test.commonsIo)
 
-  val benchJmh = l ++= Seq(Provided.levelDB, Provided.levelDBNative, Compile.jctools)
+  val benchJmh = l ++= Seq(Provided.levelDB, Provided.levelDBNative)
 
   // akka stream
 


### PR DESCRIPTION
This should test if it could be feasible to make the JCToolsMailbox the default if the final size is just big enough to be "virtually unbounded".

The main drawback is that the `MpscGrowableArrayQueue` can only grow but never shrinks so may waste memory if an actor's message box size is grown during a temporary spike of traffic.

Let's see what the tests say about that bold move.