### PR TITLE
RetryFlow: allows retries of individual stream elements with backoff

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/RetryFlow/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RetryFlow/withBackoff.md
@@ -1,0 +1,58 @@
+# RetryFlow.withBackoff
+
+Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will retry individual elements in the stream with an exponential backoff.
+
+@ref[Error handling](../index.md#error-handling)
+
+@@@div { .group-scala }
+
+## Signature
+
+@@signature [RetryFlow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala) { #withBackoff }
+
+@@@
+
+## Description
+
+When an element is emitted by the wrapped `flow` it is passed to the `retryWith` function, which decides whether
+one or more retries should be issued. The retry backoff is controlled by the `minBackoff`, `maxBackoff`
+and `randomFactor` parameters.
+
+Failures can be retried by returning one or more requests from `retryWith`:
+
+Scala
+:   @@snip [RetryFlowSpec.scala](/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RetryFlowSpec.scala) { #retry-failure }
+
+Java
+:   @@snip [RetryFlowTest.java](/akka-stream-tests/src/test/java/akka/stream/javadsl/RetryFlowTest.java) { #retry-failure }
+
+The second element of the @scala[Tuple]@java[Pair] that is passed into the `retryWith` function is a pass-through value,
+which can be used for different purposes, like:
+
+* to correlate a request with a response
+* to track the number of retries
+* to store request to be issued in the case of retry
+
+When `retryWith` returns @scala[`Option.none`]@java[`Optional.none`]@scala[ or does not match a response],
+no retries will be issued, and the failed or successful response will be emitted downstream.
+
+It is also possible to retry successful responses. In that case the successful response is emitted downstream as well as
+retry being scheduled:
+
+Scala
+:   @@snip [RetryFlowSpec.scala](/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RetryFlowSpec.scala) { #retry-success }
+
+Java
+:   @@snip [RetryFlowTest.java](/akka-stream-tests/src/test/java/akka/stream/javadsl/RetryFlowTest.java) { #retry-success }
+
+## Reactive Streams semantics
+
+@@@div { .callout }
+
+**emits** when the wrapped flow emits and the retry decision function decides not to retry or emit failure
+
+**backpressures** during backoff and when the wrapped flow backpressures
+
+**completes** when the wrapped flow completes
+
+@@@

--- a/akka-docs/src/main/paradox/stream/operators/RetryFlow/withBackoffAndContext.md
+++ b/akka-docs/src/main/paradox/stream/operators/RetryFlow/withBackoffAndContext.md
@@ -1,0 +1,29 @@
+# RetryFlow.withBackoffAndContext
+
+Wrap the given @apidoc[FlowWithContext] with a @apidoc[FlowWithContext] that will retry individual elements in the stream with an exponential backoff.
+
+@ref[Error handling](../index.md#error-handling)
+
+@@@div { .group-scala }
+
+## Signature
+
+@@signature [RetryFlow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala) { #withBackoffAndContext }
+
+@@@
+
+## Description
+
+This is equivalent to @ref[RetryFlow.withBackoff](withBackoff.md) but uses @apidoc[FlowWithContext] instead.
+
+## Reactive Streams semantics
+
+@@@div { .callout }
+
+**emits** when the wrapped flow emits and the retry decision function decides not to retry or emit failure
+
+**backpressures** during backoff and when the wrapped flow backpressures
+
+**completes** when the wrapped flow completes
+
+@@@

--- a/akka-docs/src/main/paradox/stream/operators/index.md
+++ b/akka-docs/src/main/paradox/stream/operators/index.md
@@ -309,6 +309,8 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 |RestartSource|<a name="withbackoff"></a>@ref[withBackoff](RestartSource/withBackoff.md)|Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails or complete using an exponential backoff.|
 |RestartFlow|<a name="withbackoff"></a>@ref[withBackoff](RestartFlow/withBackoff.md)|Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it fails or complete using an exponential backoff.|
 |RestartSink|<a name="withbackoff"></a>@ref[withBackoff](RestartSink/withBackoff.md)|Wrap the given @apidoc[Sink] with a @apidoc[Sink] that will restart it when it fails or complete using an exponential backoff.|
+|RetryFlow|<a name="withbackoff"></a>@ref[withBackoff](RetryFlow/withBackoff.md)|Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will retry individual elements in the stream with an exponential backoff.|
+|RetryFlow|<a name="withbackoffandcontext"></a>@ref[withBackoffAndContext](RetryFlow/withBackoffAndContext.md)|Wrap the given @apidoc[FlowWithContext] with a @apidoc[FlowWithContext] that will retry individual elements in the stream with an exponential backoff.|
 
 @@@ index
 
@@ -464,6 +466,8 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 * [withBackoff](RestartFlow/withBackoff.md)
 * [onFailuresWithBackoff](RestartFlow/onFailuresWithBackoff.md)
 * [withBackoff](RestartSink/withBackoff.md)
+* [withBackoff](RetryFlow/withBackoff.md)
+* [withBackoffAndContext](RetryFlow/withBackoffAndContext.md)
 * [actorRefWithAck](ActorSource/actorRefWithAck.md)
 * [ask](ActorFlow/ask.md)
 * [actorRef](ActorSink/actorRef.md)

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/Utils.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/Utils.scala
@@ -4,9 +4,16 @@
 
 package akka.stream.testkit
 
-import akka.actor.ActorRef
-import akka.actor.ActorRefWithCell
+import akka.NotUsed
+import akka.actor.{ActorRef, ActorRefWithCell, Cancellable}
+import akka.stream.Attributes
+import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
+import akka.stream.scaladsl.Flow
+import akka.stream.stage.{GraphStageLogic, InHandler, OutHandler, StageLogging}
+import akka.util.OptionVal
 import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.control.NoStackTrace
 
 object Utils {
@@ -24,5 +31,67 @@ object Utils {
           s"Expected $ref to use dispatcher [$dispatcher], yet used: [${r.underlying.props.dispatcher}]")
     case _ =>
       throw new Exception(s"Unable to determine dispatcher of $ref")
+  }
+
+  /**
+   * INTERNAL API
+   *
+   * Returns a flow that is almost identity but delays propagation of cancellation from downstream to upstream.
+   *
+   * Borrowed from https://github.com/akka/akka-http/blob/d85b71df0f01ce80f65fbb17e513fc2beb6d5adf/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala#L193
+   */
+  def delayCancellation[T](cancelAfter: Duration): Flow[T, T, NotUsed] = Flow.fromGraph(new DelayCancellationStage(cancelAfter))
+  final class DelayCancellationStage[T](cancelAfter: Duration) extends SimpleLinearGraphStage[T] {
+    def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with ScheduleSupport with InHandler with OutHandler with StageLogging {
+      setHandlers(in, out, this)
+
+      def onPush(): Unit = push(out, grab(in)) // using `passAlong` was considered but it seems to need some boilerplate to make it work
+      def onPull(): Unit = pull(in)
+
+      var timeout: OptionVal[Cancellable] = OptionVal.None
+
+      override def onDownstreamFinish(): Unit = {
+        cancelAfter match {
+          case finite: FiniteDuration =>
+            log.debug(s"Delaying cancellation for $finite")
+            timeout = OptionVal.Some {
+              scheduleOnce(finite) {
+                log.debug(s"Stage was canceled after delay of $cancelAfter")
+                timeout = OptionVal.None
+                completeStage()
+              }
+            }
+          case _ => // do nothing
+        }
+
+        // don't pass cancellation to upstream but keep pulling until we get completion or failure
+        setHandler(
+          in,
+          new InHandler {
+            if (!hasBeenPulled(in)) pull(in)
+
+            def onPush(): Unit = {
+              grab(in) // ignore further elements
+              pull(in)
+            }
+          }
+        )
+      }
+
+      override def postStop(): Unit = timeout match {
+        case OptionVal.Some(x) => x.cancel()
+        case OptionVal.None    => // do nothing
+      }
+    }
+  }
+
+  trait ScheduleSupport { self: GraphStageLogic =>
+    /**
+     * Schedule a block to be run once after the given duration in the context of this graph stage.
+     */
+    def scheduleOnce(delay: FiniteDuration)(block: => Unit): Cancellable =
+      materializer.scheduleOnce(delay, new Runnable { def run() = runInContext(block) })
+
+    def runInContext(block: => Unit): Unit = getAsyncCallback[AnyRef](_ => block).invoke(null)
   }
 }

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/Utils.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/Utils.scala
@@ -5,12 +5,12 @@
 package akka.stream.testkit
 
 import akka.NotUsed
-import akka.actor.{ ActorRef, ActorRefWithCell, Cancellable }
+import akka.actor.{ ActorRef, ActorRefWithCell }
+import akka.annotation.InternalApi
 import akka.stream.Attributes
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import akka.stream.scaladsl.Flow
-import akka.stream.stage.{ GraphStageLogic, InHandler, OutHandler, StageLogging }
-import akka.util.OptionVal
+import akka.stream.stage.{ GraphStageLogic, InHandler, OutHandler, StageLogging, TimerGraphStageLogic }
 import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.duration.{ Duration, FiniteDuration }
@@ -34,65 +34,53 @@ object Utils {
   }
 
   /**
-   * INTERNAL API
+   * INTERNAL API.
    *
    * Returns a flow that is almost identity but delays propagation of cancellation from downstream to upstream.
    *
    * Borrowed from https://github.com/akka/akka-http/blob/d85b71df0f01ce80f65fbb17e513fc2beb6d5adf/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala#L193
    */
-  def delayCancellation[T](cancelAfter: Duration): Flow[T, T, NotUsed] =
-    Flow.fromGraph(new DelayCancellationStage(cancelAfter))
-  final class DelayCancellationStage[T](cancelAfter: Duration) extends SimpleLinearGraphStage[T] {
-    def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
-      new GraphStageLogic(shape) with ScheduleSupport with InHandler with OutHandler with StageLogging {
-        setHandlers(in, out, this)
+  @InternalApi private[akka] def delayCancellation[T](cancelAfter: Duration): Flow[T, T, NotUsed] = {
+    final class DelayCancellationStage[S](cancelAfter: Duration) extends SimpleLinearGraphStage[S] {
+      def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+        new TimerGraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
+          setHandlers(in, out, this)
 
-        def onPush(): Unit =
-          push(out, grab(in)) // using `passAlong` was considered but it seems to need some boilerplate to make it work
-        def onPull(): Unit = pull(in)
+          def onPush(): Unit =
+            push(out, grab(in)) // using `passAlong` was considered but it seems to need some boilerplate to make it work
+          def onPull(): Unit = pull(in)
 
-        var timeout: OptionVal[Cancellable] = OptionVal.None
+          final val CompleteStageTimer = "cst"
 
-        override def onDownstreamFinish(): Unit = {
-          cancelAfter match {
-            case finite: FiniteDuration =>
-              log.debug(s"Delaying cancellation for $finite")
-              timeout = OptionVal.Some {
-                scheduleOnce(finite) {
-                  log.debug(s"Stage was canceled after delay of $cancelAfter")
-                  timeout = OptionVal.None
-                  completeStage()
-                }
+          override def onDownstreamFinish(cause: Throwable): Unit = {
+            cancelAfter match {
+              case finite: FiniteDuration =>
+                log.debug(s"Delaying cancellation for $finite")
+                scheduleOnce(CompleteStageTimer, finite)
+              case _ => // do nothing
+            }
+
+            // don't pass cancellation to upstream but keep pulling until we get completion or failure
+            setHandler(in, new InHandler {
+              if (!hasBeenPulled(in)) pull(in)
+
+              def onPush(): Unit = {
+                grab(in) // ignore further elements
+                pull(in)
               }
-            case _ => // do nothing
+            })
           }
 
-          // don't pass cancellation to upstream but keep pulling until we get completion or failure
-          setHandler(in, new InHandler {
-            if (!hasBeenPulled(in)) pull(in)
+          override def onTimer(timerKey: Any): Unit = {
+            log.debug(s"Stage was canceled after delay of $cancelAfter")
+            completeStage()
+          }
 
-            def onPush(): Unit = {
-              grab(in) // ignore further elements
-              pull(in)
-            }
-          })
+          override def postStop(): Unit = cancelTimer(CompleteStageTimer)
         }
+    }
 
-        override def postStop(): Unit = timeout match {
-          case OptionVal.Some(x) => x.cancel()
-          case OptionVal.None    => // do nothing
-        }
-      }
+    Flow.fromGraph(new DelayCancellationStage(cancelAfter))
   }
 
-  trait ScheduleSupport { self: GraphStageLogic =>
-
-    /**
-     * Schedule a block to be run once after the given duration in the context of this graph stage.
-     */
-    def scheduleOnce(delay: FiniteDuration)(block: => Unit): Cancellable =
-      materializer.scheduleOnce(delay, new Runnable { def run() = runInContext(block) })
-
-    def runInContext(block: => Unit): Unit = getAsyncCallback[AnyRef](_ => block).invoke(null)
-  }
 }

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/Utils.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/Utils.scala
@@ -5,15 +5,15 @@
 package akka.stream.testkit
 
 import akka.NotUsed
-import akka.actor.{ActorRef, ActorRefWithCell, Cancellable}
+import akka.actor.{ ActorRef, ActorRefWithCell, Cancellable }
 import akka.stream.Attributes
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import akka.stream.scaladsl.Flow
-import akka.stream.stage.{GraphStageLogic, InHandler, OutHandler, StageLogging}
+import akka.stream.stage.{ GraphStageLogic, InHandler, OutHandler, StageLogging }
 import akka.util.OptionVal
 import com.typesafe.config.ConfigFactory
 
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.util.control.NoStackTrace
 
 object Utils {
@@ -40,52 +40,53 @@ object Utils {
    *
    * Borrowed from https://github.com/akka/akka-http/blob/d85b71df0f01ce80f65fbb17e513fc2beb6d5adf/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala#L193
    */
-  def delayCancellation[T](cancelAfter: Duration): Flow[T, T, NotUsed] = Flow.fromGraph(new DelayCancellationStage(cancelAfter))
+  def delayCancellation[T](cancelAfter: Duration): Flow[T, T, NotUsed] =
+    Flow.fromGraph(new DelayCancellationStage(cancelAfter))
   final class DelayCancellationStage[T](cancelAfter: Duration) extends SimpleLinearGraphStage[T] {
-    def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with ScheduleSupport with InHandler with OutHandler with StageLogging {
-      setHandlers(in, out, this)
+    def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+      new GraphStageLogic(shape) with ScheduleSupport with InHandler with OutHandler with StageLogging {
+        setHandlers(in, out, this)
 
-      def onPush(): Unit = push(out, grab(in)) // using `passAlong` was considered but it seems to need some boilerplate to make it work
-      def onPull(): Unit = pull(in)
+        def onPush(): Unit =
+          push(out, grab(in)) // using `passAlong` was considered but it seems to need some boilerplate to make it work
+        def onPull(): Unit = pull(in)
 
-      var timeout: OptionVal[Cancellable] = OptionVal.None
+        var timeout: OptionVal[Cancellable] = OptionVal.None
 
-      override def onDownstreamFinish(): Unit = {
-        cancelAfter match {
-          case finite: FiniteDuration =>
-            log.debug(s"Delaying cancellation for $finite")
-            timeout = OptionVal.Some {
-              scheduleOnce(finite) {
-                log.debug(s"Stage was canceled after delay of $cancelAfter")
-                timeout = OptionVal.None
-                completeStage()
+        override def onDownstreamFinish(): Unit = {
+          cancelAfter match {
+            case finite: FiniteDuration =>
+              log.debug(s"Delaying cancellation for $finite")
+              timeout = OptionVal.Some {
+                scheduleOnce(finite) {
+                  log.debug(s"Stage was canceled after delay of $cancelAfter")
+                  timeout = OptionVal.None
+                  completeStage()
+                }
               }
-            }
-          case _ => // do nothing
-        }
+            case _ => // do nothing
+          }
 
-        // don't pass cancellation to upstream but keep pulling until we get completion or failure
-        setHandler(
-          in,
-          new InHandler {
+          // don't pass cancellation to upstream but keep pulling until we get completion or failure
+          setHandler(in, new InHandler {
             if (!hasBeenPulled(in)) pull(in)
 
             def onPush(): Unit = {
               grab(in) // ignore further elements
               pull(in)
             }
-          }
-        )
-      }
+          })
+        }
 
-      override def postStop(): Unit = timeout match {
-        case OptionVal.Some(x) => x.cancel()
-        case OptionVal.None    => // do nothing
+        override def postStop(): Unit = timeout match {
+          case OptionVal.Some(x) => x.cancel()
+          case OptionVal.None    => // do nothing
+        }
       }
-    }
   }
 
   trait ScheduleSupport { self: GraphStageLogic =>
+
     /**
      * Schedule a block to be run once after the given duration in the context of this graph stage.
      */

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/RetryFlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/RetryFlowTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.javadsl;
+
+import akka.NotUsed;
+import akka.japi.JavaPartialFunction;
+import akka.japi.Option;
+import akka.japi.Pair;
+import akka.stream.StreamTest;
+import akka.stream.testkit.TestPublisher;
+import akka.stream.testkit.TestSubscriber;
+import akka.stream.testkit.javadsl.TestSink;
+import akka.stream.testkit.javadsl.TestSource;
+import akka.testkit.AkkaJUnitActorSystemResource;
+import akka.testkit.AkkaSpec;
+import org.junit.ClassRule;
+import org.junit.Test;
+import scala.util.Success;
+import scala.util.Try;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class RetryFlowTest extends StreamTest {
+  public RetryFlowTest() {
+    super(actorSystemResource);
+  }
+
+  @ClassRule
+  public static AkkaJUnitActorSystemResource actorSystemResource =
+      new AkkaJUnitActorSystemResource("RetryFlowTest", AkkaSpec.testConf());
+
+  @Test
+  public void beAbleToUseRetryFlow() {
+    Flow<Pair<Integer, NotUsed>, Pair<Try<Integer>, NotUsed>, NotUsed> flow =
+        Flow.fromFunction(
+            in -> {
+              final Integer request = in.first();
+              return Pair.create(Success.apply(request / 2), NotUsed.getInstance());
+            });
+
+    final JavaPartialFunction<
+            Pair<Try<Integer>, NotUsed>, Option<Collection<Pair<Integer, NotUsed>>>>
+        retryWith =
+            new JavaPartialFunction<
+                Pair<Try<Integer>, NotUsed>, Option<Collection<Pair<Integer, NotUsed>>>>() {
+              public akka.japi.Option<Collection<Pair<Integer, NotUsed>>> apply(
+                  Pair<Try<Integer>, NotUsed> in, boolean isCheck) {
+                final Try<Integer> response = in.first();
+                if (response.isSuccess()) {
+                  final Integer result = response.get();
+                  if (result > 0) {
+                    return akka.japi.Option.some(
+                        Collections.singleton(Pair.create(result, NotUsed.getInstance())));
+                  } else {
+                    return akka.japi.Option.none();
+                  }
+                } else {
+                  return akka.japi.Option.none();
+                }
+              }
+            };
+
+    Flow<akka.japi.Pair<Integer, NotUsed>, akka.japi.Pair<Try<Integer>, NotUsed>, NotUsed>
+        retryFlow =
+            RetryFlow.withBackoff(
+                8, Duration.ofMillis(10), Duration.ofSeconds(5), 0, flow, retryWith);
+
+    Pair<TestPublisher.Probe<Integer>, TestSubscriber.Probe<Pair<Try<Integer>, NotUsed>>> probes =
+        TestSource.<Integer>probe(system)
+            .map(i -> Pair.create(i, NotUsed.getInstance()))
+            .via(retryFlow)
+            .toMat(TestSink.probe(system), Keep.both())
+            .run(materializer);
+
+    final TestPublisher.Probe<Integer> source = probes.first();
+    final TestSubscriber.Probe<Pair<Try<Integer>, NotUsed>> sink = probes.second();
+
+    sink.request(4);
+
+    source.sendNext(8);
+    assertEquals(4, sink.expectNext().first().get().intValue());
+    assertEquals(2, sink.expectNext().first().get().intValue());
+    assertEquals(1, sink.expectNext().first().get().intValue());
+    assertEquals(0, sink.expectNext().first().get().intValue());
+
+    source.sendComplete();
+    sink.expectComplete();
+  }
+}

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/RetryFlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/RetryFlowTest.java
@@ -73,7 +73,7 @@ public class RetryFlowTest extends StreamTest {
                 .map(i -> Pair.create(i, notUsed()))
                 .via(retryFlow)
                 .toMat(TestSink.probe(system), Keep.both())
-                .run(materializer);
+                .run(system);
 
     final TestPublisher.Probe<Integer> source = probes.first();
     final TestSubscriber.Probe<Pair<Try<Integer>, NotUsed>> sink = probes.second();
@@ -130,7 +130,7 @@ public class RetryFlowTest extends StreamTest {
                 .map(i -> Pair.create(i, i))
                 .via(retryFlow)
                 .toMat(TestSink.probe(system), Keep.both())
-                .run(materializer);
+                .run(system);
 
     final TestPublisher.Probe<Integer> source = probes.first();
     final TestSubscriber.Probe<Pair<Try<Integer>, Integer>> sink = probes.second();
@@ -183,7 +183,7 @@ public class RetryFlowTest extends StreamTest {
                           return Optional.empty();
                         }))
                 .toMat(TestSink.probe(system), Keep.both())
-                .run(materializer);
+                .run(system);
 
     final TestPublisher.Probe<Integer> source = probes.first();
     final TestSubscriber.Probe<Pair<Try<Integer>, Integer>> sink = probes.second();

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/RetryFlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/RetryFlowTest.java
@@ -5,8 +5,6 @@
 package akka.stream.javadsl;
 
 import akka.NotUsed;
-import akka.japi.JavaPartialFunction;
-import akka.japi.Option;
 import akka.japi.Pair;
 import akka.stream.StreamTest;
 import akka.stream.testkit.TestPublisher;
@@ -17,13 +15,15 @@ import akka.testkit.AkkaJUnitActorSystemResource;
 import akka.testkit.AkkaSpec;
 import org.junit.ClassRule;
 import org.junit.Test;
+import scala.util.Failure;
 import scala.util.Success;
 import scala.util.Try;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 
+import static akka.NotUsed.notUsed;
 import static org.junit.Assert.assertEquals;
 
 public class RetryFlowTest extends StreamTest {
@@ -36,47 +36,42 @@ public class RetryFlowTest extends StreamTest {
       new AkkaJUnitActorSystemResource("RetryFlowTest", AkkaSpec.testConf());
 
   @Test
-  public void beAbleToUseRetryFlow() {
-    Flow<Pair<Integer, NotUsed>, Pair<Try<Integer>, NotUsed>, NotUsed> flow =
+  public void retrySuccessfulResponses() {
+    final Integer parallelism = 8;
+    final Duration minBackoff = Duration.ofMillis(10);
+    final Duration maxBackoff = Duration.ofSeconds(5);
+    final Integer randomFactor = 0;
+    final Flow<Pair<Integer, NotUsed>, Pair<Try<Integer>, NotUsed>, NotUsed> flow =
         Flow.fromFunction(
             in -> {
               final Integer request = in.first();
-              return Pair.create(Success.apply(request / 2), NotUsed.getInstance());
+              return Pair.create(Success.apply(request / 2), notUsed());
             });
 
-    final JavaPartialFunction<
-            Pair<Try<Integer>, NotUsed>, Option<Collection<Pair<Integer, NotUsed>>>>
-        retryWith =
-            new JavaPartialFunction<
-                Pair<Try<Integer>, NotUsed>, Option<Collection<Pair<Integer, NotUsed>>>>() {
-              public akka.japi.Option<Collection<Pair<Integer, NotUsed>>> apply(
-                  Pair<Try<Integer>, NotUsed> in, boolean isCheck) {
-                final Try<Integer> response = in.first();
-                if (response.isSuccess()) {
-                  final Integer result = response.get();
-                  if (result > 0) {
-                    return akka.japi.Option.some(
-                        Collections.singleton(Pair.create(result, NotUsed.getInstance())));
-                  } else {
-                    return akka.japi.Option.none();
-                  }
-                } else {
-                  return akka.japi.Option.none();
-                }
+    final Flow<Pair<Integer, NotUsed>, Pair<Try<Integer>, NotUsed>, NotUsed> retryFlow =
+        RetryFlow.withBackoff(
+            parallelism,
+            minBackoff,
+            maxBackoff,
+            randomFactor,
+            flow,
+            r -> {
+              final Integer result = r.first();
+              if (result > 0) {
+                return Optional.of(Collections.singleton(Pair.create(result, notUsed())));
+              } else {
+                return Optional.empty();
               }
-            };
+            },
+            r -> Optional.empty());
 
-    Flow<akka.japi.Pair<Integer, NotUsed>, akka.japi.Pair<Try<Integer>, NotUsed>, NotUsed>
-        retryFlow =
-            RetryFlow.withBackoff(
-                8, Duration.ofMillis(10), Duration.ofSeconds(5), 0, flow, retryWith);
-
-    Pair<TestPublisher.Probe<Integer>, TestSubscriber.Probe<Pair<Try<Integer>, NotUsed>>> probes =
-        TestSource.<Integer>probe(system)
-            .map(i -> Pair.create(i, NotUsed.getInstance()))
-            .via(retryFlow)
-            .toMat(TestSink.probe(system), Keep.both())
-            .run(materializer);
+    final Pair<TestPublisher.Probe<Integer>, TestSubscriber.Probe<Pair<Try<Integer>, NotUsed>>>
+        probes =
+            TestSource.<Integer>probe(system)
+                .map(i -> Pair.create(i, notUsed()))
+                .via(retryFlow)
+                .toMat(TestSink.probe(system), Keep.both())
+                .run(materializer);
 
     final TestPublisher.Probe<Integer> source = probes.first();
     final TestSubscriber.Probe<Pair<Try<Integer>, NotUsed>> sink = probes.second();
@@ -88,6 +83,60 @@ public class RetryFlowTest extends StreamTest {
     assertEquals(2, sink.expectNext().first().get().intValue());
     assertEquals(1, sink.expectNext().first().get().intValue());
     assertEquals(0, sink.expectNext().first().get().intValue());
+
+    source.sendComplete();
+    sink.expectComplete();
+  }
+
+  @Test
+  public void retryFailedResponses() {
+    final Integer parallelism = 8;
+    final Duration minBackoff = Duration.ofMillis(10);
+    final Duration maxBackoff = Duration.ofSeconds(5);
+    final Integer randomFactor = 0;
+    final Flow<Pair<Integer, Integer>, Pair<Try<Integer>, Integer>, NotUsed> flow =
+        Flow.fromFunction(
+            in -> {
+              final Integer request = in.first();
+              if (request > 0)
+                return Pair.create(Failure.apply(new Error("Failed response")), request);
+              else return Pair.create(Success.apply(request), request);
+            });
+
+    final Flow<Pair<Integer, Integer>, Pair<Try<Integer>, Integer>, NotUsed> retryFlow =
+        RetryFlow.withBackoff(
+            parallelism,
+            minBackoff,
+            maxBackoff,
+            randomFactor,
+            flow,
+            r -> Optional.empty(),
+            r -> {
+              final Integer state = r.second();
+              if (state > 0) {
+                return Optional.of(Collections.singleton(Pair.create(state / 2, state / 2)));
+              } else {
+                return Optional.empty();
+              }
+            });
+
+    final Pair<TestPublisher.Probe<Integer>, TestSubscriber.Probe<Pair<Try<Integer>, Integer>>>
+        probes =
+            TestSource.<Integer>probe(system)
+                .map(i -> Pair.create(i, i))
+                .via(retryFlow)
+                .toMat(TestSink.probe(system), Keep.both())
+                .run(materializer);
+
+    final TestPublisher.Probe<Integer> source = probes.first();
+    final TestSubscriber.Probe<Pair<Try<Integer>, Integer>> sink = probes.second();
+
+    sink.request(1);
+    source.sendNext(8);
+
+    Pair<Try<Integer>, Integer> response = sink.expectNext();
+    assertEquals(0, response.first().get().intValue());
+    assertEquals(4, response.second().intValue());
 
     source.sendComplete();
     sink.expectComplete();

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/RetryFlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/RetryFlowTest.java
@@ -48,6 +48,7 @@ public class RetryFlowTest extends StreamTest {
               return Pair.create(Success.apply(request / 2), notUsed());
             });
 
+    //#retry-success
     final Flow<Pair<Integer, NotUsed>, Pair<Try<Integer>, NotUsed>, NotUsed> retryFlow =
         RetryFlow.withBackoff(
             parallelism,
@@ -64,6 +65,7 @@ public class RetryFlowTest extends StreamTest {
               }
               return Optional.empty();
             });
+    //#retry-success
 
     final Pair<TestPublisher.Probe<Integer>, TestSubscriber.Probe<Pair<Try<Integer>, NotUsed>>>
         probes =
@@ -103,6 +105,7 @@ public class RetryFlowTest extends StreamTest {
               else return Pair.create(Success.apply(request), request);
             });
 
+    //#retry-failure
     final Flow<Pair<Integer, Integer>, Pair<Try<Integer>, Integer>, NotUsed> retryFlow =
         RetryFlow.withBackoff(
             parallelism,
@@ -119,6 +122,7 @@ public class RetryFlowTest extends StreamTest {
               }
               return Optional.empty();
             });
+    //#retry-failure
 
     final Pair<TestPublisher.Probe<Integer>, TestSubscriber.Probe<Pair<Try<Integer>, Integer>>>
         probes =

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/RetryFlowTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/RetryFlowTest.java
@@ -48,7 +48,7 @@ public class RetryFlowTest extends StreamTest {
               return Pair.create(Success.apply(request / 2), notUsed());
             });
 
-    //#retry-success
+    // #retry-success
     final Flow<Pair<Integer, NotUsed>, Pair<Try<Integer>, NotUsed>, NotUsed> retryFlow =
         RetryFlow.withBackoff(
             parallelism,
@@ -65,7 +65,7 @@ public class RetryFlowTest extends StreamTest {
               }
               return Optional.empty();
             });
-    //#retry-success
+    // #retry-success
 
     final Pair<TestPublisher.Probe<Integer>, TestSubscriber.Probe<Pair<Try<Integer>, NotUsed>>>
         probes =
@@ -105,7 +105,7 @@ public class RetryFlowTest extends StreamTest {
               else return Pair.create(Success.apply(request), request);
             });
 
-    //#retry-failure
+    // #retry-failure
     final Flow<Pair<Integer, Integer>, Pair<Try<Integer>, Integer>, NotUsed> retryFlow =
         RetryFlow.withBackoff(
             parallelism,
@@ -122,7 +122,7 @@ public class RetryFlowTest extends StreamTest {
               }
               return Optional.empty();
             });
-    //#retry-failure
+    // #retry-failure
 
     final Pair<TestPublisher.Probe<Integer>, TestSubscriber.Probe<Pair<Try<Integer>, Integer>>>
         probes =

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RetryFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RetryFlowSpec.scala
@@ -1,0 +1,301 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.scaladsl
+
+import akka.stream.{ActorMaterializer, KillSwitches}
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
+
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+class RetryFlowSpec extends StreamSpec() {
+
+  implicit val mat = ActorMaterializer()
+
+  val failedElem: Try[Int] = Failure(new Exception("cooked failure"))
+  def flow[T] = Flow.fromFunction[(Int, T), (Try[Int], T)] {
+    case (i, j) if i % 2 == 0 => (failedElem, j)
+    case (i, j) => (Success(i + 1), j)
+  }
+
+  "RetryFlow.withBackoff" should {
+    "swallow failed elements that are retried with an empty Seq" in {
+      val (source, sink) = TestSource
+        .probe[Int]
+        .map(i => (i, i))
+        .via(RetryFlow.withBackoff(100, 1.second, 1.second, 100, flow[Int]) { (_, _) =>
+          Some(Nil)
+        })
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      sink.request(99)
+      source.sendNext(1)
+      assert(sink.expectNext()._1 === Success(2))
+      source.sendNext(2)
+      sink.expectNoMessage()
+      source.sendNext(3)
+      assert(sink.expectNext()._1 === Success(4))
+      source.sendNext(4)
+      sink.expectNoMessage()
+      source.sendComplete()
+      sink.expectComplete()
+    }
+
+    "concat incremented ints and modulo 3 incremented ints from retries" in {
+      val (source, sink) = TestSource
+        .probe[Int]
+        .map(i => (i, i))
+        .via(RetryFlow.withBackoff(100, 1.second, 1.second, 100, flow[Int]) { (_, os) =>
+          val s = (os + 1) % 3
+          if (os < 42) Some(List((os + 1, os + 1), (s, s)))
+          else if (os == 42) Some(Nil)
+          else None
+        })
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      sink.request(99)
+      source.sendNext(1)
+      assert(sink.expectNext()._1 === Success(2))
+      source.sendNext(2)
+      assert(sink.expectNext()._1 === Success(4))
+      assert(sink.expectNext()._1 === Success(2))
+      assert(sink.expectNext()._1 === Success(2))
+      source.sendNext(44)
+      assert(sink.expectNext()._1 === failedElem)
+      source.sendNext(42)
+      sink.expectNoMessage()
+      source.sendComplete()
+      sink.expectComplete()
+    }
+
+    "retry squares by division" in {
+      val (source, sink) = TestSource
+        .probe[Int]
+        .map(i => (i, i * i))
+        .via(RetryFlow.withBackoff(100, 1.second, 1.second, 100, flow[Int]) {
+          case (_, x) if x % 4 == 0 => Some(List((x / 2, x / 4)))
+          case (_, x) => {
+            val sqrt = scala.math.sqrt(x.toDouble).toInt
+            Some(List((sqrt, x)))
+          }
+        })
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      sink.request(99)
+      source.sendNext(1)
+      assert(sink.expectNext()._1 === Success(2))
+      source.sendNext(2)
+      assert(sink.expectNext()._1 === Success(2))
+      source.sendNext(4)
+      assert(sink.expectNext()._1 === Success(2))
+      sink.expectNoMessage(3.seconds)
+      source.sendComplete()
+      sink.expectComplete()
+    }
+
+    "tolerate killswitch terminations after start" in {
+      val ((source, killSwitch), sink) = TestSource
+        .probe[Int]
+        .viaMat(KillSwitches.single[Int])(Keep.both)
+        .map(i => (i, i * i))
+        .via(RetryFlow.withBackoff(100, 1.second, 1.second, 100, flow[Int]) {
+          case (_, x) if x % 4 == 0 => Some(List((x / 2, x / 4)))
+          case (_, x) => {
+            val sqrt = scala.math.sqrt(x.toDouble).toInt
+            Some(List((sqrt, x)))
+          }
+        })
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      sink.request(99)
+      source.sendNext(1)
+      assert(sink.expectNext()._1 === Success(2))
+      source.sendNext(2)
+      assert(sink.expectNext()._1 === Success(2))
+      killSwitch.abort(failedElem.failed.get)
+      sink.expectError(failedElem.failed.get)
+    }
+
+    "tolerate killswitch terminations on start" in {
+      val (killSwitch, sink) = TestSource
+        .probe[Int]
+        .viaMat(KillSwitches.single[Int])(Keep.right)
+        .map(i => (i, i))
+        .via(RetryFlow.withBackoff(100, 1.second, 1.second, 100, flow[Int]) { (_, x) =>
+          Some(List((x, x + 1)))
+        })
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      sink.request(99)
+      killSwitch.abort(failedElem.failed.get)
+      sink.expectError(failedElem.failed.get)
+    }
+
+    "tolerate killswitch terminations before start" in {
+      val (killSwitch, sink) = TestSource
+        .probe[Int]
+        .viaMat(KillSwitches.single[Int])(Keep.right)
+        .map(i => (i, i))
+        .via(RetryFlow.withBackoff(100, 1.second, 1.second, 100, flow[Int]) { (_, x) =>
+          Some(List((x, x + 1)))
+        })
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      killSwitch.abort(failedElem.failed.get)
+      sink.request(1)
+      sink.expectError(failedElem.failed.get)
+    }
+
+    "tolerate killswitch terminations inside the flow after start" in {
+      val innerFlow = flow[Int].viaMat(KillSwitches.single[(Try[Int], Int)])(Keep.right)
+      val ((source, killSwitch), sink) = TestSource
+        .probe[Int]
+        .map(i => (i, i * i))
+        .viaMat(RetryFlow.withBackoff(100, 1.second, 1.second, 100, innerFlow) {
+          case (_, x) if x % 4 == 0 => Some(List((x / 2, x / 4)))
+          case (_, x) => {
+            val sqrt = scala.math.sqrt(x.toDouble).toInt
+            Some(List((sqrt, x)))
+          }
+        })(Keep.both)
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      sink.request(99)
+      source.sendNext(1)
+      assert(sink.expectNext()._1 === Success(2))
+      source.sendNext(2)
+      assert(sink.expectNext()._1 === Success(2))
+      killSwitch.abort(failedElem.failed.get)
+      sink.expectError(failedElem.failed.get)
+    }
+
+    "tolerate killswitch terminations inside the flow on start" in {
+      val innerFlow = flow[Int].viaMat(KillSwitches.single[(Try[Int], Int)])(Keep.right)
+      val (killSwitch, sink) = TestSource
+        .probe[Int]
+        .map(i => (i, i))
+        .viaMat(RetryFlow.withBackoff(100, 1.second, 1.second, 100, innerFlow) { (_, x) =>
+          Some(List((x, x + 1)))
+        })(Keep.right)
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      sink.request(99)
+      killSwitch.abort(failedElem.failed.get)
+      sink.expectError(failedElem.failed.get)
+    }
+
+    "tolerate killswitch terminations inside the flow before start" in {
+      val innerFlow = flow[Int].viaMat(KillSwitches.single[(Try[Int], Int)])(Keep.right)
+      val (killSwitch, sink) = TestSource
+        .probe[Int]
+        .map(i => (i, i))
+        .viaMat(RetryFlow.withBackoff(100, 1.second, 1.second, 100, innerFlow) { (_, x) =>
+          Some(List((x, x + 1)))
+        })(Keep.right)
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      killSwitch.abort(failedElem.failed.get)
+      sink.request(1)
+      sink.expectError(failedElem.failed.get)
+    }
+
+    val alwaysFailingFlow = Flow.fromFunction[(Int, Int), (Try[Int], Int)] {
+      case (_, j) => (failedElem, j)
+    }
+
+    val alwaysRecoveringFunc: (Try[Int], Int) => Option[List[(Int, Int)]] = (_, i) => Some(List(i -> i))
+
+    val stuckForeverRetrying = RetryFlow.withBackoff(Int.MaxValue, 1.second, 1.second, Long.MaxValue, alwaysFailingFlow)(alwaysRecoveringFunc)
+
+    "tolerate killswitch terminations before the flow while on fail spin" in {
+      val ((source, killSwitch), sink) = TestSource
+        .probe[Int]
+        .viaMat(KillSwitches.single[Int])(Keep.both)
+        .map(i => (i, i))
+        .via(stuckForeverRetrying)
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      sink.request(99)
+      source.sendNext(1)
+      sink.expectNoMessage()
+      killSwitch.abort(failedElem.failed.get)
+      sink.expectError(failedElem.failed.get)
+    }
+
+    "tolerate killswitch terminations inside the flow while on fail spin" in {
+      val ((source, killSwitch), sink) = TestSource
+        .probe[Int]
+        .map(i => (i, i))
+        .viaMat(
+          RetryFlow.withBackoff(Int.MaxValue, 1.second, 1.second,
+            Long.MaxValue,
+            alwaysFailingFlow.viaMat(KillSwitches.single[(Try[Int], Int)])(Keep.right))(alwaysRecoveringFunc)
+        )(Keep.both)
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      sink.request(99)
+      source.sendNext(1)
+      sink.expectNoMessage()
+      killSwitch.abort(failedElem.failed.get)
+      sink.expectError(failedElem.failed.get)
+    }
+
+    "tolerate killswitch terminations after the flow while on fail spin" in {
+      val ((source, killSwitch), sink) = TestSource
+        .probe[Int]
+        .map(i => (i, i))
+        .via(stuckForeverRetrying)
+        .viaMat(KillSwitches.single[(Try[Int], Int)])(Keep.both)
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      sink.request(99)
+      source.sendNext(1)
+      sink.expectNoMessage()
+      killSwitch.abort(failedElem.failed.get)
+      sink.expectError(failedElem.failed.get)
+    }
+
+    "finish only after processing all elements in stream" in {
+      val (source, sink) = TestSource
+        .probe[Int]
+        .map(i => (i, i * i))
+        .via(RetryFlow.withBackoff(100, 1.second, 1.second, 100, flow[Int]) {
+          case (_, x) => Some(List.fill(x)(1 -> 1))
+        })
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      sink.request(99)
+      source.sendNext(1)
+      assert(sink.expectNext()._1 == Success(2))
+
+      source.sendNext(3)
+      assert(sink.expectNext()._1 == Success(4))
+
+      source.sendNext(2)
+      source.sendComplete()
+      assert(sink.expectNext()._1 == Success(2))
+      assert(sink.expectNext()._1 == Success(2))
+      assert(sink.expectNext()._1 == Success(2))
+      assert(sink.expectNext()._1 == Success(2))
+
+      sink.expectComplete()
+    }
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RetryFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RetryFlowSpec.scala
@@ -5,7 +5,7 @@
 package akka.stream.scaladsl
 
 import akka.NotUsed
-import akka.stream.{ ActorMaterializer, KillSwitches }
+import akka.stream.KillSwitches
 import akka.stream.testkit.{ StreamSpec, Utils }
 import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
 import org.scalatest.matchers.{ MatchResult, Matcher }
@@ -14,8 +14,6 @@ import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
 
 class RetryFlowSpec extends StreamSpec() with CustomMatchers {
-
-  implicit val mat: ActorMaterializer = ActorMaterializer()
 
   val failedElem: Try[Int] = Failure(new Exception("cooked failure"))
   def flow[T]: Flow[(Int, T), (Try[Int], T), NotUsed] = Flow.fromFunction {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RetryFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RetryFlowSpec.scala
@@ -5,13 +5,13 @@
 package akka.stream.scaladsl
 
 import akka.NotUsed
-import akka.stream.{ActorMaterializer, KillSwitches}
-import akka.stream.testkit.{StreamSpec, Utils}
-import akka.stream.testkit.scaladsl.{TestSink, TestSource}
-import org.scalatest.matchers.{MatchResult, Matcher}
+import akka.stream.{ ActorMaterializer, KillSwitches }
+import akka.stream.testkit.{ StreamSpec, Utils }
+import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
+import org.scalatest.matchers.{ MatchResult, Matcher }
 
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 
 class RetryFlowSpec extends StreamSpec() with CustomMatchers {
 
@@ -142,7 +142,8 @@ class RetryFlowSpec extends StreamSpec() with CustomMatchers {
     }
 
     "tolerate killswitch abort on the inner flow after start" in {
-      val innerFlow = flow[Int].via(Utils.delayCancellation(10.seconds)).viaMat(KillSwitches.single[(Try[Int], Int)])(Keep.right)
+      val innerFlow =
+        flow[Int].via(Utils.delayCancellation(10.seconds)).viaMat(KillSwitches.single[(Try[Int], Int)])(Keep.right)
       val ((source, killSwitch), sink) = TestSource
         .probe[Int]
         .map(i => (i, i))
@@ -165,7 +166,8 @@ class RetryFlowSpec extends StreamSpec() with CustomMatchers {
     }
 
     "tolerate killswitch abort on the inner flow on start" in {
-      val innerFlow = flow[Int].via(Utils.delayCancellation(10.seconds)).viaMat(KillSwitches.single[(Try[Int], Int)])(Keep.right)
+      val innerFlow =
+        flow[Int].via(Utils.delayCancellation(10.seconds)).viaMat(KillSwitches.single[(Try[Int], Int)])(Keep.right)
       val (killSwitch, sink) = TestSource
         .probe[Int]
         .map(i => (i, i))
@@ -182,7 +184,8 @@ class RetryFlowSpec extends StreamSpec() with CustomMatchers {
     }
 
     "tolerate killswitch abort on the inner flow before start" in {
-      val innerFlow = flow[Int].via(Utils.delayCancellation(10.seconds)).viaMat(KillSwitches.single[(Try[Int], Int)])(Keep.right)
+      val innerFlow =
+        flow[Int].via(Utils.delayCancellation(10.seconds)).viaMat(KillSwitches.single[(Try[Int], Int)])(Keep.right)
       val (killSwitch, sink) = TestSource
         .probe[Int]
         .map(i => (i, i))
@@ -237,8 +240,9 @@ class RetryFlowSpec extends StreamSpec() with CustomMatchers {
             10.millis,
             5.second,
             0,
-            alwaysFailingFlow.via(Utils.delayCancellation(10.seconds)).viaMat(KillSwitches.single[(Try[Int], Int)])(Keep.right))(alwaysRecoveringFunc))(
-          Keep.both)
+            alwaysFailingFlow
+              .via(Utils.delayCancellation(10.seconds))
+              .viaMat(KillSwitches.single[(Try[Int], Int)])(Keep.right))(alwaysRecoveringFunc))(Keep.both)
         .toMat(TestSink.probe)(Keep.both)
         .run()
 

--- a/akka-stream/src/main/scala/akka/stream/impl/RetryFlowCoordinator.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/RetryFlowCoordinator.scala
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.impl
+
+import akka.annotation.InternalApi
+import akka.pattern.BackoffSupervisor
+import akka.stream.impl.RetryFlowCoordinator.InternalState
+import akka.stream.{ Attributes, BidiShape, Inlet, Outlet }
+import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler, TimerGraphStageLogic }
+
+import scala.collection.immutable
+import scala.concurrent.duration._
+import scala.util.Try
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object RetryFlowCoordinator {
+  class InternalState(val numberOfRestarts: Int, val retryDeadline: Long)
+  case object InternalState {
+    def apply(): InternalState = new InternalState(0, System.currentTimeMillis())
+  }
+  case object RetryTimer
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] class RetryFlowCoordinator[In, State, Out](
+    parallelism: Long,
+    retryWith: PartialFunction[(Try[Out], State), Option[immutable.Iterable[(In, State)]]],
+    minBackoff: FiniteDuration,
+    maxBackoff: FiniteDuration,
+    randomFactor: Double)
+    extends GraphStage[
+      BidiShape[(In, State), (Try[Out], State), (Try[Out], State, InternalState), (In, State, InternalState)]] {
+
+  private val externalIn = Inlet[(In, State)]("RetryFlow.externalIn")
+  private val externalOut = Outlet[(Try[Out], State)]("RetryFlow.externalOut")
+
+  private val internalIn = Inlet[(Try[Out], State, InternalState)]("RetryFlow.internalIn")
+  private val internalOut = Outlet[(In, State, InternalState)]("RetryFlow.internalOut")
+
+  override val shape
+      : BidiShape[(In, State), (Try[Out], State), (Try[Out], State, InternalState), (In, State, InternalState)] =
+    BidiShape(externalIn, externalOut, internalIn, internalOut)
+
+  override def createLogic(attributes: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) {
+    private var numElementsInCycle = 0
+    private var queueRetries =
+      scala.collection.immutable.SortedSet.empty[(In, State, InternalState)](Ordering.fromLessThan { (e1, e2) =>
+        if (e1._3.retryDeadline != e2._3.retryDeadline) e1._3.retryDeadline < e2._3.retryDeadline
+        else e1.hashCode < e2.hashCode
+      })
+    private val queueOut = scala.collection.mutable.Queue.empty[(Try[Out], State)]
+
+    private final val RetryTimer = "retry_timer"
+
+    setHandler(
+      externalIn,
+      new InHandler {
+        override def onPush(): Unit = {
+          val is = {
+            val in = grab(externalIn)
+            (in._1, in._2, InternalState())
+          }
+          if (isAvailable(internalOut)) {
+            push(internalOut, is)
+            numElementsInCycle += 1
+          } else {
+            queueRetries += is
+          }
+        }
+
+        override def onUpstreamFinish(): Unit =
+          if (numElementsInCycle == 0 && queueRetries.isEmpty) {
+            if (queueOut.isEmpty) completeStage()
+            else emitMultiple(externalOut, queueOut.iterator, () => completeStage())
+          }
+      })
+
+    setHandler(
+      externalOut,
+      new OutHandler {
+        override def onPull(): Unit =
+          // prioritize pushing queued element if available
+          if (queueOut.isEmpty) {
+            if (!hasBeenPulled(internalIn)) pull(internalIn)
+          } else push(externalOut, queueOut.dequeue())
+      })
+
+    setHandler(
+      internalIn,
+      new InHandler {
+        override def onPush(): Unit = {
+          numElementsInCycle -= 1
+          grab(internalIn) match {
+            case (out, s, internalState) =>
+              retryWith
+                .applyOrElse[(Try[Out], State), Option[immutable.Iterable[(In, State)]]]((out, s), _ => None)
+                .fold(pushAndCompleteIfLast((out, s))) {
+                  xs =>
+                    val current = System.currentTimeMillis()
+                    xs.foreach {
+                      case (in, state) =>
+                        val numRestarts = internalState.numberOfRestarts + 1
+                        val delay = BackoffSupervisor.calculateDelay(numRestarts, minBackoff, maxBackoff, randomFactor)
+                        queueRetries += ((in, state, new InternalState(numRestarts, current + delay.toMillis)))
+                    }
+
+                    out.foreach { _ =>
+                      pushAndCompleteIfLast((out, s))
+                    }
+
+                    if (queueRetries.isEmpty) {
+                      if (isClosed(externalIn) && queueOut.isEmpty) completeStage()
+                      else pull(internalIn)
+                    } else {
+                      pull(internalIn)
+                      scheduleRetryTimer()
+                    }
+                }
+          }
+        }
+      })
+
+    override def onTimer(timerKey: Any): Unit = timerKey match {
+      case `RetryTimer` =>
+        if (isAvailable(internalOut)) {
+          val elem = queueRetries.head
+          queueRetries = queueRetries.tail
+
+          push(internalOut, elem)
+          numElementsInCycle += 1
+        }
+    }
+
+    private def pushAndCompleteIfLast(elem: (Try[Out], State)): Unit = {
+      if (isAvailable(externalOut) && queueOut.isEmpty) {
+        push(externalOut, elem)
+      } else if (queueOut.size + 1 > parallelism) {
+        failStage(new IllegalStateException(s"Buffer limit of $parallelism has been exceeded"))
+      } else {
+        queueOut.enqueue(elem)
+      }
+
+      if (isClosed(externalIn) && queueRetries.isEmpty && numElementsInCycle == 0 && queueOut.isEmpty) {
+        completeStage()
+      }
+    }
+
+    setHandler(
+      internalOut,
+      new OutHandler {
+        override def onPull(): Unit =
+          if (queueRetries.isEmpty) {
+            if (!hasBeenPulled(externalIn) && !isClosed(externalIn)) {
+              pull(externalIn)
+            }
+          } else {
+            scheduleRetryTimer()
+          }
+
+        override def onDownstreamFinish(cause: Throwable): Unit = {
+          // waiting for the failure from the upstream
+          setKeepGoing(true)
+        }
+      })
+
+    private def smallestRetryDelay(): FiniteDuration =
+      (queueRetries.head._3.retryDeadline - System.currentTimeMillis()).millis
+
+    private def scheduleRetryTimer() =
+      scheduleOnce(RetryTimer, smallestRetryDelay())
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RetryFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RetryFlow.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.javadsl
+
+import java.util
+
+import akka.NotUsed
+import akka.japi.Pair
+import akka.stream.scaladsl.RetryFlow.withBackoffAndContext
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.Duration
+import scala.runtime.AbstractPartialFunction
+import scala.util.Try
+
+object RetryFlow {
+
+  /**
+   * Allows retrying individual elements in the stream with exponential backoff.
+   *
+   * The retry condition is controlled by the `retryWith` partial function. It takes an output element of the wrapped
+   * flow and should return one or more requests to be retried.
+   *
+   * A successful or failed response will be propagated downstream if it is not matched by the `retryFlow` function.
+   *
+   * If a successful response is matched and issued a retry, the response is still propagated downstream.
+   *
+   * The implementation of the RetryFlow assumes that `flow` follows one-in-one-out element semantics.
+   *
+   * The wrapped `flow` and `retryWith` takes an additional `State` parameter which can be used to correlate a request
+   * with a response.
+   *
+   * Backoff state is tracked separately per-element coming into the wrapped `flow`.
+   *
+   * @param parallelism controls the number of in-flight requests in the wrapped flow
+   * @param minBackoff minimum duration to backoff between issuing retries
+   * @param maxBackoff maximum duration to backoff between issuing retries
+   * @param randomFactor adds jitter to the retry delay. Use 0 for no jitter
+   * @param flow a flow to retry elements from
+   * @param retryWith retry condition decision partial function
+   */
+  def withBackoff[In, Out, State, Mat](
+      parallelism: Int,
+      minBackoff: java.time.Duration,
+      maxBackoff: java.time.Duration,
+      randomFactor: Double,
+      flow: Flow[Pair[In, State], Pair[Try[Out], State], Mat],
+      retryWith: AbstractPartialFunction[Pair[Try[Out], State], akka.japi.Option[util.Collection[Pair[In, State]]]])
+      : Flow[akka.japi.Pair[In, State], akka.japi.Pair[Try[Out], State], Mat] = {
+    val retryFlow = withBackoffAndContext(
+      parallelism,
+      Duration.fromNanos(minBackoff.toNanos),
+      Duration.fromNanos(maxBackoff.toNanos),
+      randomFactor,
+      FlowWithContext.fromPairs(flow).asScala) {
+      case (t, s) =>
+        retryWith(Pair.create(t, s)).map(coll => coll.asScala.toIndexedSeq.map(pair => (pair.first, pair.second)))
+    }.asFlow
+
+    Flow
+      .create[akka.japi.Pair[In, State]]()
+      .map(p => (p.first, p.second))
+      .viaMat(retryFlow, Keep.right[NotUsed, Mat])
+      .map(t => akka.japi.Pair.create(t._1, t._2))
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RetryFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RetryFlow.scala
@@ -8,14 +8,13 @@ import java.util
 import java.util.Optional
 import java.util.function.BiFunction
 
-import akka.NotUsed
 import akka.japi.Pair
-import akka.stream.scaladsl.RetryFlow.withBackoffAndContext
+import akka.stream.scaladsl
 import akka.util.ccompat.JavaConverters._
 
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.Duration
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 
 object RetryFlow {
 
@@ -49,25 +48,56 @@ object RetryFlow {
       randomFactor: Double,
       flow: Flow[Pair[In, State], Pair[Try[Out], State], Mat],
       retryWith: BiFunction[Pair[Out, State], Pair[Throwable, State], Optional[util.Collection[Pair[In, State]]]])
-      : Flow[akka.japi.Pair[In, State], akka.japi.Pair[Try[Out], State], Mat] = {
-    val retryFlow = withBackoffAndContext(
-      parallelism,
-      Duration.fromNanos(minBackoff.toNanos),
-      Duration.fromNanos(maxBackoff.toNanos),
-      randomFactor,
-      FlowWithContext.fromPairs(flow).asScala) { case result =>
-        val retryAttempt = result match {
-          case (Success(value), s) => retryWith(Pair.create(value, s), null)
-          case (Failure(exception), s) => retryWith(null, Pair.create(exception, s))
-        }
-        retryAttempt.asScala.map(coll => coll.asScala.toIndexedSeq.map(pair => (pair.first, pair.second)))
-    }.asFlow
-
-    Flow
-      .create[akka.japi.Pair[In, State]]()
-      .map(p => (p.first, p.second))
-      .viaMat(retryFlow, Keep.right[NotUsed, Mat])
-      .map(t => akka.japi.Pair.create(t._1, t._2))
+      : Flow[Pair[In, State], Pair[Try[Out], State], Mat] = {
+    withBackoffAndContext(parallelism, minBackoff, maxBackoff, randomFactor, FlowWithContext.fromPairs(flow), retryWith)
+      .asFlow()
   }
+
+  /**
+   * Allows retrying individual elements in the stream with exponential backoff.
+   *
+   * The retry condition is controlled by the `retryWith` bi-function. On a successful response, this function is
+   * passed the response as the first argument. On a failed response, the exception is passed as the second argument.
+   * The other respective argument is passed a null. `retryWith` should return one or more requests to be retried.
+   *
+   * If a successful response is issued a retry, the response is still propagated downstream.
+   *
+   * The implementation of the RetryFlow assumes that `flow` follows one-in-one-out element semantics.
+   *
+   * The `flow` and `retryWith` take an additional `State` parameter which can be used to correlate a request
+   * with a response.
+   *
+   * Backoff state is tracked separately per-element coming into the wrapped `flow`.
+   *
+   * @param parallelism controls the number of in-flight requests in the wrapped flow
+   * @param minBackoff minimum duration to backoff between issuing retries
+   * @param maxBackoff maximum duration to backoff between issuing retries
+   * @param randomFactor adds jitter to the retry delay. Use 0 for no jitter
+   * @param flow a flow to retry elements from
+   * @param retryWith retry condition decision function
+   */
+  def withBackoffAndContext[In, Out, State, Mat](
+      parallelism: Int,
+      minBackoff: java.time.Duration,
+      maxBackoff: java.time.Duration,
+      randomFactor: Double,
+      flow: FlowWithContext[In, State, Try[Out], State, Mat],
+      retryWith: BiFunction[Pair[Out, State], Pair[Throwable, State], Optional[util.Collection[Pair[In, State]]]])
+      : FlowWithContext[In, State, Try[Out], State, Mat] =
+    scaladsl.RetryFlow
+      .withBackoffAndContext(
+        parallelism,
+        Duration.fromNanos(minBackoff.toNanos),
+        Duration.fromNanos(maxBackoff.toNanos),
+        randomFactor,
+        flow.asScala) {
+        case result =>
+          val retryAttempt = result match {
+            case (Success(value), s)     => retryWith(Pair.create(value, s), null)
+            case (Failure(exception), s) => retryWith(null, Pair.create(exception, s))
+          }
+          retryAttempt.asScala.map(coll => coll.asScala.toIndexedSeq.map(pair => (pair.first, pair.second)))
+      }
+      .asJava[In, State, Try[Out], State, Mat]
 
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RetryFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RetryFlow.scala
@@ -19,7 +19,7 @@ import scala.util.{ Failure, Success, Try }
 object RetryFlow {
 
   /**
-   * Allows retrying individual elements in the stream with exponential backoff.
+   * Allows retrying individual elements in the stream with an exponential backoff.
    *
    * The retry condition is controlled by the `retryWith` bi-function. On a successful response, this function is
    * passed the response as the first argument. On a failed response, the exception is passed as the second argument.
@@ -54,7 +54,7 @@ object RetryFlow {
   }
 
   /**
-   * Allows retrying individual elements in the stream with exponential backoff.
+   * Allows retrying individual elements in the stream with an exponential backoff.
    *
    * The retry condition is controlled by the `retryWith` bi-function. On a successful response, this function is
    * passed the response as the first argument. On a failed response, the exception is passed as the second argument.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RetryFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RetryFlow.scala
@@ -6,6 +6,7 @@ package akka.stream.javadsl
 
 import java.util
 import java.util.Optional
+import java.util.function.BiFunction
 
 import akka.NotUsed
 import akka.japi.Pair
@@ -21,14 +22,15 @@ object RetryFlow {
   /**
    * Allows retrying individual elements in the stream with exponential backoff.
    *
-   * The retry condition is controlled by the `retrySuccess` and `retryFailure` functions. These functions take a
-   * successful response or an exception respectively and should return one or more requests to be retried.
+   * The retry condition is controlled by the `retryWith` bi-function. On a successful response, this function is
+   * passed the response as the first argument. On a failed response, the exception is passed as the second argument.
+   * The other respective argument is passed a null. `retryWith` should return one or more requests to be retried.
    *
    * If a successful response is issued a retry, the response is still propagated downstream.
    *
    * The implementation of the RetryFlow assumes that `flow` follows one-in-one-out element semantics.
    *
-   * The `flow`, `retrySuccess` and `retryFailure` arguments take an additional `State` parameter which can be used to correlate a request
+   * The `flow` and `retryWith` take an additional `State` parameter which can be used to correlate a request
    * with a response.
    *
    * Backoff state is tracked separately per-element coming into the wrapped `flow`.
@@ -38,8 +40,7 @@ object RetryFlow {
    * @param maxBackoff maximum duration to backoff between issuing retries
    * @param randomFactor adds jitter to the retry delay. Use 0 for no jitter
    * @param flow a flow to retry elements from
-   * @param retrySuccess retry condition decision function on success
-   * @param retryFailure retry condition decision function on failure
+   * @param retryWith retry condition decision function
    */
   def withBackoff[In, Out, State, Mat](
       parallelism: Int,
@@ -47,8 +48,7 @@ object RetryFlow {
       maxBackoff: java.time.Duration,
       randomFactor: Double,
       flow: Flow[Pair[In, State], Pair[Try[Out], State], Mat],
-      retrySuccess: java.util.function.Function[Pair[Out, State], Optional[util.Collection[Pair[In, State]]]],
-      retryFailure: java.util.function.Function[Pair[Throwable, State], Optional[util.Collection[Pair[In, State]]]])
+      retryWith: BiFunction[Pair[Out, State], Pair[Throwable, State], Optional[util.Collection[Pair[In, State]]]])
       : Flow[akka.japi.Pair[In, State], akka.japi.Pair[Try[Out], State], Mat] = {
     val retryFlow = withBackoffAndContext(
       parallelism,
@@ -57,8 +57,8 @@ object RetryFlow {
       randomFactor,
       FlowWithContext.fromPairs(flow).asScala) { case result =>
         val retryAttempt = result match {
-          case (Success(value), s) => retrySuccess(Pair.create(value, s))
-          case (Failure(exception), s) => retryFailure(Pair.create(exception, s))
+          case (Success(value), s) => retryWith(Pair.create(value, s), null)
+          case (Failure(exception), s) => retryWith(null, Pair.create(exception, s))
         }
         retryAttempt.asScala.map(coll => coll.asScala.toIndexedSeq.map(pair => (pair.first, pair.second)))
     }.asFlow

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RetryFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RetryFlow.scala
@@ -10,7 +10,7 @@ import akka.NotUsed
 import akka.japi.Pair
 import akka.stream.scaladsl.RetryFlow.withBackoffAndContext
 
-import scala.collection.JavaConverters._
+import akka.util.ccompat.JavaConverters._
 import scala.concurrent.duration.Duration
 import scala.runtime.AbstractPartialFunction
 import scala.util.Try

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RetryFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RetryFlow.scala
@@ -8,6 +8,7 @@ import java.util
 import java.util.Optional
 import java.util.function.BiFunction
 
+import akka.annotation.ApiMayChange
 import akka.japi.Pair
 import akka.stream.scaladsl
 import akka.util.ccompat.JavaConverters._
@@ -19,6 +20,8 @@ import scala.util.{ Failure, Success, Try }
 object RetryFlow {
 
   /**
+   * API may change!
+   *
    * Allows retrying individual elements in the stream with an exponential backoff.
    *
    * The retry condition is controlled by the `retryWith` bi-function. On a successful response, this function is
@@ -41,6 +44,7 @@ object RetryFlow {
    * @param flow a flow to retry elements from
    * @param retryWith retry condition decision function
    */
+  @ApiMayChange
   def withBackoff[In, Out, State, Mat](
       parallelism: Int,
       minBackoff: java.time.Duration,
@@ -54,6 +58,8 @@ object RetryFlow {
   }
 
   /**
+   * API may change!
+   *
    * Allows retrying individual elements in the stream with an exponential backoff.
    *
    * The retry condition is controlled by the `retryWith` bi-function. On a successful response, this function is
@@ -76,6 +82,7 @@ object RetryFlow {
    * @param flow a flow to retry elements from
    * @param retryWith retry condition decision function
    */
+  @ApiMayChange
   def withBackoffAndContext[In, Out, State, Mat](
       parallelism: Int,
       minBackoff: java.time.Duration,

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala
@@ -33,7 +33,7 @@ object RetryFlow {
    *
    * If a successful response is matched and issued a retry, the response is still propagated downstream.
    *
-   * The implementation of the RetryFlow assumes that `flow` follows one-in-out-out element semantics.
+   * The implementation of the RetryFlow assumes that `flow` follows one-in-one-out element semantics.
    *
    * The wrapped `flow` and `retryWith` takes an additional `State` parameter which can be used to correlate a request
    * with a response.
@@ -76,7 +76,7 @@ object RetryFlow {
    *
    * If a successful response is matched and issued a retry, the response is still propagated downstream.
    *
-   * The implementation of the RetryFlow assumes that `flow` follows one-in-out-out element semantics.
+   * The implementation of the RetryFlow assumes that `flow` follows one-in-one-out element semantics.
    *
    * The wrapped `flow` and `retryWith` takes an additional `State` parameter which can be used to correlate a request
    * with a response.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.scaladsl
+
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.stream.{Attributes, BidiShape, FlowShape, Graph, Inlet, Outlet}
+import com.typesafe.config.ConfigFactory
+
+import scala.collection.immutable
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.util.{Success, Try}
+
+object RetryFlow {
+
+  def withBackoff[In, Out, State, Mat](
+      parallelism: Int,
+      minBackoff: FiniteDuration,
+      maxBackoff: FiniteDuration,
+      randomFactor: Double,
+      flow: Flow[(In, State), (Try[Out], State), Mat])(
+      retryWith: (Try[Out], State) => Option[immutable.Iterable[(In, State)]])
+      : Graph[FlowShape[(In, State), (Try[Out], State)], Mat] = {
+    GraphDSL.create(flow) { implicit b => origFlow =>
+      import GraphDSL.Implicits._
+
+      println(minBackoff)
+      println(maxBackoff)
+      println(randomFactor)
+
+      val retry = b.add(new RetryFlowCoordinator[In, State, Out](10, parallelism, retryWith))
+
+      retry.out2 ~> origFlow ~> retry.in2
+
+      FlowShape(retry.in1, retry.out1)
+    }
+  }
+
+}
+
+private class RetryFlowCoordinator[In, State, Out](
+    retriesLimit: Long,
+    bufferLimit: Long,
+    retryWith: (Try[Out], State) => Option[immutable.Iterable[(In, State)]])
+    extends GraphStage[BidiShape[(In, State), (Try[Out], State), (Try[Out], State), (In, State)]] {
+
+  val in1 = Inlet[(In, State)]("RetryFlow.ext.in")
+  val out1 = Outlet[(Try[Out], State)]("RetryFlow.ext.out")
+  val in2 = Inlet[(Try[Out], State)]("RetryFlow.int.in")
+  val out2 = Outlet[(In, State)]("RetryFlow.int.out")
+
+  override val shape = BidiShape[(In, State), (Try[Out], State), (Try[Out], State), (In, State)](in1, out1, in2, out2)
+
+  override def createLogic(attributes: Attributes) = new GraphStageLogic(shape) {
+    var numElementsInCycle = 0
+    val queueRetries = scala.collection.mutable.Queue.empty[(In, State)]
+    val queueOut1 = scala.collection.mutable.Queue.empty[(Try[Out], State)]
+    lazy val timeout =
+      Duration.fromNanos(ConfigFactory.load().getDuration("akka.stream.contrib.retry-timeout").toNanos)
+
+    setHandler(
+      in1,
+      new InHandler {
+        override def onPush() = {
+          val is = grab(in1)
+          if (isAvailable(out2)) {
+            push(out2, is)
+            numElementsInCycle += 1
+          } else queueRetries.enqueue(is)
+        }
+
+        override def onUpstreamFinish() =
+          if (numElementsInCycle == 0 && queueRetries.isEmpty) {
+            if (queueOut1.isEmpty) completeStage()
+            else emitMultiple(out1, queueOut1.iterator, () => completeStage())
+          }
+      })
+
+    setHandler(
+      out1,
+      new OutHandler {
+        override def onPull() =
+          // prioritize pushing queued element if available
+          if (queueOut1.isEmpty) pull(in2)
+          else push(out1, queueOut1.dequeue())
+      })
+
+    setHandler(
+      in2,
+      new InHandler {
+        override def onPush() = {
+          numElementsInCycle -= 1
+          grab(in2) match {
+            case s @ (_: Success[Out], _) => pushAndCompleteIfLast(s)
+            case failure =>
+              retryWith.tupled(failure).fold(pushAndCompleteIfLast(failure)) {
+                xs =>
+                  if (xs.size + queueRetries.size > retriesLimit)
+                    failStage(new IllegalStateException(
+                      s"Queue limit of $retriesLimit has been exceeded. Trying to append ${xs.size} elements to a queue that has ${queueRetries.size} elements."))
+                  else {
+                    xs.foreach(queueRetries.enqueue(_))
+                    if (queueRetries.isEmpty) {
+                      if (isClosed(in1) && queueOut1.isEmpty) completeStage()
+                      else pull(in2)
+                    } else {
+                      pull(in2)
+                      if (isAvailable(out2)) {
+                        val elem = queueRetries.dequeue()
+                        push(out2, elem)
+                        numElementsInCycle += 1
+                      }
+                    }
+                  }
+              }
+          }
+        }
+      })
+
+    def pushAndCompleteIfLast(elem: (Try[Out], State)): Unit = {
+      if (isAvailable(out1) && queueOut1.isEmpty) {
+        push(out1, elem)
+      } else if (queueOut1.size + 1 > bufferLimit) {
+        failStage(new IllegalStateException(
+          s"Buffer limit of $bufferLimit has been exceeded. Trying to append 1 element to a buffer that has ${queueOut1.size} elements."))
+      } else {
+        queueOut1.enqueue(elem)
+      }
+
+      if (isClosed(in1) && queueRetries.isEmpty && numElementsInCycle == 0 && queueOut1.isEmpty) {
+        completeStage()
+      }
+    }
+
+    setHandler(
+      out2,
+      new OutHandler {
+        override def onPull() =
+          if (queueRetries.isEmpty) {
+            if (!hasBeenPulled(in1) && !isClosed(in1)) {
+              pull(in1)
+            }
+          } else {
+            push(out2, queueRetries.dequeue())
+            numElementsInCycle += 1
+          }
+
+        override def onDownstreamFinish() =
+          materializer.scheduleOnce(timeout, new Runnable {
+            override def run() =
+              getAsyncCallback[Unit] { _ =>
+                if (!isClosed(in2)) {
+                  failStage(
+                    new IllegalStateException(
+                      s"inner flow canceled only upstream, while downstream remain available for $timeout"))
+                }
+              }.invoke(())
+          })
+      })
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala
@@ -204,6 +204,7 @@ private class RetryFlowCoordinator[In, State, Out](
                 .applyOrElse[(Try[Out], State), Option[immutable.Iterable[(In, State)]]]((out, s), _ => None)
                 .fold(pushAndCompleteIfLast((out, s))) {
                   xs =>
+                    val current = System.currentTimeMillis()
                     xs.foreach {
                       case (in, state) =>
                         val numRestarts = internalState.numberOfRestarts + 1
@@ -212,7 +213,7 @@ private class RetryFlowCoordinator[In, State, Out](
                           (
                             in,
                             state,
-                            InternalState(numRestarts, System.currentTimeMillis() + delay.toMillis)))
+                            InternalState(numRestarts, current + delay.toMillis)))
                     }
 
                     out.foreach { _ =>

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala
@@ -16,7 +16,7 @@ import scala.util.Try
 object RetryFlow {
 
   /**
-   * Allows retrying individual elements in the stream with exponential backoff.
+   * Allows retrying individual elements in the stream with an exponential backoff.
    *
    * The retry condition is controlled by the `retryWith` partial function. It takes an output element of the wrapped
    * flow and should return one or more requests to be retried. For example:
@@ -59,7 +59,7 @@ object RetryFlow {
       retryWith).asFlow
 
   /**
-   * Allows retrying individual elements in the stream with exponential backoff.
+   * Allows retrying individual elements in the stream with an exponential backoff.
    *
    * The retry condition is controlled by the `retryWith` partial function. It takes an output element of the wrapped
    * flow and should return one or more requests to be retried. For example:

--- a/project/StreamOperatorsIndexGenerator.scala
+++ b/project/StreamOperatorsIndexGenerator.scala
@@ -153,6 +153,8 @@ object StreamOperatorsIndexGenerator extends AutoPlugin {
         "akka-stream/src/main/scala/akka/stream/javadsl/RestartFlow.scala",
         "akka-stream/src/main/scala/akka/stream/scaladsl/RestartSink.scala",
         "akka-stream/src/main/scala/akka/stream/javadsl/RestartSink.scala",
+        "akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala",
+        "akka-stream/src/main/scala/akka/stream/javadsl/RetryFlow.scala",
 
         // akka-stream-typed
         "akka-stream-typed/src/main/scala/akka/stream/typed/javadsl/ActorSource.scala",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0-RC3
+sbt.version=1.2.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.0-RC3


### PR DESCRIPTION
> Comments on the API and the implementation welcome
> WIP because:
> * missing Java API
> * missing reference documentation

## Purpose

RetryFlow wraps a flow of shape `Request => Try[Response]` and allows to individually retry failed or successful elements. Retries are backed off exponentially and retry count is tracked per-response bases.

## References

Fixes #27230

## Background Context

Originally implemented by @hochgi in https://github.com/akka/akka-stream-contrib/blob/master/src/main/scala/akka/stream/contrib/Retry.scala

Then improved based on the use-case from https://github.com/akka/alpakka/pull/1712
