### PR TITLE
Clarified the failure conditions for Read/WriteLocal

### DIFF
--- a/akka-docs/src/main/paradox/distributed-data.md
+++ b/akka-docs/src/main/paradox/distributed-data.md
@@ -212,6 +212,10 @@ from other nodes might not be visible yet.
 When using @scala[`WriteLocal`]@java[`writeLocal`] the update is only written to the local replica and then disseminated
 in the background with the gossip protocol, which can take few seconds to spread to all nodes.
 
+When using `ReadLocal`, you will never receive a `GetFailure` response, since the local replica is always available to
+local readers. `WriteLocal` however may still reply with `UpdateFailure` messages, in the event that the `modify` function
+threw an exception, or, if using durable storage, if storing failed.
+
 `WriteAll` and `ReadAll` is the strongest consistency level, but also the slowest and with
 lowest availability. For example, it is enough that one node is unavailable for a `Get` request
 and you will not receive the value.


### PR DESCRIPTION
I was using ddata and I wasn't sure of the failure semantics when using `ReadLocal` and `WriteLocal`. So I've added this to the docs, but, I'm not sure if what I've written is true. Note that if it's not true that `ReadLocal` reads will never return a `GetFailure`, then the highly available shopping cart example has a potential infinite loop and/or busy wait, since it initially does a `ReadMajority` read, but if that fails, it does a `ReadLocal` read, and every subsequent failure results in immediately repeating that `ReadLocal` read.