### PR TITLE
Cleaned up spec output 

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/LogMessagesSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/LogMessagesSpec.scala
@@ -90,7 +90,7 @@ class LogMessagesSpec extends ScalaTestWithActorTestKit("""
           logEvent.message should ===("received message Hello")
           logEvent.mdc should ===(Map("mdc" -> true))
           true
-        case _⇒
+        case _ ⇒
           false
 
       }, occurrences = 1).intercept {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/LogMessagesSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/LogMessagesSpec.scala
@@ -85,17 +85,21 @@ class LogMessagesSpec extends ScalaTestWithActorTestKit("""
       val behavior = Behaviors.withMdc[String](Map("mdc" -> true))(Behaviors.logMessages(Behaviors.ignore))
 
       val ref = spawn(behavior)
-      EventFilter.custom({
-        case logEvent if logEvent.level == Logging.DebugLevel ⇒
-          logEvent.message should ===("received message Hello")
-          logEvent.mdc should ===(Map("mdc" -> true))
-          true
-        case _ ⇒
-          false
+      EventFilter
+        .custom(
+          {
+            case logEvent if logEvent.level == Logging.DebugLevel =>
+              logEvent.message should ===("received message Hello")
+              logEvent.mdc should ===(Map("mdc" -> true))
+              true
+            case _ ⇒
+              false
 
-      }, occurrences = 1).intercept {
-        ref ! "Hello"
-      }
+          },
+          occurrences = 1)
+        .intercept {
+          ref ! "Hello"
+        }
 
       EventFilter.debug("received signal PostStop", source = ref.path.toString, occurrences = 1).intercept {
         testKit.stop(ref)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/LogMessagesSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/LogMessagesSpec.scala
@@ -20,77 +20,87 @@ class LogMessagesSpec extends ScalaTestWithActorTestKit("""
   implicit val untyped: actor.ActorSystem = system.toUntyped
 
   "The log messages behavior" should {
-    "log signals" in {
-      val behavior: Behavior[Signal] = Behaviors.logMessages(Behaviors.empty)
 
-      val ref: ActorRef[Signal] = spawn(behavior)
-
-      EventFilter.debug("received signal PostStop", source = ref.path.toString, occurrences = 1).intercept {
-        testKit.stop(ref)
-      }
-    }
-
-    "log messages" in {
-      val behavior: Behavior[String] = Behaviors.logMessages(Behaviors.empty)
+    "log messages and signals" in {
+      val behavior: Behavior[String] = Behaviors.logMessages(Behaviors.ignore)
 
       val ref: ActorRef[String] = spawn(behavior)
 
       EventFilter.debug("received message Hello", source = ref.path.toString, occurrences = 1).intercept {
         ref ! "Hello"
       }
+
+      EventFilter.debug("received signal PostStop", source = ref.path.toString, occurrences = 1).intercept {
+        testKit.stop(ref)
+      }
     }
 
     "log messages with provided log level" in {
       val opts = LogOptions().withLevel(Logging.InfoLevel)
-      val behavior: Behavior[String] = Behaviors.logMessages(opts, Behaviors.empty)
+      val behavior: Behavior[String] = Behaviors.logMessages(opts, Behaviors.ignore)
 
       val ref: ActorRef[String] = spawn(behavior)
 
       EventFilter.info("received message Hello", source = ref.path.toString, occurrences = 1).intercept {
         ref ! "Hello"
       }
+
+      EventFilter.info("received signal PostStop", source = ref.path.toString, occurrences = 1).intercept {
+        testKit.stop(ref)
+      }
     }
 
     "log messages with provided logger" in {
       val logger = system.log
       val opts = LogOptions().withLogger(logger)
-      val behavior: Behavior[String] = Behaviors.logMessages(opts, Behaviors.empty)
+      val behavior: Behavior[String] = Behaviors.logMessages(opts, Behaviors.ignore)
 
       val ref: ActorRef[String] = spawn(behavior)
 
       EventFilter.debug("received message Hello", source = "LogMessagesSpec", occurrences = 1).intercept {
         ref ! "Hello"
       }
+
+      EventFilter.debug("received signal PostStop", source = "LogMessagesSpec", occurrences = 1).intercept {
+        testKit.stop(ref)
+      }
     }
 
     "not log messages when not enabled" in {
       val opts = LogOptions().withEnabled(false)
-      val behavior: Behavior[String] = Behaviors.logMessages(opts, Behaviors.empty)
+      val behavior: Behavior[String] = Behaviors.logMessages(opts, Behaviors.ignore)
 
       val ref: ActorRef[String] = spawn(behavior)
 
       EventFilter.debug("received message Hello", source = ref.path.toString, occurrences = 0).intercept {
         ref ! "Hello"
       }
+
+      EventFilter.debug("received signal PostStop", source = ref.path.toString, occurrences = 0).intercept {
+        testKit.stop(ref)
+      }
     }
 
     "log messages with decorated MDC values" in {
-      val behavior = Behaviors.withMdc[String](Map("mdc" -> true))(Behaviors.logMessages(Behaviors.empty))
+      val behavior = Behaviors.withMdc[String](Map("mdc" -> true))(Behaviors.logMessages(Behaviors.ignore))
 
       val ref = spawn(behavior)
-      EventFilter
-        .custom(
-          {
-            case logEvent if logEvent.level == Logging.DebugLevel =>
-              logEvent.message should ===("received message Hello")
-              logEvent.mdc should ===(Map("mdc" -> true))
-              true
-            case other => system.log.error(s"Unexpected log event: {}", other); false
-          },
-          occurrences = 1)
-        .intercept {
-          ref ! "Hello"
-        }
+      EventFilter.custom({
+        case logEvent if logEvent.level == Logging.DebugLevel ⇒
+          logEvent.message should ===("received message Hello")
+          logEvent.mdc should ===(Map("mdc" -> true))
+          true
+        case _⇒
+          false
+
+      }, occurrences = 1).intercept {
+        ref ! "Hello"
+      }
+
+      EventFilter.debug("received signal PostStop", source = ref.path.toString, occurrences = 1).intercept {
+        testKit.stop(ref)
+      }
     }
+
   }
 }


### PR DESCRIPTION
Fixes #26486

The test would log an entry from the custom event filter which would get picked up by that custom event filter and logged again and so on.

This additionally cleans up the test output by also covering signals (`PostStop`) for each of the test cases.