### PR TITLE
Don't passivate idle for remembering entities

### DIFF
--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -25,6 +25,7 @@ akka.cluster.sharding {
 
   # Set this to a time duration to have sharding passivate entities when they have not
   # received any message in this length of time. Set to 'off' to disable.
+  # It is always disabled if `remember-entities` is enabled.
   passivate-idle-entity-after = 120s
 
   # If the coordinator can't store state changes it will be stopped

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -209,7 +209,7 @@ object ClusterShardingSettings {
  * @param passivateIdleEntityAfter Passivate entities that have not received any message in this interval.
  *   Note that only messages sent through sharding are counted, so direct messages
  *   to the `ActorRef` of the actor or messages that it sends to itself are not counted as activity.
- *   Use 0 to disable automatic passivation.
+ *   Use 0 to disable automatic passivation. It is always disabled if `rememberEntities` is enabled.
  * @param tuningParameters additional tuning parameters, see descriptions in reference.conf
  */
 final class ClusterShardingSettings(

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -198,7 +198,7 @@ private[akka] class Shard(
   private var handOffStopper: Option[ActorRef] = None
 
   import context.dispatcher
-  val passivateIdleTask = if (settings.passivateIdleEntityAfter > Duration.Zero) {
+  val passivateIdleTask = if (settings.passivateIdleEntityAfter > Duration.Zero && !settings.rememberEntities) {
     val idleInterval = settings.passivateIdleEntityAfter / 2
     Some(context.system.scheduler.scheduleWithFixedDelay(idleInterval, idleInterval, self, PassivateIdleTick))
   } else {

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -490,7 +490,7 @@ private[akka] class ShardRegion(
     cluster.subscribe(self, classOf[MemberEvent])
     timers.startTimerWithFixedDelay(Retry, Retry, retryInterval)
     startRegistration()
-    if (settings.passivateIdleEntityAfter > Duration.Zero)
+    if (settings.passivateIdleEntityAfter > Duration.Zero && !settings.rememberEntities)
       log.info(
         "{}: Idle entities will be passivated after [{}]",
         typeName,

--- a/akka-docs/src/main/paradox/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/cluster-sharding.md
@@ -352,6 +352,7 @@ or by explicitly setting `ClusterShardingSettings.passivateIdleEntityAfter` to a
 time to keep the actor alive. Note that only messages sent through sharding are counted, so direct messages
 to the `ActorRef` or messages that the actor sends to itself are not counted in this activity.
 Passivation can be disabled by setting `akka.cluster.sharding.passivate-idle-entity-after = off`.
+It is always disabled if @ref:[Remembering Entities](#remembering-entities) is enabled.
 
 <a id="cluster-sharding-remembering"></a>
 ## Remembering Entities

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -251,6 +251,8 @@ To disable passivation you can use configuration:
 akka.cluster.sharding.passivate-idle-entity-after = off
 ```
 
+It is always disabled if @ref:[Remembering Entities](../cluster-sharding.md#remembering-entities) is enabled.
+
 ### CoordinatedShutdown is run from ActorSystem.terminate
 
 No migration is needed but it is mentioned here because it is a change in behavior.

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -121,3 +121,4 @@ or by explicitly setting `ClusterShardingSettings.passivateIdleEntityAfter` to a
 time to keep the actor alive. Note that only messages sent through sharding are counted, so direct messages
 to the `ActorRef` or messages that the actor sends to itself are not counted in this activity.
 Passivation can be disabled by setting `akka.cluster.sharding.passivate-idle-entity-after = off`.
+It is always disabled if @ref:[Remembering Entities](../cluster-sharding.md#remembering-entities) is enabled.


### PR DESCRIPTION
* I think passivate idle and remembering entities have conflicting
  intentions.
* Could be some rare case where passivate idle could be useful also
  for remembering entities, but let's keep it simple.
