### PR TITLE
New ReceiveTimeout not applied if it was set while handling a  messag…

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ReceiveTimeoutSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ReceiveTimeoutSpec.scala
@@ -198,14 +198,14 @@ class ReceiveTimeoutSpec extends AkkaSpec {
         context.setReceiveTimeout(initialTimeout)
 
         def receive: Receive = {
-          case Identify(_)    => context.setReceiveTimeout(Duration.Undefined)
-          case ReceiveTimeout => timeoutLatch.open
+          case TransparentTick => context.setReceiveTimeout(Duration.Undefined)
+          case ReceiveTimeout  => timeoutLatch.open
         }
       }))
 
-      timeoutActor ! Identify(None)
+      timeoutActor ! TransparentTick
 
-      Await.ready(timeoutLatch, initialTimeout * 2)
+      intercept[TimeoutException] { Await.ready(timeoutLatch, initialTimeout * 2) }
       system.stop(timeoutActor)
     }
 

--- a/akka-actor-tests/src/test/scala/akka/actor/ReceiveTimeoutSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ReceiveTimeoutSpec.scala
@@ -227,11 +227,14 @@ class ReceiveTimeoutSpec extends AkkaSpec {
         }
       }))
 
+      probe.expectNoMessage(initialTimeout / 2)
+
       timeoutActor ! TransparentTick
       timeoutActor ! TransparentTick
 
       // not triggered by initialTimeout because it was changed by the ticks
-      probe.expectNoMessage(initialTimeout) //  the last set value
+      // wait shorter than last set value, but longer than initialTimeout
+      probe.expectNoMessage(initialTimeout / 2 + 50.millis)
       // now should happen
       probe.expectMsgType[ReceiveTimeout]
       system.stop(timeoutActor)

--- a/akka-actor/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.x.backwards.excludes
@@ -21,3 +21,8 @@ ProblemFilters.exclude[MissingClassProblem]("akka.actor.dungeon.UndefinedUidActo
 
 # Protect internals against starvation #23576
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.dispatch.Dispatchers.this")
+
+# New ReceiveTimeout not applied if it was set while handling a `NotInfluenceReceiveTimeout` message #26880
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.dungeon.ReceiveTimeout.akka$actor$dungeon$ReceiveTimeout$$value_=")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.dungeon.ReceiveTimeout.akka$actor$dungeon$ReceiveTimeout$$value")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.dungeon.ReceiveTimeout.emptyReceiveTimeoutData")

--- a/akka-actor/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.x.backwards.excludes
@@ -21,8 +21,3 @@ ProblemFilters.exclude[MissingClassProblem]("akka.actor.dungeon.UndefinedUidActo
 
 # Protect internals against starvation #23576
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.dispatch.Dispatchers.this")
-
-# New ReceiveTimeout not applied if it was set while handling a `NotInfluenceReceiveTimeout` message #26880
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.dungeon.ReceiveTimeout.akka$actor$dungeon$ReceiveTimeout$$value_=")
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.dungeon.ReceiveTimeout.akka$actor$dungeon$ReceiveTimeout$$value")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.dungeon.ReceiveTimeout.emptyReceiveTimeoutData")

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -572,9 +572,9 @@ private[akka] class ActorCell(
   //Memory consistency is handled by the Mailbox (reading mailbox status then processing messages, then writing mailbox status
   final def invoke(messageHandle: Envelope): Unit = {
     val msg = messageHandle.message
+    val timeoutBeforeReceive = cancelReceiveTimeoutIfNeeded(msg)
     try {
       currentMessage = messageHandle
-      cancelReceiveTimeoutIfNeeded(msg)
       msg match {
         case _: AutoReceivedMessage => autoReceiveMessage(messageHandle)
         case msg                    => receiveMessage(msg)
@@ -584,7 +584,7 @@ private[akka] class ActorCell(
       handleInvokeFailure(Nil, e)
     } finally
     // Schedule or reschedule receive timeout
-    checkReceiveTimeoutIfNeeded(msg)
+    checkReceiveTimeoutIfNeeded(msg, timeoutBeforeReceive)
   }
 
   def autoReceiveMessage(msg: Envelope): Unit = {

--- a/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
@@ -4,24 +4,15 @@
 
 package akka.actor.dungeon
 
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
+
 import akka.actor.ActorCell
 import akka.actor.Cancellable
 import akka.actor.NotInfluenceReceiveTimeout
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.FiniteDuration
-
 private[akka] object ReceiveTimeout {
-  import ActorCell._
-
-  private final val empty: ReceiveTimeoutValue =
-    ReceiveTimeoutValue(Duration.Undefined, emptyCancellable, Duration.Undefined)
-
-  final case class ReceiveTimeoutValue(current: Duration, task: Cancellable, previous: Duration)
-
-  object ReceiveTimeoutValue {
-    def apply(): ReceiveTimeoutValue = empty
-  }
+  final val emptyReceiveTimeoutData: (Duration, Cancellable) = (Duration.Undefined, ActorCell.emptyCancellable)
 }
 
 private[akka] trait ReceiveTimeout { this: ActorCell =>
@@ -29,48 +20,52 @@ private[akka] trait ReceiveTimeout { this: ActorCell =>
   import ReceiveTimeout._
   import ActorCell._
 
-  private var value: ReceiveTimeoutValue = ReceiveTimeoutValue()
+  private var receiveTimeoutData: (Duration, Cancellable) = emptyReceiveTimeoutData
 
-  final def receiveTimeout: Duration = value.current
+  final def receiveTimeout: Duration = receiveTimeoutData._1
 
-  final def setReceiveTimeout(timeout: Duration): Unit = {
-    val prev = value.current
-    value = value.copy(current = timeout, previous = prev)
-  }
+  final def setReceiveTimeout(timeout: Duration): Unit = receiveTimeoutData = receiveTimeoutData.copy(_1 = timeout)
 
-  protected def checkReceiveTimeoutIfNeeded(message: Any): Unit =
+  /** Called after `ActorCell.receiveMessage` or `ActorCell.autoReceiveMessage`. */
+  protected def checkReceiveTimeoutIfNeeded(message: Any, beforeReceive: (Duration, Cancellable)): Unit =
     if (hasTimeoutData)
-      checkReceiveTimeout(!message.isInstanceOf[NotInfluenceReceiveTimeout] || (value.current ne value.previous))
+      checkReceiveTimeout(!message.isInstanceOf[NotInfluenceReceiveTimeout] || (receiveTimeoutData ne beforeReceive))
 
-  final def checkReceiveTimeout(reschedule: Boolean = true): Unit =
-    value.current match {
+  final def checkReceiveTimeout(reschedule: Boolean = true): Unit = {
+    val (recvtimeout, task) = receiveTimeoutData
+    recvtimeout match {
       case f: FiniteDuration =>
         // The fact that timeout is FiniteDuration and task is emptyCancellable
         // means that a user called `context.setReceiveTimeout(...)`
         // while sending the ReceiveTimeout message is not scheduled yet.
         // We have to handle the case and schedule sending the ReceiveTimeout message
         // ignoring the reschedule parameter.
-        if (reschedule || (value.task eq emptyCancellable))
+        if (reschedule || (task eq emptyCancellable))
           rescheduleReceiveTimeout(f)
 
       case _ => cancelReceiveTimeout()
     }
-
-  private def rescheduleReceiveTimeout(f: FiniteDuration): Unit = {
-    value.task.cancel() //Cancel any ongoing future
-    val t = system.scheduler.scheduleOnce(f, self, akka.actor.ReceiveTimeout)(this.dispatcher)
-    value = value.copy(current = f, task = t) // keep previous
   }
 
-  private def hasTimeoutData: Boolean = value ne empty
+  private def rescheduleReceiveTimeout(f: FiniteDuration): Unit = {
+    receiveTimeoutData._2.cancel() //Cancel any ongoing future
+    val task = system.scheduler.scheduleOnce(f, self, akka.actor.ReceiveTimeout)(this.dispatcher)
+    receiveTimeoutData = (f, task)
+  }
 
-  protected def cancelReceiveTimeoutIfNeeded(message: Any): Unit =
+  private def hasTimeoutData: Boolean = receiveTimeoutData ne emptyReceiveTimeoutData
+
+  protected def cancelReceiveTimeoutIfNeeded(message: Any): (Duration, Cancellable) = {
     if (hasTimeoutData && !message.isInstanceOf[NotInfluenceReceiveTimeout])
       cancelReceiveTimeout()
 
+    receiveTimeoutData
+  }
+
   override final def cancelReceiveTimeout(): Unit =
-    if (value.task ne emptyCancellable) {
-      value.task.cancel()
-      value = value.copy(task = emptyCancellable)
+    if (receiveTimeoutData._2 ne emptyCancellable) {
+      receiveTimeoutData._2.cancel()
+      receiveTimeoutData = (receiveTimeoutData._1, emptyCancellable)
     }
+
 }

--- a/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
@@ -12,7 +12,16 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 
 private[akka] object ReceiveTimeout {
-  final val emptyReceiveTimeoutData: (Duration, Cancellable) = (Duration.Undefined, ActorCell.emptyCancellable)
+  import ActorCell._
+
+  private final val empty: ReceiveTimeoutValue =
+    ReceiveTimeoutValue(Duration.Undefined, emptyCancellable, Duration.Undefined)
+
+  final case class ReceiveTimeoutValue(current: Duration, task: Cancellable, previous: Duration)
+
+  object ReceiveTimeoutValue {
+    def apply(): ReceiveTimeoutValue = empty
+  }
 }
 
 private[akka] trait ReceiveTimeout { this: ActorCell =>
@@ -20,48 +29,48 @@ private[akka] trait ReceiveTimeout { this: ActorCell =>
   import ReceiveTimeout._
   import ActorCell._
 
-  private var receiveTimeoutData: (Duration, Cancellable) = emptyReceiveTimeoutData
+  private var value: ReceiveTimeoutValue = ReceiveTimeoutValue()
 
-  final def receiveTimeout: Duration = receiveTimeoutData._1
+  final def receiveTimeout: Duration = value.current
 
-  final def setReceiveTimeout(timeout: Duration): Unit = receiveTimeoutData = receiveTimeoutData.copy(_1 = timeout)
+  final def setReceiveTimeout(timeout: Duration): Unit = {
+    val prev = value.current
+    value = value.copy(current = timeout, previous = prev)
+  }
 
   protected def checkReceiveTimeoutIfNeeded(message: Any): Unit =
     if (hasTimeoutData)
-      checkReceiveTimeout(!message.isInstanceOf[NotInfluenceReceiveTimeout])
+      checkReceiveTimeout(!message.isInstanceOf[NotInfluenceReceiveTimeout] || (value.current ne value.previous))
 
-  final def checkReceiveTimeout(reschedule: Boolean = true): Unit = {
-    val (recvtimeout, task) = receiveTimeoutData
-    recvtimeout match {
+  final def checkReceiveTimeout(reschedule: Boolean = true): Unit =
+    value.current match {
       case f: FiniteDuration =>
         // The fact that timeout is FiniteDuration and task is emptyCancellable
         // means that a user called `context.setReceiveTimeout(...)`
         // while sending the ReceiveTimeout message is not scheduled yet.
         // We have to handle the case and schedule sending the ReceiveTimeout message
         // ignoring the reschedule parameter.
-        if (reschedule || (task eq emptyCancellable))
+        if (reschedule || (value.task eq emptyCancellable))
           rescheduleReceiveTimeout(f)
 
       case _ => cancelReceiveTimeout()
     }
-  }
 
   private def rescheduleReceiveTimeout(f: FiniteDuration): Unit = {
-    receiveTimeoutData._2.cancel() //Cancel any ongoing future
-    val task = system.scheduler.scheduleOnce(f, self, akka.actor.ReceiveTimeout)(this.dispatcher)
-    receiveTimeoutData = (f, task)
+    value.task.cancel() //Cancel any ongoing future
+    val t = system.scheduler.scheduleOnce(f, self, akka.actor.ReceiveTimeout)(this.dispatcher)
+    value = value.copy(current = f, task = t) // keep previous
   }
 
-  private def hasTimeoutData: Boolean = receiveTimeoutData ne emptyReceiveTimeoutData
+  private def hasTimeoutData: Boolean = value ne empty
 
   protected def cancelReceiveTimeoutIfNeeded(message: Any): Unit =
     if (hasTimeoutData && !message.isInstanceOf[NotInfluenceReceiveTimeout])
       cancelReceiveTimeout()
 
   override final def cancelReceiveTimeout(): Unit =
-    if (receiveTimeoutData._2 ne emptyCancellable) {
-      receiveTimeoutData._2.cancel()
-      receiveTimeoutData = (receiveTimeoutData._1, emptyCancellable)
+    if (value.task ne emptyCancellable) {
+      value.task.cancel()
+      value = value.copy(task = emptyCancellable)
     }
-
 }

--- a/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
@@ -28,8 +28,8 @@ private[akka] trait ReceiveTimeout { this: ActorCell =>
 
   /** Called after `ActorCell.receiveMessage` or `ActorCell.autoReceiveMessage`. */
   protected def checkReceiveTimeoutIfNeeded(message: Any, beforeReceive: (Duration, Cancellable)): Unit =
-    if (hasTimeoutData)
-      checkReceiveTimeout(!message.isInstanceOf[NotInfluenceReceiveTimeout] || (receiveTimeoutData ne beforeReceive))
+    if (hasTimeoutData || receiveTimeoutChanged(beforeReceive))
+      checkReceiveTimeout(!message.isInstanceOf[NotInfluenceReceiveTimeout] || receiveTimeoutChanged(beforeReceive))
 
   final def checkReceiveTimeout(reschedule: Boolean = true): Unit = {
     val (recvtimeout, task) = receiveTimeoutData
@@ -54,6 +54,9 @@ private[akka] trait ReceiveTimeout { this: ActorCell =>
   }
 
   private def hasTimeoutData: Boolean = receiveTimeoutData ne emptyReceiveTimeoutData
+
+  private def receiveTimeoutChanged(beforeReceive: (Duration, Cancellable)): Boolean =
+    receiveTimeoutData ne beforeReceive
 
   protected def cancelReceiveTimeoutIfNeeded(message: Any): (Duration, Cancellable) = {
     if (hasTimeoutData && !message.isInstanceOf[NotInfluenceReceiveTimeout])


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->
Adds a notion of `beforeReceive` and captures receive timeout duration and task, updated on each `ReceiveTimeout.setReceiveTimeout` so that on evaluation of `ReceiveTimeout.checkReceiveTimeoutIfNeeded` can be checked for changes if modified while handling `NotInfluenceReceiveTimeout`.
 
## References
https://github.com/akka/akka/issues/26880
 
## Changes
* ReceiveTimeout handling if it was set while handling a `NotInfluenceReceiveTimeout` message
* Tests related to change - more exact on expectation of timeout on change 