### PR TITLE
Detect illegal access to ActorContext from the outside

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -122,8 +122,13 @@ private[akka] final class BehaviorTestKitImpl[T](_path: ActorPath, _initialBehav
 
   override def run(message: T): Unit = {
     try {
-      currentUncanonical = Behavior.interpretMessage(current, context, message)
-      current = Behavior.canonicalize(currentUncanonical, current, context)
+      context.setCurrentActorThread()
+      try {
+        currentUncanonical = Behavior.interpretMessage(current, context, message)
+        current = Behavior.canonicalize(currentUncanonical, current, context)
+      } finally {
+        context.clearCurrentActorThread()
+      }
       runAllTasks()
     } catch handleException
   }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -33,7 +33,14 @@ private[akka] final class BehaviorTestKitImpl[T](_path: ActorPath, _initialBehav
   private[akka] def as[U]: BehaviorTestKitImpl[U] = this.asInstanceOf[BehaviorTestKitImpl[U]]
 
   private var currentUncanonical = _initialBehavior
-  private var current = Behavior.validateAsInitial(Behavior.start(_initialBehavior, context))
+  private var current = {
+    try {
+      context.setCurrentActorThread()
+      Behavior.validateAsInitial(Behavior.start(_initialBehavior, context))
+    } finally {
+      context.clearCurrentActorThread()
+    }
+  }
 
   // execute any future tasks scheduled in Actor's constructor
   runAllTasks()

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
@@ -88,24 +88,24 @@ private[akka] final class FunctionRef[-T](override val path: ActorPath, send: (T
       "No classic ActorContext available with the stubbed actor context, to spawn materializers and run streams you will need a real actor")
 
   override def children: Iterable[ActorRef[Nothing]] = {
-    checkCurrentActorThread("children")
+    checkCurrentActorThread()
     _children.values.map(_.context.self)
   }
   def childrenNames: Iterable[String] = _children.keys
 
   override def child(name: String): Option[ActorRef[Nothing]] = {
-    checkCurrentActorThread("child")
+    checkCurrentActorThread()
     _children.get(name).map(_.context.self)
   }
 
   override def spawnAnonymous[U](behavior: Behavior[U], props: Props = Props.empty): ActorRef[U] = {
-    checkCurrentActorThread("spawnAnonymous")
+    checkCurrentActorThread()
     val btk = new BehaviorTestKitImpl[U]((path / childName.next()).withUid(rnd().nextInt()), behavior)
     _children += btk.context.self.path.name -> btk
     btk.context.self
   }
   override def spawn[U](behavior: Behavior[U], name: String, props: Props = Props.empty): ActorRef[U] = {
-    checkCurrentActorThread("spawn")
+    checkCurrentActorThread()
     _children.get(name) match {
       case Some(_) => throw classic.InvalidActorNameException(s"actor name $name is already taken")
       case None =>
@@ -120,7 +120,7 @@ private[akka] final class FunctionRef[-T](override val path: ActorPath, send: (T
    * Removal is asynchronous, explicit removeInbox is needed from outside afterwards.
    */
   override def stop[U](child: ActorRef[U]): Unit = {
-    checkCurrentActorThread("stop")
+    checkCurrentActorThread()
     if (child.path.parent != self.path)
       throw new IllegalArgumentException(
         "Only direct children of an actor can be stopped through the actor context, " +
@@ -131,19 +131,19 @@ private[akka] final class FunctionRef[-T](override val path: ActorPath, send: (T
     }
   }
   override def watch[U](other: ActorRef[U]): Unit = {
-    checkCurrentActorThread("watch")
+    checkCurrentActorThread()
   }
   override def watchWith[U](other: ActorRef[U], message: T): Unit = {
-    checkCurrentActorThread("watchWith")
+    checkCurrentActorThread()
   }
   override def unwatch[U](other: ActorRef[U]): Unit = {
-    checkCurrentActorThread("unwatch")
+    checkCurrentActorThread()
   }
   override def setReceiveTimeout(d: FiniteDuration, message: T): Unit = {
-    checkCurrentActorThread("setReceiveTimeout")
+    checkCurrentActorThread()
   }
   override def cancelReceiveTimeout(): Unit = {
-    checkCurrentActorThread("cancelReceiveTimeout")
+    checkCurrentActorThread()
   }
 
   override def scheduleOnce[U](delay: FiniteDuration, target: ActorRef[U], message: U): classic.Cancellable =
@@ -207,18 +207,18 @@ private[akka] final class FunctionRef[-T](override val path: ActorPath, send: (T
   override def toString: String = s"Inbox($self)"
 
   override def log: Logger = {
-    checkCurrentActorThread("log")
+    checkCurrentActorThread()
     logger
   }
 
   override def setLoggerName(name: String): Unit = {
     // nop as we don't track logger
-    checkCurrentActorThread("setLoggerName")
+    checkCurrentActorThread()
   }
 
   override def setLoggerName(clazz: Class[_]): Unit = {
     // nop as we don't track logger
-    checkCurrentActorThread("setLoggerName")
+    checkCurrentActorThread()
   }
 
   /**

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorThreadSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorThreadSpec.scala
@@ -52,7 +52,7 @@ class ActorThreadSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
       probe.expectMessage("initialized")
       intercept[UnsupportedOperationException] {
         context.children
-      }.getMessage should include("[children]")
+      }.getMessage should include("Unsupported access to ActorContext")
 
     }
 
@@ -76,7 +76,7 @@ class ActorThreadSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
       val l = new CountDownLatch(1)
       try {
         ref ! l
-        probe.receiveMessage().getMessage should include("[children]")
+        probe.receiveMessage().getMessage should include("Unsupported access to ActorContext")
       } finally {
         l.countDown()
       }
@@ -107,7 +107,7 @@ class ActorThreadSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
       } finally {
         l.countDown()
       }
-      probe.receiveMessage().getMessage should include("[children]")
+      probe.receiveMessage().getMessage should include("Unsupported access to ActorContext")
     }
 
     "detect illegal access from child" in {
@@ -129,7 +129,7 @@ class ActorThreadSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
       })
 
       ref ! "hello"
-      probe.receiveMessage().getMessage should include("[children]")
+      probe.receiveMessage().getMessage should include("Unsupported access to ActorContext")
     }
 
     "allow access from message adapter" in {
@@ -227,34 +227,7 @@ class ActorThreadSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
         Behaviors.empty
       })
 
-      probe.receiveMessage().getMessage should include("[children]")
-    }
-
-    "detect illegal access from AbstractBehavior constructor when missing setup" in {
-      //FIXME
-      pending
-      val probe = createTestProbe[UnsupportedOperationException]()
-
-      spawn(Behaviors.setup[String] { context =>
-        // missing setup for the new AbstractBehavior and passing in parent's context
-        context.spawnAnonymous(new AbstractBehavior[String](context) {
-          try {
-            // FIXME this isn't detected as wrong because constructor is running in parent thread here (missing setup)
-            this.context.children
-          } catch {
-            case e: UnsupportedOperationException =>
-              probe.ref ! e
-          }
-
-          override def onMessage(msg: String): Behavior[String] = {
-            Behaviors.same
-          }
-        })
-
-        Behaviors.empty
-      })
-
-      probe.receiveMessage().getMessage should include("[children]")
+      probe.receiveMessage().getMessage should include("Unsupported access to ActorContext")
     }
 
     "detect sharing of same AbstractBehavior instance" in {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorThreadSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorThreadSpec.scala
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.scaladsl
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.LoggingTestKit
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorRef
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.ActorThreadSpec.Echo
+import org.scalatest.wordspec.AnyWordSpecLike
+
+object ActorThreadSpec {
+  object Echo {
+    final case class Msg(i: Int, replyTo: ActorRef[Int])
+
+    def apply(): Behavior[Msg] =
+      Behaviors.receiveMessage {
+        case Msg(i, replyTo) =>
+          replyTo ! i
+          Behaviors.same
+      }
+  }
+
+}
+
+class ActorThreadSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
+
+  "Actor thread-safety checks" must {
+
+    "detect illegal access to ActorContext from outside" in {
+      @volatile var context: ActorContext[String] = null
+      val probe = createTestProbe[String]()
+
+      spawn(Behaviors.setup[String] { ctx =>
+        // here it's ok
+        ctx.children
+        context = ctx
+        probe.ref ! "initialized"
+        Behaviors.empty
+      })
+
+      probe.expectMessage("initialized")
+      intercept[UnsupportedOperationException] {
+        context.children
+      }.getMessage should include("[children]")
+
+    }
+
+    "detect illegal access to ActorContext from other thread when processing message" in {
+      val probe = createTestProbe[UnsupportedOperationException]()
+
+      val ref = spawn(Behaviors.receive[CountDownLatch] {
+        case (context, latch) =>
+          Future {
+            try {
+              context.children
+            } catch {
+              case e: UnsupportedOperationException =>
+                probe.ref ! e
+            }
+          }(context.executionContext)
+          latch.await(5, TimeUnit.SECONDS)
+          Behaviors.same
+      })
+
+      val l = new CountDownLatch(1)
+      try {
+        ref ! l
+        probe.receiveMessage().getMessage should include("[children]")
+      } finally {
+        l.countDown()
+      }
+    }
+
+    "detect illegal access to ActorContext from other thread after processing message" in {
+      val probe = createTestProbe[UnsupportedOperationException]()
+
+      val ref = spawn(Behaviors.receive[CountDownLatch] {
+        case (context, latch) =>
+          Future {
+            try {
+              latch.await(5, TimeUnit.SECONDS)
+              context.children
+            } catch {
+              case e: UnsupportedOperationException =>
+                probe.ref ! e
+            }
+          }(context.executionContext)
+
+          Behaviors.stopped
+      })
+
+      val l = new CountDownLatch(1)
+      try {
+        ref ! l
+        probe.expectTerminated(ref)
+      } finally {
+        l.countDown()
+      }
+      probe.receiveMessage().getMessage should include("[children]")
+    }
+
+    "detect illegal access from child" in {
+      val probe = createTestProbe[UnsupportedOperationException]()
+
+      val ref = spawn(Behaviors.receive[String] {
+        case (context, _) =>
+          // really bad idea to define a child actor like this
+          context.spawnAnonymous(Behaviors.setup[String] { _ =>
+            try {
+              context.children
+            } catch {
+              case e: UnsupportedOperationException =>
+                probe.ref ! e
+            }
+            Behaviors.empty
+          })
+          Behaviors.same
+      })
+
+      ref ! "hello"
+      probe.receiveMessage().getMessage should include("[children]")
+    }
+
+    "allow access from message adapter" in {
+      val probe = createTestProbe[String]()
+      val echo = spawn(Echo())
+
+      spawn(Behaviors.setup[String] { context =>
+        val replyAdapter = context.messageAdapter[Int] { i =>
+          // this is allowed because the mapping function is running in the target actor
+          context.children
+          i.toString
+        }
+        echo ! Echo.Msg(17, replyAdapter)
+
+        Behaviors.receiveMessage { msg =>
+          probe.ref ! msg
+          Behaviors.same
+        }
+      })
+
+      probe.expectMessage("17")
+    }
+
+    "allow access from ask response mapper" in {
+      val probe = createTestProbe[String]()
+      val echo = spawn(Echo())
+
+      spawn(Behaviors.setup[String] { context =>
+        context.ask[Echo.Msg, Int](echo, Echo.Msg(18, _)) {
+          case Success(i) =>
+            // this is allowed because the mapping function is running in the target actor
+            context.children
+            i.toString
+          case Failure(e) => throw e
+        }
+
+        Behaviors.receiveMessage { msg =>
+          probe.ref ! msg
+          Behaviors.same
+        }
+      })
+
+      probe.expectMessage("18")
+    }
+
+    "detect wrong context in construction of AbstractBehavior" in {
+      val probe = createTestProbe[String]()
+      val ref = spawn(Behaviors.setup[String] { context =>
+        // missing setup new AbstractBehavior and passing in parent's context
+        val child = context.spawnAnonymous(new AbstractBehavior[String](context) {
+          override def onMessage(msg: String): Behavior[String] = {
+            probe.ref ! msg
+            Behaviors.same
+          }
+        })
+
+        Behaviors.receiveMessage { msg =>
+          child ! msg
+          Behaviors.same
+        }
+      })
+
+      // 2 occurrences because one from PostStop also
+      LoggingTestKit
+        .error[IllegalStateException]
+        .withMessageContains("was created with wrong ActorContext")
+        .withOccurrences(2)
+        .expect {
+          // it's not detected when spawned, but when processing message
+          ref ! "hello"
+          probe.expectNoMessage()
+        }
+    }
+
+    "detect illegal access from AbstractBehavior constructor" in {
+      val probe = createTestProbe[UnsupportedOperationException]()
+
+      spawn(Behaviors.setup[String] { context =>
+        context.spawnAnonymous(
+          Behaviors.setup[String](_ =>
+            // wrongly using parent's context
+            new AbstractBehavior[String](context) {
+              try {
+                this.context.children
+              } catch {
+                case e: UnsupportedOperationException =>
+                  probe.ref ! e
+              }
+
+              override def onMessage(msg: String): Behavior[String] = {
+                Behaviors.same
+              }
+            }))
+
+        Behaviors.empty
+      })
+
+      probe.receiveMessage().getMessage should include("[children]")
+    }
+
+    "detect illegal access from AbstractBehavior constructor when missing setup" in {
+      //FIXME
+      pending
+      val probe = createTestProbe[UnsupportedOperationException]()
+
+      spawn(Behaviors.setup[String] { context =>
+        // missing setup for the new AbstractBehavior and passing in parent's context
+        context.spawnAnonymous(new AbstractBehavior[String](context) {
+          try {
+            // FIXME this isn't detected as wrong because constructor is running in parent thread here (missing setup)
+            this.context.children
+          } catch {
+            case e: UnsupportedOperationException =>
+              probe.ref ! e
+          }
+
+          override def onMessage(msg: String): Behavior[String] = {
+            Behaviors.same
+          }
+        })
+
+        Behaviors.empty
+      })
+
+      probe.receiveMessage().getMessage should include("[children]")
+    }
+
+    "detect sharing of same AbstractBehavior instance" in {
+      // extremely contrived example, but the creativity among users can be great
+      @volatile var behv: Behavior[CountDownLatch] = null
+
+      val ref1 = spawn(Behaviors.setup[CountDownLatch] { context =>
+        behv = new AbstractBehavior[CountDownLatch](context) {
+          override def onMessage(latch: CountDownLatch): Behavior[CountDownLatch] = {
+            latch.await(5, TimeUnit.SECONDS)
+            Behaviors.same
+          }
+        }
+        behv
+      })
+
+      eventually(behv != null)
+
+      // spawning same instance again
+      val ref2 = spawn(behv)
+
+      val latch1 = new CountDownLatch(1)
+      try {
+        ref1 ! latch1
+
+        // 2 occurrences because one from PostStop also
+        LoggingTestKit
+          .error[IllegalStateException]
+          .withMessageContains("was created with wrong ActorContext")
+          .withOccurrences(2)
+          .expect {
+            ref2 ! new CountDownLatch(0)
+          }
+      } finally {
+        latch1.countDown()
+      }
+    }
+
+  }
+
+}

--- a/akka-actor-typed/src/main/mima-filters/2.6.5.backwards.excludes/current-actor-thread.excludes
+++ b/akka-actor-typed/src/main/mima-filters/2.6.5.backwards.excludes/current-actor-thread.excludes
@@ -1,0 +1,7 @@
+# add internal currentActorThread to ActorContext
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.scaladsl.ActorContext.setCurrentActorThread")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.scaladsl.ActorContext.clearCurrentActorThread")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.scaladsl.ActorContext.checkCurrentActorThread")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.internal.ActorContextImpl.akka$actor$typed$internal$ActorContextImpl$$_currentActorThread_=")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.internal.ActorContextImpl.akka$actor$typed$internal$ActorContextImpl$$_currentActorThread")
+

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
@@ -75,6 +75,7 @@ import akka.util.OptionVal
   def receive: Receive = ActorAdapter.DummyReceive
 
   override protected[akka] def aroundReceive(receive: Receive, msg: Any): Unit = {
+    ctx.setCurrentActorThread()
     try {
       // as we know we never become in "normal" typed actors, it is just the current behavior that
       // changes, we can avoid some overhead with the partial function/behavior stack of untyped entirely
@@ -104,7 +105,10 @@ import akka.util.OptionVal
         case msg: T @unchecked =>
           handleMessage(msg)
       }
-    } finally ctx.clearMdc()
+    } finally {
+      ctx.clearCurrentActorThread()
+      ctx.clearMdc()
+    }
   }
 
   private def handleMessage(msg: T): Unit = {
@@ -206,32 +210,38 @@ import akka.util.OptionVal
   }
 
   override val supervisorStrategy = classic.OneForOneStrategy(loggingEnabled = false) {
-    case TypedActorFailedException(cause) =>
-      // These have already been optionally logged by typed supervision
-      recordChildFailure(cause)
-      classic.SupervisorStrategy.Stop
     case ex =>
-      val isTypedActor = sender() match {
-        case afwc: ActorRefWithCell =>
-          afwc.underlying.props.producer.actorClass == classOf[ActorAdapter[_]]
+      ctx.setCurrentActorThread()
+      try ex match {
+        case TypedActorFailedException(cause) =>
+          // These have already been optionally logged by typed supervision
+          recordChildFailure(cause)
+          classic.SupervisorStrategy.Stop
         case _ =>
-          false
-      }
-      recordChildFailure(ex)
-      val logMessage = ex match {
-        case e: ActorInitializationException if e.getCause ne null =>
-          e.getCause match {
-            case ex: InvocationTargetException if ex.getCause ne null => ex.getCause.getMessage
-            case ex                                                   => ex.getMessage
+          val isTypedActor = sender() match {
+            case afwc: ActorRefWithCell =>
+              afwc.underlying.props.producer.actorClass == classOf[ActorAdapter[_]]
+            case _ =>
+              false
           }
-        case e => e.getMessage
+          recordChildFailure(ex)
+          val logMessage = ex match {
+            case e: ActorInitializationException if e.getCause ne null =>
+              e.getCause match {
+                case ex: InvocationTargetException if ex.getCause ne null => ex.getCause.getMessage
+                case ex                                                   => ex.getMessage
+              }
+            case e => e.getMessage
+          }
+          // log at Error as that is what the supervision strategy would have done.
+          ctx.log.error(logMessage, ex)
+          if (isTypedActor)
+            classic.SupervisorStrategy.Stop
+          else
+            ActorAdapter.classicSupervisorDecider(ex)
+      } finally {
+        ctx.clearCurrentActorThread()
       }
-      // log at Error as that is what the supervision strategy would have done.
-      ctx.log.error(logMessage, ex)
-      if (isTypedActor)
-        classic.SupervisorStrategy.Stop
-      else
-        ActorAdapter.classicSupervisorDecider(ex)
   }
 
   private def recordChildFailure(ex: Throwable): Unit = {
@@ -239,6 +249,30 @@ import akka.util.OptionVal
     if (context.asInstanceOf[classic.ActorCell].isWatching(ref)) {
       failures = failures.updated(ref, ex)
     }
+  }
+
+  override protected[akka] def aroundPreStart(): Unit = {
+    ctx.setCurrentActorThread()
+    try super.aroundPreStart()
+    finally ctx.clearCurrentActorThread()
+  }
+
+  override protected[akka] def aroundPreRestart(reason: Throwable, message: Option[Any]): Unit = {
+    ctx.setCurrentActorThread()
+    try super.aroundPreRestart(reason, message)
+    finally ctx.clearCurrentActorThread()
+  }
+
+  override protected[akka] def aroundPostRestart(reason: Throwable): Unit = {
+    ctx.setCurrentActorThread()
+    try super.aroundPostRestart(reason)
+    finally ctx.clearCurrentActorThread()
+  }
+
+  override protected[akka] def aroundPostStop(): Unit = {
+    ctx.setCurrentActorThread()
+    try super.aroundPostStop()
+    finally ctx.clearCurrentActorThread()
   }
 
   override def preStart(): Unit = {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
@@ -58,13 +58,26 @@ private[akka] object ActorContextAdapter {
   final override val self = ActorRefAdapter(classicContext.self)
   final override val system = ActorSystemAdapter(classicContext.system)
   private[akka] def classicActorContext = classicContext
-  override def children: Iterable[ActorRef[Nothing]] = classicContext.children.map(ActorRefAdapter(_))
-  override def child(name: String): Option[ActorRef[Nothing]] = classicContext.child(name).map(ActorRefAdapter(_))
-  override def spawnAnonymous[U](behavior: Behavior[U], props: Props = Props.empty): ActorRef[U] =
+  override def children: Iterable[ActorRef[Nothing]] = {
+    checkCurrentActorThread("children")
+    classicContext.children.map(ActorRefAdapter(_))
+  }
+  override def child(name: String): Option[ActorRef[Nothing]] = {
+    checkCurrentActorThread("child")
+    classicContext.child(name).map(ActorRefAdapter(_))
+  }
+  override def spawnAnonymous[U](behavior: Behavior[U], props: Props = Props.empty): ActorRef[U] = {
+    checkCurrentActorThread("spawnAnonymous")
     ActorRefFactoryAdapter.spawnAnonymous(classicContext, behavior, props, rethrowTypedFailure = true)
-  override def spawn[U](behavior: Behavior[U], name: String, props: Props = Props.empty): ActorRef[U] =
+  }
+
+  override def spawn[U](behavior: Behavior[U], name: String, props: Props = Props.empty): ActorRef[U] = {
+    checkCurrentActorThread("spawn")
     ActorRefFactoryAdapter.spawn(classicContext, behavior, name, props, rethrowTypedFailure = true)
-  override def stop[U](child: ActorRef[U]): Unit =
+  }
+
+  override def stop[U](child: ActorRef[U]): Unit = {
+    checkCurrentActorThread("stop")
     if (child.path.parent == self.path) { // only if a direct child
       toClassic(child) match {
         case f: akka.actor.FunctionRef =>
@@ -90,16 +103,29 @@ private[akka] object ActorContextAdapter {
         s"but [$child] is not a child of [$self]. Stopping other actors has to be expressed as " +
         "an explicit stop message that the actor accepts.")
     }
+  }
 
-  override def watch[U](other: ActorRef[U]): Unit = { classicContext.watch(toClassic(other)) }
-  override def watchWith[U](other: ActorRef[U], msg: T): Unit = { classicContext.watchWith(toClassic(other), msg) }
-  override def unwatch[U](other: ActorRef[U]): Unit = { classicContext.unwatch(toClassic(other)) }
+  override def watch[U](other: ActorRef[U]): Unit = {
+    checkCurrentActorThread("watch")
+    classicContext.watch(toClassic(other))
+  }
+  override def watchWith[U](other: ActorRef[U], msg: T): Unit = {
+    checkCurrentActorThread("watchWith")
+    classicContext.watchWith(toClassic(other), msg)
+  }
+  override def unwatch[U](other: ActorRef[U]): Unit = {
+    checkCurrentActorThread("unwatch")
+    classicContext.unwatch(toClassic(other))
+  }
   var receiveTimeoutMsg: T = null.asInstanceOf[T]
   override def setReceiveTimeout(d: FiniteDuration, msg: T): Unit = {
+    checkCurrentActorThread("setReceiveTimeout")
     receiveTimeoutMsg = msg
     classicContext.setReceiveTimeout(d)
   }
   override def cancelReceiveTimeout(): Unit = {
+    checkCurrentActorThread("cancelReceiveTimeout")
+
     receiveTimeoutMsg = null.asInstanceOf[T]
     classicContext.setReceiveTimeout(Duration.Undefined)
   }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
@@ -59,25 +59,25 @@ private[akka] object ActorContextAdapter {
   final override val system = ActorSystemAdapter(classicContext.system)
   private[akka] def classicActorContext = classicContext
   override def children: Iterable[ActorRef[Nothing]] = {
-    checkCurrentActorThread("children")
+    checkCurrentActorThread()
     classicContext.children.map(ActorRefAdapter(_))
   }
   override def child(name: String): Option[ActorRef[Nothing]] = {
-    checkCurrentActorThread("child")
+    checkCurrentActorThread()
     classicContext.child(name).map(ActorRefAdapter(_))
   }
   override def spawnAnonymous[U](behavior: Behavior[U], props: Props = Props.empty): ActorRef[U] = {
-    checkCurrentActorThread("spawnAnonymous")
+    checkCurrentActorThread()
     ActorRefFactoryAdapter.spawnAnonymous(classicContext, behavior, props, rethrowTypedFailure = true)
   }
 
   override def spawn[U](behavior: Behavior[U], name: String, props: Props = Props.empty): ActorRef[U] = {
-    checkCurrentActorThread("spawn")
+    checkCurrentActorThread()
     ActorRefFactoryAdapter.spawn(classicContext, behavior, name, props, rethrowTypedFailure = true)
   }
 
   override def stop[U](child: ActorRef[U]): Unit = {
-    checkCurrentActorThread("stop")
+    checkCurrentActorThread()
     if (child.path.parent == self.path) { // only if a direct child
       toClassic(child) match {
         case f: akka.actor.FunctionRef =>
@@ -106,25 +106,25 @@ private[akka] object ActorContextAdapter {
   }
 
   override def watch[U](other: ActorRef[U]): Unit = {
-    checkCurrentActorThread("watch")
+    checkCurrentActorThread()
     classicContext.watch(toClassic(other))
   }
   override def watchWith[U](other: ActorRef[U], msg: T): Unit = {
-    checkCurrentActorThread("watchWith")
+    checkCurrentActorThread()
     classicContext.watchWith(toClassic(other), msg)
   }
   override def unwatch[U](other: ActorRef[U]): Unit = {
-    checkCurrentActorThread("unwatch")
+    checkCurrentActorThread()
     classicContext.unwatch(toClassic(other))
   }
   var receiveTimeoutMsg: T = null.asInstanceOf[T]
   override def setReceiveTimeout(d: FiniteDuration, msg: T): Unit = {
-    checkCurrentActorThread("setReceiveTimeout")
+    checkCurrentActorThread()
     receiveTimeoutMsg = msg
     classicContext.setReceiveTimeout(d)
   }
   override def cancelReceiveTimeout(): Unit = {
-    checkCurrentActorThread("cancelReceiveTimeout")
+    checkCurrentActorThread()
 
     receiveTimeoutMsg = null.asInstanceOf[T]
     classicContext.setReceiveTimeout(Duration.Undefined)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AbstractBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AbstractBehavior.scala
@@ -50,12 +50,13 @@ abstract class AbstractBehavior[T](context: ActorContext[T]) extends ExtensibleB
 
   protected def getContext: ActorContext[T] = context
 
-  private def checkRightContext(ctx: TypedActorContext[T]): Unit =
+  private def checkRightContext(ctx: TypedActorContext[T]): Unit = {
     if (ctx.asJava ne context)
       throw new IllegalStateException(
         s"Actor [${ctx.asJava.getSelf}] of AbstractBehavior class " +
         s"[${getClass.getName}] was created with wrong ActorContext [${context.asJava.getSelf}]. " +
         "Wrap in Behaviors.setup and pass the context to the constructor of AbstractBehavior.")
+  }
 
   @throws(classOf[Exception])
   override final def receive(ctx: TypedActorContext[T], msg: T): Behavior[T] = {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AbstractBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AbstractBehavior.scala
@@ -70,12 +70,13 @@ abstract class AbstractBehavior[T](protected val context: ActorContext[T]) exten
   @throws(classOf[Exception])
   def onSignal: PartialFunction[Signal, Behavior[T]] = PartialFunction.empty
 
-  private def checkRightContext(ctx: TypedActorContext[T]): Unit =
+  private def checkRightContext(ctx: TypedActorContext[T]): Unit = {
     if (ctx.asJava ne context)
       throw new IllegalStateException(
         s"Actor [${ctx.asJava.getSelf}] of AbstractBehavior class " +
         s"[${getClass.getName}] was created with wrong ActorContext [${context.asJava.getSelf}]. " +
         "Wrap in Behaviors.setup and pass the context to the constructor of AbstractBehavior.")
+  }
 
   @throws(classOf[Exception])
   override final def receive(ctx: TypedActorContext[T], msg: T): Behavior[T] = {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
@@ -350,6 +350,6 @@ trait ActorContext[T] extends TypedActorContext[T] with ClassicActorContextProvi
   /**
    * INTERNAL API
    */
-  @InternalApi private[akka] def checkCurrentActorThread(operationName: String): Unit
+  @InternalApi private[akka] def checkCurrentActorThread(): Unit
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
@@ -337,4 +337,19 @@ trait ActorContext[T] extends TypedActorContext[T] with ClassicActorContextProvi
   @InternalApi
   private[akka] def clearMdc(): Unit
 
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] def setCurrentActorThread(): Unit
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] def clearCurrentActorThread(): Unit
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] def checkCurrentActorThread(operationName: String): Unit
+
 }


### PR DESCRIPTION
Tried an idea of how we could add runtime checks to detect invalid access to ActorContext.

* Put the current thread in the ActorContext when processing a message
* Check that current thread is the "right" thread when accessing methods in ActorContext that are not thread-safe

An alternative could be to put the context in the thread instead, with a ThreadLocal, but that probably has higher performance impact.
