### PR TITLE
Akka Typed Add example of how to java `getSelf` for persistence typed #27061

### DIFF
--- a/akka-docs/src/main/paradox/typed/actor-lifecycle.md
+++ b/akka-docs/src/main/paradox/typed/actor-lifecycle.md
@@ -21,6 +21,33 @@ forming an actor hierarchy. @apidoc[akka.actor.typed.ActorSystem] hosts the hier
 actor at the top of the hierarchy of the `ActorSystem`. The lifecycle of a child actor is tied to the parent -- a child
 can stop itself or be stopped at any time but it can never outlive its parent.
 
+### The ActorContext
+
+The ActorContext can be accessed for many purposes such as:
+
+* Spawning child actors and supervision
+* Watching other actors (`DeathWatch`) to receive a `Terminated(otherActor)` event should the watched actor stop permanently
+* Logging
+* Creating message adapters
+* Request-response interactions (ask) with another actor
+* Access to the `self` ActorRef
+
+If a behavior needs to use the `ActorContext`, for example to spawn child actors, or use
+@scala[`context.self`]@java[`context.getSelf()`], it can be obtained by wrapping construction with `Behaviors.setup`:
+
+Scala
+:  @@snip [BasicPersistentBehaviorCompileOnly.scala](/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala) { #actor-context }
+
+Java
+:  @@snip [BasicPersistentBehaviorTest.java](/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java) { #actor-context }
+
+#### ActorContext Thread Safety
+
+Many of the methods in `ActorContext` are not thread-safe and
+
+* Must not be accessed by threads from @scala[`scala.concurrent.Future`]@java[`java.util.concurrent.CompletionStage`] callbacks  
+* Must not be shared between several actor instances
+* Should only be used in the ordinary actor message processing thread
 
 ### The Guardian Actor
 

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
@@ -4,28 +4,21 @@
 
 package jdocs.akka.persistence.typed;
 
+import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
 import akka.actor.typed.SupervisorStrategy;
 import akka.actor.typed.javadsl.ActorContext;
 import akka.actor.typed.javadsl.Behaviors;
-import akka.persistence.typed.DeleteEventsFailed;
-import akka.persistence.typed.DeleteSnapshotsFailed;
-import akka.persistence.typed.RecoveryCompleted;
-import akka.persistence.typed.SnapshotFailed;
-import akka.persistence.typed.javadsl.CommandHandler;
-import akka.persistence.typed.javadsl.EventHandler;
-// #behavior
-import akka.persistence.typed.javadsl.EventSourcedBehavior;
-import akka.persistence.typed.PersistenceId;
-
-// #behavior
-import akka.persistence.typed.javadsl.RetentionCriteria;
-import akka.persistence.typed.javadsl.SignalHandler;
+import akka.persistence.typed.*;
+import akka.persistence.typed.javadsl.*;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+// #behavior
+// #behavior
 
 public class BasicPersistentBehaviorTest {
 
@@ -341,9 +334,13 @@ public class BasicPersistentBehaviorTest {
       // this makes the context available to the command handler etc.
       private final ActorContext<Command> ctx;
 
+      // optionally if you only need `ActorContext.getSelf()`
+      private final ActorRef<Command> self;
+
       public MyPersistentBehavior(PersistenceId persistenceId, ActorContext<Command> ctx) {
         super(persistenceId);
         this.ctx = ctx;
+        this.self = ctx.getSelf();
       }
 
       // #actor-context

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
@@ -9,16 +9,24 @@ import akka.actor.typed.Behavior;
 import akka.actor.typed.SupervisorStrategy;
 import akka.actor.typed.javadsl.ActorContext;
 import akka.actor.typed.javadsl.Behaviors;
-import akka.persistence.typed.*;
-import akka.persistence.typed.javadsl.*;
+import akka.persistence.typed.DeleteEventsFailed;
+import akka.persistence.typed.DeleteSnapshotsFailed;
+import akka.persistence.typed.RecoveryCompleted;
+import akka.persistence.typed.SnapshotFailed;
+import akka.persistence.typed.javadsl.CommandHandler;
+import akka.persistence.typed.javadsl.EventHandler;
+// #behavior
+import akka.persistence.typed.javadsl.EventSourcedBehavior;
+import akka.persistence.typed.PersistenceId;
+
+// #behavior
+import akka.persistence.typed.javadsl.RetentionCriteria;
+import akka.persistence.typed.javadsl.SignalHandler;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-
-// #behavior
-// #behavior
 
 public class BasicPersistentBehaviorTest {
 


### PR DESCRIPTION
https://github.com/akka/akka/issues/27061 

## Purpose
Makes it easier to find how to access `self` from typed java API.
 
## Background Context
Motivated by a user question

## Original PR 
Closed https://github.com/akka/akka/pull/27165 
Used @raboof's suggestions which made more sense than on the ticket, and I found a better location for the addition.
 