### PR TITLE
remove State >: Null constraint in javadsl

### DIFF
--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ClusterSharding.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ClusterSharding.scala
@@ -237,7 +237,7 @@ object Entity {
    * @param createPersistentEntity Create the `PersistentEntity` for an entity given a [[EntityContext]] (includes entityId)
    * @tparam Command The type of message the entity accepts
    */
-  def ofPersistentEntity[Command, Event, State >: Null](
+  def ofPersistentEntity[Command, Event, State](
       typeKey: EntityTypeKey[Command],
       createPersistentEntity: JFunction[EntityContext[Command], EventSourcedEntity[Command, Event, State]])
       : Entity[Command, ShardingEnvelope[Command]] = {

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/EventSourcedEntity.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/EventSourcedEntity.scala
@@ -19,7 +19,7 @@ import akka.persistence.typed.javadsl.EventSourcedBehavior
  * automatically from the [[EntityTypeKey]] and `entityId` constructor parameters by using
  * [[EntityTypeKey.persistenceIdFrom]].
  */
-abstract class EventSourcedEntity[Command, Event, State >: Null] private (
+abstract class EventSourcedEntity[Command, Event, State] private (
     val entityTypeKey: EntityTypeKey[Command],
     val entityId: String,
     persistenceId: PersistenceId,

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventHandler.scala
@@ -23,12 +23,12 @@ trait EventHandler[State, Event] {
 }
 
 object EventHandlerBuilder {
-  def builder[State >: Null, Event](): EventHandlerBuilder[State, Event] =
+  def builder[State, Event](): EventHandlerBuilder[State, Event] =
     new EventHandlerBuilder[State, Event]()
 
 }
 
-final class EventHandlerBuilder[State >: Null, Event]() {
+final class EventHandlerBuilder[State, Event]() {
 
   private var builders: List[EventHandlerBuilderByState[State, State, Event]] = Nil
 
@@ -167,7 +167,7 @@ object EventHandlerBuilderByState {
    * @param stateClass The handlers defined by this builder are used when the state is an instance of the `stateClass`
    * @return A new, mutable, EventHandlerBuilderByState
    */
-  def builder[S <: State, State >: Null, Event](stateClass: Class[S]): EventHandlerBuilderByState[S, State, Event] =
+  def builder[S <: State, State, Event](stateClass: Class[S]): EventHandlerBuilderByState[S, State, Event] =
     new EventHandlerBuilderByState(stateClass, statePredicate = trueStatePredicate)
 
   /**
@@ -175,7 +175,7 @@ object EventHandlerBuilderByState {
    *                       useful for example when state type is an Optional
    * @return A new, mutable, EventHandlerBuilderByState
    */
-  def builder[State >: Null, Event](statePredicate: Predicate[State]): EventHandlerBuilderByState[State, State, Event] =
+  def builder[State, Event](statePredicate: Predicate[State]): EventHandlerBuilderByState[State, State, Event] =
     new EventHandlerBuilderByState(classOf[Any].asInstanceOf[Class[State]], statePredicate)
 
   /**
@@ -187,7 +187,7 @@ object EventHandlerBuilderByState {
       handler: BiFunction[State, Event, State])
 }
 
-final class EventHandlerBuilderByState[S <: State, State >: Null, Event](
+final class EventHandlerBuilderByState[S <: State, State, Event](
     private val stateClass: Class[S],
     private val statePredicate: Predicate[S]) {
 
@@ -316,7 +316,7 @@ final class EventHandlerBuilderByState[S <: State, State >: Null, Event](
 
     new EventHandler[State, Event] {
       def apply(state: State, event: Event): State = {
-        var result: OptionVal[State] = OptionVal.None
+        var result: OptionVal[State] = OptionVal.none
         var idx = 0
         while (idx < builtCases.length && result.isEmpty) {
           val curr = builtCases(idx)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
@@ -19,7 +19,7 @@ import akka.persistence.typed._
 import akka.persistence.typed.internal._
 
 @ApiMayChange
-abstract class EventSourcedBehavior[Command, Event, State >: Null] private[akka] (
+abstract class EventSourcedBehavior[Command, Event, State] private[akka] (
     val persistenceId: PersistenceId,
     onPersistFailure: Optional[BackoffSupervisorStrategy])
     extends DeferredBehavior[Command] {
@@ -208,7 +208,7 @@ abstract class EventSourcedBehavior[Command, Event, State >: Null] private[akka]
  * created with `Effects().reply`, `Effects().noReply`, [[Effect.thenReply]], or [[Effect.thenNoReply]].
  */
 @ApiMayChange
-abstract class EventSourcedBehaviorWithEnforcedReplies[Command, Event, State >: Null](
+abstract class EventSourcedBehaviorWithEnforcedReplies[Command, Event, State](
     persistenceId: PersistenceId,
     backoffSupervisorStrategy: Optional[BackoffSupervisorStrategy])
     extends EventSourcedBehavior[Command, Event, State](persistenceId, backoffSupervisorStrategy) {


### PR DESCRIPTION
* the original reason was that this constraint was required by OptionVal,
  but that has been removed
