### PR TITLE
Correctly throw when akka.discovery.SimpleServiceDiscovery is found

### DIFF
--- a/akka-discovery/src/main/scala/akka/discovery/Discovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/Discovery.scala
@@ -115,7 +115,11 @@ object Discovery extends ExtensionId[Discovery] with ExtensionIdProvider {
       throw new RuntimeException(
         "Old version of Akka Discovery from Akka Management found on the classpath. Remove `com.lightbend.akka.discovery:akka-discovery` from the classpath..")
     } catch {
-      case _: ClassNotFoundException => // all good
+      case _: ClassCastException ⇒
+        throw new RuntimeException(
+          "Old version of Akka Discovery from Akka Management found on the classpath. Remove `com.lightbend.akka.discovery:akka-discovery` from the classpath..")
+      case _: ClassNotFoundException =>
+      // all good
     }
   }
 


### PR DESCRIPTION
ReflectiveDynamicAccess.getClassFor checks whether the found class
is of the 'desired type' and if not throws a ClassCastException. In
this case we ignore the result, so the expected type is Nothing,
and akka.discovery.SimpleServiceDiscovery is not assignable to
Nothing.