### PR TITLE
Add title and version to Scaladoc pages

### DIFF
--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -45,7 +45,10 @@ object Scaladoc extends AutoPlugin {
 
   def scaladocOptions(ver: String, base: File): List[String] = {
     val urlString = GitHub.url(ver) + "/€{FILE_PATH}.scala"
-    val opts = List("-implicits", "-groups", "-doc-source-url", urlString, "-sourcepath", base.getAbsolutePath)
+    val opts = List("-implicits", "-groups", "-doc-source-url", urlString, "-sourcepath", base.getAbsolutePath,
+      "-doc-title", "Akka",
+      "-doc-version", ver
+    )
     CliOptions.scaladocDiagramsEnabled.ifTrue("-diagrams").toList ::: opts
   }
 


### PR DESCRIPTION
This makes Scaladoc create page titles again.

Example diff
```
+++ unidoc/akka/Version$.html
@@ -3,9 +3,9 @@
         <head>
           <meta http-equiv="X-UA-Compatible" content="IE=edge" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-          <title></title>
-          <meta name="description" content="" />
-          <meta name="keywords" content="" />
+          <title>Akka 2.5-SNAPSHOT - akka.Version</title>
+          <meta name="description" content="Akka 2.5 - SNAPSHOT - akka.Version" />
+          <meta name="keywords" content="Akka 2.5 SNAPSHOT akka.Version" />
           <meta http-equiv="content-type" content="text/html; charset=UTF-8" />

       <link href="../lib/index.css" media="screen" type="text/css" rel="stylesheet" />
@@ -28,7 +28,7 @@
         </head>
         <body>
       <div id="search">
-        <span id="doc-title"><span id="doc-version"></span></span>
+        <span id="doc-title">Akka<span id="doc-version">2.5-SNAPSHOT</span></span>
         <span class="close-results"><span class="left">&lt;</span> Back</span>
         <div id="textfilter">
           <span class="input">
```