### PR TITLE
fix ByteStringSpec for Scala 2.13, #26956

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -894,18 +894,18 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
     }
 
     "serialize correctly" when {
-      "parsing regular ByteString1C as compat" in {
-        val oldSerd =
-          if (util.Properties.versionNumberString.startsWith("2.11") || util.Properties.versionNumberString.startsWith(
-                "2.12"))
+      // note that this is serialization with Java serialization
+      // real serialization is in akka-remote
+      if (util.Properties.versionNumberString.startsWith("2.12") || util.Properties.versionNumberString.startsWith(
+            "2.11")) {
+        "parsing regular ByteString1C as compat" in {
+          val oldSerd =
             "aced000573720021616b6b612e7574696c2e42797465537472696e672442797465537472696e67314336e9eed0afcfe4a40200015b000562797465737400025b427872001b616b6b612e7574696c2e436f6d7061637442797465537472696e67fa2925150f93468f0200007870757200025b42acf317f8060854e002000078700000000a74657374737472696e67"
-          else
-            // The data is the same, but the class hierarchy changed in 2.13:
-            "aced000573720021616b6b612e7574696c2e42797465537472696e672442797465537472696e67314336e9eed0afcfe4a40200015b000562797465737400025b427872001b616b6b612e7574696c2e436f6d7061637442797465537472696e676c083a30328adea002000078720014616b6b612e7574696c2e42797465537472696e67e54813305c6d95cc0200007870757200025b42acf317f8060854e002000078700000000a74657374737472696e67"
-        val bs = ByteString("teststring", "UTF8")
-        val str = hexFromSer(bs)
+          val bs = ByteString("teststring", "UTF8")
+          val str = hexFromSer(bs)
 
-        str should be(oldSerd)
+          str should be(oldSerd)
+        }
       }
 
       "given all types of ByteString" in {

--- a/akka-remote/src/test/scala/akka/remote/serialization/PrimitivesSerializationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/serialization/PrimitivesSerializationSpec.scala
@@ -27,7 +27,7 @@ object PrimitivesSerializationSpec {
 class PrimitivesSerializationSpec extends AkkaSpec(PrimitivesSerializationSpec.testConfig) {
 
   val buffer = {
-    val b = ByteBuffer.allocate(1024)
+    val b = ByteBuffer.allocate(4096)
     b.order(ByteOrder.LITTLE_ENDIAN)
     b
   }
@@ -119,7 +119,9 @@ class PrimitivesSerializationSpec extends AkkaSpec(PrimitivesSerializationSpec.t
       "empty string" -> ByteString.empty,
       "simple content" -> ByteString("hello"),
       "concatenated content" -> (ByteString("hello") ++ ByteString("world")),
-      "sliced content" -> ByteString("helloabc").take(5)).foreach {
+      "sliced content" -> ByteString("helloabc").take(5),
+      "large concatenated" ->
+      (ByteString(Array.fill[Byte](1000)(1)) ++ ByteString(Array.fill[Byte](1000)(2)))).foreach {
       case (scenario, item) =>
         s"resolve serializer for [$scenario]" in {
           val serializer = SerializationExtension(system)


### PR DESCRIPTION
🍒 backport of https://github.com/akka/akka/pull/26969

Refs #26956

(cherry picked from commit 3e32cdc3ca73b39f662eb02cf4c33bb7544a48a1)
