### PR TITLE
Log rebalance progress at INFO per rebalance info

### DIFF
--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -98,6 +98,7 @@ akka.cluster.sharding {
     # The difference between number of shards in the region with most shards and
     # the region with least shards must be greater than (>) the `rebalanceThreshold`
     # for the rebalance to occur.
+    # It is also the maximum number of shards that will start rebalancing per rebalance-interval
     # 1 gives the best distribution and therefore typically the best choice.
     # Increasing the threshold can result in quicker rebalance but has the
     # drawback of increased difference between number of shards (and therefore load)

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -866,7 +866,13 @@ abstract class ShardCoordinator(
       }
     }
 
-  def continueRebalance(shards: Set[ShardId]): Unit =
+  def continueRebalance(shards: Set[ShardId]): Unit = {
+    if (log.isInfoEnabled && (shards.nonEmpty || rebalanceInProgress.nonEmpty)) {
+      log.info(
+        "Starting rebalance for shards [{}]. Current shards rebalancing: [{}]",
+        shards.mkString(","),
+        rebalanceInProgress.keySet.mkString(","))
+    }
     shards.foreach { shard =>
       if (!rebalanceInProgress.contains(shard)) {
         state.shards.get(shard) match {
@@ -885,6 +891,7 @@ abstract class ShardCoordinator(
 
       }
     }
+  }
 
 }
 


### PR DESCRIPTION
For cases where rebalance takes a long time due to a relatively large cluster change
e.g. when doubling number of nodes (common for 1-2, 3-6 etc) there is
little insight into what is happening unless DEBUG logging is enabled.

This adds an INFO log per rebalance-interval (default is 10s) to show
what is in progress and which new shards are starting rebalancing.

Added when looking into issues @jroper raised offline

E.g.

```
[info] [INFO] [06/18/2019 11:21:46.490] [sharding-akka.actor.default-dispatcher-4] [akka://sharding@127.0.0.1:25520/system/sharding/delayedCoordinator/singleton/coordinator] Starting rebalance for shards [49]. Current shards rebalancing: []                                                                                                                                                                                         
[info] [INFO] [06/18/2019 11:21:56.510] [sharding-akka.actor.default-dispatcher-5] [akka://sharding@127.0.0.1:25520/system/sharding/delayedCoordinator/singleton/coordinator] Starting rebalance for shards [50]. Current shards rebalancing: []                                                                                                                                                                                         
[info] [INFO] [06/18/2019 11:22:06.531] [sharding-akka.actor.default-dispatcher-4] [akka://sharding@127.0.0.1:25520/system/sharding/delayedCoordinator/singleton/coordinator] Starting rebalance for shards [51]. Current shards rebalancing: []    
```