### PR TITLE
Some improvements on the 2.6 migration guide

### DIFF
--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -126,17 +126,16 @@ blocking and protect a bit against starving the internal actors. Since the inter
 the default dispatcher has been adjusted down to `1.0` which means the number of threads will be one per core, but at least
 `8` and at most `64`. This can be tuned using the individual settings in `akka.actor.default-dispatcher.fork-join-executor`.
 
+## Akka now uses Fork Join Pool from JDK
+
+Previously, Akka contained a shaded copy of the ForkJoinPool. In benchmarks, we could not find significant benefits of keeping our own copy, so from Akka 2.6 on, the default FJP from the JDK will be used. The Akka FJP copy was removed.
+
 @@ Remoting
 
 ### Default remoting is now Artery TCP
 
 @ref[Artery TCP](../remoting-artery.md) is now the default remoting implementation.
 Classic remoting has been deprecated and will be removed in `2.7.0`.
-
-## Akka now uses Fork Join Pool from JDK
-
-Previously, Akka contained a shaded copy of the ForkJoinPool. In benchmarks, we could not find significant benefits of
-keeping our own copy, so from Akka 2.6 on, the default FJP from the JDK will be used. The Akka FJP copy was removed.
 
 <a id="classic-to-artery"></a>
 #### Migrating from classic remoting to Artery

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -128,7 +128,7 @@ the default dispatcher has been adjusted down to `1.0` which means the number of
 
 ## Akka now uses Fork Join Pool from JDK
 
-Previously, Akka contained a shaded copy of the ForkJoinPool. In benchmarks, we could not find significant benefits of keeping our own copy, so from Akka 2.6 on, the default FJP from the JDK will be used. The Akka FJP copy was removed.
+Previously, Akka contained a shaded copy of the ForkJoinPool. In benchmarks, significant benefits of keeping our own copy were not found. From Akka 2.6 on, the default FJP is from the JDK and the Akka FJP copy is removed.
 
 @@ Remoting
 

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -195,7 +195,7 @@ For TCP:
 
 ### Remaining with Classic remoting (not recommended)
 
-Classic remoting is deprecated but can be used in `2.6.` First you need to explicitly disable Artery by setting property `akka.remote.artery.enabled` to `false`. Further, any configuration under `akka.remote` that is
+Classic remoting is deprecated but can be used in `2.6.` Explicitly disable Artery by setting property `akka.remote.artery.enabled` to `false`. Further, any configuration under `akka.remote` that is
 specific to classic remoting needs to be moved to `akka.remote.classic`. To see which configuration options
 are specific to classic search for them in: [`akka-remote/reference.conf`](/akka-remote/src/main/resources/reference.conf)
 

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -195,7 +195,7 @@ For TCP:
 
 ### Remaining with Classic remoting (not recommended)
 
-Classic remoting is deprecated but can be used in `2.6.` Any configuration under `akka.remote` that is
+Classic remoting is deprecated but can be used in `2.6.` First you need to explicitly disable Artery by setting property `akka.remote.artery.enabled` to `false`. Further, any configuration under `akka.remote` that is
 specific to classic remoting needs to be moved to `akka.remote.classic`. To see which configuration options
 are specific to classic search for them in: [`akka-remote/reference.conf`](/akka-remote/src/main/resources/reference.conf)
 

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -132,13 +132,13 @@ Previously, Akka contained a shaded copy of the ForkJoinPool. In benchmarks, we 
 
 @@ Remoting
 
-### Default remoting is now Artery TCP
+## Default remoting is now Artery TCP
 
 @ref[Artery TCP](../remoting-artery.md) is now the default remoting implementation.
 Classic remoting has been deprecated and will be removed in `2.7.0`.
 
 <a id="classic-to-artery"></a>
-#### Migrating from classic remoting to Artery
+### Migrating from classic remoting to Artery
 
 Artery has the same functionality as classic remoting and you should normally only have to change the
 configuration to switch.
@@ -168,7 +168,7 @@ If using SSL then `tcp-tls` needs to be enabled and setup. See @ref[Artery docs 
 for how to do this.
 
 
-#### Migration from 2.5.x Artery to 2.6.x Artery
+### Migration from 2.5.x Artery to 2.6.x Artery
 
 The following defaults have changed:
 
@@ -193,7 +193,7 @@ For TCP:
 * `akka.remote.artery.advanced.connection-timeout` to `akka.remote.artery.advanced.tcp.connection-timeout`
 
 
-#### Remaining with Classic remoting (not recommended)
+### Remaining with Classic remoting (not recommended)
 
 Classic remoting is deprecated but can be used in `2.6.` Any configuration under `akka.remote` that is
 specific to classic remoting needs to be moved to `akka.remote.classic`. To see which configuration options


### PR DESCRIPTION
* fork-join pool paragraph move out artery section
 * unnesting artery section
 * being explicit how to disable artery