### PR TITLE
move synchronous behavior testing docs

### DIFF
--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java
@@ -75,6 +75,10 @@ public class AsyncTestingExampleTest
           });
   // #under-test
 
+  static Behavior<Ping> echoActor() {
+    return echoActor();
+  }
+
   // #under-test-2
 
   static class Message {

--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/JunitIntegrationExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/JunitIntegrationExampleTest.java
@@ -4,9 +4,14 @@
 
 package jdocs.akka.actor.testkit.typed.javadsl;
 
+import static jdocs.akka.actor.testkit.typed.javadsl.AsyncTestingExampleTest.Ping;
+import static jdocs.akka.actor.testkit.typed.javadsl.AsyncTestingExampleTest.Pong;
+import static jdocs.akka.actor.testkit.typed.javadsl.AsyncTestingExampleTest.echoActor;
+
 // #junit-integration
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
+import akka.actor.typed.ActorRef;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -16,8 +21,10 @@ public class JunitIntegrationExampleTest {
 
   @Test
   public void testSomething() {
-    TestProbe<String> probe = testKit.createTestProbe();
-    // ... assertions etc.
+    ActorRef<Ping> pinger = testKit.spawn(echoActor(), "ping");
+    TestProbe<Pong> probe = testKit.createTestProbe();
+    pinger.tell(new Ping("hello", probe.ref()));
+    probe.expectMessage(new Pong("hello"));
   }
 }
 // #junit-integration

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ScalaTestIntegrationExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ScalaTestIntegrationExampleSpec.scala
@@ -5,6 +5,7 @@
 package docs.akka.actor.testkit.typed.scaladsl
 
 import com.github.ghik.silencer.silent
+import docs.akka.actor.testkit.typed.scaladsl.AsyncTestingExampleSpec.{ echoActor, Ping, Pong }
 
 //#scalatest-integration
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
@@ -17,8 +18,10 @@ class ScalaTestIntegrationExampleSpec extends ScalaTestWithActorTestKit with Wor
 
   "Something" must {
     "behave correctly" in {
-      val probe = createTestProbe[String]()
-      // ... assertions etc.
+      val pinger = testKit.spawn(echoActor, "ping")
+      val probe = testKit.createTestProbe[Pong]()
+      pinger ! Ping("hello", probe.ref)
+      probe.expectMessage(Pong("hello"))
     }
   }
 }

--- a/akka-docs/src/main/paradox/typed/testing.md
+++ b/akka-docs/src/main/paradox/typed/testing.md
@@ -26,16 +26,178 @@ We recommend using Akka TestKit Typed with ScalaTest:
 
 ## Introduction
 
-Testing can either be done asynchronously using a real @apidoc[akka.actor.typed.ActorSystem] or synchronously on the testing thread using the @apidoc[BehaviorTestKit].
+Testing can either be done asynchronously using a real @apidoc[akka.actor.typed.ActorSystem] or synchronously on the testing thread using the
+@scala[@apidoc[akka.actor.testkit.typed.scaladsl.BehaviorTestKit]]@java[@apidoc[akka.actor.testkit.typed.javadsl.BehaviorTestKit]].
 
-For testing logic in a @apidoc[Behavior] in isolation synchronous testing is preferred. For testing interactions between multiple
-actors a more realistic asynchronous test is preferred.
+For testing logic in a @apidoc[Behavior] in isolation synchronous testing is preferred, but the features that can be
+tested are limited. For testing interactions between multiple actors a more realistic asynchronous test is preferred.
 
-Certain @apidoc[Behavior]s will be hard to test synchronously e.g. if they spawn Future's and you rely on a callback to complete
-before observing the effect you want to test. Further support for controlling the scheduler and execution context used
-will be added.
+## Asynchronous testing
+
+Asynchronous testing uses a real @apidoc[akka.actor.typed.ActorSystem] that allows you to test your Actors in a more realistic environment.
+
+The minimal setup consists of the test procedure, which provides the desired stimuli, the actor under test,
+and an actor receiving replies. Bigger systems replace the actor under test with a network of actors, apply stimuli
+at varying injection points and arrange results to be sent from different emission points, but the basic principle stays
+the same in that a single procedure drives the test.
+
+### Basic example
+
+Actor under test:
+
+Scala
+:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #under-test }
+
+Java
+:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #under-test }
+
+Tests create an instance of @apidoc[ActorTestKit]. This provides access to:
+
+* An ActorSystem
+* Methods for spawning Actors. These are created under the root guardian
+* A method to shut down the ActorSystem from the test suite
+
+This first example is using the "raw" `ActorTestKit` but if you are using @scala[ScalaTest]@java[JUnit] you can
+simplify the tests by using the @ref:[Test framework integration](#test-framework-integration). It's still good
+to read this section to understand how it works.
+
+Scala
+:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #test-header }
+
+Java
+:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-header }
+
+Your test is responsible for shutting down the @apidoc[akka.actor.typed.ActorSystem] e.g. using @scala[`BeforeAndAfterAll` when using ScalaTest]@java[`@AfterClass` when using JUnit].
+
+Scala
+:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #test-shutdown }
+
+Java
+:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-shutdown }
+
+The following demonstrates:
+
+* Creating a typed actor from the `TestKit`'s system using `spawn`
+* Creating a typed `TestProbe`
+* Verifying that the actor under test responds via the `TestProbe`
+
+Scala
+:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #test-spawn }
+
+Java
+:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-spawn }
+
+Actors can also be spawned anonymously:
+
+Scala
+:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #test-spawn-anonymous }
+
+Java
+:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-spawn-anonymous }
+
+Note that you can add `import testKit._` to get access to the `spawn` and `createTestProbe` methods at the top level
+without prefixing them with `testKit`.
+
+#### Stopping actors
+The method will wait until the actor stops or throw an assertion error in case of a timeout.
+
+Scala
+:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #test-stop-actors }
+
+Java
+:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-stop-actors }
+
+The `stop` method can only be used for actors that were spawned by the same @apidoc[ActorTestKit]. Other actors
+will not be stopped by that method.
+
+### Observing mocked behavior
+
+When testing a component (which may be an actor or not) that interacts with other actors it can be useful to not have to
+run the other actors it depends on. Instead, you might want to create mock behaviors that accept and possibly respond to
+messages in the same way the other actor would do but without executing any actual logic.
+In addition to this it can also be useful to observe those interactions to assert that the component under test did send
+the expected messages.
+This allows the same kinds of tests as untyped `TestActor`/`Autopilot`.
+
+As an example, let's assume we'd like to test the following component:
+
+Scala
+:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #under-test-2 }
+
+Java
+:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #under-test-2 }
+
+In our test, we create a mocked `publisher` actor. Additionally we use `Behaviors.monitor` with a `TestProbe` in order
+to be able to verify the interaction of the `producer` with the `publisher`:
+
+Scala
+:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #test-observe-mocked-behavior }
+
+Java
+:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-observe-mocked-behavior }
+
+### Test framework integration
+
+@@@ div { .group-java }
+
+If you are using JUnit you can use @apidoc[akka.actor.testkit.typed.javadsl.TestKitJunitResource] to have the async test kit automatically
+shutdown when the test is complete.
+
+Note that the dependency on JUnit is marked as optional from the test kit module, so your project must explicitly include
+a dependency on JUnit to use this.
+
+@@@
+
+@@@ div { .group-scala }
+
+If you are using ScalaTest you can extend @apidoc[akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit] to
+have the async test kit automatically shutdown when the test is complete. This is done in `afterAll` from
+the `BeforeAndAfterAll` trait. If you override that method you should call `super.afterAll` to shutdown the
+test kit.
+
+Note that the dependency on ScalaTest is marked as optional from the test kit module, so your project must explicitly include
+a dependency on ScalaTest to use this.
+
+@@@
+
+Scala
+:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ScalaTestIntegrationExampleSpec.scala) { #scalatest-integration }
+
+Java
+:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/JunitIntegrationExampleTest.java) { #junit-integration }
+
+### Controlling the scheduler
+
+It can be hard to reliably unit test specific scenario's when your actor relies on timing:
+especially when running many tests in parallel it can be hard to get the timing just right.
+Making such tests more reliable by using generous timeouts make the tests take a long time to run.
+
+For such situations, we provide a scheduler where you can manually, explicitly advance the clock.
+
+Scala
+:   @@snip [ManualTimerExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ManualTimerExampleSpec.scala) { #manual-scheduling-simple }
+
+Java
+:   @@snip [ManualTimerExampleTest.scala](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/ManualTimerExampleTest.java) { #manual-scheduling-simple }
+
 
 ## Synchronous behavior testing
+
+The `BehaviorTestKit` provides a very nice way of unit testing a `Behavior` in a deterministic way, but it has
+some limitations to be aware of.
+
+Certain @apidoc[Behavior]s will be hard to test synchronously and the `BehaviorTestKit` doesn't support testing of
+all features. In those cases the @ref:[asynchronous ActorTestKit](#asynchronous-testing) is recommended. Example of
+limitations:
+
+* Spawning of @scala[`Future`]@java[`CompletionStage`] or other asynchronous task and you rely on a callback to
+  complete before observing the effect you want to test.
+* Usage of scheduler or timers not supported.
+* `EventSourcedBehavior` can't be tested.
+* Interactions with other actors must be stubbed.
+* Blackbox testing style.
+
+The `BehaviorTestKit` will be improved and some of these problems will be removed but it will always have limitations.
 
 The following demonstrates how to test:
 
@@ -145,146 +307,3 @@ Java
 
 See the other public methods and API documentation on @apidoc[BehaviorTestKit] for other types of verification.
 
-## Asynchronous testing
-
-Asynchronous testing uses a real @apidoc[akka.actor.typed.ActorSystem] that allows you to test your Actors in a more realistic environment.
-
-The minimal setup consists of the test procedure, which provides the desired stimuli, the actor under test,
-and an actor receiving replies. Bigger systems replace the actor under test with a network of actors, apply stimuli
-at varying injection points and arrange results to be sent from different emission points, but the basic principle stays
-the same in that a single procedure drives the test.
-
-### Basic example
-
-Actor under test:
-
-Scala
-:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #under-test }
-
-Java
-:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #under-test }
-
-Tests create an instance of @apidoc[ActorTestKit]. This provides access to:
-
-* An ActorSystem
-* Methods for spawning Actors. These are created under the root guardian
-* A method to shut down the ActorSystem from the test suite
-
-Scala
-:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #test-header }
-
-Java
-:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-header }
-
-Your test is responsible for shutting down the @apidoc[akka.actor.typed.ActorSystem] e.g. using @scala[`BeforeAndAfterAll` when using ScalaTest]@java[`@AfterClass` when using JUnit].
-
-Scala
-:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #test-shutdown }
-
-Java
-:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-shutdown }
-
-The following demonstrates:
-
-* Creating a typed actor from the `TestKit`'s system using `spawn`
-* Creating a typed `TestProbe`
-* Verifying that the actor under test responds via the `TestProbe`
-
-Scala
-:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #test-spawn }
-
-Java
-:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-spawn }
-
-Actors can also be spawned anonymously:
-
-Scala
-:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #test-spawn-anonymous }
-
-Java
-:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-spawn-anonymous }
-
-Note that you can add `import testKit._` to get access to the `spawn` and `createTestProbe` methods at the top level
-without prefixing them with `testKit`.
-
-#### Stopping actors
-The method will wait until the actor stops or throw an assertion error in case of a timeout.
-
-Scala
-:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #test-stop-actors }
-
-Java
-:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-stop-actors }
-
-The `stop` method can only be used for actors that were spawned by the same @apidoc[ActorTestKit]. Other actors
-will not be stopped by that method.
-
-### Observing mocked behavior
-
-When testing a component (which may be an actor or not) that interacts with other actors it can be useful to not have to
-run the other actors it depends on. Instead, you might want to create mock behaviors that accept and possibly respond to
-messages in the same way the other actor would do but without executing any actual logic.
-In addition to this it can also be useful to observe those interactions to assert that the component under test did send
-the expected messages.
-This allows the same kinds of tests as untyped `TestActor`/`Autopilot`.
-
-As an example, let's assume we'd like to test the following component:
-
-Scala
-:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #under-test-2 }
-
-Java
-:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #under-test-2 }
-
-In our test, we create a mocked `publisher` actor. Additionally we use `Behaviors.monitor` with a `TestProbe` in order
-to be able to verify the interaction of the `producer` with the `publisher`:
-
-Scala
-:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala) { #test-observe-mocked-behavior }
-
-Java
-:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/AsyncTestingExampleTest.java) { #test-observe-mocked-behavior }
-
-### Test framework integration
-
-@@@ div { .group-java }
-
-If you are using JUnit you can use @apidoc[akka.actor.testkit.typed.javadsl.TestKitJunitResource] to have the async test kit automatically
-shutdown when the test is complete.
-
-Note that the dependency on JUnit is marked as optional from the test kit module, so your project must explicitly include
-a dependency on JUnit to use this.
-
-@@@
-
-@@@ div { .group-scala } 
-
-If you are using ScalaTest you can extend @apidoc[akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit] to
-have the async test kit automatically shutdown when the test is complete. This is done in `afterAll` from
-the `BeforeAndAfterAll` trait. If you override that method you should call `super.afterAll` to shutdown the
-test kit.
-
-Note that the dependency on ScalaTest is marked as optional from the test kit module, so your project must explicitly include
-a dependency on ScalaTest to use this.
-
-@@@
-
-Scala
-:  @@snip [AsyncTestingExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ScalaTestIntegrationExampleSpec.scala) { #scalatest-integration }
-
-Java
-:  @@snip [AsyncTestingExampleTest.java](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/JunitIntegrationExampleTest.java) { #junit-integration }
-
-### Controlling the scheduler
-
-It can be hard to reliably unit test specific scenario's when your actor relies on timing:
-especially when running many tests in parallel it can be hard to get the timing just right.
-Making such tests more reliable by using generous timeouts make the tests take a long time to run.
-
-For such situations, we provide a scheduler where you can manually, explicitly advance the clock.
-
-Scala
-:   @@snip [ManualTimerExampleSpec.scala](/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ManualTimerExampleSpec.scala) { #manual-scheduling-simple }
-
-Java
-:   @@snip [ManualTimerExampleTest.scala](/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/ManualTimerExampleTest.java) { #manual-scheduling-simple }


### PR DESCRIPTION
* readers tend to try what is at the top of the page
  and given the limitations of BehaviorTestKit we
  should show the full featured asyncronous TestKit first
* mention test framework integration earlier
* better example in the test framework section
