### PR TITLE
remove Future from StreamRefs mat val, #24372

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/SourceRefBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/SourceRefBenchmark.scala
@@ -47,7 +47,7 @@ class SourceRefBenchmark {
 
   @Setup(Level.Invocation)
   def setup(): Unit = {
-    sourceRef = Await.result(Source.fromGraph(new BenchTestSource(100000)).runWith(StreamRefs.sourceRef()), 10.seconds)
+    sourceRef = Source.fromGraph(new BenchTestSource(100000)).runWith(StreamRefs.sourceRef())
   }
 
   @TearDown

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterSpec.scala
@@ -193,7 +193,7 @@ class ClusterSpec extends AkkaSpec(ClusterSpec.config) with ImplicitSender {
         Cluster(sys2).join(Cluster(sys2).selfAddress)
         probe.expectMsgType[MemberUp]
         val mat = ActorMaterializer()(sys2)
-        val sink = Await.result(StreamRefs.sinkRef[String]().to(Sink.ignore).run()(mat), 10.seconds)
+        val sink = StreamRefs.sinkRef[String]().to(Sink.ignore).run()(mat)
         Source.tick(1.milli, 10.millis, "tick").to(sink).run()(mat)
 
         CoordinatedShutdown(sys2).run(CoordinatedShutdown.UnknownReason)

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -97,6 +97,13 @@ Classic remoting over UDP has been deprecated since `2.5.0` and now has been rem
 To continue to use UDP configure @ref[Artery UDP](../remoting-artery.md#configuring-ssl-tls-for-akka-remoting) or migrate to Artery TCP.
 A full cluster restart is required to change to Artery.
 
+## Streams
+
+### StreamRefs
+
+The materialized value for `StreamRefs.sinkRef` and `StreamRefs.sourceRef` is no longer wrapped in
+`Future`/`CompletionStage`. It can be sent as reply to `sender()` immediately without using the `pipe` pattern.
+
 ## Cluster Sharding
 
 ### Passivate idle entity

--- a/akka-docs/src/main/paradox/stream/stream-refs.md
+++ b/akka-docs/src/main/paradox/stream/stream-refs.md
@@ -77,8 +77,7 @@ can be offered to a remote actor system in order for it to consume some source o
 locally. 
 
 In order to share a `Source` with a remote endpoint you need to materialize it by running it into the `Sink.sourceRef`.
-That `Sink` materializes the `SourceRef` that you can then send to other nodes. Please note that it materializes into a
-`Future` so you will have to use `pipeTo`.
+That `Sink` materializes the `SourceRef` that you can then send to other nodes.
 
 Scala
 :   @@snip [FlowStreamRefsDocSpec.scala](/akka-docs/src/test/scala/docs/stream/FlowStreamRefsDocSpec.scala) { #offer-source }

--- a/akka-docs/src/test/scala/docs/stream/FlowStreamRefsDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/FlowStreamRefsDocSpec.scala
@@ -23,7 +23,6 @@ class FlowStreamRefsDocSpec extends AkkaSpec with CompileOnlySpec {
     case class LogsOffer(streamId: Int, sourceRef: SourceRef[String])
 
     class DataSource extends Actor {
-      import context.dispatcher
       implicit val mat = ActorMaterializer()(context)
 
       def receive = {
@@ -32,13 +31,13 @@ class FlowStreamRefsDocSpec extends AkkaSpec with CompileOnlySpec {
           val source: Source[String, NotUsed] = streamLogs(streamId)
 
           // materialize the SourceRef:
-          val ref: Future[SourceRef[String]] = source.runWith(StreamRefs.sourceRef())
+          val ref: SourceRef[String] = source.runWith(StreamRefs.sourceRef())
 
           // wrap the SourceRef in some domain message, such that the sender knows what source it is
-          val reply: Future[LogsOffer] = ref.map(LogsOffer(streamId, _))
+          val reply = LogsOffer(streamId, ref)
 
           // reply to sender
-          reply.pipeTo(sender())
+          sender() ! reply
       }
 
       def streamLogs(streamId: Long): Source[String, NotUsed] = ???
@@ -70,7 +69,6 @@ class FlowStreamRefsDocSpec extends AkkaSpec with CompileOnlySpec {
 
     class DataReceiver extends Actor {
 
-      import context.dispatcher
       implicit val mat = ActorMaterializer()(context)
 
       def receive = {
@@ -79,13 +77,13 @@ class FlowStreamRefsDocSpec extends AkkaSpec with CompileOnlySpec {
           val sink: Sink[String, NotUsed] = logsSinkFor(nodeId)
 
           // materialize the SinkRef (the remote is like a source of data for us):
-          val ref: Future[SinkRef[String]] = StreamRefs.sinkRef[String]().to(sink).run()
+          val ref: SinkRef[String] = StreamRefs.sinkRef[String]().to(sink).run()
 
           // wrap the SinkRef in some domain message, such that the sender knows what source it is
-          val reply: Future[MeasurementsSinkReady] = ref.map(MeasurementsSinkReady(nodeId, _))
+          val reply = MeasurementsSinkReady(nodeId, ref)
 
           // reply to sender
-          reply.pipeTo(sender())
+          sender() ! reply
       }
 
       def logsSinkFor(nodeId: String): Sink[String, NotUsed] = ???

--- a/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes
@@ -61,3 +61,6 @@ ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowO
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.zipLatest")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.zipLatestWithGraph")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.zipLatestWith")
+
+# #24372 No Future/CompletionStage in StreamRefs
+# FIXME why was change not detected?

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorRefSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorRefSource.scala
@@ -51,7 +51,7 @@ private object ActorRefSource {
       override protected def stageActorName: String =
         inheritedAttributes.get[Attributes.Name].map(_.n).getOrElse(super.stageActorName)
 
-      val ref: ActorRef = getEagerStageActor(eagerMaterializer, poisonPillCompatibility = true) {
+      override val ref: ActorRef = getEagerStageActor(eagerMaterializer, poisonPillCompatibility = true) {
         case (_, PoisonPill) =>
           log.warning("for backwards compatibility: PoisonPill will not be supported in the future")
           completeStage()

--- a/akka-stream/src/main/scala/akka/stream/impl/streamref/SinkRefImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/streamref/SinkRefImpl.scala
@@ -14,7 +14,6 @@ import akka.stream.scaladsl.Sink
 import akka.stream.stage._
 import akka.util.{ OptionVal, PrettyDuration }
 
-import scala.concurrent.{ Future, Promise }
 import scala.util.{ Failure, Success, Try }
 
 /** INTERNAL API: Implementation class, not intended to be touched directly by end-users */
@@ -25,6 +24,13 @@ private[stream] final case class SinkRefImpl[In](initialPartnerRef: ActorRef) ex
 }
 
 /**
+ * INTERNAL API
+ */
+@InternalApi private[stream] object SinkRefStageImpl {
+  private sealed trait ActorRefStage { def ref: ActorRef }
+}
+
+/**
  * INTERNAL API: Actual operator implementation backing [[SinkRef]]s.
  *
  * If initialPartnerRef is set, then the remote side is already set up. If it is none, then we are the side creating
@@ -32,7 +38,8 @@ private[stream] final case class SinkRefImpl[In](initialPartnerRef: ActorRef) ex
  */
 @InternalApi
 private[stream] final class SinkRefStageImpl[In] private[akka] (val initialPartnerRef: OptionVal[ActorRef])
-    extends GraphStageWithMaterializedValue[SinkShape[In], Future[SourceRef[In]]] {
+    extends GraphStageWithMaterializedValue[SinkShape[In], SourceRef[In]] {
+  import SinkRefStageImpl.ActorRefStage
 
   val in: Inlet[In] = Inlet[In](s"${Logging.simpleName(getClass)}($initialRefName).in")
   override def shape: SinkShape[In] = SinkShape.of(in)
@@ -43,24 +50,30 @@ private[stream] final class SinkRefStageImpl[In] private[akka] (val initialPartn
       case OptionVal.None      => "<no-initial-ref>"
     }
 
-  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
-    val promise = Promise[SourceRefImpl[In]]
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, SourceRef[In]) =
+    throw new IllegalStateException("Not supported")
 
-    val logic = new TimerGraphStageLogic(shape) with StageLogging with InHandler {
+  private[akka] override def createLogicAndMaterializedValue(
+      inheritedAttributes: Attributes,
+      eagerMaterializer: Materializer): (GraphStageLogic, SourceRef[In]) = {
 
-      private[this] lazy val streamRefsMaster = StreamRefsMaster(ActorMaterializerHelper.downcast(materializer).system)
+    val logic = new TimerGraphStageLogic(shape) with StageLogging with ActorRefStage with InHandler {
+
+      private[this] val streamRefsMaster = StreamRefsMaster(ActorMaterializerHelper.downcast(eagerMaterializer).system)
 
       // settings ---
       import StreamRefAttributes._
-      private[this] lazy val settings = ActorMaterializerHelper.downcast(materializer).settings.streamRefSettings
+      private[this] val settings = ActorMaterializerHelper.downcast(eagerMaterializer).settings.streamRefSettings
 
-      private[this] lazy val subscriptionTimeout = inheritedAttributes.get[StreamRefAttributes.SubscriptionTimeout](
+      private[this] val subscriptionTimeout = inheritedAttributes.get[StreamRefAttributes.SubscriptionTimeout](
         SubscriptionTimeout(settings.subscriptionTimeout))
       // end of settings ---
 
-      override protected lazy val stageActorName: String = streamRefsMaster.nextSinkRefStageName()
-      private[this] var self: GraphStageLogic.StageActor = _
-      implicit def selfSender: ActorRef = self.ref
+      override protected val stageActorName: String = streamRefsMaster.nextSinkRefStageName()
+      private[this] val self: GraphStageLogic.StageActor =
+        getEagerStageActor(eagerMaterializer, poisonPillCompatibility = false)(initialReceive)
+      override val ref: ActorRef = self.ref
+      implicit def selfSender: ActorRef = ref
 
       private var partnerRef: OptionVal[ActorRef] = OptionVal.None
       private def getPartnerRef: ActorRef =
@@ -84,8 +97,6 @@ private[stream] final class SinkRefStageImpl[In] private[akka] (val initialPartn
       private[this] var finishedWithAwaitingPartnerTermination: OptionVal[Try[Done]] = OptionVal.None
 
       override def preStart(): Unit = {
-        self = getStageActor(initialReceive)
-
         initialPartnerRef match {
           case OptionVal.Some(ref) =>
             // this will set the `partnerRef`
@@ -104,11 +115,9 @@ private[stream] final class SinkRefStageImpl[In] private[akka] (val initialPartn
           "Created SinkRef, pointing to remote Sink receiver: {}, local worker: {}",
           initialPartnerRef,
           self.ref)
-
-        promise.success(SourceRefImpl(self.ref))
       }
 
-      lazy val initialReceive: ((ActorRef, Any)) => Unit = {
+      def initialReceive: ((ActorRef, Any)) => Unit = {
         case (_, Terminated(ref)) =>
           if (ref == getPartnerRef)
             finishedWithAwaitingPartnerTermination match {
@@ -156,7 +165,7 @@ private[stream] final class SinkRefStageImpl[In] private[akka] (val initialPartn
         case SubscriptionTimeoutTimerKey =>
           val ex = StreamRefSubscriptionTimeoutException(
             // we know the future has been competed by now, since it is in preStart
-            s"[$stageActorName] Remote side did not subscribe (materialize) handed out Source reference [${promise.future.value}], " +
+            s"[$stageActorName] Remote side did not subscribe (materialize) handed out Source reference [$ref], " +
             s"within subscription timeout: ${PrettyDuration.format(subscriptionTimeout.timeout)}!")
 
           throw ex
@@ -231,7 +240,7 @@ private[stream] final class SinkRefStageImpl[In] private[akka] (val initialPartn
       setHandler(in, this)
     }
 
-    (logic, promise.future)
+    (logic, SourceRefImpl(logic.ref))
   }
 
   override def toString = s"${Logging.simpleName(getClass)}($initialRefName)"

--- a/akka-stream/src/main/scala/akka/stream/impl/streamref/SourceRefImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/streamref/SourceRefImpl.scala
@@ -15,13 +15,18 @@ import akka.stream.scaladsl.Source
 import akka.stream.stage._
 import akka.util.{ OptionVal, PrettyDuration }
 
-import scala.concurrent.{ Future, Promise }
-
 /** INTERNAL API: Implementation class, not intended to be touched directly by end-users */
 @InternalApi
 private[stream] final case class SourceRefImpl[T](initialPartnerRef: ActorRef) extends SourceRef[T] {
   def source: Source[T, NotUsed] =
     Source.fromGraph(new SourceRefStageImpl(OptionVal.Some(initialPartnerRef))).mapMaterializedValue(_ => NotUsed)
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[stream] object SourceRefStageImpl {
+  private sealed trait ActorRefStage { def ref: ActorRef }
 }
 
 /**
@@ -32,7 +37,8 @@ private[stream] final case class SourceRefImpl[T](initialPartnerRef: ActorRef) e
  */
 @InternalApi
 private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: OptionVal[ActorRef])
-    extends GraphStageWithMaterializedValue[SourceShape[Out], Future[SinkRef[Out]]] { stage =>
+    extends GraphStageWithMaterializedValue[SourceShape[Out], SinkRef[Out]] { stage =>
+  import SourceRefStageImpl.ActorRefStage
 
   val out: Outlet[Out] = Outlet[Out](s"${Logging.simpleName(getClass)}.out")
   override def shape = SourceShape.of(out)
@@ -43,24 +49,29 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
       case _                   => "<no-initial-ref>"
     }
 
-  override def createLogicAndMaterializedValue(
-      inheritedAttributes: Attributes): (GraphStageLogic, Future[SinkRef[Out]]) = {
-    val promise = Promise[SinkRefImpl[Out]]()
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, SinkRef[Out]) =
+    throw new IllegalStateException("Not supported")
 
-    val logic = new TimerGraphStageLogic(shape) with StageLogging with OutHandler {
-      private[this] lazy val streamRefsMaster = StreamRefsMaster(ActorMaterializerHelper.downcast(materializer).system)
+  private[akka] override def createLogicAndMaterializedValue(
+      inheritedAttributes: Attributes,
+      eagerMaterializer: Materializer): (GraphStageLogic, SinkRef[Out]) = {
+
+    val logic = new TimerGraphStageLogic(shape) with StageLogging with ActorRefStage with OutHandler {
+      private[this] val streamRefsMaster = StreamRefsMaster(ActorMaterializerHelper.downcast(eagerMaterializer).system)
 
       // settings ---
       import StreamRefAttributes._
-      private[this] lazy val settings = ActorMaterializerHelper.downcast(materializer).settings.streamRefSettings
+      private[this] val settings = ActorMaterializerHelper.downcast(eagerMaterializer).settings.streamRefSettings
 
-      private[this] lazy val subscriptionTimeout = inheritedAttributes.get[StreamRefAttributes.SubscriptionTimeout](
+      private[this] val subscriptionTimeout = inheritedAttributes.get[StreamRefAttributes.SubscriptionTimeout](
         SubscriptionTimeout(settings.subscriptionTimeout))
       // end of settings ---
 
-      override protected lazy val stageActorName: String = streamRefsMaster.nextSourceRefStageName()
-      private[this] var self: GraphStageLogic.StageActor = _
-      private[this] implicit def selfSender: ActorRef = self.ref
+      override protected val stageActorName: String = streamRefsMaster.nextSourceRefStageName()
+      private[this] val self: GraphStageLogic.StageActor =
+        getEagerStageActor(eagerMaterializer, poisonPillCompatibility = false)(initialReceive)
+      override val ref: ActorRef = self.ref
+      private[this] implicit def selfSender: ActorRef = ref
 
       val SubscriptionTimeoutTimerKey = "SubscriptionTimeoutKey"
       val DemandRedeliveryTimerKey = "DemandRedeliveryTimerKey"
@@ -88,14 +99,11 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
         receiveBuffer = FixedSizeBuffer[Out](settings.bufferCapacity)
         requestStrategy = WatermarkRequestStrategy(highWatermark = receiveBuffer.capacity)
 
-        self = getStageActor(initialReceive)
         log.debug("[{}] Allocated receiver: {}", stageActorName, self.ref)
         if (initialPartnerRef.isDefined) // this will set the partnerRef
           observeAndValidateSender(
             initialPartnerRef.get,
             "Illegal initialPartnerRef! This would be a bug in the SourceRef usage or impl.")
-
-        promise.success(SinkRefImpl(self.ref))
 
         //this timer will be cancelled if we receive the handshake from the remote SinkRef
         // either created in this method and provided as self.ref as initialPartnerRef
@@ -133,7 +141,7 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
         case SubscriptionTimeoutTimerKey =>
           val ex = StreamRefSubscriptionTimeoutException(
             // we know the future has been competed by now, since it is in preStart
-            s"[$stageActorName] Remote side did not subscribe (materialize) handed out Sink reference [${promise.future.value}]," +
+            s"[$stageActorName] Remote side did not subscribe (materialize) handed out Sink reference [$ref]," +
             s"within subscription timeout: ${PrettyDuration.format(subscriptionTimeout.timeout)}!")
 
           throw ex // this will also log the exception, unlike failStage; this should fail rarely, but would be good to have it "loud"
@@ -149,7 +157,7 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
             "(possible reasons: network partition or subscription timeout triggered termination of partner). Tearing down."))
       }
 
-      lazy val initialReceive: ((ActorRef, Any)) => Unit = {
+      def initialReceive: ((ActorRef, Any)) => Unit = {
         case (sender, msg @ StreamRefsProtocol.OnSubscribeHandshake(remoteRef)) =>
           cancelTimer(SubscriptionTimeoutTimerKey)
           observeAndValidateSender(remoteRef, "Illegal sender in SequencedOnNext")
@@ -181,9 +189,9 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
           self.unwatch(sender)
           failStage(RemoteStreamRefActorTerminatedException(s"Remote stream (${sender.path}) failed, reason: $reason"))
 
-        case (_, Terminated(ref)) =>
+        case (_, Terminated(p)) =>
           partnerRef match {
-            case OptionVal.Some(`ref`) =>
+            case OptionVal.Some(`p`) =>
               // we need to start a delayed shutdown in case we were network partitioned and the final signal complete/fail
               // will never reach us; so after the given timeout we need to forcefully terminate this side of the stream ref
               // the other (sending) side terminates by default once it gets a Terminated signal so no special handling is needed there.
@@ -193,7 +201,7 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
               // this should not have happened! It should be impossible that we watched some other actor
               failStage(
                 RemoteStreamRefActorTerminatedException(
-                  s"Received UNEXPECTED Terminated($ref) message! " +
+                  s"Received UNEXPECTED Terminated($p) message! " +
                   s"This actor was NOT our trusted remote partner, which was: $getPartnerRef. Tearing down."))
           }
 
@@ -228,8 +236,8 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
             partnerRef = OptionVal(partner)
             self.watch(partner)
 
-          case OptionVal.Some(ref) =>
-            if (partner != ref) {
+          case OptionVal.Some(p) =>
+            if (partner != p) {
               val ex = InvalidPartnerActorException(partner, getPartnerRef, msg)
               partner ! StreamRefsProtocol.RemoteStreamFailure(ex.getMessage)
               throw ex
@@ -248,7 +256,7 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
 
       setHandler(out, this)
     }
-    (logic, promise.future)
+    (logic, SinkRefImpl(logic.ref))
   }
 
   override def toString: String =

--- a/akka-stream/src/main/scala/akka/stream/javadsl/StreamRefs.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/StreamRefs.scala
@@ -4,21 +4,12 @@
 
 package akka.stream.javadsl
 
-import java.util.concurrent.CompletionStage
-
-import akka.annotation.ApiMayChange
 import akka.stream._
 
 /**
- * API MAY CHANGE: The functionality of stream refs is working, however it is expected that the materialized value
- * will eventually be able to remove the Future wrapping the stream references. For this reason the API is now marked
- * as API may change. See ticket https://github.com/akka/akka/issues/24372 for more details.
- *
  * Factories for creating stream refs.
  */
-@ApiMayChange
 object StreamRefs {
-  import scala.compat.java8.FutureConverters._
 
   /**
    * A local [[Sink]] which materializes a [[SourceRef]] which can be used by other streams (including remote ones),
@@ -28,9 +19,8 @@ object StreamRefs {
    *
    * See more detailed documentation on [[SourceRef]].
    */
-  @ApiMayChange
-  def sourceRef[T](): javadsl.Sink[T, CompletionStage[SourceRef[T]]] =
-    scaladsl.StreamRefs.sourceRef[T]().mapMaterializedValue(_.toJava).asJava
+  def sourceRef[T](): javadsl.Sink[T, SourceRef[T]] =
+    scaladsl.StreamRefs.sourceRef[T]().asJava
 
   /**
    * A local [[Sink]] which materializes a [[SourceRef]] which can be used by other streams (including remote ones),
@@ -40,8 +30,7 @@ object StreamRefs {
    *
    * See more detailed documentation on [[SinkRef]].
    */
-  @ApiMayChange
-  def sinkRef[T](): javadsl.Source[T, CompletionStage[SinkRef[T]]] =
-    scaladsl.StreamRefs.sinkRef[T]().mapMaterializedValue(_.toJava).asJava
+  def sinkRef[T](): javadsl.Source[T, SinkRef[T]] =
+    scaladsl.StreamRefs.sinkRef[T]().asJava
 
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/StreamRefs.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/StreamRefs.scala
@@ -4,44 +4,34 @@
 
 package akka.stream.scaladsl
 
-import akka.annotation.ApiMayChange
 import akka.stream.{ SinkRef, SourceRef }
 import akka.stream.impl.streamref.{ SinkRefStageImpl, SourceRefStageImpl }
 import akka.util.OptionVal
 
-import scala.concurrent.Future
-
 /**
- * API MAY CHANGE: The functionality of stream refs is working, however it is expected that the materialized value
- * will eventually be able to remove the Future wrapping the stream references. For this reason the API is now marked
- * as API may change. See ticket https://github.com/akka/akka/issues/24372 for more details.
- *
  * Factories for creating stream refs.
  */
-@ApiMayChange
 object StreamRefs {
 
   /**
    * A local [[Sink]] which materializes a [[SourceRef]] which can be used by other streams (including remote ones),
    * to consume data from this local stream, as if they were attached directly in place of the local Sink.
    *
-   * Adheres to [[StreamRefAttributes]].
+   * Adheres to [[akka.stream.StreamRefAttributes]].
    *
    * See more detailed documentation on [[SourceRef]].
    */
-  @ApiMayChange
-  def sourceRef[T](): Sink[T, Future[SourceRef[T]]] =
+  def sourceRef[T](): Sink[T, SourceRef[T]] =
     Sink.fromGraph(new SinkRefStageImpl[T](OptionVal.None))
 
   /**
    * A local [[Source]] which materializes a [[SinkRef]] which can be used by other streams (including remote ones),
    * to publish data to this local stream, as if they were attached directly in place of the local Source.
    *
-   * Adheres to [[StreamRefAttributes]].
+   * Adheres to [[akka.stream.StreamRefAttributes]].
    *
    * See more detailed documentation on [[SinkRef]].
    */
-  @ApiMayChange
-  def sinkRef[T](): Source[T, Future[SinkRef[T]]] =
+  def sinkRef[T](): Source[T, SinkRef[T]] =
     Source.fromGraph(new SourceRefStageImpl[T](OptionVal.None))
 }


### PR DESCRIPTION
## Purpose

Remove the Future wrapping of SourceRef and SinkRef.

## References

References #24372

## Changes

* use the new `eagerMaterializer` parameter to be able to access the stage ActorRef immediately when the stage logic is created (same approach as in `ActorRefSource`)
* a few lazy could also be eliminated thanks to this

## Background Context

StreamRefs was marked with ApiMayChange for the reason that the Future wasn't great to have in the API. With the new `getEagerStageActor` it was possible to get rid of the Future.