### PR TITLE
Akka 2.5.x Flow.recoverWithRetries with backoff strategy

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -4,33 +4,34 @@
 
 package akka.stream.impl.fusing
 
+import java.util.UUID
 import java.util.concurrent.TimeUnit.NANOSECONDS
 
-import akka.actor.{ ActorRef, Terminated }
-import akka.annotation.{ DoNotInherit, InternalApi }
+import akka.actor.{ActorRef, Terminated}
+import akka.annotation.{DoNotInherit, InternalApi}
 import akka.dispatch.ExecutionContexts
 import akka.event.Logging.LogLevel
-import akka.event.{ LogSource, Logging, LoggingAdapter }
-import akka.stream.Attributes.{ InputBuffer, LogLevels }
+import akka.event.{LogSource, Logging, LoggingAdapter}
+import akka.stream.Attributes.{InputBuffer, LogLevels}
 import akka.stream.OverflowStrategies._
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
-import akka.stream.impl.{ ReactiveStreamsCompliance, Buffer => BufferImpl }
-import akka.stream.scaladsl.{ Flow, Keep, Source }
+import akka.stream.impl.{ReactiveStreamsCompliance, Buffer => BufferImpl}
+import akka.stream.scaladsl.{Flow, Keep, Source}
 import akka.stream.stage._
-import akka.stream.{ Supervision, _ }
+import akka.stream.{Supervision, _}
 
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.collection.immutable.VectorBuilder
-import scala.concurrent.{ Future, Promise }
-import scala.util.control.{ NoStackTrace, NonFatal }
-import scala.util.{ Failure, Success, Try }
+import scala.concurrent.{Future, Promise}
+import scala.util.control.{NoStackTrace, NonFatal}
+import scala.util.{Failure, Success, Try}
 import akka.stream.ActorAttributes.SupervisionStrategy
 
-import scala.concurrent.duration.{ FiniteDuration, _ }
+import scala.concurrent.duration.{FiniteDuration, _}
 import scala.util.control.Exception.Catcher
 import akka.stream.impl.Stages.DefaultAttributes
-import akka.stream.impl.fusing.RecoverWithBackoff.{ Exponential, Linear, RetryContainer }
+import akka.stream.impl.fusing.RecoverWithBackoff.{Exponential, Linear, RetryBackoffStrategy, RetryContainer}
 import akka.util.OptionVal
 import akka.util.unused
 import com.github.ghik.silencer.silent

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -31,6 +31,7 @@ import akka.stream.impl.fusing.FlattenMerge
 import akka.NotUsed
 import akka.actor.ActorRef
 import akka.annotation.{ ApiMayChange, DoNotInherit }
+import akka.stream.impl.fusing.RecoverWithBackoff.RetryBackoffStrategy
 
 import scala.annotation.implicitNotFound
 import scala.reflect.ClassTag
@@ -773,6 +774,45 @@ trait FlowOps[+Out, +Mat] {
       attempts: Int,
       pf: PartialFunction[Throwable, Graph[SourceShape[T], NotUsed]]): Repr[T] =
     via(new RecoverWith(attempts, pf))
+
+  /**
+   * RecoverWithRetries allows to switch to alternative Source on flow failure. This overloaded method allows to
+   * schedule retries on intervals as specified by `initialRetryTimeout` parameter using
+   * [[akka.stream.impl.fusing.RecoverWithBackoff.RetryBackoffStrategy]] as specified by `backoffStrategy` parameter.
+   * Following strategies are supported as of now: [[akka.stream.impl.fusing.RecoverWithBackoff.Exponential]]
+   * and [[akka.stream.impl.fusing.RecoverWithBackoff.Linear]]. It will stay in effect after
+   * a failure has been recovered up to `attempts` number of times so that each time there is a failure
+   * it is fed into the `pf` and a new Source may be materialized. Note that if you pass in 0, this won't
+   * attempt to recover at all.
+   *
+   * A negative `attempts` number is interpreted as "infinite", which results in the exact same behavior as `recoverWith`.
+   *
+   * Since the underlying failure signal onError arrives out-of-band, it might jump over existing elements.
+   * This operator can recover the failure signal, but not the skipped elements, which will be dropped.
+   *
+   * Throwing an exception inside `recoverWithRetries` _will_ be logged on ERROR level automatically.
+   *
+   * '''Emits when''' element is available from the upstream or upstream is failed and element is available
+   * from alternative Source
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' upstream completes or upstream failed with exception pf can handle
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @param attempts Maximum number of retries or -1 to retry indefinitely
+   * @param initialRetryTimeout Initial timeout for retry delay, next delay is calculated based on `backoffStrategy`
+   * @param backoffStrategy The strategy used for calculating next retry attempt
+   * @param pf Receives the failure cause and returns the new Source to be materialized if any
+   *
+   */
+  def recoverWithRetries[T >: Out](
+      attempts: Int,
+      initialRetryTimeout: FiniteDuration,
+      backoffStrategy: RetryBackoffStrategy,
+      pf: PartialFunction[Throwable, Graph[SourceShape[T], NotUsed]]): Repr[T] =
+    via(new RecoverWithBackoff(attempts, initialRetryTimeout, backoffStrategy, pf))
 
   /**
    * While similar to [[recover]] this operator can be used to transform an error signal to a different one *without* logging


### PR DESCRIPTION

## Purpose

Provides backoff strategy in Flow.recoverWithRetries which can be helpful for scenarios wherein, for example, a separate implicit might not have to be defined like this:
https://github.com/akka/alpakka/pull/1712/files#diff-af410f9f2cf2d5bbc64e112ab0a691d9R22

## Changes

Add Flow.recoverWithRetries with additional parameters, initialRetryTimeout and backoffStrategy.
