### PR TITLE
Provide more helpful message when synchronous testing ActorRef is used for asking

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
@@ -45,7 +45,11 @@ private[akka] final class FunctionRef[-T](override val path: ActorPath, send: (T
   override def isLocal = true
 
   // impl InternalRecipientRef, ask not supported
-  override def provider: ActorRefProvider = throw new UnsupportedOperationException("no provider")
+  override def provider: ActorRefProvider =
+    throw new UnsupportedOperationException(
+      "ActorRefs created for synchronous testing cannot be used as targets for asking. Use asynchronous testing instead. " +
+      "See https://doc.akka.io/docs/akka/current/typed/testing.html#asynchronous-testing")
+
   // impl InternalRecipientRef
   def isTerminated: Boolean = false
 }


### PR DESCRIPTION
Reported in https://discuss.lightbend.com/t/unsupportedoperationexception-no-provider-when-testing-a-route-that-asks-a-reply-from-a-typed-actor/4630, the existing "no provider" messages when using synchronous testing is not really helpful.