### PR TITLE
try Jackson compression impact, #24155

### DIFF
--- a/akka-docs/src/main/paradox/serialization-jackson.md
+++ b/akka-docs/src/main/paradox/serialization-jackson.md
@@ -288,7 +288,8 @@ than the following configuration are compressed with GZIP.
 
 @@snip [reference.conf](/akka-serialization-jackson/src/main/resources/reference.conf) { #compression }
 
-TODO: The binary formats are currently also compressed. That may change since it might not be needed for those.
+Compression can be disabled by setting this configuration property to `off`. It will still be able to decompress
+payloads that were compressed when serialized, e.g. if this configuration is changed.
 
 ## Additional configuration
 

--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -27,7 +27,8 @@ akka.serialization.jackson {
 #//#compression
 akka.serialization.jackson {
   # The serializer will compress the payload when it's larger than this value.
-  compress-larger-than = 10 KiB
+  # Compression can be disabled with value 'off'.
+  compress-larger-than = 32 KiB
 }
 #//#compression
 


### PR DESCRIPTION
* increased the default compress-larger-than to 32 KiB,
  because gzip performance overhead
* support 'off' config value to disable completely

Refs #24155

Tried the JMH bench with the following class, which has serialized size in bytes:
* json, 6047 compressed to 3508
* cbor 5145 compressed to 3451
* smile 4317 compressed to 3416

```scala
  val rnd = new Random(17)

  def smallMsg1 = Small(rnd.nextString(3), rnd.nextInt(10))
  def smallMsg2 = Small(rnd.nextString(20), rnd.nextInt(1000))
  def smallMsg3 = Small(rnd.nextString(40), rnd.nextInt())
  def mediumMsg1 =
    Medium(
      rnd.nextString(20),
      rnd.nextString(20),
      rnd.nextString(20),
      rnd.nextInt(500),
      rnd.nextInt(),
      rnd.nextInt(),
      false,
      true,
      5.seconds,
      LocalDateTime.of(2019, 4, 29, 23, 15, rnd.nextInt(60), 12345),
      Instant.now(),
      smallMsg1,
      smallMsg2,
      smallMsg3)
  def mediumMsg2 =
    Medium(
      rnd.nextString(20),
      rnd.nextString(20),
      rnd.nextString(20),
      rnd.nextInt(500),
      rnd.nextInt(),
      rnd.nextInt(),
      false,
      true,
      5.seconds,
      LocalDateTime.of(2019, 4, 29, 23, 15, rnd.nextInt(60), 12345),
      Instant.now(),
      smallMsg1,
      smallMsg2,
      smallMsg3)
  def mediumMsg3 =
    Medium(
      rnd.nextString(20),
      rnd.nextString(20),
      rnd.nextString(20),
      rnd.nextInt(500),
      rnd.nextInt(),
      rnd.nextInt(),
      false,
      true,
      5.seconds,
      LocalDateTime.of(2019, 4, 29, 23, 15, rnd.nextInt(60), 12345),
      Instant.now(),
      smallMsg1,
      smallMsg2,
      smallMsg3)
  // json, 6047 => 3508, cbor 5145 => 3451, smile 4317 => 3416
  val largeMsg =
    Large(
      mediumMsg1,
      mediumMsg2,
      mediumMsg3,
      Vector(mediumMsg1, mediumMsg2, mediumMsg3),
      Map("a" -> mediumMsg1, "b" -> mediumMsg2, "c" -> mediumMsg3))
```

```
### compression enabled

[info] Benchmark                                                         (serializerName)   Mode  Cnt      Score       Error   Units
[info] JacksonSerializationBench.large                                       jackson-json  thrpt    5   5505.547 ±   109.829   ops/s
[info] JacksonSerializationBench.large:·gc.alloc.rate.norm                   jackson-json  thrpt    5  76195.238 ±    30.170    B/op

[info] JacksonSerializationBench.large                                       jackson-cbor  thrpt    5   5963.991 ±    68.579   ops/s
[info] JacksonSerializationBench.large:·gc.alloc.rate.norm                   jackson-cbor  thrpt    5  69588.106 ±    28.009    B/op

[info] JacksonSerializationBench.large                                      jackson-smile  thrpt    5   6550.189 ±   157.723   ops/s
[info] JacksonSerializationBench.large:·gc.alloc.rate.norm                  jackson-smile  thrpt    5  58531.764 ±    25.685    B/op


### compression disabled

[info] Benchmark                                                         (serializerName)   Mode  Cnt      Score       Error   Units
[info] JacksonSerializationBench.large                                       jackson-json  thrpt    5  22733.607 ±  1025.641   ops/s
[info] JacksonSerializationBench.large:·gc.alloc.rate.norm                   jackson-json  thrpt    5  33503.871 ±     7.282    B/op

[info] JacksonSerializationBench.large                                       jackson-cbor  thrpt    5  32229.396 ±   477.968   ops/s
[info] JacksonSerializationBench.large:·gc.alloc.rate.norm                   jackson-cbor  thrpt    5  30800.761 ±     5.187    B/op

[info] JacksonSerializationBench.large                                      jackson-smile  thrpt    5  31941.024 ±  2139.591   ops/s
[info] JacksonSerializationBench.large:·gc.alloc.rate.norm                  jackson-smile  thrpt    5  32104.760 ±     5.152    B/op
```
