### PR TITLE
Typed receptionist clashes with the clusterclient receptionist 

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/LocalReceptionistSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/LocalReceptionistSpec.scala
@@ -121,6 +121,10 @@ class LocalReceptionistSpec extends ScalaTestWithActorTestKit with WordSpecLike 
       listing.isForKey(ServiceKeyA) should ===(true)
       listing.serviceInstances(ServiceKeyA) should be(Set())
     }
+
+    "not conflict with the ClusterClient receptionist default name" in {
+      system.systemActorOf(Behaviors.ignore, "receptionist")
+    }
   }
 }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/LocalReceptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/LocalReceptionist.scala
@@ -32,7 +32,7 @@ private[akka] final class LocalReceptionist
 @InternalApi
 private[akka] object LocalReceptionist extends ReceptionistBehaviorProvider {
 
-  override val name = "local-receptionist"
+  override val name = "localReceptionist"
 
   type KV[K <: AbstractServiceKey] = ActorRef[K#Protocol]
   type LocalServiceRegistry = TypedMultiMap[AbstractServiceKey, KV]

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/LocalReceptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/LocalReceptionist.scala
@@ -19,6 +19,7 @@ import akka.util.TypedMultiMap
  */
 @InternalApi
 private[akka] trait ReceptionistBehaviorProvider {
+  def name: String
   def behavior: Behavior[Command]
 }
 
@@ -30,6 +31,8 @@ private[akka] final class LocalReceptionist
 /** INTERNAL API */
 @InternalApi
 private[akka] object LocalReceptionist extends ReceptionistBehaviorProvider {
+
+  override val name = "local-receptionist"
 
   type KV[K <: AbstractServiceKey] = ActorRef[K#Protocol]
   type LocalServiceRegistry = TypedMultiMap[AbstractServiceKey, KV]

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -51,7 +51,7 @@ abstract class Receptionist extends Extension {
     import akka.actor.typed.scaladsl.adapter._
     system.internalSystemActorOf(
       provider.behavior,
-      "receptionist",
+      provider.name,
       Props.empty.withDispatcherFromConfig(Dispatchers.InternalDispatcherId))
   }
 }

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
@@ -42,6 +42,8 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
 
   final val EmptyORMultiMap = ORMultiMap.empty[ServiceKey[_], Entry]
 
+  override val name = "cluster-receptionist"
+
   // values contain system uid to make it possible to discern actors at the same
   // path in different incarnations of a cluster node
   final case class Entry(ref: ActorRef[_], systemUid: Long) {

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
@@ -42,7 +42,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
 
   final val EmptyORMultiMap = ORMultiMap.empty[ServiceKey[_], Entry]
 
-  override val name = "cluster-receptionist"
+  override val name = "clusterReceptionist"
 
   // values contain system uid to make it possible to discern actors at the same
   // path in different incarnations of a cluster node

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -581,5 +581,14 @@ class ClusterReceptionistSpec extends WordSpec with Matchers {
       }
     }
 
+    "not conflict with the ClusterClient receptionist default name" in {
+      val testKit = ActorTestKit(s"ClusterReceptionistSpec-test-9", ClusterReceptionistSpec.config)
+      try {
+        testKit.system.systemActorOf(Behaviors.ignore, "receptionist")(3.seconds)
+      } finally {
+        testKit.shutdownTestKit()
+      }
+    }
+
   }
 }

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -174,3 +174,15 @@ and then it will behave as in Akka 2.5.x:
 ```
 akka.coordinated-shutdown.run-by-actor-system-terminate = off
 ```
+
+## Akka Typed
+
+### Receptionist has moved
+
+The receptionist had a name clash with the default Cluster Client Receptionist at `/system/receptionist` and will now 
+instead either run under `/system/localReceptionist` or `/system/clusterReceptionist`. 
+
+The path change makes it impossible to do a rolling upgrade from 2.5 to 2.6 if you use Akka Typed and the receptionist
+as the old and the new nodes receptionists will not be able to communicate.
+
+ 


### PR DESCRIPTION
Fixes #26848

Couldn't think of a reasonable single name that didn't feel contrived, so made the typed local and cluster receptionist have different paths.