### PR TITLE
cluster.joinSeedNodes(...) does not throw warnings when seed hostname contains underscores #25287

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorPathSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorPathSpec.scala
@@ -89,5 +89,10 @@ class ActorPathSpec extends WordSpec with Matchers {
       ActorPath.fromString("akka://mysys/user/boom/*")
     }
 
+    "fail fast if invalid chars in host names when not using AddressFromURIString, e.g. docker host given name" in {
+      Address("akka", "sys", Some("valid"), Some(0)).hasInvalidHostCharacters shouldBe false
+      Address("akka", "sys", Some("in_valid"), Some(0)).hasInvalidHostCharacters shouldBe true
+      intercept[MalformedURLException](AddressFromURIString("akka://sys@in_valid:5001"))
+    }
   }
 }

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorPathSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorPathSpec.scala
@@ -89,15 +89,33 @@ class ActorPathSpec extends WordSpec with Matchers {
       ActorPath.fromString("akka://mysys/user/boom/*")
     }
 
-    "detect invalid chars in host names when not using AddressFromURIString, e.g. docker host given name" in {
-      Address("akka", "sys", Some("valid"), Some(0)).hasInvalidHostCharacters shouldBe false
-      Address("akka", "sys", Some("in_valid"), Some(0)).hasInvalidHostCharacters shouldBe true
+    "detect valid and invalid chars in host names when not using AddressFromURIString, e.g. docker host given name" in {
+      Seq(
+        Address("akka", "sys", Some("valid"), Some(0)),
+        Address("akka", "sys", Some("is_valid.org"), Some(0)),
+        Address("akka", "sys", Some("fu.is_valid.org"), Some(0))).forall(_.hasInvalidHostCharacters) shouldBe false
+
+      Seq(Address("akka", "sys", Some("in_valid"), Some(0)), Address("akka", "sys", Some("invalid._org"), Some(0)))
+        .forall(_.hasInvalidHostCharacters) shouldBe true
+
       intercept[MalformedURLException](AddressFromURIString("akka://sys@in_valid:5001"))
     }
 
+    "not fail fast if the check is called on valid chars in host names" in {
+      Seq(
+        Address("akka", "sys", Some("localhost"), Some(0)),
+        Address("akka", "sys", Some("is_valid.org"), Some(0)),
+        Address("akka", "sys", Some("fu.is_valid.org"), Some(0))).foreach(_.checkHostCharacters())
+    }
+
     "fail fast if the check is called when invalid chars are in host names" in {
-      Address("akka", "sys", Some("localhost"), Some(0)).checkHostCharacters()
+      Seq(
+        Address("akka", "sys", Some("localhost"), Some(0)),
+        Address("akka", "sys", Some("is_valid.org"), Some(0)),
+        Address("akka", "sys", Some("fu.is_valid.org"), Some(0))).foreach(_.checkHostCharacters())
+
       intercept[IllegalArgumentException](Address("akka", "sys", Some("in_valid"), Some(0)).checkHostCharacters())
+      intercept[IllegalArgumentException](Address("akka", "sys", Some("invalid._org"), Some(0)).checkHostCharacters())
     }
   }
 }

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorPathSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorPathSpec.scala
@@ -89,10 +89,15 @@ class ActorPathSpec extends WordSpec with Matchers {
       ActorPath.fromString("akka://mysys/user/boom/*")
     }
 
-    "fail fast if invalid chars in host names when not using AddressFromURIString, e.g. docker host given name" in {
+    "detect invalid chars in host names when not using AddressFromURIString, e.g. docker host given name" in {
       Address("akka", "sys", Some("valid"), Some(0)).hasInvalidHostCharacters shouldBe false
       Address("akka", "sys", Some("in_valid"), Some(0)).hasInvalidHostCharacters shouldBe true
       intercept[MalformedURLException](AddressFromURIString("akka://sys@in_valid:5001"))
+    }
+
+    "fail fast if the check is called when invalid chars are in host names" in {
+      Address("akka", "sys", Some("localhost"), Some(0)).checkHostCharacters()
+      intercept[IllegalArgumentException](Address("akka", "sys", Some("in_valid"), Some(0)).checkHostCharacters())
     }
   }
 }

--- a/akka-actor/src/main/scala/akka/actor/Address.scala
+++ b/akka-actor/src/main/scala/akka/actor/Address.scala
@@ -74,7 +74,8 @@ final case class Address private (protocol: String, system: String, host: Option
    * are any unusual characters in the host string.
    */
   @InternalApi
-  private[akka] def hasInvalidHostCharacters: Boolean = host.exists(_.contains("_"))
+  private[akka] def hasInvalidHostCharacters: Boolean =
+    host.exists(Address.InvalidHostRegex.findFirstIn(_).nonEmpty)
 
   /** INTERNAL API */
   @InternalApi
@@ -84,6 +85,9 @@ final case class Address private (protocol: String, system: String, host: Option
 }
 
 object Address {
+
+  // if underscore and no dot after, then invalid
+  val InvalidHostRegex = "_[^.]*$".r
 
   /**
    * Constructs a new Address with the specified protocol and system name

--- a/akka-actor/src/main/scala/akka/actor/Address.scala
+++ b/akka-actor/src/main/scala/akka/actor/Address.scala
@@ -75,6 +75,12 @@ final case class Address private (protocol: String, system: String, host: Option
    */
   @InternalApi
   private[akka] def hasInvalidHostCharacters: Boolean = host.exists(_.contains("_"))
+
+  /** INTERNAL API */
+  @InternalApi
+  private[akka] def checkHostCharacters(): Unit =
+    require(!hasInvalidHostCharacters, s"Using invalid host characters '$host' in the Address is not allowed.")
+
 }
 
 object Address {

--- a/akka-actor/src/main/scala/akka/actor/Address.scala
+++ b/akka-actor/src/main/scala/akka/actor/Address.scala
@@ -6,8 +6,11 @@ package akka.actor
 import java.net.URI
 import java.net.URISyntaxException
 import java.net.MalformedURLException
+
 import scala.annotation.tailrec
 import scala.collection.immutable
+
+import akka.annotation.InternalApi
 
 /**
  * The address specifies the physical location under which an Actor can be
@@ -65,6 +68,13 @@ final case class Address private (protocol: String, system: String, host: Option
    * `system@host:port`
    */
   def hostPort: String = toString.substring(protocol.length + 3)
+
+  /** INTERNAL API
+   * Check if the address is not created through `AddressFromURIString`, if there
+   * are any unusual characters in the host string.
+   */
+  @InternalApi
+  private[akka] def hasInvalidHostCharacters: Boolean = host.exists(_.contains("_"))
 }
 
 object Address {

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/Cluster.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/Cluster.scala
@@ -81,7 +81,9 @@ sealed trait ClusterCommand
  * The name of the [[akka.actor.ActorSystem]] must be the same for all members of a
  * cluster.
  */
-final case class Join(address: Address) extends ClusterCommand
+final case class Join(address: Address) extends ClusterCommand {
+  address.checkHostCharacters()
+}
 
 object Join {
 
@@ -100,6 +102,7 @@ object Join {
  * cluster or to join the same cluster again.
  */
 final case class JoinSeedNodes(seedNodes: immutable.Seq[Address]) extends ClusterCommand {
+  seedNodes.foreach(_.checkHostCharacters())
 
   /**
    * Java API: Join the specified seed nodes without defining them in config.

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.cluster.typed
 
+import akka.actor.Address
 import akka.actor.typed.scaladsl.adapter._
 import akka.cluster.ClusterEvent._
 import akka.cluster.MemberStatus
@@ -42,6 +43,12 @@ class ClusterApiSpec extends ScalaTestWithActorTestKit(ClusterApiSpec.config) wi
   val untypedSystem1 = system.toUntyped
 
   "A typed Cluster" must {
+
+    "fail fast in a join attempt if invalid chars are in host names, e.g. docker host given name" in {
+      val address = Address("akka", "sys", Some("in_valid"), Some(0))
+      intercept[IllegalArgumentException](Join(address))
+      intercept[IllegalArgumentException](JoinSeedNodes(scala.collection.immutable.Seq(address)))
+    }
 
     "join a cluster and observe events from both sides" in {
 

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -301,7 +301,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
    * cluster.
    */
   def join(address: Address): Unit = {
-    checkHostCharacters(address)
+    address.checkHostCharacters()
     clusterCore ! ClusterUserAction.JoinTo(fillLocal(address))
   }
 
@@ -320,7 +320,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
    * cluster or to join the same cluster again.
    */
   def joinSeedNodes(seedNodes: immutable.Seq[Address]): Unit = {
-    seedNodes.foreach(checkHostCharacters)
+    seedNodes.foreach(_.checkHostCharacters())
     clusterCore ! InternalClusterAction.JoinSeedNodes(seedNodes.toVector.map(fillLocal))
   }
 
@@ -336,11 +336,6 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
    */
   def joinSeedNodes(seedNodes: java.util.List[Address]): Unit =
     joinSeedNodes(Util.immutableSeq(seedNodes))
-
-  private def checkHostCharacters(address: Address): Unit =
-    require(
-      !address.hasInvalidHostCharacters,
-      s"Joining the cluster using invalid host characters '${address.host}' in the Address is not allowed.")
 
   /**
    * Send command to issue state transition to LEAVING for the node specified by 'address'.

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterSpec.scala
@@ -4,26 +4,28 @@
 
 package akka.cluster
 
-import scala.concurrent.duration._
-import akka.testkit.AkkaSpec
-import akka.testkit.ImplicitSender
-import akka.actor.ExtendedActorSystem
-import akka.actor.Address
-import akka.cluster.InternalClusterAction._
 import java.lang.management.ManagementFactory
-import javax.management.ObjectName
-
-import akka.testkit.TestProbe
-import akka.actor.ActorSystem
-import akka.actor.Props
-import com.typesafe.config.ConfigFactory
-import akka.actor.CoordinatedShutdown
-import akka.cluster.ClusterEvent.MemberEvent
-import akka.cluster.ClusterEvent._
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{ Sink, Source, StreamRefs }
 
 import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import akka.actor.ActorSystem
+import akka.actor.Address
+import akka.actor.CoordinatedShutdown
+import akka.actor.ExtendedActorSystem
+import akka.actor.Props
+import akka.cluster.ClusterEvent.MemberEvent
+import akka.cluster.ClusterEvent._
+import akka.cluster.InternalClusterAction._
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.StreamRefs
+import akka.testkit.AkkaSpec
+import akka.testkit.ImplicitSender
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+import javax.management.ObjectName
 
 object ClusterSpec {
   val config = """
@@ -68,6 +70,12 @@ class ClusterSpec extends AkkaSpec(ClusterSpec.config) with ImplicitSender {
     "reply with InitJoinNack for InitJoin before joining" in {
       system.actorSelection("/system/cluster/core/daemon") ! InitJoin(system.settings.config)
       expectMsgType[InitJoinNack]
+    }
+
+    "fail fast in a join if invalid chars in host names, e.g. docker host given name" in {
+      val address = Address("akka", "sys", Some("in_valid"), Some(0))
+      intercept[IllegalArgumentException](cluster.join(address))
+      intercept[IllegalArgumentException](cluster.joinSeedNodes(scala.collection.immutable.Seq(address)))
     }
 
     "initially become singleton cluster when joining itself and reach convergence" in {


### PR DESCRIPTION
https://github.com/akka/akka/issues/25287