### PR TITLE
Update MiMa: drop 2.4, add 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 
 scala:
   - "2.12.8"
-  - "2.11.12"
   - "2.13.0-M5"
 
 before_install:

--- a/akka-docs/src/main/paradox/common/binary-compatibility-rules.md
+++ b/akka-docs/src/main/paradox/common/binary-compatibility-rules.md
@@ -42,6 +42,10 @@ OK:  3.1.n --> 3.2.0 ...
 
 If a security vulnerability is reported in Akka or a transient dependency of Akka and it cannot be solved without breaking binary compatibility then fixing the security issue is more important. In such cases binary compatibility might not be retained when releasing a minor version. Such exception is always noted in the release announcement.
 
+We do not guarantee binary compatibility with versions that are EOL, though in
+practice this does not make a big difference: only in rare cases would a change
+be binary compatible with recent previous releases but not with older ones.
+
 Some modules are excluded from the binary compatibility guarantees, such as:
 
  * `*-testkit` modules - since these are to be used only in tests, which usually are re-compiled and run on demand

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -28,7 +28,7 @@ object AkkaBuild {
     UnidocRoot.akkaSettings ++
     Protobuf.settings ++ Seq(
       parallelExecution in GlobalScope := System.getProperty("akka.parallelExecution", parallelExecutionByDefault.toString).toBoolean,
-      version in ThisBuild := "2.5-SNAPSHOT"
+      version in ThisBuild := "2.6-SNAPSHOT"
     )
  
   lazy val mayChangeSettings = Seq(

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -4,6 +4,7 @@
 
 package akka
 
+import scala.collection.immutable
 import sbt._
 import sbt.Keys._
 import com.typesafe.tools.mima.plugin.MimaPlugin
@@ -12,7 +13,8 @@ import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
 object MiMa extends AutoPlugin {
 
   private val latestPatchOf25 = 22
-  private val latestPatchOf24 = 20
+  // No 2.6 has been released yet. Update to '0' after releasing 2.6.0
+  private val latestPatchOf26 = -1
 
   override def requires = MimaPlugin
   override def trigger = allRequirements
@@ -24,41 +26,20 @@ object MiMa extends AutoPlugin {
       projectName: String,
       organization: String,
       scalaBinaryVersion: String): Set[sbt.ModuleID] = {
+
     val versions: Seq[String] = {
-      val akka24NoStreamVersions = Seq("2.4.0", "2.4.1")
-      val akka25Versions = (0 to latestPatchOf25).map(patch => s"2.5.$patch")
-      val akka24StreamVersions = (2 to 12).map("2.4." + _)
-      val akka25DiscoveryVersions = (19 to latestPatchOf25).map(patch => s"2.5.$patch")
-      val akka24WithScala212 =
-        (13 to latestPatchOf24)
-          .map("2.4." + _)
-          .filterNot(_ == "2.4.15") // 2.4.15 was released from the wrong branch and never announced
-
-      val akka242NewArtifacts = Seq("akka-stream", "akka-stream-testkit")
-      val akka250NewArtifacts = Seq("akka-persistence-query")
-      val akka2519NewArtifacts = Seq("akka-discovery")
-
       scalaBinaryVersion match {
-        case "2.11" =>
-          if (akka2519NewArtifacts.contains(projectName))
-            akka25DiscoveryVersions
-          else if (akka250NewArtifacts.contains(projectName)) akka25Versions
-          else {
-            if (!akka242NewArtifacts.contains(projectName)) akka24NoStreamVersions
-            else Seq.empty
-          } ++ akka24StreamVersions ++ akka24WithScala212 ++ akka25Versions
-
         case "2.12" =>
-          if (akka2519NewArtifacts.contains(projectName))
-            akka25DiscoveryVersions
-          else if (akka250NewArtifacts.contains(projectName))
-            akka25Versions
-          else
-            akka24WithScala212 ++ akka25Versions
+          val firstPatchOf25 =
+            if (projectName.contains("discovery")) 19
+            else 0
 
+          expandVersions(2, 5, firstPatchOf25 to latestPatchOf25) ++
+          expandVersions(2, 6, 0 to latestPatchOf26)
         case v if v.startsWith("2.13") =>
-          // no Akka released for 2.13 yet, no jars to check BC against
-          Seq.empty
+          // When 2.13.0 is actually out, release 2.5.latestPatchOf25 for that
+          // and add it here. https://github.com/akka/akka/issues/26764
+          expandVersions(2, 6, 0 to latestPatchOf26)
       }
     }
 
@@ -74,4 +55,7 @@ object MiMa extends AutoPlugin {
       organization %% adjustedProjectName % v
     }.toSet
   }
+
+  private def expandVersions(major: Int, minor: Int, patches: immutable.Seq[Int]): immutable.Seq[String] =
+    patches.map(patch => s"$major.$minor.$patch")
 }


### PR DESCRIPTION
To be merged after creating the `release-2.5` branch.

We promise binary compatibility across minor versions, which would in theory
mean we should check compatibility between 2.4 and 2.6.

However, since 2.4 is EOL, we no longer guarantee bincompat with it. In
practice this should not make much of a difference, since only in rare cases
would a change be binary compatible with 2.5 but not with 2.4.