### PR TITLE
Some more internal-dispatcher usages, #26915

### DIFF
--- a/akka-actor/src/main/scala/akka/event/EventStreamUnsubscriber.scala
+++ b/akka-actor/src/main/scala/akka/event/EventStreamUnsubscriber.scala
@@ -8,6 +8,8 @@ import akka.actor._
 import akka.event.Logging.simpleName
 import java.util.concurrent.atomic.AtomicInteger
 
+import akka.dispatch.Dispatchers
+
 /**
  * INTERNAL API
  *
@@ -75,7 +77,7 @@ private[akka] object EventStreamUnsubscriber {
   final case class UnregisterIfNoMoreSubscribedChannels(actor: ActorRef)
 
   private def props(eventStream: EventStream, debug: Boolean) =
-    Props(classOf[EventStreamUnsubscriber], eventStream, debug)
+    Props(classOf[EventStreamUnsubscriber], eventStream, debug).withDispatcher(Dispatchers.InternalDispatcherId)
 
   def start(system: ActorSystem, stream: EventStream) = {
     val debug = system.settings.config.getBoolean("akka.actor.debug.event-stream")

--- a/akka-actor/src/main/scala/akka/io/SelectionHandler.scala
+++ b/akka-actor/src/main/scala/akka/io/SelectionHandler.scala
@@ -103,13 +103,16 @@ private[io] object SelectionHandler {
 
     override def supervisorStrategy = connectionSupervisorStrategy
 
-    val selectorPool = context.actorOf(
-      props = RandomPool(nrOfSelectors)
+    val selectorPool: ActorRef = {
+      val routeeProps = Props(classOf[SelectionHandler], selectorSettings)
         .withDispatcher(context.props.dispatcher)
-        .props(Props(classOf[SelectionHandler], selectorSettings))
         .withDeploy(Deploy.local)
-        .withDispatcher(context.props.dispatcher),
-      name = "selectors")
+      context.actorOf(
+        props = RandomPool(nrOfSelectors, routerDispatcher = context.props.dispatcher)
+          .props(routeeProps)
+          .withDeploy(Deploy.local),
+        name = "selectors")
+    }
 
     final def workerForCommandHandler(pf: PartialFunction[HasFailureMessage, ChannelRegistry => Props]): Receive = {
       case cmd: HasFailureMessage if pf.isDefinedAt(cmd) => selectorPool ! WorkerForCommand(cmd, sender(), pf(cmd))

--- a/akka-actor/src/main/scala/akka/io/SelectionHandler.scala
+++ b/akka-actor/src/main/scala/akka/io/SelectionHandler.scala
@@ -104,8 +104,11 @@ private[io] object SelectionHandler {
     override def supervisorStrategy = connectionSupervisorStrategy
 
     val selectorPool = context.actorOf(
-      props =
-        RandomPool(nrOfSelectors).props(Props(classOf[SelectionHandler], selectorSettings)).withDeploy(Deploy.local),
+      props = RandomPool(nrOfSelectors)
+        .withDispatcher(context.props.dispatcher)
+        .props(Props(classOf[SelectionHandler], selectorSettings))
+        .withDeploy(Deploy.local)
+        .withDispatcher(context.props.dispatcher),
       name = "selectors")
 
     final def workerForCommandHandler(pf: PartialFunction[HasFailureMessage, ChannelRegistry => Props]): Receive = {

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -222,7 +222,9 @@ class UdpExt(system: ExtendedActorSystem) extends IO.Extension {
   val settings: UdpSettings = new UdpSettings(system.settings.config.getConfig("akka.io.udp"))
 
   val manager: ActorRef = {
-    system.systemActorOf(props = Props(classOf[UdpManager], this).withDeploy(Deploy.local), name = "IO-UDP-FF")
+    system.systemActorOf(
+      props = Props(classOf[UdpManager], this).withDispatcher(settings.ManagementDispatcher).withDeploy(Deploy.local),
+      name = "IO-UDP-FF")
   }
 
   /**

--- a/akka-actor/src/main/scala/akka/io/UdpConnected.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnected.scala
@@ -160,7 +160,9 @@ class UdpConnectedExt(system: ExtendedActorSystem) extends IO.Extension {
 
   val manager: ActorRef = {
     system.systemActorOf(
-      props = Props(classOf[UdpConnectedManager], this).withDeploy(Deploy.local),
+      props = Props(classOf[UdpConnectedManager], this)
+        .withDispatcher(settings.ManagementDispatcher)
+        .withDeploy(Deploy.local),
       name = "IO-UDP-CONN")
   }
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
@@ -13,6 +13,7 @@ import akka.cluster.ClusterEvent.MemberJoined
 import akka.cluster.ClusterEvent.MemberUp
 import akka.cluster.ClusterEvent.MemberRemoved
 import akka.cluster.ClusterEvent.MemberWeaklyUp
+import akka.dispatch.Dispatchers
 import akka.remote.FailureDetectorRegistry
 import akka.remote.RemoteWatcher
 import akka.remote.RARP
@@ -35,7 +36,7 @@ private[cluster] object ClusterRemoteWatcher {
       failureDetector,
       heartbeatInterval,
       unreachableReaperInterval,
-      heartbeatExpectedResponseAfter).withDeploy(Deploy.local)
+      heartbeatExpectedResponseAfter).withDispatcher(Dispatchers.InternalDispatcherId).withDeploy(Deploy.local)
 
   private final case class DelayedQuarantine(m: Member, previousStatus: MemberStatus)
       extends NoSerializationVerificationNeeded

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/LatencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/LatencySpec.scala
@@ -9,7 +9,9 @@ import java.util.concurrent.atomic.AtomicLongArray
 import java.util.concurrent.locks.LockSupport
 
 import scala.concurrent.duration._
+
 import akka.actor._
+import akka.dispatch.Dispatchers
 import akka.remote.RemotingMultiNodeSpec
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
@@ -66,7 +68,7 @@ object LatencySpec extends MultiNodeConfig {
   final case object Reset
 
   def echoProps(): Props =
-    Props(new Echo)
+    Props(new Echo).withDispatcher(Dispatchers.InternalDispatcherId)
 
   class Echo extends Actor {
     // FIXME to avoid using new RemoteActorRef each time
@@ -91,6 +93,7 @@ object LatencySpec extends MultiNodeConfig {
       plotsRef: ActorRef,
       BenchmarkFileReporter: BenchmarkFileReporter): Props =
     Props(new Receiver(reporter, settings, totalMessages, sendTimes, histogram, plotsRef, BenchmarkFileReporter))
+      .withDispatcher(Dispatchers.InternalDispatcherId)
 
   class Receiver(
       reporter: RateReporter,

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -862,16 +862,15 @@ akka {
         # Settings for the materializer that is used for the remote streams.
         materializer = ${akka.stream.materializer}
 
-        # If set to a nonempty string artery will use the given dispatcher for
-        # the ordinary and large message streams, otherwise the default dispatcher is used.
+        # Remoting will use the given dispatcher for the ordinary and large message
+        # streams.
         use-dispatcher = "akka.remote.default-remote-dispatcher"
 
-        # If set to a nonempty string remoting will use the given dispatcher for
-        # the control stream, otherwise the default dispatcher is used.
+        # Remoting will use the given dispatcher for the control stream.
         # It can be good to not use the same dispatcher for the control stream as
         # the dispatcher for the ordinary message stream so that heartbeat messages
         # are not disturbed.
-        use-control-stream-dispatcher = ""
+        use-control-stream-dispatcher = "akka.actor.internal-dispatcher"
 
 
         # Total number of inbound lanes, shared among all inbound associations. A value

--- a/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
@@ -9,9 +9,10 @@ import akka.dispatch.sysmsg.{ DeathWatchNotification, Watch }
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.event.AddressTerminatedTopic
 import akka.remote.artery.ArteryMessage
-
 import scala.collection.mutable
 import scala.concurrent.duration._
+
+import akka.dispatch.Dispatchers
 import akka.remote.artery.ArteryTransport
 import com.github.ghik.silencer.silent
 
@@ -33,7 +34,7 @@ private[akka] object RemoteWatcher {
       failureDetector,
       heartbeatInterval,
       unreachableReaperInterval,
-      heartbeatExpectedResponseAfter).withDeploy(Deploy.local)
+      heartbeatExpectedResponseAfter).withDispatcher(Dispatchers.InternalDispatcherId).withDeploy(Deploy.local)
 
   final case class WatchRemote(watchee: InternalActorRef, watcher: InternalActorRef)
   final case class UnwatchRemote(watchee: InternalActorRef, watcher: InternalActorRef)

--- a/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
@@ -95,16 +95,10 @@ private[akka] final class ArterySettings private (config: Config) {
     val TestMode: Boolean = getBoolean("test-mode")
     val Dispatcher: String = getString("use-dispatcher")
     val ControlStreamDispatcher: String = getString("use-control-stream-dispatcher")
-    val MaterializerSettings: ActorMaterializerSettings = {
-      val settings = ActorMaterializerSettings(config.getConfig("materializer"))
-      if (Dispatcher.isEmpty) settings
-      else settings.withDispatcher(Dispatcher)
-    }
-    val ControlStreamMaterializerSettings: ActorMaterializerSettings = {
-      val settings = ActorMaterializerSettings(config.getConfig("materializer"))
-      if (ControlStreamDispatcher.isEmpty) settings
-      else settings.withDispatcher(ControlStreamDispatcher)
-    }
+    val MaterializerSettings: ActorMaterializerSettings =
+      ActorMaterializerSettings(config.getConfig("materializer")).withDispatcher(Dispatcher)
+    val ControlStreamMaterializerSettings: ActorMaterializerSettings =
+      ActorMaterializerSettings(config.getConfig("materializer")).withDispatcher(ControlStreamDispatcher)
 
     val OutboundLanes: Int = getInt("outbound-lanes").requiring(n => n > 0, "outbound-lanes must be greater than zero")
     val InboundLanes: Int = getInt("inbound-lanes").requiring(n => n > 0, "inbound-lanes must be greater than zero")


### PR DESCRIPTION
* tried to investigate the (small) increase in LatencySpec that occured
  when the internal-dispatcher was introduced
* couldn't see significant difference when running locally
* found a few more places where the internal-dispatcher should be used
* my thinking is that the additional latency could have been caused by
  hopping between dispatchers, but I'm not sure if any of these
  changes will have an effect (we'll see in Jenkins job)

Refs #26915
