### PR TITLE
Deprecate akka.actor.TypedActor #25516

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
@@ -67,6 +67,7 @@ object TypedActorSpec {
   trait Foo {
     def pigdog(): String
 
+    @silent
     @throws(classOf[TimeoutException])
     def self = TypedActor.self[Foo]
 
@@ -132,6 +133,7 @@ object TypedActorSpec {
       Future.successful(pigdog + numbered)
     }
 
+    @silent
     def futureComposePigdogFrom(foo: Foo): Future[String] = {
       foo.futurePigdog(500 millis).map(_.toUpperCase)
     }
@@ -187,6 +189,7 @@ object TypedActorSpec {
       with LifeCycles
       with Receiver {
 
+    @silent
     private def ensureContextAvailable[T](f: => T): T = TypedActor.context match {
       case null => throw new IllegalStateException("TypedActor.context is null!")
       case _    => f
@@ -241,6 +244,7 @@ object TypedActorSpec {
 
 }
 
+@silent
 class TypedActorSpec
     extends AkkaSpec(TypedActorSpec.config)
     with BeforeAndAfterEach
@@ -564,6 +568,7 @@ class TypedActorSpec
   }
 }
 
+@silent
 class TypedActorRouterSpec
     extends AkkaSpec(TypedActorSpec.config)
     with BeforeAndAfterEach

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/supervision/SupervisionCompileOnly.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/supervision/SupervisionCompileOnly.scala
@@ -9,8 +9,6 @@ import akka.actor.typed.{ Behavior, SupervisorStrategy }
 import akka.actor.typed.scaladsl.Behaviors
 import scala.concurrent.duration._
 
-import akka.actor.TypedActor.PreRestart
-
 object SupervisionCompileOnly {
 
   val behavior = Behaviors.empty[String]

--- a/akka-actor/src/main/scala/akka/actor/TypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/TypedActor.scala
@@ -10,8 +10,10 @@ import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
 import scala.concurrent.{ Await, Future }
+
 import akka.japi.{ Creator, Option => JOption }
 import akka.japi.Util.{ immutableSeq, immutableSingletonSeq }
+import akka.pattern.AskTimeoutException
 import akka.util.Timeout
 import akka.util.Reflect.instantiator
 import akka.serialization.{ JavaSerializer, SerializationExtension, Serializers }
@@ -21,11 +23,12 @@ import java.util.concurrent.TimeoutException
 import java.io.ObjectStreamException
 import java.lang.reflect.{ InvocationHandler, InvocationTargetException, Method, Proxy }
 
-import akka.pattern.AskTimeoutException
+import com.github.ghik.silencer.silent
 
 /**
  * A TypedActorFactory is something that can created TypedActor instances.
  */
+@deprecated("Use 'akka.actor.typed' API.", since = "2.6.0")
 trait TypedActorFactory {
 
   /**
@@ -100,6 +103,7 @@ trait TypedActorFactory {
 /**
  * This represents the TypedActor Akka Extension, access to the functionality is done through a given ActorSystem.
  */
+@deprecated("Use 'akka.actor.typed' API.", since = "2.6.0")
 object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvider {
   override def get(system: ActorSystem): TypedActorExtension = super.get(system)
 
@@ -111,6 +115,7 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
    * will be children to the specified context, this allows for creating hierarchies of TypedActors.
    * Do _not_ let this instance escape the TypedActor since that will not be thread-safe.
    */
+  @deprecated("Use 'akka.actor.typed' API.", since = "2.6.0")
   def apply(context: ActorContext): TypedActorFactory = ContextualTypedActorFactory(apply(context.system), context)
 
   /**
@@ -120,7 +125,12 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
    *
    * Java API
    */
+  @silent
   def get(context: ActorContext): TypedActorFactory = apply(context)
+
+  @deprecated("Use 'akka.actor.typed' API.", since = "2.6.0")
+  @silent
+  override def apply(system: ActorSystem): TypedActorExtension = super.apply(system)
 
   /**
    * This class represents a Method call, and has a reference to the Method to be called and the parameters to supply
@@ -275,6 +285,7 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
       }
     }
 
+    @silent
     override def postStop(): Unit =
       try {
         withContext {
@@ -489,6 +500,7 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
         case some => toTypedActorInvocationHandler(some)
       }
 
+    @silent
     def toTypedActorInvocationHandler(system: ActorSystem): TypedActorInvocationHandler =
       new TypedActorInvocationHandler(TypedActor(system), new AtomVar[ActorRef](actor), new Timeout(timeout))
   }
@@ -664,12 +676,14 @@ final case class TypedProps[T <: AnyRef] protected[TypedProps] (
  * ContextualTypedActorFactory allows TypedActors to create children, effectively forming the same Actor Supervision Hierarchies
  * as normal Actors can.
  */
+@silent
 final case class ContextualTypedActorFactory(typedActor: TypedActorExtension, actorFactory: ActorContext)
     extends TypedActorFactory {
   override def getActorRefFor(proxy: AnyRef): ActorRef = typedActor.getActorRefFor(proxy)
   override def isTypedActor(proxyOrNot: AnyRef): Boolean = typedActor.isTypedActor(proxyOrNot)
 }
 
+@silent
 class TypedActorExtension(val system: ExtendedActorSystem) extends TypedActorFactory with Extension {
   import TypedActor._ //Import the goodies from the companion object
   protected def actorFactory: ActorRefFactory = system

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -45,6 +45,14 @@ Use plain `system.actorOf` instead of the DSL to create Actors if you have been 
 
 `actorFor` has been deprecated since `2.2`. Use `ActorSelection` instead.
 
+## Deprecated features
+
+### TypedActor
+
+`akka.actor.TypedActor` has been deprecated as of 2.6 in favor of the
+`akka.actor.typed` API which should be used instead. For more context on
+this deprecation [please refer to the discussion here](https://github.com/akka/akka/issues/26144).
+
 ## Internal dispatcher introduced
 
 To protect the Akka internals against starvation when user code blocks the default dispatcher (for example by accidental

--- a/akka-remote/src/test/scala/akka/remote/TypedActorRemoteDeploySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/TypedActorRemoteDeploySpec.scala
@@ -4,20 +4,23 @@
 
 package akka.remote
 
-import akka.testkit.AkkaSpec
-import com.typesafe.config._
 import scala.concurrent.{ Await, Future }
-import TypedActorRemoteDeploySpec._
-import akka.actor.{ ActorSystem, Deploy, TypedActor, TypedProps }
-import akka.util.IgnoreForScala212
 import scala.concurrent.duration._
+
+import akka.actor.{ ActorSystem, Deploy, TypedActor, TypedProps }
+import akka.testkit.AkkaSpec
+import akka.util.IgnoreForScala212
+import TypedActorRemoteDeploySpec._
+
+import com.typesafe.config._
+import com.github.ghik.silencer.silent
 
 object TypedActorRemoteDeploySpec {
   val conf = ConfigFactory.parseString("""
       akka.actor.provider = remote
       akka.remote.classic.netty.tcp.port = 0
       akka.remote.artery.canonical.port = 0
-                                                            """)
+      """)
 
   trait RemoteNameService {
     def getName: Future[String]
@@ -25,7 +28,10 @@ object TypedActorRemoteDeploySpec {
   }
 
   class RemoteNameServiceImpl extends RemoteNameService {
+    @silent
     def getName: Future[String] = Future.successful(TypedActor.context.system.name)
+
+    @silent
     def getNameSelfDeref: Future[String] = TypedActor.self[RemoteNameService].getName
   }
 
@@ -36,6 +42,7 @@ class TypedActorRemoteDeploySpec extends AkkaSpec(conf) {
   val remoteSystem = ActorSystem(remoteName, conf)
   val remoteAddress = RARP(remoteSystem).provider.getDefaultAddress
 
+  @silent
   def verify[T](f: RemoteNameService => Future[T], expected: T) = {
     val ts = TypedActor(system)
     val echoService: RemoteNameService =


### PR DESCRIPTION
## Purpose
Deprecate the old typed api in favor of the now mature typed actor api.

## References
References  https://github.com/akka/akka/issues/25516

## Background Context
I am fairly certain the usage of the annotations (on the type and some `get` and or `apply` functions) needs a re-match but this is a start. Was not entirely sure on the `@deprecated object TypedActor` but I do think it's good to show deprecation in the IDE for users with the scala/java `apply`/`get`.