### PR TITLE
Java 9+ compilation compat nitpicks

### DIFF
--- a/akka-actor/src/main/scala/akka/io/Dns.scala
+++ b/akka-actor/src/main/scala/akka/io/Dns.scala
@@ -116,7 +116,7 @@ class DnsExt private[akka] (val system: ExtendedActorSystem, resolverName: Strin
         override def apply(r: String): ActorRef = {
           val settings =
             new Settings(system.settings.config.getConfig("akka.io.dns"), "async-dns")
-          val provider = system.dynamicAccess.getClassFor[DnsProvider](settings.ProviderObjectName).get.newInstance()
+          val provider = system.dynamicAccess.createInstanceFor[DnsProvider](settings.ProviderObjectName, Nil).get
           system.log.info("Creating async dns resolver {} with manager name {}", settings.Resolver, managerName)
           system.systemActorOf(
             props = Props(
@@ -163,7 +163,7 @@ class DnsExt private[akka] (val system: ExtendedActorSystem, resolverName: Strin
 
   // System DNS resolver
   val provider: DnsProvider =
-    system.dynamicAccess.getClassFor[DnsProvider](Settings.ProviderObjectName).get.newInstance()
+    system.dynamicAccess.createInstanceFor[DnsProvider](Settings.ProviderObjectName, Nil).get
 
   // System DNS cache
   val cache: Dns = provider.cache

--- a/akka-actor/src/main/scala/akka/util/Reflect.scala
+++ b/akka-actor/src/main/scala/akka/util/Reflect.scala
@@ -42,14 +42,15 @@ private[akka] object Reflect {
    * @param clazz the class which to instantiate an instance of
    * @return a new instance from the default constructor of the given class
    */
-  private[akka] def instantiate[T](clazz: Class[T]): T =
-    try clazz.newInstance
+  private[akka] def instantiate[T](clazz: Class[T]): T = {
+    val ctor = clazz.getDeclaredConstructor()
+    try ctor.newInstance()
     catch {
       case _: IllegalAccessException =>
-        val ctor = clazz.getDeclaredConstructor()
         ctor.setAccessible(true)
         ctor.newInstance()
     }
+  }
 
   /**
    * INTERNAL API


### PR DESCRIPTION
This is generally a bit of boyscouting driven by the switch to Java 11.

In Java 9 `java.lang.Class.newInstance` was deprecated in favour of `java.lang.reflect.Constructor.newInstance`.

In order to be able to at least compile Akka on Java 9+ provided changes are currently sufficient.

<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Provided changes make Akka compile on Java 9+ without deprecation warnings and with `fatal-warnings` compile in general (using `set every targetSystemJdk := true`, of course)

## References

None

## Changes

- use of `clazz.getDeclaredConstructor().newInstance()` instead of `clazz.newInstance()` in `Reflect`
- use of `system.dynamicAccess.createInstanceFor` instead of `system.dynamicAccess.getClassFor` in `Dns`

## Background Context

Switch to Java 11 forces to adjust code
