### PR TITLE
WIP: Added NodeVector CRDT and subtypes

### DIFF
--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Gauge.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Gauge.scala
@@ -1,0 +1,263 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.ddata
+
+import akka.cluster.ClusterEvent.CurrentClusterState
+import akka.cluster.{ MemberStatus, UniqueAddress }
+
+import scala.collection.JavaConverters._
+
+object Gauge {
+  val empty: Gauge = new Gauge
+  def apply(): Gauge = empty
+
+  /**
+   * Java API
+   */
+  def create(): Gauge = empty
+
+  private val Zero = BigInt(0)
+}
+
+/**
+ * Implements a gauge CRDT.
+ *
+ * A gauge CRDT has a value for each node in the cluster. These values can then be aggregated, with a sum, average,
+ * minimum or maximum.
+ *
+ * The gauge aggregations are calculated on request by supplying the current cluster state, along with the set of
+ * member statuses that are allowed to take part in the aggregation.
+ */
+@SerialVersionUID(1L)
+final case class Gauge private[akka] (
+    private[akka] val state: Map[UniqueAddress, (BigInt, BigInt)] = Map.empty,
+    override val delta: Option[Gauge] = None)
+    extends NodeVector[(BigInt, BigInt)](state)
+    with ReplicatedDataSerialization {
+
+  type T = Gauge
+
+  import Gauge.Zero
+
+  /**
+   * Scala API: The sum of the current gauge values for each allowed node.
+   */
+  def sum(allowedStatuses: Set[MemberStatus] = Set(MemberStatus.Up))(
+      implicit currentClusterState: CurrentClusterState): BigInt = {
+    filtered(allowedStatuses, currentClusterState).sum
+  }
+
+  /**
+   * Java API: The sum of the current gauge values for each allowed node.
+   */
+  def getSum(
+      allowedStatuses: java.util.Collection[MemberStatus],
+      currentClusterState: CurrentClusterState): java.math.BigInteger =
+    sum(allowedStatuses.asScala.toSet)(currentClusterState).bigInteger
+
+  /**
+   * Scala API: The average of the current gauge values for each allowed node.
+   */
+  def average(allowedStatuses: Set[MemberStatus] = Set(MemberStatus.Up))(
+      implicit currentClusterState: CurrentClusterState): Double = {
+    val (nodes, total) = filtered(allowedStatuses, currentClusterState).foldLeft((0, 0d)) {
+      case ((nodes, total), gauge) => (nodes + 1, total + gauge.toDouble)
+    }
+    if (nodes > 0) total / nodes
+    else 0
+  }
+
+  /**
+   * Java API: The average of the current gauge values for each allowed node.
+   */
+  def getAverage(
+      allowedStatuses: java.util.Collection[MemberStatus],
+      currentClusterState: CurrentClusterState): Double =
+    average(allowedStatuses.asScala.toSet)(currentClusterState)
+
+  /**
+   * Scala API: The minimum of the current gauge values for each allowed node.
+   */
+  def min(allowedStatuses: Set[MemberStatus] = Set(MemberStatus.Up))(
+      implicit currentClusterState: CurrentClusterState): BigInt = {
+    filtered(allowedStatuses, currentClusterState).min
+  }
+
+  /**
+   * Java API: The minimum of the current gauge values for each allowed node.
+   */
+  def getMin(
+      allowedStatuses: java.util.Collection[MemberStatus],
+      currentClusterState: CurrentClusterState): java.math.BigInteger =
+    min(allowedStatuses.asScala.toSet)(currentClusterState).bigInteger
+
+  /**
+   * Scala API: The maximum of the current gauge values for each allowed node.
+   */
+  def max(allowedStatuses: Set[MemberStatus] = Set(MemberStatus.Up))(
+      implicit currentClusterState: CurrentClusterState): BigInt = {
+    filtered(allowedStatuses, currentClusterState).max
+  }
+
+  /**
+   * Java API: The maximum of the current gauge values for each allowed node.
+   */
+  def getMax(
+      allowedStatuses: java.util.Collection[MemberStatus],
+      currentClusterState: CurrentClusterState): java.math.BigInteger =
+    max(allowedStatuses.asScala.toSet)(currentClusterState).bigInteger
+
+  private def filtered(allowedStatuses: Set[MemberStatus], currentClusterState: CurrentClusterState) = {
+    state
+      .filterKeys(key =>
+        currentClusterState.members.exists { member =>
+          member.uniqueAddress == key && allowedStatuses(member.status)
+        })
+      .values
+      .map { case (increments, decrements) => increments - decrements }
+  }
+
+  /**
+   * Increment this nodes value for the gauge with the delta `n` specified.
+   * If the delta is negative then it will decrement instead of increment.
+   */
+  def :+(n: Long)(implicit node: SelfUniqueAddress): Gauge = increment(n)
+
+  /**
+   * Increment this nodes value for the gauge with the delta `n` specified.
+   * If the delta is negative then it will decrement instead of increment.
+   */
+  def :+(n: BigInt)(implicit node: SelfUniqueAddress): Gauge = increment(n)
+
+  /**
+   * Scala API: Increment this nodes value for the gauge with the delta `n` specified.
+   * If the delta is negative then it will decrement instead of increment.
+   */
+  def increment(n: Long)(implicit node: SelfUniqueAddress): Gauge = changeRelative(node.uniqueAddress, n)
+
+  /**
+   * Increment this nodes value for the gauge with the delta `n` specified.
+   * If the delta is negative then it will decrement instead of increment.
+   */
+  def increment(n: BigInt)(implicit node: SelfUniqueAddress): Gauge = changeRelative(node.uniqueAddress, n)
+
+  /**
+   * Java API: Increment this nodes value for the gauge with the delta `n` specified.
+   * If the delta is negative then it will decrement instead of increment.
+   */
+  def increment(node: SelfUniqueAddress, n: java.math.BigInteger): Gauge = changeRelative(node.uniqueAddress, n)
+
+  /**
+   * Java API: Increment this nodes value for the gauge with the delta `n` specified.
+   * If the delta is negative then it will decrement instead of increment.
+   */
+  def increment(node: SelfUniqueAddress, n: Long): Gauge = changeRelative(node.uniqueAddress, n)
+
+  /**
+   * Decrement this nodes value for the gauge with the delta `n` specified.
+   * If the delta is negative then it will increment instead of decrement.
+   */
+  def decrement(n: Long)(implicit node: SelfUniqueAddress): Gauge = changeRelative(node.uniqueAddress, -n)
+
+  /**
+   * Decrement this nodes value for the gauge with the delta `n` specified.
+   * If the delta is negative then it will increment instead of decrement.
+   */
+  def decrement(n: BigInt)(implicit node: SelfUniqueAddress): Gauge = changeRelative(node.uniqueAddress, -n)
+
+  /**
+   * Decrement this nodes value for the gauge with the delta `n` specified.
+   * If the delta `n` is negative then it will increment instead of decrement.
+   */
+  def decrement(node: SelfUniqueAddress, n: Long): Gauge = changeRelative(node.uniqueAddress, -n)
+
+  /**
+   * Scala API: Decrement this nodes value for the gauge with the delta `n` specified.
+   * If the delta `n` is negative then it will increment instead of decrement.
+   */
+  def decrement(node: SelfUniqueAddress, n: BigInt): Gauge = changeRelative(node.uniqueAddress, -n)
+
+  /**
+   * Java API: Decrement this nodes value for the gauge with the delta `n` specified.
+   * If the delta `n` is negative then it will increment instead of decrement.
+   */
+  def decrement(node: SelfUniqueAddress, n: java.math.BigInteger): Gauge =
+    changeRelative(node.uniqueAddress, -BigInt(n))
+
+  /**
+   * Scala API: Set this nodes value for the gauge to `n`.
+   */
+  def set(n: Long)(implicit node: SelfUniqueAddress): Gauge = changeAbsolute(node.uniqueAddress, n)
+
+  /**
+   * Scala API: Set this nodes value for the gauge to `n`.
+   */
+  def set(n: BigInt)(implicit node: SelfUniqueAddress): Gauge = changeAbsolute(node.uniqueAddress, n)
+
+  /**
+   * Java API: Set this nodes value for the gauge to `n`.
+   */
+  def set(node: SelfUniqueAddress, n: java.math.BigInteger): Gauge = changeAbsolute(node.uniqueAddress, n)
+
+  /**
+   * Java API: Set this nodes value for the gauge to `n`.
+   */
+  def set(node: SelfUniqueAddress, n: Long): Gauge = changeAbsolute(node.uniqueAddress, n)
+
+  private def changeRelative(address: UniqueAddress, n: BigInt) = {
+    if (n == 0) this
+    else {
+      val updated = state.get(address) match {
+        case Some((i, d)) =>
+          if (n > 0) (i + n, d)
+          else (i, d - n)
+        case None =>
+          if (n > 0) (n, Zero)
+          else (Zero, -n)
+      }
+      update(address, updated)
+    }
+  }
+
+  private def changeAbsolute(address: UniqueAddress, n: BigInt) = {
+    state.get(address) match {
+      case Some((i, d)) =>
+        val change = n - (i - d)
+        if (change == 0) this
+        else if (change > 0) update(address, (i + change, d))
+        else update(address, (i, d - change))
+      case None =>
+        if (n == 0) this
+        else if (n > 0) update(address, (n, Zero))
+        else update(address, (Zero, -n))
+    }
+  }
+
+  override protected def newVector(state: Map[UniqueAddress, (BigInt, BigInt)], delta: Option[Gauge]): Gauge =
+    new Gauge(state, delta)
+
+  override protected def mergeValues(thisValue: (BigInt, BigInt), thatValue: (BigInt, BigInt)): (BigInt, BigInt) =
+    if (thisValue == thatValue) thatValue
+    else
+      (
+        if (thisValue._1 > thatValue._1) thisValue._1 else thatValue._1,
+        if (thisValue._2 > thatValue._2) thisValue._2 else thatValue._2)
+
+  override protected def collapseInto(key: UniqueAddress, value: (BigInt, BigInt)): Gauge = this
+
+  override def zero: Gauge = Gauge.empty
+
+  // this class cannot be a `case class` because we need different `unapply`
+
+  override def toString: String =
+    s"Gauge(${state.map { case (a, v) => s"${a.address}@${a.longUid} -> ${v._1 - v._2}" }.mkString(",")})"
+}
+
+object GaugeKey {
+  def create(id: String): Key[Gauge] = GaugeKey(id)
+}
+
+@SerialVersionUID(1L)
+final case class GaugeKey(_id: String) extends Key[Gauge](_id) with ReplicatedDataSerialization

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/NodeVector.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/NodeVector.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.ddata
+
+import akka.cluster.UniqueAddress
+
+/**
+ * An abstract node vector, where each node has its own value that it and it only is responsible for.
+ *
+ * The values of the vector must have a stable merge function, implemented by [[mergeValues()]], which is used to
+ * merge different values for the same node when encountered.
+ */
+@SerialVersionUID(1L)
+abstract class NodeVector[V](private val state: Map[UniqueAddress, V])
+    extends DeltaReplicatedData
+    with ReplicatedDelta
+    with RemovedNodePruning
+    with FastMerge {
+
+  type T <: NodeVector[V]
+  final type D = T
+
+  /**
+   * Create a new vector with the given state and delta.
+   *
+   * This is needed by operations such as [[merge()]] to create the new version of this CRDT.
+   */
+  protected def newVector(state: Map[UniqueAddress, V], delta: Option[T]): T
+
+  /**
+   * Merge the given values for a node.
+   */
+  protected def mergeValues(thisValue: V, thatValue: V): V
+
+  /**
+   * Collapse the given value into the given node.
+   */
+  protected def collapseInto(key: UniqueAddress, value: V): T
+
+  // Is not final because overrides can implement it without allocating.
+  override def zero: T = newVector(Map.empty, None)
+
+  protected final def update(key: UniqueAddress, nextValue: V): T = {
+    val newDelta = delta match {
+      case None    => newVector(Map(key -> nextValue), None)
+      case Some(d) => newVector(d.state + (key -> nextValue), None)
+    }
+    assignAncestor(newVector(state + (key -> nextValue), Some(newDelta)))
+  }
+
+  override final def merge(that: T): T =
+    if ((this eq that) || that.isAncestorOf(this.asInstanceOf[that.T])) clearAncestor().asInstanceOf[T]
+    else if (this.isAncestorOf(that)) that.clearAncestor()
+    else {
+      var merged = that.state
+      for ((key, thisValue) <- state) {
+        merged.get(key) match {
+          case Some(thatValue) =>
+            val newValue = mergeValues(thisValue, thatValue)
+            if (newValue != thatValue)
+              merged = merged.updated(key, newValue)
+          case None =>
+            merged = merged.updated(key, thisValue)
+        }
+      }
+      clearAncestor()
+      newVector(merged, None)
+    }
+
+  override final def mergeDelta(thatDelta: T): T = merge(thatDelta)
+
+  override final def resetDelta: T =
+    if (delta.isEmpty) this.asInstanceOf[T]
+    else assignAncestor(newVector(state, None))
+
+  override final def modifiedByNodes: Set[UniqueAddress] = state.keySet
+
+  override final def needPruningFrom(removedNode: UniqueAddress): Boolean =
+    state.contains(removedNode)
+
+  override final def prune(removedNode: UniqueAddress, collapseInto: UniqueAddress): T =
+    state.get(removedNode) match {
+      case Some(value) => newVector(state - removedNode, None).collapseInto(collapseInto, value).asInstanceOf[T]
+      case None        => this.asInstanceOf[T]
+    }
+
+  override final def pruningCleanup(removedNode: UniqueAddress): T =
+    newVector(state - removedNode, None)
+
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Vote.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Vote.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.ddata
+
+import akka.cluster.ClusterEvent.CurrentClusterState
+import akka.cluster.{ MemberStatus, UniqueAddress }
+
+import scala.collection.JavaConverters._
+
+object Vote {
+  val empty: Vote = new Vote
+  def apply(): Vote = empty
+
+  /**
+   * Java API
+   */
+  def create(): Vote = empty
+
+  /**
+   * Decider for voting.
+   */
+  type Decider = Iterable[Boolean] => Boolean
+
+  /**
+   * At least `n` nodes must vote positive.
+   */
+  def atLeast(n: Int): Decider =
+    _.filter(identity).take(n).size >= n
+
+  /**
+   * At least one node must vote positive.
+   */
+  val AtLeastOne: Decider = atLeast(1)
+
+  /**
+   * At most `n` node must vote positive.
+   */
+  def atMost(n: Int): Decider =
+    _.filter(identity).take(n + 1).size <= n
+
+  /**
+   * All nodes must vote positive.
+   */
+  val All: Decider = _.forall(identity)
+
+  /**
+   * A majority of nodes must vote positive
+   */
+  val Majority: Decider = { votes =>
+    val (totalVoters, votesFor) = votes.foldLeft((0, 0)) {
+      case ((total, votes), vote) => (total + 1, if (vote) votes + 1 else votes)
+    }
+    votesFor > totalVoters / 2
+  }
+
+  /**
+   * Java API: Predicate for deciding a vote.
+   */
+  @FunctionalInterface
+  trait DeciderPredicate extends Decider with java.util.function.Predicate[java.lang.Iterable[java.lang.Boolean]] {
+    override final def apply(votes: Iterable[Boolean]): Boolean = {
+      test(votes.asJava.asInstanceOf[java.lang.Iterable[java.lang.Boolean]])
+    }
+  }
+
+  private val Zero = BigInt(0)
+  private val One = BigInt(1)
+}
+
+/**
+ * Implements a vote CRDT.
+ *
+ * A vote CRDT allows each node to manage its own vote. Nodes can change their vote at any time.
+ *
+ * This CRDT has the same state as a GCounter, recording votes for each node in a node vector as an integer, with
+ * odd being a positive vote, and even being a negative vote. Changing a nodes vote is done by incrementing the nodes
+ * integer by one.
+ *
+ * The result of the vote is calculated on request by supplying the current cluster state, along with the set of
+ * member statuses that are allowed to take part in the vote, and a [[akka.cluster.ddata.Vote.Decider]].
+ */
+@SerialVersionUID(1L)
+final case class Vote private[akka] (
+    private[akka] val state: Map[UniqueAddress, BigInt] = Map.empty,
+    override val delta: Option[Vote] = None)
+    extends NodeVector[BigInt](state)
+    with ReplicatedDataSerialization {
+
+  type T = Vote
+
+  import Vote.Zero
+  import Vote.One
+
+  /**
+   * Scala API: The result given the current cluster state.
+   */
+  def result(decider: Vote.Decider, allowedVoterStatuses: Set[MemberStatus] = Set(MemberStatus.Up))(
+      implicit currentClusterState: CurrentClusterState): Boolean = {
+    // this doesn't seem to be the most efficient way of determining the voters
+    // nevertheless, filterKeys/values returns a view/iterable, so this allows us to break early from calculating
+    // all the voters when possible by using take
+    val votes = state
+      .filterKeys(key =>
+        currentClusterState.members.exists { member =>
+          member.uniqueAddress == key && allowedVoterStatuses(member.status)
+        })
+      .values
+      .map(_.testBit(0))
+
+    decider(votes)
+  }
+
+  /**
+   * Java API: The result given the current cluster state.
+   */
+  def getResult(
+      decider: Vote.Decider,
+      allowedVoterStatuses: java.util.Collection[MemberStatus],
+      currentClusterState: CurrentClusterState): Boolean =
+    result(decider, allowedVoterStatuses.asScala.toSet)(currentClusterState)
+
+  /**
+   * Scala API: Place a vote.
+   */
+  def vote(vote: Boolean)(implicit node: SelfUniqueAddress): Vote = {
+    state.get(node.uniqueAddress) match {
+      case Some(v) if vote != v.testBit(0) => update(node.uniqueAddress, v + 1)
+      case None if vote                    => update(node.uniqueAddress, One)
+      case _                               => this
+    }
+  }
+
+  /**
+   * Java API: Place a vote.
+   */
+  def setVote(node: SelfUniqueAddress, vote: Boolean): Vote = {
+    this.vote(vote)(node)
+  }
+
+  override protected def newVector(state: Map[UniqueAddress, BigInt], delta: Option[Vote]): Vote =
+    new Vote(state, delta)
+
+  override protected def mergeValues(thisValue: BigInt, thatValue: BigInt): BigInt =
+    if (thisValue > thatValue) thisValue
+    else thatValue
+
+  override protected def collapseInto(key: UniqueAddress, value: BigInt): Vote = this
+
+  override def zero: Vote = Vote.empty
+
+  // this class cannot be a `case class` because we need different `unapply`
+
+  override def toString: String =
+    s"Vote(${state.map { case (a, v) => s"${a.address}@${a.longUid} -> ${v.testBit(0)}" }.mkString(",")})"
+}
+
+object VoteKey {
+  def create(id: String): Key[Vote] = VoteKey(id)
+}
+
+@SerialVersionUID(1L)
+final case class VoteKey(_id: String) extends Key[Vote](_id) with ReplicatedDataSerialization


### PR DESCRIPTION
This is an exploration of what could be provided to implement #27375.

This introduces an abstract `NodeVector` CRDT, which has been extracted from `GCounter`. It is a vector of values by node. Each value in the vector is owned by its associated node, only that node may make changes to it. The CRDT is public allowing end users to implement their own node vector based CRDTs.

The `NodeVector`'s values are required to have a merge function defined. I did consider simply making them `ReplicatedData` instances, but I decided against that because `NodeVector` is going to be subclassed anyway (allowing a mergeValues function to be defined there), and the extra object allocation per value for `GCounter` didn't seem worth it.

`NodeVector` also defines an abstract `collapseInto` method, this allows collapsing due to pruning to be customised, so a `GCounter` will collapse by adding the value to the node to collapse into, while other CRDTs might decide to discard the value.

`GCounter` has been rewritten to extend this. Because `NodeVector` is just an extraction of logic from `GCounter`, there are effectively no changes in structure or behavior of `GCounter`, except for some slight differences in logic in the merge function, the main thing is that instead of just updating when thisValue is greater than that, it invokes the `mergeValues` function and does a comparison on the result to determine whether the map should be updated with the result. This does mean an extra comparison per valued merged.

Two additional CRDTs have been created, one is a `Vote` CRDT, which is `GCounter` like, and allows for voting by cluster members whose statuses are in a configurable set, with an odd counter value meaning positive and an even meaning negative, it uses a configurable decider (built in deciders include at least n, at most n, majority and all, but any decision algorithm can be provided).

The other is a `Gauge` CRDT, which is `PNCounter` like, and offers aggregation over cluster members whose statuses are in a configurable sets values, including `sum`, `average`, `min` and `max`.

This is a WIP, serialization, tests and documentation for `Vote` and `Gauge` have not been written. I'd rather not do that until it's been decided that this feature is worth having, naming has been bikeshod.