### PR TITLE
Harden copyUSAciiBytesToStr, so that it works on Raspberry Pi, #27301

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/AsciiStringCopySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/AsciiStringCopySpec.scala
@@ -12,6 +12,20 @@ class AsciiStringCopySpec extends WordSpec with Matchers {
 
   "The copyUSAsciiStrToBytes optimization" must {
 
+    "select working algorithm" in {
+      if (Unsafe.isIsJavaVersion9Plus) {
+        Unsafe.testUSAsciiStrToBytesAlgorithm0("abc") should ===(true)
+        // this is known to fail with JDK 11 on ARM32 (Raspberry Pi),
+        // and therefore algorithm 0 is selected on that architecture
+        Unsafe.testUSAsciiStrToBytesAlgorithm1("abc") should ===(true)
+        Unsafe.testUSAsciiStrToBytesAlgorithm2("abc") should ===(false)
+      } else {
+        Unsafe.testUSAsciiStrToBytesAlgorithm0("abc") should ===(true)
+        Unsafe.testUSAsciiStrToBytesAlgorithm1("abc") should ===(false)
+        Unsafe.testUSAsciiStrToBytesAlgorithm2("abc") should ===(true)
+      }
+    }
+
     "copy string internal representation successfully" in {
       val ascii = "abcdefghijklmnopqrstuvxyz"
       val byteArray = new Array[Byte](ascii.length)

--- a/akka-actor/src/main/scala/akka/util/Unsafe.java
+++ b/akka-actor/src/main/scala/akka/util/Unsafe.java
@@ -4,17 +4,22 @@
 
 package akka.util;
 
+import akka.annotation.InternalApi;
+
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 /**
  * INTERNAL API
  */
+@InternalApi
 public final class Unsafe {
     public static final sun.misc.Unsafe instance;
 
     private static final long stringValueFieldOffset;
     private static final boolean isJavaVersion9Plus;
+    private static final int copyUSAsciiStrToBytesAlgorithm;
 
     static {
         try {
@@ -30,29 +35,110 @@ public final class Unsafe {
             else instance = found;
             stringValueFieldOffset = instance.objectFieldOffset(String.class.getDeclaredField("value"));
 
-            // See Oracle section 1.5.3 at:
-            // https://docs.oracle.com/javase/8/docs/technotes/guides/versioning/spec/versioning2.html
-            final int[] version = Arrays.
-                stream(System.getProperty("java.specification.version").split("\\.")).
-                mapToInt(Integer::parseInt).
-                toArray();
-            final int javaVersion = version[0] == 1 ? version[1] : version[0];
-            isJavaVersion9Plus = javaVersion > 8;
+            isJavaVersion9Plus = isIsJavaVersion9Plus();
+
+            // Select optimization algorithm for `copyUSAciiBytesToStr`.
+            // For example algorithm 1 will fail with JDK 11 on ARM32 (Raspberry Pi),
+            // and therefore algorithm 0 is selected on that architecture.
+            String testStr = "abc";
+            if (isJavaVersion9Plus && testUSAsciiStrToBytesAlgorithm1(testStr))
+                copyUSAsciiStrToBytesAlgorithm = 1;
+            else if (testUSAsciiStrToBytesAlgorithm2(testStr))
+                copyUSAsciiStrToBytesAlgorithm = 2;
+            else
+              copyUSAsciiStrToBytesAlgorithm = 0;
+
         } catch (Throwable t) {
             throw new ExceptionInInitializerError(t);
         }
     }
 
-    public static void copyUSAsciiStrToBytes(String str, byte[] bytes) {
-        if (isJavaVersion9Plus) {
+    static boolean isIsJavaVersion9Plus() {
+        // See Oracle section 1.5.3 at:
+        // https://docs.oracle.com/javase/8/docs/technotes/guides/versioning/spec/versioning2.html
+        final int[] version = Arrays.
+          stream(System.getProperty("java.specification.version").split("\\.")).
+          mapToInt(Integer::parseInt).
+          toArray();
+        final int javaVersion = version[0] == 1 ? version[1] : version[0];
+        return javaVersion > 8;
+    }
+
+    static boolean testUSAsciiStrToBytesAlgorithm0(String str) {
+        try {
+            byte[] bytes = new byte[str.length()];
+
+            // copy of implementation in copyUSAciiBytesToStr
+            byte[] strBytes = str.getBytes(StandardCharsets.US_ASCII);
+            System.arraycopy(strBytes, 0, bytes, 0, str.length());
+            // end copy
+
+            String result = copyUSAciiBytesToStr(str.length(), bytes);
+            return str.equals(result);
+        } catch (Throwable all) {
+            return false;
+        }
+    }
+
+    static boolean testUSAsciiStrToBytesAlgorithm1(String str) {
+        try {
+            byte[] bytes = new byte[str.length()];
+
+            // copy of implementation in copyUSAciiBytesToStr
             final byte[] chars = (byte[]) instance.getObject(str, stringValueFieldOffset);
             System.arraycopy(chars, 0, bytes, 0, str.length());
-        } else {
+            // end copy
+
+            String result = copyUSAciiBytesToStr(str.length(), bytes);
+            return str.equals(result);
+        } catch (Throwable all) {
+            return false;
+        }
+    }
+
+    static boolean testUSAsciiStrToBytesAlgorithm2(String str) {
+        try {
+            byte[] bytes = new byte[str.length()];
+
+            // copy of implementation in copyUSAciiBytesToStr
             final char[] chars = (char[]) instance.getObject(str, stringValueFieldOffset);
             int i = 0;
             while (i < str.length()) {
                 bytes[i] = (byte) chars[i++];
             }
+            // end copy
+
+            String result = copyUSAciiBytesToStr(str.length(), bytes);
+            return str.equals(result);
+        } catch (Throwable all) {
+            return false;
+        }
+    }
+
+    private static String copyUSAciiBytesToStr(int length, byte[] bytes) {
+        char[] resultChars = new char[length];
+        int i = 0;
+        while (i < length) {
+            // UsAscii
+            resultChars[i] = (char) bytes[i];
+            i += 1;
+        }
+        return String.valueOf(resultChars, 0, length);
+    }
+
+    public static void copyUSAsciiStrToBytes(String str, byte[] bytes) {
+        if (copyUSAsciiStrToBytesAlgorithm == 1) {
+            final byte[] chars = (byte[]) instance.getObject(str, stringValueFieldOffset);
+            System.arraycopy(chars, 0, bytes, 0, str.length());
+        } else if (copyUSAsciiStrToBytesAlgorithm == 2) {
+            final char[] chars = (char[]) instance.getObject(str, stringValueFieldOffset);
+            int i = 0;
+            while (i < str.length()) {
+                bytes[i] = (byte) chars[i++];
+            }
+        } else {
+            byte[] strBytes = str.getBytes(StandardCharsets.US_ASCII);
+            System.arraycopy(strBytes, 0, bytes, 0, str.length());
         }
     }
 
@@ -61,7 +147,7 @@ public final class Unsafe {
         long s1 = 601258;
         int i = 0;
 
-        if (isJavaVersion9Plus) {
+        if (copyUSAsciiStrToBytesAlgorithm == 1) {
             final byte[] chars = (byte[]) instance.getObject(str, stringValueFieldOffset);
             while (i < str.length()) {
                 long x = s0 ^ (long)chars[i++]; // Mix character into PRNG state
@@ -74,8 +160,21 @@ public final class Unsafe {
                 x ^= x >>> 17;
                 s1 = x ^ y;
             }
-        } else {
+        } else if (copyUSAsciiStrToBytesAlgorithm == 2) {
             final char[] chars = (char[]) instance.getObject(str, stringValueFieldOffset);
+            while (i < str.length()) {
+                long x = s0 ^ (long)chars[i++]; // Mix character into PRNG state
+                long y = s1;
+
+                // Xorshift128+ round
+                s0 = y;
+                x ^= x << 23;
+                y ^= y >>> 26;
+                x ^= x >>> 17;
+                s1 = x ^ y;
+            }
+        } else {
+            byte[] chars = str.getBytes(StandardCharsets.US_ASCII);
             while (i < str.length()) {
                 long x = s0 ^ (long)chars[i++]; // Mix character into PRNG state
                 long y = s1;


### PR DESCRIPTION
* With JDK 11 on ARM32 the copyUSAsciiStrToBytes injected a 0 byte
  inbetween each char
* Select optimization algorithm at startup by testing the result.
* Final fallback is plain str.getBytes("us-ascii")

Refs #27301

Example of wrong encoding:
```
19:47:56 DEBUG [Encoder(akka://pi-cluster-0-system)] - sending remote message [ActorSelectionMessage(InitJoin(Config(SimpleConfigObject({"akka":{"cluster":{"downing-provider-class":"","sharding":{"state-store-mode":"ddata"}},"version":"2.5-DEBUG-314-2"}}))),Vector(system, cluster, core, daemon),false)] to [Actor[akka://pi-cluster-0-system@node-2:2550/]] from [Actor[akka://pi-cluster-0-system/system/cluster/core/daemon/firstSeedNodeProcess-1#-240487526]]
   ByteString(391 bytes)

     00 00 00 00 D5 5C A8 A8 C2 D1 17 AC 06 00 00 00  | .....\..........
     1C 00 00 00 81 00 00 00 AA 00 00 00 63 00 61 00  | ............c.a.
     6B 00 6B 00 61 00 3A 00 2F 00 2F 00 70 00 69 00  | k.k.a.:././.p.i.
     2D 00 63 00 6C 00 75 00 73 00 74 00 65 00 72 00  | -.c.l.u.s.t.e.r.
     2D 00 30 00 2D 00 73 00 79 00 73 00 74 00 65 00  | -.0.-.s.y.s.t.e.
     6D 00 40 00 6E 00 6F 00 64 00 65 00 2D 00 31 00  | m.@.n.o.d.e.-.1.
     3A 00 32 00 35 00 35 00 30 00 2F 00 73 00 79 00  | :.2.5.5.0./.s.y.
     73 00 74 00 65 00 6D 00 2F 00 63 00 6C 00 75 00  | s.t.e.m./.c.l.u.
     73 27 00 61 00 6B 00 6B 00 61 00 3A 00 2F 00 2F  | s'.a.k.k.a.:././
     00 70 00 69 00 2D 00 63 00 6C 00 75 00 73 00 74  | .p.i.-.c.l.u.s.t
     00 65 00 72 00 2D 00 30 00 2D 00 00 0A 78 0A 76  | .e.r.-.0.-...x.v
     7B 22 61 6B 6B 61 22 3A 7B 22 63 6C 75 73 74 65  | {"akka":{"cluste
     72 22 3A 7B 22 64 6F 77 6E 69 6E 67 2D 70 72 6F  | r":{"downing-pro
     76 69 64 65 72 2D 63 6C 61 73 73 22 3A 22 22 2C  | vider-class":"",
     22 73 68 61 72 64 69 6E 67 22 3A 7B 22 73 74 61  | "sharding":{"sta
     74 65 2D 73 74 6F 72 65 2D 6D 6F 64 65 22 3A 22  | te-store-mode":"
     64 64 61 74 61 22 7D 7D 2C 22 76 65 72 73 69 6F  | ddata"}},"versio
     6E 22 3A 22 32 2E 35 2D 44 45 42 55 47 2D 33 31  | n":"2.5-DEBUG-31
     34 2D 32 22 7D 7D 10 05 1A 0A 08 01 12 06 73 79  | 4-2"}}........sy
     73 74 65 6D 1A 0B 08 01 12 07 63 6C 75 73 74 65  | stem......cluste
     72 1A 08 08 01 12 04 63 6F 72 65 1A 0A 08 01 12  | r......core.....
     06 64 61 65 6D 6F 6E 22 2C 61 6B 6B 61 2E 63 6C  | .daemon",akka.cl
     75 73 74 65 72 2E 49 6E 74 65 72 6E 61 6C 43 6C  | uster.InternalCl
     75 73 74 65 72 41 63 74 69 6F 6E 24 49 6E 69 74  | usterAction$Init
     4A 6F 69 6E 24 28 00                             | Join$(.
```