### PR TITLE
Typed docs: include the import in the code snippet where it is used

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala
@@ -89,6 +89,7 @@ class UntypedWatchingTypedSpec extends WordSpec {
 
     "support converting an untyped actor system to a typed actor system" in {
       //#convert-untyped
+
       val system = akka.actor.ActorSystem("UntypedToTypedSystem")
       val typedSystem: ActorSystem[Nothing] = system.toTyped
       //#convert-untyped

--- a/akka-docs/src/main/paradox/typed/coexisting.md
+++ b/akka-docs/src/main/paradox/typed/coexisting.md
@@ -43,10 +43,10 @@ While coexisting your application will likely still have an untyped ActorSystem.
 so that new code and migrated parts don't rely on the untyped system:
 
 Scala
-:  @@snip [UntypedWatchingTypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala) { #convert-untyped }
+:  @@snip [UntypedWatchingTypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala) { #adapter-import #convert-untyped }
 
 Java
-:  @@snip [UntypedWatchingTypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/UntypedWatchingTypedTest.java) { #convert-untyped }
+:  @@snip [UntypedWatchingTypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/UntypedWatchingTypedTest.java) { #adapter-import #convert-untyped }
 
 Then for new typed actors here's how you create, watch and send messages to
 it from an untyped actor.


### PR DESCRIPTION
It shows quite a bit further down since before.

https://doc.akka.io/docs/akka/current/typed/coexisting.html
