### PR TITLE
Fix typo in ShardingCompileOnlyTest.java

### DIFF
--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java
@@ -133,7 +133,7 @@ public class ShardingCompileOnlyTest {
     // #init
 
     // #send
-    EntityRef<CounterCommand> counterOne = sharding.entityRefFor(typeKey, "counter-`");
+    EntityRef<CounterCommand> counterOne = sharding.entityRefFor(typeKey, "counter-1");
     counterOne.tell(new Increment());
 
     shardRegion.tell(new ShardingEnvelope<>("counter-1", new Increment()));


### PR DESCRIPTION
## Purpose

Fix small typo in docs for akka typed cluster sharding

## Changes

Correct entity id in ShardingCompileOnlyTest.java
