### PR TITLE
Typed guardian startup and actor adapter simplification

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ExtensionsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ExtensionsSpec.scala
@@ -12,6 +12,8 @@ import scala.concurrent.Future
 import akka.actor.BootstrapSetup
 import akka.actor.setup.ActorSystemSetup
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.receptionist.Receptionist
+import akka.actor.typed.receptionist.ServiceKey
 import org.scalatest.WordSpecLike
 
 class DummyExtension1 extends Extension
@@ -52,11 +54,20 @@ object InstanceCountingExtension extends ExtensionId[DummyExtension1] {
   }
 }
 
+object AccessSystemFromConstructorExtensionId extends ExtensionId[AccessSystemFromConstructor] {
+  override def createExtension(system: ActorSystem[_]): AccessSystemFromConstructor =
+    new AccessSystemFromConstructor(system)
+}
+class AccessSystemFromConstructor(system: ActorSystem[_]) extends Extension {
+  system.log.info("I log from the constructor")
+  system.receptionist ! Receptionist.Find(ServiceKey[String]("i-just-made-it-up"), system.deadLetters) // or touch the receptionist!
+}
+
 object ExtensionsSpec {
   val config = ConfigFactory.parseString("""
 akka.actor.typed {
   library-extensions += "akka.actor.typed.InstanceCountingExtension"
-}
+  }
    """).resolve()
 }
 
@@ -81,7 +92,7 @@ class ExtensionsSpec extends ScalaTestWithActorTestKit with WordSpecLike {
     withEmptyActorSystem("ExtensionsSpec02") { sys =>
       // not exactly water tight but better than nothing
       import sys.executionContext
-      val futures = (0 to 1000).map(n =>
+      val futures = (0 to 1000).map(_ =>
         Future {
           sys.registerExtension(SlowExtension)
         })
@@ -216,7 +227,7 @@ class ExtensionsSpec extends ScalaTestWithActorTestKit with WordSpecLike {
           """
           akka.actor.typed.extensions = ["akka.actor.typed.DummyExtension1$", "akka.actor.typed.SlowExtension$"]
         """)),
-      Some(ActorSystemSetup(new DummyExtension1Setup(sys => new DummyExtension1ViaSetup)))) { sys =>
+      Some(ActorSystemSetup(new DummyExtension1Setup(_ => new DummyExtension1ViaSetup)))) { sys =>
       sys.hasExtension(DummyExtension1) should ===(true)
       sys.extension(DummyExtension1) shouldBe a[DummyExtension1ViaSetup]
       DummyExtension1(sys) shouldBe a[DummyExtension1ViaSetup]
@@ -224,6 +235,19 @@ class ExtensionsSpec extends ScalaTestWithActorTestKit with WordSpecLike {
 
       sys.hasExtension(SlowExtension) should ===(true)
       sys.extension(SlowExtension) shouldBe a[SlowExtension]
+    }
+
+    "allow for interaction with log from extension constructor" in {
+      withEmptyActorSystem(
+        "ExtensionsSpec11",
+        Some(
+          ConfigFactory.parseString(
+            """
+          akka.actor.typed.extensions = ["akka.actor.typed.AccessSystemFromConstructorExtensionId$"]
+        """)),
+        None) { sys =>
+        AccessSystemFromConstructorExtensionId(sys) // would throw if it couldn't
+      }
     }
   }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
@@ -20,7 +20,7 @@ class GuardianStartupSpec extends WordSpec with Matchers with ScalaFutures {
 
   "The user guardian" must {
 
-    "should get a message sent to it early" in {
+    "get a message sent to it early" in {
       var system: ActorSystem[String] = null
       val sawMsg = new CountDownLatch(1)
       val guardianBehavior = Behaviors.receiveMessage[String] { msg =>
@@ -39,7 +39,7 @@ class GuardianStartupSpec extends WordSpec with Matchers with ScalaFutures {
       }
     }
 
-    "should not start before untyped system initialization is complete" in {
+    "not start before untyped system initialization is complete" in {
       var system: ActorSystem[String] = null
       val initialized = new CountDownLatch(1)
       val guardianBehavior = Behaviors.setup[String] { ctx =>

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
@@ -31,7 +31,7 @@ class GuardianStartupSpec extends WordSpec with Matchers with ScalaFutures {
         system = ActorSystem(guardianBehavior, "GuardianStartupSpec-get-all")
         system ! "msg"
 
-        sawMsg.await(3, TimeUnit.SECONDS) should === (true)
+        sawMsg.await(3, TimeUnit.SECONDS) should ===(true)
 
       } finally {
         if (system ne null)
@@ -51,7 +51,7 @@ class GuardianStartupSpec extends WordSpec with Matchers with ScalaFutures {
         system = ActorSystem(guardianBehavior, "GuardianStartupSpec-initialized")
         system ! "msg"
 
-        initialized.await(3, TimeUnit.SECONDS) should === (true)
+        initialized.await(3, TimeUnit.SECONDS) should ===(true)
 
       } finally {
         if (system ne null)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.scaladsl.adapter
+
+import akka.actor.ActorSystemImpl
+import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+class GuardianStartupSpec extends WordSpec with Matchers {
+
+  "The user guardian" must {
+
+    "should get a message sent to it early" in {
+      var system: ActorSystem[String] = null
+      @volatile var lastMsg = ""
+      val guardianBehavior = Behaviors.receiveMessage[String] { msg =>
+        lastMsg = msg
+        Behaviors.same
+      }
+      try {
+        system = ActorSystem(guardianBehavior, "GuardianStartupSpec-get-all")
+        system ! "msg"
+
+        val probe = TestProbe()(system)
+        probe.awaitAssert(lastMsg should ===("msg"))
+
+      } finally {
+        if (system ne null)
+          ActorTestKit.shutdown(system)
+      }
+    }
+
+    "should not start before untyped system initialization is complete" in {
+      var system: ActorSystem[String] = null
+      @volatile var ok = false
+      val guardianBehavior = Behaviors.setup[String] { ctx =>
+        ctx.system.toUntyped.asInstanceOf[ActorSystemImpl].assertInitialized
+        ok = true
+        Behaviors.empty
+      }
+      try {
+        system = ActorSystem(guardianBehavior, "GuardianStartupSpec-get-all")
+        system ! "msg"
+
+        val probe = TestProbe()(system)
+        probe.awaitAssert(ok should ===(true))
+
+      } finally {
+        if (system ne null)
+          ActorTestKit.shutdown(system)
+      }
+    }
+
+  }
+
+}

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
@@ -11,8 +11,9 @@ import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.Behaviors
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
+import org.scalatest.concurrent.ScalaFutures
 
-class GuardianStartupSpec extends WordSpec with Matchers {
+class GuardianStartupSpec extends WordSpec with Matchers with ScalaFutures {
 
   "The user guardian" must {
 
@@ -38,18 +39,36 @@ class GuardianStartupSpec extends WordSpec with Matchers {
 
     "should not start before untyped system initialization is complete" in {
       var system: ActorSystem[String] = null
-      @volatile var ok = false
+      @volatile var untypedSystemInitialized = false
       val guardianBehavior = Behaviors.setup[String] { ctx =>
-        ctx.system.toUntyped.asInstanceOf[ActorSystemImpl].assertInitialized
-        ok = true
+        ctx.system.toUntyped.asInstanceOf[ActorSystemImpl].assertInitialized()
+        untypedSystemInitialized = true
         Behaviors.empty
       }
       try {
-        system = ActorSystem(guardianBehavior, "GuardianStartupSpec-get-all")
+        system = ActorSystem(guardianBehavior, "GuardianStartupSpec-initialized")
         system ! "msg"
 
         val probe = TestProbe()(system)
-        probe.awaitAssert(ok should ===(true))
+        probe.awaitAssert(untypedSystemInitialized should ===(true))
+
+      } finally {
+        if (system ne null)
+          ActorTestKit.shutdown(system)
+      }
+    }
+
+    "have its shutdown hook run on immediate shutdown (after start)" in {
+      var system: ActorSystem[String] = null
+      @volatile var stopHookExecuted = false
+      // note that an immediately stopped (ActorSystem(Behaviors.stopped) is not allowed
+      val guardianBehavior = Behaviors.setup[String](_ => Behaviors.stopped(() => stopHookExecuted = true))
+
+      try {
+        system = ActorSystem(guardianBehavior, "GuardianStartupSpec-stop-hook")
+
+        system.whenTerminated.futureValue
+        stopHookExecuted should ===(true)
 
       } finally {
         if (system ne null)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -10,12 +10,11 @@ import java.util.concurrent.ThreadFactory
 
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Future
-
 import akka.actor.BootstrapSetup
 import akka.actor.setup.ActorSystemSetup
 import akka.actor.typed.internal.InternalRecipientRef
-import akka.actor.typed.internal.adapter.GuardianActorAdapter
 import akka.actor.typed.internal.adapter.ActorSystemAdapter
+import akka.actor.typed.internal.adapter.GuardianStartupBehavior
 import akka.actor.typed.internal.adapter.PropsAdapter
 import akka.actor.typed.receptionist.Receptionist
 import akka.annotation.ApiMayChange
@@ -237,11 +236,11 @@ object ActorSystem {
       appConfig,
       cl,
       executionContext,
-      Some(PropsAdapter(() => guardianBehavior, guardianProps, isGuardian = true)),
+      Some(PropsAdapter(() => new GuardianStartupBehavior(guardianBehavior), guardianProps)),
       setup)
     system.start()
 
-    system.guardian ! GuardianActorAdapter.Start
+    system.guardian ! GuardianStartupBehavior.Start
     ActorSystemAdapter.AdapterExtension(system).adapter
   }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
@@ -12,14 +12,15 @@ import akka.actor.ActorInitializationException
 import akka.actor.typed.Behavior.DeferredBehavior
 import akka.actor.typed.Behavior.StoppedBehavior
 import akka.actor.typed.internal.adapter.ActorAdapter.TypedActorFailedException
+
 import scala.annotation.tailrec
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 import scala.util.control.Exception.Catcher
-
 import akka.{ actor => untyped }
 import akka.annotation.InternalApi
+import akka.util.OptionVal
 
 /**
  * INTERNAL API
@@ -47,9 +48,11 @@ import akka.annotation.InternalApi
   final def currentBehavior: Behavior[T] = behavior
 
   private var _ctx: ActorContextAdapter[T] = _
-  def ctx: ActorContextAdapter[T] =
-    if (_ctx ne null) _ctx
-    else throw new IllegalStateException("Context was accessed before typed actor was started.")
+  def ctx: ActorContextAdapter[T] = {
+    // lazily create ctx on first access
+    if (_ctx eq null) _ctx = new ActorContextAdapter[T](context, this)
+    _ctx
+  }
 
   /**
    * Failures from failed children, that were stopped through untyped supervision, this is what allows us to pass
@@ -188,21 +191,13 @@ import akka.annotation.InternalApi
     }
   }
 
-  override def preStart(): Unit =
-    if (!isAlive(behavior)) {
-      if (behavior == Behavior.stopped) context.stop(self)
-      else {
-        // post stop hook may touch context
-        initializeContext()
-        context.stop(self)
-      }
-    } else
-      start()
-
-  protected def start(): Unit = {
-    context.become(running)
-    initializeContext()
-    behavior = validateAsInitial(Behavior.start(behavior, ctx))
+  override def preStart(): Unit = {
+    if (isAlive(behavior)) {
+      context.become(running)
+      behavior = validateAsInitial(Behavior.start(behavior, ctx))
+    }
+    // either was stopped initially or became stopped on start
+    // FIXME what about stop signal/postStop callback here?
     if (!isAlive(behavior)) context.stop(self)
   }
 
@@ -212,14 +207,14 @@ import akka.annotation.InternalApi
   }
 
   override def postRestart(reason: Throwable): Unit = {
-    initializeContext()
     behavior = validateAsInitial(Behavior.start(behavior, ctx))
+    // FIXME what about stop signal/postStop callback here?
     if (!isAlive(behavior)) context.stop(self)
   }
 
   override def postStop(): Unit = {
     behavior match {
-      case null                   => // skip PostStop
+      case null                   => // skip PostStop - FIXME will it ever be null here?
       case _: DeferredBehavior[_] =>
       // Do not undefer a DeferredBehavior as that may cause creation side-effects, which we do not want on termination.
       case b => Behavior.interpretSignal(b, ctx, PostStop)
@@ -227,57 +222,6 @@ import akka.annotation.InternalApi
 
     behavior = Behavior.stopped
   }
-
-  protected def initializeContext(): Unit = {
-    _ctx = new ActorContextAdapter[T](context, this)
-  }
-}
-
-/**
- * INTERNAL API
- *
- * A special adapter for the guardian which will defer processing until a special `Start` signal has been received.
- * That will allow to defer typed processing until the untyped ActorSystem has completely started up.
- */
-@InternalApi
-private[typed] class GuardianActorAdapter[T](_initialBehavior: Behavior[T]) extends ActorAdapter[T](_initialBehavior) {
-  import Behavior._
-
-  override def preStart(): Unit =
-    if (!isAlive(behavior))
-      context.stop(self)
-    else
-      context.become(waitingForStart(Nil))
-
-  def waitingForStart(stashed: List[Any]): Receive = {
-    case GuardianActorAdapter.Start =>
-      start()
-
-      stashed.reverse.foreach(receive)
-    case other =>
-      // unlikely to happen but not impossible
-      context.become(waitingForStart(other :: stashed))
-  }
-
-  override def postRestart(reason: Throwable): Unit = {
-    initializeContext()
-
-    super.postRestart(reason)
-  }
-
-  override def postStop(): Unit = {
-    initializeContext()
-
-    super.postStop()
-  }
-}
-
-/**
- * INTERNAL API
- */
-@InternalApi private[typed] object GuardianActorAdapter {
-  case object Start
-
 }
 
 /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
@@ -38,12 +38,12 @@ import akka.annotation.InternalApi
 /**
  * INTERNAL API
  */
-@InternalApi private[typed] class ActorAdapter[T](_initialBehavior: Behavior[T])
+@InternalApi private[typed] final class ActorAdapter[T](_initialBehavior: Behavior[T])
     extends untyped.Actor
     with untyped.ActorLogging {
   import Behavior._
 
-  protected var behavior: Behavior[T] = _initialBehavior
+  private var behavior: Behavior[T] = _initialBehavior
   final def currentBehavior: Behavior[T] = behavior
 
   // context adapter construction must be lazy because so that it is not created before the system is ready

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
@@ -9,17 +9,17 @@ package adapter
 import java.lang.reflect.InvocationTargetException
 
 import akka.actor.ActorInitializationException
+import akka.{ actor => untyped }
 import akka.actor.typed.Behavior.DeferredBehavior
 import akka.actor.typed.Behavior.StoppedBehavior
 import akka.actor.typed.internal.adapter.ActorAdapter.TypedActorFailedException
+import akka.annotation.InternalApi
 
 import scala.annotation.tailrec
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 import scala.util.control.Exception.Catcher
-import akka.{ actor => untyped }
-import akka.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -37,7 +37,8 @@ import akka.event.LoggingFilterWithMarker
     with internal.InternalRecipientRef[T]
     with ExtensionsImpl {
 
-  untypedSystem.assertInitialized()
+  // note that the untypedSystem may not be initialized yet here, and that is fine because
+  // it is unlikely that anything gets a hold of the extension until the system is started
 
   import ActorRefAdapter.sendSystemMessage
 
@@ -58,7 +59,7 @@ import akka.event.LoggingFilterWithMarker
   def isTerminated: Boolean = whenTerminated.isCompleted
 
   final override val path
-      : untyped.ActorPath = untyped.RootActorPath(untyped.Address("akka", untypedSystem.name)) / "user"
+    : untyped.ActorPath = untyped.RootActorPath(untyped.Address("akka", untypedSystem.name)) / "user"
 
   override def toString: String = untypedSystem.toString
 
@@ -74,7 +75,7 @@ import akka.event.LoggingFilterWithMarker
   }
   override def dynamicAccess: untyped.DynamicAccess = untypedSystem.dynamicAccess
   implicit override def executionContext: scala.concurrent.ExecutionContextExecutor = untypedSystem.dispatcher
-  override val log: Logger = new LoggerAdapterImpl(
+  override lazy val log: Logger = new LoggerAdapterImpl(
     untypedSystem.eventStream,
     getClass,
     name,

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -58,8 +58,8 @@ import akka.event.LoggingFilterWithMarker
   // impl InternalRecipientRef
   def isTerminated: Boolean = whenTerminated.isCompleted
 
-  final override val path
-    : untyped.ActorPath = untyped.RootActorPath(untyped.Address("akka", untypedSystem.name)) / "user"
+  final override val path: untyped.ActorPath =
+    untyped.RootActorPath(untyped.Address("akka", untypedSystem.name)) / "user"
 
   override def toString: String = untypedSystem.toString
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -75,7 +75,7 @@ import akka.event.LoggingFilterWithMarker
   }
   override def dynamicAccess: untyped.DynamicAccess = untypedSystem.dynamicAccess
   implicit override def executionContext: scala.concurrent.ExecutionContextExecutor = untypedSystem.dispatcher
-  override lazy val log: Logger = new LoggerAdapterImpl(
+  override val log: Logger = new LoggerAdapterImpl(
     untypedSystem.eventStream,
     getClass,
     name,

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/GuardianStartupBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/GuardianStartupBehavior.scala
@@ -22,9 +22,9 @@ private[akka] object GuardianStartupBehavior {
 /**
  * INTERNAL API
  *
- * Messages to the user provided guardian must be deferred while the actor system is starting up, this
- * behavior delays starting up the user provided behavior until the Start command is delivered from the actor
- * system and we know that the bootstrap is completed and that we can access the actor context
+ * Messages to the user provided guardian must be deferred while the actor system is starting up. This
+ * behavior delays starting the user provided behavior until the Start command is delivered from the actor
+ * system, and we know that the bootstrap is completed and the actor context can be accessed.
  */
 @InternalApi
 private[akka] final class GuardianStartupBehavior[T](val guardianBehavior: Behavior[T]) extends AbstractBehavior[Any] {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/GuardianStartupBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/GuardianStartupBehavior.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.internal.adapter
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.AbstractBehavior
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.StashBuffer
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] object GuardianStartupBehavior {
+  case object Start
+}
+
+/**
+ * INTERNAL API
+ *
+ * Messages to the user provided guardian must be deferred while the actor system is starting up, this
+ * behavior delays starting up the user provided behavior until the Start command is delivered from the actor
+ * system and we know that the bootstrap is completed and that we can access the actor context
+ */
+@InternalApi
+private[akka] final class GuardianStartupBehavior[T](val guardianBehavior: Behavior[T]) extends AbstractBehavior[Any] {
+
+  import GuardianStartupBehavior.Start
+
+  private val stash = StashBuffer[T](256) // we should typically not see many messages here, worth configuring?
+
+  override def onMessage(msg: Any): Behavior[Any] =
+    msg match {
+      case Start =>
+        // ctx is not available initially so we cannot use it until here
+        Behaviors.setup(ctx =>
+          stash.unstashAll(ctx.asInstanceOf[ActorContext[T]], guardianBehavior).asInstanceOf[Behavior[Any]])
+      case other =>
+        stash.stash(other.asInstanceOf[T])
+        this
+    }
+
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/GuardianStartupBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/GuardianStartupBehavior.scala
@@ -31,14 +31,13 @@ private[akka] final class GuardianStartupBehavior[T](val guardianBehavior: Behav
 
   import GuardianStartupBehavior.Start
 
-  private val stash = StashBuffer[T](256) // we should typically not see many messages here, worth configuring?
+  private val stash = StashBuffer[T](1000)
 
   override def onMessage(msg: Any): Behavior[Any] =
     msg match {
       case Start =>
         // ctx is not available initially so we cannot use it until here
-        Behaviors.setup(ctx =>
-          stash.unstashAll(ctx.asInstanceOf[ActorContext[T]], guardianBehavior).asInstanceOf[Behavior[Any]])
+        Behaviors.setup(ctx => stash.unstashAll(ctx.asInstanceOf[ActorContext[T]], guardianBehavior).unsafeCast[Any])
       case other =>
         stash.stash(other.asInstanceOf[T])
         this

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/PropsAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/PropsAdapter.scala
@@ -13,15 +13,8 @@ import akka.annotation.InternalApi
  * INTERNAL API
  */
 @InternalApi private[akka] object PropsAdapter {
-  def apply[T](
-      behavior: () => Behavior[T],
-      deploy: Props = Props.empty,
-      isGuardian: Boolean = false): akka.actor.Props = {
-    val props =
-      if (isGuardian)
-        akka.actor.Props(new GuardianActorAdapter(behavior()))
-      else
-        akka.actor.Props(new ActorAdapter(behavior()))
+  def apply[T](behavior: () => Behavior[T], deploy: Props = Props.empty): akka.actor.Props = {
+    val props = akka.actor.Props(new ActorAdapter(behavior()))
 
     (deploy.firstOrElse[DispatcherSelector](DispatcherDefault()) match {
       case _: DispatcherDefault          => props


### PR DESCRIPTION
This feels cleaner to me, but it also undoes the "detect extension ordering bugs early" fix Johannes did in #24406 to address #24279

I _think_ I have solved that by making sure the guardian behavior isn't started until the system is ready, just like the removed `GuardianActorAdapter` did. To be able to do this, the context adapter creation must be lazily created in the `ActorAdapter` rather than in preStart, because the untyped guardian actor is started before the actor system is initialized.

There is still the case where an extension is eagerly constructed and tries to use for example the ActorSystemAdapter in its constructor, but I think that problem is also present in untyped so maybe that is ok.