### PR TITLE
Reduce boilerplate for interaction with Typed Replicator #27116

### DIFF
--- a/akka-cluster-typed/src/main/resources/reference.conf
+++ b/akka-cluster-typed/src/main/resources/reference.conf
@@ -27,6 +27,18 @@ akka.cluster.typed.receptionist {
   distributed-data.role = ""
 }
 
+akka.cluster.ddata.typed {
+  # The timeout to use for ask operations in ReplicatorMessageAdapter.
+  # This should be longer than the timeout given in Replicator.WriteConsistency and
+  # Replicator.ReadConsistency. The replicator will always send a reply within those
+  # timeouts so the unexpected ask timeout should not occur, but for cleanup in a
+  # failure situation it must still exist.
+  # If askUpdate, askGet or askDelete takes longer then this timeout a
+  # java.util.concurrent.TimeoutException will be thrown by the requesting actor and
+  # may be handled by supervision.
+  replicator-message-adapter-unexpected-ask-timeout = 20 s
+}
+
 akka {
   actor {
     serialization-identifiers {

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/DistributedData.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/DistributedData.scala
@@ -56,8 +56,13 @@ abstract class DistributedData extends Extension {
    * `ReplicatedData` types, e.g. an `OrSet<String>` and a `GCounter`, an adapter can be created
    * for each type.
    *
-   * @param context The [[ActorContext]] of the requesting actor.
+   * *Warning*: `ReplicatorMessageAdapter` is not thread-safe and must only be used from the actor
+   * corresponding to the given `ActorContext`. It must not be accessed from threads other
+   * than the ordinary actor message processing thread, such as [[java.util.concurrent.CompletionStage]]
+   * callbacks. It must not be shared between several actor instances.
    *
+   * @param context The [[ActorContext]] of the requesting actor. The `ReplicatorMessageAdapter` can only be
+   *                used in this actor.
    * @tparam A Message type of the requesting actor.
    * @tparam B Type of the [[ReplicatedData]].
    */

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/ReplicatorMessageAdapter.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/ReplicatorMessageAdapter.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.ddata.typed.javadsl
+
+import java.time.Duration
+import java.util.function.{ Function => JFunction }
+
+import scala.util.Failure
+import scala.util.Success
+
+import akka.util.JavaDurationConverters._
+import akka.actor.typed.ActorRef
+import akka.actor.typed.javadsl.ActorContext
+import akka.cluster.ddata.Key
+import akka.cluster.ddata.ReplicatedData
+import akka.util.Timeout
+
+/**
+ * When interacting with the `Replicator` from an actor this class provides convenient
+ * methods that adapts the response messages to the requesting actor's message protocol.
+ *
+ * One `ReplicatorMessageAdapter` instance can be used for a given `ReplicatedData` type,
+ * e.g. an `OrSet<String>`. Interaction with several [[Key]]s can be used via the same adapter
+ * but they must all be of the same `ReplicatedData` type. For interaction with several different
+ * `ReplicatedData` types, e.g. an `OrSet<String>` and a `GCounter`, an adapter can be created
+ * for each type.
+ *
+ * For the default replicator in the [[DistributedData]] extension a `ReplicatorMessageAdapter`
+ * can be created with [[DistributedData.replicatorMessageAdapter]].
+ *
+ * @param context The [[ActorContext]] of the requesting actor.
+ * @param replicator The replicator to interact with, typically `DistributedData.get(system).replicator`.
+ * @param unexpectedAskTimeout The timeout to use for `ask` operations. This should be longer than
+ *                             the `timeout` given in [[Replicator.WriteConsistency]] and
+ *                             [[Replicator.ReadConsistency]]. The replicator will always send
+ *                             a reply within those timeouts so the `unexpectedAskTimeout` should
+ *                             not occur, but for cleanup in a failure situation it must still exist.
+ *                             If `askUpdate`, `askGet` or `askDelete` takes longer then this
+ *                             `unexpectedAskTimeout` a [[java.util.concurrent.TimeoutException]]
+ *                             will be thrown by the requesting actor and may be handled by supervision.
+ *
+ * @tparam A Message type of the requesting actor.
+ * @tparam B Type of the [[ReplicatedData]].
+ */
+class ReplicatorMessageAdapter[A, B <: ReplicatedData](
+    context: ActorContext[A],
+    replicator: ActorRef[Replicator.Command],
+    unexpectedAskTimeout: Duration) {
+
+  private implicit val askTimeout: Timeout = Timeout(unexpectedAskTimeout.asScala)
+
+  private var changedMessageAdapters: Map[Key[B], ActorRef[Replicator.Changed[B]]] = Map.empty
+
+  /**
+   * Subscribe to changes of the given `key`. The [[Replicator.Changed]] messages from
+   * the replicator are transformed to the message protocol of the requesting actor with
+   * the given `responseAdapter` function.
+   */
+  def subscribe(key: Key[B], responseAdapter: JFunction[Replicator.Changed[B], A]): Unit = {
+    // unsubscribe in case it's called more than once per key
+    unsubscribe(key)
+    changedMessageAdapters.get(key).foreach { subscriber =>
+      replicator ! Replicator.Unsubscribe(key, subscriber)
+    }
+    val replyTo: ActorRef[Replicator.Changed[B]] =
+      context.messageAdapter(classOf[Replicator.Changed[B]], responseAdapter)
+    changedMessageAdapters = changedMessageAdapters.updated(key, replyTo)
+    replicator ! Replicator.Subscribe(key, replyTo)
+  }
+
+  /**
+   * Unsubscribe from a previous subscription of a given `key`.
+   * @see [[ReplicatorMessageAdapter.subscribe]]
+   */
+  def unsubscribe(key: Key[B]): Unit = {
+    changedMessageAdapters.get(key).foreach { subscriber =>
+      replicator ! Replicator.Unsubscribe(key, subscriber)
+    }
+  }
+
+  /**
+   * Send a [[Replicator.Update]] request to the replicator. The [[Replicator.UpdateResponse]]
+   * message is transformed to the message protocol of the requesting actor with the given
+   * `responseAdapter` function.
+   *
+   * Note that `createRequest` is a function that creates the `Update` message from the provided
+   * `ActorRef[UpdateResponse]` that the the replicator will send the response message back through.
+   * Use that `ActorRef[UpdateResponse]` as the `replyTo` parameter in the `Update` message.
+   */
+  def askUpdate(
+      createRequest: JFunction[ActorRef[Replicator.UpdateResponse[B]], Replicator.Update[B]],
+      responseAdapter: JFunction[Replicator.UpdateResponse[B], A]): Unit = {
+    context.asScala.ask[Replicator.Update[B], Replicator.UpdateResponse[B]](replicator)(askReplyTo =>
+      createRequest(askReplyTo)) {
+      case Success(value) => responseAdapter(value)
+      case Failure(ex)    => throw ex // unexpected ask timeout
+    }
+  }
+
+  /**
+   * Send a [[Replicator.Get]] request to the replicator. The [[Replicator.GetResponse]]
+   * message is transformed to the message protocol of the requesting actor with the given
+   * `responseAdapter` function.
+   *
+   * Note that `createRequest` is a function that creates the `Get` message from the provided
+   * `ActorRef[GetResponse]` that the the replicator will send the response message back through.
+   * Use that `ActorRef[GetResponse]` as the `replyTo` parameter in the `Get` message.
+   */
+  def askGet(
+      createRequest: JFunction[ActorRef[Replicator.GetResponse[B]], Replicator.Get[B]],
+      responseAdapter: JFunction[Replicator.GetResponse[B], A]): Unit = {
+    context.asScala.ask[Replicator.Get[B], Replicator.GetResponse[B]](replicator)(askReplyTo =>
+      createRequest(askReplyTo)) {
+      case Success(value) => responseAdapter(value)
+      case Failure(ex)    => throw ex // unexpected ask timeout
+    }
+  }
+
+  /**
+   * Send a [[Replicator.Delete]] request to the replicator. The [[Replicator.DeleteResponse]]
+   * message is transformed to the message protocol of the requesting actor with the given
+   * `responseAdapter` function.
+   *
+   * Note that `createRequest` is a function that creates the `Delete` message from the provided
+   * `ActorRef[DeleteResponse]` that the the replicator will send the response message back through.
+   * Use that `ActorRef[DeleteResponse]` as the `replyTo` parameter in the `Delete` message.
+   */
+  def askDelete(
+      createRequest: JFunction[ActorRef[Replicator.DeleteResponse[B]], Replicator.Delete[B]],
+      responseAdapter: JFunction[Replicator.DeleteResponse[B], A]): Unit = {
+    context.asScala.ask[Replicator.Delete[B], Replicator.DeleteResponse[B]](replicator)(askReplyTo =>
+      createRequest(askReplyTo)) {
+      case Success(value) => responseAdapter(value)
+      case Failure(ex)    => throw ex // unexpected ask timeout
+    }
+  }
+
+  /**
+   * Send a [[Replicator.GetReplicaCount]] request to the replicator. The [[Replicator.ReplicaCount]]
+   * message is transformed to the message protocol of the requesting actor with the given
+   * `responseAdapter` function.
+   *
+   * Note that `createRequest` is a function that creates the `GetReplicaCount` message from the provided
+   * `ActorRef[ReplicaCount]` that the the replicator will send the response message back through.
+   * Use that `ActorRef[ReplicaCount]` as the `replyTo` parameter in the `GetReplicaCount` message.
+   */
+  def askReplicaCount(
+      createRequest: JFunction[ActorRef[Replicator.ReplicaCount], Replicator.GetReplicaCount],
+      responseAdapter: JFunction[Replicator.ReplicaCount, A]): Unit = {
+    context.asScala.ask[Replicator.GetReplicaCount, Replicator.ReplicaCount](replicator)(askReplyTo =>
+      createRequest(askReplyTo)) {
+      case Success(value) => responseAdapter(value)
+      case Failure(ex)    => throw ex // unexpected ask timeout
+    }
+  }
+
+}

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/ReplicatorMessageAdapter.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/ReplicatorMessageAdapter.scala
@@ -30,8 +30,14 @@ import akka.util.Timeout
  * For the default replicator in the [[DistributedData]] extension a `ReplicatorMessageAdapter`
  * can be created with [[DistributedData.replicatorMessageAdapter]].
  *
- * @param context The [[ActorContext]] of the requesting actor.
- * @param replicator The replicator to interact with, typically `DistributedData.get(system).replicator`.
+ * *Warning*: `ReplicatorMessageAdapter` is not thread-safe and must only be used from the actor
+ * corresponding to the given `ActorContext`. It must not be accessed from threads other
+ * than the ordinary actor message processing thread, such as [[java.util.concurrent.CompletionStage]]
+ * callbacks. It must not be shared between several actor instances.
+ *
+ * @param context              The [[ActorContext]] of the requesting actor.  The `ReplicatorMessageAdapter` can
+ *                             only be used in this actor.
+ * @param replicator           The replicator to interact with, typically `DistributedData.get(system).replicator`.
  * @param unexpectedAskTimeout The timeout to use for `ask` operations. This should be longer than
  *                             the `timeout` given in [[Replicator.WriteConsistency]] and
  *                             [[Replicator.ReadConsistency]]. The replicator will always send
@@ -40,7 +46,6 @@ import akka.util.Timeout
  *                             If `askUpdate`, `askGet` or `askDelete` takes longer then this
  *                             `unexpectedAskTimeout` a [[java.util.concurrent.TimeoutException]]
  *                             will be thrown by the requesting actor and may be handled by supervision.
- *
  * @tparam A Message type of the requesting actor.
  * @tparam B Type of the [[ReplicatedData]].
  */

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/ReplicatorMessageAdapter.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/ReplicatorMessageAdapter.scala
@@ -28,7 +28,7 @@ import akka.util.Timeout
  * for each type.
  *
  * For the default replicator in the [[DistributedData]] extension a `ReplicatorMessageAdapter`
- * can be created with [[DistributedData.replicatorMessageAdapter]].
+ * can be created with [[DistributedData.withReplicatorMessageAdapter]].
  *
  * *Warning*: `ReplicatorMessageAdapter` is not thread-safe and must only be used from the actor
  * corresponding to the given `ActorContext`. It must not be accessed from threads other

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/DistributedData.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/DistributedData.scala
@@ -8,7 +8,8 @@ import scala.concurrent.duration.FiniteDuration
 
 import akka.actor.typed.{ ActorRef, ActorSystem, Extension, ExtensionId, Props }
 import akka.actor.ExtendedActorSystem
-import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
 import akka.annotation.InternalApi
 import akka.cluster.Cluster
 import akka.cluster.ddata.ReplicatedData
@@ -21,6 +22,36 @@ object DistributedData extends ExtensionId[DistributedData] {
 
   override def createExtension(system: ActorSystem[_]): DistributedData =
     new DistributedData(system)
+
+  /**
+   * When interacting with the [[DistributedData.replicator]] from an actor the [[ReplicatorMessageAdapter]]
+   * provides convenient methods that adapts the response messages to the requesting actor's message protocol.
+   *
+   * One `ReplicatorMessageAdapter` instance can be used for a given `ReplicatedData` type,
+   * e.g. an `OrSet[String]`. Interaction with several [[akka.cluster.ddata.Key]]s can be used via the same adapter
+   * but they must all be of the same `ReplicatedData` type. For interaction with several different
+   * `ReplicatedData` types, e.g. an `OrSet[String]` and a `GCounter`, an adapter can be created
+   * for each type.
+   *
+   * *Warning*: A `ReplicatorMessageAdapter` instance is not thread-safe and must only be used from a single actor
+   * It must not be accessed from threads other than the ordinary actor message processing thread, such as
+   * [[scala.concurrent.Future]] callbacks. It must not be shared between several actor instances.
+   *
+   * @param factory Factory of the `Behavior` for the actor that is using the `ReplicatorMessageAdapter`
+   *
+   * @tparam A Message type of the requesting actor.
+   * @tparam B Type of the [[ReplicatedData]].
+   */
+  def withReplicatorMessageAdapter[A, B <: ReplicatedData](
+      factory: ReplicatorMessageAdapter[A, B] => Behavior[A]): Behavior[A] = {
+    Behaviors.setup[A] { context =>
+      val distributedData = DistributedData(context.system)
+      val replicatorAdapter =
+        new ReplicatorMessageAdapter[A, B](context, distributedData.replicator, distributedData.unexpectedAskTimeout)
+      factory(replicatorAdapter)
+    }
+  }
+
 }
 
 /**
@@ -50,7 +81,7 @@ class DistributedData(system: ActorSystem[_]) extends Extension {
   /**
    * `ActorRef` of the [[Replicator]].
    *
-   * @see [[DistributedData.replicatorMessageAdapter]]
+   * @see [[DistributedData.withReplicatorMessageAdapter]]
    */
   val replicator: ActorRef[Replicator.Command] =
     if (isTerminated) {
@@ -73,32 +104,6 @@ class DistributedData(system: ActorSystem[_]) extends Extension {
         ReplicatorSettings.name(system),
         Props.empty.withDispatcherFromConfig(settings.dispatcher))
     }
-
-  /**
-   * When interacting with the [[DistributedData.replicator]] from an actor the [[ReplicatorMessageAdapter]]
-   * provides convenient methods that adapts the response messages to the requesting actor's message protocol.
-   *
-   * One `ReplicatorMessageAdapter` instance can be used for a given `ReplicatedData` type,
-   * e.g. an `OrSet[String]`. Interaction with several [[akka.cluster.ddata.Key]]s can be used via the same adapter
-   * but they must all be of the same `ReplicatedData` type. For interaction with several different
-   * `ReplicatedData` types, e.g. an `OrSet[String]` and a `GCounter`, an adapter can be created
-   * for each type.
-   *
-   * *Warning*: `ReplicatorMessageAdapter` is not thread-safe and must only be used from the actor
-   * corresponding to the given `ActorContext`. It must not be accessed from threads other
-   * than the ordinary actor message processing thread, such as [[scala.concurrent.Future]] callbacks.
-   * It must not be shared between several actor instances.
-   *
-   * `ReplicatorMessageAdapter` is not thread-safe and must only be used from the actor corresponding to the
-   * given `ActorContext`, and
-   *
-   * @param context The [[ActorContext]] of the requesting actor. The `ReplicatorMessageAdapter` can only be
-   *                used in this actor.
-   * @tparam A Message type of the requesting actor.
-   * @tparam B Type of the [[ReplicatedData]].
-   */
-  def replicatorMessageAdapter[A, B <: ReplicatedData](context: ActorContext[A]): ReplicatorMessageAdapter[A, B] =
-    new ReplicatorMessageAdapter(context, replicator, unexpectedAskTimeout)
 
   /**
    * Returns true if this member is not tagged with the role configured for the replicas.

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/DistributedData.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/DistributedData.scala
@@ -84,8 +84,16 @@ class DistributedData(system: ActorSystem[_]) extends Extension {
    * `ReplicatedData` types, e.g. an `OrSet[String]` and a `GCounter`, an adapter can be created
    * for each type.
    *
-   * @param context The [[ActorContext]] of the requesting actor.
+   * *Warning*: `ReplicatorMessageAdapter` is not thread-safe and must only be used from the actor
+   * corresponding to the given `ActorContext`. It must not be accessed from threads other
+   * than the ordinary actor message processing thread, such as [[scala.concurrent.Future]] callbacks.
+   * It must not be shared between several actor instances.
    *
+   * `ReplicatorMessageAdapter` is not thread-safe and must only be used from the actor corresponding to the
+   * given `ActorContext`, and
+   *
+   * @param context The [[ActorContext]] of the requesting actor. The `ReplicatorMessageAdapter` can only be
+   *                used in this actor.
    * @tparam A Message type of the requesting actor.
    * @tparam B Type of the [[ReplicatedData]].
    */

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorMessageAdapter.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorMessageAdapter.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.ddata.typed.scaladsl
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Failure
+import scala.util.Success
+
+import akka.actor.typed.ActorRef
+import akka.actor.typed.scaladsl.ActorContext
+import akka.cluster.ddata.Key
+import akka.cluster.ddata.ReplicatedData
+import akka.util.Timeout
+
+object ReplicatorMessageAdapter {
+  def apply[A, B <: ReplicatedData](
+      context: ActorContext[A],
+      replicator: ActorRef[Replicator.Command],
+      unexpectedAskTimeout: FiniteDuration): ReplicatorMessageAdapter[A, B] =
+    new ReplicatorMessageAdapter(context, replicator, unexpectedAskTimeout)
+}
+
+/**
+ * When interacting with the `Replicator` from an actor this class provides convenient
+ * methods that adapts the response messages to the requesting actor's message protocol.
+ *
+ * One `ReplicatorMessageAdapter` instance can be used for a given `ReplicatedData` type,
+ * e.g. an `OrSet[String]`. Interaction with several [[Key]]s can be used via the same adapter
+ * but they must all be of the same `ReplicatedData` type. For interaction with several different
+ * `ReplicatedData` types, e.g. an `OrSet[String]` and a `GCounter`, an adapter can be created
+ * for each type.
+ *
+ * For the default replicator in the [[DistributedData]] extension a `ReplicatorMessageAdapter`
+ * can be created with [[DistributedData.replicatorMessageAdapter]].
+ *
+ * @param context The [[ActorContext]] of the requesting actor.
+ * @param replicator The replicator to interact with, typically `DistributedData(system).replicator`.
+ * @param unexpectedAskTimeout The timeout to use for `ask` operations. This should be longer than
+ *                             the `timeout` given in [[Replicator.WriteConsistency]] and
+ *                             [[Replicator.ReadConsistency]]. The replicator will always send
+ *                             a reply within those timeouts so the `unexpectedAskTimeout` should
+ *                             not occur, but for cleanup in a failure situation it must still exist.
+ *                             If `askUpdate`, `askGet` or `askDelete` takes longer then this
+ *                             `unexpectedAskTimeout` a [[java.util.concurrent.TimeoutException]]
+ *                             will be thrown by the requesting actor and may be handled by supervision.
+ *
+ * @tparam A Message type of the requesting actor.
+ * @tparam B Type of the [[ReplicatedData]].
+ */
+class ReplicatorMessageAdapter[A, B <: ReplicatedData](
+    context: ActorContext[A],
+    replicator: ActorRef[Replicator.Command],
+    unexpectedAskTimeout: FiniteDuration) {
+
+  private implicit val askTimeout: Timeout = Timeout(unexpectedAskTimeout)
+
+  private var changedMessageAdapters: Map[Key[B], ActorRef[Replicator.Changed[B]]] = Map.empty
+
+  /**
+   * Subscribe to changes of the given `key`. The [[Replicator.Changed]] messages from
+   * the replicator are transformed to the message protocol of the requesting actor with
+   * the given `responseAdapter` function.
+   */
+  def subscribe(key: Key[B], responseAdapter: Replicator.Changed[B] => A): Unit = {
+    // unsubscribe in case it's called more than once per key
+    unsubscribe(key)
+    changedMessageAdapters.get(key).foreach { subscriber =>
+      replicator ! Replicator.Unsubscribe(key, subscriber)
+    }
+    val replyTo: ActorRef[Replicator.Changed[B]] = context.messageAdapter[Replicator.Changed[B]](responseAdapter)
+    changedMessageAdapters = changedMessageAdapters.updated(key, replyTo)
+    replicator ! Replicator.Subscribe(key, replyTo)
+  }
+
+  /**
+   * Unsubscribe from a previous subscription of a given `key`.
+   * @see [[ReplicatorMessageAdapter.subscribe]]
+   */
+  def unsubscribe(key: Key[B]): Unit = {
+    changedMessageAdapters.get(key).foreach { subscriber =>
+      replicator ! Replicator.Unsubscribe(key, subscriber)
+    }
+  }
+
+  /**
+   * Send a [[Replicator.Update]] request to the replicator. The [[Replicator.UpdateResponse]]
+   * message is transformed to the message protocol of the requesting actor with the given
+   * `responseAdapter` function.
+   *
+   * Note that `createRequest` is a function that creates the `Update` message from the provided
+   * `ActorRef[UpdateResponse]` that the the replicator will send the response message back through.
+   * Use that `ActorRef[UpdateResponse]` as the `replyTo` parameter in the `Update` message.
+   */
+  def askUpdate(
+      createRequest: ActorRef[Replicator.UpdateResponse[B]] => Replicator.Update[B],
+      responseAdapter: Replicator.UpdateResponse[B] => A): Unit = {
+    context.ask[Replicator.Update[B], Replicator.UpdateResponse[B]](replicator)(askReplyTo => createRequest(askReplyTo)) {
+      case Success(value) => responseAdapter(value)
+      case Failure(ex)    => throw ex // unexpected ask timeout
+    }
+  }
+
+  /**
+   * Send a [[Replicator.Get]] request to the replicator. The [[Replicator.GetResponse]]
+   * message is transformed to the message protocol of the requesting actor with the given
+   * `responseAdapter` function.
+   *
+   * Note that `createRequest` is a function that creates the `Get` message from the provided
+   * `ActorRef[GetResponse]` that the the replicator will send the response message back through.
+   * Use that `ActorRef[GetResponse]` as the `replyTo` parameter in the `Get` message.
+   */
+  def askGet(
+      createRequest: ActorRef[Replicator.GetResponse[B]] => Replicator.Get[B],
+      responseAdapter: Replicator.GetResponse[B] => A): Unit = {
+    context.ask[Replicator.Get[B], Replicator.GetResponse[B]](replicator)(askReplyTo => createRequest(askReplyTo)) {
+      case Success(value) => responseAdapter(value)
+      case Failure(ex)    => throw ex // unexpected ask timeout
+    }
+  }
+
+  /**
+   * Send a [[Replicator.Delete]] request to the replicator. The [[Replicator.DeleteResponse]]
+   * message is transformed to the message protocol of the requesting actor with the given
+   * `responseAdapter` function.
+   *
+   * Note that `createRequest` is a function that creates the `Delete` message from the provided
+   * `ActorRef[DeleteResponse]` that the the replicator will send the response message back through.
+   * Use that `ActorRef[DeleteResponse]` as the `replyTo` parameter in the `Delete` message.
+   */
+  def askDelete(
+      createRequest: ActorRef[Replicator.DeleteResponse[B]] => Replicator.Delete[B],
+      responseAdapter: Replicator.DeleteResponse[B] => A): Unit = {
+    context.ask[Replicator.Delete[B], Replicator.DeleteResponse[B]](replicator)(askReplyTo => createRequest(askReplyTo)) {
+      case Success(value) => responseAdapter(value)
+      case Failure(ex)    => throw ex // unexpected ask timeout
+    }
+  }
+
+  /**
+   * Send a [[Replicator.GetReplicaCount]] request to the replicator. The [[Replicator.ReplicaCount]]
+   * message is transformed to the message protocol of the requesting actor with the given
+   * `responseAdapter` function.
+   *
+   * Note that `createRequest` is a function that creates the `GetReplicaCount` message from the provided
+   * `ActorRef[ReplicaCount]` that the the replicator will send the response message back through.
+   * Use that `ActorRef[ReplicaCount]` as the `replyTo` parameter in the `GetReplicaCount` message.
+   */
+  def askReplicaCount(
+      createRequest: ActorRef[Replicator.ReplicaCount] => Replicator.GetReplicaCount,
+      responseAdapter: Replicator.ReplicaCount => A): Unit = {
+    context.ask[Replicator.GetReplicaCount, Replicator.ReplicaCount](replicator)(askReplyTo =>
+      createRequest(askReplyTo)) {
+      case Success(value) => responseAdapter(value)
+      case Failure(ex)    => throw ex // unexpected ask timeout
+    }
+  }
+
+}

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorMessageAdapter.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorMessageAdapter.scala
@@ -33,7 +33,7 @@ object ReplicatorMessageAdapter {
  * for each type.
  *
  * For the default replicator in the [[DistributedData]] extension a `ReplicatorMessageAdapter`
- * can be created with [[DistributedData.replicatorMessageAdapter]].
+ * can be created with [[DistributedData.withReplicatorMessageAdapter]].
  *
  * *Warning*: `ReplicatorMessageAdapter` is not thread-safe and must only be used from the actor
  * corresponding to the given `ActorContext`. It must not be accessed from threads other

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorMessageAdapter.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorMessageAdapter.scala
@@ -35,8 +35,14 @@ object ReplicatorMessageAdapter {
  * For the default replicator in the [[DistributedData]] extension a `ReplicatorMessageAdapter`
  * can be created with [[DistributedData.replicatorMessageAdapter]].
  *
- * @param context The [[ActorContext]] of the requesting actor.
- * @param replicator The replicator to interact with, typically `DistributedData(system).replicator`.
+ * *Warning*: `ReplicatorMessageAdapter` is not thread-safe and must only be used from the actor
+ * corresponding to the given `ActorContext`. It must not be accessed from threads other
+ * than the ordinary actor message processing thread, such as [[scala.concurrent.Future]] callbacks.
+ * It must not be shared between several actor instances.
+ *
+ * @param context              The [[ActorContext]] of the requesting actor. The `ReplicatorMessageAdapter` can
+ *                             only be used in this actor.
+ * @param replicator           The replicator to interact with, typically `DistributedData(system).replicator`.
  * @param unexpectedAskTimeout The timeout to use for `ask` operations. This should be longer than
  *                             the `timeout` given in [[Replicator.WriteConsistency]] and
  *                             [[Replicator.ReadConsistency]]. The replicator will always send
@@ -45,7 +51,6 @@ object ReplicatorMessageAdapter {
  *                             If `askUpdate`, `askGet` or `askDelete` takes longer then this
  *                             `unexpectedAskTimeout` a [[java.util.concurrent.TimeoutException]]
  *                             will be thrown by the requesting actor and may be handled by supervision.
- *
  * @tparam A Message type of the requesting actor.
  * @tparam B Type of the [[ReplicatedData]].
  */

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -324,7 +324,7 @@ made before finalizing the APIs. Compared to Akka 2.5.x the source incompatible 
   prefer `Behaviors.withTimers`.
 * `TimerScheduler.startPeriodicTimer`, replaced by `startTimerWithFixedDelay` or `startTimerAtFixedRate`
 * `Routers.pool` now take a factory function rather than a `Behavior` to protect against accidentally sharing same behavior instance and state across routees.
-* The `request` parameter in Distributed Data commands was removed, in favor of using `ask`.
+* The `request` parameter in Distributed Data commands was removed, in favor of using `ask` with the new `ReplicatorMessageAdapter`.
 * Removed `Behavior.same`, `Behavior.unhandled`, `Behavior.stopped`, `Behavior.empty`, and `Behavior.ignore` since
   they were redundant with corresponding @scala[scaladsl.Behaviors.x]@java[javadsl.Behaviors.x].
 

--- a/akka-docs/src/main/paradox/typed/distributed-data.md
+++ b/akka-docs/src/main/paradox/typed/distributed-data.md
@@ -55,11 +55,14 @@ Scala
 Java
 :  @@snip [ReplicatorTest.java](/akka-cluster-typed/src/test/java/akka/cluster/ddata/typed/javadsl/ReplicatorTest.java) { #sample }
 
+Although you can interact with the `Replicator` using the @scala[`ActorRef[Replicator.Command]`]@java[`ActorRef<Replicator.Command>`]
+from @scala[`DistributedData(ctx.system).replicator`]@java[`DistributedData(ctx.getSystem()).replicator()`] it's
+often more convenient to use the `ReplicatorMessageAdapter` as in the above example.
 
 When we start up the actor we subscribe it to changes for our key, meaning whenever the replicator observes a change
 for the counter our actor will receive a @scala[`Replicator.Changed[GCounter]`]@java[`Replicator.Changed<GCounter>`]. Since
-this is not a message in our protocol, we use an adapter to wrap it in the internal `InternalChanged` message, which
-is then handled in the regular message handling of the behavior. 
+this is not a message in our protocol, we use a message transformation function to wrap it in the internal `InternalChanged`
+message, which is then handled in the regular message handling of the behavior.
 
 For an incoming `Increment` command, we send the `replicator` a `Replicator.Update` request, it contains five values:
 
@@ -79,6 +82,19 @@ incoming message can be used when the `GetSuccess` response from the replicator 
 See the @ref[the untyped Distributed Data documentation](../distributed-data.md#using-the-replicator)
 for more details about `Get`, `Update` and `Delete` interactions with the replicator.
 
+@@@ div { .group-scala }
+There is alternative way of constructing the function for the `Update` message:
+
+Scala
+:  @@snip [ReplicatorSpec.scala](/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala) { #curried-update }
+
+Similar is supported for `Get` and `Delete`:
+
+Scala
+:  @@snip [ReplicatorSpec.scala](/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala) { #curried-get }
+
+@@@
+
 ### Replicated data types
 
 Akka contains a set of useful replicated data types and it is fully possible to implement custom replicated data types. 
@@ -91,4 +107,7 @@ it makes sense to start separate replicators, this needs to be done on all nodes
 the group of nodes tagged with a specific role. To do this with the Typed Distributed Data you will first
 have to start an untyped `Replicator` and pass it to the `Replicator.behavior` method that takes an untyped
 actor ref. All such `Replicator`s must run on the same path in the untyped actor hierarchy.
- 
+
+A standalone `ReplicatorMessageAdapter` can also be created for a given `Replicator` instead of creating
+one via the `DistributedData` extension.
+


### PR DESCRIPTION
## Purpose

Simplify API for interaction with Distributed Data Replicator, which is typically needing ask interaction from an actor.

## References

Refs #27116

Also related to (and on top of) https://github.com/akka/akka/pull/27117

## Changes

* Introducing a message adapter "helper" that is specific the Replicator
* Specific methods for askUpdate, askGet and askDelete, subscribe, unsubscribe

## Background Context

When working on the Lightbend courses I noticed that it was to difficult and too much boilerplate that required copy-paste from docs.
