### PR TITLE
Hostname verification should be done by the client only

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/SSLEngineProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/SSLEngineProvider.scala
@@ -164,7 +164,7 @@ class ConfigSSLEngineProvider(protected val config: Config, protected val log: M
 
     val engine = sslContext.createSSLEngine(hostname, port)
 
-    if (HostnameVerification) {
+    if (HostnameVerification && role == akka.stream.Client) {
       val sslParams = sslContext.getDefaultSSLParameters
       sslParams.setEndpointIdentificationAlgorithm("HTTPS")
       engine.setSSLParameters(sslParams)


### PR DESCRIPTION
Issue: #26905 

Setting the endpoint identification algorithm to HTTPS on the server engine
forces the client to present a certificate that contains the server name. This
is rather unlikely and it fails TLS handshake today.

This change will allow hostname verification to be done by the client only
