### PR TITLE
Increase timeout to fix PersistentActorJavaDslTest

### DIFF
--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -29,7 +29,6 @@ import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
-import scala.Function0;
 
 import java.io.Serializable;
 import java.time.Duration;
@@ -413,7 +412,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
                   }
 
                   @Override
-                  public SignalHandler signalHandler() {
+                  public SignalHandler<State> signalHandler() {
                     return newSignalHandlerBuilder()
                         .onSignal(
                             SnapshotCompleted.class,
@@ -462,7 +461,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     TestProbe<State> probe = testKit.createTestProbe();
     ActorRef<Command> c = testKit.spawn(counter(new PersistenceId("c12")));
     c.tell(StopThenLog.INSTANCE);
-    probe.expectTerminated(c, Duration.ofSeconds(1));
+    probe.expectTerminated(c, Duration.ofSeconds(3));
   }
 
   @Test
@@ -474,7 +473,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
                 new CounterBehavior(new PersistenceId("c5"), ctx) {
 
                   @Override
-                  public SignalHandler signalHandler() {
+                  public SignalHandler<State> signalHandler() {
                     return newSignalHandlerBuilder()
                         .onSignal(
                             PostStop.instance(),
@@ -635,7 +634,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     }
 
     @Override
-    public SignalHandler signalHandler() {
+    public SignalHandler<Object> signalHandler() {
       return newSignalHandlerBuilder()
           .onSignal(
               RecoveryCompleted.class,
@@ -716,7 +715,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     }
 
     @Override
-    public SignalHandler signalHandler() {
+    public SignalHandler<String> signalHandler() {
       return newSignalHandlerBuilder()
           .onSignal(
               RecoveryCompleted.class,

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -461,7 +461,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     TestProbe<State> probe = testKit.createTestProbe();
     ActorRef<Command> c = testKit.spawn(counter(new PersistenceId("c12")));
     c.tell(StopThenLog.INSTANCE);
-    probe.expectTerminated(c, Duration.ofSeconds(3));
+    probe.expectTerminated(c);
   }
 
   @Test


### PR DESCRIPTION
Refs #26466

I think it is that the timeout was a bit tight. Also added some missing type params the compiler complained about.