### PR TITLE
Update genjavadoc

### DIFF
--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -149,7 +149,7 @@ object BootstrapGenjavadoc extends AutoPlugin {
 
   override lazy val projectSettings = UnidocRoot.CliOptions.genjavadocEnabled.ifTrue(
     Seq(
-      unidocGenjavadocVersion := "0.11",
+      unidocGenjavadocVersion := "0.12",
       scalacOptions in Compile ++= Seq("-P:genjavadoc:fabricateParams=true", "-P:genjavadoc:suppressSynthetic=false")
     )
   ).getOrElse(Nil)


### PR DESCRIPTION
This should produce Java code that is valid enough to be processed even in the
presence of -Yrangepos #23756

Tested locally, seems to have the desired effect