### PR TITLE
FlowDelay with EmitEarly caused a NPE

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDelaySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDelaySpec.scala
@@ -219,5 +219,16 @@ class FlowDelaySpec extends StreamSpec {
 
       probe.request(10).expectNextN(1 to 2).expectComplete()
     }
+
+    // repeater for #27095
+    "not throw NPE when using EmitEarly and buffer is full" taggedAs TimingTest in {
+      val result =
+        Source(1 to 9)
+          .delay(1.second, DelayOverflowStrategy.emitEarly).addAttributes(Attributes.inputBuffer(5, 5))
+          .runWith(Sink.seq)
+          .futureValue
+
+      result should === ((1 to 9).toSeq)
+    }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDelaySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDelaySpec.scala
@@ -224,11 +224,12 @@ class FlowDelaySpec extends StreamSpec {
     "not throw NPE when using EmitEarly and buffer is full" taggedAs TimingTest in {
       val result =
         Source(1 to 9)
-          .delay(1.second, DelayOverflowStrategy.emitEarly).addAttributes(Attributes.inputBuffer(5, 5))
+          .delay(1.second, DelayOverflowStrategy.emitEarly)
+          .addAttributes(Attributes.inputBuffer(5, 5))
           .runWith(Sink.seq)
           .futureValue
 
-      result should === ((1 to 9).toSeq)
+      result should ===((1 to 9).toSeq)
     }
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -1775,10 +1775,17 @@ private[stream] object Collect {
         }
       }
 
-      def pullCondition: Boolean =
-        !strategy.isBackpressure || buffer.used < size
+      def pullCondition: Boolean = strategy match {
+        case EmitEarly =>
+          // when buffer is full we can only emit early if out is available
+          buffer.used < size || isAvailable(out)
+        case _ =>
+          !strategy.isBackpressure || buffer.used < size
+      }
+
 
       def grabAndPull(): Unit = {
+        if (buffer.used == size) throw new IllegalStateException("Trying to enqueue but buffer is full")
         buffer.enqueue((System.nanoTime(), grab(in)))
         if (pullCondition) pull(in)
       }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -1783,7 +1783,6 @@ private[stream] object Collect {
           !strategy.isBackpressure || buffer.used < size
       }
 
-
       def grabAndPull(): Unit = {
         if (buffer.used == size) throw new IllegalStateException("Trying to enqueue but buffer is full")
         buffer.enqueue((System.nanoTime(), grab(in)))


### PR DESCRIPTION
## Purpose
Using `EmitEarly` with `Flow.delay` could end up in a situation where it pulled from upstream when the buffer is full, even if downstream was not available for early emit.

## References
Refs #27095

## Changes
Changed to not pull when buffer is full unless out is ready for a push.