### PR TITLE
FlowDelay with EmitEarly caused a NPE (#27170)

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDelaySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDelaySpec.scala
@@ -219,5 +219,17 @@ class FlowDelaySpec extends StreamSpec {
 
       probe.request(10).expectNextN(1 to 2).expectComplete()
     }
+
+    // repeater for #27095
+    "not throw NPE when using EmitEarly and buffer is full" taggedAs TimingTest in {
+      val result =
+        Source(1 to 9)
+          .delay(1.second, DelayOverflowStrategy.emitEarly)
+          .addAttributes(Attributes.inputBuffer(5, 5))
+          .runWith(Sink.seq)
+          .futureValue
+
+      result should ===((1 to 9).toSeq)
+    }
   }
 }


### PR DESCRIPTION
🍒 backport of https://github.com/akka/akka/pull/27170

(cherry picked from commit 7c6d3b818a8e0646371e256db18964b7e3fa54d6)
