### PR TITLE
QueueSource should complete future returned by `.offer()` only when element is sent to downstream

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/QueueSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/QueueSource.scala
@@ -12,8 +12,9 @@ import akka.stream.OverflowStrategies._
 import akka.stream._
 import akka.stream.stage._
 import akka.stream.scaladsl.SourceQueueWithComplete
+
 import scala.compat.java8.FutureConverters._
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{Future, Promise}
 
 /**
  * INTERNAL API
@@ -24,14 +25,13 @@ import scala.concurrent.{ Future, Promise }
   final case class Offer[+T](elem: T, promise: Promise[QueueOfferResult]) extends Input[T]
   case object Completion extends Input[Nothing]
   final case class Failure(ex: Throwable) extends Input[Nothing]
-
 }
 
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] final class QueueSource[T](maxBuffer: Int, overflowStrategy: OverflowStrategy)
-    extends GraphStageWithMaterializedValue[SourceShape[T], SourceQueueWithComplete[T]] {
+@InternalApi private[akka] final class QueueSource[T](maxBuffer: Int, overflowStrategy: OverflowStrategy) extends GraphStageWithMaterializedValue[SourceShape[T], SourceQueueWithComplete[T]] {
+
   import QueueSource._
 
   val out = Outlet[T]("queueSource.out")
@@ -43,53 +43,59 @@ import scala.concurrent.{ Future, Promise }
     val stageLogic = new GraphStageLogic(shape) with OutHandler with SourceQueueWithComplete[T] with StageLogging {
       override protected def logSource: Class[_] = classOf[QueueSource[_]]
 
-      var buffer: Buffer[T] = _
+      var buffer: Buffer[Offer[T]] = _
       var pendingOffer: Option[Offer[T]] = None
       var terminating = false
 
       override def preStart(): Unit = {
         if (maxBuffer > 0) buffer = Buffer(maxBuffer, materializer)
       }
+
       override def postStop(): Unit = {
+        completePendingOffers(QueueOfferResult.QueueClosed)
         val exception = new StreamDetachedException()
         completion.tryFailure(exception)
       }
 
-      private def enqueueAndSuccess(offer: Offer[T]): Unit = {
-        buffer.enqueue(offer.elem)
-        offer.promise.success(QueueOfferResult.Enqueued)
+      private def completePendingOffers(result: QueueOfferResult): Unit = {
+        if (maxBuffer != 0)
+          while (buffer.nonEmpty)
+            buffer.dropHead().promise.success(result)
+
+        pendingOffer.foreach { case Offer(_, promise) =>
+          promise.success(result)
+          pendingOffer = None
+        }
       }
 
       private def bufferElem(offer: Offer[T]): Unit = {
         if (!buffer.isFull) {
-          enqueueAndSuccess(offer)
+          buffer.enqueue(offer)
         } else
           overflowStrategy match {
             case s: DropHead =>
-              log.log(
-                s.logLevel,
-                "Dropping the head element because buffer is full and overflowStrategy is: [DropHead]")
-              buffer.dropHead()
-              enqueueAndSuccess(offer)
+              log.log(s.logLevel, "Dropping the head element because buffer is full and overflowStrategy is: [DropHead]")
+              buffer.dropHead().promise.success(QueueOfferResult.Dropped)
+              buffer.enqueue(offer)
             case s: DropTail =>
-              log.log(
-                s.logLevel,
-                "Dropping the tail element because buffer is full and overflowStrategy is: [DropTail]")
-              buffer.dropTail()
-              enqueueAndSuccess(offer)
+              log.log(s.logLevel, "Dropping the tail element because buffer is full and overflowStrategy is: [DropTail]")
+              buffer.dropTail().promise.success(QueueOfferResult.Dropped)
+              buffer.enqueue(offer)
             case s: DropBuffer =>
-              log.log(
-                s.logLevel,
-                "Dropping all the buffered elements because buffer is full and overflowStrategy is: [DropBuffer]")
-              buffer.clear()
-              enqueueAndSuccess(offer)
+              log.log(s.logLevel, "Dropping all the buffered elements because buffer is full and overflowStrategy is: [DropBuffer]")
+              while (buffer.nonEmpty)
+                buffer.dequeue().promise.success(QueueOfferResult.Dropped)
+              buffer.enqueue(offer)
             case s: DropNew =>
               log.log(s.logLevel, "Dropping the new element because buffer is full and overflowStrategy is: [DropNew]")
               offer.promise.success(QueueOfferResult.Dropped)
             case s: Fail =>
               log.log(s.logLevel, "Failing because buffer is full and overflowStrategy is: [Fail]")
               val bufferOverflowException = BufferOverflowException(s"Buffer overflow (max capacity was: $maxBuffer)!")
-              offer.promise.success(QueueOfferResult.Failure(bufferOverflowException))
+              val result = QueueOfferResult.Failure(bufferOverflowException)
+              while (buffer.nonEmpty)
+                buffer.dequeue().promise.success(result)
+              offer.promise.success(result)
               completion.failure(bufferOverflowException)
               failStage(bufferOverflowException)
             case s: Backpressure =>
@@ -109,40 +115,47 @@ import scala.concurrent.{ Future, Promise }
         case Offer(_, promise) if terminating =>
           promise.success(QueueOfferResult.Dropped)
 
-        case offer @ Offer(elem, promise) =>
+        case offer@Offer(elem, promise) =>
+          // Put everything to buffer if it's enabled
           if (maxBuffer != 0) {
             bufferElem(offer)
-            if (isAvailable(out)) push(out, buffer.dequeue())
+            // And send the oldest element of buffer to downstream if it's ready
+            if (isAvailable(out)) {
+              val t = buffer.dequeue()
+              push(out, t.elem)
+              t.promise.success(QueueOfferResult.Enqueued)
+            }
           } else if (isAvailable(out)) {
+            // Otherwise instantly push item to downstream and complete Future returned by .offer()
             push(out, elem)
             promise.success(QueueOfferResult.Enqueued)
-          } else if (pendingOffer.isEmpty)
+          } else if (pendingOffer.isEmpty) {
+            // If everything is busy and full save current item in single-item "buffer"
             pendingOffer = Some(offer)
-          else
+          } else
             overflowStrategy match {
-              case s @ (_: DropHead | _: DropBuffer) =>
+              case s@(_: DropHead | _: DropBuffer) =>
                 log.log(s.logLevel, "Dropping element because buffer is full and overflowStrategy is: [{}]", s)
                 pendingOffer.get.promise.success(QueueOfferResult.Dropped)
                 pendingOffer = Some(offer)
-              case s @ (_: DropTail | _: DropNew) =>
+              case s@(_: DropTail | _: DropNew) =>
                 log.log(s.logLevel, "Dropping element because buffer is full and overflowStrategy is: [{}]", s)
                 promise.success(QueueOfferResult.Dropped)
               case s: Fail =>
+                // Major difference between Fail and Backpressure strategies is that Fail terminates whole stream
                 log.log(s.logLevel, "Failing because buffer is full and overflowStrategy is: [Fail]")
-                val bufferOverflowException =
-                  BufferOverflowException(s"Buffer overflow (max capacity was: $maxBuffer)!")
+                val bufferOverflowException = BufferOverflowException(s"Buffer overflow (max capacity was: $maxBuffer)!")
                 promise.success(QueueOfferResult.Failure(bufferOverflowException))
                 completion.failure(bufferOverflowException)
                 failStage(bufferOverflowException)
               case s: Backpressure =>
                 log.log(s.logLevel, "Failing because buffer is full and overflowStrategy is: [Backpressure]")
-                promise.failure(
-                  new IllegalStateException(
-                    "You have to wait for previous offer to be resolved to send another request"))
+                promise.failure(new IllegalStateException("You have to wait for previous offer to be resolved to send another request"))
             }
 
         case Completion =>
-          if (maxBuffer != 0 && buffer.nonEmpty || pendingOffer.nonEmpty) terminating = true
+          if (maxBuffer != 0 && buffer.nonEmpty || pendingOffer.nonEmpty)
+            terminating = true
           else {
             completion.success(Done)
             completeStage()
@@ -156,12 +169,7 @@ import scala.concurrent.{ Future, Promise }
       setHandler(out, this)
 
       override def onDownstreamFinish(): Unit = {
-        pendingOffer match {
-          case Some(Offer(_, promise)) =>
-            promise.success(QueueOfferResult.QueueClosed)
-            pendingOffer = None
-          case None => // do nothing
-        }
+        completePendingOffers(QueueOfferResult.QueueClosed)
         completion.success(Done)
         completeStage()
       }
@@ -180,10 +188,13 @@ import scala.concurrent.{ Future, Promise }
             case None =>
           }
         } else if (buffer.nonEmpty) {
-          push(out, buffer.dequeue())
+          val t = buffer.dequeue()
+          push(out, t.elem)
+          t.promise.success(QueueOfferResult.Enqueued)
+
           pendingOffer match {
             case Some(offer) =>
-              enqueueAndSuccess(offer)
+              buffer.enqueue(offer)
               pendingOffer = None
             case None => //do nothing
           }
@@ -195,16 +206,17 @@ import scala.concurrent.{ Future, Promise }
       }
 
       override def watchCompletion() = completion.future
+
       override def offer(element: T): Future[QueueOfferResult] = {
         val p = Promise[QueueOfferResult]
-        callback
-          .invokeWithFeedback(Offer(element, p))
+        callback.invokeWithFeedback(Offer(element, p))
           .onComplete {
             case scala.util.Success(_) =>
             case scala.util.Failure(e) => p.tryFailure(e)
           }(akka.dispatch.ExecutionContexts.sameThreadExecutionContext)
         p.future
       }
+
       override def complete(): Unit = callback.invoke(Completion)
 
       override def fail(ex: Throwable): Unit = callback.invoke(Failure(ex))


### PR DESCRIPTION
## References

https://github.com/akka/akka/issues/26696

## Changes

PR changes behavior of `QueueSource` in backpressure mode although it should not affect existing client. It allows multiple producers call `QueueSource.offer` and backpressure on returned Future-s.

## Notes

It's first time I made PR for akka thus I'm not very familiar with its test toolkit. For some reason test that go after those that I modified fail. Executed separatelly all tests pass. I suspect it has something to do with `testActor` but I couldn't figure out what. Please advise.
