### PR TITLE
Make Artery connect failure logging less verbose, #26865

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -168,11 +168,15 @@ private[remote] class ArteryTcpTransport(
       // Restart of inner connection part important in control stream, since system messages
       // are buffered and resent from the outer SystemMessageDelivery stage. No maxRestarts limit for control
       // stream. For message stream it's best effort retry a few times.
-      RestartFlow.withBackoff[ByteString, ByteString](
-        settings.Advanced.OutboundRestartBackoff,
-        settings.Advanced.OutboundRestartBackoff * 5,
-        0.1,
-        maxRestarts)(flowFactory)
+      RestartFlow
+        .withBackoff[ByteString, ByteString](
+          settings.Advanced.OutboundRestartBackoff,
+          settings.Advanced.OutboundRestartBackoff * 5,
+          0.1,
+          maxRestarts)(flowFactory)
+        // silence "Restarting graph due to failure" logging by RestartFlow
+        .addAttributes(Attributes.logLevels(onFailure = LogLevels.Off))
+
     }
 
     Flow[EnvelopeBuffer]

--- a/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes
@@ -105,6 +105,9 @@ ProblemFilters.exclude[MissingClassProblem]("akka.stream.impl.SourceQueueAdapter
 # Remove deprecated features since 2.5.0 https://github.com/akka/akka/issues/26492
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.ActorMaterializerSettings.withAutoFusing")
 
+# Add attributes to constructor of internal class
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartWithBackoffLogic.this")
+
 # #26910 scheduleWithFixedDelay vs scheduleAtFixedRate
 # Adding methods to Materializer is not compatible but we don't support other Materializer implementations
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.Materializer.scheduleAtFixedRate")

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSink.scala
@@ -95,6 +95,7 @@ private final class RestartWithBackoffSink[T](
     new RestartWithBackoffLogic(
       "Sink",
       shape,
+      inheritedAttributes,
       minBackoff,
       maxBackoff,
       randomFactor,

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSource.scala
@@ -170,7 +170,15 @@ private final class RestartWithBackoffSource[T](
 
   override def shape = SourceShape(out)
   override def createLogic(inheritedAttributes: Attributes) =
-    new RestartWithBackoffLogic("Source", shape, minBackoff, maxBackoff, randomFactor, onlyOnFailures, maxRestarts) {
+    new RestartWithBackoffLogic(
+      "Source",
+      shape,
+      inheritedAttributes,
+      minBackoff,
+      maxBackoff,
+      randomFactor,
+      onlyOnFailures,
+      maxRestarts) {
 
       override protected def logSource = self.getClass
 


### PR DESCRIPTION
* also made RestartFlow and friends aware of `LogLevels` attribute to be able to silence "Restarting graph due to failure" warning logging, since we have more contextual logging of that in Artery

Refs #26865