### PR TITLE
Flow.recoverWithRetries with backoff strategy

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowRecoverWithSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowRecoverWithSpec.scala
@@ -4,15 +4,20 @@
 
 package akka.stream.scaladsl
 
-import akka.stream.stage.{ GraphStage, GraphStageLogic }
+import akka.actor.Status.Failure
+import akka.stream.stage.{GraphStage, GraphStageLogic}
 import akka.stream.testkit.StreamSpec
 import akka.stream.testkit.scaladsl.TestSink
 import akka.stream._
+import akka.stream.impl.fusing.RecoverWithBackoff
 import akka.stream.testkit.Utils._
 import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.testkit.TestProbe
+
 import com.github.ghik.silencer.silent
 
 import scala.util.control.NoStackTrace
+import scala.concurrent.duration._
 
 @silent // tests deprecated APIs
 class FlowRecoverWithSpec extends StreamSpec {
@@ -156,6 +161,26 @@ class FlowRecoverWithSpec extends StreamSpec {
         .expectNextN(List(11, 22))
         .expectNextN(List(11, 22))
         .expectError(ex)
+    }
+
+    "terminate with exception after set number of retries using Linear backoff strategy" in assertAllStagesStopped {
+      val probe = TestProbe()
+      val indexOutOfBoundsException = new IndexOutOfBoundsException()
+      val maxTimeout = 10.seconds
+
+      Source(1 to 2)
+        .map { a => if (a == 2) throw indexOutOfBoundsException else a
+        }
+        .recoverWithRetries(2, 1.milliseconds, RecoverWithBackoff.Linear, {
+          case t: Throwable =>
+            Source(List(11, 22)).map(m => if (m == 22) throw indexOutOfBoundsException else m)
+        })
+        .runWith(Sink.actorRef(probe.ref, "completed"))
+
+      probe.expectMsg(maxTimeout, 1)
+      probe.expectMsg(maxTimeout, 11)
+      probe.expectMsg(maxTimeout, 11)
+      probe.expectMsgType[Failure](maxTimeout)
     }
 
     "not attempt recovering when attempts is zero" in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowRecoverWithSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowRecoverWithSpec.scala
@@ -5,7 +5,7 @@
 package akka.stream.scaladsl
 
 import akka.actor.Status.Failure
-import akka.stream.stage.{GraphStage, GraphStageLogic}
+import akka.stream.stage.{ GraphStage, GraphStageLogic }
 import akka.stream.testkit.StreamSpec
 import akka.stream.testkit.scaladsl.TestSink
 import akka.stream._
@@ -169,7 +169,8 @@ class FlowRecoverWithSpec extends StreamSpec {
       val maxTimeout = 10.seconds
 
       Source(1 to 2)
-        .map { a => if (a == 2) throw indexOutOfBoundsException else a
+        .map { a =>
+          if (a == 2) throw indexOutOfBoundsException else a
         }
         .recoverWithRetries(2, 1.milliseconds, RecoverWithBackoff.Linear, {
           case t: Throwable =>

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -7,28 +7,28 @@ package akka.stream.impl.fusing
 import java.util.UUID
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
-import akka.actor.{ActorRef, Terminated}
-import akka.annotation.{DoNotInherit, InternalApi}
+import akka.actor.{ ActorRef, Terminated }
+import akka.annotation.{ DoNotInherit, InternalApi }
 import akka.dispatch.ExecutionContexts
 import akka.event.Logging.LogLevel
-import akka.event.{LogSource, Logging, LoggingAdapter}
-import akka.stream.Attributes.{InputBuffer, LogLevels}
+import akka.event.{ LogSource, Logging, LoggingAdapter }
+import akka.stream.Attributes.{ InputBuffer, LogLevels }
 import akka.stream.OverflowStrategies._
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import akka.stream.impl.{ ReactiveStreamsCompliance, Buffer => BufferImpl }
 import akka.stream.scaladsl.{ DelayStrategy, Flow, Keep, Source }
 import akka.stream.stage._
-import akka.stream.{Supervision, _}
+import akka.stream.{ Supervision, _ }
 
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.collection.immutable.VectorBuilder
-import scala.concurrent.{Future, Promise}
-import scala.util.control.{NoStackTrace, NonFatal}
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.{ Future, Promise }
+import scala.util.control.{ NoStackTrace, NonFatal }
+import scala.util.{ Failure, Success, Try }
 import akka.stream.ActorAttributes.SupervisionStrategy
 
-import scala.concurrent.duration.{FiniteDuration, _}
+import scala.concurrent.duration.{ FiniteDuration, _ }
 import scala.util.control.Exception.Catcher
 import akka.stream.impl.Stages.DefaultAttributes
 import akka.util.OptionVal
@@ -2021,30 +2021,28 @@ object RecoverWithBackoff {
 }
 
 /**
-  * INTERNAL API
-  */
-@InternalApi private[akka] final class RecoverWithBackoff[T, M](val maximumAttempts: Int,
-                                                                val initialRetryTimeout: FiniteDuration,
-                                                                val backoffStrategy: RetryBackoffStrategy,
-                                                                val pf: PartialFunction[Throwable, Graph[SourceShape[T], M]])
-  extends SimpleLinearGraphStage[T] {
+ * INTERNAL API
+ */
+@InternalApi private[akka] final class RecoverWithBackoff[T, M](
+    val maximumAttempts: Int,
+    val initialRetryTimeout: FiniteDuration,
+    val backoffStrategy: RetryBackoffStrategy,
+    val pf: PartialFunction[Throwable, Graph[SourceShape[T], M]])
+    extends SimpleLinearGraphStage[T] {
 
   override def toString: String = "RecoverWithBackoff"
 
   override def createLogic(attr: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) with StageLogging {
     var attempt = 0
 
-    setHandler(
-      in,
-      new InHandler {
-        override def onPush(): Unit = {
-          val elem = grab(in)
-          push(out, elem)
-        }
-
-        override def onUpstreamFailure(ex: Throwable): Unit = onFailure(ex)
+    setHandler(in, new InHandler {
+      override def onPush(): Unit = {
+        val elem = grab(in)
+        push(out, elem)
       }
-    )
+
+      override def onUpstreamFailure(ex: Throwable): Unit = onFailure(ex)
+    })
 
     setHandler(out, new OutHandler {
       override def onPull(): Unit = pull(in)
@@ -2062,7 +2060,7 @@ object RecoverWithBackoff {
         val delay =
           backoffStrategy match {
             case Exponential => initialRetryTimeout * Math.pow(2, attempt - 1).toInt
-            case Linear => initialRetryTimeout * attempt
+            case Linear      => initialRetryTimeout * attempt
           }
         log.debug(s"Retry attempt $attempt for exception $ex to be scheduled after $delay ${delay.unit}")
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -4,35 +4,37 @@
 
 package akka.stream.impl.fusing
 
+import java.util.UUID
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
-import akka.actor.{ ActorRef, Terminated }
-import akka.annotation.{ DoNotInherit, InternalApi }
+import akka.actor.{ActorRef, Terminated}
+import akka.annotation.{DoNotInherit, InternalApi}
 import akka.dispatch.ExecutionContexts
 import akka.event.Logging.LogLevel
-import akka.event.{ LogSource, Logging, LoggingAdapter }
-import akka.stream.Attributes.{ InputBuffer, LogLevels }
+import akka.event.{LogSource, Logging, LoggingAdapter}
+import akka.stream.Attributes.{InputBuffer, LogLevels}
 import akka.stream.OverflowStrategies._
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import akka.stream.impl.{ ReactiveStreamsCompliance, Buffer => BufferImpl }
 import akka.stream.scaladsl.{ DelayStrategy, Flow, Keep, Source }
 import akka.stream.stage._
-import akka.stream.{ Supervision, _ }
+import akka.stream.{Supervision, _}
 
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.collection.immutable.VectorBuilder
-import scala.concurrent.{ Future, Promise }
-import scala.util.control.{ NoStackTrace, NonFatal }
-import scala.util.{ Failure, Success, Try }
+import scala.concurrent.{Future, Promise}
+import scala.util.control.{NoStackTrace, NonFatal}
+import scala.util.{Failure, Success, Try}
 import akka.stream.ActorAttributes.SupervisionStrategy
 
-import scala.concurrent.duration.{ FiniteDuration, _ }
+import scala.concurrent.duration.{FiniteDuration, _}
 import scala.util.control.Exception.Catcher
 import akka.stream.impl.Stages.DefaultAttributes
 import akka.util.OptionVal
 import akka.util.unused
 import com.github.ghik.silencer.silent
+import akka.stream.impl.fusing.RecoverWithBackoff._
 
 /**
  * INTERNAL API
@@ -2008,6 +2010,94 @@ private[stream] object Collect {
   }
 
   override def toString: String = "RecoverWith"
+}
+
+object RecoverWithBackoff {
+  private[akka] case class RetryContainer(ex: Throwable, id: UUID = UUID.randomUUID)
+
+  sealed trait RetryBackoffStrategy
+  case object Exponential extends RetryBackoffStrategy
+  case object Linear extends RetryBackoffStrategy
+}
+
+/**
+  * INTERNAL API
+  */
+@InternalApi private[akka] final class RecoverWithBackoff[T, M](val maximumAttempts: Int,
+                                                                val initialRetryTimeout: FiniteDuration,
+                                                                val backoffStrategy: RetryBackoffStrategy,
+                                                                val pf: PartialFunction[Throwable, Graph[SourceShape[T], M]])
+  extends SimpleLinearGraphStage[T] {
+
+  override def toString: String = "RecoverWithBackoff"
+
+  override def createLogic(attr: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) with StageLogging {
+    var attempt = 0
+
+    setHandler(
+      in,
+      new InHandler {
+        override def onPush(): Unit = {
+          val elem = grab(in)
+          push(out, elem)
+        }
+
+        override def onUpstreamFailure(ex: Throwable): Unit = onFailure(ex)
+      }
+    )
+
+    setHandler(out, new OutHandler {
+      override def onPull(): Unit = pull(in)
+    })
+
+    override protected def onTimer(timerKey: Any): Unit = {
+      val key = timerKey.asInstanceOf[RetryContainer]
+      switchTo(key)
+    }
+
+    def onFailure(ex: Throwable): Unit =
+      if ((maximumAttempts < 0 || attempt < maximumAttempts) && pf.isDefinedAt(ex)) {
+        attempt += 1
+
+        val delay =
+          backoffStrategy match {
+            case Exponential => initialRetryTimeout * Math.pow(2, attempt - 1).toInt
+            case Linear => initialRetryTimeout * attempt
+          }
+        log.debug(s"Retry attempt $attempt for exception $ex to be scheduled after $delay ${delay.unit}")
+
+        scheduleOnce(RetryContainer(ex), delay)
+      } else {
+        failStage(ex)
+      }
+
+    def switchTo(key: RetryContainer): Unit = {
+      val sinkIn = new SubSinkInlet[T]("RecoverWithBackoffSink")
+
+      sinkIn.setHandler(new InHandler {
+        override def onPush(): Unit = {
+          val elem = sinkIn.grab()
+          push(out, elem)
+        }
+
+        override def onUpstreamFinish(): Unit = completeStage()
+
+        override def onUpstreamFailure(ex: Throwable): Unit = onFailure(ex)
+      })
+
+      val outHandler = new OutHandler {
+        override def onPull(): Unit = sinkIn.pull()
+
+        override def onDownstreamFinish(cause: Throwable): Unit = sinkIn.cancel(cause)
+      }
+
+      Source.fromGraph(pf(key.ex)).runWith(sinkIn.sink)(interpreter.subFusingMaterializer)
+      setHandler(out, outHandler)
+      if (isAvailable(out)) {
+        sinkIn.pull()
+      }
+    }
+  }
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -25,17 +25,17 @@ import akka.actor.ClassicActorSystemProvider
 import akka.annotation.ApiMayChange
 import akka.dispatch.ExecutionContexts
 import akka.event.LoggingAdapter
+import akka.japi.function
 import akka.japi.Pair
 import akka.japi.Util
-import akka.japi.function
+import akka.japi.function.Creator
 import akka.stream._
 import akka.stream.impl.fusing.LazyFlow
 import akka.stream.impl.fusing.RecoverWithBackoff.RetryBackoffStrategy
-import akka.util.JavaDurationConverters._
 import akka.util.unused
+import akka.util.JavaDurationConverters._
 import akka.util.ConstantFun
 import akka.util.Timeout
-import akka.japi.function.Creator
 
 import com.github.ghik.silencer.silent
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -4,15 +4,25 @@
 
 package akka.stream.javadsl
 
-import java.util.concurrent.CompletionStage
-import java.util.function.BiFunction
-import java.util.function.Supplier
 import java.util.Comparator
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.function.BiFunction
+import java.util.function.Supplier
 
+import org.reactivestreams.Processor
+
+import scala.annotation.unchecked.uncheckedVariance
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.duration.FiniteDuration
+import scala.reflect.ClassTag
+
+import akka.Done
+import akka.NotUsed
 import akka.actor.ActorRef
 import akka.actor.ClassicActorSystemProvider
+import akka.annotation.ApiMayChange
 import akka.dispatch.ExecutionContexts
 import akka.event.LoggingAdapter
 import akka.japi.Pair
@@ -20,20 +30,14 @@ import akka.japi.Util
 import akka.japi.function
 import akka.stream._
 import akka.stream.impl.fusing.LazyFlow
+import akka.stream.impl.fusing.RecoverWithBackoff.RetryBackoffStrategy
 import akka.util.JavaDurationConverters._
 import akka.util.unused
 import akka.util.ConstantFun
 import akka.util.Timeout
-import akka.Done
-import akka.NotUsed
 import akka.japi.function.Creator
-import com.github.ghik.silencer.silent
-import org.reactivestreams.Processor
 
-import scala.annotation.unchecked.uncheckedVariance
-import scala.compat.java8.FutureConverters._
-import scala.concurrent.duration.FiniteDuration
-import scala.reflect.ClassTag
+import com.github.ghik.silencer.silent
 
 object Flow {
 
@@ -1635,6 +1639,45 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
       attempts: Int,
       pf: PartialFunction[Throwable, Graph[SourceShape[Out], NotUsed]]): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.recoverWithRetries(attempts, pf))
+
+  /**
+   * RecoverWithRetries allows to switch to alternative Source on flow failure. This overloaded method allows to
+   * schedule retries on intervals as specified by `initialRetryTimeout` parameter using
+   * [[akka.stream.impl.fusing.RecoverWithBackoff.RetryBackoffStrategy]] as specified by `backoffStrategy` parameter.
+   * Following strategies are supported as of now: [[akka.stream.impl.fusing.RecoverWithBackoff.Exponential]]
+   * and [[akka.stream.impl.fusing.RecoverWithBackoff.Linear]]. It will stay in effect after
+   * a failure has been recovered up to `attempts` number of times so that each time there is a failure
+   * it is fed into the `pf` and a new Source may be materialized. Note that if you pass in 0, this won't
+   * attempt to recover at all.
+   *
+   * A negative `attempts` number is interpreted as "infinite", which results in the exact same behavior as `recoverWith`.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This operator can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Throwing an exception inside `recoverWithRetries` _will_ be logged on ERROR level automatically.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and element is available
+   * from alternative Source
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @param attempts Maximum number of retries or -1 to retry indefinitely
+   * @param initialRetryTimeout Initial timeout for retry delay, next delay is calculated based on `backoffStrategy`
+   * @param backoffStrategy The strategy used for calculating next retry attempt
+   * @param pf Receives the failure cause and returns the new Source to be materialized if any
+   *
+   */
+  def recoverWithRetries(
+      attempts: Int,
+      initialRetryTimeout: FiniteDuration,
+      backoffStrategy: RetryBackoffStrategy,
+      pf: PartialFunction[Throwable, Graph[SourceShape[Out], NotUsed]]): javadsl.Flow[In, Out, Mat] =
+    new Flow(delegate.recoverWithRetries(attempts, initialRetryTimeout, backoffStrategy, pf))
 
   /**
    * RecoverWithRetries allows to switch to alternative Source on flow failure. It will stay in effect after

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -22,7 +22,6 @@ import akka.Done
 import akka.NotUsed
 import akka.actor.ActorRef
 import akka.actor.ClassicActorSystemProvider
-import akka.annotation.ApiMayChange
 import akka.dispatch.ExecutionContexts
 import akka.event.LoggingAdapter
 import akka.japi.function

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -7,11 +7,20 @@ package akka.stream.scaladsl
 import akka.event.LoggingAdapter
 import akka.stream._
 import akka.Done
-import akka.stream.impl.{LinearTraversalBuilder, ProcessorModule, SetupFlowStage, SubFlowImpl, Throttle, Timers, TraversalBuilder, fusing}
+import akka.stream.impl.{
+  fusing,
+  LinearTraversalBuilder,
+  ProcessorModule,
+  SetupFlowStage,
+  SubFlowImpl,
+  Throttle,
+  Timers,
+  TraversalBuilder
+}
 import akka.stream.impl.fusing._
 import akka.stream.stage._
-import akka.util.{ConstantFun, Timeout}
-import org.reactivestreams.{Processor, Publisher, Subscriber, Subscription}
+import akka.util.{ ConstantFun, Timeout }
+import org.reactivestreams.{ Processor, Publisher, Subscriber, Subscription }
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
@@ -841,37 +850,37 @@ trait FlowOps[+Out, +Mat] {
     via(new RecoverWith(attempts, pf))
 
   /**
-    * RecoverWithRetries allows to switch to alternative Source on flow failure. This overloaded method allows to
-    * schedule retries on intervals as specified by `initialRetryTimeout` parameter using
-    * [[akka.stream.impl.fusing.RecoverWithBackoff.RetryBackoffStrategy]] as specified by `backoffStrategy` parameter.
-    * Following strategies are supported as of now: [[akka.stream.impl.fusing.RecoverWithBackoff.Exponential]]
-    * and [[akka.stream.impl.fusing.RecoverWithBackoff.Linear]]. It will stay in effect after
-    * a failure has been recovered up to `attempts` number of times so that each time there is a failure
-    * it is fed into the `pf` and a new Source may be materialized. Note that if you pass in 0, this won't
-    * attempt to recover at all.
-    *
-    * A negative `attempts` number is interpreted as "infinite", which results in the exact same behavior as `recoverWith`.
-    *
-    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
-    * This operator can recover the failure signal, but not the skipped elements, which will be dropped.
-    *
-    * Throwing an exception inside `recoverWithRetries` _will_ be logged on ERROR level automatically.
-    *
-    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
-    * from alternative Source
-    *
-    * '''Backpressures when''' downstream backpressures
-    *
-    * '''Completes when''' upstream completes or upstream failed with exception pf can handle
-    *
-    * '''Cancels when''' downstream cancels
-    *
-    * @param attempts Maximum number of retries or -1 to retry indefinitely
-    * @param initialRetryTimeout Initial timeout for retry delay, next delay is calculated based on `backoffStrategy`
-    * @param backoffStrategy The strategy used for calculating next retry attempt
-    * @param pf Receives the failure cause and returns the new Source to be materialized if any
-    *
-    */
+   * RecoverWithRetries allows to switch to alternative Source on flow failure. This overloaded method allows to
+   * schedule retries on intervals as specified by `initialRetryTimeout` parameter using
+   * [[akka.stream.impl.fusing.RecoverWithBackoff.RetryBackoffStrategy]] as specified by `backoffStrategy` parameter.
+   * Following strategies are supported as of now: [[akka.stream.impl.fusing.RecoverWithBackoff.Exponential]]
+   * and [[akka.stream.impl.fusing.RecoverWithBackoff.Linear]]. It will stay in effect after
+   * a failure has been recovered up to `attempts` number of times so that each time there is a failure
+   * it is fed into the `pf` and a new Source may be materialized. Note that if you pass in 0, this won't
+   * attempt to recover at all.
+   *
+   * A negative `attempts` number is interpreted as "infinite", which results in the exact same behavior as `recoverWith`.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This operator can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Throwing an exception inside `recoverWithRetries` _will_ be logged on ERROR level automatically.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and element is available
+   * from alternative Source
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @param attempts Maximum number of retries or -1 to retry indefinitely
+   * @param initialRetryTimeout Initial timeout for retry delay, next delay is calculated based on `backoffStrategy`
+   * @param backoffStrategy The strategy used for calculating next retry attempt
+   * @param pf Receives the failure cause and returns the new Source to be materialized if any
+   *
+   */
   def recoverWithRetries[T >: Out](
       attempts: Int,
       initialRetryTimeout: FiniteDuration,

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -7,20 +7,11 @@ package akka.stream.scaladsl
 import akka.event.LoggingAdapter
 import akka.stream._
 import akka.Done
-import akka.stream.impl.{
-  fusing,
-  LinearTraversalBuilder,
-  ProcessorModule,
-  SetupFlowStage,
-  SubFlowImpl,
-  Throttle,
-  Timers,
-  TraversalBuilder
-}
+import akka.stream.impl.{LinearTraversalBuilder, ProcessorModule, SetupFlowStage, SubFlowImpl, Throttle, Timers, TraversalBuilder, fusing}
 import akka.stream.impl.fusing._
 import akka.stream.stage._
-import akka.util.{ ConstantFun, Timeout }
-import org.reactivestreams.{ Processor, Publisher, Subscriber, Subscription }
+import akka.util.{ConstantFun, Timeout}
+import org.reactivestreams.{Processor, Publisher, Subscriber, Subscription}
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
@@ -30,6 +21,7 @@ import akka.stream.impl.fusing.FlattenMerge
 import akka.NotUsed
 import akka.actor.ActorRef
 import akka.annotation.DoNotInherit
+import akka.stream.impl.fusing.RecoverWithBackoff.RetryBackoffStrategy
 
 import scala.annotation.implicitNotFound
 import scala.reflect.ClassTag
@@ -847,6 +839,45 @@ trait FlowOps[+Out, +Mat] {
       attempts: Int,
       pf: PartialFunction[Throwable, Graph[SourceShape[T], NotUsed]]): Repr[T] =
     via(new RecoverWith(attempts, pf))
+
+  /**
+    * RecoverWithRetries allows to switch to alternative Source on flow failure. This overloaded method allows to
+    * schedule retries on intervals as specified by `initialRetryTimeout` parameter using
+    * [[akka.stream.impl.fusing.RecoverWithBackoff.RetryBackoffStrategy]] as specified by `backoffStrategy` parameter.
+    * Following strategies are supported as of now: [[akka.stream.impl.fusing.RecoverWithBackoff.Exponential]]
+    * and [[akka.stream.impl.fusing.RecoverWithBackoff.Linear]]. It will stay in effect after
+    * a failure has been recovered up to `attempts` number of times so that each time there is a failure
+    * it is fed into the `pf` and a new Source may be materialized. Note that if you pass in 0, this won't
+    * attempt to recover at all.
+    *
+    * A negative `attempts` number is interpreted as "infinite", which results in the exact same behavior as `recoverWith`.
+    *
+    * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+    * This operator can recover the failure signal, but not the skipped elements, which will be dropped.
+    *
+    * Throwing an exception inside `recoverWithRetries` _will_ be logged on ERROR level automatically.
+    *
+    * '''Emits when''' element is available from the upstream or upstream is failed and element is available
+    * from alternative Source
+    *
+    * '''Backpressures when''' downstream backpressures
+    *
+    * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+    *
+    * '''Cancels when''' downstream cancels
+    *
+    * @param attempts Maximum number of retries or -1 to retry indefinitely
+    * @param initialRetryTimeout Initial timeout for retry delay, next delay is calculated based on `backoffStrategy`
+    * @param backoffStrategy The strategy used for calculating next retry attempt
+    * @param pf Receives the failure cause and returns the new Source to be materialized if any
+    *
+    */
+  def recoverWithRetries[T >: Out](
+      attempts: Int,
+      initialRetryTimeout: FiniteDuration,
+      backoffStrategy: RetryBackoffStrategy,
+      pf: PartialFunction[Throwable, Graph[SourceShape[T], NotUsed]]): Repr[T] =
+    via(new RecoverWithBackoff(attempts, initialRetryTimeout, backoffStrategy, pf))
 
   /**
    * While similar to [[recover]] this operator can be used to transform an error signal to a different one *without* logging


### PR DESCRIPTION
## Purpose

Provides backoff strategy in Flow.recoverWithRetries which can be helpful for scenarios wherein, for example, a separate implicit might not have to be defined like this:
https://github.com/akka/alpakka/pull/1712/files#diff-af410f9f2cf2d5bbc64e112ab0a691d9R22

## Changes

Add Flow.recoverWithRetries with additional parameters, initialRetryTimeout and backoffStrategy.

