### PR TITLE
Replace map.filterKeys with map.filter to prevent a memory leak in De…

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/DeathWatch.scala
@@ -116,7 +116,7 @@ private[akka] trait DeathWatch { this: ActorCell =>
   @silent
   private def removeFromMap[T](subject: ActorRef, map: Map[ActorRef, T]): Map[ActorRef, T] =
     if (subject.path.uid != ActorCell.undefinedUid) (map - subject) - new UndefinedUidActorRef(subject)
-    else map.filterKeys(_.path != subject.path).toMap
+    else map.filter { case (k, _) => k.path != subject.path }
 
   private def updateWatching(ref: InternalActorRef, newMessage: Option[Any]): Unit =
     watching = watching.updated(ref, newMessage)


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

To fix a memory leak in `DeathWatch.removeFromMap`.

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #27459 