### PR TITLE
upgrade to ScalaTest 3.0.8

### DIFF
--- a/akka-actor-tests/src/test/java/akka/actor/JavaAPI.java
+++ b/akka-actor-tests/src/test/java/akka/actor/JavaAPI.java
@@ -20,14 +20,13 @@ import akka.testkit.TestProbe;
 
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
 import scala.Option;
 
 import java.util.Optional;
 
 import static org.junit.Assert.*;
 
-public class JavaAPI extends JUnitSuite {
+public class JavaAPI {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-actor-tests/src/test/java/akka/actor/JavaExtension.java
+++ b/akka-actor-tests/src/test/java/akka/actor/JavaExtension.java
@@ -8,11 +8,10 @@ import akka.testkit.AkkaJUnitActorSystemResource;
 import org.junit.*;
 import akka.testkit.AkkaSpec;
 import com.typesafe.config.ConfigFactory;
-import org.scalatest.junit.JUnitSuite;
 
 import static org.junit.Assert.*;
 
-public class JavaExtension extends JUnitSuite {
+public class JavaExtension {
 
   static class TestExtensionId extends AbstractExtensionId<TestExtension>
       implements ExtensionIdProvider {

--- a/akka-actor-tests/src/test/java/akka/actor/StashJavaAPI.java
+++ b/akka-actor-tests/src/test/java/akka/actor/StashJavaAPI.java
@@ -9,9 +9,8 @@ import akka.testkit.TestProbe;
 
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
 
-public class StashJavaAPI extends JUnitSuite {
+public class StashJavaAPI {
 
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =

--- a/akka-actor-tests/src/test/java/akka/japi/JavaAPITestBase.java
+++ b/akka-actor-tests/src/test/java/akka/japi/JavaAPITestBase.java
@@ -9,13 +9,12 @@ import akka.event.LoggingAdapter;
 import akka.event.NoLogging;
 import akka.serialization.JavaSerializer;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
 
 import java.util.concurrent.Callable;
 
 import static org.junit.Assert.*;
 
-public class JavaAPITestBase extends JUnitSuite {
+public class JavaAPITestBase {
 
   @Test
   public void shouldCreateSomeString() {

--- a/akka-actor-tests/src/test/java/akka/util/JavaDuration.java
+++ b/akka-actor-tests/src/test/java/akka/util/JavaDuration.java
@@ -5,10 +5,9 @@
 package akka.util;
 
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 
-public class JavaDuration extends JUnitSuite {
+public class JavaDuration {
 
   @Test
   public void testCreation() {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,12 +30,7 @@ object Dependencies {
           case Some((2, n)) if n >= 12 => "1.14.0" // does not work for 2.11
           case _                       => "1.13.2"
         }),
-    scalaTestVersion := {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, n)) if n >= 13 => "3.0.8"
-        case _                       => "3.0.7"
-      }
-    },
+    scalaTestVersion := "3.0.8",
     java8CompatVersion := {
       CrossVersion.partialVersion(scalaVersion.value) match {
         // java8-compat is only used in a couple of places for 2.13,


### PR DESCRIPTION
this would be helpful to me for the Scala community build, where we're
already on 3.0.8