### PR TITLE
Performance optimization for `akka.cluster.VectorClock.Node#hash`

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/VectorClock.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/VectorClock.scala
@@ -26,12 +26,19 @@ private[cluster] object VectorClock {
 
     def fromHash(hash: String): Node = hash
 
-    private def hash(name: String): String = {
+    private[this] def hash(name: String): String = {
       val digester = MessageDigest.getInstance("MD5")
       digester.update(name.getBytes("UTF-8"))
-      digester.digest.map { h =>
-        "%02x".format(0xFF & h)
-      }.mkString
+      val digest = digester.digest
+      val ch = new Array[Char](digest.length * 2)
+      var i = 0
+      while (i < digest.length) {
+        val h = digest(i)
+        ch(i * 2) = Character.forDigit((h >> 4) & 0xF, 16)
+        ch(i * 2 + 1) = Character.forDigit(h & 0xF, 16)
+        i += 1
+      }
+      String.valueOf(ch)
     }
   }
 


### PR DESCRIPTION
Previous version of `hash` calculation for `VectorClock` was pretty inefficient because of using `String.format`.

This variant is a bit more complicated, but have way better time and allocation perf.

<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Performance optimization

## References

None

## Changes

Changed algorithm for `hash` calculation

## Background Context

I'm cleaning up my boyscouting queue with the changes that can hopefullt improve Akka :)
