### PR TITLE
Remove Behavior.orElse, #26867

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
@@ -11,7 +11,6 @@ import scala.reflect.ClassTag
 import akka.actor.InvalidMessageException
 import akka.actor.typed.internal.BehaviorImpl
 import akka.actor.typed.internal.BehaviorImpl.DeferredBehavior
-import akka.actor.typed.internal.BehaviorImpl.OrElseBehavior
 import akka.actor.typed.internal.BehaviorImpl.StoppedBehavior
 import akka.actor.typed.internal.BehaviorTags
 import akka.actor.typed.internal.InterceptorImpl
@@ -60,16 +59,6 @@ abstract class Behavior[T](private[akka] val _tag: Int) { behavior =>
    */
   @InternalApi private[akka] final def unsafeCast[U]: Behavior[U] = this.asInstanceOf[Behavior[U]]
 
-  /**
-   * Composes this `Behavior` with a fallback `Behavior` which
-   * is used when this `Behavior` doesn't handle the message or signal, i.e.
-   * when `unhandled` is returned.
-   *
-   *  @param that the fallback `Behavior`
-   **/
-  final def orElse(that: Behavior[T]): Behavior[T] = BehaviorImpl.DeferredBehavior[T] { ctx =>
-    new OrElseBehavior[T](Behavior.start(this, ctx), Behavior.start(that, ctx))
-  }
 }
 
 /**

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/BehaviorImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/BehaviorImpl.scala
@@ -167,31 +167,4 @@ private[akka] object BehaviorTags {
   def intercept[O, I](interceptor: () => BehaviorInterceptor[O, I])(behavior: Behavior[I]): Behavior[O] =
     InterceptorImpl(interceptor, behavior)
 
-  class OrElseBehavior[T](first: Behavior[T], second: Behavior[T]) extends ExtensibleBehavior[T] {
-
-    override def receive(ctx: AC[T], msg: T): Behavior[T] = {
-      Behavior.interpretMessage(first, ctx, msg) match {
-        case _: UnhandledBehavior.type => Behavior.interpretMessage(second, ctx, msg)
-        case handled                   => handled
-      }
-    }
-
-    override def receiveSignal(ctx: AC[T], msg: Signal): Behavior[T] = {
-      val result: Behavior[T] = try {
-        Behavior.interpretSignal(first, ctx, msg)
-      } catch {
-        case _: DeathPactException =>
-          // since we don't know what kind of concrete Behavior `first` is, if it is intercepted etc.
-          // the only way we can fallback to second behavior if Terminated wasn't handled is to
-          // catch the DeathPact here and pretend like it was just `unhandled`
-          BehaviorImpl.unhandled
-      }
-
-      result match {
-        case _: UnhandledBehavior.type => Behavior.interpretSignal(second, ctx, msg)
-        case handled                   => handled
-      }
-    }
-  }
-
 }

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -390,6 +390,7 @@ made before finalizing the APIs. Compared to Akka 2.5.x the source incompatible 
 * `BehaviorInterceptor`, `Behaviors.monitor`, `Behaviors.withMdc` and @scala[`widen`]@java[`Behaviors.widen`] takes
   a @scala[`ClassTag` parameter (probably source compatible)]@java[`interceptMessageClass` parameter].
   `interceptMessageType` method in `BehaviorInterceptor` is replaced with this @scala[`ClassTag`]@java[`Class`] parameter.
+* `Behavior.orElse` has been removed because it wasn't safe together with `narrow`.
 
 #### Akka Typed Stream API changes
 


### PR DESCRIPTION
* Kept part of OrElseSpec to illustrate composition with functions or partial functions.
* Also added an experiment with an interceptor that delegates to behaviors. That is
  much more useful for independent composition than the original OrElseBehavior,
  but it has the same type safety problem when combined with narrow

Refs https://github.com/akka/akka/issues/26867
