### PR TITLE
Fix minor text omissions in actor docs

### DIFF
--- a/akka-docs/src/main/paradox/actors.md
+++ b/akka-docs/src/main/paradox/actors.md
@@ -662,7 +662,7 @@ Messages are sent to an Actor through one of the following methods.
 
  * @scala[`!`] @java[`tell` ] means “fire-and-forget”, e.g. send a message asynchronously and return
 immediately. @scala[Also known as `tell`.]
- * @scala[`?`] @java[`ask`] sends a message asynchronously and returns a @scala:[`Future`]@java:[`CompletionStage`]
+ * @scala[`?`] @java[`ask`] sends a message asynchronously and returns a @scala[`Future`]@java[`CompletionStage`]
 representing a possible reply. @scala[Also known as `ask`.]
 
 Message ordering is guaranteed on a per-sender basis.
@@ -737,24 +737,24 @@ Java
 This example demonstrates `ask` together with the `pipeTo` pattern on
 futures, because this is likely to be a common combination. Please note that
 all of the above is completely non-blocking and asynchronous: `ask` produces
-a @scala:[`Future`]@java:[`CompletionStage`], @scala[three] @java[two] of which are composed into a new future using the
+a @scala[`Future`]@java[`CompletionStage`], @scala[three] @java[two] of which are composed into a new future using the
 @scala[for-comprehension and then `pipeTo` installs an `onComplete`-handler on the `Future` to affect]
 @java[`CompletableFuture.allOf` and `thenApply` methods and then `pipe` installs a handler on the `CompletionStage` to effect]
 the submission of the aggregated `Result` to another actor.
 
 Using `ask` will send a message to the receiving Actor as with `tell`, and
 the receiving actor must reply with @scala[`sender() ! reply`] @java[`getSender().tell(reply, getSelf())` ] in order to
-complete the returned @scala:[`Future`]@java:[`CompletionStage`] with a value. The `ask` operation involves creating
+complete the returned @scala[`Future`]@java[`CompletionStage`] with a value. The `ask` operation involves creating
 an internal actor for handling this reply, which needs to have a timeout after
 which it is destroyed in order not to leak resources; see more below.
 
 @@@ warning
 
-To complete the @scala:[`Future`]@java:[`CompletionStage`] with an exception you need to send an `akka.actor.Status.Failure` message to the sender.
+To complete the @scala[`Future`]@java[`CompletionStage`] with an exception you need to send an `akka.actor.Status.Failure` message to the sender.
 This is *not done automatically* when an actor throws an exception while processing a message. 
 
-@scala:[Please note that Scala's `Try` sub types `scala.util.Failure` and `scala.util.Success` are not treated
-specially, and would complete the ask @scala:[`Future`]@java:[`CompletionStage`] with the given value - only the `akka.actor.Status` messages
+@scala[Please note that Scala's `Try` sub types `scala.util.Failure` and `scala.util.Success` are not treated
+specially, and would complete the ask @scala[`Future`]@java[`CompletionStage`] with the given value - only the `akka.actor.Status` messages
 are treated specially by the ask pattern.]
 
 @@@
@@ -765,7 +765,7 @@ Scala
 Java
 :  @@snip [ActorDocTest.java](/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java) { #reply-exception }
 
-If the actor does not complete the @scala:[`Future`]@java:[`CompletionStage`], it will expire after the timeout period,
+If the actor does not complete the @scala[`Future`]@java[`CompletionStage`], it will expire after the timeout period,
 @scala[completing it with an `AskTimeoutException`. The timeout is taken from one of the following locations in order of precedence:]
 @java[specified as parameter to the `ask` method; this will complete the `CompletionStage` with an `AskTimeoutException`.]
 
@@ -783,8 +783,8 @@ See @ref:[Futures](futures.md) for more information on how to await or query a f
 
 @@@
 
-The @scala:[`onComplete` method of the `Future`]@java:[`thenRun` method of the `CompletionStage`] can be
-used to register a callback to get a notification when the @scala:[`Future`]@java:[`CompletionStage`] completes, giving
+The @scala[`onComplete` method of the `Future`]@java[`thenRun` method of the `CompletionStage`] can be
+used to register a callback to get a notification when the @scala[`Future`]@java[`CompletionStage`] completes, giving
 you a way to avoid blocking.
 
 @@@ warning


### PR DESCRIPTION
I noticed the Actor page in the docs was lacking so words such as Future in some places. Removing some colons in the .md seems to fix it.