### PR TITLE
Akka 27103/streams zip all [#27103]

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zipAll.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zipAll.md
@@ -19,7 +19,7 @@ Combines all elements from each of multiple sources into @scala[tuples] @java[*P
 
 @@@div { .callout }
 
-**emits** when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+**emits** at first emits when both inputs emit, and then as long as any input emits (coupled to the default value of the completed input).
 
 **backpressures** when downstream backpressures
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zipAll.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zipAll.md
@@ -1,0 +1,35 @@
+# zipAll
+
+Combines all elements from each of multiple sources into @scala[tuples] @java[*Pair*] and passes the @scala[tuples] @java[pairs] downstream.
+
+@ref[Fan-in operators](../index.md#fan-in-operators)
+
+@@@div { .group-scala }
+
+## Signature
+
+@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #zipAll }
+
+@@@
+
+## Description
+
+Combines all elements from each of multiple sources into @scala[tuples] @java[*Pair*] and passes the @scala[tuples] @java[pairs] downstream.
+
+
+@@@div { .callout }
+
+**emits** when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+
+**backpressures** when downstream backpressures
+
+**completes** when all upstream completes
+
+@@@
+
+## Example
+Scala
+:   @@snip [FlowZipSpec.scala](/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipSpec.scala) { #zip }
+
+Java
+:   @@snip [SourceOrFlow.java](/akka-docs/src/test/java/jdocs/stream/operators/SourceOrFlow.java) { #zip }

--- a/akka-docs/src/main/paradox/stream/operators/index.md
+++ b/akka-docs/src/main/paradox/stream/operators/index.md
@@ -249,6 +249,7 @@ the inputs in different ways.
 |Source/Flow|<a name="orelse"></a>@ref[orElse](Source-or-Flow/orElse.md)|If the primary source completes without emitting any elements, the elements from the secondary source are emitted.|
 |Source/Flow|<a name="prepend"></a>@ref[prepend](Source-or-Flow/prepend.md)|Prepends the given source to the flow, consuming it until completion before the original source is consumed.|
 |Source/Flow|<a name="zip"></a>@ref[zip](Source-or-Flow/zip.md)|Combines elements from each of multiple sources into @scala[tuples] @java[*Pair*] and passes the @scala[tuples] @java[pairs] downstream.|
+|Source/Flow|<a name="zipall"></a>@ref[zipAll](Source-or-Flow/zipAll.md)|Combines all elements from each of multiple sources into @scala[tuples] @java[*Pair*] and passes the @scala[tuples] @java[pairs] downstream.|
 |Source/Flow|<a name="ziplatest"></a>@ref[zipLatest](Source-or-Flow/zipLatest.md)|Combines elements from each of multiple sources into @scala[tuples] @java[*Pair*] and passes the @scala[tuples] @java[pairs] downstream, picking always the latest element of each.|
 |Source/Flow|<a name="ziplatestwith"></a>@ref[zipLatestWith](Source-or-Flow/zipLatestWith.md)|Combines elements from multiple sources through a `combine` function and passes the returned value downstream, picking always the latest element of each.|
 |Source/Flow|<a name="zipwith"></a>@ref[zipWith](Source-or-Flow/zipWith.md)|Combines elements from multiple sources through a `combine` function and passes the returned value downstream.|
@@ -346,6 +347,7 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 * [merge](Source-or-Flow/merge.md)
 * [mergeSorted](Source-or-Flow/mergeSorted.md)
 * [zip](Source-or-Flow/zip.md)
+* [zipAll](Source-or-Flow/zipAll.md)
 * [zipLatest](Source-or-Flow/zipLatest.md)
 * [zipWith](Source-or-Flow/zipWith.md)
 * [zipLatestWith](Source-or-Flow/zipLatestWith.md)

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceTest.java
@@ -894,6 +894,38 @@ public class SourceTest extends StreamTest {
   }
 
   @Test
+  public void mustBeAbleToZipAll() {
+    final TestKit probe = new TestKit(system);
+    final Iterable<String> input1 =
+        Arrays.asList("A", "B", "C", "D", "new kid on the block1", "second newbie");
+    final Iterable<Integer> input2 = Arrays.asList(1, 2, 3, 4);
+
+    Source<String, NotUsed> src1 = Source.from(input1);
+    Source<Integer, NotUsed> src2 = Source.from(input2);
+    Sink<Pair<String, Integer>, CompletionStage<Done>> sink =
+        Sink.foreach(
+            new Procedure<Pair<String, Integer>>() {
+              @Override
+              public void apply(Pair<String, Integer> param) throws Exception {
+                probe.getRef().tell(param, ActorRef.noSender());
+              }
+            });
+    Source<Pair<String, Integer>, NotUsed> zippedSrc = src1.zipAll(src2, "MISSING", -1);
+    zippedSrc.runWith(sink, materializer);
+
+    List<Object> output = probe.receiveN(6);
+    List<Pair<String, Integer>> expected =
+        Arrays.asList(
+            new Pair<String, Integer>("A", 1),
+            new Pair<String, Integer>("B", 2),
+            new Pair<String, Integer>("C", 3),
+            new Pair<String, Integer>("D", 4),
+            new Pair<String, Integer>("new kid on the block1", -1),
+            new Pair<String, Integer>("second newbie", -1));
+    assertEquals(expected, output);
+  }
+
+  @Test
   public void createEmptySource() throws Exception {
     List<Integer> actual =
         Source.empty(Integer.class).runWith(Sink.seq(), materializer).toCompletableFuture().get();

--- a/akka-stream-tests/src/test/scala/akka/stream/DslConsistencySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/DslConsistencySpec.scala
@@ -63,6 +63,7 @@ class DslConsistencySpec extends WordSpec with Matchers {
     "zipWithGraph",
     "zipLatestGraph",
     "zipLatestWithGraph",
+    "zipAllFlow",
     "mergeGraph",
     "mergeSortedGraph",
     "interleaveGraph",

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipAllSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipAllSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.scaladsl
+
+import akka.stream.testkit.{BaseTwoStreamsSetup, TestSubscriber}
+import akka.stream.testkit.scaladsl.StreamTestKit._
+import org.reactivestreams.Publisher
+
+class FlowZipAllSpec extends BaseTwoStreamsSetup {
+  override type Outputs = (Int, Int)
+
+  override def setup(p1: Publisher[Int], p2: Publisher[Int]) = {
+    val subscriber = TestSubscriber.probe[Outputs]()
+    Source.fromPublisher(p1).zip(Source.fromPublisher(p2)).runWith(Sink.fromSubscriber(subscriber))
+    subscriber
+  }
+
+  "A zipAll for Flow" must {
+    "work for shorter left side" in assertAllStagesStopped {
+      val probe = TestSubscriber.manualProbe[(Int, String)]()
+      Source(1 to 4)
+        .zipAll(Source(List("A", "B", "C", "D", "E", "F")), -1, "MISSING")
+        .runWith(Sink.fromSubscriber(probe))
+      val subscription = probe.expectSubscription()
+
+      subscription.request(2)
+      probe.expectNext((1, "A"))
+      probe.expectNext((2, "B"))
+
+      subscription.request(1)
+      probe.expectNext((3, "C"))
+      subscription.request(1)
+      probe.expectNext((4, "D"))
+
+      subscription.request(2)
+      probe.expectNext((-1, "E"))
+      probe.expectNext((-1, "F"))
+
+      subscription.request(1)
+      probe.expectComplete()
+    }
+
+    "work for shorter right side" in assertAllStagesStopped {
+      val probe = TestSubscriber.manualProbe[(Int, String)]()
+      Source(1 to 8)
+        .zipAll(Source(List("A", "B", "C", "D", "E", "F")), -1, "MISSING")
+        .runWith(Sink.fromSubscriber(probe))
+      val subscription = probe.expectSubscription()
+
+      subscription.request(2)
+      probe.expectNext((1, "A"))
+      probe.expectNext((2, "B"))
+
+      subscription.request(1)
+      probe.expectNext((3, "C"))
+      subscription.request(1)
+      probe.expectNext((4, "D"))
+
+      subscription.request(2)
+      probe.expectNext((5, "E"))
+      probe.expectNext((6, "F"))
+
+      subscription.request(2)
+      probe.expectNext((7, "MISSING"))
+      probe.expectNext((8, "MISSING"))
+
+      subscription.request(1)
+      probe.expectComplete()
+    }
+
+    "work for equal lengths" in assertAllStagesStopped {
+      val probe = TestSubscriber.manualProbe[(Int, String)]()
+      Source(1 to 6)
+        .zipAll(Source(List("A", "B", "C", "D", "E", "F")), -1, "MISSING")
+        .runWith(Sink.fromSubscriber(probe))
+      val subscription = probe.expectSubscription()
+
+      subscription.request(2)
+      probe.expectNext((1, "A"))
+      probe.expectNext((2, "B"))
+
+      subscription.request(1)
+      probe.expectNext((3, "C"))
+      subscription.request(1)
+      probe.expectNext((4, "D"))
+
+      subscription.request(2)
+      probe.expectNext((5, "E"))
+      probe.expectNext((6, "F"))
+
+      subscription.request(1)
+      probe.expectComplete()
+    }
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipAllSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipAllSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.scaladsl
 
-import akka.stream.testkit.{BaseTwoStreamsSetup, TestSubscriber}
+import akka.stream.testkit.{ BaseTwoStreamsSetup, TestSubscriber }
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import org.reactivestreams.Publisher
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -2550,34 +2550,35 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
       matF)
 
   /**
-    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
-    *
-    * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
-    *
-    * '''Backpressures when''' downstream backpressures
-    *
-    * '''Completes when''' all upstream completes
-    *
-    * '''Cancels when''' downstream cancels
-    */
-  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem : A, thatElem : U): Flow[In, Pair[A, U], Mat] =
-    new Flow(delegate.zipAll(that, thisElem, thatElem).map{case (a,u) => Pair.create(a,u)} )
+   * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
+   *
+   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' all upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem: A, thatElem: U): Flow[In, Pair[A, U], Mat] =
+    new Flow(delegate.zipAll(that, thisElem, thatElem).map { case (a, u) => Pair.create(a, u) })
 
   /**
-    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
-    *
-    * @see [[#zipAll]]
-    *
-    * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
-    *
-    * '''Backpressures when''' downstream backpressures
-    *
-    * '''Completes when''' all upstream completes
-    *
-    * '''Cancels when''' downstream cancels
-    */
-  def zipAllMat[U, Mat2, Mat3, A >: Out](that: Graph[SourceShape[U], Mat2], thisElem : A, thatElem : U)(matF: (Mat, Mat2) => Mat3): Flow[In, Pair[A, U], Mat3] =
-    new Flow(delegate.zipAllMat(that, thisElem, thatElem)(matF).map{case (a,u) => Pair.create(a,u)})
+   * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
+   *
+   * @see [[#zipAll]]
+   *
+   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' all upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def zipAllMat[U, Mat2, Mat3, A >: Out](that: Graph[SourceShape[U], Mat2], thisElem: A, thatElem: U)(
+      matF: (Mat, Mat2) => Mat3): Flow[In, Pair[A, U], Mat3] =
+    new Flow(delegate.zipAllMat(that, thisElem, thatElem)(matF).map { case (a, u) => Pair.create(a, u) })
 
   /**
    * Combine the elements of 2 streams into a stream of tuples, picking always the latest element of each.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -2560,8 +2560,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     *
     * '''Cancels when''' downstream cancels
     */
-  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem : A, thatElem : U): Flow[In, (A, U), Mat] =
-    new Flow(delegate.zipAll(that, thisElem, thatElem))
+  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem : A, thatElem : U): Flow[In, Pair[A, U], Mat] =
+    new Flow(delegate.zipAll(that, thisElem, thatElem).map{case (a,u) => Pair.create(a,u)} )
 
   /**
     * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
@@ -2576,8 +2576,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     *
     * '''Cancels when''' downstream cancels
     */
-  def zipAllMat[U, Mat2, Mat3, A >: Out](that: Graph[SourceShape[U], Mat2], thisElem : A, thatElem : U)(matF: (Mat, Mat2) => Mat3): Flow[In, (A, U), Mat3] =
-    new Flow(delegate.zipAllMat(that, thisElem, thatElem)(matF))
+  def zipAllMat[U, Mat2, Mat3, A >: Out](that: Graph[SourceShape[U], Mat2], thisElem : A, thatElem : U)(matF: (Mat, Mat2) => Mat3): Flow[In, Pair[A, U], Mat3] =
+    new Flow(delegate.zipAllMat(that, thisElem, thatElem)(matF).map{case (a,u) => Pair.create(a,u)})
 
   /**
    * Combine the elements of 2 streams into a stream of tuples, picking always the latest element of each.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -2550,6 +2550,36 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
       matF)
 
   /**
+    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
+    *
+    * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+    *
+    * '''Backpressures when''' downstream backpressures
+    *
+    * '''Completes when''' all upstream completes
+    *
+    * '''Cancels when''' downstream cancels
+    */
+  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem : A, thatElem : U): Flow[In, (A, U), Mat] =
+    new Flow(delegate.zipAll(that, thisElem, thatElem))
+
+  /**
+    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
+    *
+    * @see [[#zipAll]]
+    *
+    * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+    *
+    * '''Backpressures when''' downstream backpressures
+    *
+    * '''Completes when''' all upstream completes
+    *
+    * '''Cancels when''' downstream cancels
+    */
+  def zipAllMat[U, Mat2, Mat3, A >: Out](that: Graph[SourceShape[U], Mat2], thisElem : A, thatElem : U)(matF: (Mat, Mat2) => Mat3): Flow[In, (A, U), Mat3] =
+    new Flow(delegate.zipAllMat(that, thisElem, thatElem)(matF))
+
+  /**
    * Combine the elements of 2 streams into a stream of tuples, picking always the latest element of each.
    *
    * A `ZipLatest` has a `left` and a `right` input port and one `out` port.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -2552,7 +2552,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
   /**
    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
    *
-   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   * '''Emits when''' at first emits when both inputs emit, and then as long as any input emits (coupled to the default value of the completed input).
    *
    * '''Backpressures when''' downstream backpressures
    *
@@ -2568,7 +2568,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * @see [[#zipAll]]
    *
-   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   * '''Emits when''' at first emits when both inputs emit, and then as long as any input emits (coupled to the default value of the completed input).
    *
    * '''Backpressures when''' downstream backpressures
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -1166,8 +1166,8 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
     *
     * '''Cancels when''' downstream cancels
     */
-  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem : A, thatElem : U): Source[(A, U), Mat] =
-    new Source(delegate.zipAll(that, thisElem, thatElem))
+  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem : A, thatElem : U): Source[Pair[A, U], Mat] =
+    new Source(delegate.zipAll(that, thisElem, thatElem).map{case (a,u) => Pair.create(a,u)})
 
   /**
     * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
@@ -1182,8 +1182,8 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
     *
     * '''Cancels when''' downstream cancels
     */
-  def zipAllMat[U, Mat2, Mat3, A >: Out](that: Graph[SourceShape[U], Mat2], thisElem : A, thatElem : U)(matF: (Mat, Mat2) => Mat3): Source[(A, U), Mat3] =
-    new Source(delegate.zipAllMat(that, thisElem, thatElem)(matF))
+  def zipAllMat[U, Mat2, Mat3, A >: Out](that: Graph[SourceShape[U], Mat2], thisElem : A, thatElem : U)(matF: (Mat, Mat2) => Mat3): Source[Pair[A, U], Mat3] =
+    new Source(delegate.zipAllMat(that, thisElem, thatElem)(matF).map{case (a,u) => Pair.create(a,u)})
 
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -1158,7 +1158,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
   /**
    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
    *
-   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   * '''Emits when''' at first emits when both inputs emit, and then as long as any input emits (coupled to the default value of the completed input).
    *
    * '''Backpressures when''' downstream backpressures
    *
@@ -1174,7 +1174,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * @see [[#zipAll]]
    *
-   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   * '''Emits when''' at first emits when both inputs emit, and then as long as any input emits (coupled to the default value of the completed input).
    *
    * '''Backpressures when''' downstream backpressures
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -7,27 +7,27 @@ package akka.stream.javadsl
 import java.util
 import java.util.Optional
 
-import akka.actor.{ActorRef, Cancellable, Props}
+import akka.actor.{ ActorRef, Cancellable, Props }
 import akka.annotation.ApiMayChange
 import akka.event.LoggingAdapter
-import akka.japi.{Pair, Util, function}
+import akka.japi.{ function, Pair, Util }
 import akka.stream._
 import akka.stream.impl.LinearTraversalBuilder
-import akka.util.{ConstantFun, Timeout}
+import akka.util.{ ConstantFun, Timeout }
 import akka.util.JavaDurationConverters._
-import akka.{Done, NotUsed}
-import org.reactivestreams.{Publisher, Subscriber}
+import akka.{ Done, NotUsed }
+import org.reactivestreams.{ Publisher, Subscriber }
 
 import scala.annotation.unchecked.uncheckedVariance
 import akka.util.ccompat.JavaConverters._
 
 import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.{ Future, Promise }
 import scala.compat.java8.OptionConverters._
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.CompletableFuture
-import java.util.function.{BiFunction, Supplier}
+import java.util.function.{ BiFunction, Supplier }
 
 import akka.util.unused
 import com.github.ghik.silencer.silent
@@ -1156,35 +1156,35 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
     this.viaMat(Flow.create[Out].zipMat(that, Keep.right[NotUsed, M]), matF)
 
   /**
-    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
-    *
-    * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
-    *
-    * '''Backpressures when''' downstream backpressures
-    *
-    * '''Completes when''' all upstream completes
-    *
-    * '''Cancels when''' downstream cancels
-    */
-  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem : A, thatElem : U): Source[Pair[A, U], Mat] =
-    new Source(delegate.zipAll(that, thisElem, thatElem).map{case (a,u) => Pair.create(a,u)})
+   * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
+   *
+   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' all upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem: A, thatElem: U): Source[Pair[A, U], Mat] =
+    new Source(delegate.zipAll(that, thisElem, thatElem).map { case (a, u) => Pair.create(a, u) })
 
   /**
-    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
-    *
-    * @see [[#zipAll]]
-    *
-    * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
-    *
-    * '''Backpressures when''' downstream backpressures
-    *
-    * '''Completes when''' all upstream completes
-    *
-    * '''Cancels when''' downstream cancels
-    */
-  def zipAllMat[U, Mat2, Mat3, A >: Out](that: Graph[SourceShape[U], Mat2], thisElem : A, thatElem : U)(matF: (Mat, Mat2) => Mat3): Source[Pair[A, U], Mat3] =
-    new Source(delegate.zipAllMat(that, thisElem, thatElem)(matF).map{case (a,u) => Pair.create(a,u)})
-
+   * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
+   *
+   * @see [[#zipAll]]
+   *
+   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' all upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def zipAllMat[U, Mat2, Mat3, A >: Out](that: Graph[SourceShape[U], Mat2], thisElem: A, thatElem: U)(
+      matF: (Mat, Mat2) => Mat3): Source[Pair[A, U], Mat3] =
+    new Source(delegate.zipAllMat(that, thisElem, thatElem)(matF).map { case (a, u) => Pair.create(a, u) })
 
   /**
    * Combine the elements of 2 streams into a stream of tuples, picking always the latest element of each.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -1544,7 +1544,7 @@ class SubFlow[In, Out, Mat](
   /**
    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
    *
-   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   * '''Emits when''' at first emits when both inputs emit, and then as long as any input emits (coupled to the default value of the completed input).
    *
    * '''Backpressures when''' downstream backpressures
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -6,15 +6,14 @@ package akka.stream.javadsl
 
 import akka.NotUsed
 import akka.event.LoggingAdapter
-import akka.japi.function
+import akka.japi.{Pair, Util, function}
 import akka.stream._
 import akka.util.ConstantFun
 import akka.util.JavaDurationConverters._
-
 import akka.util.ccompat.JavaConverters._
+
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.duration.FiniteDuration
-import akka.japi.Util
 import java.util.Comparator
 
 import scala.compat.java8.FutureConverters._
@@ -1541,6 +1540,20 @@ class SubFlow[In, Out, Mat](
    */
   def zip[T](source: Graph[SourceShape[T], _]): SubFlow[In, akka.japi.Pair[Out @uncheckedVariance, T], Mat] =
     new SubFlow(delegate.zip(source).map { case (o, t) => akka.japi.Pair.create(o, t) })
+
+  /**
+    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
+    *
+    * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+    *
+    * '''Backpressures when''' downstream backpressures
+    *
+    * '''Completes when''' all upstream completes
+    *
+    * '''Cancels when''' downstream cancels
+    */
+  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem: A, thatElem: U): SubFlow[In, akka.japi.Pair[A, U], Mat] =
+    new SubFlow(delegate.zipAll(that, thisElem, thatElem).map { case (a, u) => Pair.create(a, u) })
 
   /**
    * Combine the elements of current [[Flow]] and the given [[Source]] into a stream of tuples, picking always the latest element of each.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -6,7 +6,7 @@ package akka.stream.javadsl
 
 import akka.NotUsed
 import akka.event.LoggingAdapter
-import akka.japi.{Pair, Util, function}
+import akka.japi.{ function, Pair, Util }
 import akka.stream._
 import akka.util.ConstantFun
 import akka.util.JavaDurationConverters._
@@ -1542,17 +1542,20 @@ class SubFlow[In, Out, Mat](
     new SubFlow(delegate.zip(source).map { case (o, t) => akka.japi.Pair.create(o, t) })
 
   /**
-    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
-    *
-    * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
-    *
-    * '''Backpressures when''' downstream backpressures
-    *
-    * '''Completes when''' all upstream completes
-    *
-    * '''Cancels when''' downstream cancels
-    */
-  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem: A, thatElem: U): SubFlow[In, akka.japi.Pair[A, U], Mat] =
+   * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
+   *
+   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' all upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def zipAll[U, A >: Out](
+      that: Graph[SourceShape[U], _],
+      thisElem: A,
+      thatElem: U): SubFlow[In, akka.japi.Pair[A, U], Mat] =
     new SubFlow(delegate.zipAll(that, thisElem, thatElem).map { case (a, u) => Pair.create(a, u) })
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -6,7 +6,7 @@ package akka.stream.javadsl
 
 import akka.NotUsed
 import akka.event.LoggingAdapter
-import akka.japi.{Pair, Util, function}
+import akka.japi.{ function, Pair, Util }
 import akka.stream._
 import akka.util.ConstantFun
 import akka.util.JavaDurationConverters._
@@ -1522,17 +1522,20 @@ class SubSource[Out, Mat](
     new SubSource(delegate.zip(source).map { case (o, t) => akka.japi.Pair.create(o, t) })
 
   /**
-    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
-    *
-    * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
-    *
-    * '''Backpressures when''' downstream backpressures
-    *
-    * '''Completes when''' all upstream completes
-    *
-    * '''Cancels when''' downstream cancels
-    */
-  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem: A, thatElem: U): SubSource[akka.japi.Pair[A, U], Mat] =
+   * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
+   *
+   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' all upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def zipAll[U, A >: Out](
+      that: Graph[SourceShape[U], _],
+      thisElem: A,
+      thatElem: U): SubSource[akka.japi.Pair[A, U], Mat] =
     new SubSource(delegate.zipAll(that, thisElem, thatElem).map { case (a, u) => Pair.create(a, u) })
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -6,12 +6,12 @@ package akka.stream.javadsl
 
 import akka.NotUsed
 import akka.event.LoggingAdapter
-import akka.japi.{ function, Util }
+import akka.japi.{Pair, Util, function}
 import akka.stream._
 import akka.util.ConstantFun
 import akka.util.JavaDurationConverters._
-
 import akka.util.ccompat.JavaConverters._
+
 import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.duration.FiniteDuration
 import java.util.Comparator
@@ -1520,6 +1520,20 @@ class SubSource[Out, Mat](
    */
   def zip[T](source: Graph[SourceShape[T], _]): SubSource[akka.japi.Pair[Out @uncheckedVariance, T], Mat] =
     new SubSource(delegate.zip(source).map { case (o, t) => akka.japi.Pair.create(o, t) })
+
+  /**
+    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
+    *
+    * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+    *
+    * '''Backpressures when''' downstream backpressures
+    *
+    * '''Completes when''' all upstream completes
+    *
+    * '''Cancels when''' downstream cancels
+    */
+  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem: A, thatElem: U): SubSource[akka.japi.Pair[A, U], Mat] =
+    new SubSource(delegate.zipAll(that, thisElem, thatElem).map { case (a, u) => Pair.create(a, u) })
 
   /**
    * Combine the elements of current [[Flow]] and the given [[Source]] into a stream of tuples, picking always the latest element of each.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -1524,7 +1524,7 @@ class SubSource[Out, Mat](
   /**
    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
    *
-   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   * '''Emits when''' at first emits when both inputs emit, and then as long as any input emits (coupled to the default value of the completed input).
    *
    * '''Backpressures when''' downstream backpressures
    *

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -2417,7 +2417,7 @@ trait FlowOps[+Out, +Mat] {
     */
   def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem : A, thatElem : U): Repr[(A, U)] = {
     case object passedEnd
-    def passedEndSrc = Source.repeat(passedEnd)
+    val passedEndSrc = Source.repeat(passedEnd)
     val left: Flow[Out, Any, NotUsed] = Flow[Out].concat(passedEndSrc)
     val right: Source[Any, Any] = Source.fromGraph(that).concat(passedEndSrc)
     val zipFlow : Flow[Out, (A, U), NotUsed] = left

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -2407,7 +2407,7 @@ trait FlowOps[+Out, +Mat] {
   /**
    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
    *
-   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   * '''Emits when''' at first emits when both inputs emit, and then as long as any input emits (coupled to the default value of the completed input).
    *
    * '''Backpressures when''' downstream backpressures
    *
@@ -2952,7 +2952,7 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    *
    * @see [[#zipAll]]
    *
-   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   * '''Emits when''' at first emits when both inputs emit, and then as long as any input emits (coupled to the default value of the completed input).
    *
    * '''Backpressures when''' downstream backpressures
    *

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -2405,31 +2405,31 @@ trait FlowOps[+Out, +Mat] {
   def zip[U](that: Graph[SourceShape[U], _]): Repr[(Out, U)] = via(zipGraph(that))
 
   /**
-    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
-    *
-    * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
-    *
-    * '''Backpressures when''' downstream backpressures
-    *
-    * '''Completes when''' all upstream completes
-    *
-    * '''Cancels when''' downstream cancels
-    */
-  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem : A, thatElem : U): Repr[(A, U)] = {
+   * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
+   *
+   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' all upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem: A, thatElem: U): Repr[(A, U)] = {
     case object passedEnd
     val passedEndSrc = Source.repeat(passedEnd)
     val left: Flow[Out, Any, NotUsed] = Flow[Out].concat(passedEndSrc)
     val right: Source[Any, Any] = Source.fromGraph(that).concat(passedEndSrc)
-    val zipFlow : Flow[Out, (A, U), NotUsed] = left
+    val zipFlow: Flow[Out, (A, U), NotUsed] = left
       .zip(right)
-      .takeWhile{
+      .takeWhile {
         case (`passedEnd`, `passedEnd`) => false
-        case _ => true
+        case _                          => true
       }
-      .map{
-        case (`passedEnd`, r : U @unchecked) => (thisElem, r)
-        case (l : A @ unchecked, `passedEnd`) => (l, thatElem)
-        case t : (A, U) @ unchecked => t
+      .map {
+        case (`passedEnd`, r: U @unchecked) => (thisElem, r)
+        case (l: A @unchecked, `passedEnd`) => (l, thatElem)
+        case t: (A, U) @unchecked           => t
       }
     via(zipFlow)
   }
@@ -2941,38 +2941,37 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
     viaMat(zipGraph(that))(matF)
 
   /**
-    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
-    *
-    * @see [[#zipAll]]
-    *
-    * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
-    *
-    * '''Backpressures when''' downstream backpressures
-    *
-    * '''Completes when''' all upstream completes
-    *
-    * '''Cancels when''' downstream cancels
-    */
-  def zipAllMat[U, Mat2, Mat3, A >: Out](that: Graph[SourceShape[U], Mat2], thisElem : A, thatElem : U)(matF: (Mat, Mat2) => Mat3): ReprMat[(A, U), Mat3] = {
+   * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
+   *
+   * @see [[#zipAll]]
+   *
+   * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' all upstream completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def zipAllMat[U, Mat2, Mat3, A >: Out](that: Graph[SourceShape[U], Mat2], thisElem: A, thatElem: U)(
+      matF: (Mat, Mat2) => Mat3): ReprMat[(A, U), Mat3] = {
     case object passedEnd
     val passedEndSrc = Source.repeat(passedEnd)
     val left: Flow[Out, Any, NotUsed] = Flow[Out].concat(passedEndSrc)
     val right: Source[Any, Mat2] = Source.fromGraph(that).concatMat(passedEndSrc)(Keep.left)
     val zipFlow: Flow[Out, (A, U), Mat2] = left
       .zipMat(right)(Keep.right)
-      .takeWhile{
+      .takeWhile {
         case (`passedEnd`, `passedEnd`) => false
-        case _ => true
+        case _                          => true
       }
-      .map{
-        case (`passedEnd`, r : U @unchecked) => (thisElem, r)
-        case (l : A @ unchecked, `passedEnd`) => (l, thatElem)
-        case t : (A, U) @ unchecked => t
+      .map {
+        case (`passedEnd`, r: U @unchecked) => (thisElem, r)
+        case (l: A @unchecked, `passedEnd`) => (l, thatElem)
+        case t: (A, U) @unchecked           => t
       }
     viaMat(zipFlow)(matF)
   }
-
-
 
   /**
    * Put together the elements of current flow and the given [[Source]]

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -2419,7 +2419,10 @@ trait FlowOps[+Out, +Mat] {
     via(zipAllFlow(that, thisElem, thatElem))
   }
 
-  protected def zipAllFlow[U, A >: Out, Mat2](that: Graph[SourceShape[U], Mat2], thisElem: A, thatElem: U): Flow[Out @uncheckedVariance, (A, U), Mat2] = {
+  protected def zipAllFlow[U, A >: Out, Mat2](
+      that: Graph[SourceShape[U], Mat2],
+      thisElem: A,
+      thatElem: U): Flow[Out @uncheckedVariance, (A, U), Mat2] = {
     case object passedEnd
     val passedEndSrc = Source.repeat(passedEnd)
     val left: Flow[Out, Any, NotUsed] = Flow[A].concat(passedEndSrc)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -2404,6 +2404,36 @@ trait FlowOps[+Out, +Mat] {
    */
   def zip[U](that: Graph[SourceShape[U], _]): Repr[(Out, U)] = via(zipGraph(that))
 
+  /**
+    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
+    *
+    * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+    *
+    * '''Backpressures when''' downstream backpressures
+    *
+    * '''Completes when''' all upstream completes
+    *
+    * '''Cancels when''' downstream cancels
+    */
+  def zipAll[U, A >: Out](that: Graph[SourceShape[U], _], thisElem : A, thatElem : U): Repr[(A, U)] = {
+    case object passedEnd
+    def passedEndSrc = Source.repeat(passedEnd)
+    val left: Flow[Out, Any, NotUsed] = Flow[Out].concat(passedEndSrc)
+    val right: Source[Any, Any] = Source.fromGraph(that).concat(passedEndSrc)
+    val zipFlow : Flow[Out, (A, U), NotUsed] = left
+      .zip(right)
+      .takeWhile{
+        case (`passedEnd`, `passedEnd`) => false
+        case _ => true
+      }
+      .map{
+        case (`passedEnd`, r : U @unchecked) => (thisElem, r)
+        case (l : A @ unchecked, `passedEnd`) => (l, thatElem)
+        case t : (A, U) @ unchecked => t
+      }
+    via(zipFlow)
+  }
+
   protected def zipGraph[U, M](that: Graph[SourceShape[U], M]): Graph[FlowShape[Out @uncheckedVariance, (Out, U)], M] =
     GraphDSL.create(that) { implicit b => r =>
       val zip = b.add(Zip[Out, U]())
@@ -2909,6 +2939,40 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    */
   def zipMat[U, Mat2, Mat3](that: Graph[SourceShape[U], Mat2])(matF: (Mat, Mat2) => Mat3): ReprMat[(Out, U), Mat3] =
     viaMat(zipGraph(that))(matF)
+
+  /**
+    * Combine the elements of current flow and the given [[Source]] into a stream of tuples.
+    *
+    * @see [[#zipAll]]
+    *
+    * '''Emits when''' when all of the inputs have an element available, once part (but not all) of the inputs complete their values are substituted by the provided defaults.
+    *
+    * '''Backpressures when''' downstream backpressures
+    *
+    * '''Completes when''' all upstream completes
+    *
+    * '''Cancels when''' downstream cancels
+    */
+  def zipAllMat[U, Mat2, Mat3, A >: Out](that: Graph[SourceShape[U], Mat2], thisElem : A, thatElem : U)(matF: (Mat, Mat2) => Mat3): ReprMat[(A, U), Mat3] = {
+    case object passedEnd
+    val passedEndSrc = Source.repeat(passedEnd)
+    val left: Flow[Out, Any, NotUsed] = Flow[Out].concat(passedEndSrc)
+    val right: Source[Any, Mat2] = Source.fromGraph(that).concatMat(passedEndSrc)(Keep.left)
+    val zipFlow: Flow[Out, (A, U), Mat2] = left
+      .zipMat(right)(Keep.right)
+      .takeWhile{
+        case (`passedEnd`, `passedEnd`) => false
+        case _ => true
+      }
+      .map{
+        case (`passedEnd`, r : U @unchecked) => (thisElem, r)
+        case (l : A @ unchecked, `passedEnd`) => (l, thatElem)
+        case t : (A, U) @ unchecked => t
+      }
+    viaMat(zipFlow)(matF)
+  }
+
+
 
   /**
    * Put together the elements of current flow and the given [[Source]]


### PR DESCRIPTION
## Purpose

This PR adds the zipAll functionality to akka streams Source and Flow interfaces. 
This operator is basically taken from scala's standard library, it zips two streams, right-padding the shorter side with default value provided by the caller.

please see #27103 for more details.

## References

References #27103

## Changes

* FlowOps now has zipAll and zipAllMat methods.
* javadsl Source and Flow also have these methods now, implemented based on the FlowOps methods.
* added documentation for the new operator.

## Background Context

This brings the akka streams API a bit closer to scala's standard library's collections.