### PR TITLE
Update tutorial_4.md

### DIFF
--- a/akka-docs/src/main/paradox/guide/tutorial_4.md
+++ b/akka-docs/src/main/paradox/guide/tutorial_4.md
@@ -118,7 +118,7 @@ Java
 
 @@@ note
 
-We used the `expectNoMsg()` helper method from @scala[`TestProbe`]@java[`TestKit`]. This assertion waits until the defined time-limit and fails if it receives any messages during this period. If no messages are received during the waiting period, the assertion passes. It is usually a good idea to keep these timeouts low (but not too low) because they add significant test execution time.
+We used the `expectNoMessage()` helper method from @scala[`TestProbe`]@java[`TestKit`]. This assertion waits until the defined time-limit and fails if it receives any messages during this period. If no messages are received during the waiting period, the assertion passes. It is usually a good idea to keep these timeouts low (but not too low) because they add significant test execution time.
 
 @@@
 


### PR DESCRIPTION
The method expectNoMsg() is deprecated since 2.5.10. The code examples have already been updated to use expectNoMessage() but the Note section still contains a reference to expectNoMsg() method.

<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #xxxx

## Changes

<!-- Bullets for important changes in this PR -->

## Background Context

<!-- Why did you take this approach? -->
