### PR TITLE
include state in EventSourcedBehavior.receiveSignal, #26574

### DIFF
--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
@@ -127,13 +127,13 @@ object ClusterShardingPersistenceSpec {
               Effect.unstashAll()
           },
         eventHandler = (state, evt) ⇒ if (state.isEmpty) evt else state + "|" + evt).receiveSignal {
-        case RecoveryCompleted(state) ⇒
+        case (state, RecoveryCompleted) ⇒
           ctx.log.debug("onRecoveryCompleted: [{}]", state)
           lifecycleProbes.get(entityId) match {
             case null ⇒ ctx.log.debug("no lifecycleProbe (onRecoveryCompleted) for [{}]", entityId)
             case p ⇒ p ! s"recoveryCompleted:$state"
           }
-        case PostStop ⇒
+        case (_, PostStop) ⇒
           lifecycleProbes.get(entityId) match {
             case null ⇒ ctx.log.debug("no lifecycleProbe (postStop) for [{}]", entityId)
             case p ⇒ p ! "stopped"

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/EventSourcedSignal.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/EventSourcedSignal.scala
@@ -16,12 +16,9 @@ import akka.annotation.InternalApi
 @DoNotInherit
 sealed trait EventSourcedSignal extends Signal
 
-final case class RecoveryCompleted[State](state: State) extends EventSourcedSignal {
-
-  /**
-   * Java API
-   */
-  def getState(): State = state
+@DoNotInherit sealed abstract class RecoveryCompleted extends EventSourcedSignal
+case object RecoveryCompleted extends RecoveryCompleted {
+  def instance: RecoveryCompleted = this
 }
 
 final case class RecoveryFailed(failure: Throwable) extends EventSourcedSignal {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -71,7 +71,7 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
     recovery: Recovery = Recovery(),
     retention: RetentionCriteria = RetentionCriteria(),
     supervisionStrategy: SupervisorStrategy = SupervisorStrategy.stop,
-    override val signalHandler: PartialFunction[Signal, Unit] = PartialFunction.empty)
+    override val signalHandler: PartialFunction[(State, Signal), Unit] = PartialFunction.empty)
     extends EventSourcedBehavior[Command, Event, State] {
 
   import EventSourcedBehaviorImpl.WriterIdentity
@@ -87,23 +87,23 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
     // stashState outside supervise because StashState should survive restarts due to persist failures
     val stashState = new StashState(settings)
 
-    val actualSignalHandler: PartialFunction[Signal, Unit] = signalHandler.orElse {
+    val actualSignalHandler: PartialFunction[(State, Signal), Unit] = signalHandler.orElse {
       // default signal handler is always the fallback
-      case SnapshotCompleted(meta) ⇒
+      case (_, SnapshotCompleted(meta)) ⇒
         ctx.log.debug("Save snapshot successful, snapshot metadata [{}].", meta)
-      case SnapshotFailed(meta, failure) ⇒
+      case (_, SnapshotFailed(meta, failure)) ⇒
         ctx.log.error(failure, "Save snapshot failed, snapshot metadata [{}].", meta)
-      case DeleteSnapshotsCompleted(DeletionTarget.Individual(meta)) =>
+      case (_, DeleteSnapshotsCompleted(DeletionTarget.Individual(meta))) =>
         ctx.log.debug("Persistent snapshot [{}] deleted successfully.", meta)
-      case DeleteSnapshotsCompleted(DeletionTarget.Criteria(criteria)) =>
+      case (_, DeleteSnapshotsCompleted(DeletionTarget.Criteria(criteria))) =>
         ctx.log.debug("Persistent snapshots given criteria [{}] deleted successfully.", criteria)
-      case DeleteSnapshotsFailed(DeletionTarget.Individual(meta), failure) =>
+      case (_, DeleteSnapshotsFailed(DeletionTarget.Individual(meta), failure)) =>
         ctx.log.warning("Failed to delete snapshot with meta [{}] due to [{}].", meta, failure)
-      case DeleteSnapshotsFailed(DeletionTarget.Criteria(criteria), failure) =>
+      case (_, DeleteSnapshotsFailed(DeletionTarget.Criteria(criteria), failure)) =>
         ctx.log.warning("Failed to delete snapshots given criteria [{}] due to [{}].", criteria, failure)
-      case DeleteEventsCompleted(toSequenceNr) =>
+      case (_, DeleteEventsCompleted(toSequenceNr)) =>
         ctx.log.debug("Events successfully deleted to sequence number [{}].", toSequenceNr)
-      case DeleteEventsFailed(toSequenceNr, failure) =>
+      case (_, DeleteEventsFailed(toSequenceNr, failure)) =>
         ctx.log.warning("Failed to delete events to sequence number [{}] due to [{}].", toSequenceNr, failure)
     }
 
@@ -142,14 +142,7 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
                 // clear stash to be GC friendly
                 stashState.clearStashBuffers()
               }
-              val nextBehavior = target(ctx, signal)
-              try {
-                eventSourcedSetup.onSignal(signal)
-              } catch {
-                case NonFatal(ex) =>
-                  ctx.asScala.log.error(ex, s"Error while processing signal [{}]", signal)
-              }
-              nextBehavior
+              target(ctx, signal)
             }
             override def toString: String = "onStopInterceptor"
           }
@@ -167,7 +160,8 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
       .onFailure[JournalFailureException](supervisionStrategy)
   }
 
-  override def receiveSignal(handler: PartialFunction[Signal, Unit]): EventSourcedBehavior[Command, Event, State] =
+  override def receiveSignal(
+      handler: PartialFunction[(State, Signal), Unit]): EventSourcedBehavior[Command, Event, State] =
     copy(signalHandler = handler)
 
   override def snapshotWhen(predicate: (State, Event, Long) => Boolean): EventSourcedBehavior[Command, Event, State] =

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -68,7 +68,7 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
           case (_, PoisonPill) =>
             stay(receivedPoisonPill = true)
           case (_, signal) =>
-            setup.onSignal(setup.emptyState, signal)
+            setup.onSignal(setup.emptyState, signal, catchAndLog = true)
             Behaviors.same
         })
     }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -67,6 +67,9 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
         .receiveSignal(returnPermitOnStop.orElse {
           case (_, PoisonPill) =>
             stay(receivedPoisonPill = true)
+          case (_, signal) =>
+            setup.onSignal(setup.emptyState, signal)
+            Behaviors.same
         })
     }
     stay(receivedPoisonPillInPreviousPhase)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/RequestingRecoveryPermit.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/RequestingRecoveryPermit.scala
@@ -58,7 +58,7 @@ private[akka] class RequestingRecoveryPermit[C, E, S](override val setup: Behavi
           case (_, PoisonPill) =>
             stay(receivedPoisonPill = true)
           case (_, signal) =>
-            setup.onSignal(setup.emptyState, signal)
+            setup.onSignal(setup.emptyState, signal, catchAndLog = true)
             Behaviors.same
         }
     }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/RequestingRecoveryPermit.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/RequestingRecoveryPermit.scala
@@ -12,7 +12,7 @@ import akka.annotation.InternalApi
 /**
  * INTERNAL API
  *
- * First (of four) behaviour of an PersistentBehaviour.
+ * First (of four) behavior of an PersistentBehaviour.
  *
  * Requests a permit to start replaying this actor; this is tone to avoid
  * hammering the journal with too many concurrently replaying actors.
@@ -55,7 +55,11 @@ private[akka] class RequestingRecoveryPermit[C, E, S](override val setup: Behavi
 
         }
         .receiveSignal {
-          case (_, PoisonPill) => stay(receivedPoisonPill = true)
+          case (_, PoisonPill) =>
+            stay(receivedPoisonPill = true)
+          case (_, signal) =>
+            setup.onSignal(setup.emptyState, signal)
+            Behaviors.same
         }
     }
     stay(receivedPoisonPill = false)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -115,7 +115,7 @@ private[akka] object Running {
         if (isInternalStashEmpty && !isUnstashAllInProgress) Behaviors.stopped
         else new HandlingCommands(state.copy(receivedPoisonPill = true))
       case signal =>
-        setup.onSignal(state.state, signal)
+        setup.onSignal(state.state, signal, catchAndLog = false)
         this
     }
 
@@ -307,7 +307,7 @@ private[akka] object Running {
         state = state.copy(receivedPoisonPill = true)
         this
       case signal =>
-        setup.onSignal(visibleState.state, signal)
+        setup.onSignal(visibleState.state, signal, catchAndLog = false)
         this
     }
 
@@ -351,7 +351,7 @@ private[akka] object Running {
       }
 
       setup.log.debug("Received snapshot response [{}], emitting signal [{}].", response, signal)
-      signal.foreach(setup.onSignal(state.state, _))
+      signal.foreach(setup.onSignal(state.state, _, catchAndLog = false))
     }
 
     Behaviors
@@ -376,7 +376,7 @@ private[akka] object Running {
           // wait for snapshot response before stopping
           storingSnapshot(state.copy(receivedPoisonPill = true), sideEffects)
         case (_, signal) =>
-          setup.onSignal(state.state, signal)
+          setup.onSignal(state.state, signal, catchAndLog = false)
           Behaviors.same
       }
 
@@ -443,7 +443,7 @@ private[akka] object Running {
 
     signal match {
       case Some(sig) =>
-        setup.onSignal(state, sig)
+        setup.onSignal(state, sig, catchAndLog = false)
         Behaviors.same
       case None =>
         Behaviors.unhandled // unexpected journal response
@@ -470,7 +470,7 @@ private[akka] object Running {
 
     signal match {
       case Some(sig) =>
-        setup.onSignal(state, sig)
+        setup.onSignal(state, sig, catchAndLog = false)
         Behaviors.same
       case None =>
         Behaviors.unhandled // unexpected snapshot response

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -48,15 +48,15 @@ import akka.persistence.typed.scaladsl.Effect
  * In this phase recovery has completed successfully and we continue handling incoming commands,
  * as well as persisting new events as dictated by the user handlers.
  *
- * This behavior operates in two phases (also behaviors):
+ * This behavior operates in three phases (also behaviors):
  * - HandlingCommands - where the command handler is invoked for incoming commands
  * - PersistingEvents - where incoming commands are stashed until persistence completes
+ * - storingSnapshot - where incoming commands are stashed until snapshot storage completes
  *
  * This is implemented as such to avoid creating many EventSourced Running instances,
  * which perform the Persistence extension lookup on creation and similar things (config lookup)
  *
  * See previous [[ReplayingEvents]].
- * TODO rename
  */
 @InternalApi
 private[akka] object Running {
@@ -105,8 +105,8 @@ private[akka] object Running {
 
     def onMessage(msg: InternalProtocol): Behavior[InternalProtocol] = msg match {
       case IncomingCommand(c: C @unchecked) => onCommand(state, c)
-      case JournalResponse(r)               => onDeleteEventsJournalResponse(r)
-      case SnapshotterResponse(r)           => onDeleteSnapshotResponse(r)
+      case JournalResponse(r)               => onDeleteEventsJournalResponse(r, state.state)
+      case SnapshotterResponse(r)           => onDeleteSnapshotResponse(r, state.state)
       case _                                => Behaviors.unhandled
     }
 
@@ -114,6 +114,9 @@ private[akka] object Running {
       case PoisonPill =>
         if (isInternalStashEmpty && !isUnstashAllInProgress) Behaviors.stopped
         else new HandlingCommands(state.copy(receivedPoisonPill = true))
+      case signal =>
+        setup.onSignal(state.state, signal)
+        this
     }
 
     def onCommand(state: RunningState[S], cmd: C): Behavior[InternalProtocol] = {
@@ -150,7 +153,7 @@ private[akka] object Running {
 
           val shouldSnapshotAfterPersist = setup.snapshotWhen(newState2.state, event, newState2.seqNr)
 
-          persistingEvents(newState2, numberOfEvents = 1, shouldSnapshotAfterPersist, sideEffects)
+          persistingEvents(newState2, state, numberOfEvents = 1, shouldSnapshotAfterPersist, sideEffects)
 
         case PersistAll(events) =>
           if (events.nonEmpty) {
@@ -169,7 +172,7 @@ private[akka] object Running {
 
             val newState2 = internalPersistAll(eventsToPersist, newState)
 
-            persistingEvents(newState2, events.size, shouldSnapshotAfterPersist, sideEffects)
+            persistingEvents(newState2, state, events.size, shouldSnapshotAfterPersist, sideEffects)
 
           } else {
             // run side-effects even when no events are emitted
@@ -209,16 +212,18 @@ private[akka] object Running {
 
   def persistingEvents(
       state: RunningState[S],
+      visibleState: RunningState[S], // previous state until write success
       numberOfEvents: Int,
       shouldSnapshotAfterPersist: Boolean,
       sideEffects: immutable.Seq[SideEffect[S]]): Behavior[InternalProtocol] = {
     setup.setMdc(persistingEventsMdc)
-    new PersistingEvents(state, numberOfEvents, shouldSnapshotAfterPersist, sideEffects)
+    new PersistingEvents(state, visibleState, numberOfEvents, shouldSnapshotAfterPersist, sideEffects)
   }
 
   /** INTERNAL API */
   @InternalApi private[akka] class PersistingEvents(
       var state: RunningState[S],
+      var visibleState: RunningState[S], // previous state until write success
       numberOfEvents: Int,
       shouldSnapshotAfterPersist: Boolean,
       var sideEffects: immutable.Seq[SideEffect[S]])
@@ -231,7 +236,7 @@ private[akka] object Running {
       msg match {
         case JournalResponse(r)                => onJournalResponse(r)
         case in: IncomingCommand[C @unchecked] => onCommand(in)
-        case SnapshotterResponse(r)            => onDeleteSnapshotResponse(r)
+        case SnapshotterResponse(r)            => onDeleteSnapshotResponse(r, visibleState.state)
         case RecoveryTickEvent(_)              => Behaviors.unhandled
         case RecoveryPermitGranted             => Behaviors.unhandled
       }
@@ -258,6 +263,7 @@ private[akka] object Running {
         // only once all things are applied we can revert back
         if (eventCounter < numberOfEvents) this
         else {
+          visibleState = state
           if (shouldSnapshotAfterPersist && state.state != null) {
             internalSaveSnapshot(state)
             storingSnapshot(state, sideEffects)
@@ -291,7 +297,7 @@ private[akka] object Running {
           this // it will be stopped by the first WriteMessageFailure message; not applying side effects
 
         case _ =>
-          onDeleteEventsJournalResponse(response)
+          onDeleteEventsJournalResponse(response, visibleState.state)
       }
     }
 
@@ -300,9 +306,12 @@ private[akka] object Running {
         // wait for journal responses before stopping
         state = state.copy(receivedPoisonPill = true)
         this
+      case signal =>
+        setup.onSignal(visibleState.state, signal)
+        this
     }
 
-    override def currentSequenceNumber: Long = state.seqNr
+    override def currentSequenceNumber: Long = visibleState.seqNr
   }
 
   // ===============================================
@@ -342,7 +351,7 @@ private[akka] object Running {
       }
 
       setup.log.debug("Received snapshot response [{}], emitting signal [{}].", response, signal)
-      signal.foreach(setup.onSignal)
+      signal.foreach(setup.onSignal(state.state, _))
     }
 
     Behaviors
@@ -350,14 +359,14 @@ private[akka] object Running {
         case cmd: IncomingCommand[C] @unchecked =>
           onCommand(cmd)
         case JournalResponse(r) =>
-          onDeleteEventsJournalResponse(r)
+          onDeleteEventsJournalResponse(r, state.state)
         case SnapshotterResponse(response) =>
           response match {
             case _: SaveSnapshotSuccess | _: SaveSnapshotFailure =>
               onSaveSnapshotResponse(response)
               tryUnstashOne(applySideEffects(sideEffects, state))
             case _ =>
-              onDeleteSnapshotResponse(response)
+              onDeleteSnapshotResponse(response, state.state)
           }
         case _ =>
           Behaviors.unhandled
@@ -366,6 +375,9 @@ private[akka] object Running {
         case (_, PoisonPill) =>
           // wait for snapshot response before stopping
           storingSnapshot(state.copy(receivedPoisonPill = true), sideEffects)
+        case (_, signal) =>
+          setup.onSignal(state.state, signal)
+          Behaviors.same
       }
 
   }
@@ -414,7 +426,7 @@ private[akka] object Running {
    * Handle journal responses for non-persist events workloads.
    * These are performed in the background and may happen in all phases.
    */
-  def onDeleteEventsJournalResponse(response: JournalProtocol.Response): Behavior[InternalProtocol] = {
+  def onDeleteEventsJournalResponse(response: JournalProtocol.Response, state: S): Behavior[InternalProtocol] = {
     val signal = response match {
       case DeleteMessagesSuccess(toSequenceNr) =>
         setup.log.debug("Persistent events to sequenceNr [{}] deleted successfully.", toSequenceNr)
@@ -431,7 +443,7 @@ private[akka] object Running {
 
     signal match {
       case Some(sig) =>
-        setup.onSignal(sig)
+        setup.onSignal(state, sig)
         Behaviors.same
       case None =>
         Behaviors.unhandled // unexpected journal response
@@ -442,7 +454,7 @@ private[akka] object Running {
    * Handle snapshot responses for non-persist events workloads.
    * These are performed in the background and may happen in all phases.
    */
-  def onDeleteSnapshotResponse(response: SnapshotProtocol.Response): Behavior[InternalProtocol] = {
+  def onDeleteSnapshotResponse(response: SnapshotProtocol.Response, state: S): Behavior[InternalProtocol] = {
     val signal = response match {
       case DeleteSnapshotsSuccess(criteria) =>
         Some(DeleteSnapshotsCompleted(DeletionTarget.Criteria(SnapshotSelectionCriteria.fromUntyped(criteria))))
@@ -458,7 +470,7 @@ private[akka] object Running {
 
     signal match {
       case Some(sig) =>
-        setup.onSignal(sig)
+        setup.onSignal(state, sig)
         Behaviors.same
       case None =>
         Behaviors.unhandled // unexpected snapshot response

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
@@ -79,12 +79,13 @@ abstract class EventSourcedBehavior[Command, Event, State >: Null] private[akka]
    *
    * Use [[EventSourcedBehavior#newSignalHandlerBuilder]] to define the signal handler.
    */
-  protected def signalHandler(): SignalHandler = SignalHandler.Empty
+  protected def signalHandler(): SignalHandler[State] = SignalHandler.empty[State]
 
   /**
    * @return A new, mutable signal handler builder
    */
-  protected final def newSignalHandlerBuilder(): SignalHandlerBuilder = new SignalHandlerBuilder
+  protected final def newSignalHandlerBuilder(): SignalHandlerBuilder[State] =
+    SignalHandlerBuilder.builder[State]
 
   /**
    * @return A new, mutable, command handler builder

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/SignalHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/SignalHandler.scala
@@ -4,16 +4,19 @@
 
 package akka.persistence.typed.javadsl
 
+import java.util.function.BiConsumer
+import java.util.function.Consumer
+
 import akka.actor.typed.Signal
 import akka.annotation.InternalApi
-import akka.japi.function.Procedure
-import akka.japi.function.{ Effect ⇒ JEffect }
 
 object SignalHandler {
-  val Empty: SignalHandler = new SignalHandler(PartialFunction.empty)
+  private val Empty: SignalHandler[Any] = new SignalHandler[Any](PartialFunction.empty)
+
+  def empty[State]: SignalHandler[State] = Empty.asInstanceOf[SignalHandler[State]]
 }
 
-final class SignalHandler(_handler: PartialFunction[Signal, Unit]) {
+final class SignalHandler[State](_handler: PartialFunction[(State, Signal), Unit]) {
 
   /**
    * INTERNAL API
@@ -25,7 +28,11 @@ final class SignalHandler(_handler: PartialFunction[Signal, Unit]) {
    * INTERNAL API
    */
   @InternalApi
-  private[akka] def handler: PartialFunction[Signal, Unit] = _handler
+  private[akka] def handler: PartialFunction[(State, Signal), Unit] = _handler
+}
+
+object SignalHandlerBuilder {
+  def builder[State]: SignalHandlerBuilder[State] = new SignalHandlerBuilder
 }
 
 /**
@@ -33,17 +40,17 @@ final class SignalHandler(_handler: PartialFunction[Signal, Unit]) {
  *
  * Not for user instantiation, use [[EventSourcedBehavior#newSignalHandlerBuilder()]] to get an instance.
  */
-final class SignalHandlerBuilder {
+final class SignalHandlerBuilder[State] {
 
-  private var handler: PartialFunction[Signal, Unit] = PartialFunction.empty
+  private var handler: PartialFunction[(State, Signal), Unit] = PartialFunction.empty
 
   /**
    * If the behavior recieves a signal of type `T`, `callback` is invoked with the signal instance as input.
    */
-  def onSignal[T <: Signal](signalType: Class[T], callback: Procedure[T]): SignalHandlerBuilder = {
-    val newPF: PartialFunction[Signal, Unit] = {
-      case t if signalType.isInstance(t) ⇒
-        callback(t.asInstanceOf[T])
+  def onSignal[T <: Signal](signalType: Class[T], callback: BiConsumer[State, T]): SignalHandlerBuilder[State] = {
+    val newPF: PartialFunction[(State, Signal), Unit] = {
+      case (state, t) if signalType.isInstance(t) ⇒
+        callback.accept(state, t.asInstanceOf[T])
     }
     handler = newPF.orElse(handler)
     this
@@ -52,15 +59,15 @@ final class SignalHandlerBuilder {
   /**
    * If the behavior receives exactly the signal `signal`, `callback` is invoked.
    */
-  def onSignal[T <: Signal](signal: T, callback: JEffect): SignalHandlerBuilder = {
-    val newPF: PartialFunction[Signal, Unit] = {
-      case `signal` ⇒
-        callback()
+  def onSignal[T <: Signal](signal: T, callback: Consumer[State]): SignalHandlerBuilder[State] = {
+    val newPF: PartialFunction[(State, Signal), Unit] = {
+      case (state, `signal`) ⇒
+        callback.accept(state)
     }
     handler = newPF.orElse(handler)
     this
   }
 
-  def build: SignalHandler = new SignalHandler(handler)
+  def build: SignalHandler[State] = new SignalHandler(handler)
 
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/EventSourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/EventSourcedBehavior.scala
@@ -129,12 +129,12 @@ object EventSourcedBehavior {
    * Akka Persistence specific signals (snapshot and recovery related). Those are all subtypes of
    * [[akka.persistence.typed.EventSourcedSignal]]
    */
-  def receiveSignal(signalHandler: PartialFunction[Signal, Unit]): EventSourcedBehavior[Command, Event, State]
+  def receiveSignal(signalHandler: PartialFunction[(State, Signal), Unit]): EventSourcedBehavior[Command, Event, State]
 
   /**
    * @return The currently defined signal handler or an empty handler if no custom handler previously defined
    */
-  def signalHandler: PartialFunction[Signal, Unit]
+  def signalHandler: PartialFunction[(State, Signal), Unit]
 
   /**
    * Initiates a snapshot if the given function returns true.

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/EventSourcedActorFailureTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/EventSourcedActorFailureTest.java
@@ -48,13 +48,13 @@ class FailingEventSourcedActor extends EventSourcedBehavior<String, String, Stri
   public SignalHandler signalHandler() {
     return newSignalHandlerBuilder()
         .onSignal(
-            RecoveryCompleted.class,
-            (recoveryCompleted) -> {
+            RecoveryCompleted.instance(),
+            state -> {
               probe.tell("starting");
             })
         .onSignal(
             RecoveryFailed.class,
-            (signal) -> {
+            (state, signal) -> {
               recoveryFailureProbe.tell(signal.getFailure());
             })
         .build();

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/LoggerSourceTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/LoggerSourceTest.java
@@ -78,7 +78,7 @@ public class LoggerSourceTest extends JUnitSuite {
     public SignalHandler signalHandler() {
       return newSignalHandlerBuilder()
           .onSignal(
-              RecoveryCompleted.class,
+              RecoveryCompleted.instance(),
               (signal) -> {
                 ctx.getLog().info("recovery-completed");
               })

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/NullEmptyStateTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/NullEmptyStateTest.java
@@ -43,9 +43,9 @@ public class NullEmptyStateTest extends JUnitSuite {
     public SignalHandler signalHandler() {
       return newSignalHandlerBuilder()
           .onSignal(
-              RecoveryCompleted.class,
-              (completed) -> {
-                probe.tell("onRecoveryCompleted:" + completed.getState());
+              RecoveryCompleted.instance(),
+              state -> {
+                probe.tell("onRecoveryCompleted:" + state);
               })
           .build();
     }

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -417,12 +417,12 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
                     return newSignalHandlerBuilder()
                         .onSignal(
                             SnapshotCompleted.class,
-                            (completed) -> {
+                            (state, completed) -> {
                               snapshotProbe.ref().tell(Optional.empty());
                             })
                         .onSignal(
                             SnapshotFailed.class,
-                            (signal) -> {
+                            (state, signal) -> {
                               snapshotProbe.ref().tell(Optional.of(signal.getFailure()));
                             })
                         .build();
@@ -478,7 +478,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
                     return newSignalHandlerBuilder()
                         .onSignal(
                             PostStop.instance(),
-                            () -> {
+                            state -> {
                               probe.ref().tell("stopped");
                             })
                         .build();
@@ -639,7 +639,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
       return newSignalHandlerBuilder()
           .onSignal(
               RecoveryCompleted.class,
-              (completed) -> {
+              (state, completed) -> {
                 startedProbe.tell("started!");
               })
           .build();
@@ -720,7 +720,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
       return newSignalHandlerBuilder()
           .onSignal(
               RecoveryCompleted.class,
-              (completed) -> {
+              (state, completed) -> {
                 probe.tell(lastSequenceNumber(context) + " onRecoveryCompleted");
               })
           .build();

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PrimitiveStateTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PrimitiveStateTest.java
@@ -43,9 +43,9 @@ public class PrimitiveStateTest extends JUnitSuite {
     public SignalHandler signalHandler() {
       return newSignalHandlerBuilder()
           .onSignal(
-              RecoveryCompleted.class,
-              (completed) -> {
-                probe.tell("onRecoveryCompleted:" + completed.getState());
+              RecoveryCompleted.instance(),
+              state -> {
+                probe.tell("onRecoveryCompleted:" + state);
               })
           .build();
     }

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
@@ -206,8 +206,8 @@ public class BasicPersistentBehaviorTest {
       public SignalHandler signalHandler() {
         return newSignalHandlerBuilder()
             .onSignal(
-                RecoveryCompleted.class,
-                (completed) -> {
+                RecoveryCompleted.instance(),
+                state -> {
                   throw new RuntimeException("TODO: add some end-of-recovery side-effect here");
                 })
             .build();
@@ -296,18 +296,18 @@ public class BasicPersistentBehaviorTest {
         return newSignalHandlerBuilder()
             .onSignal(
                 SnapshotFailed.class,
-                (completed) -> {
+                (state, completed) -> {
                   throw new RuntimeException("TODO: add some on-snapshot-failed side-effect here");
                 })
             .onSignal(
                 DeleteSnapshotsFailed.class,
-                (completed) -> {
+                (state, completed) -> {
                   throw new RuntimeException(
                       "TODO: add some on-delete-snapshot-failed side-effect here");
                 })
             .onSignal(
                 DeleteEventsFailed.class,
-                (completed) -> {
+                (state, completed) -> {
                   throw new RuntimeException(
                       "TODO: add some on-delete-snapshot-failed side-effect here");
                 })

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
@@ -56,7 +56,7 @@ object RecoveryPermitterSpec {
       eventHandler = { (state, event) =>
         eventProbe.ref ! event; state
       }).receiveSignal {
-      case RecoveryCompleted(state) =>
+      case (_, RecoveryCompleted) =>
         eventProbe.ref ! Recovered
         if (throwOnRecovery) throw new TE
     }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRecoveryTimeoutSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRecoveryTimeoutSpec.scala
@@ -45,7 +45,7 @@ object EventSourcedBehaviorRecoveryTimeoutSpec {
         emptyState = "",
         commandHandler = (_, command) => Effect.persist(command).thenRun(_ => probe ! command),
         eventHandler = (state, evt) => state + evt).receiveSignal {
-        case RecoveryFailed(cause) =>
+        case (_, RecoveryFailed(cause)) =>
           probe ! cause
       }
     }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -318,12 +318,12 @@ object EventSourcedBehaviorSpec {
             probe ! ((state, evt))
             State(state.value + delta, state.history :+ state.value)
         }).receiveSignal {
-      case RecoveryCompleted(_) ⇒ ()
-      case SnapshotCompleted(metadata) ⇒
+      case (_, RecoveryCompleted) ⇒ ()
+      case (_, SnapshotCompleted(metadata)) ⇒
         snapshotProbe ! Success(metadata)
-      case SnapshotFailed(_, failure) ⇒
+      case (_, SnapshotFailed(_, failure)) ⇒
         snapshotProbe ! Failure(failure)
-      case e: EventSourcedSignal =>
+      case (_, e: EventSourcedSignal) =>
         retentionProbe ! Success(e)
     }
   }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
@@ -109,9 +109,8 @@ object EventSourcedBehaviorStashSpec {
         .restartWithBackoff(1.second, maxBackoff = 2.seconds, 0.0)
         .withLoggingEnabled(enabled = false))
       .receiveSignal {
-        // FIXME #26574: the state type of RecoveryCompleted can't be infered, do we need to include state as param in the partial function?
-        case RecoveryCompleted(state: State) => signalProbe.foreach(_ ! s"RecoveryCompleted-${state.value}")
-        case PostStop                        => signalProbe.foreach(_ ! "PostStop")
+        case (state, RecoveryCompleted) => signalProbe.foreach(_ ! s"RecoveryCompleted-${state.value}")
+        case (_, PostStop)              => signalProbe.foreach(_ ! "PostStop")
       }
   }
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
@@ -39,7 +39,7 @@ class EventSourcedSequenceNumberSpec
         probe ! (EventSourcedBehavior.lastSequenceNumber(ctx) + " eventHandler")
         state + evt
       }).receiveSignal {
-        case RecoveryCompleted(_) ⇒
+        case (_, RecoveryCompleted) ⇒
           probe ! (EventSourcedBehavior.lastSequenceNumber(ctx) + " onRecoveryComplete")
       })
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/LoggerSourceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/LoggerSourceSpec.scala
@@ -41,9 +41,9 @@ class LoggerSourceSpec
       ctx.log.info("event-received")
       state
     }).receiveSignal {
-      case RecoveryCompleted(_) ⇒ ctx.log.info("recovery-completed")
-      case SnapshotCompleted(_) ⇒
-      case SnapshotFailed(_, _) ⇒
+      case (_, RecoveryCompleted) ⇒ ctx.log.info("recovery-completed")
+      case (_, SnapshotCompleted(_)) ⇒
+      case (_, SnapshotFailed(_, _)) ⇒
     }
   }
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/NullEmptyStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/NullEmptyStateSpec.scala
@@ -44,8 +44,8 @@ class NullEmptyStateSpec extends ScalaTestWithActorTestKit(NullEmptyStateSpec.co
         probe.tell("eventHandler:" + state + ":" + event)
         if (state == null) event else state + event
       }).receiveSignal {
-      case RecoveryCompleted(s) ⇒
-        probe.tell("onRecoveryCompleted:" + s)
+      case (state, RecoveryCompleted) ⇒
+        probe.tell("onRecoveryCompleted:" + state)
     }
 
   "A typed persistent actor with primitive state" must {

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
@@ -87,7 +87,7 @@ object PerformanceSpec {
           eventHandler = {
             case (state, _) => state
           }).receiveSignal {
-          case RecoveryCompleted(_) =>
+          case (_, RecoveryCompleted) =>
             if (parameters.every(1000)) print("r")
         }
       })

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
@@ -94,7 +94,7 @@ object PersistentActorCompileOnlyTest {
                 case SideEffectAcknowledged(correlationId) =>
                   state.copy(dataByCorrelationId = state.dataByCorrelationId - correlationId)
               }).receiveSignal {
-            case RecoveryCompleted(state: EventsInFlight) =>
+            case (state, RecoveryCompleted) =>
               state.dataByCorrelationId.foreach {
                 case (correlationId, data) => performSideEffect(ctx.self, correlationId, data)
               }
@@ -288,7 +288,7 @@ object PersistentActorCompileOnlyTest {
             case ItemAdded(id)   => id +: state
             case ItemRemoved(id) => state.filter(_ != id)
           }).receiveSignal {
-        case RecoveryCompleted(state: List[Id]) =>
+        case (state, RecoveryCompleted) =>
           state.foreach(id => metadataRegistry ! GetMetaData(id, adapt))
       }
     }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
@@ -41,7 +41,7 @@ class PrimitiveStateSpec extends ScalaTestWithActorTestKit(PrimitiveStateSpec.co
         probe.tell("eventHandler:" + state + ":" + event)
         state + event
       }).receiveSignal {
-      case RecoveryCompleted(n) =>
+      case (n, RecoveryCompleted) =>
         probe.tell("onRecoveryCompleted:" + n)
     }
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotMutableStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotMutableStateSpec.scala
@@ -107,9 +107,9 @@ object SnapshotMutableStateSpec {
             probe ! s"incremented-${state.value}"
             state
         }).receiveSignal {
-      case SnapshotCompleted(meta) =>
+      case (_, SnapshotCompleted(meta)) =>
         probe ! s"snapshot-success-${meta.sequenceNr}"
-      case SnapshotFailed(meta, _) =>
+      case (_, SnapshotFailed(meta, _)) =>
         probe ! s"snapshot-failure-${meta.sequenceNr}"
     }
   }

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
@@ -84,7 +84,7 @@ object BasicPersistentBehaviorCompileOnly {
       commandHandler = (state, cmd) => throw new RuntimeException("TODO: process the command & return an Effect"),
       eventHandler = (state, evt) => throw new RuntimeException("TODO: process the event return the next state"))
       .receiveSignal {
-        case RecoveryCompleted(state) ⇒
+        case (state, RecoveryCompleted) ⇒
           throw new RuntimeException("TODO: add some end-of-recovery side-effect here")
       }
   //#recovery
@@ -106,7 +106,7 @@ object BasicPersistentBehaviorCompileOnly {
     commandHandler = (state, cmd) => throw new RuntimeException("TODO: process the command & return an Effect"),
     eventHandler = (state, evt) => throw new RuntimeException("TODO: process the event return the next state"))
     .receiveSignal {
-      case RecoveryCompleted(state) ⇒
+      case (state, RecoveryCompleted) ⇒
         throw new RuntimeException("TODO: add some end-of-recovery side-effect here")
     }
 
@@ -221,9 +221,9 @@ object BasicPersistentBehaviorCompileOnly {
     }
     .withRetention(RetentionCriteria(snapshotEveryNEvents = 1000, keepNSnapshots = 5, deleteEventsOnSnapshot = true))
     .receiveSignal { // optionally respond to signals
-      case _: SnapshotFailed        => // react to failure
-      case _: DeleteSnapshotsFailed => // react to failure
-      case _: DeleteEventsFailed    => // react to failure
+      case (state, _: SnapshotFailed)        => // react to failure
+      case (state, _: DeleteSnapshotsFailed) => // react to failure
+      case (state, _: DeleteEventsFailed)    => // react to failure
     }
   //#fullDeletesSampleWithSignals
 


### PR DESCRIPTION
* because state type can't be inferred in RecoveryCompleted
* and probably useful to always have access to the state for the signals
* PartialFunction with (state,signal) tuple

Refs #26574