### PR TITLE
ActorHierarchyExperiments: Send a `start` message to the first actor

### DIFF
--- a/akka-docs/src/test/java/jdocs/typed/tutorial_1/ActorHierarchyExperiments.java
+++ b/akka-docs/src/test/java/jdocs/typed/tutorial_1/ActorHierarchyExperiments.java
@@ -188,7 +188,8 @@ class Main extends AbstractBehavior<String> {
 
 public class ActorHierarchyExperiments {
   public static void main(String[] args) {
-    ActorSystem.create(Main.createBehavior(), "testSystem");
+    ActorRef<String> testSystem = ActorSystem.create(Main.createBehavior(), "testSystem");
+    testSystem.tell("start");
   }
 }
 // #print-refs

--- a/akka-docs/src/test/scala/typed/tutorial_1/ActorHierarchyExperiments.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_1/ActorHierarchyExperiments.scala
@@ -146,7 +146,8 @@ class Main(context: ActorContext[String]) extends AbstractBehavior[String] {
 }
 
 object ActorHierarchyExperiments extends App {
-  ActorSystem(Main(), "testSystem")
+  val testSystem = ActorSystem(Main(), "testSystem")
+  testSystem ! "start"
 }
 //#print-refs
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose
Makes the example code behave like discribed in the documentation: https://doc.akka.io/docs/akka/current/typed/guide/tutorial_1.html

## Changes
Send a `start` message to the first actor.
Otherwise, only the actor system is started, but none of the actors.