### PR TITLE
Add configuration for all Jackson Features

### DIFF
--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -66,17 +66,32 @@ akka.serialization.jackson {
 
   # Configuration of the ObjectMapper mapper features.
   # See com.fasterxml.jackson.databind.MapperFeature
-  # Enum values corresponding to the MapperFeature and their boolean value.
+  # Enum values corresponding to the MapperFeature and their
+  # boolean values, for example:
+  #
+  # mapper-features {
+  #   SORT_PROPERTIES_ALPHABETICALLY = on
+  # }
   mapper-features {}
 
   # Configuration of the ObjectMapper JsonParser features.
   # See com.fasterxml.jackson.core.JsonParser.Feature
-  # Enum values corresponding to the JsonParser.Feature and their boolean value.
+  # Enum values corresponding to the JsonParser.Feature and their
+  # boolean value, for example:
+  #
+  # json-parser-features {
+  #   ALLOW_SINGLE_QUOTES = on
+  # }
   json-parser-features {}
 
   # Configuration of the ObjectMapper JsonParser features.
   # See com.fasterxml.jackson.core.JsonGenerator.Feature
-  # Enum values corresponding to the JsonGenerator.Feature and their boolean value.
+  # Enum values corresponding to the JsonGenerator.Feature and
+  # their boolean value, for example:
+  #
+  # json-generator-features {
+  #   WRITE_NUMBERS_AS_STRINGS = on
+  # }
   json-generator-features {}
 
   # Additional classes that are allowed even if they are not defined in `serialization-bindings`.

--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -64,6 +64,11 @@ akka.serialization.jackson {
     FAIL_ON_UNKNOWN_PROPERTIES = off
   }
 
+  # Configuration of the ObjectMapper mapper features.
+  # See com.fasterxml.jackson.databind.MapperFeature
+  # Enum values corresponding to the MapperFeature and their boolean value.
+  mapper-features {}
+
   # Additional classes that are allowed even if they are not defined in `serialization-bindings`.
   # This is useful when a class is not used for serialization any more and therefore removed
   # from `serialization-bindings`, but should still be possible to deserialize.

--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -74,6 +74,11 @@ akka.serialization.jackson {
   # Enum values corresponding to the JsonParser.Feature and their boolean value.
   json-parser-features {}
 
+  # Configuration of the ObjectMapper JsonParser features.
+  # See com.fasterxml.jackson.core.JsonGenerator.Feature
+  # Enum values corresponding to the JsonGenerator.Feature and their boolean value.
+  json-generator-features {}
+
   # Additional classes that are allowed even if they are not defined in `serialization-bindings`.
   # This is useful when a class is not used for serialization any more and therefore removed
   # from `serialization-bindings`, but should still be possible to deserialize.

--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -69,6 +69,11 @@ akka.serialization.jackson {
   # Enum values corresponding to the MapperFeature and their boolean value.
   mapper-features {}
 
+  # Configuration of the ObjectMapper JsonParser features.
+  # See com.fasterxml.jackson.core.JsonParser.Feature
+  # Enum values corresponding to the JsonParser.Feature and their boolean value.
+  json-parser-features {}
+
   # Additional classes that are allowed even if they are not defined in `serialization-bindings`.
   # This is useful when a class is not used for serialization any more and therefore removed
   # from `serialization-bindings`, but should still be possible to deserialize.

--- a/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -108,7 +108,8 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
     val configuredJsonParserFeatures = features(config, "json-parser-features").map {
       case (enumName, value) => JsonParser.Feature.valueOf(enumName) -> value
     }
-    val jsonParserFeatures = objectMapperFactory.overrideConfiguredJsonParserFeatures(bindingName, configuredJsonParserFeatures)
+    val jsonParserFeatures =
+      objectMapperFactory.overrideConfiguredJsonParserFeatures(bindingName, configuredJsonParserFeatures)
     jsonParserFeatures.foreach {
       case (feature, value) => mapper.configure(feature, value)
     }
@@ -116,7 +117,8 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
     val configuredJsonGeneratorFeatures = features(config, "json-generator-features").map {
       case (enumName, value) => JsonGenerator.Feature.valueOf(enumName) -> value
     }
-    val jsonGeneratorFeatures = objectMapperFactory.overrideConfiguredJsonGeneratorFeatures(bindingName, configuredJsonGeneratorFeatures)
+    val jsonGeneratorFeatures =
+      objectMapperFactory.overrideConfiguredJsonGeneratorFeatures(bindingName, configuredJsonGeneratorFeatures)
     jsonGeneratorFeatures.foreach {
       case (feature, value) => mapper.configure(feature, value)
     }
@@ -364,8 +366,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredMapperFeatures(
       @unused bindingName: String,
-      configuredFeatures: immutable.Seq[(MapperFeature, Boolean)])
-      : immutable.Seq[(MapperFeature, Boolean)] =
+      configuredFeatures: immutable.Seq[(MapperFeature, Boolean)]): immutable.Seq[(MapperFeature, Boolean)] =
     configuredFeatures
 
   /**
@@ -378,8 +379,7 @@ class JacksonObjectMapperFactory {
    */
   def overrideConfiguredJsonParserFeatures(
       @unused bindingName: String,
-      configuredFeatures: immutable.Seq[(JsonParser.Feature, Boolean)])
-      : immutable.Seq[(JsonParser.Feature, Boolean)] =
+      configuredFeatures: immutable.Seq[(JsonParser.Feature, Boolean)]): immutable.Seq[(JsonParser.Feature, Boolean)] =
     configuredFeatures
 
   /**

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -47,6 +47,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Matchers
 import org.scalatest.WordSpecLike
 import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonGenerator
 
 object ScalaTestMessages {
   trait TestMessage
@@ -157,6 +158,9 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
           # off is Jackson's default
           json-parser-features.ALLOW_COMMENTS = on
+
+          # on is Jackson's default
+          json-generator-features.AUTO_CLOSE_TARGET = off
         }
       """) { sys =>
 
@@ -200,6 +204,14 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
           defaultObjectMapper.isEnabled(JsonParser.Feature.ALLOW_COMMENTS) should ===(false)
         }
 
+        "support json generator features" in {
+          identifiedObjectMapper.isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET) should ===(false)
+          namedObjectMapper.isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET) should ===(false)
+
+          // Default mapper follows Jackson and reference.conf default configuration
+          defaultObjectMapper.isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET) should ===(true)
+        }
+
         "fallback to defaults when object mapper is not configured" in {
           val notConfigured = JacksonObjectMapperProvider(sys).getOrCreate("jackson-not-configured", None)
           // Use Jacksons and Akka defaults
@@ -207,6 +219,7 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
           notConfigured.isEnabled(DeserializationFeature.EAGER_DESERIALIZER_FETCH) should ===(true)
           notConfigured.isEnabled(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY) should ===(false)
           notConfigured.isEnabled(JsonParser.Feature.ALLOW_COMMENTS) should ===(false)
+          notConfigured.isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET) should ===(true)
         }
       }
     }

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -163,10 +163,11 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
           json-generator-features.AUTO_CLOSE_TARGET = off
         }
       """) { sys =>
-
-        val identifiedObjectMapper = serialization(sys).serializerByIdentity(999).asInstanceOf[JacksonJsonSerializer].objectMapper
+        val identifiedObjectMapper =
+          serialization(sys).serializerByIdentity(999).asInstanceOf[JacksonJsonSerializer].objectMapper
         val namedObjectMapper = JacksonObjectMapperProvider(sys).getOrCreate("jackson-json2", None)
-        val defaultObjectMapper = serializerFor(ScalaTestMessages.SimpleCommand("abc")).asInstanceOf[JacksonJsonSerializer].objectMapper
+        val defaultObjectMapper =
+          serializerFor(ScalaTestMessages.SimpleCommand("abc")).asInstanceOf[JacksonJsonSerializer].objectMapper
 
         println(s"identifiedObjectMapper => $identifiedObjectMapper")
         println(s"namedObjectMapper => $namedObjectMapper")

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -46,6 +46,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Matchers
 import org.scalatest.WordSpecLike
+import com.fasterxml.jackson.core.JsonParser
 
 object ScalaTestMessages {
   trait TestMessage
@@ -153,6 +154,9 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
           # off is Jackson's default
           mapper-features.SORT_PROPERTIES_ALPHABETICALLY = on
+
+          # off is Jackson's default
+          json-parser-features.ALLOW_COMMENTS = on
         }
       """) { sys =>
 
@@ -188,12 +192,21 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
           defaultObjectMapper.isEnabled(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY) should ===(false)
         }
 
+        "support json parser features" in {
+          identifiedObjectMapper.isEnabled(JsonParser.Feature.ALLOW_COMMENTS) should ===(true)
+          namedObjectMapper.isEnabled(JsonParser.Feature.ALLOW_COMMENTS) should ===(true)
+
+          // Default mapper follows Jackson and reference.conf default configuration
+          defaultObjectMapper.isEnabled(JsonParser.Feature.ALLOW_COMMENTS) should ===(false)
+        }
+
         "fallback to defaults when object mapper is not configured" in {
           val notConfigured = JacksonObjectMapperProvider(sys).getOrCreate("jackson-not-configured", None)
           // Use Jacksons and Akka defaults
           notConfigured.isEnabled(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS) should ===(true)
           notConfigured.isEnabled(DeserializationFeature.EAGER_DESERIALIZER_FETCH) should ===(true)
           notConfigured.isEnabled(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY) should ===(false)
+          notConfigured.isEnabled(JsonParser.Feature.ALLOW_COMMENTS) should ===(false)
         }
       }
     }


### PR DESCRIPTION
## Purpose

Previously only [serialization](https://github.com/FasterXML/jackson-databind/wiki/Serialization-Features) and [deserialization](https://github.com/FasterXML/jackson-databind/wiki/Deserialization-Features) features were supported. This adds support for [MapperFeatures](https://github.com/FasterXML/jackson-databind/wiki/Mapper-Features), JsonParser and JsonGenerator features, making the `ObjectMapper` mostly configurable using `.conf` files.

## References

References #26870.

## Changes

- Support `MapperFeatures` configurations
- Support `JsonParser.Feature` configurations
- Support `JsonCreator.Feature` configurations
