### PR TITLE
Set useful description in sbt setting

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -149,7 +149,7 @@ object AkkaBuild {
 
     licenses := Seq(("Apache License, Version 2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
     homepage := Some(url("https://akka.io/")),
-    description := "Akka is a toolkit for building highly concurrent, distributed, and resilient message-driven applications for Java and Scala.".
+    description := "Akka is a toolkit for building highly concurrent, distributed, and resilient message-driven applications for Java and Scala.",
 
     apiURL := Some(url(s"https://doc.akka.io/api/akka/${version.value}")),
 

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -149,6 +149,7 @@ object AkkaBuild {
 
     licenses := Seq(("Apache License, Version 2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
     homepage := Some(url("https://akka.io/")),
+    description := "Akka is a toolkit for building highly concurrent, distributed, and resilient message-driven applications for Java and Scala.".
 
     apiURL := Some(url(s"https://doc.akka.io/api/akka/${version.value}")),
 


### PR DESCRIPTION
## Purpose

Set a meaningful description.

## References

https://github.com/akka/akka.github.com/issues/566

## Background Context

The default `description` setting becomes `akka-docs` which is used as description meta tag in the html pages.
