### PR TITLE
Make internals starvation safe

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -11,6 +11,7 @@ import akka.actor.typed.{
   ActorRef,
   ActorSystem,
   Behavior,
+  DispatcherDefault,
   DispatcherSelector,
   Dispatchers,
   Extension,
@@ -65,7 +66,8 @@ import com.github.ghik.silencer.silent
   implicit override def executionContext: scala.concurrent.ExecutionContextExecutor = controlledExecutor
   override def dispatchers: akka.actor.typed.Dispatchers = new Dispatchers {
     def lookup(selector: DispatcherSelector): ExecutionContextExecutor = controlledExecutor
-    def shutdown(): Unit = ()
+    override private[akka] def internalDispatcherSelector: DispatcherSelector = DispatcherDefault(Props.empty)
+    override def blockingDispatcherSelector: DispatcherSelector = DispatcherDefault(Props.empty)
   }
 
   override def dynamicAccess: untyped.DynamicAccess = new untyped.ReflectiveDynamicAccess(getClass.getClassLoader)

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemDispatchersSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemDispatchersSpec.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor
+
+import akka.actor.setup.ActorSystemSetup
+import akka.dispatch.ExecutionContexts
+import akka.testkit.{ AkkaSpec, ImplicitSender, TestActors, TestProbe }
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+object ActorSystemDispatchersSpec {
+
+  class SnitchingExecutionContext(testActor: ActorRef, underlying: ExecutionContext) extends ExecutionContext {
+
+    def execute(runnable: Runnable): Unit = {
+      testActor ! "called"
+      underlying.execute(runnable)
+    }
+
+    def reportFailure(t: Throwable): Unit = {
+      testActor ! "failed"
+      underlying.reportFailure(t)
+    }
+  }
+
+}
+
+class ActorSystemDispatchersSpec extends AkkaSpec with ImplicitSender {
+
+  import ActorSystemDispatchersSpec._
+
+  "The ActorSystem" must {
+
+    "work with a passed in ExecutionContext" in {
+      val ecProbe = TestProbe()
+      val ec = new SnitchingExecutionContext(ecProbe.ref, ExecutionContexts.global())
+
+      val system2 = ActorSystem(name = "ActorSystemDispatchersSpec-passed-in-ec", defaultExecutionContext = Some(ec))
+
+      try {
+        val ref = system2.actorOf(Props(new Actor {
+          def receive = {
+            case "ping" => sender() ! "pong"
+          }
+        }))
+
+        val probe = TestProbe()
+
+        ref.tell("ping", probe.ref)
+
+        ecProbe.expectMsg(1.second, "called")
+        probe.expectMsg(1.second, "pong")
+      } finally {
+        shutdown(system2)
+      }
+    }
+
+    "not use passed in ExecutionContext if executor is configured" in {
+      val ecProbe = TestProbe()
+      val ec = new SnitchingExecutionContext(ecProbe.ref, ExecutionContexts.global())
+
+      val config = ConfigFactory.parseString("akka.actor.default-dispatcher.executor = \"fork-join-executor\"")
+      val system2 = ActorSystem(
+        name = "ActorSystemDispatchersSpec-ec-configured",
+        config = Some(config),
+        defaultExecutionContext = Some(ec))
+
+      try {
+        val ref = system2.actorOf(TestActors.echoActorProps)
+        val probe = TestProbe()
+
+        ref.tell("ping", probe.ref)
+
+        ecProbe.expectNoMessage(200.millis)
+        probe.expectMsg(1.second, "ping")
+      } finally {
+        shutdown(system2)
+      }
+    }
+
+    def userGuardianDispatcher(system: ActorSystem): String = {
+      val impl = system.asInstanceOf[ActorSystemImpl]
+      impl.guardian.asInstanceOf[ActorRefWithCell].underlying.asInstanceOf[ActorCell].dispatcher.id
+    }
+
+    "provide a single place to override the internal dispatcher" in {
+      val sys = ActorSystem(
+        "ActorSystemDispatchersSpec-override-internal-disp",
+        ConfigFactory.parseString("""
+            akka.actor.internal-dispatcher = akka.actor.default-dispatcher
+          """))
+      try {
+        // that the user guardian runs on the overriden dispatcher instead of internal
+        // isn't really a guarantee any internal actor has been made running on the right one
+        // but it's better than no test coverage at all
+        userGuardianDispatcher(sys) should ===("akka.actor.default-dispatcher")
+      } finally {
+        shutdown(sys)
+      }
+    }
+
+    "provide internal dispatcher instance through BootstrapSetup" in {
+      pending // Not sure how important this is and quite tricky to implement, deferring
+      // would be something like
+      // ActorSystem("name", BootstrapSetup().withCustomInternalExecutionContext(myEc))
+    }
+
+    "use an internal dispatcher for the guardian by default" in {
+      userGuardianDispatcher(system) should ===("akka.actor.default-internal-dispatcher")
+    }
+
+    "use the default dispatcher by a user provided user guardian" in {
+      val sys = new ActorSystemImpl(
+        "ActorSystemDispatchersSpec-custom-user-guardian",
+        ConfigFactory.defaultReference(),
+        getClass.getClassLoader,
+        None,
+        Some(Props.empty),
+        ActorSystemSetup.empty)
+      sys.start()
+      try {
+        userGuardianDispatcher(sys) should ===("akka.actor.default-dispatcher")
+      } finally shutdown(sys)
+    }
+
+  }
+
+}

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
@@ -592,8 +592,8 @@ class DispatcherModelSpec extends ActorModelSpec(DispatcherModelSpec.config) {
       system.stop(a)
       system.stop(b)
 
-      probe.expectTerminated(a)
-      probe.expectTerminated(b)
+      // shutdown ordering is not deterministic
+      (Set(probe.expectMsgType[Terminated], probe.expectMsgType[Terminated]).map(_.actor)) should ===(Set(a, b))
 
       assertRefDefaultZero(a)(registers = 1, unregisters = 1, msgsReceived = 1, msgsProcessed = 1)
       assertRefDefaultZero(b)(registers = 1, unregisters = 1, msgsReceived = 1, msgsProcessed = 1)

--- a/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
@@ -94,7 +94,7 @@ class ConfigSpec extends AkkaSpec(ConfigFactory.defaultReference(ActorSystem.fin
         {
           val pool = c.getConfig("fork-join-executor")
           pool.getInt("parallelism-min") should ===(8)
-          pool.getDouble("parallelism-factor") should ===(3.0)
+          pool.getDouble("parallelism-factor") should ===(1.0)
           pool.getInt("parallelism-max") should ===(64)
           pool.getString("task-peeking-mode") should be("FIFO")
         }

--- a/akka-actor-tests/src/test/scala/akka/dispatch/DispatcherShutdownSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/DispatcherShutdownSpec.scala
@@ -23,7 +23,9 @@ class DispatcherShutdownSpec extends WordSpec with Matchers {
           .dumpAllThreads(false, false)
           .toList
           .map(_.getThreadName)
-          .filter(_.startsWith("DispatcherShutdownSpec-akka.actor.default"))
+          .filter(name =>
+            name.startsWith("DispatcherShutdownSpec-akka.actor.default") || name.startsWith(
+              "DispatcherShutdownSpec-akka.actor.internal")) // nothing is run on default without any user actors started
           .size
 
       val system = ActorSystem("DispatcherShutdownSpec")

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/DispatchersDocTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/DispatchersDocTest.java
@@ -21,7 +21,10 @@ public class DispatchersDocTest {
             context.spawn(yourBehavior, "DefaultDispatcher");
             context.spawn(
                 yourBehavior, "ExplicitDefaultDispatcher", DispatcherSelector.defaultDispatcher());
-            context.spawn(yourBehavior, "BlockingDispatcher", DispatcherSelector.blocking());
+            context.spawn(
+                yourBehavior,
+                "BlockingDispatcher",
+                context.getSystem().dispatchers().blockingDispatcherSelector());
             context.spawn(
                 yourBehavior,
                 "DispatcherFromConfig",

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/DispatchersDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/DispatchersDocSpec.scala
@@ -45,7 +45,7 @@ object DispatchersDocSpec {
 
     context.spawn(yourBehavior, "DefaultDispatcher")
     context.spawn(yourBehavior, "ExplicitDefaultDispatcher", DispatcherSelector.default())
-    context.spawn(yourBehavior, "BlockingDispatcher", DispatcherSelector.blocking())
+    context.spawn(yourBehavior, "BlockingDispatcher", context.system.dispatchers.blockingDispatcherSelector)
     context.spawn(yourBehavior, "DispatcherFromConfig", DispatcherSelector.fromConfig("your-dispatcher"))
     //#spawn-dispatcher
 
@@ -65,7 +65,8 @@ class DispatchersDocSpec extends ScalaTestWithActorTestKit(DispatchersDocSpec.co
       withDefault ! WhichDispatcher(probe.ref)
       probe.receiveMessage().id shouldEqual "akka.actor.default-dispatcher"
 
-      val withBlocking = actor.ask(Spawn(giveMeYourDispatcher, "default", DispatcherSelector.blocking())).futureValue
+      val withBlocking =
+        actor.ask(Spawn(giveMeYourDispatcher, "default", system.dispatchers.blockingDispatcherSelector)).futureValue
       withBlocking ! WhichDispatcher(probe.ref)
       probe.receiveMessage().id shouldEqual "akka.actor.default-blocking-io-dispatcher"
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Dispatchers.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Dispatchers.scala
@@ -4,6 +4,8 @@
 
 package akka.actor.typed
 
+import akka.annotation.DoNotInherit
+
 import scala.concurrent.ExecutionContextExecutor
 
 object Dispatchers {
@@ -12,13 +14,28 @@ object Dispatchers {
    * The id of the default dispatcher, also the full key of the
    * configuration of the default dispatcher.
    */
-  final val DefaultDispatcherId = "akka.actor.default-dispatcher"
+  final val DefaultDispatcherId = akka.dispatch.Dispatchers.DefaultDispatcherId
 }
 
 /**
  * An [[ActorSystem]] looks up all its thread pools via a Dispatchers instance.
+ *
+ * Not for user instantiation or extension
  */
+@DoNotInherit
 abstract class Dispatchers {
   def lookup(selector: DispatcherSelector): ExecutionContextExecutor
-  def shutdown(): Unit
+
+  /**
+   * A selector that will use the default dispatcher for actors performing blocking operations as configured
+   * with the 'akka.actor.blocking-dispatcher' setting.
+   */
+  def blockingDispatcherSelector: DispatcherSelector
+
+  /**
+   * INTERNAL API
+   *
+   * Dispatcher for internal actors, configured with the 'akka.actor.internal-dispatcher' setting.
+   */
+  private[akka] def internalDispatcherSelector: DispatcherSelector
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
@@ -167,9 +167,13 @@ object DispatcherSelector {
 
   /**
    *  Run the actor on the default blocking dispatcher that is
-   *  configured under default-blocking-io-dispatcher
+   *  configured under blocking-dispatcher.
+   *
+   *  Note that for optimal handling of blocking it may make sense
+   *  to create resource specific dispatchers and tune them to the
+   *  individual resource instead of using the globally shared blocking dispatcher.
    */
-  def blocking(): DispatcherSelector = fromConfig("akka.actor.default-blocking-io-dispatcher")
+  def blocking(): DispatcherSelector = BlockingDispatcher()
 
   /**
    * Look up an executor definition in the [[ActorSystem]] configuration.
@@ -198,6 +202,19 @@ object DispatcherDefault {
    * Retrieve an instance for this configuration node with empty `next` reference.
    */
   def apply(): DispatcherDefault = empty
+}
+
+/**
+ * Indirectly looks up an executor definition id in the [[ActorSystem]] configuration
+ * and then uses the dispatcher that id points to
+ * ExecutorServices created in this fashion will be shut down when the
+ * ActorSystem terminates.
+ *
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] final case class BlockingDispatcher(next: Props = Props.empty) extends DispatcherSelector {
+  override def withNext(next: Props): Props = copy(next = next)
 }
 
 /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
@@ -167,13 +167,16 @@ object DispatcherSelector {
 
   /**
    *  Run the actor on the default blocking dispatcher that is
-   *  configured under blocking-dispatcher.
+   *  configured under 'akka.actor.blocking-dispatcher'.
    *
    *  Note that for optimal handling of blocking it may make sense
    *  to create resource specific dispatchers and tune them to the
    *  individual resource instead of using the globally shared blocking dispatcher.
    */
-  def blocking(): DispatcherSelector = BlockingDispatcher()
+  @deprecated("Use syste.dispatchers.blockingDispatcherSelector instead", "2.6.0")
+  def blocking(): DispatcherSelector =
+    // will not adhere to changes to 'akka.actor.blocking-dispatcher'
+    DispatcherFromConfig("akka.actor.default-blocking-dispatcher")
 
   /**
    * Look up an executor definition in the [[ActorSystem]] configuration.
@@ -202,19 +205,6 @@ object DispatcherDefault {
    * Retrieve an instance for this configuration node with empty `next` reference.
    */
   def apply(): DispatcherDefault = empty
-}
-
-/**
- * Indirectly looks up an executor definition id in the [[ActorSystem]] configuration
- * and then uses the dispatcher that id points to
- * ExecutorServices created in this fashion will be shut down when the
- * ActorSystem terminates.
- *
- * INTERNAL API
- */
-@InternalApi
-private[akka] final case class BlockingDispatcher(next: Props = Props.empty) extends DispatcherSelector {
-  override def withNext(next: Props): Props = copy(next = next)
 }
 
 /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -71,9 +71,14 @@ import akka.event.LoggingFilterWithMarker
       selector match {
         case DispatcherDefault(_)         => untypedSystem.dispatcher
         case DispatcherFromConfig(str, _) => untypedSystem.dispatchers.lookup(str)
-        case BlockingDispatcher(_)        => untypedSystem.dispatchers.blockingDispatcher
       }
-    override def shutdown(): Unit = () // there was no shutdown in untyped Akka
+
+    override private[akka] def internalDispatcherSelector: DispatcherSelector =
+      DispatcherFromConfig(untypedSystem.dispatchers.internalDispatcherId)
+
+    override def blockingDispatcherSelector: DispatcherSelector =
+      DispatcherFromConfig(untypedSystem.dispatchers.blockingDispatcherId)
+
   }
   override def dynamicAccess: untyped.DynamicAccess = untypedSystem.dynamicAccess
   implicit override def executionContext: scala.concurrent.ExecutionContextExecutor = untypedSystem.dispatcher

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -71,6 +71,7 @@ import akka.event.LoggingFilterWithMarker
       selector match {
         case DispatcherDefault(_)         => untypedSystem.dispatcher
         case DispatcherFromConfig(str, _) => untypedSystem.dispatchers.lookup(str)
+        case BlockingDispatcher(_)        => untypedSystem.dispatchers.blockingDispatcher
       }
     override def shutdown(): Unit = () // there was no shutdown in untyped Akka
   }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -4,14 +4,12 @@
 
 package akka.actor.typed.receptionist
 
-import akka.actor.typed.{ ActorRef, ActorSystem, Extension, ExtensionId }
+import akka.actor.typed.{ ActorRef, ActorSystem, Extension, ExtensionId, ExtensionSetup }
 import akka.actor.typed.internal.receptionist._
 import akka.annotation.DoNotInherit
+
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
-
-import akka.actor.typed.ExtensionSetup
-import akka.actor.typed.Props
 import akka.annotation.InternalApi
 
 /**
@@ -51,7 +49,7 @@ abstract class Receptionist extends Extension {
       } else LocalReceptionist
 
     import akka.actor.typed.scaladsl.adapter._
-    system.internalSystemActorOf(provider.behavior, "receptionist", Props.empty)
+    system.internalSystemActorOf(provider.behavior, "receptionist", system.dispatchers.internalDispatcherSelector)
   }
 }
 

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -552,7 +552,7 @@ akka {
 
     # The full config path of a dispatcher to use for blocking operations
     # FIXME more settings would likely need to use this indirection as a default just like with the internal-dispatcher
-    blocking-io-dispatcher = "akka.actor.default-blocking-io-dispatcher"
+    blocking-dispatcher = "akka.actor.default-blocking-io-dispatcher"
 
     default-blocking-io-dispatcher {
       type = "Dispatcher"
@@ -896,7 +896,7 @@ akka {
 
       # Fully qualified config path which holds the dispatcher configuration
       # on which file IO tasks are scheduled, if left empty (the default), the
-      # dispatcher id from 'akka.actor.blocking-io-dispatcher' is used
+      # dispatcher id from 'akka.actor.blocking-dispatcher' is used
       file-io-dispatcher = ""
 
       # The maximum number of bytes (or "unlimited") to transfer in one batch

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -25,9 +25,8 @@ akka {
   # (akka.actor.ActorSystem.Settings, akka.event.EventStream) parameters.
   logging-filter = "akka.event.DefaultLoggingFilter"
 
-  # Specifies the default loggers dispatcher. If left empty (the default),
-  # the dispatcher id from 'akka.actor.internal-dispatcher' is used.
-  loggers-dispatcher = ""
+  # Specifies the default loggers dispatcher.
+  loggers-dispatcher = "akka.actor.default-dispatcher"
 
   # Loggers are created and registered synchronously during ActorSystem
   # start-up, and since they are actors, this timeout is used to bound the
@@ -535,11 +534,11 @@ akka {
     }
 
     # The full config path of a dispatcher to use for all internal actors to
-    # avoid starvation in the default dispatcher affecting Akka internals
+    # avoid starvation in the default dispatcher affecting Akka internals.
     internal-dispatcher = "akka.actor.default-internal-dispatcher"
 
-    # Default separate internal dispatcher, if 'akka.actor.internal-dispatcher' is changed this
-    # dispatcher is not used
+    # Default separate internal dispatcher, if 'akka.actor.internal-dispatcher'
+    # is changed this dispatcher is not used.
     default-internal-dispatcher {
       type = "Dispatcher"
       executor = "fork-join-executor"
@@ -547,11 +546,13 @@ akka {
       fork-join-executor {
         parallelism-min = 4
         parallelism-factor = 1.0
-        # FIXME no use to have a high number here, but what is reasonable?
-        parallelism-max = 8
+        parallelism-max = 64
       }
     }
 
+    # The full config path of a dispatcher to use for blocking operations
+    # FIXME more settings would likely need to use this indirection as a default just like with the internal-dispatcher
+    blocking-io-dispatcher = "akka.actor.default-blocking-io-dispatcher"
 
     default-blocking-io-dispatcher {
       type = "Dispatcher"
@@ -894,8 +895,9 @@ akka {
       management-dispatcher = ""
 
       # Fully qualified config path which holds the dispatcher configuration
-      # on which file IO tasks are scheduled
-      file-io-dispatcher = "akka.actor.default-blocking-io-dispatcher"
+      # on which file IO tasks are scheduled, if left empty (the default), the
+      # dispatcher id from 'akka.actor.blocking-io-dispatcher' is used
+      file-io-dispatcher = ""
 
       # The maximum number of bytes (or "unlimited") to transfer in one batch
       # when using `WriteFile` command which uses `FileChannel.transferTo` to
@@ -1040,8 +1042,9 @@ akka {
       # Fully qualified config path which holds the dispatcher configuration
       # for the manager and resolver router actors.
       # For actual router configuration see akka.actor.deployment./IO-DNS/*
-      # If left empty (the default), the dispatcher id from 'akka.actor.internal-dispatcher'
-      # is used.
+      # If left empty (the default) the selected dispatcher depends on the resolver chosen:
+      #  'async-dns' - the dispatcher id from 'akka.actor.internal-dispatcher' is used.
+      #  'inet-address' - the dispatcher id from 'akka.actor.blocking-io-dispatcher' is used
       dispatcher = ""
 
       # Name of the subconfig at path akka.io.dns, see inet-address below

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -25,8 +25,9 @@ akka {
   # (akka.actor.ActorSystem.Settings, akka.event.EventStream) parameters.
   logging-filter = "akka.event.DefaultLoggingFilter"
 
-  # Specifies the default loggers dispatcher
-  loggers-dispatcher = "akka.actor.default-dispatcher"
+  # Specifies the default loggers dispatcher. If left empty (the default),
+  # the dispatcher id from 'akka.actor.internal-dispatcher' is used.
+  loggers-dispatcher = ""
 
   # Loggers are created and registered synchronously during ActorSystem
   # start-up, and since they are actors, this timeout is used to bound the
@@ -451,7 +452,7 @@ akka {
         # The parallelism factor is used to determine thread pool size using the
         # following formula: ceil(available processors * factor). Resulting size
         # is then bounded by the parallelism-min and parallelism-max values.
-        parallelism-factor = 3.0
+        parallelism-factor = 1.0
 
         # Max number of threads to cap factor-based parallelism number to
         parallelism-max = 64
@@ -532,6 +533,25 @@ akka {
       # be a subtype of this type. The empty string signifies no requirement.
       mailbox-requirement = ""
     }
+
+    # The full config path of a dispatcher to use for all internal actors to
+    # avoid starvation in the default dispatcher affecting Akka internals
+    internal-dispatcher = "akka.actor.default-internal-dispatcher"
+
+    # Default separate internal dispatcher, if 'akka.actor.internal-dispatcher' is changed this
+    # dispatcher is not used
+    default-internal-dispatcher {
+      type = "Dispatcher"
+      executor = "fork-join-executor"
+      throughput = 5
+      fork-join-executor {
+        parallelism-min = 4
+        parallelism-factor = 1.0
+        # FIXME no use to have a high number here, but what is reasonable?
+        parallelism-max = 8
+      }
+    }
+
 
     default-blocking-io-dispatcher {
       type = "Dispatcher"
@@ -864,12 +884,14 @@ akka {
       selector-dispatcher = "akka.io.pinned-dispatcher"
 
       # Fully qualified config path which holds the dispatcher configuration
-      # for the read/write worker actors
-      worker-dispatcher = "akka.actor.default-dispatcher"
+      # for the read/write worker actors. If left empty (the default), the dispatcher
+      # id from 'akka.actor.internal-dispatcher' is used.
+      worker-dispatcher = ""
 
       # Fully qualified config path which holds the dispatcher configuration
-      # for the selector management actors
-      management-dispatcher = "akka.actor.default-dispatcher"
+      # for the selector management actors. If left empty (the default), the dispatcher
+      # id from 'akka.actor.internal-dispatcher' is used.
+      management-dispatcher = ""
 
       # Fully qualified config path which holds the dispatcher configuration
       # on which file IO tasks are scheduled
@@ -946,12 +968,14 @@ akka {
       selector-dispatcher = "akka.io.pinned-dispatcher"
 
       # Fully qualified config path which holds the dispatcher configuration
-      # for the read/write worker actors
-      worker-dispatcher = "akka.actor.default-dispatcher"
+      # for the read/write worker actors. If left empty (the default), the dispatcher
+      # id from 'akka.actor.internal-dispatcher' is used.
+      worker-dispatcher = ""
 
       # Fully qualified config path which holds the dispatcher configuration
-      # for the selector management actors
-      management-dispatcher = "akka.actor.default-dispatcher"
+      # for the selector management actors. If left empty (the default), the dispatcher
+      # id from 'akka.actor.internal-dispatcher' is used.
+      management-dispatcher = ""
     }
 
     udp-connected {
@@ -1002,19 +1026,23 @@ akka {
       selector-dispatcher = "akka.io.pinned-dispatcher"
 
       # Fully qualified config path which holds the dispatcher configuration
-      # for the read/write worker actors
-      worker-dispatcher = "akka.actor.default-dispatcher"
+      # for the read/write worker actors. If left empty (the default), the dispatcher
+      # id from 'akka.actor.internal-dispatcher' is used.
+      worker-dispatcher = ""
 
       # Fully qualified config path which holds the dispatcher configuration
-      # for the selector management actors
-      management-dispatcher = "akka.actor.default-dispatcher"
+      # for the selector management actors. If left empty (the default), the dispatcher
+      # id from 'akka.actor.internal-dispatcher' is used.
+      management-dispatcher = ""
     }
 
     dns {
       # Fully qualified config path which holds the dispatcher configuration
       # for the manager and resolver router actors.
       # For actual router configuration see akka.actor.deployment./IO-DNS/*
-      dispatcher = "akka.actor.default-dispatcher"
+      # If left empty (the default), the dispatcher id from 'akka.actor.internal-dispatcher'
+      # is used.
+      dispatcher = ""
 
       # Name of the subconfig at path akka.io.dns, see inet-address below
       #

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -632,7 +632,7 @@ private[akka] class LocalActorRefProvider private[akka] (
     val dispatcher =
       system.guardianProps match {
         case None =>
-          // run on internal dispatcher if user provided the guardian
+          // run on internal dispatcher if user didn't provide the guardian
           internalDispatcher
         case Some(props) =>
           // user provided guardian runs on user specified dispatcher or default dispatcher

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -384,7 +384,7 @@ object ActorSystem {
 
     final val SchedulerClass: String = getString("akka.scheduler.implementation")
     final val InternalDispatcher: String = getString("akka.actor.internal-dispatcher")
-    final val BlockingIODispatcher: String = getString("akka.actor.blocking-io-dispatcher")
+    final val BlockingDispatcher: String = getString("akka.actor.blocking-dispatcher")
 
     final val Daemonicity: Boolean = getBoolean("akka.daemonic")
     final val JvmExitOnFatalError: Boolean = getBoolean("akka.jvm-exit-on-fatal-error")

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -384,6 +384,7 @@ object ActorSystem {
 
     final val SchedulerClass: String = getString("akka.scheduler.implementation")
     final val InternalDispatcher: String = getString("akka.actor.internal-dispatcher")
+    final val BlockingIODispatcher: String = getString("akka.actor.blocking-io-dispatcher")
 
     final val Daemonicity: Boolean = getBoolean("akka.daemonic")
     final val JvmExitOnFatalError: Boolean = getBoolean("akka.jvm-exit-on-fatal-error")

--- a/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
+++ b/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
@@ -454,7 +454,7 @@ final class CoordinatedShutdown private[akka] (
    */
   def run(reason: Reason, fromPhase: Option[String]): Future[Done] = {
     if (runStarted.compareAndSet(None, Some(reason))) {
-      import system.dispatcher
+      implicit val executionContext = system.dispatchers.internalDispatcher
       val debugEnabled = log.isDebugEnabled
       def loop(remainingPhases: List[String]): Future[Done] = {
         remainingPhases match {

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
@@ -11,6 +11,7 @@ import akka.actor.{ ActorSystem, DynamicAccess, Scheduler }
 import akka.event.Logging.Warning
 import akka.event.EventStream
 import akka.ConfigurationException
+import akka.annotation.InternalApi
 import akka.util.Helpers.ConfigOps
 import com.github.ghik.silencer.silent
 
@@ -46,9 +47,11 @@ object Dispatchers {
 
   /**
    * The id of the default dispatcher, also the full key of the
-   * configuration of the default dispatcher.
+   * configuration of the default dispatcher unless it was passed to the system
+   * with the BootstrapSetup or as a actor system creation parameter.
    */
   final val DefaultDispatcherId = "akka.actor.default-dispatcher"
+
 }
 
 /**
@@ -74,6 +77,17 @@ class Dispatchers(val settings: ActorSystem.Settings, val prerequisites: Dispatc
   def defaultGlobalDispatcher: MessageDispatcher = lookup(DefaultDispatcherId)
 
   private val dispatcherConfigurators = new ConcurrentHashMap[String, MessageDispatcherConfigurator]
+
+  @InternalApi
+  private[akka] val internalDispatcherId: String = settings.InternalDispatcher
+
+  /**
+   * INTERNAL API
+   *
+   * internal dispatcher for non-user actors etc.
+   */
+  @InternalApi
+  private[akka] val internalDispatcher: MessageDispatcher = lookup(internalDispatcherId)
 
   /**
    * Returns a dispatcher as specified in configuration. Please note that this

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
@@ -78,8 +78,21 @@ class Dispatchers(val settings: ActorSystem.Settings, val prerequisites: Dispatc
 
   private val dispatcherConfigurators = new ConcurrentHashMap[String, MessageDispatcherConfigurator]
 
+  /**
+   * INTERNAL API
+   *
+   * Dispatcher ID for internal actors
+   */
   @InternalApi
   private[akka] val internalDispatcherId: String = settings.InternalDispatcher
+
+  /**
+   * INTERNAL API
+   *
+   * Dispatcher ID for blocking tasks
+   */
+  @InternalApi
+  private[akka] val blockingIODispatcherId: String = settings.BlockingIODispatcher
 
   /**
    * INTERNAL API
@@ -88,6 +101,14 @@ class Dispatchers(val settings: ActorSystem.Settings, val prerequisites: Dispatc
    */
   @InternalApi
   private[akka] val internalDispatcher: MessageDispatcher = lookup(internalDispatcherId)
+
+  /**
+   * INTERNAL API
+   *
+   * Dispatcher for blocking tasks
+   */
+  @InternalApi
+  private[akka] val blockingIODispatcher: MessageDispatcher = lookup(settings.BlockingIODispatcher)
 
   /**
    * Returns a dispatcher as specified in configuration. Please note that this

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
@@ -92,7 +92,7 @@ class Dispatchers(val settings: ActorSystem.Settings, val prerequisites: Dispatc
    * Dispatcher ID for blocking tasks
    */
   @InternalApi
-  private[akka] val blockingIODispatcherId: String = settings.BlockingIODispatcher
+  private[akka] val blockingDispatcherId: String = settings.BlockingDispatcher
 
   /**
    * INTERNAL API
@@ -108,7 +108,7 @@ class Dispatchers(val settings: ActorSystem.Settings, val prerequisites: Dispatc
    * Dispatcher for blocking tasks
    */
   @InternalApi
-  private[akka] val blockingIODispatcher: MessageDispatcher = lookup(settings.BlockingIODispatcher)
+  private[akka] val blockingDispatcher: MessageDispatcher = lookup(settings.BlockingDispatcher)
 
   /**
    * Returns a dispatcher as specified in configuration. Please note that this

--- a/akka-actor/src/main/scala/akka/event/ActorClassificationUnsubscriber.scala
+++ b/akka-actor/src/main/scala/akka/event/ActorClassificationUnsubscriber.scala
@@ -79,7 +79,9 @@ private[akka] object ActorClassificationUnsubscriber {
     val debug = system.settings.config.getBoolean("akka.actor.debug.event-stream")
     system
       .asInstanceOf[ExtendedActorSystem]
-      .systemActorOf(props(bus, debug), "actorClassificationUnsubscriber-" + unsubscribersCount.incrementAndGet())
+      .systemActorOf(
+        props(bus, debug).withDispatcher(system.dispatchers.internalDispatcherId),
+        "actorClassificationUnsubscriber-" + unsubscribersCount.incrementAndGet())
   }
 
   private def props(eventBus: ManagedActorClassification, debug: Boolean) =

--- a/akka-actor/src/main/scala/akka/event/EventStreamUnsubscriber.scala
+++ b/akka-actor/src/main/scala/akka/event/EventStreamUnsubscriber.scala
@@ -81,7 +81,9 @@ private[akka] object EventStreamUnsubscriber {
     val debug = system.settings.config.getBoolean("akka.actor.debug.event-stream")
     system
       .asInstanceOf[ExtendedActorSystem]
-      .systemActorOf(props(stream, debug), "eventStreamUnsubscriber-" + unsubscribersCount.incrementAndGet())
+      .systemActorOf(
+        props(stream, debug).withDispatcher(system.dispatchers.internalDispatcherId),
+        "eventStreamUnsubscriber-" + unsubscribersCount.incrementAndGet())
   }
 
 }

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -146,7 +146,7 @@ trait LoggingBus extends ActorEventBus {
                 case UnhandledMessage(msg, sender, rcp) =>
                   publish(Debug(rcp.path.toString, rcp.getClass, "unhandled message from " + sender + ": " + msg))
               }
-            }), "UnhandledMessageForwarder"),
+            }).withDispatcher(system.dispatchers.internalDispatcherId), "UnhandledMessageForwarder"),
             classOf[UnhandledMessage])
       } catch {
         case _: InvalidActorNameException => // ignore if it is already running

--- a/akka-actor/src/main/scala/akka/io/Dns.scala
+++ b/akka-actor/src/main/scala/akka/io/Dns.scala
@@ -161,7 +161,7 @@ class DnsExt private[akka] (val system: ExtendedActorSystem, resolverName: Strin
       case "" =>
         Resolver match {
           case "async-dns"    => system.dispatchers.internalDispatcherId
-          case "inet-address" => system.dispatchers.blockingIODispatcherId
+          case "inet-address" => system.dispatchers.blockingDispatcherId
           case unknown =>
             throw new IllegalArgumentException(
               s"Unknown type of dns resolver: [$unknown], please specify dispatcher explicitly with 'akka.io.dns.dispatcher'")

--- a/akka-actor/src/main/scala/akka/io/Dns.scala
+++ b/akka-actor/src/main/scala/akka/io/Dns.scala
@@ -156,7 +156,10 @@ class DnsExt private[akka] (val system: ExtendedActorSystem, resolverName: Strin
      */
     def this(config: Config) = this(config, config.getString("resolver"))
 
-    val Dispatcher: String = config.getString("dispatcher")
+    val Dispatcher: String = config.getString("dispatcher").trim match {
+      case ""       => system.dispatchers.internalDispatcherId
+      case nonEmpty => nonEmpty
+    }
     val Resolver: String = resolverName
     val ResolverConfig: Config = config.getConfig(Resolver)
     val ProviderObjectName: String = ResolverConfig.getString("provider-object")

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -594,7 +594,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
 class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
 
   val Settings = new Settings(system.settings.config.getConfig("akka.io.tcp"))
-  class Settings private[TcpExt] (_config: Config) extends SelectionHandlerSettings(_config) {
+  class Settings private[TcpExt] (_config: Config) extends SelectionHandlerSettings(_config, system) {
     import akka.util.Helpers.ConfigOps
     import _config._
 
@@ -615,7 +615,10 @@ class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
       case ""       => system.dispatchers.internalDispatcherId
       case nonEmpty => nonEmpty
     }
-    val FileIODispatcher: String = getString("file-io-dispatcher")
+    val FileIODispatcher: String = getString("file-io-dispatcher").trim match {
+      case ""       => system.dispatchers.blockingIODispatcherId
+      case nonEmpty => nonEmpty
+    }
     val TransferToLimit: Int = getString("file-io-transferTo-limit") match {
       case "unlimited" => Int.MaxValue
       case _           => getIntBytes("file-io-transferTo-limit")

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -611,7 +611,10 @@ class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
       case "unlimited" => Int.MaxValue
       case _           => getIntBytes("max-received-message-size")
     }
-    val ManagementDispatcher: String = getString("management-dispatcher")
+    val ManagementDispatcher: String = getString("management-dispatcher").trim match {
+      case ""       => system.dispatchers.internalDispatcherId
+      case nonEmpty => nonEmpty
+    }
     val FileIODispatcher: String = getString("file-io-dispatcher")
     val TransferToLimit: Int = getString("file-io-transferTo-limit") match {
       case "unlimited" => Int.MaxValue

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -616,7 +616,7 @@ class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
       case nonEmpty => nonEmpty
     }
     val FileIODispatcher: String = getString("file-io-dispatcher").trim match {
-      case ""       => system.dispatchers.blockingIODispatcherId
+      case ""       => system.dispatchers.blockingDispatcherId
       case nonEmpty => nonEmpty
     }
     val TransferToLimit: Int = getString("file-io-transferTo-limit") match {

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -14,6 +14,7 @@ import akka.io.Inet.{ SoJavaFactories, SocketOption }
 import akka.util.Helpers.Requiring
 import akka.util.ByteString
 import akka.actor._
+import akka.annotation.InternalApi
 import akka.util.ccompat._
 import com.github.ghik.silencer.silent
 
@@ -195,7 +196,12 @@ object Udp extends ExtensionId[UdpExt] with ExtensionIdProvider {
 
   }
 
-  private[io] class UdpSettings(_config: Config) extends SelectionHandlerSettings(_config) {
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private[io] class UdpSettings(_config: Config, _system: ActorSystem)
+      extends SelectionHandlerSettings(_config, _system) {
     import _config._
 
     val NrOfSelectors: Int = getInt("nr-of-selectors").requiring(_ > 0, "nr-of-selectors must be > 0")
@@ -222,7 +228,7 @@ class UdpExt(system: ExtendedActorSystem) extends IO.Extension {
 
   import Udp.UdpSettings
 
-  val settings: UdpSettings = new UdpSettings(system.settings.config.getConfig("akka.io.udp"))
+  val settings: UdpSettings = new UdpSettings(system.settings.config.getConfig("akka.io.udp"), system)
 
   val manager: ActorRef = {
     system.systemActorOf(

--- a/akka-actor/src/main/scala/akka/io/UdpConnected.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnected.scala
@@ -156,7 +156,7 @@ object UdpConnected extends ExtensionId[UdpConnectedExt] with ExtensionIdProvide
 
 class UdpConnectedExt(system: ExtendedActorSystem) extends IO.Extension {
 
-  val settings: UdpSettings = new UdpSettings(system.settings.config.getConfig("akka.io.udp-connected"))
+  val settings: UdpSettings = new UdpSettings(system.settings.config.getConfig("akka.io.udp-connected"), system)
 
   val manager: ActorRef = {
     system.systemActorOf(

--- a/akka-actor/src/main/scala/akka/io/UdpConnected.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnected.scala
@@ -160,7 +160,9 @@ class UdpConnectedExt(system: ExtendedActorSystem) extends IO.Extension {
 
   val manager: ActorRef = {
     system.systemActorOf(
-      props = Props(classOf[UdpConnectedManager], this).withDeploy(Deploy.local),
+      props = Props(classOf[UdpConnectedManager], this)
+        .withDeploy(Deploy.local)
+        .withDispatcher(settings.ManagementDispatcher.getOrElse(system.dispatchers.internalDispatcherId)),
       name = "IO-UDP-CONN")
   }
 

--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -149,7 +149,7 @@ akka {
     publish-stats-interval = off
 
     # The id of the dispatcher to use for cluster actors. If not specified
-    # default dispatcher is used.
+    # default internal dispatcher is used (configured with 'akka.actor.internal-dispatcher').
     # If specified you need to define the settings of the actual dispatcher.
     use-dispatcher = ""
 

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -59,7 +59,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
 
   import ClusterEvent._
 
-  val settings = new ClusterSettings(system.settings.config, system.name)
+  val settings = new ClusterSettings(system.settings.config, system.name, system)
   import ClusterLogger._
   import settings._
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
@@ -45,16 +45,18 @@ private[akka] class ClusterActorRefProvider(
 
   override protected def createRemoteWatcher(system: ActorSystemImpl): ActorRef = {
     // make sure Cluster extension is initialized/loaded from init thread
-    Cluster(system)
+    val cluster = Cluster(system)
 
     import remoteSettings._
     val failureDetector = createRemoteWatcherFailureDetector(system)
     system.systemActorOf(
-      ClusterRemoteWatcher.props(
-        failureDetector,
-        heartbeatInterval = WatchHeartBeatInterval,
-        unreachableReaperInterval = WatchUnreachableReaperInterval,
-        heartbeatExpectedResponseAfter = WatchHeartbeatExpectedResponseAfter),
+      ClusterRemoteWatcher
+        .props(
+          failureDetector,
+          heartbeatInterval = WatchHeartBeatInterval,
+          unreachableReaperInterval = WatchUnreachableReaperInterval,
+          heartbeatExpectedResponseAfter = WatchHeartbeatExpectedResponseAfter)
+        .withDispatcher(cluster.settings.UseDispatcher),
       "remote-watcher")
   }
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -233,9 +233,15 @@ private[cluster] final class ClusterDaemon(joinConfigCompatChecker: JoinConfigCo
         createChildren()
       coreSupervisor.foreach(_.forward(msg))
     case AddOnMemberUpListener(code) =>
-      context.actorOf(Props(classOf[OnMemberStatusChangedListener], code, Up).withDeploy(Deploy.local))
+      context.actorOf(
+        Props(classOf[OnMemberStatusChangedListener], code, Up)
+          .withDispatcher(context.props.dispatcher)
+          .withDeploy(Deploy.local))
     case AddOnMemberRemovedListener(code) =>
-      context.actorOf(Props(classOf[OnMemberStatusChangedListener], code, Removed).withDeploy(Deploy.local))
+      context.actorOf(
+        Props(classOf[OnMemberStatusChangedListener], code, Removed)
+          .withDispatcher(context.props.dispatcher)
+          .withDeploy(Deploy.local))
     case CoordinatedShutdownLeave.LeaveReq =>
       val ref = context.actorOf(CoordinatedShutdownLeave.props().withDispatcher(context.props.dispatcher))
       // forward the ask request

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
@@ -9,10 +9,8 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigObject
 
 import scala.concurrent.duration.Duration
-import akka.actor.Address
-import akka.actor.AddressFromURIString
+import akka.actor.{ ActorSystem, Address, AddressFromURIString }
 import akka.annotation.InternalApi
-import akka.dispatch.Dispatchers
 import akka.util.Helpers.{ toRootLowerCase, ConfigOps, Requiring }
 
 import scala.concurrent.duration.FiniteDuration
@@ -35,7 +33,10 @@ object ClusterSettings {
 
 }
 
-final class ClusterSettings(val config: Config, val systemName: String) {
+/**
+ * Not for user instantiation.
+ */
+final class ClusterSettings private[akka] (val config: Config, val systemName: String, system: ActorSystem) {
   import ClusterSettings._
   private val cc = config.getConfig("akka.cluster")
 
@@ -180,7 +181,7 @@ final class ClusterSettings(val config: Config, val systemName: String) {
   val JmxEnabled: Boolean = cc.getBoolean("jmx.enabled")
   val JmxMultiMbeansInSameEnabled: Boolean = cc.getBoolean("jmx.multi-mbeans-in-same-jvm")
   val UseDispatcher: String = cc.getString("use-dispatcher") match {
-    case "" => Dispatchers.DefaultDispatcherId
+    case "" => system.dispatchers.internalDispatcherId
     case id => id
   }
   val GossipDifferentViewProbability: Double = cc.getDouble("gossip-different-view-probability")

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterConfigSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterConfigSpec.scala
@@ -8,7 +8,6 @@ import language.postfixOps
 import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 import akka.testkit.AkkaSpec
-import akka.dispatch.Dispatchers
 import akka.remote.PhiAccrualFailureDetector
 import akka.util.Helpers.ConfigOps
 import akka.actor.Address
@@ -19,7 +18,7 @@ class ClusterConfigSpec extends AkkaSpec {
   "Clustering" must {
 
     "be able to parse generic cluster config elements" in {
-      val settings = new ClusterSettings(system.settings.config, system.name)
+      val settings = new ClusterSettings(system.settings.config, system.name, system)
       import settings._
       LogInfo should ===(true)
       FailureDetectorConfig.getDouble("threshold") should ===(8.0 +- 0.0001)
@@ -48,7 +47,7 @@ class ClusterConfigSpec extends AkkaSpec {
       SelfDataCenter should ===("default")
       Roles should ===(Set(ClusterSettings.DcRolePrefix + "default"))
       JmxEnabled should ===(true)
-      UseDispatcher should ===(Dispatchers.DefaultDispatcherId)
+      UseDispatcher should ===(system.dispatchers.internalDispatcherId)
       GossipDifferentViewProbability should ===(0.8 +- 0.0001)
       ReduceGossipDifferentViewProbability should ===(400)
       SchedulerTickDuration should ===(33 millis)
@@ -65,7 +64,8 @@ class ClusterConfigSpec extends AkkaSpec {
           |  }
           |}
         """.stripMargin).withFallback(ConfigFactory.load()),
-        system.name)
+        system.name,
+        system)
       import settings._
       Roles should ===(Set("hamlet", ClusterSettings.DcRolePrefix + "blue"))
       SelfDataCenter should ===("blue")

--- a/akka-stream-tests/src/test/scala/akka/stream/io/FileSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/FileSinkSpec.scala
@@ -155,7 +155,7 @@ class FileSinkSpec extends StreamSpec(UnboundedMailboxConfig) {
       }
     }
 
-    "use dedicated blocking-io-dispatcher by default" in assertAllStagesStopped {
+    "use dedicated blocking dispatcher by default" in assertAllStagesStopped {
       targetFile { f =>
         val sys = ActorSystem("dispatcher-testing", UnboundedMailboxConfig)
         val materializer = ActorMaterializer()(sys)
@@ -167,7 +167,7 @@ class FileSinkSpec extends StreamSpec(UnboundedMailboxConfig) {
             .supervisor
             .tell(StreamSupervisor.GetChildren, testActor)
           val ref = expectMsgType[Children].children.find(_.path.toString contains "fileSink").get
-          assertDispatcher(ref, "akka.stream.default-blocking-io-dispatcher")
+          assertDispatcher(ref, system.dispatchers.blockingDispatcherId)
         } finally shutdown(sys)
       }
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/io/FileSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/FileSourceSpec.scala
@@ -240,7 +240,7 @@ class FileSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
       }
     }
 
-    "use dedicated blocking-io-dispatcher by default" in assertAllStagesStopped {
+    "use dedicated blocking dispatcher by default" in assertAllStagesStopped {
       val sys = ActorSystem("dispatcher-testing", UnboundedMailboxConfig)
       val materializer = ActorMaterializer()(sys)
       try {
@@ -251,7 +251,7 @@ class FileSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
           .supervisor
           .tell(StreamSupervisor.GetChildren, testActor)
         val ref = expectMsgType[Children].children.find(_.path.toString contains "fileSource").get
-        try assertDispatcher(ref, "akka.stream.default-blocking-io-dispatcher")
+        try assertDispatcher(ref, system.dispatchers.blockingDispatcherId)
         finally p.cancel()
       } finally shutdown(sys)
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSinkSpec.scala
@@ -213,7 +213,7 @@ class InputStreamSinkSpec extends StreamSpec(UnboundedMailboxConfig) {
       e.getCause should ===(ex)
     }
 
-    "use dedicated default-blocking-io-dispatcher by default" in assertAllStagesStopped {
+    "use dedicated blocking dispatcher by default" in assertAllStagesStopped {
       val sys = ActorSystem("dispatcher-testing", UnboundedMailboxConfig)
       val materializer = ActorMaterializer()(sys)
       try {
@@ -223,7 +223,7 @@ class InputStreamSinkSpec extends StreamSpec(UnboundedMailboxConfig) {
           .supervisor
           .tell(StreamSupervisor.GetChildren, testActor)
         val ref = expectMsgType[Children].children.find(_.path.toString contains "inputStreamSink").get
-        assertDispatcher(ref, "akka.stream.default-blocking-io-dispatcher")
+        assertDispatcher(ref, system.dispatchers.blockingDispatcherId)
       } finally shutdown(sys)
     }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkAsJavaStreamSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkAsJavaStreamSpec.scala
@@ -80,7 +80,7 @@ class SinkAsJavaStreamSpec extends StreamSpec(UnboundedMailboxConfig) {
           .supervisor
           .tell(StreamSupervisor.GetChildren, testActor)
         val ref = expectMsgType[Children].children.find(_.path.toString contains "asJavaStream").get
-        assertDispatcher(ref, "akka.stream.default-blocking-io-dispatcher")
+        assertDispatcher(ref, system.dispatchers.blockingDispatcherId)
       } finally shutdown(sys)
     }
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/UnfoldResourceAsyncSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/UnfoldResourceAsyncSourceSpec.scala
@@ -309,7 +309,7 @@ class UnfoldResourceAsyncSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
       out.expectError().getMessage should ===("start-error")
     }
 
-    "use dedicated blocking-io-dispatcher by default" in assertAllStagesStopped {
+    "use dedicated blocking dispatcher by default" in assertAllStagesStopped {
       val sys = ActorSystem("dispatcher-testing", UnboundedMailboxConfig)
       val materializer = ActorMaterializer()(sys)
       try {
@@ -325,7 +325,7 @@ class UnfoldResourceAsyncSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
           .supervisor
           .tell(StreamSupervisor.GetChildren, testActor)
         val ref = expectMsgType[Children].children.find(_.path.toString contains "unfoldResourceSourceAsync").get
-        assertDispatcher(ref, "akka.stream.default-blocking-io-dispatcher")
+        assertDispatcher(ref, system.dispatchers.blockingDispatcherId)
       } finally shutdown(sys)
     }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/UnfoldResourceSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/UnfoldResourceSourceSpec.scala
@@ -147,7 +147,7 @@ class UnfoldResourceSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
       c.expectComplete()
     }
 
-    "use dedicated blocking-io-dispatcher by default" in assertAllStagesStopped {
+    "use dedicated blocking0 dispatcher by default" in assertAllStagesStopped {
       val sys = ActorSystem("dispatcher-testing", UnboundedMailboxConfig)
       val materializer = ActorMaterializer()(sys)
       try {
@@ -163,7 +163,7 @@ class UnfoldResourceSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
           .supervisor
           .tell(StreamSupervisor.GetChildren, testActor)
         val ref = expectMsgType[Children].children.find(_.path.toString contains "unfoldResourceSource").get
-        try assertDispatcher(ref, "akka.stream.default-blocking-io-dispatcher")
+        try assertDispatcher(ref, system.dispatchers.blockingDispatcherId)
         finally p.cancel()
       } finally shutdown(sys)
     }

--- a/akka-stream/src/main/resources/reference.conf
+++ b/akka-stream/src/main/resources/reference.conf
@@ -18,7 +18,11 @@ akka {
       # When this value is left empty, the default-dispatcher will be used.
       dispatcher = ""
 
-      blocking-io-dispatcher = "akka.stream.default-blocking-io-dispatcher"
+      # Fully qualified config path which holds the dispatcher configuration
+      # to use for operators that do blocking operations
+      # When this value is left empty, the 'akka.actor.blocking-dispatcher' setting
+      # is used
+      blocking-io-dispatcher = ""
 
       # Cleanup leaked publishers and subscribers when they are not used within a given
       # deadline
@@ -125,8 +129,9 @@ akka {
     # Deprecated, use akka.stream.materializer.blocking-io-dispatcher, this setting
     # was never applied because of bug #24357
     # It must still have a valid value because used from Akka HTTP.
-    blocking-io-dispatcher = "akka.stream.default-blocking-io-dispatcher"
+    blocking-io-dispatcher = "akka.actor.default-blocking-io-dispatcher"
 
+    # Deprecated, this is no longer used by the default configuration
     default-blocking-io-dispatcher {
       type = "Dispatcher"
       executor = "thread-pool-executor"

--- a/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
@@ -648,6 +648,11 @@ final class ActorMaterializerSettings @InternalApi private (
     if (streamRefSettings == this.streamRefSettings) this
     else copy(streamRefSettings = streamRefSettings)
 
+  /**
+   * Operators that are doing blocking operations or have the [[akka.stream.ActorAttributes#IODispatcher()]] assigned
+   * will use the dispatcher that this full config path points to. If set to an empty string the
+   * 'akka.actor.blocking-dispatcher' setting is used.
+   */
   def withBlockingIoDispatcher(newBlockingIoDispatcher: String): ActorMaterializerSettings =
     if (newBlockingIoDispatcher == blockingIoDispatcher) this
     else copy(blockingIoDispatcher = newBlockingIoDispatcher)

--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -782,7 +782,7 @@ private final case class SavedIslandData(
       case _ =>
         val props = ActorGraphInterpreter
           .props(shell)
-          .withDispatcher(ActorAttributes.Dispatcher.resolve(effectiveAttributes, settings))
+          .withDispatcher(ActorAttributes.Dispatcher.resolve(effectiveAttributes, settings, materializer.system))
 
         val actorName = fullIslandName match {
           case OptionVal.Some(n) => n
@@ -933,7 +933,7 @@ private final case class SavedIslandData(
   def materializeAtomic(mod: AtomicModule[Shape, Any], attributes: Attributes): (NotUsed, Any) = {
     val tls = mod.asInstanceOf[TlsModule]
 
-    val dispatcher = ActorAttributes.Dispatcher.resolve(attributes, materializer.settings)
+    val dispatcher = ActorAttributes.Dispatcher.resolve(attributes, materializer.settings, materializer.system)
     val maxInputBuffer = attributes.mandatoryAttribute[Attributes.InputBuffer].max
 
     val props =


### PR DESCRIPTION
Fixes #23576

Early push, so far only the akka-actor module:
 * New setting `akka.actor.internal-dispatcher` points to a dispatcher id
 * Default is `akka.actor.default-internal-dispatcher` which is a isolated FJP
 * System guardian and internal ActorSystem actors runs on the internal-dispatcher
 * IO actors default to run on the `internal-dispatcher`