### PR TITLE
use ISO-8601 date/time format in Jackson serializer, #24155

### DIFF
--- a/akka-docs/src/main/paradox/serialization-jackson.md
+++ b/akka-docs/src/main/paradox/serialization-jackson.md
@@ -305,3 +305,21 @@ It's also possible to define several bindings and use different configuration fo
 different settings for remote messages and persisted events.
 
 @@snip [config](/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala) { #several-config }
+
+## Additional configuration
+
+Additional Jackson serialization features can be enabled/disabled in configuration. The default values from
+Jackson are used aside from the the following that are changed in Akka's default configuration.
+
+@@snip [reference.conf](/akka-serialization-jackson/src/main/resources/reference.conf) { #features }
+
+### Date/time format
+
+`WRITE_DATES_AS_TIMESTAMPS` is by default disabled, which means that date/time fields are serialized in
+ISO-8601 (rfc3339) `yyyy-MM-dd'T'HH:mm:ss.SSSZ` format instead of numeric arrays. This is better for
+interoperability but it is slower. If you don't need the ISO format for interoperability with external systems
+you can change the following configuration for better performance of date/time fields.
+
+@@snip [config](/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala) { #date-time }
+
+Jackson is still be able to deserialize the other format independent of this setting.

--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -44,15 +44,23 @@ akka.serialization.jackson {
   migrations {
   }
 
+}
+
+#//#features
+akka.serialization.jackson {
   # Configuration of the ObjectMapper serialization features.
   # See com.fasterxml.jackson.databind.SerializationFeature
   # Enum values corresponding to the SerializationFeature and their boolean value.
   serialization-features {
-
+    # Date/time in ISO-8601 (rfc3339) yyyy-MM-dd'T'HH:mm:ss.SSSZ format
+    # as defined by com.fasterxml.jackson.databind.util.StdDateFormat
+    # For interoperability it's better to use the ISO format, i.e. WRITE_DATES_AS_TIMESTAMPS=off,
+    # but WRITE_DATES_AS_TIMESTAMPS=on has better performance.
+    WRITE_DATES_AS_TIMESTAMPS = off
   }
 
   # Configuration of the ObjectMapper deserialization features.
-  # See com.fasterxml.jackson.databind.SeserializationFeature
+  # See com.fasterxml.jackson.databind.DeserializationFeature
   # Enum values corresponding to the DeserializationFeature and their boolean value.
   deserialization-features {
     FAIL_ON_UNKNOWN_PROPERTIES = off
@@ -71,6 +79,7 @@ akka.serialization.jackson {
   jackson-smile {}
 
 }
+#//#features
 
 akka.actor {
   serializers {

--- a/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala
@@ -104,5 +104,12 @@ object SerializationDocSpec {
   final case class Elephant(name: String, age: Int) extends Animal
   //#polymorphism
 
+  val configDateTime = """
+    #//#date-time
+    akka.serialization.jackson.serialization-features {
+      WRITE_DATES_AS_TIMESTAMPS = on
+    }
+    #//#date-time
+    """
 }
 // FIXME add real tests for the migrations, see EventMigrationTest.java in Lagom


### PR DESCRIPTION
* better for interoperability
* ~~performance is actually better, but it generates more garbage~~

edit: I read the numbers backwards, it's slower and generates more garbage

* deserialization from both formats are supported

Refs #24155
