### PR TITLE
[WIP] Minimal changes to choose JDK FJP alongside the Akka imported one

### DIFF
--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -341,6 +341,8 @@ abstract class MessageDispatcherConfigurator(_config: Config, val prerequisites:
   def configureExecutor(): ExecutorServiceConfigurator = {
     def configurator(executor: String): ExecutorServiceConfigurator = executor match {
       case null | "" | "fork-join-executor" =>
+        new JVMForkJoinExecutorConfigurator(config.getConfig("fork-join-executor"), prerequisites)
+      case "fork-join-executor-akka" =>
         new ForkJoinExecutorConfigurator(config.getConfig("fork-join-executor"), prerequisites)
       case "thread-pool-executor" =>
         new ThreadPoolExecutorConfigurator(config.getConfig("thread-pool-executor"), prerequisites)

--- a/akka-actor/src/main/scala/akka/dispatch/JVMForkJoinExecutorConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/JVMForkJoinExecutorConfigurator.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.dispatch
+
+import java.util.concurrent.{ ForkJoinPool, ForkJoinTask }
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.ExecutorService
+import com.typesafe.config.Config
+
+object JVMForkJoinExecutorConfigurator {
+
+  /**
+   * INTERNAL AKKA USAGE ONLY
+   */
+  final class JVMForkJoinPool(
+                                parallelism: Int,
+                                threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
+                                unhandledExceptionHandler: Thread.UncaughtExceptionHandler,
+                                asyncMode: Boolean)
+    extends ForkJoinPool(parallelism, threadFactory, unhandledExceptionHandler, asyncMode)
+      with LoadMetrics {
+    def this(
+              parallelism: Int,
+              threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
+              unhandledExceptionHandler: Thread.UncaughtExceptionHandler) =
+      this(parallelism, threadFactory, unhandledExceptionHandler, asyncMode = true)
+
+    override def execute(r: Runnable): Unit =
+      if (r ne null)
+        super.execute(
+          (if (r.isInstanceOf[ForkJoinTask[_]]) r else new JVMForkJoinTask(r)).asInstanceOf[ForkJoinTask[Any]])
+      else
+        throw new NullPointerException("Runnable was null")
+
+    def atFullThrottle(): Boolean = this.getActiveThreadCount() >= this.getParallelism()
+  }
+
+  /**
+   * INTERNAL AKKA USAGE ONLY
+   */
+  @SerialVersionUID(1L)
+  final class JVMForkJoinTask(runnable: Runnable) extends ForkJoinTask[Unit] {
+    override def getRawResult(): Unit = ()
+    override def setRawResult(unit: Unit): Unit = ()
+    final override def exec(): Boolean =
+      try {
+        runnable.run(); true
+      } catch {
+        case _: InterruptedException =>
+          Thread.currentThread.interrupt()
+          false
+        case anything: Throwable =>
+          val t = Thread.currentThread
+          t.getUncaughtExceptionHandler match {
+            case null =>
+            case some => some.uncaughtException(t, anything)
+          }
+          throw anything
+      }
+  }
+}
+
+class JVMForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherPrerequisites)
+  extends ExecutorServiceConfigurator(config, prerequisites) {
+  import JVMForkJoinExecutorConfigurator._
+
+  def validate(t: ThreadFactory): ForkJoinPool.ForkJoinWorkerThreadFactory = t match {
+    case correct: ForkJoinPool.ForkJoinWorkerThreadFactory => correct
+    case _ =>
+      throw new IllegalStateException(
+        "The prerequisites for the ForkJoinExecutorConfigurator is a ForkJoinPool.ForkJoinWorkerThreadFactory!")
+  }
+
+  class JVMForkJoinExecutorServiceFactory(
+                                        val threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
+                                        val parallelism: Int,
+                                        val asyncMode: Boolean)
+    extends ExecutorServiceFactory {
+    def this(threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory, parallelism: Int) =
+      this(threadFactory, parallelism, asyncMode = true)
+    def createExecutorService: ExecutorService =
+      new JVMForkJoinPool(parallelism, threadFactory, MonitorableThreadFactory.doNothing, asyncMode)
+  }
+
+  final def createExecutorServiceFactory(id: String, threadFactory: ThreadFactory): ExecutorServiceFactory = {
+    val tf = threadFactory match {
+      case m: MonitorableThreadFactory =>
+        // add the dispatcher id to the thread names
+        m.withName(m.name + "-" + id)
+      case other => other
+    }
+
+    val asyncMode = config.getString("task-peeking-mode") match {
+      case "FIFO" => true
+      case "LIFO" => false
+      case _ =>
+        throw new IllegalArgumentException(
+          "Cannot instantiate ForkJoinExecutorServiceFactory. " +
+          """"task-peeking-mode" in "fork-join-executor" section could only set to "FIFO" or "LIFO".""")
+    }
+
+    new JVMForkJoinExecutorServiceFactory(
+      validate(tf),
+      ThreadPoolConfig.scaledPoolSize(
+        config.getInt("parallelism-min"),
+        config.getDouble("parallelism-factor"),
+        config.getInt("parallelism-max")),
+      asyncMode)
+  }
+}

--- a/akka-actor/src/main/scala/akka/dispatch/JVMForkJoinExecutorConfigurator.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/JVMForkJoinExecutorConfigurator.scala
@@ -15,16 +15,16 @@ object JVMForkJoinExecutorConfigurator {
    * INTERNAL AKKA USAGE ONLY
    */
   final class JVMForkJoinPool(
-                                parallelism: Int,
-                                threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
-                                unhandledExceptionHandler: Thread.UncaughtExceptionHandler,
-                                asyncMode: Boolean)
-    extends ForkJoinPool(parallelism, threadFactory, unhandledExceptionHandler, asyncMode)
+      parallelism: Int,
+      threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
+      unhandledExceptionHandler: Thread.UncaughtExceptionHandler,
+      asyncMode: Boolean)
+      extends ForkJoinPool(parallelism, threadFactory, unhandledExceptionHandler, asyncMode)
       with LoadMetrics {
     def this(
-              parallelism: Int,
-              threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
-              unhandledExceptionHandler: Thread.UncaughtExceptionHandler) =
+        parallelism: Int,
+        threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
+        unhandledExceptionHandler: Thread.UncaughtExceptionHandler) =
       this(parallelism, threadFactory, unhandledExceptionHandler, asyncMode = true)
 
     override def execute(r: Runnable): Unit =
@@ -63,7 +63,7 @@ object JVMForkJoinExecutorConfigurator {
 }
 
 class JVMForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherPrerequisites)
-  extends ExecutorServiceConfigurator(config, prerequisites) {
+    extends ExecutorServiceConfigurator(config, prerequisites) {
   import JVMForkJoinExecutorConfigurator._
 
   def validate(t: ThreadFactory): ForkJoinPool.ForkJoinWorkerThreadFactory = t match {
@@ -74,10 +74,10 @@ class JVMForkJoinExecutorConfigurator(config: Config, prerequisites: DispatcherP
   }
 
   class JVMForkJoinExecutorServiceFactory(
-                                        val threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
-                                        val parallelism: Int,
-                                        val asyncMode: Boolean)
-    extends ExecutorServiceFactory {
+      val threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory,
+      val parallelism: Int,
+      val asyncMode: Boolean)
+      extends ExecutorServiceFactory {
     def this(threadFactory: ForkJoinPool.ForkJoinWorkerThreadFactory, parallelism: Int) =
       this(threadFactory, parallelism, asyncMode = true)
     def createExecutorService: ExecutorService =

--- a/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/ThreadPoolBuilder.scala
@@ -6,11 +6,23 @@ package akka.dispatch
 
 import java.util.Collection
 
-import scala.concurrent.{BlockContext, CanAwait}
+import scala.concurrent.{ BlockContext, CanAwait }
 import scala.concurrent.duration.Duration
 import akka.dispatch.forkjoin._
-import java.util.concurrent.{ArrayBlockingQueue, BlockingQueue, Callable, ExecutorService, LinkedBlockingQueue, RejectedExecutionException, RejectedExecutionHandler, SynchronousQueue, ThreadFactory, ThreadPoolExecutor, TimeUnit}
-import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
+import java.util.concurrent.{
+  ArrayBlockingQueue,
+  BlockingQueue,
+  Callable,
+  ExecutorService,
+  LinkedBlockingQueue,
+  RejectedExecutionException,
+  RejectedExecutionHandler,
+  SynchronousQueue,
+  ThreadFactory,
+  ThreadPoolExecutor,
+  TimeUnit
+}
+import java.util.concurrent.atomic.{ AtomicLong, AtomicReference }
 
 object ThreadPoolConfig {
   type QueueFactory = () => BlockingQueue[Runnable]
@@ -168,7 +180,7 @@ object MonitorableThreadFactory {
   }
 
   private[akka] class JVMForkJoinWorkerThread(_pool: java.util.concurrent.ForkJoinPool)
-    extends java.util.concurrent.ForkJoinWorkerThread(_pool)
+      extends java.util.concurrent.ForkJoinWorkerThread(_pool)
       with BlockContext {
     override def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
       val result = new AtomicReference[Option[T]](None)


### PR DESCRIPTION
Wanted to share that here mostly for easy experimentation and running benchmarks.

 * `fork-join-executor` -> JDK FJP
 * `fork-join-executor-akka` -> Akka FJP

Let's see if PR validation runs through.