### PR TITLE
Fix typo of DispatcherSelector's Scaladoc

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
@@ -145,7 +145,7 @@ sealed abstract class DispatcherSelector extends Props
 
 /**
  * Factories for [[DispatcherSelector]]s which describe which thread pool shall be used to run
- * the actor to which this configuration is applied. Se the individual factory methods for details
+ * the actor to which this configuration is applied. See the individual factory methods for details
  * on the options.
  *
  * The default configuration if none of these options are present is to run


### PR DESCRIPTION
straight forward