### PR TITLE
remove upload of whitesource report from release script, #26866

### DIFF
--- a/project/scripts/release
+++ b/project/scripts/release
@@ -325,14 +325,6 @@ else
   important git push origin --tags
 fi
 
-echolog "Uploading whitesource report"
-if [ $dry_run ]; then
-  echodry "Not actually uploading whitesource report. Commands:"
-  echodry "  sbt $RELEASE_OPT whitesourceUpdate"
-else
-  important sbt $RELEASE_OPT whitesourceUpdate
-fi
-
 # push the release to the server
 echolog "Pushing ${release_dir} to ${publish_path} ..."
 if [ $dry_run ]; then


### PR DESCRIPTION
* to avoid it for milestones
* will be done by Travis on tag build instead
* note that `whitesourceCheckPolicies` is still done from release script

Refs #26866

Ticket https://github.com/akka/akka/issues/27015 for doing it from the Travis build instead.