### PR TITLE
remove Jackson afterburner, since no visible improvement #24155

### DIFF
--- a/akka-bench-jmh/src/main/java/akka/serialization/jackson/JavaMessages.java
+++ b/akka-bench-jmh/src/main/java/akka/serialization/jackson/JavaMessages.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.serialization.jackson;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public class JavaMessages {
+  interface JTestMessage {}
+
+  public static class JSmall implements JTestMessage {
+    public final String name;
+    public final int num;
+
+    public JSmall(String name, int num) {
+      this.name = name;
+      this.num = num;
+    }
+  }
+
+  public static class JMedium implements JTestMessage {
+    public final String field1;
+    public final String field2;
+    public final String field3;
+    public final int num1;
+    public final int num2;
+    public final int num3;
+    public final boolean flag1;
+    public final boolean flag2;
+    public final Duration duration;
+
+    public final LocalDateTime date;
+    public final Instant instant;
+    public final JSmall nested1;
+    public final JSmall nested2;
+    public final JSmall nested3;
+
+    public JMedium(
+        String field1,
+        String field2,
+        String field3,
+        int num1,
+        int num2,
+        int num3,
+        boolean flag1,
+        boolean flag2,
+        Duration duration,
+        LocalDateTime date,
+        Instant instant,
+        JSmall nested1,
+        JSmall nested2,
+        JSmall nested3) {
+      this.field1 = field1;
+      this.field2 = field2;
+      this.field3 = field3;
+      this.num1 = num1;
+      this.num2 = num2;
+      this.num3 = num3;
+      this.flag1 = flag1;
+      this.flag2 = flag2;
+      this.duration = duration;
+      this.date = date;
+      this.instant = instant;
+      this.nested1 = nested1;
+      this.nested2 = nested2;
+      this.nested3 = nested3;
+    }
+  }
+
+  public static class JLarge implements JTestMessage {
+    public final JMedium nested1;
+    public final JMedium nested2;
+    public final JMedium nested3;
+    public final List<JMedium> list;
+    public final Map<String, JMedium> map;
+
+    public JLarge(
+        JMedium nested1,
+        JMedium nested2,
+        JMedium nested3,
+        List<JMedium> list,
+        Map<String, JMedium> map) {
+      this.nested1 = nested1;
+      this.nested2 = nested2;
+      this.nested3 = nested3;
+      this.list = list;
+      this.map = map;
+    }
+  }
+}

--- a/akka-bench-jmh/src/main/scala/akka/serialization/jackson/JacksonSerializationBench.scala
+++ b/akka-bench-jmh/src/main/scala/akka/serialization/jackson/JacksonSerializationBench.scala
@@ -262,9 +262,9 @@ class JacksonSerializationBench {
     serializeDeserialize(jLargeMsg)
   }
 
-//  @Benchmark
-//  def timeMessage(): TimeMessage = {
-//    serializeDeserialize(timeMsg)
-//  }
+  @Benchmark
+  def timeMessage(): TimeMessage = {
+    serializeDeserialize(timeMsg)
+  }
 
 }

--- a/akka-bench-jmh/src/main/scala/akka/serialization/jackson/JacksonSerializationBench.scala
+++ b/akka-bench-jmh/src/main/scala/akka/serialization/jackson/JacksonSerializationBench.scala
@@ -6,6 +6,8 @@ package akka.serialization.jackson
 
 import java.time.Instant
 import java.time.LocalDateTime
+import java.time.{ Duration => JDuration }
+import java.util
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.Await
@@ -51,11 +53,10 @@ object JacksonSerializationBench {
   final class TimeMessage(val duration: FiniteDuration, val date: LocalDateTime, val instant: Instant)
       extends TestMessage
 
-  // FIXME try with plain java classes (not case class)
 }
 
 @State(Scope.Benchmark)
-@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
 @BenchmarkMode(Array(Mode.Throughput))
 @Fork(2)
 @Warmup(iterations = 4)
@@ -120,6 +121,66 @@ class JacksonSerializationBench {
 
   val timeMsg = new TimeMessage(5.seconds, LocalDateTime.of(2019, 4, 29, 23, 15, 3, 12345), Instant.now())
 
+  import JavaMessages._
+  val jSmallMsg1 = new JSmall("abc", 17)
+  val jSmallMsg2 = new JSmall("def", 18)
+  val jSmallMsg3 = new JSmall("ghi", 19)
+  val jMediumMsg1 = new JMedium(
+    "abc",
+    "def",
+    "ghi",
+    1,
+    2,
+    3,
+    false,
+    true,
+    JDuration.ofSeconds(5),
+    LocalDateTime.of(2019, 4, 29, 23, 15, 3, 12345),
+    Instant.now(),
+    jSmallMsg1,
+    jSmallMsg2,
+    jSmallMsg3)
+  val jMediumMsg2 = new JMedium(
+    "ABC",
+    "DEF",
+    "GHI",
+    10,
+    20,
+    30,
+    true,
+    false,
+    JDuration.ofMillis(5),
+    LocalDateTime.of(2019, 4, 29, 23, 15, 4, 12345),
+    Instant.now(),
+    jSmallMsg1,
+    jSmallMsg2,
+    jSmallMsg3)
+  val jMediumMsg3 = new JMedium(
+    "abcABC",
+    "defDEF",
+    "ghiGHI",
+    100,
+    200,
+    300,
+    true,
+    true,
+    JDuration.ofMillis(200),
+    LocalDateTime.of(2019, 4, 29, 23, 15, 5, 12345),
+    Instant.now(),
+    jSmallMsg1,
+    jSmallMsg2,
+    jSmallMsg3)
+  val jMap = new util.HashMap[String, JMedium]()
+  jMap.put("a", jMediumMsg1)
+  jMap.put("b", jMediumMsg2)
+  jMap.put("c", jMediumMsg3)
+  val jLargeMsg = new JLarge(
+    jMediumMsg1,
+    jMediumMsg2,
+    jMediumMsg3,
+    java.util.Arrays.asList(jMediumMsg1, jMediumMsg2, jMediumMsg3),
+    jMap)
+
   var system: ActorSystem = _
   var serialization: Serialization = _
 
@@ -133,7 +194,8 @@ class JacksonSerializationBench {
           loglevel = WARNING
           actor {
             serialization-bindings {
-              "akka.serialization.jackson.JacksonSerializationBench$$TestMessage" = $serializerName
+              "${classOf[TestMessage].getName}" = $serializerName
+              "${classOf[JTestMessage].getName}" = $serializerName
             }
           }
           serialization.jackson {
@@ -186,8 +248,23 @@ class JacksonSerializationBench {
   }
 
   @Benchmark
-  def timeMessage(): TimeMessage = {
-    serializeDeserialize(timeMsg)
+  def jSmall(): JSmall = {
+    serializeDeserialize(jSmallMsg1)
   }
+
+  @Benchmark
+  def jMedium(): JMedium = {
+    serializeDeserialize(jMediumMsg1)
+  }
+
+  @Benchmark
+  def jLarge(): JLarge = {
+    serializeDeserialize(jLargeMsg)
+  }
+
+//  @Benchmark
+//  def timeMessage(): TimeMessage = {
+//    serializeDeserialize(timeMsg)
+//  }
 
 }

--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -18,9 +18,6 @@ akka.serialization.jackson {
   jackson-modules += "com.fasterxml.jackson.datatype.jdk8.Jdk8Module"
   jackson-modules += "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule"
   jackson-modules += "com.fasterxml.jackson.module.scala.DefaultScalaModule"
-  jackson-modules += "com.fasterxml.jackson.module.afterburner.AfterburnerModule"
-  #jackson-modules += "com.fasterxml.jackson.datatype.pcollections.PCollectionsModule"
-  #jackson-modules += "com.fasterxml.jackson.datatype.guava.GuavaModule"
 }
 #//#jackson-modules
 

--- a/akka-serialization-jackson/src/test/java/akka/serialization/jackson/JavaTestMessages.java
+++ b/akka-serialization-jackson/src/test/java/akka/serialization/jackson/JavaTestMessages.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -201,6 +202,39 @@ public interface JavaTestMessages {
     @Override
     public String toString() {
       return "TimeCommand{" + "timestamp=" + timestamp + ", duration=" + duration + '}';
+    }
+  }
+
+  public class InstantCommand implements TestMessage {
+    public final Instant instant;
+
+    @JsonCreator
+    public InstantCommand(Instant instant) {
+      this.instant = instant;
+    }
+
+    public Instant getInstant() {
+      return instant;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      InstantCommand that = (InstantCommand) o;
+
+      return instant.equals(that.instant);
+    }
+
+    @Override
+    public int hashCode() {
+      return instant.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return "InstantCommand{" + "instant=" + instant + '}';
     }
   }
 

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -39,7 +39,7 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException
 import com.fasterxml.jackson.databind.node.IntNode
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Matchers
@@ -251,7 +251,7 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
             bindingName: String,
             configuredModules: immutable.Seq[Module]): immutable.Seq[Module] =
           if (bindingName == "jackson-json") {
-            configuredModules.filterNot(_.isInstanceOf[AfterburnerModule])
+            configuredModules.filterNot(_.isInstanceOf[JavaTimeModule])
           } else
             super.overrideConfiguredModules(bindingName, configuredModules)
       }

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -5,6 +5,7 @@
 package akka.serialization.jackson
 
 import java.time.Duration
+import java.time.Instant
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import java.util.Arrays
@@ -61,6 +62,7 @@ object ScalaTestMessages {
   final case class OptionCommand(maybe: Option[String]) extends TestMessage
   final case class BooleanCommand(published: Boolean) extends TestMessage
   final case class TimeCommand(timestamp: LocalDateTime, duration: FiniteDuration) extends TestMessage
+  final case class InstantCommand(instant: Instant) extends TestMessage
   final case class CollectionsCommand(strings: List[String], objects: Vector[SimpleCommand]) extends TestMessage
   final case class CommandWithActorRef(name: String, replyTo: ActorRef) extends TestMessage
   final case class CommandWithTypedActorRef(name: String, replyTo: akka.actor.typed.ActorRef[String])
@@ -209,6 +211,16 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
       }
     }
 
+    "serialize Instant as text with ISO-8601 date format (default)" in {
+      val msg = new InstantCommand(Instant.ofEpochMilli(1559907792075L))
+      val json = serializeToJsonString(msg)
+      val expected = """{"instant":"2019-06-07T11:43:12.075Z"}"""
+      json should ===(expected)
+
+      // and full round trip
+      checkSerialization(msg)
+    }
+
     // FAIL_ON_UNKNOWN_PROPERTIES = off is default in reference.conf
     "not fail on unknown properties" in {
       val json = """{"name":"abc","name2":"def","name3":"ghi"}"""
@@ -262,15 +274,12 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
         .withSetup(JacksonObjectMapperProviderSetup(customJacksonObjectMapperFactory))
         .withSetup(BootstrapSetup(config))
       withSystem(setup) { sys =>
-        val msg = SimpleCommand2("a", "b")
+        val msg = InstantCommand(Instant.ofEpochMilli(1559907792075L))
         val json = serializeToJsonString(msg, sys)
-        // using the custom ObjectMapper with pretty printing enabled
-        val expected =
-          """|{
-             |  "name" : "a",
-             |  "name2" : "b"
-             |}""".stripMargin
-        json should ===(expected)
+        // using the custom ObjectMapper with pretty printing enabled, and no JavaTimeModule
+        json should include("""  "instant" : {""")
+        json should include("""    "seconds" : 1559907792,""")
+        json should include("""    "nanos" : 75000000,""")
       }
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -106,6 +106,7 @@ lazy val benchJmh = akkaModule("akka-bench-jmh")
   .dependsOn(Seq(actor, stream, streamTests, persistence, distributedData, jackson, testkit).map(
     _ % "compile->compile;compile->test"): _*)
   .settings(Dependencies.benchJmh)
+  .settings(javacOptions += "-parameters") // for Jackson
   .enablePlugins(JmhPlugin, ScaladocNoVerificationOfDiagrams, NoPublish, CopyrightHeader)
   .disablePlugins(MimaPlugin, WhiteSourcePlugin, ValidatePullRequest, CopyrightHeaderInPr)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -96,7 +96,6 @@ object Dependencies {
     val jacksonJsr310 = "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion // ApacheV2
     val jacksonScala = "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion // ApacheV2
     val jacksonParameterNames = "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonVersion // ApacheV2
-    val jacksonAfterburner = "com.fasterxml.jackson.module" % "jackson-module-afterburner" % jacksonVersion // ApacheV2
     val jacksonCbor = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion // ApacheV2
 
     object Docs {
@@ -243,7 +242,6 @@ object Dependencies {
         jacksonJdk8,
         jacksonJsr310,
         jacksonParameterNames,
-        jacksonAfterburner,
         jacksonCbor,
         Test.junit,
         Test.scalatest.value)


### PR DESCRIPTION
Couldn't see any significant difference in benchmark results with the [afterburner](https://github.com/FasterXML/jackson-modules-base/tree/master/afterburner) enabled or disabled. Removing it to reduce dependencies and risk of bugs. Users can enable it if they find it useful.

Refs #24155

Tried with both Scala case classes and plain Java classes.

jmh:run -prof gc -i 5 -wi 3 -f1 -t1 akka.serialization.jackson.JacksonSerializationBench

```
### disabled

[info] Benchmark                                                          (serializerName)   Mode  Cnt       Score       Error   Units
[info] JacksonSerializationBench.jLarge                                       jackson-json  thrpt    5   18071.055 ±   258.122   ops/s
[info] JacksonSerializationBench.jLarge:·gc.alloc.rate.norm                   jackson-json  thrpt    5   71465.362 ±     9.276    B/op

[info] JacksonSerializationBench.jLarge                                       jackson-cbor  thrpt    5   19427.743 ±   177.169   ops/s
[info] JacksonSerializationBench.jLarge:·gc.alloc.rate.norm                   jackson-cbor  thrpt    5   70481.259 ±     8.553    B/op

[info] JacksonSerializationBench.jLarge                                      jackson-smile  thrpt    5   19343.822 ±   164.497   ops/s
[info] JacksonSerializationBench.jLarge:·gc.alloc.rate.norm                  jackson-smile  thrpt    5   67265.268 ±     8.621    B/op

[info] JacksonSerializationBench.jMedium                                      jackson-json  thrpt    5  126204.122 ±  1364.038   ops/s
[info] JacksonSerializationBench.jMedium:·gc.alloc.rate.norm                  jackson-json  thrpt    5    8224.194 ±     1.319    B/op

[info] JacksonSerializationBench.jMedium                                      jackson-cbor  thrpt    5  135642.484 ±  1473.655   ops/s
[info] JacksonSerializationBench.jMedium:·gc.alloc.rate.norm                  jackson-cbor  thrpt    5    8024.180 ±     1.226    B/op

[info] JacksonSerializationBench.jMedium                                     jackson-smile  thrpt    5  132236.758 ±   943.981   ops/s
[info] JacksonSerializationBench.jMedium:·gc.alloc.rate.norm                 jackson-smile  thrpt    5    8392.186 ±     1.263    B/op

[info] JacksonSerializationBench.jSmall                                       jackson-json  thrpt    5  776988.376 ±  8438.859   ops/s
[info] JacksonSerializationBench.jSmall:·gc.alloc.rate.norm                   jackson-json  thrpt    5    1200.032 ±     0.215    B/op

[info] JacksonSerializationBench.jSmall                                       jackson-cbor  thrpt    5  787936.543 ±  9480.992   ops/s
[info] JacksonSerializationBench.jSmall:·gc.alloc.rate.norm                   jackson-cbor  thrpt    5    1064.031 ±     0.213    B/op

[info] JacksonSerializationBench.jSmall                                      jackson-smile  thrpt    5  712910.800 ± 11263.049   ops/s
[info] JacksonSerializationBench.jSmall:·gc.alloc.rate.norm                  jackson-smile  thrpt    5    1112.035 ±     0.235    B/op

[info] JacksonSerializationBench.large                                        jackson-json  thrpt    5   18180.206 ±   268.773   ops/s
[info] JacksonSerializationBench.large:·gc.alloc.rate.norm                    jackson-json  thrpt    5   71177.344 ±     9.137    B/op

[info] JacksonSerializationBench.large                                        jackson-cbor  thrpt    5   18863.021 ±   245.192   ops/s
[info] JacksonSerializationBench.large:·gc.alloc.rate.norm                    jackson-cbor  thrpt    5   71657.298 ±     8.823    B/op

[info] JacksonSerializationBench.large                                       jackson-smile  thrpt    5   19787.733 ±   128.325   ops/s
[info] JacksonSerializationBench.large:·gc.alloc.rate.norm                   jackson-smile  thrpt    5   68273.237 ±     8.403    B/op

[info] JacksonSerializationBench.medium                                       jackson-json  thrpt    5  128731.696 ±   563.928   ops/s
[info] JacksonSerializationBench.medium:·gc.alloc.rate.norm                   jackson-json  thrpt    5    8248.190 ±     1.294    B/op

[info] JacksonSerializationBench.medium                                       jackson-cbor  thrpt    5  139035.377 ±  1488.745   ops/s
[info] JacksonSerializationBench.medium:·gc.alloc.rate.norm                   jackson-cbor  thrpt    5    8048.177 ±     1.203    B/op

[info] JacksonSerializationBench.medium                                      jackson-smile  thrpt    5  132799.989 ±   697.114   ops/s
[info] JacksonSerializationBench.medium:·gc.alloc.rate.norm                  jackson-smile  thrpt    5    8416.185 ±     1.256    B/op

[info] JacksonSerializationBench.small                                        jackson-json  thrpt    5  708425.233 ±  4896.778   ops/s
[info] JacksonSerializationBench.small:·gc.alloc.rate.norm                    jackson-json  thrpt    5    1248.035 ±     0.236    B/op

[info] JacksonSerializationBench.small                                        jackson-cbor  thrpt    5  710613.152 ±  8061.227   ops/s
[info] JacksonSerializationBench.small:·gc.alloc.rate.norm                    jackson-cbor  thrpt    5    1152.034 ±     0.234    B/op

[info] JacksonSerializationBench.small                                       jackson-smile  thrpt    5  655954.541 ±  4936.907   ops/s
[info] JacksonSerializationBench.small:·gc.alloc.rate.norm                   jackson-smile  thrpt    5    1112.037 ±     0.253    B/op

### enabled

[info] Benchmark                                                           (serializerName)   Mode  Cnt       Score       Error   Units
[info] JacksonSerializationBench.jLarge                                        jackson-json  thrpt    5   17137.699 ±   429.692   ops/s
[info] JacksonSerializationBench.jLarge:·gc.alloc.rate.norm                    jackson-json  thrpt    5   70889.436 ±     9.796    B/op

[info] JacksonSerializationBench.jLarge                                        jackson-cbor  thrpt    5   18926.604 ±   213.689   ops/s
[info] JacksonSerializationBench.jLarge:·gc.alloc.rate.norm                    jackson-cbor  thrpt    5   70337.296 ±     8.817    B/op

[info] JacksonSerializationBench.jLarge                                       jackson-smile  thrpt    5   19101.281 ±   210.746   ops/s
[info] JacksonSerializationBench.jLarge:·gc.alloc.rate.norm                   jackson-smile  thrpt    5   66473.280 ±     8.695    B/op

[info] JacksonSerializationBench.jMedium                                       jackson-json  thrpt    5  123833.824 ± 13908.945   ops/s
[info] JacksonSerializationBench.jMedium:·gc.alloc.rate.norm                   jackson-json  thrpt    5    8160.194 ±     1.311    B/op

[info] JacksonSerializationBench.jMedium                                       jackson-cbor  thrpt    5  141889.046 ±  1482.134   ops/s
[info] JacksonSerializationBench.jMedium:·gc.alloc.rate.norm                   jackson-cbor  thrpt    5    8000.172 ±     1.169    B/op

[info] JacksonSerializationBench.jMedium                                      jackson-smile  thrpt    5  130206.331 ±  1777.154   ops/s
[info] JacksonSerializationBench.jMedium:·gc.alloc.rate.norm                  jackson-smile  thrpt    5    8328.188 ±     1.274    B/op

[info] JacksonSerializationBench.jSmall                                        jackson-json  thrpt    5  726424.779 ±  7998.677   ops/s
[info] JacksonSerializationBench.jSmall:·gc.alloc.rate.norm                    jackson-json  thrpt    5    1184.034 ±     0.229    B/op

[info] JacksonSerializationBench.jSmall                                        jackson-cbor  thrpt    5  803983.074 ± 10658.694   ops/s
[info] JacksonSerializationBench.jSmall:·gc.alloc.rate.norm                    jackson-cbor  thrpt    5    1096.031 ±     0.208    B/op

[info] JacksonSerializationBench.jSmall                                       jackson-smile  thrpt    5  717744.836 ±  7840.629   ops/s
[info] JacksonSerializationBench.jSmall:·gc.alloc.rate.norm                   jackson-smile  thrpt    5    1096.034 ±     0.233    B/op

[info] JacksonSerializationBench.large                                         jackson-json  thrpt    5   17516.718 ±   168.693   ops/s
[info] JacksonSerializationBench.large:·gc.alloc.rate.norm                     jackson-json  thrpt    5   71937.396 ±     9.499    B/op

[info] JacksonSerializationBench.large                                         jackson-cbor  thrpt    5   18383.418 ±   241.421   ops/s
[info] JacksonSerializationBench.large:·gc.alloc.rate.norm                     jackson-cbor  thrpt    5   70889.330 ±     9.037    B/op

[info] JacksonSerializationBench.large                                        jackson-smile  thrpt    5   19222.609 ±   107.810   ops/s
[info] JacksonSerializationBench.large:·gc.alloc.rate.norm                    jackson-smile  thrpt    5   67737.273 ±     8.662    B/op

[info] JacksonSerializationBench.medium                                        jackson-json  thrpt    5  124113.917 ±  1294.906   ops/s
[info] JacksonSerializationBench.medium:·gc.alloc.rate.norm                    jackson-json  thrpt    5    8184.197 ±     1.340    B/op

[info] JacksonSerializationBench.medium                                        jackson-cbor  thrpt    5  135899.570 ±  1634.126   ops/s
[info] JacksonSerializationBench.medium:·gc.alloc.rate.norm                    jackson-cbor  thrpt    5    7984.180 ±     1.223    B/op

[info] JacksonSerializationBench.medium                                       jackson-smile  thrpt    5  129382.248 ±  5840.497   ops/s
[info] JacksonSerializationBench.medium:·gc.alloc.rate.norm                   jackson-smile  thrpt    5    8256.192 ±     1.313    B/op

[info] JacksonSerializationBench.small                                         jackson-json  thrpt    5  691240.717 ± 11957.261   ops/s
[info] JacksonSerializationBench.small:·gc.alloc.rate.norm                     jackson-json  thrpt    5    1184.036 ±     0.243    B/op

[info] JacksonSerializationBench.small                                         jackson-cbor  thrpt    5  714488.027 ±  8084.776   ops/s
[info] JacksonSerializationBench.small:·gc.alloc.rate.norm                     jackson-cbor  thrpt    5    1096.034 ±     0.233    B/op

[info] JacksonSerializationBench.small                                        jackson-smile  thrpt    5  666457.860 ±  4091.659   ops/s
[info] JacksonSerializationBench.small:·gc.alloc.rate.norm                    jackson-smile  thrpt    5    1096.037 ±     0.250    B/op
```