### PR TITLE
Move event stream messages to EventStream.*, #27211

### DIFF
--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/eventstream/EventStreamTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/eventstream/EventStreamTest.java
@@ -12,7 +12,6 @@ public class EventStreamTest {
   static class SomeClass {}
 
   public static void compileOnlyTest(ActorSystem<?> actorSystem, ActorRef<SomeClass> actorRef) {
-    actorSystem.eventStream().tell(Subscribe.of(SomeClass.class, actorRef));
-    actorSystem.eventStream().tell(new Subscribe<>(SomeClass.class, actorRef));
+    actorSystem.eventStream().tell(new EventStream.Subscribe<>(SomeClass.class, actorRef));
   }
 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/eventstream/EventStreamSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/eventstream/EventStreamSpec.scala
@@ -13,6 +13,7 @@ import org.scalatest.WordSpecLike
 class EventStreamSpec extends ScalaTestWithActorTestKit with WordSpecLike {
 
   import EventStreamSpec._
+  import EventStream._
 
   private final val ShortWait = 100.millis
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.{ CompletionStage, ThreadFactory }
 
 import akka.actor.BootstrapSetup
 import akka.actor.setup.ActorSystemSetup
+import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.internal.{ EventStreamExtension, InternalRecipientRef }
 import akka.actor.typed.internal.adapter.{ ActorSystemAdapter, GuardianStartupBehavior, PropsAdapter }
 import akka.actor.typed.receptionist.Receptionist
@@ -16,7 +17,6 @@ import akka.util.Helpers.Requiring
 import akka.util.Timeout
 import akka.{ Done, actor => untyped }
 import com.typesafe.config.{ Config, ConfigFactory }
-
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 
 /**
@@ -160,9 +160,9 @@ abstract class ActorSystem[-T] extends ActorRef[T] with Extensions { this: Inter
 
   /**
    * Main event bus of this actor system, used for example for logging.
-   * Accepts [[akka.actor.typed.eventstream.Command]].
+   * Accepts [[akka.actor.typed.eventstream.EventStream.Command]].
    */
-  def eventStream: ActorRef[eventstream.Command] =
+  def eventStream: ActorRef[EventStream.Command] =
     EventStreamExtension(this).ref
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/eventstream/EventStream.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/eventstream/EventStream.scala
@@ -6,80 +6,57 @@ package akka.actor.typed.eventstream
 
 import akka.actor.typed.ActorRef
 import akka.annotation.{ DoNotInherit, InternalApi }
-
 import scala.reflect.ClassTag
 
-/**
- * Not for user Extension
- */
-@DoNotInherit sealed trait Command
-
-/**
- * Publish an event of type E
- * @param event
- * @tparam E
- */
-final case class Publish[E](event: E) extends Command
-
-object Publish {
+object EventStream {
 
   /**
-   * Java API.
+   * The set of commands accepted by the [[akka.actor.typed.ActorSystem.eventStream]].
+   *
+   * Not for user Extension
    */
-  def of[E](event: E): Publish[E] = apply(event)
-}
-
-/**
- * Subscribe a typed actor to listen for types or subtypes of E.
- * ==Simple example==
- * {{{
- *   sealed trait A
- *   case object A1 extends A
- *   //listen for all As
- *   def subscribe(actorSystem: ActorSystem[_], actorRef: ActorRef[A]) =
- *     actorSystem.eventStream ! Subscribe(actorRef)
- *   //listen for A1s only
- *   def subscribe(actorSystem: ActorSystem[_], actorRef: ActorRef[A]) =
- *     actorSystem.eventStream ! Subscribe[A1](actorRef)
- * }}}
- *
- * @param subscriber
- * @param classTag
- * @tparam E
- */
-final case class Subscribe[E](subscriber: ActorRef[E])(implicit classTag: ClassTag[E]) extends Command {
+  @DoNotInherit sealed trait Command
 
   /**
-   * Java API.
+   * Publish an event of type E by sending this command to
+   * the [[akka.actor.typed.ActorSystem.eventStream]].
    */
-  def this(clazz: Class[E], subscriber: ActorRef[E]) = this(subscriber)(ClassTag(clazz))
+  final case class Publish[E](event: E) extends Command
 
   /**
-   * INTERNAL API
+   * Subscribe a typed actor to listen for types or subtypes of E
+   * by sending this command to the [[akka.actor.typed.ActorSystem.eventStream]].
+   *
+   * ==Simple example==
+   * {{{
+   *   sealed trait A
+   *   case object A1 extends A
+   *   //listen for all As
+   *   def subscribe(actorSystem: ActorSystem[_], actorRef: ActorRef[A]) =
+   *     actorSystem.eventStream ! EventStream.Subscribe(actorRef)
+   *   //listen for A1s only
+   *   def subscribe(actorSystem: ActorSystem[_], actorRef: ActorRef[A]) =
+   *     actorSystem.eventStream ! EventStream.Subscribe[A1](actorRef)
+   * }}}
+   *
    */
-  @InternalApi private[akka] def topic: Class[_] = classTag.runtimeClass
-}
+  final case class Subscribe[E](subscriber: ActorRef[E])(implicit classTag: ClassTag[E]) extends Command {
 
-object Subscribe {
+    /**
+     * Java API.
+     */
+    def this(clazz: Class[E], subscriber: ActorRef[E]) = this(subscriber)(ClassTag(clazz))
+
+    /**
+     * INTERNAL API
+     */
+    @InternalApi private[akka] def topic: Class[_] = classTag.runtimeClass
+  }
 
   /**
-   * Java API.
+   * Unsubscribe an actor ref from the event stream
+   * by sending this command to the [[akka.actor.typed.ActorSystem.eventStream]].
    */
-  def of[E](clazz: java.lang.Class[E], subscriber: ActorRef[E]): Subscribe[E] =
-    Subscribe(subscriber)(ClassTag(clazz))
-}
+  final case class Unsubscribe[E](subscriber: ActorRef[E]) extends Command
 
-/**
- * Unsubscribe an actor ref from the event stream
- * @param subscriber
- * @tparam E
- */
-final case class Unsubscribe[E](subscriber: ActorRef[E]) extends Command
-
-object Unsubscribe {
-
-  /**
-   * Java API.
-   */
-  def of[E](subscriber: ActorRef[E]): Unsubscribe[E] = apply(subscriber)
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/EventStreamExtension.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/EventStreamExtension.scala
@@ -4,9 +4,9 @@
 
 package akka.actor.typed.internal
 
-import akka.actor.typed.eventstream.Command
 import akka.actor.typed.internal.adapter.EventStreamAdapter
 import akka.actor.typed._
+import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.scaladsl.adapter._
 import akka.annotation.InternalApi
 
@@ -18,7 +18,7 @@ import akka.annotation.InternalApi
  * It is used as an extension to ensure a single instance per actor system.
  */
 @InternalApi private[akka] final class EventStreamExtension(actorSystem: ActorSystem[_]) extends Extension {
-  val ref: ActorRef[Command] =
+  val ref: ActorRef[EventStream.Command] =
     actorSystem.internalSystemActorOf(EventStreamAdapter.behavior, "eventstream", Props.empty)
 }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/EventStreamAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/EventStreamAdapter.scala
@@ -5,7 +5,7 @@
 package akka.actor.typed.internal.adapter
 
 import akka.actor.typed.Behavior
-import akka.actor.typed.eventstream._
+import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
 import akka.annotation.InternalApi
@@ -16,21 +16,21 @@ import akka.annotation.InternalApi
  */
 @InternalApi private[akka] object EventStreamAdapter {
 
-  private[akka] val behavior: Behavior[Command] =
+  private[akka] val behavior: Behavior[EventStream.Command] =
     Behaviors.setup { ctx =>
       val eventStream = ctx.system.toUntyped.eventStream
       eventStreamBehavior(eventStream)
     }
 
-  private def eventStreamBehavior(eventStream: akka.event.EventStream): Behavior[Command] =
+  private def eventStreamBehavior(eventStream: akka.event.EventStream): Behavior[EventStream.Command] =
     Behaviors.receiveMessage {
-      case Publish(event) =>
+      case EventStream.Publish(event) =>
         eventStream.publish(event)
         Behaviors.same
-      case s @ Subscribe(subscriber) =>
+      case s @ EventStream.Subscribe(subscriber) =>
         eventStream.subscribe(subscriber.toUntyped, s.topic)
         Behaviors.same
-      case Unsubscribe(subscriber) =>
+      case EventStream.Unsubscribe(subscriber) =>
         eventStream.unsubscribe(subscriber.toUntyped)
         Behaviors.same
     }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistImpl.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.internal.receptionist
+
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Dispatchers
+import akka.actor.typed.Props
+import akka.actor.typed.receptionist.Receptionist
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] class ReceptionistImpl(system: ActorSystem[_]) extends Receptionist {
+
+  override val ref: ActorRef[Receptionist.Command] = {
+    val provider: ReceptionistBehaviorProvider =
+      if (system.settings.untypedSettings.ProviderSelectionType.hasCluster) {
+        system.dynamicAccess
+          .getObjectFor[ReceptionistBehaviorProvider]("akka.cluster.typed.internal.receptionist.ClusterReceptionist")
+          .recover {
+            case e =>
+              throw new RuntimeException(
+                "ClusterReceptionist could not be loaded dynamically. Make sure you have " +
+                "'akka-cluster-typed' in the classpath.",
+                e)
+          }
+          .get
+      } else LocalReceptionist
+
+    import akka.actor.typed.scaladsl.adapter._
+    system.internalSystemActorOf(
+      provider.behavior,
+      provider.name,
+      Props.empty.withDispatcherFromConfig(Dispatchers.InternalDispatcherId))
+  }
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/GroupRouterImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/GroupRouterImpl.scala
@@ -6,7 +6,7 @@ package akka.actor.typed.internal.routing
 
 import akka.actor.Dropped
 import akka.actor.typed._
-import akka.actor.typed.eventstream.Publish
+import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.receptionist.Receptionist
 import akka.actor.typed.receptionist.ServiceKey
 import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, StashBuffer }
@@ -61,7 +61,7 @@ private final class InitialGroupRouterImpl[T](
       import akka.actor.typed.scaladsl.adapter._
       if (!stash.isFull) stash.stash(msg)
       else
-        ctx.system.eventStream ! Publish(Dropped(
+        ctx.system.eventStream ! EventStream.Publish(Dropped(
           msg,
           s"Stash is full in group router for [$serviceKey]",
           ctx.self.toUntyped)) // don't fail on full stash
@@ -95,7 +95,7 @@ private final class GroupRouterImpl[T](
       import akka.actor.typed.scaladsl.adapter._
       if (!routeesEmpty) routingLogic.selectRoutee() ! msg
       else
-        ctx.system.eventStream ! Publish(
+        ctx.system.eventStream ! EventStream.Publish(
           Dropped(msg, s"No routees in group router for [$serviceKey]", ctx.self.toUntyped))
       this
   }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -4,13 +4,12 @@
 
 package akka.actor.typed.receptionist
 
-import akka.actor.typed.{ ActorRef, ActorSystem, Dispatchers, Extension, ExtensionId, ExtensionSetup, Props }
+import akka.actor.typed.{ ActorRef, ActorSystem, Extension, ExtensionId, ExtensionSetup }
 import akka.actor.typed.internal.receptionist._
 import akka.annotation.DoNotInherit
 
 import akka.util.ccompat.JavaConverters._
 import scala.reflect.ClassTag
-import akka.annotation.InternalApi
 
 /**
  * This class is not intended for user extension other than for test purposes (e.g.
@@ -20,34 +19,6 @@ import akka.annotation.InternalApi
 @DoNotInherit
 abstract class Receptionist extends Extension {
   def ref: ActorRef[Receptionist.Command]
-}
-
-/**
- * INTERNAL API
- */
-@InternalApi private[akka] class ReceptionistImpl(system: ActorSystem[_]) extends Receptionist {
-
-  override val ref: ActorRef[Receptionist.Command] = {
-    val provider: ReceptionistBehaviorProvider =
-      if (system.settings.untypedSettings.ProviderSelectionType.hasCluster) {
-        system.dynamicAccess
-          .getObjectFor[ReceptionistBehaviorProvider]("akka.cluster.typed.internal.receptionist.ClusterReceptionist")
-          .recover {
-            case e =>
-              throw new RuntimeException(
-                "ClusterReceptionist could not be loaded dynamically. Make sure you have " +
-                "'akka-cluster-typed' in the classpath.",
-                e)
-          }
-          .get
-      } else LocalReceptionist
-
-    import akka.actor.typed.scaladsl.adapter._
-    system.internalSystemActorOf(
-      provider.behavior,
-      provider.name,
-      Props.empty.withDispatcherFromConfig(Dispatchers.InternalDispatcherId))
-  }
 }
 
 object ServiceKey {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -12,6 +12,8 @@ import akka.util.ccompat.JavaConverters._
 import scala.reflect.ClassTag
 
 /**
+ * Register and discover actors that implement a service with a protocol defined by a [[ServiceKey]].
+ *
  * This class is not intended for user extension other than for test purposes (e.g.
  * stub implementation). More methods may be added in the future and that may break
  * such implementations.
@@ -91,8 +93,10 @@ object Receptionist extends ExtensionId[Receptionist] {
   @DoNotInherit abstract class Command
 
   /**
-   * Associate the given [[akka.actor.typed.ActorRef]] with the given [[ServiceKey]]. Multiple
-   * registrations can be made for the same key. De-registration is implied by
+   * `Register` message. Associate the given [[akka.actor.typed.ActorRef]] with the given [[ServiceKey]]
+   * by sending this command to the [[Receptionist.ref]].
+   *
+   * Multiple registrations can be made for the same key. De-registration is implied by
    * the end of the referenced Actor’s lifecycle.
    *
    * Registration will be acknowledged with the [[Registered]] message to the given replyTo actor
@@ -114,12 +118,24 @@ object Receptionist extends ExtensionId[Receptionist] {
   }
 
   /**
-   * Java API: A Register message without Ack that the service was registered
+   * Java API: A Register message without Ack that the service was registered.
+   * Associate the given [[akka.actor.typed.ActorRef]] with the given [[ServiceKey]]
+   * by sending this command to the [[Receptionist.ref]].
+   *
+   * Multiple registrations can be made for the same key. De-registration is implied by
+   * the end of the referenced Actor’s lifecycle.
    */
   def register[T](key: ServiceKey[T], service: ActorRef[T]): Command = Register(key, service)
 
   /**
-   * Java API: A Register message with Ack that the service was registered
+   * Java API: A `Register` message with Ack that the service was registered.
+   * Associate the given [[akka.actor.typed.ActorRef]] with the given [[ServiceKey]]
+   * by sending this command to the [[Receptionist.ref]].
+   *
+   * Multiple registrations can be made for the same key. De-registration is implied by
+   * the end of the referenced Actor’s lifecycle.
+   *
+   * Registration will be acknowledged with the [[Registered]] message to the given replyTo actor.
    */
   def register[T](key: ServiceKey[T], service: ActorRef[T], replyTo: ActorRef[Registered]): Command =
     Register(key, service, replyTo)
@@ -173,7 +189,8 @@ object Receptionist extends ExtensionId[Receptionist] {
     Registered(key, serviceInstance)
 
   /**
-   * Subscribe the given actor to service updates. When new instances are registered or unregistered to the given key
+   * `Subscribe` message. The given actor will subscribe to service updates when this command is sent to
+   * the [[Receptionist.ref]]. When new instances are registered or unregistered to the given key
    * the given subscriber will be sent a [[Listing]] with the new set of instances for that service.
    *
    * The subscription will be acknowledged by sending out a first [[Listing]]. The subscription automatically ends
@@ -190,7 +207,8 @@ object Receptionist extends ExtensionId[Receptionist] {
   }
 
   /**
-   * Java API: Subscribe the given actor to service updates. When new instances are registered or unregistered to the given key
+   * Java API: `Subscribe` message. The given actor to service updates when this command is sent to
+   * * the [[Receptionist.ref]]. When new instances are registered or unregistered to the given key
    * the given subscriber will be sent a [[Listing]] with the new set of instances for that service.
    *
    * The subscription will be acknowledged by sending out a first [[Listing]]. The subscription automatically ends
@@ -199,8 +217,8 @@ object Receptionist extends ExtensionId[Receptionist] {
   def subscribe[T](key: ServiceKey[T], subscriber: ActorRef[Listing]): Command = Subscribe(key, subscriber)
 
   /**
-   * Query the Receptionist for a list of all Actors implementing the given
-   * protocol at one point in time.
+   * `Find` message. Query the Receptionist for a list of all Actors implementing the given
+   * protocol at one point in time by sending this command to the [[Receptionist.ref]].
    */
   object Find {
 
@@ -215,8 +233,8 @@ object Receptionist extends ExtensionId[Receptionist] {
   }
 
   /**
-   * Java API: Query the Receptionist for a list of all Actors implementing the given
-   * protocol at one point in time.
+   * Java API: `Find` message. Query the Receptionist for a list of all Actors implementing the given
+   * protocol at one point in time by sending this command to the [[Receptionist.ref]].
    */
   def find[T](key: ServiceKey[T], replyTo: ActorRef[Listing]): Command =
     Find(key, replyTo)


### PR DESCRIPTION
* for better prefix usage, e.g. EventStream.Publish
* and consistency with Receptionist

Refs #27211

some other cleanup at the same time