### PR TITLE
Remove Scala 2.11 from crossScalaVersions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ cache:
 script:
   - jabba use "adopt@~1.8.202-08"
   # need to override as the default is to test
-  - sbt -jvm-opts .jvmopts-travis ";++$TRAVIS_SCALA_VERSION update ;++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues ;++$TRAVIS_SCALA_VERSION test:compile ;++$TRAVIS_SCALA_VERSION validateCompile"
+  - sbt -jvm-opts .jvmopts-travis -Dakka.build.scalaVersion=$TRAVIS_SCALA_VERSION ";update ;mimaReportBinaryIssues ;test:compile ;validateCompile"
   # make 'git branch' work again
   - git branch -f "$TRAVIS_BRANCH" && git checkout "$TRAVIS_BRANCH"
   # check policies, if on master also upload

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -234,10 +234,6 @@ object AkkaBuild {
     javacOptions in doc ++= Seq("-Xdoclint:none", "--ignore-source-errors"))
 
 
-  lazy val noScala211 = Seq(
-    crossScalaVersions := crossScalaVersions.value.filterNot(_.startsWith("2.11"))
-  )
-
   def loadSystemProperties(fileName: String): Unit = {
     import scala.collection.JavaConverters._
     val file = new File(fileName)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,14 +21,15 @@ object Dependencies {
   val aeronVersion = "1.15.1"
 
   val Versions = Seq(
-    crossScalaVersions := Seq("2.12.8", "2.11.12", "2.13.0-M5"),
+    crossScalaVersions := Seq("2.12.8", "2.13.0-M5"),
     scalaVersion := System.getProperty("akka.build.scalaVersion", crossScalaVersions.value.head),
     scalaStmVersion := sys.props.get("akka.build.scalaStmVersion").getOrElse("0.9"),
-    scalaCheckVersion := sys.props.get("akka.build.scalaCheckVersion").getOrElse(
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, n)) if n >= 12 => "1.14.0" // does not work for 2.11
-        case _                       => "1.13.2"
-      }),
+    scalaCheckVersion := sys.props
+        .get("akka.build.scalaCheckVersion")
+        .getOrElse(CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((2, n)) if n >= 12 => "1.14.0" // does not work for 2.11
+          case _                       => "1.13.2"
+        }),
     scalaTestVersion := "3.0.7",
     java8CompatVersion := {
       CrossVersion.partialVersion(scalaVersion.value) match {
@@ -41,7 +42,7 @@ object Dependencies {
   object Compile {
     // Compile
 
-    val camelCore = "org.apache.camel" % "camel-core" % "2.17.7" exclude ("org.slf4j", "slf4j-api") // ApacheV2
+    val camelCore = ("org.apache.camel" % "camel-core" % "2.17.7").exclude("org.slf4j", "slf4j-api") // ApacheV2
 
     // when updating config version, update links ActorSystem ScalaDoc to link to the updated version
     val config = "com.typesafe" % "config" % "1.3.3" // ApacheV2
@@ -76,7 +77,6 @@ object Dependencies {
 
     val aeronDriver = "io.aeron" % "aeron-driver" % aeronVersion // ApacheV2
     val aeronClient = "io.aeron" % "aeron-client" % aeronVersion // ApacheV2
-
 
     object Docs {
       val sprayJson = "io.spray" %% "spray-json" % "1.3.4" % "test"
@@ -124,17 +124,15 @@ object Dependencies {
       // If changed, update akka-docs/build.sbt as well
       val sigarLoader = "io.kamon" % "sigar-loader" % "1.6.6-rev002" % "optional;provided;test" // ApacheV2
 
-       // Non-default module in Java9, removed in Java11. For Camel.
+      // Non-default module in Java9, removed in Java11. For Camel.
       val jaxb = "javax.xml.bind" % "jaxb-api" % "2.3.0" % "provided;test"
       val activation = "com.sun.activation" % "javax.activation" % "1.2.0" % "provided;test"
-
 
       val levelDB = "org.iq80.leveldb" % "leveldb" % "0.10" % "optional;provided" // ApacheV2
       val levelDBmultiJVM = "org.iq80.leveldb" % "leveldb" % "0.10" % "optional;provided;multi-jvm" // ApacheV2
       val levelDBNative = "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8" % "optional;provided" // New BSD
 
       val junit = Compile.junit % "optional;provided;test"
-
 
       val scalatest = Def.setting { "org.scalatest" %% "scalatest" % scalaTestVersion.value % "optional;provided;test" } // ApacheV2
 
@@ -155,10 +153,16 @@ object Dependencies {
   val testkit = l ++= Seq(Test.junit, Test.scalatest.value) ++ Test.metricsAll
 
   val actorTests = l ++= Seq(
-    Test.junit, Test.scalatest.value, Test.commonsCodec, Test.commonsMath,
-    Test.mockito, Test.scalacheck.value, Test.jimfs,
-    Test.dockerClient, Provided.activation // dockerClient needs javax.activation.DataSource in JDK 11+
-  )
+        Test.junit,
+        Test.scalatest.value,
+        Test.commonsCodec,
+        Test.commonsMath,
+        Test.mockito,
+        Test.scalacheck.value,
+        Test.jimfs,
+        Test.dockerClient,
+        Provided.activation // dockerClient needs javax.activation.DataSource in JDK 11+
+      )
 
   val actorTestkitTyped = l ++= Seq(Provided.junit, Provided.scalatest.value)
 
@@ -170,7 +174,12 @@ object Dependencies {
 
   val clusterTools = l ++= Seq(Test.junit, Test.scalatest.value)
 
-  val clusterSharding = l ++= Seq(Provided.levelDBmultiJVM, Provided.levelDBNative, Test.junit, Test.scalatest.value, Test.commonsIo)
+  val clusterSharding = l ++= Seq(
+        Provided.levelDBmultiJVM,
+        Provided.levelDBNative,
+        Test.junit,
+        Test.scalatest.value,
+        Test.commonsIo)
 
   val clusterMetrics = l ++= Seq(Provided.sigarLoader, Test.slf4jJul, Test.slf4jLog4j, Test.logback, Test.mockito)
 
@@ -180,17 +189,49 @@ object Dependencies {
 
   val agent = l ++= Seq(scalaStm.value, Test.scalatest.value, Test.junit)
 
-  val persistence = l ++= Seq(Provided.levelDB, Provided.levelDBNative, Test.scalatest.value, Test.junit, Test.commonsIo, Test.commonsCodec, Test.scalaXml)
+  val persistence = l ++= Seq(
+        Provided.levelDB,
+        Provided.levelDBNative,
+        Test.scalatest.value,
+        Test.junit,
+        Test.commonsIo,
+        Test.commonsCodec,
+        Test.scalaXml)
 
-  val persistenceQuery = l ++= Seq(Test.scalatest.value, Test.junit, Test.commonsIo, Provided.levelDB, Provided.levelDBNative)
+  val persistenceQuery = l ++= Seq(
+        Test.scalatest.value,
+        Test.junit,
+        Test.commonsIo,
+        Provided.levelDB,
+        Provided.levelDBNative)
 
-  val persistenceTck = l ++= Seq(Test.scalatest.value.withConfigurations(Some("compile")), Test.junit.withConfigurations(Some("compile")), Provided.levelDB, Provided.levelDBNative)
+  val persistenceTck = l ++= Seq(
+        Test.scalatest.value.withConfigurations(Some("compile")),
+        Test.junit.withConfigurations(Some("compile")),
+        Provided.levelDB,
+        Provided.levelDBNative)
 
   val persistenceShared = l ++= Seq(Provided.levelDB, Provided.levelDBNative)
 
-  val camel = l ++= Seq(camelCore, Provided.jaxb, Provided.activation, Test.scalatest.value, Test.junit, Test.mockito, Test.logback, Test.commonsIo)
+  val camel = l ++= Seq(
+        camelCore,
+        Provided.jaxb,
+        Provided.activation,
+        Test.scalatest.value,
+        Test.junit,
+        Test.mockito,
+        Test.logback,
+        Test.commonsIo)
 
-  val osgi = l ++= Seq(osgiCore, osgiCompendium, Test.logback, Test.commonsIo, Test.pojosr, Test.tinybundles, Test.scalatest.value, Test.junit)
+  val osgi = l ++= Seq(
+        osgiCore,
+        osgiCompendium,
+        Test.logback,
+        Test.commonsIo,
+        Test.pojosr,
+        Test.tinybundles,
+        Test.scalatest.value,
+        Test.junit)
 
   val docs = l ++= Seq(Test.scalatest.value, Test.junit, Docs.sprayJson, Docs.gson, Provided.levelDB)
 
@@ -200,10 +241,7 @@ object Dependencies {
 
   // akka stream
 
-  lazy val stream = l ++= Seq[sbt.ModuleID](
-    reactiveStreams,
-    sslConfigCore,
-    Test.scalatest.value)
+  lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, sslConfigCore, Test.scalatest.value)
 
   lazy val streamTestkit = l ++= Seq(Test.scalatest.value, Test.scalacheck.value, Test.junit)
 
@@ -241,6 +279,6 @@ object DependencyHelpers {
     // 2.12.0
     case version @ ScalaVersion() => version
     // transforms 2.12.0-custom-version to 2.12.0
-    case version                  => version.takeWhile(_ != '-')
+    case version => version.takeWhile(_ != '-')
   }
 }

--- a/project/scripts/release
+++ b/project/scripts/release
@@ -299,6 +299,7 @@ else
   RELEASE_OPT="-Dakka.genjavadoc.enabled=true"
 fi
 try sbt $RELEASE_OPT +buildRelease
+try sbt -Dakka.build.scalaVersion=2.11.12 -D$RELEASE_OPT buildRelease
 try sbt $RELEASE_OPT buildDocs
 echolog "Successfully created local release"
 


### PR DESCRIPTION
* because +buildRelease doesn't work with mixed crossScalaVersions
* let's use akka.build.scalaVersion when building for 2.11
* aggregatedProjects adjusted depending on akka.build.scalaVersion is 2.11 or not,
  there excluding/including the -typed modules

Refs https://github.com/akka/akka/issues/26651

Some Jenkins/Travis jobs will have to change and use `akka.build.scalaVersion`.