### PR TITLE
WIP draft: Disable remote watch and remote deployment outside Cluster

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -363,6 +363,8 @@ object ActorSystem {
 
     final val ProviderClass: String = ProviderSelectionType.fqcn
 
+    final val HasCluster: Boolean = ProviderSelectionType.hasCluster
+
     final val SupervisorStrategyClass: String = getString("akka.actor.guardian-supervisor-strategy")
     final val CreationTimeout: Timeout = Timeout(config.getMillisDuration("akka.actor.creation-timeout"))
     final val UnstartedPushTimeout: Timeout = Timeout(config.getMillisDuration("akka.actor.unstarted-push-timeout"))

--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -109,7 +109,7 @@ case object LocalScope extends LocalScope {
   /**
    * Java API: get the singleton instance
    */
-  def getInstance: LocalScope.type = this
+  def getInstance = this
 
   def withFallback(other: Scope): Scope = this
 }
@@ -127,7 +127,7 @@ case object NoScopeGiven extends NoScopeGiven {
   /**
    * Java API: get the singleton instance
    */
-  def getInstance: NoScopeGiven.type = this
+  def getInstance = this
 }
 
 /**

--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -109,7 +109,7 @@ case object LocalScope extends LocalScope {
   /**
    * Java API: get the singleton instance
    */
-  def getInstance = this
+  def getInstance: LocalScope.type = this
 
   def withFallback(other: Scope): Scope = this
 }
@@ -127,7 +127,7 @@ case object NoScopeGiven extends NoScopeGiven {
   /**
    * Java API: get the singleton instance
    */
-  def getInstance = this
+  def getInstance: NoScopeGiven.type = this
 }
 
 /**
@@ -153,12 +153,11 @@ private[akka] class Deployer(val settings: ActorSystem.Settings, val dynamicAcce
       .toMap
 
   config.root.asScala
-    .map {
+    .flatMap {
       case ("default", _)             => None
       case (key, value: ConfigObject) => parseConfig(key, value.toConfig)
       case _                          => None
     }
-    .flatten
     .foreach(deploy)
 
   def lookup(path: ActorPath): Option[Deploy] = lookup(path.elements.drop(1))

--- a/akka-cluster/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-cluster/src/main/mima-filters/2.5.x.backwards.excludes
@@ -1,2 +1,6 @@
 # #24710 remove internal ClusterReadView.refreshCurrentState
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterReadView.refreshCurrentState")
+
+# Disable remote watch and remote deployment outside Cluster #26176
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterRemoteWatcher.watchNode")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterRemoteWatcher.props")

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
@@ -159,8 +159,8 @@ private[cluster] class ClusterRemoteWatcher(
   private def inCluster(address: Address): Boolean = clusterNodes(address)
 
   /** Returns true if the `watcher` is not `self` and the `watchee` is in the cluster. */
-  override protected def isSafeWatch(self: ActorRef, watcher: InternalActorRef, watchee: InternalActorRef): Boolean =
-    inCluster(watchee.path.address) && super.isSafeWatch(self, watcher, watchee)
+  override protected def shouldWatch(watchee: InternalActorRef): Boolean =
+    inCluster(watchee.path.address) && super.shouldWatch(watchee)
 
   /**
    * When a cluster node is added this class takes over the

--- a/akka-cluster/src/test/scala/akka/cluster/EnableRemoteFeaturesWithClusterSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/EnableRemoteFeaturesWithClusterSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster
+
+import akka.remote.RemoteFeaturesSpec
+import com.typesafe.config.ConfigFactory
+
+class EnableRemoteFeaturesWithClusterSpec
+    extends RemoteFeaturesSpec(
+      ConfigFactory.parseString("""akka.actor.provider = "cluster" """).withFallback(RemoteFeaturesSpec.remote)) {
+
+  "Remoting with Cluster" must {
+
+    "have the correct settings" in {
+      system.settings.HasCluster shouldBe true
+      system.settings.ProviderClass shouldEqual "akka.cluster.ClusterActorRefProvider"
+      provider.transport.system.settings.HasCluster shouldBe true
+      provider.remoteSettings.UseUnsafeRemoteFeaturesWithoutCluster shouldBe false
+    }
+
+    "create a ClusterRemoteWatcher" in {
+      provider.remoteWatcher.isDefined shouldBe true
+    }
+
+    "use ClusterDeployer" in {
+      provider.deployer.getClass == classOf[ClusterDeployer] shouldBe true
+    }
+  }
+}

--- a/akka-docs/src/test/scala/docs/remoting/RemoteDeploymentDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/remoting/RemoteDeploymentDocSpec.scala
@@ -23,6 +23,7 @@ class RemoteDeploymentDocSpec extends AkkaSpec("""
     akka.actor.provider = remote
     akka.remote.classic.netty.tcp.port = 0
     akka.remote.artery.canonical.port = 0
+    akka.remote.use-unsafe-remote-features-without-cluster = on
 """) with ImplicitSender {
 
   import RemoteDeploymentDocSpec._

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteDeliverySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteDeliverySpec.scala
@@ -4,17 +4,13 @@
 
 package akka.remote
 
-import scala.language.postfixOps
-
 import scala.concurrent.duration._
-import com.typesafe.config.ConfigFactory
+
 import akka.actor.Actor
 import akka.actor.ActorRef
 import akka.actor.Props
-import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
-import akka.actor.ActorIdentity
-import akka.actor.Identify
+import com.typesafe.config.ConfigFactory
 
 class RemoteDeliveryConfig(artery: Boolean) extends MultiNodeConfig {
   val first = role("first")
@@ -46,15 +42,10 @@ object RemoteDeliverySpec {
 
 abstract class RemoteDeliverySpec(multiNodeConfig: RemoteDeliveryConfig)
     extends RemotingMultiNodeSpec(multiNodeConfig) {
-  import multiNodeConfig._
   import RemoteDeliverySpec._
+  import multiNodeConfig._
 
   override def initialParticipants = roles.size
-
-  def identify(role: RoleName, actorName: String): ActorRef = within(10 seconds) {
-    system.actorSelection(node(role) / "user" / actorName) ! Identify(actorName)
-    expectMsgType[ActorIdentity].ref.get
-  }
 
   "Remote message delivery" must {
 

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteFeaturesSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteFeaturesSpec.scala
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.remote
+
+import scala.concurrent.duration._
+
+import akka.actor.ActorRef
+import akka.actor.InternalActorRef
+import akka.actor.Nobody
+import akka.actor.Props
+import akka.dispatch.sysmsg.Watch
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.MultiNodeConfig
+import com.typesafe.config.ConfigFactory
+
+class RemotingFeaturesConfig(val useUnsafe: Boolean, artery: Boolean) extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+
+  protected val baseConfig = ConfigFactory.parseString(s"""
+      akka.remote.use-unsafe-remote-features-without-cluster = $useUnsafe
+      akka.remote.log-remote-lifecycle-events = off
+      akka.remote.artery.enabled = $artery
+      akka.remote.artery.advanced.flight-recorder.enabled = off
+      """).withFallback(RemotingMultiNodeSpec.commonConfig)
+
+  commonConfig(debugConfig(on = false).withFallback(baseConfig))
+
+  def remoteRole(myself: RoleName): RoleName = if (myself == first) second else first
+
+}
+
+class RemotingFeaturesSafeMultiJvmNode1 extends RemotingFeaturesSafeSpec
+class RemotingFeaturesSafeMultiJvmNode2 extends RemotingFeaturesSafeSpec
+
+class RemotingFeaturesUnsafeMultiJvmNode1 extends RemotingFeaturesUnsafeSpec
+class RemotingFeaturesUnsafeMultiJvmNode2 extends RemotingFeaturesUnsafeSpec
+
+abstract class RemotingFeaturesSafeSpec
+    extends RemotingFeaturesSpec(new RemotingFeaturesConfig(useUnsafe = false, artery = true)) {
+
+  import RemoteNodeDeathWatchSpec.Ack
+  import RemoteNodeDeathWatchSpec.ProbeActor
+  import RemoteNodeDeathWatchSpec.WatchIt
+  import multiNodeConfig._
+
+  "Remoting without Cluster" must {
+
+    "not create 'remoteWatcher' in `RemoteActorRefProvider`" in {
+      provider.remoteWatcher.isEmpty shouldBe true
+    }
+
+    "not intercept system `Watch`/`Unwatch` for `remoteWatcher`" in {
+      runOn(second) {
+        system.actorOf(Props(new ProbeActor(testActor)), "watchee1")
+        enterBarrier("started-watchee1")
+      }
+
+      runOn(first) {
+        val watcher = system.actorOf(Props(new ProbeActor(testActor)), "watcher1")
+        enterBarrier("started-watchee1")
+
+        val watchee = identify(second, "watchee1")
+        watcher ! WatchIt(watchee) // will never get sent to internal destination
+        expectMsg(1.second, Ack) // just for show that context.watch(remote) is not happening
+        watchee ! "hello1"
+        enterBarrier("received-hello1")
+
+        assertWatchNotIntercepted(watcher, watchee)
+        enterBarrier("watchee1-stopped")
+        expectNoMessage(2.seconds)
+        info(s"$myself did not receive Terminated")
+        enterBarrier("watch-not-established")
+      }
+      runOn(second) {
+        expectMsg(5.seconds, "hello1")
+        enterBarrier("received-hello1")
+
+        val watchee = identify(second, "watchee1")
+        assertWatchNotIntercepted(identify(first, "watcher1"), watchee)
+        info(s"$myself stopping watchee.")
+        system.stop(watchee)
+        enterBarrier("watchee1-stopped")
+        enterBarrier("watch-not-established")
+      }
+
+      def assertWatchNotIntercepted(watcher: ActorRef, watchee: ActorRef): Unit = {
+        val rar = remoteActorRef(remoteRole)
+        rar.isWatchIntercepted(watchee = rar, watcher = watcher) shouldBe false
+        rar.isWatchIntercepted(watchee = watchee, watcher = watcher) shouldBe false
+        enterBarrier("watch-not-intercepted")
+      }
+    }
+
+    "not send remote system messages" in {
+      runOn(second) {
+        system.actorOf(Props(new ProbeActor(testActor)), "watchee2")
+        enterBarrier("started-watchee2")
+        enterBarrier("finished")
+      }
+      runOn(first) {
+        val watcher = identify(first, "watcher1").asInstanceOf[InternalActorRef]
+        val watchee = identify(second, "watchee2").asInstanceOf[InternalActorRef]
+        enterBarrier("started-watchee2")
+
+        watcher ! WatchIt(watchee) // will never get sent to internal destination
+        expectMsg(1.second, Ack) // meaningless
+
+        val rar = remoteActorRef(second)
+        rar.sendSystemMessage(Watch(watchee, watcher))
+        expectNoMessage()
+
+        rar.suspend()
+        expectNoMessage()
+        enterBarrier("finished")
+      }
+    }
+  }
+}
+
+abstract class RemotingFeaturesUnsafeSpec
+    extends RemotingFeaturesSpec(new RemotingFeaturesConfig(useUnsafe = true, artery = true)) {
+
+  import RemoteNodeDeathWatchSpec.Ack
+  import RemoteNodeDeathWatchSpec.ProbeActor
+  import RemoteNodeDeathWatchSpec.WatchIt
+  import RemoteNodeDeathWatchSpec.WrappedTerminated
+  import multiNodeConfig._
+
+  "Remoting without Cluster" must {
+
+    "create 'remoteWatcher' in `RemoteActorRefProvider`" in {
+      provider.remoteWatcher.isDefined shouldBe true
+    }
+
+    "intercept system `Watch`/`Unwatch` for `remoteWatcher`" in {
+      runOn(second) {
+        system.actorOf(Props(new ProbeActor(testActor)), "watchee1")
+        enterBarrier("started-watchee1")
+      }
+
+      runOn(first) {
+        val watcher = system.actorOf(Props(new ProbeActor(testActor)), "watcher1")
+        enterBarrier("started-watchee1")
+
+        val watchee = identify(second, "watchee1")
+        watcher ! WatchIt(watchee)
+        expectMsg(1.second, Ack)
+        watchee ! "hello1"
+        enterBarrier("received-hello1")
+
+        assertWatchIntercepted(watcher, watchee)
+        enterBarrier("watchee1-stopped")
+        expectMsgType[WrappedTerminated].t.actor shouldEqual watchee
+        enterBarrier("watch-established")
+      }
+      runOn(second) {
+        expectMsg(5.seconds, "hello1")
+        enterBarrier("received-hello1")
+
+        val watchee = identify(second, "watchee1")
+        assertWatchIntercepted(identify(first, "watcher1"), watchee)
+        system.stop(watchee)
+        enterBarrier("watchee1-stopped")
+        enterBarrier("watch-established")
+      }
+
+      def assertWatchIntercepted(watcher: ActorRef, watchee: ActorRef): Unit = {
+        val remoteWatcher = identifyWithPath(remoteRole, "system", "remote-watcher")
+        val rar = remoteActorRef(remoteRole)
+        rar.isWatchIntercepted(watchee = rar, watcher = watcher) shouldBe true
+        rar.isWatchIntercepted(watchee = rar, watcher = remoteWatcher) shouldBe true
+        enterBarrier("watch-intercepted")
+
+        rar.isWatchIntercepted(watchee = watchee, watcher = rar) shouldBe false
+        enterBarrier("watch-not-intercepted")
+      }
+    }
+
+    "send remote system messages" in {
+      // TODO test
+    }
+  }
+}
+
+abstract class RemotingFeaturesSpec(val multiNodeConfig: RemotingFeaturesConfig)
+    extends RemotingMultiNodeSpec(multiNodeConfig) {
+
+  import RemoteWatcher._
+
+  override def initialParticipants: Int = roles.size
+
+  muteDeadLetters(Heartbeat.getClass)()
+
+  val provider: RemoteActorRefProvider = RARP(system).provider
+
+  val remoteRole: RoleName = multiNodeConfig.remoteRole(myself)
+
+  def remoteActorRef(role: RoleName): RemoteActorRef = {
+    val remotePath = node(role)
+    val rar = new RemoteActorRef(
+      provider.transport,
+      provider.transport.localAddressForRemote(remotePath.address),
+      remotePath,
+      Nobody,
+      None,
+      None)
+
+    rar.start()
+    rar
+  }
+}

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteNodeDeathWatchSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteNodeDeathWatchSpec.scala
@@ -62,8 +62,9 @@ abstract class RemoteNodeDeathWatchSlowSpec(artery: Boolean)
 }
 
 object RemoteNodeDeathWatchSpec {
-  final case class WatchIt(watchee: ActorRef)
-  final case class UnwatchIt(watchee: ActorRef)
+  sealed trait DeathWatchIt
+  final case class WatchIt(watchee: ActorRef) extends DeathWatchIt
+  final case class UnwatchIt(watchee: ActorRef) extends DeathWatchIt
   case object Ack
 
   /**

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteNodeRestartDeathWatchSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteNodeRestartDeathWatchSpec.scala
@@ -6,19 +6,16 @@ package akka.remote
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import com.typesafe.config.ConfigFactory
+
 import akka.actor.Actor
-import akka.actor.ActorIdentity
-import akka.actor.ActorRef
-import akka.actor.Identify
-import akka.actor.Props
-import akka.remote.testconductor.RoleName
-import akka.remote.transport.ThrottlerTransportAdapter.Direction
-import akka.remote.testkit.MultiNodeConfig
-import akka.testkit._
-import akka.actor.ExtendedActorSystem
 import akka.actor.ActorSystem
+import akka.actor.ExtendedActorSystem
+import akka.actor.Props
 import akka.actor.RootActorPath
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.transport.ThrottlerTransportAdapter.Direction
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
 
 class RemoteNodeRestartDeathWatchConfig(artery: Boolean) extends MultiNodeConfig {
   val first = role("first")
@@ -30,6 +27,7 @@ class RemoteNodeRestartDeathWatchConfig(artery: Boolean) extends MultiNodeConfig
       akka.remote.classic.transport-failure-detector.heartbeat-interval = 1 s
       akka.remote.classic.transport-failure-detector.acceptable-heartbeat-pause = 3 s
       akka.remote.artery.enabled = $artery
+      akka.remote.use-unsafe-remote-features-without-cluster = on
     """)))
 
   testTransport(on = true)
@@ -60,15 +58,10 @@ object RemoteNodeRestartDeathWatchSpec {
 
 abstract class RemoteNodeRestartDeathWatchSpec(multiNodeConfig: RemoteNodeRestartDeathWatchConfig)
     extends RemotingMultiNodeSpec(multiNodeConfig) {
-  import multiNodeConfig._
   import RemoteNodeRestartDeathWatchSpec._
+  import multiNodeConfig._
 
-  override def initialParticipants = roles.size
-
-  def identify(role: RoleName, actorName: String): ActorRef = {
-    system.actorSelection(node(role) / "user" / actorName) ! Identify(actorName)
-    expectMsgType[ActorIdentity].ref.get
-  }
+  override def initialParticipants: Int = roles.size
 
   "RemoteNodeRestartDeathWatch" must {
 

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemotingMultiNodeSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemotingMultiNodeSpec.scala
@@ -6,11 +6,24 @@ package akka.remote
 
 import java.util.UUID
 
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
+
+import akka.actor.ActorIdentity
+import akka.actor.ActorRef
+import akka.actor.Identify
 import akka.remote.artery.ArterySpecSupport
-import akka.remote.testkit.{ FlightRecordingSupport, MultiNodeConfig, MultiNodeSpec, STMultiNodeSpec }
-import akka.testkit.{ DefaultTimeout, ImplicitSender }
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.FlightRecordingSupport
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.remote.testkit.STMultiNodeSpec
+import akka.testkit.DefaultTimeout
+import akka.testkit.ImplicitSender
+import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{ Outcome, Suite }
+import org.scalatest.Outcome
+import org.scalatest.Suite
 
 object RemotingMultiNodeSpec {
 
@@ -33,6 +46,8 @@ abstract class RemotingMultiNodeSpec(config: MultiNodeConfig)
     with ImplicitSender
     with DefaultTimeout { self: MultiNodeSpec =>
 
+  private val probe = TestProbe()
+
   // Keep track of failure so we can print artery flight recording on failure
   private var failed = false
   final override protected def withFixture(test: NoArgTest): Outcome = {
@@ -47,5 +62,29 @@ abstract class RemotingMultiNodeSpec(config: MultiNodeConfig)
       printFlightRecording()
     }
     deleteFlightRecorderFile()
+  }
+
+  /** Identify a user actor by actor name for the given `role`.
+   * {{{
+   *   runOn(first) {
+   *     val a = identify(second, "your-actor")
+   *   }
+   * }}}
+   */
+  def identify(role: RoleName, actorName: String, within: FiniteDuration = 10.seconds): ActorRef =
+    identifyWithPath(role, "user", actorName, within)
+
+  /** Identify an actor by `role / path / name`. Use for system actors as well. */
+  private[akka] def identifyWithPath(
+      role: RoleName,
+      path: String,
+      actorName: String,
+      within: FiniteDuration = 10.seconds): ActorRef = {
+    import system.dispatcher
+    //(system.actorSelection(node(role) / "user" / actorName)).tell(Identify(actorName), p.ref)
+    system.actorSelection(node(role) / path / actorName).resolveOne(within).map(probe.send(_, Identify(actorName)))
+    val actorIdentity = probe.expectMsgType[ActorIdentity](remainingOrDefault)
+    assert(actorIdentity.ref.isDefined, s"Unable to Identify actor: $actorName on node: $role")
+    actorIdentity.ref.get
   }
 }

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemotingMultiNodeSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemotingMultiNodeSpec.scala
@@ -80,11 +80,9 @@ abstract class RemotingMultiNodeSpec(config: MultiNodeConfig)
       path: String,
       actorName: String,
       within: FiniteDuration = 10.seconds): ActorRef = {
-    import system.dispatcher
-    //(system.actorSelection(node(role) / "user" / actorName)).tell(Identify(actorName), p.ref)
-    system.actorSelection(node(role) / path / actorName).resolveOne(within).map(probe.send(_, Identify(actorName)))
-    val actorIdentity = probe.expectMsgType[ActorIdentity](remainingOrDefault)
-    assert(actorIdentity.ref.isDefined, s"Unable to Identify actor: $actorName on node: $role")
+    system.actorSelection(node(role) / path.split("/") / actorName).tell(Identify(actorName), probe.ref)
+    val actorIdentity = probe.expectMsgType[ActorIdentity](within)
+    assert(actorIdentity.ref.isDefined, s"Unable to Identify actor [$actorName] on node [$role]")
     actorIdentity.ref.get
   }
 }

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/TransportFailSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/TransportFailSpec.scala
@@ -7,14 +7,12 @@ package akka.remote
 import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.concurrent.duration._
+
 import akka.actor.Actor
-import akka.actor.ActorIdentity
 import akka.actor.ActorRef
-import akka.actor.Identify
 import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.event.EventStream
-import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
 import akka.testkit._
 import akka.util.unused
@@ -27,6 +25,7 @@ object TransportFailConfig extends MultiNodeConfig {
 
   commonConfig(debugConfig(on = false).withFallback(ConfigFactory.parseString(s"""
       akka.loglevel = INFO
+      akka.remote.use-unsafe-remote-features-without-cluster = on
       akka.remote.classic {
         transport-failure-detector {
           implementation-class = "akka.remote.TransportFailSpec$$TestFailureDetector"
@@ -99,12 +98,6 @@ abstract class TransportFailSpec extends RemotingMultiNodeSpec(TransportFailConf
   import TransportFailSpec._
 
   override def initialParticipants = roles.size
-
-  def identify(role: RoleName, actorName: String): ActorRef = {
-    val p = TestProbe()
-    (system.actorSelection(node(role) / "user" / actorName)).tell(Identify(actorName), p.ref)
-    p.expectMsgType[ActorIdentity](remainingOrDefault).ref.get
-  }
 
   "TransportFail" must {
 

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/RemoteNodeRestartGateSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/RemoteNodeRestartGateSpec.scala
@@ -4,17 +4,19 @@
 
 package akka.remote.classic
 
-import akka.actor.{ ActorIdentity, Identify, _ }
-import akka.remote.testconductor.RoleName
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import akka.actor.ActorIdentity
+import akka.actor.Identify
+import akka.actor._
 import akka.remote.testkit.MultiNodeConfig
 import akka.remote.transport.AssociationHandle
 import akka.remote.transport.ThrottlerTransportAdapter.ForceDisassociateExplicitly
-import akka.remote.{ RARP, RemotingMultiNodeSpec }
+import akka.remote.RARP
+import akka.remote.RemotingMultiNodeSpec
 import akka.testkit._
 import com.typesafe.config.ConfigFactory
-
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 object RemoteNodeRestartGateSpec extends MultiNodeConfig {
   val first = role("first")
@@ -48,11 +50,6 @@ abstract class RemoteNodeRestartGateSpec extends RemotingMultiNodeSpec(RemoteNod
   import RemoteNodeRestartGateSpec._
 
   override def initialParticipants = 2
-
-  def identify(role: RoleName, actorName: String): ActorRef = {
-    system.actorSelection(node(role) / "user" / actorName) ! Identify(actorName)
-    expectMsgType[ActorIdentity].ref.get
-  }
 
   "RemoteNodeRestartGate" must {
 

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/RemoteNodeShutdownAndComesBackSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/RemoteNodeShutdownAndComesBackSpec.scala
@@ -4,17 +4,20 @@
 
 package akka.remote.classic
 
-import akka.actor.{ ActorIdentity, Identify, _ }
-import akka.remote.testconductor.RoleName
-import akka.remote.testkit.MultiNodeConfig
-import akka.remote.transport.ThrottlerTransportAdapter.{ Direction, ForceDisassociate }
-import akka.remote.{ RARP, RemotingMultiNodeSpec }
-import akka.testkit._
-import com.typesafe.config.ConfigFactory
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
+
+import akka.actor.ActorIdentity
+import akka.actor.Identify
+import akka.actor._
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.transport.ThrottlerTransportAdapter.Direction
+import akka.remote.transport.ThrottlerTransportAdapter.ForceDisassociate
+import akka.remote.RARP
+import akka.remote.RemotingMultiNodeSpec
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
 
 object RemoteNodeShutdownAndComesBackSpec extends MultiNodeConfig {
   val first = role("first")
@@ -30,6 +33,7 @@ object RemoteNodeShutdownAndComesBackSpec extends MultiNodeConfig {
       akka.remote.classic.transport-failure-detector.heartbeat-interval = 1 s
       akka.remote.classic.transport-failure-detector.acceptable-heartbeat-pause = 3 s
       akka.remote.watch-failure-detector.acceptable-heartbeat-pause = 60 s
+      akka.remote.use-unsafe-remote-features-without-cluster = on
     """)))
 
   testTransport(on = true)
@@ -51,11 +55,6 @@ abstract class RemoteNodeShutdownAndComesBackSpec extends RemotingMultiNodeSpec(
   import RemoteNodeShutdownAndComesBackSpec._
 
   override def initialParticipants = roles.size
-
-  def identify(role: RoleName, actorName: String): ActorRef = {
-    system.actorSelection(node(role) / "user" / actorName) ! Identify(actorName)
-    expectMsgType[ActorIdentity].ref.get
-  }
 
   "RemoteNodeShutdownAndComesBack" must {
 

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/Ticket15109Spec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/Ticket15109Spec.scala
@@ -4,17 +4,17 @@
 
 package akka.remote.classic
 
-import akka.actor.{ ActorIdentity, Identify, _ }
-import akka.remote.testconductor.RoleName
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import akka.actor._
 import akka.remote.testkit.MultiNodeConfig
 import akka.remote.transport.AssociationHandle
 import akka.remote.transport.ThrottlerTransportAdapter.ForceDisassociateExplicitly
-import akka.remote.{ RARP, RemotingMultiNodeSpec }
+import akka.remote.RARP
+import akka.remote.RemotingMultiNodeSpec
 import akka.testkit._
 import com.typesafe.config.ConfigFactory
-
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 object Ticket15109Spec extends MultiNodeConfig {
   val first = role("first")
@@ -49,12 +49,7 @@ abstract class Ticket15109Spec extends RemotingMultiNodeSpec(Ticket15109Spec) {
 
   import Ticket15109Spec._
 
-  override def initialParticipants = roles.size
-
-  def identify(role: RoleName, actorName: String): ActorRef = {
-    system.actorSelection(node(role) / "user" / actorName) ! Identify(0)
-    expectMsgType[ActorIdentity](5.seconds).getActorRef.get
-  }
+  override def initialParticipants: Int = roles.size
 
   def ping(ref: ActorRef) = {
     within(30.seconds) {
@@ -78,7 +73,7 @@ abstract class Ticket15109Spec extends RemotingMultiNodeSpec(Ticket15109Spec) {
 
       runOn(first) {
         // Acquire ActorRef from first system
-        subject = identify(second, "subject")
+        subject = identify(second, "subject", 5.seconds)
       }
 
       enterBarrier("actor-identified")

--- a/akka-remote/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-remote/src/main/mima-filters/2.5.x.backwards.excludes
@@ -22,3 +22,8 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.ArterySet
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.ArterySettings#Advanced.DriverTimeout")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.ArterySettings#Advanced.ConnectionTimeout")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.ArterySettings.LogAeronCounters")
+
+# Disable remote watch and remote deployment outside Cluster #26176
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.remote.RemoteActorRefProvider.remoteWatcher")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.RemoteWatcher.props")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.RemoteWatcher.watchNode")

--- a/akka-remote/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-remote/src/main/mima-filters/2.5.x.backwards.excludes
@@ -27,3 +27,4 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.ArterySet
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.remote.RemoteActorRefProvider.remoteWatcher")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.RemoteWatcher.props")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.RemoteWatcher.watchNode")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.remote.RemoteActorRefProvider.createDeployer")

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -181,16 +181,16 @@ akka {
     # Using remoting directly is typically not desirable, so a warning will
     # be shown to make this clear. Set this setting to 'off' to suppress that.
     # warning.
-    warn-about-direct-use = "on"
+    warn-about-direct-use = on
 
     # If Cluster is not used, remote watch and deployment are disabled.
     # To optionally use them while not using Cluster, set to 'on'.
-    use-unsafe-remote-features-without-cluster = "off"
+    use-unsafe-remote-features-without-cluster = off
 
-    # A warning will be logged on remote watch attempts if either
-    # Cluster is in use or `use-unsafe-remote-features-without-cluster`
-    # is enabled. Set this to 'off' to suppress these.
-    warn-unsafe-watch-without-cluster = "on"
+    # A warning will be logged on remote watch attempts if Cluster
+    # is not in use and 'use-unsafe-remote-features-without-cluster'
+    # is 'off'. Set this to 'off' to suppress these.
+    warn-unsafe-watch-without-cluster = on
 
     # Settings for the Phi accrual failure detector (http://www.jaist.ac.jp/~defago/files/pdf/IS_RR_2004_010.pdf
     # [Hayashibara et al]) used for remote death watch.

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -179,13 +179,18 @@ akka {
     ### Settings shared by classic remoting and Artery (the new implementation of remoting)
 
     # Using remoting directly is typically not desirable, so a warning will
-    # be shown to make this clear. Set this setting to 'off' to suppress that
+    # be shown to make this clear. Set this setting to 'off' to suppress that.
     # warning.
     warn-about-direct-use = "on"
 
     # If Cluster is not used, remote watch and deployment are disabled.
     # To optionally use them while not using Cluster, set to 'on'.
     use-unsafe-remote-features-without-cluster = "off"
+
+    # A warning will be logged on remote watch attempts if either
+    # Cluster is in use or `use-unsafe-remote-features-without-cluster`
+    # is enabled. Set this to 'off' to suppress these.
+    warn-unsafe-watch-without-cluster = "on"
 
     # Settings for the Phi accrual failure detector (http://www.jaist.ac.jp/~defago/files/pdf/IS_RR_2004_010.pdf
     # [Hayashibara et al]) used for remote death watch.

--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -183,6 +183,10 @@ akka {
     # warning.
     warn-about-direct-use = "on"
 
+    # If Cluster is not used, remote watch and deployment are disabled.
+    # To optionally use them while not using Cluster, set to 'on'.
+    use-unsafe-remote-features-without-cluster = "off"
+
     # Settings for the Phi accrual failure detector (http://www.jaist.ac.jp/~defago/files/pdf/IS_RR_2004_010.pdf
     # [Hayashibara et al]) used for remote death watch.
     # The default PhiAccrualFailureDetector will trigger if there are no heartbeats within
@@ -237,6 +241,7 @@ akka {
 
     # remote deployment configuration section
     deployment {
+
       # If true, will only allow specific classes to be instanciated on this system via remote deployment
       enable-whitelist = off
 

--- a/akka-remote/src/main/scala/akka/remote/FailureDetectorRegistry.scala
+++ b/akka-remote/src/main/scala/akka/remote/FailureDetectorRegistry.scala
@@ -4,10 +4,12 @@
 
 package akka.remote
 
-import akka.actor.{ ActorContext, ActorSystem, ExtendedActorSystem }
-import com.typesafe.config.Config
-import akka.event.EventStream
 import akka.ConfigurationException
+import akka.actor.ActorContext
+import akka.actor.ActorSystem
+import akka.actor.ExtendedActorSystem
+import akka.event.EventStream
+import com.typesafe.config.Config
 
 /**
  * Interface for a registry of Akka failure detectors. New resources are implicitly registered when heartbeat is first
@@ -86,8 +88,9 @@ private[akka] object FailureDetectorLoader {
    *
    * @param fqcn Fully qualified class name of the implementation to be loaded.
    * @param config Configuration that will be passed to the implementation
-   * @return
    */
-  def apply(fqcn: String, config: Config)(implicit ctx: ActorContext) = load(fqcn, config, ctx.system)
+  def apply(fqcn: String, config: Config)(implicit ctx: ActorContext): FailureDetector = load(fqcn, config, ctx.system)
 
+  def apply(system: ExtendedActorSystem, settings: RemoteSettings): FailureDetector =
+    load(settings.WatchFailureDetectorImplementationClass, settings.WatchFailureDetectorConfig, system)
 }

--- a/akka-remote/src/main/scala/akka/remote/RemoteDeployer.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDeployer.scala
@@ -4,14 +4,13 @@
 
 package akka.remote
 
-import akka.actor._
-import akka.routing._
-import akka.remote.routing._
 import akka.ConfigurationException
+import akka.actor._
 import akka.japi.Util.immutableSeq
-import com.typesafe.config._
-import akka.routing.Pool
 import akka.remote.routing.RemoteRouterConfig
+import akka.routing.Pool
+import akka.routing._
+import com.typesafe.config._
 
 @SerialVersionUID(1L)
 final case class RemoteScope(node: Address) extends Scope {
@@ -29,7 +28,7 @@ private[akka] class RemoteDeployer(_settings: ActorSystem.Settings, _pm: Dynamic
       case d @ Some(deploy) =>
         deploy.config.getString("remote") match {
           case AddressFromURIString(r) => Some(deploy.copy(scope = RemoteScope(r)))
-          case str if !str.isEmpty     => throw new ConfigurationException(s"unparseable remote node name [${str}]")
+          case str if !str.isEmpty     => throw new ConfigurationException(s"Unparseable remote node name [${str}].")
           case _ =>
             val nodes = immutableSeq(deploy.config.getStringList("target.nodes")).map(AddressFromURIString(_))
             if (nodes.isEmpty || deploy.routerConfig == NoRouter) d

--- a/akka-remote/src/main/scala/akka/remote/RemoteDeploymentWatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteDeploymentWatcher.scala
@@ -8,6 +8,7 @@ import akka.actor.InternalActorRef
 import akka.actor.Terminated
 import akka.actor.Actor
 import akka.actor.ActorRef
+import akka.actor.Props
 import akka.dispatch.sysmsg.DeathWatchNotification
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 
@@ -15,6 +16,9 @@ import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
  * INTERNAL API
  */
 private[akka] object RemoteDeploymentWatcher {
+
+  def props(settings: RemoteSettings): Props = settings.configureDispatcher(Props(new RemoteDeploymentWatcher()))
+
   final case class WatchRemote(actor: ActorRef, supervisor: ActorRef)
 }
 

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -124,6 +124,9 @@ final class RemoteSettings(val config: Config) {
     Timeout(config.getMillisDuration("akka.remote.classic.command-ack-timeout"))
   }.requiring(_.duration > Duration.Zero, "command-ack-timeout must be > 0")
 
+  val UseUnsafeRemoteFeaturesWithoutCluster: Boolean = getBoolean(
+    "akka.remote.use-unsafe-remote-features-without-cluster")
+
   val WatchFailureDetectorConfig: Config = getConfig("akka.remote.watch-failure-detector")
   val WatchFailureDetectorImplementationClass: String = WatchFailureDetectorConfig.getString("implementation-class")
   val WatchHeartBeatInterval: FiniteDuration = {

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -127,6 +127,8 @@ final class RemoteSettings(val config: Config) {
   val UseUnsafeRemoteFeaturesWithoutCluster: Boolean = getBoolean(
     "akka.remote.use-unsafe-remote-features-without-cluster")
 
+  val WarnUnsafeWatchWithoutCluster: Boolean = getBoolean("akka.remote.warn-unsafe-watch-without-cluster")
+
   val WatchFailureDetectorConfig: Config = getConfig("akka.remote.watch-failure-detector")
   val WatchFailureDetectorImplementationClass: String = WatchFailureDetectorConfig.getString("implementation-class")
   val WatchHeartBeatInterval: FiniteDuration = {

--- a/akka-remote/src/test/scala/akka/remote/RemoteFeaturesSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteFeaturesSpec.scala
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.remote
+
+import java.net.InetAddress
+
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.ActorSystemImpl
+import akka.actor.Deployer
+import akka.actor.Nobody
+import akka.actor.Props
+import akka.dispatch.sysmsg.Supervise
+import akka.testkit.AkkaSpec
+import akka.testkit.ImplicitSender
+import akka.testkit.SocketUtil
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+
+object RemoteFeaturesSpec {
+
+  val disabled: Config = ConfigFactory.parseString("""akka.actor.provider = "remote"""")
+
+  // cluster with default
+  val safe: Config =
+    ConfigFactory.parseString("""akka.actor.provider = "cluster" """).withFallback(RemoteFeaturesSpec.disabled)
+
+  // no cluster, with remote watcher & deployer enabled
+  val unsafe: Config = ConfigFactory.parseString("""
+      akka.actor.provider = "remote"
+      akka.remote.use-unsafe-remote-features-without-cluster = "on"
+      """).withFallback(disabled)
+
+  class RemoteActor(listener: ActorRef) extends Actor {
+    def receive: Actor.Receive = {
+      case e => listener ! e
+    }
+  }
+}
+
+import RemoteFeaturesSpec.RemoteActor
+
+abstract class RemoteFeaturesSpec(c: Config) extends AkkaSpec(c) with ImplicitSender {
+
+  protected final val provider = RARP(system).provider
+  provider.init(system.asInstanceOf[ActorSystemImpl])
+
+  protected final val address = SocketUtil.temporaryServerAddress(InetAddress.getLocalHost.getHostAddress, udp = false)
+
+  private val config = ConfigFactory.parseString(s"""
+        akka.remote.artery.canonical.port = ${address.getPort}
+        akka.remote.artery.bind.port = 0
+      """)
+
+  implicit final val remoteSystem = ActorSystem("sys", config.withFallback(ConfigFactory.load()))
+
+  override def beforeTermination(): Unit = remoteSystem.terminate()
+
+}
+
+class DisableRemoteFeaturesWithoutClusterSpec extends RemoteFeaturesSpec(RemoteFeaturesSpec.disabled) {
+
+  "Remoting without Cluster" must {
+
+    "have the expected settings" in {
+      provider.remoteSettings.UseUnsafeRemoteFeaturesWithoutCluster shouldBe false
+      provider.transport.system.settings.HasCluster shouldBe false
+    }
+
+    "not create a RemoteWatcher" in {
+      provider.remoteWatcher shouldEqual None
+    }
+
+    "not send system messages to remote" in {
+      val remote = remoteSystem.actorOf(Props(new RemoteActor(self)))
+      val local = system.actorOf(Props(new RemoteActor(self)))
+      val rar = new RemoteActorRef(
+        provider.transport,
+        provider.transport.localAddressForRemote(remote.path.address),
+        remote.path,
+        Nobody,
+        props = None,
+        deploy = None)
+
+      rar.start()
+      rar.isWatchIntercepted(watchee = remote, watcher = provider.remoteWatcher.get) shouldBe false
+      rar.isWatchIntercepted(watchee = provider.remoteWatcher.get, watcher = remote) shouldBe false
+      rar.isWatchIntercepted(watchee = local, watcher = remote) shouldBe false
+      rar.isWatchIntercepted(watchee = remote, watcher = local) shouldBe false
+
+      rar.suspend()
+      expectNoMessage()
+    }
+
+    "use a local Deployer" in {
+      provider.deployer.getClass shouldEqual classOf[Deployer]
+    }
+  }
+}
+
+class EnableRemoteFeaturesWithoutClusterSpec extends RemoteFeaturesSpec(RemoteFeaturesSpec.unsafe) {
+
+  "Remoting without Cluster optionally set to use unsafe remote features" must {
+    "have the expected settings" in {
+      provider.remoteSettings.UseUnsafeRemoteFeaturesWithoutCluster shouldBe true
+      provider.transport.system.settings.HasCluster shouldBe false
+    }
+
+    "create a RemoteWatcher" in {
+      provider.remoteWatcher.isDefined shouldBe true
+    }
+
+    "send system messages - RemoteActorRef is remote" in {
+      val remote = remoteSystem.actorOf(Props(new RemoteActor(self)))
+      val local = system.actorOf(Props(new RemoteActor(self)))
+      val rar = new RemoteActorRef(
+        provider.transport,
+        provider.transport.localAddressForRemote(remote.path.address),
+        remote.path,
+        Nobody,
+        props = None,
+        deploy = None)
+
+      rar.start()
+      rar.isWatchIntercepted(watchee = remote, watcher = local) shouldBe true
+      rar.isWatchIntercepted(watchee = remote, watcher = provider.remoteWatcher.get) shouldBe false
+      rar.isWatchIntercepted(watchee = local, watcher = remote) shouldBe false
+      rar.sendSystemMessage(Supervise(self, async = true))
+      expectMsgType[Supervise].child shouldEqual self
+      lastSender shouldEqual remote
+    }
+
+    "send system messages - RemoteActorRef is local" in {
+      // TODO maybe we don't need this test
+      val remote = remoteSystem.actorOf(Props(new RemoteActor(self)))
+      val local = system.actorOf(Props(new RemoteActor(self)))
+      val rar =
+        new RemoteActorRef(provider.transport, local.path.address, local.path, Nobody, props = None, deploy = None)
+
+      rar.start()
+      rar.isWatchIntercepted(watchee = local, watcher = remote) shouldBe true
+      rar.isWatchIntercepted(watchee = remote, watcher = local) shouldBe false
+      rar.sendSystemMessage(Supervise(self, async = true))
+      expectMsgType[Supervise].child shouldEqual self
+      lastSender shouldEqual local
+    }
+
+    "use a RemoteDeployer" in {
+      provider.deployer.getClass shouldEqual classOf[RemoteDeployer]
+    }
+  }
+}
+
+class EnableRemoteFeaturesWithClusterSpec extends RemoteFeaturesSpec(RemoteFeaturesSpec.safe) {
+
+  "Remoting with Cluster" must {
+    "have the correct settings" in {
+      system.settings.HasCluster shouldBe true
+      system.settings.ProviderClass shouldEqual "akka.cluster.ClusterActorRefProvider"
+      provider.transport.system.settings.HasCluster shouldBe true
+      provider.remoteSettings.UseUnsafeRemoteFeaturesWithoutCluster shouldBe false
+    }
+
+    "create a RemoteWatcher" in {
+      provider.remoteWatcher.isDefined shouldBe true
+    }
+
+    "should send system messages" in {
+      val remote = remoteSystem.actorOf(Props(new RemoteActor(self)))
+      val local = system.actorOf(Props(new RemoteActor(self)))
+      val rar = new RemoteActorRef(
+        provider.transport,
+        provider.transport.localAddressForRemote(remote.path.address),
+        remote.path,
+        Nobody,
+        props = None,
+        deploy = None)
+
+      rar.start()
+      rar.isWatchIntercepted(watchee = remote, watcher = local) shouldBe true
+      rar.isWatchIntercepted(watchee = remote, watcher = provider.remoteWatcher.get) shouldBe false
+      rar.isWatchIntercepted(watchee = provider.remoteWatcher.get, watcher = remote) shouldBe false
+      rar.isWatchIntercepted(watchee = local, watcher = remote) shouldBe false
+
+      rar.sendSystemMessage(Supervise(self, async = true))
+      expectMsgType[Supervise].child shouldEqual self
+      lastSender shouldEqual remote
+    }
+
+    "use ClusterDeployer (when cluster is on cp, here it is not, so it should not be local Deployer)" in {
+      // TODO test in cluster with ClusterDeployer on the cp: provider.deployer.getClass shouldEqual classOf[ClusterDeployer]
+      provider.deployer.getClass != classOf[Deployer] shouldBe true
+    }
+  }
+}

--- a/akka-remote/src/test/scala/akka/remote/RemoteFeaturesSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteFeaturesSpec.scala
@@ -4,35 +4,27 @@
 
 package akka.remote
 
-import java.net.InetAddress
-
 import akka.actor.Actor
 import akka.actor.ActorRef
-import akka.actor.ActorSystem
-import akka.actor.ActorSystemImpl
 import akka.actor.Deployer
-import akka.actor.Nobody
-import akka.actor.Props
-import akka.dispatch.sysmsg.Supervise
 import akka.testkit.AkkaSpec
 import akka.testkit.ImplicitSender
-import akka.testkit.SocketUtil
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
 object RemoteFeaturesSpec {
 
-  val disabled: Config = ConfigFactory.parseString("""akka.actor.provider = "remote"""")
-
-  // cluster with default
-  val safe: Config =
-    ConfigFactory.parseString("""akka.actor.provider = "cluster" """).withFallback(RemoteFeaturesSpec.disabled)
+  val remote: Config =
+    ConfigFactory.parseString("""
+        akka.actor.provider = "remote"
+        akka.remote.artery.canonical.port = 0
+        akka.log-dead-letters-during-shutdown = off
+        """)
 
   // no cluster, with remote watcher & deployer enabled
   val unsafe: Config = ConfigFactory.parseString("""
-      akka.actor.provider = "remote"
       akka.remote.use-unsafe-remote-features-without-cluster = "on"
-      """).withFallback(disabled)
+      """).withFallback(remote)
 
   class RemoteActor(listener: ActorRef) extends Actor {
     def receive: Actor.Receive = {
@@ -41,28 +33,13 @@ object RemoteFeaturesSpec {
   }
 }
 
-import RemoteFeaturesSpec.RemoteActor
-
 abstract class RemoteFeaturesSpec(c: Config) extends AkkaSpec(c) with ImplicitSender {
 
-  protected final val provider = RARP(system).provider
-  provider.init(system.asInstanceOf[ActorSystemImpl])
-
-  protected final val address = SocketUtil.temporaryServerAddress(InetAddress.getLocalHost.getHostAddress, udp = false)
-
-  private val config = ConfigFactory.parseString(s"""
-        akka.remote.artery.canonical.port = ${address.getPort}
-        akka.remote.artery.bind.port = 0
-      """)
-
-  implicit final val remoteSystem = ActorSystem("sys", config.withFallback(ConfigFactory.load()))
-
-  override def beforeTermination(): Unit = remoteSystem.terminate()
+  protected val provider = RARP(system).provider
 
 }
 
-class DisableRemoteFeaturesWithoutClusterSpec extends RemoteFeaturesSpec(RemoteFeaturesSpec.disabled) {
-
+class DisableRemoteFeaturesWithoutClusterSpec extends RemoteFeaturesSpec(RemoteFeaturesSpec.remote) {
   "Remoting without Cluster" must {
 
     "have the expected settings" in {
@@ -74,27 +51,6 @@ class DisableRemoteFeaturesWithoutClusterSpec extends RemoteFeaturesSpec(RemoteF
       provider.remoteWatcher shouldEqual None
     }
 
-    "not send system messages to remote" in {
-      val remote = remoteSystem.actorOf(Props(new RemoteActor(self)))
-      val local = system.actorOf(Props(new RemoteActor(self)))
-      val rar = new RemoteActorRef(
-        provider.transport,
-        provider.transport.localAddressForRemote(remote.path.address),
-        remote.path,
-        Nobody,
-        props = None,
-        deploy = None)
-
-      rar.start()
-      rar.isWatchIntercepted(watchee = remote, watcher = provider.remoteWatcher.get) shouldBe false
-      rar.isWatchIntercepted(watchee = provider.remoteWatcher.get, watcher = remote) shouldBe false
-      rar.isWatchIntercepted(watchee = local, watcher = remote) shouldBe false
-      rar.isWatchIntercepted(watchee = remote, watcher = local) shouldBe false
-
-      rar.suspend()
-      expectNoMessage()
-    }
-
     "use a local Deployer" in {
       provider.deployer.getClass shouldEqual classOf[Deployer]
     }
@@ -102,8 +58,8 @@ class DisableRemoteFeaturesWithoutClusterSpec extends RemoteFeaturesSpec(RemoteF
 }
 
 class EnableRemoteFeaturesWithoutClusterSpec extends RemoteFeaturesSpec(RemoteFeaturesSpec.unsafe) {
-
   "Remoting without Cluster optionally set to use unsafe remote features" must {
+
     "have the expected settings" in {
       provider.remoteSettings.UseUnsafeRemoteFeaturesWithoutCluster shouldBe true
       provider.transport.system.settings.HasCluster shouldBe false
@@ -113,86 +69,8 @@ class EnableRemoteFeaturesWithoutClusterSpec extends RemoteFeaturesSpec(RemoteFe
       provider.remoteWatcher.isDefined shouldBe true
     }
 
-    "send system messages - RemoteActorRef is remote" in {
-      val remote = remoteSystem.actorOf(Props(new RemoteActor(self)))
-      val local = system.actorOf(Props(new RemoteActor(self)))
-      val rar = new RemoteActorRef(
-        provider.transport,
-        provider.transport.localAddressForRemote(remote.path.address),
-        remote.path,
-        Nobody,
-        props = None,
-        deploy = None)
-
-      rar.start()
-      rar.isWatchIntercepted(watchee = remote, watcher = local) shouldBe true
-      rar.isWatchIntercepted(watchee = remote, watcher = provider.remoteWatcher.get) shouldBe false
-      rar.isWatchIntercepted(watchee = local, watcher = remote) shouldBe false
-      rar.sendSystemMessage(Supervise(self, async = true))
-      expectMsgType[Supervise].child shouldEqual self
-      lastSender shouldEqual remote
-    }
-
-    "send system messages - RemoteActorRef is local" in {
-      // TODO maybe we don't need this test
-      val remote = remoteSystem.actorOf(Props(new RemoteActor(self)))
-      val local = system.actorOf(Props(new RemoteActor(self)))
-      val rar =
-        new RemoteActorRef(provider.transport, local.path.address, local.path, Nobody, props = None, deploy = None)
-
-      rar.start()
-      rar.isWatchIntercepted(watchee = local, watcher = remote) shouldBe true
-      rar.isWatchIntercepted(watchee = remote, watcher = local) shouldBe false
-      rar.sendSystemMessage(Supervise(self, async = true))
-      expectMsgType[Supervise].child shouldEqual self
-      lastSender shouldEqual local
-    }
-
     "use a RemoteDeployer" in {
       provider.deployer.getClass shouldEqual classOf[RemoteDeployer]
-    }
-  }
-}
-
-class EnableRemoteFeaturesWithClusterSpec extends RemoteFeaturesSpec(RemoteFeaturesSpec.safe) {
-
-  "Remoting with Cluster" must {
-    "have the correct settings" in {
-      system.settings.HasCluster shouldBe true
-      system.settings.ProviderClass shouldEqual "akka.cluster.ClusterActorRefProvider"
-      provider.transport.system.settings.HasCluster shouldBe true
-      provider.remoteSettings.UseUnsafeRemoteFeaturesWithoutCluster shouldBe false
-    }
-
-    "create a RemoteWatcher" in {
-      provider.remoteWatcher.isDefined shouldBe true
-    }
-
-    "should send system messages" in {
-      val remote = remoteSystem.actorOf(Props(new RemoteActor(self)))
-      val local = system.actorOf(Props(new RemoteActor(self)))
-      val rar = new RemoteActorRef(
-        provider.transport,
-        provider.transport.localAddressForRemote(remote.path.address),
-        remote.path,
-        Nobody,
-        props = None,
-        deploy = None)
-
-      rar.start()
-      rar.isWatchIntercepted(watchee = remote, watcher = local) shouldBe true
-      rar.isWatchIntercepted(watchee = remote, watcher = provider.remoteWatcher.get) shouldBe false
-      rar.isWatchIntercepted(watchee = provider.remoteWatcher.get, watcher = remote) shouldBe false
-      rar.isWatchIntercepted(watchee = local, watcher = remote) shouldBe false
-
-      rar.sendSystemMessage(Supervise(self, async = true))
-      expectMsgType[Supervise].child shouldEqual self
-      lastSender shouldEqual remote
-    }
-
-    "use ClusterDeployer (when cluster is on cp, here it is not, so it should not be local Deployer)" in {
-      // TODO test in cluster with ClusterDeployer on the cp: provider.deployer.getClass shouldEqual classOf[ClusterDeployer]
-      provider.deployer.getClass != classOf[Deployer] shouldBe true
     }
   }
 }

--- a/akka-remote/src/test/scala/akka/remote/RemoteFeaturesSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteFeaturesSpec.scala
@@ -45,6 +45,7 @@ class DisableRemoteFeaturesWithoutClusterSpec extends RemoteFeaturesSpec(RemoteF
     "have the expected settings" in {
       provider.remoteSettings.UseUnsafeRemoteFeaturesWithoutCluster shouldBe false
       provider.transport.system.settings.HasCluster shouldBe false
+      provider.remoteSettings.WarnUnsafeWatchWithoutCluster shouldBe true
     }
 
     "not create a RemoteWatcher" in {
@@ -63,6 +64,7 @@ class EnableRemoteFeaturesWithoutClusterSpec extends RemoteFeaturesSpec(RemoteFe
     "have the expected settings" in {
       provider.remoteSettings.UseUnsafeRemoteFeaturesWithoutCluster shouldBe true
       provider.transport.system.settings.HasCluster shouldBe false
+      provider.remoteSettings.WarnUnsafeWatchWithoutCluster shouldBe true
     }
 
     "create a RemoteWatcher" in {

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteDeathWatchSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteDeathWatchSpec.scala
@@ -27,6 +27,7 @@ object RemoteDeathWatchSpec {
             }
         }
         test.filter-leeway = 10s
+        remote.use-unsafe-remote-features-without-cluster = on
         remote.watch-failure-detector.acceptable-heartbeat-pause = 2s
 
         # reduce handshake timeout for quicker test of unknownhost, but

--- a/akka-remote/src/test/scala/akka/remote/classic/RemoteDeathWatchSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/RemoteDeathWatchSpec.scala
@@ -22,6 +22,7 @@ akka {
             /watchers.remote = "akka.tcp://other@localhost:2666"
         }
     }
+    remote.use-unsafe-remote-features-without-cluster = on
     remote.artery.enabled = off
     remote.classic {
       retry-gate-closed-for = 1 s

--- a/akka-remote/src/test/scala/akka/remote/classic/RemoteDeploymentWhitelistSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/RemoteDeploymentWhitelistSpec.scala
@@ -56,6 +56,7 @@ object RemoteDeploymentWhitelistSpec {
       actor.provider = remote
 
       remote {
+        use-unsafe-remote-features-without-cluster = on
         classic.enabled-transports = [
           "akka.remote.test",
           "akka.remote.classic.netty.tcp"


### PR DESCRIPTION
 #26176  

TODO 
- [ ] Add more deployer tests 
- [ ] Update the remaining tests that are affected, most may be updated already
- [ ] Add to migration guide
- [ ] Fix RemoteWatcherSpec, line 288: expectMsg(Stats.empty) but has 1 watcher still
         