### PR TITLE
Support Graceful Stopping of Child Routees

### DIFF
--- a/akka-actor/src/main/scala/akka/routing/Balancing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Balancing.scala
@@ -9,6 +9,7 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import akka.actor.ActorContext
 import akka.actor.ActorSystem
+import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.actor.SupervisorStrategy
 import akka.dispatch.BalancingDispatcherConfigurator
@@ -80,6 +81,13 @@ final case class BalancingPool(
    * @param nr initial number of routees in the pool
    */
   def this(nr: Int) = this(nrOfInstances = nr)
+
+  /**
+   * Since routees don't have distinct identities, this message cannot be sent to specific actors.
+   * However, the [[akka.routing.RemoveRoutee]] message is handled by this class of router,
+   * which could result in the delivery of this message, so it must be defined.
+   */
+  override def routeeStopMessage: Any = PoisonPill
 
   override def createRouter(system: ActorSystem): Router = new Router(BalancingRoutingLogic())
 

--- a/akka-actor/src/main/scala/akka/routing/Broadcast.scala
+++ b/akka-actor/src/main/scala/akka/routing/Broadcast.scala
@@ -7,6 +7,7 @@ package akka.routing
 import scala.collection.immutable
 import akka.dispatch.Dispatchers
 import com.typesafe.config.Config
+import akka.actor.PoisonPill
 import akka.actor.SupervisorStrategy
 import akka.japi.Util.immutableSeq
 import akka.actor.ActorSystem
@@ -48,6 +49,8 @@ final class BroadcastRoutingLogic extends RoutingLogic {
  *
  * @param nrOfInstances initial number of routees in the pool
  *
+ * @param routeeStopMessage message router sends to routee when removing from collection of routees
+ *
  * @param resizer optional resizer that dynamically adjust the pool size
  *
  * @param supervisorStrategy strategy for supervising the routees, see 'Supervision Setup'
@@ -58,6 +61,7 @@ final class BroadcastRoutingLogic extends RoutingLogic {
 @SerialVersionUID(1L)
 final case class BroadcastPool(
     val nrOfInstances: Int,
+    override val routeeStopMessage: Any = PoisonPill,
     override val resizer: Option[Resizer] = None,
     override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,

--- a/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
+++ b/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
@@ -12,6 +12,7 @@ import akka.japi.Util.immutableSeq
 import akka.actor.Address
 import akka.actor.ExtendedActorSystem
 import akka.actor.ActorSystem
+import akka.actor.PoisonPill
 import java.util.concurrent.atomic.AtomicReference
 import akka.serialization.SerializationExtension
 import scala.util.control.NonFatal
@@ -260,6 +261,8 @@ final case class ConsistentHashingRoutingLogic(
  *
  * @param nrOfInstances initial number of routees in the pool
  *
+ * @param routeeStopMessage message router sends to routee when removing from collection of routees
+ *
  * @param resizer optional resizer that dynamically adjust the pool size
  *
  * @param virtualNodesFactor number of virtual nodes per node, used in [[akka.routing.ConsistentHash]]
@@ -275,6 +278,7 @@ final case class ConsistentHashingRoutingLogic(
 @SerialVersionUID(1L)
 final case class ConsistentHashingPool(
     val nrOfInstances: Int,
+    override val routeeStopMessage: Any = PoisonPill,
     override val resizer: Option[Resizer] = None,
     val virtualNodesFactor: Int = 0,
     val hashMapping: ConsistentHashingRouter.ConsistentHashMapping = ConsistentHashingRouter.emptyConsistentHashMapping,

--- a/akka-actor/src/main/scala/akka/routing/Random.scala
+++ b/akka-actor/src/main/scala/akka/routing/Random.scala
@@ -8,6 +8,7 @@ import scala.collection.immutable
 import java.util.concurrent.ThreadLocalRandom
 import akka.dispatch.Dispatchers
 import com.typesafe.config.Config
+import akka.actor.PoisonPill
 import akka.actor.SupervisorStrategy
 import akka.japi.Util.immutableSeq
 import akka.actor.ActorSystem
@@ -49,6 +50,8 @@ final class RandomRoutingLogic extends RoutingLogic {
  *
  * @param nrOfInstances initial number of routees in the pool
  *
+ * @param routeeStopMessage message router sends to routee when removing from collection of routees
+ *
  * @param resizer optional resizer that dynamically adjust the pool size
  *
  * @param supervisorStrategy strategy for supervising the routees, see 'Supervision Setup'
@@ -59,6 +62,7 @@ final class RandomRoutingLogic extends RoutingLogic {
 @SerialVersionUID(1L)
 final case class RandomPool(
     val nrOfInstances: Int,
+    override val routeeStopMessage: Any = PoisonPill,
     override val resizer: Option[Resizer] = None,
     override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,

--- a/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicLong
 import scala.collection.immutable
 import akka.dispatch.Dispatchers
 import com.typesafe.config.Config
+import akka.actor.PoisonPill
 import akka.actor.SupervisorStrategy
 import akka.japi.Util.immutableSeq
 import akka.actor.ActorSystem
@@ -57,6 +58,8 @@ final class RoundRobinRoutingLogic extends RoutingLogic {
  *
  * @param nrOfInstances initial number of routees in the pool
  *
+ * @param routeeStopMessage message router sends to routee when removing from collection of routees
+ *
  * @param resizer optional resizer that dynamically adjust the pool size
  *
  * @param supervisorStrategy strategy for supervising the routees, see 'Supervision Setup'
@@ -67,6 +70,7 @@ final class RoundRobinRoutingLogic extends RoutingLogic {
 @SerialVersionUID(1L)
 final case class RoundRobinPool(
     val nrOfInstances: Int,
+    override val routeeStopMessage: Any = PoisonPill,
     override val resizer: Option[Resizer] = None,
     override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,

--- a/akka-actor/src/main/scala/akka/routing/RoutedActorCell.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoutedActorCell.scala
@@ -11,7 +11,6 @@ import akka.actor.ActorRef
 import akka.actor.ActorSystemImpl
 import akka.actor.IndirectActorProducer
 import akka.actor.InternalActorRef
-import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.actor.SupervisorStrategy
 import akka.actor.Terminated
@@ -94,9 +93,10 @@ private[akka] class RoutedActorCell(
       child(ref.path.name) match {
         case Some(`ref`) =>
           // The reason for the delay is to give concurrent
-          // messages a chance to be placed in mailbox before sending PoisonPill,
+          // messages a chance to be placed in mailbox before sending the
+          // provided routeeStopMessage, which defaults to a PoisonPill,
           // best effort.
-          system.scheduler.scheduleOnce(100.milliseconds, ref, PoisonPill)(dispatcher)
+          system.scheduler.scheduleOnce(100.milliseconds, ref, routerConfig.routeeStopMessage)(dispatcher)
         case _ =>
       }
     case _ =>

--- a/akka-actor/src/main/scala/akka/routing/ScatterGatherFirstCompleted.scala
+++ b/akka-actor/src/main/scala/akka/routing/ScatterGatherFirstCompleted.scala
@@ -10,6 +10,7 @@ import com.typesafe.config.Config
 import akka.actor.SupervisorStrategy
 import akka.japi.Util.immutableSeq
 import akka.actor.ActorRef
+import akka.actor.PoisonPill
 import scala.concurrent.Promise
 import akka.pattern.ask
 import akka.pattern.pipe
@@ -87,6 +88,8 @@ private[akka] final case class ScatterGatherFirstCompletedRoutees(
  *
  * @param nrOfInstances initial number of routees in the pool
  *
+ * @param routeeStopMessage message router sends to routee when removing from collection of routees
+ *
  * @param resizer optional resizer that dynamically adjust the pool size
  *
  * @param within expecting at least one reply within this duration, otherwise
@@ -100,6 +103,7 @@ private[akka] final case class ScatterGatherFirstCompletedRoutees(
 @SerialVersionUID(1L)
 final case class ScatterGatherFirstCompletedPool(
     val nrOfInstances: Int,
+    override val routeeStopMessage: Any = PoisonPill,
     override val resizer: Option[Resizer] = None,
     within: FiniteDuration,
     override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,

--- a/akka-actor/src/main/scala/akka/routing/SmallestMailbox.scala
+++ b/akka-actor/src/main/scala/akka/routing/SmallestMailbox.scala
@@ -10,6 +10,7 @@ import java.util.concurrent.ThreadLocalRandom
 import com.typesafe.config.Config
 import akka.actor.ActorCell
 import akka.actor.ActorRefWithCell
+import akka.actor.PoisonPill
 import akka.actor.SupervisorStrategy
 import akka.dispatch.Dispatchers
 import akka.actor.ActorSystem
@@ -167,6 +168,8 @@ class SmallestMailboxRoutingLogic extends RoutingLogic {
  *
  * @param nrOfInstances initial number of routees in the pool
  *
+ * @param routeeStopMessage message router sends to routee when removing from collection of routees
+ *
  * @param resizer optional resizer that dynamically adjust the pool size
  *
  * @param supervisorStrategy strategy for supervising the routees, see 'Supervision Setup'
@@ -177,6 +180,7 @@ class SmallestMailboxRoutingLogic extends RoutingLogic {
 @SerialVersionUID(1L)
 final case class SmallestMailboxPool(
     val nrOfInstances: Int,
+    override val routeeStopMessage: Any = PoisonPill,
     override val resizer: Option[Resizer] = None,
     override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,

--- a/akka-actor/src/main/scala/akka/routing/TailChopping.scala
+++ b/akka-actor/src/main/scala/akka/routing/TailChopping.scala
@@ -136,6 +136,8 @@ private[akka] final case class TailChoppingRoutees(
  *
  * @param nrOfInstances initial number of routees in the pool
  *
+ * @param routeeStopMessage message router sends to routee when removing from collection of routees
+ *
  * @param resizer optional resizer that dynamically adjust the pool size
  *
  * @param within expecting at least one reply within this duration, otherwise
@@ -151,6 +153,7 @@ private[akka] final case class TailChoppingRoutees(
 @SerialVersionUID(1L)
 final case class TailChoppingPool(
     val nrOfInstances: Int,
+    override val routeeStopMessage: Any = PoisonPill,
     override val resizer: Option[Resizer] = None,
     within: FiniteDuration,
     interval: FiniteDuration,

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsRouting.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsRouting.scala
@@ -15,6 +15,7 @@ import akka.actor.ActorSystem
 import akka.actor.Address
 import akka.actor.DynamicAccess
 import akka.actor.NoSerializationVerificationNeeded
+import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.actor.SupervisorStrategy
 import akka.cluster.Cluster
@@ -117,6 +118,8 @@ final case class AdaptiveLoadBalancingRoutingLogic(
  *
  * @param nrOfInstances initial number of routees in the pool
  *
+ * @param routeeStopMessage message router sends to routee when removing from collection of routees
+ *
  * @param supervisorStrategy strategy for supervising the routees, see 'Supervision Setup'
  *
  * @param routerDispatcher dispatcher to use for the router head actor, which handles
@@ -126,6 +129,7 @@ final case class AdaptiveLoadBalancingRoutingLogic(
 final case class AdaptiveLoadBalancingPool(
     metricsSelector: MetricsSelector = MixMetricsSelector,
     val nrOfInstances: Int = 0,
+    override val routeeStopMessage: Any = PoisonPill,
     override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
     override val usePoolDispatcher: Boolean = false)

--- a/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
@@ -329,6 +329,8 @@ final case class ClusterRouterPool(local: Pool, settings: ClusterRouterPoolSetti
 
   override def resizer: Option[Resizer] = local.resizer
 
+  override def routeeStopMessage: Any = local.routeeStopMessage
+
   /**
    * INTERNAL API
    */

--- a/akka-remote/src/main/scala/akka/remote/routing/RemoteRouterConfig.scala
+++ b/akka-remote/src/main/scala/akka/remote/routing/RemoteRouterConfig.scala
@@ -67,6 +67,8 @@ final case class RemoteRouterConfig(local: Pool, nodes: Iterable[Address]) exten
 
   override def supervisorStrategy: SupervisorStrategy = local.supervisorStrategy
 
+  override def routeeStopMessage: Any = local.routeeStopMessage
+
   override def routerDispatcher: String = local.routerDispatcher
 
   override def resizer: Option[Resizer] = local.resizer


### PR DESCRIPTION
## Purpose

Allow end users to choose which message a router sends to a child routee when the router decreases the number of routees. This change enables graceful stopping of child routees, thus providing support for stateful routees.

## References

References: None known

## Changes

- Add abstract member `routeeStopMessage` to `RouterConfig` trait.
- Adjust `RoutedActorCell` to send the `routeeStopMessage` when stopping child routees.
- Define the `routeeStopMessage` to throw exceptions in the `Group` and `NoRouter` traits since these traits have routees which are, by definition, not children of the router.
- Add `routeeStopMessage` argument to all router apply methods which extend the `Pool` trait since routees are, by definition, children of those routers. In order to maintain the original functionality, and prevent breaking changes, the argument is defaulted to `PoisonPill` in all cases.
- Define `routeeStopMessage` to `PoisonPill` in the `CustomRouterConfig` in order to maintain original functionality. Member is overridable.

## Background Context

For routers managing stateful routees, it would be helpful to enable routees to gracefully stop themselves. The current functionality is simply to send a `PoisonPill` to routees that are children and that need to be stopped. The proposed changes allow for end users to override the default message, which is still `PoisonPill`, without altering the current functionality in any way. Specific use cases include pool routers with a resizer, the `ClusterRouterPool`, and any time a pool router receives the `RemoveRoutee` message. In all three cases, the router can stop routees at any time. As such, it becomes tricky to maintain any type of state in routees. The proposed changes enable routees to maintain state more safely by giving the routees a chance to persist their state.

Since the length of actor shutdown is immaterial to the router's ability to function, the router should not need to waste time ensuring the successful shutdown of the child routee. As such, the router sends the `routeeStopMessage` once and expects the routee to stop itself.

The proposed changes were inspired by the `handOffStopMessage` defined for `ClusterSharding`. 

The original functionality is maintained for end users, and this proposal should not introduce any breaking changes.

## Remaining Work

If the proposed changes are accepted, I will need help determining where to add documentation and understanding testing norms for the akka project.