### PR TITLE
Use SPDX short identifier for license

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -157,7 +157,7 @@ object AkkaBuild {
 
     ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet,
 
-    licenses := Seq(("Apache License, Version 2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
+    licenses := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
     homepage := Some(url("https://akka.io/")),
     description := "Akka is a toolkit for building highly concurrent, distributed, and resilient message-driven applications for Java and Scala.",
 

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -157,7 +157,7 @@ object AkkaBuild {
 
     ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet,
 
-    licenses := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
+    licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))),
     homepage := Some(url("https://akka.io/")),
     description := "Akka is a toolkit for building highly concurrent, distributed, and resilient message-driven applications for Java and Scala.",
 


### PR DESCRIPTION
The [SPDX license list](https://spdx.org/licenses/) defines a standard for identifying licenses that allows tooling to unambiguously identify a license. This changes Akka to use the SPDX short identifier for the Apache 2 license.

Any developer wishing to publish their own build of Akka to bintray will need to make this change, as bintray uses the SPDX short identifier to verify that artifacts being published to free accounts are indeed open source. So this will make it easier for people to publish their own builds.