### PR TITLE
workaround in release script for missing Jackson dependency for Scala 2.13.0-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] = List[ProjectReference](
     testkit) ++
   (if (isScala213) List.empty[ProjectReference]
    else
-     List[ProjectReference](jackson, benchJmh, benchJmhTyped)) // FIXME move 2.13 condition when Jackson ScalaModule has been released for Scala 2.13.0
+     List[ProjectReference](jackson, benchJmh, benchJmhTyped)) // FIXME #27019 remove 2.13 condition when Jackson ScalaModule has been released for Scala 2.13
 
 lazy val root = Project(id = "akka", base = file("."))
   .aggregate(aggregatedProjects: _*)
@@ -244,7 +244,7 @@ lazy val jackson = akkaModule("akka-serialization-jackson")
   .settings(AutomaticModuleName.settings("akka.serialization.jackson"))
   .settings(OSGi.jackson)
   .settings(javacOptions += "-parameters")
-  // FIXME remove when Jackson ScalaModule has been released for Scala 2.13.0
+  // FIXME #27019 remove when Jackson ScalaModule has been released for Scala 2.13
   .settings(crossScalaVersions -= Dependencies.scala213Version)
   .enablePlugins(ScaladocNoVerificationOfDiagrams)
   .disablePlugins(MimaPlugin)

--- a/project/scripts/release
+++ b/project/scripts/release
@@ -271,7 +271,12 @@ if [ ! $dry_run ]; then
 else
   RELEASE_OPT="-Dakka.build.version=${version} -Dakka.genjavadoc.enabled=true"
 fi
-try sbt $RELEASE_OPT +buildRelease
+
+# FIXME #27019 change back to +buildRelease when Jackson ScalaModule has been released for Scala 2.13
+#try sbt $RELEASE_OPT +buildRelease
+try sbt $RELEASE_OPT buildRelease
+try sbt $RELEASE_OPT -Dakka.build.scalaVersion=2.13.0-RC2 buildRelease
+
 try sbt $RELEASE_OPT buildDocs
 echolog "Successfully created local release"
 


### PR DESCRIPTION
* Thought that the `crossScalaVersions -= Dependencies.scala213Version` in
  the akka-serialization-jackson project would work also for the +buildRelease, but
  in dry-run it didn't so building twice with explicit Scala versions instead.
* akka-serialization-jackson is then excluded from the aggregate for 2.13
