### PR TITLE
Harden TestProbeSpec: increase short timeouts

### DIFF
--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestProbeSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestProbeSpec.scala
@@ -14,9 +14,11 @@ class TestProbeSpec extends ScalaTestWithActorTestKit with WordSpecLike {
 
   import TestProbeSpec._
 
+  val shortDuration = 400.millis
+
   def compileOnlyApiTest(): Unit = {
     val probe = TestProbe[AnyRef]()
-    probe.fishForMessage(100.millis) {
+    probe.fishForMessage(shortDuration) {
       case _ => FishingOutcomes.complete
     }
     probe.awaitAssert({
@@ -25,9 +27,9 @@ class TestProbeSpec extends ScalaTestWithActorTestKit with WordSpecLike {
     probe.expectMessageType[String]
     probe.expectMessage("whoa")
     probe.expectNoMessage()
-    probe.expectNoMessage(300.millis)
-    probe.expectTerminated(system.deadLetters, 100.millis)
-    probe.within(100.millis) {
+    probe.expectNoMessage(shortDuration)
+    probe.expectTerminated(system.deadLetters, shortDuration)
+    probe.within(shortDuration) {
       "result"
     }
   }
@@ -37,7 +39,7 @@ class TestProbeSpec extends ScalaTestWithActorTestKit with WordSpecLike {
     "allow probing for actor stop when actor already stopped" in {
       val probe = TestProbe()
       val ref = spawn(Behaviors.stopped)
-      probe.expectTerminated(ref, 100.millis)
+      probe.expectTerminated(ref)
     }
 
     "allow probing for actor stop when actor has not stopped yet" in {
@@ -61,7 +63,7 @@ class TestProbeSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       probe.ref ! "one"
       probe.ref ! "two"
 
-      val result = probe.fishForMessage(300.millis) {
+      val result = probe.fishForMessage(shortDuration) {
         case "one" => FishingOutcomes.continue
         case "two" => FishingOutcomes.complete
       }
@@ -77,7 +79,7 @@ class TestProbeSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       probe.ref ! "two"
 
       intercept[AssertionError] {
-        probe.fishForMessage(300.millis) {
+        probe.fishForMessage(shortDuration) {
           case "one" => FishingOutcomes.continue
           case "two" => FishingOutcomes.fail("not the fish I'm looking for")
         }
@@ -102,7 +104,7 @@ class TestProbeSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       probe.ref ! "two"
 
       intercept[AssertionError] {
-        probe.fishForMessage(300.millis) {
+        probe.fishForMessage(shortDuration) {
           case "one" => FishingOutcomes.continue
         }
       }
@@ -114,7 +116,7 @@ class TestProbeSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       probe.ref ! "one"
 
       intercept[AssertionError] {
-        probe.fishForMessage(300.millis) {
+        probe.fishForMessage(shortDuration) {
           case "one" => FishingOutcomes.continue
         }
       }


### PR DESCRIPTION
🍒 backport of https://github.com/akka/akka/pull/26791

* Harden TestProbeSpec: increase short timeouts
* Use default timeout for termination in TestProbeSpec

(cherry picked from commit 69bf1a7c186e11aca6184d0ad1bc7d904e46da85)

Refs #26681
