### PR TITLE
Option to target system JDK instead of JDK8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,6 @@ import spray.boilerplate.BoilerplatePlugin
 initialize := {
   // Load system properties from a file to make configuration from Jenkins easier
   loadSystemProperties("project/akka-build.properties")
-  assert(CrossJava.Keys.fullJavaHomes.value.contains("8"), "JDK 8 is not installed but required to build akka")
   initialize.value
 }
 

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -10,8 +10,11 @@ import java.time.format.DateTimeFormatter
 import java.time.ZonedDateTime
 import java.time.ZoneOffset
 
-import sbt.Keys._
+// Overriding CrossJava imports #26935
+import sbt.Keys.{fullJavaHomes=>_,_}
 import sbt._
+
+import CrossJava.autoImport._
 import org.scalafmt.sbt.ScalafmtPlugin.autoImport._
 
 import scala.collection.breakOut
@@ -115,21 +118,15 @@ object AkkaBuild {
 
     // compile options
     scalacOptions in Compile ++= DefaultScalacOptions,
-    // Makes sure that, even when compiling with a jdk version greater than 8, the resulting jar will not refer to
-    // methods not found in jdk8. To test whether this has the desired effect, compile akka-remote and check the
-    // invocation of 'ByteBuffer.clear()' in EnvelopeBuffer.class with 'javap -c': it should refer to
-    // "java/nio/ByteBuffer.clear:()Ljava/nio/Buffer" and not "java/nio/ByteBuffer.clear:()Ljava/nio/ByteBuffer":
-    scalacOptions in Compile ++= (
-      if (JavaVersion.isJdk8)
-        Seq("-target:jvm-1.8")
-      else
-        // -release 8 is not enough, for some reason we need the 8 rt.jar explicitly #25330
-        Seq("-release", "8", "-javabootclasspath", CrossJava.Keys.fullJavaHomes.value("8") + "/jre/lib/rt.jar")),
+    scalacOptions in Compile ++=
+      CrossJava.targetJdkScalacOptions(targetSystemJdk.value, fullJavaHomes.value),
     scalacOptions in Compile ++= (if (allWarnings) Seq("-deprecation") else Nil),
     scalacOptions in Test := (scalacOptions in Test).value.filterNot(opt =>
       opt == "-Xlog-reflective-calls" || opt.contains("genjavadoc")),
-    javacOptions in compile ++= DefaultJavacOptions ++ JavaVersion.sourceAndTarget(CrossJava.Keys.fullJavaHomes.value("8")),
-    javacOptions in test ++= DefaultJavacOptions ++ JavaVersion.sourceAndTarget(CrossJava.Keys.fullJavaHomes.value("8")),
+    javacOptions in compile ++= DefaultJavacOptions ++
+      CrossJava.targetJdkJavacOptions(targetSystemJdk.value, fullJavaHomes.value),
+    javacOptions in test ++= DefaultJavacOptions ++
+      CrossJava.targetJdkJavacOptions(targetSystemJdk.value, fullJavaHomes.value),
     javacOptions in compile ++= (if (allWarnings) Seq("-Xlint:deprecation") else Nil),
     javacOptions in doc ++= Seq(),
 


### PR DESCRIPTION
Refs #26222

Inspired by the proposal by @nvollmar in 0940dfc

Had to move the error out of the `initialize` because there it does not
have access to the `targetSystemJdk` setting yet.