### PR TITLE
Deprecate Serialization.deserialize that takes  parameter #25945

### DIFF
--- a/akka-actor/src/main/scala/akka/serialization/Serialization.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serialization.scala
@@ -189,6 +189,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
    * using the optional type hint to the Serializer.
    * Returns either the resulting object or an Exception if one was thrown.
    */
+  @deprecated("Use deserialize that accepts the `manifest` as a class name.", since = "2.6.0")
   def deserialize[T](bytes: Array[Byte], serializerId: Int, clazz: Option[Class[_ <: T]]): Try[T] =
     Try {
       val serializer = try getSerializerById(serializerId)


### PR DESCRIPTION
## References
https://github.com/akka/akka/issues/25945 
 
Does this warrant a deprecation notice in the migration guide? I am now thinking it does not.