### PR TITLE
Fix startup race condition in ActorRefSource, #26714

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefSourceSpec.scala
@@ -11,9 +11,11 @@ import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.scaladsl._
 import akka.stream._
-import akka.stream.testkit.TestSubscriber.OnComplete
-
 import scala.concurrent.duration._
+
+import akka.actor.ActorRef
+import akka.stream.testkit.TestSubscriber.OnComplete
+import org.reactivestreams.Publisher
 
 class ActorRefSourceSpec extends StreamSpec {
   private implicit val materializer = ActorMaterializer()
@@ -22,7 +24,8 @@ class ActorRefSourceSpec extends StreamSpec {
 
     "emit received messages to the stream" in {
       val s = TestSubscriber.manualProbe[Int]()
-      val ref = Source.actorRef(10, OverflowStrategy.fail).to(Sink.fromSubscriber(s)).run()
+      val materializer2 = ActorMaterializer()
+      val ref = Source.actorRef(10, OverflowStrategy.fail).to(Sink.fromSubscriber(s)).run()(materializer2)
       val sub = s.expectSubscription()
       sub.request(2)
       ref ! 1
@@ -113,43 +116,54 @@ class ActorRefSourceSpec extends StreamSpec {
       for (n <- 1 to 20) ref ! n
       ref ! Status.Success(CompletionStrategy.Draining)
 
-      s.request(20)
-      for (n <- 1 to 20) s.expectNext(n)
+      s.request(10)
+      for (n <- 1 to 10) s.expectNext(n)
+      s.expectNoMessage(20.millis)
+      s.request(10)
+      for (n <- 11 to 20) s.expectNext(n)
       s.expectComplete()
     }
 
     "not signal buffered elements but complete immediately the stream after receiving a Status.Success with CompletionStrategy.Immediately" in assertAllStagesStopped {
-      val (ref, s) = Source
-        .actorRef(100, OverflowStrategy.fail)
-        .toMat(TestSink.probe[Int].addAttributes(Attributes.inputBuffer(initial = 1, max = 1)))(Keep.both)
-        .run()
+      val (ref, s) = Source.actorRef(100, OverflowStrategy.fail).toMat(TestSink.probe[Int])(Keep.both).run()
 
       for (n <- 1 to 20) ref ! n
       ref ! Status.Success(CompletionStrategy.Immediately)
 
-      s.request(20)
-      var e: Either[OnComplete.type, Int] = null
-      do {
-        e = s.expectNextOrComplete()
-        if (e.right.exists(_ > 10)) fail("Must not drain all remaining elements: " + e)
-      } while (e.isRight)
+      s.request(10)
+
+      def verifyNext(n: Int): Unit = {
+        if (n > 10)
+          s.expectComplete()
+        else
+          s.expectNextOrComplete() match {
+            case Right(`n`) => verifyNext(n + 1)
+            case Right(x)   => fail("expected $n, got $x")
+            case Left(_)    => // ok, completed
+          }
+      }
+      verifyNext(1)
     }
 
     "not signal buffered elements but complete immediately the stream after receiving a PoisonPill (backwards compatibility)" in assertAllStagesStopped {
-      val (ref, s) = Source
-        .actorRef(100, OverflowStrategy.fail)
-        .toMat(TestSink.probe[Int].addAttributes(Attributes.inputBuffer(initial = 1, max = 1)))(Keep.both)
-        .run()
+      val (ref, s) = Source.actorRef(100, OverflowStrategy.fail).toMat(TestSink.probe[Int])(Keep.both).run()
 
       for (n <- 1 to 20) ref ! n
       ref ! PoisonPill
 
-      s.request(20)
-      var e: Either[OnComplete.type, Int] = null
-      do {
-        e = s.expectNextOrComplete()
-        if (e.right.exists(_ > 10)) fail("Must not drain all remaining elements: " + e)
-      } while (e.isRight)
+      s.request(10)
+
+      def verifyNext(n: Int): Unit = {
+        if (n > 10)
+          s.expectComplete()
+        else
+          s.expectNextOrComplete() match {
+            case Right(`n`) => verifyNext(n + 1)
+            case Right(x)   => fail("expected $n, got $x")
+            case Left(_)    => // ok, completed
+          }
+      }
+      verifyNext(1)
     }
 
     "not buffer elements after receiving Status.Success" in assertAllStagesStopped {
@@ -195,6 +209,16 @@ class ActorRefSourceSpec extends StreamSpec {
         .run()
       ref.path.name.contains(name) should ===(true)
       ref ! PoisonPill
+    }
+
+    "be possible to run immediately, reproducer of #26714" in {
+      (1 to 100).foreach { _ =>
+        val mat = ActorMaterializer()
+        val source: Source[String, ActorRef] = Source.actorRef[String](10000, OverflowStrategy.fail)
+        val (_: ActorRef, _: Publisher[String]) =
+          source.toMat(Sink.asPublisher(false))(Keep.both).run()(mat)
+        mat.shutdown()
+      }
     }
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorRefSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorRefSource.scala
@@ -53,7 +53,7 @@ private object ActorRefSource {
 
       val ref: ActorRef = getEagerStageActor(eagerMaterializer, poisonPillCompatibility = true) {
         case (_, PoisonPill) ⇒
-          log.warning("for backwards compatibility: PoisonPill will note be supported in the future")
+          log.warning("for backwards compatibility: PoisonPill will not be supported in the future")
           completeStage()
         case (_, m) if failureMatcher.isDefinedAt(m) ⇒
           failStage(failureMatcher(m))


### PR DESCRIPTION
## Purpose

Fix bug in new implementation of Source.actorRef (regression introduced in 2.5.22).

## References

Refs #26714

## Changes

* fallback to sending message if materializer.supervisor RepointableActorRef
  is not started
* also harden test of CompletionStrategy.Immediately, which
  failed if Thread.sleep(100) in RepointableActorRef.point

## Background Context

* not nice to use Await, but should be rare and that is also used in
  ActorMaterializer.actorOf for similar thing
