### PR TITLE
Enable strict scalac options for akka-protobuf

### DIFF
--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/LoggerSourceTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/LoggerSourceTest.java
@@ -16,7 +16,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
+import org.scalatest.junit.JUnitSuite;
 
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/akka-protobuf/src/main/java/akka/protobuf/AbstractParser.java
+++ b/akka-protobuf/src/main/java/akka/protobuf/AbstractParser.java
@@ -114,10 +114,6 @@ public abstract class AbstractParser<MessageType extends MessageLite>
       return message;
     } catch (InvalidProtocolBufferException e) {
       throw e;
-    } catch (IOException e) {
-      throw new RuntimeException(
-          "Reading from a ByteString threw an IOException (should " +
-          "never happen).", e);
     }
   }
 
@@ -151,10 +147,6 @@ public abstract class AbstractParser<MessageType extends MessageLite>
       return message;
     } catch (InvalidProtocolBufferException e) {
       throw e;
-    } catch (IOException e) {
-      throw new RuntimeException(
-          "Reading from a byte array threw an IOException (should " +
-          "never happen).", e);
     }
   }
 

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -24,10 +24,12 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
   val fatalWarningsFor = Set(
     "akka-discovery",
     "akka-distributed-data",
+    "akka-protobuf",
   )
 
   val strictProjects = Set(
     "akka-discovery",
+    "akka-protobuf",
   )
 
   lazy val scalaFixSettings = Seq(


### PR DESCRIPTION
Unfortunately it still produces a Java warning, but I see no safe way around
that (so we can't just add `-Werror` to javacOptions)

Part of #26088