### PR TITLE
Revert "Update to Scala 2.12.9"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
   val jacksonVersion = "2.9.9"
   val jacksonDatabindVersion = "2.9.9.1"
 
-  val scala212Version = "2.12.9"
+  val scala212Version = "2.12.8"
   val scala213Version = "2.13.0"
 
   val sslConfigVersion = "0.3.8"


### PR DESCRIPTION
Reverts akka/akka#27384 because strange things are afoot today in Travis related to the cache. We can put this back after after it is ruled out to be related.