### PR TITLE
Use ExecutionContext.parasitic for Scala 2.13, #26655

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -19,6 +19,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.language.postfixOps
+import scala.util.Properties
 
 object ActorSystemSpec {
 
@@ -130,9 +131,13 @@ class ActorSystemSpec extends AkkaSpec(ActorSystemSpec.config) with ImplicitSend
 
   "An ActorSystem" must {
 
-    "use scala.concurrent.Future's InternalCallbackEC" in {
-      system.asInstanceOf[ActorSystemImpl].internalCallingThreadExecutionContext.getClass.getName should ===(
-        "scala.concurrent.Future$InternalCallbackExecutor$")
+    "use scala.concurrent InternalCallbackExecutor/parasitic" in {
+      val ec = system.asInstanceOf[ActorSystemImpl].internalCallingThreadExecutionContext
+      val scalaVersion = Properties.versionNumberString
+      if (scalaVersion.startsWith("2.13") && scalaVersion != "2.13.0-M5")
+        ec.getClass.getName should ===("scala.concurrent.ExecutionContext$parasitic$")
+      else
+        ec.getClass.getName should ===("scala.concurrent.Future$InternalCallbackExecutor$")
     }
 
     "reject invalid names" in {

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -847,11 +847,10 @@ private[akka] class ActorSystemImpl(
   val internalCallingThreadExecutionContext: ExecutionContext =
     dynamicAccess
       .getObjectFor[ExecutionContext]("scala.concurrent.Future$InternalCallbackExecutor$")
-      .getOrElse(new ExecutionContext with BatchingExecutor {
-        override protected def unbatchedExecute(r: Runnable): Unit = r.run()
-        override protected def resubmitOnBlock: Boolean = false // Since we execute inline, no gain in resubmitting
-        override def reportFailure(t: Throwable): Unit = dispatcher.reportFailure(t)
-      })
+      .getOrElse(
+        dynamicAccess
+          .getObjectFor[ExecutionContext]("scala.concurrent.ExecutionContext$parasitic$")
+          .getOrElse(ExecutionContexts.sameThreadExecutionContext))
 
   private[this] final val terminationCallbacks = new TerminationCallbacks(provider.terminationFuture)(dispatcher)
 


### PR DESCRIPTION
* scala.concurrent.Future$InternalCallbackExecutor$ doesn't exist in
  Scala 2.13
* also changed the fallback to use sameThreadExecutionContext since they
  seems to be identical
* I have tried that it can load the `parasitic` with 2.13.0-pre-b4926ef in community build

I'd like to follow up with a more thorough cleanup in Akka 2.6. A few question that I think we can address in such cleanup:
* Why do we have `akka.dispatch.BatchingExecutor`? What is the difference between this and then one in Scala?
* `ActorSystem.internalCallingThreadExecutionContext` vs `akka.dispatch.ExecutionContexts.sameThreadExecutionContext`
* Use 2.13/2.12 specific source files instead of loading with reflection, at least 2.13 parasitic is public

Refs #26655