### PR TITLE
Update to Scala 2.13.0-RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 scala:
   - "2.12.8"
   - "2.11.12"
-  - "2.13.0-M5"
+  - "2.13.0-RC1"
 
 before_install:
   # using jabba for custom jdk management

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/CapturedLogEvent.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/CapturedLogEvent.scala
@@ -11,7 +11,7 @@ import akka.annotation.InternalApi
 import akka.event.Logging.LogLevel
 import akka.util.OptionVal
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
 /**

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -13,7 +13,7 @@ import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
 import akka.actor.testkit.typed.Effect._
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.reflect.ClassTag
 import scala.util.control.Exception.Catcher

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
@@ -12,7 +12,7 @@ import java.util.function.Supplier
 import java.util.{ List => JList }
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestInbox.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestInbox.scala
@@ -10,7 +10,7 @@ import akka.actor.testkit.typed.internal.TestInboxImpl
 
 import java.util.concurrent.ThreadLocalRandom
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.collection.immutable
 
 object TestInbox {

--- a/akka-actor-tests/src/test/java/akka/japi/ThrowablesTest.java
+++ b/akka-actor-tests/src/test/java/akka/japi/ThrowablesTest.java
@@ -14,14 +14,11 @@ public class ThrowablesTest {
     Assert.assertTrue(Throwables.isNonFatal(new IllegalArgumentException("isNonFatal")));
   }
 
-  private static class ControlThrowableImpl extends Throwable implements ControlThrowable {}
-
   @Test
   public void testIsFatal() {
     Assert.assertTrue(Throwables.isFatal(new StackOverflowError("fatal")));
     Assert.assertTrue(Throwables.isFatal(new ThreadDeath()));
     Assert.assertTrue(Throwables.isFatal(new InterruptedException("fatal")));
     Assert.assertTrue(Throwables.isFatal(new LinkageError("fatal")));
-    Assert.assertTrue(Throwables.isFatal(new ControlThrowableImpl()));
   }
 }

--- a/akka-actor-tests/src/test/scala/akka/AkkaVersionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/AkkaVersionSpec.scala
@@ -59,7 +59,7 @@ class AkkaVersionSpec extends WordSpec with Matchers {
     }
 
     "succeed if Akka version is SNAPSHOT" in {
-      AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5-SNAPSHOT")
+      AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.23")
     }
 
     "succeed if Akka version is timestamped SNAPSHOT" in {

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorLookupSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorLookupSpec.scala
@@ -68,7 +68,7 @@ class ActorLookupSpec extends AkkaSpec with DefaultTimeout {
       system.actorFor(system.child("c2").child("c21")) should ===(c21) // test Java API
       system.actorFor(system / Seq("c2", "c21")) should ===(c21)
 
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       system.actorFor(system.descendant(Seq("c2", "c21").asJava)) // test Java API
     }
 
@@ -245,7 +245,7 @@ class ActorLookupSpec extends AkkaSpec with DefaultTimeout {
     }
 
     "return deadLetters or EmptyLocalActorRef, respectively, for non-existing paths" in {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
 
       def checkOne(looker: ActorRef, query: Query, result: ActorRef): Unit = {
         val lookup = Await.result(looker ? query, timeout.duration)

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSelectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSelectionSpec.scala
@@ -95,7 +95,7 @@ class ActorSelectionSpec extends AkkaSpec with DefaultTimeout {
       identify(system.child("c2").child("c21")) should ===(Some(c21)) // test Java API
       identify(system / Seq("c2", "c21")) should ===(Some(c21))
 
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       identify(system.descendant(Seq("c2", "c21").asJava)) // test Java API
     }
 
@@ -244,7 +244,7 @@ class ActorSelectionSpec extends AkkaSpec with DefaultTimeout {
     }
 
     "return deadLetters or ActorIdentity(None), respectively, for non-existing paths" in {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
 
       def checkOne(looker: ActorRef, query: Query, result: Option[ActorRef]): Unit = {
         val lookup = askNode(looker, query)

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
@@ -15,7 +15,7 @@ import com.github.ghik.silencer.silent
 
 import scala.concurrent.duration._
 import org.scalatest.BeforeAndAfterEach
-import org.scalatestplus.junit.JUnitSuiteLike
+import org.scalatest.junit.JUnitSuiteLike
 
 object ActorWithStashSpec {
 
@@ -102,6 +102,7 @@ object ActorWithStashSpec {
 
 }
 
+@silent
 class JavaActorWithStashSpec extends StashJavaAPI with JUnitSuiteLike
 
 @silent

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
@@ -15,6 +15,7 @@ import com.github.ghik.silencer.silent
 
 import scala.concurrent.duration._
 import org.scalatest.BeforeAndAfterEach
+// FIXME workaround for https://github.com/scala/bug/issues/11512
 import org.scalatest.junit.JUnitSuiteLike
 
 object ActorWithStashSpec {

--- a/akka-actor-tests/src/test/scala/akka/actor/CoordinatedShutdownSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/CoordinatedShutdownSpec.scala
@@ -15,7 +15,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import akka.actor.CoordinatedShutdown.Phase
 import akka.actor.CoordinatedShutdown.UnknownReason
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.concurrent.Promise
 import java.util.concurrent.TimeoutException
 

--- a/akka-actor-tests/src/test/scala/akka/actor/ExtensionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ExtensionSpec.scala
@@ -10,10 +10,12 @@ import akka.testkit.EventFilter
 import akka.testkit.TestKit._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{ Matchers, WordSpec }
-import org.scalatestplus.junit.JUnitSuiteLike
+import org.scalatest.junit.JUnitSuiteLike
 
 import scala.util.control.NoStackTrace
 
+import com.github.ghik.silencer.silent
+@silent
 class JavaExtensionSpec extends JavaExtension with JUnitSuiteLike
 
 object TestExtension extends ExtensionId[TestExtension] with ExtensionIdProvider {

--- a/akka-actor-tests/src/test/scala/akka/actor/ExtensionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ExtensionSpec.scala
@@ -10,6 +10,7 @@ import akka.testkit.EventFilter
 import akka.testkit.TestKit._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{ Matchers, WordSpec }
+// FIXME https://github.com/scala/bug/issues/11512
 import org.scalatest.junit.JUnitSuiteLike
 
 import scala.util.control.NoStackTrace

--- a/akka-actor-tests/src/test/scala/akka/actor/FSMActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMActorSpec.scala
@@ -251,7 +251,7 @@ class FSMActorSpec extends AkkaSpec(Map("akka.actor.debug.fsm" -> true)) with Im
     }
 
     "log events and transitions if asked to do so" in {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       val config = ConfigFactory
         .parseMap(Map(
           "akka.loglevel" -> "DEBUG",

--- a/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMTransitionSpec.scala
@@ -27,7 +27,7 @@ object FSMTransitionSpec {
   }
 
   class MyFSM(target: ActorRef) extends Actor with FSM[Int, Unit] {
-    startWith(0, Unit)
+    startWith(0, ())
     when(0) {
       case Event("tick", _) => goto(1)
     }

--- a/akka-actor-tests/src/test/scala/akka/actor/JavaAPISpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/JavaAPISpec.scala
@@ -4,6 +4,8 @@
 
 package akka.actor
 
-import org.scalatestplus.junit.JUnitSuiteLike
+import org.scalatest.junit.JUnitSuiteLike
 
+import com.github.ghik.silencer.silent
+@silent
 class JavaAPISpec extends JavaAPI with JUnitSuiteLike

--- a/akka-actor-tests/src/test/scala/akka/actor/JavaAPISpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/JavaAPISpec.scala
@@ -4,6 +4,7 @@
 
 package akka.actor
 
+// FIXME workaround for https://github.com/scala/bug/issues/11512
 import org.scalatest.junit.JUnitSuiteLike
 
 import com.github.ghik.silencer.silent

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
@@ -409,7 +409,7 @@ abstract class ActorModelSpec(config: String) extends AkkaSpec(config) with Defa
                   System.err.println(
                     "Teammates left: " + team.size + " stopLatch: " + stopLatch.getCount + " inhab:" + dispatcher.inhabitants)
 
-                  import scala.collection.JavaConverters._
+                  import akka.util.ccompat.JavaConverters._
                   team.asScala.toList.sortBy(_.self.path).foreach { cell: ActorCell =>
                     System.err.println(
                       " - " + cell.self.path + " " + cell.isTerminated + " " + cell.mailbox.currentStatus + " "
@@ -452,7 +452,7 @@ abstract class ActorModelSpec(config: String) extends AkkaSpec(config) with Defa
         val f6 = a ? Reply("bar2")
 
         val c = system.scheduler.scheduleOnce(2.seconds) {
-          import collection.JavaConverters._
+          import akka.util.ccompat.JavaConverters._
           Thread.getAllStackTraces().asScala.foreach {
             case (thread, stack) =>
               println(s"$thread:")

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatchersSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatchersSpec.scala
@@ -4,7 +4,6 @@
 
 package akka.actor.dispatch
 
-import scala.collection.JavaConverters.mapAsJavaMapConverter
 import scala.reflect.ClassTag
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
@@ -122,6 +121,8 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
   val defaultDispatcherConfig = settings.config.getConfig("akka.actor.default-dispatcher")
 
   lazy val allDispatchers: Map[String, MessageDispatcher] = {
+    import akka.util.ccompat.JavaConverters._
+
     validTypes
       .map(t => (t, from(ConfigFactory.parseMap(Map(tipe -> t, id -> t).asJava).withFallback(defaultDispatcherConfig))))
       .toMap
@@ -160,6 +161,7 @@ class DispatchersSpec extends AkkaSpec(DispatchersSpec.config) with ImplicitSend
     }
 
     "throw ConfigurationException if type does not exist" in {
+      import akka.util.ccompat.JavaConverters._
       intercept[ConfigurationException] {
         from(
           ConfigFactory

--- a/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 import akka.testkit._
 import org.scalatest.WordSpec
 import com.typesafe.config.ConfigFactory
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import akka.actor._
 import scala.annotation.tailrec
 

--- a/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
@@ -1108,7 +1108,7 @@ class TcpConnectionSpec extends AkkaSpec("""
     def assertThisConnectionActorTerminated(): Unit = {
       watch(connectionActor)
       expectTerminated(connectionActor)
-      clientSideChannel should not be ('open)
+      clientSideChannel.isOpen should be(false)
     }
 
     def selectedAs(interest: Int, duration: Duration): BeMatcher[SelectionKey] =

--- a/akka-actor-tests/src/test/scala/akka/io/dns/DockerBindDnsService.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/DockerBindDnsService.scala
@@ -4,7 +4,7 @@
 
 package akka.io.dns
 
-import collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import akka.testkit.AkkaSpec
 import com.spotify.docker.client.DefaultDockerClient
 import com.spotify.docker.client.DockerClient.{ ListContainersParam, LogsParam }

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/ResolvConfParserSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/ResolvConfParserSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.{ Matchers, WordSpec }
 class ResolvConfParserSpec extends WordSpec with Matchers {
 
   private def parse(str: String): ResolvConf = {
-    ResolvConfParser.parseLines(str.lines)
+    ResolvConfParser.parseLines(str.linesIterator)
   }
 
   "The ResolvConfParser" should {

--- a/akka-actor-tests/src/test/scala/akka/japi/JavaAPITest.scala
+++ b/akka-actor-tests/src/test/scala/akka/japi/JavaAPITest.scala
@@ -4,6 +4,8 @@
 
 package akka.japi
 
-import org.scalatestplus.junit.JUnitSuiteLike
+import org.scalatest.junit.JUnitSuiteLike
 
+import com.github.ghik.silencer.silent
+@silent
 class JavaAPITest extends JavaAPITestBase with JUnitSuiteLike

--- a/akka-actor-tests/src/test/scala/akka/japi/JavaAPITest.scala
+++ b/akka-actor-tests/src/test/scala/akka/japi/JavaAPITest.scala
@@ -4,6 +4,7 @@
 
 package akka.japi
 
+// FIXME workaround for https://github.com/scala/bug/issues/11512
 import org.scalatest.junit.JUnitSuiteLike
 
 import com.github.ghik.silencer.silent

--- a/akka-actor-tests/src/test/scala/akka/pattern/BackoffOnRestartSupervisorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/BackoffOnRestartSupervisorSpec.scala
@@ -161,7 +161,7 @@ class BackoffOnRestartSupervisorSpec extends AkkaSpec with ImplicitSender {
 
       supervisor ! BackoffSupervisor.GetCurrentChild
       // new instance
-      val Some(child) = expectMsgType[BackoffSupervisor.CurrentChild].ref
+      val child = expectMsgType[BackoffSupervisor.CurrentChild].ref.get
 
       child ! "PING"
       expectMsg("PONG")

--- a/akka-actor-tests/src/test/scala/akka/util/BoundedBlockingQueueSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/BoundedBlockingQueueSpec.scala
@@ -17,7 +17,7 @@ import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar._
 import org.scalatest.{ Matchers, WordSpec }
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.collection.mutable
 import scala.concurrent.{ Await, ExecutionContext, ExecutionContextExecutor, Future }
 import scala.util.control.Exception

--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -742,7 +742,7 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
           a.asByteBuffers.forall(_.isReadOnly)
         }
         check { (a: ByteString) =>
-          import scala.collection.JavaConverters.iterableAsScalaIterableConverter
+          import akka.util.ccompat.JavaConverters._
           a.asByteBuffers.zip(a.getByteBuffers().asScala).forall(x => x._1 == x._2)
         }
       }

--- a/akka-actor-tests/src/test/scala/akka/util/JavaDurationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/JavaDurationSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.util
 
-import org.scalatestplus.junit.JUnitSuiteLike
-
+import org.scalatest.junit.JUnitSuiteLike
+import com.github.ghik.silencer.silent
+@silent
 class JavaDurationSpec extends JavaDuration with JUnitSuiteLike

--- a/akka-actor-tests/src/test/scala/akka/util/JavaDurationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/JavaDurationSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.util
 
+// FIXME workaround for https://github.com/scala/bug/issues/11512
 import org.scalatest.junit.JUnitSuiteLike
 import com.github.ghik.silencer.silent
 @silent

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ExtensionsImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ExtensionsImpl.scala
@@ -10,7 +10,7 @@ import akka.annotation.InternalApi
 import akka.actor.typed.{ ActorSystem, Extension, ExtensionId, Extensions }
 import scala.annotation.tailrec
 import scala.util.{ Failure, Success, Try }
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 import akka.actor.typed.ExtensionSetup
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/LoggerAdapterImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/LoggerAdapterImpl.scala
@@ -10,7 +10,7 @@ import akka.event.Logging._
 import akka.event.{ LoggingBus, LoggingFilterWithMarker, LogMarker => UntypedLM }
 import akka.util.OptionVal
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 /**
  * INTERNAL API

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistMessages.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistMessages.scala
@@ -9,7 +9,7 @@ import akka.actor.typed.receptionist.Receptionist.Command
 import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
 import akka.annotation.InternalApi
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 /**
  * Internal API

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
@@ -14,7 +14,7 @@ import akka.japi.function.{ Effect, Function2 => JapiFunction2 }
 import akka.japi.pf.PFBuilder
 import akka.util.unused
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.reflect.ClassTag
 
 /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -7,7 +7,7 @@ package akka.actor.typed.receptionist
 import akka.actor.typed.{ ActorRef, ActorSystem, Extension, ExtensionId }
 import akka.actor.typed.internal.receptionist._
 import akka.annotation.DoNotInherit
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.reflect.ClassTag
 
 import akka.actor.typed.ExtensionSetup

--- a/akka-actor/src/main/mima-filters/2.5.22.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.22.backwards.excludes
@@ -1,0 +1,7 @@
+# These were added for bincompat with 2.4 but no longer part of the public API,
+# so can be safely excluded now. Required to avoid naming clashes with extension
+# methods generated on Scala 2.13 (https://github.com/scala/scala/commit/f9879b63a87b1e3062c58abd9ce30e68d9fee8ca)
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.pattern.AskableActorRef.ask$extension")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.pattern.AskableActorRef.?$extension")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.pattern.AskableActorSelection.ask$extension")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.pattern.AskableActorSelection.?$extension")

--- a/akka-actor/src/main/scala-2.13+/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala-2.13+/akka/util/ByteString.scala
@@ -143,6 +143,7 @@ object ByteString {
 
   val empty: ByteString = CompactByteString(Array.empty[Byte])
 
+  // workaround for https://github.com/scala/bug/issues/11509
   /** Java API */
   val emptyByteString: ByteString = empty
 

--- a/akka-actor/src/main/scala-2.13+/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala-2.13+/akka/util/ByteString.scala
@@ -7,13 +7,15 @@ package akka.util
 import java.io.{ ObjectInputStream, ObjectOutputStream }
 import java.nio.{ ByteBuffer, ByteOrder }
 import java.lang.{ Iterable => JIterable }
+import java.nio.charset.{ Charset, StandardCharsets }
 
 import scala.annotation.{ tailrec, varargs }
 import scala.collection.mutable.{ Builder, WrappedArray }
 import scala.collection.{ immutable, mutable }
 import scala.collection.immutable.{ IndexedSeq, IndexedSeqOps, StrictOptimizedSeqOps, VectorBuilder }
 import scala.reflect.ClassTag
-import java.nio.charset.{ Charset, StandardCharsets }
+
+import com.github.ghik.silencer.silent
 
 object ByteString {
 
@@ -384,7 +386,7 @@ object ByteString {
       }
     }
 
-    override protected def writeReplace(): AnyRef = new SerializationProxy(this)
+    protected def writeReplace(): AnyRef = new SerializationProxy(this)
   }
 
   private[akka] object ByteStrings extends Companion {
@@ -626,7 +628,7 @@ object ByteString {
       }
     }
 
-    override protected def writeReplace(): AnyRef = new SerializationProxy(this)
+    protected def writeReplace(): AnyRef = new SerializationProxy(this)
   }
 
   @SerialVersionUID(1L)
@@ -675,10 +677,7 @@ sealed abstract class ByteString
 
   override protected def fromSpecific(coll: IterableOnce[Byte]): ByteString = ByteString(coll)
   override protected def newSpecificBuilder: mutable.Builder[Byte, ByteString] = ByteString.newBuilder
-
-  // FIXME this is a workaround for
-  //  https://github.com/scala/bug/issues/11192#issuecomment-436926231
-  protected[this] override def writeReplace(): AnyRef = this
+  override def empty: ByteString = ByteString.empty
 
   def apply(idx: Int): Byte
   private[akka] def byteStringCompanion: ByteString.Companion
@@ -814,6 +813,7 @@ sealed abstract class ByteString
    * Java API: Returns an Iterable of read-only ByteBuffers that directly wraps this ByteStrings
    * all fragments. Will always have at least one entry.
    */
+  @silent
   def getByteBuffers(): JIterable[ByteBuffer] = {
     import scala.collection.JavaConverters.asJavaIterableConverter
     asByteBuffers.asJava

--- a/akka-actor/src/main/scala-2.13+/akka/util/ccompat/package.scala
+++ b/akka-actor/src/main/scala-2.13+/akka/util/ccompat/package.scala
@@ -14,4 +14,10 @@ package akka.util
 package object ccompat {
   private[akka] type Factory[-A, +C] = scala.collection.Factory[A, C]
   private[akka] val Factory = scala.collection.Factory
+
+  // When we drop support for 2.12 we can delete this concept
+  // and import scala.jdk.CollectionConverters.Ops._ instead
+  object JavaConverters
+      extends scala.collection.convert.AsJavaExtensions
+      with scala.collection.convert.AsScalaExtensions
 }

--- a/akka-actor/src/main/scala-2.13-/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala-2.13-/akka/util/ByteString.scala
@@ -138,6 +138,7 @@ object ByteString {
 
   val empty: ByteString = CompactByteString(Array.empty[Byte])
 
+  // workaround for https://github.com/scala/bug/issues/11509
   /** Java API */
   val emptyByteString: ByteString = empty
 

--- a/akka-actor/src/main/scala-2.13-/akka/util/ccompat/package.scala
+++ b/akka-actor/src/main/scala-2.13-/akka/util/ccompat/package.scala
@@ -82,4 +82,6 @@ package object ccompat {
   implicit class ImmutableSortedSetOps[A](val real: i.SortedSet[A]) extends AnyVal {
     def unsorted: i.Set[A] = real
   }
+
+  object JavaConverters extends scala.collection.convert.DecorateAsJava with scala.collection.convert.DecorateAsScala
 }

--- a/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
+++ b/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
@@ -282,7 +282,7 @@ object CoordinatedShutdown extends ExtensionId[CoordinatedShutdown] with Extensi
    * INTERNAL API
    */
   private[akka] def phasesFromConfig(conf: Config): Map[String, Phase] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     val defaultPhaseTimeout = conf.getString("default-phase-timeout")
     val phasesConf = conf.getConfig("phases")
     val defaultPhaseConfig = ConfigFactory.parseString(s"""
@@ -575,7 +575,7 @@ final class CoordinatedShutdown private[akka] (
    * Sum of timeouts of all phases that have some task.
    */
   def totalTimeout(): FiniteDuration = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     tasks.keySet.asScala.foldLeft(Duration.Zero) {
       case (acc, phase) => acc + timeout(phase)
     }

--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -135,7 +135,7 @@ case object NoScopeGiven extends NoScopeGiven {
  */
 private[akka] class Deployer(val settings: ActorSystem.Settings, val dynamicAccess: DynamicAccess) {
 
-  import scala.collection.JavaConverters._
+  import akka.util.ccompat.JavaConverters._
 
   private val resizerEnabled: Config = ConfigFactory.parseString("resizer.enabled=on")
   private val deployments = new AtomicReference(WildcardIndex[Deploy]())

--- a/akka-actor/src/main/scala/akka/actor/Stash.scala
+++ b/akka-actor/src/main/scala/akka/actor/Stash.scala
@@ -75,6 +75,7 @@ trait UnrestrictedStash extends Actor with StashSupport {
    *  Overridden callback. Prepends all messages in the stash to the mailbox,
    *  clears the stash, stops all children and invokes the postStop() callback.
    */
+  @throws(classOf[Exception])
   override def preRestart(reason: Throwable, message: Option[Any]): Unit = {
     try unstashAll()
     finally super.preRestart(reason, message)
@@ -85,6 +86,7 @@ trait UnrestrictedStash extends Actor with StashSupport {
    *  Must be called when overriding this method, otherwise stashed messages won't be propagated to DeadLetters
    *  when actor stops.
    */
+  @throws(classOf[Exception])
   override def postStop(): Unit =
     try unstashAll()
     finally super.postStop()

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
@@ -30,6 +30,7 @@ private[akka] trait Children { this: ActorCell =>
     Unsafe.instance.getObjectVolatile(this, AbstractActorCell.childrenOffset).asInstanceOf[ChildrenContainer]
 
   final def children: immutable.Iterable[ActorRef] = childrenRefs.children
+  @silent
   final def getChildren(): java.lang.Iterable[ActorRef] =
     scala.collection.JavaConverters.asJavaIterableConverter(children).asJava
 

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
@@ -136,7 +136,7 @@ class Dispatchers(val settings: ActorSystem.Settings, val prerequisites: Dispatc
    * INTERNAL API
    */
   private[akka] def config(id: String, appConfig: Config): Config = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     def simpleName = id.substring(id.lastIndexOf('.') + 1)
     idConfig(id)
       .withFallback(appConfig)
@@ -145,7 +145,7 @@ class Dispatchers(val settings: ActorSystem.Settings, val prerequisites: Dispatc
   }
 
   private def idConfig(id: String): Config = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     ConfigFactory.parseMap(Map("id" -> id).asJava)
   }
 

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -93,7 +93,7 @@ object ExecutionContexts {
  * Futures is the Java API for Futures and Promises
  */
 object Futures {
-  import scala.collection.JavaConverters.iterableAsScalaIterableConverter
+  import akka.util.ccompat.JavaConverters._
 
   /**
    * Starts an asynchronous computation and returns a `Future` object with the result of that computation.

--- a/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
@@ -55,7 +55,7 @@ private[akka] class Mailboxes(
   private val mailboxTypeConfigurators = new ConcurrentHashMap[String, MailboxType]
 
   private val mailboxBindings: Map[Class[_ <: Any], String] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     settings.config
       .getConfig("akka.actor.mailbox.requirements")
       .root
@@ -255,7 +255,7 @@ private[akka] class Mailboxes(
 
   //INTERNAL API
   private def config(id: String): Config = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     ConfigFactory
       .parseMap(Map("id" -> id).asJava)
       .withFallback(settings.config.getConfig(id))

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -745,7 +745,7 @@ object Logging {
      * Java API: Retrieve the contents of the MDC.
      */
     def getMDC: java.util.Map[String, Any] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       mdc.asJava
     }
   }
@@ -1565,7 +1565,7 @@ trait DiagnosticLoggingAdapter extends LoggingAdapter {
 
   import Logging._
 
-  import scala.collection.JavaConverters._
+  import akka.util.ccompat.JavaConverters._
 
   private var _mdc = emptyMDC
 

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -12,7 +12,7 @@ import com.typesafe.config.Config
 
 import scala.concurrent.duration._
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import akka.util.{ ByteString, Helpers }
 import akka.util.Helpers.Requiring
 import akka.util.JavaDurationConverters._

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -243,7 +243,7 @@ class UdpExt(system: ExtendedActorSystem) extends IO.Extension {
 object UdpMessage {
   import Udp._
   import java.lang.{ Iterable => JIterable }
-  import scala.collection.JavaConverters._
+  import akka.util.ccompat.JavaConverters._
 
   /**
    * Each [[Udp.Send]] can optionally request a positive acknowledgment to be sent

--- a/akka-actor/src/main/scala/akka/io/UdpConnected.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnected.scala
@@ -254,7 +254,7 @@ object UdpConnectedMessage {
   def resumeReading: Command = ResumeReading
 
   implicit private def fromJava[T](coll: JIterable[T]): immutable.Iterable[T] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     coll.asScala.to(immutable.Iterable)
   }
 }

--- a/akka-actor/src/main/scala/akka/io/dns/DnsProtocol.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/DnsProtocol.scala
@@ -9,7 +9,7 @@ import java.util
 import akka.actor.NoSerializationVerificationNeeded
 
 import scala.collection.{ immutable => im }
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 /**
  * Supersedes [[akka.io.Dns]] protocol.

--- a/akka-actor/src/main/scala/akka/io/dns/DnsSettings.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/DnsSettings.scala
@@ -15,7 +15,7 @@ import akka.util.Helpers
 import akka.util.JavaDurationConverters._
 import com.typesafe.config.{ Config, ConfigValueType }
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 import scala.util.{ Failure, Success, Try }

--- a/akka-actor/src/main/scala/akka/io/dns/internal/ResolvConfParser.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/ResolvConfParser.scala
@@ -7,7 +7,7 @@ package akka.io.dns.internal
 import java.io.File
 import java.nio.file.Files
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.util.Try
 
 private[dns] case class ResolvConf(search: List[String], ndots: Int)

--- a/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
@@ -261,18 +261,6 @@ trait ExplicitAskSupport {
 
 object AskableActorRef {
 
-  /**
-   * INTERNAL API: for binary compatibility
-   */
-  private[pattern] def ask$extension(actorRef: ActorRef, message: Any, timeout: Timeout): Future[Any] =
-    actorRef.internalAsk(message, timeout, ActorRef.noSender)
-
-  /**
-   * INTERNAL API: for binary compatibility
-   */
-  private[pattern] def $qmark$extension(actorRef: ActorRef, message: Any, timeout: Timeout): Future[Any] =
-    actorRef.internalAsk(message, timeout, ActorRef.noSender)
-
   private def messagePartOfException(message: Any, sender: ActorRef): String = {
     val msg = if (message == null) "unknown" else message
     val wasSentBy = if (sender == ActorRef.noSender) "" else s" was sent by [$sender]"
@@ -400,21 +388,6 @@ final class ExplicitlyAskableActorRef(val actorRef: ActorRef) extends AnyVal {
           if (sender == null) null else messageFactory(sender.asInstanceOf[InternalActorRef].provider.deadLetters)
         Future.failed[Any](AskableActorRef.unsupportedRecipientType(actorRef, message, sender))
     }
-}
-
-object AskableActorSelection {
-
-  /**
-   * INTERNAL API: for binary compatibility
-   */
-  private[pattern] def ask$extension(actorSel: ActorSelection, message: Any, timeout: Timeout): Future[Any] =
-    actorSel.internalAsk(message, timeout, ActorRef.noSender)
-
-  /**
-   * INTERNAL API: for binary compatibility
-   */
-  private[pattern] def $qmark$extension(actorSel: ActorSelection, message: Any, timeout: Timeout): Future[Any] =
-    actorSel.internalAsk(message, timeout, ActorRef.noSender)
 }
 
 /*

--- a/akka-actor/src/main/scala/akka/routing/ConsistentHash.scala
+++ b/akka-actor/src/main/scala/akka/routing/ConsistentHash.scala
@@ -126,7 +126,7 @@ object ConsistentHash {
    * Java API: Factory method to create a ConsistentHash
    */
   def create[T](nodes: java.lang.Iterable[T], virtualNodesFactor: Int): ConsistentHash[T] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     apply(nodes.asScala, virtualNodesFactor)(ClassTag(classOf[Any].asInstanceOf[Class[T]]))
   }
 

--- a/akka-actor/src/main/scala/akka/routing/Router.scala
+++ b/akka-actor/src/main/scala/akka/routing/Router.scala
@@ -78,7 +78,7 @@ final case class SeveralRoutees(routees: immutable.IndexedSeq[Routee]) extends R
    * Java API
    */
   def getRoutees(): java.util.List[Routee] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     routees.asJava
   }
 

--- a/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
+++ b/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
@@ -405,7 +405,7 @@ final case class Routees(routees: immutable.IndexedSeq[Routee]) {
    * Java API
    */
   def getRoutees: java.util.List[Routee] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     routees.asJava
   }
 }

--- a/akka-actor/src/main/scala/akka/serialization/Serialization.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serialization.scala
@@ -63,7 +63,7 @@ object Serialization {
     }
 
     private final def configToMap(cfg: Config): Map[String, String] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       cfg.root.unwrapped.asScala.toMap.map { case (k, v) => (k -> v.toString) }
     }
   }

--- a/akka-actor/src/main/scala/akka/serialization/SerializationSetup.scala
+++ b/akka-actor/src/main/scala/akka/serialization/SerializationSetup.scala
@@ -8,7 +8,7 @@ import akka.actor.ExtendedActorSystem
 import akka.actor.setup.Setup
 
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 object SerializationSetup {
 

--- a/akka-actor/src/main/scala/akka/util/Index.scala
+++ b/akka-actor/src/main/scala/akka/util/Index.scala
@@ -8,7 +8,11 @@ import annotation.tailrec
 
 import java.util.concurrent.{ ConcurrentHashMap, ConcurrentSkipListSet }
 import java.util.Comparator
-import scala.collection.JavaConverters.{ asScalaIteratorConverter, collectionAsScalaIterableConverter }
+
+import scala.collection.JavaConverters.collectionAsScalaIterableConverter
+import akka.util.ccompat.JavaConverters._
+
+import com.github.ghik.silencer.silent
 
 /**
  * An implementation of a ConcurrentMultiMap
@@ -143,6 +147,7 @@ class Index[K, V](val mapSize: Int, val valueComparator: Comparator[V]) {
     if (set ne null) {
       set.synchronized {
         container.remove(key, set)
+        @silent
         val ret = collectionAsScalaIterableConverter(set.clone()).asScala // Make copy since we need to clear the original
         set.clear() // Clear the original set to signal to any pending writers that there was a conflict
         Some(ret)

--- a/akka-actor/src/main/scala/akka/util/Unused.scala
+++ b/akka-actor/src/main/scala/akka/util/Unused.scala
@@ -4,6 +4,8 @@
 
 package akka.util
 
+import com.github.ghik.silencer.silent
+
 import akka.annotation.InternalApi
 
 /**
@@ -12,6 +14,15 @@ import akka.annotation.InternalApi
  * or other reason. Useful in combination with
  * `-Ywarn-unused:explicits,implicits` compiler options.
  *
+ * Extends 'deprecated' to make sure using a parameter marked @unused
+ * produces a warning, and not using a parameter marked @unused does not
+ * produce an 'unused parameter' warning.
+ *
+ * Extending 'deprecated' is deprecated in Scala 2.13 and scheduled to be
+ * removed in 2.14. Perhaps we should promote introducing an `@unused`
+ * to Scala? https://contributors.scala-lang.org/t/more-error-reporting-annotations/1681/7
+ *
  * INTERNAL API
  */
+@silent
 @InternalApi private[akka] class unused extends deprecated("unused", "")

--- a/akka-bench-jmh-typed/src/main/scala/akka/BenchRunner.scala
+++ b/akka-bench-jmh-typed/src/main/scala/akka/BenchRunner.scala
@@ -10,7 +10,7 @@ import org.openjdk.jmh.runner.options.CommandLineOptions
 
 object BenchRunner {
   def main(args: Array[String]) = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
 
     val args2 = args.toList.flatMap {
       case "quick"    => "-i 1 -wi 1 -f1 -t1".split(" ").toList

--- a/akka-bench-jmh/src/main/scala/akka/BenchRunner.scala
+++ b/akka-bench-jmh/src/main/scala/akka/BenchRunner.scala
@@ -10,7 +10,7 @@ import org.openjdk.jmh.runner.options.CommandLineOptions
 
 object BenchRunner {
   def main(args: Array[String]) = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
 
     val args2 = args.toList.flatMap {
       case "quick"    => "-i 1 -wi 1 -f1 -t1".split(" ").toList

--- a/akka-camel/src/main/scala/akka/camel/CamelMessage.scala
+++ b/akka-camel/src/main/scala/akka/camel/CamelMessage.scala
@@ -12,7 +12,7 @@ import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime
 import scala.util.Try
 import akka.dispatch.Mapper
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 /**
  * An immutable representation of a Camel message.

--- a/akka-camel/src/main/scala/akka/camel/Consumer.scala
+++ b/akka-camel/src/main/scala/akka/camel/Consumer.scala
@@ -28,6 +28,7 @@ trait Consumer extends Actor with CamelSupport {
    * Registers the consumer endpoint. Note: when overriding this method, be sure to
    * call 'super.preRestart', otherwise the consumer endpoint will not be registered.
    */
+  @throws[Exception]
   override def preStart(): Unit = {
     super.preStart()
     // Possible FIXME. registering the endpoint here because of problems

--- a/akka-camel/src/main/scala/akka/camel/Producer.scala
+++ b/akka-camel/src/main/scala/akka/camel/Producer.scala
@@ -18,6 +18,7 @@ trait ProducerSupport extends Actor with CamelSupport {
   private[this] var messages = Vector.empty[(ActorRef, Any)]
   private[this] var producerChild: Option[ActorRef] = None
 
+  @throws[Exception]
   override def preStart(): Unit = {
     super.preStart()
     register()

--- a/akka-camel/src/main/scala/akka/camel/internal/CamelExchangeAdapter.scala
+++ b/akka-camel/src/main/scala/akka/camel/internal/CamelExchangeAdapter.scala
@@ -80,7 +80,7 @@ private[camel] class CamelExchangeAdapter(val exchange: Exchange) {
    *                in the exchange.
    */
   def toAkkaCamelException(headers: Map[String, Any]): AkkaCamelException = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     new AkkaCamelException(exchange.getException, headers ++ response.getHeaders.asScala)
   }
 
@@ -96,7 +96,7 @@ private[camel] class CamelExchangeAdapter(val exchange: Exchange) {
    *                in the Camel message.
    */
   def toFailureResult(headers: Map[String, Any]): FailureResult = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     FailureResult(exchange.getException, headers ++ response.getHeaders.asScala)
   }
 

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsCollector.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsCollector.scala
@@ -16,6 +16,8 @@ import akka.cluster.MemberStatus
 import java.util.concurrent.ThreadLocalRandom
 import akka.actor.DeadLetterSuppression
 
+import com.github.ghik.silencer.silent
+
 /**
  *  Runtime collection management commands.
  */
@@ -92,6 +94,7 @@ trait ClusterMetricsEvent
 final case class ClusterMetricsChanged(nodeMetrics: Set[NodeMetrics]) extends ClusterMetricsEvent {
 
   /** Java API */
+  @silent
   def getNodeMetrics: java.lang.Iterable[NodeMetrics] =
     scala.collection.JavaConverters.asJavaIterableConverter(nodeMetrics).asJava
 }

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/Metric.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/Metric.scala
@@ -9,6 +9,8 @@ import scala.util.Success
 import scala.util.Failure
 import scala.util.Try
 
+import com.github.ghik.silencer.silent
+
 /**
  * Metrics key/value.
  *
@@ -323,6 +325,7 @@ final case class NodeMetrics(address: Address, timestamp: Long, metrics: Set[Met
   /**
    * Java API
    */
+  @silent
   def getMetrics: java.lang.Iterable[Metric] =
     scala.collection.JavaConverters.asJavaIterableConverter(metrics).asJava
 

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/protobuf/MessageSerializer.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/protobuf/MessageSerializer.scala
@@ -18,7 +18,7 @@ import akka.util.ccompat._
 
 import scala.annotation.tailrec
 import scala.collection.immutable
-import scala.collection.JavaConverters.{ asJavaIterableConverter, asScalaBufferConverter, setAsJavaSetConverter }
+import akka.util.ccompat.JavaConverters._
 import java.io.NotSerializableException
 
 import akka.dispatch.Dispatchers

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -8,7 +8,7 @@ import java.net.URLEncoder
 import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.Await
 import scala.util.control.NonFatal

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -109,14 +109,14 @@ object ShardCoordinator {
         shardId: ShardId,
         currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardId]]): Future[ActorRef] = {
 
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       allocateShard(requester, shardId, currentShardAllocations.asJava)
     }
 
     override final def rebalance(
         currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardId]],
         rebalanceInProgress: Set[ShardId]): Future[Set[ShardId]] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       implicit val ec = ExecutionContexts.sameThreadExecutionContext
       rebalance(currentShardAllocations.asJava, rebalanceInProgress.asJava).map(_.asScala.toSet)
     }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -242,7 +242,7 @@ object ShardRegion {
      * Java API
      */
     def getRegions: java.util.Set[Address] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       regions.asJava
     }
 
@@ -269,7 +269,7 @@ object ShardRegion {
      * Java API
      */
     def getRegions(): java.util.Map[Address, ShardRegionStats] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       regions.asJava
     }
   }
@@ -297,7 +297,7 @@ object ShardRegion {
      * Java API
      */
     def getStats(): java.util.Map[ShardId, Int] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       stats.asJava
     }
 
@@ -329,7 +329,7 @@ object ShardRegion {
      * If gathering the shard information times out the set of shards will be empty.
      */
     def getShards(): java.util.Set[ShardState] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       shards.asJava
     }
   }
@@ -340,7 +340,7 @@ object ShardRegion {
      * Java API:
      */
     def getEntityIds(): java.util.Set[EntityId] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       entityIds.asJava
     }
   }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/protobuf/ClusterShardingMessageSerializer.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/protobuf/ClusterShardingMessageSerializer.scala
@@ -9,7 +9,7 @@ import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import akka.actor.ActorRef
 import akka.actor.ExtendedActorSystem

--- a/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
@@ -153,7 +153,7 @@ final class ClusterClientSettings(
    * Java API
    */
   def withInitialContacts(initialContacts: java.util.Set[ActorPath]): ClusterClientSettings = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     withInitialContacts(initialContacts.asScala.toSet)
   }
 
@@ -263,7 +263,7 @@ case object GetContactPoints extends GetContactPoints {
  * @param contactPoints The presently known list of contact points.
  */
 final case class ContactPoints(contactPoints: Set[ActorPath]) {
-  import scala.collection.JavaConverters._
+  import akka.util.ccompat.JavaConverters._
 
   /**
    * Java API
@@ -815,7 +815,7 @@ case object GetClusterClients extends GetClusterClients {
  * @param clusterClients The presently known list of cluster clients.
  */
 final case class ClusterClients(clusterClients: Set[ActorRef]) {
-  import scala.collection.JavaConverters._
+  import akka.util.ccompat.JavaConverters._
 
   /**
    * Java API

--- a/akka-cluster-tools/src/main/scala/akka/cluster/client/protobuf/ClusterClientMessageSerializer.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/client/protobuf/ClusterClientMessageSerializer.scala
@@ -4,7 +4,7 @@
 
 package akka.cluster.client.protobuf
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import akka.actor.ExtendedActorSystem
 import akka.serialization.BaseSerializer
 import akka.serialization.SerializerWithStringManifest

--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
@@ -237,7 +237,7 @@ object DistributedPubSubMediator {
      * Java API
      */
     def getTopics(): java.util.Set[String] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       topics.asJava
     }
   }

--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializer.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializer.scala
@@ -12,7 +12,7 @@ import java.util.zip.GZIPOutputStream
 import java.util.zip.GZIPInputStream
 import scala.annotation.tailrec
 import akka.cluster.pubsub.protobuf.msg.{ DistributedPubSubMessages => dm }
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import akka.cluster.pubsub.DistributedPubSubMediator._
 import akka.cluster.pubsub.DistributedPubSubMediator.Internal._
 import akka.actor.ActorRef

--- a/akka-cluster-tools/src/test/scala/akka/cluster/TestLease.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/TestLease.scala
@@ -15,7 +15,7 @@ import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.{ Future, Promise }
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 object TestLeaseExt extends ExtensionId[TestLeaseExt] with ExtensionIdProvider {
   override def get(system: ActorSystem): TestLeaseExt = super.get(system)

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -26,6 +26,8 @@ import scala.util.control.NonFatal
 
 import akka.event.Logging.LogLevel
 
+import com.github.ghik.silencer.silent
+
 /**
  * Cluster Extension Id and factory for creating Cluster extension.
  */
@@ -94,6 +96,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
   /**
    * Java API: roles that this member has
    */
+  @silent
   def getSelfRoles: java.util.Set[String] =
     scala.collection.JavaConverters.setAsJavaSetConverter(selfRoles).asJava
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
@@ -19,6 +19,8 @@ import akka.util.ccompat._
 
 import scala.runtime.AbstractFunction5
 
+import com.github.ghik.silencer.silent
+
 /**
  * Domain events published to the event bus.
  * Subscribe with:
@@ -120,25 +122,28 @@ object ClusterEvent {
      * Java API: get current member list.
      */
     def getMembers: java.lang.Iterable[Member] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       members.asJava
     }
 
     /**
      * Java API: get current unreachable set.
      */
+    @silent
     def getUnreachable: java.util.Set[Member] =
       scala.collection.JavaConverters.setAsJavaSetConverter(unreachable).asJava
 
     /**
      * Java API: All data centers in the cluster
      */
+    @silent
     def getUnreachableDataCenters: java.util.Set[String] =
       scala.collection.JavaConverters.setAsJavaSetConverter(unreachableDataCenters).asJava
 
     /**
      * Java API: get current “seen-by” set.
      */
+    @silent
     def getSeenBy: java.util.Set[Address] =
       scala.collection.JavaConverters.setAsJavaSetConverter(seenBy).asJava
 
@@ -166,6 +171,7 @@ object ClusterEvent {
     /**
      * Java API: All node roles in the cluster
      */
+    @silent
     def getAllRoles: java.util.Set[String] =
       scala.collection.JavaConverters.setAsJavaSetConverter(allRoles).asJava
 
@@ -177,6 +183,7 @@ object ClusterEvent {
     /**
      * Java API: All data centers in the cluster
      */
+    @silent
     def getAllDataCenters: java.util.Set[String] =
       scala.collection.JavaConverters.setAsJavaSetConverter(allDataCenters).asJava
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterSettings.scala
@@ -167,7 +167,7 @@ final class ClusterSettings(val config: Config, val systemName: String) {
     cc.getInt("min-nr-of-members")
   }.requiring(_ > 0, "min-nr-of-members must be > 0")
   val MinNrOfMembersOfRole: Map[String, Int] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     cc.getConfig("role")
       .root
       .asScala
@@ -190,7 +190,7 @@ final class ClusterSettings(val config: Config, val systemName: String) {
 
   val ByPassConfigCompatCheck: Boolean = !cc.getBoolean("configuration-compatibility-check.enforce-on-join")
   val ConfigCompatCheckers: Set[String] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     cc.getConfig("configuration-compatibility-check.checkers")
       .root
       .unwrapped
@@ -204,7 +204,7 @@ final class ClusterSettings(val config: Config, val systemName: String) {
   }
 
   val SensitiveConfigPaths = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
 
     val sensitiveKeys =
       cc.getConfig("configuration-compatibility-check.sensitive-config-paths")

--- a/akka-cluster/src/main/scala/akka/cluster/JoinConfigCompatChecker.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/JoinConfigCompatChecker.scala
@@ -11,7 +11,7 @@ import akka.annotation.{ DoNotInherit, InternalApi }
 import akka.util.ccompat._
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValue }
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.collection.{ immutable => im }
 
 abstract class JoinConfigCompatChecker {

--- a/akka-cluster/src/main/scala/akka/cluster/Member.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Member.scala
@@ -49,6 +49,7 @@ class Member private[cluster] (
   /**
    * Java API
    */
+  @silent
   def getRoles: java.util.Set[String] =
     scala.collection.JavaConverters.setAsJavaSetConverter(roles).asJava
 

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -15,13 +15,12 @@ import akka.protobuf.{ ByteString, MessageLite }
 
 import scala.annotation.tailrec
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.concurrent.duration.Deadline
 import akka.annotation.InternalApi
 import akka.cluster.InternalClusterAction._
 import akka.cluster.routing.{ ClusterRouterPool, ClusterRouterPoolSettings }
 import akka.routing.Pool
-import akka.util.ccompat._
 import akka.util.ccompat._
 import com.github.ghik.silencer.silent
 import com.typesafe.config.{ Config, ConfigFactory, ConfigRenderOptions }
@@ -184,6 +183,7 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem)
     builder.build()
   }
 
+  @silent
   private def clusterRouterPoolSettingsToProto(settings: ClusterRouterPoolSettings): cm.ClusterRouterPoolSettings = {
     val builder = cm.ClusterRouterPoolSettings.newBuilder()
     builder
@@ -193,8 +193,7 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem)
       .addAllUseRoles(settings.useRoles.asJava)
 
     // for backwards compatibility
-    @silent
-    val _ = settings.useRole.foreach(builder.setUseRole)
+    settings.useRole.foreach(builder.setUseRole)
 
     builder.build()
   }

--- a/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
@@ -30,7 +30,7 @@ import com.typesafe.config.ConfigFactory
 
 import scala.annotation.{ tailrec, varargs }
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 object ClusterRouterGroupSettings {
   @deprecated("useRole has been replaced with useRoles", since = "2.5.4")

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -770,7 +770,7 @@ abstract class StressSpec
       .append(" MB")
     sb.append("\n")
 
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     val args = runtime.getInputArguments.asScala.filterNot(_.contains("classpath")).mkString("\n  ")
     sb.append("Args:\n  ").append(args)
     sb.append("\n")

--- a/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
@@ -35,7 +35,7 @@ object ServiceDiscovery {
      * Java API
      */
     def getAddresses: java.util.List[ResolvedTarget] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       addresses.asJava
     }
 
@@ -58,6 +58,8 @@ object ServiceDiscovery {
   object ResolvedTarget {
     // Simply compare the bytes of the address.
     // This may not work in exotic cases such as IPv4 addresses encoded as IPv6 addresses.
+    import com.github.ghik.silencer.silent
+    @silent
     private implicit val inetAddressOrdering: Ordering[InetAddress] =
       Ordering.by[InetAddress, Iterable[Byte]](_.getAddress)
 

--- a/akka-discovery/src/main/scala/akka/discovery/aggregate/AggregateServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/aggregate/AggregateServiceDiscovery.scala
@@ -13,7 +13,7 @@ import akka.event.Logging
 import akka.util.Helpers.Requiring
 import com.typesafe.config.Config
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal

--- a/akka-discovery/src/main/scala/akka/discovery/config/ConfigServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/config/ConfigServiceDiscovery.scala
@@ -11,7 +11,7 @@ import akka.discovery.ServiceDiscovery.{ Resolved, ResolvedTarget }
 import akka.event.Logging
 import com.typesafe.config.Config
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/DurableStore.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/DurableStore.scala
@@ -8,7 +8,7 @@ import java.io.File
 import java.nio.ByteBuffer
 import java.util.concurrent.TimeUnit
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.concurrent.duration._
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -301,7 +301,7 @@ final class LmdbDurableStore(config: Config) extends Actor with ActorLogging {
             TimeUnit.NANOSECONDS.toMillis(System.nanoTime - t0))
       } catch {
         case NonFatal(e) =>
-          import scala.collection.JavaConverters._
+          import akka.util.ccompat.JavaConverters._
           log.error(e, "failed to store [{}]", pending.keySet.asScala.mkString(","))
           tx.abort()
       } finally {

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/GSet.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/GSet.scala
@@ -43,7 +43,7 @@ final case class GSet[A] private (elements: Set[A])(override val delta: Option[G
    * Java API
    */
   def getElements(): java.util.Set[A] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     elements.asJava
   }
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWMap.scala
@@ -75,7 +75,7 @@ final class LWWMap[A, B] private[akka] (private[akka] val underlying: ORMap[A, L
    * Java API: All entries of the map.
    */
   def getEntries(): java.util.Map[A, B] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     entries.asJava
   }
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMap.scala
@@ -196,7 +196,7 @@ final class ORMap[A, B <: ReplicatedData] private[akka] (
    * Java API: All entries of the map.
    */
   def getEntries(): java.util.Map[A, B] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     entries.asJava
   }
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMultiMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMultiMap.scala
@@ -102,7 +102,7 @@ final class ORMultiMap[A, B] private[akka] (
    * Java API: All entries of a multimap where keys are strings and values are sets.
    */
   def getEntries(): java.util.Map[A, java.util.Set[B]] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     val result = new java.util.HashMap[A, java.util.Set[B]]
     if (withValueDeltas)
       underlying.entries.foreach {
@@ -165,14 +165,14 @@ final class ORMultiMap[A, B] private[akka] (
    * replicated data set.
    */
   def put(node: SelfUniqueAddress, key: A, value: java.util.Set[B]): ORMultiMap[A, B] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     put(node.uniqueAddress, key, value.asScala.toSet)
   }
 
   @Deprecated
   @deprecated("Use `put` that takes a `SelfUniqueAddress` parameter instead.", since = "2.5.20")
   def put(node: Cluster, key: A, value: java.util.Set[B]): ORMultiMap[A, B] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     put(node.selfUniqueAddress, key, value.asScala.toSet)
   }
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORSet.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORSet.scala
@@ -309,7 +309,7 @@ final class ORSet[A] private[akka] (
    * Java API
    */
   def getElements(): java.util.Set[A] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     elements.asJava
   }
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounterMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounterMap.scala
@@ -54,7 +54,7 @@ final class PNCounterMap[A] private[akka] (private[akka] val underlying: ORMap[A
 
   /** Java API */
   def getEntries: java.util.Map[A, BigInteger] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     underlying.entries.map { case (k, c) => k -> c.value.bigInteger }.asJava
   }
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
@@ -90,7 +90,7 @@ object ReplicatorSettings {
       case _               => config.getDuration("pruning-interval", MILLISECONDS).millis
     }
 
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     new ReplicatorSettings(
       role = roleOption(config.getString("role")),
       gossipInterval = config.getDuration("gossip-interval", MILLISECONDS).millis,
@@ -328,7 +328,7 @@ final class ReplicatorSettings(
    * Java API
    */
   def withDurableKeys(durableKeys: java.util.Set[String]): ReplicatorSettings = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     withDurableKeys(durableKeys.asScala.toSet)
   }
 
@@ -467,7 +467,7 @@ object Replicator {
      * Java API
      */
     def getKeyIds: java.util.Set[String] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       keyIds.asJava
     }
   }

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
@@ -11,7 +11,7 @@ import java.util.Comparator
 import java.util.TreeSet
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.collection.immutable
 
 import akka.actor.ExtendedActorSystem

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatorMessageSerializer.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatorMessageSerializer.scala
@@ -6,7 +6,7 @@ package akka.cluster.ddata.protobuf
 
 import scala.concurrent.duration._
 import java.util.concurrent.TimeUnit
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.duration.Duration
 import akka.actor.ExtendedActorSystem

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/SerializationSupport.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/SerializationSupport.scala
@@ -10,7 +10,7 @@ import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 import scala.annotation.tailrec
 import scala.collection.immutable.TreeMap
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import akka.actor.ActorRef
 import akka.actor.Address
 import akka.actor.ExtendedActorSystem

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMapSpec.scala
@@ -133,8 +133,8 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "illustrate the danger of using remove+put to replace an entry" in {
-      val m1 = ORMap.empty.put(node1, "a", GSet.empty + "A").put(node1, "b", GSet.empty + "B")
-      val m2 = ORMap.empty.put(node2, "c", GSet.empty + "C")
+      val m1 = ORMap.empty[String, GSet[String]].put(node1, "a", GSet.empty + "A").put(node1, "b", GSet.empty + "B")
+      val m2 = ORMap.empty[String, GSet[String]].put(node2, "c", GSet.empty + "C")
 
       val merged1 = m1.merge(m2)
 
@@ -150,7 +150,7 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "do not have divergence in dot versions between the underlying map and ormap delta" in {
-      val m1 = ORMap.empty.put(node1, "a", GSet.empty + "A")
+      val m1 = ORMap.empty[String, ReplicatedData].put(node1, "a", GSet.empty + "A")
 
       val deltaVersion = m1.delta.get match {
         case ORMap.PutDeltaOp(delta, _, _) =>
@@ -174,8 +174,8 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas" in {
-      val m1 = ORMap.empty.put(node1, "a", GSet.empty + "A").put(node1, "b", GSet.empty + "B")
-      val m2 = ORMap.empty.put(node2, "c", GSet.empty + "C")
+      val m1 = ORMap.empty[String, GSet[String]].put(node1, "a", GSet.empty + "A").put(node1, "b", GSet.empty + "B")
+      val m2 = ORMap.empty[String, GSet[String]].put(node2, "c", GSet.empty + "C")
 
       val merged1 = m1.merge(m2)
 
@@ -198,8 +198,8 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 2" in {
-      val m1 = ORMap.empty.put(node1, "a", ORSet.empty.add(node1, "A")).put(node1, "b", ORSet.empty.add(node1, "B"))
-      val m2 = ORMap.empty.put(node2, "c", ORSet.empty.add(node2, "C"))
+      val m1 = ORMap.empty[String, ORSet[String]].put(node1, "a", ORSet.empty[String].add(node1, "A")).put(node1, "b", ORSet.empty[String].add(node1, "B"))
+      val m2 = ORMap.empty[String, ORSet[String]].put(node2, "c", ORSet.empty[String].add(node2, "C"))
 
       val merged1 = m1.merge(m2)
 
@@ -222,8 +222,8 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 3" in {
-      val m1 = ORMap.empty.put(node1, "a", ORSet.empty.add(node1, "A")).put(node1, "b", ORSet.empty.add(node1, "B"))
-      val m2 = ORMap.empty.put(node2, "c", ORSet.empty.add(node2, "C"))
+      val m1 = ORMap.empty[String, ORSet[String]].put(node1, "a", ORSet.empty[String].add(node1, "A")).put(node1, "b", ORSet.empty[String].add(node1, "B"))
+      val m2 = ORMap.empty[String, ORSet[String]].put(node2, "c", ORSet.empty[String].add(node2, "C"))
 
       val merged1 = m1.merge(m2)
 
@@ -246,8 +246,8 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 4" in {
-      val m1 = ORMap.empty.put(node1, "a", ORSet.empty.add(node1, "A")).put(node1, "b", ORSet.empty.add(node1, "B"))
-      val m2 = ORMap.empty.put(node2, "c", ORSet.empty.add(node2, "C"))
+      val m1 = ORMap.empty[String, ORSet[String]].put(node1, "a", ORSet.empty[String].add(node1, "A")).put(node1, "b", ORSet.empty[String].add(node1, "B"))
+      val m2 = ORMap.empty[String, ORSet[String]].put(node2, "c", ORSet.empty[String].add(node2, "C"))
 
       val merged1 = m1.merge(m2)
 
@@ -270,8 +270,8 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 5" in {
-      val m1 = ORMap.empty.put(node1, "a", GSet.empty + "A").put(node1, "b", GSet.empty + "B")
-      val m2 = ORMap.empty.put(node2, "c", GSet.empty + "C")
+      val m1 = ORMap.empty[String, GSet[String]].put(node1, "a", GSet.empty + "A").put(node1, "b", GSet.empty + "B")
+      val m2 = ORMap.empty[String, GSet[String]].put(node2, "c", GSet.empty + "C")
 
       val merged1 = m1.merge(m2)
 
@@ -294,8 +294,8 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 6" in {
-      val m1 = ORMap.empty.put(node1, "a", ORSet.empty.add(node1, "A")).put(node1, "b", ORSet.empty.add(node1, "B"))
-      val m2 = ORMap.empty.put(node2, "b", ORSet.empty.add(node2, "B3"))
+      val m1 = ORMap.empty[String, ORSet[String]].put(node1, "a", ORSet.empty[String].add(node1, "A")).put(node1, "b", ORSet.empty[String].add(node1, "B"))
+      val m2 = ORMap.empty[String, ORSet[String]].put(node2, "b", ORSet.empty[String].add(node2, "B3"))
 
       val merged1 = m1.merge(m2)
 
@@ -319,11 +319,11 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 7" in {
-      val m1 = ORMap.empty
-        .put(node1, "a", ORSet.empty.add(node1, "A"))
-        .put(node1, "b", ORSet.empty.add(node1, "B1"))
+      val m1 = ORMap.empty[String, ORSet[String]]
+        .put(node1, "a", ORSet.empty[String].add(node1, "A"))
+        .put(node1, "b", ORSet.empty[String].add(node1, "B1"))
         .remove(node1, "b")
-      val m2 = ORMap.empty.put(node1, "a", ORSet.empty.add(node1, "A")).put(node1, "b", ORSet.empty.add(node1, "B2"))
+      val m2 = ORMap.empty[String, ORSet[String]].put(node1, "a", ORSet.empty[String].add(node1, "A")).put(node1, "b", ORSet.empty[String].add(node1, "B2"))
       val m2d = m2.resetDelta.remove(node1, "b")
       val m2u = m2.resetDelta
         .updated(node1, "b", ORSet.empty[String])(_.add(node1, "B3"))
@@ -337,11 +337,11 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 8" in {
-      val m1 = ORMap.empty
+      val m1 = ORMap.empty[String, GSet[String]]
         .put(node1, "a", GSet.empty + "A")
         .put(node1, "b", GSet.empty + "B")
         .put(node2, "b", GSet.empty + "B")
-      val m2 = ORMap.empty.put(node2, "c", GSet.empty + "C")
+      val m2 = ORMap.empty[String, GSet[String]].put(node2, "c", GSet.empty + "C")
 
       val merged1 = m1.merge(m2)
 
@@ -362,11 +362,11 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 9" in {
-      val m1 = ORMap.empty
-        .put(node1, "a", GSet.empty + "A")
-        .put(node1, "b", GSet.empty + "B")
-        .put(node2, "b", GSet.empty + "B")
-      val m2 = ORMap.empty.put(node2, "c", GSet.empty + "C")
+      val m1 = ORMap.empty[String, GSet[String]]
+        .put(node1, "a", GSet.empty[String] + "A")
+        .put(node1, "b", GSet.empty[String] + "B")
+        .put(node2, "b", GSet.empty[String] + "B")
+      val m2 = ORMap.empty[String, GSet[String]].put(node2, "c", GSet.empty + "C")
 
       val merged1 = m1.merge(m2)
 
@@ -389,7 +389,7 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 10" in {
-      val m1 = ORMap.empty.put(node2, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
+      val m1 = ORMap.empty[String, GSet[String]].put(node2, "a", GSet.empty[String] + "A").put(node2, "b", GSet.empty[String] + "B")
 
       val m3 = m1.resetDelta.remove(node2, "b")
       val m4 = m3.resetDelta.put(node2, "b", GSet.empty + "B2").updated(node2, "b", GSet.empty[String])(_.add("B3"))
@@ -406,9 +406,9 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 11" in {
-      val m1 = ORMap.empty.put(node1, "a", GSet.empty + "A")
+      val m1 = ORMap.empty[String, GSet[String]].put(node1, "a", GSet.empty[String] + "A")
 
-      val m2 = ORMap.empty.put(node2, "a", GSet.empty[String]).remove(node2, "a")
+      val m2 = ORMap.empty[String, GSet[String]].put(node2, "a", GSet.empty[String]).remove(node2, "a")
 
       val merged1 = m1.merge(m2)
 
@@ -423,8 +423,8 @@ class ORMapSpec extends WordSpec with Matchers {
       // please note that the current ORMultiMap has the same anomaly
       // because the condition of keeping global vvector is violated
       // by removal of the whole entry for the removed key "b" which results in removal of it's value's vvector
-      val m1 = ORMap.empty.put(node1, "a", ORSet.empty.add(node1, "A")).put(node1, "b", ORSet.empty.add(node1, "B"))
-      val m2 = ORMap.empty.put(node2, "c", ORSet.empty.add(node2, "C"))
+      val m1 = ORMap.empty[String, ORSet[String]].put(node1, "a", ORSet.empty[String].add(node1, "A")).put(node1, "b", ORSet.empty[String].add(node1, "B"))
+      val m2 = ORMap.empty[String, ORSet[String]].put(node2, "c", ORSet.empty[String].add(node2, "C"))
 
       // m1 - node1 gets the update from m2
       val merged1 = m1.merge(m2)
@@ -470,7 +470,7 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "work with delta-coalescing scenario 1" in {
-      val m1 = ORMap.empty.put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
+      val m1 = ORMap.empty[String, GSet[String]].put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
       val m2 = m1.resetDelta.put(node2, "b", GSet.empty + "B2").updated(node2, "b", GSet.empty[String])(_.add("B3"))
 
       val merged1 = m1.merge(m2)
@@ -483,7 +483,7 @@ class ORMapSpec extends WordSpec with Matchers {
       merged2.entries("a").elements should be(Set("A"))
       merged2.entries("b").elements should be(Set("B", "B2", "B3"))
 
-      val m3 = ORMap.empty.put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
+      val m3 = ORMap.empty[String, GSet[String]].put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
       val m4 = m3.resetDelta.put(node2, "b", GSet.empty + "B2").put(node2, "b", GSet.empty + "B3")
 
       val merged3 = m3.merge(m4)
@@ -496,7 +496,7 @@ class ORMapSpec extends WordSpec with Matchers {
       merged4.entries("a").elements should be(Set("A"))
       merged4.entries("b").elements should be(Set("B", "B3"))
 
-      val m5 = ORMap.empty.put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
+      val m5 = ORMap.empty[String, GSet[String]].put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
       val m6 = m5.resetDelta
         .put(node2, "b", GSet.empty + "B2")
         .updated(node2, "b", GSet.empty[String])(_.add("B3"))
@@ -512,7 +512,7 @@ class ORMapSpec extends WordSpec with Matchers {
       merged6.entries("a").elements should be(Set("A"))
       merged6.entries("b").elements should be(Set("B", "B2", "B3", "B4"))
 
-      val m7 = ORMap.empty.put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
+      val m7 = ORMap.empty[String, GSet[String]].put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
       val m8 = m7.resetDelta
         .put(node2, "b", GSet.empty + "B2")
         .put(node2, "d", GSet.empty + "D")
@@ -530,7 +530,7 @@ class ORMapSpec extends WordSpec with Matchers {
       merged8.entries("b").elements should be(Set("B", "B3"))
       merged8.entries("d").elements should be(Set("D"))
 
-      val m9 = ORMap.empty.put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
+      val m9 = ORMap.empty[String, GSet[String]].put(node1, "a", GSet.empty + "A").put(node2, "b", GSet.empty + "B")
       val m10 = m9.resetDelta
         .put(node2, "b", GSet.empty + "B2")
         .put(node2, "d", GSet.empty + "D")
@@ -549,7 +549,7 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "work with deltas and updated for GSet elements type" in {
-      val m1 = ORMap.empty.put(node1, "a", GSet.empty + "A")
+      val m1 = ORMap.empty[String, GSet[String]].put(node1, "a", GSet.empty + "A")
       val m2 = m1.resetDelta.updated(node1, "a", GSet.empty[String])(_.add("B"))
       val m3 = ORMap().mergeDelta(m1.delta.get).mergeDelta(m2.delta.get)
       val GSet(d3) = m3.entries("a")
@@ -557,7 +557,7 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "work with deltas and updated for ORSet elements type" in {
-      val m1 = ORMap.empty.put(node1, "a", ORSet.empty.add(node1, "A"))
+      val m1 = ORMap.empty[String, ORSet[String]].put(node1, "a", ORSet.empty[String].add(node1, "A"))
       val m2 = m1.resetDelta.updated(node1, "a", ORSet.empty[String])(_.add(node1, "B"))
       val m3 = ORMap().mergeDelta(m1.delta.get).mergeDelta(m2.delta.get)
 
@@ -566,7 +566,7 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "work with aggregated deltas and updated for GSet elements type" in {
-      val m1 = ORMap.empty.put(node1, "a", GSet.empty + "A")
+      val m1 = ORMap.empty[String, GSet[String]].put(node1, "a", GSet.empty + "A")
       val m2 = m1.resetDelta
         .updated(node1, "a", GSet.empty[String])(_.add("B"))
         .updated(node1, "a", GSet.empty[String])(_.add("C"))
@@ -576,7 +576,7 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "work with deltas and updated for GCounter elements type" in {
-      val m1 = ORMap.empty.put(node1, "a", GCounter.empty)
+      val m1 = ORMap.empty[String, GCounter].put(node1, "a", GCounter.empty)
       val m2 = m1.resetDelta.updated(node1, "a", GCounter.empty)(_.increment(node1, 10))
       val m3 = m2.resetDelta.updated(node2, "a", GCounter.empty)(_.increment(node2, 10))
       val m4 = ORMap().mergeDelta(m1.delta.get).mergeDelta(m2.delta.get).mergeDelta(m3.delta.get)
@@ -585,7 +585,7 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "work with deltas and updated for PNCounter elements type" in {
-      val m1 = ORMap.empty.put(node1, "a", PNCounter.empty)
+      val m1 = ORMap.empty[String, PNCounter].put(node1, "a", PNCounter.empty)
       val m2 = m1.resetDelta.updated(node1, "a", PNCounter.empty)(_.increment(node1, 10))
       val m3 = m2.resetDelta.updated(node2, "a", PNCounter.empty)(_.decrement(node2, 10))
       val m4 = ORMap().mergeDelta(m1.delta.get).mergeDelta(m2.delta.get).mergeDelta(m3.delta.get)
@@ -594,7 +594,7 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "work with deltas and updated for Flag elements type" in {
-      val m1 = ORMap.empty.put(node1, "a", Flag(false))
+      val m1 = ORMap.empty[String, Flag].put(node1, "a", Flag(false))
       val m2 = m1.resetDelta.updated(node1, "a", Flag.Disabled)(_.switchOn)
       val m3 = ORMap().mergeDelta(m1.delta.get).mergeDelta(m2.delta.get)
       val Flag(d3) = m3.entries("a")
@@ -612,9 +612,9 @@ class ORMapSpec extends WordSpec with Matchers {
     "be able to update entry" in {
       val m1 = ORMap
         .empty[String, ORSet[String]]
-        .put(node1, "a", ORSet.empty.add(node1, "A"))
-        .put(node1, "b", ORSet.empty.add(node1, "B01").add(node1, "B02").add(node1, "B03"))
-      val m2 = ORMap.empty[String, ORSet[String]].put(node2, "c", ORSet.empty.add(node2, "C"))
+        .put(node1, "a", ORSet.empty[String].add(node1, "A"))
+        .put(node1, "b", ORSet.empty[String].add(node1, "B01").add(node1, "B02").add(node1, "B03"))
+      val m2 = ORMap.empty[String, ORSet[String]].put(node2, "c", ORSet.empty[String].add(node2, "C"))
 
       val merged1: ORMap[String, ORSet[String]] = m1.merge(m2)
 
@@ -635,17 +635,17 @@ class ORMapSpec extends WordSpec with Matchers {
     "be able to update ORSet entry with remove+put" in {
       val m1 = ORMap
         .empty[String, ORSet[String]]
-        .put(node1, "a", ORSet.empty.add(node1, "A01"))
+        .put(node1, "a", ORSet.empty[String].add(node1, "A01"))
         .updated(node1, "a", ORSet.empty[String])(_.add(node1, "A02"))
         .updated(node1, "a", ORSet.empty[String])(_.add(node1, "A03"))
-        .put(node1, "b", ORSet.empty.add(node1, "B01").add(node1, "B02").add(node1, "B03"))
-      val m2 = ORMap.empty[String, ORSet[String]].put(node2, "c", ORSet.empty.add(node2, "C"))
+        .put(node1, "b", ORSet.empty[String].add(node1, "B01").add(node1, "B02").add(node1, "B03"))
+      val m2 = ORMap.empty[String, ORSet[String]].put(node2, "c", ORSet.empty[String].add(node2, "C"))
 
       val merged1 = m1.merge(m2)
 
       // note that remove + put work because the new VersionVector version is incremented
       // from a global counter
-      val m3 = merged1.remove(node1, "b").put(node1, "b", ORSet.empty.add(node1, "B2"))
+      val m3 = merged1.remove(node1, "b").put(node1, "b", ORSet.empty[String].add(node1, "B2"))
 
       val merged2 = merged1.merge(m3)
       merged2.entries("a").elements should be(Set("A01", "A02", "A03"))
@@ -660,10 +660,10 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "be able to update ORSet entry with remove -> merge -> put" in {
-      val m1 = ORMap.empty
-        .put(node1, "a", ORSet.empty.add(node1, "A"))
-        .put(node1, "b", ORSet.empty.add(node1, "B01").add(node1, "B02").add(node1, "B03"))
-      val m2 = ORMap.empty.put(node2, "c", ORSet.empty.add(node2, "C"))
+      val m1 = ORMap.empty[String, ORSet[String]]
+        .put(node1, "a", ORSet.empty[String].add(node1, "A"))
+        .put(node1, "b", ORSet.empty[String].add(node1, "B01").add(node1, "B02").add(node1, "B03"))
+      val m2 = ORMap.empty[String, ORSet[String]].put(node2, "c", ORSet.empty[String].add(node2, "C"))
 
       val merged1 = m1.merge(m2)
 
@@ -674,10 +674,10 @@ class ORMapSpec extends WordSpec with Matchers {
       merged2.contains("b") should be(false)
       merged2.entries("c").elements should be(Set("C"))
 
-      val m4 = merged2.put(node1, "b", ORSet.empty.add(node1, "B2"))
+      val m4 = merged2.put(node1, "b", ORSet.empty[String].add(node1, "B2"))
       val m5 = merged2
         .updated(node2, "c", ORSet.empty[String])(_.add(node2, "C2"))
-        .put(node2, "b", ORSet.empty.add(node2, "B3"))
+        .put(node2, "b", ORSet.empty[String].add(node2, "B3"))
 
       val merged3 = m5.merge(m4)
       merged3.entries("a").elements should be(Set("A"))
@@ -686,7 +686,7 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "have unapply extractor" in {
-      val m1 = ORMap.empty.put(node1, "a", Flag(true)).put(node2, "b", Flag(false))
+      val m1 = ORMap.empty[String, Flag].put(node1, "a", Flag(true)).put(node2, "b", Flag(false))
       val _: ORMap[String, Flag] = m1
       val ORMap(entries1) = m1
       val entries2: Map[String, Flag] = entries1

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMapSpec.scala
@@ -133,6 +133,7 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "illustrate the danger of using remove+put to replace an entry" in {
+      // FIXME workaround for https://github.com/scala/bug/issues/11511
       val m1 = ORMap.empty[String, GSet[String]].put(node1, "a", GSet.empty + "A").put(node1, "b", GSet.empty + "B")
       val m2 = ORMap.empty[String, GSet[String]].put(node2, "c", GSet.empty + "C")
 
@@ -198,7 +199,10 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 2" in {
-      val m1 = ORMap.empty[String, ORSet[String]].put(node1, "a", ORSet.empty[String].add(node1, "A")).put(node1, "b", ORSet.empty[String].add(node1, "B"))
+      val m1 = ORMap
+        .empty[String, ORSet[String]]
+        .put(node1, "a", ORSet.empty[String].add(node1, "A"))
+        .put(node1, "b", ORSet.empty[String].add(node1, "B"))
       val m2 = ORMap.empty[String, ORSet[String]].put(node2, "c", ORSet.empty[String].add(node2, "C"))
 
       val merged1 = m1.merge(m2)
@@ -222,7 +226,10 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 3" in {
-      val m1 = ORMap.empty[String, ORSet[String]].put(node1, "a", ORSet.empty[String].add(node1, "A")).put(node1, "b", ORSet.empty[String].add(node1, "B"))
+      val m1 = ORMap
+        .empty[String, ORSet[String]]
+        .put(node1, "a", ORSet.empty[String].add(node1, "A"))
+        .put(node1, "b", ORSet.empty[String].add(node1, "B"))
       val m2 = ORMap.empty[String, ORSet[String]].put(node2, "c", ORSet.empty[String].add(node2, "C"))
 
       val merged1 = m1.merge(m2)
@@ -246,7 +253,10 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 4" in {
-      val m1 = ORMap.empty[String, ORSet[String]].put(node1, "a", ORSet.empty[String].add(node1, "A")).put(node1, "b", ORSet.empty[String].add(node1, "B"))
+      val m1 = ORMap
+        .empty[String, ORSet[String]]
+        .put(node1, "a", ORSet.empty[String].add(node1, "A"))
+        .put(node1, "b", ORSet.empty[String].add(node1, "B"))
       val m2 = ORMap.empty[String, ORSet[String]].put(node2, "c", ORSet.empty[String].add(node2, "C"))
 
       val merged1 = m1.merge(m2)
@@ -294,7 +304,10 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 6" in {
-      val m1 = ORMap.empty[String, ORSet[String]].put(node1, "a", ORSet.empty[String].add(node1, "A")).put(node1, "b", ORSet.empty[String].add(node1, "B"))
+      val m1 = ORMap
+        .empty[String, ORSet[String]]
+        .put(node1, "a", ORSet.empty[String].add(node1, "A"))
+        .put(node1, "b", ORSet.empty[String].add(node1, "B"))
       val m2 = ORMap.empty[String, ORSet[String]].put(node2, "b", ORSet.empty[String].add(node2, "B3"))
 
       val merged1 = m1.merge(m2)
@@ -319,11 +332,15 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 7" in {
-      val m1 = ORMap.empty[String, ORSet[String]]
+      val m1 = ORMap
+        .empty[String, ORSet[String]]
         .put(node1, "a", ORSet.empty[String].add(node1, "A"))
         .put(node1, "b", ORSet.empty[String].add(node1, "B1"))
         .remove(node1, "b")
-      val m2 = ORMap.empty[String, ORSet[String]].put(node1, "a", ORSet.empty[String].add(node1, "A")).put(node1, "b", ORSet.empty[String].add(node1, "B2"))
+      val m2 = ORMap
+        .empty[String, ORSet[String]]
+        .put(node1, "a", ORSet.empty[String].add(node1, "A"))
+        .put(node1, "b", ORSet.empty[String].add(node1, "B2"))
       val m2d = m2.resetDelta.remove(node1, "b")
       val m2u = m2.resetDelta
         .updated(node1, "b", ORSet.empty[String])(_.add(node1, "B3"))
@@ -337,7 +354,8 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 8" in {
-      val m1 = ORMap.empty[String, GSet[String]]
+      val m1 = ORMap
+        .empty[String, GSet[String]]
         .put(node1, "a", GSet.empty + "A")
         .put(node1, "b", GSet.empty + "B")
         .put(node2, "b", GSet.empty + "B")
@@ -362,7 +380,8 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 9" in {
-      val m1 = ORMap.empty[String, GSet[String]]
+      val m1 = ORMap
+        .empty[String, GSet[String]]
         .put(node1, "a", GSet.empty[String] + "A")
         .put(node1, "b", GSet.empty[String] + "B")
         .put(node2, "b", GSet.empty[String] + "B")
@@ -389,7 +408,10 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "not have anomalies for remove+updated scenario and deltas 10" in {
-      val m1 = ORMap.empty[String, GSet[String]].put(node2, "a", GSet.empty[String] + "A").put(node2, "b", GSet.empty[String] + "B")
+      val m1 = ORMap
+        .empty[String, GSet[String]]
+        .put(node2, "a", GSet.empty[String] + "A")
+        .put(node2, "b", GSet.empty[String] + "B")
 
       val m3 = m1.resetDelta.remove(node2, "b")
       val m4 = m3.resetDelta.put(node2, "b", GSet.empty + "B2").updated(node2, "b", GSet.empty[String])(_.add("B3"))
@@ -423,7 +445,10 @@ class ORMapSpec extends WordSpec with Matchers {
       // please note that the current ORMultiMap has the same anomaly
       // because the condition of keeping global vvector is violated
       // by removal of the whole entry for the removed key "b" which results in removal of it's value's vvector
-      val m1 = ORMap.empty[String, ORSet[String]].put(node1, "a", ORSet.empty[String].add(node1, "A")).put(node1, "b", ORSet.empty[String].add(node1, "B"))
+      val m1 = ORMap
+        .empty[String, ORSet[String]]
+        .put(node1, "a", ORSet.empty[String].add(node1, "A"))
+        .put(node1, "b", ORSet.empty[String].add(node1, "B"))
       val m2 = ORMap.empty[String, ORSet[String]].put(node2, "c", ORSet.empty[String].add(node2, "C"))
 
       // m1 - node1 gets the update from m2
@@ -660,7 +685,8 @@ class ORMapSpec extends WordSpec with Matchers {
     }
 
     "be able to update ORSet entry with remove -> merge -> put" in {
-      val m1 = ORMap.empty[String, ORSet[String]]
+      val m1 = ORMap
+        .empty[String, ORSet[String]]
         .put(node1, "a", ORSet.empty[String].add(node1, "A"))
         .put(node1, "b", ORSet.empty[String].add(node1, "B01").add(node1, "B02").add(node1, "B03"))
       val m2 = ORMap.empty[String, ORSet[String]].put(node2, "c", ORSet.empty[String].add(node2, "C"))

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMultiMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMultiMapSpec.scala
@@ -551,7 +551,7 @@ class ORMultiMapSpec extends WordSpec with Matchers {
   }
 
   "have unapply extractor" in {
-    val m1 = ORMultiMap.empty.put(node1, "a", Set(1L, 2L)).put(node2, "b", Set(3L))
+    val m1 = ORMultiMap.empty[String, Long].put(node1, "a", Set(1L, 2L)).put(node2, "b", Set(3L))
     val _: ORMultiMap[String, Long] = m1
     val ORMultiMap(entries1) = m1
     val entries2: Map[String, Set[Long]] = entries1

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORSetSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORSetSpec.scala
@@ -599,7 +599,7 @@ class ORSetSpec extends WordSpec with Matchers {
     }
 
     "have unapply extractor" in {
-      val s1 = ORSet.empty.add(node1, "a").add(node2, "b")
+      val s1 = ORSet.empty[String].add(node1, "a").add(node2, "b")
       val _: ORSet[String] = s1
       val ORSet(elements1) = s1 // `unapply[A](s: ORSet[A])` is used here
       val elements2: Set[String] = elements1

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/PNCounterMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/PNCounterMapSpec.scala
@@ -19,8 +19,12 @@ class PNCounterMapSpec extends WordSpec with Matchers {
 
     "be able to increment and decrement entries with implicit SelfUniqueAddress" in {
       implicit val node = SelfUniqueAddress(node1)
-      PNCounterMap[String]().incrementBy("a", 2).incrementBy("b", 1).incrementBy("b", 2).decrementBy("a", 1).entries should be(
-        Map("a" -> 1, "b" -> 3))
+      PNCounterMap[String]()
+        .incrementBy("a", 2)
+        .incrementBy("b", 1)
+        .incrementBy("b", 2)
+        .decrementBy("a", 1)
+        .entries should be(Map("a" -> 1, "b" -> 3))
     }
 
     "be able to increment and decrement entries" in {

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/PNCounterMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/PNCounterMapSpec.scala
@@ -19,18 +19,18 @@ class PNCounterMapSpec extends WordSpec with Matchers {
 
     "be able to increment and decrement entries with implicit SelfUniqueAddress" in {
       implicit val node = SelfUniqueAddress(node1)
-      PNCounterMap().incrementBy("a", 2).incrementBy("b", 1).incrementBy("b", 2).decrementBy("a", 1).entries should be(
+      PNCounterMap[String]().incrementBy("a", 2).incrementBy("b", 1).incrementBy("b", 2).decrementBy("a", 1).entries should be(
         Map("a" -> 1, "b" -> 3))
     }
 
     "be able to increment and decrement entries" in {
-      val m = PNCounterMap().increment(node1, "a", 2).increment(node1, "b", 3).decrement(node2, "a", 1)
+      val m = PNCounterMap[String]().increment(node1, "a", 2).increment(node1, "b", 3).decrement(node2, "a", 1)
       m.entries should be(Map("a" -> 1, "b" -> 3))
     }
 
     "be able to have its entries correctly merged with another ORMap with other entries" in {
-      val m1 = PNCounterMap().increment(node1, "a", 1).increment(node1, "b", 3).increment(node1, "c", 2)
-      val m2 = PNCounterMap().increment(node2, "c", 5)
+      val m1 = PNCounterMap[String]().increment(node1, "a", 1).increment(node1, "b", 3).increment(node1, "c", 2)
+      val m2 = PNCounterMap[String]().increment(node2, "c", 5)
 
       // merge both ways
       val expected = Map("a" -> 1, "b" -> 3, "c" -> 7)
@@ -39,8 +39,8 @@ class PNCounterMapSpec extends WordSpec with Matchers {
     }
 
     "be able to remove entry" in {
-      val m1 = PNCounterMap().increment(node1, "a", 1).increment(node1, "b", 3).increment(node1, "c", 2)
-      val m2 = PNCounterMap().increment(node2, "c", 5)
+      val m1 = PNCounterMap[String]().increment(node1, "a", 1).increment(node1, "b", 3).increment(node1, "c", 2)
+      val m2 = PNCounterMap[String]().increment(node2, "c", 5)
 
       val merged1 = m1.merge(m2)
 
@@ -53,8 +53,8 @@ class PNCounterMapSpec extends WordSpec with Matchers {
     }
 
     "be able to work with deltas" in {
-      val m1 = PNCounterMap().increment(node1, "a", 1).increment(node1, "b", 3).increment(node1, "c", 2)
-      val m2 = PNCounterMap().increment(node2, "c", 5)
+      val m1 = PNCounterMap[String]().increment(node1, "a", 1).increment(node1, "b", 3).increment(node1, "c", 2)
+      val m2 = PNCounterMap[String]().increment(node2, "c", 5)
 
       val expected = Map("a" -> 1, "b" -> 3, "c" -> 7)
       PNCounterMap().mergeDelta(m1.delta.get).mergeDelta(m2.delta.get).entries should be(expected)
@@ -71,7 +71,7 @@ class PNCounterMapSpec extends WordSpec with Matchers {
     }
 
     "have unapply extractor" in {
-      val m1 = PNCounterMap.empty.increment(node1, "a", 1).increment(node2, "b", 2)
+      val m1 = PNCounterMap.empty[String].increment(node1, "a", 1).increment(node2, "b", 2)
       val PNCounterMap(entries1) = m1
       val entries2: Map[String, BigInt] = entries1
       entries2 should be(Map("a" -> 1L, "b" -> 2L))

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializerSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializerSpec.scala
@@ -293,12 +293,12 @@ class ReplicatedDataSerializerSpec
 
     "serialize PNCounterMap" in {
       checkSerialization(PNCounterMap())
-      checkSerialization(PNCounterMap().increment(address1, "a", 3))
-      checkSerialization(PNCounterMap().increment(address1, 1, 3))
-      checkSerialization(PNCounterMap().increment(address1, 1L, 3))
-      checkSerialization(PNCounterMap().increment(address1, Flag(), 3))
+      checkSerialization(PNCounterMap[String]().increment(address1, "a", 3))
+      checkSerialization(PNCounterMap[Int]().increment(address1, 1, 3))
+      checkSerialization(PNCounterMap[Long]().increment(address1, 1L, 3))
+      checkSerialization(PNCounterMap[Flag]().increment(address1, Flag(), 3))
       checkSerialization(
-        PNCounterMap().increment(address1, "a", 3).decrement(address2, "a", 2).increment(address2, "b", 5))
+        PNCounterMap[String]().increment(address1, "a", 3).decrement(address2, "a", 2).increment(address2, "b", 5))
     }
 
     "be compatible with old PNCounterMap serialization" in {

--- a/akka-docs/src/test/java/jdocs/persistence/LambdaPersistenceDocTest.java
+++ b/akka-docs/src/test/java/jdocs/persistence/LambdaPersistenceDocTest.java
@@ -85,6 +85,16 @@ public class LambdaPersistenceDocTest {
                     })
                 .build();
           }
+
+          @Override
+          public boolean recoveryRunning() {
+            return super.recoveryRunning();
+          }
+
+          @Override
+          public boolean recoveryFinished() {
+            return super.recoveryFinished();
+          }
         }
 
         // #recovery-completed

--- a/akka-docs/src/test/java/jdocs/persistence/LambdaPersistenceDocTest.java
+++ b/akka-docs/src/test/java/jdocs/persistence/LambdaPersistenceDocTest.java
@@ -86,11 +86,13 @@ public class LambdaPersistenceDocTest {
                 .build();
           }
 
+          // FIXME workaround for https://github.com/scala/bug/issues/11512
           @Override
           public boolean recoveryRunning() {
             return super.recoveryRunning();
           }
 
+          // FIXME workaround for https://github.com/scala/bug/issues/11512
           @Override
           public boolean recoveryFinished() {
             return super.recoveryFinished();

--- a/akka-docs/src/test/java/jdocs/persistence/LambdaPersistencePluginDocTest.java
+++ b/akka-docs/src/test/java/jdocs/persistence/LambdaPersistencePluginDocTest.java
@@ -127,82 +127,83 @@ public class LambdaPersistencePluginDocTest {
     }
   }
 
-  static Object o2 = new Object() {
-        // https://github.com/akka/akka/issues/26826
+  static Object o2 =
+      new Object() {
         // #journal-tck-java
-        // class MyJournalSpecTest extends JavaJournalSpec {
+        class MyJournalSpecTest extends JavaJournalSpec {
 
-        //   public MyJournalSpecTest() {
-        //     super(
-        //         ConfigFactory.parseString(
-        //             "persistence.journal.plugin = "
-        //                 + "\"akka.persistence.journal.leveldb-shared\""));
-        //   }
+          public MyJournalSpecTest() {
+            super(
+                ConfigFactory.parseString(
+                    "persistence.journal.plugin = "
+                        + "\"akka.persistence.journal.leveldb-shared\""));
+          }
 
-        //   @Override
-        //   public CapabilityFlag supportsRejectingNonSerializableObjects() {
-        //     return CapabilityFlag.off();
-        //   }
-        // }
+          @Override
+          public CapabilityFlag supportsRejectingNonSerializableObjects() {
+            return CapabilityFlag.off();
+          }
+        }
         // #journal-tck-java
       };
 
-  static Object o3 = new Object() {
-        // https://github.com/akka/akka/issues/26826
+  static Object o3 =
+      new Object() {
         // #snapshot-store-tck-java
-        // class MySnapshotStoreTest extends JavaSnapshotStoreSpec {
+        class MySnapshotStoreTest extends JavaSnapshotStoreSpec {
 
-        //   public MySnapshotStoreTest() {
-        //     super(
-        //         ConfigFactory.parseString(
-        //             "akka.persistence.snapshot-store.plugin = "
-        //                 + "\"akka.persistence.snapshot-store.local\""));
-        //   }
-        // }
+          public MySnapshotStoreTest() {
+            super(
+                ConfigFactory.parseString(
+                    "akka.persistence.snapshot-store.plugin = "
+                        + "\"akka.persistence.snapshot-store.local\""));
+          }
+        }
         // #snapshot-store-tck-java
       };
 
-  static Object o4 = new Object() {
+  static Object o4 =
+      new Object() {
         // https://github.com/akka/akka/issues/26826
         // #journal-tck-before-after-java
-        // class MyJournalSpecTest extends JavaJournalSpec {
+        class MyJournalSpecTest extends JavaJournalSpec {
 
-        //   List<File> storageLocations = new ArrayList<File>();
+          List<File> storageLocations = new ArrayList<File>();
 
-        //   public MyJournalSpecTest() {
-        //     super(
-        //         ConfigFactory.parseString(
-        //             "persistence.journal.plugin = "
-        //                 + "\"akka.persistence.journal.leveldb-shared\""));
+          public MyJournalSpecTest() {
+            super(
+                ConfigFactory.parseString(
+                    "persistence.journal.plugin = "
+                        + "\"akka.persistence.journal.leveldb-shared\""));
 
-        //     Config config = system().settings().config();
-        //     storageLocations.add(
-        //         new File(config.getString("akka.persistence.journal.leveldb.dir")));
-        //     storageLocations.add(
-        //         new File(config.getString("akka.persistence.snapshot-store.local.dir")));
-        //   }
+            Config config = system().settings().config();
+            storageLocations.add(
+                new File(config.getString("akka.persistence.journal.leveldb.dir")));
+            storageLocations.add(
+                new File(config.getString("akka.persistence.snapshot-store.local.dir")));
+          }
 
-        //   @Override
-        //   public CapabilityFlag supportsRejectingNonSerializableObjects() {
-        //     return CapabilityFlag.on();
-        //   }
+          @Override
+          public CapabilityFlag supportsRejectingNonSerializableObjects() {
+            return CapabilityFlag.on();
+          }
 
-        //   @Override
-        //   public void beforeAll() {
-        //     for (File storageLocation : storageLocations) {
-        //       FileUtils.deleteRecursively(storageLocation);
-        //     }
-        //     super.beforeAll();
-        //   }
+          @Override
+          public void beforeAll() {
+            for (File storageLocation : storageLocations) {
+              FileUtils.deleteRecursively(storageLocation);
+            }
+            super.beforeAll();
+          }
 
-        //   @Override
-        //   public void afterAll() {
-        //     super.afterAll();
-        //     for (File storageLocation : storageLocations) {
-        //       FileUtils.deleteRecursively(storageLocation);
-        //     }
-        //   }
-        // }
+          @Override
+          public void afterAll() {
+            super.afterAll();
+            for (File storageLocation : storageLocations) {
+              FileUtils.deleteRecursively(storageLocation);
+            }
+          }
+        }
         // #journal-tck-before-after-java
       };
 }

--- a/akka-docs/src/test/java/jdocs/persistence/LambdaPersistencePluginDocTest.java
+++ b/akka-docs/src/test/java/jdocs/persistence/LambdaPersistencePluginDocTest.java
@@ -127,82 +127,82 @@ public class LambdaPersistencePluginDocTest {
     }
   }
 
-  static Object o2 =
-      new Object() {
+  static Object o2 = new Object() {
+        // https://github.com/akka/akka/issues/26826
         // #journal-tck-java
-        class MyJournalSpecTest extends JavaJournalSpec {
+        // class MyJournalSpecTest extends JavaJournalSpec {
 
-          public MyJournalSpecTest() {
-            super(
-                ConfigFactory.parseString(
-                    "persistence.journal.plugin = "
-                        + "\"akka.persistence.journal.leveldb-shared\""));
-          }
+        //   public MyJournalSpecTest() {
+        //     super(
+        //         ConfigFactory.parseString(
+        //             "persistence.journal.plugin = "
+        //                 + "\"akka.persistence.journal.leveldb-shared\""));
+        //   }
 
-          @Override
-          public CapabilityFlag supportsRejectingNonSerializableObjects() {
-            return CapabilityFlag.off();
-          }
-        }
+        //   @Override
+        //   public CapabilityFlag supportsRejectingNonSerializableObjects() {
+        //     return CapabilityFlag.off();
+        //   }
+        // }
         // #journal-tck-java
       };
 
-  static Object o3 =
-      new Object() {
+  static Object o3 = new Object() {
+        // https://github.com/akka/akka/issues/26826
         // #snapshot-store-tck-java
-        class MySnapshotStoreTest extends JavaSnapshotStoreSpec {
+        // class MySnapshotStoreTest extends JavaSnapshotStoreSpec {
 
-          public MySnapshotStoreTest() {
-            super(
-                ConfigFactory.parseString(
-                    "akka.persistence.snapshot-store.plugin = "
-                        + "\"akka.persistence.snapshot-store.local\""));
-          }
-        }
+        //   public MySnapshotStoreTest() {
+        //     super(
+        //         ConfigFactory.parseString(
+        //             "akka.persistence.snapshot-store.plugin = "
+        //                 + "\"akka.persistence.snapshot-store.local\""));
+        //   }
+        // }
         // #snapshot-store-tck-java
       };
 
-  static Object o4 =
-      new Object() {
+  static Object o4 = new Object() {
+        // https://github.com/akka/akka/issues/26826
         // #journal-tck-before-after-java
-        class MyJournalSpecTest extends JavaJournalSpec {
+        // class MyJournalSpecTest extends JavaJournalSpec {
 
-          List<File> storageLocations = new ArrayList<File>();
+        //   List<File> storageLocations = new ArrayList<File>();
 
-          public MyJournalSpecTest() {
-            super(
-                ConfigFactory.parseString(
-                    "persistence.journal.plugin = "
-                        + "\"akka.persistence.journal.leveldb-shared\""));
+        //   public MyJournalSpecTest() {
+        //     super(
+        //         ConfigFactory.parseString(
+        //             "persistence.journal.plugin = "
+        //                 + "\"akka.persistence.journal.leveldb-shared\""));
 
-            Config config = system().settings().config();
-            storageLocations.add(
-                new File(config.getString("akka.persistence.journal.leveldb.dir")));
-            storageLocations.add(
-                new File(config.getString("akka.persistence.snapshot-store.local.dir")));
-          }
+        //     Config config = system().settings().config();
+        //     storageLocations.add(
+        //         new File(config.getString("akka.persistence.journal.leveldb.dir")));
+        //     storageLocations.add(
+        //         new File(config.getString("akka.persistence.snapshot-store.local.dir")));
+        //   }
 
-          @Override
-          public CapabilityFlag supportsRejectingNonSerializableObjects() {
-            return CapabilityFlag.on();
-          }
+        //   @Override
+        //   public CapabilityFlag supportsRejectingNonSerializableObjects() {
+        //     return CapabilityFlag.on();
+        //   }
 
-          @Override
-          public void beforeAll() {
-            for (File storageLocation : storageLocations) {
-              FileUtils.deleteRecursively(storageLocation);
-            }
-            super.beforeAll();
-          }
+        //   @Override
+        //   public void beforeAll() {
+        //     for (File storageLocation : storageLocations) {
+        //       FileUtils.deleteRecursively(storageLocation);
+        //     }
+        //     super.beforeAll();
+        //   }
 
-          @Override
-          public void afterAll() {
-            super.afterAll();
-            for (File storageLocation : storageLocations) {
-              FileUtils.deleteRecursively(storageLocation);
-            }
-          }
-        }
+        //   @Override
+        //   public void afterAll() {
+        //     super.afterAll();
+        //     for (File storageLocation : storageLocations) {
+        //       FileUtils.deleteRecursively(storageLocation);
+        //     }
+        //   }
+        // }
         // #journal-tck-before-after-java
       };
 }

--- a/akka-docs/src/test/scala/docs/ddata/DistributedDataDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/ddata/DistributedDataDocSpec.scala
@@ -400,7 +400,7 @@ class DistributedDataDocSpec extends AkkaSpec(DistributedDataDocSpec.config) {
   }
 
   "test japi.TwoPhaseSetSerializer" in {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     val s1 = ddata.TwoPhaseSet.create().add("a").add("b").add("c").remove("b")
     s1.getElements.asScala should be(Set("a", "c"))
     val serializer = SerializationExtension(system).findSerializerFor(s1)

--- a/akka-docs/src/test/scala/docs/ddata/protobuf/TwoPhaseSetSerializer.scala
+++ b/akka-docs/src/test/scala/docs/ddata/protobuf/TwoPhaseSetSerializer.scala
@@ -7,7 +7,7 @@ package docs.ddata.protobuf
 //#serializer
 import java.util.ArrayList
 import java.util.Collections
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import akka.actor.ExtendedActorSystem
 import akka.cluster.ddata.GSet
 import akka.cluster.ddata.protobuf.SerializationSupport

--- a/akka-docs/src/test/scala/docs/io/ScalaUdpMulticastSpec.scala
+++ b/akka-docs/src/test/scala/docs/io/ScalaUdpMulticastSpec.scala
@@ -13,7 +13,7 @@ import akka.testkit.TestKit
 import org.scalatest.{ BeforeAndAfter, WordSpecLike }
 import org.scalatest.BeforeAndAfterAll
 import akka.testkit.SocketUtil
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 class ScalaUdpMulticastSpec
     extends TestKit(ActorSystem("ScalaUdpMulticastSpec"))

--- a/akka-docs/src/test/scala/docs/persistence/query/PersistenceQueryDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/persistence/query/PersistenceQueryDocSpec.scala
@@ -127,7 +127,7 @@ object PersistenceQueryDocSpec {
     // possibility to add more plugin specific queries
 
     def byTagsWithMeta(tags: java.util.Set[String]): javadsl.Source[RichEvent, QueryMetadata] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       scaladslReadJournal.byTagsWithMeta(tags.asScala.toSet).asJava
     }
   }

--- a/akka-docs/src/test/scala/docs/routing/RouterDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/routing/RouterDocSpec.scala
@@ -24,7 +24,7 @@ import akka.routing.ScatterGatherFirstCompletedPool
 import akka.routing.BalancingPool
 import akka.routing.TailChoppingGroup
 import akka.routing.TailChoppingPool
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 object RouterDocSpec {
 

--- a/akka-docs/src/test/scala/docs/stream/GraphStageDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/GraphStageDocSpec.scala
@@ -349,7 +349,7 @@ class GraphStageDocSpec extends AkkaSpec {
 
     out.expectNext(1)
 
-    switch.success(Unit)
+    switch.success(())
 
     out.expectComplete()
   }

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
@@ -240,7 +240,7 @@ object MultiNodeSpec {
       """)
 
   private def mapToConfig(map: Map[String, Any]): Config = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     ConfigFactory.parseMap(map.asJava)
   }
 
@@ -466,7 +466,7 @@ abstract class MultiNodeSpec(
               base.replace(tag, replaceWith)
           }
       }
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       ConfigFactory.parseString(deployString).root.asScala.foreach {
         case (key, value: ConfigObject) => deployer.parseConfig(key, value.toConfig).foreach(deployer.deploy)
         case (key, x) =>

--- a/akka-osgi/src/main/scala/akka/osgi/BundleDelegatingClassLoader.scala
+++ b/akka-osgi/src/main/scala/akka/osgi/BundleDelegatingClassLoader.scala
@@ -9,7 +9,7 @@ import java.util.Enumeration
 import org.osgi.framework.{ Bundle, BundleContext }
 import scala.util.Try
 import org.osgi.framework.wiring.{ BundleRevision, BundleWire, BundleWiring }
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.util.Success
 import scala.util.Failure
 import scala.annotation.tailrec

--- a/akka-osgi/src/test/scala/akka/osgi/PojoSRTestSupport.scala
+++ b/akka-osgi/src/test/scala/akka/osgi/PojoSRTestSupport.scala
@@ -6,7 +6,7 @@ package akka.osgi
 
 import de.kalpatec.pojosr.framework.launch.{ BundleDescriptor, ClasspathScanner, PojoServiceRegistryFactory }
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import org.apache.commons.io.IOUtils.copy
 
 import org.osgi.framework._

--- a/akka-persistence-tck/src/main/scala/akka/persistence/japi/journal/JavaJournalSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/japi/journal/JavaJournalSpec.scala
@@ -7,6 +7,7 @@ package akka.persistence.japi.journal
 import akka.persistence.CapabilityFlag
 import akka.persistence.journal.JournalSpec
 import com.typesafe.config.Config
+import org.scalatest.{ Args, ConfigMap, Filter, Status, Suite, TestData }
 
 /**
  * JAVA API
@@ -21,6 +22,22 @@ import com.typesafe.config.Config
  * @param config configures the Journal plugin to be tested
  */
 class JavaJournalSpec(config: Config) extends JournalSpec(config) {
+
+  // FIXME workarounds for https://github.com/scala/bug/issues/11512
+  override def rerunner: Option[String] = super.rerunner
+  override def runTest(testName: String, args: Args) = super.runTest(testName, args)
+  override def run(testName: Option[String], args: Args): Status = super.run(testName, args)
+  override def testDataFor(testName: String, theConfigMap: ConfigMap): TestData =
+    super.testDataFor(testName, theConfigMap)
+  override def testNames: Set[String] = super.testNames
+  override def runTests(testName: Option[String], args: Args): Status = super.runTests(testName, args)
+  override def tags: Map[String, Set[String]] = super.tags
+  override def expectedTestCount(filter: Filter): Int = super.expectedTestCount(filter)
+  override def suiteId: String = super.suiteId
+  override def suiteName: String = super.suiteName
+  override def runNestedSuites(args: Args): Status = super.runNestedSuites(args)
+  override def nestedSuites = super.nestedSuites
+
   override protected def supportsRejectingNonSerializableObjects: CapabilityFlag = CapabilityFlag.on
 
   override protected def supportsSerialization: CapabilityFlag = CapabilityFlag.on

--- a/akka-persistence-tck/src/main/scala/akka/persistence/japi/snapshot/JavaSnapshotStoreSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/japi/snapshot/JavaSnapshotStoreSpec.scala
@@ -7,6 +7,7 @@ package akka.persistence.japi.snapshot
 import akka.persistence.CapabilityFlag
 import akka.persistence.snapshot.SnapshotStoreSpec
 import com.typesafe.config.Config
+import org.scalatest.{ Args, ConfigMap, Filter, Status, Suite, TestData }
 
 /**
  * JAVA API
@@ -20,5 +21,20 @@ import com.typesafe.config.Config
  * @see [[akka.persistence.snapshot.SnapshotStoreSpec]]
  */
 class JavaSnapshotStoreSpec(config: Config) extends SnapshotStoreSpec(config) {
+  // FIXME workarounds for https://github.com/scala/bug/issues/11512
+  override def rerunner: Option[String] = super.rerunner
+  override def runTest(testName: String, args: Args): Status = super.runTest(testName, args)
+  override def run(testName: Option[String], args: Args): Status = super.run(testName, args)
+  override def testDataFor(testName: String, theConfigMap: ConfigMap): TestData =
+    super.testDataFor(testName, theConfigMap)
+  override def testNames: Set[String] = super.testNames
+  override def runTests(testName: Option[String], args: Args): Status = super.runTests(testName, args)
+  override def tags: Map[String, Set[String]] = super.tags
+  override def expectedTestCount(filter: Filter): Int = super.expectedTestCount(filter)
+  override def suiteId: String = super.suiteId
+  override def suiteName: String = super.suiteName
+  override def runNestedSuites(args: Args): Status = super.runNestedSuites(args)
+  override def nestedSuites = super.nestedSuites
+
   override protected def supportsSerialization: CapabilityFlag = CapabilityFlag.on
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Effect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Effect.scala
@@ -4,7 +4,7 @@
 
 package akka.persistence.typed.javadsl
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
 import akka.japi.function

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
@@ -160,7 +160,7 @@ abstract class EventSourcedBehavior[Command, Event, State] private[akka] (
     val snapshotWhen: (State, Event, Long) => Boolean = (state, event, seqNr) => shouldSnapshot(state, event, seqNr)
 
     val tagger: Event => Set[String] = { event =>
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       val tags = tagsFor(event)
       if (tags.isEmpty) Set.empty
       else tags.asScala.toSet

--- a/akka-persistence/src/main/scala/akka/persistence/AtLeastOnceDelivery.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/AtLeastOnceDelivery.scala
@@ -34,7 +34,7 @@ object AtLeastOnceDelivery {
      * Java API
      */
     def getUnconfirmedDeliveries: java.util.List[UnconfirmedDelivery] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       unconfirmedDeliveries.asJava
     }
 
@@ -50,7 +50,7 @@ object AtLeastOnceDelivery {
      * Java API
      */
     def getUnconfirmedDeliveries: java.util.List[UnconfirmedDelivery] = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       unconfirmedDeliveries.asJava
     }
   }

--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
@@ -404,7 +404,7 @@ object PersistentFSM {
     @deprecated(
       "Internal API easily to be confused with regular FSM's using. Use regular events (`applying`). Internally, `copy` can be used instead.",
       "2.5.5")
-    private[akka] def using(@deprecatedName('nextStateDate) nextStateData: D): State[S, D, E] = {
+    private[akka] def using(@deprecatedName(Symbol("nextStateDate")) nextStateData: D): State[S, D, E] = {
       copy(stateData = nextStateData)
     }
 

--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
@@ -483,8 +483,10 @@ abstract class AbstractPersistentFSM[S <: FSMState, D, E]
    */
   def domainEventClass: Class[E]
 
+  // FIXME workaround, possibly for https://github.com/scala/bug/issues/11512
   override def receive: Receive = super.receive
 
+  // FIXME workaround, possibly for https://github.com/scala/bug/issues/11512
   @throws[Exception]
   override def postStop(): Unit = super.postStop()
 }

--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
@@ -482,6 +482,11 @@ abstract class AbstractPersistentFSM[S <: FSMState, D, E]
    * Used for identifying domain events during recovery
    */
   def domainEventClass: Class[E]
+
+  override def receive: Receive = super.receive
+
+  @throws[Exception]
+  override def postStop(): Unit = super.postStop()
 }
 
 /**

--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSMBase.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSMBase.scala
@@ -518,6 +518,7 @@ trait PersistentFSMBase[S, D, E] extends Actor with Listeners with ActorLogging 
    * so override that one if `onTermination` shall not be called during
    * restart.
    */
+  @throws(classOf[Exception])
   override def postStop(): Unit = {
     /*
      * setting this instance’s state to terminated does no harm during restart

--- a/akka-persistence/src/main/scala/akka/persistence/journal/EventAdapters.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/EventAdapters.scala
@@ -162,14 +162,14 @@ private[akka] object EventAdapters {
       .to(immutable.Seq)
 
   private final def configToMap(config: Config, path: String): Map[String, String] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     if (config.hasPath(path)) {
       config.getConfig(path).root.unwrapped.asScala.toMap.map { case (k, v) => k -> v.toString }
     } else Map.empty
   }
 
   private final def configToListMap(config: Config, path: String): Map[String, immutable.Seq[String]] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     if (config.hasPath(path)) {
       config.getConfig(path).root.unwrapped.asScala.toMap.map {
         case (k, v: util.ArrayList[_]) if v.isInstanceOf[util.ArrayList[_]] => k -> v.asScala.map(_.toString).toList

--- a/akka-persistence/src/main/scala/akka/persistence/journal/Tagged.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/Tagged.scala
@@ -4,7 +4,7 @@
 
 package akka.persistence.journal
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 /**
  * The journal may support tagging of events that are used by the

--- a/akka-persistence/src/main/scala/akka/persistence/journal/japi/AsyncRecovery.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/japi/AsyncRecovery.scala
@@ -21,7 +21,7 @@ abstract class AsyncRecovery extends SAsyncReplay with AsyncRecoveryPlugin { thi
       replayCallback: (PersistentRepr) => Unit) =
     doAsyncReplayMessages(persistenceId, fromSequenceNr, toSequenceNr, max, new Consumer[PersistentRepr] {
       def accept(p: PersistentRepr) = replayCallback(p)
-    }).map(Unit.unbox)
+    }).map(_ => ())
 
   final def asyncReadHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] =
     doAsyncReadHighestSequenceNr(persistenceId, fromSequenceNr: Long).map(_.longValue)

--- a/akka-persistence/src/main/scala/akka/persistence/journal/japi/AsyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/japi/AsyncWriteJournal.scala
@@ -5,7 +5,7 @@
 package akka.persistence.journal.japi
 
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import akka.persistence._
 import akka.persistence.journal.{ AsyncWriteJournal => SAsyncWriteJournal }
 import akka.util.ccompat._
@@ -32,5 +32,5 @@ abstract class AsyncWriteJournal extends AsyncRecovery with SAsyncWriteJournal w
     }
 
   final def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long) =
-    doAsyncDeleteMessagesTo(persistenceId, toSequenceNr).map(Unit.unbox)
+    doAsyncDeleteMessagesTo(persistenceId, toSequenceNr).map(_ => ())
 }

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbStore.scala
@@ -14,7 +14,7 @@ import akka.serialization.SerializationExtension
 import org.iq80.leveldb._
 
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.util._
 import scala.concurrent.Future
 import scala.util.control.NonFatal
@@ -52,8 +52,11 @@ private[persistence] trait LeveldbStore
   override val compactionIntervals: Map[String, Long] =
     LeveldbStore.toCompactionIntervalMap(config.getObject("compaction-intervals"))
 
+  import com.github.ghik.silencer.silent
+  @silent
   private val persistenceIdSubscribers = new mutable.HashMap[String, mutable.Set[ActorRef]]
   with mutable.MultiMap[String, ActorRef]
+  @silent
   private val tagSubscribers = new mutable.HashMap[String, mutable.Set[ActorRef]]
   with mutable.MultiMap[String, ActorRef]
   private var allPersistenceIdsSubscribers = Set.empty[ActorRef]

--- a/akka-persistence/src/main/scala/akka/persistence/serialization/MessageSerializer.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/serialization/MessageSerializer.scala
@@ -113,7 +113,7 @@ class MessageSerializer(val system: ExtendedActorSystem) extends BaseSerializer 
 
   def atLeastOnceDeliverySnapshot(
       atLeastOnceDeliverySnapshot: mf.AtLeastOnceDeliverySnapshot): AtLeastOnceDeliverySnapshot = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     val unconfirmedDeliveries = new VectorBuilder[UnconfirmedDelivery]()
     atLeastOnceDeliverySnapshot.getUnconfirmedDeliveriesList().iterator().asScala.foreach { next =>
       unconfirmedDeliveries += UnconfirmedDelivery(
@@ -205,7 +205,7 @@ class MessageSerializer(val system: ExtendedActorSystem) extends BaseSerializer 
   }
 
   private def atomicWrite(atomicWrite: mf.AtomicWrite): AtomicWrite = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     AtomicWrite(atomicWrite.getPayloadList.asScala.iterator.map(persistent).to(immutable.IndexedSeq))
   }
 

--- a/akka-persistence/src/main/scala/akka/persistence/snapshot/japi/SnapshotStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/snapshot/japi/SnapshotStore.scala
@@ -22,7 +22,7 @@ abstract class SnapshotStore extends SSnapshotStore with SnapshotStorePlugin {
     doLoadAsync(persistenceId, criteria).map(option)
 
   override final def saveAsync(metadata: SnapshotMetadata, snapshot: Any): Future[Unit] =
-    doSaveAsync(metadata, snapshot).map(Unit.unbox)
+    doSaveAsync(metadata, snapshot).map(_ => ())
 
   override final def deleteAsync(metadata: SnapshotMetadata): Future[Unit] =
     doDeleteAsync(metadata).map(_ => ())

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/TestMessage.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/TestMessage.scala
@@ -49,7 +49,7 @@ class TestMessageSerializer(val system: ExtendedActorSystem) extends SerializerW
 
   override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = {
     val protoMsg = proto.TestMessage.parseFrom(bytes)
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     val items = protoMsg.getItemsList.asScala.map { item =>
       TestMessage.Item(item.getId, item.getName)
     }.toVector

--- a/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDaemon.scala
@@ -74,7 +74,7 @@ private[akka] class RemoteSystemDaemon(
 
   private val whitelistEnabled = system.settings.config.getBoolean("akka.remote.deployment.enable-whitelist")
   private val remoteDeploymentWhitelist: immutable.Set[String] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     if (whitelistEnabled) system.settings.config.getStringList("akka.remote.deployment.whitelist").asScala.toSet
     else Set.empty
   }

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -18,7 +18,7 @@ import akka.remote.artery.ArterySettings
 
 final class RemoteSettings(val config: Config) {
   import config._
-  import scala.collection.JavaConverters._
+  import akka.util.ccompat.JavaConverters._
 
   val Artery = ArterySettings(getConfig("akka.remote.artery"))
 

--- a/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
@@ -115,10 +115,12 @@ private[akka] class RemoteWatcher(
     }
 
   // actors that this node is watching, map of watchee -> Set(watchers)
+  @silent
   val watching = new mutable.HashMap[InternalActorRef, mutable.Set[InternalActorRef]]()
   with mutable.MultiMap[InternalActorRef, InternalActorRef]
 
   // nodes that this node is watching, i.e. expecting heartbeats from these nodes. Map of address -> Set(watchee) on this address
+  @silent
   val watcheeByNodes = new mutable.HashMap[Address, mutable.Set[InternalActorRef]]()
   with mutable.MultiMap[Address, InternalActorRef]
   def watchingNodes = watcheeByNodes.keySet

--- a/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
@@ -61,6 +61,7 @@ final case class AssociationErrorEvent(
 
 @SerialVersionUID(1L)
 final case class RemotingListenEvent(listenAddresses: Set[Address]) extends RemotingLifecycleEvent {
+  @silent
   def getListenAddresses: java.util.Set[Address] =
     scala.collection.JavaConverters.setAsJavaSetConverter(listenAddresses).asJava
   override def logLevel: Logging.LogLevel = Logging.InfoLevel

--- a/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
@@ -6,7 +6,7 @@ package akka.remote.artery
 
 import java.net.InetAddress
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.concurrent.duration._
 
 import akka.NotUsed

--- a/akka-remote/src/main/scala/akka/remote/artery/RemoteInstrument.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/RemoteInstrument.scala
@@ -330,7 +330,7 @@ private[remote] object RemoteInstruments {
   def create(system: ExtendedActorSystem, @unused log: LoggingAdapter): Vector[RemoteInstrument] = {
     val c = system.settings.config
     val path = "akka.remote.artery.advanced.instruments"
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     c.getStringList(path)
       .asScala
       .iterator

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala
@@ -149,7 +149,7 @@ private[remote] final class InboundCompressionsImpl(
   }
 
   override def currentOriginUids: Set[Long] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     // can't use union because of java.lang.Long and Scala Long mismatch,
     // only used for testing so doesn't matter
     val result = Set.empty[java.lang.Long] ++ _actorRefsIns.keySet.asScala.iterator ++

--- a/akka-remote/src/main/scala/akka/remote/serialization/ArteryMessageSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/ArteryMessageSerializer.scala
@@ -108,7 +108,7 @@ private[akka] final class ArteryMessageSerializer(val system: ExtendedActorSyste
           s"Manifest '$manifest' not defined for ArteryControlMessageSerializer (serializer id $identifier)")
     }
 
-  import scala.collection.JavaConverters._
+  import akka.util.ccompat.JavaConverters._
 
   def serializeQuarantined(quarantined: Quarantined): ArteryControlFormats.Quarantined =
     ArteryControlFormats.Quarantined

--- a/akka-remote/src/main/scala/akka/remote/serialization/DaemonMsgCreateSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/DaemonMsgCreateSerializer.scala
@@ -155,7 +155,7 @@ private[akka] final class DaemonMsgCreateSerializer(val system: ExtendedActorSys
     }
 
     def props = {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       val protoProps = proto.getProps
       val actorClass = system.dynamicAccess.getClassFor[AnyRef](protoProps.getClazz).get
       val args: Vector[AnyRef] =

--- a/akka-remote/src/main/scala/akka/remote/serialization/MessageContainerSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/MessageContainerSerializer.scala
@@ -69,7 +69,7 @@ class MessageContainerSerializer(val system: ExtendedActorSystem) extends BaseSe
       .deserialize(selectionEnvelope.getEnclosedMessage.toByteArray, selectionEnvelope.getSerializerId, manifest)
       .get
 
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     val elements: immutable.Iterable[SelectionPathElement] = selectionEnvelope.getPatternList.asScala.iterator
       .map { x =>
         x.getType match {

--- a/akka-remote/src/main/scala/akka/remote/serialization/MiscMessageSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/MiscMessageSerializer.scala
@@ -19,7 +19,7 @@ import akka.routing._
 import akka.serialization.{ BaseSerializer, Serialization, SerializationExtension, SerializerWithStringManifest }
 import com.typesafe.config.{ Config, ConfigFactory, ConfigRenderOptions }
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.concurrent.duration.{ FiniteDuration, TimeUnit }
 
 class MiscMessageSerializer(val system: ExtendedActorSystem) extends SerializerWithStringManifest with BaseSerializer {

--- a/akka-remote/src/main/scala/akka/remote/serialization/ThrowableSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/ThrowableSupport.scala
@@ -70,7 +70,7 @@ private[akka] class ThrowableSupport(system: ExtendedActorSystem) {
         system.dynamicAccess.createInstanceFor[Throwable](clazz, List(classOf[String] -> protoT.getMessage)).get
       }
 
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     val stackTrace =
       protoT.getStackTraceList.asScala.map { elem =>
         val fileName = elem.getFileName

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaPduCodec.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaPduCodec.scala
@@ -207,7 +207,7 @@ private[remote] object AkkaPduProtobufCodec extends AkkaPduCodec {
     val ackAndEnvelope = AckAndEnvelopeContainer.parseFrom(raw.toArray)
 
     val ackOption = if (ackAndEnvelope.hasAck) {
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       Some(
         Ack(
           SeqNo(ackAndEnvelope.getAck.getCumulativeAck),

--- a/akka-remote/src/main/scala/akka/remote/transport/FailureInjectorTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/FailureInjectorTransportAdapter.scala
@@ -101,9 +101,9 @@ private[remote] class FailureInjectorTransportAdapter(
 
   protected def interceptAssociate(remoteAddress: Address, statusPromise: Promise[AssociationHandle]): Unit = {
     // Association is simulated to be failed if there was either an inbound or outbound message drop
-    if (shouldDropInbound(remoteAddress, Unit, "interceptAssociate") || shouldDropOutbound(
+    if (shouldDropInbound(remoteAddress, (), "interceptAssociate") || shouldDropOutbound(
           remoteAddress,
-          Unit,
+          (),
           "interceptAssociate"))
       statusPromise.failure(new FailureInjectorException("Simulated failure of association to " + remoteAddress))
     else

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -81,7 +81,7 @@ object NettyFutureBridge {
   }
 
   def apply(nettyFuture: ChannelGroupFuture): Future[ChannelGroup] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     val p = Promise[ChannelGroup]
     nettyFuture.addListener(new ChannelGroupFutureListener {
       def operationComplete(future: ChannelGroupFuture): Unit =

--- a/akka-remote/src/test/scala/akka/remote/DaemonicSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/DaemonicSpec.scala
@@ -11,7 +11,7 @@ import akka.actor.{ ActorSystem, Address }
 import akka.util.ccompat._
 import com.typesafe.config.ConfigFactory
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 @ccompatUsedUntil213
 class DaemonicSpec extends AkkaSpec {

--- a/akka-remote/src/test/scala/akka/remote/RemoteInitErrorSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteInitErrorSpec.scala
@@ -9,7 +9,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.{ Matchers, WordSpec }
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.collection.mutable.Set
 import scala.concurrent.duration._
 import scala.language.postfixOps

--- a/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
@@ -89,12 +89,12 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
 
     case event @ Info(logSource, logClass, message) =>
       withMdc(logSource, event) {
-        Logger(logClass, logSource).info(markerIfPresent(event), "{}", message.asInstanceOf[AnyRef])
+        Logger(logClass, logSource).info(markerIfPresent(event), "{}", message: Any)
       }
 
     case event @ Debug(logSource, logClass, message) =>
       withMdc(logSource, event) {
-        Logger(logClass, logSource).debug(markerIfPresent(event), "{}", message.asInstanceOf[AnyRef])
+        Logger(logClass, logSource).debug(markerIfPresent(event), "{}", message: Any)
       }
 
     case InitializeLogger(_) =>

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FramingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FramingSpec.scala
@@ -299,6 +299,7 @@ class FramingSpec extends StreamSpec {
     }
 
     "report truncated frames" taggedAs LongRunningTest in {
+      // 2 * 10 * 4 * (13 minus a few) = 520 iterations
       for {
         //_ <- 1 to 10
         byteOrder <- byteOrders
@@ -306,7 +307,6 @@ class FramingSpec extends StreamSpec {
         fieldLength <- fieldLengths
         frameLength <- frameLengths if frameLength < (1 << (fieldLength * 8)) && (frameLength != 0)
       } {
-
         val fullFrame = encode(referenceChunk.take(frameLength), fieldOffset, fieldLength, byteOrder)
         val partialFrame = fullFrame.dropRight(1)
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FramingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FramingSpec.scala
@@ -299,7 +299,6 @@ class FramingSpec extends StreamSpec {
     }
 
     "report truncated frames" taggedAs LongRunningTest in {
-      // 2 * 10 * 4 * (13 minus a few) = 520 iterations
       for {
         //_ <- 1 to 10
         byteOrder <- byteOrders
@@ -307,6 +306,7 @@ class FramingSpec extends StreamSpec {
         fieldLength <- fieldLengths
         frameLength <- frameLengths if frameLength < (1 << (fieldLength * 8)) && (frameLength != 0)
       } {
+
         val fullFrame = encode(referenceChunk.take(frameLength), fieldOffset, fieldLength, byteOrder)
         val partialFrame = fullFrame.dropRight(1)
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
@@ -360,7 +360,7 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
       result.map(println)(system.dispatcher)
       // 55
       //#reduce-operator-example
-      assert(result.futureValue == (1 to 10 sum))
+      assert(result.futureValue == (1 to 10).sum)
     }
   }
 

--- a/akka-stream/src/main/scala/akka/stream/Attributes.scala
+++ b/akka-stream/src/main/scala/akka/stream/Attributes.scala
@@ -201,7 +201,7 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
    * `get` to get the most specific attribute value.
    */
   def getAttributeList(): java.util.List[Attribute] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     attributeList.asJava
   }
 

--- a/akka-stream/src/main/scala/akka/stream/Shape.scala
+++ b/akka-stream/src/main/scala/akka/stream/Shape.scala
@@ -6,7 +6,7 @@ package akka.stream
 
 import akka.util.Collections.EmptyImmutableSeq
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.annotation.unchecked.uncheckedVariance
 import akka.annotation.InternalApi
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/StreamOfStreams.scala
@@ -23,7 +23,7 @@ import scala.util.control.NonFatal
 import scala.annotation.tailrec
 
 import akka.stream.impl.{ Buffer => BufferImpl }
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 import akka.stream.impl.TraversalBuilder
 import akka.stream.impl.fusing.GraphStages.SingleSource

--- a/akka-stream/src/main/scala/akka/stream/impl/io/FileSubscriber.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/FileSubscriber.scala
@@ -15,7 +15,7 @@ import akka.stream.actor.{ ActorSubscriberMessage, WatermarkRequestStrategy }
 import akka.util.ByteString
 import com.github.ghik.silencer.silent
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.concurrent.Promise
 import scala.util.{ Failure, Success, Try }
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FileIO.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FileIO.scala
@@ -12,7 +12,7 @@ import java.util.concurrent.CompletionStage
 import akka.stream.{ javadsl, scaladsl, IOResult }
 import akka.util.ByteString
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 /**
  * Java API: Factories to create sinks and sources from files

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -298,7 +298,7 @@ object Flow {
 
 /** Create a `Flow` which can process elements of type `T`. */
 final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Graph[FlowShape[In, Out], Mat] {
-  import scala.collection.JavaConverters._
+  import akka.util.ccompat.JavaConverters._
 
   override def shape: FlowShape[In, Out] = delegate.shape
   override def traversalBuilder = delegate.traversalBuilder

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FlowWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FlowWithContext.scala
@@ -11,7 +11,7 @@ import akka.event.LoggingAdapter
 import akka.util.ConstantFun
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import java.util.concurrent.CompletionStage
 
 import scala.compat.java8.FutureConverters._

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -12,7 +12,7 @@ import akka.japi.{ function, Pair }
 import akka.util.ConstantFun
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import akka.stream.scaladsl.GenericGraph
 import akka.util.unused
 
@@ -455,7 +455,7 @@ object ZipN {
  */
 object ZipWithN {
   def create[A, O](zipper: function.Function[java.util.List[A], O], n: Int): Graph[UniformFanInShape[A, O], NotUsed] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     scaladsl.ZipWithN[A, O](seq => zipper.apply(seq.asJava))(n)
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/MergeLatest.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/MergeLatest.scala
@@ -7,7 +7,7 @@ package akka.stream.javadsl
 import akka.stream.stage.GraphStage
 import akka.stream.{ scaladsl, UniformFanInShape }
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 
 /**
  * MergeLatest joins elements from N input streams into stream of lists of size N.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -198,7 +198,7 @@ object Sink {
    * If there is a failure signaled in the stream the `CompletionStage` will be completed with failure.
    */
   def takeLast[In](n: Int): Sink[In, CompletionStage[java.util.List[In]]] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     new Sink(
       scaladsl.Sink
         .takeLast[In](n)
@@ -216,7 +216,7 @@ object Sink {
    * See also [[Flow.limit]], [[Flow.limitWeighted]], [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
    */
   def seq[In]: Sink[In, CompletionStage[java.util.List[In]]] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     new Sink(
       scaladsl.Sink
         .seq[In]
@@ -303,7 +303,7 @@ object Sink {
       output2: Sink[U, _],
       rest: java.util.List[Sink[U, _]],
       strategy: function.Function[java.lang.Integer, Graph[UniformFanOutShape[T, U], NotUsed]]): Sink[T, NotUsed] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     val seq = if (rest != null) rest.asScala.map(_.asScala).toSeq else immutable.Seq()
     new Sink(scaladsl.Sink.combine(output1.asScala, output2.asScala, seq: _*)(num => strategy.apply(num)))
   }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -19,7 +19,7 @@ import akka.{ Done, NotUsed }
 import org.reactivestreams.{ Publisher, Subscriber }
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ Future, Promise }
@@ -141,9 +141,6 @@ object Source {
     // but there is not anything we can do to prevent that from happening.
     // ConcurrentModificationException will be thrown in some cases.
     val scalaIterable = new immutable.Iterable[O] {
-
-      import collection.JavaConverters._
-
       override def iterator: Iterator[O] = iterable.iterator().asScala
     }
     new Source(scaladsl.Source(scalaIterable))
@@ -560,7 +557,7 @@ object Source {
  */
 final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[SourceShape[Out], Mat] {
 
-  import scala.collection.JavaConverters._
+  import akka.util.ccompat.JavaConverters._
 
   override def shape: SourceShape[Out] = delegate.shape
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SourceWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SourceWithContext.scala
@@ -11,7 +11,7 @@ import akka.event.LoggingAdapter
 import akka.util.ConstantFun
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import java.util.concurrent.CompletionStage
 
 import scala.compat.java8.FutureConverters._

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -11,7 +11,7 @@ import akka.stream._
 import akka.util.ConstantFun
 import akka.util.JavaDurationConverters._
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.duration.FiniteDuration
 import akka.japi.Util

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -11,7 +11,7 @@ import akka.stream._
 import akka.util.ConstantFun
 import akka.util.JavaDurationConverters._
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.duration.FiniteDuration
 import java.util.Comparator

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -742,7 +742,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
       andThen: Procedure[java.util.List[T]],
       onClose: Procedure[java.util.List[T]]): Unit = {
     //FIXME `onClose` is a poor name for `onComplete` rename this at the earliest possible opportunity
-    import collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     readN(in, n)(seq => andThen(seq.asJava), seq => onClose(seq.asJava))
   }
 
@@ -852,7 +852,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
    * signal.
    */
   final protected def emitMultiple[T](out: Outlet[T], elems: java.util.Iterator[T]): Unit = {
-    import collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     emitMultiple(out, elems.asScala, DoNothing)
   }
 
@@ -865,7 +865,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
    * signal.
    */
   final protected def emitMultiple[T](out: Outlet[T], elems: java.util.Iterator[T], andThen: Effect): Unit = {
-    import collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     emitMultiple(out, elems.asScala, andThen.apply _)
   }
 

--- a/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.util.Try

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -131,7 +131,7 @@ class TestActor(queue: BlockingDeque[TestActor.Message]) extends Actor {
   }
 
   override def postStop() = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     queue.asScala.foreach { m =>
       context.system.deadLetters.tell(DeadLetter(m.msg, m.sender, self), m.sender)
     }

--- a/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
@@ -12,7 +12,7 @@ import akka.testkit.{ TestActor, TestDuration, TestProbe }
 import akka.util.JavaDurationConverters._
 
 import scala.annotation.varargs
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.concurrent.duration._
 
 /**

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -40,7 +40,7 @@ object AkkaSpec {
                                                     """)
 
   def mapToConfig(map: Map[String, Any]): Config = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     ConfigFactory.parseMap(map.asJava)
   }
 

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpecSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpecSpec.scala
@@ -35,7 +35,7 @@ class AkkaSpecSpec extends WordSpec with Matchers {
 
     "terminate all actors" in {
       // verbose config just for demonstration purposes, please leave in in case of debugging
-      import scala.collection.JavaConverters._
+      import akka.util.ccompat.JavaConverters._
       val conf = Map(
         "akka.actor.debug.lifecycle" -> true,
         "akka.actor.debug.event-stream" -> true,

--- a/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestActorRefSpec.scala
@@ -214,7 +214,6 @@ class TestActorRefSpec extends AkkaSpec("disp1.type=Dispatcher") with BeforeAndA
       val a = TestActorRef[WorkerActor]
       val f = a ? "work"
       // CallingThreadDispatcher means that there is no delay
-      f should be('completed)
       Await.result(f, timeout.duration) should ===("workDone")
     }
 

--- a/akka-testkit/src/test/scala/akka/testkit/TestProbeSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestProbeSpec.scala
@@ -25,7 +25,6 @@ class TestProbeSpec extends AkkaSpec with DefaultTimeout with Eventually {
       val future = tk.ref ? "hello"
       tk.expectMsg(0 millis, "hello") // TestActor runs on CallingThreadDispatcher
       tk.lastMessage.sender ! "world"
-      future should be('completed)
       Await.result(future, timeout.duration) should ===("world")
     }
 

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/FileDescriptorMetricSet.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/FileDescriptorMetricSet.scala
@@ -5,7 +5,7 @@
 package akka.testkit.metrics
 
 import java.util
-import collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import java.lang.management.{ ManagementFactory, OperatingSystemMXBean }
 import com.codahale.metrics.{ Gauge, Metric, MetricSet }
 import com.codahale.metrics.MetricRegistry._

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKit.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKit.scala
@@ -29,7 +29,7 @@ private[akka] trait MetricsKit extends MetricsKitOps {
   this: Notifying =>
 
   import MetricsKit._
-  import collection.JavaConverters._
+  import akka.util.ccompat.JavaConverters._
 
   private var reporters: List[ScheduledReporter] = Nil
 
@@ -148,7 +148,7 @@ private[akka] trait MetricsKit extends MetricsKitOps {
   }
 
   private[metrics] def getOrRegister[M <: Metric](key: String, metric: => M)(implicit tag: ClassTag[M]): M = {
-    import collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     registry.getMetrics.asScala.find(_._1 == key).map(_._2) match {
       case Some(existing: M) => existing
       case Some(_) =>
@@ -192,7 +192,7 @@ trait AkkaMetricRegistry {
   def getHdrHistograms = filterFor(classOf[HdrHistogram])
   def getAveragingGauges = filterFor(classOf[AveragingGauge])
 
-  import collection.JavaConverters._
+  import akka.util.ccompat.JavaConverters._
   private def filterFor[T](clazz: Class[T]): mutable.Iterable[(String, T)] =
     for {
       (key, metric) <- getMetrics.asScala

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKitOps.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/MetricsKitOps.scala
@@ -100,7 +100,7 @@ private[metrics] trait MetricsPrefix extends MetricSet {
 
   abstract override def getMetrics: util.Map[String, Metric] = {
     // does not have to be fast, is only called once during registering registry
-    import collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     (super.getMetrics.asScala.map { case (k, v) => (prefix / k).toString -> v }).asJava
   }
 }

--- a/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaConsoleReporter.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/metrics/reporter/AkkaConsoleReporter.scala
@@ -29,7 +29,7 @@ class AkkaConsoleReporter(registry: AkkaMetricRegistry, verbose: Boolean, output
       histograms: util.SortedMap[String, Histogram],
       meters: util.SortedMap[String, Meter],
       timers: util.SortedMap[String, Timer]): Unit = {
-    import collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
 
     // default Metrics types
     printMetrics(gauges.asScala, printGauge)

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -34,7 +34,7 @@ object AkkaBuild {
   }
   
   def akkaVersion: String = {
-    val default = "2.5-SNAPSHOT"
+    val default = "2.5.23"
     sys.props.getOrElse("akka.build.version", default) match {
       case "timestamp" => s"2.5-$currentDateTime" // used when publishing timestamped snapshots
       case "file" => akkaVersionFromFile(default)

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -112,8 +112,7 @@ object AkkaBuild {
       Seq(resolvers += Resolver.sonatypeRepo("snapshots"))
     else Seq.empty
   } ++ Seq(
-    pomIncludeRepository := (_ => false), // do not leak internal repositories during staging
-    resolvers += "java8 compat staging" at "https://oss.sonatype.org/content/repositories/orgscala-lang-1731"
+    pomIncludeRepository := (_ => false) // do not leak internal repositories during staging
   )
 
   private def allWarnings: Boolean = System.getProperty("akka.allwarnings", "false").toBoolean

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -112,7 +112,8 @@ object AkkaBuild {
       Seq(resolvers += Resolver.sonatypeRepo("snapshots"))
     else Seq.empty
   } ++ Seq(
-    pomIncludeRepository := (_ => false) // do not leak internal repositories during staging
+    pomIncludeRepository := (_ => false), // do not leak internal repositories during staging
+    resolvers += "java8 compat staging" at "https://oss.sonatype.org/content/repositories/orgscala-lang-1731"
   )
 
   private def allWarnings: Boolean = System.getProperty("akka.allwarnings", "false").toBoolean

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -43,7 +43,7 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
     })
 
   lazy val silencerSettings = {
-    val silencerVersion = "1.3.1"
+    val silencerVersion = "1.3.3"
     Seq(
       libraryDependencies ++= Seq(
           compilerPlugin("com.github.ghik" %% "silencer-plugin" % silencerVersion),
@@ -55,7 +55,7 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
     silencerSettings ++
     scoverageSettings ++ Seq(
       Compile / scalacOptions ++= (
-          if (!scalaVersion.value.startsWith("2.11") && !nonFatalWarningsFor(name.value)) Seq("-Xfatal-warnings")
+          if (!scalaVersion.value.startsWith("2.11") && !scalaVersion.value.startsWith("2.13") && !nonFatalWarningsFor(name.value)) Seq("-Xfatal-warnings")
           else Seq.empty
         ),
       Test / scalacOptions --= testUndicipline,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,30 +14,36 @@ object Dependencies {
   lazy val scalaStmVersion = settingKey[String]("The version of ScalaSTM to use.")
   lazy val scalaCheckVersion = settingKey[String]("The version of ScalaCheck to use.")
   lazy val java8CompatVersion = settingKey[String]("The version of scala-java8-compat to use.")
+  lazy val sslConfigVersion = settingKey[String]("The version of ssl-config to use.")
   val junitVersion = "4.12"
-  val sslConfigVersion = "0.3.7"
   val slf4jVersion = "1.7.25"
   val scalaXmlVersion = "1.0.6"
   val aeronVersion = "1.15.1"
 
   val Versions = Seq(
-    crossScalaVersions := Seq("2.12.8", "2.13.0-M5"),
+    crossScalaVersions := Seq("2.12.8", "2.13.0-RC1"),
     scalaVersion := System.getProperty("akka.build.scalaVersion", crossScalaVersions.value.head),
-    scalaStmVersion := sys.props.get("akka.build.scalaStmVersion").getOrElse("0.9"),
+    scalaStmVersion := sys.props.get("akka.build.scalaStmVersion").getOrElse("0.9.1"),
     scalaCheckVersion := sys.props
         .get("akka.build.scalaCheckVersion")
         .getOrElse(CrossVersion.partialVersion(scalaVersion.value) match {
           case Some((2, n)) if n >= 12 => "1.14.0" // does not work for 2.11
           case _                       => "1.13.2"
         }),
-    scalaTestVersion := "3.0.7",
+    scalaTestVersion := "3.0.8-RC2",
     java8CompatVersion := {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, n)) if n >= 13 => "0.9.0"
+        // FIXME depends on https://github.com/scala/scala-java8-compat/pull/139
+        case Some((2, n)) if n >= 13 => "0.9.1-SNAPSHOT"
         case Some((2, n)) if n == 12 => "0.8.0"
         case _                       => "0.7.0"
       }
-    })
+    },
+    sslConfigVersion := {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n >= 13 => "0.4.0"
+        case _                       => "0.3.7"
+    }})
 
   object Compile {
     // Compile
@@ -66,7 +72,7 @@ object Dependencies {
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % "1.0.2" // CC0
 
     // ssl-config
-    val sslConfigCore = "com.typesafe" %% "ssl-config-core" % sslConfigVersion // ApacheV2
+    val sslConfigCore = Def.setting { "com.typesafe" %% "ssl-config-core" % sslConfigVersion.value } // ApacheV2
 
     val lmdb = "org.lmdbjava" % "lmdbjava" % "0.6.1" // ApacheV2, OpenLDAP Public License
 
@@ -79,7 +85,7 @@ object Dependencies {
     val aeronClient = "io.aeron" % "aeron-client" % aeronVersion // ApacheV2
 
     object Docs {
-      val sprayJson = "io.spray" %% "spray-json" % "1.3.4" % "test"
+      val sprayJson = "io.spray" %% "spray-json" % "1.3.5" % "test"
       val gson = "com.google.code.gson" % "gson" % "2.8.5" % "test"
     }
 
@@ -241,7 +247,7 @@ object Dependencies {
 
   // akka stream
 
-  lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, sslConfigCore, Test.scalatest.value)
+  lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, sslConfigCore.value, Test.scalatest.value)
 
   lazy val streamTestkit = l ++= Seq(Test.scalatest.value, Test.scalacheck.value, Test.junit)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,8 +33,7 @@ object Dependencies {
     scalaTestVersion := "3.0.8-RC2",
     java8CompatVersion := {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        // FIXME depends on https://github.com/scala/scala-java8-compat/pull/139
-        case Some((2, n)) if n >= 13 => "0.9.1-SNAPSHOT"
+        case Some((2, n)) if n >= 13 => "0.9.0"
         case Some((2, n)) if n == 12 => "0.8.0"
         case _                       => "0.7.0"
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,6 +33,8 @@ object Dependencies {
     scalaTestVersion := "3.0.8-RC2",
     java8CompatVersion := {
       CrossVersion.partialVersion(scalaVersion.value) match {
+        // java8-compat is only used in a couple of places for 2.13,
+        // it is probably possible to remove the dependency if needed.
         case Some((2, n)) if n >= 13 => "0.9.0"
         case Some((2, n)) if n == 12 => "0.8.0"
         case _                       => "0.7.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,7 +22,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0") // for maintenance of copyright file header
 addSbtPlugin("com.hpe.sbt" % "sbt-pull-request-validator" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0-M5")
-addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.20")
+addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.21")
 
 // used for @unidoc directive
 libraryDependencies += "io.github.classgraph" % "classgraph" % "4.4.12"


### PR DESCRIPTION
Prepare the `release-2.5` branch for releasing with scala 2.13.0-RC1

Depends on https://github.com/scala/scala-java8-compat/pull/139