### PR TITLE
Remove Jackson Smile format, #24155

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/serialization/jackson/JacksonSerializationBench.scala
+++ b/akka-bench-jmh/src/main/scala/akka/serialization/jackson/JacksonSerializationBench.scala
@@ -123,7 +123,7 @@ class JacksonSerializationBench {
   var system: ActorSystem = _
   var serialization: Serialization = _
 
-  @Param(Array("jackson-json", "jackson-cbor", "jackson-smile")) // "java"
+  @Param(Array("jackson-json", "jackson-cbor")) // "java"
   private var serializerName: String = _
 
   @Setup(Level.Trial)

--- a/akka-docs/src/main/paradox/serialization-jackson.md
+++ b/akka-docs/src/main/paradox/serialization-jackson.md
@@ -80,7 +80,7 @@ configuration as described above.
 * `jackson-json` - ordinary text based JSON
 * `jackson-cbor` - binary [CBOR data format](https://github.com/FasterXML/jackson-dataformats-binary/tree/master/cbor)
 
-The binary format is more compact and have slightly better better performance than the JSON format.
+The binary format is more compact, with slightly better performance than the JSON format.
 
 ## Annotations
 

--- a/akka-docs/src/main/paradox/serialization-jackson.md
+++ b/akka-docs/src/main/paradox/serialization-jackson.md
@@ -35,7 +35,7 @@ Java
 :  @@snip [MySerializable.java](/akka-serialization-jackson/src/test/java/jdoc/akka/serialization/jackson/MySerializable.java) { #marker-interface }
 
 Then you configure the class name of the marker @scala[trait]@java[interface] in `serialization-bindings` to
-one of the supported Jackson formats: `jackson-json`, `jackson-cbor` or `jackson-smile`
+one of the supported Jackson formats: `jackson-json` or `jackson-cbor`
 
 @@snip [config](/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala) { #serialization-bindings }
 
@@ -79,11 +79,8 @@ configuration as described above.
 
 * `jackson-json` - ordinary text based JSON
 * `jackson-cbor` - binary [CBOR data format](https://github.com/FasterXML/jackson-dataformats-binary/tree/master/cbor)
-* `jackson-smile` - binary [Smile data format](https://github.com/FasterXML/jackson-dataformats-binary/tree/master/smile)
 
-The binary formats are more compact and have slightly better better performance than the JSON format.
-
-TODO: It's undecided if we will support both CBOR or and Smile since the difference is small
+The binary format is more compact and have slightly better better performance than the JSON format.
 
 ## Annotations
 

--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -74,10 +74,6 @@ akka.serialization.jackson {
   # override the settings in 'akka.serialization.jackson'
   jackson-cbor {}
 
-  # Specific settings for jackson-smile binding can be defined in this section to
-  # override the settings in 'akka.serialization.jackson'
-  jackson-smile {}
-
 }
 #//#features
 
@@ -85,12 +81,10 @@ akka.actor {
   serializers {
     jackson-json = "akka.serialization.jackson.JacksonJsonSerializer"
     jackson-cbor = "akka.serialization.jackson.JacksonCborSerializer"
-    jackson-smile = "akka.serialization.jackson.JacksonSmileSerializer"
   }
   serialization-identifiers {
     jackson-json = 31
     jackson-cbor = 32
-    jackson-smile = 33
   }
   serialization-bindings {
     # Define bindings for classes or interfaces use Jackson serializer, e.g.

--- a/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -168,7 +168,7 @@ final class JacksonObjectMapperProvider(system: ExtendedActorSystem) extends Ext
    * modifications are not thread-safe.
    *
    * @param bindingName name of this `ObjectMapper`
-   * @param jsonFactory optional `JsonFactory` such as `SmileFactory`, for plain JSON `None` (defaults)
+   * @param jsonFactory optional `JsonFactory` such as `CBORFactory`, for plain JSON `None` (defaults)
    *                    can be used
    */
   def getOrCreate(bindingName: String, jsonFactory: Option[JsonFactory]): ObjectMapper = {
@@ -183,7 +183,7 @@ final class JacksonObjectMapperProvider(system: ExtendedActorSystem) extends Ext
    * if the `ActorSystem` is started with such [[akka.actor.setup.ActorSystemSetup]].
    *
    * @param bindingName name of this `ObjectMapper`
-   * @param jsonFactory optional `JsonFactory` such as `SmileFactory`, for plain JSON `None` (defaults)
+   * @param jsonFactory optional `JsonFactory` such as `CBORFactory`, for plain JSON `None` (defaults)
    *                    can be used
    * @see [[JacksonObjectMapperProvider#getOrCreate]]
    */
@@ -239,7 +239,7 @@ class JacksonObjectMapperFactory {
    * Override this method to create a new custom instance of `ObjectMapper` for the given `serializerIdentifier`.
    *
    * @param bindingName name of this `ObjectMapper`
-   * @param jsonFactory optional `JsonFactory` such as `SmileFactory`, for plain JSON `None` (defaults)
+   * @param jsonFactory optional `JsonFactory` such as `CBORFactory`, for plain JSON `None` (defaults)
    *                    can be used
    */
   def newObjectMapper(@unused bindingName: String, jsonFactory: Option[JsonFactory]): ObjectMapper =

--- a/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonSerializer.scala
+++ b/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonSerializer.scala
@@ -26,7 +26,6 @@ import akka.util.Helpers.toRootLowerCase
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.jsontype.impl.SubTypeValidator
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory
-import com.fasterxml.jackson.dataformat.smile.SmileFactory
 
 /**
  * INTERNAL API
@@ -97,17 +96,6 @@ import com.fasterxml.jackson.dataformat.smile.SmileFactory
 /**
  * INTERNAL API: only public by configuration
  *
- * Akka serializer for Jackson with Smile.
- */
-@InternalApi private[akka] final class JacksonSmileSerializer(system: ExtendedActorSystem, bindingName: String)
-    extends JacksonSerializer(
-      system,
-      bindingName: String,
-      JacksonObjectMapperProvider(system).getOrCreate(bindingName, Some(new SmileFactory)))
-
-/**
- * INTERNAL API: only public by configuration
- *
  * Akka serializer for Jackson with CBOR.
  */
 @InternalApi private[akka] final class JacksonCborSerializer(system: ExtendedActorSystem, bindingName: String)
@@ -115,9 +103,6 @@ import com.fasterxml.jackson.dataformat.smile.SmileFactory
       system,
       bindingName,
       JacksonObjectMapperProvider(system).getOrCreate(bindingName, Some(new CBORFactory)))
-
-// FIXME Look into if we should support both Smile and CBOR, and what we should recommend if there is a choice.
-//       Make dependencies optional/provided.
 
 /**
  * INTERNAL API: Base class for Jackson serializers.

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -101,8 +101,6 @@ class ScalaTestEventMigration extends JacksonMigration {
 
 class JacksonCborSerializerSpec extends JacksonSerializerSpec("jackson-cbor")
 
-class JacksonSmileSerializerSpec extends JacksonSerializerSpec("jackson-smile")
-
 class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
   def serializeToJsonString(obj: AnyRef, sys: ActorSystem = system): String = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -98,7 +98,6 @@ object Dependencies {
     val jacksonParameterNames = "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonVersion // ApacheV2
     val jacksonAfterburner = "com.fasterxml.jackson.module" % "jackson-module-afterburner" % jacksonVersion // ApacheV2
     val jacksonCbor = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion // ApacheV2
-    val jacksonSmile = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-smile" % jacksonVersion // ApacheV2
 
     object Docs {
       val sprayJson = "io.spray" %% "spray-json" % "1.3.5" % "test"
@@ -245,7 +244,6 @@ object Dependencies {
         jacksonJsr310,
         jacksonParameterNames,
         jacksonAfterburner,
-        jacksonSmile,
         jacksonCbor,
         Test.junit,
         Test.scalatest.value)


### PR DESCRIPTION
* No clear advantage over CBOR
* One less choice for users
* CBOR seems to have a stronger specification and therefore potential
  for wider adoption
* Performance of CBOR is equals to Smile
* Smile can be slightly more compact
  (I think it does more to reduce repeated field names),
  but that might be better to solve with good compression

Refs #24155

Some measured numbers for the size in https://github.com/akka/akka/pull/27067

Performance numbers in https://github.com/akka/akka/pull/27064