### PR TITLE
Document interceptor instance sharing in typed

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/BehaviorInterceptor.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/BehaviorInterceptor.scala
@@ -11,6 +11,9 @@ import akka.annotation.{ DoNotInherit, InternalApi }
  * transform, filter, send to a side channel etc. It is the core API for decoration of behaviors. Many built-in
  * intercepting behaviors are provided through factories in the respective `Behaviors`.
  *
+ * If the interceptor does keep mutable state care must be taken to create the instance in a `setup` block
+ * so that a new instance is created per spawned actor rather than shared among actor instance.
+ *
  * @tparam O The outer message type – the type of messages the intercepting behavior will accept
  * @tparam I The inner message type - the type of message the wrapped behavior accepts
  */

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
@@ -171,6 +171,9 @@ object Behaviors {
    * When a behavior returns a new behavior as a result of processing a signal or message and that behavior already contains
    * the same interceptor (defined by the [[akka.actor.typed.BehaviorInterceptor#isSame]] method) only the innermost interceptor
    * is kept. This is to protect against stack overflow when recursively defining behaviors.
+   *
+   * If the interceptor does keep mutable state care must be taken to create the instance in a `setup` block
+   * so that a new instance is created per spawned actor rather than shared among actor instance.
    */
   def intercept[O, I](behaviorInterceptor: BehaviorInterceptor[O, I], behavior: Behavior[I]): Behavior[O] =
     BehaviorImpl.intercept(behaviorInterceptor)(behavior)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
@@ -144,6 +144,9 @@ object Behaviors {
    * When a behavior returns a new behavior as a result of processing a signal or message and that behavior already contains
    * the same interceptor (defined by the `isSame` method on the `BehaviorInterceptor`) only the innermost interceptor
    * is kept. This is to protect against stack overflow when recursively defining behaviors.
+   *
+   * If the interceptor does keep mutable state care must be taken to create the instance in a `setup` block
+   * so that a new instance is created per spawned actor rather than shared among actor instance.
    */
   def intercept[O, I](behaviorInterceptor: BehaviorInterceptor[O, I])(behavior: Behavior[I]): Behavior[O] =
     BehaviorImpl.intercept(behaviorInterceptor)(behavior)


### PR DESCRIPTION
And fix bug in supervision. 

Fixes #26706

Alternative would be to change API to take a factory, but this avoids the API change and avoids an additional lambda alloc for all the cases where the interceptor is stateless