### PR TITLE
Specific minimal scheduler API for typed 

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -7,18 +7,17 @@ package akka.actor.testkit.typed.internal
 import java.util.concurrent.{ CompletionStage, ThreadFactory }
 
 import akka.actor.typed.internal.ActorRefImpl
-import akka.actor.typed.{
-  ActorRef,
-  ActorSystem,
-  Behavior,
-  DispatcherSelector,
-  Dispatchers,
-  Extension,
-  ExtensionId,
-  Logger,
-  Props,
-  Settings
-}
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.DispatcherSelector
+import akka.actor.typed.Dispatchers
+import akka.actor.typed.Extension
+import akka.actor.typed.ExtensionId
+import akka.actor.typed.Logger
+import akka.actor.typed.Props
+import akka.actor.typed.Scheduler
+import akka.actor.typed.Settings
 import akka.annotation.InternalApi
 import akka.util.Timeout
 import akka.{ actor => untyped }
@@ -72,7 +71,7 @@ import com.github.ghik.silencer.silent
 
   override def logConfiguration(): Unit = log.info(settings.toString)
 
-  override def scheduler: untyped.Scheduler = throw new UnsupportedOperationException("no scheduler")
+  override def scheduler: Scheduler = throw new UnsupportedOperationException("no scheduler")
 
   private val terminationPromise = Promise[Done]
   override def terminate(): Unit = terminationPromise.trySuccess(Done)

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ActorTestKit.scala
@@ -6,8 +6,11 @@ package akka.actor.testkit.typed.javadsl
 
 import java.time.Duration
 
-import akka.actor.Scheduler
-import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, Props }
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.Props
+import akka.actor.typed.Scheduler
 import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.internal.TestKitUtils
 import akka.actor.testkit.typed.scaladsl

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestKitJunitResource.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestKitJunitResource.scala
@@ -4,10 +4,13 @@
 
 package akka.actor.testkit.typed.javadsl
 
-import akka.actor.Scheduler
 import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.internal.TestKitUtils
-import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, Props }
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.Props
+import akka.actor.typed.Scheduler
 import akka.util.Timeout
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -7,15 +7,21 @@ package akka.actor.testkit.typed.scaladsl
 import java.util.concurrent.TimeoutException
 
 import akka.actor.typed.scaladsl.AskPattern._
-import akka.actor.typed.{ ActorRef, ActorSystem, Behavior, Props }
-import akka.annotation.{ ApiMayChange, InternalApi }
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.Props
+import akka.actor.typed.Scheduler
+import akka.annotation.ApiMayChange
+import akka.annotation.InternalApi
 import akka.actor.testkit.typed.TestKitSettings
-import akka.actor.testkit.typed.internal.{ ActorTestKitGuardian, TestKitUtils }
-import com.typesafe.config.{ Config, ConfigFactory }
+import akka.actor.testkit.typed.internal.ActorTestKitGuardian
+import akka.actor.testkit.typed.internal.TestKitUtils
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import akka.actor.Scheduler
 import akka.util.Timeout
 
 object ActorTestKit {

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitBase.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitBase.scala
@@ -4,12 +4,12 @@
 
 package akka.actor.testkit.typed.scaladsl
 
-import akka.actor.Scheduler
 import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.internal.TestKitUtils
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
+import akka.actor.typed.Scheduler
 import akka.actor.typed.Props
 import akka.util.Timeout
 import com.typesafe.config.Config

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ManualTime.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ManualTime.scala
@@ -5,6 +5,7 @@
 package akka.actor.testkit.typed.scaladsl
 
 import akka.actor.typed.ActorSystem
+import akka.actor.typed.internal.adapter.SchedulerAdapter
 import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.annotation.varargs
@@ -30,11 +31,17 @@ object ManualTime {
    */
   def apply()(implicit system: ActorSystem[_]): ManualTime =
     system.scheduler match {
-      case sc: akka.testkit.ExplicitlyTriggeredScheduler => new ManualTime(sc)
-      case _ =>
+      case adapter: SchedulerAdapter =>
+        adapter.untypedScheduler match {
+          case sc: akka.testkit.ExplicitlyTriggeredScheduler => new ManualTime(sc)
+          case _ =>
+            throw new IllegalArgumentException(
+              "ActorSystem not configured with explicitly triggered scheduler, " +
+              "make sure to include akka.actor.testkit.typed.scaladsl.ManualTime.config() when setting up the test")
+        }
+      case s =>
         throw new IllegalArgumentException(
-          "ActorSystem not configured with explicitly triggered scheduler, " +
-          "make sure to include akka.actor.testkit.typed.scaladsl.ManualTime.config() when setting up the test")
+          s"ActorSystem.scheduler is not an untyped SchedulerAdapter but a ${s.getClass.getName}, this is not supported")
     }
 
 }

--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java
@@ -4,9 +4,9 @@
 
 package jdocs.akka.actor.testkit.typed.javadsl;
 
-import akka.actor.Scheduler;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
+import akka.actor.typed.Scheduler;
 import akka.actor.typed.javadsl.AskPattern;
 import akka.actor.typed.javadsl.Behaviors;
 // #test-header

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala
@@ -4,8 +4,7 @@
 
 package docs.akka.actor.testkit.typed.scaladsl
 
-import akka.actor.Scheduler
-//#test-header
+import akka.actor.typed.Scheduler
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 
 //#test-header

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/SchedulerTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/SchedulerTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed;
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+import java.time.Duration;
+
+public class SchedulerTest {
+
+  public void compileOnly() {
+    // accepts a lambda
+    ActorSystem<Void> system = null;
+    system
+        .scheduler()
+        .scheduleAtFixedRate(
+            Duration.ofMillis(10),
+            Duration.ofMillis(10),
+            () -> system.log().info("Woo!"),
+            system.executionContext());
+    system
+        .scheduler()
+        .scheduleOnce(
+            Duration.ofMillis(10), () -> system.log().info("Woo!"), system.executionContext());
+  }
+}

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/SchedulerTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/SchedulerTest.java
@@ -1,11 +1,7 @@
 /*
- * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
- */
-
-package akka.actor.typed;
-/*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+package akka.actor.typed;
 
 import java.time.Duration;
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SchedulerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SchedulerSpec.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed
+
+import scala.concurrent.duration._
+
+class SchedulerSpec {
+
+  def compileOnly(): Unit = {
+    val system: ActorSystem[Nothing] = ???
+    import system.executionContext
+
+    // verify a lambda works
+    system.scheduler.scheduleAtFixedRate(10.milliseconds, 10.milliseconds, () => system.log.info("Woho!"))
+    system.scheduler.scheduleOnce(10.milliseconds, () => system.log.info("Woho!"))
+  }
+
+}

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
@@ -24,7 +24,7 @@ import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Props
 import akka.util.Timeout
-import akka.actor.Scheduler
+import akka.actor.typed.Scheduler
 
 //#imports2
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -85,7 +85,7 @@ abstract class ActorSystem[-T] extends ActorRef[T] with Extensions { this: Inter
    * It is recommended to use the ActorContext’s scheduling capabilities for sending
    * messages to actors instead of registering a Runnable for execution using this facility.
    */
-  def scheduler: untyped.Scheduler
+  def scheduler: Scheduler
 
   /**
    * Facilities for lookup up thread-pools from configuration.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Scheduler.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Scheduler.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration.FiniteDuration
 /**
  * The ActorSystem facility for scheduling tasks.
  *
- * For user scheduling needs `Behaviors.withTimers` should be preferred.
+ * For scheduling within actors `Behaviors.withTimers` should be preferred.
  *
  * Not for user extension
  */
@@ -28,7 +28,7 @@ trait Scheduler {
    * @throws IllegalArgumentException if the given delays exceed the maximum
    * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
    *
-   * Note: For user scheduling needs `Behaviors.withTimers` should be preferred.
+   * Note: For scheduling within actors `Behaviors.withTimers` or `ActorContext.scheduleOnce` should be preferred.
    *
    * Scala API
    */
@@ -41,7 +41,7 @@ trait Scheduler {
    * @throws IllegalArgumentException if the given delays exceed the maximum
    * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
    *
-   * Note: For user scheduling needs `Behaviors.withTimers` should be preferred.
+   * Note: For scheduling within actors `Behaviors.withTimers` or `ActorContext.scheduleOnce` should be preferred.
    *
    * Java API
    */
@@ -68,7 +68,7 @@ trait Scheduler {
    *
    * Scala API
    */
-  def schedule(initialDelay: FiniteDuration, interval: FiniteDuration, runnable: Runnable)(
+  def scheduleAtFixedRate(initialDelay: FiniteDuration, interval: FiniteDuration, runnable: Runnable)(
       implicit executor: ExecutionContext): Cancellable
 
   /**
@@ -92,7 +92,7 @@ trait Scheduler {
    *
    * Java API
    */
-  def schedule(
+  def scheduleAtFixedRate(
       initialDelay: java.time.Duration,
       interval: java.time.Duration,
       runnable: Runnable,

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Scheduler.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Scheduler.scala
@@ -74,8 +74,8 @@ trait Scheduler {
   /**
    * Schedules a `Runnable` to be run repeatedly with an initial delay and
    * a frequency. E.g. if you would like the function to be run after 2
-   * seconds and thereafter every 100ms you would set delay = Duration(2,
-   * TimeUnit.SECONDS) and interval = Duration(100, TimeUnit.MILLISECONDS). If
+   * seconds and thereafter every 100ms you would set delay to `Duration.ofSeconds(2)`,
+   * and interval to `Duration.ofMillis(100)`. If
    * the execution of the runnable takes longer than the interval, the
    * subsequent execution will start immediately after the prior one completes
    * (there will be no overlap of executions of the runnable). In such cases,

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Scheduler.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Scheduler.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed
+
+import akka.actor.Cancellable
+import akka.annotation.DoNotInherit
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * The ActorSystem facility for scheduling tasks.
+ *
+ * For user scheduling needs `Behaviors.withTimers` should be preferred.
+ *
+ * Not for user extension
+ */
+@DoNotInherit
+trait Scheduler {
+
+  /**
+   *
+   * Schedules a Runnable to be run once with a delay, i.e. a time period that
+   * has to pass before the runnable is executed.
+   *
+   * @throws IllegalArgumentException if the given delays exceed the maximum
+   * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
+   *
+   * Note: For user scheduling needs `Behaviors.withTimers` should be preferred.
+   *
+   * Scala API
+   */
+  def scheduleOnce(delay: FiniteDuration, runnable: Runnable)(implicit executor: ExecutionContext): Cancellable
+
+  /**
+   * Schedules a Runnable to be run once with a delay, i.e. a time period that
+   * has to pass before the runnable is executed.
+   *
+   * @throws IllegalArgumentException if the given delays exceed the maximum
+   * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
+   *
+   * Note: For user scheduling needs `Behaviors.withTimers` should be preferred.
+   *
+   * Java API
+   */
+  def scheduleOnce(delay: java.time.Duration, runnable: Runnable, executor: ExecutionContext): Cancellable
+
+  /**
+   * Schedules a `Runnable` to be run repeatedly with an initial delay and
+   * a frequency. E.g. if you would like the function to be run after 2
+   * seconds and thereafter every 100ms you would set delay = Duration(2,
+   * TimeUnit.SECONDS) and interval = Duration(100, TimeUnit.MILLISECONDS). If
+   * the execution of the runnable takes longer than the interval, the
+   * subsequent execution will start immediately after the prior one completes
+   * (there will be no overlap of executions of the runnable). In such cases,
+   * the actual execution interval will differ from the interval passed to this
+   * method.
+   *
+   * If the `Runnable` throws an exception the repeated scheduling is aborted,
+   * i.e. the function will not be invoked any more.
+   *
+   * @throws IllegalArgumentException if the given delays exceed the maximum
+   * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
+   *
+   * Note: For user scheduling needs `Behaviors.withTimers` should be preferred.
+   *
+   * Scala API
+   */
+  def schedule(initialDelay: FiniteDuration, interval: FiniteDuration, runnable: Runnable)(
+      implicit executor: ExecutionContext): Cancellable
+
+  /**
+   * Schedules a `Runnable` to be run repeatedly with an initial delay and
+   * a frequency. E.g. if you would like the function to be run after 2
+   * seconds and thereafter every 100ms you would set delay = Duration(2,
+   * TimeUnit.SECONDS) and interval = Duration(100, TimeUnit.MILLISECONDS). If
+   * the execution of the runnable takes longer than the interval, the
+   * subsequent execution will start immediately after the prior one completes
+   * (there will be no overlap of executions of the runnable). In such cases,
+   * the actual execution interval will differ from the interval passed to this
+   * method.
+   *
+   * If the `Runnable` throws an exception the repeated scheduling is aborted,
+   * i.e. the function will not be invoked any more.
+   *
+   * @throws IllegalArgumentException if the given delays exceed the maximum
+   * reach (calculated as: `delay / tickNanos > Int.MaxValue`).
+   *
+   * Note: For user scheduling needs `Behaviors.withTimers` should be preferred.
+   *
+   * Java API
+   */
+  def schedule(
+      initialDelay: java.time.Duration,
+      interval: java.time.Duration,
+      runnable: Runnable,
+      executor: ExecutionContext): Cancellable
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
@@ -76,7 +76,7 @@ import akka.util.OptionVal
 
     val task =
       if (repeat)
-        ctx.system.scheduler.schedule(delay, delay, () => ctx.self.unsafeUpcast ! timerMsg)(
+        ctx.system.scheduler.scheduleAtFixedRate(delay, delay, () => ctx.self.unsafeUpcast ! timerMsg)(
           ExecutionContexts.sameThreadExecutionContext)
       else
         ctx.system.scheduler

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
@@ -76,13 +76,11 @@ import akka.util.OptionVal
 
     val task =
       if (repeat)
-        ctx.system.scheduler.schedule(delay, delay) {
-          ctx.self.unsafeUpcast ! timerMsg
-        }(ExecutionContexts.sameThreadExecutionContext)
+        ctx.system.scheduler.schedule(delay, delay, () => ctx.self.unsafeUpcast ! timerMsg)(
+          ExecutionContexts.sameThreadExecutionContext)
       else
-        ctx.system.scheduler.scheduleOnce(delay) {
-          ctx.self.unsafeUpcast ! timerMsg
-        }(ExecutionContexts.sameThreadExecutionContext)
+        ctx.system.scheduler
+          .scheduleOnce(delay, () => ctx.self.unsafeUpcast ! timerMsg)(ExecutionContexts.sameThreadExecutionContext)
 
     val nextTimer = Timer(key, msg, repeat, nextGen, task)
     ctx.log.debug("Start timer [{}] with generation [{}]", key, nextGen)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -83,7 +83,7 @@ import akka.event.LoggingFilterWithMarker
     LoggingFilterWithMarker.wrap(untypedSystem.logFilter))
   override def logConfiguration(): Unit = untypedSystem.logConfiguration()
   override def name: String = untypedSystem.name
-  override def scheduler: akka.actor.Scheduler = untypedSystem.scheduler
+  override val scheduler: Scheduler = new SchedulerAdapter(untypedSystem.scheduler)
   override def settings: Settings = new Settings(untypedSystem.settings)
   override def startTime: Long = untypedSystem.startTime
   override def threadFactory: java.util.concurrent.ThreadFactory = untypedSystem.threadFactory

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/SchedulerAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/SchedulerAdapter.scala
@@ -16,7 +16,8 @@ import scala.concurrent.duration.FiniteDuration
 /**
  * INTERNAL API
  */
-@InternalApi final class SchedulerAdapter(untypedScheduler: akka.actor.Scheduler) extends Scheduler {
+@InternalApi
+private[akka] final class SchedulerAdapter(private[akka] val untypedScheduler: akka.actor.Scheduler) extends Scheduler {
   override def scheduleOnce(delay: FiniteDuration, runnable: Runnable)(
       implicit executor: ExecutionContext): Cancellable =
     untypedScheduler.scheduleOnce(delay, runnable)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/SchedulerAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/SchedulerAdapter.scala
@@ -24,11 +24,11 @@ import scala.concurrent.duration.FiniteDuration
   override def scheduleOnce(delay: Duration, runnable: Runnable, executor: ExecutionContext): Cancellable =
     untypedScheduler.scheduleOnce(delay, runnable)(executor)
 
-  override def schedule(initialDelay: FiniteDuration, interval: FiniteDuration, runnable: Runnable)(
+  override def scheduleAtFixedRate(initialDelay: FiniteDuration, interval: FiniteDuration, runnable: Runnable)(
       implicit executor: ExecutionContext): Cancellable =
     untypedScheduler.schedule(initialDelay, interval, runnable)
 
-  override def schedule(
+  override def scheduleAtFixedRate(
       initialDelay: Duration,
       interval: Duration,
       runnable: Runnable,

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/SchedulerAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/SchedulerAdapter.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.internal.adapter
+
+import java.time.Duration
+
+import akka.actor.Cancellable
+import akka.actor.typed.Scheduler
+import akka.annotation.InternalApi
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * INTERNAL API
+ */
+@InternalApi final class SchedulerAdapter(untypedScheduler: akka.actor.Scheduler) extends Scheduler {
+  override def scheduleOnce(delay: FiniteDuration, runnable: Runnable)(
+      implicit executor: ExecutionContext): Cancellable =
+    untypedScheduler.scheduleOnce(delay, runnable)
+
+  override def scheduleOnce(delay: Duration, runnable: Runnable, executor: ExecutionContext): Cancellable =
+    untypedScheduler.scheduleOnce(delay, runnable)(executor)
+
+  override def schedule(initialDelay: FiniteDuration, interval: FiniteDuration, runnable: Runnable)(
+      implicit executor: ExecutionContext): Cancellable =
+    untypedScheduler.schedule(initialDelay, interval, runnable)
+
+  override def schedule(
+      initialDelay: Duration,
+      interval: Duration,
+      runnable: Runnable,
+      executor: ExecutionContext): Cancellable =
+    untypedScheduler.schedule(initialDelay, interval, runnable)(executor)
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AskPattern.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AskPattern.scala
@@ -8,7 +8,7 @@ package javadsl
 import java.time.Duration
 import java.util.concurrent.CompletionStage
 
-import akka.actor.Scheduler
+import akka.actor.typed.Scheduler
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.japi.function.{ Function => JFunction }
 import akka.util.JavaDurationConverters._

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
@@ -7,8 +7,9 @@ package akka.actor.typed.scaladsl
 import java.util.concurrent.TimeoutException
 
 import scala.concurrent.Future
-import akka.actor.{ Address, RootActorPath, Scheduler }
+import akka.actor.{ Address, RootActorPath }
 import akka.actor.typed.ActorRef
+import akka.actor.typed.Scheduler
 import akka.actor.typed.internal.{ adapter => adapt }
 import akka.annotation.InternalApi
 import akka.pattern.PromiseActorRef

--- a/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
@@ -9,7 +9,7 @@ import akka.actor.testkit.typed.TestKitSettings
 import akka.cluster.ddata.SelfUniqueAddress
 
 // #sample
-import akka.actor.Scheduler
+import akka.actor.typed.Scheduler
 import akka.actor.typed.{ ActorRef, Behavior }
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.scaladsl.Behaviors

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -210,4 +210,4 @@ Akka Typed APIs are still marked as [may change](../common/may-change.md) and th
 * Factory method `Entity.ofPersistentEntity` is renamed to `Entity.ofEventSourcedEntity` in the Java API for Akka Cluster Sharding Typed.
 * New abstract class `EventSourcedEntityWithEnforcedReplies` in Java API for Akka Cluster Sharding Typed and corresponding factory method `Entity.ofEventSourcedEntityWithEnforcedReplies` to ease the creation of `EventSourcedBehavior` with enforced replies.
 * New method `EventSourcedEntity.withEnforcedReplies` added to Scala API to ease the creation of `EventSourcedBehavior` with enforced replies.
- 
+* `ActorSystem.scheduler` previously gave access to the untyped `akka.actor.Scheduler` but now returns a typed specific `akka.actor.typed.Scheduler` - user code that needs to schedule tasks should prefer `Behaviors.withTimers`.  

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -210,4 +210,4 @@ Akka Typed APIs are still marked as [may change](../common/may-change.md) and th
 * Factory method `Entity.ofPersistentEntity` is renamed to `Entity.ofEventSourcedEntity` in the Java API for Akka Cluster Sharding Typed.
 * New abstract class `EventSourcedEntityWithEnforcedReplies` in Java API for Akka Cluster Sharding Typed and corresponding factory method `Entity.ofEventSourcedEntityWithEnforcedReplies` to ease the creation of `EventSourcedBehavior` with enforced replies.
 * New method `EventSourcedEntity.withEnforcedReplies` added to Scala API to ease the creation of `EventSourcedBehavior` with enforced replies.
-* `ActorSystem.scheduler` previously gave access to the untyped `akka.actor.Scheduler` but now returns a typed specific `akka.actor.typed.Scheduler` - user code that needs to schedule tasks should prefer `Behaviors.withTimers`.  
+* `ActorSystem.scheduler` previously gave access to the untyped `akka.actor.Scheduler` but now returns a typed specific `akka.actor.typed.Scheduler`. Additionally `.schedule` has been renamed to `.scheduleAtFixedRate`. Actors that needs to schedule tasks should prefer `Behaviors.withTimers`. 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
@@ -98,7 +98,7 @@ private[akka] final class BehaviorSetup[C, E, S](
         context.system.scheduler
           .scheduleOnce(settings.recoveryEventTimeout, context.self.toUntyped, RecoveryTickEvent(snapshot = true))
       else
-        context.system.scheduler.schedule(
+        context.system.scheduler.scheduleAtFixedRate(
           settings.recoveryEventTimeout,
           settings.recoveryEventTimeout,
           context.self.toUntyped,

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
@@ -95,14 +95,12 @@ private[akka] final class BehaviorSetup[C, E, S](
     implicit val ec: ExecutionContext = context.executionContext
     val timer =
       if (snapshot)
-        context.system.scheduler
-          .scheduleOnce(settings.recoveryEventTimeout, context.self.toUntyped, RecoveryTickEvent(snapshot = true))
+        context.scheduleOnce(settings.recoveryEventTimeout, context.self, RecoveryTickEvent(snapshot = true))
       else
         context.system.scheduler.scheduleAtFixedRate(
           settings.recoveryEventTimeout,
           settings.recoveryEventTimeout,
-          context.self.toUntyped,
-          RecoveryTickEvent(snapshot = false))
+          () => context.self ! RecoveryTickEvent(snapshot = false))
     recoveryTimer = OptionVal.Some(timer)
   }
 

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java
@@ -4,10 +4,10 @@
 
 package akka.persistence.typed.javadsl;
 
-import akka.actor.Scheduler;
 import akka.actor.typed.Behavior;
 import akka.actor.typed.javadsl.ActorContext;
 import akka.actor.typed.ActorRef;
+import akka.actor.typed.Scheduler;
 import akka.actor.typed.javadsl.Behaviors;
 import akka.japi.function.Procedure;
 import akka.persistence.typed.SnapshotSelectionCriteria;

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
@@ -64,7 +64,7 @@ object PersistentActorCompileOnlyTest {
     def performSideEffect(sender: ActorRef[AcknowledgeSideEffect], correlationId: Int, data: String): Unit = {
       import akka.actor.typed.scaladsl.AskPattern._
       implicit val timeout: akka.util.Timeout = 1.second
-      implicit val scheduler: akka.actor.Scheduler = ???
+      implicit val scheduler: akka.actor.typed.Scheduler = ???
       implicit val ec: ExecutionContext = ???
 
       val response: Future[RecoveryComplete.Response] =


### PR DESCRIPTION
## Purpose
To not paint ourselves into a corner for the future we want minimal untyped APIs to leak through the typeds APIs. `akka.actor.Scheduler` was such a case.

## References
Fixes #26971

## Changes
* A minimal `akka.actor.typed.Scheduler` is introduced, essentially only containing what is needed to implement `Behaviors.withTimers`
* `ActorSystem.scheduler` returns the typed scheduler
* All uses of scheduler in typed is replaced with the typed one