### PR TITLE
Use embedded media driver for StressSpec

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SharedMediaDriverSupport.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SharedMediaDriverSupport.scala
@@ -10,9 +10,9 @@ import java.util.function.Consumer
 
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
-
 import akka.remote.RemoteSettings
 import akka.remote.artery.ArterySettings
+import akka.remote.artery.ArterySettings.AeronUpd
 import akka.remote.artery.aeron.TaskRunner
 import akka.remote.testkit.MultiNodeConfig
 import akka.remote.testkit.MultiNodeSpec
@@ -27,11 +27,11 @@ object SharedMediaDriverSupport {
   private val mediaDriver = new AtomicReference[Option[MediaDriver]](None)
 
   def loadArterySettings(config: MultiNodeConfig): ArterySettings =
-    (new RemoteSettings(ConfigFactory.load(config.config))).Artery
+    new RemoteSettings(ConfigFactory.load(config.config)).Artery
 
   def startMediaDriver(config: MultiNodeConfig): Unit = {
     val arterySettings = loadArterySettings(config)
-    if (arterySettings.Enabled) {
+    if (arterySettings.Enabled && arterySettings.Transport == AeronUpd) {
       val aeronDir = arterySettings.Advanced.Aeron.AeronDirectoryName
       require(aeronDir.nonEmpty, "aeron-dir must be defined")
 
@@ -48,7 +48,7 @@ object SharedMediaDriverSupport {
           })
           catch {
             case NonFatal(e) =>
-              println(e.getMessage)
+              println("Exception checking isDriverActive: " + e.getMessage)
               false
           }
           if (active) false

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -130,8 +130,6 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
 
     akka.remote.artery.advanced.aeron {
       idle-cpu-level = 1
-      embedded-media-driver = off
-      aeron-dir = "target/aeron-StressSpec"
     }
 
     akka.actor.default-dispatcher.fork-join-executor {
@@ -676,11 +674,7 @@ class StressMultiJvmNode12 extends StressSpec
 class StressMultiJvmNode13 extends StressSpec
 
 abstract class StressSpec
-    extends MultiNodeSpec({
-      // Aeron media driver must be started before ActorSystem
-      SharedMediaDriverSupport.startMediaDriver(StressMultiJvmSpec)
-      StressMultiJvmSpec
-    })
+    extends MultiNodeSpec(StressMultiJvmSpec)
     with MultiNodeClusterSpec
     with BeforeAndAfterEach
     with ImplicitSender {


### PR DESCRIPTION
The current setup starts a media driver for each JVM in the same
directory which is caused the cnc file to be courruped in some way
so that the client in Akka timed out waiting for it to be initialized.

This test is disabled for Artery, see
https://github.com/akka/akka/issues/21810 so all it does is startup
and then end the test right away.

Will look at enabling the test again separately.

Fixes #27030