### PR TITLE
adjust Cluster in docs ToC

### DIFF
--- a/akka-docs/src/main/paradox/typed/cluster.md
+++ b/akka-docs/src/main/paradox/typed/cluster.md
@@ -1,4 +1,4 @@
-# Cluster
+# Cluster Membership
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/typed/index-cluster.md
+++ b/akka-docs/src/main/paradox/typed/index-cluster.md
@@ -1,4 +1,4 @@
-# Akka Cluster
+# Cluster
 
 @@toc { depth=2 }
 


### PR DESCRIPTION
Looked strange to prefix Cluster with Akka, when nothing else used that