### PR TITLE
Update links of moved modules to doc.akka.io

### DIFF
--- a/akka-docs/src/main/paradox/additional/deploy.md
+++ b/akka-docs/src/main/paradox/additional/deploy.md
@@ -58,7 +58,7 @@ For this reason, it is best to avoid `--cpus` and `--cpu-quota` entirely, and in
 
 ### Cluster bootstrap
 
-To take advantage of the fact that your are running inside of Kubernetes while forming a cluster, you can use the [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/current/bootstrap/) module.
+To take advantage of the fact that your are running inside of Kubernetes while forming a cluster, you can use the [Akka Cluster Bootstrap](https://doc.akka.io/docs/akka-management/current/bootstrap/) module.
 
 You can look at the
 @extref[Cluster with Kubernetes example project](samples:akka-sample-cluster-kubernetes-java)

--- a/akka-docs/src/main/paradox/cluster-client.md
+++ b/akka-docs/src/main/paradox/cluster-client.md
@@ -26,7 +26,7 @@ can both connect and be connected to with Akka Remoting from all the nodes in th
 This creates a tight coupling in that the client and cluster systems may need to have the same version of 
 both Akka, libraries, message classes, serializers and potentially even the JVM. In many cases it is a better solution 
 to use a more explicit and decoupling protocol such as [HTTP](https://doc.akka.io/docs/akka-http/current/index.html) or 
-[gRPC](https://developer.lightbend.com/docs/akka-grpc/current/).
+[gRPC](https://doc.akka.io/docs/akka-grpc/current/).
 
 Additionally since Akka Remoting is primarily designed as a protocol for Akka Cluster there is no explicit resource
 management, when a @apidoc[ClusterClient] has been used it will cause connections with the cluster until the ActorSystem is 

--- a/akka-docs/src/main/paradox/cluster-dc.md
+++ b/akka-docs/src/main/paradox/cluster-dc.md
@@ -179,7 +179,7 @@ Especially when used together with Akka Persistence that is based on the single-
 it is important to avoid running the same entity at multiple locations at the same time with a
 shared data store. That would result in corrupt data since the events stored by different instances
 may be interleaved and would be interpreted differently in a later replay. For active active persistent
-entities see Lightbend's [Multi-DC Persistence](https://developer.lightbend.com/docs/akka-commercial-addons/current/persistence-dc/index.html)
+entities see Lightbend's [Multi-DC Persistence](https://doc.akka.io/docs/akka-enhancements/current/persistence-dc/index.html)
 
 If you need global entities you have to pick one data center to host that entity type and only start
 `ClusterSharding` on nodes of that data center. If the data center is unreachable from another data center the

--- a/akka-docs/src/main/paradox/cluster-usage.md
+++ b/akka-docs/src/main/paradox/cluster-usage.md
@@ -54,9 +54,9 @@ intra-service communication can take advantage of Akka Cluster, failure manageme
 is convenient to use and has great performance.
 
 Between different services [Akka HTTP](https://doc.akka.io/docs/akka-http/current) or
-[Akka gRPC](https://developer.lightbend.com/docs/akka-grpc/current/) can be used for synchronous (yet non-blocking)
+[Akka gRPC](https://doc.akka.io/docs/akka-grpc/current/) can be used for synchronous (yet non-blocking)
 communication and [Akka Streams Kafka](https://doc.akka.io/docs/akka-stream-kafka/current/home.html) or other
-[Alpakka](https://developer.lightbend.com/docs/alpakka/current/) connectors for integration asynchronous communication.
+[Alpakka](https://doc.akka.io/docs/alpakka/current/) connectors for integration asynchronous communication.
 All those communication mechanisms work well with streaming of messages with end-to-end back-pressure, and the
 synchronous communication tools can also be used for single request response interactions. It is also important
 to note that when using these tools both sides of the communication do not have to be implemented with Akka,
@@ -165,7 +165,7 @@ It contains instructions on how to run the `SimpleClusterApp`.
 @@@ note
   When starting clusters on cloud systems such as Kubernetes, AWS, Google Cloud, Azure, Mesos or others which maintain 
   DNS or other ways of discovering nodes, you may want to use the automatic joining process implemented by the open source
-  [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/current/bootstrap/index.html) module.
+  [Akka Cluster Bootstrap](https://doc.akka.io/docs/akka-management/current/bootstrap/index.html) module.
 @@@
 
 ### Joining configured seed nodes
@@ -217,7 +217,7 @@ and don't stop all of them at the same time.
 Instead of manually configuring seed nodes, which is useful in development or statically assigned node IPs, you may want
 to automate the discovery of seed nodes using your cloud providers or cluster orchestrator, or some other form of service
 discovery (such as managed DNS). The open source Akka Management library includes the
-[Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/current/bootstrap/index.html) module which handles
+[Cluster Bootstrap](https://doc.akka.io/docs/akka-management/current/bootstrap/index.html) module which handles
 just that. Please refer to its documentation for more details.
 
 ### Programatically joining to seed nodes with `joinSeedNodes`

--- a/akka-docs/src/main/paradox/common/other-modules.md
+++ b/akka-docs/src/main/paradox/common/other-modules.md
@@ -4,7 +4,7 @@
 
 A full server- and client-side HTTP stack on top of akka-actor and akka-stream.
 
-## [Alpakka](https://developer.lightbend.com/docs/alpakka/current/)
+## [Alpakka](https://doc.akka.io/docs/alpakka/current/)
 
 Various Akka Streams connectors, integration patterns, and data transformations for integration use cases
 
@@ -20,11 +20,11 @@ A Akka Persistence journal and snapshot store backed by Apache Cassandra.
 
 A Akka Persistence journal and snapshot store backed by Couchbase.
 
-## [Akka Management](https://developer.lightbend.com/docs/akka-management/current/)
+## [Akka Management](https://doc.akka.io/docs/akka-management/current/)
 
 Utilities for managing a running Akka Cluster.
 
-## [Akka gRPC](https://developer.lightbend.com/docs/akka-grpc/current/)
+## [Akka gRPC](https://doc.akka.io/docs/akka-grpc/current/)
 
 Akka gRPC provides support for building streaming gRPC servers and clients on top of Akka Streams.
 
@@ -45,16 +45,16 @@ Lagom is a microservice framework which strives to be opinionated and encode bes
 
 ### Akka Resilience Enhancements:
 
-* [Akka Split Brain Resolver](https://developer.lightbend.com/docs/akka-commercial-addons/current/split-brain-resolver.html)
-* [Kubernetes Lease](https://developer.lightbend.com/docs/akka-commercial-addons/current/kubernetes-lease.html)
-* [Akka Thread Starvation Detector](https://developer.lightbend.com/docs/akka-commercial-addons/current/starvation-detector.html)
-* [Akka Configuration Checker](https://developer.lightbend.com/docs/akka-commercial-addons/current/config-checker.html)
-* [Akka Diagnostics Recorder](https://developer.lightbend.com/docs/akka-commercial-addons/current/diagnostics-recorder.html)
+* [Akka Split Brain Resolver](https://doc.akka.io/docs/akka-enhancements/current/split-brain-resolver.html)
+* [Kubernetes Lease](https://doc.akka.io/docs/akka-enhancements/current/kubernetes-lease.html)
+* [Akka Thread Starvation Detector](https://doc.akka.io/docs/akka-enhancements/current/starvation-detector.html)
+* [Akka Configuration Checker](https://doc.akka.io/docs/akka-enhancements/current/config-checker.html)
+* [Akka Diagnostics Recorder](https://doc.akka.io/docs/akka-enhancements/current/diagnostics-recorder.html)
 
 ### Akka Persistence Enhancements:
 
-* [Akka Multi-DC Persistence](https://developer.lightbend.com/docs/akka-commercial-addons/current/persistence-dc/index.html)
-* [Akka GDPR for Persistence](https://developer.lightbend.com/docs/akka-commercial-addons/current/gdpr/index.html)
+* [Akka Multi-DC Persistence](https://doc.akka.io/docs/akka-enhancements/current/persistence-dc/index.html)
+* [Akka GDPR for Persistence](https://doc.akka.io/docs/akka-enhancements/current/gdpr/index.html)
 
 ### [Lightbend Telemetry](https://developer.lightbend.com/docs/telemetry/current/home.html)
 

--- a/akka-docs/src/main/paradox/coordination.md
+++ b/akka-docs/src/main/paradox/coordination.md
@@ -62,7 +62,7 @@ Leases can be used for @ref[Cluster Singletons](cluster-singleton.md#lease) and 
 
 ## Lease implementations
 
-* [Kubernetes API](https://developer.lightbend.com/docs/akka-commercial-addons/current/kubernetes-lease.html)
+* [Kubernetes API](https://doc.akka.io/docs/akka-enhancements/current/kubernetes-lease.html)
 
 ## Implementing a lease
 

--- a/akka-docs/src/main/paradox/discovery/index.md
+++ b/akka-docs/src/main/paradox/discovery/index.md
@@ -6,7 +6,7 @@ Akka Discovery provides an interface around various ways of locating services. T
 * DNS
 * Aggregate
 
-In addition [Akka Management](https://developer.lightbend.com/docs/akka-management/current/) contains methods such as:
+In addition [Akka Management](https://doc.akka.io/docs/akka-management/current/) contains methods such as:
 
 * Kubernetes API
 * AWS

--- a/akka-docs/src/main/paradox/guide/modules.md
+++ b/akka-docs/src/main/paradox/guide/modules.md
@@ -17,13 +17,13 @@ The following capabilities are included with Akka OSS and are introduced later o
 
 With a Lightbend subscription, you can use [Enterprise Suite](https://www.lightbend.com/platform/production) in production. Enterprise Suite includes the following extensions to Akka core functionality:
 
-* [Split Brain Resolver](https://developer.lightbend.com/docs/akka-commercial-addons/current/split-brain-resolver.html) &#8212; Detects and recovers from network partitions, eliminating data inconsistencies and possible downtime.
-* [Multi-DC Persistence](https://developer.lightbend.com/docs/akka-commercial-addons/current/persistence-dc/index.html) &#8212; For active-active persistent entities across multiple data centers.
-* [GDPR for Akka Persistence](https://developer.lightbend.com/docs/akka-commercial-addons/current/gdpr/index.html) &#8212; Data shredding can be used to forget information in events.
-* [Fast Failover](https://developer.lightbend.com/docs/akka-commercial-addons/current/fast-failover.html) &#8212; Fast failover for Cluster Sharding.
-* [Configuration Checker](https://developer.lightbend.com/docs/akka-commercial-addons/current/config-checker.html) &#8212; Checks for potential configuration issues and logs suggestions.
-* [Diagnostics Recorder](https://developer.lightbend.com/docs/akka-commercial-addons/current/diagnostics-recorder.html) &#8212; Captures configuration and system information in a format that makes it easy to troubleshoot issues during development and production.
-* [Thread Starvation Detector](https://developer.lightbend.com/docs/akka-commercial-addons/current/starvation-detector.html) &#8212; Monitors an Akka system dispatcher and logs warnings if it becomes unresponsive.
+* [Split Brain Resolver](https://doc.akka.io/docs/akka-enhancements/current/split-brain-resolver.html) &#8212; Detects and recovers from network partitions, eliminating data inconsistencies and possible downtime.
+* [Multi-DC Persistence](https://doc.akka.io/docs/akka-enhancements/current/persistence-dc/index.html) &#8212; For active-active persistent entities across multiple data centers.
+* [GDPR for Akka Persistence](https://doc.akka.io/docs/akka-enhancements/current/gdpr/index.html) &#8212; Data shredding can be used to forget information in events.
+* [Fast Failover](https://doc.akka.io/docs/akka-enhancements/current/fast-failover.html) &#8212; Fast failover for Cluster Sharding.
+* [Configuration Checker](https://doc.akka.io/docs/akka-enhancements/current/config-checker.html) &#8212; Checks for potential configuration issues and logs suggestions.
+* [Diagnostics Recorder](https://doc.akka.io/docs/akka-enhancements/current/diagnostics-recorder.html) &#8212; Captures configuration and system information in a format that makes it easy to troubleshoot issues during development and production.
+* [Thread Starvation Detector](https://doc.akka.io/docs/akka-enhancements/current/starvation-detector.html) &#8212; Monitors an Akka system dispatcher and logs warnings if it becomes unresponsive.
 
 This page does not list all available modules, but overviews the main functionality and gives you an idea of the level of sophistication you can reach when you start building systems on top of Akka.
 

--- a/akka-docs/src/main/paradox/persistence.md
+++ b/akka-docs/src/main/paradox/persistence.md
@@ -45,7 +45,7 @@ The General Data Protection Regulation (GDPR) requires that personal information
 Deleting or modifying events that carry personal information would be difficult. Data shredding can be used to forget
 information instead of deleting or modifying it. This is achieved by encrypting the data with a key for a given data
 subject id (person) and deleting the key when that data subject is to be forgotten. Lightbend's
-[GDPR for Akka Persistence](https://developer.lightbend.com/docs/akka-commercial-addons/current/gdpr/index.html)
+[GDPR for Akka Persistence](https://doc.akka.io/docs/akka-enhancements/current/gdpr/index.html)
 provides tools to facilitate in building GDPR capable systems.
 
 @@@
@@ -722,7 +722,7 @@ Akka Persistence is based on the single-writer principle. For a particular `pers
 instance should be active at one time. If multiple instances were to persist events at the same time, the events would
 be interleaved and might not be interpreted correctly on replay. Cluster Sharding ensures that there is only one
 active entity (`PersistentActor`) for each id within a data center. Lightbend's
-[Multi-DC Persistence](https://developer.lightbend.com/docs/akka-commercial-addons/current/persistence-dc/index.html)
+[Multi-DC Persistence](https://doc.akka.io/docs/akka-enhancements/current/persistence-dc/index.html)
 supports active-active persistent entities across data centers.
 
 The [Lagom framework](https://www.lagomframework.com), which is built on top of Akka encodes many of the best practices 

--- a/akka-docs/src/main/paradox/remoting-artery.md
+++ b/akka-docs/src/main/paradox/remoting-artery.md
@@ -9,7 +9,7 @@ When building an Akka application, you would usually not use the Remoting concep
 directly, but instead use the more high-level
 @ref[Akka Cluster](index-cluster.md) utilities or technology-agnostic protocols
 such as [HTTP](https://doc.akka.io/docs/akka-http/current/),
-[gRPC](https://developer.lightbend.com/docs/akka-grpc/current/) etc.
+[gRPC](https://doc.akka.io/docs/akka-grpc/current/) etc.
 
 @@@
 

--- a/akka-docs/src/main/paradox/remoting.md
+++ b/akka-docs/src/main/paradox/remoting.md
@@ -15,7 +15,7 @@ When building an Akka application, you would usually not use the Remoting concep
 directly, but instead use the more high-level
 @ref[Akka Cluster](index-cluster.md) utilities or technology-agnostic protocols
 such as [HTTP](https://doc.akka.io/docs/akka-http/current/),
-[gRPC](https://developer.lightbend.com/docs/akka-grpc/current/) etc.
+[gRPC](https://doc.akka.io/docs/akka-grpc/current/) etc.
 
 
 @@@

--- a/akka-docs/src/main/paradox/typed/guide/modules.md
+++ b/akka-docs/src/main/paradox/typed/guide/modules.md
@@ -16,13 +16,13 @@ The following capabilities are included with Akka OSS and are introduced later o
 
 With a Lightbend subscription, you can use [Enterprise Suite](https://www.lightbend.com/platform/production) in production. Enterprise Suite includes the following extensions to Akka core functionality:
 
-* [Split Brain Resolver](https://developer.lightbend.com/docs/akka-commercial-addons/current/split-brain-resolver.html) &#8212; Detects and recovers from network partitions, eliminating data inconsistencies and possible downtime.
-* [Multi-DC Persistence](https://developer.lightbend.com/docs/akka-commercial-addons/current/persistence-dc/index.html) &#8212; For active-active persistent entities across multiple data centers.
-* [GDPR for Akka Persistence](https://developer.lightbend.com/docs/akka-commercial-addons/current/gdpr/index.html) &#8212; Data shredding can be used to forget information in events.
-* [Fast Failover](https://developer.lightbend.com/docs/akka-commercial-addons/current/fast-failover.html) &#8212; Fast failover for Cluster Sharding.
-* [Configuration Checker](https://developer.lightbend.com/docs/akka-commercial-addons/current/config-checker.html) &#8212; Checks for potential configuration issues and logs suggestions.
-* [Diagnostics Recorder](https://developer.lightbend.com/docs/akka-commercial-addons/current/diagnostics-recorder.html) &#8212; Captures configuration and system information in a format that makes it easy to troubleshoot issues during development and production.
-* [Thread Starvation Detector](https://developer.lightbend.com/docs/akka-commercial-addons/current/starvation-detector.html) &#8212; Monitors an Akka system dispatcher and logs warnings if it becomes unresponsive.
+* [Split Brain Resolver](https://doc.akka.io/docs/akka-enhancements/current/split-brain-resolver.html) &#8212; Detects and recovers from network partitions, eliminating data inconsistencies and possible downtime.
+* [Multi-DC Persistence](https://doc.akka.io/docs/akka-enhancements/current/persistence-dc/index.html) &#8212; For active-active persistent entities across multiple data centers.
+* [GDPR for Akka Persistence](https://doc.akka.io/docs/akka-enhancements/current/gdpr/index.html) &#8212; Data shredding can be used to forget information in events.
+* [Fast Failover](https://doc.akka.io/docs/akka-enhancements/current/fast-failover.html) &#8212; Fast failover for Cluster Sharding.
+* [Configuration Checker](https://doc.akka.io/docs/akka-enhancements/current/config-checker.html) &#8212; Checks for potential configuration issues and logs suggestions.
+* [Diagnostics Recorder](https://doc.akka.io/docs/akka-enhancements/current/diagnostics-recorder.html) &#8212; Captures configuration and system information in a format that makes it easy to troubleshoot issues during development and production.
+* [Thread Starvation Detector](https://doc.akka.io/docs/akka-enhancements/current/starvation-detector.html) &#8212; Monitors an Akka system dispatcher and logs warnings if it becomes unresponsive.
 
 This page does not list all available modules, but overviews the main functionality and gives you an idea of the level of sophistication you can reach when you start building systems on top of Akka.
 


### PR DESCRIPTION
## Purpose

Update links of Akka gRPC, Akka Management and Akka Enhancements to point to doc.akka.io

## References

https://github.com/akka/akka.github.com/issues/561
https://github.com/akka/akka.github.com/issues/568
https://github.com/akka/akka.github.com/issues/607
