### PR TITLE
Add mapMaterializedValue for Source/Flow withContext akka 2.5

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceWithContextSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceWithContextSpec.scala
@@ -107,5 +107,15 @@ class SourceWithContextSpec extends StreamSpec {
         .expectNext((Seq("a-1", "a-2"), Seq(1L, 1L)), (Seq("a-3", "a-4"), Seq(1L, 1L)))
         .expectComplete()
     }
+
+    "be able to change meterialized value via mapMaterializedValue" in {
+      val materializedValue = "MatedValue"
+      Source
+        .empty[Message]
+        .asSourceWithContext(_.offset)
+        .mapMaterializedValue(_ => materializedValue)
+        .to(Sink.ignore)
+        .run() shouldBe materializedValue
+    }
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FlowWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FlowWithContext.scala
@@ -74,6 +74,14 @@ final class FlowWithContext[In, CtxIn, Out, CtxOut, +Mat](
     viaScala(_.withAttributes(attr))
 
   /**
+   * Context-preserving variant of [[akka.stream.javadsl.Flow.mapMaterializedValue]].
+   *
+   * @see [[akka.stream.scaladsl.Flow.mapMaterializedValue]]
+   */
+  def mapMaterializedValue[Mat2](f: function.Function[Mat, Mat2]): FlowWithContext[In, CtxIn, Out, CtxOut, Mat2] =
+    new FlowWithContext(delegate.mapMaterializedValue[Mat2](f))
+
+  /**
    * Creates a regular flow of pairs (data, context).
    */
   def asFlow(): Flow[Pair[In, CtxIn], Pair[Out, CtxOut], Mat] @uncheckedVariance =

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SourceWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SourceWithContext.scala
@@ -67,6 +67,14 @@ final class SourceWithContext[+Out, +Ctx, +Mat](delegate: scaladsl.SourceWithCon
     viaScala(_.withAttributes(attr))
 
   /**
+   * Context-preserving variant of [[akka.stream.javadsl.Source.mapMaterializedValue]].
+   *
+   * @see [[akka.stream.javadsl.Flow.mapMaterializedValue]]
+   */
+  def mapMaterializedValue[Mat2](f: function.Function[Mat, Mat2]): SourceWithContext[Out, Ctx, Mat2] =
+    viaScala(_.mapMaterializedValue(f.apply _))
+
+  /**
    * Stops automatic context propagation from here and converts this to a regular
    * stream of a pair of (data, context).
    */

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContext.scala
@@ -65,6 +65,14 @@ final class FlowWithContext[-In, -CtxIn, +Out, +CtxOut, +Mat](delegate: Flow[(In
   override def withAttributes(attr: Attributes): FlowWithContext[In, CtxIn, Out, CtxOut, Mat] =
     new FlowWithContext(delegate.withAttributes(attr))
 
+  /**
+   * Context-preserving variant of [[akka.stream.scaladsl.Flow.mapMaterializedValue]].
+   *
+   * @see [[akka.stream.scaladsl.Flow.mapMaterializedValue]]
+   */
+  def mapMaterializedValue[Mat2](f: Mat => Mat2): FlowWithContext[In, CtxIn, Out, CtxOut, Mat2] =
+    new FlowWithContext(delegate.mapMaterializedValue(f))
+
   def asFlow: Flow[(In, CtxIn), (Out, CtxOut), Mat] = delegate
 
   def asJava[JIn <: In, JCtxIn <: CtxIn, JOut >: Out, JCtxOut >: CtxOut, JMat >: Mat]

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
@@ -49,7 +49,7 @@ trait FlowWithContextOps[+Out, +Ctx, +Mat] {
    * The `combine` function is used to compose the materialized values of this flow and that
    * flow into the materialized value of the resulting Flow.
    *
-   * @see [[akka.stream.scaladsl.FlowOps.viaMat]]
+   * @see [[akka.stream.scaladsl.FlowOpsMat.viaMat]]
    */
   def viaMat[Out2, Ctx2, Mat2, Mat3](flow: Graph[FlowShape[(Out, Ctx), (Out2, Ctx2)], Mat2])(
       combine: (Mat, Mat2) => Mat3): ReprMat[Out2, Ctx2, Mat3]

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/SourceWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/SourceWithContext.scala
@@ -54,6 +54,14 @@ final class SourceWithContext[+Out, +Ctx, +Mat] private[stream] (delegate: Sourc
     new SourceWithContext(delegate.withAttributes(attr))
 
   /**
+   * Context-preserving variant of [[akka.stream.scaladsl.Source.mapMaterializedValue]].
+   *
+   * @see [[akka.stream.scaladsl.Source.mapMaterializedValue]]
+   */
+  def mapMaterializedValue[Mat2](f: Mat => Mat2): SourceWithContext[Out, Ctx, Mat2] =
+    new SourceWithContext(delegate.mapMaterializedValue(f))
+
+  /**
    * Connect this [[akka.stream.scaladsl.SourceWithContext]] to a [[akka.stream.scaladsl.Sink]],
    * concatenating the processing steps of both.
    */


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose
Provide mapMaterializedValue method for Source/Flow withContext for scala- and java- dsl
<!-- What does this PR do? -->

## References
implement feature https://github.com/akka/akka/issues/26836
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->