### PR TITLE
actor: ignore more messages while TcpConnection is shutting down

### DIFF
--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -199,6 +199,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   def unregistering: Receive = {
     case Unregistered                                                               => context.stop(self) // postStop will notify interested parties
     case ChannelReadable | ChannelWritable | ChannelAcceptable | ChannelConnectable => // ignore, we are going away soon anyway
+    case _: DeadLetterSuppression                                                   => // ignore
   }
 
   // AUXILIARIES and IMPLEMENTATION


### PR DESCRIPTION
Otherwise, there will be noisy warnings in the log for messages that
carry `DeadLetterSupression` like all the `CloseCommands`.