### PR TITLE
Remoting test tagged as IgnoreForScala212 failed in Jenkins nightly, needs one line of config

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/TypedActorRemoteDeploySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/TypedActorRemoteDeploySpec.scala
@@ -20,6 +20,7 @@ object TypedActorRemoteDeploySpec {
       akka.actor.provider = remote
       akka.remote.classic.netty.tcp.port = 0
       akka.remote.artery.canonical.port = 0
+      akka.remote.use-unsafe-remote-features-without-cluster = on
       """)
 
   trait RemoteNameService {


### PR DESCRIPTION
Test tagged as `IgnoreForScala212` ran in nightly job, it was not hit in the other CI jobs to catch it sooner.  

Resolved by adding one line of config to the test:
`akka.remote.use-unsafe-remote-features-without-cluster = on`

