### PR TITLE
Replaces composite map-flatten with flatMap

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -147,18 +147,15 @@ private[akka] class Deployer(val settings: ActorSystem.Settings, val dynamicAcce
       .root
       .unwrapped
       .asScala
-      .collect {
-        case (key, value: String) => (key -> value)
-      }
+      .collect { case (key, value: String) => (key -> value) }
       .toMap
 
   config.root.asScala
-    .map {
+    .flatMap {
       case ("default", _)             => None
       case (key, value: ConfigObject) => parseConfig(key, value.toConfig)
       case _                          => None
     }
-    .flatten
     .foreach(deploy)
 
   def lookup(path: ActorPath): Option[Deploy] = lookup(path.elements.drop(1))

--- a/akka-actor/src/main/scala/akka/util/LineNumbers.scala
+++ b/akka-actor/src/main/scala/akka/util/LineNumbers.scala
@@ -276,8 +276,9 @@ object LineNumbers {
     if (debug) println(s"LNB: reading $count methods")
     if (c.contains("Code") && c.contains("LineNumberTable")) {
       (1 to count)
-        .map(_ => readMethod(d, c("Code"), c("LineNumberTable"), filter))
-        .flatten
+        .flatMap { _ =>
+          readMethod(d, c("Code"), c("LineNumberTable"), filter)
+        }
         .foldLeft(Int.MaxValue -> 0) {
           case ((low, high), (start, end)) => (Math.min(low, start), Math.max(high, end))
         } match {

--- a/akka-actor/src/main/scala/akka/util/LockUtil.scala
+++ b/akka-actor/src/main/scala/akka/util/LockUtil.scala
@@ -4,8 +4,8 @@
 
 package akka.util
 
-import java.util.concurrent.locks.{ ReentrantLock }
-import java.util.concurrent.atomic.{ AtomicBoolean }
+import java.util.concurrent.locks.ReentrantLock
+import java.util.concurrent.atomic.AtomicBoolean
 
 final class ReentrantGuard extends ReentrantLock {
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

- Replace `map + flatten` with `flatMap`
- Remove the redundant `{ }` when only one element is imported

For instance

```scala
  val list = List(1, 2, 3, 4, 5)
  def f(i: Int): Option[Int] = if (i > 2) Some(i) else None
  list.map(f).flatten 
  // List(3, 4, 5)
  list.flatMap(f)
  // List(3, 4, 5)

  import java.util.concurrent.locks.{ ReentrantLock }
 // here { } is redundant

```

<!-- What does this PR do? -->


## Changes

- `akka.util.LineNumbers.scala`
- `akka.actor.Deployer.scala`
- `akka.util.LockUtil.scala`
<!-- Bullets for important changes in this PR -->
