### PR TITLE
Revert "Remove source/sink fromPublisher/fromSubscriber (#27288)"

### DIFF
--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -73,8 +73,6 @@ Use @apidoc[AbstractPersistentActorWithAtLeastOnceDelivery] instead.
 * `CircuitBreaker.onOpen` use `CircuitBreaker.addOnOpenListener`
 * `CircuitBreaker.onHalfOpen` use `CircuitBreaker.addOnHalfOpenListener`
 * `CircuitBreaker.onClose` use `CircuitBreaker.addOnCloseListener`
-* `Source.actorSubscriber`, use `Source.fromGraph` instead.
-* `Source.actorActorPublisher`, use `Source.fromGraph` instead.
 
 ### JavaTestKit removed
 

--- a/akka-stream-tests/src/test/scala/akka/stream/ActorMaterializerSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/ActorMaterializerSpec.scala
@@ -10,7 +10,7 @@ import akka.stream.ActorMaterializerSpec.ActorWithMaterializer
 import akka.stream.impl.{ PhasedFusingActorMaterializer, StreamSupervisor }
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.stream.testkit.{ StreamSpec, TestPublisher }
-import akka.testkit.{ ImplicitSender, TestProbe }
+import akka.testkit.{ ImplicitSender, TestActor, TestProbe }
 import com.github.ghik.silencer.silent
 
 import scala.concurrent.Await
@@ -82,6 +82,14 @@ class ActorMaterializerSpec extends StreamSpec with ImplicitSender {
       p.expectMsg("hello")
       a ! PoisonPill
       val Failure(_) = p.expectMsgType[Try[Done]]
+    }
+
+    "handle properly broken Props" in {
+      val m = ActorMaterializer.create(system)
+      an[IllegalArgumentException] should be thrownBy
+      Await.result(
+        Source.actorPublisher(Props(classOf[TestActor], "wrong", "arguments")).runWith(Sink.head)(m),
+        3.seconds)
     }
 
     "report correctly if it has been shut down from the side" in {

--- a/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes
@@ -112,12 +112,6 @@ ProblemFilters.exclude[MissingClassProblem]("akka.stream.impl.io.FileSubscriber$
 ProblemFilters.exclude[MissingClassProblem]("akka.stream.impl.io.FileSink")
 ProblemFilters.exclude[MissingClassProblem]("akka.stream.impl.io.FileSubscriber")
 
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.javadsl.Source.actorPublisher")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.javadsl.Sink.actorSubscriber")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Source.actorPublisher")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Sink.actorSubscriber")
-
-
 
 # #25045 adding Java/Scala interop to SourceQueue and SinkQueue
 ProblemFilters.exclude[MissingClassProblem]("akka.stream.impl.SinkQueueAdapter")

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -7,7 +7,7 @@ package akka.stream.javadsl
 import java.util.Optional
 
 import akka.{ japi, Done, NotUsed }
-import akka.actor.ActorRef
+import akka.actor.{ ActorRef, Props }
 import akka.dispatch.ExecutionContexts
 import akka.japi.function
 import akka.stream.impl.LinearTraversalBuilder
@@ -263,6 +263,19 @@ object Sink {
       onFailureMessage: function.Function[Throwable, Any]): Sink[In, NotUsed] =
     new Sink(
       scaladsl.Sink.actorRefWithAck[In](ref, onInitMessage, ackMessage, onCompleteMessage, onFailureMessage.apply _))
+
+  /**
+   * Creates a `Sink` that is materialized to an [[akka.actor.ActorRef]] which points to an Actor
+   * created according to the passed in [[akka.actor.Props]]. Actor created by the `props` should
+   * be [[akka.stream.actor.ActorSubscriber]].
+   *
+   * @deprecated Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
+   */
+  @deprecated(
+    "Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.",
+    since = "2.5.0")
+  def actorSubscriber[T](props: Props): Sink[T, ActorRef] =
+    new Sink(scaladsl.Sink.actorSubscriber(props))
 
   /**
    * A graph with the shape of a sink logically is a sink, this method makes

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -7,7 +7,7 @@ package akka.stream.javadsl
 import java.util
 import java.util.Optional
 
-import akka.actor.{ ActorRef, Cancellable }
+import akka.actor.{ ActorRef, Cancellable, Props }
 import akka.event.LoggingAdapter
 import akka.japi.{ function, Pair, Util }
 import akka.stream._
@@ -285,6 +285,19 @@ object Source {
    */
   def asSubscriber[T](): Source[T, Subscriber[T]] =
     new Source(scaladsl.Source.asSubscriber)
+
+  /**
+   * Creates a `Source` that is materialized to an [[akka.actor.ActorRef]] which points to an Actor
+   * created according to the passed in [[akka.actor.Props]]. Actor created by the `props` should
+   * be [[akka.stream.actor.ActorPublisher]].
+   *
+   * @deprecated Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
+   */
+  @deprecated(
+    "Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.",
+    since = "2.5.0")
+  def actorPublisher[T](props: Props): Source[T, ActorRef] =
+    new Source(scaladsl.Source.actorPublisher(props))
 
   /**
    * Creates a `Source` that is materialized as an [[akka.actor.ActorRef]].

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -6,8 +6,9 @@ package akka.stream.scaladsl
 
 import akka.{ Done, NotUsed }
 import akka.dispatch.ExecutionContexts
-import akka.actor.{ ActorRef, Status }
+import akka.actor.{ ActorRef, Props, Status }
 import akka.annotation.InternalApi
+import akka.stream.actor.ActorSubscriber
 import akka.stream.impl.Stages.DefaultAttributes
 import akka.stream.impl._
 import akka.stream.impl.fusing.GraphStages
@@ -16,6 +17,7 @@ import akka.stream.{ javadsl, _ }
 import org.reactivestreams.{ Publisher, Subscriber }
 
 import scala.annotation.tailrec
+import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
 import scala.collection.immutable
@@ -515,6 +517,21 @@ object Sink {
       onCompleteMessage: Any,
       onFailureMessage: (Throwable) => Any = Status.Failure): Sink[T, NotUsed] =
     actorRefWithAck(ref, _ => identity, _ => onInitMessage, ackMessage, onCompleteMessage, onFailureMessage)
+
+  /**
+   * Creates a `Sink` that is materialized to an [[akka.actor.ActorRef]] which points to an Actor
+   * created according to the passed in [[akka.actor.Props]]. Actor created by the `props` must
+   * be [[akka.stream.actor.ActorSubscriber]].
+   *
+   * @deprecated Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
+   */
+  @deprecated(
+    "Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.",
+    since = "2.5.0")
+  def actorSubscriber[T](props: Props): Sink[T, ActorRef] = {
+    require(classOf[ActorSubscriber].isAssignableFrom(props.actorClass()), "Actor must be ActorSubscriber")
+    fromGraph(new ActorSubscriberSink(props, DefaultAttributes.actorSubscriberSink, shape("ActorSubscriberSink")))
+  }
 
   /**
    * Creates a `Sink` that is materialized as an [[akka.stream.scaladsl.SinkQueueWithCancel]].

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -6,8 +6,9 @@ package akka.stream.scaladsl
 
 import java.util.concurrent.CompletionStage
 
-import akka.actor.{ ActorRef, Cancellable }
+import akka.actor.{ ActorRef, Cancellable, Props }
 import akka.annotation.InternalApi
+import akka.stream.actor.ActorPublisher
 import akka.stream.impl.Stages.DefaultAttributes
 import akka.stream.impl.fusing.GraphStages
 import akka.stream.impl.fusing.GraphStages._
@@ -455,6 +456,21 @@ object Source {
    */
   def asSubscriber[T]: Source[T, Subscriber[T]] =
     fromGraph(new SubscriberSource[T](DefaultAttributes.subscriberSource, shape("SubscriberSource")))
+
+  /**
+   * Creates a `Source` that is materialized to an [[akka.actor.ActorRef]] which points to an Actor
+   * created according to the passed in [[akka.actor.Props]]. Actor created by the `props` must
+   * be [[akka.stream.actor.ActorPublisher]].
+   *
+   * @deprecated Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.
+   */
+  @deprecated(
+    "Use `akka.stream.stage.GraphStage` and `fromGraph` instead, it allows for all operations an Actor would and is more type-safe as well as guaranteed to be ReactiveStreams compliant.",
+    since = "2.5.0")
+  def actorPublisher[T](props: Props): Source[T, ActorRef] = {
+    require(classOf[ActorPublisher[_]].isAssignableFrom(props.actorClass()), "Actor must be ActorPublisher")
+    fromGraph(new ActorPublisherSource(props, DefaultAttributes.actorPublisherSource, shape("ActorPublisherSource")))
+  }
 
   /**
    * INTERNAL API


### PR DESCRIPTION
This reverts commit 09838a71e543793d5f2f1d90f09dd8a84374b4b1.

We want to first update Akka HTTP to avoid using this construct before removing it here.