### PR TITLE
WIP New ReceiveTimeout not applied if it was set while handling a  me…

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
@@ -12,56 +12,95 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 
 private[akka] object ReceiveTimeout {
-  final val emptyReceiveTimeoutData: (Duration, Cancellable) = (Duration.Undefined, ActorCell.emptyCancellable)
+  import ActorCell.emptyCancellable
+
+  private final val empty: ReceiveTimeoutValue =
+    ReceiveTimeoutValue(Duration.Undefined, emptyCancellable, Duration.Undefined)
+
+  final case class ReceiveTimeoutValue(current: Duration, task: Cancellable, previous: Duration) {
+
+    def :+(latest: Duration): ReceiveTimeoutValue = latest match {
+      case null => this // user input check
+      case _ =>
+        val prev = current
+        copy(previous = prev, current = latest)
+    }
+
+    /** Returns true if `current` is different from `previous` duration. */
+    def changed: Boolean = current ne previous
+
+    def clear(): ReceiveTimeoutValue = copy(task = emptyCancellable)
+
+    /* read-only functions */
+    def nonEmpty: Boolean = this ne empty
+    def taskIsEmpty: Boolean = task eq emptyCancellable
+    def taskNonEmpty: Boolean = !taskIsEmpty
+  }
+
+  object ReceiveTimeoutValue {
+    def apply(): ReceiveTimeoutValue = empty
+
+    def apply(duration: FiniteDuration, task: Cancellable): ReceiveTimeoutValue =
+      ReceiveTimeoutValue(duration, task, Duration.Undefined)
+  }
 }
 
 private[akka] trait ReceiveTimeout { this: ActorCell =>
 
   import ReceiveTimeout._
-  import ActorCell._
 
-  private var receiveTimeoutData: (Duration, Cancellable) = emptyReceiveTimeoutData
+  private var _receiveTimeout: ReceiveTimeoutValue = ReceiveTimeoutValue()
 
-  final def receiveTimeout: Duration = receiveTimeoutData._1
+  final def receiveTimeout: Duration = _receiveTimeout.current
 
-  final def setReceiveTimeout(timeout: Duration): Unit = receiveTimeoutData = receiveTimeoutData.copy(_1 = timeout)
+  final def setReceiveTimeout(timeout: Duration): Unit = _receiveTimeout :+= timeout
 
-  protected def checkReceiveTimeoutIfNeeded(message: Any): Unit =
-    if (hasTimeoutData)
-      checkReceiveTimeout(!message.isInstanceOf[NotInfluenceReceiveTimeout])
+  protected def rescheduleOrCancelReceiveTimeoutIfNeeded(message: Any): Unit =
+    if (_receiveTimeout.nonEmpty)
+      rescheduleOrCancelReceiveTimeout(shouldInfluenceReceiveTimeout(message))
 
-  final def checkReceiveTimeout(reschedule: Boolean = true): Unit = {
-    val (recvtimeout, task) = receiveTimeoutData
-    recvtimeout match {
+  protected final def rescheduleOrCancelReceiveTimeout(reschedule: Boolean): Unit =
+    _receiveTimeout.current match {
       case f: FiniteDuration =>
         // The fact that timeout is FiniteDuration and task is emptyCancellable
         // means that a user called `context.setReceiveTimeout(...)`
         // while sending the ReceiveTimeout message is not scheduled yet.
         // We have to handle the case and schedule sending the ReceiveTimeout message
         // ignoring the reschedule parameter.
-        if (reschedule || (task eq emptyCancellable))
+        if (reschedule || _receiveTimeout.taskIsEmpty)
           rescheduleReceiveTimeout(f)
 
       case _ => cancelReceiveTimeout()
     }
-  }
 
   private def rescheduleReceiveTimeout(f: FiniteDuration): Unit = {
-    receiveTimeoutData._2.cancel() //Cancel any ongoing future
+    _receiveTimeout.task.cancel() //Cancel any ongoing future
     val task = system.scheduler.scheduleOnce(f, self, akka.actor.ReceiveTimeout)(this.dispatcher)
-    receiveTimeoutData = (f, task)
+    _receiveTimeout = ReceiveTimeoutValue(f, task)
   }
 
-  private def hasTimeoutData: Boolean = receiveTimeoutData ne emptyReceiveTimeoutData
-
   protected def cancelReceiveTimeoutIfNeeded(message: Any): Unit =
-    if (hasTimeoutData && !message.isInstanceOf[NotInfluenceReceiveTimeout])
+    if (_receiveTimeout.nonEmpty && shouldInfluenceReceiveTimeout(message))
       cancelReceiveTimeout()
 
   override final def cancelReceiveTimeout(): Unit =
-    if (receiveTimeoutData._2 ne emptyCancellable) {
-      receiveTimeoutData._2.cancel()
-      receiveTimeoutData = (receiveTimeoutData._1, emptyCancellable)
+    if (_receiveTimeout.taskNonEmpty) {
+      _receiveTimeout.task.cancel()
+      _receiveTimeout = _receiveTimeout.clear()
     }
 
+  /** Returns true if `receiveTimeout` is changed while handling a `NotInfluenceReceiveTimeout`. */
+  protected final def changedDuringNotInfluence(message: Any): Boolean =
+    _receiveTimeout.changed && !shouldInfluenceReceiveTimeout(message)
+
+  /** Returns true if the message is not a `NotInfluenceReceiveTimeout`
+   * and should not reset the receive timeout.
+   */
+  private def shouldInfluenceReceiveTimeout(message: Any): Boolean = {
+    // may shave a few ms off: !message.isInstanceOf[NotInfluenceReceiveTimeout]
+    message match {
+      case _: NotInfluenceReceiveTimeout => false
+      case _                             => true
+    }
+  }
 }


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose
From https://github.com/akka/akka/issues/26880
> If the receive timeout timeout is changed during handling a NotInfluenceReceiveTimeout message, the new timeout is not applied immediately but only after a regular message has been handled. It is certainly an edge case and probably not well-specified (from where should the timeout count if the current message shouldn't reset the timeout?).

This WIP is just an initial look into the `specify and fix it` option.
* This feels over engineered
* And it's incomplete but maybe there's something here we can use

## References
https://github.com/akka/akka/issues/26880

## Background Context
Related to https://github.com/akka/akka/pull/26420