### PR TITLE
Enable Jackson for 2.13

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/serialization/jackson/JacksonSerializationBench.scala
+++ b/akka-bench-jmh/src/main/scala/akka/serialization/jackson/JacksonSerializationBench.scala
@@ -157,10 +157,10 @@ class JacksonSerializationBench {
 
   private def serializeDeserialize[T <: AnyRef](msg: T): T = {
     serialization.findSerializerFor(msg) match {
-      case serializer: SerializerWithStringManifest ⇒
+      case serializer: SerializerWithStringManifest =>
         val blob = serializer.toBinary(msg)
         serializer.fromBinary(blob, serializer.manifest(msg)).asInstanceOf[T]
-      case serializer ⇒
+      case serializer =>
         val blob = serializer.toBinary(msg)
         if (serializer.includeManifest)
           serializer.fromBinary(blob, Some(msg.getClass)).asInstanceOf[T]

--- a/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -65,7 +65,8 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
       config: Config,
       dynamicAccess: DynamicAccess,
       log: Option[LoggingAdapter]) = {
-    import scala.collection.JavaConverters._
+
+    import akka.util.ccompat.JavaConverters._
 
     val mapper = objectMapperFactory.newObjectMapper(bindingName, jsonFactory)
 
@@ -146,7 +147,7 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
   }
 
   private def features(config: Config, section: String): immutable.Seq[(String, Boolean)] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     val cfg = config.getConfig(section)
     cfg.root.keySet().asScala.map(key => key -> cfg.getBoolean(key)).toList
   }

--- a/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -96,11 +96,11 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
       if (configuredModules.contains("*"))
         ObjectMapper.findModules(dynamicAccess.classLoader).asScala
       else
-        configuredModules.flatMap { fqcn ⇒
+        configuredModules.flatMap { fqcn =>
           if (isModuleEnabled(fqcn, dynamicAccess)) {
             dynamicAccess.createInstanceFor[Module](fqcn, Nil) match {
-              case Success(m) ⇒ Some(m)
-              case Failure(e) ⇒
+              case Success(m) => Some(m)
+              case Failure(e) =>
                 log.foreach(
                   _.error(
                     e,
@@ -113,7 +113,7 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
             None
         }
 
-    val modules2 = modules1.map { module ⇒
+    val modules2 = modules1.map { module =>
       if (module.isInstanceOf[ParameterNamesModule])
         // ParameterNamesModule needs a special case for the constructor to ensure that single-parameter
         // constructors are handled the same way as constructors with multiple parameters.

--- a/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonSerializer.scala
+++ b/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonSerializer.scala
@@ -178,7 +178,7 @@ import com.fasterxml.jackson.dataformat.smile.SmileFactory
     checkAllowedClass(obj.getClass)
     migrations.get(className) match {
       case Some(transformer) => className + "#" + transformer.currentVersion
-      case None => className
+      case None              => className
     }
   }
 

--- a/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonSerializer.scala
+++ b/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonSerializer.scala
@@ -150,7 +150,7 @@ import com.fasterxml.jackson.dataformat.smile.SmileFactory
     }
   }
   private val migrations: Map[String, JacksonMigration] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     conf.getConfig("migrations").root.unwrapped.asScala.toMap.map {
       case (k, v) =>
         val transformer = system.dynamicAccess.createInstanceFor[JacksonMigration](v.toString, Nil).get
@@ -159,7 +159,7 @@ import com.fasterxml.jackson.dataformat.smile.SmileFactory
   }
   private val blacklist: GadgetClassBlacklist = new GadgetClassBlacklist
   private val whitelistClassPrefix = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     conf.getStringList("whitelist-class-prefix").asScala.toVector
   }
 

--- a/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonSerializer.scala
+++ b/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonSerializer.scala
@@ -152,7 +152,7 @@ import com.fasterxml.jackson.dataformat.smile.SmileFactory
   private val migrations: Map[String, JacksonMigration] = {
     import scala.collection.JavaConverters._
     conf.getConfig("migrations").root.unwrapped.asScala.toMap.map {
-      case (k, v) ⇒
+      case (k, v) =>
         val transformer = system.dynamicAccess.createInstanceFor[JacksonMigration](v.toString, Nil).get
         k -> transformer
     }
@@ -177,8 +177,8 @@ import com.fasterxml.jackson.dataformat.smile.SmileFactory
     checkAllowedClassName(className)
     checkAllowedClass(obj.getClass)
     migrations.get(className) match {
-      case Some(transformer) ⇒ className + "#" + transformer.currentVersion
-      case None ⇒ className
+      case Some(transformer) => className + "#" + transformer.currentVersion
+      case None => className
     }
   }
 
@@ -221,20 +221,20 @@ import com.fasterxml.jackson.dataformat.smile.SmileFactory
     val migration = migrations.get(manifestClassName)
 
     val className = migration match {
-      case Some(transformer) if fromVersion < transformer.currentVersion ⇒
+      case Some(transformer) if fromVersion < transformer.currentVersion =>
         transformer.transformClassName(fromVersion, manifestClassName)
-      case Some(transformer) if fromVersion > transformer.currentVersion ⇒
+      case Some(transformer) if fromVersion > transformer.currentVersion =>
         throw new IllegalStateException(
           s"Migration version ${transformer.currentVersion} is " +
           s"behind version $fromVersion of deserialized type [$manifestClassName]")
-      case _ ⇒ manifestClassName
+      case _ => manifestClassName
     }
     if (className ne manifestClassName)
       checkAllowedClassName(className)
 
     val clazz = system.dynamicAccess.getClassFor[AnyRef](className) match {
-      case Success(c) ⇒ c
-      case Failure(_) ⇒
+      case Success(c) => c
+      case Failure(_) =>
         throw new NotSerializableException(
           s"Cannot find manifest class [$className] for serializer [${getClass.getName}].")
     }
@@ -243,11 +243,11 @@ import com.fasterxml.jackson.dataformat.smile.SmileFactory
     val decompressBytes = if (compressed) decompress(bytes) else bytes
 
     val result = migration match {
-      case Some(transformer) if fromVersion < transformer.currentVersion ⇒
+      case Some(transformer) if fromVersion < transformer.currentVersion =>
         val jsonTree = objectMapper.readTree(decompressBytes)
         val newJsonTree = transformer.transform(fromVersion, jsonTree)
         objectMapper.treeToValue(newJsonTree, clazz)
-      case _ ⇒
+      case _ =>
         objectMapper.readValue(decompressBytes, clazz)
     }
 
@@ -386,8 +386,8 @@ import com.fasterxml.jackson.dataformat.smile.SmileFactory
     val buffer = new Array[Byte](BufferSize)
 
     @tailrec def readChunk(): Unit = in.read(buffer) match {
-      case -1 ⇒ ()
-      case n ⇒
+      case -1 => ()
+      case n =>
         out.write(buffer, 0, n)
         readChunk()
     }

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -369,8 +369,8 @@ abstract class JacksonSerializerSpec(serializerName: String)
 
   def serializerFor(obj: AnyRef, sys: ActorSystem = system): JacksonSerializer =
     serialization(sys).findSerializerFor(obj) match {
-      case serializer: JacksonSerializer ⇒ serializer
-      case s ⇒
+      case serializer: JacksonSerializer => serializer
+      case s =>
         throw new IllegalStateException(s"Wrong serializer ${s.getClass} for ${obj.getClass}")
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -247,8 +247,6 @@ lazy val jackson = akkaModule("akka-serialization-jackson")
   .settings(AutomaticModuleName.settings("akka.serialization.jackson"))
   .settings(OSGi.jackson)
   .settings(javacOptions += "-parameters")
-  // FIXME #27019 remove when Jackson ScalaModule has been released for Scala 2.13
-  .settings(crossScalaVersions -= Dependencies.scala213Version)
   .enablePlugins(ScaladocNoVerificationOfDiagrams)
   .disablePlugins(MimaPlugin)
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,8 @@ lazy val aggregatedProjects: Seq[ProjectReference] = List[ProjectReference](
     actorTestkitTyped,
     actorTyped,
     actorTypedTests,
+    benchJmh,
+    benchJmhTyped,
     cluster,
     clusterMetrics,
     clusterSharding,
@@ -52,6 +54,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] = List[ProjectReference](
     discovery,
     distributedData,
     docs,
+    jackson,
     multiNodeTestkit,
     osgi,
     persistence,
@@ -68,10 +71,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] = List[ProjectReference](
     streamTests,
     streamTestsTck,
     streamTyped,
-    testkit) ++
-  (if (isScala213) List.empty[ProjectReference]
-   else
-     List[ProjectReference](jackson, benchJmh, benchJmhTyped)) // FIXME #27019 remove 2.13 condition when Jackson ScalaModule has been released for Scala 2.13
+    testkit)
 
 lazy val root = Project(id = "akka", base = file("."))
   .aggregate(aggregatedProjects: _*)


### PR DESCRIPTION
I was investiagting how some unicode arrows got in and they only fail the build
for 2.13 and notived jackson scala was released 30 minutes ago for 2.13.