### PR TITLE
EventSourcedBehaviorSpec failure in CI: delete events - state issue #26601

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -331,7 +331,7 @@ private[akka] object Running {
           // # 24698 The deletion of old events are automatic, snapshots are triggered by the SaveSnapshotSuccess.
           setup.log.debug(s"Persistent snapshot [{}] saved successfully", meta)
           if (setup.retention.deleteEventsOnSnapshot)
-            internalDeleteEvents(e, state)
+            internalDeleteEvents(setup.retention.toSequenceNumber(state.seqNr), state.seqNr)
           else
             internalDeleteSnapshots(setup.retention.toSequenceNumber(meta.sequenceNr))
 


### PR DESCRIPTION
In CI the test is failing on `EventSourcedBehaviorSpec`.
If you have
* the test unchanged
* `Retention` unchanged`

And modify `Running` to this it passes, which is odd-ish
* `internalDeleteEvents(setup.retention.toSequenceNumber(state.seqNr), state.seqNr)`

Or modify `Running` to this it fails still, which is what we were feeding into the function
* `internalDeleteEvents(setup.retention.toSequenceNumber(e.metadata.sequenceNr), state.seqNr)`

@patriknw You have to run each a few times to see its flaky and there's a race condition I think.
The way it is now in master and these two  pass a few times and then fail. So this isn't a fix but may help to find it. Feel free to use.