### PR TITLE
Akka Typed Add example of how to java `getSelf` for persistence typed #27061

### DIFF
--- a/akka-docs/src/main/paradox/includes/actor-context.md
+++ b/akka-docs/src/main/paradox/includes/actor-context.md
@@ -1,0 +1,15 @@
+
+<!--- #actor-context-typed-access --->
+## Accessing the ActorContext
+
+If the behavior needs to use the `ActorContext`, for example to spawn child actors, or use
+@scala[`context.self`]@java[`context.getSelf()`], it can be obtained by wrapping construction with `Behaviors.setup`:
+
+Scala
+:  @@snip [BasicPersistentBehaviorCompileOnly.scala](/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala) { #actor-context }
+
+Java
+:  @@snip [BasicPersistentBehaviorTest.java](/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java) { #actor-context }
+
+<!--- #actor-context-typed-access --->
+ 

--- a/akka-docs/src/main/paradox/includes/actor-context.md
+++ b/akka-docs/src/main/paradox/includes/actor-context.md
@@ -2,7 +2,16 @@
 <!--- #actor-context-typed-access --->
 ## Accessing the ActorContext
 
-If the behavior needs to use the `ActorContext`, for example to spawn child actors, or use
+The ActorContext can be accessed for many purposes such as:
+
+* Spawning child actors and supervision
+* Watching other actors (`DeathWatch`) to receive a `Terminated(otherActor)` event should the watched actor stop permanently
+* Logging
+* Creating message adapters
+* Request-response interactions (ask) with another actor
+* Access to the `self` ActorRef
+
+If a behavior needs to use the `ActorContext`, for example to spawn child actors, or use
 @scala[`context.self`]@java[`context.getSelf()`], it can be obtained by wrapping construction with `Behaviors.setup`:
 
 Scala
@@ -10,6 +19,14 @@ Scala
 
 Java
 :  @@snip [BasicPersistentBehaviorTest.java](/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java) { #actor-context }
+
+### ActorContext Thread Safety
+
+Many of the methods in `ActorContext` are not thread-safe and
+
+* Must not be accessed from threads from@scala[`scala.concurrent.Future`]@java[`java.util.concurrent.CompletionStage`] callbacks  
+* Must not be shared between several actor instances
+* Should only be used in the ordinary actor message processing thread
 
 <!--- #actor-context-typed-access --->
  

--- a/akka-docs/src/main/paradox/typed/actors.md
+++ b/akka-docs/src/main/paradox/typed/actors.md
@@ -439,6 +439,7 @@ Therefore after creating the Actor system with the `main` Actor’s
 `Behavior` we can let the `main` method return, the `ActorSystem` will continue running and 
 the JVM alive until the root actor stops.
 
+@@include[actor-context.md](/akka-docs/src/main/paradox/includes/actor-context.md) { #actor-context-typed-access }
 
 ## Relation to Akka (untyped) Actors
 

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -142,18 +142,7 @@ If multiple instances were to persist events at the same time, the events would 
 interpreted correctly on replay. Cluster Sharding ensures that there is only one active entity for each id. The
 @ref:[Cluster Sharding example](cluster-sharding.md#persistence-example) illustrates this common combination.
 
-## Accessing the ActorContext
-
-If the persistent behavior needs to use the `ActorContext`, for example to spawn child actors, it can be obtained by 
-wrapping construction with `Behaviors.setup`:
-
-Scala
-:  @@snip [BasicPersistentBehaviorCompileOnly.scala](/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala) { #actor-context }
-
-Java
-:  @@snip [BasicPersistentBehaviorTest.java](/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java) { #actor-context }
-
-
+@@include[actor-context.md](/akka-docs/src/main/paradox/includes/actor-context.md) { #actor-context-typed-access }
 
 ## Changing Behavior
 

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
@@ -4,6 +4,7 @@
 
 package jdocs.akka.persistence.typed;
 
+import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
 import akka.actor.typed.SupervisorStrategy;
 import akka.actor.typed.javadsl.ActorContext;
@@ -341,9 +342,13 @@ public class BasicPersistentBehaviorTest {
       // this makes the context available to the command handler etc.
       private final ActorContext<Command> ctx;
 
+      // optionally if you need `ActorContext.getSelf()`
+      private final ActorRef<Command> self;
+
       public MyPersistentBehavior(PersistenceId persistenceId, ActorContext<Command> ctx) {
         super(persistenceId);
         this.ctx = ctx;
+        this.self = ctx.getSelf();
       }
 
       // #actor-context

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
@@ -342,7 +342,7 @@ public class BasicPersistentBehaviorTest {
       // this makes the context available to the command handler etc.
       private final ActorContext<Command> ctx;
 
-      // optionally if you need `ActorContext.getSelf()`
+      // optionally if you only need `ActorContext.getSelf()`
       private final ActorRef<Command> self;
 
       public MyPersistentBehavior(PersistenceId persistenceId, ActorContext<Command> ctx) {


### PR DESCRIPTION
https://github.com/akka/akka/issues/27061 - Initial commit - using paradox includes of doc snippet, new /includes/actor-context.md to share among typed and untyped doc files via hierarchical naming scheme.

- [x] TODO if we want to also add this into /typed/actors.md and where, any differences 

## Purpose
Makes it easier to find how to access `self` from typed java API.
 
## Background Context
Motivated by a user question