### PR TITLE
Mailbox selection for Akka Typed actors

### DIFF
--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/MailboxSelectorTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/MailboxSelectorTest.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed;
+
+public class MailboxSelectorTest {
+  // Compile time only test to verify
+  // mailbox factories are accessible from Java
+
+  private MailboxSelector def = MailboxSelector.defaultMailbox();
+  private MailboxSelector bounded = MailboxSelector.bounded(1000);
+  private MailboxSelector conf = MailboxSelector.fromConfig("somepath");
+}

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/MailboxDocTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/MailboxDocTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package jdocs.akka.typed;
+
+import akka.actor.typed.Behavior;
+import akka.actor.typed.MailboxSelector;
+import akka.actor.typed.javadsl.Behaviors;
+
+public class MailboxDocTest {
+
+  static Behavior<String> childBehavior = null;
+
+  static Behavior<Void> parentBehavior = Behaviors.setup(context -> {
+
+    // #select-mailbox
+    context.spawn(
+        childBehavior,
+        "bounded-mailbox-child",
+        MailboxSelector.bounded(100));
+
+    context.spawn(
+        childBehavior,
+        "from-config-mailbox-child",
+        MailboxSelector.fromConfig("absolute.config.path")
+    );
+    // #select-mailbox
+
+    return Behaviors.empty();
+  });
+
+}

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/MailboxDocTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/MailboxDocTest.java
@@ -1,32 +1,48 @@
 /*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package jdocs.akka.typed;
 
+import akka.Done;
+import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
+import akka.actor.testkit.typed.javadsl.TestProbe;
+import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
 import akka.actor.typed.MailboxSelector;
 import akka.actor.typed.javadsl.Behaviors;
+import com.typesafe.config.ConfigFactory;
+import org.junit.ClassRule;
+import org.junit.Test;
 
 public class MailboxDocTest {
 
-  static Behavior<String> childBehavior = null;
+  @ClassRule
+  public static final TestKitJunitResource testKit =
+      new TestKitJunitResource(ConfigFactory.load("mailbox-config-sample.conf"));
 
-  static Behavior<Void> parentBehavior = Behaviors.setup(context -> {
+  @Test
+  public void startSomeActorsWithDifferentMailboxes() {
+    TestProbe<Done> testProbe = testKit.createTestProbe();
+    Behavior<String> childBehavior = Behaviors.empty();
 
-    // #select-mailbox
-    context.spawn(
-        childBehavior,
-        "bounded-mailbox-child",
-        MailboxSelector.bounded(100));
+    Behavior<Void> setup =
+        Behaviors.setup(
+            context -> {
+              // #select-mailbox
+              context.spawn(childBehavior, "bounded-mailbox-child", MailboxSelector.bounded(100));
 
-    context.spawn(
-        childBehavior,
-        "from-config-mailbox-child",
-        MailboxSelector.fromConfig("absolute.config.path")
-    );
-    // #select-mailbox
+              context.spawn(
+                  childBehavior,
+                  "from-config-mailbox-child",
+                  MailboxSelector.fromConfig("my-app.my-special-mailbox"));
+              // #select-mailbox
 
-    return Behaviors.empty();
-  });
+              testProbe.ref().tell(Done.getInstance());
+              return Behaviors.stopped();
+            });
 
+    ActorRef<Void> ref = testKit.spawn(setup);
+    testProbe.receiveMessage();
+  }
 }

--- a/akka-actor-typed-tests/src/test/resources/mailbox-config-sample.conf
+++ b/akka-actor-typed-tests/src/test/resources/mailbox-config-sample.conf
@@ -1,0 +1,5 @@
+my-app {
+  my-special-mailbox {
+    mailbox-type = "akka.dispatch.SingleConsumerOnlyUnboundedMailbox"
+  }
+}

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
@@ -74,19 +74,17 @@ class MailboxSelectorSpec extends ScalaTestWithActorTestKit("""
       actor ! "one" // actor will block here
       actor ! "two"
       actor ! "three"
-      EventFilter.info(
-        pattern = ".*\\[1\\] dead letters encountered.*",
-        occurrences = 1).intercept {
+      EventFilter.info(pattern = ".*\\[1\\] dead letters encountered.*", occurrences = 1).intercept {
         actor ! "four" // doesn't fit in mailbox
       }
       continueProbe.ref ! Continue
     }
 
     "select an arbitrary mailbox from config" in {
-      val actor = spawn(behavior,  MailboxSelector.fromConfig("specific-mailbox"))
+      val actor = spawn(behavior, MailboxSelector.fromConfig("specific-mailbox"))
       val mailbox = actor.ask(WhatsYourMailbox).futureValue
       mailbox shouldBe a[BoundedMessageQueueSemantics]
-      mailbox.asInstanceOf[BoundedNodeMessageQueue].capacity should === (4)
+      mailbox.asInstanceOf[BoundedNodeMessageQueue].capacity should ===(4)
 
     }
   }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.actor.typed
+
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.scaladsl.Behaviors
+import org.scalatest.WordSpecLike
+
+class MailboxSelectorSpec extends ScalaTestWithActorTestKit("""
+    specific-mailbox {
+      mailbox-type = "akka.dispatch.NonBlockingBoundedMailbox"
+      mailbox-capacity = 4 
+    }
+  """) with WordSpecLike {
+
+  "The Mailbox selectors" must {
+    "default to unbounded" in {
+      spawn(Behaviors.empty[String])
+      // FIXME how to verify?
+      fail()
+    }
+
+    "select a bounded mailbox" in {
+      spawn(Behaviors.empty[String], MailboxSelector.bounded(3))
+      // FIXME how to verify?
+      fail()
+    }
+
+    "select an arbitrary mailbox from config" in {
+      spawn(Behaviors.empty[String], MailboxSelector.fromConfig("specific-mailbox"))
+      // FIXME how to verify?
+      fail()
+    }
+  }
+
+}

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
@@ -83,7 +83,6 @@ class MailboxSelectorSpec extends ScalaTestWithActorTestKit("""
         actor ! "four"
       }
       latch.open()
-      Thread.sleep(200)
     }
 
     "select an arbitrary mailbox from config" in {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/MailboxDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/MailboxDocSpec.scala
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.akka.typed
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.MailboxSelector
+import akka.actor.typed.scaladsl.Behaviors
+
+object MailboxDocSpec {
+
+  def childBehavior: Behavior[String] = ???
+
+  val parent = Behaviors.setup[Nothing] { context =>
+    // #select-mailbox
+    context.spawn(
+      childBehavior,
+      "bounded-mailbox-child",
+      MailboxSelector.bounded(100))
+
+    context.spawn(
+      childBehavior,
+      "from-config-mailbox-child",
+      MailboxSelector.fromConfig("absolute.config.path")
+    )
+    // #select-mailbox
+
+    Behaviors.empty
+  }
+}

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/MailboxDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/MailboxDocSpec.scala
@@ -1,23 +1,40 @@
-/**
+/*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package docs.akka.typed
 
+import akka.Done
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.typed.Behavior
 import akka.actor.typed.MailboxSelector
 import akka.actor.typed.scaladsl.Behaviors
+import com.typesafe.config.ConfigFactory
+import org.scalatest.WordSpecLike
 
-object MailboxDocSpec {
+class MailboxDocSpec
+    extends ScalaTestWithActorTestKit(ConfigFactory.load("mailbox-config-sample.conf"))
+    with WordSpecLike {
 
-  def childBehavior: Behavior[String] = ???
+  "Specifying mailbox through props" must {
+    "work" in {
+      val probe = createTestProbe[Done]()
+      val childBehavior: Behavior[String] = Behaviors.empty
+      val parent: Behavior[Unit] = Behaviors.setup { context =>
+        // #select-mailbox
+        context.spawn(childBehavior, "bounded-mailbox-child", MailboxSelector.bounded(100))
 
-  val parent = Behaviors.setup[Nothing] { context =>
-    // #select-mailbox
-    context.spawn(childBehavior, "bounded-mailbox-child", MailboxSelector.bounded(100))
+        val props = MailboxSelector.fromConfig("my-app.my-special-mailbox")
+        context.spawn(childBehavior, "from-config-mailbox-child", props)
+        // #select-mailbox
 
-    context.spawn(childBehavior, "from-config-mailbox-child", MailboxSelector.fromConfig("absolute.config.path"))
-    // #select-mailbox
+        probe.ref ! Done
+        Behaviors.stopped
+      }
+      spawn(parent)
 
-    Behaviors.empty
+      probe.receiveMessage()
+    }
   }
+
 }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/MailboxDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/MailboxDocSpec.scala
@@ -1,7 +1,6 @@
 /**
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package docs.akka.typed
 
 import akka.actor.typed.Behavior
@@ -14,16 +13,9 @@ object MailboxDocSpec {
 
   val parent = Behaviors.setup[Nothing] { context =>
     // #select-mailbox
-    context.spawn(
-      childBehavior,
-      "bounded-mailbox-child",
-      MailboxSelector.bounded(100))
+    context.spawn(childBehavior, "bounded-mailbox-child", MailboxSelector.bounded(100))
 
-    context.spawn(
-      childBehavior,
-      "from-config-mailbox-child",
-      MailboxSelector.fromConfig("absolute.config.path")
-    )
+    context.spawn(childBehavior, "from-config-mailbox-child", MailboxSelector.fromConfig("absolute.config.path"))
     // #select-mailbox
 
     Behaviors.empty

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
@@ -196,7 +196,7 @@ object MailboxSelector {
   def defaultMailbox(): MailboxSelector = _default
 
   /**
-   * A mailbox with a max capacity after which new messages are dropped (passed to deadletters)
+   * A mailbox with a max capacity after which new messages are dropped (passed to deadletters).
    * @param capacity The maximum number of messages in the mailbox before new messages are dropped
    */
   def bounded(capacity: Int): MailboxSelector = BoundedMailboxSelector(capacity)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
@@ -184,16 +184,19 @@ object DispatcherSelector {
  * Not for user extension.
  */
 @DoNotInherit
-sealed abstract class MailboxSelector extends Props
+abstract class MailboxSelector extends Props
 
 object MailboxSelector {
 
-  private val _default = DefaultMailboxSelector()
+  /**
+   * Scala API: The default mailbox is unbounded and backed by a [[java.util.concurrent.ConcurrentLinkedQueue]]
+   */
+  def default(): MailboxSelector = DefaultMailboxSelector.empty
 
   /**
-   * The default mailbox is unbounded and backed by a [[java.util.concurrent.ConcurrentLinkedQueue]]
+   * Java API: The default mailbox is unbounded and backed by a [[java.util.concurrent.ConcurrentLinkedQueue]]
    */
-  def defaultMailbox(): MailboxSelector = _default
+  def defaultMailbox(): MailboxSelector = default()
 
   /**
    * A mailbox with a max capacity after which new messages are dropped (passed to deadletters).
@@ -207,32 +210,4 @@ object MailboxSelector {
    * This is a power user settings default or bounded should be preferred unless you know what you are doing.
    */
   def fromConfig(path: String): MailboxSelector = MailboxFromConfigSelector(path)
-}
-
-/**
- * INTERNAL API
- */
-@InternalApi
-private[akka] final case class DefaultMailboxSelector(next: Props = Props.empty) extends MailboxSelector {
-  def withNext(next: Props): Props = copy(next = next)
-}
-
-/**
- * INTERNAL API
- */
-@InternalApi
-private[akka] final case class BoundedMailboxSelector(capacity: Int, next: Props = Props.empty)
-    extends MailboxSelector {
-  def withNext(next: Props): Props = copy(next = next)
-}
-
-/**
- * Select a mailbox config using an absolute config path.
- *
- * INTERNAL API
- */
-@InternalApi
-private[akka] final case class MailboxFromConfigSelector(path: String, next: Props = Props.empty)
-    extends MailboxSelector {
-  def withNext(next: Props): Props = copy(next = next)
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Props.scala
@@ -179,3 +179,60 @@ object DispatcherSelector {
    */
   def sameAsParent(): DispatcherSelector = DispatcherSameAsParent.empty
 }
+
+/**
+ * Not for user extension.
+ */
+@DoNotInherit
+sealed abstract class MailboxSelector extends Props
+
+object MailboxSelector {
+
+  private val _default = DefaultMailboxSelector()
+
+  /**
+   * The default mailbox is unbounded and backed by a [[java.util.concurrent.ConcurrentLinkedQueue]]
+   */
+  def defaultMailbox(): MailboxSelector = _default
+
+  /**
+   * A mailbox with a max capacity after which new messages are dropped (passed to deadletters)
+   * @param capacity The maximum number of messages in the mailbox before new messages are dropped
+   */
+  def bounded(capacity: Int): MailboxSelector = BoundedMailboxSelector(capacity)
+
+  /**
+   * Select a mailbox from the config file using an absolute config path.
+   *
+   * This is a power user settings default or bounded should be preferred unless you know what you are doing.
+   */
+  def fromConfig(path: String): MailboxSelector = MailboxFromConfigSelector(path)
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] final case class DefaultMailboxSelector(next: Props = Props.empty) extends MailboxSelector {
+  def withNext(next: Props): Props = copy(next = next)
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] final case class BoundedMailboxSelector(capacity: Int, next: Props = Props.empty)
+    extends MailboxSelector {
+  def withNext(next: Props): Props = copy(next = next)
+}
+
+/**
+ * Select a mailbox config using an absolute config path.
+ *
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] final case class MailboxFromConfigSelector(path: String, next: Props = Props.empty)
+    extends MailboxSelector {
+  def withNext(next: Props): Props = copy(next = next)
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/PropsImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/PropsImpl.scala
@@ -4,8 +4,7 @@
 
 package akka.actor.typed.internal
 
-import akka.actor.typed.DispatcherSelector
-import akka.actor.typed.Props
+import akka.actor.typed.{ DispatcherSelector, MailboxSelector, Props }
 import akka.annotation.InternalApi
 
 /**
@@ -38,6 +37,21 @@ import akka.annotation.InternalApi
   }
   object DispatcherSameAsParent {
     val empty = DispatcherSameAsParent(EmptyProps)
+  }
+
+  final case class DefaultMailboxSelector(next: Props = Props.empty) extends MailboxSelector {
+    def withNext(next: Props): Props = copy(next = next)
+  }
+  object DefaultMailboxSelector {
+    val empty = DefaultMailboxSelector(EmptyProps)
+  }
+
+  final case class BoundedMailboxSelector(capacity: Int, next: Props = Props.empty) extends MailboxSelector {
+    def withNext(next: Props): Props = copy(next = next)
+  }
+
+  final case class MailboxFromConfigSelector(path: String, next: Props = Props.empty) extends MailboxSelector {
+    def withNext(next: Props): Props = copy(next = next)
   }
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/PropsAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/PropsAdapter.scala
@@ -29,7 +29,7 @@ import akka.dispatch.Mailboxes
       case _: DispatcherSameAsParent     => props.withDispatcher(Deploy.DispatcherSameAsParent)
     }).withDeploy(Deploy.local) // disallow remote deployment for typed actors
 
-    val p2 = deploy.firstOrElse[MailboxSelector](MailboxSelector.defaultMailbox()) match {
+    val p2 = deploy.firstOrElse[MailboxSelector](MailboxSelector.default()) match {
       case _: DefaultMailboxSelector           => p1
       case BoundedMailboxSelector(capacity, _) =>
         // specific support in untyped Mailboxes

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/PropsAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/PropsAdapter.scala
@@ -6,10 +6,7 @@ package akka.actor.typed.internal.adapter
 
 import akka.actor.Deploy
 import akka.actor.typed.Behavior
-import akka.actor.typed.BoundedMailboxSelector
-import akka.actor.typed.DefaultMailboxSelector
 import akka.actor.typed.DispatcherSelector
-import akka.actor.typed.MailboxFromConfigSelector
 import akka.actor.typed.MailboxSelector
 import akka.actor.typed.Props
 import akka.actor.typed.internal.PropsImpl._

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/PropsAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/PropsAdapter.scala
@@ -31,7 +31,7 @@ import akka.annotation.InternalApi
       case _: DispatcherSameAsParent     => props.withDispatcher(Deploy.DispatcherSameAsParent)
     }).withDeploy(Deploy.local) // disallow remote deployment for typed actors
 
-    val p2 = deploy.firstOrElse[MailboxSelector](MailboxSelector.default()) match {
+    val p2 = deploy.firstOrElse[MailboxSelector](MailboxSelector.defaultMailbox()) match {
       case _: DefaultMailboxSelector           => p1
       case BoundedMailboxSelector(capacity, _) =>
         // specific support in untyped Mailboxes

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/PropsAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/PropsAdapter.scala
@@ -6,7 +6,11 @@ package akka.actor.typed.internal.adapter
 
 import akka.actor.Deploy
 import akka.actor.typed.Behavior
+import akka.actor.typed.BoundedMailboxSelector
+import akka.actor.typed.DefaultMailboxSelector
 import akka.actor.typed.DispatcherSelector
+import akka.actor.typed.MailboxFromConfigSelector
+import akka.actor.typed.MailboxSelector
 import akka.actor.typed.Props
 import akka.actor.typed.internal.PropsImpl._
 import akka.annotation.InternalApi
@@ -21,11 +25,22 @@ import akka.annotation.InternalApi
       rethrowTypedFailure: Boolean = true): akka.actor.Props = {
     val props = akka.actor.Props(new ActorAdapter(behavior(), rethrowTypedFailure))
 
-    (deploy.firstOrElse[DispatcherSelector](DispatcherDefault.empty) match {
+    val p1 = (deploy.firstOrElse[DispatcherSelector](DispatcherDefault.empty) match {
       case _: DispatcherDefault          => props
       case DispatcherFromConfig(name, _) => props.withDispatcher(name)
       case _: DispatcherSameAsParent     => props.withDispatcher(Deploy.DispatcherSameAsParent)
     }).withDeploy(Deploy.local) // disallow remote deployment for typed actors
+
+    val p2 = deploy.firstOrElse[MailboxSelector](MailboxSelector.default()) match {
+      case _: DefaultMailboxSelector           => p1
+      case BoundedMailboxSelector(capacity, _) =>
+        // specific support in untyped Mailboxes
+        p1.withMailbox(s"typed-bounded:$capacity")
+      case MailboxFromConfigSelector(path, _) =>
+        props.withMailbox(path)
+    }
+
+    p2.withDeploy(Deploy.local) // disallow remote deployment for typed actors
   }
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/PropsAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/PropsAdapter.scala
@@ -14,6 +14,7 @@ import akka.actor.typed.MailboxSelector
 import akka.actor.typed.Props
 import akka.actor.typed.internal.PropsImpl._
 import akka.annotation.InternalApi
+import akka.dispatch.Mailboxes
 
 /**
  * INTERNAL API
@@ -35,7 +36,7 @@ import akka.annotation.InternalApi
       case _: DefaultMailboxSelector           => p1
       case BoundedMailboxSelector(capacity, _) =>
         // specific support in untyped Mailboxes
-        p1.withMailbox(s"typed-bounded:$capacity")
+        p1.withMailbox(s"${Mailboxes.BoundedCapacityPrefix}$capacity")
       case MailboxFromConfigSelector(path, _) =>
         props.withMailbox(path)
     }

--- a/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
@@ -208,8 +208,9 @@ private[akka] class Mailboxes(
           // TODO RK remove these two for Akka 2.3
           case "unbounded"                          => UnboundedMailbox()
           case "bounded"                            => new BoundedMailbox(settings, config(id))
-          case _ if id.startsWith("bounded-typed:") =>
-            // hack to allow programmatic set of capacity through props in akka-typed
+          case _ if id.startsWith("typed-bounded:") =>
+            // hack to allow programmatic set of capacity through props in akka-typed but still share
+            // mailbox configurators for the same size
             val capacity = id.split(':')(1).toInt
             new BoundedMailbox(capacity, Duration.Zero)
 

--- a/akka-docs/src/main/paradox/dispatchers.md
+++ b/akka-docs/src/main/paradox/dispatchers.md
@@ -13,7 +13,7 @@ For the new API see @ref[dispatchers](typed/dispatchers.md).
 
 ## Dependency
 
-Dispatchers are part of core akka, which means that they are part of the akka-actor dependency:
+Dispatchers are part of core Akka, which means that they are part of the akka-actor dependency:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"

--- a/akka-docs/src/main/paradox/logging.md
+++ b/akka-docs/src/main/paradox/logging.md
@@ -532,7 +532,7 @@ trigger emails and other notifications immediately.
 Markers are available through the LoggingAdapters, when obtained via `Logging.withMarker`.
 The first argument passed into all log calls then should be a `akka.event.LogMarker`.
 
-The slf4j bridge provided by akka in `akka-slf4j` will automatically pick up this marker value and make it available to SLF4J.
+The slf4j bridge provided by Akka in `akka-slf4j` will automatically pick up this marker value and make it available to SLF4J.
 For example you could use it like this:
 
 ```

--- a/akka-docs/src/main/paradox/persistence-query.md
+++ b/akka-docs/src/main/paradox/persistence-query.md
@@ -18,7 +18,7 @@ Akka persistence query complements @ref:[Persistence](persistence.md) by providi
 query interface that various journal plugins can implement in order to expose their query capabilities.
 
 The most typical use case of persistence query is implementing the so-called query side (also known as "read side")
-in the popular CQRS architecture pattern - in which the writing side of the application (e.g. implemented using akka
+in the popular CQRS architecture pattern - in which the writing side of the application (e.g. implemented using Akka
 persistence) is completely separated from the "query side". Akka Persistence Query itself is *not* directly the query
 side of an application, however it can help to migrate data from the write side to the query side database. In very
 simple scenarios Persistence Query may be powerful enough to fulfill the query needs of your app, however we highly

--- a/akka-docs/src/main/paradox/typed/index.md
+++ b/akka-docs/src/main/paradox/typed/index.md
@@ -6,6 +6,7 @@
 
 * [actors](actors.md)
 * [dispatchers](dispatchers.md)
+* [mailboxes](mailboxes.md)
 * [coexisting](coexisting.md)
 * [actor-lifecycle](actor-lifecycle.md)
 * [interaction patterns](interaction-patterns.md)

--- a/akka-docs/src/main/paradox/typed/mailboxes.md
+++ b/akka-docs/src/main/paradox/typed/mailboxes.md
@@ -1,0 +1,33 @@
+# Mailboxes
+
+## Dependency
+
+Mailboxes are part of core akka, which means that they are part of the akka-actor-typed dependency:
+
+@@dependency[sbt,Maven,Gradle] {
+  group="com.typesafe.akka"
+  artifact="akka-actor-typed_$scala.binary_version$"
+  version="$akka.version$"
+}
+
+## Introduction 
+
+Each actor in Akka has a `Mailbox`, this is where the messages are enqueued before being processed by the actor.
+
+By default an unbounded mailbox is used, this means any number of messages can be enqueued into the mailbox. 
+
+The unbounded mailbox is a convenient default but in a scenario where messages are constantly added in a higher rate than the actor can process them, this can lead to running out of memory.
+For this reason a bounded mailbox can be specified, the bounded mailbox will pass new messages to `deadletters` when the
+mailbox is full.
+
+For advanced use cases it is also possible to defer mailbox selection to config by pointing to a config path.
+
+## Selecting what mailbox is used
+
+To select mailbox for an actor use `MailboxSelector` to create a `Props` instance for spawning your actor:
+
+Scala
+:  @@snip [MailboxDocSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/MailboxDocSpec.scala) { #select-mailbox }
+
+Java
+:  @@snip [MailboxDocTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/MailboxDocTest.java) { #select-mailbox }

--- a/akka-docs/src/main/paradox/typed/mailboxes.md
+++ b/akka-docs/src/main/paradox/typed/mailboxes.md
@@ -16,7 +16,8 @@ Each actor in Akka has a `Mailbox`, this is where the messages are enqueued befo
 
 By default an unbounded mailbox is used, this means any number of messages can be enqueued into the mailbox. 
 
-The unbounded mailbox is a convenient default but in a scenario where messages are constantly added in a higher rate than the actor can process them, this can lead to running out of memory.
+The unbounded mailbox is a convenient default but in a scenario where messages are added to the mailbox faster
+than the actor can process them, this can lead to the application running out of memory.
 For this reason a bounded mailbox can be specified, the bounded mailbox will pass new messages to `deadletters` when the
 mailbox is full.
 
@@ -31,3 +32,9 @@ Scala
 
 Java
 :  @@snip [MailboxDocTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/MailboxDocTest.java) { #select-mailbox }
+
+`fromConfig` takes an absolute config path to a block defining the dispatcher in the config file like this:
+
+@@snip [MailboxDocSpec.scala](/akka-actor-typed-tests/src/test/resources/mailbox-config-sample.conf) { }
+
+For more details on advanced mailbox config and custom mailbox implementations, see @ref[Classic Mailboxes](../mailboxes.md#builtin-mailbox-implementations).

--- a/akka-docs/src/main/paradox/typed/mailboxes.md
+++ b/akka-docs/src/main/paradox/typed/mailboxes.md
@@ -2,7 +2,7 @@
 
 ## Dependency
 
-Mailboxes are part of core akka, which means that they are part of the akka-actor-typed dependency:
+Mailboxes are part of core Akka, which means that they are part of the akka-actor-typed dependency:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"


### PR DESCRIPTION
## Purpose
Allow for selection of mailbox type in Akka Typed through `Props`

## References
Fixes #27124 

## Changes
New API `MailboxSelector`, support in `PropsAdapter`, hack in `akka-actor` to allow for programmatic passing of bounded mailbox capacity from typed.