### PR TITLE
Remove extra cherrypick step from contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,6 @@ Using, for example: current.version 2.5.22, previous.version 2.5, milestone.vers
 1. Label this PR with `to-be-backported`
 1. Mark this PR with Milestone `${milestone.version}`
 1. Mark the issue with Milestone `${current.version}`
-1. `cherry-pick to release-${previous.version}`
 1. `git checkout release-${previous.version}`
 1. `git pull`
 1. Create wip branch


### PR DESCRIPTION
I wasn't sure what was meant by this cherry pick step, the cherry pick command is a few steps after, was it a top level heading saying the following steps are for cherry picking?