### PR TITLE
Include 'reproducible builds' sbt plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -522,6 +522,7 @@ lazy val discovery = akkaModule("akka-discovery")
 
 def akkaModule(name: String): Project =
   Project(id = name, base = file(name))
+    .enablePlugins(ReproducibleBuildsPlugin)
     .settings(akka.AkkaBuild.buildSettings)
     .settings(akka.AkkaBuild.defaultSettings)
     .enablePlugins(BootstrapGenjavadoc)

--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -9,6 +9,7 @@ import com.typesafe.sbt.osgi.SbtOsgi._
 import com.typesafe.sbt.osgi.SbtOsgi.autoImport._
 import sbt._
 import sbt.Keys._
+import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin
 
 object OSGi {
 
@@ -16,7 +17,7 @@ object OSGi {
   // in the .../bundles directory which makes testing locally published artifacts
   // a pain. Create bundles but publish them to the normal .../jars directory.
   def osgiSettings = defaultOsgiSettings ++ Seq(
-    Compile / packageBin := OsgiKeys.bundle.value,
+    Compile / packageBin := ReproducibleBuildsPlugin.postProcessJar(OsgiKeys.bundle.value),
     // This will fail the build instead of accidentally removing classes from the resulting artifact.
     // Each package contained in a project MUST be known to be private or exported, if it's undecided we MUST resolve this
     OsgiKeys.failOnUndecidedPackage := true,

--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -17,7 +17,15 @@ object OSGi {
   // in the .../bundles directory which makes testing locally published artifacts
   // a pain. Create bundles but publish them to the normal .../jars directory.
   def osgiSettings = defaultOsgiSettings ++ Seq(
-    Compile / packageBin := ReproducibleBuildsPlugin.postProcessJar(OsgiKeys.bundle.value),
+    Compile / packageBin := {
+      val bundle = OsgiKeys.bundle.value
+      // This normally happens automatically when loading the
+      // sbt-reproducible-builds plugin, but because we replace
+      // `packageBin` wholesale here we need to invoke the post-processing
+      // manually. See also
+      // https://github.com/raboof/sbt-reproducible-builds#sbt-osgi
+      ReproducibleBuildsPlugin.postProcessJar(bundle)
+    },
     // This will fail the build instead of accidentally removing classes from the resulting artifact.
     // Each package contained in a project MUST be known to be private or exported, if it's undecided we MUST resolve this
     OsgiKeys.failOnUndecidedPackage := true,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,6 +22,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0") // for maintenance of copyright file header
 addSbtPlugin("com.hpe.sbt" % "sbt-pull-request-validator" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0-M5")
+addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.20")
 
 // used for @unidoc directive
 libraryDependencies += "io.github.classgraph" % "classgraph" % "4.4.12"


### PR DESCRIPTION
This does 2 things:
* publish a 'buildinfo' report along with the project artifacts to describe
the build context and parameters
* post-process the jars to remove 'arbitrary' differences, such as jar file
ordering and timestamps.

This makes it easier to detect and explain when 2 builds of the same source
don't produce a bit-per-bit identical result. This for example can improve
our confidence that our distribution pipeline has not been compromised.