### PR TITLE
Provide cancellation for CoordinatedShutdown tasks (#27335)

### DIFF
--- a/akka-docs/src/main/paradox/coordinated-shutdown.md
+++ b/akka-docs/src/main/paradox/coordinated-shutdown.md
@@ -25,6 +25,14 @@ Scala
 Java
 :  @@snip [ActorDocTest.java](/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java) { #coordinated-shutdown-addTask }
 
+If cancellation of previously added tasks is required:
+
+Scala
+:  @@snip [ActorDocSpec.scala](/akka-docs/src/test/scala/docs/actor/ActorDocSpec.scala) { #coordinated-shutdown-cancellable }
+
+Java
+:  @@snip [ActorDocTest.java](/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java) { #coordinated-shutdown-cancellable }
+
 The returned @scala[`Future[Done]`] @java[`CompletionStage<Done>`] should be completed when the task is completed. The task name parameter
 is only used for debugging/logging.
 

--- a/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
+++ b/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
@@ -13,7 +13,6 @@ import static jdocs.actor.Messages.Swap.Swap;
 import static jdocs.actor.Messages.*;
 import akka.actor.CoordinatedShutdown;
 
-import akka.util.Timeout;
 import akka.Done;
 
 import java.util.Optional;
@@ -848,6 +847,10 @@ public class ActorDocTest extends AbstractJavaTest {
     };
   }
 
+  private CompletionStage<Done> cleanup() {
+    return null;
+  }
+
   @Test
   public void coordinatedShutdown() {
     final ActorRef someActor = system.actorOf(Props.create(FirstActor.class));
@@ -861,6 +864,15 @@ public class ActorDocTest extends AbstractJavaTest {
                   .thenApply(reply -> Done.getInstance());
             });
     // #coordinated-shutdown-addTask
+
+    // #coordinated-shutdown-cancellable
+    Cancellable cancellable =
+        CoordinatedShutdown.get(system)
+            .addCancellableTask(
+                CoordinatedShutdown.PhaseBeforeServiceUnbind(), "someTaskCleanup", () -> cleanup());
+    // much later...
+    cancellable.cancel();
+    // #coordinated-shutdown-cancellable
 
     // #coordinated-shutdown-jvm-hook
     CoordinatedShutdown.get(system)

--- a/akka-docs/src/test/scala/docs/actor/ActorDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/actor/ActorDocSpec.scala
@@ -736,6 +736,23 @@ class ActorDocSpec extends AkkaSpec("""
     //#coordinated-shutdown-addTask
 
     {
+      def cleanup(): Unit = {}
+      import system.dispatcher
+      //#coordinated-shutdown-cancellable
+      val c = CoordinatedShutdown(system).addCancellableTask(CoordinatedShutdown.PhaseBeforeServiceUnbind, "cleanup") {
+        () =>
+          Future {
+            cleanup()
+            Done
+          }
+      }
+
+      // much later...
+      c.cancel()
+      //#coordinated-shutdown-cancellable
+    }
+
+    {
       val someActor = system.actorOf(Props(classOf[Replier], this))
       someActor ! PoisonPill
       //#coordinated-shutdown-addActorTerminationTask


### PR DESCRIPTION
* Add CoordinatedShutdown.addCancellableTask (Scala and Java APIs)
* Ensure that tasks only run once even if submitted multiple times

<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #27335 

## Changes

<!-- Bullets for important changes in this PR -->

## Background Context

<!-- Why did you take this approach? -->
