### PR TITLE
act: TcpConnection: ignore late signals from SelectionHandler while shutting down

### DIFF
--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -197,7 +197,8 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
 
   /** stopWith sets this state while waiting for the SelectionHandler to execute the `cancelAndClose` thunk */
   def unregistering: Receive = {
-    case Unregistered => context.stop(self) // postStop will notify interested parties
+    case Unregistered                                                               => context.stop(self) // postStop will notify interested parties
+    case ChannelReadable | ChannelWritable | ChannelAcceptable | ChannelConnectable => // ignore, we are going away soon anyway
   }
 
   // AUXILIARIES and IMPLEMENTATION


### PR DESCRIPTION
As reported at https://discuss.lightbend.com/t/file-upload-data-not-being-discarded-on-route-rejection/4185, in recent versions TcpConnection is prone to extra log messages since a few versions.

The most likely reason is https://github.com/akka/akka/commit/7899708ca684ce696fd3aa306cf56b396637b632 which introduced that extra `unregistering` state which doesn't handle late signals from the SelectionHandler.