### PR TITLE
Improve takeWithin precision

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -1842,10 +1842,17 @@ private[stream] object Collect {
 /**
  * INTERNAL API
  */
+@InternalApi private[akka] object TakeWithin {
+  val Threshold = 1.second
+}
+
+/**
+ * INTERNAL API
+ */
 @InternalApi private[akka] final class TakeWithin[T](val timeout: FiniteDuration) extends SimpleLinearGraphStage[T] {
 
   // avoid excessive system calls for longer timeouts
-  private val shortTimeout = timeout < 1.second
+  private val shortTimeout = timeout < TakeWithin.Threshold
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new TimerGraphStageLogic(shape) with InHandler with OutHandler {

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -1250,7 +1250,7 @@ private[stream] object Collect {
               case Supervision.Stop => failStage(ex)
               case _                => pushNextIfPossible()
             }
-      })
+        })
 
       override def preStart(): Unit = buffer = BufferImpl(parallelism, materializer)
 
@@ -1725,50 +1725,43 @@ private[stream] object Collect {
 
       val onPushWhenBufferFull: () => Unit = strategy match {
         case EmitEarly =>
-          () =>
-            {
-              if (!isTimerActive(timerName))
-                push(out, buffer.dequeue()._2)
-              else {
-                cancelTimer(timerName)
-                onTimer(timerName)
-              }
-              grabAndPull()
+          () => {
+            if (!isTimerActive(timerName))
+              push(out, buffer.dequeue()._2)
+            else {
+              cancelTimer(timerName)
+              onTimer(timerName)
             }
+            grabAndPull()
+          }
         case _: DropHead =>
-          () =>
-            {
-              buffer.dropHead()
-              grabAndPull()
-            }
+          () => {
+            buffer.dropHead()
+            grabAndPull()
+          }
         case _: DropTail =>
-          () =>
-            {
-              buffer.dropTail()
-              grabAndPull()
-            }
+          () => {
+            buffer.dropTail()
+            grabAndPull()
+          }
         case _: DropNew =>
-          () =>
-            {
-              grab(in)
-              pull(in)
-            }
+          () => {
+            grab(in)
+            pull(in)
+          }
         case _: DropBuffer =>
-          () =>
-            {
-              buffer.clear()
-              grabAndPull()
-            }
+          () => {
+            buffer.clear()
+            grabAndPull()
+          }
         case _: Fail =>
-          () =>
-            {
-              failStage(BufferOverflowException(s"Buffer overflow for delay operator (max capacity was: $size)!"))
-            }
+          () => {
+            failStage(BufferOverflowException(s"Buffer overflow for delay operator (max capacity was: $size)!"))
+          }
         case _: Backpressure =>
-          () =>
-            {
-              throw new IllegalStateException("Delay buffer must never overflow in Backpressure mode")
-            }
+          () => {
+            throw new IllegalStateException("Delay buffer must never overflow in Backpressure mode")
+          }
       }
 
       def onPush(): Unit = {

--- a/project/hydra.sbt
+++ b/project/hydra.sbt
@@ -1,3 +1,0 @@
-// resolvers += Resolver.url("Triplequote Plugins Releases",
-//  url("https://repo.triplequote.com/artifactory/sbt-plugins-release/"))(Resolver.ivyStylePatterns)
-//addSbtPlugin("com.triplequote" % "sbt-hydra" % "2.1.8")

--- a/project/hydra.sbt
+++ b/project/hydra.sbt
@@ -1,0 +1,3 @@
+// resolvers += Resolver.url("Triplequote Plugins Releases",
+//  url("https://repo.triplequote.com/artifactory/sbt-plugins-release/"))(Resolver.ivyStylePatterns)
+//addSbtPlugin("com.triplequote" % "sbt-hydra" % "2.1.8")


### PR DESCRIPTION
## Purpose
Improve takeWithin precision so it is less likely to let elements through after the timeout when a tight timeout is used.

## Changes
In addition to completing the stage on a scheduled timer event, which may be delayed because of
the graph interpreter being busy with other stages, we also check for each push and pull if the timeout
has hit already and complete the stage immediately in that case.