### PR TITLE
Prepare to separate cluster sharding readiness from shards queries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,7 +253,6 @@ All wire protocol changes that may concern rolling upgrades should be documented
 [Rolling Update Changelog](https://doc.akka.io/docs/akka/current/project/rolling-update.html#change-log) 
 (found in akka-docs/src/main/paradox/project/rolling-update.md)
 
-
 ## Pull request requirements
 
 For a pull request to be considered at all it has to meet these requirements:

--- a/akka-cluster-sharding/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.5.x.backwards.excludes
@@ -4,8 +4,6 @@ ProblemFilters.exclude[Problem]("akka.cluster.sharding.Shard.*")
 # #25191
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.ShardRegion.retryTask")
 
-# #27299 Separate cluster sharding readiness from stats query
-ProblemFilters.exclude[FinalClassProblem]("akka.cluster.sharding.ShardRegion$GetClusterShardingStats")
-ProblemFilters.exclude[FinalClassProblem]("akka.cluster.sharding.ShardRegion$GetShardRegionStats$")
+# #27299 Prepare to separate cluster sharding readiness from shards queries #27360
+# askAllShards was an internal function, renamed and changed to query all or a subset of shards
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.ShardRegion.askAllShards")
-ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.sharding.ShardRegion.receiveQuery")

--- a/akka-cluster-sharding/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.5.x.backwards.excludes
@@ -3,3 +3,9 @@ ProblemFilters.exclude[Problem]("akka.cluster.sharding.Shard.*")
 
 # #25191
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.ShardRegion.retryTask")
+
+# #27299 Separate cluster sharding readiness from stats query
+ProblemFilters.exclude[FinalClassProblem]("akka.cluster.sharding.ShardRegion$GetClusterShardingStats")
+ProblemFilters.exclude[FinalClassProblem]("akka.cluster.sharding.ShardRegion$GetShardRegionStats$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.ShardRegion.askAllShards")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.sharding.ShardRegion.receiveQuery")

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -8,10 +8,11 @@ import java.net.URLEncoder
 import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 
-import akka.util.ccompat.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.Await
 import scala.util.control.NonFatal
+
+import akka.util.ccompat.JavaConverters._
 import akka.actor.Actor
 import akka.actor.ActorRef
 import akka.actor.ActorSystem

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -252,7 +252,7 @@ private[akka] class Shard(
   def processChange[E <: StateChange](event: E)(handler: E => Unit): Unit =
     handler(event)
 
-  def receive = receiveCommand
+  def receive: Receive = receiveCommand
 
   // Don't send back ShardInitialized so that messages are buffered in the ShardRegion
   // while awaiting the lease

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -765,7 +765,7 @@ private[akka] class ShardRegion(
    * Query all or a subset of shards, e.g. unresponsive shards that initially timed out.
    * If the number of `shards` are less than this.shards.size, this could be a retry.
    * Returns a partitioned set of any shards that may have not replied within the
-   * timeout and shards did reply, to provide retry on only that subset.
+   * timeout and shards that did reply, to provide retry on only that subset.
    *
    * Logs a warning if any of the group timed out.
    *

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -765,7 +765,7 @@ private[akka] class ShardRegion(
       .recover {
         case _: AskTimeoutException =>
           log.warning("{} shards queried but timed out after {}.", shards.size, settings.shardRegionQueryTimeout)
-          ShardRegion.ShardRegionStats(shards.keySet.map(_ -> 0).toMap)
+          ShardRegionStats(Map.empty)
       }
       .pipeTo(ref)
   }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardingQueries.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardingQueries.scala
@@ -4,69 +4,76 @@
 
 package akka.cluster.sharding
 
+import scala.reflect.ClassTag
+
 import akka.annotation.InternalApi
 
 /** INTERNAL API */
 @InternalApi
 private[sharding] object ShardingQueries {
 
-  private def func[T] = (t: T) => t
-
-  def separateE[A, B](ps: Seq[Either[A, B]]): (Seq[A], Seq[B]) =
-    separate(ps)(func)
-
-  def separate[T, A, B](ps: Seq[T])(f: T => Either[A, B]): (Seq[A], Seq[B]) = {
-    val (a, b) = ps.foldLeft((Nil: Seq[A], Nil: Seq[B]))((xs, y) => prependEither(xs, f(y)))
-    (a.reverse, b.reverse)
-  }
-
-  def prependEither[A, B](acc: (Seq[A], Seq[B]), next: Either[A, B]): (Seq[A], Seq[B]) =
-    next match {
-      case Left(l)  => (l +: acc._1, acc._2)
-      case Right(r) => (acc._1, r +: acc._2)
-    }
-
   /**
-   * The result metadata of a group query, which can be applied to any granularity of sharding:
-   * regions, shards, entities.
+   * INTERNAL API
+   * The result of a group query and metadata.
    *
-   * @param total the total number of actors tracked versus a possible subset
-   * @param queried the number of actors queried, which could equal the total or be a
-   *                subset if a retry of failures only
-   * @param unresponsive the number of non-responses within the configured timeout, which
+   * @param timedout the number of non-responses within the configured timeout, which
    *                     could be indicative of several states, e.g. still in initialization,
    *                     restart, heavily loaded and busy, where returning a simple zero is
    *                     not indicative of the reason
-   * @param responsive the number of responses received from the query
+   * @param responses the number of responses received from the query
+   * @param total the total number of shards tracked versus a possible subset
+   * @param queried the number of shards queried, which could equal the total or be a
+   *                subset if this was a retry of those that timed out
+   * @tparam A
+   * @tparam B
    */
-  final case class Metadata(total: Int, queried: Int, unresponsive: Int, responsive: Int) {
+  @InternalApi
+  private[sharding] final case class ShardsQueryResult[A, B](
+      timedout: Seq[A],
+      responses: Seq[B],
+      total: Int,
+      queried: Int) {
 
     /** Returns true if all in context were queried and all were unresponsive within the timeout. */
-    def isTotalFailed: Boolean = unresponsive == total
+    def isTotalFailed: Boolean = timedout.size == total
 
     /** Returns true if this was from a subset query and all were unresponsive within the timeout. */
-    def isAllSubsetFailed: Boolean = queried < total && unresponsive == queried
-    def unresponsiveNonEmpty: Boolean = unresponsive > 0
+    def isAllSubsetFailed: Boolean = queried < total && timedout.size == queried
 
     override val toString: String = {
+      val unresponsive = timedout.size
       if (isTotalFailed || isAllSubsetFailed) {
         s"All $unresponsive ${if (isAllSubsetFailed) "of subset" else ""} queried were unresponsive."
       } else {
-        s"Queried $queried: $responsive responsive $unresponsive unresponsive within the timeout."
+        s"Queried $queried: ${responses.size} responsive, $unresponsive unresponsive within the timeout."
       }
     }
   }
-
-  object Metadata {
+  private[sharding] object ShardsQueryResult {
 
     /**
+     * @param ps the partitioned results of actors queried that did not reply by
+     *           the timeout and those that did
      * @param total the total number of actors tracked versus a possible subset
-     * @param u the results of actors queried that did not reply by the timeout
-     * @param t the results of actors queried that did reply
+     * @tparam A
+     * @tparam B
      */
-    def apply(total: Int, u: Seq[_], t: Seq[_]): Metadata = {
-      val queried = u.size + t.size
-      Metadata(total, queried, u.size, t.size)
+    def apply[A: ClassTag, B: ClassTag](ps: Seq[Either[A, B]], total: Int): ShardsQueryResult[A, B] = {
+      val (t, r) = partition(ps)(func)
+      ShardsQueryResult(t, r, total, ps.size)
     }
+
+    def func[T] = (t: T) => t
+
+    def partition[T, A, B](ps: Seq[T])(f: T => Either[A, B]): (Seq[A], Seq[B]) = {
+      val (a, b) = ps.foldLeft((Nil: Seq[A], Nil: Seq[B]))((xs, y) => prepend(xs, f(y)))
+      (a.reverse, b.reverse)
+    }
+
+    def prepend[A, B](acc: (Seq[A], Seq[B]), next: Either[A, B]): (Seq[A], Seq[B]) =
+      next match {
+        case Left(l)  => (l +: acc._1, acc._2)
+        case Right(r) => (acc._1, r +: acc._2)
+      }
   }
 }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardingQueries.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardingQueries.scala
@@ -59,11 +59,9 @@ private[sharding] object ShardingQueries {
      * @tparam B
      */
     def apply[A: ClassTag, B: ClassTag](ps: Seq[Either[A, B]], total: Int): ShardsQueryResult[A, B] = {
-      val (t, r) = partition(ps)(func)
+      val (t, r) = partition(ps)(identity)
       ShardsQueryResult(t, r, total, ps.size)
     }
-
-    def func[T] = (t: T) => t
 
     def partition[T, A, B](ps: Seq[T])(f: T => Either[A, B]): (Seq[A], Seq[B]) = {
       val (a, b) = ps.foldLeft((Nil: Seq[A], Nil: Seq[B]))((xs, y) => prepend(xs, f(y)))

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardingQueries.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardingQueries.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import akka.annotation.InternalApi
+
+/** INTERNAL API */
+@InternalApi
+private[sharding] object ShardingQueries {
+
+  private def func[T] = (t: T) => t
+
+  def separateE[A, B](ps: Seq[Either[A, B]]): (Seq[A], Seq[B]) =
+    separate(ps)(func)
+
+  def separate[T, A, B](ps: Seq[T])(f: T => Either[A, B]): (Seq[A], Seq[B]) = {
+    val (a, b) = ps.foldLeft((Nil: Seq[A], Nil: Seq[B]))((xs, y) => prependEither(xs, f(y)))
+    (a.reverse, b.reverse)
+  }
+
+  def prependEither[A, B](acc: (Seq[A], Seq[B]), next: Either[A, B]): (Seq[A], Seq[B]) =
+    next match {
+      case Left(l)  => (l +: acc._1, acc._2)
+      case Right(r) => (acc._1, r +: acc._2)
+    }
+
+  /**
+   * The result metadata of a group query, which can be applied to any granularity of sharding:
+   * regions, shards, entities.
+   *
+   * @param total the total number of actors tracked versus a possible subset
+   * @param queried the number of actors queried, which could equal the total or be a
+   *                subset if a retry of failures only
+   * @param unresponsive the number of non-responses within the configured timeout, which
+   *                     could be indicative of several states, e.g. still in initialization,
+   *                     restart, heavily loaded and busy, where returning a simple zero is
+   *                     not indicative of the reason
+   * @param responsive the number of responses received from the query
+   */
+  final case class Metadata(total: Int, queried: Int, unresponsive: Int, responsive: Int) {
+
+    /** Returns true if all in context were queried and all were unresponsive within the timeout. */
+    def isTotalFailed: Boolean = unresponsive == total
+
+    /** Returns true if this was from a subset query and all were unresponsive within the timeout. */
+    def isAllSubsetFailed: Boolean = queried < total && unresponsive == queried
+    def unresponsiveNonEmpty: Boolean = unresponsive > 0
+
+    override val toString: String = {
+      if (isTotalFailed || isAllSubsetFailed) {
+        s"All $unresponsive ${if (isAllSubsetFailed) "of subset" else ""} queried were unresponsive."
+      } else {
+        s"Queried $queried: $responsive responsive $unresponsive unresponsive within the timeout."
+      }
+    }
+  }
+
+  object Metadata {
+
+    /**
+     * @param total the total number of actors tracked versus a possible subset
+     * @param u the results of actors queried that did not reply by the timeout
+     * @param t the results of actors queried that did reply
+     */
+    def apply(total: Int, u: Seq[_], t: Seq[_]): Metadata = {
+      val queried = u.size + t.size
+      Metadata(total, queried, u.size, t.size)
+    }
+  }
+}

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/protobuf/ClusterShardingMessageSerializerSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/protobuf/ClusterShardingMessageSerializerSpec.scala
@@ -5,13 +5,16 @@
 package akka.cluster.sharding.protobuf
 
 import scala.concurrent.duration._
+
 import akka.actor.Address
 import akka.actor.ExtendedActorSystem
-import akka.testkit.AkkaSpec
 import akka.actor.Props
+import akka.cluster.sharding.Shard
+import akka.cluster.sharding.ShardCoordinator
+import akka.cluster.sharding.ShardRegion
 import akka.cluster.sharding.ShardRegion.ShardId
-import akka.cluster.sharding.{ Shard, ShardCoordinator, ShardRegion }
 import akka.serialization.SerializationExtension
+import akka.testkit.AkkaSpec
 
 class ClusterShardingMessageSerializerSpec extends AkkaSpec {
   import ShardCoordinator.Internal._


### PR DESCRIPTION
Separate cluster sharding readiness and the need to return empty maps or counts of zero from stats query #27299. Empty maps or zero shards are not indicative across the board of the actual timeout case, it may or may not be in a state of initialization, restart, shards down, and in relation to parent ticket, busy shards not responding within the timeout.

## Purpose
* Separates only internally in this PR, but sets up for external in the parent ticket
* Existing tests exercise the change and can remain the same because of this. Test changes/additions will of course apply in #27100

## References
Precursor to work coming in: Productionize: GetShardRegionStats returns empty shard set on ask timeout #27100

## Changes
Internal function changes to ShardRegion:
* Added timeout handling when querying all shards and each shard, to retain the timed out shards in the overall `ask` context per region. This should be propagated up to the region and cluster queries but requires a proto change which I am avoiding here, but will do in #27100
* Added ability to not just query all shards per region, but run against a subset of shards that, for example, were unresponsive within the timeout

Added a `@InternalApi private[sharding] object ShardingQueries` for 
* Internal private helper functions 
* enriching status and logging

## Background Context
Do not want to modify the protobufs unless/until necessary.