### PR TITLE
Remove catchall silents from prod code

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -33,7 +33,8 @@ import com.github.ghik.silencer.silent
 /**
  * INTERNAL API
  */
-@silent @InternalApi private[akka] final class ActorSystemStub(val name: String)
+//@silent
+@InternalApi private[akka] final class ActorSystemStub(val name: String)
     extends ActorSystem[Nothing]
     with ActorRef[Nothing]
     with ActorRefImpl[Nothing]

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -33,7 +33,7 @@ import com.github.ghik.silencer.silent
 /**
  * INTERNAL API
  */
-//@silent
+@silent
 @InternalApi private[akka] final class ActorSystemStub(val name: String)
     extends ActorSystem[Nothing]
     with ActorRef[Nothing]

--- a/akka-actor-tests/src/test/scala/akka/pattern/BackoffSupervisorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/BackoffSupervisorSpec.scala
@@ -47,13 +47,13 @@ object BackoffSupervisorSpec {
 class BackoffSupervisorSpec extends AkkaSpec with ImplicitSender with Eventually {
   import BackoffSupervisorSpec._
 
-  @silent
+  @silent("deprecated")
   def onStopOptions(props: Props = Child.props(testActor), maxNrOfRetries: Int = -1) =
     Backoff.onStop(props, "c1", 100.millis, 3.seconds, 0.2, maxNrOfRetries)
-  @silent
+  @silent("deprecated")
   def onFailureOptions(props: Props = Child.props(testActor), maxNrOfRetries: Int = -1) =
     Backoff.onFailure(props, "c1", 100.millis, 3.seconds, 0.2, maxNrOfRetries)
-  @silent
+  @silent("deprecated")
   def create(options: BackoffOptions) = system.actorOf(BackoffSupervisor.props(options))
 
   "BackoffSupervisor" must {
@@ -178,7 +178,7 @@ class BackoffSupervisorSpec extends AkkaSpec with ImplicitSender with Eventually
 
     "reply to sender if replyWhileStopped is specified" in {
       filterException[TestException] {
-        @silent
+        @silent("deprecated")
         val supervisor = create(
           Backoff
             .onFailure(Child.props(testActor), "c1", 100.seconds, 300.seconds, 0.2, maxNrOfRetries = -1)
@@ -204,7 +204,7 @@ class BackoffSupervisorSpec extends AkkaSpec with ImplicitSender with Eventually
 
     "not reply to sender if replyWhileStopped is NOT specified" in {
       filterException[TestException] {
-        @silent
+        @silent("deprecated")
         val supervisor =
           create(Backoff.onFailure(Child.props(testActor), "c1", 100.seconds, 300.seconds, 0.2, maxNrOfRetries = -1))
         supervisor ! BackoffSupervisor.GetCurrentChild

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
@@ -96,7 +96,7 @@ object AskPattern {
      *
      * @tparam Res The response protocol, what the other actor sends back
      */
-    @silent
+    @silent("never used")
     def ask[Res](replyTo: ActorRef[Res] => Req)(implicit timeout: Timeout, scheduler: Scheduler): Future[Res] = {
       // We do not currently use the implicit sched, but want to require it
       // because it might be needed when we move to a 'native' typed runtime, see #24219

--- a/akka-actor/src/main/boilerplate/akka/japi/function/Functions.scala.template
+++ b/akka-actor/src/main/boilerplate/akka/japi/function/Functions.scala.template
@@ -24,7 +24,7 @@ trait Function1[[#-T1#], +R] extends java.io.Serializable {
  * A Procedure is like a Function, but it doesn't produce a return value.
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(##1L)
 trait Procedure1[[#-T1#]] extends java.io.Serializable {
   @throws(classOf[Exception])

--- a/akka-actor/src/main/scala/akka/actor/AbstractActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/AbstractActor.scala
@@ -273,7 +273,7 @@ abstract class AbstractActor extends Actor {
   // TODO In 2.6.0 we can remove deprecation and make the method final
   @deprecated("Override preRestart with message parameter with Optional type instead", "2.5.0")
   @throws(classOf[Exception])
-  @silent
+  @silent("deprecated")
   override def preRestart(reason: Throwable, message: Option[Any]): Unit = {
     import scala.compat.java8.OptionConverters._
     preRestart(reason, message.asJava)

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -404,7 +404,7 @@ private[akka] object ActorCell {
  * supported APIs in this place. This is not the API you were looking
  * for! (waves hand)
  */
-@silent
+@silent("deprecated")
 private[akka] class ActorCell(
     val system: ActorSystemImpl,
     val self: InternalActorRef,

--- a/akka-actor/src/main/scala/akka/actor/ActorPath.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorPath.scala
@@ -151,7 +151,8 @@ object ActorPath {
  * references are compared the unique id of the actor is not taken into account
  * when comparing actor paths.
  */
-@silent
+@silent("@SerialVersionUID has no effect on traits")
+@silent("deprecated")
 @SerialVersionUID(1L)
 sealed trait ActorPath extends Comparable[ActorPath] with Serializable {
 

--- a/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
@@ -326,7 +326,7 @@ private[akka] final case class ActorSelectionMessage(
 /**
  * INTERNAL API
  */
-@silent
+@silent("@SerialVersionUID has no effect on traits")
 @SerialVersionUID(1L)
 private[akka] sealed trait SelectionPathElement
 

--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -99,7 +99,7 @@ trait Scope {
   def withFallback(other: Scope): Scope
 }
 
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 abstract class LocalScope extends Scope
 
@@ -108,7 +108,7 @@ abstract class LocalScope extends Scope
  * which do not set a different scope. It is also the only scope handled by
  * the LocalActorRefProvider.
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 case object LocalScope extends LocalScope {
 
@@ -123,7 +123,7 @@ case object LocalScope extends LocalScope {
 /**
  * This is the default value and as such allows overrides.
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 abstract class NoScopeGiven extends Scope
 @SerialVersionUID(1L)

--- a/akka-actor/src/main/scala/akka/actor/FSM.scala
+++ b/akka-actor/src/main/scala/akka/actor/FSM.scala
@@ -251,7 +251,7 @@ object FSM {
      * Modify state transition descriptor with new state data. The data will be
      * set when transitioning to the new state.
      */
-    @silent
+    @silent("deprecated")
     def using(@deprecatedName(Symbol("nextStateDate")) nextStateData: D): State[S, D] = {
       copy(stateData = nextStateData)
     }

--- a/akka-actor/src/main/scala/akka/actor/IndirectActorProducer.scala
+++ b/akka-actor/src/main/scala/akka/actor/IndirectActorProducer.scala
@@ -41,7 +41,6 @@ private[akka] object IndirectActorProducer {
   val CreatorFunctionConsumerClass = classOf[CreatorFunctionConsumer]
   val CreatorConsumerClass = classOf[CreatorConsumer]
   val TypedCreatorFunctionConsumerClass = classOf[TypedCreatorFunctionConsumer]
-
   @silent
   def apply(clazz: Class[_], args: immutable.Seq[Any]): IndirectActorProducer = {
     if (classOf[IndirectActorProducer].isAssignableFrom(clazz)) {

--- a/akka-actor/src/main/scala/akka/actor/Scheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/Scheduler.scala
@@ -153,7 +153,7 @@ trait Scheduler {
    *
    * Note: For scheduling within actors `with Timers` should be preferred.
    */
-  @silent
+  @silent("deprecated")
   final def scheduleWithFixedDelay(
       initialDelay: FiniteDuration,
       delay: FiniteDuration,
@@ -228,7 +228,7 @@ trait Scheduler {
    *
    * Note: For scheduling within actors `with Timers` should be preferred.
    */
-  @silent
+  @silent("deprecated")
   final def scheduleAtFixedRate(initialDelay: FiniteDuration, interval: FiniteDuration)(runnable: Runnable)(
       implicit executor: ExecutionContext): Cancellable =
     schedule(initialDelay, interval, runnable)(executor)
@@ -297,7 +297,7 @@ trait Scheduler {
    *
    * Note: For scheduling within actors `with Timers` should be preferred.
    */
-  @silent
+  @silent("deprecated")
   final def scheduleAtFixedRate(
       initialDelay: FiniteDuration,
       interval: FiniteDuration,
@@ -350,7 +350,7 @@ trait Scheduler {
     "Use scheduleWithFixedDelay or scheduleAtFixedRate instead. This has the same semantics as " +
     "scheduleAtFixedRate, but scheduleWithFixedDelay is often preferred.",
     since = "2.6.0")
-  @silent
+  @silent("deprecated")
   final def schedule(initialDelay: FiniteDuration, interval: FiniteDuration, receiver: ActorRef, message: Any)(
       implicit
       executor: ExecutionContext,

--- a/akka-actor/src/main/scala/akka/actor/TypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/TypedActor.scala
@@ -125,11 +125,11 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
    *
    * Java API
    */
-  @silent
+  @silent("deprecated")
   def get(context: ActorContext): TypedActorFactory = apply(context)
 
   @deprecated("Use 'akka.actor.typed' API.", since = "2.6.0")
-  @silent
+  @silent("deprecated")
   override def apply(system: ActorSystem): TypedActorExtension = super.apply(system)
 
   /**
@@ -285,7 +285,7 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
       }
     }
 
-    @silent
+    @silent("deprecated")
     override def postStop(): Unit =
       try {
         withContext {
@@ -500,7 +500,7 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
         case some => toTypedActorInvocationHandler(some)
       }
 
-    @silent
+    @silent("deprecated")
     def toTypedActorInvocationHandler(system: ActorSystem): TypedActorInvocationHandler =
       new TypedActorInvocationHandler(TypedActor(system), new AtomVar[ActorRef](actor), new Timeout(timeout))
   }
@@ -676,14 +676,14 @@ final case class TypedProps[T <: AnyRef] protected[TypedProps] (
  * ContextualTypedActorFactory allows TypedActors to create children, effectively forming the same Actor Supervision Hierarchies
  * as normal Actors can.
  */
-@silent
+@silent("deprecated")
 final case class ContextualTypedActorFactory(typedActor: TypedActorExtension, actorFactory: ActorContext)
     extends TypedActorFactory {
   override def getActorRefFor(proxy: AnyRef): ActorRef = typedActor.getActorRefFor(proxy)
   override def isTypedActor(proxyOrNot: AnyRef): Boolean = typedActor.isTypedActor(proxyOrNot)
 }
 
-@silent
+@silent("deprecated")
 class TypedActorExtension(val system: ExtendedActorSystem) extends TypedActorFactory with Extension {
   import TypedActor._ //Import the goodies from the companion object
   protected def actorFactory: ActorRefFactory = system

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
@@ -22,7 +22,7 @@ private[akka] trait Children { this: ActorCell =>
 
   import ChildrenContainer._
 
-  @silent
+  @silent("never used")
   @volatile
   private var _childrenRefsDoNotCallMeDirectly: ChildrenContainer = EmptyChildrenContainer
 
@@ -30,7 +30,7 @@ private[akka] trait Children { this: ActorCell =>
     Unsafe.instance.getObjectVolatile(this, AbstractActorCell.childrenOffset).asInstanceOf[ChildrenContainer]
 
   final def children: immutable.Iterable[ActorRef] = childrenRefs.children
-  @silent
+  @silent("deprecated")
   final def getChildren(): java.lang.Iterable[ActorRef] =
     scala.collection.JavaConverters.asJavaIterableConverter(children).asJava
 

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
@@ -48,7 +48,7 @@ class Dispatcher(
    * At first glance this var does not seem to be updated anywhere, but in
    * fact it is, via the esUpdater [[AtomicReferenceFieldUpdater]] below.
    */
-  @silent
+  @silent("never updated")
   @volatile private var executorServiceDelegate: LazyExecutorServiceDelegate =
     new LazyExecutorServiceDelegate(executorServiceFactoryProvider.createExecutorServiceFactory(id, threadFactory))
 

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
@@ -299,7 +299,7 @@ private[akka] object BalancingDispatcherConfigurator {
  * Returns the same dispatcher instance for each invocation
  * of the `dispatcher()` method.
  */
-@silent
+@silent("deprecated")
 class BalancingDispatcherConfigurator(_config: Config, _prerequisites: DispatcherPrerequisites)
     extends MessageDispatcherConfigurator(BalancingDispatcherConfigurator.amendConfig(_config), _prerequisites) {
 

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -241,7 +241,7 @@ object japi {
  *
  * Java API
  */
-@silent
+@silent("deprecated")
 abstract class OnSuccess[-T] extends japi.CallbackBridge[T] {
   protected final override def internal(result: T) = onSuccess(result)
 
@@ -259,7 +259,7 @@ abstract class OnSuccess[-T] extends japi.CallbackBridge[T] {
  *
  * Java API
  */
-@silent
+@silent("deprecated")
 abstract class OnFailure extends japi.CallbackBridge[Throwable] {
   protected final override def internal(failure: Throwable) = onFailure(failure)
 
@@ -277,7 +277,7 @@ abstract class OnFailure extends japi.CallbackBridge[Throwable] {
  *
  * Java API
  */
-@silent
+@silent("deprecated")
 abstract class OnComplete[-T] extends japi.CallbackBridge[Try[T]] {
   protected final override def internal(value: Try[T]): Unit = value match {
     case Failure(t) => onComplete(t, null.asInstanceOf[T])
@@ -300,7 +300,7 @@ abstract class OnComplete[-T] extends japi.CallbackBridge[Try[T]] {
  *
  * Java API
  */
-@silent
+@silent("deprecated")
 abstract class Recover[+T] extends japi.RecoverBridge[T] {
   protected final override def internal(result: Throwable): T = recover(result)
 
@@ -354,7 +354,7 @@ object Filter {
  * SAM (Single Abstract Method) class
  * Java API
  */
-@silent
+@silent("deprecated")
 abstract class Foreach[-T] extends japi.UnitFunctionBridge[T] {
   override final def internal(t: T): Unit = each(t)
 

--- a/akka-actor/src/main/scala/akka/event/EventStream.scala
+++ b/akka-actor/src/main/scala/akka/event/EventStream.scala
@@ -40,7 +40,7 @@ class EventStream(sys: ActorSystem, private val debug: Boolean) extends LoggingB
   protected def classify(event: Any): Class[_] = event.getClass
 
   // TODO consider avoiding the deprecated `isTerminated`?
-  @silent
+  @silent("deprecated")
   protected def publish(event: Any, subscriber: ActorRef) = {
     if (sys == null && subscriber.isTerminated) unsubscribe(subscriber)
     else subscriber ! event

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -12,7 +12,8 @@ import akka.actor._
 import akka.annotation.{ DoNotInherit, InternalApi }
 import akka.dispatch.RequiresMessageQueue
 import akka.event.Logging._
-import akka.util.{ unused, Helpers, ReentrantGuard }
+import akka.util.unused
+import akka.util.{ Helpers, ReentrantGuard }
 import akka.{ AkkaException, ConfigurationException }
 import com.github.ghik.silencer.silent
 
@@ -167,7 +168,7 @@ trait LoggingBus extends ActorEventBus {
    * Internal Akka use only
    */
   private[akka] def stopDefaultLoggers(system: ActorSystem): Unit = {
-    @silent
+    @silent("never used")
     val level = _logLevel // volatile access before reading loggers
     if (!(loggers contains StandardOutLogger)) {
       setUpStdoutLogger(system.settings)
@@ -1496,7 +1497,7 @@ trait LoggingFilter {
  * In retrospect should have been abstract, but we cannot change that
  * without breaking binary compatibility
  */
-@silent
+@silent("never us")
 trait LoggingFilterWithMarker extends LoggingFilter {
   def isErrorEnabled(logClass: Class[_], logSource: String, marker: LogMarker): Boolean =
     isErrorEnabled(logClass, logSource)

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -117,7 +117,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    * @param localAddress optionally specifies a specific address to bind to
    * @param options Please refer to the `Tcp.SO` object for a list of all supported options.
    */
-  @silent
+  @silent("deprecated")
   final case class Connect(
       remoteAddress: InetSocketAddress,
       localAddress: Option[InetSocketAddress] = None,
@@ -145,7 +145,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    *
    * @param options Please refer to the `Tcp.SO` object for a list of all supported options.
    */
-  @silent
+  @silent("deprecated")
   final case class Bind(
       handler: ActorRef,
       localAddress: InetSocketAddress,

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -204,7 +204,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   // AUXILIARIES and IMPLEMENTATION
 
   /** used in subclasses to start the common machinery above once a channel is connected */
-  @silent
+  @silent("deprecated")
   def completeConnect(
       registration: ChannelRegistration,
       commander: ActorRef,

--- a/akka-actor/src/main/scala/akka/io/TcpIncomingConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpIncomingConnection.scala
@@ -17,7 +17,7 @@ import com.github.ghik.silencer.silent
  *
  * INTERNAL API
  */
-@silent
+@silent("deprecated")
 private[io] class TcpIncomingConnection(
     _tcp: TcpExt,
     _channel: SocketChannel,

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -98,7 +98,7 @@ object Udp extends ExtensionId[UdpExt] with ExtensionIdProvider {
    * The listener actor for the newly bound port will reply with a [[Bound]]
    * message, or the manager will reply with a [[CommandFailed]] message.
    */
-  @silent
+  @silent("deprecated")
   final case class Bind(
       handler: ActorRef,
       localAddress: InetSocketAddress,
@@ -122,7 +122,7 @@ object Udp extends ExtensionId[UdpExt] with ExtensionIdProvider {
    * The “simple sender” will not stop itself, you will have to send it a [[akka.actor.PoisonPill]]
    * when you want to close the socket.
    */
-  @silent
+  @silent("deprecated")
   case class SimpleSender(options: immutable.Traversable[SocketOption] = Nil) extends Command
   object SimpleSender extends SimpleSender(Nil)
 

--- a/akka-actor/src/main/scala/akka/io/UdpConnected.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnected.scala
@@ -91,7 +91,7 @@ object UdpConnected extends ExtensionId[UdpConnectedExt] with ExtensionIdProvide
    * which is restricted to sending to and receiving from the given `remoteAddress`.
    * All received datagrams will be sent to the designated `handler` actor.
    */
-  @silent
+  @silent("deprecated")
   final case class Connect(
       handler: ActorRef,
       remoteAddress: InetSocketAddress,

--- a/akka-actor/src/main/scala/akka/io/UdpSender.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpSender.scala
@@ -17,7 +17,7 @@ import com.github.ghik.silencer.silent
 /**
  * INTERNAL API
  */
-@silent
+@silent("deprecated")
 private[io] class UdpSender(
     val udp: UdpExt,
     channelRegistry: ChannelRegistry,

--- a/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
@@ -73,7 +73,7 @@ import scala.concurrent.duration._
   /**
    * Silent to allow map update syntax
    */
-  @silent
+  @silent()
   def ready(socket: ActorRef): Receive = {
     case DropRequest(id) =>
       log.debug("Dropping request [{}]", id)

--- a/akka-actor/src/main/scala/akka/io/dns/internal/DnsMessage.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/DnsMessage.scala
@@ -156,7 +156,7 @@ private[internal] object Message {
     }
 
     import scala.language.implicitConversions
-    @silent
+    @silent("deprecated")
     implicit def flattener[T](tried: Try[T]): GenTraversableOnce[T] =
       if (flags.isTruncated) tried.toOption
       else

--- a/akka-actor/src/main/scala/akka/japi/JavaAPI.scala
+++ b/akka-actor/src/main/scala/akka/japi/JavaAPI.scala
@@ -83,7 +83,7 @@ object Pair {
  *
  * This class is kept for compatibility, but for future API's please prefer [[akka.japi.function.Creator]].
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait Creator[T] extends Serializable {
 

--- a/akka-actor/src/main/scala/akka/japi/function/Function.scala
+++ b/akka-actor/src/main/scala/akka/japi/function/Function.scala
@@ -11,7 +11,7 @@ import com.github.ghik.silencer.silent
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Function` counterpart does not.
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait Function[-T, +R] extends java.io.Serializable {
   @throws(classOf[Exception])
@@ -23,7 +23,7 @@ trait Function[-T, +R] extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.BiFunction` counterpart does not.
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait Function2[-T1, -T2, +R] extends java.io.Serializable {
   @throws(classOf[Exception])
@@ -35,7 +35,7 @@ trait Function2[-T1, -T2, +R] extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Consumer` counterpart does not.
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait Procedure[-T] extends java.io.Serializable {
   @throws(classOf[Exception])
@@ -47,7 +47,7 @@ trait Procedure[-T] extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Effect` counterpart does not.
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait Effect extends java.io.Serializable {
 
@@ -60,7 +60,7 @@ trait Effect extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Predicate` counterpart does not.
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait Predicate[-T] extends java.io.Serializable {
   def test(param: T): Boolean
@@ -70,7 +70,7 @@ trait Predicate[-T] extends java.io.Serializable {
  * A constructor/factory, takes no parameters but creates a new value of type T every call.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Creator` counterpart does not.
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait Creator[+T] extends Serializable {
 

--- a/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
@@ -10,7 +10,6 @@ import akka.actor._
 import akka.annotation.InternalApi
 import akka.dispatch.sysmsg._
 import akka.util.{ Timeout, Unsafe }
-
 import com.github.ghik.silencer.silent
 
 import scala.annotation.tailrec
@@ -499,11 +498,11 @@ private[akka] final class PromiseActorRef private (
    * Stopped               => stopped, path not yet created
    */
   @volatile
-  @silent
+  @silent("never used")
   private[this] var _stateDoNotCallMeDirectly: AnyRef = _
 
   @volatile
-  @silent
+  @silent("never used")
   private[this] var _watchedByDoNotCallMeDirectly: Set[ActorRef] = ActorCell.emptyActorRefSet
 
   @inline

--- a/akka-actor/src/main/scala/akka/pattern/Backoff.scala
+++ b/akka-actor/src/main/scala/akka/pattern/Backoff.scala
@@ -566,7 +566,7 @@ trait BackoffOptions {
   private[akka] def props: Props
 }
 
-@silent
+@silent("deprecated")
 private final case class BackoffOptionsImpl(
     backoffType: BackoffType = RestartImpliesFailure,
     childProps: Props,

--- a/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
@@ -23,7 +23,6 @@ import scala.concurrent.TimeoutException
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 import akka.dispatch.ExecutionContexts.sameThreadExecutionContext
-
 import com.github.ghik.silencer.silent
 
 import scala.compat.java8.FutureConverters
@@ -196,14 +195,14 @@ class CircuitBreaker(
    * Holds reference to current state of CircuitBreaker - *access only via helper methods*
    */
   @volatile
-  @silent
+  @silent("never used")
   private[this] var _currentStateDoNotCallMeDirectly: State = Closed
 
   /**
    * Holds reference to current resetTimeout of CircuitBreaker - *access only via helper methods*
    */
   @volatile
-  @silent
+  @silent("never used")
   private[this] var _currentResetTimeoutDoNotCallMeDirectly: FiniteDuration = resetTimeout
 
   /**

--- a/akka-actor/src/main/scala/akka/routing/Balancing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Balancing.scala
@@ -26,7 +26,7 @@ private[akka] object BalancingRoutingLogic {
  * INTERNAL API
  * Selects the first routee, balancing will be done by the dispatcher.
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 private[akka] final class BalancingRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =

--- a/akka-actor/src/main/scala/akka/routing/Broadcast.scala
+++ b/akka-actor/src/main/scala/akka/routing/Broadcast.scala
@@ -19,7 +19,7 @@ object BroadcastRoutingLogic {
 /**
  * Broadcasts a message to all its routees.
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 final class BroadcastRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =

--- a/akka-actor/src/main/scala/akka/routing/MurmurHash.scala
+++ b/akka-actor/src/main/scala/akka/routing/MurmurHash.scala
@@ -132,7 +132,7 @@ object MurmurHash {
    *  where the order of appearance of elements does not matter.
    *  This is useful for hashing sets, for example.
    */
-  @silent
+  @silent("deprecated")
   def symmetricHash[T](xs: IterableOnce[T], seed: Int): Int = {
     var a, b, n = 0
     var c = 1

--- a/akka-actor/src/main/scala/akka/routing/Random.scala
+++ b/akka-actor/src/main/scala/akka/routing/Random.scala
@@ -21,7 +21,7 @@ object RandomRoutingLogic {
 /**
  * Randomly selects one of the target routees to send a message to
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 final class RandomRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =

--- a/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
@@ -22,7 +22,7 @@ object RoundRobinRoutingLogic {
  * Uses round-robin to select a routee. For concurrent calls,
  * round robin is just a best effort.
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 final class RoundRobinRoutingLogic extends RoutingLogic {
   val next = new AtomicLong

--- a/akka-actor/src/main/scala/akka/routing/RoutedActorRef.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoutedActorRef.scala
@@ -23,7 +23,7 @@ import com.github.ghik.silencer.silent
  * A RoutedActorRef is an ActorRef that has a set of connected ActorRef and it uses a Router to
  * send a message to one (or more) of these actors.
  */
-@silent
+@silent("deprecated")
 private[akka] class RoutedActorRef(
     _system: ActorSystemImpl,
     _routerProps: Props,

--- a/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
+++ b/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
@@ -37,7 +37,7 @@ import com.github.ghik.silencer.silent
  * someone tries sending a message to that reference before the constructor of
  * RoutedActorRef has returned, there will be a `NullPointerException`!
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait RouterConfig extends Serializable {
 
@@ -374,7 +374,7 @@ case object NoRouter extends NoRouter {
 /**
  * INTERNAL API
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 private[akka] trait RouterManagementMesssage
 
@@ -383,7 +383,7 @@ private[akka] trait RouterManagementMesssage
  * A [[Routees]] message is sent asynchronously to the "requester" containing information
  * about what routees the router is routing over.
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 abstract class GetRoutees extends RouterManagementMesssage
 

--- a/akka-actor/src/main/scala/akka/routing/SmallestMailbox.scala
+++ b/akka-actor/src/main/scala/akka/routing/SmallestMailbox.scala
@@ -31,7 +31,7 @@ object SmallestMailboxRoutingLogic {
  *     since their mailbox size is unknown</li>
  * </ul>
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 class SmallestMailboxRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =
@@ -81,7 +81,7 @@ class SmallestMailboxRoutingLogic extends RoutingLogic {
   }
 
   // TODO should we rewrite this not to use isTerminated?
-  @silent
+  @silent("deprecated")
   protected def isTerminated(a: Routee): Boolean = a match {
     case ActorRefRoutee(ref) => ref.isTerminated
     case _                   => false
@@ -179,7 +179,7 @@ class SmallestMailboxRoutingLogic extends RoutingLogic {
  * @param routerDispatcher dispatcher to use for the router head actor, which handles
  *   supervision, death watch and router management messages
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 final case class SmallestMailboxPool(
     nrOfInstances: Int,

--- a/akka-actor/src/main/scala/akka/util/Index.scala
+++ b/akka-actor/src/main/scala/akka/util/Index.scala
@@ -147,7 +147,7 @@ class Index[K, V](val mapSize: Int, val valueComparator: Comparator[V]) {
     if (set ne null) {
       set.synchronized {
         container.remove(key, set)
-        @silent
+        @silent("deprecated")
         val ret = collectionAsScalaIterableConverter(set.clone()).asScala // Make copy since we need to clear the original
         set.clear() // Clear the original set to signal to any pending writers that there was a conflict
         Some(ret)

--- a/akka-actor/src/main/scala/akka/util/ManifestInfo.scala
+++ b/akka-actor/src/main/scala/akka/util/ManifestInfo.scala
@@ -163,7 +163,7 @@ final class ManifestInfo(val system: ExtendedActorSystem) extends Extension {
    * Verify that the version is the same for all given artifacts.
    */
   def checkSameVersion(productName: String, dependencies: immutable.Seq[String], logWarning: Boolean): Boolean = {
-    @silent
+    @silent("deprecated")
     val filteredVersions = versions.filterKeys(dependencies.toSet)
     val values = filteredVersions.values.toSet
     if (values.size > 1) {

--- a/akka-actor/src/main/scala/akka/util/Unused.scala
+++ b/akka-actor/src/main/scala/akka/util/Unused.scala
@@ -24,5 +24,5 @@ import akka.annotation.InternalApi
  *
  * INTERNAL API
  */
-@silent
+@silent("deprecated")
 @InternalApi private[akka] class unused extends deprecated("unused", "")

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsCollector.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsCollector.scala
@@ -94,7 +94,7 @@ trait ClusterMetricsEvent
 final case class ClusterMetricsChanged(nodeMetrics: Set[NodeMetrics]) extends ClusterMetricsEvent {
 
   /** Java API */
-  @silent
+  @silent("deprecated")
   def getNodeMetrics: java.lang.Iterable[NodeMetrics] =
     scala.collection.JavaConverters.asJavaIterableConverter(nodeMetrics).asJava
 }

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsRouting.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsRouting.scala
@@ -419,7 +419,7 @@ object MetricsSelector {
 /**
  * A MetricsSelector is responsible for producing weights from the node metrics.
  */
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait MetricsSelector extends Serializable {
 
@@ -433,7 +433,7 @@ trait MetricsSelector extends Serializable {
  * A MetricsSelector producing weights from remaining capacity.
  * The weights are typically proportional to the remaining capacity.
  */
-@silent
+@silent("deprecated")
 @SerialVersionUID(1L)
 abstract class CapacityMetricsSelector extends MetricsSelector {
 

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/Metric.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/Metric.scala
@@ -323,7 +323,7 @@ final case class NodeMetrics(address: Address, timestamp: Long, metrics: Set[Met
   /**
    * Java API
    */
-  @silent
+  @silent("deprecated")
   def getMetrics: java.lang.Iterable[Metric] =
     scala.collection.JavaConverters.asJavaIterableConverter(metrics).asJava
 

--- a/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
@@ -45,7 +45,7 @@ object ClusterSingletonManagerSettings {
    * Create settings from the default configuration
    * `akka.cluster.singleton`.
    */
-  @silent // deprecated setting
+  @silent("deprecated") // DownRemovalMargin
   def apply(system: ActorSystem): ClusterSingletonManagerSettings =
     apply(system.settings.config.getConfig("akka.cluster.singleton"))
     // note that this setting has some additional logic inside the ClusterSingletonManager

--- a/akka-cluster/src/main/scala/akka/cluster/AutoDown.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/AutoDown.scala
@@ -32,7 +32,7 @@ final class AutoDowning(system: ActorSystem) extends DowningProvider {
 
   private def clusterSettings = Cluster(system).settings
 
-  @silent
+  @silent("deprecated")
   override def downRemovalMargin: FiniteDuration = clusterSettings.DownRemovalMargin
 
   override def downingActorProps: Option[Props] =

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -96,7 +96,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
   /**
    * Java API: roles that this member has
    */
-  @silent
+  @silent("deprecated")
   def getSelfRoles: java.util.Set[String] =
     scala.collection.JavaConverters.setAsJavaSetConverter(selfRoles).asJava
 
@@ -164,7 +164,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
 
         override def maxFrequency: Double = systemScheduler.maxFrequency
 
-        @silent
+        @silent("deprecated")
         override def schedule(initialDelay: FiniteDuration, interval: FiniteDuration, runnable: Runnable)(
             implicit executor: ExecutionContext): Cancellable =
           systemScheduler.schedule(initialDelay, interval, runnable)

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
@@ -126,7 +126,7 @@ private[akka] class ClusterDeployer(_settings: ActorSystem.Settings, _pm: Dynami
 
 }
 
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 abstract class ClusterScope extends Scope
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -426,7 +426,7 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef, joinConfigCompatCh
     }
   }
 
-  @silent
+  @silent("deprecated")
   private def subscribeQuarantinedEvent(): Unit = {
     context.system.eventStream.subscribe(self, classOf[QuarantinedEvent])
     context.system.eventStream.subscribe(self, classOf[ClassicQuarantinedEvent])

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
@@ -129,21 +129,21 @@ object ClusterEvent {
     /**
      * Java API: get current unreachable set.
      */
-    @silent
+    @silent("deprecated")
     def getUnreachable: java.util.Set[Member] =
       scala.collection.JavaConverters.setAsJavaSetConverter(unreachable).asJava
 
     /**
      * Java API: All data centers in the cluster
      */
-    @silent
+    @silent("deprecated")
     def getUnreachableDataCenters: java.util.Set[String] =
       scala.collection.JavaConverters.setAsJavaSetConverter(unreachableDataCenters).asJava
 
     /**
      * Java API: get current “seen-by” set.
      */
-    @silent
+    @silent("deprecated")
     def getSeenBy: java.util.Set[Address] =
       scala.collection.JavaConverters.setAsJavaSetConverter(seenBy).asJava
 
@@ -171,7 +171,7 @@ object ClusterEvent {
     /**
      * Java API: All node roles in the cluster
      */
-    @silent
+    @silent("deprecated")
     def getAllRoles: java.util.Set[String] =
       scala.collection.JavaConverters.setAsJavaSetConverter(allRoles).asJava
 
@@ -183,7 +183,7 @@ object ClusterEvent {
     /**
      * Java API: All data centers in the cluster
      */
-    @silent
+    @silent("deprecated")
     def getAllDataCenters: java.util.Set[String] =
       scala.collection.JavaConverters.setAsJavaSetConverter(allDataCenters).asJava
 

--- a/akka-cluster/src/main/scala/akka/cluster/DowningProvider.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/DowningProvider.scala
@@ -65,7 +65,7 @@ abstract class DowningProvider {
  * is not enabled.
  */
 final class NoDowning(system: ActorSystem) extends DowningProvider {
-  @silent
+  @silent("deprecated")
   override def downRemovalMargin: FiniteDuration = Cluster(system).settings.DownRemovalMargin
   override val downingActorProps: Option[Props] = None
 }

--- a/akka-cluster/src/main/scala/akka/cluster/Member.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Member.scala
@@ -49,7 +49,7 @@ class Member private[cluster] (
   /**
    * Java API
    */
-  @silent
+  @silent("deprecated")
   def getRoles: java.util.Set[String] =
     scala.collection.JavaConverters.setAsJavaSetConverter(roles).asJava
 
@@ -322,7 +322,7 @@ final case class UniqueAddress(address: Address, longUid: Long) extends Ordered[
    * Stops `copy(Address, Long)` copy from being generated, use `apply` instead.
    */
   @deprecated("Use Long UID constructor instead", since = "2.4.11")
-  @silent
+  @silent("deprecated")
   def copy(address: Address = address, uid: Int = uid) = new UniqueAddress(address, uid.toLong)
 
 }

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -189,7 +189,7 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem)
     builder.build()
   }
 
-  @silent
+  @silent("deprecated")
   private def clusterRouterPoolSettingsToProto(settings: ClusterRouterPoolSettings): cm.ClusterRouterPoolSettings = {
     val builder = cm.ClusterRouterPoolSettings.newBuilder()
     builder

--- a/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
@@ -101,7 +101,7 @@ final case class ClusterRouterGroupSettings(
 
   // For binary compatibility
   @deprecated("Use constructor with useRoles instead", since = "2.5.4")
-  @silent
+  @silent("deprecated")
   def copy(
       totalInstances: Int = totalInstances,
       routeesPaths: immutable.Seq[String] = routeesPaths,
@@ -196,7 +196,7 @@ final case class ClusterRouterPoolSettings(
 
   // For binary compatibility
   @deprecated("Use copy with useRoles instead", since = "2.5.4")
-  @silent
+  @silent("deprecated")
   def copy(
       totalInstances: Int = totalInstances,
       maxInstancesPerNode: Int = maxInstancesPerNode,

--- a/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
@@ -59,7 +59,7 @@ object ServiceDiscovery {
     // Simply compare the bytes of the address.
     // This may not work in exotic cases such as IPv4 addresses encoded as IPv6 addresses.
     import com.github.ghik.silencer.silent
-    @silent
+    @silent("deprecated")
     private implicit val inetAddressOrdering: Ordering[InetAddress] =
       Ordering.by[InetAddress, Iterable[Byte]](_.getAddress)
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
@@ -1336,9 +1336,9 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
   // possibility to disable Gossip for testing purpose
   var fullStateGossipEnabled = true
 
-  @silent
+  @silent("deprecated")
   val subscribers = new mutable.HashMap[KeyId, mutable.Set[ActorRef]] with mutable.MultiMap[KeyId, ActorRef]
-  @silent
+  @silent("deprecated")
   val newSubscribers = new mutable.HashMap[KeyId, mutable.Set[ActorRef]] with mutable.MultiMap[KeyId, ActorRef]
   var subscriptionKeys = Map.empty[KeyId, KeyR]
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
@@ -47,7 +47,7 @@ private object ReplicatedDataSerializer {
     def getKey(entry: A): Any
     final def compare(x: A, y: A): Int = compareKeys(getKey(x), getKey(y))
 
-    @silent
+    @silent("deprecated")
     private final def compareKeys(t1: Any, t2: Any): Int = (t1, t2) match {
       case (k1: String, k2: String)             => k1.compareTo(k2)
       case (_: String, _)                       => -1

--- a/akka-osgi/src/main/scala/akka/osgi/ActorSystemActivator.scala
+++ b/akka-osgi/src/main/scala/akka/osgi/ActorSystemActivator.scala
@@ -7,7 +7,7 @@ package akka.osgi
 import akka.actor.ActorSystem
 import java.util.{ Dictionary, Properties }
 
-import com.github.ghik.silencer.silent
+import akka.util.unused
 import org.osgi.framework._
 import org.osgi.service.log.LogService
 import com.typesafe.config.{ Config, ConfigFactory }
@@ -114,8 +114,7 @@ abstract class ActorSystemActivator extends BundleActivator {
    * @param context the bundle context
    * @return the actor system name
    */
-  @silent
-  def getActorSystemName(context: BundleContext): String = null
+  def getActorSystemName(@unused context: BundleContext): String = null
 
   /**
    * Override this method to define a configuration for your [[akka.actor.ActorSystem]] instance.
@@ -127,7 +126,6 @@ abstract class ActorSystemActivator extends BundleActivator {
    * @param context the bundle context
    * @return the actor system specific configuration, ConfigFactory.empty by default
    */
-  @silent
-  def getActorSystemConfiguration(context: BundleContext): Config = ConfigFactory.empty
+  def getActorSystemConfiguration(@unused context: BundleContext): Config = ConfigFactory.empty
 
 }

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -88,7 +88,7 @@ private[persistence] trait Eventsourced
 
   private var journalBatch = Vector.empty[PersistentEnvelope]
   // no longer used, but kept for binary compatibility
-  @silent
+  @silent("never used")
   private val maxMessageBatchSize = {
     val journalPluginConfig = this match {
       case c: RuntimePluginConfig => c.journalPluginConfig

--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
@@ -119,7 +119,7 @@ trait PersistentFSM[S <: FSMState, D, E] extends PersistentActor with Persistent
   /**
    * Discover the latest recorded state
    */
-  @silent
+  @silent("deprecated")
   override def receiveRecover: Receive = {
     case domainEventTag(event)                      => startWith(stateName, applyEvent(event, stateData))
     case StateChangeEvent(stateIdentifier, timeout) => startWith(statesMap(stateIdentifier), stateData, timeout)
@@ -520,7 +520,7 @@ abstract class AbstractPersistentFSM[S <: FSMState, D, E]
  * Persistent Finite State Machine actor abstract base class with FSM Logging
  *
  */
-@silent
+@silent("deprecated")
 abstract class AbstractPersistentLoggingFSM[S <: FSMState, D, E]
     extends AbstractPersistentFSM[S, D, E]
     with LoggingPersistentFSM[S, D, E]

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbStore.scala
@@ -53,10 +53,10 @@ private[persistence] trait LeveldbStore
     LeveldbStore.toCompactionIntervalMap(config.getObject("compaction-intervals"))
 
   import com.github.ghik.silencer.silent
-  @silent
+  @silent("deprecated")
   private val persistenceIdSubscribers = new mutable.HashMap[String, mutable.Set[ActorRef]]
   with mutable.MultiMap[String, ActorRef]
-  @silent
+  @silent("deprecated")
   private val tagSubscribers = new mutable.HashMap[String, mutable.Set[ActorRef]]
   with mutable.MultiMap[String, ActorRef]
   private var allPersistenceIdsSubscribers = Set.empty[ActorRef]

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/TransportFailSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/TransportFailSpec.scala
@@ -97,7 +97,7 @@ object TransportFailSpec {
  * This was fixed by not stopping the ReliableDeliverySupervisor so that the
  * receive buffer was preserved.
  */
-@silent // deprecated
+@silent("deprecated")
 abstract class TransportFailSpec extends RemotingMultiNodeSpec(TransportFailConfig) {
   import TransportFailConfig._
   import TransportFailSpec._

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/SurviveNetworkPartitionSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/SurviveNetworkPartitionSpec.scala
@@ -36,7 +36,7 @@ object SurviveNetworkPartitionSpec extends MultiNodeConfig {
 class SurviveNetworkPartitionSpecMultiJvmNode1 extends SurviveNetworkPartitionSpec
 class SurviveNetworkPartitionSpecMultiJvmNode2 extends SurviveNetworkPartitionSpec
 
-@silent // deprecated
+@silent("deprecated")
 abstract class SurviveNetworkPartitionSpec extends RemotingMultiNodeSpec(SurviveNetworkPartitionSpec) {
 
   import SurviveNetworkPartitionSpec._

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/RemoteGatePiercingSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/RemoteGatePiercingSpec.scala
@@ -47,7 +47,7 @@ object RemoteGatePiercingSpec extends MultiNodeConfig {
 class RemoteGatePiercingSpecMultiJvmNode1 extends RemoteGatePiercingSpec
 class RemoteGatePiercingSpecMultiJvmNode2 extends RemoteGatePiercingSpec
 
-@silent // deprecated
+@silent("deprecated")
 abstract class RemoteGatePiercingSpec extends RemotingMultiNodeSpec(RemoteGatePiercingSpec) {
 
   import RemoteGatePiercingSpec._

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/RemoteNodeRestartGateSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/RemoteNodeRestartGateSpec.scala
@@ -44,7 +44,7 @@ object RemoteNodeRestartGateSpec extends MultiNodeConfig {
 class RemoteNodeRestartGateSpecMultiJvmNode1 extends RemoteNodeRestartGateSpec
 class RemoteNodeRestartGateSpecMultiJvmNode2 extends RemoteNodeRestartGateSpec
 
-@silent // deprecated
+@silent("deprecated")
 abstract class RemoteNodeRestartGateSpec extends RemotingMultiNodeSpec(RemoteNodeRestartGateSpec) {
 
   import RemoteNodeRestartGateSpec._

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/Ticket15109Spec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/Ticket15109Spec.scala
@@ -46,7 +46,7 @@ object Ticket15109Spec extends MultiNodeConfig {
 class Ticket15109SpecMultiJvmNode1 extends Ticket15109Spec
 class Ticket15109SpecMultiJvmNode2 extends Ticket15109Spec
 
-@silent // deprecated
+@silent("deprecated")
 abstract class Ticket15109Spec extends RemotingMultiNodeSpec(Ticket15109Spec) {
 
   import Ticket15109Spec._

--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -54,7 +54,7 @@ private[remote] trait InboundMessageDispatcher {
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] class DefaultMessageDispatcher(
     private val system: ExtendedActorSystem,
     private val provider: RemoteActorRefProvider,
@@ -245,7 +245,7 @@ private[remote] object ReliableDeliverySupervisor {
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] class ReliableDeliverySupervisor(
     handleOrActive: Option[AkkaProtocolHandle],
     val localAddress: Address,
@@ -536,7 +536,7 @@ private[remote] class ReliableDeliverySupervisor(
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] abstract class EndpointActor(
     val localAddress: Address,
     val remoteAddress: Address,
@@ -563,7 +563,7 @@ private[remote] abstract class EndpointActor(
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] object EndpointWriter {
 
   def props(
@@ -620,7 +620,7 @@ private[remote] object EndpointWriter {
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] class EndpointWriter(
     handleOrActive: Option[AkkaProtocolHandle],
     localAddress: Address,
@@ -1035,7 +1035,7 @@ private[remote] class EndpointWriter(
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] object EndpointReader {
 
   def props(
@@ -1067,7 +1067,7 @@ private[remote] object EndpointReader {
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] class EndpointReader(
     localAddress: Address,
     remoteAddress: Address,

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -659,7 +659,7 @@ private[akka] class RemoteActorRef private[akka] (
   // used by artery to direct messages to separate specialized streams
   @volatile private[remote] var cachedSendQueueIndex: Int = -1
 
-  @silent
+  @silent("deprecated")
   def getChild(name: Iterator[String]): InternalActorRef = {
     val s = name.toStream
     s.headOption match {

--- a/akka-remote/src/main/scala/akka/remote/RemoteMetricsExtension.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteMetricsExtension.scala
@@ -23,7 +23,7 @@ import com.github.ghik.silencer.silent
  * Extension that keeps track of remote metrics, such
  * as max size of different message types.
  */
-@silent // deprecated
+@silent("deprecated")
 private[akka] object RemoteMetricsExtension extends ExtensionId[RemoteMetrics] with ExtensionIdProvider {
   override def get(system: ActorSystem): RemoteMetrics = super.get(system)
 
@@ -59,7 +59,7 @@ private[akka] class RemoteMetricsOff extends RemoteMetrics {
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[akka] class RemoteMetricsOn(system: ExtendedActorSystem) extends RemoteMetrics {
 
   private val logFrameSizeExceeding: Int =

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -45,7 +45,7 @@ final class RemoteSettings(val config: Config) {
   /**
    * INTERNAL API
    */
-  @silent
+  @silent("deprecated")
   @InternalApi private[akka] def untrustedMode: Boolean =
     if (Artery.Enabled) Artery.UntrustedMode else UntrustedMode
   @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
@@ -67,7 +67,7 @@ final class RemoteSettings(val config: Config) {
   @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
   val Dispatcher: String = getString("akka.remote.classic.use-dispatcher")
 
-  @silent
+  @silent("deprecated")
   def configureDispatcher(props: Props): Props =
     if (Artery.Enabled) {
       if (Artery.Advanced.Dispatcher.isEmpty) props else props.withDispatcher(Artery.Advanced.Dispatcher)

--- a/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
@@ -110,18 +110,18 @@ private[akka] class RemoteWatcher(
     if (artery) (ArteryHeartbeat, ArteryHeartbeatRsp(AddressUidExtension(context.system).longAddressUid))
     else {
       // For classic remoting the 'int' part is sufficient
-      @silent
+      @silent("deprecated")
       val addressUid = AddressUidExtension(context.system).addressUid
       (Heartbeat, HeartbeatRsp(addressUid))
     }
 
   // actors that this node is watching, map of watchee -> Set(watchers)
-  @silent
+  @silent("deprecated")
   val watching = new mutable.HashMap[InternalActorRef, mutable.Set[InternalActorRef]]()
   with mutable.MultiMap[InternalActorRef, InternalActorRef]
 
   // nodes that this node is watching, i.e. expecting heartbeats from these nodes. Map of address -> Set(watchee) on this address
-  @silent
+  @silent("deprecated")
   val watcheeByNodes = new mutable.HashMap[Address, mutable.Set[InternalActorRef]]()
   with mutable.MultiMap[Address, InternalActorRef]
   def watchingNodes = watcheeByNodes.keySet

--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -779,7 +779,7 @@ private[remote] class EndpointManager(conf: Config, log: LoggingAdapter)
     case ShutdownAndFlush =>
       // Shutdown all endpoints and signal to sender() when ready (and whether all endpoints were shut down gracefully)
 
-      @silent
+      @silent("deprecated")
       def shutdownAll[T](resources: IterableOnce[T])(shutdown: T => Future[Boolean]): Future[Boolean] = {
         Future.sequence(resources.toList.map(shutdown)).map(_.forall(identity)).recover {
           case NonFatal(_) => false

--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -77,7 +77,7 @@ private[akka] trait HeartbeatMessage extends PriorityMessage
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] object Remoting {
 
   final val EndpointManagerName = "endpointManager"
@@ -133,7 +133,7 @@ private[remote] object Remoting {
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 @ccompatUsedUntil213
 private[remote] class Remoting(_system: ExtendedActorSystem, _provider: RemoteActorRefProvider)
     extends RemoteTransport(_system, _provider) {
@@ -287,7 +287,7 @@ private[remote] class Remoting(_system: ExtendedActorSystem, _provider: RemoteAc
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] object EndpointManager {
 
   // Messages between Remoting and EndpointManager
@@ -480,7 +480,7 @@ private[remote] object EndpointManager {
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] class EndpointManager(conf: Config, log: LoggingAdapter)
     extends Actor
     with RequiresMessageQueue[UnboundedMessageQueueSemantics] {

--- a/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
@@ -11,14 +11,14 @@ import com.github.ghik.silencer.silent
 
 import scala.runtime.AbstractFunction2
 
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
 sealed trait RemotingLifecycleEvent extends Serializable {
   def logLevel: Logging.LogLevel
 }
 
-@silent
+@silent("@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
 sealed trait AssociationEvent extends RemotingLifecycleEvent {
@@ -65,9 +65,8 @@ final case class AssociationErrorEvent(
 }
 
 @SerialVersionUID(1L)
-@deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
+@silent("deprecated")
 final case class RemotingListenEvent(listenAddresses: Set[Address]) extends RemotingLifecycleEvent {
-  @silent
   def getListenAddresses: java.util.Set[Address] =
     scala.collection.JavaConverters.setAsJavaSetConverter(listenAddresses).asJava
   override def logLevel: Logging.LogLevel = Logging.InfoLevel
@@ -115,7 +114,7 @@ final case class QuarantinedEvent(address: Address, longUid: Long) extends Remot
   @deprecated("Use long uid", "2.4.x")
   def uid: Int = longUid.toInt
 
-  @silent
+  @silent("deprecated")
   @deprecated("Use long uid copy method", "2.4.x")
   def copy(address: Address = address, uid: Int = uid) = new QuarantinedEvent(address, uid.toLong)
 }
@@ -144,7 +143,7 @@ final case class ThisActorSystemQuarantinedEvent(localAddress: Address, remoteAd
 /**
  * INTERNAL API
  */
-@silent
+@silent("deprecated")
 private[remote] class EventPublisher(system: ActorSystem, log: LoggingAdapter, logLevel: Logging.LogLevel) {
   def notifyListeners(message: RemotingLifecycleEvent): Unit = {
     system.eventStream.publish(message)

--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -244,7 +244,7 @@ private[remote] class Association(
    * Holds reference to shared state of Association - *access only via helper methods*
    */
   @volatile
-  @silent
+  @silent("never used")
   private[this] var _sharedStateDoNotCallMeDirectly: AssociationState = AssociationState()
 
   /**
@@ -334,7 +334,7 @@ private[remote] class Association(
       outboundEnvelopePool.acquire().init(recipient, message.asInstanceOf[AnyRef], sender)
 
     // volatile read to see latest queue array
-    @silent
+    @silent("never used")
     val unused = queuesVisibility
 
     def dropped(queueIndex: Int, qSize: Int, env: OutboundEnvelope): Unit = {
@@ -726,7 +726,7 @@ private[remote] class Association(
   }
 
   private def getOrCreateQueueWrapper(queueIndex: Int, capacity: Int): QueueWrapper = {
-    @silent
+    @silent("never used")
     val unused = queuesVisibility // volatile read to see latest queues array
     queues(queueIndex) match {
       case existing: QueueWrapper => existing

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaPduCodec.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaPduCodec.scala
@@ -26,7 +26,7 @@ private[remote] class PduCodecException(msg: String, cause: Throwable) extends A
  * Companion object of the [[akka.remote.transport.AkkaPduCodec]] trait. Contains the representation case classes
  * of decoded Akka Protocol Data Units (PDUs).
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] object AkkaPduCodec {
 
   /**
@@ -57,7 +57,7 @@ private[remote] object AkkaPduCodec {
  *
  * A Codec that is able to convert Akka PDUs (Protocol Data Units) from and to [[akka.util.ByteString]]s.
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] trait AkkaPduCodec {
   import AkkaPduCodec._
 
@@ -117,7 +117,7 @@ private[remote] trait AkkaPduCodec {
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] object AkkaPduProtobufCodec extends AkkaPduCodec {
   import AkkaPduCodec._
 

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
@@ -154,7 +154,7 @@ private[transport] class AkkaProtocolManager(
       val failureDetector = createTransportFailureDetector()
 
       // Using the 'int' addressUid rather than the 'long' is sufficient for Classic Remoting
-      @silent
+      @silent("deprecated")
       val addressUid = AddressUidExtension(context.system).addressUid
 
       context.actorOf(
@@ -186,7 +186,7 @@ private[transport] class AkkaProtocolManager(
     val failureDetector = createTransportFailureDetector()
 
     // Using the 'int' addressUid rather than the 'long' is sufficient for Classic Remoting
-    @silent
+    @silent("deprecated")
     val addressUid = AddressUidExtension(context.system).addressUid
 
     context.actorOf(

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
@@ -63,7 +63,7 @@ private[remote] class AkkaProtocolSettings(config: Config) {
   }
 }
 
-@silent // deprecated
+@silent("deprecated")
 private[remote] object AkkaProtocolTransport { //Couldn't these go into the Remoting Extension/ RemoteSettings instead?
   val AkkaScheme: String = "akka"
   val AkkaOverhead: Int = 0 //Don't know yet
@@ -101,7 +101,7 @@ final case class HandshakeInfo(origin: Address, uid: Int, cookie: Option[String]
  * @param codec
  *   the codec that will be used to encode/decode Akka PDUs
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] class AkkaProtocolTransport(
     wrappedTransport: Transport,
     private val system: ActorSystem,
@@ -131,7 +131,7 @@ private[remote] class AkkaProtocolTransport(
   }
 }
 
-@silent // deprecated
+@silent("deprecated")
 private[transport] class AkkaProtocolManager(
     private val wrappedTransport: Transport,
     private val settings: AkkaProtocolSettings)
@@ -208,7 +208,7 @@ private[transport] class AkkaProtocolManager(
 
 }
 
-@silent // deprecated
+@silent("deprecated")
 private[remote] class AkkaProtocolHandle(
     _localAddress: Address,
     _remoteAddress: Address,
@@ -226,7 +226,7 @@ private[remote] class AkkaProtocolHandle(
   def disassociate(info: DisassociateInfo): Unit = stateActor ! DisassociateUnderlying(info)
 }
 
-@silent // deprecated
+@silent("deprecated")
 private[remote] object ProtocolStateActor {
   sealed trait AssociationState
 
@@ -329,7 +329,7 @@ private[remote] object ProtocolStateActor {
       failureDetector).withDeploy(Deploy.local)
 }
 
-@silent // deprecated
+@silent("deprecated")
 private[remote] class ProtocolStateActor(
     initialData: InitialProtocolStateData,
     private val localHandshakeInfo: HandshakeInfo,

--- a/akka-remote/src/main/scala/akka/remote/transport/FailureInjectorTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/FailureInjectorTransportAdapter.scala
@@ -60,7 +60,7 @@ private[remote] object FailureInjectorTransportAdapter {
 /**
  * INTERNAL API
  */
-@silent
+@silent("deprecated")
 private[remote] class FailureInjectorTransportAdapter(
     wrappedTransport: Transport,
     val extendedSystem: ExtendedActorSystem)
@@ -161,7 +161,7 @@ private[remote] class FailureInjectorTransportAdapter(
 /**
  * INTERNAL API
  */
-@silent
+@silent("deprecated")
 private[remote] final case class FailureInjectorHandle(
     _wrappedHandle: AssociationHandle,
     private val gremlinAdapter: FailureInjectorTransportAdapter)
@@ -188,7 +188,7 @@ private[remote] final case class FailureInjectorHandle(
   @deprecated(
     message = "Use method that states reasons to make sure disassociation reasons are logged.",
     since = "2.5.3")
-  @silent
+  @silent("deprecated")
   override def disassociate(): Unit =
     wrappedHandle.disassociate()
 

--- a/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
@@ -232,7 +232,7 @@ class ThrottlerTransportAdapter(_wrappedTransport: Transport, _system: ExtendedA
 /**
  * INTERNAL API
  */
-@silent
+@silent("deprecated")
 private[transport] object ThrottlerManager {
   final case class Checkin(origin: Address, handle: ThrottlerHandle) extends NoSerializationVerificationNeeded
 
@@ -250,7 +250,7 @@ private[transport] object ThrottlerManager {
 /**
  * INTERNAL API
  */
-@silent
+@silent("deprecated")
 private[transport] class ThrottlerManager(wrappedTransport: Transport)
     extends ActorTransportAdapterManager
     with ActorLogging {
@@ -349,7 +349,7 @@ private[transport] class ThrottlerManager(wrappedTransport: Transport)
   }
 
   // silent because of use of isTerminated
-  @silent
+  @silent("deprecated")
   private def askModeWithDeathCompletion(target: ActorRef, mode: ThrottleMode)(
       implicit timeout: Timeout): Future[SetThrottleAck.type] = {
     if (target.isTerminated) Future.successful(SetThrottleAck)
@@ -420,7 +420,7 @@ private[transport] object ThrottledAssociation {
 /**
  * INTERNAL API
  */
-@silent
+@silent("deprecated")
 private[transport] class ThrottledAssociation(
     val manager: ActorRef,
     val associationHandler: AssociationEventListener,
@@ -584,7 +584,7 @@ private[transport] class ThrottledAssociation(
 /**
  * INTERNAL API
  */
-@silent
+@silent("deprecated")
 private[transport] final case class ThrottlerHandle(_wrappedHandle: AssociationHandle, throttlerActor: ActorRef)
     extends AbstractTransportAdapterHandle(_wrappedHandle, SchemeIdentifier) {
 

--- a/akka-remote/src/main/scala/akka/remote/transport/Transport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/Transport.scala
@@ -282,7 +282,7 @@ trait AssociationHandle {
    * be notified, but this is not guaranteed. The Transport that provides the handle MUST guarantee that disassociate()
    * could be called arbitrarily many times.
    */
-  @silent
+  @silent("deprecated")
   def disassociate(reason: String, log: LoggingAdapter): Unit = {
     if (log.isDebugEnabled)
       log.debug(

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettySSLSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettySSLSupport.scala
@@ -43,7 +43,7 @@ private[akka] class SSLSettings(config: Config) {
  * The `SSLEngine` is created via the configured [[SSLEngineProvider]].
  */
 @ccompatUsedUntil213
-@silent // deprecated
+@silent("deprecated")
 private[akka] object NettySSLSupport {
 
   /**

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -167,7 +167,7 @@ class NettyTransportSettings(config: Config) {
   val PortSelector: Int = getInt("port")
 
   @deprecated("WARNING: This should only be used by professionals.", "2.4")
-  @silent
+  @silent("deprecated")
   val BindPortSelector: Int = getString("bind-port") match {
     case ""    => PortSelector
     case value => value.toInt
@@ -495,7 +495,7 @@ class NettyTransport(val settings: NettyTransportSettings, val system: ExtendedA
   }
 
   override def listen: Future[(Address, Promise[AssociationEventListener])] = {
-    @silent
+    @silent("deprecated")
     val bindPort = settings.BindPortSelector
 
     for {
@@ -513,7 +513,7 @@ class NettyTransport(val settings: NettyTransportSettings, val system: ExtendedA
 
         serverChannel = newServerChannel
 
-        @silent
+        @silent("deprecated")
         val port = if (settings.PortSelector == 0) None else Some(settings.PortSelector)
 
         addressFromSocketAddress(

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -210,7 +210,7 @@ class NettyTransportSettings(config: Config) {
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[netty] trait CommonHandlers extends NettyHelpers {
   protected val transport: NettyTransport
 
@@ -253,7 +253,7 @@ private[netty] trait CommonHandlers extends NettyHelpers {
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[netty] abstract class ServerHandler(
     protected final val transport: NettyTransport,
     private final val associationListenerFuture: Future[AssociationEventListener])
@@ -285,7 +285,7 @@ private[netty] abstract class ServerHandler(
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[netty] abstract class ClientHandler(protected final val transport: NettyTransport, remoteAddress: Address)
     extends NettyClientHelpers
     with CommonHandlers {

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/TcpSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/TcpSupport.scala
@@ -29,7 +29,7 @@ private[remote] object ChannelLocalActor extends ChannelLocal[Option[HandleEvent
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] trait TcpHandlers extends CommonHandlers {
   protected def log: LoggingAdapter
 
@@ -65,7 +65,7 @@ private[remote] trait TcpHandlers extends CommonHandlers {
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] class TcpServerHandler(
     _transport: NettyTransport,
     _associationListenerFuture: Future[AssociationEventListener],
@@ -81,7 +81,7 @@ private[remote] class TcpServerHandler(
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] class TcpClientHandler(_transport: NettyTransport, remoteAddress: Address, val log: LoggingAdapter)
     extends ClientHandler(_transport, remoteAddress)
     with TcpHandlers {
@@ -94,7 +94,7 @@ private[remote] class TcpClientHandler(_transport: NettyTransport, remoteAddress
 /**
  * INTERNAL API
  */
-@silent // deprecated
+@silent("deprecated")
 private[remote] class TcpAssociationHandle(
     val localAddress: Address,
     val remoteAddress: Address,

--- a/akka-remote/src/test/scala/akka/remote/AckedDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/AckedDeliverySpec.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.ThreadLocalRandom
 
 import com.github.ghik.silencer.silent
 
-@silent // deprecated
+@silent("deprecated")
 object AckedDeliverySpec {
 
   final case class Sequenced(seq: SeqNo, body: String) extends HasSequenceNumber {
@@ -19,7 +19,7 @@ object AckedDeliverySpec {
 
 }
 
-@silent // deprecated
+@silent("deprecated")
 class AckedDeliverySpec extends AkkaSpec {
   import AckedDeliverySpec._
 

--- a/akka-remote/src/test/scala/akka/remote/RemoteFeaturesSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteFeaturesSpec.scala
@@ -57,7 +57,7 @@ abstract class RemoteFeaturesSpec(c: Config) extends ArteryMultiNodeSpec(c) with
 
   protected val remoteSystem1 = newRemoteSystem(name = Some("RS1"), extraConfig = Some(common(useUnsafe)))
 
-  @silent // deprecated
+  @silent("deprecated")
   private def mute(): Unit = {
     Seq(system, remoteSystem1).foreach(
       muteDeadLetters(

--- a/akka-remote/src/test/scala/akka/remote/Ticket1978CommunicationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/Ticket1978CommunicationSpec.scala
@@ -23,7 +23,7 @@ import scala.reflect.classTag
 import akka.remote.transport.netty.ConfigSSLEngineProvider
 import com.github.ghik.silencer.silent
 
-@silent // deprecated
+@silent("deprecated")
 object Configuration {
   // set this in your JAVA_OPTS to see all ssl debug info: "-Djavax.net.debug=ssl,keymanager"
   // The certificate will expire in 2109
@@ -121,7 +121,7 @@ class Ticket1978CrappyRSAWithMD5OnlyHereToMakeSureThingsWorkSpec
 class Ticket1978NonExistingRNGSecureSpec
     extends Ticket1978CommunicationSpec(CipherConfig(false, AkkaSpec.testConf, "NonExistingRNG", 12345, 12346, None))
 
-@silent // deprecated
+@silent("deprecated")
 abstract class Ticket1978CommunicationSpec(val cipherConfig: CipherConfig)
     extends AkkaSpec(cipherConfig.config)
     with ImplicitSender {

--- a/akka-remote/src/test/scala/akka/remote/classic/RemoteDeploymentWhitelistSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/RemoteDeploymentWhitelistSpec.scala
@@ -103,7 +103,7 @@ object RemoteDeploymentWhitelistSpec {
   }
 }
 
-@silent // deprecated
+@silent("deprecated")
 class RemoteDeploymentWhitelistSpec
     extends AkkaSpec(RemoteDeploymentWhitelistSpec.cfg)
     with ImplicitSender

--- a/akka-remote/src/test/scala/akka/remote/classic/RemoteSettingsSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/RemoteSettingsSpec.scala
@@ -9,7 +9,7 @@ import com.github.ghik.silencer.silent
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{ Matchers, WordSpec }
 
-@silent // deprecated
+@silent("deprecated")
 class RemoteSettingsSpec extends WordSpec with Matchers {
 
   "Remote settings" must {

--- a/akka-remote/src/test/scala/akka/remote/classic/RemoteWatcherSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/RemoteWatcherSpec.scala
@@ -67,7 +67,7 @@ object RemoteWatcherSpec {
 
 }
 
-@silent // deprecated
+@silent("deprecated")
 class RemoteWatcherSpec extends AkkaSpec("""
      akka {
        loglevel = INFO

--- a/akka-remote/src/test/scala/akka/remote/classic/transport/AkkaProtocolSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/transport/AkkaProtocolSpec.scala
@@ -43,7 +43,7 @@ object AkkaProtocolSpec {
 
 }
 
-@silent // deprecated
+@silent("deprecated")
 class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = remote """) with ImplicitSender {
 
   val conf = ConfigFactory.parseString("""

--- a/akka-remote/src/test/scala/akka/remote/classic/transport/GenericTransportSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/transport/GenericTransportSpec.scala
@@ -16,7 +16,7 @@ import scala.concurrent.{ Await, Future }
 
 import com.github.ghik.silencer.silent
 
-@silent // deprecated
+@silent("deprecated")
 abstract class GenericTransportSpec(withAkkaProtocol: Boolean = false)
     extends AkkaSpec("""
          akka.remote.artery.enabled = false

--- a/akka-remote/src/test/scala/akka/remote/classic/transport/SystemMessageDeliveryStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/transport/SystemMessageDeliveryStressTest.scala
@@ -102,7 +102,7 @@ object SystemMessageDeliveryStressTest {
 
 }
 
-@silent // deprecated
+@silent("deprecated")
 abstract class SystemMessageDeliveryStressTest(msg: String, cfg: String)
     extends AkkaSpec(ConfigFactory.parseString(cfg).withFallback(SystemMessageDeliveryStressTest.baseConfig))
     with ImplicitSender

--- a/akka-remote/src/test/scala/akka/remote/classic/transport/TestTransportSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/transport/TestTransportSpec.scala
@@ -15,7 +15,7 @@ import scala.concurrent._
 
 import com.github.ghik.silencer.silent
 
-@silent // deprecated
+@silent("deprecated")
 class TestTransportSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
 
   val addressA: Address = Address("test", "testsytemA", "testhostA", 4321)

--- a/akka-remote/src/test/scala/akka/remote/classic/transport/ThrottlerTransportAdapterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/transport/ThrottlerTransportAdapterSpec.scala
@@ -73,7 +73,7 @@ object ThrottlerTransportAdapterSpec {
   final case class Lost(msg: String)
 }
 
-@silent // deprecated
+@silent("deprecated")
 class ThrottlerTransportAdapterSpec extends AkkaSpec(configA) with ImplicitSender with DefaultTimeout {
 
   val systemB = ActorSystem("systemB", system.settings.config)
@@ -160,7 +160,7 @@ class ThrottlerTransportAdapterSpec extends AkkaSpec(configA) with ImplicitSende
   override def afterTermination(): Unit = shutdown(systemB)
 }
 
-@silent // deprecated
+@silent("deprecated")
 class ThrottlerTransportAdapterGenericSpec extends GenericTransportSpec(withAkkaProtocol = true) {
 
   def transportName = "ThrottlerTransportAdapter"

--- a/akka-stream-tests/src/test/scala/akka/stream/ActorMaterializerSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/ActorMaterializerSpec.scala
@@ -17,7 +17,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.{ Failure, Try }
 
-@silent // tests deprecated APIs
+@silent
 class ActorMaterializerSpec extends StreamSpec with ImplicitSender {
 
   "ActorMaterializer" must {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipSpec.scala
@@ -9,7 +9,7 @@ import akka.stream.testkit.{ BaseTwoStreamsSetup, TestSubscriber }
 import com.github.ghik.silencer.silent
 import org.reactivestreams.Publisher
 
-//@silent // keep unused imports
+@silent // keep unused imports
 class FlowZipSpec extends BaseTwoStreamsSetup {
 
 //#zip

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipSpec.scala
@@ -9,7 +9,7 @@ import akka.stream.testkit.{ BaseTwoStreamsSetup, TestSubscriber }
 import com.github.ghik.silencer.silent
 import org.reactivestreams.Publisher
 
-@silent // keep unused imports
+//@silent // keep unused imports
 class FlowZipSpec extends BaseTwoStreamsSetup {
 
 //#zip

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
@@ -15,7 +15,7 @@ import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-@silent // tests deprecated APIs
+@silent("deprecated")
 class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
 
   import GraphDSL.Implicits._

--- a/akka-stream/src/main/scala/akka/stream/IOResult.scala
+++ b/akka-stream/src/main/scala/akka/stream/IOResult.scala
@@ -16,7 +16,7 @@ import scala.util.{ Failure, Success, Try }
  * @param count Numeric value depending on context, for example IO operations performed or bytes processed.
  * @param status Status of the result. Can be either [[akka.Done]] or an exception.
  */
-@silent // deprecated success
+@silent("deprecated") // Status
 final case class IOResult(
     count: Long,
     @deprecated("status is always set to Success(Done)", "2.6.0") status: Try[Done]) {

--- a/akka-stream/src/main/scala/akka/stream/Materializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/Materializer.scala
@@ -23,7 +23,7 @@ import scala.concurrent.duration.FiniteDuration
  *
  * Once the SPI is final this notice will be removed.
  */
-@silent // deprecatedName(symbol) is deprecated but older Scala versions don't have a string signature, since "2.5.8"
+@silent("deprecated") // Name(symbol) is deprecated but older Scala versions don't have a string signature, since "2.5.8"
 abstract class Materializer {
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/actor/ActorPublisher.scala
+++ b/akka-stream/src/main/scala/akka/stream/actor/ActorPublisher.scala
@@ -408,7 +408,7 @@ trait ActorPublisher[T] extends Actor {
 /**
  * INTERNAL API
  */
-@silent
+@silent("deprecated")
 private[akka] final case class ActorPublisherImpl[T](ref: ActorRef) extends Publisher[T] {
   import ActorPublisher.Internal._
 

--- a/akka-stream/src/main/scala/akka/stream/impl/Modules.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Modules.scala
@@ -99,7 +99,7 @@ import com.github.ghik.silencer.silent
     shape: SourceShape[Out])
     extends SourceModule[Out, ActorRef](shape) {
 
-  @silent
+  @silent("deprecated")
   override def create(context: MaterializationContext) = {
     val publisherRef = ActorMaterializerHelper.downcast(context.materializer).actorOf(context, props)
     (akka.stream.actor.ActorPublisher[Out](publisherRef), publisherRef)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
@@ -109,7 +109,7 @@ object BidiFlow {
    * every second in one direction, but no elements are flowing in the other direction. I.e. this operator considers
    * the *joint* frequencies of the elements in both directions.
    */
-  @silent
+  @silent("deprecated")
   def bidirectionalIdleTimeout[I, O](timeout: java.time.Duration): BidiFlow[I, I, O, O, NotUsed] = {
     import akka.util.JavaDurationConverters._
     bidirectionalIdleTimeout(timeout.asScala)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1140,7 +1140,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * `n` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent
+  @silent("deprecated")
   def groupedWithin(n: Int, d: java.time.Duration): javadsl.Flow[In, java.util.List[Out], Mat] =
     groupedWithin(n, d.asScala)
 
@@ -1188,7 +1188,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * `maxWeight` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent
+  @silent("deprecated")
   def groupedWeightedWithin(
       maxWeight: Long,
       costFn: function.Function[Out, java.lang.Long],
@@ -1250,7 +1250,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * @param of time to shift all messages
    * @param strategy Strategy that is used when incoming elements cannot fit inside the buffer
    */
-  @silent
+  @silent("deprecated")
   def delay(of: java.time.Duration, strategy: DelayOverflowStrategy): Flow[In, Out, Mat] =
     delay(of.asScala, strategy)
 
@@ -1296,7 +1296,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def dropWithin(d: java.time.Duration): javadsl.Flow[In, Out, Mat] =
     dropWithin(d.asScala)
 
@@ -1445,7 +1445,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * '''Cancels when''' downstream cancels
    *
    */
-  @silent
+  @silent("deprecated")
   def recoverWith(pf: PartialFunction[Throwable, _ <: Graph[SourceShape[Out], NotUsed]]): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.recoverWith(pf))
 
@@ -1605,7 +1605,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * See also [[Flow.limit]], [[Flow.limitWeighted]]
    */
-  @silent
+  @silent("deprecated")
   def takeWithin(d: java.time.Duration): javadsl.Flow[In, Out, Mat] =
     takeWithin(d.asScala)
 
@@ -2821,7 +2821,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def initialTimeout(timeout: java.time.Duration): javadsl.Flow[In, Out, Mat] =
     initialTimeout(timeout.asScala)
 
@@ -2854,7 +2854,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def completionTimeout(timeout: java.time.Duration): javadsl.Flow[In, Out, Mat] =
     completionTimeout(timeout.asScala)
 
@@ -2889,7 +2889,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def idleTimeout(timeout: java.time.Duration): javadsl.Flow[In, Out, Mat] =
     idleTimeout(timeout.asScala)
 
@@ -2924,7 +2924,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def backpressureTimeout(timeout: java.time.Duration): javadsl.Flow[In, Out, Mat] =
     backpressureTimeout(timeout.asScala)
 
@@ -2967,7 +2967,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def keepAlive(maxIdle: java.time.Duration, injectedElem: function.Creator[Out]): javadsl.Flow[In, Out, Mat] =
     keepAlive(maxIdle.asScala, injectedElem)
 
@@ -3375,7 +3375,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def initialDelay(delay: java.time.Duration): javadsl.Flow[In, Out, Mat] =
     initialDelay(delay.asScala)
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartFlow.scala
@@ -79,7 +79,7 @@ object RestartFlow {
    *   In order to skip this additional delay pass in `0`.
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
-  @silent
+  @silent("deprecated")
   def withBackoff[In, Out](
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
@@ -154,7 +154,7 @@ object RestartFlow {
    *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
-  @silent
+  @silent("deprecated")
   def withBackoff[In, Out](
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
@@ -230,7 +230,7 @@ object RestartFlow {
    *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
-  @silent
+  @silent("deprecated")
   def onFailuresWithBackoff[In, Out](
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartSink.scala
@@ -81,7 +81,7 @@ object RestartSink {
    *   In order to skip this additional delay pass in `0`.
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
-  @silent
+  @silent("deprecated")
   def withBackoff[T](
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
@@ -158,7 +158,7 @@ object RestartSink {
    *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
-  @silent
+  @silent("deprecated")
   def withBackoff[T](
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartSource.scala
@@ -73,7 +73,7 @@ object RestartSource {
    *   In order to skip this additional delay pass in `0`.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
-  @silent
+  @silent("deprecated")
   def withBackoff[T](
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
@@ -144,7 +144,7 @@ object RestartSource {
    *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
-  @silent
+  @silent("deprecated")
   def withBackoff[T](
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
@@ -209,7 +209,7 @@ object RestartSource {
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    *
    */
-  @silent
+  @silent("deprecated")
   def onFailuresWithBackoff[T](
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
@@ -278,7 +278,7 @@ object RestartSource {
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    *
    */
-  @silent
+  @silent("deprecated")
   def onFailuresWithBackoff[T](
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -225,7 +225,7 @@ object Source {
    * element is produced it will not receive that tick element later. It will
    * receive new tick elements as soon as it has requested more elements.
    */
-  @silent
+  @silent("deprecated")
   def tick[O](initialDelay: java.time.Duration, interval: java.time.Duration, tick: O): javadsl.Source[O, Cancellable] =
     Source.tick(initialDelay.asScala, interval.asScala, tick)
 
@@ -1515,7 +1515,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * '''Cancels when''' downstream cancels
    *
    */
-  @silent
+  @silent("deprecated")
   def recoverWith(pf: PartialFunction[Throwable, _ <: Graph[SourceShape[Out], NotUsed]]): Source[Out, Mat] =
     new Source(delegate.recoverWith(pf))
 
@@ -2190,7 +2190,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * `n` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent
+  @silent("deprecated")
   def groupedWithin(n: Int, d: java.time.Duration): javadsl.Source[java.util.List[Out @uncheckedVariance], Mat] =
     groupedWithin(n, d.asScala)
 
@@ -2238,7 +2238,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * `maxWeight` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent
+  @silent("deprecated")
   def groupedWeightedWithin(
       maxWeight: Long,
       costFn: function.Function[Out, java.lang.Long],
@@ -2300,7 +2300,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * @param of time to shift all messages
    * @param strategy Strategy that is used when incoming elements cannot fit inside the buffer
    */
-  @silent
+  @silent("deprecated")
   def delay(of: java.time.Duration, strategy: DelayOverflowStrategy): Source[Out, Mat] =
     delay(of.asScala, strategy)
 
@@ -2346,7 +2346,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def dropWithin(d: java.time.Duration): javadsl.Source[Out, Mat] =
     dropWithin(d.asScala)
 
@@ -2472,7 +2472,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels or timer fires
    */
-  @silent
+  @silent("deprecated")
   def takeWithin(d: java.time.Duration): javadsl.Source[Out, Mat] =
     takeWithin(d.asScala)
 
@@ -3021,7 +3021,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def initialTimeout(timeout: java.time.Duration): javadsl.Source[Out, Mat] =
     initialTimeout(timeout.asScala)
 
@@ -3054,7 +3054,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def completionTimeout(timeout: java.time.Duration): javadsl.Source[Out, Mat] =
     completionTimeout(timeout.asScala)
 
@@ -3089,7 +3089,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def idleTimeout(timeout: java.time.Duration): javadsl.Source[Out, Mat] =
     idleTimeout(timeout.asScala)
 
@@ -3124,7 +3124,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def backpressureTimeout(timeout: java.time.Duration): javadsl.Source[Out, Mat] =
     backpressureTimeout(timeout.asScala)
 
@@ -3167,7 +3167,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def keepAlive(maxIdle: java.time.Duration, injectedElem: function.Creator[Out]): javadsl.Source[Out, Mat] =
     keepAlive(maxIdle.asScala, injectedElem)
 
@@ -3573,7 +3573,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def initialDelay(delay: java.time.Duration): javadsl.Source[Out, Mat] =
     initialDelay(delay.asScala)
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/StreamConverters.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/StreamConverters.scala
@@ -112,7 +112,7 @@ object StreamConverters {
    *
    * @param readTimeout the max time the read operation on the materialized InputStream should block
    */
-  @silent
+  @silent("deprecated")
   def asInputStream(readTimeout: java.time.Duration): Sink[ByteString, InputStream] = {
     import akka.util.JavaDurationConverters._
     asInputStream(readTimeout.asScala)
@@ -188,7 +188,7 @@ object StreamConverters {
    *
    * @param writeTimeout the max time the write operation on the materialized OutputStream should block
    */
-  @silent
+  @silent("deprecated")
   def asOutputStream(writeTimeout: java.time.Duration): javadsl.Source[ByteString, OutputStream] = {
     import akka.util.JavaDurationConverters._
     asOutputStream(writeTimeout.asScala)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -677,7 +677,7 @@ class SubFlow[In, Out, Mat](
    * `n` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent
+  @silent("deprecated")
   def groupedWithin(n: Int, d: java.time.Duration): SubFlow[In, java.util.List[Out @uncheckedVariance], Mat] =
     groupedWithin(n, d.asScala)
 
@@ -725,7 +725,7 @@ class SubFlow[In, Out, Mat](
    * `maxWeight` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent
+  @silent("deprecated")
   def groupedWeightedWithin(
       maxWeight: Long,
       costFn: function.Function[Out, java.lang.Long],
@@ -787,7 +787,7 @@ class SubFlow[In, Out, Mat](
    * @param of time to shift all messages
    * @param strategy Strategy that is used when incoming elements cannot fit inside the buffer
    */
-  @silent
+  @silent("deprecated")
   def delay(of: java.time.Duration, strategy: DelayOverflowStrategy): SubFlow[In, Out, Mat] =
     delay(of.asScala, strategy)
 
@@ -833,7 +833,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def dropWithin(d: java.time.Duration): SubFlow[In, Out, Mat] =
     dropWithin(d.asScala)
 
@@ -1048,7 +1048,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels or timer fires
    */
-  @silent
+  @silent("deprecated")
   def takeWithin(d: java.time.Duration): SubFlow[In, Out, Mat] =
     takeWithin(d.asScala)
 
@@ -1698,7 +1698,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def initialTimeout(timeout: java.time.Duration): SubFlow[In, Out, Mat] =
     initialTimeout(timeout.asScala)
 
@@ -1731,7 +1731,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def completionTimeout(timeout: java.time.Duration): SubFlow[In, Out, Mat] =
     completionTimeout(timeout.asScala)
 
@@ -1766,7 +1766,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def idleTimeout(timeout: java.time.Duration): SubFlow[In, Out, Mat] =
     idleTimeout(timeout.asScala)
 
@@ -1801,7 +1801,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def backpressureTimeout(timeout: java.time.Duration): SubFlow[In, Out, Mat] =
     backpressureTimeout(timeout.asScala)
 
@@ -1844,7 +1844,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def keepAlive(maxIdle: java.time.Duration, injectedElem: function.Creator[Out]): SubFlow[In, Out, Mat] =
     keepAlive(maxIdle.asScala, injectedElem)
 
@@ -2212,7 +2212,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def initialDelay(delay: java.time.Duration): SubFlow[In, Out, Mat] =
     initialDelay(delay.asScala)
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -665,7 +665,7 @@ class SubSource[Out, Mat](
    * `n` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent
+  @silent("deprecated")
   def groupedWithin(n: Int, d: java.time.Duration): SubSource[java.util.List[Out @uncheckedVariance], Mat] =
     groupedWithin(n, d.asScala)
 
@@ -713,7 +713,7 @@ class SubSource[Out, Mat](
    * `maxWeight` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent
+  @silent("deprecated")
   def groupedWeightedWithin(
       maxWeight: Long,
       costFn: function.Function[Out, java.lang.Long],
@@ -762,7 +762,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def dropWithin(d: java.time.Duration): SubSource[Out, Mat] =
     dropWithin(d.asScala)
 
@@ -879,7 +879,7 @@ class SubSource[Out, Mat](
    * @param of time to shift all messages
    * @param strategy Strategy that is used when incoming elements cannot fit inside the buffer
    */
-  @silent
+  @silent("deprecated")
   def delay(of: java.time.Duration, strategy: DelayOverflowStrategy): SubSource[Out, Mat] =
     delay(of.asScala, strategy)
 
@@ -1029,7 +1029,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels or timer fires
    */
-  @silent
+  @silent("deprecated")
   def takeWithin(d: java.time.Duration): SubSource[Out, Mat] =
     takeWithin(d.asScala)
 
@@ -1678,7 +1678,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def initialTimeout(timeout: java.time.Duration): SubSource[Out, Mat] =
     initialTimeout(timeout.asScala)
 
@@ -1711,7 +1711,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def completionTimeout(timeout: java.time.Duration): SubSource[Out, Mat] =
     completionTimeout(timeout.asScala)
 
@@ -1746,7 +1746,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def idleTimeout(timeout: java.time.Duration): SubSource[Out, Mat] =
     idleTimeout(timeout.asScala)
 
@@ -1781,7 +1781,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def backpressureTimeout(timeout: java.time.Duration): SubSource[Out, Mat] =
     backpressureTimeout(timeout.asScala)
 
@@ -1824,7 +1824,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def keepAlive(maxIdle: java.time.Duration, injectedElem: function.Creator[Out]): SubSource[Out, Mat] =
     keepAlive(maxIdle.asScala, injectedElem)
 
@@ -2188,7 +2188,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent
+  @silent("deprecated")
   def initialDelay(delay: java.time.Duration): SubSource[Out, Mat] =
     initialDelay(delay.asScala)
 


### PR DESCRIPTION
This will stop us accidently missing a warnings. I don't think the feature
existed when we stated using silent.