### PR TITLE
Add 'core' and 'dumps' to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ factorial2.txt
 
 # Default sigar library extract location.
 native/
+
+/dumps/
+/core


### PR DESCRIPTION
'core' is sometimes left behind by graphviz, and a 'dumps' directory
is sometimes left behind when running with jdk11 and graal.