### PR TITLE
enable serializer for ShardRegionStats, #25348

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -76,9 +76,10 @@ private[akka] object Shard {
 
   @SerialVersionUID(1L) final case class CurrentShardState(shardId: ShardRegion.ShardId, entityIds: Set[EntityId])
 
-  @SerialVersionUID(1L) case object GetShardStats extends ShardQuery
+  @SerialVersionUID(1L) case object GetShardStats extends ShardQuery with ClusterShardingSerializable
 
   @SerialVersionUID(1L) final case class ShardStats(shardId: ShardRegion.ShardId, entityCount: Int)
+      extends ClusterShardingSerializable
 
   object State {
     val Empty = State()

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -14,12 +14,12 @@ import akka.cluster.Cluster
 import akka.cluster.ClusterEvent._
 import akka.cluster.Member
 import akka.cluster.MemberStatus
-
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 import scala.concurrent.Promise
+
 import akka.Done
 import akka.annotation.InternalApi
 import akka.cluster.ClusterSettings
@@ -283,14 +283,15 @@ object ShardRegion {
    *
    * For the statistics for the entire cluster, see [[GetClusterShardingStats$]].
    */
-  @SerialVersionUID(1L) case object GetShardRegionStats extends ShardRegionQuery
+  @SerialVersionUID(1L) case object GetShardRegionStats extends ShardRegionQuery with ClusterShardingSerializable
 
   /**
    * Java API:
    */
   def getRegionStatsInstance = GetShardRegionStats
 
-  @SerialVersionUID(1L) final case class ShardRegionStats(stats: Map[ShardId, Int]) {
+  @SerialVersionUID(1L) final case class ShardRegionStats(stats: Map[ShardId, Int])
+      extends ClusterShardingSerializable {
 
     /**
      * Java API

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/protobuf/ClusterShardingMessageSerializerSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/protobuf/ClusterShardingMessageSerializerSpec.scala
@@ -9,6 +9,7 @@ import akka.testkit.AkkaSpec
 import akka.actor.Props
 import akka.cluster.sharding.ShardRegion.ShardId
 import akka.cluster.sharding.{ Shard, ShardCoordinator, ShardRegion }
+import akka.serialization.SerializationExtension
 
 class ClusterShardingMessageSerializerSpec extends AkkaSpec {
   import ShardCoordinator.Internal._
@@ -22,6 +23,7 @@ class ClusterShardingMessageSerializerSpec extends AkkaSpec {
   val regionProxy2 = system.actorOf(Props.empty, "regionProxy2")
 
   def checkSerialization(obj: AnyRef): Unit = {
+    SerializationExtension(system).findSerializerFor(obj).identifier should ===(serializer.identifier)
     val blob = serializer.toBinary(obj)
     val ref = serializer.fromBinary(blob, serializer.manifest(obj))
     ref should ===(obj)

--- a/akka-docs/src/main/paradox/project/rolling-update.md
+++ b/akka-docs/src/main/paradox/project/rolling-update.md
@@ -71,5 +71,19 @@ This change required a two phase update where the data was duplicated to be comp
 This means that you can't update from 2.5.13 directly to 2.5.17. You must first update to one of the intermediate
 versions 2.5.14, 2.5.15, or 2.5.16.
 
+### 2.5.22 ClusterSharding serializer for `ShardRegionStats`
 
+Issue: [#25348](https://github.com/akka/akka/issues/25348)
+
+Intentional change was done in 2.5.22.
+
+Changed serializer for classes: `GetShardRegionStats`, `ShardRegionStats`, `GetShardStats`, `ShardStats`
+
+This change required a two phase update where new serializer was introduced but not enabled in an earlier version.
+
+* 2.5.18 - serializer was added but not enabled, `JavaSerializer` still used
+* 2.5.22 - `ClusterShardingMessageSerializer` was enabled for these classes
+
+This means that you can't update from 2.5.17 directly to 2.5.22. You must first update to one of the intermediate
+versions 2.5.18, 2.5.19, 2.5.20 or 2.5.21.
 


### PR DESCRIPTION
When rolling update from 2.5.21 to 2.5.22:
* old nodes will send with JavaSerializer (id 1) and new nodes can deserialize that as before
* new nodes will send with ClusterShardingSerializer (id 13) and old nodes can deserialize that since the serializer exists and can handle those manifest strings

Refs #25348
