### PR TITLE
Support separate conf per JacksonSerializer binding, #24155

### DIFF
--- a/akka-actor/src/main/scala/akka/serialization/Serialization.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serialization.scala
@@ -386,6 +386,14 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
    * loading is performed by the system’s [[akka.actor.DynamicAccess]].
    */
   def serializerOf(serializerFQN: String): Try[Serializer] = {
+    serializerOf(bindingName = "", serializerFQN) // for backwards compatibility since it's a public method
+  }
+
+  /**
+   * Tries to load the specified Serializer by the fully-qualified name; the actual
+   * loading is performed by the system’s [[akka.actor.DynamicAccess]].
+   */
+  private def serializerOf(bindingName: String, serializerFQN: String): Try[Serializer] = {
     // We override each instantiation of the JavaSerializer with the "disabled" serializer which will log warnings if used.
     val fqn =
       if (!system.settings.AllowJavaSerialization && serializerFQN == classOf[JavaSerializer].getName) {
@@ -397,9 +405,14 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
 
     system.dynamicAccess.createInstanceFor[Serializer](fqn, List(classOf[ExtendedActorSystem] -> system)).recoverWith {
       case _: NoSuchMethodException =>
-        system.dynamicAccess.createInstanceFor[Serializer](fqn, Nil)
-      // FIXME only needed on 2.13.0-M5 due to https://github.com/scala/bug/issues/11242
-      case t => Failure(t)
+        system.dynamicAccess.createInstanceFor[Serializer](fqn, Nil).recoverWith {
+          case e: NoSuchMethodException =>
+            if (bindingName == "") throw e // compatibility with (public) serializerOf method without bindingName
+            else
+              system.dynamicAccess.createInstanceFor[Serializer](
+                fqn,
+                List(classOf[ExtendedActorSystem] -> system, classOf[String] -> bindingName))
+        }
     }
   }
 
@@ -424,7 +437,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
    * By default always contains the following mapping: "java" -> akka.serialization.JavaSerializer
    */
   private val serializers: Map[String, Serializer] = {
-    val fromConfig = for ((k: String, v: String) <- settings.Serializers) yield k -> serializerOf(v).get
+    val fromConfig = for ((k: String, v: String) <- settings.Serializers) yield k -> serializerOf(k, v).get
     val result = fromConfig ++ serializerDetails.map(d => d.alias -> d.serializer)
     ensureOnlyAllowedSerializers(result.iterator.map { case (_, ser) => ser })
     result

--- a/akka-actor/src/main/scala/akka/serialization/Serializer.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serializer.scala
@@ -258,7 +258,12 @@ object BaseSerializer {
   /** INTERNAL API */
   @InternalApi
   private[akka] def identifierFromConfig(clazz: Class[_], system: ExtendedActorSystem): Int =
-    system.settings.config.getInt(s"""${SerializationIdentifiers}."${clazz.getName}"""")
+    system.settings.config.getInt(s"""$SerializationIdentifiers."${clazz.getName}"""")
+
+  /** INTERNAL API */
+  @InternalApi
+  private[akka] def identifierFromConfig(bindingName: String, system: ExtendedActorSystem): Int =
+    system.settings.config.getInt(s"""$SerializationIdentifiers."$bindingName"""")
 }
 
 /**

--- a/akka-docs/src/main/paradox/serialization-jackson.md
+++ b/akka-docs/src/main/paradox/serialization-jackson.md
@@ -289,3 +289,18 @@ than the following configuration are compressed with GZIP.
 @@snip [reference.conf](/akka-serialization-jackson/src/main/resources/reference.conf) { #compression }
 
 TODO: The binary formats are currently also compressed. That may change since it might not be needed for those.
+
+## Additional configuration
+
+### Configuration per binding
+
+By default the configuration for the Jackson serializers and their `ObjectMapper`s is defined in
+the `akka.serialization.jackson` section. It is possible to override that configuration in a more
+specific `akka.serialization.jackson.<binding name>` section.
+
+@@snip [config](/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala) { #specific-config }
+
+It's also possible to define several bindings and use different configuration for them. For example,
+different settings for remote messages and persisted events.
+
+@@snip [config](/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala) { #several-config }

--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -57,6 +57,17 @@ akka.serialization.jackson {
     FAIL_ON_UNKNOWN_PROPERTIES = off
   }
 
+  # Specific settings for jackson-json binding can be defined in this section to
+  # override the settings in 'akka.serialization.jackson'
+  jackson-json {}
+
+  # Specific settings for jackson-cbor binding can be defined in this section to
+  # override the settings in 'akka.serialization.jackson'
+  jackson-cbor {}
+
+  # Specific settings for jackson-smile binding can be defined in this section to
+  # override the settings in 'akka.serialization.jackson'
+  jackson-smile {}
 
 }
 
@@ -65,6 +76,11 @@ akka.actor {
     jackson-json = "akka.serialization.jackson.JacksonJsonSerializer"
     jackson-cbor = "akka.serialization.jackson.JacksonCborSerializer"
     jackson-smile = "akka.serialization.jackson.JacksonSmileSerializer"
+  }
+  serialization-identifiers {
+    jackson-json = 31
+    jackson-cbor = 32
+    jackson-smile = 33
   }
   serialization-bindings {
     # Define bindings for classes or interfaces use Jackson serializer, e.g.
@@ -75,10 +91,5 @@ akka.actor {
     # open ended types that might be target to be deserialization gadgets, such as
     # java.lang.Object, java.io.Serializable, java.util.Comparable
 
-  }
-  serialization-identifiers {
-    "akka.serialization.jackson.JacksonJsonSerializer" = 31
-    "akka.serialization.jackson.JacksonCborSerializer" = 32
-    "akka.serialization.jackson.JacksonSmileSerializer" = 33
   }
 }

--- a/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala
@@ -43,6 +43,52 @@ object SerializationDocSpec {
     #//#migrations-conf-rename
   """
 
+  val configSpecific = """
+    #//#specific-config
+    akka.serialization.jackson.jackson-json {
+      serialization-features {
+        WRITE_DATES_AS_TIMESTAMPS = off
+      }
+    }
+    akka.serialization.jackson.jackson-cbor {
+      serialization-features {
+        WRITE_DATES_AS_TIMESTAMPS = on
+      }
+    }
+    #//#specific-config
+  """
+
+  val configSeveral = """
+    #//#several-config
+    akka.actor {
+      serializers {
+        jackson-json-message = "akka.serialization.jackson.JacksonJsonSerializer"
+        jackson-json-event   = "akka.serialization.jackson.JacksonJsonSerializer"
+      }
+      serialization-identifiers {
+        jackson-json-message = 9001
+        jackson-json-event = 9002
+      }
+      serialization-bindings {
+        "com.myservice.MyMessage" = jackson-json-message
+        "com.myservice.MyEvent" = jackson-json-event
+      }
+    }
+    akka.serialization.jackson {
+      jackson-json-message {
+        serialization-features {
+          WRITE_DATES_AS_TIMESTAMPS = on
+        }
+      }
+      jackson-json-event {
+        serialization-features {
+          WRITE_DATES_AS_TIMESTAMPS = off
+        }
+      }
+    }
+    #//#several-config
+  """
+
   //#polymorphism
   final case class Zoo(primaryAttraction: Animal) extends MySerializable
 


### PR DESCRIPTION
* Needed in Lagom to be able to have separate object mappers with different
  config for exernal and internal usage.
* Can also be good to be able to have different config for json and cbor
  serializers, or different for remote messages and persisted events.
* Pass in binding name when creating the serializer if it has a matching
  constructor
* Serialization identifiers loaded from config via the binding name instead
  of class name, for JacksonSerializer.

Refs #24155
