### PR TITLE
fix wrong BackoffOpts in ClusterSharding, #26724

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -750,7 +750,7 @@ private[akka] class ClusterShardingGuardian extends Actor {
                 ShardCoordinator.props(typeName, settings, allocationStrategy, rep, majorityMinCap)
             val singletonProps =
               BackoffOpts
-                .onFailure(
+                .onStop(
                   childProps = coordinatorProps,
                   childName = "coordinator",
                   minBackoff = coordinatorFailureBackoff,


### PR DESCRIPTION
* note that this regression was never released, change was after 2.5.22
* change was part of warning fixup https://github.com/akka/akka/pull/26648/files#r275357812

Refs #26724