### PR TITLE
Always intercept TimerMsg, also when restarted, #26556

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
@@ -306,4 +306,5 @@ private[akka] final class FunctionRef[-T](override val path: ActorPath, send: (T
   def clearUnhandled(): Unit = unhandled = Nil
 
   override private[akka] def currentBehavior: Behavior[T] = currentBehaviorProvider()
+
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
@@ -42,6 +42,8 @@ import akka.util.JavaDurationConverters._
       timer
   }
 
+  def hasTimer: Boolean = _timer.isDefined
+
   override def asJava: javadsl.ActorContext[T] = this
 
   override def asScala: scaladsl.ActorContext[T] = this

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
@@ -42,7 +42,12 @@ import akka.util.JavaDurationConverters._
       timer
   }
 
-  def hasTimer: Boolean = _timer.isDefined
+  override private[akka] def hasTimer: Boolean = _timer.isDefined
+
+  override private[akka] def cancelAllTimers(): Unit = {
+    if (hasTimer)
+      timer.cancelAll()
+  }
 
   override def asJava: javadsl.ActorContext[T] = this
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
@@ -308,6 +308,19 @@ trait ActorContext[T] extends TypedActorContext[T] {
   /**
    * INTERNAL API
    */
+  @InternalApi
   private[akka] def currentBehavior: Behavior[T]
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private[akka] def hasTimer: Boolean
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private[akka] def cancelAllTimers(): Unit
 
 }


### PR DESCRIPTION
* To avoid ClassCastException of TimerMsg if TimerMsg is already enqueued
  in mailbox and there is a restart with initial behavior that is not using withTimers

Refs #26556