### PR TITLE
Replace SnapshotSelectionCriteria and SnapshotMetadata, #26536

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/EventSourcedSignal.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/EventSourcedSignal.scala
@@ -6,8 +6,7 @@ package akka.persistence.typed
 
 import akka.actor.typed.Signal
 import akka.annotation.DoNotInherit
-import akka.persistence.SnapshotMetadata
-import akka.persistence.SnapshotSelectionCriteria
+import akka.annotation.InternalApi
 
 /**
  * Supertype for all Akka Persistence Typed specific signals
@@ -24,6 +23,7 @@ final case class RecoveryCompleted[State](state: State) extends EventSourcedSign
    */
   def getState(): State = state
 }
+
 final case class RecoveryFailed(failure: Throwable) extends EventSourcedSignal {
 
   /**
@@ -39,6 +39,7 @@ final case class SnapshotCompleted(metadata: SnapshotMetadata) extends EventSour
    */
   def getSnapshotMetadata(): SnapshotMetadata = metadata
 }
+
 final case class SnapshotFailed(metadata: SnapshotMetadata, failure: Throwable) extends EventSourcedSignal {
 
   /**
@@ -52,6 +53,37 @@ final case class SnapshotFailed(metadata: SnapshotMetadata, failure: Throwable) 
   def getSnapshotMetadata(): SnapshotMetadata = metadata
 }
 
+object SnapshotMetadata {
+
+  /**
+   * @param persistenceId id of persistent actor from which the snapshot was taken.
+   * @param sequenceNr sequence number at which the snapshot was taken.
+   * @param timestamp time at which the snapshot was saved, defaults to 0 when unknown.
+   *                  in milliseconds from the epoch of 1970-01-01T00:00:00Z.
+   */
+  def apply(persistenceId: String, sequenceNr: Long, timestamp: Long): SnapshotMetadata =
+    new SnapshotMetadata(persistenceId, sequenceNr, timestamp)
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] def fromUntyped(metadata: akka.persistence.SnapshotMetadata): SnapshotMetadata =
+    new SnapshotMetadata(metadata.persistenceId, metadata.sequenceNr, metadata.timestamp)
+}
+
+/**
+ * Snapshot metadata.
+ *
+ * @param persistenceId id of persistent actor from which the snapshot was taken.
+ * @param sequenceNr sequence number at which the snapshot was taken.
+ * @param timestamp time at which the snapshot was saved, defaults to 0 when unknown.
+ *                  in milliseconds from the epoch of 1970-01-01T00:00:00Z.
+ */
+final class SnapshotMetadata(val persistenceId: String, val sequenceNr: Long, val timestamp: Long) {
+  override def toString: String =
+    s"SnapshotMetadata($persistenceId,$sequenceNr,$timestamp)"
+}
+
 final case class DeleteSnapshotsCompleted(target: DeletionTarget) extends EventSourcedSignal {
 
   /**
@@ -59,6 +91,7 @@ final case class DeleteSnapshotsCompleted(target: DeletionTarget) extends EventS
    */
   def getTarget(): DeletionTarget = target
 }
+
 final case class DeleteSnapshotsFailed(target: DeletionTarget, failure: Throwable) extends EventSourcedSignal {
 
   /**
@@ -79,6 +112,7 @@ final case class DeleteEventsCompleted(toSequenceNr: Long) extends EventSourcedS
    */
   def getToSequenceNr(): Long = toSequenceNr
 }
+
 final case class DeleteEventsFailed(toSequenceNr: Long, failure: Throwable) extends EventSourcedSignal {
 
   /**

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/SnapshotSelectionCriteria.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/SnapshotSelectionCriteria.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed
+
+import akka.annotation.InternalApi
+import akka.persistence.{ SnapshotSelectionCriteria => UntypedSnapshotSelectionCriteria }
+import akka.util.HashCode
+
+object SnapshotSelectionCriteria {
+
+  /**
+   * The latest saved snapshot.
+   */
+  val latest: SnapshotSelectionCriteria =
+    new SnapshotSelectionCriteria(
+      maxSequenceNr = Long.MaxValue,
+      maxTimestamp = Long.MaxValue,
+      minSequenceNr = 0L,
+      minTimestamp = 0L)
+
+  /**
+   * No saved snapshot matches.
+   */
+  val none: SnapshotSelectionCriteria =
+    new SnapshotSelectionCriteria(maxSequenceNr = 0L, maxTimestamp = 0L, minSequenceNr = 0L, minTimestamp = 0L)
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] def fromUntyped(c: UntypedSnapshotSelectionCriteria): SnapshotSelectionCriteria =
+    new SnapshotSelectionCriteria(c.maxSequenceNr, c.maxTimestamp, c.minSequenceNr, c.minTimestamp)
+
+}
+
+/**
+ * Selection criteria for loading and deleting snapshots.
+ */
+final class SnapshotSelectionCriteria @InternalApi private[akka] (
+    val maxSequenceNr: Long,
+    val maxTimestamp: Long,
+    val minSequenceNr: Long,
+    val minTimestamp: Long) {
+
+  /**
+   * upper bound for a selected snapshot's sequence number
+   */
+  def withMaxSequenceNr(newMaxSequenceNr: Long): SnapshotSelectionCriteria =
+    copy(maxSequenceNr = newMaxSequenceNr)
+
+  /**
+   * upper bound for a selected snapshot's timestamp, in milliseconds from the epoch
+   * of 1970-01-01T00:00:00Z.
+   */
+  def withMaxTimestamp(newMaxTimestamp: Long): SnapshotSelectionCriteria =
+    copy(maxTimestamp = newMaxTimestamp)
+
+  /**
+   * lower bound for a selected snapshot's sequence number
+   */
+  def withMinSequenceNr(newMinSequenceNr: Long): SnapshotSelectionCriteria =
+    copy(minSequenceNr = newMinSequenceNr)
+
+  /**
+   * lower bound for a selected snapshot's timestamp, in milliseconds from the epoch
+   * of 1970-01-01T00:00:00Z.
+   */
+  def withMinTimestamp(newMinTimestamp: Long): SnapshotSelectionCriteria =
+    copy(minTimestamp = newMinTimestamp)
+
+  private def copy(
+      maxSequenceNr: Long = maxSequenceNr,
+      maxTimestamp: Long = maxTimestamp,
+      minSequenceNr: Long = minSequenceNr,
+      minTimestamp: Long = minTimestamp): SnapshotSelectionCriteria =
+    new SnapshotSelectionCriteria(maxSequenceNr, maxTimestamp, minSequenceNr, minTimestamp)
+
+  override def toString: String =
+    s"SnapshotSelectionCriteria($maxSequenceNr,$maxTimestamp,$minSequenceNr,$minTimestamp)"
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] def toUntyped: akka.persistence.SnapshotSelectionCriteria =
+    akka.persistence.SnapshotSelectionCriteria(maxSequenceNr, maxTimestamp, minSequenceNr, minTimestamp)
+
+  override def equals(other: Any): Boolean = other match {
+    case that: SnapshotSelectionCriteria =>
+      maxSequenceNr == that.maxSequenceNr &&
+      maxTimestamp == that.maxTimestamp &&
+      minSequenceNr == that.minSequenceNr &&
+      minTimestamp == that.minTimestamp
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    var result = HashCode.SEED
+    result = HashCode.hash(result, maxSequenceNr)
+    result = HashCode.hash(result, maxTimestamp)
+    result = HashCode.hash(result, minSequenceNr)
+    result = HashCode.hash(result, minTimestamp)
+    result
+  }
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -19,7 +19,11 @@ import akka.actor.typed.SupervisorStrategy
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
 import akka.annotation.InternalApi
-import akka.persistence._
+import akka.persistence.JournalProtocol
+import akka.persistence.Recovery
+import akka.persistence.RecoveryPermitter
+import akka.persistence.SnapshotMetadata
+import akka.persistence.SnapshotProtocol
 import akka.persistence.typed.DeleteEventsFailed
 import akka.persistence.typed.DeleteSnapshotsCompleted
 import akka.persistence.typed.DeleteSnapshotsFailed
@@ -30,6 +34,7 @@ import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.RetentionCriteria
 import akka.persistence.typed.SnapshotCompleted
 import akka.persistence.typed.SnapshotFailed
+import akka.persistence.typed.SnapshotSelectionCriteria
 import akka.persistence.typed.scaladsl._
 import akka.util.ConstantFun
 
@@ -84,7 +89,7 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
 
     val actualSignalHandler: PartialFunction[Signal, Unit] = signalHandler.orElse {
       // default signal handler is always the fallback
-      case SnapshotCompleted(meta: SnapshotMetadata) ⇒
+      case SnapshotCompleted(meta) ⇒
         ctx.log.debug("Save snapshot successful, snapshot metadata [{}]", meta)
       case SnapshotFailed(meta, failure) ⇒
         ctx.log.error(failure, "Save snapshot failed, snapshot metadata [{}]", meta)
@@ -185,7 +190,7 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
 
   override def withSnapshotSelectionCriteria(
       selection: SnapshotSelectionCriteria): EventSourcedBehavior[Command, Event, State] = {
-    copy(recovery = Recovery(selection))
+    copy(recovery = Recovery(selection.toUntyped))
   }
 
   override def withRetention(criteria: RetentionCriteria): EventSourcedBehavior[Command, Event, State] =

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
@@ -14,7 +14,6 @@ import akka.actor.typed.Behavior.DeferredBehavior
 import akka.actor.typed.javadsl.ActorContext
 import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
-import akka.persistence.SnapshotSelectionCriteria
 import akka.persistence.typed.EventAdapter
 import akka.persistence.typed._
 import akka.persistence.typed.internal._
@@ -140,7 +139,7 @@ abstract class EventSourcedBehavior[Command, Event, State >: Null] private[akka]
    * You may configure the behavior to skip replaying snapshots completely, in which case the recovery will be
    * performed by replaying all events -- which may take a long time.
    */
-  def snapshotSelectionCriteria: SnapshotSelectionCriteria = SnapshotSelectionCriteria.Latest
+  def snapshotSelectionCriteria: SnapshotSelectionCriteria = SnapshotSelectionCriteria.latest
 
   /**
    * The `tagger` function should give event tags, which will be used in persistence query

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/EventSourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/EventSourcedBehavior.scala
@@ -10,16 +10,16 @@ import akka.actor.typed.BackoffSupervisorStrategy
 import akka.actor.typed.Behavior
 import akka.actor.typed.Behavior.DeferredBehavior
 import akka.actor.typed.Signal
-import akka.actor.typed.internal.LoggerClass
 import akka.actor.typed.internal.InterceptorImpl
+import akka.actor.typed.internal.LoggerClass
 import akka.actor.typed.internal.adapter.ActorContextAdapter
 import akka.actor.typed.scaladsl.ActorContext
 import akka.annotation.DoNotInherit
-import akka.persistence._
 import akka.persistence.typed.EventAdapter
 import akka.persistence.typed.ExpectingReply
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.RetentionCriteria
+import akka.persistence.typed.SnapshotSelectionCriteria
 import akka.persistence.typed.internal._
 
 object EventSourcedBehavior {

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java
@@ -9,7 +9,7 @@ import akka.actor.typed.Behavior;
 import akka.actor.typed.javadsl.ActorContext;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.javadsl.Behaviors;
-import akka.persistence.SnapshotSelectionCriteria;
+import akka.persistence.typed.SnapshotSelectionCriteria;
 import akka.persistence.typed.EventAdapter;
 import akka.actor.testkit.typed.javadsl.TestInbox;
 import akka.persistence.typed.PersistenceId;

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -11,7 +11,6 @@ import akka.actor.typed.javadsl.Adapter;
 import akka.actor.typed.javadsl.Behaviors;
 import akka.event.Logging;
 import akka.japi.Pair;
-import akka.persistence.SnapshotMetadata;
 import akka.persistence.query.EventEnvelope;
 import akka.persistence.query.NoOffset;
 import akka.persistence.query.PersistenceQuery;

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotMutableStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotMutableStateSpec.scala
@@ -8,18 +8,17 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.Future
-import scala.util.Failure
-import scala.util.Success
+
 import akka.actor.testkit.typed.scaladsl._
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
 import akka.persistence.SelectedSnapshot
-import akka.persistence.SnapshotMetadata
-import akka.persistence.SnapshotSelectionCriteria
 import akka.persistence.snapshot.SnapshotStore
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.SnapshotCompleted
 import akka.persistence.typed.SnapshotFailed
+import akka.persistence.{ SnapshotSelectionCriteria => UntypedSnapshotSelectionCriteria }
+import akka.persistence.{ SnapshotMetadata => UntypedSnapshotMetadata }
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.WordSpecLike
@@ -28,15 +27,17 @@ object SnapshotMutableStateSpec {
 
   class SlowInMemorySnapshotStore extends SnapshotStore {
 
-    private var state = Map.empty[String, (Any, SnapshotMetadata)]
+    private var state = Map.empty[String, (Any, UntypedSnapshotMetadata)]
 
-    def loadAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
+    def loadAsync(
+        persistenceId: String,
+        criteria: UntypedSnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
       Future.successful(state.get(persistenceId).map {
         case (snap, meta) => SelectedSnapshot(meta, snap)
       })
     }
 
-    def saveAsync(metadata: SnapshotMetadata, snapshot: Any): Future[Unit] = {
+    def saveAsync(metadata: UntypedSnapshotMetadata, snapshot: Any): Future[Unit] = {
       val snapshotState = snapshot.asInstanceOf[MutableState]
       val value1 = snapshotState.value
       Thread.sleep(50)
@@ -51,8 +52,8 @@ object SnapshotMutableStateSpec {
       }
     }
 
-    def deleteAsync(metadata: SnapshotMetadata) = ???
-    def deleteAsync(persistenceId: String, criteria: SnapshotSelectionCriteria) = ???
+    def deleteAsync(metadata: UntypedSnapshotMetadata) = ???
+    def deleteAsync(persistenceId: String, criteria: UntypedSnapshotSelectionCriteria) = ???
   }
 
   def conf: Config = ConfigFactory.parseString(s"""

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
@@ -165,14 +165,14 @@ object BasicPersistentBehaviorCompileOnly {
   //#snapshottingPredicate
 
   //#snapshotSelection
-  import akka.persistence.SnapshotSelectionCriteria
+  import akka.persistence.typed.SnapshotSelectionCriteria
 
   val snapshotSelection = EventSourcedBehavior[Command, Event, State](
     persistenceId = PersistenceId("abc"),
     emptyState = State(),
     commandHandler = (state, cmd) => throw new RuntimeException("TODO: process the command & return an Effect"),
     eventHandler = (state, evt) => throw new RuntimeException("TODO: process the event return the next state"))
-    .withSnapshotSelectionCriteria(SnapshotSelectionCriteria.None)
+    .withSnapshotSelectionCriteria(SnapshotSelectionCriteria.none)
   //#snapshotSelection
 
 }


### PR DESCRIPTION
* This may look like a duplicating the existing classes from untyped
  persistence without any value, but those two classes were there only
  two from untyped that were exposed in end user APIs.
* This makes the API independent of untyped.
* Those classes can be evolved (much) easier since they are not case classes.

Refs #26536