### PR TITLE
Update example documentation of retry.

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/RetrySupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/RetrySupport.scala
@@ -30,7 +30,7 @@ trait RetrySupport {
    * private val sendReceiveRetry: HttpRequest => Future[HttpResponse] = (req: HttpRequest) => retry[HttpResponse](
    *   attempt = () => sendAndReceive(req),
    *   attempts = 10,
-   *   delay = 2 seconds
+   *   delay = 2.seconds
    * )
    * }}}
    */

--- a/akka-actor/src/main/scala/akka/pattern/RetrySupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/RetrySupport.scala
@@ -31,7 +31,6 @@ trait RetrySupport {
    *   attempt = () => sendAndReceive(req),
    *   attempts = 10,
    *   delay = 2 seconds,
-   *   scheduler = context.system.scheduler
    * )
    * }}}
    */

--- a/akka-actor/src/main/scala/akka/pattern/RetrySupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/RetrySupport.scala
@@ -30,7 +30,7 @@ trait RetrySupport {
    * private val sendReceiveRetry: HttpRequest => Future[HttpResponse] = (req: HttpRequest) => retry[HttpResponse](
    *   attempt = () => sendAndReceive(req),
    *   attempts = 10,
-   *   delay = 2 seconds,
+   *   delay = 2 seconds
    * )
    * }}}
    */


### PR DESCRIPTION
Normally "retry" method should have tree parameters , currently it contains fours parameters in the example of retry function.
scheduler = context.system.scheduler should be in the implicit parameters .
