### PR TITLE
fix serialization failure in ClusterShardingSpec

### DIFF
--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingSpec.scala
@@ -177,6 +177,8 @@ abstract class ClusterShardingSpecConfig(val mode: String, val entityRecoveryStr
       "${classOf[ClusterShardingSpec.EntityEnvelope].getName}" = java-test
       "${ClusterShardingSpec.Stop.getClass.getName}" = java-test
       "${classOf[ClusterShardingSpec.CounterChanged].getName}" = java-test
+      "${classOf[ShardRegion.Passivate].getName}" = java-test
+      
     }
 
     """)


### PR DESCRIPTION
Failed in for example https://jenkins.akka.io:8498/job/akka-nightly/6734/

`Passivate` is only supposed to be sent to local (parent), but test is doing crazy stuff.

Couldn't reproduce locally, but I guess it depends on if where the shard happens to be located.