### PR TITLE
specify travis safelist for branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,10 @@ env:
   global:
     # encrypt with: travis encrypt WHITESOURCE_KEY=...
     - secure: "L/wJ7TbgY+oPULgbv+giFZejnQERfv/8/9Ex/nwRni8qnpxw5Q6BqB86Sch6b79irQiOdb+hr2tq3/m3KzXjC58xppRPfnmXsu3yI9XAln9WPi/sPvqUL8WPJmRfGswAw3L8w2JdD9VBP4iv0dWpRghGD27iqgipVRdN62PU+nU="
+
+# safelist
+branches:
+  only:
+  - master
+  - release-2.5
+  - /^v\d+\.\d+(\.\d+)?(-\S*)?$/


### PR DESCRIPTION
To avoid double builds of wip branches. PRs should still be built as usual if I understand the docs correctly:
https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches
https://docs.travis-ci.com/user/pull-requests/