### PR TITLE
Reimplement Behavior#start into a tail-rec paradigm.

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
@@ -157,27 +157,31 @@ object Behavior {
     }
 
   @tailrec
-  private def startTail(behavior: Behavior[Any],stack: Seq[InterceptorImpl[Any,Any]],ctx:TypedActorContext[Any], isReducing: Boolean): Behavior[Any] = {
-    if(isReducing){
-      if(stack.nonEmpty) {
+  private def startTail(
+      behavior: Behavior[Any],
+      stack: Seq[InterceptorImpl[Any, Any]],
+      ctx: TypedActorContext[Any],
+      isReducing: Boolean): Behavior[Any] = {
+    if (isReducing) {
+      if (stack.nonEmpty) {
         val wrapped = stack.head
-        if(wrapped.nestedBehavior ne behavior)
+        if (wrapped.nestedBehavior ne behavior)
           startTail(wrapped.replaceNested(behavior), stack.tail, ctx, isReducing = true)
         else
-          startTail(wrapped,stack.tail,ctx,isReducing = true)
-      }else{
+          startTail(wrapped, stack.tail, ctx, isReducing = true)
+      } else {
         behavior
       }
-    }else{
+    } else {
       behavior match {
         case innerDeferred: DeferredBehavior[Any] @unchecked =>
-          startTail(innerDeferred(ctx),stack, ctx,isReducing = false)
-        case wrapped: InterceptorImpl[Any,Any] @unchecked =>
-          startTail(wrapped.nestedBehavior,wrapped +: stack,ctx,isReducing = false)
+          startTail(innerDeferred(ctx), stack, ctx, isReducing = false)
+        case wrapped: InterceptorImpl[Any, Any] @unchecked =>
+          startTail(wrapped.nestedBehavior, wrapped +: stack, ctx, isReducing = false)
         case _ =>
-          if(stack.nonEmpty){
-            startTail(behavior,stack,ctx,isReducing = true)
-          }else{
+          if (stack.nonEmpty) {
+            startTail(behavior, stack, ctx, isReducing = true)
+          } else {
             behavior
           }
       }
@@ -188,8 +192,9 @@ object Behavior {
    * Starts deferred behavior and nested deferred behaviors until all deferred behaviors in the stack are started
    * and then the resulting behavior is returned.
    */
-  def start[T](behavior: Behavior[T], ctx: TypedActorContext[T]): Behavior[T] = startTail(behavior.asInstanceOf[Behavior[Any]],Nil,ctx.asInstanceOf[TypedActorContext[Any]],isReducing = false).asInstanceOf[Behavior[T]]
-
+  def start[T](behavior: Behavior[T], ctx: TypedActorContext[T]): Behavior[T] =
+    startTail(behavior.asInstanceOf[Behavior[Any]], Nil, ctx.asInstanceOf[TypedActorContext[Any]], isReducing = false)
+      .asInstanceOf[Behavior[T]]
 
   /**
    * Go through the behavior stack and apply a predicate to see if any nested behavior

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Behavior.scala
@@ -7,7 +7,6 @@ package akka.actor.typed
 import scala.annotation.switch
 import scala.annotation.tailrec
 import scala.reflect.ClassTag
-
 import akka.actor.InvalidMessageException
 import akka.actor.typed.internal.BehaviorImpl
 import akka.actor.typed.internal.BehaviorImpl.DeferredBehavior
@@ -157,22 +156,40 @@ object Behavior {
       case _ => behavior
     }
 
+  @tailrec
+  private def startTail(behavior: Behavior[Any],stack: Seq[InterceptorImpl[Any,Any]],ctx:TypedActorContext[Any], isReducing: Boolean): Behavior[Any] = {
+    if(isReducing){
+      if(stack.nonEmpty) {
+        val wrapped = stack.head
+        if(wrapped.nestedBehavior ne behavior)
+          startTail(wrapped.replaceNested(behavior), stack.tail, ctx, isReducing = true)
+        else
+          startTail(wrapped,stack.tail,ctx,isReducing = true)
+      }else{
+        behavior
+      }
+    }else{
+      behavior match {
+        case innerDeferred: DeferredBehavior[Any] @unchecked =>
+          startTail(innerDeferred(ctx),stack, ctx,isReducing = false)
+        case wrapped: InterceptorImpl[Any,Any] @unchecked =>
+          startTail(wrapped.nestedBehavior,wrapped +: stack,ctx,isReducing = false)
+        case _ =>
+          if(stack.nonEmpty){
+            startTail(behavior,stack,ctx,isReducing = true)
+          }else{
+            behavior
+          }
+      }
+    }
+  }
+
   /**
    * Starts deferred behavior and nested deferred behaviors until all deferred behaviors in the stack are started
    * and then the resulting behavior is returned.
    */
-  def start[T](behavior: Behavior[T], ctx: TypedActorContext[T]): Behavior[T] = {
-    // TODO can this be made @tailrec?
-    behavior match {
-      case innerDeferred: DeferredBehavior[T]          => start(innerDeferred(ctx), ctx)
-      case wrapped: InterceptorImpl[T, Any] @unchecked =>
-        // make sure that a deferred behavior wrapped inside some other behavior is also started
-        val startedInner = start(wrapped.nestedBehavior, ctx.asInstanceOf[TypedActorContext[Any]])
-        if (startedInner eq wrapped.nestedBehavior) wrapped
-        else wrapped.replaceNested(startedInner)
-      case _ => behavior
-    }
-  }
+  def start[T](behavior: Behavior[T], ctx: TypedActorContext[T]): Behavior[T] = startTail(behavior.asInstanceOf[Behavior[Any]],Nil,ctx.asInstanceOf[TypedActorContext[Any]],isReducing = false).asInstanceOf[Behavior[T]]
+
 
   /**
    * Go through the behavior stack and apply a predicate to see if any nested behavior


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->
Reimplement the Behavior#start into a tail recursion paradigm.

## References
There is a TODO comment in the Behavior#start function.
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->

## Changes

<!-- Bullets for important changes in this PR -->

- reimplement Behavior#start into tail-rec. But the tradeoff is losing type info.

## Background Context

<!-- Why did you take this approach? -->
