### PR TITLE
Use dilated timeout in enterBarrier

### DIFF
--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
@@ -393,7 +393,6 @@ abstract class MultiNodeSpec(
   /**
    * Enter the named barriers in the order given. Use the remaining duration from
    * the innermost enclosing `within` block or the default `BarrierTimeout`.
-   *
    */
   def enterBarrier(name: String*): Unit =
     testConductor.enter(

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
@@ -392,12 +392,23 @@ abstract class MultiNodeSpec(
 
   /**
    * Enter the named barriers in the order given. Use the remaining duration from
-   * the innermost enclosing `within` block or the default `BarrierTimeout`
+   * the innermost enclosing `within` block or the default `BarrierTimeout`.
+   *
    */
   def enterBarrier(name: String*): Unit =
     testConductor.enter(
       Timeout.durationToTimeout(remainingOr(testConductor.Settings.BarrierTimeout.duration)),
       name.to(immutable.Seq))
+
+  /**
+   * Enter the named barriers in the order given. Use the remaining duration from
+   * the innermost enclosing `within` block or the passed `max` timeout.
+   *
+   * Note that the `max` timeout is scaled using Duration.dilated,
+   * which uses the configuration entry "akka.test.timefactor".
+   */
+  def enterBarrier(max: FiniteDuration, name: String*): Unit =
+    testConductor.enter(Timeout.durationToTimeout(remainingOr(max.dilated)), name.to(immutable.Seq))
 
   /**
    * Query the controller for the transport address of the given node (by role name) and


### PR DESCRIPTION
The current `enterBarrier` method uses a timeout that is not dilated. That's ok when using inside a `within` block in which case it will use the remaining dilated timeout from `within`. 

The problem becomes more apparent when using a mix of tests methods with and without using `within` method. Since `enterBarrier` is cross node, it can be impacted by tests pending completion on another node.

For instance: 

```scala

// config ->  akka.test.timefactor = 3

"My Tests" must {

    "test1" in within(20.seconds) { // effectively 60.5
		enterBarrier("test 1") // 30s, but actually remaning of 60.5
		// run some long tests
    }

	"test2" in  {
		enterBarrier("test 2") // 30s
    }
}
```

We can have node1 finishing "test1" quickly, moving to test2 and waiting at the barrier. 

Node2 for some reason takes time to complete "test1" and its timeout is dialted to 60 (actually 60.5, assuming `akka.test.timefactor = 3`). 

The `enterBarrier` call in node1 will fail after 30s (default, not dilated). 

That makes it harder to reason about because:

1. dilation time factor is global and defined by config
1. barrier timeout can only be defined via config
2. users can programmaticaly define timeouts, but not always
2. `enterBarrier` is cross test barrier and can be impacted by tests on other nodes

If we make the timeout inside `enterBarrier` to be dilated we will the following instead:

```scala 
"My Tests" must {

    "test1" in within(20.seconds) { // effectively 60.5
		enterBarrier("test 1") // 90.5s, but actually remaning of 60.5
		// run some long tests
    }

	"test2" in  {
		enterBarrier("test 2") // 90.5s
    }
}
```

Additionally, it won't hurt to extend `enterBarrier` and have

```scala

def enterBarrier(max: FiniteDuration, name: String*): Unit = {
  import akka.testkit._
  testConductor.enter(
   Timeout.durationToTimeout(remainingOr(max.dilated)),
    name.to(immutable.Seq))
  )
}
```

Not included (yet) on this PR though.
