### PR TITLE
Typed unstash improvements

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -28,7 +28,7 @@ private[akka] final class BehaviorTestKitImpl[T](_path: ActorPath, _initialBehav
     with akka.actor.testkit.typed.scaladsl.BehaviorTestKit[T] {
 
   // really this should be private, make so when we port out tests that need it
-  private[akka] val context = new EffectfulActorContext[T](_path)
+  private[akka] val context = new EffectfulActorContext[T](_path, () => currentBehavior)
 
   private[akka] def as[U]: BehaviorTestKitImpl[U] = this.asInstanceOf[BehaviorTestKitImpl[U]]
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/EffectfulActorContext.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/EffectfulActorContext.scala
@@ -20,7 +20,10 @@ import scala.compat.java8.FunctionConverters._
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] final class EffectfulActorContext[T](path: ActorPath) extends StubbedActorContext[T](path) {
+@InternalApi private[akka] final class EffectfulActorContext[T](
+    path: ActorPath,
+    currentBehaviorProvider: () => Behavior[T])
+    extends StubbedActorContext[T](path, currentBehaviorProvider) {
 
   private[akka] val effectQueue = new ConcurrentLinkedQueue[Effect]
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
@@ -159,10 +159,11 @@ private[akka] final class FunctionRef[-T](override val path: ActorPath, send: (T
  * provides only stubs for the effects an Actor can perform and replaces
  * created child Actors by a synchronous Inbox (see `Inbox.sync`).
  */
-@InternalApi private[akka] class StubbedActorContext[T](val path: ActorPath) extends ActorContextImpl[T] {
+@InternalApi private[akka] class StubbedActorContext[T](val path: ActorPath, currentBehaviorProvider: () => Behavior[T])
+    extends ActorContextImpl[T] {
 
-  def this(name: String) = {
-    this((TestInbox.address / name).withUid(rnd().nextInt()))
+  def this(name: String, currentBehaviorProvider: () => Behavior[T]) = {
+    this((TestInbox.address / name).withUid(rnd().nextInt()), currentBehaviorProvider)
   }
 
   /**
@@ -175,6 +176,7 @@ private[akka] final class FunctionRef[-T](override val path: ActorPath, send: (T
   private var _children = TreeMap.empty[String, BehaviorTestKitImpl[_]]
   private val childName = Iterator.from(0).map(Helpers.base64(_))
   private val loggingAdapter = new StubbedLogger
+  private var unhandled: List[T] = Nil
 
   override def children: Iterable[ActorRef[Nothing]] = _children.values.map(_.context.self)
   def childrenNames: Iterable[String] = _children.keys
@@ -289,4 +291,19 @@ private[akka] final class FunctionRef[-T](override val path: ActorPath, send: (T
    * Clear the log entries
    */
   def clearLog(): Unit = loggingAdapter.clearLog()
+
+  override private[akka] def onUnhandled(msg: T): Unit =
+    unhandled = msg :: unhandled
+
+  /**
+   * Messages that are marked as unhandled
+   */
+  def unhandledMessages: List[T] = unhandled.reverse
+
+  /**
+   * Clear the list of captured unhandled messages
+   */
+  def clearUnhandled(): Unit = unhandled = Nil
+
+  override private[akka] def currentBehavior: Behavior[T] = currentBehaviorProvider()
 }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
@@ -288,7 +288,7 @@ private[akka] final class FunctionRef[-T](override val path: ActorPath, send: (T
   def logEntries: List[CapturedLogEvent] = loggingAdapter.logEntries
 
   /**
-   * Clear the log entries
+   * Clear the log entries.
    */
   def clearLog(): Unit = loggingAdapter.clearLog()
 
@@ -296,12 +296,12 @@ private[akka] final class FunctionRef[-T](override val path: ActorPath, send: (T
     unhandled = msg :: unhandled
 
   /**
-   * Messages that are marked as unhandled
+   * Messages that are marked as unhandled.
    */
   def unhandledMessages: List[T] = unhandled.reverse
 
   /**
-   * Clear the list of captured unhandled messages
+   * Clear the list of captured unhandled messages.
    */
   def clearUnhandled(): Unit = unhandled = Nil
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashBufferSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashBufferSpec.scala
@@ -11,7 +11,9 @@ import org.scalatest.{ Matchers, WordSpec }
 
 class StashBufferSpec extends WordSpec with Matchers {
 
-  val context = new StubbedActorContext[String]("StashBufferSpec")
+  val context = new StubbedActorContext[String](
+    "StashBufferSpec",
+    () => throw new UnsupportedOperationException("Will never be invoked in this test"))
 
   "A StashBuffer" must {
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
@@ -14,7 +14,6 @@ import scala.util.control.NonFatal
 import akka.actor.typed.Behavior
 import akka.actor.typed.Signal
 import akka.actor.typed.TypedActorContext
-import akka.actor.typed.internal.adapter.ActorContextAdapter
 import akka.actor.typed.javadsl
 import akka.actor.typed.scaladsl
 import akka.annotation.InternalApi
@@ -140,7 +139,7 @@ import akka.util.ConstantFun
         val actualNext =
           if (interpretResult == Behavior.same) b2
           else if (Behavior.isUnhandled(interpretResult)) {
-            ctx.asScala.asInstanceOf[ActorContextAdapter[_]].onUnhandled(message)
+            ctx.asScala.onUnhandled(message)
             b2
           } else {
             interpretResult
@@ -160,7 +159,7 @@ import akka.util.ConstantFun
       if (Behavior.isUnhandled(started))
         throw new IllegalArgumentException("Cannot unstash with unhandled as starting behavior")
       else if (started == Behavior.same) {
-        ctx.asScala.asInstanceOf[ActorContextAdapter[T]].currentBehavior
+        ctx.asScala.currentBehavior
       } else started
 
     if (Behavior.isAlive(actualInitialBehavior)) {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
@@ -153,10 +153,15 @@ import akka.util.ConstantFun
     }
 
     val started = Behavior.start(behavior, ctx)
-    if (Behavior.isUnhandled(started))
-      throw new IllegalArgumentException("Cannot unstash with unhandled as starting behavior")
-    if (Behavior.isAlive(started)) {
-      interpretOne(started)
+    val actualInitialBehavior =
+      if (Behavior.isUnhandled(started))
+        throw new IllegalArgumentException("Cannot unstash with unhandled as starting behavior")
+      else if (started == Behavior.same) {
+        ctx.asScala.asInstanceOf[ActorContextAdapter[T]].currentBehavior
+      } else started
+
+    if (Behavior.isAlive(actualInitialBehavior)) {
+      interpretOne(actualInitialBehavior)
     } else {
       // fixme rest of stash to dead letter?
       started

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
@@ -110,6 +110,12 @@ import scala.concurrent.duration._
   override def setLoggerClass(clazz: Class[_]): Unit = {
     initLoggerWithClass(clazz)
   }
+
+  /**
+   * Made accessible only to allow stash to deal with unhandled messages just like if they were interpreted by
+   * the adapter itself, even though the unstashing is actually happen inside the behavior stack
+   */
+  def onUnhandled(msg: Any): Unit = adapter.unhandled(msg)
 }
 
 /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
@@ -25,7 +25,7 @@ import scala.concurrent.duration._
 
   import ActorRefAdapter.toUntyped
 
-  private[akka] def currentBehavior: Behavior[T] = adapter.currentBehavior
+  private[akka] override def currentBehavior: Behavior[T] = adapter.currentBehavior
 
   // lazily initialized
   private var actorLogger: OptionVal[Logger] = OptionVal.None
@@ -115,7 +115,7 @@ import scala.concurrent.duration._
    * Made accessible only to allow stash to deal with unhandled messages just like if they were interpreted by
    * the adapter itself, even though the unstashing is actually happen inside the behavior stack
    */
-  def onUnhandled(msg: Any): Unit = adapter.unhandled(msg)
+  private[akka] override def onUnhandled(msg: T): Unit = adapter.unhandled(msg)
 }
 
 /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
@@ -112,8 +112,8 @@ import scala.concurrent.duration._
   }
 
   /**
-   * Made accessible only to allow stash to deal with unhandled messages just like if they were interpreted by
-   * the adapter itself, even though the unstashing is actually happen inside the behavior stack
+   * Made accessible to allow stash to deal with unhandled messages as though they were interpreted by
+   * the adapter itself, even though the unstashing occurs inside the behavior stack.
    */
   private[akka] override def onUnhandled(msg: T): Unit = adapter.unhandled(msg)
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/StashBuffer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/StashBuffer.scala
@@ -100,6 +100,8 @@ object StashBuffer {
    * It's allowed to stash messages while unstashing. Those newly added
    * messages will not be processed by this call and have to be unstashed
    * in another call.
+   *
+   * The `behavior` passed to `unstashAll` must not be `unhandled`.
    */
   def unstashAll(ctx: ActorContext[T], behavior: Behavior[T]): Behavior[T]
 
@@ -121,6 +123,8 @@ object StashBuffer {
    * It's allowed to stash messages while unstashing. Those newly added
    * messages will not be processed by this call and have to be unstashed
    * in another call.
+   *
+   * The `behavior` passed to `unstash` must not be `unhandled`.
    */
   def unstash(ctx: ActorContext[T], behavior: Behavior[T], numberOfMessages: Int, wrap: JFunction[T, T]): Behavior[T]
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
@@ -299,4 +299,15 @@ trait ActorContext[T] extends TypedActorContext[T] {
    */
   def pipeToSelf[Value](future: Future[Value])(mapResult: Try[Value] => T): Unit
 
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private[akka] def onUnhandled(msg: T): Unit
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def currentBehavior: Behavior[T]
+
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/StashBuffer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/StashBuffer.scala
@@ -95,7 +95,7 @@ object StashBuffer {
    * messages will not be processed by this call and have to be unstashed
    * in another call.
    *
-   * The initial `behavior` passed to `unstashAll` must not be stopped or unhandled
+   * The initial `behavior` passed to `unstashAll` must not be `unhandled`
    */
   def unstashAll(ctx: ActorContext[T], behavior: Behavior[T]): Behavior[T]
 
@@ -118,7 +118,7 @@ object StashBuffer {
    * messages will not be processed by this call and have to be unstashed
    * in another call.
    *
-   * The `behavior` passed to `unstash` must not be stopped or unhandled
+   * The `behavior` passed to `unstash` must not be `unhandled`
    */
   def unstash(ctx: ActorContext[T], behavior: Behavior[T], numberOfMessages: Int, wrap: T => T): Behavior[T]
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/StashBuffer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/StashBuffer.scala
@@ -95,7 +95,7 @@ object StashBuffer {
    * messages will not be processed by this call and have to be unstashed
    * in another call.
    *
-   * The initial `behavior` passed to `unstashAll` must not be `unhandled`
+   * The initial `behavior` passed to `unstashAll` must not be `unhandled`.
    */
   def unstashAll(ctx: ActorContext[T], behavior: Behavior[T]): Behavior[T]
 
@@ -118,7 +118,7 @@ object StashBuffer {
    * messages will not be processed by this call and have to be unstashed
    * in another call.
    *
-   * The `behavior` passed to `unstash` must not be `unhandled`
+   * The `behavior` passed to `unstash` must not be `unhandled`.
    */
   def unstash(ctx: ActorContext[T], behavior: Behavior[T], numberOfMessages: Int, wrap: T => T): Behavior[T]
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/StashBuffer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/StashBuffer.scala
@@ -94,6 +94,8 @@ object StashBuffer {
    * It's allowed to stash messages while unstashing. Those newly added
    * messages will not be processed by this call and have to be unstashed
    * in another call.
+   *
+   * The initial `behavior` passed to `unstashAll` must not be stopped or unhandled
    */
   def unstashAll(ctx: ActorContext[T], behavior: Behavior[T]): Behavior[T]
 
@@ -115,6 +117,8 @@ object StashBuffer {
    * It's allowed to stash messages while unstashing. Those newly added
    * messages will not be processed by this call and have to be unstashed
    * in another call.
+   *
+   * The `behavior` passed to `unstash` must not be stopped or unhandled
    */
   def unstash(ctx: ActorContext[T], behavior: Behavior[T], numberOfMessages: Int, wrap: T => T): Behavior[T]
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/EventSourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/EventSourcedBehavior.scala
@@ -12,7 +12,6 @@ import akka.actor.typed.Behavior.DeferredBehavior
 import akka.actor.typed.Signal
 import akka.actor.typed.internal.InterceptorImpl
 import akka.actor.typed.internal.LoggerClass
-import akka.actor.typed.internal.adapter.ActorContextAdapter
 import akka.actor.typed.scaladsl.ActorContext
 import akka.annotation.DoNotInherit
 import akka.persistence.typed.EventAdapter
@@ -103,15 +102,10 @@ object EventSourcedBehavior {
         case concrete                           => concrete
       }
 
-    context match {
-      case impl: ActorContextAdapter[_] =>
-        extractConcreteBehavior(impl.currentBehavior) match {
-          case w: Running.WithSeqNrAccessible => w.currentSequenceNumber
-          case s =>
-            throw new IllegalStateException(s"Cannot extract the lastSequenceNumber in state ${s.getClass.getName}")
-        }
-      case c =>
-        throw new IllegalStateException(s"Cannot extract the lastSequenceNumber from context ${c.getClass.getName}")
+    extractConcreteBehavior(context.currentBehavior) match {
+      case w: Running.WithSeqNrAccessible => w.currentSequenceNumber
+      case s =>
+        throw new IllegalStateException(s"Cannot extract the lastSequenceNumber in state ${s.getClass.getName}")
     }
   }
 


### PR DESCRIPTION
Fixes #26362 

* Makes unhandled from unstashing a message handled the same way as regular unhandled
* Allows stopping in the middle of unstashing (one ? here though about what to do with stash contents)
* Allows `same` as the initial behavior to start from current actor behavior when unstashing