### PR TITLE
Don't use Unsafe.{get,put}ObjectVolatile

### DIFF
--- a/akka-actor/src/main/java/akka/dispatch/AbstractBoundedNodeQueue.java
+++ b/akka-actor/src/main/java/akka/dispatch/AbstractBoundedNodeQueue.java
@@ -37,26 +37,22 @@ public abstract class AbstractBoundedNodeQueue<T> {
         setEnq(n);
     }
 
-    private final void setEnq(Node<T> n) {
-        Unsafe.instance.putObjectVolatile(this, enqOffset, n);
-    }
+    private final void setEnq(Node<T> n) { this._enqDoNotCallMeDirectly = n; }
 
     @SuppressWarnings("unchecked")
     private final Node<T> getEnq() {
-        return (Node<T>)Unsafe.instance.getObjectVolatile(this, enqOffset);
+        return _enqDoNotCallMeDirectly;
     }
 
     private final boolean casEnq(Node<T> old, Node<T> nju) {
         return Unsafe.instance.compareAndSwapObject(this, enqOffset, old, nju);
     }
 
-    private final void setDeq(Node<T> n) {
-        Unsafe.instance.putObjectVolatile(this, deqOffset, n);
-    }
+    private final void setDeq(Node<T> n) { this._deqDoNotCallMeDirectly = n; }
 
     @SuppressWarnings("unchecked")
     private final Node<T> getDeq() {
-        return (Node<T>)Unsafe.instance.getObjectVolatile(this, deqOffset);
+        return _deqDoNotCallMeDirectly;
     }
 
     private final boolean casDeq(Node<T> old, Node<T> nju) {
@@ -196,21 +192,21 @@ public abstract class AbstractBoundedNodeQueue<T> {
 
         @SuppressWarnings("unchecked")
         public final Node<T> next() {
-            return (Node<T>)Unsafe.instance.getObjectVolatile(this, nextOffset);
+            return _nextDoNotCallMeDirectly;
         }
 
         protected final void setNext(final Node<T> newNext) {
           Unsafe.instance.putOrderedObject(this, nextOffset, newNext);
         }
-        
+
         private final static long nextOffset;
-        
+
         static {
             try {
                 nextOffset = Unsafe.instance.objectFieldOffset(Node.class.getDeclaredField("_nextDoNotCallMeDirectly"));
             } catch(Throwable t){
                 throw new ExceptionInInitializerError(t);
-            } 
+            }
         }
-    } 
+    }
 }

--- a/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
@@ -51,8 +51,8 @@ private[akka] class RepointableActorRef(
   @silent @volatile private var _cellDoNotCallMeDirectly: Cell = _
   @silent @volatile private var _lookupDoNotCallMeDirectly: Cell = _
 
-  def underlying: Cell = Unsafe.instance.getObjectVolatile(this, cellOffset).asInstanceOf[Cell]
-  def lookup = Unsafe.instance.getObjectVolatile(this, lookupOffset).asInstanceOf[Cell]
+  def underlying: Cell = _cellDoNotCallMeDirectly
+  def lookup = _lookupDoNotCallMeDirectly
 
   @tailrec final def swapCell(next: Cell): Cell = {
     val old = underlying

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
@@ -26,8 +26,7 @@ private[akka] trait Children { this: ActorCell =>
   @volatile
   private var _childrenRefsDoNotCallMeDirectly: ChildrenContainer = EmptyChildrenContainer
 
-  def childrenRefs: ChildrenContainer =
-    Unsafe.instance.getObjectVolatile(this, AbstractActorCell.childrenOffset).asInstanceOf[ChildrenContainer]
+  def childrenRefs: ChildrenContainer = _childrenRefsDoNotCallMeDirectly
 
   final def children: immutable.Iterable[ActorRef] = childrenRefs.children
   final def getChildren(): java.lang.Iterable[ActorRef] =
@@ -50,8 +49,7 @@ private[akka] trait Children { this: ActorCell =>
     makeChild(this, props, checkName(name), async = true, systemService = systemService)
 
   @silent @volatile private var _functionRefsDoNotCallMeDirectly = Map.empty[String, FunctionRef]
-  private def functionRefs: Map[String, FunctionRef] =
-    Unsafe.instance.getObjectVolatile(this, AbstractActorCell.functionRefsOffset).asInstanceOf[Map[String, FunctionRef]]
+  private def functionRefs: Map[String, FunctionRef] = _functionRefsDoNotCallMeDirectly
 
   private[akka] def getFunctionRefOrNobody(name: String, uid: Int = ActorCell.undefinedUid): InternalActorRef =
     functionRefs.getOrElse(name, Children.GetNobody()) match {
@@ -163,8 +161,7 @@ private[akka] trait Children { this: ActorCell =>
     }
   }
 
-  final protected def setTerminated(): Unit =
-    Unsafe.instance.putObjectVolatile(this, AbstractActorCell.childrenOffset, TerminatedChildrenContainer)
+  final protected def setTerminated(): Unit = _childrenRefsDoNotCallMeDirectly = TerminatedChildrenContainer
 
   /*
    * ActorCell-internal API

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Dispatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Dispatch.scala
@@ -38,8 +38,7 @@ private[akka] trait Dispatch { this: ActorCell =>
   @silent @volatile private var _mailboxDoNotCallMeDirectly
       : Mailbox = _ //This must be volatile since it isn't protected by the mailbox status
 
-  @inline final def mailbox: Mailbox =
-    Unsafe.instance.getObjectVolatile(this, AbstractActorCell.mailboxOffset).asInstanceOf[Mailbox]
+  @inline final def mailbox: Mailbox = _mailboxDoNotCallMeDirectly
 
   @tailrec final def swapMailbox(newMailbox: Mailbox): Mailbox = {
     val oldMailbox = mailbox

--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -206,8 +206,7 @@ private[akka] abstract class Mailbox(val messageQueue: MessageQueue)
   protected final def systemQueueGet: LatestFirstSystemMessageList =
     // Note: contrary how it looks, there is no allocation here, as SystemMessageList is a value class and as such
     // it just exists as a typed view during compile-time. The actual return type is still SystemMessage.
-    new LatestFirstSystemMessageList(
-      Unsafe.instance.getObjectVolatile(this, AbstractMailbox.systemMessageOffset).asInstanceOf[SystemMessage])
+    new LatestFirstSystemMessageList(_systemQueueDoNotCallMeDirectly)
 
   protected final def systemQueuePut(_old: LatestFirstSystemMessageList, _new: LatestFirstSystemMessageList): Boolean =
     // Note: calling .head is not actually existing on the bytecode level as the parameters _old and _new

--- a/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
@@ -534,8 +534,7 @@ private[akka] final class PromiseActorRef private (
   private[this] var _watchedByDoNotCallMeDirectly: Set[ActorRef] = ActorCell.emptyActorRefSet
 
   @inline
-  private[this] def watchedBy: Set[ActorRef] =
-    Unsafe.instance.getObjectVolatile(this, watchedByOffset).asInstanceOf[Set[ActorRef]]
+  private[this] def watchedBy: Set[ActorRef] = _watchedByDoNotCallMeDirectly
 
   @inline
   private[this] def updateWatchedBy(oldWatchedBy: Set[ActorRef], newWatchedBy: Set[ActorRef]): Boolean =
@@ -560,14 +559,14 @@ private[akka] final class PromiseActorRef private (
   }
 
   @inline
-  private[this] def state: AnyRef = Unsafe.instance.getObjectVolatile(this, stateOffset)
+  private[this] def state: AnyRef = _stateDoNotCallMeDirectly
 
   @inline
   private[this] def updateState(oldState: AnyRef, newState: AnyRef): Boolean =
     Unsafe.instance.compareAndSwapObject(this, stateOffset, oldState, newState)
 
   @inline
-  private[this] def setState(newState: AnyRef): Unit = Unsafe.instance.putObjectVolatile(this, stateOffset, newState)
+  private[this] def setState(newState: AnyRef): Unit = this._stateDoNotCallMeDirectly = newState
 
   override def getParent: InternalActorRef = provider.tempContainer
 

--- a/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
@@ -223,8 +223,7 @@ class CircuitBreaker(
    * @return Reference to current state
    */
   @inline
-  private[this] def currentState: State =
-    Unsafe.instance.getObjectVolatile(this, AbstractCircuitBreaker.stateOffset).asInstanceOf[State]
+  private[this] def currentState: State = _currentStateDoNotCallMeDirectly
 
   /**
    * Helper method for updating the underlying resetTimeout via Unsafe
@@ -241,8 +240,7 @@ class CircuitBreaker(
    * Helper method for accessing to the underlying resetTimeout via Unsafe
    */
   @inline
-  private[this] def currentResetTimeout: FiniteDuration =
-    Unsafe.instance.getObjectVolatile(this, AbstractCircuitBreaker.resetTimeoutOffset).asInstanceOf[FiniteDuration]
+  private[this] def currentResetTimeout: FiniteDuration = _currentResetTimeoutDoNotCallMeDirectly
 
   /**
    * Wraps invocations of asynchronous calls that need to be protected

--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -254,8 +254,7 @@ private[remote] class Association(
   /**
    * @return Reference to current shared state
    */
-  def associationState: AssociationState =
-    Unsafe.instance.getObjectVolatile(this, AbstractAssociation.sharedStateOffset).asInstanceOf[AssociationState]
+  def associationState: AssociationState = _sharedStateDoNotCallMeDirectly
 
   def setControlIdleKillSwitch(killSwitch: OptionVal[SharedKillSwitch]): Unit = {
     val current = associationState


### PR DESCRIPTION
It seems using Unsafe is slower than just accessing the volatile field directly.

It's hard to find information about those methods but for me it seems we are not using them for good reasons. Good reasons would be:
 * accessing a field not marked with `@volatile` with volatile semantics
 * accessing a single element of an array with volatile semantics (e.g. like it's used in ForkJoinPool)

Everything else just seems to add a bit of overhead that I could observe in the ActorBenchmark.

Let's see if the tests agree that this is fine.