### PR TITLE
Fix typo in akka-cluster reference.conf

### DIFF
--- a/akka-cluster/src/main/resources/reference.conf
+++ b/akka-cluster/src/main/resources/reference.conf
@@ -288,7 +288,7 @@ akka {
       # Enforce configuration compatibility checks when joining a cluster.
       # Set to off to allow joining nodes to join a cluster even when configuration incompatibilities are detected or
       # when the cluster does not support this feature. Compatibility checks are always performed and warning and
-      # error messsages are logged.
+      # error messages are logged.
       #
       # This is particularly useful for rolling updates on clusters that do not support that feature. Since the old
       # cluster won't be able to send the compatibility confirmation to the joining node, the joining node won't be able


### PR DESCRIPTION
## Purpose

This is very minor update to fix typo in comment from `reference.conf` file.

## References

N/A

## Changes

N/A

## Background Context

N/A
