### PR TITLE
Remove request parameter in Typed Replicator messages, #27115

### DIFF
--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/Replicator.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/Replicator.scala
@@ -51,22 +51,17 @@ object Replicator {
      * Convenience for `ask`.
      */
     def apply[A <: ReplicatedData](key: Key[A], consistency: ReadConsistency): ActorRef[GetResponse[A]] => Get[A] =
-      replyTo => Get(key, consistency, replyTo, None)
+      replyTo => Get(key, consistency, replyTo)
   }
 
   /**
    * Send this message to the local `Replicator` to retrieve a data value for the
    * given `key`. The `Replicator` will reply with one of the [[GetResponse]] messages.
-   *
-   * The optional `request` context is included in the reply messages. This is a convenient
-   * way to pass contextual information (e.g. original sender) without having to use `ask`
-   * or maintain local correlation data structures.
    */
   final case class Get[A <: ReplicatedData](
       key: Key[A],
       consistency: ReadConsistency,
-      replyTo: ActorRef[GetResponse[A]],
-      request: Option[Any] = None)
+      replyTo: ActorRef[GetResponse[A]])
       extends Command
 
   /**
@@ -74,12 +69,12 @@ object Replicator {
    */
   type GetResponse[A <: ReplicatedData] = dd.Replicator.GetResponse[A]
   object GetSuccess {
-    def unapply[A <: ReplicatedData](rsp: GetSuccess[A]): Option[(Key[A], Option[Any])] = Some((rsp.key, rsp.request))
+    def unapply[A <: ReplicatedData](rsp: GetSuccess[A]): Option[Key[A]] = Some(rsp.key)
   }
   type GetSuccess[A <: ReplicatedData] = dd.Replicator.GetSuccess[A]
   type NotFound[A <: ReplicatedData] = dd.Replicator.NotFound[A]
   object NotFound {
-    def unapply[A <: ReplicatedData](rsp: NotFound[A]): Option[(Key[A], Option[Any])] = Some((rsp.key, rsp.request))
+    def unapply[A <: ReplicatedData](rsp: NotFound[A]): Option[Key[A]] = Some(rsp.key)
   }
 
   /**
@@ -88,7 +83,7 @@ object Replicator {
    */
   type GetFailure[A <: ReplicatedData] = dd.Replicator.GetFailure[A]
   object GetFailure {
-    def unapply[A <: ReplicatedData](rsp: GetFailure[A]): Option[(Key[A], Option[Any])] = Some((rsp.key, rsp.request))
+    def unapply[A <: ReplicatedData](rsp: GetFailure[A]): Option[Key[A]] = Some(rsp.key)
   }
 
   object Update {
@@ -99,25 +94,20 @@ object Replicator {
      * The current value for the `key` is passed to the `modify` function.
      * If there is no current data value for the `key` the `initial` value will be
      * passed to the `modify` function.
-     *
-     * The optional `request` context is included in the reply messages. This is a convenient
-     * way to pass contextual information (e.g. original sender) without having to use `ask`
-     * or local correlation data structures.
      */
     def apply[A <: ReplicatedData](
         key: Key[A],
         initial: A,
         writeConsistency: WriteConsistency,
-        replyTo: ActorRef[UpdateResponse[A]],
-        request: Option[Any] = None)(modify: A => A): Update[A] =
-      Update(key, writeConsistency, replyTo, request)(modifyWithInitial(initial, modify))
+        replyTo: ActorRef[UpdateResponse[A]])(modify: A => A): Update[A] =
+      Update(key, writeConsistency, replyTo)(modifyWithInitial(initial, modify))
 
     /**
      * Convenience for `ask`.
      */
     def apply[A <: ReplicatedData](key: Key[A], initial: A, writeConsistency: WriteConsistency)(
         modify: A => A): ActorRef[UpdateResponse[A]] => Update[A] =
-      (replyTo => Update(key, writeConsistency, replyTo, None)(modifyWithInitial(initial, modify)))
+      (replyTo => Update(key, writeConsistency, replyTo)(modifyWithInitial(initial, modify)))
 
     private def modifyWithInitial[A <: ReplicatedData](initial: A, modify: A => A): Option[A] => A = {
       case Some(data) => modify(data)
@@ -144,21 +134,20 @@ object Replicator {
   final case class Update[A <: ReplicatedData](
       key: Key[A],
       writeConsistency: WriteConsistency,
-      replyTo: ActorRef[UpdateResponse[A]],
-      request: Option[Any])(val modify: Option[A] => A)
+      replyTo: ActorRef[UpdateResponse[A]])(val modify: Option[A] => A)
       extends Command
       with NoSerializationVerificationNeeded {}
 
   type UpdateResponse[A <: ReplicatedData] = dd.Replicator.UpdateResponse[A]
   type UpdateSuccess[A <: ReplicatedData] = dd.Replicator.UpdateSuccess[A]
   object UpdateSuccess {
-    def unapply[A <: ReplicatedData](rsp: UpdateSuccess[A]): Option[(Key[A], Option[Any])] =
-      Some((rsp.key, rsp.request))
+    def unapply[A <: ReplicatedData](rsp: UpdateSuccess[A]): Option[Key[A]] =
+      Some(rsp.key)
   }
   type UpdateFailure[A <: ReplicatedData] = dd.Replicator.UpdateFailure[A]
   object UpdateFailure {
-    def unapply[A <: ReplicatedData](rsp: UpdateFailure[A]): Option[(Key[A], Option[Any])] =
-      Some((rsp.key, rsp.request))
+    def unapply[A <: ReplicatedData](rsp: UpdateFailure[A]): Option[Key[A]] =
+      Some(rsp.key)
   }
 
   /**
@@ -172,8 +161,8 @@ object Replicator {
    */
   type UpdateTimeout[A <: ReplicatedData] = dd.Replicator.UpdateTimeout[A]
   object UpdateTimeout {
-    def unapply[A <: ReplicatedData](rsp: UpdateTimeout[A]): Option[(Key[A], Option[Any])] =
-      Some((rsp.key, rsp.request))
+    def unapply[A <: ReplicatedData](rsp: UpdateTimeout[A]): Option[Key[A]] =
+      Some(rsp.key)
   }
 
   /**
@@ -182,8 +171,8 @@ object Replicator {
    */
   type ModifyFailure[A <: ReplicatedData] = dd.Replicator.ModifyFailure[A]
   object ModifyFailure {
-    def unapply[A <: ReplicatedData](rsp: ModifyFailure[A]): Option[(Key[A], String, Throwable, Option[Any])] =
-      Some((rsp.key, rsp.errorMessage, rsp.cause, rsp.request))
+    def unapply[A <: ReplicatedData](rsp: ModifyFailure[A]): Option[(Key[A], String, Throwable)] =
+      Some((rsp.key, rsp.errorMessage, rsp.cause))
   }
 
   /**
@@ -198,8 +187,8 @@ object Replicator {
    */
   type StoreFailure[A <: ReplicatedData] = dd.Replicator.StoreFailure[A]
   object StoreFailure {
-    def unapply[A <: ReplicatedData](rsp: StoreFailure[A]): Option[(Key[A], Option[Any])] =
-      Some((rsp.key, rsp.request))
+    def unapply[A <: ReplicatedData](rsp: StoreFailure[A]): Option[Key[A]] =
+      Some(rsp.key)
   }
 
   /**
@@ -244,40 +233,35 @@ object Replicator {
     def apply[A <: ReplicatedData](
         key: Key[A],
         consistency: WriteConsistency): ActorRef[DeleteResponse[A]] => Delete[A] =
-      (replyTo => Delete(key, consistency, replyTo, None))
+      (replyTo => Delete(key, consistency, replyTo))
   }
 
   /**
    * Send this message to the local `Replicator` to delete a data value for the
    * given `key`. The `Replicator` will reply with one of the [[DeleteResponse]] messages.
-   *
-   * The optional `request` context is included in the reply messages. This is a convenient
-   * way to pass contextual information (e.g. original sender) without having to use `ask`
-   * or maintain local correlation data structures.
    */
   final case class Delete[A <: ReplicatedData](
       key: Key[A],
       consistency: WriteConsistency,
-      replyTo: ActorRef[DeleteResponse[A]],
-      request: Option[Any])
+      replyTo: ActorRef[DeleteResponse[A]])
       extends Command
       with NoSerializationVerificationNeeded
 
   type DeleteResponse[A <: ReplicatedData] = dd.Replicator.DeleteResponse[A]
   type DeleteSuccess[A <: ReplicatedData] = dd.Replicator.DeleteSuccess[A]
   object DeleteSuccess {
-    def unapply[A <: ReplicatedData](rsp: DeleteSuccess[A]): Option[(Key[A], Option[Any])] =
-      Some((rsp.key, rsp.request))
+    def unapply[A <: ReplicatedData](rsp: DeleteSuccess[A]): Option[Key[A]] =
+      Some(rsp.key)
   }
   type ReplicationDeleteFailure[A <: ReplicatedData] = dd.Replicator.ReplicationDeleteFailure[A]
   object ReplicationDeleteFailure {
-    def unapply[A <: ReplicatedData](rsp: ReplicationDeleteFailure[A]): Option[(Key[A], Option[Any])] =
-      Some((rsp.key, rsp.request))
+    def unapply[A <: ReplicatedData](rsp: ReplicationDeleteFailure[A]): Option[Key[A]] =
+      Some(rsp.key)
   }
   type DataDeleted[A <: ReplicatedData] = dd.Replicator.DataDeleted[A]
   object DataDeleted {
-    def unapply[A <: ReplicatedData](rsp: DataDeleted[A]): Option[(Key[A], Option[Any])] =
-      Some((rsp.key, rsp.request))
+    def unapply[A <: ReplicatedData](rsp: DataDeleted[A]): Option[Key[A]] =
+      Some(rsp.key)
   }
 
   object GetReplicaCount {

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -324,6 +324,7 @@ made before finalizing the APIs. Compared to Akka 2.5.x the source incompatible 
   prefer `Behaviors.withTimers`.
 * `TimerScheduler.startPeriodicTimer`, replaced by `startTimerWithFixedDelay` or `startTimerAtFixedRate`
 * `Routers.pool` now take a factory function rather than a `Behavior` to protect against accidentally sharing same behavior instance and state across routees.
+* The `request` parameter in Distributed Data commands was removed, in favor of using `ask`.
 * Removed `Behavior.same`, `Behavior.unhandled`, `Behavior.stopped`, `Behavior.empty`, and `Behavior.ignore` since
   they were redundant with corresponding @scala[scaladsl.Behaviors.x]@java[javadsl.Behaviors.x].
 

--- a/akka-docs/src/main/paradox/typed/distributed-data.md
+++ b/akka-docs/src/main/paradox/typed/distributed-data.md
@@ -56,8 +56,8 @@ Java
 :  @@snip [ReplicatorTest.java](/akka-cluster-typed/src/test/java/akka/cluster/ddata/typed/javadsl/ReplicatorTest.java) { #sample }
 
 
-When we start up the actor we subscribe it to changes for our key, this means that whenever the replicator see a change
-for the counter our actor will get a @scala[`Replicator.Changed[GCounter]`]@java[`Replicator.Changed<GCounter>`], since
+When we start up the actor we subscribe it to changes for our key, meaning whenever the replicator observes a change
+for the counter our actor will receive a @scala[`Replicator.Changed[GCounter]`]@java[`Replicator.Changed<GCounter>`]. Since
 this is not a message in our protocol, we use an adapter to wrap it in the internal `InternalChanged` message, which
 is then handled in the regular message handling of the behavior. 
 
@@ -73,18 +73,16 @@ For an incoming `Increment` command, we send the `replicator` a `Replicator.Upda
 Whenever the distributed counter is updated, we cache the value so that we can answer requests about the value without
 the extra interaction with the replicator using the `GetCachedValue` command.
 
-We also support asking the replicator, using the `GetValue`, demonstrating how many of the replicator commands take
-a pass-along value that will be put in the response message so that we do not need to keep a local state tracking
-what actors are waiting for responses, but can extract the `replyTo` actor from the replicator when it responds 
-with a `GetSuccess`. See the @ref[the untyped Distributed Data documentation](../distributed-data.md#using-the-replicator)
-for more details about what interactions with the replicator there are.
+The example also supports asking the replicator using the `GetValue` command. Note how the `replyTo` from the
+incoming message can be used when the `GetSuccess` response from the replicator is received.
 
+See the @ref[the untyped Distributed Data documentation](../distributed-data.md#using-the-replicator)
+for more details about `Get`, `Update` and `Delete` interactions with the replicator.
 
 ### Replicated data types
 
 Akka contains a set of useful replicated data types and it is fully possible to implement custom replicated data types. 
-For more details, read @ref[the untyped Distributed Data documentation](../distributed-data.md#data-types) 
-
+For more details, read @ref[the untyped Distributed Data documentation](../distributed-data.md#data-types)
 
 ### Running separate instances of the replicator
 


### PR DESCRIPTION
* Simplifies the API
* Ask can be used instead, with better type safety the request parameter was Any

Refs #27115