### PR TITLE
Allow build to run on JDK 8

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -19,6 +19,8 @@ object AkkaBuild {
 
   val parallelExecutionByDefault = false // TODO: enable this once we're sure it does not break things
 
+  val jdkVersion = sys.props("java.specification.version")
+
   lazy val buildSettings = Dependencies.Versions ++ Seq(
     organization := "com.typesafe.akka",
     // use the same value as in the build scope, so it can be overriden by stampVersion
@@ -231,7 +233,11 @@ object AkkaBuild {
   lazy val docLintingSettings = Seq(
     javacOptions in compile ++= Seq("-Xdoclint:none"),
     javacOptions in test ++= Seq("-Xdoclint:none"),
-    javacOptions in doc ++= Seq("-Xdoclint:none", "--ignore-source-errors"))
+    javacOptions in doc ++= {
+      if (jdkVersion == "1.8") Seq("-Xdoclint:none")
+      else Seq("-Xdoclint:none", "--ignore-source-errors")
+    }
+  )
 
 
   lazy val noScala211 = Seq(

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -122,11 +122,15 @@ object UnidocRoot extends AutoPlugin {
   val akkaSettings = UnidocRoot.CliOptions.genjavadocEnabled
     .ifTrue(
       Seq(
-        javacOptions in (JavaUnidoc, unidoc) := Seq(
+        javacOptions in (JavaUnidoc, unidoc) := {
+          if (AkkaBuild.jdkVersion == "1.8") Seq("-Xdoclint:none")
+          else Seq(
             "-Xdoclint:none",
             "--frames",
             "--ignore-source-errors",
-            "--no-module-directories")))
+            "--no-module-directories")
+        }
+      ))
     .getOrElse(Nil)
 
   override lazy val projectSettings = {


### PR DESCRIPTION

## Purpose

Currently Akka fails to build on sbt community build, which runs on JDK 8. Likely it will fail on Scala community build as well due to `--ignore-source-errors`.

It will be useful for Scala toolchain to be able to validate its latest using latest Akka if possible.

## References

Ref #26233
Ref https://github.com/sbt/sbt-validator/issues/36

## Changes

This makes the flag conditional based on the running JDK.
