### PR TITLE
Log Dropped from DeadLetterListener, #26432

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -180,11 +180,13 @@ class ActorSystemSpec extends AkkaSpec(ActorSystemSpec.config) with ImplicitSend
         probe.watch(a)
         a.tell("run", probe.ref)
         probe.expectTerminated(a)
+
+        a.tell("boom", ActorRef.noSender)
         EventFilter
-          .info(pattern = "without sender.*not delivered", occurrences = 1)
+          .info(pattern = ".*not delivered", occurrences = 1)
           .intercept {
             EventFilter
-              .warning(pattern = "received dead letter without sender", occurrences = 1)
+              .warning(pattern = "received dead letter: boom", occurrences = 1)
               .intercept {
                 a.tell("boom", ActorRef.noSender)
               }(sys)

--- a/akka-actor-tests/src/test/scala/akka/actor/DeadLetterSuspensionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/DeadLetterSuspensionSpec.scala
@@ -9,27 +9,46 @@ import akka.testkit.EventFilter
 import akka.testkit.ImplicitSender
 import akka.testkit.TestActors
 
+object DeadLetterSuspensionSpec {
+
+  object Dropping {
+    def props(): Props = Props(new Dropping)
+  }
+
+  class Dropping extends Actor {
+    override def receive: Receive = {
+      case n: Int =>
+        context.system.eventStream.publish(Dropped(n, "Don't like numbers", self))
+    }
+  }
+}
+
 class DeadLetterSuspensionSpec extends AkkaSpec("""
   akka.loglevel = INFO
   akka.log-dead-letters = 3
   akka.log-dead-letters-suspend-duration = 2s
   """) with ImplicitSender {
+  import DeadLetterSuspensionSpec._
 
-  val deadActor = system.actorOf(TestActors.echoActorProps)
+  private val deadActor = system.actorOf(TestActors.echoActorProps)
   watch(deadActor)
   deadActor ! PoisonPill
   expectTerminated(deadActor)
 
+  private val droppingActor = system.actorOf(Dropping.props(), "droppingActor")
+
   private def expectedDeadLettersLogMessage(count: Int): String =
     s"Message [java.lang.Integer] from $testActor to $deadActor was not delivered. [$count] dead letters encountered"
 
-  "must suspend dead-letters logging when reaching 'akka.log-dead-letters', and then re-enable" in {
+  private def expectedDroppedLogMessage(count: Int): String =
+    s"Message [java.lang.Integer] to $droppingActor was dropped. Don't like numbers. [$count] dead letters encountered"
 
+  "must suspend dead-letters logging when reaching 'akka.log-dead-letters', and then re-enable" in {
     EventFilter.info(start = expectedDeadLettersLogMessage(1), occurrences = 1).intercept {
       deadActor ! 1
     }
-    EventFilter.info(start = expectedDeadLettersLogMessage(2), occurrences = 1).intercept {
-      deadActor ! 2
+    EventFilter.info(start = expectedDroppedLogMessage(2), occurrences = 1).intercept {
+      droppingActor ! 2
     }
     EventFilter
       .info(start = expectedDeadLettersLogMessage(3) + ", no more dead letters will be logged in next", occurrences = 1)
@@ -37,7 +56,7 @@ class DeadLetterSuspensionSpec extends AkkaSpec("""
         deadActor ! 3
       }
     deadActor ! 4
-    deadActor ! 5
+    droppingActor ! 5
 
     // let suspend-duration elapse
     Thread.sleep(2050)

--- a/akka-actor-tests/src/test/scala/akka/dispatch/MailboxConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/MailboxConfigSpec.scala
@@ -136,50 +136,48 @@ abstract class MailboxSpec extends AkkaSpec with BeforeAndAfterAll with BeforeAn
     val q = factory(config)
     ensureInitialMailboxState(config, q)
 
-    EventFilter
-      .warning(pattern = "received dead letter without sender", occurrences = (enqueueN - dequeueN))
-      .intercept {
+    EventFilter.warning(pattern = "received dead letter", occurrences = (enqueueN - dequeueN)).intercept {
 
-        def createProducer(fromNum: Int, toNum: Int): Future[Vector[Envelope]] = spawn {
-          val messages = Vector() ++ (for (i <- fromNum to toNum) yield createMessageInvocation(i))
-          for (i <- messages) q.enqueue(testActor, i)
-          messages
-        }
-
-        val producers = {
-          val step = 500
-          val ps = for (i <- (1 to enqueueN by step).toList) yield createProducer(i, Math.min(enqueueN, i + step - 1))
-
-          if (parallel == false)
-            ps.foreach { Await.ready(_, remainingOrDefault) }
-
-          ps
-        }
-
-        def createConsumer: Future[Vector[Envelope]] = spawn {
-          var r = Vector[Envelope]()
-
-          while (producers.exists(_.isCompleted == false) || q.hasMessages) Option(q.dequeue).foreach { message =>
-            r = r :+ message
-          }
-
-          r
-        }
-
-        val consumers = List.fill(maxConsumers)(createConsumer)
-
-        val ps = producers.map(Await.result(_, remainingOrDefault))
-        val cs = consumers.map(Await.result(_, remainingOrDefault))
-
-        ps.map(_.size).sum should ===(enqueueN) //Must have produced 1000 messages
-        cs.map(_.size).sum should ===(dequeueN) //Must have consumed all produced messages
-        //No message is allowed to be consumed by more than one consumer
-        cs.flatten.distinct.size should ===(dequeueN)
-        //All consumed messages should have been produced
-        cs.flatten.diff(ps.flatten).size should ===(0)
-        //The ones that were produced and not consumed
-        ps.flatten.diff(cs.flatten).size should ===(enqueueN - dequeueN)
+      def createProducer(fromNum: Int, toNum: Int): Future[Vector[Envelope]] = spawn {
+        val messages = Vector() ++ (for (i <- fromNum to toNum) yield createMessageInvocation(i))
+        for (i <- messages) q.enqueue(testActor, i)
+        messages
       }
+
+      val producers = {
+        val step = 500
+        val ps = for (i <- (1 to enqueueN by step).toList) yield createProducer(i, Math.min(enqueueN, i + step - 1))
+
+        if (parallel == false)
+          ps.foreach { Await.ready(_, remainingOrDefault) }
+
+        ps
+      }
+
+      def createConsumer: Future[Vector[Envelope]] = spawn {
+        var r = Vector[Envelope]()
+
+        while (producers.exists(_.isCompleted == false) || q.hasMessages) Option(q.dequeue).foreach { message =>
+          r = r :+ message
+        }
+
+        r
+      }
+
+      val consumers = List.fill(maxConsumers)(createConsumer)
+
+      val ps = producers.map(Await.result(_, remainingOrDefault))
+      val cs = consumers.map(Await.result(_, remainingOrDefault))
+
+      ps.map(_.size).sum should ===(enqueueN) //Must have produced 1000 messages
+      cs.map(_.size).sum should ===(dequeueN) //Must have consumed all produced messages
+      //No message is allowed to be consumed by more than one consumer
+      cs.flatten.distinct.size should ===(dequeueN)
+      //All consumed messages should have been produced
+      cs.flatten.diff(ps.flatten).size should ===(0)
+      //The ones that were produced and not consumed
+      ps.flatten.diff(cs.flatten).size should ===(enqueueN - dequeueN)
+    }
   }
 }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -789,14 +789,16 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
         ref ! Throw(new Exc1)
         probe.expectMessage(ReceivedSignal(PreRestart))
       }
-      ref ! Ping(1)
-      ref ! Ping(2)
-      ref ! Ping(3)
-      ref ! Ping(4)
-      probe.expectMessage(Pong(1))
-      probe.expectMessage(Pong(2))
-      droppedMessagesProbe.expectMessage(Dropped(Ping(3), "Stash is full in [BackoffSupervisor]", ref.toUntyped))
-      droppedMessagesProbe.expectMessage(Dropped(Ping(4), "Stash is full in [BackoffSupervisor]", ref.toUntyped))
+      EventFilter.warning(start = "dropped message", occurrences = 2).intercept {
+        ref ! Ping(1)
+        ref ! Ping(2)
+        ref ! Ping(3)
+        ref ! Ping(4)
+        probe.expectMessage(Pong(1))
+        probe.expectMessage(Pong(2))
+        droppedMessagesProbe.expectMessage(Dropped(Ping(3), "Stash is full in [RestartSupervisor]", ref.toUntyped))
+        droppedMessagesProbe.expectMessage(Dropped(Ping(4), "Stash is full in [RestartSupervisor]", ref.toUntyped))
+      }
     }
 
     "restart after exponential backoff" in {
@@ -820,7 +822,9 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
         ref ! IncrementState
         ref ! Throw(new Exc1)
         probe.expectMessage(ReceivedSignal(PreRestart))
-        ref ! Ping(1) // dropped due to backoff, no stashing
+        EventFilter.warning(start = "dropped message", occurrences = 1).intercept {
+          ref ! Ping(1) // dropped due to backoff, no stashing
+        }
       }
 
       startedProbe.expectNoMessage(minBackoff - 100.millis)
@@ -834,7 +838,9 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
         ref ! IncrementState
         ref ! Throw(new Exc1)
         probe.expectMessage(ReceivedSignal(PreRestart))
-        ref ! Ping(2) // dropped due to backoff, no stashing
+        EventFilter.warning(start = "dropped message", occurrences = 1).intercept {
+          ref ! Ping(2) // dropped due to backoff, no stashing
+        }
       }
 
       startedProbe.expectNoMessage((minBackoff * 2) - 100.millis)
@@ -890,7 +896,9 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
         ref ! IncrementState
         ref ! Throw(new Exc1)
         probe.expectMessage(ReceivedSignal(PreRestart))
-        ref ! Ping(1) // dropped due to backoff, no stash
+        EventFilter.warning(start = "dropped message", occurrences = 1).intercept {
+          ref ! Ping(1) // dropped due to backoff, no stash
+        }
       }
 
       probe.expectNoMessage(minBackoff + 100.millis.dilated)
@@ -903,7 +911,9 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
         ref ! IncrementState
         ref ! Throw(new Exc1)
         probe.expectMessage(ReceivedSignal(PreRestart))
-        ref ! Ping(2) // dropped due to backoff
+        EventFilter.warning(start = "dropped message", occurrences = 1).intercept {
+          ref ! Ping(2) // dropped due to backoff
+        }
       }
 
       // backoff was reset, so restarted after the minBackoff

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -19,6 +19,8 @@ import org.scalatest.{ Matchers, WordSpec, WordSpecLike }
 
 import scala.util.control.NoStackTrace
 import scala.concurrent.duration._
+
+import akka.actor.Dropped
 import akka.actor.typed.SupervisorStrategy.Resume
 import akka.event.Logging
 
@@ -793,8 +795,8 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       ref ! Ping(4)
       probe.expectMessage(Pong(1))
       probe.expectMessage(Pong(2))
-      droppedMessagesProbe.expectMessage(Dropped(Ping(3), ref))
-      droppedMessagesProbe.expectMessage(Dropped(Ping(4), ref))
+      droppedMessagesProbe.expectMessage(Dropped(Ping(3), "Stash is full in [BackoffSupervisor]", ref.toUntyped))
+      droppedMessagesProbe.expectMessage(Dropped(Ping(4), "Stash is full in [BackoffSupervisor]", ref.toUntyped))
     }
 
     "restart after exponential backoff" in {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
@@ -126,8 +126,8 @@ class ActorContextAskSpec extends ScalaTestWithActorTestKit(ActorContextAskSpec.
         }
       }
 
-      EventFilter.warning(occurrences = 1, message = "received dead letter without sender: boo").intercept {
-        EventFilter.info(occurrences = 1, start = "Message [java.lang.String] without sender").intercept {
+      EventFilter.warning(occurrences = 1, message = "received dead letter: boo").intercept {
+        EventFilter.info(occurrences = 1, start = "Message [java.lang.String]").intercept {
           spawn(snitch)
         }
       }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/MessageAndSignals.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/MessageAndSignals.scala
@@ -7,16 +7,6 @@ package akka.actor.typed
 import akka.annotation.DoNotInherit
 
 /**
- * Envelope that is published on the eventStream for every message that is
- * dropped due to overfull queues or routers with no routees.
- */
-final case class Dropped(msg: Any, recipient: ActorRef[Nothing]) {
-
-  /** Java API */
-  def getRecipient(): ActorRef[Void] = recipient.asInstanceOf[ActorRef[Void]]
-}
-
-/**
  * Exception that an actor fails with if it does not handle a Terminated message.
  */
 final case class DeathPactException(ref: ActorRef[Nothing])

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
@@ -14,6 +14,7 @@ import scala.util.control.Exception.Catcher
 import scala.util.control.NonFatal
 
 import akka.actor.DeadLetterSuppression
+import akka.actor.Dropped
 import akka.actor.typed.BehaviorInterceptor.PreStartTarget
 import akka.actor.typed.BehaviorInterceptor.ReceiveTarget
 import akka.actor.typed.BehaviorInterceptor.SignalTarget
@@ -89,7 +90,8 @@ private abstract class AbstractSupervisor[O, I, Thr <: Throwable](strategy: Supe
 
   def dropped(ctx: TypedActorContext[_], signalOrMessage: Any): Unit = {
     import akka.actor.typed.scaladsl.adapter._
-    ctx.asScala.system.toUntyped.eventStream.publish(Dropped(signalOrMessage, ctx.asScala.self))
+    ctx.asScala.system.toUntyped.eventStream
+      .publish(Dropped(signalOrMessage, s"Stash is full in [${getClass.getSimpleName}]", ctx.asScala.self.toUntyped))
   }
 
   protected def handleExceptionOnStart(ctx: TypedActorContext[O], target: PreStartTarget[I]): Catcher[Behavior[I]]

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -474,7 +474,10 @@ private[akka] trait MinimalActorRef extends InternalActorRef with LocalRef {
   protected def writeReplace(): AnyRef = SerializedActorRef(this)
 }
 
-/** Subscribe to this class to be notified about all DeadLetters (also the suppressed ones). */
+/**
+ * Subscribe to this class to be notified about all [[DeadLetter]] (also the suppressed ones)
+ * and [[Dropped]].
+ */
 sealed trait AllDeadLetters {
   def message: Any
   def sender: ActorRef
@@ -510,6 +513,14 @@ final case class SuppressedDeadLetter(message: DeadLetterSuppression, sender: Ac
     extends AllDeadLetters {
   require(sender ne null, "DeadLetter sender may not be null")
   require(recipient ne null, "DeadLetter recipient may not be null")
+}
+
+/**
+ * Envelope that is published on the eventStream wrapped in [[akka.actor.DeadLetter]] for every message that is
+ * dropped due to overfull queues or routers with no routees.
+ */
+final case class Dropped(message: Any, reason: String, recipient: ActorRef) extends AllDeadLetters {
+  override def sender: ActorRef = ActorRef.noSender
 }
 
 private[akka] object DeadLetterActorRef {

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -518,9 +518,18 @@ final case class SuppressedDeadLetter(message: DeadLetterSuppression, sender: Ac
 /**
  * Envelope that is published on the eventStream wrapped in [[akka.actor.DeadLetter]] for every message that is
  * dropped due to overfull queues or routers with no routees.
+ *
+ * When this message was sent without a sender [[ActorRef]], `sender` will be `ActorRef.noSender`, i.e. `null`.
  */
-final case class Dropped(message: Any, reason: String, recipient: ActorRef) extends AllDeadLetters {
-  override def sender: ActorRef = ActorRef.noSender
+final case class Dropped(message: Any, reason: String, sender: ActorRef, recipient: ActorRef) extends AllDeadLetters
+
+object Dropped {
+
+  /**
+   * Convenience for creating `Cropped` without `sender`.
+   */
+  def apply(message: Any, reason: String, recipient: ActorRef): Dropped =
+    Dropped(message, reason, ActorRef.noSender, recipient)
 }
 
 private[akka] object DeadLetterActorRef {

--- a/akka-actor/src/main/scala/akka/event/DeadLetterListener.scala
+++ b/akka-actor/src/main/scala/akka/event/DeadLetterListener.scala
@@ -95,13 +95,13 @@ class DeadLetterListener extends Actor {
   }
 
   private def logDeadLetter(d: AllDeadLetters, doneMsg: String): Unit = {
+    val origin = if (isReal(d.sender)) s" from ${d.sender}" else ""
     val logMessage = d match {
       case dropped: Dropped =>
         val destination = if (isReal(d.recipient)) s" to ${d.recipient}" else ""
-        s"Message [${d.message.getClass.getName}]$destination was dropped. ${dropped.reason}. " +
+        s"Message [${d.message.getClass.getName}]$origin$destination was dropped. ${dropped.reason}. " +
         s"[$count] dead letters encountered$doneMsg. "
       case _ =>
-        val origin = if (isReal(d.sender)) s" from ${d.sender}" else ""
         s"Message [${d.message.getClass.getName}]$origin to ${d.recipient} was not delivered. " +
         s"[$count] dead letters encountered$doneMsg. " +
         s"If this is not an expected behavior then ${d.recipient} may have terminated unexpectedly. "
@@ -116,7 +116,7 @@ class DeadLetterListener extends Actor {
   }
 
   private def isReal(snd: ActorRef): Boolean = {
-    (snd ne context.system.deadLetters) && !snd.isInstanceOf[DeadLetterActorRef]
+    (snd ne ActorRef.noSender) && (snd ne context.system.deadLetters) && !snd.isInstanceOf[DeadLetterActorRef]
   }
 
 }

--- a/akka-actor/src/main/scala/akka/event/DeadLetterListener.scala
+++ b/akka-actor/src/main/scala/akka/event/DeadLetterListener.scala
@@ -9,7 +9,10 @@ import scala.concurrent.duration.FiniteDuration
 
 import akka.actor.Actor
 import akka.actor.ActorRef
+import akka.actor.AllDeadLetters
 import akka.actor.DeadLetter
+import akka.actor.DeadLetterActorRef
+import akka.actor.Dropped
 import akka.event.Logging.Info
 import akka.util.PrettyDuration._
 
@@ -20,8 +23,10 @@ class DeadLetterListener extends Actor {
   private val isAlwaysLoggingDeadLetters = maxCount == Int.MaxValue
   protected var count: Int = 0
 
-  override def preStart(): Unit =
+  override def preStart(): Unit = {
     eventStream.subscribe(self, classOf[DeadLetter])
+    eventStream.subscribe(self, classOf[Dropped])
+  }
 
   // don't re-subscribe, skip call to preStart
   override def postRestart(reason: Throwable): Unit = ()
@@ -51,54 +56,67 @@ class DeadLetterListener extends Actor {
       }
 
   private def receiveWithAlwaysLogging: Receive = {
-    case DeadLetter(message, snd, recipient) =>
+    case d: AllDeadLetters =>
       incrementCount()
-      logDeadLetter(message, snd, recipient, doneMsg = "")
+      logDeadLetter(d, doneMsg = "")
   }
 
   private def receiveWithMaxCountLogging: Receive = {
-    case DeadLetter(message, snd, recipient) =>
+    case d: AllDeadLetters =>
       incrementCount()
       if (count == maxCount) {
-        logDeadLetter(message, snd, recipient, ", no more dead letters will be logged")
+        logDeadLetter(d, ", no more dead letters will be logged")
         context.stop(self)
       } else {
-        logDeadLetter(message, snd, recipient, "")
+        logDeadLetter(d, "")
       }
   }
 
   private def receiveWithSuspendLogging(suspendDuration: FiniteDuration): Receive = {
-    case DeadLetter(message, snd, recipient) =>
+    case d: AllDeadLetters =>
       incrementCount()
       if (count == maxCount) {
         val doneMsg = s", no more dead letters will be logged in next [${suspendDuration.pretty}]"
-        logDeadLetter(message, snd, recipient, doneMsg)
+        logDeadLetter(d, doneMsg)
         context.become(receiveWhenSuspended(suspendDuration, Deadline.now + suspendDuration))
       } else
-        logDeadLetter(message, snd, recipient, "")
+        logDeadLetter(d, "")
   }
 
   private def receiveWhenSuspended(suspendDuration: FiniteDuration, suspendDeadline: Deadline): Receive = {
-    case DeadLetter(message, snd, recipient) =>
+    case d: AllDeadLetters =>
       incrementCount()
       if (suspendDeadline.isOverdue()) {
         val doneMsg = s", of which ${count - maxCount - 1} were not logged. The counter will be reset now"
-        logDeadLetter(message, snd, recipient, doneMsg)
+        logDeadLetter(d, doneMsg)
         count = 0
         context.become(receiveWithSuspendLogging(suspendDuration))
       }
   }
 
-  private def logDeadLetter(message: Any, snd: ActorRef, recipient: ActorRef, doneMsg: String): Unit = {
-    val origin = if (snd eq context.system.deadLetters) "without sender" else s"from $snd"
+  private def logDeadLetter(d: AllDeadLetters, doneMsg: String): Unit = {
+    val logMessage = d match {
+      case dropped: Dropped =>
+        val destination = if (isReal(d.recipient)) s" to ${d.recipient}" else ""
+        s"Message [${d.message.getClass.getName}]$destination was dropped. ${dropped.reason}. " +
+        s"[$count] dead letters encountered$doneMsg. "
+      case _ =>
+        val origin = if (isReal(d.sender)) s" from ${d.sender}" else ""
+        s"Message [${d.message.getClass.getName}]$origin to ${d.recipient} was not delivered. " +
+        s"[$count] dead letters encountered$doneMsg. " +
+        s"If this is not an expected behavior then ${d.recipient} may have terminated unexpectedly. "
+    }
     eventStream.publish(
       Info(
-        recipient.path.toString,
-        recipient.getClass,
-        s"Message [${message.getClass.getName}] $origin to $recipient was not delivered. [$count] dead letters encountered$doneMsg. " +
-        s"If this is not an expected behavior then $recipient may have terminated unexpectedly. " +
+        d.recipient.path.toString,
+        d.recipient.getClass,
+        logMessage +
         "This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' " +
         "and 'akka.log-dead-letters-during-shutdown'."))
+  }
+
+  private def isReal(snd: ActorRef): Boolean = {
+    (snd ne context.system.deadLetters) && !snd.isInstanceOf[DeadLetterActorRef]
   }
 
 }

--- a/akka-bench-jmh/src/main/scala/akka/remote/artery/CodecBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/remote/artery/CodecBenchmark.scala
@@ -63,6 +63,7 @@ class CodecBenchmark {
     override def completeHandshake(peer: UniqueAddress): Future[Done] = ???
     override lazy val settings: ArterySettings =
       ArterySettings(ConfigFactory.load().getConfig("akka.remote.artery"))
+    override def publishDropped(inbound: InboundEnvelope, reason: String): Unit = ()
   }
 
   private var materializer: ActorMaterializer = _

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/StashManagement.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/StashManagement.scala
@@ -5,7 +5,7 @@
 package akka.persistence.typed.internal
 
 import akka.actor.typed.Behavior
-import akka.actor.typed.Dropped
+import akka.actor.Dropped
 import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.scaladsl.StashOverflowException
 import akka.actor.typed.scaladsl.ActorContext
@@ -52,7 +52,7 @@ private[akka] trait StashManagement[C, E, S] {
               }
               context.log.warning("Stash buffer is full, dropping message [{}]", dropName)
             }
-            context.system.toUntyped.eventStream.publish(Dropped(msg, context.self))
+            context.system.toUntyped.eventStream.publish(Dropped(msg, "Stash buffer is full", context.self.toUntyped))
           case StashOverflowStrategy.Fail =>
             throw e
         }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
@@ -15,7 +15,7 @@ import akka.actor.testkit.typed.TestException
 import akka.actor.testkit.typed.scaladsl._
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
-import akka.actor.typed.Dropped
+import akka.actor.Dropped
 import akka.actor.typed.PostStop
 import akka.actor.typed.SupervisorStrategy
 import akka.actor.typed.internal.PoisonPill

--- a/akka-remote/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-remote/src/main/mima-filters/2.5.x.backwards.excludes
@@ -26,3 +26,7 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.ArterySet
 # Disable remote watch and remote deployment outside Cluster #26176
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.remote.RemoteActorRefProvider.remoteWatcher")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.RemoteWatcher.props")
+
+# #26432 Log of Dropped
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.artery.InboundContext.publishDropped")
+

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -24,6 +24,7 @@ import scala.util.Success
 import scala.util.Try
 import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
+
 import akka.Done
 import akka.NotUsed
 import akka.actor.Actor
@@ -92,6 +93,8 @@ private[remote] trait InboundContext {
   def completeHandshake(peer: UniqueAddress): Future[Done]
 
   def settings: ArterySettings
+
+  def publishDropped(inbound: InboundEnvelope, reason: String): Unit
 
 }
 
@@ -985,6 +988,10 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
         if (manifest) c.runNextClassManifestAdvertisement()
       case _ =>
     }
+  }
+
+  override def publishDropped(env: InboundEnvelope, reason: String): Unit = {
+    system.eventStream.publish(Dropped(env.message, reason, env.recipient.getOrElse(system.deadLetters)))
   }
 
 }

--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -343,7 +343,8 @@ private[remote] class Association(
       val reason =
         if (removed) "Due to removed unused quarantined association"
         else s"Due to overflow of send queue, size [$qSize]"
-      transport.system.eventStream.publish(Dropped(message, reason, recipient.getOrElse(deadletters)))
+      transport.system.eventStream
+        .publish(Dropped(message, reason, env.sender.getOrElse(ActorRef.noSender), recipient.getOrElse(deadletters)))
 
       flightRecorder.hiFreq(Transport_SendQueueOverflow, queueIndex)
       deadletters ! env

--- a/akka-remote/src/main/scala/akka/remote/artery/Handshake.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Handshake.scala
@@ -294,14 +294,10 @@ private[remote] class InboundHandshake(inboundContext: InboundContext, inControl
         if (isKnownOrigin(env))
           push(out, env)
         else {
-          if (log.isDebugEnabled)
-            log.debug(
-              s"Dropping message [{}] from unknown system with UID [{}]. " +
-              "This system with UID [{}] was probably restarted. " +
-              "Messages will be accepted when new handshake has been completed.",
-              env.message.getClass.getName,
-              env.originUid,
-              inboundContext.localAddress.uid)
+          val dropReason = s"Unknown system with UID [${env.originUid}]. " +
+            s"This system with UID [${inboundContext.localAddress.uid}] was probably restarted. " +
+            "Messages will be accepted when new handshake has been completed."
+          inboundContext.publishDropped(env, dropReason)
           pull(in)
         }
       }

--- a/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
@@ -7,9 +7,11 @@ package akka.remote.artery
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ThreadLocalRandom
+
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.util.Success
+
 import akka.Done
 import akka.actor.ActorRef
 import akka.actor.Address
@@ -63,6 +65,8 @@ private[remote] class TestInboundContext(
 
   override lazy val settings: ArterySettings =
     ArterySettings(ConfigFactory.load().getConfig("akka.remote.artery"))
+
+  override def publishDropped(env: InboundEnvelope, reason: String): Unit = ()
 }
 
 private[remote] class TestOutboundContext(

--- a/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
@@ -570,10 +570,11 @@ class TestEventListener extends Logging.DefaultLogger {
         }
       }
     case UnhandledMessage(msg, sender, rcp) =>
-      val event = Warning(rcp.path.toString, rcp.getClass, "unhandled message from " + sender + ": " + msg)
+      val event = Warning(rcp.path.toString, rcp.getClass, s"unhandled message from $sender: $msg")
       if (!filter(event)) print(event)
-    case Dropped(msg, reason, rcp) =>
-      val event = Warning(rcp.path.toString, rcp.getClass, "dropped message. " + reason + ": " + msg)
+    case Dropped(msg, reason, sender, rcp) =>
+      val event =
+        Warning(rcp.path.toString, rcp.getClass, s"dropped message from $sender. $reason: $msg")
       if (!filter(event)) print(event)
 
     case m => print(Debug(context.system.name, this.getClass, m))

--- a/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
@@ -8,6 +8,7 @@ import scala.util.matching.Regex
 import scala.collection.immutable
 import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
+
 import akka.actor.{ ActorSystem, DeadLetter, UnhandledMessage }
 import akka.dispatch.sysmsg.{ SystemMessage, Terminate }
 import akka.event.Logging.{ Debug, Error, Info, InitializeLogger, LogEvent, LoggerInitialized, Warning }
@@ -15,6 +16,8 @@ import akka.event.Logging
 import akka.actor.NoSerializationVerificationNeeded
 import akka.japi.Util.immutableSeq
 import java.lang.{ Iterable => JIterable }
+
+import akka.actor.Dropped
 import akka.util.BoxedType
 import akka.util.ccompat._
 
@@ -548,7 +551,7 @@ class TestEventListener extends Logging.DefaultLogger {
 
   override def receive = {
     case InitializeLogger(bus) =>
-      Seq(classOf[Mute], classOf[UnMute], classOf[DeadLetter], classOf[UnhandledMessage])
+      Seq(classOf[Mute], classOf[UnMute], classOf[DeadLetter], classOf[UnhandledMessage], classOf[Dropped])
         .foreach(bus.subscribe(context.self, _))
       sender() ! LoggerInitialized
     case Mute(filters)   => filters.foreach(addFilter)
@@ -560,7 +563,7 @@ class TestEventListener extends Logging.DefaultLogger {
         if (!filter(event)) {
           val msgPrefix =
             if (msg.isInstanceOf[SystemMessage]) "received dead system message"
-            else if (snd eq context.system.deadLetters) "received dead letter without sender"
+            else if (snd eq context.system.deadLetters) "received dead letter"
             else "received dead letter from " + snd
           val event2 = Warning(rcp.path.toString, rcp.getClass, msgPrefix + ": " + msg)
           if (!filter(event2)) print(event2)
@@ -569,6 +572,10 @@ class TestEventListener extends Logging.DefaultLogger {
     case UnhandledMessage(msg, sender, rcp) =>
       val event = Warning(rcp.path.toString, rcp.getClass, "unhandled message from " + sender + ": " + msg)
       if (!filter(event)) print(event)
+    case Dropped(msg, reason, rcp) =>
+      val event = Warning(rcp.path.toString, rcp.getClass, "dropped message. " + reason + ": " + msg)
+      if (!filter(event)) print(event)
+
     case m => print(Debug(context.system.name, this.getClass, m))
   }
 


### PR DESCRIPTION
* Move Dropped from akka-actor-typed to akka-actor
* Use it in Artery
* Use in right way from GroupRouter, not via deadLetters
* Remove "without sender" in log message from DeadLetterListener,
  since there is no sender in Typed

Refs #26432