### PR TITLE
Attempt to fix multi-jvm failure when untyped system is adapted from typed system

### DIFF
--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Conductor.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Conductor.scala
@@ -83,7 +83,7 @@ trait Conductor { this: TestConductorExt =>
       name: RoleName,
       controllerPort: InetSocketAddress): Future[InetSocketAddress] = {
     if (_controller ne null) throw new RuntimeException("TestConductorServer was already started")
-    _controller = system.actorOf(Props(classOf[Controller], participants, controllerPort), "controller")
+    _controller = system.systemActorOf(Props(classOf[Controller], participants, controllerPort), "controller")
     import Settings.BarrierTimeout
     import system.dispatcher
     (controller ? GetSockAddr).flatMap {

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
@@ -88,8 +88,8 @@ trait Player { this: TestConductorExt =>
     import Settings.BarrierTimeout
 
     if (_client ne null) throw new IllegalStateException("TestConductorClient already started")
-    _client = system.actorOf(Props(classOf[ClientFSM], name, controllerAddr), "TestConductorClient")
-    val a = system.actorOf(Player.waiterProps)
+    _client = system.systemActorOf(Props(classOf[ClientFSM], name, controllerAddr), "TestConductorClient")
+    val a = system.systemActorOf(Player.waiterProps, "TestConductorWaiter")
     (a ? client).mapTo(classTag[Done])
   }
 

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
@@ -279,10 +279,10 @@ private[akka] class ClientFSM(name: RoleName, controllerAddr: InetSocketAddress)
           stay
         case TerminateMsg(Left(false)) =>
           context.system.terminate()
-          stay
+          stop()
         case TerminateMsg(Left(true)) =>
           context.system.asInstanceOf[ActorSystemImpl].abort()
-          stay
+          stop()
         case TerminateMsg(Right(exitValue)) =>
           System.exit(exitValue)
           stay // needed because Java doesn’t have Nothing


### PR DESCRIPTION
Spawn system space actors instead of user space internally in akka-multi-node-testkit

## Purpose

Resolves #26779

## References

https://discuss.lightbend.com/t/cannot-migrate-to-akka-typed-if-there-are-multi-jvm-multi-node-tests-in-project/4013

## Background Context

Internal actors of `MultiNodeSpec` need to be created in system space instead of user space as `untypedSystem.systemActorOf` does not throw exception when untypedSystem is adapted from typedSystem.
