### PR TITLE
ResetSystemMessageSeqNrSpec should not run with classic remoting, #26849

### DIFF
--- a/akka-cluster/src/test/scala/akka/cluster/ResetSystemMessageSeqNrSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ResetSystemMessageSeqNrSpec.scala
@@ -9,7 +9,6 @@ import scala.concurrent.duration._
 import akka.actor.ActorIdentity
 import akka.actor.Identify
 import akka.actor.PoisonPill
-import akka.remote.RARP
 import akka.remote.artery.ArteryMultiNodeSpec
 import akka.testkit.ImplicitSender
 import akka.testkit.TestActors
@@ -23,68 +22,66 @@ class ResetSystemMessageSeqNrSpec extends ArteryMultiNodeSpec("""
   akka.cluster.jmx.multi-mbeans-in-same-jvm = on
   """) with ImplicitSender {
 
-  // This test is not for classic remoting
-  if (RARP(system).provider.remoteSettings.Artery.Enabled)
-    "System messages sequence numbers" should {
+  "System messages sequence numbers" should {
 
-      "be reset when connecting to new incarnation" in {
+    "be reset when connecting to new incarnation" in {
 
-        val sys2 = newRemoteSystem(name = Some(system.name))
+      val sys2 = newRemoteSystem(name = Some(system.name))
 
-        Cluster(system).join(Cluster(system).selfAddress)
-        Cluster(sys2).join(Cluster(system).selfAddress)
-        within(10.seconds) {
-          awaitAssert {
-            Cluster(system).state.members.map(_.uniqueAddress) should ===(
-              Set(Cluster(system).selfUniqueAddress, Cluster(sys2).selfUniqueAddress))
-          }
+      Cluster(system).join(Cluster(system).selfAddress)
+      Cluster(sys2).join(Cluster(system).selfAddress)
+      within(10.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.map(_.uniqueAddress) should ===(
+            Set(Cluster(system).selfUniqueAddress, Cluster(sys2).selfUniqueAddress))
         }
-
-        sys2.actorOf(TestActors.echoActorProps, name = "echo1")
-        system.actorSelection(rootActorPath(sys2) / "user" / "echo1") ! Identify("1")
-        val echo1 = expectMsgType[ActorIdentity].ref.get
-        watch(echo1)
-
-        sys2.actorOf(TestActors.echoActorProps, name = "echo2")
-        system.actorSelection(rootActorPath(sys2) / "user" / "echo2") ! Identify("2")
-        val echo2 = expectMsgType[ActorIdentity].ref.get
-        watch(echo2)
-        echo2 ! PoisonPill
-        expectTerminated(echo2) // now we know that the watch of echo1 has been established
-
-        Cluster(sys2).leave(Cluster(sys2).selfAddress)
-        within(10.seconds) {
-          awaitAssert {
-            Cluster(system).state.members.map(_.uniqueAddress) should not contain Cluster(sys2).selfUniqueAddress
-          }
-        }
-
-        expectTerminated(echo1)
-        shutdown(sys2)
-
-        val sys3 = newRemoteSystem(
-          name = Some(system.name),
-          extraConfig = Some(s"akka.remote.artery.canonical.port=${Cluster(sys2).selfAddress.port.get}"))
-        Cluster(sys3).join(Cluster(system).selfAddress)
-        within(10.seconds) {
-          awaitAssert {
-            Cluster(system).state.members.map(_.uniqueAddress) should ===(
-              Set(Cluster(system).selfUniqueAddress, Cluster(sys3).selfUniqueAddress))
-          }
-        }
-
-        sys3.actorOf(TestActors.echoActorProps, name = "echo3")
-        system.actorSelection(rootActorPath(sys3) / "user" / "echo3") ! Identify("3")
-        val echo3 = expectMsgType[ActorIdentity].ref.get
-        watch(echo3)
-
-        // To clearly see the reproducer for issue #24847 one could put a sleep here and observe the
-        // "negative acknowledgment" log messages, but it also failed on the next expectTerminated because
-        // the Watch message was never delivered.
-
-        echo3 ! PoisonPill
-        expectTerminated(echo3)
       }
 
+      sys2.actorOf(TestActors.echoActorProps, name = "echo1")
+      system.actorSelection(rootActorPath(sys2) / "user" / "echo1") ! Identify("1")
+      val echo1 = expectMsgType[ActorIdentity].ref.get
+      watch(echo1)
+
+      sys2.actorOf(TestActors.echoActorProps, name = "echo2")
+      system.actorSelection(rootActorPath(sys2) / "user" / "echo2") ! Identify("2")
+      val echo2 = expectMsgType[ActorIdentity].ref.get
+      watch(echo2)
+      echo2 ! PoisonPill
+      expectTerminated(echo2) // now we know that the watch of echo1 has been established
+
+      Cluster(sys2).leave(Cluster(sys2).selfAddress)
+      within(10.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.map(_.uniqueAddress) should not contain Cluster(sys2).selfUniqueAddress
+        }
+      }
+
+      expectTerminated(echo1)
+      shutdown(sys2)
+
+      val sys3 = newRemoteSystem(
+        name = Some(system.name),
+        extraConfig = Some(s"akka.remote.artery.canonical.port=${Cluster(sys2).selfAddress.port.get}"))
+      Cluster(sys3).join(Cluster(system).selfAddress)
+      within(10.seconds) {
+        awaitAssert {
+          Cluster(system).state.members.map(_.uniqueAddress) should ===(
+            Set(Cluster(system).selfUniqueAddress, Cluster(sys3).selfUniqueAddress))
+        }
+      }
+
+      sys3.actorOf(TestActors.echoActorProps, name = "echo3")
+      system.actorSelection(rootActorPath(sys3) / "user" / "echo3") ! Identify("3")
+      val echo3 = expectMsgType[ActorIdentity].ref.get
+      watch(echo3)
+
+      // To clearly see the reproducer for issue #24847 one could put a sleep here and observe the
+      // "negative acknowledgment" log messages, but it also failed on the next expectTerminated because
+      // the Watch message was never delivered.
+
+      echo3 ! PoisonPill
+      expectTerminated(echo3)
     }
+
+  }
 }

--- a/akka-cluster/src/test/scala/akka/cluster/ResetSystemMessageSeqNrSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ResetSystemMessageSeqNrSpec.scala
@@ -9,6 +9,7 @@ import scala.concurrent.duration._
 import akka.actor.ActorIdentity
 import akka.actor.Identify
 import akka.actor.PoisonPill
+import akka.remote.RARP
 import akka.remote.artery.ArteryMultiNodeSpec
 import akka.testkit.ImplicitSender
 import akka.testkit.TestActors
@@ -22,66 +23,68 @@ class ResetSystemMessageSeqNrSpec extends ArteryMultiNodeSpec("""
   akka.cluster.jmx.multi-mbeans-in-same-jvm = on
   """) with ImplicitSender {
 
-  "System messages sequence numbers" should {
+  // This test is not for classic remoting
+  if (RARP(system).provider.remoteSettings.Artery.Enabled)
+    "System messages sequence numbers" should {
 
-    "be reset when connecting to new incarnation" in {
+      "be reset when connecting to new incarnation" in {
 
-      val sys2 = newRemoteSystem(name = Some(system.name))
+        val sys2 = newRemoteSystem(name = Some(system.name))
 
-      Cluster(system).join(Cluster(system).selfAddress)
-      Cluster(sys2).join(Cluster(system).selfAddress)
-      within(10.seconds) {
-        awaitAssert {
-          Cluster(system).state.members.map(_.uniqueAddress) should ===(
-            Set(Cluster(system).selfUniqueAddress, Cluster(sys2).selfUniqueAddress))
+        Cluster(system).join(Cluster(system).selfAddress)
+        Cluster(sys2).join(Cluster(system).selfAddress)
+        within(10.seconds) {
+          awaitAssert {
+            Cluster(system).state.members.map(_.uniqueAddress) should ===(
+              Set(Cluster(system).selfUniqueAddress, Cluster(sys2).selfUniqueAddress))
+          }
         }
+
+        sys2.actorOf(TestActors.echoActorProps, name = "echo1")
+        system.actorSelection(rootActorPath(sys2) / "user" / "echo1") ! Identify("1")
+        val echo1 = expectMsgType[ActorIdentity].ref.get
+        watch(echo1)
+
+        sys2.actorOf(TestActors.echoActorProps, name = "echo2")
+        system.actorSelection(rootActorPath(sys2) / "user" / "echo2") ! Identify("2")
+        val echo2 = expectMsgType[ActorIdentity].ref.get
+        watch(echo2)
+        echo2 ! PoisonPill
+        expectTerminated(echo2) // now we know that the watch of echo1 has been established
+
+        Cluster(sys2).leave(Cluster(sys2).selfAddress)
+        within(10.seconds) {
+          awaitAssert {
+            Cluster(system).state.members.map(_.uniqueAddress) should not contain Cluster(sys2).selfUniqueAddress
+          }
+        }
+
+        expectTerminated(echo1)
+        shutdown(sys2)
+
+        val sys3 = newRemoteSystem(
+          name = Some(system.name),
+          extraConfig = Some(s"akka.remote.artery.canonical.port=${Cluster(sys2).selfAddress.port.get}"))
+        Cluster(sys3).join(Cluster(system).selfAddress)
+        within(10.seconds) {
+          awaitAssert {
+            Cluster(system).state.members.map(_.uniqueAddress) should ===(
+              Set(Cluster(system).selfUniqueAddress, Cluster(sys3).selfUniqueAddress))
+          }
+        }
+
+        sys3.actorOf(TestActors.echoActorProps, name = "echo3")
+        system.actorSelection(rootActorPath(sys3) / "user" / "echo3") ! Identify("3")
+        val echo3 = expectMsgType[ActorIdentity].ref.get
+        watch(echo3)
+
+        // To clearly see the reproducer for issue #24847 one could put a sleep here and observe the
+        // "negative acknowledgment" log messages, but it also failed on the next expectTerminated because
+        // the Watch message was never delivered.
+
+        echo3 ! PoisonPill
+        expectTerminated(echo3)
       }
 
-      sys2.actorOf(TestActors.echoActorProps, name = "echo1")
-      system.actorSelection(rootActorPath(sys2) / "user" / "echo1") ! Identify("1")
-      val echo1 = expectMsgType[ActorIdentity].ref.get
-      watch(echo1)
-
-      sys2.actorOf(TestActors.echoActorProps, name = "echo2")
-      system.actorSelection(rootActorPath(sys2) / "user" / "echo2") ! Identify("2")
-      val echo2 = expectMsgType[ActorIdentity].ref.get
-      watch(echo2)
-      echo2 ! PoisonPill
-      expectTerminated(echo2) // now we know that the watch of echo1 has been established
-
-      Cluster(sys2).leave(Cluster(sys2).selfAddress)
-      within(10.seconds) {
-        awaitAssert {
-          Cluster(system).state.members.map(_.uniqueAddress) should not contain Cluster(sys2).selfUniqueAddress
-        }
-      }
-
-      expectTerminated(echo1)
-      shutdown(sys2)
-
-      val sys3 = newRemoteSystem(
-        name = Some(system.name),
-        extraConfig = Some(s"akka.remote.artery.canonical.port=${Cluster(sys2).selfAddress.port.get}"))
-      Cluster(sys3).join(Cluster(system).selfAddress)
-      within(10.seconds) {
-        awaitAssert {
-          Cluster(system).state.members.map(_.uniqueAddress) should ===(
-            Set(Cluster(system).selfUniqueAddress, Cluster(sys3).selfUniqueAddress))
-        }
-      }
-
-      sys3.actorOf(TestActors.echoActorProps, name = "echo3")
-      system.actorSelection(rootActorPath(sys3) / "user" / "echo3") ! Identify("3")
-      val echo3 = expectMsgType[ActorIdentity].ref.get
-      watch(echo3)
-
-      // To clearly see the reproducer for issue #24847 one could put a sleep here and observe the
-      // "negative acknowledgment" log messages, but it also failed on the next expectTerminated because
-      // the Watch message was never delivered.
-
-      echo3 ! PoisonPill
-      expectTerminated(echo3)
     }
-
-  }
 }

--- a/akka-remote/src/test/scala/akka/remote/artery/ArteryMultiNodeSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/ArteryMultiNodeSpec.scala
@@ -9,6 +9,8 @@ import akka.actor.setup.ActorSystemSetup
 import akka.remote.RARP
 import akka.testkit.{ AkkaSpec, SocketUtil }
 import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.Outcome
+import org.scalatest.Pending
 
 /**
  * Base class for remoting tests what needs to test interaction between a "local" actor system
@@ -37,6 +39,15 @@ abstract class ArteryMultiNodeSpec(config: Config)
   }
 
   private var remoteSystems: Vector[ActorSystem] = Vector.empty
+
+  override protected def withFixture(test: NoArgTest): Outcome = {
+    // note that withFixture is also used in FlightRecorderSpecIntegration
+    if (!RARP(system).provider.remoteSettings.Artery.Enabled) {
+      info(s"${getClass.getName} is only enabled for Artery")
+      Pending
+    } else
+      super.withFixture(test)
+  }
 
   /**
    * @return A new actor system configured with artery enabled. The system will


### PR DESCRIPTION
* Jenkins job overrides config with -Dakka.remote.artery.enabled=off

Refs #26849