### PR TITLE
Allow shard rebalancing to be based on a factor

### DIFF
--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -110,10 +110,10 @@ akka.cluster.sharding {
     # be used. If this is zero, then just the rebalance-factor will be used. If both
     # this and the rebalance factor are zero, then the rebalance-threshold will be
     # used as the limit.
-    rebalance-number = 0
+    max-rebalance-per-interval = 0
 
     # The factor to apply to the number of shards in the region with the most shards,
-    # used to decide how many shards to start rebalancing on eac rebalance decision.
+    # used to decide how many shards to start rebalancing on each rebalance decision.
     # Using a factor may be useful because it sets a percentage of total work to
     # migrate, so when a nodes number of shards is low, it can migrate just a small
     # number assuming each shard represents a large amount of work, but when it's high,

--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -99,12 +99,36 @@ akka.cluster.sharding {
     # the region with least shards must be greater than (>) the `rebalanceThreshold`
     # for the rebalance to occur.
     # 1 gives the best distribution and therefore typically the best choice.
-    # Increasing the threshold can result in quicker rebalance but has the
-    # drawback of increased difference between number of shards (and therefore load)
-    # on different nodes before rebalance will occur.
     rebalance-threshold = 1
 
-    # The number of ongoing rebalancing processes is limited to this number.
+    # The maximum number of shards to start rebalancing on each rebalance decision.
+    # Increasing this will increase the speed at which rebalancing occurs.
+    # This differs from max-simultaneous-rebalance, in that the latter applies across
+    # multiple rebalance intervals, whereas this only applies to a single rebalance
+    # interval decision.
+    # The smaller of this number and the limit decided by the rebalance-factor will
+    # be used. If this is zero, then just the rebalance-factor will be used. If both
+    # this and the rebalance factor are zero, then the rebalance-threshold will be
+    # used as the limit.
+    rebalance-number = 0
+
+    # The factor to apply to the number of shards in the region with the most shards,
+    # used to decide how many shards to start rebalancing on eac rebalance decision.
+    # Using a factor may be useful because it sets a percentage of total work to
+    # migrate, so when a nodes number of shards is low, it can migrate just a small
+    # number assuming each shard represents a large amount of work, but when it's high,
+    # it can migrate a large number assuming each shard represents a small amount of
+    # work.
+    # Must be a value between 0 and 0.5 (values greater than 0.5 don't make sense since
+    # migrating more than half the shards from one region to another will always
+    # overshoot a balanced distribution).
+    # If this is zero, then the number of shards to migrate is not selected based on
+    # the current number of shards, but rather rebalance-number is used to set an
+    # absolute limit.
+    rebalance-factor = 0.0
+
+    # The number of ongoing rebalancing processes, across all regions, is limited to
+    # this number.
     max-simultaneous-rebalance = 3
   }
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -651,7 +651,9 @@ class ClusterSharding(system: ExtendedActorSystem) extends Extension {
   def defaultShardAllocationStrategy(settings: ClusterShardingSettings): ShardAllocationStrategy = {
     val threshold = settings.tuningParameters.leastShardAllocationRebalanceThreshold
     val maxSimultaneousRebalance = settings.tuningParameters.leastShardAllocationMaxSimultaneousRebalance
-    new LeastShardAllocationStrategy(threshold, maxSimultaneousRebalance)
+    val maxRebalancePerInterval = settings.tuningParameters.leastShardAllocationMaxRebalancePerInterval
+    val rebalanceFactor = settings.tuningParameters.leastShardAllocationRebalanceFactor
+    new LeastShardAllocationStrategy(threshold, maxSimultaneousRebalance, maxRebalancePerInterval, rebalanceFactor)
   }
 }
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -46,7 +46,8 @@ object ClusterShardingSettings {
       leastShardAllocationRebalanceThreshold = config.getInt("least-shard-allocation-strategy.rebalance-threshold"),
       leastShardAllocationMaxSimultaneousRebalance =
         config.getInt("least-shard-allocation-strategy.max-simultaneous-rebalance"),
-      leastShardAllocationRebalanceNumber = config.getInt("least-shard-allocation-strategy.rebalance-number"),
+      leastShardAllocationMaxRebalancePerInterval =
+        config.getInt("least-shard-allocation-strategy.max-rebalance-per-interval"),
       leastShardAllocationRebalanceFactor = config.getDouble("least-shard-allocation-strategy.rebalance-factor"),
       waitingForStateTimeout = config.getDuration("waiting-for-state-timeout", MILLISECONDS).millis,
       updatingStateTimeout = config.getDuration("updating-state-timeout", MILLISECONDS).millis,
@@ -110,7 +111,7 @@ object ClusterShardingSettings {
       val keepNrOfBatches: Int,
       val leastShardAllocationRebalanceThreshold: Int,
       val leastShardAllocationMaxSimultaneousRebalance: Int,
-      val leastShardAllocationRebalanceNumber: Int,
+      val leastShardAllocationMaxRebalancePerInterval: Int,
       val leastShardAllocationRebalanceFactor: Double,
       val waitingForStateTimeout: FiniteDuration,
       val updatingStateTimeout: FiniteDuration,

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -46,6 +46,8 @@ object ClusterShardingSettings {
       leastShardAllocationRebalanceThreshold = config.getInt("least-shard-allocation-strategy.rebalance-threshold"),
       leastShardAllocationMaxSimultaneousRebalance =
         config.getInt("least-shard-allocation-strategy.max-simultaneous-rebalance"),
+      leastShardAllocationRebalanceNumber = config.getInt("least-shard-allocation-strategy.rebalance-number"),
+      leastShardAllocationRebalanceFactor = config.getDouble("least-shard-allocation-strategy.rebalance-factor"),
       waitingForStateTimeout = config.getDuration("waiting-for-state-timeout", MILLISECONDS).millis,
       updatingStateTimeout = config.getDuration("updating-state-timeout", MILLISECONDS).millis,
       entityRecoveryStrategy = config.getString("entity-recovery-strategy"),
@@ -108,6 +110,8 @@ object ClusterShardingSettings {
       val keepNrOfBatches: Int,
       val leastShardAllocationRebalanceThreshold: Int,
       val leastShardAllocationMaxSimultaneousRebalance: Int,
+      val leastShardAllocationRebalanceNumber: Int,
+      val leastShardAllocationRebalanceFactor: Double,
       val waitingForStateTimeout: FiniteDuration,
       val updatingStateTimeout: FiniteDuration,
       val entityRecoveryStrategy: String,
@@ -117,6 +121,50 @@ object ClusterShardingSettings {
     require(
       entityRecoveryStrategy == "all" || entityRecoveryStrategy == "constant",
       s"Unknown 'entity-recovery-strategy' [$entityRecoveryStrategy], valid values are 'all' or 'constant'")
+    require(
+      leastShardAllocationRebalanceFactor >= 0 && leastShardAllocationRebalanceFactor <= 0.5,
+      s"Invalid 'least-shard-allocation-strategy.rebalance-factor' [$leastShardAllocationRebalanceFactor], must be between 0 and 0.5.")
+
+    // included for binary compatibility
+    def this(
+        coordinatorFailureBackoff: FiniteDuration,
+        retryInterval: FiniteDuration,
+        bufferSize: Int,
+        handOffTimeout: FiniteDuration,
+        shardStartTimeout: FiniteDuration,
+        shardFailureBackoff: FiniteDuration,
+        entityRestartBackoff: FiniteDuration,
+        rebalanceInterval: FiniteDuration,
+        snapshotAfter: Int,
+        keepNrOfBatches: Int,
+        leastShardAllocationRebalanceThreshold: Int,
+        leastShardAllocationMaxSimultaneousRebalance: Int,
+        waitingForStateTimeout: FiniteDuration,
+        updatingStateTimeout: FiniteDuration,
+        entityRecoveryStrategy: String,
+        entityRecoveryConstantRateStrategyFrequency: FiniteDuration,
+        entityRecoveryConstantRateStrategyNumberOfEntities: Int) = {
+      this(
+        coordinatorFailureBackoff,
+        retryInterval,
+        bufferSize,
+        handOffTimeout,
+        shardStartTimeout,
+        shardFailureBackoff,
+        entityRestartBackoff,
+        rebalanceInterval,
+        snapshotAfter,
+        keepNrOfBatches,
+        leastShardAllocationRebalanceThreshold,
+        leastShardAllocationMaxSimultaneousRebalance,
+        0,
+        0,
+        waitingForStateTimeout,
+        updatingStateTimeout,
+        entityRecoveryStrategy,
+        entityRecoveryConstantRateStrategyFrequency,
+        entityRecoveryConstantRateStrategyNumberOfEntities)
+    }
 
     // included for binary compatibility
     def this(

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -182,7 +182,7 @@ object ShardCoordinator {
   class LeastShardAllocationStrategy(
       rebalanceThreshold: Int,
       maxSimultaneousRebalance: Int,
-      rebalanceNumber: Int,
+      maxRebalancePerInterval: Int,
       rebalanceFactor: Double)
       extends ShardAllocationStrategy
       with Serializable {
@@ -212,7 +212,7 @@ object ShardCoordinator {
         val difference = mostShards.size - leastShards.size
         if (difference > rebalanceThreshold) {
 
-          val iterationRebalanceLimit = (rebalanceFactor, rebalanceNumber) match {
+          val iterationRebalanceLimit = (rebalanceFactor, maxRebalancePerInterval) match {
             // This condition is to maintain semantic backwards compatibility, from when rebalanceThreshold was also
             // the number of shards to move.
             case (0.0, 0)            => rebalanceThreshold

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/LeastShardAllocationStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/LeastShardAllocationStrategySpec.scala
@@ -129,6 +129,119 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
         Set("003", "004"))
     }
 
+    "rebalance from region with most number of shards [3, 0, 0], rebalanceThreshold=1, rebalanceNumber=2" in {
+      val allocationStrategy = new LeastShardAllocationStrategy(
+        rebalanceThreshold = 1,
+        maxSimultaneousRebalance = 10,
+        rebalanceNumber = 2,
+        rebalanceFactor = 0.0)
+      val allocations = createAllocations(aCount = 3)
+
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001"))
+      allocationStrategy.rebalance(allocations, Set("001")).futureValue should ===(Set("002"))
+    }
+
+    "rebalance from region with most number of shards [5, 0, 0], rebalanceThreshold=1, rebalanceNumber=2" in {
+      val allocationStrategy = new LeastShardAllocationStrategy(
+        rebalanceThreshold = 1,
+        maxSimultaneousRebalance = 10,
+        rebalanceNumber = 2,
+        rebalanceFactor = 0.0)
+      val allocations = createAllocations(aCount = 5)
+
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001", "002"))
+      allocationStrategy.rebalance(allocations, Set("001")).futureValue should ===(Set("002", "003"))
+    }
+
+    "rebalance from region with most number of shards [6, 0, 0], rebalanceThreshold=1, rebalanceNumber=2" in {
+      val allocationStrategy = new LeastShardAllocationStrategy(
+        rebalanceThreshold = 1,
+        maxSimultaneousRebalance = 10,
+        rebalanceNumber = 2,
+        rebalanceFactor = 0.0)
+      val allocations = createAllocations(aCount = 6)
+
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001", "002"))
+      allocationStrategy.rebalance(allocations, Set("001")).futureValue should ===(Set("002", "003"))
+    }
+
+    "rebalance from region with most number of shards [3, 0, 0], rebalanceThreshold=1, rebalanceFactor=0.5" in {
+      val allocationStrategy = new LeastShardAllocationStrategy(
+        rebalanceThreshold = 1,
+        maxSimultaneousRebalance = 10,
+        rebalanceNumber = 0,
+        rebalanceFactor = 0.5)
+      val allocations = createAllocations(aCount = 3)
+
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001"))
+    }
+
+    "rebalance from region with most number of shards [5, 0, 0], rebalanceThreshold=1, rebalanceFactor=0.5" in {
+      val allocationStrategy = new LeastShardAllocationStrategy(
+        rebalanceThreshold = 1,
+        maxSimultaneousRebalance = 10,
+        rebalanceNumber = 0,
+        rebalanceFactor = 0.5)
+      val allocations = createAllocations(aCount = 5)
+
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001", "002"))
+    }
+
+    "rebalance from region with most number of shards [6, 0, 0], rebalanceThreshold=1, rebalanceFactor=0.5" in {
+      val allocationStrategy = new LeastShardAllocationStrategy(
+        rebalanceThreshold = 1,
+        maxSimultaneousRebalance = 10,
+        rebalanceNumber = 0,
+        rebalanceFactor = 0.5)
+      val allocations = createAllocations(aCount = 6)
+
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001", "002", "003"))
+    }
+
+    "rebalance from region with most number of shards [6, 0, 0], rebalanceThreshold=1, rebalanceFactor=0.2" in {
+      val allocationStrategy = new LeastShardAllocationStrategy(
+        rebalanceThreshold = 1,
+        maxSimultaneousRebalance = 10,
+        rebalanceNumber = 0,
+        rebalanceFactor = 0.2)
+      val allocations = createAllocations(aCount = 6)
+
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001"))
+    }
+
+    "rebalance from region with most number of shards [6, 0, 0], rebalanceThreshold=1, rebalanceFactor=0.4" in {
+      val allocationStrategy = new LeastShardAllocationStrategy(
+        rebalanceThreshold = 1,
+        maxSimultaneousRebalance = 10,
+        rebalanceNumber = 0,
+        rebalanceFactor = 0.4)
+      val allocations = createAllocations(aCount = 6)
+
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001", "002"))
+    }
+
+    "rebalance from region with most number of shards [6, 0, 0], rebalanceThreshold=1, rebalanceNumber=2, rebalanceFactor=0.5" in {
+      val allocationStrategy = new LeastShardAllocationStrategy(
+        rebalanceThreshold = 1,
+        maxSimultaneousRebalance = 10,
+        rebalanceNumber = 2,
+        rebalanceFactor = 0.5)
+      val allocations = createAllocations(aCount = 6)
+
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001", "002"))
+    }
+
+    "rebalance from region with most number of shards [6, 0, 0], rebalanceThreshold=1, rebalanceNumber=2, rebalanceFactor=0.2" in {
+      val allocationStrategy = new LeastShardAllocationStrategy(
+        rebalanceThreshold = 1,
+        maxSimultaneousRebalance = 10,
+        rebalanceNumber = 2,
+        rebalanceFactor = 0.2)
+      val allocations = createAllocations(aCount = 6)
+
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001"))
+    }
+
     "limit number of simultaneous rebalance" in {
       val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 3, maxSimultaneousRebalance = 2)
       val allocations = createAllocations(aCount = 1, bCount = 10)

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/LeastShardAllocationStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/LeastShardAllocationStrategySpec.scala
@@ -129,11 +129,11 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
         Set("003", "004"))
     }
 
-    "rebalance from region with most number of shards [3, 0, 0], rebalanceThreshold=1, rebalanceNumber=2" in {
+    "rebalance from region with most number of shards [3, 0, 0], rebalanceThreshold=1, maxRebalancePerInterval=2" in {
       val allocationStrategy = new LeastShardAllocationStrategy(
         rebalanceThreshold = 1,
         maxSimultaneousRebalance = 10,
-        rebalanceNumber = 2,
+        maxRebalancePerInterval = 2,
         rebalanceFactor = 0.0)
       val allocations = createAllocations(aCount = 3)
 
@@ -141,11 +141,11 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
       allocationStrategy.rebalance(allocations, Set("001")).futureValue should ===(Set("002"))
     }
 
-    "rebalance from region with most number of shards [5, 0, 0], rebalanceThreshold=1, rebalanceNumber=2" in {
+    "rebalance from region with most number of shards [5, 0, 0], rebalanceThreshold=1, maxRebalancePerInterval=2" in {
       val allocationStrategy = new LeastShardAllocationStrategy(
         rebalanceThreshold = 1,
         maxSimultaneousRebalance = 10,
-        rebalanceNumber = 2,
+        maxRebalancePerInterval = 2,
         rebalanceFactor = 0.0)
       val allocations = createAllocations(aCount = 5)
 
@@ -153,11 +153,11 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
       allocationStrategy.rebalance(allocations, Set("001")).futureValue should ===(Set("002", "003"))
     }
 
-    "rebalance from region with most number of shards [6, 0, 0], rebalanceThreshold=1, rebalanceNumber=2" in {
+    "rebalance from region with most number of shards [6, 0, 0], rebalanceThreshold=1, maxRebalancePerInterval=2" in {
       val allocationStrategy = new LeastShardAllocationStrategy(
         rebalanceThreshold = 1,
         maxSimultaneousRebalance = 10,
-        rebalanceNumber = 2,
+        maxRebalancePerInterval = 2,
         rebalanceFactor = 0.0)
       val allocations = createAllocations(aCount = 6)
 
@@ -169,7 +169,7 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
       val allocationStrategy = new LeastShardAllocationStrategy(
         rebalanceThreshold = 1,
         maxSimultaneousRebalance = 10,
-        rebalanceNumber = 0,
+        maxRebalancePerInterval = 0,
         rebalanceFactor = 0.5)
       val allocations = createAllocations(aCount = 3)
 
@@ -180,7 +180,7 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
       val allocationStrategy = new LeastShardAllocationStrategy(
         rebalanceThreshold = 1,
         maxSimultaneousRebalance = 10,
-        rebalanceNumber = 0,
+        maxRebalancePerInterval = 0,
         rebalanceFactor = 0.5)
       val allocations = createAllocations(aCount = 5)
 
@@ -191,7 +191,7 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
       val allocationStrategy = new LeastShardAllocationStrategy(
         rebalanceThreshold = 1,
         maxSimultaneousRebalance = 10,
-        rebalanceNumber = 0,
+        maxRebalancePerInterval = 0,
         rebalanceFactor = 0.5)
       val allocations = createAllocations(aCount = 6)
 
@@ -202,7 +202,7 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
       val allocationStrategy = new LeastShardAllocationStrategy(
         rebalanceThreshold = 1,
         maxSimultaneousRebalance = 10,
-        rebalanceNumber = 0,
+        maxRebalancePerInterval = 0,
         rebalanceFactor = 0.2)
       val allocations = createAllocations(aCount = 6)
 
@@ -213,29 +213,29 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
       val allocationStrategy = new LeastShardAllocationStrategy(
         rebalanceThreshold = 1,
         maxSimultaneousRebalance = 10,
-        rebalanceNumber = 0,
+        maxRebalancePerInterval = 0,
         rebalanceFactor = 0.4)
       val allocations = createAllocations(aCount = 6)
 
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001", "002"))
     }
 
-    "rebalance from region with most number of shards [6, 0, 0], rebalanceThreshold=1, rebalanceNumber=2, rebalanceFactor=0.5" in {
+    "rebalance from region with most number of shards [6, 0, 0], rebalanceThreshold=1, maxRebalancePerInterval=2, rebalanceFactor=0.5" in {
       val allocationStrategy = new LeastShardAllocationStrategy(
         rebalanceThreshold = 1,
         maxSimultaneousRebalance = 10,
-        rebalanceNumber = 2,
+        maxRebalancePerInterval = 2,
         rebalanceFactor = 0.5)
       val allocations = createAllocations(aCount = 6)
 
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001", "002"))
     }
 
-    "rebalance from region with most number of shards [6, 0, 0], rebalanceThreshold=1, rebalanceNumber=2, rebalanceFactor=0.2" in {
+    "rebalance from region with most number of shards [6, 0, 0], rebalanceThreshold=1, maxRebalancePerInterval=2, rebalanceFactor=0.2" in {
       val allocationStrategy = new LeastShardAllocationStrategy(
         rebalanceThreshold = 1,
         maxSimultaneousRebalance = 10,
-        rebalanceNumber = 2,
+        maxRebalancePerInterval = 2,
         rebalanceFactor = 0.2)
       val allocations = createAllocations(aCount = 6)
 


### PR DESCRIPTION
Currently, the `rebalance-threshold` is used to decide how many shards should be rebalanced per rebalance iteration, with `max-simultaneous-rebalance` limiting the number of ongoing hand offs in cases where it takes more than the rebalance interval to hand off a shard. In some environments, this can make rebalancing too slow, for example, with 100 shards, going from one node to two nodes takes 8 minutes to completely rebalance with the default configuration. The alternative is to select a higher `rebalance-threshold`, but that has a trade off of less even shard allocations.

This separates the `rebalance-threshold` configuration from the number of shards that gets rebalanced, and allows it to be an absolute number, or a factor of the total number of shards that the region with the most shards has. If both are configured, the minimum of the two are selected.

I've called the absolute number `rebalance-number`. Probably not a good name, but I'm not sure what a better name would be, `max-rebalance` could work, but that's very close to `max-simultaneous-rebalance`, while the comments in `reference.conf` make it clear what the difference is, if you just saw those configuration attributes in `application.conf`, it would not be clear at all.

I haven't written any documentation other than in `reference.conf`, it certainly would be good to have some more docs than that, but that's possibly a bigger task that needs to describe rebalancing in general, perhaps worth a different PR.