### PR TITLE
Cluster aware routers for typed

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/ReceptionistApiSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/ReceptionistApiSpec.scala
@@ -69,16 +69,15 @@ object ReceptionistApiSpec {
       // to cover as much of the API as possible
       context.system.receptionist ! Receptionist.Register(key, context.self.narrow, context.self.narrow)
 
-      Behaviors.receive { (context, message) =>
-        message match {
-          case key.Listing(services) =>
-            services.foreach(_ ! "woho")
-            Behaviors.same
-          case key.Registered(service) => // ack on Register above
-            service ! "woho"
-            Behaviors.same
-        }
+      Behaviors.receiveMessage {
+        case key.Listing(services) =>
+          services.foreach(_ ! "woho")
+          Behaviors.same
+        case key.Registered(service) => // ack on Register above
+          service ! "woho"
+          Behaviors.same
       }
+
     }
   }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/LocalReceptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/LocalReceptionist.scala
@@ -80,7 +80,10 @@ private[akka] object LocalReceptionist extends ReceptionistBehaviorProvider {
 
       def notifySubscribersFor[T](key: AbstractServiceKey): Unit = {
         val newListing = newRegistry.get(key)
-        subscriptions.get(key).foreach(_ ! ReceptionistMessages.Listing(key.asServiceKey, newListing, newListing, true))
+        subscriptions
+          .get(key)
+          .foreach(
+            _ ! ReceptionistMessages.Listing(key.asServiceKey, newListing, newListing, onlyReachabilityChanged = false))
       }
 
       changedKeysHint.foreach(notifySubscribersFor)
@@ -89,7 +92,7 @@ private[akka] object LocalReceptionist extends ReceptionistBehaviorProvider {
 
     def replyWithListing[T](key: ServiceKey[T], replyTo: ActorRef[Listing]): Unit = {
       val listing = serviceRegistry.get(key)
-      replyTo ! ReceptionistMessages.Listing(key, listing, listing, true)
+      replyTo ! ReceptionistMessages.Listing(key, listing, listing, onlyReachabilityChanged = false)
     }
 
     def onCommand(ctx: ActorContext[Any], cmd: Command): Behavior[Any] = cmd match {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/LocalReceptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/LocalReceptionist.scala
@@ -80,15 +80,17 @@ private[akka] object LocalReceptionist extends ReceptionistBehaviorProvider {
 
       def notifySubscribersFor[T](key: AbstractServiceKey): Unit = {
         val newListing = newRegistry.get(key)
-        subscriptions.get(key).foreach(_ ! ReceptionistMessages.Listing(key.asServiceKey, newListing))
+        subscriptions.get(key).foreach(_ ! ReceptionistMessages.Listing(key.asServiceKey, newListing, newListing, true))
       }
 
       changedKeysHint.foreach(notifySubscribersFor)
       next(newRegistry = newRegistry)
     }
 
-    def replyWithListing[T](key: ServiceKey[T], replyTo: ActorRef[Listing]): Unit =
-      replyTo ! ReceptionistMessages.Listing(key, serviceRegistry.get(key))
+    def replyWithListing[T](key: ServiceKey[T], replyTo: ActorRef[Listing]): Unit = {
+      val listing = serviceRegistry.get(key)
+      replyTo ! ReceptionistMessages.Listing(key, listing, listing, true)
+    }
 
     def onCommand(ctx: ActorContext[Any], cmd: Command): Behavior[Any] = cmd match {
       case ReceptionistMessages.Register(key, serviceInstance, maybeReplyTo) =>

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/LocalReceptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/LocalReceptionist.scala
@@ -83,7 +83,8 @@ private[akka] object LocalReceptionist extends ReceptionistBehaviorProvider {
         subscriptions
           .get(key)
           .foreach(
-            _ ! ReceptionistMessages.Listing(key.asServiceKey, newListing, newListing, onlyReachabilityChanged = false))
+            _ ! ReceptionistMessages
+              .Listing(key.asServiceKey, newListing, newListing, servicesWereAddedOrRemoved = true))
       }
 
       changedKeysHint.foreach(notifySubscribersFor)
@@ -92,7 +93,7 @@ private[akka] object LocalReceptionist extends ReceptionistBehaviorProvider {
 
     def replyWithListing[T](key: ServiceKey[T], replyTo: ActorRef[Listing]): Unit = {
       val listing = serviceRegistry.get(key)
-      replyTo ! ReceptionistMessages.Listing(key, listing, listing, onlyReachabilityChanged = false)
+      replyTo ! ReceptionistMessages.Listing(key, listing, listing, servicesWereAddedOrRemoved = true)
     }
 
     def onCommand(ctx: ActorContext[Any], cmd: Command): Behavior[Any] = cmd match {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistMessages.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistMessages.scala
@@ -46,7 +46,7 @@ private[akka] object ReceptionistMessages {
       key: ServiceKey[T],
       _serviceInstances: Set[ActorRef[T]],
       _allServiceInstances: Set[ActorRef[T]],
-      onlyReachabilityChanged: Boolean)
+      servicesWereAddedOrRemoved: Boolean)
       extends Receptionist.Listing {
 
     def isForKey(key: ServiceKey[_]): Boolean = key == this.key

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistMessages.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistMessages.scala
@@ -4,8 +4,6 @@
 
 package akka.actor.typed.internal.receptionist
 
-import java.util
-
 import akka.actor.typed.ActorRef
 import akka.actor.typed.receptionist.Receptionist.Command
 import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
@@ -68,7 +66,7 @@ private[akka] object ReceptionistMessages {
       _allServiceInstances.asInstanceOf[Set[ActorRef[M]]]
     }
 
-    override def getAllServiceInstances[M](key: ServiceKey[M]): util.Set[ActorRef[M]] =
+    override def getAllServiceInstances[M](key: ServiceKey[M]): java.util.Set[ActorRef[M]] =
       allServiceInstances(key).asJava
 
     override def getAllServiceInstancesChanged: Boolean = allServiceInstancesChanged

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistMessages.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistMessages.scala
@@ -46,7 +46,7 @@ private[akka] object ReceptionistMessages {
       key: ServiceKey[T],
       _serviceInstances: Set[ActorRef[T]],
       _allServiceInstances: Set[ActorRef[T]],
-      allServiceInstancesChanged: Boolean)
+      onlyReachabilityChanged: Boolean)
       extends Receptionist.Listing {
 
     def isForKey(key: ServiceKey[_]): Boolean = key == this.key
@@ -68,8 +68,6 @@ private[akka] object ReceptionistMessages {
 
     override def getAllServiceInstances[M](key: ServiceKey[M]): java.util.Set[ActorRef[M]] =
       allServiceInstances(key).asJava
-
-    override def getAllServiceInstancesChanged: Boolean = allServiceInstancesChanged
   }
 
   final case class Subscribe[T] private[akka] (key: ServiceKey[T], subscriber: ActorRef[Receptionist.Listing])

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/GroupRouterImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/GroupRouterImpl.scala
@@ -94,8 +94,7 @@ private[akka] final class GroupRouterImpl[T](
           // are unreachable, in that case trying the unreachable ones is better than dropping messages
           l.allServiceInstances(serviceKey)
       routeesEmpty = routees.isEmpty
-      if (!routeesEmpty)
-        routingLogic.routeesUpdated(routees)
+      routingLogic.routeesUpdated(routees)
       this
     case msg: T @unchecked =>
       import akka.actor.typed.scaladsl.adapter._

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/GroupRouterImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/GroupRouterImpl.scala
@@ -80,13 +80,11 @@ private[akka] final class GroupRouterImpl[T](
     routeesInitiallyEmpty: Boolean)
     extends AbstractBehavior[T] {
 
-  // casting trix to avoid having to wrap incoming messages - note that this will cause problems if intercepting
-  // messages to a router
-  ctx.system.receptionist ! Receptionist.Subscribe(serviceKey, ctx.self.unsafeUpcast[Any].narrow[Receptionist.Listing])
   private var routeesEmpty = routeesInitiallyEmpty
 
   def onMessage(msg: T): Behavior[T] = msg match {
     case l @ serviceKey.Listing(update) =>
+      ctx.log.debug("Update from receptionist: [{}]", l)
       val routees =
         if (update.nonEmpty) update
         else

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -331,22 +331,15 @@ object Receptionist extends ExtensionId[Receptionist] {
     def getAllServiceInstances[T](key: ServiceKey[T]): java.util.Set[ActorRef[T]]
 
     /**
-     * Scala API: `true` only if new services were added or removed and `false` if this listing is
-     * only about reachability changes. Useful for subscribers only concerned with [[#allServiceInstances]].
+     * Returns `false` only if new services were added or removed and `true` if this listing is
+     * only about reachability changes. Useful for subscribers only concerned with [[#allServiceInstances]]
+     * or [[#getAllServiceInstances]] that can then ignore such `Listing`s.
      *
-     * In a non-clustered `ActorSystem` this will be `true` for all listings.
-     * For `Find` queries and the initial listing for a `Subscribe` this will always be `true`.
+     * In a non-clustered `ActorSystem` this will be `false` for all listings.
+     * For `Find` queries and the initial listing for a `Subscribe` this will always be `false`.
      */
-    def allServiceInstancesChanged: Boolean
+    def onlyReachabilityChanged: Boolean
 
-    /**
-     * JavaAPI: `true` only if new services were added or removed and `false` if this listing is
-     * only about reachability changes. Useful for subscribers only concerned with [[#getAllServiceInstances]].
-     *
-     * In a non-clustered `ActorSystem` this will be `true` for all listings.
-     * For `Find` queries and the initial listing for a `Subscribe` this will always be `true`.
-     */
-    def getAllServiceInstancesChanged: Boolean
   }
 
   /**
@@ -356,22 +349,22 @@ object Receptionist extends ExtensionId[Receptionist] {
 
     /** Scala API: */
     def apply[T](key: ServiceKey[T], serviceInstances: Set[ActorRef[T]]): Listing =
-      apply(key, serviceInstances, serviceInstances, allServiceInstancesChanged = true)
+      apply(key, serviceInstances, serviceInstances, onlyReachabilityChanged = false)
 
     /** Scala API: */
     def apply[T](
         key: ServiceKey[T],
         serviceInstances: Set[ActorRef[T]],
         allServiceInstances: Set[ActorRef[T]],
-        allServiceInstancesChanged: Boolean): Listing =
-      new ReceptionistMessages.Listing[T](key, serviceInstances, allServiceInstances, allServiceInstancesChanged)
+        onlyReachabilityChanged: Boolean): Listing =
+      new ReceptionistMessages.Listing[T](key, serviceInstances, allServiceInstances, onlyReachabilityChanged)
   }
 
   /**
    * Java API: Sent by the receptionist, available here for easier testing
    */
   def listing[T](key: ServiceKey[T], serviceInstances: java.util.Set[ActorRef[T]]): Listing =
-    Listing(key, Set[ActorRef[T]](serviceInstances.asScala.toSeq: _*))
+    Listing(key, serviceInstances.asScala.toSet)
 
   /**
    * Java API: Sent by the receptionist, available here for easier testing
@@ -381,11 +374,7 @@ object Receptionist extends ExtensionId[Receptionist] {
       serviceInstances: java.util.Set[ActorRef[T]],
       allServiceInstances: java.util.Set[ActorRef[T]],
       allServiceInstancesChanged: Boolean): Listing =
-    Listing(
-      key,
-      Set[ActorRef[T]](serviceInstances.asScala.toSeq: _*),
-      Set[ActorRef[T]](allServiceInstances.asScala.toSeq: _*),
-      allServiceInstancesChanged)
+    Listing(key, serviceInstances.asScala.toSet, allServiceInstances.asScala.toSet, allServiceInstancesChanged)
 
 }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -331,14 +331,17 @@ object Receptionist extends ExtensionId[Receptionist] {
     def getAllServiceInstances[T](key: ServiceKey[T]): java.util.Set[ActorRef[T]]
 
     /**
-     * Returns `true` if this listing is only about reachability changes and `false` if new services were
-     * actually added or removed to the receptionist. Useful for subscribers only concerned with [[#allServiceInstances]]
-     * or [[#getAllServiceInstances]] that can then ignore `Listing`s related to reachability.
+     * Returns `true` only if this `Listing` was sent triggered by new actors added or removed to the receptionist.
+     * When `false` the event is only about reachability changes - meaning that the full set of actors
+     * ([[#allServiceInstances]] or [[#getAllServiceInstances]]) is the same as the previous `Listing`.
      *
-     * In a non-clustered `ActorSystem` this will be `false` for all listings.
-     * For `Find` queries and the initial listing for a `Subscribe` this will always be `false`.
+     * knowing this is useful for subscribers only concerned with [[#allServiceInstances]] or [[#getAllServiceInstances]]
+     * that can then ignore `Listing`s related to reachability.
+     *
+     * In a non-clustered `ActorSystem` this will be `true` for all listings.
+     * For `Find` queries and the initial listing for a `Subscribe` this will always be `true`.
      */
-    def onlyReachabilityChanged: Boolean
+    def servicesWereAddedOrRemoved: Boolean
 
   }
 
@@ -349,15 +352,15 @@ object Receptionist extends ExtensionId[Receptionist] {
 
     /** Scala API: */
     def apply[T](key: ServiceKey[T], serviceInstances: Set[ActorRef[T]]): Listing =
-      apply(key, serviceInstances, serviceInstances, onlyReachabilityChanged = false)
+      apply(key, serviceInstances, serviceInstances, servicesWereAddedOrRemoved = true)
 
     /** Scala API: */
     def apply[T](
         key: ServiceKey[T],
         serviceInstances: Set[ActorRef[T]],
         allServiceInstances: Set[ActorRef[T]],
-        onlyReachabilityChanged: Boolean): Listing =
-      new ReceptionistMessages.Listing[T](key, serviceInstances, allServiceInstances, onlyReachabilityChanged)
+        servicesWereAddedOrRemoved: Boolean): Listing =
+      new ReceptionistMessages.Listing[T](key, serviceInstances, allServiceInstances, servicesWereAddedOrRemoved)
   }
 
   /**
@@ -373,8 +376,8 @@ object Receptionist extends ExtensionId[Receptionist] {
       key: ServiceKey[T],
       serviceInstances: java.util.Set[ActorRef[T]],
       allServiceInstances: java.util.Set[ActorRef[T]],
-      allServiceInstancesChanged: Boolean): Listing =
-    Listing(key, serviceInstances.asScala.toSet, allServiceInstances.asScala.toSet, allServiceInstancesChanged)
+      servicesWereAddedOrRemoved: Boolean): Listing =
+    Listing(key, serviceInstances.asScala.toSet, allServiceInstances.asScala.toSet, servicesWereAddedOrRemoved)
 
 }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -333,14 +333,18 @@ object Receptionist extends ExtensionId[Receptionist] {
     /**
      * Scala API: `true` only if new services was added or removed and `false` if this listing is
      * only about reachability changes. Useful for subscribers that only cares about [[#allServiceInstances]].
+     *
      * In a non-clustered `ActorSystem` this will be `true` for all listings.
+     * For `Find` queries and the initial listing for a `Subscribe` this will always be `true`.
      */
     def allServiceInstancesChanged: Boolean
 
     /**
      * JavaAPI: `true` only if new services was added or removed and `false` if this listing is
      * only about reachability changes. Useful for subscribers that only cares about [[#getAllServiceInstances]].
+     *
      * In a non-clustered `ActorSystem` this will be `true` for all listings.
+     * For `Find` queries and the initial listing for a `Subscribe` this will always be `true`.
      */
     def getAllServiceInstancesChanged: Boolean
   }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -89,9 +89,9 @@ abstract class ServiceKey[T] extends AbstractServiceKey { key =>
    *   case MyServiceKey.Listing(reachable) =>
    * ```
    *
-   * In a non-clustered actorsystem this will always be all registered instances
-   * for a service key. For a clustered environment services on nodes that has
-   * been observed unreachable is not among these (note that they could have
+   * In a non-clustered `ActorSystem` this will always be all registered instances
+   * for a service key. For a clustered environment services on nodes that have
+   * been observed unreachable are not among these (note that they could have
    * become unreachable between this message being sent and the receiving actor
    * processing it).
    */
@@ -331,8 +331,8 @@ object Receptionist extends ExtensionId[Receptionist] {
     def getAllServiceInstances[T](key: ServiceKey[T]): java.util.Set[ActorRef[T]]
 
     /**
-     * Scala API: `true` only if new services was added or removed and `false` if this listing is
-     * only about reachability changes. Useful for subscribers that only cares about [[#allServiceInstances]].
+     * Scala API: `true` only if new services were added or removed and `false` if this listing is
+     * only about reachability changes. Useful for subscribers only concerned with [[#allServiceInstances]].
      *
      * In a non-clustered `ActorSystem` this will be `true` for all listings.
      * For `Find` queries and the initial listing for a `Subscribe` this will always be `true`.
@@ -340,8 +340,8 @@ object Receptionist extends ExtensionId[Receptionist] {
     def allServiceInstancesChanged: Boolean
 
     /**
-     * JavaAPI: `true` only if new services was added or removed and `false` if this listing is
-     * only about reachability changes. Useful for subscribers that only cares about [[#getAllServiceInstances]].
+     * JavaAPI: `true` only if new services were added or removed and `false` if this listing is
+     * only about reachability changes. Useful for subscribers that only care about [[#getAllServiceInstances]].
      *
      * In a non-clustered `ActorSystem` this will be `true` for all listings.
      * For `Find` queries and the initial listing for a `Subscribe` this will always be `true`.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -341,7 +341,7 @@ object Receptionist extends ExtensionId[Receptionist] {
 
     /**
      * JavaAPI: `true` only if new services were added or removed and `false` if this listing is
-     * only about reachability changes. Useful for subscribers that only care about [[#getAllServiceInstances]].
+     * only about reachability changes. Useful for subscribers only concerned with [[#getAllServiceInstances]].
      *
      * In a non-clustered `ActorSystem` this will be `true` for all listings.
      * For `Find` queries and the initial listing for a `Subscribe` this will always be `true`.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/receptionist/Receptionist.scala
@@ -331,9 +331,9 @@ object Receptionist extends ExtensionId[Receptionist] {
     def getAllServiceInstances[T](key: ServiceKey[T]): java.util.Set[ActorRef[T]]
 
     /**
-     * Returns `false` only if new services were added or removed and `true` if this listing is
-     * only about reachability changes. Useful for subscribers only concerned with [[#allServiceInstances]]
-     * or [[#getAllServiceInstances]] that can then ignore such `Listing`s.
+     * Returns `true` if this listing is only about reachability changes and `false` if new services were
+     * actually added or removed to the receptionist. Useful for subscribers only concerned with [[#allServiceInstances]]
+     * or [[#getAllServiceInstances]] that can then ignore `Listing`s related to reachability.
      *
      * In a non-clustered `ActorSystem` this will be `false` for all listings.
      * For `Find` queries and the initial listing for a `Subscribe` this will always be `false`.

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
@@ -16,14 +16,17 @@ import akka.cluster.ddata.{ ORMultiMap, ORMultiMapKey, Replicator }
 import akka.cluster.{ Cluster, ClusterEvent, UniqueAddress }
 import akka.remote.AddressUidExtension
 import akka.util.TypedMultiMap
-import scala.concurrent.duration._
 
+import scala.concurrent.duration._
 import akka.actor.Address
 import akka.cluster.ClusterEvent.ClusterDomainEvent
 import akka.cluster.ClusterEvent.ClusterShuttingDown
 import akka.cluster.ClusterEvent.MemberJoined
 import akka.cluster.ClusterEvent.MemberUp
 import akka.cluster.ClusterEvent.MemberWeaklyUp
+import akka.cluster.ClusterEvent.ReachabilityEvent
+import akka.cluster.ClusterEvent.ReachableMember
+import akka.cluster.ClusterEvent.UnreachableMember
 import akka.cluster.ddata.SelfUniqueAddress
 
 // just to provide a log class
@@ -60,6 +63,8 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
       extends InternalCommand
   private final case class NodeAdded(addresses: UniqueAddress) extends InternalCommand
   private final case class NodeRemoved(addresses: UniqueAddress) extends InternalCommand
+  private final case class NodeUnreachable(addresses: UniqueAddress) extends InternalCommand
+  private final case class NodeReachable(addresses: UniqueAddress) extends InternalCommand
   private final case class ChangeFromReplicator(key: DDataKey, value: ORMultiMap[ServiceKey[_], Entry])
       extends InternalCommand
   private case object RemoveTick extends InternalCommand
@@ -109,11 +114,13 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
         // remove entries when members are removed
         val clusterEventMessageAdapter: ActorRef[ClusterDomainEvent] =
           ctx.messageAdapter[ClusterDomainEvent] {
-            case MemberJoined(member)     => NodeAdded(member.uniqueAddress)
-            case MemberWeaklyUp(member)   => NodeAdded(member.uniqueAddress)
-            case MemberUp(member)         => NodeAdded(member.uniqueAddress)
-            case MemberRemoved(member, _) => NodeRemoved(member.uniqueAddress)
-            case ClusterShuttingDown      => NodeRemoved(setup.cluster.selfUniqueAddress)
+            case MemberJoined(member)      => NodeAdded(member.uniqueAddress)
+            case MemberWeaklyUp(member)    => NodeAdded(member.uniqueAddress)
+            case MemberUp(member)          => NodeAdded(member.uniqueAddress)
+            case MemberRemoved(member, _)  => NodeRemoved(member.uniqueAddress)
+            case UnreachableMember(member) => NodeUnreachable(member.uniqueAddress)
+            case ReachableMember(member)   => NodeReachable(member.uniqueAddress)
+            case ClusterShuttingDown       => NodeRemoved(setup.cluster.selfUniqueAddress)
             case other =>
               throw new IllegalStateException(s"Unexpected ClusterDomainEvent $other. Please report bug.")
           }
@@ -124,6 +131,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
           classOf[MemberWeaklyUp],
           classOf[MemberUp],
           classOf[MemberRemoved],
+          classOf[ReachabilityEvent],
           ClusterShuttingDown.getClass)
 
         // also periodic cleanup in case removal from ORMultiMap is skipped due to concurrent update,
@@ -231,15 +239,18 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
           Behaviors.same
 
         case ReceptionistMessages.Find(key, replyTo) =>
-          replyTo ! ReceptionistMessages.Listing(key.asServiceKey, registry.activeActorRefsFor(key, selfUniqueAddress))
+          val (reachable, all) = registry.activeActorRefsFor(key, selfUniqueAddress)
+          replyTo ! ReceptionistMessages.Listing(key.asServiceKey, reachable, all, true)
           Behaviors.same
 
         case ReceptionistMessages.Subscribe(key, subscriber) =>
           watchWith(ctx, subscriber, SubscriberTerminated(key, subscriber))
 
           // immediately reply with initial listings to the new subscriber
-          val listing =
-            ReceptionistMessages.Listing(key.asServiceKey, registry.activeActorRefsFor(key, selfUniqueAddress))
+          val listing = {
+            val (reachable, all) = registry.activeActorRefsFor(key, selfUniqueAddress)
+            ReceptionistMessages.Listing(key.asServiceKey, reachable, all, true)
+          }
           subscriber ! listing
 
           next(newSubscriptions = subscriptions.inserted(key)(subscriber))
@@ -287,9 +298,8 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
 
               val subscribers = subscriptions.get(changedKey)
               if (subscribers.nonEmpty) {
-                val listing =
-                  ReceptionistMessages
-                    .Listing(serviceKey, newRegistry.activeActorRefsFor(serviceKey, selfUniqueAddress))
+                val (reachable, all) = newRegistry.activeActorRefsFor(serviceKey, selfUniqueAddress)
+                val listing = ReceptionistMessages.Listing(serviceKey, reachable, all, true)
                 subscribers.foreach(_ ! listing)
               }
 
@@ -339,6 +349,50 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
 
             next(registry.removeNode(uniqueAddress))
           }
+
+        case NodeUnreachable(uniqueAddress) =>
+          val keysForNode = registry.keysFor(uniqueAddress)
+          val newRegistry = registry.addUnreachable(uniqueAddress)
+          if (keysForNode.nonEmpty) {
+            ctx.log.debug(
+              "ClusterReceptionist [{}] - Node with registered services unreachable [{}]",
+              cluster.selfAddress,
+              uniqueAddress)
+            keysForNode.foreach { changedKey =>
+              val serviceKey = changedKey.asServiceKey
+
+              val subscribers = subscriptions.get(changedKey)
+              if (subscribers.nonEmpty) {
+                val (reachable, all) = newRegistry.activeActorRefsFor(serviceKey, selfUniqueAddress)
+                val listing =
+                  ReceptionistMessages.Listing(serviceKey, reachable, all, allServiceInstancesChanged = false)
+                subscribers.foreach(_ ! listing)
+              }
+            }
+          }
+          next(newRegistry)
+
+        case NodeReachable(uniqueAddress) =>
+          val keysForNode = registry.keysFor(uniqueAddress)
+          val newRegistry = registry.removeUnreachable(uniqueAddress)
+          if (keysForNode.nonEmpty) {
+            ctx.log.debug(
+              "ClusterReceptionist [{}] - Node with registered services reachable again [{}]",
+              cluster.selfAddress,
+              uniqueAddress)
+            keysForNode.foreach { changedKey =>
+              val serviceKey = changedKey.asServiceKey
+
+              val subscribers = subscriptions.get(changedKey)
+              if (subscribers.nonEmpty) {
+                val (reachable, all) = newRegistry.activeActorRefsFor(serviceKey, selfUniqueAddress)
+                val listing =
+                  ReceptionistMessages.Listing(serviceKey, reachable, all, allServiceInstancesChanged = false)
+                subscribers.foreach(_ ! listing)
+              }
+            }
+          }
+          next(newRegistry)
 
         case RemoveTick =>
           // ok to update from several nodes but more efficient to try to do it from one node

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
@@ -240,7 +240,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
 
         case ReceptionistMessages.Find(key, replyTo) =>
           val (reachable, all) = registry.activeActorRefsFor(key, selfUniqueAddress)
-          replyTo ! ReceptionistMessages.Listing(key.asServiceKey, reachable, all, onlyReachabilityChanged = false)
+          replyTo ! ReceptionistMessages.Listing(key.asServiceKey, reachable, all, servicesWereAddedOrRemoved = true)
           Behaviors.same
 
         case ReceptionistMessages.Subscribe(key, subscriber) =>
@@ -249,7 +249,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
           // immediately reply with initial listings to the new subscriber
           val listing = {
             val (reachable, all) = registry.activeActorRefsFor(key, selfUniqueAddress)
-            ReceptionistMessages.Listing(key.asServiceKey, reachable, all, onlyReachabilityChanged = false)
+            ReceptionistMessages.Listing(key.asServiceKey, reachable, all, servicesWereAddedOrRemoved = true)
           }
           subscriber ! listing
 
@@ -299,7 +299,8 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
               val subscribers = subscriptions.get(changedKey)
               if (subscribers.nonEmpty) {
                 val (reachable, all) = newRegistry.activeActorRefsFor(serviceKey, selfUniqueAddress)
-                val listing = ReceptionistMessages.Listing(serviceKey, reachable, all, onlyReachabilityChanged = false)
+                val listing =
+                  ReceptionistMessages.Listing(serviceKey, reachable, all, servicesWereAddedOrRemoved = true)
                 subscribers.foreach(_ ! listing)
               }
 
@@ -365,7 +366,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
               if (subscribers.nonEmpty) {
                 val (reachable, all) = newRegistry.activeActorRefsFor(serviceKey, selfUniqueAddress)
                 val listing =
-                  ReceptionistMessages.Listing(serviceKey, reachable, all, onlyReachabilityChanged = true)
+                  ReceptionistMessages.Listing(serviceKey, reachable, all, servicesWereAddedOrRemoved = true)
                 subscribers.foreach(_ ! listing)
               }
             }
@@ -387,7 +388,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
               if (subscribers.nonEmpty) {
                 val (reachable, all) = newRegistry.activeActorRefsFor(serviceKey, selfUniqueAddress)
                 val listing =
-                  ReceptionistMessages.Listing(serviceKey, reachable, all, onlyReachabilityChanged = true)
+                  ReceptionistMessages.Listing(serviceKey, reachable, all, servicesWereAddedOrRemoved = true)
                 subscribers.foreach(_ ! listing)
               }
             }

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
@@ -240,7 +240,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
 
         case ReceptionistMessages.Find(key, replyTo) =>
           val (reachable, all) = registry.activeActorRefsFor(key, selfUniqueAddress)
-          replyTo ! ReceptionistMessages.Listing(key.asServiceKey, reachable, all, true)
+          replyTo ! ReceptionistMessages.Listing(key.asServiceKey, reachable, all, onlyReachabilityChanged = false)
           Behaviors.same
 
         case ReceptionistMessages.Subscribe(key, subscriber) =>
@@ -249,7 +249,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
           // immediately reply with initial listings to the new subscriber
           val listing = {
             val (reachable, all) = registry.activeActorRefsFor(key, selfUniqueAddress)
-            ReceptionistMessages.Listing(key.asServiceKey, reachable, all, true)
+            ReceptionistMessages.Listing(key.asServiceKey, reachable, all, onlyReachabilityChanged = false)
           }
           subscriber ! listing
 
@@ -299,7 +299,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
               val subscribers = subscriptions.get(changedKey)
               if (subscribers.nonEmpty) {
                 val (reachable, all) = newRegistry.activeActorRefsFor(serviceKey, selfUniqueAddress)
-                val listing = ReceptionistMessages.Listing(serviceKey, reachable, all, true)
+                val listing = ReceptionistMessages.Listing(serviceKey, reachable, all, onlyReachabilityChanged = false)
                 subscribers.foreach(_ ! listing)
               }
 
@@ -365,7 +365,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
               if (subscribers.nonEmpty) {
                 val (reachable, all) = newRegistry.activeActorRefsFor(serviceKey, selfUniqueAddress)
                 val listing =
-                  ReceptionistMessages.Listing(serviceKey, reachable, all, allServiceInstancesChanged = false)
+                  ReceptionistMessages.Listing(serviceKey, reachable, all, onlyReachabilityChanged = true)
                 subscribers.foreach(_ ! listing)
               }
             }
@@ -387,7 +387,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
               if (subscribers.nonEmpty) {
                 val (reachable, all) = newRegistry.activeActorRefsFor(serviceKey, selfUniqueAddress)
                 val listing =
-                  ReceptionistMessages.Listing(serviceKey, reachable, all, allServiceInstancesChanged = false)
+                  ReceptionistMessages.Listing(serviceKey, reachable, all, onlyReachabilityChanged = true)
                 subscribers.foreach(_ ! listing)
               }
             }

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/Registry.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/Registry.scala
@@ -23,7 +23,7 @@ import scala.concurrent.duration.Deadline
       val key = ORMultiMapKey[ServiceKey[_], Entry](s"ReceptionistKey_$n")
       key -> new ServiceRegistry(EmptyORMultiMap)
     }.toMap
-    new ShardedServiceRegistry(emptyRegistries, Map.empty, Set.empty)
+    new ShardedServiceRegistry(emptyRegistries, Map.empty, Set.empty, Set.empty)
   }
 
 }
@@ -42,7 +42,8 @@ import scala.concurrent.duration.Deadline
 @InternalApi private[akka] final case class ShardedServiceRegistry(
     serviceRegistries: Map[DDataKey, ServiceRegistry],
     tombstones: Map[ActorRef[_], Deadline],
-    nodes: Set[UniqueAddress]) {
+    nodes: Set[UniqueAddress],
+    unreachable: Set[UniqueAddress]) {
 
   private val keys = serviceRegistries.keySet.toArray
 
@@ -63,14 +64,34 @@ import scala.concurrent.duration.Deadline
     serviceRegistries(ddataKey).actorRefsFor(key)
   }
 
-  def activeActorRefsFor[T](key: ServiceKey[T], selfUniqueAddress: UniqueAddress): Set[ActorRef[T]] = {
+  /**
+   * @return keys that has a registered service instance on the given `address`
+   */
+  def keysFor(address: UniqueAddress)(implicit node: SelfUniqueAddress): Set[AbstractServiceKey] =
+    serviceRegistries.valuesIterator.flatMap(_.keysFor(address)).toSet
+
+  /**
+   * @return (reachable-nodes, all)
+   */
+  def activeActorRefsFor[T](
+      key: ServiceKey[T],
+      selfUniqueAddress: UniqueAddress): (Set[ActorRef[T]], Set[ActorRef[T]]) = {
     val ddataKey = ddataKeyFor(key)
     val entries = serviceRegistries(ddataKey).entriesFor(key)
     val selfAddress = selfUniqueAddress.address
-    entries.collect {
-      case entry if nodes.contains(entry.uniqueAddress(selfAddress)) && !hasTombstone(entry.ref) =>
-        entry.ref.asInstanceOf[ActorRef[key.Protocol]]
+    val (reachable, all) = entries.foldLeft((Set.newBuilder[ActorRef[T]], Set.newBuilder[ActorRef[T]])) {
+      case (builders @ (reachable, all), entry) =>
+        val entryAddress = entry.uniqueAddress(selfAddress)
+        if (nodes.contains(entryAddress) && !hasTombstone(entry.ref)) {
+          val ref = entry.ref.asInstanceOf[ActorRef[key.Protocol]]
+          all += ref
+          if (!unreachable.contains(entryAddress)) {
+            reachable += ref
+          }
+        }
+        builders
     }
+    (reachable.result(), all.result())
   }
 
   def withServiceRegistry(ddataKey: DDataKey, registry: ServiceRegistry): ShardedServiceRegistry =
@@ -113,7 +134,13 @@ import scala.concurrent.duration.Deadline
     copy(nodes = nodes + node)
 
   def removeNode(node: UniqueAddress): ShardedServiceRegistry =
-    copy(nodes = nodes - node)
+    copy(nodes = nodes - node, unreachable = unreachable - node)
+
+  def addUnreachable(uniqueAddress: UniqueAddress): ShardedServiceRegistry =
+    copy(unreachable = unreachable + uniqueAddress)
+
+  def removeUnreachable(uniqueAddress: UniqueAddress): ShardedServiceRegistry =
+    copy(unreachable = unreachable - uniqueAddress)
 
 }
 
@@ -128,6 +155,12 @@ import scala.concurrent.duration.Deadline
 
   def entriesFor(key: AbstractServiceKey): Set[Entry] =
     entries.getOrElse(key.asServiceKey, Set.empty[Entry])
+
+  def keysFor(address: UniqueAddress)(implicit node: SelfUniqueAddress): Set[ServiceKey[_]] =
+    entries.entries.collect {
+      case (key, entries) if entries.exists(_.uniqueAddress(node.uniqueAddress.address) == address) =>
+        key
+    }.toSet
 
   def addBinding[T](key: ServiceKey[T], value: Entry)(implicit node: SelfUniqueAddress): ServiceRegistry =
     copy(entries = entries.addBinding(node, key, value))

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/Registry.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/Registry.scala
@@ -79,17 +79,17 @@ import scala.concurrent.duration.Deadline
     val ddataKey = ddataKeyFor(key)
     val entries = serviceRegistries(ddataKey).entriesFor(key)
     val selfAddress = selfUniqueAddress.address
-    val (reachable, all) = entries.foldLeft((Set.newBuilder[ActorRef[T]], Set.newBuilder[ActorRef[T]])) {
-      case (builders @ (reachable, all), entry) =>
-        val entryAddress = entry.uniqueAddress(selfAddress)
-        if (nodes.contains(entryAddress) && !hasTombstone(entry.ref)) {
-          val ref = entry.ref.asInstanceOf[ActorRef[key.Protocol]]
-          all += ref
-          if (!unreachable.contains(entryAddress)) {
-            reachable += ref
-          }
+    val reachable = Set.newBuilder[ActorRef[T]]
+    val all = Set.newBuilder[ActorRef[T]]
+    entries.foreach { entry =>
+      val entryAddress = entry.uniqueAddress(selfAddress)
+      if (nodes.contains(entryAddress) && !hasTombstone(entry.ref)) {
+        val ref = entry.ref.asInstanceOf[ActorRef[key.Protocol]]
+        all += ref
+        if (!unreachable.contains(entryAddress)) {
+          reachable += ref
         }
-        builders
+      }
     }
     (reachable.result(), all.result())
   }

--- a/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/internal/ClusterReceptionistUnreachabilitySpec.scala
+++ b/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/internal/ClusterReceptionistUnreachabilitySpec.scala
@@ -75,7 +75,7 @@ abstract class ClusterReceptionistUnreachabilitySpec
       val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
       listing.serviceInstances(MyServiceKey) should ===(Set.empty)
       listing.allServiceInstances(MyServiceKey) should ===(Set.empty)
-      listing.allServiceInstancesChanged should ===(true)
+      listing.onlyReachabilityChanged should ===(false)
       enterBarrier("all subscribed")
     }
 
@@ -110,7 +110,7 @@ abstract class ClusterReceptionistUnreachabilitySpec
         val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
         listing.serviceInstances(MyServiceKey) should have size (3)
         listing.allServiceInstances(MyServiceKey) should have size (3)
-        listing.allServiceInstancesChanged should ===(true)
+        listing.onlyReachabilityChanged should ===(false)
       }, 20.seconds)
 
       enterBarrier("all seen registered")
@@ -129,7 +129,7 @@ abstract class ClusterReceptionistUnreachabilitySpec
           val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
           listing.serviceInstances(MyServiceKey) should have size (2)
           listing.allServiceInstances(MyServiceKey) should have size (3)
-          listing.allServiceInstancesChanged should ===(false)
+          listing.onlyReachabilityChanged should ===(true)
         }, 20.seconds)
       }
       runOn(second) {
@@ -138,7 +138,7 @@ abstract class ClusterReceptionistUnreachabilitySpec
           val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
           listing.serviceInstances(MyServiceKey) should have size (1)
           listing.allServiceInstances(MyServiceKey) should have size (3)
-          listing.allServiceInstancesChanged should ===(false)
+          listing.onlyReachabilityChanged should ===(true)
         }, 20.seconds)
       }
       enterBarrier("all seen unreachable")
@@ -155,7 +155,7 @@ abstract class ClusterReceptionistUnreachabilitySpec
         val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
         listing.serviceInstances(MyServiceKey) should have size (3)
         listing.allServiceInstances(MyServiceKey) should have size (3)
-        listing.allServiceInstancesChanged should ===(false)
+        listing.onlyReachabilityChanged should ===(true)
       })
       enterBarrier("all seen reachable-again")
     }

--- a/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/internal/ClusterReceptionistUnreachabilitySpec.scala
+++ b/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/internal/ClusterReceptionistUnreachabilitySpec.scala
@@ -10,18 +10,16 @@ import akka.actor.typed.Behavior
 import akka.actor.typed.SpawnProtocol
 import akka.actor.typed.receptionist.Receptionist
 import akka.actor.typed.receptionist.ServiceKey
+import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.scaladsl.Behaviors
-import akka.cluster.MemberStatus
-import akka.cluster.typed.Join
+import akka.actor.typed.scaladsl.adapter._
+import akka.cluster.MultiNodeClusterSpec
 import akka.cluster.typed.MultiDcClusterSingletonSpecConfig.first
 import akka.cluster.typed.MultiDcClusterSingletonSpecConfig.second
 import akka.cluster.typed.MultiDcClusterSingletonSpecConfig.third
 import akka.cluster.typed.MultiNodeTypedClusterSpec
 import akka.remote.testkit.MultiNodeConfig
 import akka.remote.testkit.MultiNodeSpec
-import akka.actor.typed.scaladsl.adapter._
-import akka.actor.typed.scaladsl.AskPattern._
-import akka.cluster.MultiNodeClusterSpec
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
@@ -80,18 +78,7 @@ abstract class ClusterReceptionistUnreachabilitySpec
     }
 
     "form a cluster" in {
-      runOn(first) {
-        cluster.manager ! Join(cluster.selfMember.address)
-      }
-      runOn(second, third) {
-        cluster.manager ! Join(first)
-      }
-      enterBarrier("form-cluster-join-attempt")
-      runOn(first, second, third) {
-        within(20.seconds) {
-          awaitAssert(clusterView.members.filter(_.status == MemberStatus.Up) should have size 3)
-        }
-      }
+      formCluster(first, second, third)
       enterBarrier("cluster started")
     }
 

--- a/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/internal/ClusterReceptionistUnreachabilitySpec.scala
+++ b/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/internal/ClusterReceptionistUnreachabilitySpec.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.typed.internal
+
+import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.typed.ActorRef
+import akka.actor.typed.Behavior
+import akka.actor.typed.SpawnProtocol
+import akka.actor.typed.receptionist.Receptionist
+import akka.actor.typed.receptionist.ServiceKey
+import akka.actor.typed.scaladsl.Behaviors
+import akka.cluster.MemberStatus
+import akka.cluster.typed.Join
+import akka.cluster.typed.MultiDcClusterSingletonSpecConfig.first
+import akka.cluster.typed.MultiDcClusterSingletonSpecConfig.second
+import akka.cluster.typed.MultiDcClusterSingletonSpecConfig.third
+import akka.cluster.typed.MultiNodeTypedClusterSpec
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.actor.typed.scaladsl.adapter._
+import akka.actor.typed.scaladsl.AskPattern._
+import akka.cluster.MultiNodeClusterSpec
+import akka.remote.transport.ThrottlerTransportAdapter.Direction
+import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+object ClusterReceptionistUnreachabilitySpecConfig extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+
+  commonConfig(ConfigFactory.parseString("""
+        akka.loglevel = INFO
+      """).withFallback(MultiNodeClusterSpec.clusterConfig))
+
+  testTransport(on = true)
+}
+
+object ClusterReceptionistUnreachabilitySpec {
+  val MyServiceKey = ServiceKey[String]("my-service")
+}
+
+class ClusterReceptionistUnreachabilityMultiJvmNode1 extends ClusterReceptionistUnreachabilitySpec
+class ClusterReceptionistUnreachabilityMultiJvmNode2 extends ClusterReceptionistUnreachabilitySpec
+class ClusterReceptionistUnreachabilityMultiJvmNode3 extends ClusterReceptionistUnreachabilitySpec
+
+abstract class ClusterReceptionistUnreachabilitySpec
+    extends MultiNodeSpec(ClusterReceptionistUnreachabilitySpecConfig)
+    with MultiNodeTypedClusterSpec {
+
+  import ClusterReceptionistUnreachabilitySpec._
+
+  val spawnActor = system.actorOf(PropsAdapter(SpawnProtocol.behavior)).toTyped[SpawnProtocol]
+  def spawn[T](behavior: Behavior[T], name: String): ActorRef[T] = {
+    implicit val timeout: Timeout = 3.seconds
+    implicit val scheduler = typedSystem.scheduler
+    val f: Future[ActorRef[T]] = spawnActor.ask(ref => SpawnProtocol.Spawn(behavior, name)(ref))
+
+    Await.result(f, 3.seconds)
+  }
+
+  val probe = TestProbe[AnyRef]()
+  val receptionistProbe = TestProbe[AnyRef]()
+
+  "The clustered receptionist" must {
+
+    "subscribe to the receptionist" in {
+      typedSystem.receptionist ! Receptionist.Subscribe(MyServiceKey, receptionistProbe.ref)
+      val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
+      listing.serviceInstances(MyServiceKey) should ===(Set.empty)
+      listing.allServiceInstances(MyServiceKey) should ===(Set.empty)
+      listing.allServiceInstancesChanged should ===(true)
+      enterBarrier("all subscribed")
+    }
+
+    "form a cluster" in {
+      runOn(first) {
+        cluster.manager ! Join(cluster.selfMember.address)
+      }
+      runOn(second, third) {
+        cluster.manager ! Join(first)
+      }
+      enterBarrier("form-cluster-join-attempt")
+      runOn(first, second, third) {
+        within(20.seconds) {
+          awaitAssert(clusterView.members.filter(_.status == MemberStatus.Up) should have size 3)
+        }
+      }
+      enterBarrier("cluster started")
+    }
+
+    "register a service" in {
+      val localServiceRef = spawn(Behaviors.receiveMessage[String] {
+        case msg =>
+          probe.ref ! msg
+          Behaviors.same
+      }, "my-service")
+      typedSystem.receptionist ! Receptionist.Register(MyServiceKey, localServiceRef)
+      enterBarrier("all registered")
+    }
+
+    "see registered services" in {
+      awaitAssert({
+        val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
+        listing.serviceInstances(MyServiceKey) should have size (3)
+        listing.allServiceInstances(MyServiceKey) should have size (3)
+        listing.allServiceInstancesChanged should ===(true)
+      }, 20.seconds)
+
+      enterBarrier("all seen registered")
+    }
+
+    "remove unreachable from listing" in {
+      // make second unreachable
+      runOn(first) {
+        testConductor.blackhole(first, second, Direction.Both).await
+        testConductor.blackhole(third, second, Direction.Both).await
+      }
+
+      runOn(first, third) {
+        // assert service on 2 is not in listing but in all and flag is false
+        awaitAssert({
+          val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
+          listing.serviceInstances(MyServiceKey) should have size (2)
+          listing.allServiceInstances(MyServiceKey) should have size (3)
+          listing.allServiceInstancesChanged should ===(false)
+        }, 20.seconds)
+      }
+      runOn(second) {
+        // assert service on 1 and 3 is not in listing but in all and flag is false
+        awaitAssert({
+          val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
+          listing.serviceInstances(MyServiceKey) should have size (1)
+          listing.allServiceInstances(MyServiceKey) should have size (3)
+          listing.allServiceInstancesChanged should ===(false)
+        }, 20.seconds)
+      }
+      enterBarrier("all seen unreachable")
+    }
+
+    "add again-reachable to list again" in {
+      // make second unreachable
+      runOn(first) {
+        testConductor.passThrough(first, second, Direction.Both).await
+        testConductor.passThrough(third, second, Direction.Both).await
+      }
+
+      awaitAssert({
+        val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
+        listing.serviceInstances(MyServiceKey) should have size (3)
+        listing.allServiceInstances(MyServiceKey) should have size (3)
+        listing.allServiceInstancesChanged should ===(false)
+      })
+      enterBarrier("all seen reachable-again")
+    }
+
+  }
+
+}

--- a/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/internal/ClusterReceptionistUnreachabilitySpec.scala
+++ b/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/internal/ClusterReceptionistUnreachabilitySpec.scala
@@ -75,7 +75,7 @@ abstract class ClusterReceptionistUnreachabilitySpec
       val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
       listing.serviceInstances(MyServiceKey) should ===(Set.empty)
       listing.allServiceInstances(MyServiceKey) should ===(Set.empty)
-      listing.onlyReachabilityChanged should ===(false)
+      listing.servicesWereAddedOrRemoved should ===(true)
       enterBarrier("all subscribed")
     }
 
@@ -110,7 +110,7 @@ abstract class ClusterReceptionistUnreachabilitySpec
         val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
         listing.serviceInstances(MyServiceKey) should have size (3)
         listing.allServiceInstances(MyServiceKey) should have size (3)
-        listing.onlyReachabilityChanged should ===(false)
+        listing.servicesWereAddedOrRemoved should ===(true)
       }, 20.seconds)
 
       enterBarrier("all seen registered")
@@ -129,7 +129,7 @@ abstract class ClusterReceptionistUnreachabilitySpec
           val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
           listing.serviceInstances(MyServiceKey) should have size (2)
           listing.allServiceInstances(MyServiceKey) should have size (3)
-          listing.onlyReachabilityChanged should ===(true)
+          listing.servicesWereAddedOrRemoved should ===(false)
         }, 20.seconds)
       }
       runOn(second) {
@@ -138,7 +138,7 @@ abstract class ClusterReceptionistUnreachabilitySpec
           val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
           listing.serviceInstances(MyServiceKey) should have size (1)
           listing.allServiceInstances(MyServiceKey) should have size (3)
-          listing.onlyReachabilityChanged should ===(true)
+          listing.servicesWereAddedOrRemoved should ===(false)
         }, 20.seconds)
       }
       enterBarrier("all seen unreachable")
@@ -155,7 +155,7 @@ abstract class ClusterReceptionistUnreachabilitySpec
         val listing = receptionistProbe.expectMessageType[Receptionist.Listing]
         listing.serviceInstances(MyServiceKey) should have size (3)
         listing.allServiceInstances(MyServiceKey) should have size (3)
-        listing.onlyReachabilityChanged should ===(true)
+        listing.servicesWereAddedOrRemoved should ===(false)
       })
       enterBarrier("all seen reachable-again")
     }

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -192,7 +192,10 @@ class ClusterReceptionistSpec extends WordSpec with Matchers {
           clusterNode1.manager ! Leave(clusterNode2.selfMember.address)
         }
 
-        regProbe1.expectMessage(10.seconds, Listing(PingKey, Set(service1)))
+        regProbe1.awaitAssert({
+          // we will also potentially get an update that the service was unreachable before the expected one
+          regProbe1.expectMessage(10.seconds, Listing(PingKey, Set(service1)))
+        }, 10.seconds)
 
         // register another after removal
         val service1b = testKit1.spawn(pingPongBehavior)
@@ -244,7 +247,10 @@ class ClusterReceptionistSpec extends WordSpec with Matchers {
 
         clusterNode2.manager ! Down(clusterNode1.selfMember.address)
         // service1 removed
-        regProbe2.expectMessage(10.seconds, Listing(PingKey, Set(service2)))
+        regProbe2.awaitAssert({
+          // we will also potentially get an update that the service was unreachable before the expected one
+          regProbe2.expectMessage(10.seconds, Listing(PingKey, Set(service2)))
+        }, 10.seconds)
       } finally {
         testKit1.shutdownTestKit()
         testKit2.shutdownTestKit()
@@ -299,8 +305,11 @@ class ClusterReceptionistSpec extends WordSpec with Matchers {
         system2.terminate()
         Await.ready(system2.whenTerminated, 10.seconds)
         clusterNode1.manager ! Down(clusterNode2.selfMember.address)
+        regProbe1.awaitAssert({
 
-        regProbe1.expectMessage(10.seconds, Listing(PingKey, Set.empty[ActorRef[PingProtocol]]))
+          // we will also potentially get an update that the service was unreachable before the expected one
+          regProbe1.expectMessage(10.seconds, Listing(PingKey, Set.empty[ActorRef[PingProtocol]]))
+        }, 10.seconds)
       } finally {
         testKit1.shutdownTestKit()
         testKit2.shutdownTestKit()

--- a/akka-docs/src/main/paradox/typed/actor-discovery.md
+++ b/akka-docs/src/main/paradox/typed/actor-discovery.md
@@ -83,5 +83,5 @@ will eventually reach the same set of actors per `ServiceKey`.
 registered actors that are reachable. The full set of actors, including unreachable ones, is available through 
 @scala[`Listing.allServiceInstances`]@java[`Listing.getAllServiceInstances`].
 
-One important difference from a local only receptions is the serialisation concerns, all messages sent to and back from 
+One important difference from local only receptions are the serialization concerns, all messages sent to and back from 
 an actor on another node must be serializable, see @ref:[clustering](cluster.md#serialization).

--- a/akka-docs/src/main/paradox/typed/actor-discovery.md
+++ b/akka-docs/src/main/paradox/typed/actor-discovery.md
@@ -73,8 +73,15 @@ sends a `Ping` message and when receiving the `Pong` reply it stops.
 
 ## Cluster Receptionist
 
-The `Receptionist` also works in a cluster, an actor registered to the receptionist will appear in the receptionist of the other nodes of the cluster.
+The `Receptionist` also works in a cluster, an actor registered to the receptionist will appear in the receptionist 
+of the other nodes of the cluster.
 
-The state for the receptionist is propagated via @ref:[distributed data](../distributed-data.md) which means that each node will eventually reach the same set of actors per `ServiceKey`.
+The state for the receptionist is propagated via @ref:[distributed data](../distributed-data.md) which means that each node 
+will eventually reach the same set of actors per `ServiceKey`.
 
-One important difference from a local only receptions is the serialisation concerns, all messages sent to and back from an actor on another node must be serializable, see @ref:[clustering](cluster.md#serialization).
+`Subscription`s and `Find` queries to a clustered receptionist will keep track of cluster reachability and only list 
+registered actors that are reachable. The full set of actors, including unreachable ones, is available through 
+@scala[`Listing.allServiceInstances`]@java[`Listing.getAllServiceInstances`].
+
+One important difference from a local only receptions is the serialisation concerns, all messages sent to and back from 
+an actor on another node must be serializable, see @ref:[clustering](cluster.md#serialization).

--- a/akka-docs/src/main/paradox/typed/routers.md
+++ b/akka-docs/src/main/paradox/typed/routers.md
@@ -43,8 +43,8 @@ Java
 The group router is created with a `ServiceKey` and uses the receptionist (see @ref:[Receptionist](actor-discovery.md#receptionist)) to discover
 available actors for that key and routes messages to one of the currently known registered actors for a key.
 
-Since the receptionist is used this means the group router is cluster aware out of the box and will pick up routees
-registered on any node in the cluster (there is currently no logic to avoid routing to unreachable nodes, see [#26355](https://github.com/akka/akka/issues/26355)).
+Since the receptionist is used this means the group router is cluster aware out of the box and will route to 
+registered actors on any node in the cluster that is reachable.
 
 It also means that the set of routees is eventually consistent, and that immediately when the group router is started
 the set of routees it knows about is empty. When the set of routees is empty messages sent to the router is forwarded

--- a/akka-docs/src/main/paradox/typed/routers.md
+++ b/akka-docs/src/main/paradox/typed/routers.md
@@ -43,12 +43,16 @@ Java
 The group router is created with a `ServiceKey` and uses the receptionist (see @ref:[Receptionist](actor-discovery.md#receptionist)) to discover
 available actors for that key and routes messages to one of the currently known registered actors for a key.
 
-Since the receptionist is used this means the group router is cluster aware out of the box and will route to 
-registered actors on any node in the cluster that is reachable.
+Since the receptionist is used this means the group router is cluster aware out of the box. The router route
+messages to registered actors on any node in the cluster that is reachable. If no reachable actor exists the router
+will fallback and route messages to actors on nodes marked as unreachable.
 
-It also means that the set of routees is eventually consistent, and that immediately when the group router is started
-the set of routees it knows about is empty. When the set of routees is empty messages sent to the router is forwarded
-to dead letters.
+That the receptionist is used also means that the set of routees is eventually consistent, and that immediately when 
+the group router is started the set of routees it knows about is empty, until it has seen a listing from the receptionist
+it stashes incoming messages and forwards them as soon as it gets a listing from the receptionist.  
+
+When the router has received a listing from the receptionist and the set of registered actors is empty the router will
+drop them (published them to the event stream as `akka.actor.Dropped`).
 
 Scala
 :  @@snip [RouterSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala) { #group }


### PR DESCRIPTION
## Purpose
Make cluster routers (and anything that uses the receptionist) aware of unreachability so that nodes that are reachable will be preferred.

## References
Refs #26355 

## Changes
The default listing from the receptionist is changed to be only reachable nodes, a separate method to access both reachable and unreachable is added for special cases.

## Background Context
This will give applications reachability awareness "for free" without changing the main API.