### PR TITLE
Handle InitJoin messages correctly, #27169

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -444,7 +444,7 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef, joinConfigCompatCh
 
   def uninitialized: Actor.Receive =
     ({
-      case InitJoin =>
+      case InitJoin(_) =>
         logInfo("Received InitJoin message from [{}], but this node is not initialized yet", sender())
         sender() ! InitJoinNack(selfAddress)
       case ClusterUserAction.JoinTo(address) =>
@@ -465,7 +465,7 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef, joinConfigCompatCh
     ({
       case Welcome(from, gossip) =>
         welcome(joinWith, from, gossip)
-      case InitJoin =>
+      case InitJoin(_) =>
         logInfo("Received InitJoin message from [{}], but this node is not a member yet", sender())
         sender() ! InitJoinNack(selfAddress)
       case ClusterUserAction.JoinTo(address) =>

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterSpec.scala
@@ -65,6 +65,11 @@ class ClusterSpec extends AkkaSpec(ClusterSpec.config) with ImplicitSender {
       info.getOperations.length should be > (0)
     }
 
+    "reply with InitJoinNack for InitJoin before joining" in {
+      system.actorSelection("/system/cluster/core/daemon") ! InitJoin(system.settings.config)
+      expectMsgType[InitJoinNack]
+    }
+
     "initially become singleton cluster when joining itself and reach convergence" in {
       clusterView.members.size should ===(0)
       cluster.join(selfAddress)
@@ -73,6 +78,11 @@ class ClusterSpec extends AkkaSpec(ClusterSpec.config) with ImplicitSender {
       clusterView.self.address should ===(selfAddress)
       clusterView.members.map(_.address) should ===(Set(selfAddress))
       awaitAssert(clusterView.status should ===(MemberStatus.Up))
+    }
+
+    "reply with InitJoinAck for InitJoin after joining" in {
+      system.actorSelection("/system/cluster/core/daemon") ! InitJoin(system.settings.config)
+      expectMsgType[InitJoinAck]
     }
 
     "publish initial state as snapshot to subscribers" in {


### PR DESCRIPTION
* IntiJoin message changed from companion message to case class with config
  parameter when the join compat check was added. Some `case InitJoin =>` were
  not changed.
* Resulting in unhandled InitJoin and no InitJoinNack replies.

Refs #27169
