### PR TITLE
Fix race in AkkaProtocolSpec

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/classic/transport/AkkaProtocolSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/transport/AkkaProtocolSpec.scala
@@ -217,7 +217,7 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = remote """) wit
       })
     }
 
-    "in outbound mode delay readiness until hadnshake finished" in {
+    "in outbound mode delay readiness until handshake finished" in {
       val (failureDetector, registry, transport, handle) = collaborators
       transport.associateBehavior.pushConstant(handle)
 
@@ -235,7 +235,7 @@ class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = remote """) wit
           refuseUid = None))
 
       awaitCond(lastActivityIsAssociate(registry, 42, None))
-      failureDetector.called should ===(true)
+      awaitCond(failureDetector.called)
 
       // keeps sending heartbeats
       awaitCond(lastActivityIsHeartbeat(registry))


### PR DESCRIPTION
The heartbeat happens after the send associate in
AkkaProtocolTransport so test can't assume the heartbeat
has happened.

Fixes #26974