### PR TITLE
more classic remoting leftovers

### DIFF
--- a/akka-actor-tests/src/test/java/akka/actor/JavaAPI.java
+++ b/akka-actor-tests/src/test/java/akka/actor/JavaAPI.java
@@ -51,7 +51,7 @@ public class JavaAPI extends JUnitSuite {
     final NoRouter nr = NoRouter.getInstance();
     final FromConfig fc = FromConfig.getInstance();
 
-    final ActorPath p = ActorPaths.fromString("akka.tcp://Sys@localhost:1234/user/abc");
+    final ActorPath p = ActorPaths.fromString("akka://Sys@localhost:1234/user/abc");
   }
 
   @Test

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorPathSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorPathSpec.scala
@@ -13,7 +13,7 @@ class ActorPathSpec extends WordSpec with Matchers {
   "An ActorPath" must {
 
     "support parsing its String rep" in {
-      val path = RootActorPath(Address("akka.tcp", "mysys")) / "user"
+      val path = RootActorPath(Address("akka", "mysys")) / "user"
       ActorPath.fromString(path.toString) should ===(path)
     }
 
@@ -31,20 +31,20 @@ class ActorPathSpec extends WordSpec with Matchers {
     }
 
     "create correct toString" in {
-      val a = Address("akka.tcp", "mysys")
-      RootActorPath(a).toString should ===("akka.tcp://mysys/")
-      (RootActorPath(a) / "user").toString should ===("akka.tcp://mysys/user")
-      (RootActorPath(a) / "user" / "foo").toString should ===("akka.tcp://mysys/user/foo")
-      (RootActorPath(a) / "user" / "foo" / "bar").toString should ===("akka.tcp://mysys/user/foo/bar")
+      val a = Address("akka", "mysys")
+      RootActorPath(a).toString should ===("akka://mysys/")
+      (RootActorPath(a) / "user").toString should ===("akka://mysys/user")
+      (RootActorPath(a) / "user" / "foo").toString should ===("akka://mysys/user/foo")
+      (RootActorPath(a) / "user" / "foo" / "bar").toString should ===("akka://mysys/user/foo/bar")
     }
 
     "have correct path elements" in {
-      (RootActorPath(Address("akka.tcp", "mysys")) / "user" / "foo" / "bar").elements.toSeq should ===(
+      (RootActorPath(Address("akka", "mysys")) / "user" / "foo" / "bar").elements.toSeq should ===(
         Seq("user", "foo", "bar"))
     }
 
     "create correct toStringWithoutAddress" in {
-      val a = Address("akka.tcp", "mysys")
+      val a = Address("akka", "mysys")
       RootActorPath(a).toStringWithoutAddress should ===("/")
       (RootActorPath(a) / "user").toStringWithoutAddress should ===("/user")
       (RootActorPath(a) / "user" / "foo").toStringWithoutAddress should ===("/user/foo")
@@ -57,32 +57,32 @@ class ActorPathSpec extends WordSpec with Matchers {
     }
 
     "create correct toStringWithAddress" in {
-      val local = Address("akka.tcp", "mysys")
+      val local = Address("akka", "mysys")
       val a = local.copy(host = Some("aaa"), port = Some(2552))
       val b = a.copy(host = Some("bb"))
       val c = a.copy(host = Some("cccc"))
       val root = RootActorPath(local)
-      root.toStringWithAddress(a) should ===("akka.tcp://mysys@aaa:2552/")
-      (root / "user").toStringWithAddress(a) should ===("akka.tcp://mysys@aaa:2552/user")
-      (root / "user" / "foo").toStringWithAddress(a) should ===("akka.tcp://mysys@aaa:2552/user/foo")
+      root.toStringWithAddress(a) should ===("akka://mysys@aaa:2552/")
+      (root / "user").toStringWithAddress(a) should ===("akka://mysys@aaa:2552/user")
+      (root / "user" / "foo").toStringWithAddress(a) should ===("akka://mysys@aaa:2552/user/foo")
 
-      //      root.toStringWithAddress(b) should ===("akka.tcp://mysys@bb:2552/")
-      (root / "user").toStringWithAddress(b) should ===("akka.tcp://mysys@bb:2552/user")
-      (root / "user" / "foo").toStringWithAddress(b) should ===("akka.tcp://mysys@bb:2552/user/foo")
+      //      root.toStringWithAddress(b) should ===("akka://mysys@bb:2552/")
+      (root / "user").toStringWithAddress(b) should ===("akka://mysys@bb:2552/user")
+      (root / "user" / "foo").toStringWithAddress(b) should ===("akka://mysys@bb:2552/user/foo")
 
-      root.toStringWithAddress(c) should ===("akka.tcp://mysys@cccc:2552/")
-      (root / "user").toStringWithAddress(c) should ===("akka.tcp://mysys@cccc:2552/user")
-      (root / "user" / "foo").toStringWithAddress(c) should ===("akka.tcp://mysys@cccc:2552/user/foo")
+      root.toStringWithAddress(c) should ===("akka://mysys@cccc:2552/")
+      (root / "user").toStringWithAddress(c) should ===("akka://mysys@cccc:2552/user")
+      (root / "user" / "foo").toStringWithAddress(c) should ===("akka://mysys@cccc:2552/user/foo")
 
       val rootA = RootActorPath(a)
-      rootA.toStringWithAddress(b) should ===("akka.tcp://mysys@aaa:2552/")
-      (rootA / "user").toStringWithAddress(b) should ===("akka.tcp://mysys@aaa:2552/user")
-      (rootA / "user" / "foo").toStringWithAddress(b) should ===("akka.tcp://mysys@aaa:2552/user/foo")
+      rootA.toStringWithAddress(b) should ===("akka://mysys@aaa:2552/")
+      (rootA / "user").toStringWithAddress(b) should ===("akka://mysys@aaa:2552/user")
+      (rootA / "user" / "foo").toStringWithAddress(b) should ===("akka://mysys@aaa:2552/user/foo")
     }
 
     "not allow path separators in RootActorPath's name" in {
       intercept[IllegalArgumentException] {
-        RootActorPath(Address("akka.tcp", "mysys"), "/user/boom/*") // illegally pass in a path where name is expected
+        RootActorPath(Address("akka", "mysys"), "/user/boom/*") // illegally pass in a path where name is expected
       }.getMessage should include("is a path separator")
 
       // sanity check that creating such path still works

--- a/akka-bench-jmh/src/main/scala/akka/cluster/ddata/ORSetMergeBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/cluster/ddata/ORSetMergeBenchmark.scala
@@ -31,11 +31,11 @@ class ORSetMergeBenchmark {
   @Param(Array("1", "10", "20", "100"))
   var set1Size = 0
 
-  val nodeA = UniqueAddress(Address("akka.tcp", "Sys", "aaaa", 2552), 1)
-  val nodeB = UniqueAddress(nodeA.address.copy(host = Some("bbbb")), 2)
-  val nodeC = UniqueAddress(nodeA.address.copy(host = Some("cccc")), 3)
-  val nodeD = UniqueAddress(nodeA.address.copy(host = Some("dddd")), 4)
-  val nodeE = UniqueAddress(nodeA.address.copy(host = Some("eeee")), 5)
+  val nodeA = UniqueAddress(Address("akka", "Sys", "aaaa", 2552), 1L)
+  val nodeB = UniqueAddress(nodeA.address.copy(host = Some("bbbb")), 2L)
+  val nodeC = UniqueAddress(nodeA.address.copy(host = Some("cccc")), 3L)
+  val nodeD = UniqueAddress(nodeA.address.copy(host = Some("dddd")), 4L)
+  val nodeE = UniqueAddress(nodeA.address.copy(host = Some("eeee")), 5L)
   val nodes = Vector(nodeA, nodeB, nodeC, nodeD, nodeE)
   val nodesIndex = Iterator.from(0)
   def nextNode(): UniqueAddress = nodes(nodesIndex.next() % nodes.size)

--- a/akka-bench-jmh/src/main/scala/akka/cluster/ddata/ORSetSerializationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/cluster/ddata/ORSetSerializationBenchmark.scala
@@ -37,7 +37,7 @@ class ORSetSerializationBenchmark {
 
   private val config = ConfigFactory.parseString("""
     akka.actor.provider=cluster
-    akka.remote.netty.tcp.port=0
+    akka.remote.classic.netty.tcp.port=0
     akka.remote.artery.canonical.port = 0
     akka.actor {
       serialize-messages = off

--- a/akka-bench-jmh/src/main/scala/akka/cluster/ddata/VersionVectorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/cluster/ddata/VersionVectorBenchmark.scala
@@ -31,11 +31,11 @@ class VersionVectorBenchmark {
   @Param(Array("1", "2", "5"))
   var size = 0
 
-  val nodeA = UniqueAddress(Address("akka.tcp", "Sys", "aaaa", 2552), 1)
-  val nodeB = UniqueAddress(nodeA.address.copy(host = Some("bbbb")), 2)
-  val nodeC = UniqueAddress(nodeA.address.copy(host = Some("cccc")), 3)
-  val nodeD = UniqueAddress(nodeA.address.copy(host = Some("dddd")), 4)
-  val nodeE = UniqueAddress(nodeA.address.copy(host = Some("eeee")), 5)
+  val nodeA = UniqueAddress(Address("akka", "Sys", "aaaa", 2552), 1L)
+  val nodeB = UniqueAddress(nodeA.address.copy(host = Some("bbbb")), 2L)
+  val nodeC = UniqueAddress(nodeA.address.copy(host = Some("cccc")), 3L)
+  val nodeD = UniqueAddress(nodeA.address.copy(host = Some("dddd")), 4L)
+  val nodeE = UniqueAddress(nodeA.address.copy(host = Some("eeee")), 5L)
   val nodes = Vector(nodeA, nodeB, nodeC, nodeD, nodeE)
   val nodesIndex = Iterator.from(0)
   def nextNode(): UniqueAddress = nodes(nodesIndex.next() % nodes.size)

--- a/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/ClusterMetricsRoutingSpec.scala
+++ b/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/ClusterMetricsRoutingSpec.scala
@@ -18,10 +18,10 @@ class MetricsSelectorSpec extends WordSpec with Matchers {
     override def capacity(nodeMetrics: Set[NodeMetrics]): Map[Address, Double] = Map.empty
   }
 
-  val a1 = Address("akka.tcp", "sys", "a1", 2551)
-  val b1 = Address("akka.tcp", "sys", "b1", 2551)
-  val c1 = Address("akka.tcp", "sys", "c1", 2551)
-  val d1 = Address("akka.tcp", "sys", "d1", 2551)
+  val a1 = Address("akka", "sys", "a1", 2551)
+  val b1 = Address("akka", "sys", "b1", 2551)
+  val c1 = Address("akka", "sys", "c1", 2551)
+  val d1 = Address("akka", "sys", "d1", 2551)
 
   val decayFactor = Some(0.18)
 

--- a/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/MetricSpec.scala
+++ b/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/MetricSpec.scala
@@ -58,8 +58,8 @@ class MetricNumericConverterSpec extends WordSpec with Matchers with MetricNumer
 @silent
 class NodeMetricsSpec extends WordSpec with Matchers {
 
-  val node1 = Address("akka.tcp", "sys", "a", 2554)
-  val node2 = Address("akka.tcp", "sys", "a", 2555)
+  val node1 = Address("akka", "sys", "a", 2554)
+  val node2 = Address("akka", "sys", "a", 2555)
 
   "NodeMetrics must" must {
 
@@ -151,8 +151,8 @@ class MetricsGossipSpec
 
   "A MetricsGossip" must {
     "add new NodeMetrics" in {
-      val m1 = NodeMetrics(Address("akka.tcp", "sys", "a", 2554), newTimestamp, collector.sample.metrics)
-      val m2 = NodeMetrics(Address("akka.tcp", "sys", "a", 2555), newTimestamp, collector.sample.metrics)
+      val m1 = NodeMetrics(Address("akka", "sys", "a", 2554), newTimestamp, collector.sample.metrics)
+      val m2 = NodeMetrics(Address("akka", "sys", "a", 2555), newTimestamp, collector.sample.metrics)
 
       m1.metrics.size should be > 3
       m2.metrics.size should be > 3
@@ -168,8 +168,8 @@ class MetricsGossipSpec
     }
 
     "merge peer metrics" in {
-      val m1 = NodeMetrics(Address("akka.tcp", "sys", "a", 2554), newTimestamp, collector.sample.metrics)
-      val m2 = NodeMetrics(Address("akka.tcp", "sys", "a", 2555), newTimestamp, collector.sample.metrics)
+      val m1 = NodeMetrics(Address("akka", "sys", "a", 2554), newTimestamp, collector.sample.metrics)
+      val m2 = NodeMetrics(Address("akka", "sys", "a", 2555), newTimestamp, collector.sample.metrics)
 
       val g1 = MetricsGossip.empty :+ m1 :+ m2
       g1.nodes.size should ===(2)
@@ -183,9 +183,9 @@ class MetricsGossipSpec
     }
 
     "merge an existing metric set for a node and update node ring" in {
-      val m1 = NodeMetrics(Address("akka.tcp", "sys", "a", 2554), newTimestamp, collector.sample.metrics)
-      val m2 = NodeMetrics(Address("akka.tcp", "sys", "a", 2555), newTimestamp, collector.sample.metrics)
-      val m3 = NodeMetrics(Address("akka.tcp", "sys", "a", 2556), newTimestamp, collector.sample.metrics)
+      val m1 = NodeMetrics(Address("akka", "sys", "a", 2554), newTimestamp, collector.sample.metrics)
+      val m2 = NodeMetrics(Address("akka", "sys", "a", 2555), newTimestamp, collector.sample.metrics)
+      val m3 = NodeMetrics(Address("akka", "sys", "a", 2556), newTimestamp, collector.sample.metrics)
       val m2Updated = m2.copy(metrics = newSample(m2.metrics), timestamp = m2.timestamp + 1000)
 
       val g1 = MetricsGossip.empty :+ m1 :+ m2
@@ -204,14 +204,14 @@ class MetricsGossipSpec
     }
 
     "get the current NodeMetrics if it exists in the local nodes" in {
-      val m1 = NodeMetrics(Address("akka.tcp", "sys", "a", 2554), newTimestamp, collector.sample.metrics)
+      val m1 = NodeMetrics(Address("akka", "sys", "a", 2554), newTimestamp, collector.sample.metrics)
       val g1 = MetricsGossip.empty :+ m1
       g1.nodeMetricsFor(m1.address).map(_.metrics) should ===(Some(m1.metrics))
     }
 
     "remove a node if it is no longer Up" in {
-      val m1 = NodeMetrics(Address("akka.tcp", "sys", "a", 2554), newTimestamp, collector.sample.metrics)
-      val m2 = NodeMetrics(Address("akka.tcp", "sys", "a", 2555), newTimestamp, collector.sample.metrics)
+      val m1 = NodeMetrics(Address("akka", "sys", "a", 2554), newTimestamp, collector.sample.metrics)
+      val m2 = NodeMetrics(Address("akka", "sys", "a", 2555), newTimestamp, collector.sample.metrics)
 
       val g1 = MetricsGossip.empty :+ m1 :+ m2
       g1.nodes.size should ===(2)
@@ -223,8 +223,8 @@ class MetricsGossipSpec
     }
 
     "filter nodes" in {
-      val m1 = NodeMetrics(Address("akka.tcp", "sys", "a", 2554), newTimestamp, collector.sample.metrics)
-      val m2 = NodeMetrics(Address("akka.tcp", "sys", "a", 2555), newTimestamp, collector.sample.metrics)
+      val m1 = NodeMetrics(Address("akka", "sys", "a", 2554), newTimestamp, collector.sample.metrics)
+      val m2 = NodeMetrics(Address("akka", "sys", "a", 2555), newTimestamp, collector.sample.metrics)
 
       val g1 = MetricsGossip.empty :+ m1 :+ m2
       g1.nodes.size should ===(2)
@@ -243,8 +243,8 @@ class MetricValuesSpec extends AkkaSpec(MetricsConfig.defaultEnabled) with Metri
 
   val collector = createMetricsCollector
 
-  val node1 = NodeMetrics(Address("akka.tcp", "sys", "a", 2554), 1, collector.sample.metrics)
-  val node2 = NodeMetrics(Address("akka.tcp", "sys", "a", 2555), 1, collector.sample.metrics)
+  val node1 = NodeMetrics(Address("akka", "sys", "a", 2554), 1, collector.sample.metrics)
+  val node2 = NodeMetrics(Address("akka", "sys", "a", 2555), 1, collector.sample.metrics)
 
   val nodes: Seq[NodeMetrics] = {
     (1 to 100).foldLeft(List(node1, node2)) { (nodes, _) =>

--- a/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/protobuf/MessageSerializerSpec.scala
+++ b/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/protobuf/MessageSerializerSpec.scala
@@ -31,12 +31,12 @@ class MessageSerializerSpec extends AkkaSpec("""
 
   import MemberStatus._
 
-  val a1 = TestMember(Address("akka.tcp", "sys", "a", 2552), Joining, Set.empty)
-  val b1 = TestMember(Address("akka.tcp", "sys", "b", 2552), Up, Set("r1"))
-  val c1 = TestMember(Address("akka.tcp", "sys", "c", 2552), Leaving, Set("r2"))
-  val d1 = TestMember(Address("akka.tcp", "sys", "d", 2552), Exiting, Set("r1", "r2"))
-  val e1 = TestMember(Address("akka.tcp", "sys", "e", 2552), Down, Set("r3"))
-  val f1 = TestMember(Address("akka.tcp", "sys", "f", 2552), Removed, Set("r2", "r3"))
+  val a1 = TestMember(Address("akka", "sys", "a", 2552), Joining, Set.empty)
+  val b1 = TestMember(Address("akka", "sys", "b", 2552), Up, Set("r1"))
+  val c1 = TestMember(Address("akka", "sys", "c", 2552), Leaving, Set("r2"))
+  val d1 = TestMember(Address("akka", "sys", "d", 2552), Exiting, Set("r1", "r2"))
+  val e1 = TestMember(Address("akka", "sys", "e", 2552), Down, Set("r3"))
+  val f1 = TestMember(Address("akka", "sys", "f", 2552), Removed, Set("r2", "r3"))
 
   "ClusterMessages" must {
 

--- a/akka-cluster-tools/src/main/resources/reference.conf
+++ b/akka-cluster-tools/src/main/resources/reference.conf
@@ -101,7 +101,7 @@ akka.cluster.client {
   # that the client will try to contact initially. It is mandatory to specify
   # at least one initial contact. 
   # Comma separated full actor paths defined by a string on the form of
-  # "akka.tcp://system@hostname:port/system/receptionist"
+  # "akka://system@hostname:port/system/receptionist"
   initial-contacts = []
   
   # Interval at which the client retries to establish contact with one of 

--- a/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
@@ -88,7 +88,7 @@ object ClusterClientSettings {
  *   the servers (cluster nodes) that the client will try to contact initially.
  *   It is mandatory to specify at least one initial contact. The path of the
  *   default receptionist is
- *   "akka.tcp://system@hostname:port/system/receptionist"
+ *   "akka://system@hostname:port/system/receptionist"
  * @param establishingGetContactsInterval Interval at which the client retries
  *   to establish contact with one of ClusterReceptionist on the servers (cluster nodes)
  * @param refreshContactsInterval Interval at which the client will ask the

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientSpec.scala
@@ -194,8 +194,8 @@ class ClusterClientSpec extends MultiNodeSpec(ClusterClientSpec) with STMultiNod
   def docOnly = { //not used, only demo
     //#initialContacts
     val initialContacts = Set(
-      ActorPath.fromString("akka.tcp://OtherSys@host1:2552/system/receptionist"),
-      ActorPath.fromString("akka.tcp://OtherSys@host2:2552/system/receptionist"))
+      ActorPath.fromString("akka://OtherSys@host1:2552/system/receptionist"),
+      ActorPath.fromString("akka://OtherSys@host2:2552/system/receptionist"))
     val settings = ClusterClientSettings(system).withInitialContacts(initialContacts)
     //#initialContacts
 

--- a/akka-cluster-tools/src/test/java/akka/cluster/client/ClusterClientTest.java
+++ b/akka-cluster-tools/src/test/java/akka/cluster/client/ClusterClientTest.java
@@ -32,8 +32,8 @@ public class ClusterClientTest extends JUnitSuite {
   Set<ActorPath> initialContacts() {
     return new HashSet<ActorPath>(
         Arrays.asList(
-            ActorPaths.fromString("akka.tcp://OtherSys@host1:2552/system/receptionist"),
-            ActorPaths.fromString("akka.tcp://OtherSys@host2:2552/system/receptionist")));
+            ActorPaths.fromString("akka://OtherSys@host1:2552/system/receptionist"),
+            ActorPaths.fromString("akka://OtherSys@host2:2552/system/receptionist")));
   }
   // #initialContacts
 

--- a/akka-cluster-tools/src/test/scala/akka/cluster/client/protobuf/ClusterClientMessageSerializerSpec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/client/protobuf/ClusterClientMessageSerializerSpec.scala
@@ -22,9 +22,9 @@ class ClusterClientMessageSerializerSpec extends AkkaSpec {
 
     "be serializable" in {
       val contactPoints = Vector(
-        "akka.tcp://system@node-1:2552/system/receptionist",
-        "akka.tcp://system@node-2:2552/system/receptionist",
-        "akka.tcp://system@node-3:2552/system/receptionist")
+        "akka://system@node-1:2552/system/receptionist",
+        "akka://system@node-2:2552/system/receptionist",
+        "akka://system@node-3:2552/system/receptionist")
       checkSerialization(Contacts(contactPoints))
       checkSerialization(GetContacts)
       checkSerialization(Heartbeat)

--- a/akka-cluster-tools/src/test/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializerSpec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/pubsub/protobuf/DistributedPubSubMessageSerializerSpec.scala
@@ -24,9 +24,9 @@ class DistributedPubSubMessageSerializerSpec extends AkkaSpec {
   " DistributedPubSubMessages" must {
 
     "be serializable" in {
-      val address1 = Address("akka.tcp", "system", "some.host.org", 4711)
-      val address2 = Address("akka.tcp", "system", "other.host.org", 4711)
-      val address3 = Address("akka.tcp", "system", "some.host.org", 4712)
+      val address1 = Address("akka", "system", "some.host.org", 4711)
+      val address2 = Address("akka", "system", "other.host.org", 4711)
+      val address3 = Address("akka", "system", "some.host.org", 4712)
       val u1 = system.actorOf(Props.empty, "u1")
       val u2 = system.actorOf(Props.empty, "u2")
       val u3 = system.actorOf(Props.empty, "u3")

--- a/akka-cluster-tools/src/test/scala/akka/cluster/singleton/ClusterSingletonLeavingSpeedSpec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/singleton/ClusterSingletonLeavingSpeedSpec.scala
@@ -52,7 +52,7 @@ class ClusterSingletonLeavingSpeedSpec
   # akka.cluster.gossip-interval = 2s
 
   akka.remote {
-    netty.tcp {
+    classic.netty.tcp {
       hostname = "127.0.0.1"
       port = 0
     }

--- a/akka-cluster-tools/src/test/scala/akka/cluster/singleton/ClusterSingletonProxySpec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/singleton/ClusterSingletonProxySpec.scala
@@ -69,8 +69,8 @@ object ClusterSingletonProxySpec {
       cluster.jmx.enabled = off
       actor.provider = "cluster"
       remote {
-        log-remote-lifecycle-events = off
-        netty.tcp {
+        classic.log-remote-lifecycle-events = off
+        classic.netty.tcp {
           hostname = "127.0.0.1"
           port = 0
         }

--- a/akka-cluster-tools/src/test/scala/akka/cluster/singleton/ClusterSingletonRestart2Spec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/singleton/ClusterSingletonRestart2Spec.scala
@@ -33,7 +33,7 @@ class ClusterSingletonRestart2Spec extends AkkaSpec("""
   akka.cluster.auto-down-unreachable-after = 2s
   akka.cluster.singleton.min-number-of-hand-over-retries = 5
   akka.remote {
-    netty.tcp {
+    classic.netty.tcp {
       hostname = "127.0.0.1"
       port = 0
     }

--- a/akka-cluster-tools/src/test/scala/akka/cluster/singleton/ClusterSingletonRestartSpec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/singleton/ClusterSingletonRestartSpec.scala
@@ -19,7 +19,7 @@ class ClusterSingletonRestartSpec extends AkkaSpec("""
   akka.actor.provider = akka.cluster.ClusterActorRefProvider
   akka.cluster.auto-down-unreachable-after = 2s
   akka.remote {
-    netty.tcp {
+    classic.netty.tcp {
       hostname = "127.0.0.1"
       port = 0
     }

--- a/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/BasicClusterExampleTest.java
+++ b/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/BasicClusterExampleTest.java
@@ -21,8 +21,8 @@ public class BasicClusterExampleTest { // extends JUnitSuite {
       ConfigFactory.parseString(
           "akka { \n"
               + "  actor.provider = cluster \n"
-              + "  remote { \n"
-              + "    netty.tcp { \n"
+              + "  remote.artery { \n"
+              + "    canonical { \n"
               + "      hostname = \"127.0.0.1\" \n"
               + "      port = 2551 \n"
               + "    } \n"

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
@@ -27,8 +27,8 @@ akka {
   actor {
     provider = "cluster"
   }
-  remote {
-    netty.tcp {
+  remote.artery {
+    canonical {
       hostname = "127.0.0.1"
       port = 2551
     }
@@ -36,8 +36,8 @@ akka {
 
   cluster {
     seed-nodes = [
-      "akka.tcp://ClusterSystem@127.0.0.1:2551",
-      "akka.tcp://ClusterSystem@127.0.0.1:2552"]
+      "akka://ClusterSystem@127.0.0.1:2551",
+      "akka://ClusterSystem@127.0.0.1:2552"]
   }
 }
 #config-seeds
@@ -62,7 +62,7 @@ class BasicClusterConfigSpec extends WordSpec with ScalaFutures with Eventually 
       val sys2Port = SocketUtil.temporaryLocalPort()
       def config(port: Int) = ConfigFactory.parseString(s"""
           akka.remote.classic.netty.tcp.port = $port
-          akka.cluster.seed-nodes = [ "akka.tcp://ClusterSystem@127.0.0.1:$sys1Port", "akka.tcp://ClusterSystem@127.0.0.1:$sys2Port" ]
+          akka.cluster.seed-nodes = [ "akka://ClusterSystem@127.0.0.1:$sys1Port", "akka://ClusterSystem@127.0.0.1:$sys2Port" ]
         """)
 
       val system1 = ActorSystem[Nothing](Behaviors.empty, "ClusterSystem", config(sys1Port).withFallback(configSystem1))
@@ -86,8 +86,8 @@ object BasicClusterManualSpec {
 #config
 akka {
   actor.provider = "cluster"
-  remote {
-    netty.tcp {
+  remote.artery {
+    canonical {
       hostname = "127.0.0.1"
       port = 2551
     }

--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -11,7 +11,7 @@ akka {
     # Initial contact points of the cluster.
     # The nodes to join automatically at startup.
     # Comma separated full URIs defined by a string on the form of
-    # "akka.tcp://system@hostname:port"
+    # "akka://system@hostname:port"
     # Leave as empty if the node is supposed to be joined manually.
     seed-nodes = []
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterJmx.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterJmx.scala
@@ -24,13 +24,13 @@ trait ClusterNodeMBean {
 
   /**
    * Comma separated addresses of member nodes, sorted in the cluster ring order.
-   * The address format is `akka.tcp://actor-system-name@hostname:port`
+   * The address format is `akka://actor-system-name@hostname:port`
    */
   def getMembers: String
 
   /**
    * Comma separated addresses of unreachable member nodes.
-   * The address format is `akka.tcp://actor-system-name@hostname:port`
+   * The address format is `akka://actor-system-name@hostname:port`
    */
   def getUnreachable: String
 
@@ -38,31 +38,31 @@ trait ClusterNodeMBean {
    * JSON format of the status of all nodes in the cluster as follows:
    * {{{
    * {
-   *   "self-address": "akka.tcp://system@host1:2552",
+   *   "self-address": "akka://system@host1:2552",
    *   "members": [
    *     {
-   *       "address": "akka.tcp://system@host1:2552",
+   *       "address": "akka://system@host1:2552",
    *       "status": "Up",
    *       "roles": [
    *         "frontend"
    *       ]
    *     },
    *     {
-   *       "address": "akka.tcp://system@host2:2552",
+   *       "address": "akka://system@host2:2552",
    *       "status": "Up",
    *       "roles": [
    *         "frontend"
    *       ]
    *     },
    *     {
-   *       "address": "akka.tcp://system@host3:2552",
+   *       "address": "akka://system@host3:2552",
    *       "status": "Down",
    *       "roles": [
    *         "backend"
    *       ]
    *     },
    *     {
-   *       "address": "akka.tcp://system@host4:2552",
+   *       "address": "akka://system@host4:2552",
    *       "status": "Joining",
    *       "roles": [
    *         "backend"
@@ -71,17 +71,17 @@ trait ClusterNodeMBean {
    *   ],
    *   "unreachable": [
    *     {
-   *       "node": "akka.tcp://system@host2:2552",
+   *       "node": "akka://system@host2:2552",
    *       "observed-by": [
-   *         "akka.tcp://system@host1:2552",
-   *         "akka.tcp://system@host3:2552"
+   *         "akka://system@host1:2552",
+   *         "akka://system@host3:2552"
    *       ]
    *     },
    *     {
-   *       "node": "akka.tcp://system@host3:2552",
+   *       "node": "akka://system@host3:2552",
    *       "observed-by": [
-   *         "akka.tcp://system@host1:2552",
-   *         "akka.tcp://system@host2:2552"
+   *         "akka://system@host1:2552",
+   *         "akka://system@host2:2552"
    *       ]
    *     }
    *   ]
@@ -92,7 +92,7 @@ trait ClusterNodeMBean {
 
   /**
    * Get the address of the current leader.
-   * The address format is `akka.tcp://actor-system-name@hostname:port`
+   * The address format is `akka://actor-system-name@hostname:port`
    */
   def getLeader: String
 
@@ -109,20 +109,20 @@ trait ClusterNodeMBean {
 
   /**
    * Try to join this cluster node with the node specified by 'address'.
-   * The address format is `akka.tcp://actor-system-name@hostname:port`.
+   * The address format is `akka://actor-system-name@hostname:port`.
    * A 'Join(thisNodeAddress)' command is sent to the node to join.
    */
   def join(address: String): Unit
 
   /**
    * Send command to issue state transition to LEAVING for the node specified by 'address'.
-   * The address format is `akka.tcp://actor-system-name@hostname:port`
+   * The address format is `akka://actor-system-name@hostname:port`
    */
   def leave(address: String): Unit
 
   /**
    * Send command to DOWN the node specified by 'address'.
-   * The address format is `akka.tcp://actor-system-name@hostname:port`
+   * The address format is `akka://actor-system-name@hostname:port`
    */
   def down(address: String): Unit
 }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeChurnSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeChurnSpec.scala
@@ -24,7 +24,7 @@ object NodeChurnMultiJvmSpec extends MultiNodeConfig {
     debugConfig(on = false).withFallback(ConfigFactory.parseString("""
       akka.cluster.auto-down-unreachable-after = 1s
       akka.cluster.prune-gossip-tombstones-after = 1s
-      akka.remote.log-frame-size-exceeding = 1200b
+      akka.remote.classic.log-frame-size-exceeding = 1200b
       akka.remote.artery.advanced.aeron {
         idle-cpu-level = 1
         embedded-media-driver = off

--- a/akka-cluster/src/test/java/akka/cluster/ClusterJavaCompileTest.java
+++ b/akka-cluster/src/test/java/akka/cluster/ClusterJavaCompileTest.java
@@ -18,7 +18,7 @@ public class ClusterJavaCompileTest {
   final Cluster cluster = null;
 
   public void compileJoinSeedNodesInJava() {
-    final List<Address> addresses = Collections.singletonList(new Address("akka.tcp", "MySystem"));
+    final List<Address> addresses = Collections.singletonList(new Address("akka", "MySystem"));
     cluster.joinSeedNodes(addresses);
   }
 }

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterDomainEventSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterDomainEventSpec.scala
@@ -16,25 +16,25 @@ class ClusterDomainEventSpec extends WordSpec with Matchers {
   import ClusterEvent._
 
   val aRoles = Set("AA", "AB")
-  val aJoining = TestMember(Address("akka.tcp", "sys", "a", 2552), Joining, aRoles)
-  val aUp = TestMember(Address("akka.tcp", "sys", "a", 2552), Up, aRoles)
-  val aRemoved = TestMember(Address("akka.tcp", "sys", "a", 2552), Removed, aRoles)
+  val aJoining = TestMember(Address("akka", "sys", "a", 2552), Joining, aRoles)
+  val aUp = TestMember(Address("akka", "sys", "a", 2552), Up, aRoles)
+  val aRemoved = TestMember(Address("akka", "sys", "a", 2552), Removed, aRoles)
   val bRoles = Set("AB", "BB")
-  val bUp = TestMember(Address("akka.tcp", "sys", "b", 2552), Up, bRoles)
-  val bDown = TestMember(Address("akka.tcp", "sys", "b", 2552), Down, bRoles)
-  val bRemoved = TestMember(Address("akka.tcp", "sys", "b", 2552), Removed, bRoles)
+  val bUp = TestMember(Address("akka", "sys", "b", 2552), Up, bRoles)
+  val bDown = TestMember(Address("akka", "sys", "b", 2552), Down, bRoles)
+  val bRemoved = TestMember(Address("akka", "sys", "b", 2552), Removed, bRoles)
   val cRoles = Set.empty[String]
-  val cUp = TestMember(Address("akka.tcp", "sys", "c", 2552), Up, cRoles)
-  val cLeaving = TestMember(Address("akka.tcp", "sys", "c", 2552), Leaving, cRoles)
+  val cUp = TestMember(Address("akka", "sys", "c", 2552), Up, cRoles)
+  val cLeaving = TestMember(Address("akka", "sys", "c", 2552), Leaving, cRoles)
   val dRoles = Set("DD", "DE")
-  val dLeaving = TestMember(Address("akka.tcp", "sys", "d", 2552), Leaving, dRoles)
-  val dExiting = TestMember(Address("akka.tcp", "sys", "d", 2552), Exiting, dRoles)
-  val dRemoved = TestMember(Address("akka.tcp", "sys", "d", 2552), Removed, dRoles)
+  val dLeaving = TestMember(Address("akka", "sys", "d", 2552), Leaving, dRoles)
+  val dExiting = TestMember(Address("akka", "sys", "d", 2552), Exiting, dRoles)
+  val dRemoved = TestMember(Address("akka", "sys", "d", 2552), Removed, dRoles)
   val eRoles = Set("EE", "DE")
-  val eJoining = TestMember(Address("akka.tcp", "sys", "e", 2552), Joining, eRoles)
-  val eUp = TestMember(Address("akka.tcp", "sys", "e", 2552), Up, eRoles)
-  val eDown = TestMember(Address("akka.tcp", "sys", "e", 2552), Down, eRoles)
-  val selfDummyAddress = UniqueAddress(Address("akka.tcp", "sys", "selfDummy", 2552), 17L)
+  val eJoining = TestMember(Address("akka", "sys", "e", 2552), Joining, eRoles)
+  val eUp = TestMember(Address("akka", "sys", "e", 2552), Up, eRoles)
+  val eDown = TestMember(Address("akka", "sys", "e", 2552), Down, eRoles)
+  val selfDummyAddress = UniqueAddress(Address("akka", "sys", "selfDummy", 2552), 17L)
 
   private[cluster] def converge(gossip: Gossip): (Gossip, Set[UniqueAddress]) =
     gossip.members.foldLeft((gossip, Set.empty[UniqueAddress])) {
@@ -91,12 +91,12 @@ class ClusterDomainEventSpec extends WordSpec with Matchers {
     }
 
     "be produced for reachability observations between data centers" in {
-      val dc2AMemberUp = TestMember(Address("akka.tcp", "sys", "dc2A", 2552), Up, Set.empty[String], "dc2")
-      val dc2AMemberDown = TestMember(Address("akka.tcp", "sys", "dc2A", 2552), Down, Set.empty[String], "dc2")
-      val dc2BMemberUp = TestMember(Address("akka.tcp", "sys", "dc2B", 2552), Up, Set.empty[String], "dc2")
+      val dc2AMemberUp = TestMember(Address("akka", "sys", "dc2A", 2552), Up, Set.empty[String], "dc2")
+      val dc2AMemberDown = TestMember(Address("akka", "sys", "dc2A", 2552), Down, Set.empty[String], "dc2")
+      val dc2BMemberUp = TestMember(Address("akka", "sys", "dc2B", 2552), Up, Set.empty[String], "dc2")
 
-      val dc3AMemberUp = TestMember(Address("akka.tcp", "sys", "dc3A", 2552), Up, Set.empty[String], "dc3")
-      val dc3BMemberUp = TestMember(Address("akka.tcp", "sys", "dc3B", 2552), Up, Set.empty[String], "dc3")
+      val dc3AMemberUp = TestMember(Address("akka", "sys", "dc3A", 2552), Up, Set.empty[String], "dc3")
+      val dc3BMemberUp = TestMember(Address("akka", "sys", "dc3B", 2552), Up, Set.empty[String], "dc3")
 
       val reachability1 = Reachability.empty
       val g1 = Gossip(
@@ -128,8 +128,8 @@ class ClusterDomainEventSpec extends WordSpec with Matchers {
     }
 
     "not be produced for same reachability observations between data centers" in {
-      val dc2AMemberUp = TestMember(Address("akka.tcp", "sys", "dc2A", 2552), Up, Set.empty[String], "dc2")
-      val dc2AMemberDown = TestMember(Address("akka.tcp", "sys", "dc2A", 2552), Down, Set.empty[String], "dc2")
+      val dc2AMemberUp = TestMember(Address("akka", "sys", "dc2A", 2552), Up, Set.empty[String], "dc2")
+      val dc2AMemberDown = TestMember(Address("akka", "sys", "dc2A", 2552), Down, Set.empty[String], "dc2")
 
       val reachability1 = Reachability.empty
       val g1 = Gossip(members = SortedSet(aUp, dc2AMemberUp), overview = GossipOverview(reachability = reachability1))

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterHeartbeatSenderStateSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterHeartbeatSenderStateSpec.scala
@@ -40,11 +40,11 @@ object ClusterHeartbeatSenderStateSpec {
 class ClusterHeartbeatSenderStateSpec extends WordSpec with Matchers {
   import ClusterHeartbeatSenderStateSpec._
 
-  val aa = UniqueAddress(Address("akka.tcp", "sys", "aa", 2552), 1L)
-  val bb = UniqueAddress(Address("akka.tcp", "sys", "bb", 2552), 2L)
-  val cc = UniqueAddress(Address("akka.tcp", "sys", "cc", 2552), 3L)
-  val dd = UniqueAddress(Address("akka.tcp", "sys", "dd", 2552), 4L)
-  val ee = UniqueAddress(Address("akka.tcp", "sys", "ee", 2552), 5L)
+  val aa = UniqueAddress(Address("akka", "sys", "aa", 2552), 1L)
+  val bb = UniqueAddress(Address("akka", "sys", "bb", 2552), 2L)
+  val cc = UniqueAddress(Address("akka", "sys", "cc", 2552), 3L)
+  val dd = UniqueAddress(Address("akka", "sys", "dd", 2552), 4L)
+  val ee = UniqueAddress(Address("akka", "sys", "ee", 2552), 5L)
 
   private def emptyState: ClusterHeartbeatSenderState = emptyState(aa)
 
@@ -151,9 +151,8 @@ class ClusterHeartbeatSenderStateSpec extends WordSpec with Matchers {
 
     "behave correctly for random operations" in {
       val rnd = ThreadLocalRandom.current
-      val nodes = (1 to rnd.nextInt(10, 200))
-        .map(n => UniqueAddress(Address("akka.tcp", "sys", "n" + n, 2552), n.toLong))
-        .toVector
+      val nodes =
+        (1 to rnd.nextInt(10, 200)).map(n => UniqueAddress(Address("akka", "sys", "n" + n, 2552), n.toLong)).toVector
       def rndNode() = nodes(rnd.nextInt(0, nodes.size))
       val selfUniqueAddress = rndNode()
       var state = emptyState(selfUniqueAddress)

--- a/akka-cluster/src/test/scala/akka/cluster/DowningProviderSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/DowningProviderSpec.scala
@@ -39,7 +39,7 @@ class DowningProviderSpec extends WordSpec with Matchers {
         loglevel = WARNING
         actor.provider = "cluster"
         remote {
-          netty.tcp {
+          classic.netty.tcp {
             hostname = "127.0.0.1"
             port = 0
           }

--- a/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
@@ -16,22 +16,22 @@ class GossipSpec extends WordSpec with Matchers {
 
   import MemberStatus._
 
-  val a1 = TestMember(Address("akka.tcp", "sys", "a", 2552), Up)
+  val a1 = TestMember(Address("akka", "sys", "a", 2552), Up)
   val a2 = TestMember(a1.address, Joining)
-  val b1 = TestMember(Address("akka.tcp", "sys", "b", 2552), Up)
+  val b1 = TestMember(Address("akka", "sys", "b", 2552), Up)
   val b2 = TestMember(b1.address, Removed)
-  val c1 = TestMember(Address("akka.tcp", "sys", "c", 2552), Leaving)
+  val c1 = TestMember(Address("akka", "sys", "c", 2552), Leaving)
   val c2 = TestMember(c1.address, Up)
   val c3 = TestMember(c1.address, Exiting)
-  val d1 = TestMember(Address("akka.tcp", "sys", "d", 2552), Leaving)
-  val e1 = TestMember(Address("akka.tcp", "sys", "e", 2552), Joining)
+  val d1 = TestMember(Address("akka", "sys", "d", 2552), Leaving)
+  val e1 = TestMember(Address("akka", "sys", "e", 2552), Joining)
   val e2 = TestMember(e1.address, Up)
   val e3 = TestMember(e1.address, Down)
 
-  val dc1a1 = TestMember(Address("akka.tcp", "sys", "a", 2552), Up, Set.empty, dataCenter = "dc1")
-  val dc1b1 = TestMember(Address("akka.tcp", "sys", "b", 2552), Up, Set.empty, dataCenter = "dc1")
-  val dc2c1 = TestMember(Address("akka.tcp", "sys", "c", 2552), Up, Set.empty, dataCenter = "dc2")
-  val dc2d1 = TestMember(Address("akka.tcp", "sys", "d", 2552), Up, Set.empty, dataCenter = "dc2")
+  val dc1a1 = TestMember(Address("akka", "sys", "a", 2552), Up, Set.empty, dataCenter = "dc1")
+  val dc1b1 = TestMember(Address("akka", "sys", "b", 2552), Up, Set.empty, dataCenter = "dc1")
+  val dc2c1 = TestMember(Address("akka", "sys", "c", 2552), Up, Set.empty, dataCenter = "dc2")
+  val dc2d1 = TestMember(Address("akka", "sys", "d", 2552), Up, Set.empty, dataCenter = "dc2")
   val dc2d2 = TestMember(dc2d1.address, status = Down, roles = Set.empty, dataCenter = dc2d1.dataCenter)
   // restarted with another uid
   val dc2d3 =
@@ -487,7 +487,7 @@ class GossipSpec extends WordSpec with Matchers {
     }
 
     "update members" in {
-      val joining = TestMember(Address("akka.tcp", "sys", "d", 2552), Joining, Set.empty, dataCenter = "dc2")
+      val joining = TestMember(Address("akka", "sys", "d", 2552), Joining, Set.empty, dataCenter = "dc2")
       val g = Gossip(members = SortedSet(dc1a1, joining))
 
       g.member(joining.uniqueAddress).status should ===(Joining)

--- a/akka-cluster/src/test/scala/akka/cluster/GossipTargetSelectorSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/GossipTargetSelectorSpec.scala
@@ -13,17 +13,17 @@ import scala.collection.immutable.SortedSet
 
 class GossipTargetSelectorSpec extends WordSpec with Matchers {
 
-  val aDc1 = TestMember(Address("akka.tcp", "sys", "a", 2552), Up, Set.empty, dataCenter = "dc1")
-  val bDc1 = TestMember(Address("akka.tcp", "sys", "b", 2552), Up, Set.empty, dataCenter = "dc1")
-  val cDc1 = TestMember(Address("akka.tcp", "sys", "c", 2552), Up, Set.empty, dataCenter = "dc1")
+  val aDc1 = TestMember(Address("akka", "sys", "a", 2552), Up, Set.empty, dataCenter = "dc1")
+  val bDc1 = TestMember(Address("akka", "sys", "b", 2552), Up, Set.empty, dataCenter = "dc1")
+  val cDc1 = TestMember(Address("akka", "sys", "c", 2552), Up, Set.empty, dataCenter = "dc1")
 
-  val eDc2 = TestMember(Address("akka.tcp", "sys", "e", 2552), Up, Set.empty, dataCenter = "dc2")
-  val fDc2 = TestMember(Address("akka.tcp", "sys", "f", 2552), Up, Set.empty, dataCenter = "dc2")
+  val eDc2 = TestMember(Address("akka", "sys", "e", 2552), Up, Set.empty, dataCenter = "dc2")
+  val fDc2 = TestMember(Address("akka", "sys", "f", 2552), Up, Set.empty, dataCenter = "dc2")
 
-  val gDc3 = TestMember(Address("akka.tcp", "sys", "g", 2552), Up, Set.empty, dataCenter = "dc3")
-  val hDc3 = TestMember(Address("akka.tcp", "sys", "h", 2552), Up, Set.empty, dataCenter = "dc3")
+  val gDc3 = TestMember(Address("akka", "sys", "g", 2552), Up, Set.empty, dataCenter = "dc3")
+  val hDc3 = TestMember(Address("akka", "sys", "h", 2552), Up, Set.empty, dataCenter = "dc3")
 
-  val iDc4 = TestMember(Address("akka.tcp", "sys", "i", 2552), Up, Set.empty, dataCenter = "dc4")
+  val iDc4 = TestMember(Address("akka", "sys", "i", 2552), Up, Set.empty, dataCenter = "dc4")
 
   val defaultSelector =
     new GossipTargetSelector(reduceGossipDifferentViewProbability = 400, crossDcGossipProbability = 0.2)

--- a/akka-cluster/src/test/scala/akka/cluster/HeartbeatNodeRingPerfSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/HeartbeatNodeRingPerfSpec.scala
@@ -15,7 +15,7 @@ class HeartbeatNodeRingPerfSpec extends WordSpec with Matchers {
   val iterations = sys.props.get("akka.cluster.HeartbeatNodeRingPerfSpec.iterations").getOrElse("1000").toInt
 
   def createHeartbeatNodeRingOfSize(size: Int): HeartbeatNodeRing = {
-    val nodes = (1 to size).map(n => UniqueAddress(Address("akka.tcp", "sys", "node-" + n, 2552), n.toLong))
+    val nodes = (1 to size).map(n => UniqueAddress(Address("akka", "sys", "node-" + n, 2552), n.toLong))
     val selfAddress = nodes(size / 2)
     HeartbeatNodeRing(selfAddress, nodes.toSet, Set.empty, 5)
   }

--- a/akka-cluster/src/test/scala/akka/cluster/HeartbeatNodeRingSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/HeartbeatNodeRingSpec.scala
@@ -10,12 +10,12 @@ import akka.actor.Address
 
 class HeartbeatNodeRingSpec extends WordSpec with Matchers {
 
-  val aa = UniqueAddress(Address("akka.tcp", "sys", "aa", 2552), 1L)
-  val bb = UniqueAddress(Address("akka.tcp", "sys", "bb", 2552), 2L)
-  val cc = UniqueAddress(Address("akka.tcp", "sys", "cc", 2552), 3L)
-  val dd = UniqueAddress(Address("akka.tcp", "sys", "dd", 2552), 4L)
-  val ee = UniqueAddress(Address("akka.tcp", "sys", "ee", 2552), 5L)
-  val ff = UniqueAddress(Address("akka.tcp", "sys", "ff", 2552), 6L)
+  val aa = UniqueAddress(Address("akka", "sys", "aa", 2552), 1L)
+  val bb = UniqueAddress(Address("akka", "sys", "bb", 2552), 2L)
+  val cc = UniqueAddress(Address("akka", "sys", "cc", 2552), 3L)
+  val dd = UniqueAddress(Address("akka", "sys", "dd", 2552), 4L)
+  val ee = UniqueAddress(Address("akka", "sys", "ee", 2552), 5L)
+  val ff = UniqueAddress(Address("akka", "sys", "ff", 2552), 6L)
 
   val nodes = Set(aa, bb, cc, dd, ee, ff)
 

--- a/akka-cluster/src/test/scala/akka/cluster/MemberOrderingSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/MemberOrderingSpec.scala
@@ -35,8 +35,8 @@ class MemberOrderingSpec extends WordSpec with Matchers {
     "be sorted by address correctly" in {
       import Member.ordering
       // sorting should be done on host and port, only
-      val m1 = m(Address("akka.tcp", "sys1", "host1", 9000), Up)
-      val m2 = m(Address("akka.tcp", "sys1", "host1", 10000), Up)
+      val m1 = m(Address("akka", "sys1", "host1", 9000), Up)
+      val m2 = m(Address("akka", "sys1", "host1", 10000), Up)
       val m3 = m(Address("cluster", "sys2", "host2", 8000), Up)
       val m4 = m(Address("cluster", "sys2", "host2", 9000), Up)
       val m5 = m(Address("cluster", "sys1", "host2", 10000), Up)
@@ -48,7 +48,7 @@ class MemberOrderingSpec extends WordSpec with Matchers {
     }
 
     "have stable equals and hashCode" in {
-      val address = Address("akka.tcp", "sys1", "host1", 9000)
+      val address = Address("akka", "sys1", "host1", 9000)
       val m1 = m(address, Joining)
       val m11 = Member(UniqueAddress(address, -3L), Set.empty)
       val m2 = m1.copy(status = Up)
@@ -70,7 +70,7 @@ class MemberOrderingSpec extends WordSpec with Matchers {
     }
 
     "have consistent ordering and equals" in {
-      val address1 = Address("akka.tcp", "sys1", "host1", 9001)
+      val address1 = Address("akka", "sys1", "host1", 9001)
       val address2 = address1.copy(port = Some(9002))
 
       val x = m(address1, Exiting)
@@ -88,7 +88,7 @@ class MemberOrderingSpec extends WordSpec with Matchers {
     }
 
     "work with SortedSet" in {
-      val address1 = Address("akka.tcp", "sys1", "host1", 9001)
+      val address1 = Address("akka", "sys1", "host1", 9001)
       val address2 = address1.copy(port = Some(9002))
       val address3 = address1.copy(port = Some(9003))
 
@@ -152,7 +152,7 @@ class MemberOrderingSpec extends WordSpec with Matchers {
   "Leader status ordering" must {
 
     "order members with status Joining, Exiting and Down last" in {
-      val address = Address("akka.tcp", "sys1", "host1", 5000)
+      val address = Address("akka", "sys1", "host1", 5000)
       val m1 = m(address, Joining)
       val m2 = m(address.copy(port = Some(7000)), Joining)
       val m3 = m(address.copy(port = Some(3000)), Exiting)

--- a/akka-cluster/src/test/scala/akka/cluster/MembershipStateSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/MembershipStateSpec.scala
@@ -12,18 +12,18 @@ import scala.collection.immutable.SortedSet
 
 class MembershipStateSpec extends WordSpec with Matchers {
   // DC-a is in reverse age order
-  val a1 = TestMember(Address("akka.tcp", "sys", "a4", 2552), Up, 1, "dc-a")
-  val a2 = TestMember(Address("akka.tcp", "sys", "a3", 2552), Up, 2, "dc-a")
-  val a3 = TestMember(Address("akka.tcp", "sys", "a2", 2552), Up, 3, "dc-a")
-  val a4 = TestMember(Address("akka.tcp", "sys", "a1", 2552), Up, 4, "dc-a")
+  val a1 = TestMember(Address("akka", "sys", "a4", 2552), Up, 1, "dc-a")
+  val a2 = TestMember(Address("akka", "sys", "a3", 2552), Up, 2, "dc-a")
+  val a3 = TestMember(Address("akka", "sys", "a2", 2552), Up, 3, "dc-a")
+  val a4 = TestMember(Address("akka", "sys", "a1", 2552), Up, 4, "dc-a")
 
   // DC-b it is the first and the last that are the oldest
-  val b1 = TestMember(Address("akka.tcp", "sys", "b3", 2552), Up, 1, "dc-b")
-  val b3 = TestMember(Address("akka.tcp", "sys", "b2", 2552), Up, 3, "dc-b")
+  val b1 = TestMember(Address("akka", "sys", "b3", 2552), Up, 1, "dc-b")
+  val b3 = TestMember(Address("akka", "sys", "b2", 2552), Up, 3, "dc-b")
   // Won't be replaced by b3
-  val b2 = TestMember(Address("akka.tcp", "sys", "b1", 2552), Up, 2, "dc-b")
+  val b2 = TestMember(Address("akka", "sys", "b1", 2552), Up, 2, "dc-b")
   // for the case that we don't replace it ever
-  val bOldest = TestMember(Address("akka.tcp", "sys", "b0", 2552), Up, 0, "dc-b")
+  val bOldest = TestMember(Address("akka", "sys", "b0", 2552), Up, 0, "dc-b")
 
   "Membership state" must {
     "sort by upNumber for oldest top members" in {
@@ -52,43 +52,43 @@ class MembershipStateSpec extends WordSpec with Matchers {
 
     "find two oldest per role as targets for Exiting change" in {
       val a5 = TestMember(
-        Address("akka.tcp", "sys", "a5", 2552),
+        Address("akka", "sys", "a5", 2552),
         MemberStatus.Exiting,
         roles = Set("role1", "role2"),
         upNumber = 5,
         dataCenter = "dc-a")
       val a6 = TestMember(
-        Address("akka.tcp", "sys", "a6", 2552),
+        Address("akka", "sys", "a6", 2552),
         MemberStatus.Exiting,
         roles = Set("role1", "role3"),
         upNumber = 6,
         dataCenter = "dc-a")
       val a7 = TestMember(
-        Address("akka.tcp", "sys", "a7", 2552),
+        Address("akka", "sys", "a7", 2552),
         MemberStatus.Exiting,
         roles = Set("role1"),
         upNumber = 7,
         dataCenter = "dc-a")
       val a8 = TestMember(
-        Address("akka.tcp", "sys", "a8", 2552),
+        Address("akka", "sys", "a8", 2552),
         MemberStatus.Exiting,
         roles = Set("role1"),
         upNumber = 8,
         dataCenter = "dc-a")
       val a9 = TestMember(
-        Address("akka.tcp", "sys", "a9", 2552),
+        Address("akka", "sys", "a9", 2552),
         MemberStatus.Exiting,
         roles = Set("role2"),
         upNumber = 9,
         dataCenter = "dc-a")
       val b5 = TestMember(
-        Address("akka.tcp", "sys", "b5", 2552),
+        Address("akka", "sys", "b5", 2552),
         MemberStatus.Exiting,
         roles = Set("role1"),
         upNumber = 5,
         dataCenter = "dc-b")
       val b6 = TestMember(
-        Address("akka.tcp", "sys", "b6", 2552),
+        Address("akka", "sys", "b6", 2552),
         MemberStatus.Exiting,
         roles = Set("role2"),
         upNumber = 6,

--- a/akka-cluster/src/test/scala/akka/cluster/ReachabilityPerfSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ReachabilityPerfSpec.scala
@@ -15,8 +15,8 @@ class ReachabilityPerfSpec extends WordSpec with Matchers {
   // increase for serious measurements
   val iterations = sys.props.get("akka.cluster.ReachabilityPerfSpec.iterations").getOrElse("100").toInt
 
-  val address = Address("akka.tcp", "sys", "a", 2552)
-  val node = Address("akka.tcp", "sys", "a", 2552)
+  val address = Address("akka", "sys", "a", 2552)
+  val node = Address("akka", "sys", "a", 2552)
 
   private def createReachabilityOfSize(base: Reachability, size: Int): Reachability =
     (1 to size).foldLeft(base) {

--- a/akka-cluster/src/test/scala/akka/cluster/ReachabilitySpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ReachabilitySpec.scala
@@ -12,11 +12,11 @@ class ReachabilitySpec extends WordSpec with Matchers {
 
   import Reachability.{ Reachable, Record, Terminated, Unreachable }
 
-  val nodeA = UniqueAddress(Address("akka.tcp", "sys", "a", 2552), 1L)
-  val nodeB = UniqueAddress(Address("akka.tcp", "sys", "b", 2552), 2L)
-  val nodeC = UniqueAddress(Address("akka.tcp", "sys", "c", 2552), 3L)
-  val nodeD = UniqueAddress(Address("akka.tcp", "sys", "d", 2552), 4L)
-  val nodeE = UniqueAddress(Address("akka.tcp", "sys", "e", 2552), 5L)
+  val nodeA = UniqueAddress(Address("akka", "sys", "a", 2552), 1L)
+  val nodeB = UniqueAddress(Address("akka", "sys", "b", 2552), 2L)
+  val nodeC = UniqueAddress(Address("akka", "sys", "c", 2552), 3L)
+  val nodeD = UniqueAddress(Address("akka", "sys", "d", 2552), 4L)
+  val nodeE = UniqueAddress(Address("akka", "sys", "e", 2552), 5L)
 
   "Reachability table" must {
 

--- a/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
@@ -39,19 +39,19 @@ class ClusterMessageSerializerSpec extends AkkaSpec("akka.actor.provider = clust
 
   import MemberStatus._
 
-  val a1 = TestMember(Address("akka.tcp", "sys", "a", 2552), Joining, Set.empty[String])
-  val b1 = TestMember(Address("akka.tcp", "sys", "b", 2552), Up, Set("r1"))
-  val c1 = TestMember(Address("akka.tcp", "sys", "c", 2552), Leaving, Set.empty[String], "foo")
-  val d1 = TestMember(Address("akka.tcp", "sys", "d", 2552), Exiting, Set("r1"), "foo")
-  val e1 = TestMember(Address("akka.tcp", "sys", "e", 2552), Down, Set("r3"))
-  val f1 = TestMember(Address("akka.tcp", "sys", "f", 2552), Removed, Set("r3"), "foo")
+  val a1 = TestMember(Address("akka", "sys", "a", 2552), Joining, Set.empty[String])
+  val b1 = TestMember(Address("akka", "sys", "b", 2552), Up, Set("r1"))
+  val c1 = TestMember(Address("akka", "sys", "c", 2552), Leaving, Set.empty[String], "foo")
+  val d1 = TestMember(Address("akka", "sys", "d", 2552), Exiting, Set("r1"), "foo")
+  val e1 = TestMember(Address("akka", "sys", "e", 2552), Down, Set("r3"))
+  val f1 = TestMember(Address("akka", "sys", "f", 2552), Removed, Set("r3"), "foo")
 
   "ClusterMessages" must {
 
     "be serializable" in {
-      val address = Address("akka.tcp", "system", "some.host.org", 4711)
+      val address = Address("akka", "system", "some.host.org", 4711)
       val uniqueAddress = UniqueAddress(address, 17L)
-      val address2 = Address("akka.tcp", "system", "other.host.org", 4711)
+      val address2 = Address("akka", "system", "other.host.org", 4711)
       val uniqueAddress2 = UniqueAddress(address2, 18L)
       checkSerialization(InternalClusterAction.Join(uniqueAddress, Set("foo", "bar", "dc-A")))
       checkSerialization(ClusterUserAction.Leave(address))
@@ -103,7 +103,7 @@ class ClusterMessageSerializerSpec extends AkkaSpec("akka.actor.provider = clust
       // we must use the old singleton class name so that the other side will see an InitJoin
       // but discard the config as it does not know about the config check
       val initJoinAck = InternalClusterAction.InitJoinAck(
-        Address("akka.tcp", "cluster", "127.0.0.1", 2552),
+        Address("akka", "cluster", "127.0.0.1", 2552),
         InternalClusterAction.UncheckedConfig)
       val serializedInitJoinAckPre2510 = serializer.addressToProto(initJoinAck.address).build().toByteArray
 
@@ -114,7 +114,7 @@ class ClusterMessageSerializerSpec extends AkkaSpec("akka.actor.provider = clust
 
     "serialize to wire format of version 2.5.9 (using serialized address for InitJoinAck)" in {
       val initJoinAck = InternalClusterAction.InitJoinAck(
-        Address("akka.tcp", "cluster", "127.0.0.1", 2552),
+        Address("akka", "cluster", "127.0.0.1", 2552),
         InternalClusterAction.ConfigCheckUnsupportedByJoiningNode)
       val bytes = serializer.toBinary(initJoinAck)
 

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/PerformanceSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/PerformanceSpec.scala
@@ -31,8 +31,8 @@ object PerformanceSpec extends MultiNodeConfig {
     akka.actor.provider = "cluster"
     akka.log-dead-letters = off
     akka.log-dead-letters-during-shutdown = off
-    akka.remote.log-remote-lifecycle-events = ERROR
-    akka.remote.log-frame-size-exceeding=1000b
+    akka.remote.classic.log-remote-lifecycle-events = ERROR
+    akka.remote.classic.log-frame-size-exceeding=1000b
     akka.testconductor.barrier-timeout = 60 s
     akka.cluster.distributed-data.gossip-interval = 1 s
     akka.actor.serialize-messages = off

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/DataEnvelopeSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/DataEnvelopeSpec.scala
@@ -13,7 +13,7 @@ import akka.cluster.ddata.Replicator.Internal.DataEnvelope
 class DataEnvelopeSpec extends WordSpec with Matchers {
   import PruningState._
 
-  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("akka", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
   val node4 = UniqueAddress(node1.address.copy(port = Some(2554)), 4L)

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/GCounterSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/GCounterSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.Matchers
 import org.scalatest.WordSpec
 
 class GCounterSpec extends WordSpec with Matchers {
-  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("akka", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
 

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/LWWMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/LWWMapSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.WordSpec
 class LWWMapSpec extends WordSpec with Matchers {
   import LWWRegister.defaultClock
 
-  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("akka", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
 
   "A LWWMap" must {

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/LWWRegisterSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/LWWRegisterSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.WordSpec
 class LWWRegisterSpec extends WordSpec with Matchers {
   import LWWRegister.defaultClock
 
-  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("akka", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
 
   "A LWWRegister" must {

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/LotsOfDataBot.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/LotsOfDataBot.scala
@@ -32,13 +32,12 @@ object LotsOfDataBot {
       // Override the configuration of the port
       val config = ConfigFactory
         .parseString("akka.remote.classic.netty.tcp.port=" + port)
-        .withFallback(
-          ConfigFactory.load(ConfigFactory.parseString("""
+        .withFallback(ConfigFactory.load(ConfigFactory.parseString("""
             passive = off
             max-entries = 100000
             akka.actor.provider = "cluster"
             akka.remote {
-              netty.tcp {
+              artery.canonical {
                 hostname = "127.0.0.1"
                 port = 0
               }
@@ -46,13 +45,11 @@ object LotsOfDataBot {
 
             akka.cluster {
               seed-nodes = [
-                "akka.tcp://ClusterSystem@127.0.0.1:2551",
-                "akka.tcp://ClusterSystem@127.0.0.1:2552"]
+                "akka://ClusterSystem@127.0.0.1:2551",
+                "akka://ClusterSystem@127.0.0.1:2552"]
 
               auto-down-unreachable-after = 10s
             }
-            akka.cluster.distributed-data.use-offheap-memory = off
-            akka.remote.log-frame-size-exceeding = 10000b
             """)))
 
       // Create an Akka system

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMapSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.WordSpec
 
 class ORMapSpec extends WordSpec with Matchers {
 
-  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("akka", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
 
   "A ORMap" must {

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMultiMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORMultiMapSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.{ Matchers, WordSpec }
 
 class ORMultiMapSpec extends WordSpec with Matchers {
 
-  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("akka", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
 
   "A ORMultiMap" must {

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORSetSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/ORSetSpec.scala
@@ -14,11 +14,11 @@ import org.scalatest.WordSpec
 
 class ORSetSpec extends WordSpec with Matchers {
 
-  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("akka", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
 
-  val nodeA = UniqueAddress(Address("akka.tcp", "Sys", "a", 2552), 1L)
+  val nodeA = UniqueAddress(Address("akka", "Sys", "a", 2552), 1L)
   val nodeB = UniqueAddress(nodeA.address.copy(host = Some("b")), 2L)
   val nodeC = UniqueAddress(nodeA.address.copy(host = Some("c")), 3L)
   val nodeD = UniqueAddress(nodeA.address.copy(host = Some("d")), 4L)

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/PNCounterMapSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/PNCounterMapSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.WordSpec
 
 class PNCounterMapSpec extends WordSpec with Matchers {
 
-  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("akka", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
 
   "A PNCounterMap" must {

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/PNCounterSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/PNCounterSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.Matchers
 import org.scalatest.WordSpec
 
 class PNCounterSpec extends WordSpec with Matchers {
-  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("akka", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
 
   "A PNCounter" must {

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/PruningStateSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/PruningStateSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.WordSpec
 class PruningStateSpec extends WordSpec with Matchers {
   import PruningState._
 
-  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("akka", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
   val node4 = UniqueAddress(node1.address.copy(port = Some(2554)), 4L)

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/VersionVectorSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/VersionVectorSpec.scala
@@ -18,7 +18,7 @@ class VersionVectorSpec
     with Matchers
     with BeforeAndAfterAll {
 
-  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1L)
+  val node1 = UniqueAddress(Address("akka", "Sys", "localhost", 2551), 1L)
   val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2L)
   val node3 = UniqueAddress(node1.address.copy(port = Some(2553)), 3L)
   val node4 = UniqueAddress(node1.address.copy(port = Some(2554)), 4L)

--- a/akka-docs/src/main/paradox/actors.md
+++ b/akka-docs/src/main/paradox/actors.md
@@ -596,7 +596,7 @@ Scala
 Java
 :  @@snip [ActorDocTest.java](/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java) { #selection-remote }
 
-An example demonstrating actor look-up is given in @ref:[Remoting Sample](remoting.md#remote-sample).
+An example demonstrating actor look-up is given in @ref:[Remoting Sample](remoting-artery.md#looking-up-remote-actors).
 
 ## Messages and immutability
 

--- a/akka-docs/src/main/paradox/additional/deploy.md
+++ b/akka-docs/src/main/paradox/additional/deploy.md
@@ -29,7 +29,7 @@ Follow the instructions for the `JavaAppPackaging` in the [sbt-native-packager p
 
 You can use both Akka remoting and Akka Cluster inside of Docker containers. But note
 that you will need to take special care with the network configuration when using Docker,
-described here: @ref:[Akka behind NAT or in a Docker container](../remoting.md#remote-configuration-nat)
+described here: @ref:[Akka behind NAT or in a Docker container](../remoting-artery.md#remote-configuration-nat-artery)
 
 You can look at the
 @java[@extref[Cluster with docker-compse example project](samples:akka-sample-cluster-docker-compose-java)]

--- a/akka-docs/src/main/paradox/additional/faq.md
+++ b/akka-docs/src/main/paradox/additional/faq.md
@@ -98,11 +98,7 @@ to see all sent and received messages (logged at DEBUG level).
 
 ### Which options shall I enable when debugging remoting issues?
 
-Have a look at the @ref:[Remote Configuration](../remoting.md#remote-configuration), the typical candidates are:
-
- * *akka.remote.log-sent-messages*
- * *akka.remote.log-received-messages*
- * *akka.remote.log-remote-lifecycle-events* (this also includes deserialization errors)
+Have a look at the @ref:[Remote Configuration](../logging.md#auxiliary-remote-logging-options).
 
 ### What is the name of a remote actor?
 
@@ -110,16 +106,14 @@ When you want to send messages to an actor on a remote host, you need to know
 its @ref:[full path](../general/addressing.md), which is of the form:
 
 ```
-akka.protocol://system@host:1234/user/my/actor/hierarchy/path
+akka://system@host:1234/user/my/actor/hierarchy/path
 ```
 
 Observe all the parts you need here:
 
- * `protocol` is the protocol to be used to communicate with the remote system.
- Most of the cases this is *tcp*.
  * `system` is the remote system’s name (must match exactly, case-sensitive!)
  * `host` is the remote system’s IP address or DNS name, and it must match that
-system’s configuration (i.e. *akka.remote.classic.netty.tcp.hostname*)
+system’s configuration (i.e. *akka.remote.artery.canonical.hostname*)
  * `1234` is the port number on which the remote system is listening for
 connections and receiving messages
  * `/user/my/actor/hierarchy/path` is the absolute path of the remote actor in

--- a/akka-docs/src/main/paradox/cluster-usage.md
+++ b/akka-docs/src/main/paradox/cluster-usage.md
@@ -108,18 +108,17 @@ akka {
   actor {
     provider = "cluster"
   }
-  remote {
-    log-remote-lifecycle-events = off
-    netty.tcp {
+  remote.artery {
+    canonical {
       hostname = "127.0.0.1"
-      port = 0
+      port = 2551
     }
   }
 
   cluster {
     seed-nodes = [
-      "akka.tcp://ClusterSystem@127.0.0.1:2551",
-      "akka.tcp://ClusterSystem@127.0.0.1:2552"]
+      "akka://ClusterSystem@127.0.0.1:2551",
+      "akka://ClusterSystem@127.0.0.1:2552"]
 
     # auto downing is NOT safe for production deployments.
     # you may want to use it during development, read more about it in the docs.
@@ -128,22 +127,16 @@ akka {
   }
 }
 
-# Enable metrics extension in akka-cluster-metrics.
-akka.extensions=["akka.cluster.metrics.ClusterMetricsExtension"]
-
-# Sigar native library extract location during tests.
-# Note: use per-jvm-instance folder when running multiple jvm on one host.
-akka.cluster.metrics.native-library-extract-folder=${user.dir}/target/native
 ```
 
-To enable cluster capabilities in your Akka project you should, at a minimum, add the @ref:[Remoting](remoting.md)
+To enable cluster capabilities in your Akka project you should, at a minimum, add the @ref:[Remoting](remoting-artery.md)
 settings, but with `cluster`.
 The `akka.cluster.seed-nodes` should normally also be added to your `application.conf` file.
 
 @@@ note
 
 If you are running Akka in a Docker container or the nodes for some other reason have separate internal and
-external ip addresses you must configure remoting according to @ref:[Akka behind NAT or in a Docker container](remoting.md#remote-configuration-nat)
+external ip addresses you must configure remoting according to @ref:[Akka behind NAT or in a Docker container](remoting-artery.md#remote-configuration-nat-artery)
 
 @@@
 
@@ -190,15 +183,15 @@ You define the seed nodes in the [configuration](#cluster-configuration) file (a
 
 ```
 akka.cluster.seed-nodes = [
-  "akka.tcp://ClusterSystem@host1:2552",
-  "akka.tcp://ClusterSystem@host2:2552"]
+  "akka://ClusterSystem@host1:2552",
+  "akka://ClusterSystem@host2:2552"]
 ```
 
 This can also be defined as Java system properties when starting the JVM using the following syntax:
 
 ```
--Dakka.cluster.seed-nodes.0=akka.tcp://ClusterSystem@host1:2552
--Dakka.cluster.seed-nodes.1=akka.tcp://ClusterSystem@host2:2552
+-Dakka.cluster.seed-nodes.0=akka://ClusterSystem@host1:2552
+-Dakka.cluster.seed-nodes.1=akka://ClusterSystem@host2:2552
 ```
 
 The seed nodes can be started in any order and it is not necessary to have all
@@ -846,7 +839,7 @@ Where the <node-url> should be on the format of
   'akka.<protocol>://<actor-system-name>@<hostname>:<port>'
 
 Examples: ./akka-cluster localhost 9999 is-available
-          ./akka-cluster localhost 9999 join akka.tcp://MySystem@darkstar:2552
+          ./akka-cluster localhost 9999 join akka://MySystem@darkstar:2552
           ./akka-cluster localhost 9999 cluster-status
 ```
 

--- a/akka-docs/src/main/paradox/general/addressing.md
+++ b/akka-docs/src/main/paradox/general/addressing.md
@@ -95,12 +95,10 @@ by which the corresponding actor is reachable, followed by the names of the
 actors in the hierarchy from the root up. Examples are:
 
 ```
-"akka://my-sys/user/service-a/worker1"                   // purely local
-"akka.tcp://my-sys@host.example.com:5678/user/service-b" // remote
+"akka://my-sys/user/service-a/worker1"               // purely local
+"akka://my-sys@host.example.com:5678/user/service-b" // remote
 ```
 
-Here, `akka.tcp` is the default remote transport for the 2.4 release; other transports
-are pluggable.
 The interpretation of the host and port part (i.e. `host.example.com:5678` in the example)
 depends on the transport mechanism used, but it must abide by the URI structural rules.
 

--- a/akka-docs/src/main/paradox/general/configuration.md
+++ b/akka-docs/src/main/paradox/general/configuration.md
@@ -155,9 +155,9 @@ akka {
     }
   }
 
-  remote {
-    # The port clients should connect to. Default is 2552.
-    netty.tcp.port = 4711
+  remote.artery {
+    # The port clients should connect to.
+    canonical.port = 4711
   }
 }
 ```

--- a/akka-docs/src/main/paradox/general/remoting.md
+++ b/akka-docs/src/main/paradox/general/remoting.md
@@ -66,7 +66,7 @@ containers violates assumption 1, unless additional steps are taken in the
 network configuration to allow symmetric communication between involved systems.
 In such situations Akka can be configured to bind to a different network
 address than the one used for establishing connections between Akka nodes.
-See @ref:[Akka behind NAT or in a Docker container](../remoting.md#remote-configuration-nat).
+See @ref:[Akka behind NAT or in a Docker container](../remoting-artery.md#remote-configuration-nat-artery).
 
 ## Marking Points for Scaling Up with Routers
 

--- a/akka-docs/src/main/paradox/index-cluster.md
+++ b/akka-docs/src/main/paradox/index-cluster.md
@@ -14,10 +14,11 @@
 * [cluster-metrics](cluster-metrics.md)
 * [distributed-data](distributed-data.md)
 * [cluster-dc](cluster-dc.md)
+* [serialization](serialization.md)
 * [multi-jvm-testing](multi-jvm-testing.md)
 * [multi-node-testing](multi-node-testing.md)
-* [remoting](remoting.md)
 * [remoting-artery](remoting-artery.md)
-* [serialization](serialization.md)
+* [remoting](remoting.md)
+
 
 @@@

--- a/akka-docs/src/main/paradox/logging.md
+++ b/akka-docs/src/main/paradox/logging.md
@@ -209,41 +209,20 @@ akka {
 If you want to see all messages that are sent through remoting at DEBUG log level, use the following config option. Note that this logs the messages as they are sent by the transport layer, not by an actor.
 
 ```ruby
-akka {
-  remote {
-    # If this is "on", Akka will log all outbound messages at DEBUG level,
-    # if off then they are not logged
-    log-sent-messages = on
-  }
+akka.remote.artery {
+  # If this is "on", Akka will log all outbound messages at DEBUG level,
+  # if off then they are not logged
+  log-sent-messages = on
 }
 ```
 
 If you want to see all messages that are received through remoting at DEBUG log level, use the following config option. Note that this logs the messages as they are received by the transport layer, not by an actor.
 
 ```ruby
-akka {
-  remote {
-    # If this is "on", Akka will log all inbound messages at DEBUG level,
-    # if off then they are not logged
-    log-received-messages = on
-  }
-}
-```
-
-If you want to see message types with payload size in bytes larger than
-a specified limit at INFO log level:
-
-```ruby
-akka {
-  remote {
-    # Logging of message types with payload size in bytes larger than
-    # this value. Maximum detected size per message type is logged once,
-    # with an increase threshold of 10%.
-    # By default this feature is turned off. Activate it by setting the property to
-    # a value in bytes, such as 1000b. Note that for all messages larger than this
-    # limit there will be extra performance and scalability cost.
-    log-frame-size-exceeding = 1000b
-  }
+akka.remote.artery {
+  # If this is "on", Akka will log all inbound messages at DEBUG level,
+  # if off then they are not logged
+  log-received-messages = on
 }
 ```
 

--- a/akka-docs/src/main/paradox/security/index.md
+++ b/akka-docs/src/main/paradox/security/index.md
@@ -18,9 +18,9 @@ to ensure that a fix can be provided without delay.
 
 ## Security Related Documentation
 
- * @ref:[Disabling the Java Serializer](../remoting.md#disable-java-serializer)
+ * @ref:[Disabling the Java Serializer](../remoting-artery.md#disable-java-serializer)
  * @ref:[Remote deployment whitelist](../remoting.md#remote-deployment-whitelist)
- * @ref:[Remote Security](../remoting.md#remote-security)
+ * @ref:[Remote Security](../remoting-artery.md#remote-security)
 
 ## Fixed Security Vulnerabilities
 

--- a/akka-docs/src/main/paradox/serialization.md
+++ b/akka-docs/src/main/paradox/serialization.md
@@ -53,7 +53,7 @@ depending on the akka-remote module), so normally you don't need to add
 configuration for that; since `com.google.protobuf.GeneratedMessage`
 implements `java.io.Serializable`, protobuf messages will always be
 serialized using the protobuf protocol unless specifically overridden. In order
-to disable a default serializer, see @ref:[Disabling the Java Serializer](remoting.md#disable-java-serializer)
+to disable a default serializer, see @ref:[Disabling the Java Serializer](remoting-artery.md#disable-java-serializer)
 
 ### Enable additional bindings
 

--- a/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
+++ b/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
@@ -337,7 +337,7 @@ public class ActorDocTest extends AbstractJavaTest {
       // #selection-wildcard
 
       // #selection-remote
-      getContext().actorSelection("akka.tcp://app@otherhost:1234/user/serviceB");
+      getContext().actorSelection("akka://app@otherhost:1234/user/serviceB");
       // #selection-remote
     }
   }

--- a/akka-docs/src/test/java/jdocs/persistence/LambdaPersistencePluginDocTest.java
+++ b/akka-docs/src/test/java/jdocs/persistence/LambdaPersistencePluginDocTest.java
@@ -44,7 +44,7 @@ public class LambdaPersistencePluginDocTest {
         class SharedStorageUsage extends AbstractActor {
           @Override
           public void preStart() throws Exception {
-            String path = "akka.tcp://example@127.0.0.1:2552/user/store";
+            String path = "akka://example@127.0.0.1:2552/user/store";
             ActorSelection selection = getContext().actorSelection(path);
             selection.tell(new Identify(1), getSelf());
           }

--- a/akka-docs/src/test/java/jdocs/remoting/RemoteDeploymentDocTest.java
+++ b/akka-docs/src/test/java/jdocs/remoting/RemoteDeploymentDocTest.java
@@ -49,8 +49,8 @@ public class RemoteDeploymentDocTest extends AbstractJavaTest {
   @Test
   public void demonstrateDeployment() {
     // #make-address
-    Address addr = new Address("akka.tcp", "sys", "host", 1234);
-    addr = AddressFromURIString.parse("akka.tcp://sys@host:1234"); // the same
+    Address addr = new Address("akka", "sys", "host", 1234);
+    addr = AddressFromURIString.parse("akka://sys@host:1234"); // the same
     // #make-address
     // #deploy
     ActorRef ref =

--- a/akka-docs/src/test/java/jdocs/routing/RouterDocTest.java
+++ b/akka-docs/src/test/java/jdocs/routing/RouterDocTest.java
@@ -451,8 +451,8 @@ public class RouterDocTest extends AbstractJavaTest {
   public void demonstrateRemoteDeploy() {
     // #remoteRoutees
     Address[] addresses = {
-      new Address("akka.tcp", "remotesys", "otherhost", 1234),
-      AddressFromURIString.parse("akka.tcp://othersys@anotherhost:1234")
+      new Address("akka", "remotesys", "otherhost", 1234),
+      AddressFromURIString.parse("akka://othersys@anotherhost:1234")
     };
     ActorRef routerRemote =
         system.actorOf(

--- a/akka-docs/src/test/scala/docs/actor/ActorDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/actor/ActorDocSpec.scala
@@ -623,7 +623,7 @@ class ActorDocSpec extends AkkaSpec("""
     context.actorSelection("../*")
     //#selection-wildcard
     //#selection-remote
-    context.actorSelection("akka.tcp://app@otherhost:1234/user/serviceB")
+    context.actorSelection("akka://app@otherhost:1234/user/serviceB")
     //#selection-remote
   }
 

--- a/akka-docs/src/test/scala/docs/config/ConfigDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/config/ConfigDocSpec.scala
@@ -41,7 +41,7 @@ class ConfigDocSpec extends WordSpec with Matchers {
   
     # '/user/actorA/actorB' is a remote deployed actor
     /actorA/actorB {
-      remote = "akka.tcp://sampleActorSystem@127.0.0.1:2553"
+      remote = "akka://sampleActorSystem@127.0.0.1:2553"
     }
     
     # all direct children of '/user/actorC' have a dedicated dispatcher 

--- a/akka-docs/src/test/scala/docs/persistence/PersistencePluginDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/persistence/PersistencePluginDocSpec.scala
@@ -129,7 +129,7 @@ object SharedLeveldbPluginDocSpec {
   //#shared-store-usage
   trait SharedStoreUsage extends Actor {
     override def preStart(): Unit = {
-      context.actorSelection("akka.tcp://example@127.0.0.1:2552/user/store") ! Identify(1)
+      context.actorSelection("akka://example@127.0.0.1:2552/user/store") ! Identify(1)
     }
 
     def receive = {

--- a/akka-docs/src/test/scala/docs/remoting/RemoteDeploymentDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/remoting/RemoteDeploymentDocSpec.scala
@@ -29,7 +29,7 @@ class RemoteDeploymentDocSpec extends AkkaSpec("""
 
   val other = ActorSystem("remote", system.settings.config)
   val address =
-    other.asInstanceOf[ExtendedActorSystem].provider.getExternalAddressFor(Address("akka.tcp", "s", "host", 1)).get
+    other.asInstanceOf[ExtendedActorSystem].provider.getExternalAddressFor(Address("akka", "s", "host", 1)).get
 
   override def afterTermination(): Unit = { shutdown(other) }
 
@@ -51,8 +51,8 @@ class RemoteDeploymentDocSpec extends AkkaSpec("""
 
   "demonstrate address extractor" in {
     //#make-address
-    val one = AddressFromURIString("akka.tcp://sys@host:1234")
-    val two = Address("akka.tcp", "sys", "host", 1234) // this gives the same
+    val one = AddressFromURIString("akka://sys@host:1234")
+    val two = Address("akka", "sys", "host", 1234) // this gives the same
     //#make-address
     one should be(two)
   }

--- a/akka-docs/src/test/scala/docs/routing/RouterDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/routing/RouterDocSpec.scala
@@ -210,7 +210,7 @@ akka.actor.deployment {
   /parent/remotePool {
     router = round-robin-pool
     nr-of-instances = 10
-    target.nodes = ["akka.tcp://app@10.0.0.2:2552", "akka.tcp://app@10.0.0.3:2552"]
+    target.nodes = ["akka://app@10.0.0.2:2552", "akka://app@10.0.0.3:2552"]
   }
 }
 #//#config-remote-round-robin-pool
@@ -230,9 +230,9 @@ akka.actor.deployment {
   /parent/remoteGroup {
     router = round-robin-group
     routees.paths = [
-      "akka.tcp://app@10.0.0.1:2552/user/workers/w1",
-      "akka.tcp://app@10.0.0.2:2552/user/workers/w1",
-      "akka.tcp://app@10.0.0.3:2552/user/workers/w1"]
+      "akka://app@10.0.0.1:2552/user/workers/w1",
+      "akka://app@10.0.0.2:2552/user/workers/w1",
+      "akka://app@10.0.0.3:2552/user/workers/w1"]
   }
 }
 #//#config-remote-round-robin-group
@@ -596,9 +596,8 @@ class RouterDocSpec extends AkkaSpec(RouterDocSpec.config) with ImplicitSender {
     //#remoteRoutees
     import akka.actor.{ Address, AddressFromURIString }
     import akka.remote.routing.RemoteRouterConfig
-    val addresses = Seq(
-      Address("akka.tcp", "remotesys", "otherhost", 1234),
-      AddressFromURIString("akka.tcp://othersys@anotherhost:1234"))
+    val addresses =
+      Seq(Address("akka", "remotesys", "otherhost", 1234), AddressFromURIString("akka://othersys@anotherhost:1234"))
     val routerRemote = system.actorOf(RemoteRouterConfig(RoundRobinPool(5), addresses).props(Props[Echo]))
     //#remoteRoutees
   }

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -153,14 +153,14 @@ akka {
       default {
 
         # if this is set to a valid remote address, the named actor will be
-        # deployed at that node e.g. "akka.tcp://sys@host:port"
+        # deployed at that node e.g. "akka://sys@host:port"
         remote = ""
 
         target {
 
           # A list of hostnames and ports for instantiating the children of a
           # router
-          #   The format should be on "akka.tcp://sys@host:port", where:
+          #   The format should be on "akka://sys@host:port", where:
           #    - sys is the remote actor system name
           #    - hostname can be either hostname or IP address the remote actor
           #      should connect to

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -303,11 +303,11 @@ private[akka] class RemoteActorRefProvider(
        *
        * Example:
        *
-       * akka.tcp://sys@home:1234/remote/akka/sys@remote:6667/remote/akka/sys@other:3333/user/a/b/c
+       * akka://sys@home:1234/remote/akka/sys@remote:6667/remote/akka/sys@other:3333/user/a/b/c
        *
-       * means that the logical parent originates from “akka.tcp://sys@other:3333” with
-       * one child (may be “a” or “b”) being deployed on “akka.tcp://sys@remote:6667” and
-       * finally either “b” or “c” being created on “akka.tcp://sys@home:1234”, where
+       * means that the logical parent originates from “akka://sys@other:3333” with
+       * one child (may be “a” or “b”) being deployed on “akka://sys@remote:6667” and
+       * finally either “b” or “c” being created on “akka://sys@home:1234”, where
        * this whole thing actually resides. Thus, the logical path is
        * “/user/a/b/c” and the physical path contains all remote placement
        * information.

--- a/akka-remote/src/test/scala/akka/remote/DaemonicSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/DaemonicSpec.scala
@@ -30,14 +30,16 @@ class DaemonicSpec extends AkkaSpec {
         akka.actor.provider = remote
         akka.remote.classic.netty.tcp.transport-class = "akka.remote.transport.netty.NettyTransport"
         akka.remote.classic.netty.tcp.port = 0
+        akka.remote.artery.canonical.port = 0
         akka.log-dead-letters-during-shutdown = off
       """))
 
       try {
         val unusedPort = 86 // very unlikely to ever be used, "system port" range reserved for Micro Focus Cobol
 
+        val protocol = if (RARP(daemonicSystem).provider.remoteSettings.Artery.Enabled) "akka" else "akka.tcp"
         val unusedAddress =
-          RARP(daemonicSystem).provider.getExternalAddressFor(Address(s"akka.tcp", "", "", unusedPort)).get
+          RARP(daemonicSystem).provider.getExternalAddressFor(Address(protocol, "", "", unusedPort)).get
         val selection = daemonicSystem.actorSelection(s"$unusedAddress/user/SomeActor")
         selection ! "whatever"
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamRefsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamRefsSpec.scala
@@ -155,7 +155,7 @@ object StreamRefsSpec {
       }
       remote {
         artery.canonical.port = 0
-        netty.tcp.port = 0
+        classic.netty.tcp.port = 0
       }
     }
   """).withFallback(ConfigFactory.load())


### PR DESCRIPTION
* fix several tests that were using akka.remote.netty.tcp config
* replace akka.tcp with akka in more places
* some doc cross references to remoting.md

I intended to do a quick fix of failing tests in https://jenkins.akka.io:8498/job/akka-classic-cluster-tests/15/ but found much more...