### PR TITLE
Allow specifying a log level when logging exceptions being seen the SupervisorStrategy

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -16,10 +16,11 @@ import akka.testkit.EventFilter
 import akka.actor.testkit.typed.scaladsl._
 import akka.actor.testkit.typed._
 import org.scalatest.{ Matchers, WordSpec, WordSpecLike }
+
 import scala.util.control.NoStackTrace
 import scala.concurrent.duration._
-
 import akka.actor.typed.SupervisorStrategy.Resume
+import akka.event.Logging
 
 object SupervisionSpec {
 
@@ -1207,6 +1208,30 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       }
       actor ! "ping"
       probe.expectMessage("pong")
+    }
+
+    "log exceptions when logging is enabled and provided log level matches" in {
+      val probe = TestProbe[Event]("evt")
+      val behv = Behaviors
+        .supervise(targetBehavior(probe.ref))
+        .onFailure[Exc1](SupervisorStrategy.restart.withLoggingEnabled(true).withLogLevel(Logging.InfoLevel))
+      val ref = spawn(behv)
+      EventFilter.info(pattern = "exc-1", source = ref.path.toString, occurrences = 1).intercept {
+        ref ! Throw(new Exc1)
+        probe.expectMessage(ReceivedSignal(PreRestart))
+      }
+    }
+
+    "do not log exceptions when logging is enabled and provided log level does not match" in {
+      val probe = TestProbe[Event]("evt")
+      val behv = Behaviors
+        .supervise(targetBehavior(probe.ref))
+        .onFailure[Exc1](SupervisorStrategy.restart.withLoggingEnabled(true).withLogLevel(Logging.DebugLevel))
+      val ref = spawn(behv)
+      EventFilter.info(pattern = "exc-1", source = ref.path.toString, occurrences = 0).intercept {
+        ref ! Throw(new Exc1)
+        probe.expectMessage(ReceivedSignal(PreRestart))
+      }
     }
 
   }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
@@ -82,7 +82,11 @@ private abstract class AbstractSupervisor[O, I, Thr <: Throwable](strategy: Supe
   def log(ctx: TypedActorContext[_], t: Throwable): Unit = {
     if (strategy.loggingEnabled) {
       val unwrapped = UnstashException.unwrap(t)
-      ctx.asScala.log.error(unwrapped, "Supervisor {} saw failure: {}", this, unwrapped.getMessage)
+      strategy.logLevel match {
+        case Logging.ErrorLevel => ctx.asScala.log.error(unwrapped, "Supervisor {} saw failure: {}", this, unwrapped.getMessage)
+        case Logging.WarningLevel => ctx.asScala.log.warning(unwrapped, "Supervisor {} saw failure: {}", this, unwrapped.getMessage)
+        case level  => ctx.asScala.log.log(level, "Supervisor {} saw failure: {}", this, unwrapped.getMessage)
+      }
     }
   }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
@@ -83,9 +83,11 @@ private abstract class AbstractSupervisor[O, I, Thr <: Throwable](strategy: Supe
     if (strategy.loggingEnabled) {
       val unwrapped = UnstashException.unwrap(t)
       strategy.logLevel match {
-        case Logging.ErrorLevel => ctx.asScala.log.error(unwrapped, "Supervisor {} saw failure: {}", this, unwrapped.getMessage)
-        case Logging.WarningLevel => ctx.asScala.log.warning(unwrapped, "Supervisor {} saw failure: {}", this, unwrapped.getMessage)
-        case level  => ctx.asScala.log.log(level, "Supervisor {} saw failure: {}", this, unwrapped.getMessage)
+        case Logging.ErrorLevel =>
+          ctx.asScala.log.error(unwrapped, "Supervisor {} saw failure: {}", this, unwrapped.getMessage)
+        case Logging.WarningLevel =>
+          ctx.asScala.log.warning(unwrapped, "Supervisor {} saw failure: {}", this, unwrapped.getMessage)
+        case level => ctx.asScala.log.log(level, "Supervisor {} saw failure: {}", this, unwrapped.getMessage)
       }
     }
   }


### PR DESCRIPTION

<!--
# Pull Request Checklist

* [X ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose
Currently when logging gets enabled on the SupervisorStrategy in Akka Typed, all exceptions are being logged with the error level. It might not always be though the level a user wants thus it would be useful if there is a way how to specify the level the exceptions should be logged with .
## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #27133

## Changes

<!-- Bullets for important changes in this PR -->
Adding `withLogLevel(level: LogLevel)` method to the SupervisorStrategy which allows to set the desired log level

## Background Context

<!-- Why did you take this approach? -->
