### PR TITLE
Test for WatchWith had a race 

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
@@ -290,6 +290,7 @@ class WatchSpec extends ScalaTestWithActorTestKit(WatchSpec.config) with WordSpe
       watcher ! StartWatchingWith(terminator, CustomTerminationMessage)
       watcher ! StartWatchingWith(terminator, CustomTerminationMessage2)
       watchProbe.expectMessage(Done)
+      watchProbe.expectMessage(Done)
       terminator ! Stop
 
       receivedTerminationSignal.future.futureValue shouldEqual CustomTerminationMessage2


### PR DESCRIPTION
Fixes #25955

The test only waited for the first `Done` so there was a race in whether it had seen the second `StartWatchingWith` before the watchee was stopped or not.