### PR TITLE
Small fix and test coverage for unfoldResourceAsync

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/UnfoldResourceAsyncSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/UnfoldResourceAsyncSourceSpec.scala
@@ -14,7 +14,7 @@ import akka.stream.testkit.Utils._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.{ StreamSpec, TestSubscriber }
 import akka.stream.{ ActorMaterializer, _ }
-import akka.testkit.TestLatch
+import akka.testkit.{ TestLatch, TestProbe }
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
@@ -207,7 +207,7 @@ class UnfoldResourceAsyncSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
             Future.successful {
               startCount.incrementAndGet()
               List(1, 2, 3).iterator
-            },
+          },
           reader =>
             if (!failed) {
               failed = true
@@ -232,7 +232,7 @@ class UnfoldResourceAsyncSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
             Future.successful {
               startCount.incrementAndGet()
               List(1, 2, 3).iterator
-            },
+          },
           reader =>
             if (!failed) {
               failed = true
@@ -342,7 +342,7 @@ class UnfoldResourceAsyncSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
             Future.successful {
               closeLatch.countDown()
               Done
-            })
+          })
         .runWith(Sink.asPublisher(false))(mat)
       val c = TestSubscriber.manualProbe[String]()
       p.subscribe(c)
@@ -380,6 +380,36 @@ class UnfoldResourceAsyncSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
         .runWith(Sink.cancelled)
 
       closed.future.futureValue // will timeout if bug is still here
+    }
+
+    "close the resource when reading an element returns a failed future" in assertAllStagesStopped {
+      val closeProbe = TestProbe()
+      val probe = TestSubscriber.probe[Unit]()
+      Source
+        .unfoldResourceAsync[Unit, Unit](() => Future.successful(()), _ => Future.failed(TE("read failed")), { _ =>
+          closeProbe.ref ! "closed"
+          Future.successful(Done)
+        })
+        .runWith(Sink.fromSubscriber(probe))
+      probe.ensureSubscription()
+      probe.request(1L)
+      probe.expectError()
+      closeProbe.expectMsg("closed")
+    }
+
+    "close the resource when reading an element throws" in assertAllStagesStopped {
+      val closeProbe = TestProbe()
+      val probe = TestSubscriber.probe[Unit]()
+      Source
+        .unfoldResourceAsync[Unit, Unit](() => Future.successful(()), _ => throw TE("read failed"), { _ =>
+          closeProbe.ref ! "closed"
+          Future.successful(Done)
+        })
+        .runWith(Sink.fromSubscriber(probe))
+      probe.ensureSubscription()
+      probe.request(1L)
+      probe.expectError()
+      closeProbe.expectMsg("closed")
     }
   }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/UnfoldResourceAsyncSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/UnfoldResourceAsyncSourceSpec.scala
@@ -207,7 +207,7 @@ class UnfoldResourceAsyncSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
             Future.successful {
               startCount.incrementAndGet()
               List(1, 2, 3).iterator
-          },
+            },
           reader =>
             if (!failed) {
               failed = true
@@ -232,7 +232,7 @@ class UnfoldResourceAsyncSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
             Future.successful {
               startCount.incrementAndGet()
               List(1, 2, 3).iterator
-          },
+            },
           reader =>
             if (!failed) {
               failed = true
@@ -342,7 +342,7 @@ class UnfoldResourceAsyncSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
             Future.successful {
               closeLatch.countDown()
               Done
-          })
+            })
         .runWith(Sink.asPublisher(false))(mat)
       val c = TestSubscriber.manualProbe[String]()
       p.subscribe(c)

--- a/akka-stream/src/main/scala/akka/stream/impl/UnfoldResourceSourceAsync.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/UnfoldResourceSourceAsync.scala
@@ -107,14 +107,13 @@ import scala.util.control.NonFatal
 
     private def createResource(): Unit = {
       create().onComplete { resource =>
-        createdCallback(resource).failed.foreach {
-          case _: StreamDetachedException =>
-            // stream stopped
-            resource match {
-              case Success(r) =>
-                close(r)
-              case Failure(ex) => throw ex // failed to open but stream is stopped already
-            }
+        createdCallback(resource).failed.foreach { _ =>
+          // stream stopped
+          resource match {
+            case Success(r) =>
+              close(r)
+            case Failure(ex) => throw ex // failed to open but stream is stopped already
+          }
         }
       }
     }


### PR DESCRIPTION
Refs #25862

The claimed but was actually not there, but added test coverage for the scenario.

While doing that I noticed that there was a match error in the stage when the close methods throws being logged when the test runs so I fixed that.