### PR TITLE
Serialization of case object with Jackson, #27283

### DIFF
--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -68,6 +68,7 @@ object ScalaTestMessages {
   final case class CommandWithTypedActorRef(name: String, replyTo: akka.actor.typed.ActorRef[String])
       extends TestMessage
   final case class CommandWithAddress(name: String, address: Address) extends TestMessage
+  case object SingletonCaseObject extends TestMessage
 
   final case class Event1(field1: String) extends TestMessage
   final case class Event2(field1V2: String, field2: Int) extends TestMessage
@@ -508,6 +509,11 @@ abstract class JacksonSerializerSpec(serializerName: String)
       }
     }
 
+    "serialize case object" in {
+      checkSerialization(TopLevelSingletonCaseObject)
+      checkSerialization(SingletonCaseObject)
+    }
+
     "serialize with ActorRef" in {
       val echo = system.actorOf(TestActors.echoActorProps)
       checkSerialization(CommandWithActorRef("echo", echo))
@@ -617,3 +623,5 @@ abstract class JacksonSerializerSpec(serializerName: String)
 
   }
 }
+
+case object TopLevelSingletonCaseObject extends ScalaTestMessages.TestMessage


### PR DESCRIPTION
* the serializer must treat case objects specially since
  the way the class is loaded is different, and Jackson
  object mapper shouldn't be involved in fromBinary

Refs #27283
