### PR TITLE
Don't log internal messages as an event

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingEvents.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingEvents.scala
@@ -175,7 +175,7 @@ private[akka] final class ReplayingEvents[C, E, S](
     val msg = event match {
       case Some(_: Message) | None =>
         s"Exception during recovery. Last known sequence number [$sequenceNr]. " +
-          s"PersistenceId [${setup.persistenceId.id}]. ${cause.getMessage}"
+        s"PersistenceId [${setup.persistenceId.id}]. ${cause.getMessage}"
       case Some(evt) =>
         s"Exception during recovery while handling [${evt.getClass.getName}] with sequence number [$sequenceNr]. " +
         s"PersistenceId [${setup.persistenceId.id}]. ${cause.getMessage}"

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingEvents.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingEvents.scala
@@ -173,11 +173,11 @@ private[akka] final class ReplayingEvents[C, E, S](
 
     val sequenceNr = state.seqNr
     val msg = event match {
+      case Some(_: Message) | None =>
+        s"Exception during recovery. Last known sequence number [$sequenceNr]. " +
+          s"PersistenceId [${setup.persistenceId.id}]. ${cause.getMessage}"
       case Some(evt) =>
         s"Exception during recovery while handling [${evt.getClass.getName}] with sequence number [$sequenceNr]. " +
-        s"PersistenceId [${setup.persistenceId.id}]. ${cause.getMessage}"
-      case None =>
-        s"Exception during recovery. Last known sequence number [$sequenceNr]. " +
         s"PersistenceId [${setup.persistenceId.id}]. ${cause.getMessage}"
     }
 


### PR DESCRIPTION
The Journal protocol gets logged as the user's event in some cases which is darn confusing 