### PR TITLE
Netty is not optional for multi jvm test kit

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -193,7 +193,7 @@ object Dependencies {
 
   val remoteTests = l ++= Seq(Test.junit, Test.scalatest.value, Test.scalaXml) ++ remoteDependencies
 
-  val multiNodeTestkit = l ++= remoteOptionalDependencies
+  val multiNodeTestkit = l ++= remoteDependencies
 
   val cluster = l ++= Seq(Test.junit, Test.scalatest.value)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -193,7 +193,7 @@ object Dependencies {
 
   val remoteTests = l ++= Seq(Test.junit, Test.scalatest.value, Test.scalaXml) ++ remoteDependencies
 
-  val multiNodeTestkit = l ++= remoteDependencies
+  val multiNodeTestkit = l ++= Seq(netty)
 
   val cluster = l ++= Seq(Test.junit, Test.scalatest.value)
 


### PR DESCRIPTION
Netty is used internally and is always loaded even if artery is enabled.
That could be improved but for now netty is needed.

This fixes the Akka HTTP against master build