### PR TITLE
do not nullify context on actor termination #25040

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
@@ -167,6 +167,7 @@ class ActorLifeCycleSpec
 
           Future {
             latch.await()
+            Thread.sleep(50)
             "po"
           }.flatMap(x => Future { x + "ng" }).recover { case _: NullPointerException => "npe" }.pipeTo(replyTo)
       }

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
@@ -160,7 +160,7 @@ class ActorLifeCycleSpec
       import akka.pattern._
 
       override def receive: Receive = {
-        case "ping" ⇒
+        case "ping" =>
           val replyTo = sender()
 
           context.stop(self)
@@ -168,7 +168,7 @@ class ActorLifeCycleSpec
           Future {
             latch.await()
             "po"
-          }.flatMap(x ⇒ Future { x + "ng" }).recover { case _: NullPointerException ⇒ "npe" }.pipeTo(replyTo)
+          }.flatMap(x => Future { x + "ng" }).recover { case _: NullPointerException => "npe" }.pipeTo(replyTo)
       }
     }
 

--- a/akka-actor-tests/src/test/scala/akka/pattern/PromiseRefSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/PromiseRefSpec.scala
@@ -20,7 +20,6 @@ object PromiseRefSpec {
 
 class PromiseRefSpec extends AkkaSpec with ImplicitSender {
   import PromiseRefSpec._
-  import akka.pattern._
 
   "The PromiseRef" must {
     "complete promise with received message" in {

--- a/akka-actor/src/main/mima-filters/2.5.22.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.22.backwards.excludes
@@ -1,0 +1,3 @@
+# NPE when using import context.dispatcher #25040
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.actor.ActorCell.setActorFields")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.ActorCell.clearActorFields")

--- a/akka-actor/src/main/mima-filters/2.5.24.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.24.backwards.excludes
@@ -1,0 +1,2 @@
+# NPE when using import context.dispatcher #25040
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.ActorCell.clearActorFields")

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -685,15 +685,25 @@ private[akka] class ActorCell(
       throw new IllegalArgumentException("ActorCell has no props field")
   }
 
-  final protected def clearActorFields(actorInstance: Actor, recreate: Boolean): Unit = {
-    setActorFields(actorInstance, context = null, self = if (recreate) self else system.deadLetters)
+  final protected def clearActorFields(
+      actorInstance: Actor,
+      recreate: Boolean,
+      context: Option[ActorContext] = Some(null)): Unit = {
+    setActorFields(actorInstance, context = context, self = if (recreate) self else system.deadLetters)
     currentMessage = null
     behaviorStack = emptyBehaviorStack
   }
 
-  final protected def setActorFields(actorInstance: Actor, context: ActorContext, self: ActorRef): Unit =
+  final protected def clearActorFieldsOnTerminate(actorInstance: Actor): Unit =
+    clearActorFields(actorInstance, recreate = false, context = None)
+
+  final protected def setActorFields(actorInstance: Actor, context: Option[ActorContext], self: ActorRef): Unit =
     if (actorInstance ne null) {
-      if (!Reflect.lookupAndSetField(actorInstance.getClass, actorInstance, "context", context)
+      if ((context.isDefined && !Reflect.lookupAndSetField(
+            actorInstance.getClass,
+            actorInstance,
+            "context",
+            context.get))
           || !Reflect.lookupAndSetField(actorInstance.getClass, actorInstance, "self", self))
         throw IllegalActorStateException(
           s"${actorInstance.getClass} is not an Actor class. It doesn't extend the 'Actor' trait")

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -685,10 +685,7 @@ private[akka] class ActorCell(
       throw new IllegalArgumentException("ActorCell has no props field")
   }
 
-  final protected def clearActorFields(
-      actorInstance: Actor,
-      recreate: Boolean,
-      context: ActorContext = null): Unit = {
+  final protected def clearActorFields(actorInstance: Actor, recreate: Boolean, context: ActorContext = null): Unit = {
     setActorFields(actorInstance, context = context, self = if (recreate) self else system.deadLetters)
     currentMessage = null
     behaviorStack = emptyBehaviorStack
@@ -699,7 +696,11 @@ private[akka] class ActorCell(
       s"${actorInstance.getClass} is not an Actor class. It doesn't extend the 'Actor' trait")
 
   final protected def clearActorFieldsOnTerminate(actorInstance: Actor): Unit = {
-    if ((actorInstance ne null) && (!Reflect.lookupAndSetField(actorInstance.getClass, actorInstance, "self", system.deadLetters)))
+    if ((actorInstance ne null) && (!Reflect.lookupAndSetField(
+          actorInstance.getClass,
+          actorInstance,
+          "self",
+          system.deadLetters)))
       throwIllegalActorState(actorInstance)
 
     currentMessage = null
@@ -708,11 +709,7 @@ private[akka] class ActorCell(
 
   final protected def setActorFields(actorInstance: Actor, context: ActorContext, self: ActorRef): Unit =
     if (actorInstance ne null) {
-      if (!Reflect.lookupAndSetField(
-            actorInstance.getClass,
-            actorInstance,
-            "context",
-            context)
+      if (!Reflect.lookupAndSetField(actorInstance.getClass, actorInstance, "context", context)
           || !Reflect.lookupAndSetField(actorInstance.getClass, actorInstance, "self", self))
         throwIllegalActorState(actorInstance)
     }

--- a/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
@@ -241,7 +241,7 @@ private[akka] trait FaultHandling { this: ActorCell =>
 
       val freshActor = newActor()
       actor = freshActor // this must happen before postRestart has a chance to fail
-      if (freshActor eq failedActor) setActorFields(freshActor, Some(this), self) // If the creator returns the same instance, we need to restore our nulled out fields.
+      if (freshActor eq failedActor) setActorFields(freshActor, this, self) // If the creator returns the same instance, we need to restore our nulled out fields.
 
       freshActor.aroundPostRestart(cause)
       if (system.settings.DebugLifecycle) publish(Debug(self.path.toString, clazz(freshActor), "restarted"))

--- a/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
@@ -225,7 +225,7 @@ private[akka] trait FaultHandling { this: ActorCell =>
       if (system.settings.DebugLifecycle)
         publish(Debug(self.path.toString, clazz(a), "stopped"))
 
-      clearActorFields(a, recreate = false)
+      clearActorFieldsOnTerminate(a)
       clearActorCellFields(this)
       actor = null
     }
@@ -241,7 +241,7 @@ private[akka] trait FaultHandling { this: ActorCell =>
 
       val freshActor = newActor()
       actor = freshActor // this must happen before postRestart has a chance to fail
-      if (freshActor eq failedActor) setActorFields(freshActor, this, self) // If the creator returns the same instance, we need to restore our nulled out fields.
+      if (freshActor eq failedActor) setActorFields(freshActor, Some(this), self) // If the creator returns the same instance, we need to restore our nulled out fields.
 
       freshActor.aroundPostRestart(cause)
       if (system.settings.DebugLifecycle) publish(Debug(self.path.toString, clazz(freshActor), "restarted"))


### PR DESCRIPTION
`context` is not anymore set to null on actor termination.

References #25040

