### PR TITLE
Removes the redundant val/final modifier in akka.dispatch/routing

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
@@ -209,12 +209,12 @@ object ActorSelection {
    */
   def apply(anchorRef: ActorRef, elements: Iterable[String]): ActorSelection = {
     val compiled: immutable.IndexedSeq[SelectionPathElement] = elements.iterator
-      .collect({
+      .collect {
         case x if !x.isEmpty =>
           if ((x.indexOf('?') != -1) || (x.indexOf('*') != -1)) SelectChildPattern(x)
           else if (x == "..") SelectParent
           else SelectChildName(x)
-      })
+      }
       .to(immutable.IndexedSeq)
     new ActorSelection with ScalaActorSelection {
       override val anchor = anchorRef

--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -216,18 +216,18 @@ private[akka] class Deployer(val settings: ActorSystem.Settings, val dynamicAcce
       val args2 = List(classOf[Config] -> deployment2, classOf[DynamicAccess] -> dynamicAccess)
       dynamicAccess
         .createInstanceFor[RouterConfig](fqn, args1)
-        .recover({
+        .recover {
           case e @ (_: IllegalArgumentException | _: ConfigException) => throw e
           case e: NoSuchMethodException =>
             dynamicAccess
               .createInstanceFor[RouterConfig](fqn, args2)
-              .recover({
+              .recover {
                 case e @ (_: IllegalArgumentException | _: ConfigException) => throw e
                 case _                                                      => throwCannotInstantiateRouter(args2, e)
-              })
+              }
               .get
           case e => throwCannotInstantiateRouter(args2, e)
-        })
+        }
         .get
     }
 

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -351,14 +351,14 @@ abstract class MessageDispatcherConfigurator(_config: Config, val prerequisites:
         val args = List(classOf[Config] -> config, classOf[DispatcherPrerequisites] -> prerequisites)
         prerequisites.dynamicAccess
           .createInstanceFor[ExecutorServiceConfigurator](fqcn, args)
-          .recover({
+          .recover {
             case exception =>
               throw new IllegalArgumentException(
                 ("""Cannot instantiate ExecutorServiceConfigurator ("executor = [%s]"), defined in [%s],
                 make sure it has an accessible constructor with a [%s,%s] signature""")
                   .format(fqcn, config.getString("id"), classOf[Config], classOf[DispatcherPrerequisites]),
                 exception)
-          })
+          }
           .get
     }
 

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
@@ -33,13 +33,13 @@ trait DispatcherPrerequisites {
  * INTERNAL API
  */
 private[akka] final case class DefaultDispatcherPrerequisites(
-    val threadFactory: ThreadFactory,
-    val eventStream: EventStream,
-    val scheduler: Scheduler,
-    val dynamicAccess: DynamicAccess,
-    val settings: ActorSystem.Settings,
-    val mailboxes: Mailboxes,
-    val defaultExecutionContext: Option[ExecutionContext])
+    threadFactory: ThreadFactory,
+    eventStream: EventStream,
+    scheduler: Scheduler,
+    dynamicAccess: DynamicAccess,
+    settings: ActorSystem.Settings,
+    mailboxes: Mailboxes,
+    defaultExecutionContext: Option[ExecutionContext])
     extends DispatcherPrerequisites
 
 object Dispatchers {
@@ -190,14 +190,14 @@ class Dispatchers(val settings: ActorSystem.Settings, val prerequisites: Dispatc
         val args = List(classOf[Config] -> cfg, classOf[DispatcherPrerequisites] -> prerequisites)
         prerequisites.dynamicAccess
           .createInstanceFor[MessageDispatcherConfigurator](fqn, args)
-          .recover({
+          .recover {
             case exception =>
               throw new ConfigurationException(
                 ("Cannot instantiate MessageDispatcherConfigurator type [%s], defined in [%s], " +
                 "make sure it has constructor with [com.typesafe.config.Config] and " +
                 "[akka.dispatch.DispatcherPrerequisites] parameters").format(fqn, cfg.getString("id")),
                 exception)
-          })
+          }
           .get
     }
   }

--- a/akka-actor/src/main/scala/akka/dispatch/ForkJoinExecutorConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ForkJoinExecutorConfigurator.scala
@@ -44,7 +44,7 @@ object ForkJoinExecutorConfigurator {
   final class AkkaForkJoinTask(runnable: Runnable) extends ForkJoinTask[Unit] {
     override def getRawResult(): Unit = ()
     override def setRawResult(unit: Unit): Unit = ()
-    final override def exec(): Boolean =
+    override def exec(): Boolean =
       try {
         runnable.run(); true
       } catch {

--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -645,7 +645,7 @@ final case class UnboundedMailbox() extends MailboxType with ProducesMessageQueu
 
   def this(settings: ActorSystem.Settings, config: Config) = this()
 
-  final override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue =
+  override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue =
     new UnboundedMailbox.MessageQueue
 }
 
@@ -678,7 +678,7 @@ final case class SingleConsumerOnlyUnboundedMailbox() extends MailboxType with P
  *
  * NOTE: NonBlockingBoundedMailbox does not use `mailbox-push-timeout-time` as it is non-blocking.
  */
-case class NonBlockingBoundedMailbox(val capacity: Int)
+case class NonBlockingBoundedMailbox(capacity: Int)
     extends MailboxType
     with ProducesMessageQueue[BoundedNodeMessageQueue] {
 
@@ -693,7 +693,7 @@ case class NonBlockingBoundedMailbox(val capacity: Int)
 /**
  * BoundedMailbox is the default bounded MailboxType used by Akka Actors.
  */
-final case class BoundedMailbox(val capacity: Int, override val pushTimeOut: FiniteDuration)
+final case class BoundedMailbox(capacity: Int, override val pushTimeOut: FiniteDuration)
     extends MailboxType
     with ProducesMessageQueue[BoundedMailbox.MessageQueue]
     with ProducesPushTimeoutSemanticsMailbox {
@@ -704,7 +704,7 @@ final case class BoundedMailbox(val capacity: Int, override val pushTimeOut: Fin
   if (capacity < 0) throw new IllegalArgumentException("The capacity for BoundedMailbox can not be negative")
   if (pushTimeOut eq null) throw new IllegalArgumentException("The push time-out for BoundedMailbox can not be null")
 
-  final override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue =
+  override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue =
     new BoundedMailbox.MessageQueue(capacity, pushTimeOut)
 }
 
@@ -821,7 +821,7 @@ final case class UnboundedDequeBasedMailbox()
 
   def this(settings: ActorSystem.Settings, config: Config) = this()
 
-  final override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue =
+  override def create(owner: Option[ActorRef], system: Option[ActorSystem]): MessageQueue =
     new UnboundedDequeBasedMailbox.MessageQueue
 }
 

--- a/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
@@ -90,7 +90,7 @@ final case class ThreadPoolConfig(
       service
     }
   }
-  final def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory = {
+  def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory = {
     val tf = threadFactory match {
       case m: MonitorableThreadFactory =>
         // add the dispatcher id to the thread names

--- a/akka-actor/src/main/scala/akka/dispatch/affinity/AffinityPool.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/affinity/AffinityPool.scala
@@ -248,9 +248,7 @@ private[akka] class AffinityPool(
   override def toString: String =
     s"${Logging.simpleName(this)}(id = $id, parallelism = $parallelism, affinityGroupSize = $affinityGroupSize, threadFactory = $threadFactory, idleCpuLevel = $idleCpuLevel, queueSelector = $queueSelector, rejectionHandler = $rejectionHandler)"
 
-  private[this] final class AffinityPoolWorker(
-      val q: BoundedAffinityTaskQueue,
-      val idleStrategy: IdleStrategy)
+  private[this] final class AffinityPoolWorker(val q: BoundedAffinityTaskQueue, val idleStrategy: IdleStrategy)
       extends Runnable {
     val thread: Thread = threadFactory.newThread(this)
 

--- a/akka-actor/src/main/scala/akka/dispatch/affinity/AffinityPool.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/affinity/AffinityPool.scala
@@ -72,14 +72,14 @@ private[affinity] object AffinityPool {
     private[this] var parkPeriodNs = 0L
     @volatile private[this] var idling = false
 
-    @inline private[this] final def transitionTo(newState: IdleState): Unit = {
+    @inline private[this] def transitionTo(newState: IdleState): Unit = {
       state = newState
       turns = 0
     }
 
-    final def isIdling: Boolean = idling
+    def isIdling: Boolean = idling
 
-    final def idle(): Unit = {
+    def idle(): Unit = {
       (state: @switch) match {
         case Initial =>
           idling = true
@@ -104,7 +104,7 @@ private[affinity] object AffinityPool {
       }
     }
 
-    final def reset(): Unit = {
+    def reset(): Unit = {
       idling = false
       transitionTo(Initial)
     }
@@ -249,17 +249,17 @@ private[akka] class AffinityPool(
     s"${Logging.simpleName(this)}(id = $id, parallelism = $parallelism, affinityGroupSize = $affinityGroupSize, threadFactory = $threadFactory, idleCpuLevel = $idleCpuLevel, queueSelector = $queueSelector, rejectionHandler = $rejectionHandler)"
 
   private[this] final class AffinityPoolWorker(
-      final val q: BoundedAffinityTaskQueue,
-      final val idleStrategy: IdleStrategy)
+      val q: BoundedAffinityTaskQueue,
+      val idleStrategy: IdleStrategy)
       extends Runnable {
-    final val thread: Thread = threadFactory.newThread(this)
+    val thread: Thread = threadFactory.newThread(this)
 
-    final def start(): Unit =
+    def start(): Unit =
       if (thread eq null)
         throw new IllegalStateException(s"Was not able to allocate worker thread for ${AffinityPool.this}")
       else thread.start()
 
-    override final def run(): Unit = {
+    override def run(): Unit = {
       // Returns true if it executed something, false otherwise
       def executeNext(): Boolean = {
         val c = q.poll()
@@ -329,22 +329,22 @@ private[akka] final class AffinityPoolConfigurator(config: Config, prerequisites
   private val queueSelectorFactory: QueueSelectorFactory =
     prerequisites.dynamicAccess
       .createInstanceFor[QueueSelectorFactory](queueSelectorFactoryFQCN, immutable.Seq(classOf[Config] -> config))
-      .recover({
+      .recover {
         case _ =>
           throw new IllegalArgumentException(
             s"Cannot instantiate QueueSelectorFactory(queueSelector = $queueSelectorFactoryFQCN), make sure it has an accessible constructor which accepts a Config parameter")
-      })
+      }
       .get
 
   private val rejectionHandlerFactoryFCQN = config.getString("rejection-handler")
   private val rejectionHandlerFactory = prerequisites.dynamicAccess
     .createInstanceFor[RejectionHandlerFactory](rejectionHandlerFactoryFCQN, Nil)
-    .recover({
+    .recover {
       case exception =>
         throw new IllegalArgumentException(
           s"Cannot instantiate RejectionHandlerFactory(rejection-handler = $rejectionHandlerFactoryFCQN), make sure it has an accessible empty constructor",
           exception)
-    })
+    }
     .get
 
   override def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory = {
@@ -389,7 +389,7 @@ trait QueueSelector {
 
   /**
    * Must be deterministic—return the same value for the same input.
-   * @returns given a `Runnable` a number between 0 .. `queues` (exclusive)
+   * @return given a `Runnable` a number between 0 .. `queues` (exclusive)
    * @throws NullPointerException when `command` is `null`
    */
   def getQueue(command: Runnable, queues: Int): Int
@@ -401,9 +401,9 @@ trait QueueSelector {
 @InternalApi
 @ApiMayChange
 private[akka] final class ThrowOnOverflowRejectionHandler extends RejectionHandlerFactory with RejectionHandler {
-  override final def reject(command: Runnable, service: ExecutorService): Unit =
+  override def reject(command: Runnable, service: ExecutorService): Unit =
     throw new RejectedExecutionException(s"Task $command rejected from $service")
-  override final def create(): RejectionHandler = this
+  override def create(): RejectionHandler = this
 }
 
 /**
@@ -411,7 +411,7 @@ private[akka] final class ThrowOnOverflowRejectionHandler extends RejectionHandl
  */
 @InternalApi
 @ApiMayChange
-private[akka] final class FairDistributionHashCache(final val config: Config) extends QueueSelectorFactory {
+private[akka] final class FairDistributionHashCache(val config: Config) extends QueueSelectorFactory {
   private final val MaxFairDistributionThreshold = 2048
 
   private[this] final val fairDistributionThreshold = config
@@ -420,7 +420,7 @@ private[akka] final class FairDistributionHashCache(final val config: Config) ex
       thr => 0 <= thr && thr <= MaxFairDistributionThreshold,
       s"fair-work-distribution.threshold must be between 0 and $MaxFairDistributionThreshold")
 
-  override final def create(): QueueSelector =
+  override def create(): QueueSelector =
     new AtomicReference[ImmutableIntMap](ImmutableIntMap.empty) with QueueSelector {
       override def toString: String =
         s"FairDistributionHashCache(fairDistributionThreshold = $fairDistributionThreshold)"

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -122,16 +122,16 @@ trait LoggingBus extends ActorEventBus {
         } yield {
           system.dynamicAccess
             .getClassFor[Actor](loggerName)
-            .map({
-              case actorClass => addLogger(system, actorClass, level, logName)
-            })
-            .recover({
+            .map { actorClass =>
+              addLogger(system, actorClass, level, logName)
+            }
+            .recover {
               case e =>
                 throw new ConfigurationException(
                   "Logger specified in config can't be loaded [" + loggerName +
                   "] due to [" + e.toString + "]",
                   e)
-            })
+            }
             .get
         }
       guard.withGuard {
@@ -1064,7 +1064,7 @@ object Logging {
       val size = mdc.size
       if (size == 0) ""
       else if (size == 1) s"[${mdc.head._1}:${mdc.head._2}]"
-      else mdc.map({ case (k, v) => s"$k:$v" }).mkString("[", "][", "]")
+      else mdc.map { case (k, v) => s"$k:$v" }.mkString("[", "][", "]")
     }
   }
   object StdOutLogger {

--- a/akka-actor/src/main/scala/akka/io/Dns.scala
+++ b/akka-actor/src/main/scala/akka/io/Dns.scala
@@ -59,16 +59,10 @@ object Dns extends ExtensionId[DnsExt] with ExtensionIdProvider {
 
   object Resolved {
     def apply(name: String, addresses: Iterable[InetAddress]): Resolved = {
-      val ipv4: immutable.Seq[Inet4Address] = addresses.iterator
-        .collect({
-          case a: Inet4Address => a
-        })
-        .to(immutable.IndexedSeq)
-      val ipv6: immutable.Seq[Inet6Address] = addresses.iterator
-        .collect({
-          case a: Inet6Address => a
-        })
-        .to(immutable.IndexedSeq)
+      val ipv4: immutable.Seq[Inet4Address] =
+        addresses.iterator.collect { case a: Inet4Address => a }.to(immutable.IndexedSeq)
+      val ipv6: immutable.Seq[Inet6Address] =
+        addresses.iterator.collect { case a: Inet6Address => a }.to(immutable.IndexedSeq)
       Resolved(name, ipv4, ipv6)
     }
   }

--- a/akka-actor/src/main/scala/akka/routing/Balancing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Balancing.scala
@@ -69,7 +69,7 @@ private[akka] final class BalancingRoutingLogic extends RoutingLogic {
  */
 @SerialVersionUID(1L)
 final case class BalancingPool(
-    val nrOfInstances: Int,
+    nrOfInstances: Int,
     override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
     extends Pool {

--- a/akka-actor/src/main/scala/akka/routing/Broadcast.scala
+++ b/akka-actor/src/main/scala/akka/routing/Broadcast.scala
@@ -59,7 +59,7 @@ final class BroadcastRoutingLogic extends RoutingLogic {
  */
 @SerialVersionUID(1L)
 final case class BroadcastPool(
-    val nrOfInstances: Int,
+    nrOfInstances: Int,
     override val resizer: Option[Resizer] = None,
     override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
@@ -123,7 +123,7 @@ final case class BroadcastPool(
  */
 @SerialVersionUID(1L)
 final case class BroadcastGroup(
-    val paths: immutable.Iterable[String],
+    paths: immutable.Iterable[String],
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
     extends Group {
 

--- a/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
+++ b/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
@@ -274,10 +274,10 @@ final case class ConsistentHashingRoutingLogic(
  */
 @SerialVersionUID(1L)
 final case class ConsistentHashingPool(
-    val nrOfInstances: Int,
+    nrOfInstances: Int,
     override val resizer: Option[Resizer] = None,
-    val virtualNodesFactor: Int = 0,
-    val hashMapping: ConsistentHashingRouter.ConsistentHashMapping = ConsistentHashingRouter.emptyConsistentHashMapping,
+    virtualNodesFactor: Int = 0,
+    hashMapping: ConsistentHashingRouter.ConsistentHashMapping = ConsistentHashingRouter.emptyConsistentHashMapping,
     override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
     override val usePoolDispatcher: Boolean = false)
@@ -363,9 +363,9 @@ final case class ConsistentHashingPool(
  */
 @SerialVersionUID(1L)
 final case class ConsistentHashingGroup(
-    val paths: immutable.Iterable[String],
-    val virtualNodesFactor: Int = 0,
-    val hashMapping: ConsistentHashingRouter.ConsistentHashMapping = ConsistentHashingRouter.emptyConsistentHashMapping,
+    paths: immutable.Iterable[String],
+    virtualNodesFactor: Int = 0,
+    hashMapping: ConsistentHashingRouter.ConsistentHashMapping = ConsistentHashingRouter.emptyConsistentHashMapping,
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
     extends Group {
 

--- a/akka-actor/src/main/scala/akka/routing/Listeners.scala
+++ b/akka-actor/src/main/scala/akka/routing/Listeners.scala
@@ -41,9 +41,6 @@ trait Listeners { self: Actor =>
 
   /**
    * Sends the supplied message to all current listeners using the provided sender() as sender.
-   *
-   * @param msg    supplied message
-   * @param sender the sender
    */
   protected def gossip(msg: Any)(implicit sender: ActorRef = Actor.noSender): Unit = {
     val i = listeners.iterator

--- a/akka-actor/src/main/scala/akka/routing/Listeners.scala
+++ b/akka-actor/src/main/scala/akka/routing/Listeners.scala
@@ -42,8 +42,8 @@ trait Listeners { self: Actor =>
   /**
    * Sends the supplied message to all current listeners using the provided sender() as sender.
    *
-   * @param msg
-   * @param sender
+   * @param msg    supplied message
+   * @param sender the sender
    */
   protected def gossip(msg: Any)(implicit sender: ActorRef = Actor.noSender): Unit = {
     val i = listeners.iterator

--- a/akka-actor/src/main/scala/akka/routing/Resizer.scala
+++ b/akka-actor/src/main/scala/akka/routing/Resizer.scala
@@ -128,13 +128,13 @@ case object DefaultResizer {
  */
 @SerialVersionUID(1L)
 case class DefaultResizer(
-    val lowerBound: Int = 1,
-    val upperBound: Int = 10,
-    val pressureThreshold: Int = 1,
-    val rampupRate: Double = 0.2,
-    val backoffThreshold: Double = 0.3,
-    val backoffRate: Double = 0.1,
-    val messagesPerResize: Int = 10)
+    lowerBound: Int = 1,
+    upperBound: Int = 10,
+    pressureThreshold: Int = 1,
+    rampupRate: Double = 0.2,
+    backoffThreshold: Double = 0.3,
+    backoffRate: Double = 0.1,
+    messagesPerResize: Int = 10)
     extends Resizer {
 
   /**

--- a/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
@@ -69,7 +69,7 @@ final class RoundRobinRoutingLogic extends RoutingLogic {
  */
 @SerialVersionUID(1L)
 final case class RoundRobinPool(
-    val nrOfInstances: Int,
+    nrOfInstances: Int,
     override val resizer: Option[Resizer] = None,
     override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,
@@ -134,7 +134,7 @@ final case class RoundRobinPool(
  */
 @SerialVersionUID(1L)
 final case class RoundRobinGroup(
-    val paths: immutable.Iterable[String],
+    paths: immutable.Iterable[String],
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
     extends Group {
 

--- a/akka-actor/src/main/scala/akka/routing/Router.scala
+++ b/akka-actor/src/main/scala/akka/routing/Router.scala
@@ -94,7 +94,7 @@ final case class SeveralRoutees(routees: immutable.IndexedSeq[Routee]) extends R
  *
  * A `Router` is immutable and the [[RoutingLogic]] must be thread safe.
  */
-final case class Router(val logic: RoutingLogic, val routees: immutable.IndexedSeq[Routee] = Vector.empty) {
+final case class Router(logic: RoutingLogic, routees: immutable.IndexedSeq[Routee] = Vector.empty) {
 
   /**
    * Java API

--- a/akka-actor/src/main/scala/akka/routing/ScatterGatherFirstCompleted.scala
+++ b/akka-actor/src/main/scala/akka/routing/ScatterGatherFirstCompleted.scala
@@ -99,7 +99,7 @@ private[akka] final case class ScatterGatherFirstCompletedRoutees(
  */
 @SerialVersionUID(1L)
 final case class ScatterGatherFirstCompletedPool(
-    val nrOfInstances: Int,
+    nrOfInstances: Int,
     override val resizer: Option[Resizer] = None,
     within: FiniteDuration,
     override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
@@ -179,7 +179,7 @@ final case class ScatterGatherFirstCompletedPool(
  */
 @SerialVersionUID(1L)
 final case class ScatterGatherFirstCompletedGroup(
-    val paths: immutable.Iterable[String],
+    paths: immutable.Iterable[String],
     within: FiniteDuration,
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)
     extends Group {

--- a/akka-actor/src/main/scala/akka/routing/SmallestMailbox.scala
+++ b/akka-actor/src/main/scala/akka/routing/SmallestMailbox.scala
@@ -182,7 +182,7 @@ class SmallestMailboxRoutingLogic extends RoutingLogic {
 @silent
 @SerialVersionUID(1L)
 final case class SmallestMailboxPool(
-    val nrOfInstances: Int,
+    nrOfInstances: Int,
     override val resizer: Option[Resizer] = None,
     override val supervisorStrategy: SupervisorStrategy = Pool.defaultSupervisorStrategy,
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId,

--- a/akka-actor/src/main/scala/akka/routing/TailChopping.scala
+++ b/akka-actor/src/main/scala/akka/routing/TailChopping.scala
@@ -150,7 +150,7 @@ private[akka] final case class TailChoppingRoutees(
  */
 @SerialVersionUID(1L)
 final case class TailChoppingPool(
-    val nrOfInstances: Int,
+    nrOfInstances: Int,
     override val resizer: Option[Resizer] = None,
     within: FiniteDuration,
     interval: FiniteDuration,
@@ -248,7 +248,7 @@ final case class TailChoppingPool(
  *   router management messages
  */
 final case class TailChoppingGroup(
-    val paths: immutable.Iterable[String],
+    paths: immutable.Iterable[String],
     within: FiniteDuration,
     interval: FiniteDuration,
     override val routerDispatcher: String = Dispatchers.DefaultDispatcherId)


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose
Remove the redundant modifier such as `val` or `final` in `class`.
For example,
 ```scala
      case class Hello(val x: Int, val y: String)
      // val-modifier is redundant for the fields of "case class"

      final class City(name: String) {
         final def someMethod(): Int = 1  // here for 'someMethod', final-modifier  is redundant, because City is a final-class
      }

      final class People(final val name: String) {  // here for field 'name',  final-modifier is redundant
         def sayHello() = println("hello, world")
      }

      // see line 332-336 of akka/dispatch/affinity/AffinityPool.scala
      // for a scala function that owns one argument, we can use { } to replace ( )
      // for instance,
      val list = List(1, 2, 3)
      list.collect({ 
        case i if i > 1 => i + 10
      })
      // can be simplified to:
      list.collect { 
        case i if i > 1 => i + 10
      }

      // ( ) is not necessary for scala-guard
      catch {
        case NonFatal(_) if (hasMailboxRequirement) =>          // here ( ) is not necessary
      }
```
<!-- What does this PR do? -->


<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->

## Changes
   This submission mainly associated with two packages:  `akka.dispatch` and `akka.routing`
  
<!-- Bullets for important changes in this PR -->

<!-- Why did you take this approach? -->
