### PR TITLE
[WIP/testing] Multi jvm test reporting

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,11 @@
 // these comment markers are for including code into the docs
 //#sbt-multi-jvm
-addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
+//addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
+libraryDependencies += Defaults.sbtPluginExtra(
+  "com.eed3si9n" % "sbt-assembly" % "0.14.5",
+  (sbtBinaryVersion in pluginCrossBuild).value,
+  (scalaBinaryVersion in pluginCrossBuild).value
+)
 //#sbt-multi-jvm
 
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.1")

--- a/project/src/main/scala/com/typesafe/sbt/SbtMultiJvm.scala
+++ b/project/src/main/scala/com/typesafe/sbt/SbtMultiJvm.scala
@@ -1,0 +1,443 @@
+/**
+ * Copyright (C) 2011-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package com.typesafe.sbt
+
+import com.typesafe.sbt.multijvm.{Jvm, JvmLogger}
+import com.typesafe.sbt.multijvm.Compat.{Process, _}
+import com.typesafe.sbt.multijvm.Compat.Implicits._
+import sbt._
+import Keys._
+import java.io.File
+import java.lang.Boolean.getBoolean
+
+import scala.Console.{ GREEN, RESET }
+
+import sbtassembly.AssemblyPlugin.assemblySettings
+import sbtassembly.{MergeStrategy, AssemblyKeys}
+import AssemblyKeys._
+
+object MultiJvmPlugin extends AutoPlugin {
+
+  case class Options(jvm: Seq[String], extra: String => Seq[String], run: String => Seq[String])
+
+  object MultiJvmKeys {
+    val MultiJvm = config("multi-jvm") extend(Test)
+
+    val multiJvmMarker = SettingKey[String]("multi-jvm-marker")
+
+    val multiJvmTests = TaskKey[Map[String, Seq[TestDefinition]]]("multi-jvm-tests")
+    val multiJvmTestNames = TaskKey[Seq[String]]("multi-jvm-test-names")
+
+    val multiJvmApps = TaskKey[Map[String, Seq[String]]]("multi-jvm-apps")
+    val multiJvmAppNames = TaskKey[Seq[String]]("multi-jvm-app-names")
+
+    val multiJvmJavaCommand = TaskKey[File]("multi-jvm-java-command")
+
+    val jvmOptions = TaskKey[Seq[String]]("jvm-options") // TODO: shouldn't that be regular `javaOptions`?
+    val extraOptions = SettingKey[String => Seq[String]]("extra-options")
+    val multiJvmCreateLogger = TaskKey[String => Logger]("multi-jvm-create-logger")
+
+    val scalatestRunner = SettingKey[String]("scalatest-runner")
+    val scalatestOptions = SettingKey[Seq[String]]("scalatest-options")
+    val scalatestClasspath = TaskKey[Classpath]("scalatest-classpath")
+    val scalatestScalaOptions = TaskKey[String => Seq[String]]("scalatest-scala-options")
+    val scalatestMultiNodeScalaOptions = TaskKey[String => Seq[String]]("scalatest-multi-node-scala-options")
+    val multiTestOptions = TaskKey[Options]("multi-test-options")
+    val multiNodeTestOptions = TaskKey[Options]("multi-node-test-options")
+
+    val appScalaOptions = TaskKey[String => Seq[String]]("app-scala-options")
+    val multiRunOptions = TaskKey[Options]("multi-run-options")
+
+    val multiRunCopiedClassLocation = SettingKey[File]("multi-run-copied-class-location")
+
+    val multiJvmTestJar = TaskKey[String]("multi-jvm-test-jar")
+    val multiJvmTestJarName = TaskKey[String]("multi-jvm-test-jar-name")
+
+    val multiNodeTest = TaskKey[Unit]("multi-node-test")
+    val multiNodeExecuteTests = TaskKey[Tests.Output]("multi-node-execute-tests")
+    val multiNodeTestOnly = InputKey[Unit]("multi-node-test-only")
+
+    val multiNodeHosts = SettingKey[Seq[String]]("multi-node-hosts")
+    val multiNodeHostsFileName = SettingKey[String]("multi-node-hosts-file-name")
+    val multiNodeProcessedHosts = TaskKey[(IndexedSeq[String], IndexedSeq[String])]("multi-node-processed-hosts")
+    val multiNodeTargetDirName = SettingKey[String]("multi-node-target-dir-name")
+    val multiNodeJavaName = SettingKey[String]("multi-node-java-name")
+
+    // TODO fugly workaround for now
+    val multiNodeWorkAround = TaskKey[(String, (IndexedSeq[String], IndexedSeq[String]), String)]("multi-node-workaround")
+  }
+
+  val autoImport = MultiJvmKeys
+
+  import MultiJvmKeys._
+
+  override def requires = plugins.JvmPlugin
+
+  override def projectConfigurations = Seq(MultiJvm)
+
+  override def projectSettings = multiJvmSettings
+
+  private[this] def noTestsMessage(scoped: ScopedKey[_])(implicit display: Show[ScopedKey[_]]): String =
+    "No tests to run for " + display.show(scoped)
+
+  lazy val multiJvmSettings: Seq[Def.Setting[_]] = inConfig(MultiJvm)(Defaults.configSettings ++ internalMultiJvmSettings)
+
+  // https://github.com/sbt/sbt/blob/v0.13.15/main/actions/src/main/scala/sbt/Tests.scala#L296-L298
+  private[this] def showResults(log: Logger, results: Tests.Output, noTestsMessage: => String): Unit =
+    TestResultLogger.Default.copy(printNoTests = TestResultLogger.const(_ info noTestsMessage))
+      .run(log, results, "")
+
+  private def internalMultiJvmSettings = assemblySettings ++ Seq(
+    multiJvmMarker := "MultiJvm",
+    loadedTestFrameworks := (loadedTestFrameworks in Test).value,
+    definedTests := Defaults.detectTests.value,
+    multiJvmTests := collectMultiJvm(definedTests.value, multiJvmMarker.value)( _.name),
+    multiJvmTestNames := (multiJvmTests.map(_.keys.toSeq) storeAs multiJvmTestNames triggeredBy compile).value,
+    multiJvmApps := collectMultiJvm(discoveredMainClasses.value, multiJvmMarker.value)( identity),
+    multiJvmAppNames := (multiJvmApps.map(_.keys.toSeq) storeAs multiJvmAppNames triggeredBy compile).value,
+    multiJvmJavaCommand := javaCommand(javaHome.value, "java"),
+    jvmOptions := Seq.empty,
+    extraOptions := { (name: String) => Seq.empty },
+    multiJvmCreateLogger := { (name: String) => new JvmLogger(name) },
+    scalatestRunner := "org.scalatest.tools.Runner",
+    scalatestOptions := defaultScalatestOptions,
+    scalatestClasspath := managedClasspath.value.filter(_.data.name.contains("scalatest")),
+    multiRunCopiedClassLocation := new File(target.value, "multi-run-copied-libraries"),
+    scalatestScalaOptions := scalaOptionsForScalatest(scalatestRunner.value, scalatestOptions.value, fullClasspath.value, multiRunCopiedClassLocation.value),
+    scalatestMultiNodeScalaOptions := scalaMultiNodeOptionsForScalatest(scalatestRunner.value, scalatestOptions.value),
+    multiTestOptions := Options(jvmOptions.value, extraOptions.value, scalatestScalaOptions.value),
+    multiNodeTestOptions := Options(jvmOptions.value, extraOptions.value, scalatestMultiNodeScalaOptions.value),
+    appScalaOptions := scalaOptionsForApps(fullClasspath.value),
+    connectInput := true,
+    multiRunOptions := Options(jvmOptions.value, extraOptions.value, appScalaOptions.value),
+
+    executeTests := multiJvmExecuteTests.value,
+    testOnly := multiJvmTestOnly.evaluated,
+    test := showResults(streams.value.log, executeTests.value, "No tests to run for MultiJvm"),
+    run := multiJvmRun.evaluated,
+    runMain := multiJvmRun.evaluated,
+
+    // TODO try to make sure that this is only generated on a need to have basis
+    multiJvmTestJar := (assemblyOutputPath in assembly).map(_.getAbsolutePath).dependsOn(assembly).value,
+    multiJvmTestJarName := (assemblyOutputPath in assembly).value.getAbsolutePath,
+
+    multiNodeTest := {
+      implicit val display = Project.showContextKey(state.value)
+      showResults(streams.value.log, multiNodeExecuteTests.value, noTestsMessage(resolvedScoped.value)) },
+    multiNodeExecuteTests := multiNodeExecuteTestsTask.value,
+    multiNodeTestOnly := multiNodeTestOnlyTask.evaluated,
+    multiNodeHosts := Seq.empty,
+    multiNodeHostsFileName := "multi-node-test.hosts",
+    multiNodeProcessedHosts := processMultiNodeHosts(multiNodeHosts.value, multiNodeHostsFileName.value, multiNodeJavaName.value, streams.value),
+    multiNodeTargetDirName := "multi-node-test",
+    multiNodeJavaName := "java",
+    // TODO there must be a way get at keys in the tasks that I just don't get
+    multiNodeWorkAround := (multiJvmTestJar.value, multiNodeProcessedHosts.value, multiNodeTargetDirName.value),
+
+    // here follows the assembly parts of the config
+    // don't run the tests when creating the assembly
+    test in assembly := {},
+
+    // we want everything including the tests and test frameworks
+    fullClasspath in assembly := (fullClasspath in MultiJvm).value,
+
+    // the first class wins just like a classpath
+    // just concatenate conflicting text files
+    assemblyMergeStrategy in assembly := {
+        case n if n.endsWith(".class") => MergeStrategy.first
+        case n if n.endsWith(".txt") => MergeStrategy.concat
+        case n if n.endsWith("NOTICE") => MergeStrategy.concat
+        case n => (assemblyMergeStrategy in assembly).value.apply(n)
+    },
+
+    assemblyJarName in assembly := {
+      name.value + "_" + scalaVersion.value + "-" + version.value + "-multi-jvm-assembly.jar"
+    }
+  )
+
+  def collectMultiJvm[T](discovered: Seq[T], marker: String)(nameOf: T => String): Map[String, Seq[T]] = {
+    val found = discovered filter (t => nameOf(t).contains(marker)) groupBy (t => multiName(nameOf(t), marker))
+    found map {
+      case (key, values) =>
+        val totalNodes = sys.props.get(marker + "." + key + ".nrOfNodes").getOrElse(values.size.toString).toInt
+        val sortedClasses = values.sortBy(nameOf)
+        val totalClasses = sortedClasses.padTo(totalNodes, sortedClasses.last)
+        (key, totalClasses)
+    }
+  }
+
+  def multiName(name: String, marker: String) = name.split(marker).head
+
+  def multiSimpleName(name: String) = name.split("\\.").last
+
+  def javaCommand(javaHome: Option[File], name: String): File = {
+    val home = javaHome.getOrElse(new File(System.getProperty("java.home")))
+    new File(new File(home, "bin"), name)
+  }
+
+  def defaultScalatestOptions: Seq[String] = {
+    if (getBoolean("sbt.log.noformat")) Seq("-oW") else Seq("-o")
+  }
+
+  def scalaOptionsForScalatest(runner: String, options: Seq[String], fullClasspath: Classpath, multiRunCopiedClassDir: File) = {
+    val directoryBasedClasspathEntries = fullClasspath.files.filter(_.isDirectory)
+    // Copy over just the jars to this folder.
+    fullClasspath.files.filter(_.isFile).foreach(classpathFile => IO.copyFile(classpathFile, new File(multiRunCopiedClassDir, classpathFile.getName), true))
+    val cp = directoryBasedClasspathEntries.absString + File.pathSeparator + multiRunCopiedClassDir.getAbsolutePath + File.separator + "*"
+    (testClass: String) => { Seq("-cp", cp, runner, "-s", testClass) ++ options }
+  }
+
+  def scalaMultiNodeOptionsForScalatest(runner: String, options: Seq[String]) = {
+    (testClass: String) => { Seq(runner, "-s", testClass) ++ options }
+  }
+
+  def scalaOptionsForApps(classpath: Classpath) = {
+    val cp = classpath.files.absString
+    (mainClass: String) => Seq("-cp", cp, mainClass)
+  }
+
+  def multiJvmExecuteTests: Def.Initialize[sbt.Task[Tests.Output]] = Def.task {
+    runMultiJvmTests(multiJvmTests.value, multiJvmMarker.value, multiJvmJavaCommand.value, multiTestOptions.value, sourceDirectory.value, multiJvmCreateLogger.value, streams.value.log)
+  }
+
+  def multiJvmTestOnly: Def.Initialize[sbt.InputTask[Unit]] = InputTask.createDyn(
+    loadForParser(multiJvmTestNames)((s, i) => Defaults.testOnlyParser(s, i getOrElse Nil))
+  ) {
+    Def.task { case (selection, _extraOptions) =>
+      val s = streams.value
+      val options = multiTestOptions.value
+      val opts = options.copy(extra = (s: String) => { options.extra(s) ++ _extraOptions })
+      val filters = selection.map(GlobFilter(_))
+      val tests = multiJvmTests.value.filterKeys(name => filters.exists(_.accept(name)))
+      Def.task {
+        val results = runMultiJvmTests(tests, multiJvmMarker.value, multiJvmJavaCommand.value, opts, sourceDirectory.value, multiJvmCreateLogger.value, s.log)
+        showResults(s.log, results, "No tests to run for MultiJvm")
+      }
+    }
+  }
+
+  def runMultiJvmTests(tests: Map[String, Seq[TestDefinition]], marker: String, javaBin: File, options: Options,
+                       srcDir: File, createLogger: String => Logger, log: Logger): Tests.Output = {
+    val results =
+      if (tests.isEmpty)
+        List()
+      else tests.map {
+        case (_name, testDefs) => multiTest(_name, testDefs, marker, javaBin, options, srcDir, false, createLogger, log)
+      }
+    Tests.Output(Tests.overall(results.map(_._2)), Map.empty, results.map(result => Tests.Summary("multi-jvm", result._1)))
+  }
+
+  def multiJvmRun: Def.Initialize[sbt.InputTask[Unit]] = InputTask.createDyn(
+    loadForParser(multiJvmAppNames)((s, i) => runParser(s, i getOrElse Nil))
+  ) {
+      Def.task {
+        val s = streams.value
+        val apps = multiJvmApps.value
+        val j = multiJvmJavaCommand.value
+        val c = connectInput.value
+        val dir = sourceDirectory.value
+        val options = multiRunOptions.value
+        val marker = multiJvmMarker.value
+        val createLogger = multiJvmCreateLogger.value
+
+        result => {
+          val classes = apps.getOrElse(result, Seq.empty)
+          Def.task {
+            if (classes.isEmpty) s.log.info("No apps to run.")
+            else multi(result, classes, marker, j, options, dir, c, createLogger, s.log)
+          }
+        }
+      }
+    }
+
+  def runParser: (State, Seq[String]) => complete.Parser[String] = {
+    import complete.DefaultParsers._
+    (state, appClasses) => Space ~> token(NotSpace examples appClasses.toSet)
+  }
+
+  def multiTest(name: String, testDefs: Seq[TestDefinition], marker: String, javaBin: File, options: Options, srcDir: File,
+            input: Boolean, createLogger: String => Logger, log: Logger): (String, TestResultValue) = {
+    val classes = testDefs.map(_.name)
+    val logName = "* " + name
+    log.info(if (log.ansiCodesSupported) GREEN + logName + RESET else logName)
+    val classesHostsJavas = getClassesHostsJavas(classes, IndexedSeq.empty, IndexedSeq.empty, "")
+    val hosts = classesHostsJavas.map(_._2)
+    val processes = classes.zipWithIndex map {
+      case (testClass, index) =>
+        val className = multiSimpleName(testClass)
+        val jvmName = "JVM-" + (index + 1) + "-" + className
+        val jvmLogger = createLogger(jvmName)
+        val optionsFile = (srcDir ** (className + ".opts")).get.headOption
+        val optionsFromFile = optionsFile map (IO.read(_)) map (_.trim.replace("\\n", " ").split("\\s+").toList) getOrElse (Seq.empty[String])
+        val multiNodeOptions = getMultiNodeCommandLineOptions(hosts, index, classes.size)
+        val allJvmOptions = options.jvm ++ multiNodeOptions ++ optionsFromFile ++ options.extra(className)
+        val runOptions = options.run(testClass)
+        val connectInput = input && index == 0
+        log.debug("Starting %s for %s" format (jvmName, testClass))
+        log.debug("  with JVM options: %s" format allJvmOptions.mkString(" "))
+
+        /*val forkOptions = ForkOptions()
+        val result =
+          Fork.java(forkOptions)*/
+
+        (testClass, Jvm.startJvm(javaBin, allJvmOptions, runOptions, jvmLogger, connectInput))
+    }
+    processExitCodes(name, processes, log)
+  }
+
+  def multi(name: String, classes: Seq[String], marker: String, javaBin: File, options: Options, srcDir: File,
+            input: Boolean, createLogger: String => Logger, log: Logger): (String, TestResultValue) = {
+    val logName = "* " + name
+    log.info(if (log.ansiCodesSupported) GREEN + logName + RESET else logName)
+    val classesHostsJavas = getClassesHostsJavas(classes, IndexedSeq.empty, IndexedSeq.empty, "")
+    val hosts = classesHostsJavas.map(_._2)
+    val processes = classes.zipWithIndex map {
+      case (testClass, index) =>
+        val className = multiSimpleName(testClass)
+        val jvmName = "JVM-" + (index + 1) + "-" + className
+        val jvmLogger = createLogger(jvmName)
+        val optionsFile = (srcDir ** (className + ".opts")).get.headOption
+        val optionsFromFile = optionsFile map (IO.read(_)) map (_.trim.replace("\\n", " ").split("\\s+").toList) getOrElse (Seq.empty[String])
+        val multiNodeOptions = getMultiNodeCommandLineOptions(hosts, index, classes.size)
+        val allJvmOptions = options.jvm ++ multiNodeOptions ++ optionsFromFile ++ options.extra(className)
+        val runOptions = options.run(testClass)
+        val connectInput = input && index == 0
+        log.debug("Starting %s for %s" format (jvmName, testClass))
+        log.debug("  with JVM options: %s" format allJvmOptions.mkString(" "))
+
+        (testClass, Jvm.startJvm(javaBin, allJvmOptions, runOptions, jvmLogger, connectInput))
+    }
+    processExitCodes(name, processes, log)
+  }
+
+  def processExitCodes(name: String, processes: Seq[(String, Process)], log: Logger): (String, TestResultValue) = {
+    val exitCodes = processes map {
+      case (testClass, process) => (testClass, process.exitValue())
+    }
+    val failures = exitCodes flatMap {
+      case (testClass, exit) if exit > 0 => Some("Failed: " + testClass)
+      case _ => None
+    }
+    failures foreach(log.error(_))
+    (name, if(failures.nonEmpty) TestResult.Failed else TestResult.Passed)
+  }
+
+  def multiNodeExecuteTestsTask: Def.Initialize[sbt.Task[Tests.Output]] = Def.task {
+    val (_jarName, (hostsAndUsers, javas), targetDir) = multiNodeWorkAround.value
+    runMultiNodeTests(multiJvmTests.value.mapValues(_.map(_.name)), multiJvmMarker.value, multiNodeJavaName.value, multiNodeTestOptions.value, sourceDirectory.value, _jarName, hostsAndUsers, javas, targetDir, multiJvmCreateLogger.value, streams.value.log)
+  }
+
+  def multiNodeTestOnlyTask: Def.Initialize[InputTask[Unit]] = InputTask.createDyn(
+    loadForParser(multiJvmTestNames)((s, i) => Defaults.testOnlyParser(s, i getOrElse Nil))
+  ) {
+    Def.task { case (selected, _extraOptions) =>
+      val options = multiNodeTestOptions.value
+      val (_jarName, (hostsAndUsers, javas), targetDir) = multiNodeWorkAround.value
+      val s = streams.value
+      val opts = options.copy(extra = (s: String) => { options.extra(s) ++ _extraOptions })
+      val tests = selected flatMap { name => multiJvmTests.value.get(name).map(_.map(_.name)) map ((name, _)) }
+      Def.task {
+        val results = runMultiNodeTests(tests.toMap, multiJvmMarker.value, multiNodeJavaName.value, opts, sourceDirectory.value, _jarName, hostsAndUsers, javas, targetDir, multiJvmCreateLogger.value, s.log)
+        showResults(s.log, results, "No tests to run for MultiNode")
+      }
+    }
+  }
+
+  def runMultiNodeTests(tests: Map[String, Seq[String]], marker: String, java: String, options: Options,
+                        srcDir: File, jarName: String, hostsAndUsers: IndexedSeq[String],
+                        javas: IndexedSeq[String], targetDir: String,
+                        createLogger: String => Logger, log: Logger): Tests.Output = {
+    val results =
+      if (tests.isEmpty)
+        List()
+      else tests.map {
+        case (_name, classes) => multiNode(_name, classes, marker, java, options, srcDir, false, jarName,
+          hostsAndUsers, javas, targetDir, createLogger, log)
+      }
+    Tests.Output(Tests.overall(results.map(_._2)), Map.empty, results.map(result => Tests.Summary("multi-jvm", result._1)))
+  }
+
+  def multiNode(name: String, classes: Seq[String], marker: String, defaultJava: String, options: Options, srcDir: File,
+                input: Boolean, testJar: String, hostsAndUsers: IndexedSeq[String], javas: IndexedSeq[String], targetDir: String,
+                createLogger: String => Logger, log: Logger): (String, TestResultValue) = {
+    val logName = "* " + name
+    log.info(if (log.ansiCodesSupported) GREEN + logName + RESET else logName)
+    val classesHostsJavas = getClassesHostsJavas(classes, hostsAndUsers, javas, defaultJava)
+    val hosts = classesHostsJavas.map(_._2)
+    // TODO move this out, maybe to the hosts string as well?
+    val syncProcesses = classesHostsJavas.map {
+      case ((testClass, hostAndUser, java)) =>
+        (testClass + " sync", Jvm.syncJar(testJar, hostAndUser, targetDir, log))
+    }
+    val syncResult = processExitCodes(name, syncProcesses, log)
+    if (syncResult._2 == TestResult.Passed) {
+      val processes = classesHostsJavas.zipWithIndex map {
+        case ((testClass, hostAndUser, java), index) => {
+          val jvmName = "JVM-" + (index + 1)
+          val jvmLogger = createLogger(jvmName)
+          val className = multiSimpleName(testClass)
+          val optionsFile = (srcDir ** (className + ".opts")).get.headOption
+          val optionsFromFile = optionsFile map (IO.read(_)) map (_.trim.replace("\\n", " ").split("\\s+").toList) getOrElse (Seq.empty[String])
+          val multiNodeOptions = getMultiNodeCommandLineOptions(hosts, index, classes.size)
+          val allJvmOptions = options.jvm ++ optionsFromFile ++ options.extra(className) ++ multiNodeOptions
+          val runOptions = options.run(testClass)
+          val connectInput = input && index == 0
+          log.debug("Starting %s for %s" format (jvmName, testClass))
+          log.debug("  with JVM options: %s" format allJvmOptions.mkString(" "))
+          (testClass, Jvm.forkRemoteJava(java, allJvmOptions, runOptions, testJar, hostAndUser, targetDir,
+            jvmLogger, connectInput, log))
+        }
+      }
+      processExitCodes(name, processes, log)
+    }
+    else {
+      syncResult
+    }
+  }
+
+  private def padSeqOrDefaultTo(seq: IndexedSeq[String], default: String, max: Int): IndexedSeq[String] = {
+    val realSeq = if (seq.isEmpty) IndexedSeq(default) else seq
+    if (realSeq.size >= max)
+      realSeq
+    else
+      (realSeq /: (0 until (max - realSeq.size)))((mySeq, pos) => mySeq :+ realSeq(pos % realSeq.size))
+  }
+
+  private def getClassesHostsJavas(classes: Seq[String], hostsAndUsers: IndexedSeq[String], javas: IndexedSeq[String],
+                                   defaultJava: String): IndexedSeq[(String, String, String)] = {
+    val max = classes.length
+    val tuple = (classes.toIndexedSeq, padSeqOrDefaultTo(hostsAndUsers, "localhost", max), padSeqOrDefaultTo(javas, defaultJava, max))
+    tuple.zipped.map { case (className: String, hostAndUser: String, _java: String) => (className, hostAndUser, _java) }
+  }
+
+  private def getMultiNodeCommandLineOptions(hosts: Seq[String], index: Int, maxNodes: Int): Seq[String] = {
+    Seq("-Dmultinode.max-nodes=" + maxNodes, "-Dmultinode.server-host=" + hosts(0).split("@").last,
+      "-Dmultinode.host=" + hosts(index).split("@").last, "-Dmultinode.index=" + index)
+  }
+
+  private def processMultiNodeHosts(hosts: Seq[String], hostsFileName: String, defaultJava: String, s: Types.Id[Keys.TaskStreams]):
+    (IndexedSeq[String], IndexedSeq[String]) = {
+    val hostsFile = new File(hostsFileName)
+    val theHosts: IndexedSeq[String] =
+      if (hosts.isEmpty) {
+        if (hostsFile.exists && hostsFile.canRead) {
+          s.log.info("Using hosts defined in file " + hostsFile.getAbsolutePath)
+          IO.readLines(hostsFile).map(_.trim).filter(_.length > 0).toIndexedSeq
+        }
+        else
+          hosts.toIndexedSeq
+      }
+      else {
+        if (hostsFile.exists && hostsFile.canRead)
+          s.log.info("Hosts from setting " + multiNodeHosts.key.label + " is overrriding file " + hostsFile.getAbsolutePath)
+        hosts.toIndexedSeq
+      }
+
+    theHosts.map { x =>
+      val elems = x.split(":").toList.take(2).padTo(2, defaultJava)
+      (elems(0), elems(1))
+    } unzip
+  }
+}

--- a/project/src/main/scala/com/typesafe/sbt/SbtMultiJvm.scala
+++ b/project/src/main/scala/com/typesafe/sbt/SbtMultiJvm.scala
@@ -1,5 +1,5 @@
-/**
- * Copyright (C) 2011-2012 Typesafe Inc. <http://www.typesafe.com>
+/*
+ * Copyright (C) 2011-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package com.typesafe.sbt

--- a/project/src/main/scala/com/typesafe/sbt/SbtMultiJvm.scala
+++ b/project/src/main/scala/com/typesafe/sbt/SbtMultiJvm.scala
@@ -261,6 +261,11 @@ object MultiJvmPlugin extends AutoPlugin {
         multiTest(testRunner, name, testDefs, marker, javaBin, options, srcDir, false, createLogger, log)
         .map(reduced)
 
+    // the magic sauce
+    // The sequencing is the important part here, runOne will create parallel tasks for ABCMultiJvmN instances
+    // classes for one test case.
+    // To prevent that more than one test case is submitted to the task engine (which is synchronous and only has a certain number of slots),
+    // `tests` are folded over and chained with `flatMap` to introduce a synthetic dependency between different test runs.
     tests.toSeq.foldLeft(Option.empty[Task[Tests.Output]]) { (curResult, nextSet) =>
       curResult match {
         case None => Some(runOne(nextSet._1, nextSet._2))

--- a/project/src/main/scala/com/typesafe/sbt/multijvm/Compat.scala
+++ b/project/src/main/scala/com/typesafe/sbt/multijvm/Compat.scala
@@ -1,0 +1,12 @@
+package com.typesafe.sbt.multijvm
+
+private[sbt] object Compat {
+
+  type Process = scala.sys.process.Process
+  val Process = scala.sys.process.Process
+
+  val Implicits = sjsonnew.BasicJsonProtocol
+
+  type TestResultValue = sbt.TestResult
+
+}

--- a/project/src/main/scala/com/typesafe/sbt/multijvm/Compat.scala
+++ b/project/src/main/scala/com/typesafe/sbt/multijvm/Compat.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package com.typesafe.sbt.multijvm
 
 private[sbt] object Compat {

--- a/project/src/main/scala/com/typesafe/sbt/multijvm/Jvm.scala
+++ b/project/src/main/scala/com/typesafe/sbt/multijvm/Jvm.scala
@@ -1,5 +1,5 @@
-/**
- * Copyright (C) 2011-2012 Typesafe Inc. <http://www.typesafe.com>
+/*
+ * Copyright (C) 2011-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package com.typesafe.sbt.multijvm

--- a/project/src/main/scala/com/typesafe/sbt/multijvm/Jvm.scala
+++ b/project/src/main/scala/com/typesafe/sbt/multijvm/Jvm.scala
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2011-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package com.typesafe.sbt.multijvm
+
+import java.io.File
+import java.lang.{ProcessBuilder => JProcessBuilder}
+
+import sbt._
+import com.typesafe.sbt.multijvm.Compat.{Process, _}
+
+object Jvm {
+  def startJvm(javaBin: File, jvmOptions: Seq[String], runOptions: Seq[String], logger: Logger, connectInput: Boolean) = {
+    forkJava(javaBin, jvmOptions ++ runOptions, logger, connectInput)
+  }
+
+  def forkJava(javaBin: File, options: Seq[String], logger: Logger, connectInput: Boolean) = {
+    val java = javaBin.toString
+    val command = (java :: options.toList).toArray
+    val builder = new JProcessBuilder(command: _*)
+    Process(builder).run(logger, connectInput)
+  }
+
+  /**
+   * check if the current operating system is some OS
+  **/
+  def isOS(os:String) = try {
+    System.getProperty("os.name").toUpperCase startsWith os.toUpperCase
+  } catch {
+    case _ : Throwable => false
+  }
+
+  /**
+   * convert to proper path for the operating system
+  **/
+  def osPath(path:String) = if (isOS("WINDOWS")) Process(Seq("cygpath", path)).lineStream.mkString else path
+
+  def syncJar(jarName: String, hostAndUser: String, remoteDir: String, sbtLogger: Logger) : Process = {
+    val command: Array[String] = Array("ssh", hostAndUser, "mkdir -p " + remoteDir)
+    val builder = new JProcessBuilder(command: _*)
+    sbtLogger.debug("Jvm.syncJar about to run " + command.mkString(" "))
+    val process = Process(builder).run(sbtLogger, false)
+    if (process.exitValue() == 0) {
+      val command: Array[String] = Array("rsync", "-ace", "ssh", osPath(jarName), hostAndUser +":" + remoteDir +"/")
+      val builder = new JProcessBuilder(command: _*)
+      sbtLogger.debug("Jvm.syncJar about to run " + command.mkString(" "))
+      Process(builder).run(sbtLogger, false)
+    }
+    else {
+      process
+    }
+  }
+
+  def forkRemoteJava(java: String, jvmOptions: Seq[String], appOptions: Seq[String], jarName: String,
+                     hostAndUser: String, remoteDir: String, logger: Logger, connectInput: Boolean,
+                     sbtLogger: Logger): Process = {
+    sbtLogger.debug("About to use java " + java)
+    val shortJarName = new File(jarName).getName
+    val javaCommand = List(List(java), jvmOptions, List("-cp", shortJarName), appOptions).flatten
+    val command = Array("ssh", hostAndUser, ("cd " :: (remoteDir :: (" ; " :: javaCommand))).mkString(" "))
+    sbtLogger.debug("Jvm.forkRemoteJava about to run " + command.mkString(" "))
+    val builder = new JProcessBuilder(command: _*)
+    Process(builder).run(logger, connectInput)
+  }
+}
+
+class JvmBasicLogger(name: String) extends BasicLogger {
+  def jvm(message: String) = "[%s] %s" format (name, message)
+
+  def log(level: Level.Value, message: => String) = System.out.synchronized {
+    System.out.println(jvm(message))
+  }
+
+  def trace(t: => Throwable) = System.out.synchronized {
+    val traceLevel = getTrace
+    if (traceLevel >= 0) System.out.print(StackTrace.trimmed(t, traceLevel))
+  }
+
+  def success(message: => String) = log(Level.Info, message)
+  def control(event: ControlEvent.Value, message: => String) = log(Level.Info, message)
+
+  def logAll(events: Seq[LogEvent]) = System.out.synchronized { events.foreach(log) }
+}
+
+final class JvmLogger(name: String) extends JvmBasicLogger(name)

--- a/project/src/main/scala/com/typesafe/sbt/package.scala
+++ b/project/src/main/scala/com/typesafe/sbt/package.scala
@@ -1,0 +1,11 @@
+/**
+ * Copyright (C) 2011-2012 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package com.typesafe
+
+package object sbt {
+
+  // For backwards compatibility
+  val SbtMultiJvm = MultiJvmPlugin
+}

--- a/project/src/main/scala/com/typesafe/sbt/package.scala
+++ b/project/src/main/scala/com/typesafe/sbt/package.scala
@@ -1,5 +1,5 @@
-/**
- * Copyright (C) 2011-2012 Typesafe Inc. <http://www.typesafe.com>
+/*
+ * Copyright (C) 2011-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package com.typesafe

--- a/project/src/main/scala/sbt/AccessForkTests.scala
+++ b/project/src/main/scala/sbt/AccessForkTests.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package sbt
 package multijvmaccess
 

--- a/project/src/main/scala/sbt/AccessForkTests.scala
+++ b/project/src/main/scala/sbt/AccessForkTests.scala
@@ -1,0 +1,18 @@
+package sbt
+package multijvmaccess
+
+import sbt.ConcurrentRestrictions.Tag
+import sbt.Tests.Execution
+import sbt.testing.Runner
+
+object Access {
+  def ForkTests(
+             runners: Map[TestFramework, Runner],
+             tests: Vector[TestDefinition],
+             config: Execution,
+             classpath: Seq[File],
+             fork: ForkOptions,
+             log: Logger,
+             tag: Tag
+           ): Task[sbt.Tests.Output] = sbt.ForkTests(runners, tests, config, classpath, fork, log, tag)
+}


### PR DESCRIPTION
I finally had a successful stab at trying out how to improve test reporting for multi-jvm tests. Test reporting currently don't works properly because sbt-multi-jvm built its own infrastructure for forking test launchers (maybe because it existed before forking tests was implemented in sbt). When forking tests it's tricky to collect test events live at runtime because those need to be communicated from the forked process to sbt in a structured way.

For testing, I moved the sbt-multi-jvm sources over into the akka sources and adapted the task for running multi-jvm tests locally to use the internal sbt forking to get full test report coverage.

I open the PR here only to let it run through the PR validator to see if jenkins can now pick up the test results.