### PR TITLE
System wide materializer

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -55,6 +55,11 @@ import com.github.ghik.silencer.silent
 
   // impl InternalRecipientRef, ask not supported
   override def provider: ActorRefProvider = throw new UnsupportedOperationException("no provider")
+
+  // stream materialization etc. using stub not supported
+  override private[akka] def classicSystem =
+    throw new UnsupportedOperationException("no untyped actor system available")
+
   // impl InternalRecipientRef
   def isTerminated: Boolean = whenTerminated.isCompleted
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -6,6 +6,7 @@ package akka.actor.typed
 
 import java.util.concurrent.{ CompletionStage, ThreadFactory }
 
+import akka.actor.ClassicActorSystemProvider
 import akka.actor.BootstrapSetup
 import akka.actor.setup.ActorSystemSetup
 import akka.actor.typed.eventstream.EventStream
@@ -17,6 +18,7 @@ import akka.util.Helpers.Requiring
 import akka.util.Timeout
 import akka.{ Done, actor => untyped }
 import com.typesafe.config.{ Config, ConfigFactory }
+
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 
 /**
@@ -29,7 +31,8 @@ import scala.concurrent.{ ExecutionContextExecutor, Future }
  * Not for user extension.
  */
 @DoNotInherit
-abstract class ActorSystem[-T] extends ActorRef[T] with Extensions { this: InternalRecipientRef[T] =>
+abstract class ActorSystem[-T] extends ActorRef[T] with Extensions with ClassicActorSystemProvider {
+  this: InternalRecipientRef[T] =>
 
   /**
    * The name of this actor system, used to distinguish multiple ones within

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -55,6 +55,8 @@ import akka.{ actor => untyped }
 
   import ActorRefAdapter.sendSystemMessage
 
+  override private[akka] def classicSystem: untyped.ActorSystem = untypedSystem
+
   // Members declared in akka.actor.typed.ActorRef
   override def tell(msg: T): Unit = {
     if (msg == null) throw InvalidMessageException("[null] is not an allowed message")

--- a/akka-actor/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.x.backwards.excludes
@@ -82,3 +82,7 @@ ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.pattern.CircuitBreaker
 
 # streamref serialization #27304
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.DynamicAccess.classIsOnClasspath")
+
+# system wide materializer #25559
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.actor.ExtendedActorSystem.classicSystem")
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.actor.ActorSystem.classicSystem")

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -470,7 +470,7 @@ object ActorSystem {
  * extending [[akka.actor.ExtendedActorSystem]] instead, but beware that you
  * are completely on your own in that case!
  */
-abstract class ActorSystem extends ActorRefFactory {
+abstract class ActorSystem extends ActorRefFactory with ClassicActorSystemProvider {
   import ActorSystem._
 
   /**
@@ -915,6 +915,8 @@ private[akka] class ActorSystemImpl(
 
   def /(actorName: String): ActorPath = guardian.path / actorName
   def /(path: Iterable[String]): ActorPath = guardian.path / path
+
+  override private[akka] def classicSystem: ActorSystem = this
 
   // Used for ManifestInfo.checkSameVersion
   private def allModules: List[String] =

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -13,12 +13,14 @@ import akka.actor.dungeon.ChildrenContainer
 import akka.actor.setup.{ ActorSystemSetup, Setup }
 import akka.annotation.InternalApi
 import akka.ConfigurationException
+import akka.annotation.DoNotInherit
 import akka.dispatch._
 import akka.event._
 import akka.japi.Util.immutableSeq
 import akka.util.Helpers.toRootLowerCase
 import akka.util._
 import com.typesafe.config.{ Config, ConfigFactory }
+
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.compat.java8.FutureConverters
@@ -674,6 +676,7 @@ abstract class ActorSystem extends ActorRefFactory with ClassicActorSystemProvid
  * actually roll your own Akka, beware that you are completely on your own in
  * that case!
  */
+@DoNotInherit
 abstract class ExtendedActorSystem extends ActorSystem {
 
   /**

--- a/akka-actor/src/main/scala/akka/actor/ClassicActorSystemProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ClassicActorSystemProvider.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor
+
+import akka.annotation.DoNotInherit
+import akka.annotation.InternalApi
+
+/**
+ * Glue API introduced to allow minimal user effort integration between classic and typed for example for streams.
+ *
+ * Not for user extension.
+ */
+@DoNotInherit
+trait ClassicActorSystemProvider {
+
+  /** INTERNAL API */
+  @InternalApi
+  private[akka] def classicSystem: ActorSystem
+}

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -502,3 +502,16 @@ made before finalizing the APIs. Compared to Akka 2.5.x the source incompatible 
 
 * `ActorSource.actorRef` relying on `PartialFunction` has been replaced in the Java API with a variant more suitable to be called by Java.
 
+
+## Additional changes
+
+### System global Materializer provided
+
+A default materializer is now provided out of the box. For the Java API just pass `system` when running streams,
+for Scala an implicit materializer is provided if there is an implicit `ActorSystem` available. This avoids leaking 
+materializers and simplifies most stream use cases somewhat.
+
+Having a default materializer available means that most, if not all, usages of Java `ActorMaterializer.create()` 
+and Scala `implicit val materializer = ActorMaterializer()` should be removed. 
+
+Details about the stream materializer can be found in [Actor Materializer Lifecycle](../stream/stream-flows-and-basics.md#actor-materializer-lifecycle)

--- a/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
+++ b/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
@@ -266,7 +266,7 @@ and `runWith()` methods defined on `Source` and `Flow` elements as well as a sma
 well-known sinks, such as @scala[`runForeach(el => ...)`]@java[`runForeach(el -> ...)`]
 (being an alias to @scala[`runWith(Sink.foreach(el => ...))`]@java[`runWith(Sink.foreach(el -> ...))`]).
 
-Materialization is currently performed synchronously on the materializing thread by an `ActorSystem` global `Materializer`.
+Materialization is performed synchronously on the materializing thread by an `ActorSystem` global `Materializer`.
 The actual stream processing is handled by actors started up during the streams materialization,
 which will be running on the thread pools they have been configured to run on - which defaults to the dispatcher set in
 `MaterializationSettings` while constructing the `ActorMaterializer`.

--- a/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
+++ b/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
@@ -266,7 +266,7 @@ and `runWith()` methods defined on `Source` and `Flow` elements as well as a sma
 well-known sinks, such as @scala[`runForeach(el => ...)`]@java[`runForeach(el -> ...)`]
 (being an alias to @scala[`runWith(Sink.foreach(el => ...))`]@java[`runWith(Sink.foreach(el -> ...))`]).
 
-Materialization is currently performed synchronously on the materializing thread.
+Materialization is currently performed synchronously on the materializing thread by an `ActorSystem` global `Materializer`.
 The actual stream processing is handled by actors started up during the streams materialization,
 which will be running on the thread pools they have been configured to run on - which defaults to the dispatcher set in
 `MaterializationSettings` while constructing the `ActorMaterializer`.
@@ -376,20 +376,25 @@ merge is performed.
 
 ## Actor Materializer Lifecycle
 
+The `Materializer` is a component that is responsible for turning the stream blueprint into a running stream
+and emitting the "materialized value". An `ActorSystem` wide `Materializer` is provided by the Akka `Extension` 
+`SystemMaterializer` by @scala[having an implicit `ActorSystem` in scope]@java[passing the `ActorSystem` to the 
+various `run` methods] this way there is no need to worry about the `Materializer` unless there are special requirements.
+
+The use cases that may require a custom instance of `Materializer` are:
+
+ * When wanting to change some specific default settings for a set of streams (FIXME we should phase this out)
+ * When all streams materialized in an actor should be tied to the Actor lifecycle and stop if the Actor stops or crashes 
+
+Currently the `Materializer` has one concrete implementation, the `ActorMaterializer`. 
+
 An important aspect of working with streams and actors is understanding an `ActorMaterializer`'s life-cycle.
 The materializer is bound to the lifecycle of the `ActorRefFactory` it is created from, which in practice will
-be either an `ActorSystem` or `ActorContext` (when the materializer is created within an `Actor`).
+be either an `ActorSystem` or `ActorContext` (when the materializer is created within an `Actor`). 
 
-The usual way of creating an `ActorMaterializer` is to create it next to your `ActorSystem`,
-which likely is in a "main" class of your application:
+Tying it to the `ActorSystem` should be replaced with using the system materializer from Akka 2.6 and on.
 
-Scala
-:   @@snip [FlowDocSpec.scala](/akka-docs/src/test/scala/docs/stream/FlowDocSpec.scala) { #materializer-from-system }
-
-Java
-:   @@snip [FlowDocTest.java](/akka-docs/src/test/java/jdocs/stream/FlowDocTest.java) { #materializer-from-system }
-
-In this case the streams run by the materializer will run until it is shut down. When the materializer is shut down
+When run by the system materializer the streams will run until the `ActorSystem` is shut down. When the materializer is shut down
 *before* the streams have run to completion, they will be terminated abruptly. This is a little different than the
 usual way to terminate streams, which is by cancelling/completing them. The stream lifecycles are bound to the materializer
 like this to prevent leaks, and in normal operations you should not rely on the mechanism and rather use `KillSwitch` or

--- a/akka-docs/src/main/paradox/stream/stream-quickstart.md
+++ b/akka-docs/src/main/paradox/stream/stream-quickstart.md
@@ -113,7 +113,7 @@ whether the stream terminated normally or exceptionally.
 
 ### Browser-embedded example
 
-FIXME: fiddle won't work until Akka 2.6 is released and fiddle updated with that
+FIXME: fiddle won't work until Akka 2.6 is released and fiddle updated with that [#27510](https://github.com/akka/akka/issues/27510)
  
 <a name="here-is-another-example-that-you-can-edit-and-run-in-the-browser-"></a>
 Here is another example that you can edit and run in the browser:

--- a/akka-docs/src/main/paradox/stream/stream-quickstart.md
+++ b/akka-docs/src/main/paradox/stream/stream-quickstart.md
@@ -35,7 +35,8 @@ Scala
 Java
 :   @@snip [QuickStartDocTest.java](/akka-docs/src/test/java/jdocs/stream/QuickStartDocTest.java) { #other-imports }
 
-And @scala[an object]@java[a class] to hold your code, for example:
+And @scala[an object]@java[a class] to start an Akka `ActorSystem` and hold your code @scala[. Making the `ActorSystem`
+implicit makes it available to the streams without manually passing it when running them]:
 
 Scala
 :   @@snip [QuickStartDocSpec.scala](/akka-docs/src/test/scala/docs/stream/QuickStartDocSpec.scala) { #main-app }
@@ -52,11 +53,12 @@ Java
 :   @@snip [QuickStartDocTest.java](/akka-docs/src/test/java/jdocs/stream/QuickStartDocTest.java) { #create-source }
 
 The `Source` type is parameterized with two types: the first one is the
-type of element that this source emits and the second one may signal that
-running the source produces some auxiliary value (e.g. a network source may
+type of element that this source emits and the second one, the "materialized value", allows
+running the source to produce some auxiliary value (e.g. a network source may
 provide information about the bound port or the peer’s address). Where no
-auxiliary information is produced, the type `akka.NotUsed` is used—and a
-simple range of integers surely falls into this category.
+auxiliary information is produced, the type `akka.NotUsed` is used. A
+simple range of integers falls into this category - running our stream produces
+a `NotUsed`.
 
 Having created this source means that we have a description of how to emit the
 first 100 natural numbers, but this source is not yet active. In order to get
@@ -83,24 +85,6 @@ Scala
 
 Java
 :   @@snip [QuickStartDocTest.java](/akka-docs/src/test/java/jdocs/stream/QuickStartDocTest.java) { #run-source-and-terminate }
-
-You may wonder where the Actor gets created that runs the stream, and you are
-probably also asking yourself what this `materializer` means. In order to get
-this value we first need to create an Actor system:
-
-Scala
-:   @@snip [QuickStartDocSpec.scala](/akka-docs/src/test/scala/docs/stream/QuickStartDocSpec.scala) { #create-materializer }
-
-Java
-:   @@snip [QuickStartDocTest.java](/akka-docs/src/test/java/jdocs/stream/QuickStartDocTest.java) { #create-materializer }
-
-There are other ways to create a materializer, e.g. from an
-`ActorContext` when using streams from within Actors. The
-`Materializer` is a factory for stream execution engines, it is the
-thing that makes streams run—you don’t need to worry about any of the details
-right now apart from that you need one for calling any of the `run` methods on
-a `Source`. @scala[The materializer is picked up implicitly if it is omitted
-from the `run` method call arguments, which we will do in the following.]
 
 The nice thing about Akka Streams is that the `Source` is a
 description of what you want to run, and like an architect’s blueprint it can
@@ -129,6 +113,8 @@ whether the stream terminated normally or exceptionally.
 
 ### Browser-embedded example
 
+FIXME: fiddle won't work until Akka 2.6 is released and fiddle updated with that
+ 
 <a name="here-is-another-example-that-you-can-edit-and-run-in-the-browser-"></a>
 Here is another example that you can edit and run in the browser:
 
@@ -243,14 +229,13 @@ sections of the docs, and then come back to this quickstart to see it all pieced
 The example application we will be looking at is a simple Twitter feed stream from which we'll want to extract certain information,
 like for example finding all twitter handles of users who tweet about `#akka`.
 
-In order to prepare our environment by creating an `ActorSystem` and `ActorMaterializer`,
-which will be responsible for materializing and running the streams we are about to create:
+In order to prepare our environment by creating an `ActorSystem` which will be responsible for running the streams we are about to create:
 
 Scala
-:   @@snip [TwitterStreamQuickstartDocSpec.scala](/akka-docs/src/test/scala/docs/stream/TwitterStreamQuickstartDocSpec.scala) { #materializer-setup }
+:   @@snip [TwitterStreamQuickstartDocSpec.scala](/akka-docs/src/test/scala/docs/stream/TwitterStreamQuickstartDocSpec.scala) { #system-setup }
 
 Java
-:   @@snip [TwitterStreamQuickstartDocTest.java](/akka-docs/src/test/java/jdocs/stream/TwitterStreamQuickstartDocTest.java) { #materializer-setup }
+:   @@snip [TwitterStreamQuickstartDocTest.java](/akka-docs/src/test/java/jdocs/stream/TwitterStreamQuickstartDocTest.java) { #system-setup }
 
 The `ActorMaterializer` can optionally take `ActorMaterializerSettings` which can be used to define
 materialization properties, such as default buffer sizes (see also @ref:[Buffers for asynchronous operators](stream-rate.md#async-stream-buffers)), the dispatcher to

--- a/akka-docs/src/test/java/jdocs/persistence/query/LeveldbPersistenceQueryDocTest.java
+++ b/akka-docs/src/test/java/jdocs/persistence/query/LeveldbPersistenceQueryDocTest.java
@@ -15,7 +15,6 @@ import akka.persistence.query.EventEnvelope;
 import akka.persistence.query.Sequence;
 import akka.persistence.query.PersistenceQuery;
 import akka.persistence.query.journal.leveldb.javadsl.LeveldbReadJournal;
-import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Source;
 
 public class LeveldbPersistenceQueryDocTest {
@@ -24,8 +23,6 @@ public class LeveldbPersistenceQueryDocTest {
 
   public void demonstrateReadJournal() {
     // #get-read-journal
-    final ActorMaterializer mat = ActorMaterializer.create(system);
-
     LeveldbReadJournal queries =
         PersistenceQuery.get(system)
             .getReadJournalFor(LeveldbReadJournal.class, LeveldbReadJournal.Identifier());

--- a/akka-docs/src/test/java/jdocs/stream/BidiFlowDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/BidiFlowDocTest.java
@@ -32,19 +32,16 @@ import static org.junit.Assert.assertArrayEquals;
 public class BidiFlowDocTest extends AbstractJavaTest {
 
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("FlowDocTest");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   // #codec
@@ -261,7 +258,7 @@ public class BidiFlowDocTest extends AbstractJavaTest {
             .<Message>map(id -> new Ping(id))
             .via(flow)
             .grouped(10)
-            .runWith(Sink.<List<Message>>head(), mat);
+            .runWith(Sink.<List<Message>>head(), system);
     assertArrayEquals(
         new Message[] {new Pong(0), new Pong(1), new Pong(2)},
         result.toCompletableFuture().get(1, TimeUnit.SECONDS).toArray(new Message[0]));

--- a/akka-docs/src/test/java/jdocs/stream/CompositionDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/CompositionDocTest.java
@@ -27,19 +27,16 @@ import akka.util.ByteString;
 public class CompositionDocTest extends AbstractJavaTest {
 
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("CompositionDocTest");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   @Test

--- a/akka-docs/src/test/java/jdocs/stream/FlowDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/FlowDocTest.java
@@ -33,19 +33,16 @@ import static org.junit.Assert.assertEquals;
 public class FlowDocTest extends AbstractJavaTest {
 
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("FlowDocTest");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   @Test
@@ -54,16 +51,16 @@ public class FlowDocTest extends AbstractJavaTest {
     final Source<Integer, NotUsed> source =
         Source.from(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
     source.map(x -> 0); // has no effect on source, since it's immutable
-    source.runWith(Sink.fold(0, (agg, next) -> agg + next), mat); // 55
+    source.runWith(Sink.fold(0, (agg, next) -> agg + next), system); // 55
 
     // returns new Source<Integer>, with `map()` appended
     final Source<Integer, NotUsed> zeroes = source.map(x -> 0);
     final Sink<Integer, CompletionStage<Integer>> fold =
         Sink.<Integer, Integer>fold(0, (agg, next) -> agg + next);
-    zeroes.runWith(fold, mat); // 0
+    zeroes.runWith(fold, system); // 0
     // #source-immutable
 
-    int result = zeroes.runWith(fold, mat).toCompletableFuture().get(3, TimeUnit.SECONDS);
+    int result = zeroes.runWith(fold, system).toCompletableFuture().get(3, TimeUnit.SECONDS);
     assertEquals(0, result);
   }
 
@@ -80,7 +77,7 @@ public class FlowDocTest extends AbstractJavaTest {
     final RunnableGraph<CompletionStage<Integer>> runnable = source.toMat(sink, Keep.right());
 
     // materialize the flow
-    final CompletionStage<Integer> sum = runnable.run(mat);
+    final CompletionStage<Integer> sum = runnable.run(system);
     // #materialization-in-steps
 
     int result = sum.toCompletableFuture().get(3, TimeUnit.SECONDS);
@@ -96,7 +93,7 @@ public class FlowDocTest extends AbstractJavaTest {
         Sink.<Integer, Integer>fold(0, (aggr, next) -> aggr + next);
 
     // materialize the flow, getting the Sinks materialized value
-    final CompletionStage<Integer> sum = source.runWith(sink, mat);
+    final CompletionStage<Integer> sum = source.runWith(sink, system);
     // #materialization-runWith
 
     int result = sum.toCompletableFuture().get(3, TimeUnit.SECONDS);
@@ -113,8 +110,8 @@ public class FlowDocTest extends AbstractJavaTest {
         Source.from(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)).toMat(sink, Keep.right());
 
     // get the materialized value of the FoldSink
-    final CompletionStage<Integer> sum1 = runnable.run(mat);
-    final CompletionStage<Integer> sum2 = runnable.run(mat);
+    final CompletionStage<Integer> sum1 = runnable.run(system);
+    final CompletionStage<Integer> sum2 = runnable.run(system);
 
     // sum1 and sum2 are different Futures!
     // #stream-reuse
@@ -135,7 +132,7 @@ public class FlowDocTest extends AbstractJavaTest {
     // akka.actor.Cancellable
     final Source<Object, Cancellable> timer = Source.tick(oneSecond, oneSecond, tick);
 
-    Sink.ignore().runWith(timer, mat);
+    Sink.ignore().runWith(timer, system);
 
     final Source<String, Cancellable> timerMap = timer.map(t -> "tick");
     // WRONG: returned type is not the timers Cancellable!
@@ -144,7 +141,7 @@ public class FlowDocTest extends AbstractJavaTest {
 
     // #compound-source-is-not-keyed-run
     // retain the materialized map, in order to retrieve the timer's Cancellable
-    final Cancellable timerCancellable = timer.to(Sink.ignore()).run(mat);
+    final Cancellable timerCancellable = timer.to(Sink.ignore()).run(system);
     timerCancellable.cancel();
     // #compound-source-is-not-keyed-run
   }
@@ -239,10 +236,10 @@ public class FlowDocTest extends AbstractJavaTest {
 
     // Using runWith will always give the materialized values of the stages added
     // by runWith() itself
-    CompletionStage<Integer> r4 = source.via(flow).runWith(sink, mat);
-    CompletableFuture<Optional<Integer>> r5 = flow.to(sink).runWith(source, mat);
+    CompletionStage<Integer> r4 = source.via(flow).runWith(sink, system);
+    CompletableFuture<Optional<Integer>> r5 = flow.to(sink).runWith(source, system);
     Pair<CompletableFuture<Optional<Integer>>, CompletionStage<Integer>> r6 =
-        flow.runWith(source, sink, mat);
+        flow.runWith(source, sink, system);
 
     // Using more complex combinations
     RunnableGraph<Pair<CompletableFuture<Optional<Integer>>, Cancellable>> r7 =
@@ -280,12 +277,12 @@ public class FlowDocTest extends AbstractJavaTest {
     Source<String, ActorRef> matValuePoweredSource = Source.actorRef(100, OverflowStrategy.fail());
 
     Pair<ActorRef, Source<String, NotUsed>> actorRefSourcePair =
-        matValuePoweredSource.preMaterialize(mat);
+        matValuePoweredSource.preMaterialize(system);
 
     actorRefSourcePair.first().tell("Hello!", ActorRef.noSender());
 
     // pass source around for materialization
-    actorRefSourcePair.second().runWith(Sink.foreach(System.out::println), mat);
+    actorRefSourcePair.second().runWith(Sink.foreach(System.out::println), system);
     // #source-prematerialization
   }
 

--- a/akka-docs/src/test/java/jdocs/stream/FlowDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/FlowDocTest.java
@@ -292,15 +292,6 @@ public class FlowDocTest extends AbstractJavaTest {
     // #flow-async
   }
 
-  static {
-    // #materializer-from-system
-    ActorSystem system = ActorSystem.create("ExampleSystem");
-
-    // created from `system`:
-    ActorMaterializer mat = ActorMaterializer.create(system);
-    // #materializer-from-system
-  }
-
   // #materializer-from-actor-context
   final class RunWithMyself extends AbstractActor {
 
@@ -333,10 +324,11 @@ public class FlowDocTest extends AbstractJavaTest {
 
   // #materializer-from-system-in-actor
   final class RunForever extends AbstractActor {
-    final ActorMaterializer mat;
 
-    RunForever(ActorMaterializer mat) {
-      this.mat = mat;
+    private final Materializer materializer;
+
+    public RunForever(Materializer materializer) {
+      this.materializer = materializer;
     }
 
     @Override
@@ -347,7 +339,7 @@ public class FlowDocTest extends AbstractJavaTest {
                   tryDone -> {
                     System.out.println("Terminated stream: " + tryDone);
                   }),
-              mat);
+              materializer);
     }
 
     @Override

--- a/akka-docs/src/test/java/jdocs/stream/FlowErrorDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/FlowErrorDocTest.java
@@ -20,8 +20,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
-import akka.stream.ActorMaterializerSettings;
 import akka.stream.Materializer;
 import akka.stream.Supervision;
 import akka.stream.javadsl.Flow;
@@ -48,14 +46,13 @@ public class FlowErrorDocTest extends AbstractJavaTest {
   @Test(expected = ExecutionException.class)
   public void demonstrateFailStream() throws Exception {
     // #stop
-    final Materializer mat = ActorMaterializer.create(system);
     final Source<Integer, NotUsed> source =
         Source.from(Arrays.asList(0, 1, 2, 3, 4, 5)).map(elem -> 100 / elem);
     final Sink<Integer, CompletionStage<Integer>> fold =
         Sink.<Integer, Integer>fold(0, (acc, elem) -> acc + elem);
-    final CompletionStage<Integer> result = source.runWith(fold, mat);
+    final CompletionStage<Integer> result = source.runWith(fold, system);
     // division by zero will fail the stream and the
-    // result here will be a Future completed with Failure(ArithmeticException)
+    // result here will be a CompletionStage failed with ArithmeticException
     // #stop
 
     result.toCompletableFuture().get(3, TimeUnit.SECONDS);
@@ -69,15 +66,14 @@ public class FlowErrorDocTest extends AbstractJavaTest {
           if (exc instanceof ArithmeticException) return Supervision.resume();
           else return Supervision.stop();
         };
-    final Materializer mat =
-        ActorMaterializer.create(
-            ActorMaterializerSettings.create(system).withSupervisionStrategy(decider), system);
     final Source<Integer, NotUsed> source =
-        Source.from(Arrays.asList(0, 1, 2, 3, 4, 5)).map(elem -> 100 / elem);
+        Source.from(Arrays.asList(0, 1, 2, 3, 4, 5))
+            .map(elem -> 100 / elem)
+            .withAttributes(ActorAttributes.withSupervisionStrategy(decider));
     final Sink<Integer, CompletionStage<Integer>> fold = Sink.fold(0, (acc, elem) -> acc + elem);
-    final CompletionStage<Integer> result = source.runWith(fold, mat);
+    final CompletionStage<Integer> result = source.runWith(fold, system);
     // the element causing division by zero will be dropped
-    // result here will be a Future completed with Success(228)
+    // result here will be a CompletionStage completed with 228
     // #resume
 
     assertEquals(Integer.valueOf(228), result.toCompletableFuture().get(3, TimeUnit.SECONDS));
@@ -86,7 +82,6 @@ public class FlowErrorDocTest extends AbstractJavaTest {
   @Test
   public void demonstrateResumeSectionStream() throws Exception {
     // #resume-section
-    final Materializer mat = ActorMaterializer.create(system);
     final Function<Throwable, Supervision.Directive> decider =
         exc -> {
           if (exc instanceof ArithmeticException) return Supervision.resume();
@@ -100,9 +95,9 @@ public class FlowErrorDocTest extends AbstractJavaTest {
     final Source<Integer, NotUsed> source = Source.from(Arrays.asList(0, 1, 2, 3, 4, 5)).via(flow);
     final Sink<Integer, CompletionStage<Integer>> fold =
         Sink.<Integer, Integer>fold(0, (acc, elem) -> acc + elem);
-    final CompletionStage<Integer> result = source.runWith(fold, mat);
+    final CompletionStage<Integer> result = source.runWith(fold, system);
     // the elements causing division by zero will be dropped
-    // result here will be a Future completed with Success(150)
+    // result here will be a Future completed with 150
     // #resume-section
 
     assertEquals(Integer.valueOf(150), result.toCompletableFuture().get(3, TimeUnit.SECONDS));
@@ -111,7 +106,6 @@ public class FlowErrorDocTest extends AbstractJavaTest {
   @Test
   public void demonstrateRestartSectionStream() throws Exception {
     // #restart-section
-    final Materializer mat = ActorMaterializer.create(system);
     final Function<Throwable, Supervision.Directive> decider =
         exc -> {
           if (exc instanceof IllegalArgumentException) return Supervision.restart();
@@ -128,10 +122,10 @@ public class FlowErrorDocTest extends AbstractJavaTest {
             .withAttributes(ActorAttributes.withSupervisionStrategy(decider));
     final Source<Integer, NotUsed> source = Source.from(Arrays.asList(1, 3, -1, 5, 7)).via(flow);
     final CompletionStage<List<Integer>> result =
-        source.grouped(1000).runWith(Sink.<List<Integer>>head(), mat);
+        source.grouped(1000).runWith(Sink.<List<Integer>>head(), system);
     // the negative element cause the scan stage to be restarted,
     // i.e. start from 0 again
-    // result here will be a Future completed with Success(List(0, 1, 4, 0, 5, 12))
+    // result here will be a Future completed with List(0, 1, 4, 0, 5, 12)
     // #restart-section
 
     assertEquals(
@@ -141,7 +135,6 @@ public class FlowErrorDocTest extends AbstractJavaTest {
   @Test
   public void demonstrateRecover() {
     // #recover
-    final Materializer mat = ActorMaterializer.create(system);
     Source.from(Arrays.asList(0, 1, 2, 3, 4, 5, 6))
         .map(
             n -> {
@@ -149,7 +142,7 @@ public class FlowErrorDocTest extends AbstractJavaTest {
               else throw new RuntimeException("Boom!");
             })
         .recover(new PFBuilder().match(RuntimeException.class, ex -> "stream truncated").build())
-        .runForeach(System.out::println, mat);
+        .runForeach(System.out::println, system);
     // #recover
 
     /*
@@ -168,7 +161,6 @@ public class FlowErrorDocTest extends AbstractJavaTest {
   @Test
   public void demonstrateRecoverWithRetries() {
     // #recoverWithRetries
-    final Materializer mat = ActorMaterializer.create(system);
     Source<String, NotUsed> planB = Source.from(Arrays.asList("five", "six", "seven", "eight"));
 
     Source.from(Arrays.asList(0, 1, 2, 3, 4, 5, 6))
@@ -180,7 +172,7 @@ public class FlowErrorDocTest extends AbstractJavaTest {
         .recoverWithRetries(
             1, // max attempts
             new PFBuilder().match(RuntimeException.class, ex -> planB).build())
-        .runForeach(System.out::println, mat);
+        .runForeach(System.out::println, system);
     // #recoverWithRetries
 
     /*

--- a/akka-docs/src/test/java/jdocs/stream/FlowParallelismDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/FlowParallelismDocTest.java
@@ -19,19 +19,16 @@ import akka.stream.javadsl.*;
 public class FlowParallelismDocTest extends AbstractJavaTest {
 
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("FlowParallellismDocTest");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   static class ScoopOfBatter {}

--- a/akka-docs/src/test/java/jdocs/stream/GraphCyclesDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/GraphCyclesDocTest.java
@@ -21,19 +21,16 @@ import akka.stream.scaladsl.MergePreferred.MergePreferredShape;
 public class GraphCyclesDocTest extends AbstractJavaTest {
 
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("GraphCyclesDocTest");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   static final SilenceSystemOut.System System = SilenceSystemOut.get();

--- a/akka-docs/src/test/java/jdocs/stream/HubDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/HubDocTest.java
@@ -26,19 +26,16 @@ import java.util.function.ToLongBiFunction;
 public class HubDocTest extends AbstractJavaTest {
 
   static ActorSystem system;
-  static Materializer materializer;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("GraphDSLDocTest");
-    materializer = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    materializer = null;
   }
 
   @Test
@@ -55,10 +52,10 @@ public class HubDocTest extends AbstractJavaTest {
     // now have access to feed elements into it. This Sink can be materialized
     // any number of times, and every element that enters the Sink will
     // be consumed by our consumer.
-    Sink<String, NotUsed> toConsumer = runnableGraph.run(materializer);
+    Sink<String, NotUsed> toConsumer = runnableGraph.run(system);
 
-    Source.single("Hello!").runWith(toConsumer, materializer);
-    Source.single("Hub!").runWith(toConsumer, materializer);
+    Source.single("Hello!").runWith(toConsumer, system);
+    Source.single("Hub!").runWith(toConsumer, system);
     // #merge-hub
   }
 
@@ -99,7 +96,7 @@ public class HubDocTest extends AbstractJavaTest {
     Pair<Sink<String, NotUsed>, Source<String, NotUsed>> sinkAndSource =
         MergeHub.of(String.class, 16)
             .toMat(BroadcastHub.of(String.class, 256), Keep.both())
-            .run(materializer);
+            .run(system);
 
     Sink<String, NotUsed> sink = sinkAndSource.first();
     Source<String, NotUsed> source = sinkAndSource.second();
@@ -109,7 +106,7 @@ public class HubDocTest extends AbstractJavaTest {
     // Ensure that the Broadcast output is dropped if there are no listening parties.
     // If this dropping Sink is not attached, then the broadcast hub will not drop any
     // elements itself when there are no subscribers, backpressuring the producer instead.
-    source.runWith(Sink.ignore(), materializer);
+    source.runWith(Sink.ignore(), system);
     // #pub-sub-2
 
     // #pub-sub-3
@@ -127,7 +124,7 @@ public class HubDocTest extends AbstractJavaTest {
         Source.repeat("Hello World!")
             .viaMat(busFlow, Keep.right())
             .to(Sink.foreach(System.out::println))
-            .run(materializer);
+            .run(system);
 
     // Shut down externally
     killSwitch.shutdown();

--- a/akka-docs/src/test/java/jdocs/stream/Main.java
+++ b/akka-docs/src/test/java/jdocs/stream/Main.java
@@ -4,9 +4,12 @@
 
 package jdocs.stream;
 
+import akka.actor.ActorSystem;
+
 // #main-app
 public class Main {
   public static void main(String[] argv) {
+    final ActorSystem system = ActorSystem.create("QuickStart");
     // Code here
   }
 }

--- a/akka-docs/src/test/java/jdocs/stream/QuickStartDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/QuickStartDocTest.java
@@ -34,10 +34,7 @@ public class QuickStartDocTest extends AbstractJavaTest {
 
   @Test
   public void demonstrateSource() throws InterruptedException, ExecutionException {
-    // #create-materializer
     final ActorSystem system = ActorSystem.create("QuickStart");
-    // FIXME materializer not needed
-    // #create-materializer
 
     // #create-source
     final Source<Integer, NotUsed> source = Source.range(1, 100);

--- a/akka-docs/src/test/java/jdocs/stream/QuickStartDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/QuickStartDocTest.java
@@ -36,7 +36,7 @@ public class QuickStartDocTest extends AbstractJavaTest {
   public void demonstrateSource() throws InterruptedException, ExecutionException {
     // #create-materializer
     final ActorSystem system = ActorSystem.create("QuickStart");
-    final Materializer materializer = ActorMaterializer.create(system);
+    // FIXME materializer not needed
     // #create-materializer
 
     // #create-source
@@ -44,7 +44,7 @@ public class QuickStartDocTest extends AbstractJavaTest {
     // #create-source
 
     // #run-source
-    source.runForeach(i -> System.out.println(i), materializer);
+    source.runForeach(i -> System.out.println(i), system);
     // #run-source
 
     // #transform-source
@@ -54,11 +54,11 @@ public class QuickStartDocTest extends AbstractJavaTest {
     final CompletionStage<IOResult> result =
         factorials
             .map(num -> ByteString.fromString(num.toString() + "\n"))
-            .runWith(FileIO.toPath(Paths.get("factorials.txt")), materializer);
+            .runWith(FileIO.toPath(Paths.get("factorials.txt")), system);
     // #transform-source
 
     // #use-transformed-sink
-    factorials.map(BigInteger::toString).runWith(lineSink("factorial2.txt"), materializer);
+    factorials.map(BigInteger::toString).runWith(lineSink("factorial2.txt"), system);
     // #use-transformed-sink
 
     // #add-streams
@@ -68,11 +68,11 @@ public class QuickStartDocTest extends AbstractJavaTest {
         // #add-streams
         .take(2)
         // #add-streams
-        .runForeach(s -> System.out.println(s), materializer);
+        .runForeach(s -> System.out.println(s), system);
     // #add-streams
 
     // #run-source-and-terminate
-    final CompletionStage<Done> done = source.runForeach(i -> System.out.println(i), materializer);
+    final CompletionStage<Done> done = source.runForeach(i -> System.out.println(i), system);
 
     done.thenRun(() -> system.terminate());
     // #run-source-and-terminate

--- a/akka-docs/src/test/java/jdocs/stream/SinkRecipeDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/SinkRecipeDocTest.java
@@ -7,8 +7,6 @@ package jdocs.stream;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.japi.function.Function;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Source;
 import akka.stream.javadsl.Sink;
 import jdocs.AbstractJavaTest;
@@ -20,12 +18,10 @@ import java.util.concurrent.CompletionStage;
 
 public class SinkRecipeDocTest extends AbstractJavaTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("SinkRecipeDocTest");
-    mat = ActorMaterializer.create(system);
   }
 
   @Test
@@ -38,7 +34,7 @@ public class SinkRecipeDocTest extends AbstractJavaTest {
 
     final Source<Integer, NotUsed> numberSource = Source.range(1, 100);
 
-    numberSource.runWith(Sink.foreachAsync(10, asyncProcessing), mat);
+    numberSource.runWith(Sink.foreachAsync(10, asyncProcessing), system);
     // #forseachAsync-processing
   }
 }

--- a/akka-docs/src/test/java/jdocs/stream/StreamBuffersRateDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/StreamBuffersRateDocTest.java
@@ -23,19 +23,16 @@ public class StreamBuffersRateDocTest extends AbstractJavaTest {
   static class Job {}
 
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("StreamBuffersDocTest");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   final SilenceSystemOut.System System = SilenceSystemOut.get();
@@ -62,7 +59,7 @@ public class StreamBuffersRateDocTest extends AbstractJavaTest {
               return i;
             })
         .async()
-        .runWith(Sink.ignore(), mat);
+        .runWith(Sink.ignore(), system);
     // #pipelining
   }
 
@@ -109,7 +106,7 @@ public class StreamBuffersRateDocTest extends AbstractJavaTest {
                   b.from(zipper.out()).to(b.add(Sink.foreach(elem -> System.out.println(elem))));
                   return ClosedShape.getInstance();
                 }))
-        .run(mat);
+        .run(system);
     // #buffering-abstraction-leak
   }
 

--- a/akka-docs/src/test/java/jdocs/stream/StreamPartialGraphDSLDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/StreamPartialGraphDSLDocTest.java
@@ -28,19 +28,16 @@ import static org.junit.Assert.assertEquals;
 public class StreamPartialGraphDSLDocTest extends AbstractJavaTest {
 
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("StreamPartialGraphDSLDocTest");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   @Test
@@ -78,7 +75,7 @@ public class StreamPartialGraphDSLDocTest extends AbstractJavaTest {
                   return ClosedShape.getInstance();
                 }));
 
-    final CompletionStage<Integer> max = g.run(mat);
+    final CompletionStage<Integer> max = g.run(system);
     // #simple-partial-graph-dsl
     assertEquals(Integer.valueOf(3), max.toCompletableFuture().get(3, TimeUnit.SECONDS));
   }
@@ -119,7 +116,7 @@ public class StreamPartialGraphDSLDocTest extends AbstractJavaTest {
                 }));
 
     final CompletionStage<Pair<Integer, Integer>> firstPair =
-        pairs.runWith(Sink.<Pair<Integer, Integer>>head(), mat);
+        pairs.runWith(Sink.<Pair<Integer, Integer>>head(), system);
     // #source-from-partial-graph-dsl
     assertEquals(new Pair<>(0, 1), firstPair.toCompletableFuture().get(3, TimeUnit.SECONDS));
   }
@@ -146,7 +143,7 @@ public class StreamPartialGraphDSLDocTest extends AbstractJavaTest {
     // #flow-from-partial-graph-dsl
     final CompletionStage<Pair<Integer, String>> matSink =
         // #flow-from-partial-graph-dsl
-        Source.single(1).via(pairs).runWith(Sink.<Pair<Integer, String>>head(), mat);
+        Source.single(1).via(pairs).runWith(Sink.<Pair<Integer, String>>head(), system);
     // #flow-from-partial-graph-dsl
 
     assertEquals(new Pair<>(1, "1"), matSink.toCompletableFuture().get(3, TimeUnit.SECONDS));
@@ -163,7 +160,7 @@ public class StreamPartialGraphDSLDocTest extends AbstractJavaTest {
     // #source-combine
     final CompletionStage<Integer> result =
         // #source-combine
-        sources.runWith(Sink.<Integer, Integer>fold(0, (a, b) -> a + b), mat);
+        sources.runWith(Sink.<Integer, Integer>fold(0, (a, b) -> a + b), system);
     // #source-combine
 
     assertEquals(Integer.valueOf(3), result.toCompletableFuture().get(3, TimeUnit.SECONDS));
@@ -184,7 +181,7 @@ public class StreamPartialGraphDSLDocTest extends AbstractJavaTest {
     Sink<Integer, NotUsed> sinks =
         Sink.combine(sendRemotely, localProcessing, new ArrayList<>(), a -> Broadcast.create(a));
 
-    Source.<Integer>from(Arrays.asList(new Integer[] {0, 1, 2})).runWith(sinks, mat);
+    Source.<Integer>from(Arrays.asList(new Integer[] {0, 1, 2})).runWith(sinks, system);
     // #sink-combine
     probe.expectMsgEquals(0);
     probe.expectMsgEquals(1);

--- a/akka-docs/src/test/java/jdocs/stream/SubstreamDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/SubstreamDocTest.java
@@ -22,19 +22,16 @@ import java.util.List;
 public class SubstreamDocTest extends AbstractJavaTest {
 
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("FlowDocTest");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   @Test
@@ -47,26 +44,26 @@ public class SubstreamDocTest extends AbstractJavaTest {
     Source.from(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
         .groupBy(3, elem -> elem % 3)
         .to(Sink.ignore())
-        .run(mat);
+        .run(system);
     // #groupBy2
 
     // #groupBy3
     Source.from(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
         .groupBy(3, elem -> elem % 3)
         .mergeSubstreams()
-        .runWith(Sink.ignore(), mat);
+        .runWith(Sink.ignore(), system);
     // #groupBy3
 
     // #groupBy4
     Source.from(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
         .groupBy(3, elem -> elem % 3)
         .mergeSubstreamsWithParallelism(2)
-        .runWith(Sink.ignore(), mat);
+        .runWith(Sink.ignore(), system);
     // concatSubstreams is equivalent to mergeSubstreamsWithParallelism(1)
     Source.from(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
         .groupBy(3, elem -> elem % 3)
         .concatSubstreams()
-        .runWith(Sink.ignore(), mat);
+        .runWith(Sink.ignore(), system);
     // #groupBy4
   }
 
@@ -89,7 +86,7 @@ public class SubstreamDocTest extends AbstractJavaTest {
         .map(x -> 1)
         .reduce((x, y) -> x + y)
         .to(Sink.foreach(x -> System.out.println(x)))
-        .run(mat);
+        .run(system);
     // #wordCount
     Thread.sleep(1000);
   }
@@ -99,13 +96,13 @@ public class SubstreamDocTest extends AbstractJavaTest {
     // #flatMapConcat
     Source.from(Arrays.asList(1, 2))
         .flatMapConcat(i -> Source.from(Arrays.asList(i, i, i)))
-        .runWith(Sink.ignore(), mat);
+        .runWith(Sink.ignore(), system);
     // #flatMapConcat
 
     // #flatMapMerge
     Source.from(Arrays.asList(1, 2))
         .flatMapMerge(2, i -> Source.from(Arrays.asList(i, i, i)))
-        .runWith(Sink.ignore(), mat);
+        .runWith(Sink.ignore(), system);
     // #flatMapMerge
   }
 }

--- a/akka-docs/src/test/java/jdocs/stream/TwitterStreamQuickstartDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/TwitterStreamQuickstartDocTest.java
@@ -41,19 +41,15 @@ public class TwitterStreamQuickstartDocTest extends AbstractJavaTest {
 
   static ActorSystem system;
 
-  static Materializer mat;
-
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("TwitterStreamQuickstartDocTest");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   abstract static class Model {
@@ -203,7 +199,7 @@ public class TwitterStreamQuickstartDocTest extends AbstractJavaTest {
     // #first-sample
     // #materializer-setup
     final ActorSystem system = ActorSystem.create("reactive-tweets");
-    final Materializer mat = ActorMaterializer.create(system);
+    // FIXME no materializer needed
     // #first-sample
     // #materializer-setup
   }
@@ -263,12 +259,12 @@ public class TwitterStreamQuickstartDocTest extends AbstractJavaTest {
     // #first-sample
 
     // #authors-foreachsink-println
-    authors.runWith(Sink.foreach(a -> System.out.println(a)), mat);
+    authors.runWith(Sink.foreach(a -> System.out.println(a)), system);
     // #first-sample
     // #authors-foreachsink-println
 
     // #authors-foreach-println
-    authors.runForeach(a -> System.out.println(a), mat);
+    authors.runForeach(a -> System.out.println(a), system);
     // #authors-foreach-println
   }
 
@@ -310,7 +306,7 @@ public class TwitterStreamQuickstartDocTest extends AbstractJavaTest {
                   b.from(bcast).via(toTags).to(hashtags);
                   return ClosedShape.getInstance();
                 }))
-        .run(mat);
+        .run(system);
     // #graph-dsl-broadcast
   }
 
@@ -329,7 +325,7 @@ public class TwitterStreamQuickstartDocTest extends AbstractJavaTest {
     tweets
         .buffer(10, OverflowStrategy.dropHead())
         .map(t -> slowComputation(t))
-        .runWith(Sink.ignore(), mat);
+        .runWith(Sink.ignore(), system);
     // #tweets-slow-consumption-dropHead
   }
 
@@ -342,7 +338,7 @@ public class TwitterStreamQuickstartDocTest extends AbstractJavaTest {
     final RunnableGraph<CompletionStage<Integer>> counter =
         tweets.map(t -> 1).toMat(sumSink, Keep.right());
 
-    final CompletionStage<Integer> sum = counter.run(mat);
+    final CompletionStage<Integer> sum = counter.run(system);
 
     sum.thenAcceptAsync(
         c -> System.out.println("Total tweets processed: " + c), system.dispatcher());
@@ -350,7 +346,7 @@ public class TwitterStreamQuickstartDocTest extends AbstractJavaTest {
 
     new Object() {
       // #tweets-fold-count-oneline
-      final CompletionStage<Integer> sum = tweets.map(t -> 1).runWith(sumSink, mat);
+      final CompletionStage<Integer> sum = tweets.map(t -> 1).runWith(sumSink, system);
       // #tweets-fold-count-oneline
     };
   }
@@ -370,9 +366,9 @@ public class TwitterStreamQuickstartDocTest extends AbstractJavaTest {
             .toMat(sumSink, Keep.right());
 
     // materialize the stream once in the morning
-    final CompletionStage<Integer> morningTweetsCount = counterRunnableGraph.run(mat);
+    final CompletionStage<Integer> morningTweetsCount = counterRunnableGraph.run(system);
     // and once in the evening, reusing the blueprint
-    final CompletionStage<Integer> eveningTweetsCount = counterRunnableGraph.run(mat);
+    final CompletionStage<Integer> eveningTweetsCount = counterRunnableGraph.run(system);
     // #tweets-runnable-flow-materialized-twice
 
   }

--- a/akka-docs/src/test/java/jdocs/stream/TwitterStreamQuickstartDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/TwitterStreamQuickstartDocTest.java
@@ -197,11 +197,10 @@ public class TwitterStreamQuickstartDocTest extends AbstractJavaTest {
 
   abstract static class Example1 {
     // #first-sample
-    // #materializer-setup
+    // #system-setup
     final ActorSystem system = ActorSystem.create("reactive-tweets");
-    // FIXME no materializer needed
     // #first-sample
-    // #materializer-setup
+    // #system-setup
   }
 
   static class Example2 {

--- a/akka-docs/src/test/java/jdocs/stream/io/StreamFileDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/io/StreamFileDocTest.java
@@ -31,19 +31,15 @@ public class StreamFileDocTest extends AbstractJavaTest {
 
   static ActorSystem system;
 
-  static Materializer mat;
-
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("StreamFileDocTest");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   final SilenceSystemOut.System System = SilenceSystemOut.get();
@@ -70,7 +66,7 @@ public class StreamFileDocTest extends AbstractJavaTest {
       Sink<ByteString, CompletionStage<Done>> printlnSink =
           Sink.<ByteString>foreach(chunk -> System.out.println(chunk.utf8String()));
 
-      CompletionStage<IOResult> ioResult = FileIO.fromPath(file).to(printlnSink).run(mat);
+      CompletionStage<IOResult> ioResult = FileIO.fromPath(file).to(printlnSink).run(system);
       // #file-source
     } finally {
       Files.delete(file);
@@ -102,7 +98,7 @@ public class StreamFileDocTest extends AbstractJavaTest {
       Source<String, NotUsed> textSource = Source.single("Hello Akka Stream!");
 
       CompletionStage<IOResult> ioResult =
-          textSource.map(ByteString::fromString).runWith(fileSink, mat);
+          textSource.map(ByteString::fromString).runWith(fileSink, system);
       // #file-sink
     } finally {
       Files.delete(file);

--- a/akka-docs/src/test/java/jdocs/stream/io/StreamTcpDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/io/StreamTcpDocTest.java
@@ -20,10 +20,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import akka.actor.ActorSystem;
-import akka.stream.*;
 import akka.stream.javadsl.*;
 import akka.stream.javadsl.Tcp.*;
-import akka.stream.stage.*;
 import akka.testkit.SocketUtil;
 import akka.testkit.TestProbe;
 import akka.util.ByteString;
@@ -31,19 +29,16 @@ import akka.util.ByteString;
 public class StreamTcpDocTest extends AbstractJavaTest {
 
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("StreamTcpDocTest");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   final SilenceSystemOut.System System = SilenceSystemOut.get();
@@ -88,9 +83,9 @@ public class StreamTcpDocTest extends AbstractJavaTest {
                     .map(s -> s + "!!!\n")
                     .map(ByteString::fromString);
 
-            connection.handleWith(echo, mat);
+            connection.handleWith(echo, system);
           },
-          mat);
+          system);
       // #echo-server-simple-handle
     }
   }
@@ -141,9 +136,9 @@ public class StreamTcpDocTest extends AbstractJavaTest {
                               .map(s -> s + "\n")
                               .map(ByteString::fromString);
 
-                      connection.handleWith(serverLogic, mat);
+                      connection.handleWith(serverLogic, system);
                     }))
-            .run(mat);
+            .run(system);
     // #welcome-banner-chat-server
 
     // make sure server is bound before we do anything else
@@ -179,7 +174,7 @@ public class StreamTcpDocTest extends AbstractJavaTest {
               .map(elem -> readLine("> "))
               .via(replParser);
 
-      CompletionStage<OutgoingConnection> connectionCS = connection.join(repl).run(mat);
+      CompletionStage<OutgoingConnection> connectionCS = connection.join(repl).run(system);
       // #repl-client
 
       // make sure it got connected (or fails the test)

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeAdhocSourceTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeAdhocSourceTest.java
@@ -32,20 +32,17 @@ import static org.junit.Assert.assertEquals;
 
 public class RecipeAdhocSourceTest extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
   Duration duration200mills = Duration.ofMillis(200);
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeAdhocSource");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   // #adhoc-source
@@ -93,7 +90,7 @@ public class RecipeAdhocSourceTest extends RecipeTest {
         TestSubscriber.Probe<String> probe =
             adhocSource(Source.repeat("a"), duration200mills, 3)
                 .toMat(TestSink.probe(system), Keep.right())
-                .run(mat);
+                .run(system);
         probe.requestNext("a");
       }
     };
@@ -113,7 +110,7 @@ public class RecipeAdhocSourceTest extends RecipeTest {
                     duration200mills,
                     3)
                 .toMat(TestSink.probe(system), Keep.right())
-                .run(mat);
+                .run(system);
 
         probe.requestNext("a");
         Thread.sleep(300);
@@ -136,7 +133,7 @@ public class RecipeAdhocSourceTest extends RecipeTest {
                     duration200mills,
                     3)
                 .toMat(TestSink.probe(system), Keep.right())
-                .run(mat);
+                .run(system);
 
         probe.requestNext("a");
         Thread.sleep(100);
@@ -174,7 +171,7 @@ public class RecipeAdhocSourceTest extends RecipeTest {
                     duration200mills,
                     3)
                 .toMat(TestSink.probe(system), Keep.right())
-                .run(mat);
+                .run(system);
 
         probe.requestNext("a");
         assertEquals(1, startedCount.get());
@@ -204,7 +201,7 @@ public class RecipeAdhocSourceTest extends RecipeTest {
                     duration200mills,
                     3)
                 .toMat(TestSink.probe(system), Keep.right())
-                .run(mat);
+                .run(system);
 
         probe.requestNext("a");
         assertEquals(1, startedCount.get());

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeByteStrings.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeByteStrings.java
@@ -30,19 +30,16 @@ import static org.junit.Assert.assertTrue;
 
 public class RecipeByteStrings extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeByteStrings");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   final Source<ByteString, NotUsed> rawBytes =
@@ -142,7 +139,7 @@ public class RecipeByteStrings extends RecipeTest {
         // #bytestring-chunker2
 
         CompletionStage<List<ByteString>> chunksFuture =
-            chunksStream.limit(10).runWith(Sink.seq(), mat);
+            chunksStream.limit(10).runWith(Sink.seq(), system);
 
         List<ByteString> chunks = chunksFuture.toCompletableFuture().get(3, TimeUnit.SECONDS);
 
@@ -242,7 +239,7 @@ public class RecipeByteStrings extends RecipeTest {
             bytes1
                 .via(limiter)
                 .limit(10)
-                .runWith(Sink.seq(), mat)
+                .runWith(Sink.seq(), system)
                 .toCompletableFuture()
                 .get(3, TimeUnit.SECONDS);
         ByteString acc = emptyByteString();
@@ -256,7 +253,7 @@ public class RecipeByteStrings extends RecipeTest {
           bytes2
               .via(limiter)
               .limit(10)
-              .runWith(Sink.seq(), mat)
+              .runWith(Sink.seq(), system)
               .toCompletableFuture()
               .get(3, TimeUnit.SECONDS);
         } catch (ExecutionException ex) {
@@ -287,7 +284,7 @@ public class RecipeByteStrings extends RecipeTest {
         List<ByteString> got =
             compacted
                 .limit(10)
-                .runWith(Sink.seq(), mat)
+                .runWith(Sink.seq(), system)
                 .toCompletableFuture()
                 .get(3, TimeUnit.SECONDS);
 

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeDecompress.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeDecompress.java
@@ -6,8 +6,6 @@ package jdocs.stream.javadsl.cookbook;
 
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Compression;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
@@ -23,19 +21,16 @@ import java.util.concurrent.TimeUnit;
 public class RecipeDecompress extends RecipeTest {
 
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeDecompress");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   @Test
@@ -52,7 +47,7 @@ public class RecipeDecompress extends RecipeTest {
 
     ByteString decompressedData =
         decompressedStream
-            .runFold(emptyByteString(), ByteString::concat, mat)
+            .runFold(emptyByteString(), ByteString::concat, system)
             .toCompletableFuture()
             .get(1, TimeUnit.SECONDS);
     String decompressedString = decompressedData.utf8String();

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeDigest.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeDigest.java
@@ -24,19 +24,16 @@ import static org.junit.Assert.assertEquals;
 
 public class RecipeDigest extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeDigest");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   // #calculating-digest
@@ -111,7 +108,7 @@ public class RecipeDigest extends RecipeTest {
         // #calculating-digest2
 
         ByteString got =
-            digest.runWith(Sink.head(), mat).toCompletableFuture().get(3, TimeUnit.SECONDS);
+            digest.runWith(Sink.head(), system).toCompletableFuture().get(3, TimeUnit.SECONDS);
 
         assertEquals(
             ByteString.fromInts(

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeDroppyBroadcast.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeDroppyBroadcast.java
@@ -20,19 +20,16 @@ import java.util.concurrent.CompletionStage;
 
 public class RecipeDroppyBroadcast extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeDroppyBroadcast");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   @Test

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeFlattenList.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeFlattenList.java
@@ -6,8 +6,6 @@ package jdocs.stream.javadsl.cookbook;
 
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
@@ -23,19 +21,16 @@ import static org.junit.Assert.assertEquals;
 
 public class RecipeFlattenList extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeFlattenList");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   @Test
@@ -56,7 +51,7 @@ public class RecipeFlattenList extends RecipeTest {
         List<Message> got =
             flattened
                 .limit(10)
-                .runWith(Sink.seq(), mat)
+                .runWith(Sink.seq(), system)
                 .toCompletableFuture()
                 .get(1, TimeUnit.SECONDS);
         assertEquals(got.get(0), new Message("1"));

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeGlobalRateLimit.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeGlobalRateLimit.java
@@ -24,19 +24,16 @@ import static junit.framework.TestCase.assertTrue;
 
 public class RecipeGlobalRateLimit extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeGlobalRateLimit");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   public
@@ -229,7 +226,7 @@ public class RecipeGlobalRateLimit extends RecipeTest {
                           builder.from(merge).to(s);
                           return ClosedShape.getInstance();
                         }))
-                .run(mat);
+                .run(system);
 
         probe.expectSubscription().request(1000);
 

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeHold.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeHold.java
@@ -16,7 +16,6 @@ import akka.stream.testkit.TestSubscriber;
 import akka.stream.testkit.javadsl.TestSink;
 import akka.stream.testkit.javadsl.TestSource;
 import akka.testkit.javadsl.TestKit;
-import akka.util.ByteString;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -26,19 +25,16 @@ import java.util.concurrent.TimeUnit;
 
 public class RecipeHold extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeHold");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   // #hold-version-1
@@ -151,7 +147,7 @@ public class RecipeHold extends RecipeTest {
         final Sink<Integer, TestSubscriber.Probe<Integer>> sink = TestSink.probe(system);
 
         Pair<TestPublisher.Probe<Integer>, TestSubscriber.Probe<Integer>> pubSub =
-            source.via(new HoldWithInitial<>(0)).toMat(sink, Keep.both()).run(mat);
+            source.via(new HoldWithInitial<>(0)).toMat(sink, Keep.both()).run(system);
         TestPublisher.Probe<Integer> pub = pubSub.first();
         TestSubscriber.Probe<Integer> sub = pubSub.second();
 
@@ -179,7 +175,7 @@ public class RecipeHold extends RecipeTest {
         final Sink<Integer, TestSubscriber.Probe<Integer>> sink = TestSink.probe(system);
 
         Pair<TestPublisher.Probe<Integer>, TestSubscriber.Probe<Integer>> pubSub =
-            source.via(new HoldWithWait<>()).toMat(sink, Keep.both()).run(mat);
+            source.via(new HoldWithWait<>()).toMat(sink, Keep.both()).run(system);
         TestPublisher.Probe<Integer> pub = pubSub.first();
         TestSubscriber.Probe<Integer> sub = pubSub.second();
 

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeKeepAlive.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeKeepAlive.java
@@ -6,8 +6,6 @@ package jdocs.stream.javadsl.cookbook;
 
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Flow;
 import akka.testkit.javadsl.TestKit;
 import akka.util.ByteString;
@@ -19,19 +17,16 @@ import java.time.Duration;
 
 public class RecipeKeepAlive extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeKeepAlive");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   class Tick {}

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeLoggingElements.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeLoggingElements.java
@@ -8,9 +8,7 @@ import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
-import akka.stream.ActorMaterializer;
 import akka.stream.Attributes;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.DebugFilter;
@@ -26,7 +24,6 @@ import java.util.Arrays;
 
 public class RecipeLoggingElements extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
@@ -35,14 +32,12 @@ public class RecipeLoggingElements extends RecipeTest {
             "RecipeLoggingElements",
             ConfigFactory.parseString(
                 "akka.loglevel=DEBUG\nakka.loggers = [akka.testkit.TestEventListener]"));
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   @Test
@@ -95,7 +90,7 @@ public class RecipeLoggingElements extends RecipeTest {
             .intercept(
                 new AbstractFunction0<Object>() {
                   public Void apply() {
-                    mySource.log("custom", adapter).runWith(Sink.ignore(), mat);
+                    mySource.log("custom", adapter).runWith(Sink.ignore(), system);
                     return null;
                   }
                 },
@@ -112,7 +107,7 @@ public class RecipeLoggingElements extends RecipeTest {
         Source.from(Arrays.asList(-1, 0, 1))
             .map(x -> 1 / x) // throwing ArithmeticException: / by zero
             .log("error logging")
-            .runWith(Sink.ignore(), mat);
+            .runWith(Sink.ignore(), system);
         // #log-error
       }
     };

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeManualTrigger.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeManualTrigger.java
@@ -23,19 +23,16 @@ import java.util.concurrent.TimeUnit;
 
 public class RecipeManualTrigger extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeManualTrigger");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   class Trigger {}
@@ -75,7 +72,7 @@ public class RecipeManualTrigger extends RecipeTest {
                         }));
         // #manually-triggered-stream
 
-        Pair<TestPublisher.Probe<Trigger>, TestSubscriber.Probe<Message>> pubSub = g.run(mat);
+        Pair<TestPublisher.Probe<Trigger>, TestSubscriber.Probe<Message>> pubSub = g.run(system);
         TestPublisher.Probe<Trigger> pub = pubSub.first();
         TestSubscriber.Probe<Message> sub = pubSub.second();
 
@@ -130,7 +127,7 @@ public class RecipeManualTrigger extends RecipeTest {
                         }));
         // #manually-triggered-stream-zipwith
 
-        Pair<TestPublisher.Probe<Trigger>, TestSubscriber.Probe<Message>> pubSub = g.run(mat);
+        Pair<TestPublisher.Probe<Trigger>, TestSubscriber.Probe<Message>> pubSub = g.run(system);
         TestPublisher.Probe<Trigger> pub = pubSub.first();
         TestSubscriber.Probe<Message> sub = pubSub.second();
 

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeMissedTicks.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeMissedTicks.java
@@ -7,8 +7,6 @@ package jdocs.stream.javadsl.cookbook;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.japi.Pair;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
@@ -28,19 +26,16 @@ import java.util.concurrent.TimeUnit;
 
 public class RecipeMissedTicks extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeMissedTicks");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   @Test
@@ -70,7 +65,7 @@ public class RecipeMissedTicks extends RecipeTest {
                     });
 
         Pair<TestPublisher.Probe<Tick>, TestSubscriber.Probe<Integer>> pubSub =
-            tickStream.via(realMissedTicks).toMat(sink, Keep.both()).run(mat);
+            tickStream.via(realMissedTicks).toMat(sink, Keep.both()).run(system);
         TestPublisher.Probe<Tick> pub = pubSub.first();
         TestSubscriber.Probe<Integer> sub = pubSub.second();
 

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeMultiGroupByTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeMultiGroupByTest.java
@@ -8,8 +8,6 @@ import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.japi.Function;
 import akka.japi.Pair;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.javadsl.SubSource;
@@ -29,19 +27,16 @@ import static junit.framework.TestCase.assertTrue;
 
 public class RecipeMultiGroupByTest extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeMultiGroupBy");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   static class Topic {
@@ -142,7 +137,7 @@ public class RecipeMultiGroupByTest extends RecipeTest {
                               "]");
                     })
                 .grouped(10)
-                .runWith(Sink.head(), mat);
+                .runWith(Sink.head(), system);
 
         List<String> got = result.toCompletableFuture().get(3, TimeUnit.SECONDS);
         assertTrue(got.contains("1[1: a, 1: b, all: c, all: d, 1: e]"));

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeParseLines.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeParseLines.java
@@ -6,8 +6,6 @@ package jdocs.stream.javadsl.cookbook;
 
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Framing;
 import akka.stream.javadsl.FramingTruncation;
 import akka.stream.javadsl.Sink;
@@ -24,19 +22,16 @@ import java.util.concurrent.TimeUnit;
 public class RecipeParseLines extends RecipeTest {
 
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeParseLines");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   @Test
@@ -56,6 +51,6 @@ public class RecipeParseLines extends RecipeTest {
             .via(Framing.delimiter(ByteString.fromString("\r\n"), 100, FramingTruncation.ALLOW))
             .map(b -> b.utf8String());
     // #parse-lines
-    lines.limit(10).runWith(Sink.seq(), mat).toCompletableFuture().get(1, TimeUnit.SECONDS);
+    lines.limit(10).runWith(Sink.seq(), system).toCompletableFuture().get(1, TimeUnit.SECONDS);
   }
 }

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeReduceByKeyTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeReduceByKeyTest.java
@@ -9,8 +9,6 @@ import akka.actor.ActorSystem;
 import akka.japi.Pair;
 import akka.japi.function.Function;
 import akka.japi.function.Function2;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
@@ -30,19 +28,16 @@ import java.util.stream.Collectors;
 
 public class RecipeReduceByKeyTest extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeReduceByKey");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   @Test
@@ -68,7 +63,7 @@ public class RecipeReduceByKeyTest extends RecipeTest {
         // #word-count
 
         final CompletionStage<List<Pair<String, Integer>>> f =
-            counts.grouped(10).runWith(Sink.head(), mat);
+            counts.grouped(10).runWith(Sink.head(), system);
         final Set<Pair<String, Integer>> result =
             f.toCompletableFuture().get(3, TimeUnit.SECONDS).stream().collect(Collectors.toSet());
         final Set<Pair<String, Integer>> expected = new HashSet<>();
@@ -117,7 +112,7 @@ public class RecipeReduceByKeyTest extends RecipeTest {
 
         // #reduce-by-key-general2
         final CompletionStage<List<Pair<String, Integer>>> f =
-            counts.grouped(10).runWith(Sink.head(), mat);
+            counts.grouped(10).runWith(Sink.head(), system);
         final Set<Pair<String, Integer>> result =
             f.toCompletableFuture().get(3, TimeUnit.SECONDS).stream().collect(Collectors.toSet());
         final Set<Pair<String, Integer>> expected = new HashSet<>();

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeSeq.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeSeq.java
@@ -6,8 +6,6 @@ package jdocs.stream.javadsl.cookbook;
 
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
@@ -22,19 +20,16 @@ import java.util.concurrent.TimeUnit;
 
 public class RecipeSeq extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeLoggingElements");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   @Test
@@ -44,7 +39,7 @@ public class RecipeSeq extends RecipeTest {
         final Source<String, NotUsed> mySource = Source.from(Arrays.asList("1", "2", "3"));
         // #draining-to-list-unsafe
         // Dangerous: might produce a collection with 2 billion elements!
-        final CompletionStage<List<String>> strings = mySource.runWith(Sink.seq(), mat);
+        final CompletionStage<List<String>> strings = mySource.runWith(Sink.seq(), system);
         // #draining-to-list-unsafe
 
         strings.toCompletableFuture().get(3, TimeUnit.SECONDS);
@@ -63,7 +58,7 @@ public class RecipeSeq extends RecipeTest {
         // OK. Future will fail with a `StreamLimitReachedException`
         // if the number of incoming elements is larger than max
         final CompletionStage<List<String>> strings =
-            mySource.limit(MAX_ALLOWED_SIZE).runWith(Sink.seq(), mat);
+            mySource.limit(MAX_ALLOWED_SIZE).runWith(Sink.seq(), system);
         // #draining-to-list-safe
 
         strings.toCompletableFuture().get(1, TimeUnit.SECONDS);
@@ -81,7 +76,7 @@ public class RecipeSeq extends RecipeTest {
 
         // OK. Collect up until max-th elements only, then cancel upstream
         final CompletionStage<List<String>> strings =
-            mySource.take(MAX_ALLOWED_SIZE).runWith(Sink.seq(), mat);
+            mySource.take(MAX_ALLOWED_SIZE).runWith(Sink.seq(), system);
         // #draining-to-list-safe
 
         strings.toCompletableFuture().get(1, TimeUnit.SECONDS);

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeSimpleDrop.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeSimpleDrop.java
@@ -7,8 +7,6 @@ package jdocs.stream.javadsl.cookbook;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.japi.Pair;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Flow;
 import akka.stream.testkit.TestPublisher;
 import akka.stream.testkit.TestSubscriber;
@@ -26,19 +24,16 @@ import java.util.concurrent.TimeUnit;
 
 public class RecipeSimpleDrop extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeSimpleDrop");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   @Test
@@ -63,7 +58,7 @@ public class RecipeSimpleDrop extends RecipeTest {
             TestSource.<Message>probe(system)
                 .via(realDroppyStream)
                 .toMat(TestSink.probe(system), (pub, sub) -> new Pair<>(pub, sub))
-                .run(mat);
+                .run(system);
         final TestPublisher.Probe<Message> pub = pubSub.first();
         final TestSubscriber.Probe<Message> sub = pubSub.second();
 

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeSourceFromFunction.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeSourceFromFunction.java
@@ -6,8 +6,6 @@ package jdocs.stream.javadsl.cookbook;
 
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
@@ -23,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 
 public class RecipeSourceFromFunction extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
@@ -32,14 +29,12 @@ public class RecipeSourceFromFunction extends RecipeTest {
             "RecipeSourceFromFunction",
             ConfigFactory.parseString(
                 "akka.loglevel=DEBUG\nakka.loggers = [akka.testkit.TestEventListener]"));
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   @Test
@@ -56,7 +51,11 @@ public class RecipeSourceFromFunction extends RecipeTest {
         // #source-from-function
 
         final List<String> result =
-            source.take(2).runWith(Sink.seq(), mat).toCompletableFuture().get(3, TimeUnit.SECONDS);
+            source
+                .take(2)
+                .runWith(Sink.seq(), system)
+                .toCompletableFuture()
+                .get(3, TimeUnit.SECONDS);
 
         Assert.assertEquals(2, result.size());
       }

--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeWorkerPool.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeWorkerPool.java
@@ -23,19 +23,16 @@ import static org.junit.Assert.assertTrue;
 
 public class RecipeWorkerPool extends RecipeTest {
   static ActorSystem system;
-  static Materializer mat;
 
   @BeforeClass
   public static void setup() {
     system = ActorSystem.create("RecipeWorkerPool");
-    mat = ActorMaterializer.create(system);
   }
 
   @AfterClass
   public static void tearDown() {
     TestKit.shutdownActorSystem(system);
     system = null;
-    mat = null;
   }
 
   // #worker-pool
@@ -75,7 +72,7 @@ public class RecipeWorkerPool extends RecipeTest {
 
         FiniteDuration timeout = FiniteDuration.create(200, TimeUnit.MILLISECONDS);
         CompletionStage<List<String>> future =
-            processedJobs.map(m -> m.msg).limit(10).runWith(Sink.seq(), mat);
+            processedJobs.map(m -> m.msg).limit(10).runWith(Sink.seq(), system);
         List<String> got = future.toCompletableFuture().get(1, TimeUnit.SECONDS);
         assertTrue(got.contains("1 done"));
         assertTrue(got.contains("2 done"));

--- a/akka-docs/src/test/java/jdocs/stream/operators/SinkDocExamples.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/SinkDocExamples.java
@@ -7,8 +7,6 @@ package jdocs.stream.operators;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
 
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 // #takeLast-operator-example
@@ -22,13 +20,12 @@ import java.util.concurrent.TimeoutException;
 public class SinkDocExamples {
 
   private static final ActorSystem system = ActorSystem.create("SourceFromExample");
-  private static final Materializer materializer = ActorMaterializer.create(system);
 
   static void reduceExample() throws InterruptedException, ExecutionException, TimeoutException {
 
     // #reduce-operator-example
     Source<Integer, NotUsed> ints = Source.from(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
-    CompletionStage<Integer> sum = ints.runWith(Sink.reduce((a, b) -> a + b), materializer);
+    CompletionStage<Integer> sum = ints.runWith(Sink.reduce((a, b) -> a + b), system);
     sum.thenAccept(System.out::println);
     // 55
     // #reduce-operator-example
@@ -48,7 +45,7 @@ public class SinkDocExamples {
 
     Source<Pair, NotUsed> studentSource = Source.from(sortedStudents);
 
-    CompletionStage<List<Pair>> topThree = studentSource.runWith(Sink.takeLast(3), materializer);
+    CompletionStage<List<Pair>> topThree = studentSource.runWith(Sink.takeLast(3), system);
 
     topThree.thenAccept(
         result -> {
@@ -70,7 +67,7 @@ public class SinkDocExamples {
   static void lastExample() throws InterruptedException, ExecutionException, TimeoutException {
     // #last-operator-example
     Source<Integer, NotUsed> source = Source.from(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
-    CompletionStage<Integer> result = source.runWith(Sink.last(), materializer);
+    CompletionStage<Integer> result = source.runWith(Sink.last(), system);
     result.thenAccept(System.out::println);
     // 10
     // #last-operator-example
@@ -80,7 +77,7 @@ public class SinkDocExamples {
       throws InterruptedException, ExecutionException, TimeoutException {
     // #lastOption-operator-example
     Source<Integer, NotUsed> source = Source.empty();
-    CompletionStage<Optional<Integer>> result = source.runWith(Sink.lastOption(), materializer);
+    CompletionStage<Optional<Integer>> result = source.runWith(Sink.lastOption(), system);
     result.thenAccept(System.out::println);
     // Optional.empty
     // #lastOption-operator-example

--- a/akka-docs/src/test/java/jdocs/stream/operators/SourceDocExamples.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/SourceDocExamples.java
@@ -10,8 +10,6 @@ import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.actor.testkit.typed.javadsl.ManualTime;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Source;
 // #range-imports
 
@@ -35,23 +33,21 @@ public class SourceDocExamples {
   public static void fromExample() {
     // #source-from-example
     final ActorSystem system = ActorSystem.create("SourceFromExample");
-    final Materializer materializer = ActorMaterializer.create(system);
 
     Source<Integer, NotUsed> ints = Source.from(Arrays.asList(0, 1, 2, 3, 4, 5));
-    ints.runForeach(System.out::println, materializer);
+    ints.runForeach(System.out::println, system);
 
     String text =
         "Perfection is finally attained not when there is no longer more to add,"
             + "but when there is no longer anything to take away.";
     Source<String, NotUsed> words = Source.from(Arrays.asList(text.split("\\s")));
-    words.runForeach(System.out::println, materializer);
+    words.runForeach(System.out::println, system);
     // #source-from-example
   }
 
   static void rangeExample() {
 
     final ActorSystem system = ActorSystem.create("Source");
-    final Materializer materializer = ActorMaterializer.create(system);
 
     // #range
 
@@ -69,7 +65,7 @@ public class SourceDocExamples {
     // #range
 
     // #run-range
-    source.runForeach(i -> System.out.println(i), materializer);
+    source.runForeach(i -> System.out.println(i), system);
     // #run-range
   }
 
@@ -77,12 +73,11 @@ public class SourceDocExamples {
     // #actor-ref
 
     final ActorSystem system = ActorSystem.create();
-    final Materializer materializer = ActorMaterializer.create(system);
 
     int bufferSize = 100;
     Source<Object, ActorRef> source = Source.actorRef(bufferSize, OverflowStrategy.dropHead());
 
-    ActorRef actorRef = source.to(Sink.foreach(System.out::println)).run(materializer);
+    ActorRef actorRef = source.to(Sink.foreach(System.out::println)).run(system);
     actorRef.tell("hello", ActorRef.noSender());
     actorRef.tell("hello", ActorRef.noSender());
 
@@ -96,11 +91,10 @@ public class SourceDocExamples {
 
     // #actor-ref-with-ack
     final ActorSystem system = ActorSystem.create();
-    final Materializer materializer = ActorMaterializer.create(system);
 
     Source<Object, ActorRef> source = Source.actorRefWithAck("ack");
 
-    ActorRef actorRef = source.to(Sink.foreach(System.out::println)).run(materializer);
+    ActorRef actorRef = source.to(Sink.foreach(System.out::println)).run(system);
     probe.send(actorRef, "hello");
     probe.expectMsg("ack");
     probe.send(actorRef, "hello");

--- a/akka-docs/src/test/scala/docs/persistence/query/LeveldbPersistenceQueryDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/persistence/query/LeveldbPersistenceQueryDocSpec.scala
@@ -5,16 +5,10 @@
 package docs.persistence.query
 
 import akka.NotUsed
-import akka.persistence.journal.{ EventAdapter, EventSeq }
 import akka.testkit.AkkaSpec
 import akka.persistence.query.{ EventEnvelope, PersistenceQuery, Sequence }
-import akka.persistence.query.scaladsl._
 import akka.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal
-import akka.persistence.journal.Tagged
 import akka.stream.scaladsl.Source
-import akka.stream.ActorMaterializer
-
-import scala.annotation.tailrec
 
 object LeveldbPersistenceQueryDocSpec {
   //#tagger
@@ -54,7 +48,6 @@ class LeveldbPersistenceQueryDocSpec(config: String) extends AkkaSpec(config) {
 
     "demonstrate EventsByPersistenceId" in {
       //#EventsByPersistenceId
-      implicit val mat = ActorMaterializer()(system)
       val queries = PersistenceQuery(system).readJournalFor[LeveldbReadJournal](LeveldbReadJournal.Identifier)
 
       val src: Source[EventEnvelope, NotUsed] =
@@ -66,7 +59,6 @@ class LeveldbPersistenceQueryDocSpec(config: String) extends AkkaSpec(config) {
 
     "demonstrate AllPersistenceIds" in {
       //#AllPersistenceIds
-      implicit val mat = ActorMaterializer()(system)
       val queries = PersistenceQuery(system).readJournalFor[LeveldbReadJournal](LeveldbReadJournal.Identifier)
 
       val src: Source[String, NotUsed] = queries.persistenceIds()
@@ -75,7 +67,6 @@ class LeveldbPersistenceQueryDocSpec(config: String) extends AkkaSpec(config) {
 
     "demonstrate EventsByTag" in {
       //#EventsByTag
-      implicit val mat = ActorMaterializer()(system)
       val queries = PersistenceQuery(system).readJournalFor[LeveldbReadJournal](LeveldbReadJournal.Identifier)
 
       val src: Source[EventEnvelope, NotUsed] =

--- a/akka-docs/src/test/scala/docs/persistence/query/PersistenceQueryDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/persistence/query/PersistenceQueryDocSpec.scala
@@ -6,14 +6,11 @@ package docs.persistence.query
 
 import akka.NotUsed
 import akka.actor._
-import akka.persistence.{ PersistentActor, Recovery }
 import akka.persistence.query._
-import akka.stream.{ ActorMaterializer, FlowShape }
 import akka.stream.scaladsl.{ Flow, Sink, Source }
 import akka.stream.javadsl
 import akka.testkit.AkkaSpec
 import akka.util.Timeout
-import docs.persistence.query.PersistenceQueryDocSpec.TheOneWhoWritesToQueryJournal
 import org.reactivestreams.Subscriber
 
 import scala.collection.immutable
@@ -151,7 +148,6 @@ object PersistenceQueryDocSpec {
 
     //#projection-into-different-store-rs
     implicit val system = ActorSystem()
-    implicit val mat = ActorMaterializer()
 
     val readJournal =
       PersistenceQuery(system).readJournalFor[MyScaladslReadJournal](JournalId)
@@ -202,8 +198,6 @@ class PersistenceQueryDocSpec(s: String) extends AkkaSpec(s) {
       """)
   }
 
-  implicit val mat = ActorMaterializer()
-
   class BasicUsage {
     //#basic-usage
     // obtain read journal by plugin id
@@ -215,7 +209,6 @@ class PersistenceQueryDocSpec(s: String) extends AkkaSpec(s) {
       readJournal.eventsByPersistenceId("user-1337", 0, Long.MaxValue)
 
     // materialize stream, consuming events
-    implicit val mat = ActorMaterializer()
     source.runForeach { event =>
       println("Event: " + event)
     }

--- a/akka-docs/src/test/scala/docs/stream/BidiFlowDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/BidiFlowDocSpec.scala
@@ -148,8 +148,6 @@ object BidiFlowDocSpec {
 class BidiFlowDocSpec extends AkkaSpec {
   import BidiFlowDocSpec._
 
-  implicit val materializer = ActorMaterializer()
-
   "A BidiFlow" must {
 
     "compose" in {

--- a/akka-docs/src/test/scala/docs/stream/CompositionDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/CompositionDocSpec.scala
@@ -16,7 +16,6 @@ import scala.concurrent.{ Future, Promise }
 class CompositionDocSpec extends AkkaSpec {
 
   implicit val ec = system.dispatcher
-  implicit val materializer = ActorMaterializer()
 
   "nonnested flow" in {
     //#non-nested-flow

--- a/akka-docs/src/test/scala/docs/stream/FlowDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/FlowDocSpec.scala
@@ -4,9 +4,11 @@
 
 package docs.stream
 
-import akka.{ Done, NotUsed }
+import akka.NotUsed
 import akka.actor.{ Actor, ActorSystem, Cancellable }
-import akka.stream.{ ActorMaterializer, ClosedShape, FlowShape, Materializer, OverflowStrategy }
+import akka.stream.ActorMaterializer
+import akka.stream.Materializer
+import akka.stream.{ ClosedShape, FlowShape, OverflowStrategy }
 import akka.stream.scaladsl._
 import akka.testkit.AkkaSpec
 import docs.CompileOnlySpec
@@ -17,12 +19,6 @@ import scala.util.{ Failure, Success }
 class FlowDocSpec extends AkkaSpec with CompileOnlySpec {
 
   implicit val ec = system.dispatcher
-
-  //#imports
-  import akka.stream.ActorMaterializer
-  //#imports
-
-  implicit val materializer = ActorMaterializer()
 
   "source is immutable" in {
     //#source-immutable
@@ -250,8 +246,7 @@ object FlowDocSpec {
   {
     //#materializer-from-system
     implicit val system = ActorSystem("ExampleSystem")
-
-    implicit val mat = ActorMaterializer() // created from `system`
+    // TODO not needed update text?
     //#materializer-from-system
   }
 

--- a/akka-docs/src/test/scala/docs/stream/FlowDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/FlowDocSpec.scala
@@ -243,13 +243,6 @@ class FlowDocSpec extends AkkaSpec with CompileOnlySpec {
 
 object FlowDocSpec {
 
-  {
-    //#materializer-from-system
-    implicit val system = ActorSystem("ExampleSystem")
-    // TODO not needed update text?
-    //#materializer-from-system
-  }
-
   //#materializer-from-actor-context
   final class RunWithMyself extends Actor {
     implicit val mat = ActorMaterializer()

--- a/akka-docs/src/test/scala/docs/stream/FlowErrorDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/FlowErrorDocSpec.scala
@@ -18,7 +18,6 @@ class FlowErrorDocSpec extends AkkaSpec {
 
   "demonstrate fail stream" in {
     //#stop
-    implicit val materializer = ActorMaterializer()
     val source = Source(0 to 5).map(100 / _)
     val result = source.runWith(Sink.fold(0)(_ + _))
     // division by zero will fail the stream and the
@@ -48,7 +47,6 @@ class FlowErrorDocSpec extends AkkaSpec {
 
   "demonstrate resume section" in {
     //#resume-section
-    implicit val materializer = ActorMaterializer()
     val decider: Supervision.Decider = {
       case _: ArithmeticException => Supervision.Resume
       case _                      => Supervision.Stop
@@ -69,7 +67,6 @@ class FlowErrorDocSpec extends AkkaSpec {
 
   "demonstrate restart section" in {
     //#restart-section
-    implicit val materializer = ActorMaterializer()
     val decider: Supervision.Decider = {
       case _: IllegalArgumentException => Supervision.Restart
       case _                           => Supervision.Stop
@@ -91,7 +88,6 @@ class FlowErrorDocSpec extends AkkaSpec {
   }
 
   "demonstrate recover" in {
-    implicit val materializer = ActorMaterializer()
     //#recover
     Source(0 to 6)
       .map(n =>
@@ -117,7 +113,6 @@ stream truncated
   }
 
   "demonstrate recoverWithRetries" in {
-    implicit val materializer = ActorMaterializer()
     //#recoverWithRetries
     val planB = Source(List("five", "six", "seven", "eight"))
 

--- a/akka-docs/src/test/scala/docs/stream/FlowStreamRefsDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/FlowStreamRefsDocSpec.scala
@@ -10,7 +10,6 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.testkit.AkkaSpec
 import docs.CompileOnlySpec
-import scala.concurrent.Future
 
 class FlowStreamRefsDocSpec extends AkkaSpec with CompileOnlySpec {
 
@@ -91,7 +90,6 @@ class FlowStreamRefsDocSpec extends AkkaSpec with CompileOnlySpec {
 
     //#offer-sink
 
-    implicit val mat = ActorMaterializer()
     def localMetrics(): Source[String, NotUsed] = Source.single("")
 
     //#offer-sink-use
@@ -106,8 +104,6 @@ class FlowStreamRefsDocSpec extends AkkaSpec with CompileOnlySpec {
   }
 
   "show how to configure timeouts with attrs" in compileOnlySpec {
-
-    implicit val mat: ActorMaterializer = null
     //#attr-sub-timeout
     // configure the timeout for source
     import scala.concurrent.duration._

--- a/akka-docs/src/test/scala/docs/stream/GraphCyclesSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/GraphCyclesSpec.scala
@@ -10,8 +10,6 @@ import akka.testkit.AkkaSpec
 
 class GraphCyclesSpec extends AkkaSpec {
 
-  implicit val materializer = ActorMaterializer()
-
   "Cycle demonstration" must {
     val source = Source.fromIterator(() => Iterator.from(0))
 

--- a/akka-docs/src/test/scala/docs/stream/GraphDSLDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/GraphDSLDocSpec.scala
@@ -17,8 +17,6 @@ class GraphDSLDocSpec extends AkkaSpec {
 
   implicit val ec = system.dispatcher
 
-  implicit val materializer = ActorMaterializer()
-
   "build simple graph" in {
     //format: OFF
     //#simple-graph-dsl

--- a/akka-docs/src/test/scala/docs/stream/GraphStageDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/GraphStageDocSpec.scala
@@ -18,8 +18,6 @@ import scala.collection.immutable.Iterable
 
 class GraphStageDocSpec extends AkkaSpec {
 
-  implicit val materializer = ActorMaterializer()
-
   "Demonstrate creation of GraphStage boilerplate" in {
     //#boilerplate-example
     import akka.stream.SourceShape

--- a/akka-docs/src/test/scala/docs/stream/GraphStageLoggingDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/GraphStageLoggingDocSpec.scala
@@ -12,7 +12,6 @@ import akka.testkit.{ AkkaSpec, EventFilter }
 
 class GraphStageLoggingDocSpec extends AkkaSpec("akka.loglevel = DEBUG") {
 
-  implicit val materializer = ActorMaterializer()
   implicit val ec = system.dispatcher
 
   //#operator-with-logging

--- a/akka-docs/src/test/scala/docs/stream/HubsDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/HubsDocSpec.scala
@@ -5,7 +5,7 @@
 package docs.stream
 
 import akka.NotUsed
-import akka.stream.{ ActorMaterializer, KillSwitches, UniqueKillSwitch }
+import akka.stream.{ KillSwitches, UniqueKillSwitch }
 import akka.stream.scaladsl._
 import akka.testkit.AkkaSpec
 import docs.CompileOnlySpec
@@ -14,7 +14,6 @@ import scala.concurrent.duration._
 import akka.stream.ThrottleMode
 
 class HubsDocSpec extends AkkaSpec with CompileOnlySpec {
-  implicit val materializer = ActorMaterializer()
 
   "Hubs" must {
 

--- a/akka-docs/src/test/scala/docs/stream/IntegrationDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/IntegrationDocSpec.scala
@@ -13,7 +13,7 @@ import akka.stream._
 
 import scala.concurrent.Future
 import akka.testkit.TestProbe
-import akka.actor.{ Actor, ActorLogging, ActorRef, Props, Status }
+import akka.actor.{ Actor, ActorLogging, ActorRef, Props }
 import com.typesafe.config.ConfigFactory
 import akka.util.Timeout
 
@@ -21,9 +21,6 @@ import scala.concurrent.ExecutionContext
 import java.util.concurrent.atomic.AtomicInteger
 
 import akka.stream.scaladsl.Flow
-import akka.Done
-import akka.actor.Status.Status
-import akka.stream.QueueOfferResult.{ Dropped, Enqueued }
 
 object IntegrationDocSpec {
   import TwitterStreamQuickstartDocSpec._
@@ -137,7 +134,6 @@ class IntegrationDocSpec extends AkkaSpec(IntegrationDocSpec.config) {
   import TwitterStreamQuickstartDocSpec._
   import IntegrationDocSpec._
 
-  implicit val materializer = ActorMaterializer()
   val ref: ActorRef = system.actorOf(Props[Translator])
 
   "ask" in {

--- a/akka-docs/src/test/scala/docs/stream/KillSwitchDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/KillSwitchDocSpec.scala
@@ -5,7 +5,7 @@
 package docs.stream
 
 import akka.stream.scaladsl._
-import akka.stream.{ ActorMaterializer, DelayOverflowStrategy, KillSwitches }
+import akka.stream.{ DelayOverflowStrategy, KillSwitches }
 import akka.testkit.AkkaSpec
 import docs.CompileOnlySpec
 
@@ -13,8 +13,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class KillSwitchDocSpec extends AkkaSpec with CompileOnlySpec {
-
-  implicit val materializer = ActorMaterializer()
 
   "Unique kill switch" must {
 

--- a/akka-docs/src/test/scala/docs/stream/QuickStartDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/QuickStartDocSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.concurrent._
 
 //#main-app
 object Main extends App {
+  implicit val system = ActorSystem("QuickStart")
   // Code here
 }
 //#main-app
@@ -33,18 +34,14 @@ class QuickStartDocSpec extends WordSpec with BeforeAndAfterAll with ScalaFuture
   def println(any: Any) = () // silence printing stuff
 
   "demonstrate Source" in {
-    //#create-materializer
-    // TODO no need, update text
     implicit val system = ActorSystem("QuickStart")
-    implicit val materializer = ActorMaterializer()
-    //#create-materializer
 
     //#create-source
     val source: Source[Int, NotUsed] = Source(1 to 100)
     //#create-source
 
     //#run-source
-    source.runForeach(i => println(i))(materializer)
+    source.runForeach(i => println(i))
     //#run-source
 
     //#transform-source
@@ -69,7 +66,7 @@ class QuickStartDocSpec extends WordSpec with BeforeAndAfterAll with ScalaFuture
     //#add-streams
 
     //#run-source-and-terminate
-    val done: Future[Done] = source.runForeach(i => println(i))(materializer)
+    val done: Future[Done] = source.runForeach(i => println(i))
 
     implicit val ec = system.dispatcher
     done.onComplete(_ => system.terminate())

--- a/akka-docs/src/test/scala/docs/stream/QuickStartDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/QuickStartDocSpec.scala
@@ -34,6 +34,7 @@ class QuickStartDocSpec extends WordSpec with BeforeAndAfterAll with ScalaFuture
 
   "demonstrate Source" in {
     //#create-materializer
+    // TODO no need, update text
     implicit val system = ActorSystem("QuickStart")
     implicit val materializer = ActorMaterializer()
     //#create-materializer

--- a/akka-docs/src/test/scala/docs/stream/RateTransformationDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/RateTransformationDocSpec.scala
@@ -4,7 +4,6 @@
 
 package docs.stream
 
-import akka.stream._
 import akka.stream.scaladsl._
 import akka.stream.testkit.scaladsl._
 
@@ -17,8 +16,6 @@ import akka.testkit.{ AkkaSpec, TestLatch }
 import scala.concurrent.Await
 
 class RateTransformationDocSpec extends AkkaSpec {
-
-  implicit val materializer = ActorMaterializer()
 
   "conflate should summarize" in {
     //#conflate-summarize

--- a/akka-docs/src/test/scala/docs/stream/ReactiveStreamsDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/ReactiveStreamsDocSpec.scala
@@ -5,7 +5,6 @@
 package docs.stream
 
 import akka.NotUsed
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Flow, Sink, Source }
 import akka.stream.testkit._
 import org.reactivestreams.Processor
@@ -13,8 +12,6 @@ import akka.testkit.AkkaSpec
 
 class ReactiveStreamsDocSpec extends AkkaSpec {
   import TwitterStreamQuickstartDocSpec._
-
-  implicit val materializer = ActorMaterializer()
 
   //#imports
   import org.reactivestreams.Publisher

--- a/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
@@ -5,7 +5,7 @@
 package docs.stream
 
 import akka.NotUsed
-import akka.stream.{ ActorMaterializer, KillSwitches }
+import akka.stream.KillSwitches
 import akka.stream.scaladsl._
 import akka.testkit.AkkaSpec
 import docs.CompileOnlySpec
@@ -14,7 +14,6 @@ import scala.concurrent.duration._
 import scala.concurrent._
 
 class RestartDocSpec extends AkkaSpec with CompileOnlySpec {
-  implicit val materializer = ActorMaterializer()
   import system.dispatcher
 
   // Mock akka-http interfaces

--- a/akka-docs/src/test/scala/docs/stream/StreamBuffersRateSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/StreamBuffersRateSpec.scala
@@ -10,7 +10,6 @@ import akka.stream.scaladsl._
 import akka.testkit.AkkaSpec
 
 class StreamBuffersRateSpec extends AkkaSpec {
-  implicit val materializer = ActorMaterializer()
 
   "Demonstrate pipelining" in {
     def println(s: Any) = ()

--- a/akka-docs/src/test/scala/docs/stream/StreamPartialGraphDSLDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/StreamPartialGraphDSLDocSpec.scala
@@ -16,8 +16,6 @@ class StreamPartialGraphDSLDocSpec extends AkkaSpec {
 
   implicit val ec = system.dispatcher
 
-  implicit val materializer = ActorMaterializer()
-
   "build with open ports" in {
     //#simple-partial-graph-dsl
     val pickMaxOfThree = GraphDSL.create() { implicit b =>

--- a/akka-docs/src/test/scala/docs/stream/StreamTestKitDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/StreamTestKitDocSpec.scala
@@ -6,7 +6,6 @@ package docs.stream
 
 import akka.stream._
 import akka.stream.scaladsl._
-import akka.stream.testkit._
 import akka.stream.testkit.scaladsl._
 import scala.util._
 import scala.concurrent.duration._
@@ -15,8 +14,6 @@ import akka.testkit.{ AkkaSpec, TestProbe }
 import akka.pattern
 
 class StreamTestKitDocSpec extends AkkaSpec {
-
-  implicit val materializer = ActorMaterializer()
 
   "strict collection" in {
     //#strict-collection

--- a/akka-docs/src/test/scala/docs/stream/SubstreamDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/SubstreamDocSpec.scala
@@ -5,11 +5,10 @@
 package docs.stream
 
 import akka.stream.scaladsl.{ Sink, Source }
-import akka.stream.{ ActorMaterializer, SubstreamCancelStrategy }
+import akka.stream.{ SubstreamCancelStrategy }
 import akka.testkit.AkkaSpec
 
 class SubstreamDocSpec extends AkkaSpec {
-  implicit val materializer = ActorMaterializer()
 
   "generate substreams by groupBy" in {
     //#groupBy1

--- a/akka-docs/src/test/scala/docs/stream/TwitterStreamQuickstartDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/TwitterStreamQuickstartDocSpec.scala
@@ -79,10 +79,9 @@ class TwitterStreamQuickstartDocSpec extends AkkaSpec {
   trait Example1 {
     //#fiddle_code
     //#first-sample
-    //#materializer-setup
+    //#system-setup
     implicit val system = ActorSystem("reactive-tweets")
-    // TODO not needed anymore, update text
-    //#materializer-setup
+    //#system-setup
     //#first-sample
 
     //#fiddle_code

--- a/akka-docs/src/test/scala/docs/stream/TwitterStreamQuickstartDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/TwitterStreamQuickstartDocSpec.scala
@@ -8,7 +8,7 @@ package docs.stream
 
 import akka.{ Done, NotUsed }
 import akka.actor.ActorSystem
-import akka.stream.{ ActorMaterializer, ClosedShape, OverflowStrategy }
+import akka.stream.{ ClosedShape, OverflowStrategy }
 import akka.stream.scaladsl._
 import scala.concurrent.Await
 import scala.concurrent.Future
@@ -81,14 +81,12 @@ class TwitterStreamQuickstartDocSpec extends AkkaSpec {
     //#first-sample
     //#materializer-setup
     implicit val system = ActorSystem("reactive-tweets")
-    implicit val materializer = ActorMaterializer()
+    // TODO not needed anymore, update text
     //#materializer-setup
     //#first-sample
 
     //#fiddle_code
   }
-
-  implicit val materializer = ActorMaterializer()
 
   "filter and map" in {
     //#first-sample

--- a/akka-docs/src/test/scala/docs/stream/cookbook/RecipeSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/cookbook/RecipeSpec.scala
@@ -4,12 +4,10 @@
 
 package docs.stream.cookbook
 
-import akka.stream.ActorMaterializer
 import akka.testkit.AkkaSpec
 
 trait RecipeSpec extends AkkaSpec {
 
-  implicit val m = ActorMaterializer()
   type Message = String
 
 }

--- a/akka-docs/src/test/scala/docs/stream/io/StreamFileDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/io/StreamFileDocSpec.scala
@@ -17,7 +17,6 @@ import scala.concurrent.Future
 class StreamFileDocSpec extends AkkaSpec(UnboundedMailboxConfig) {
 
   implicit val ec = system.dispatcher
-  implicit val materializer = ActorMaterializer()
 
   // silence sysout
   def println(s: String) = ()

--- a/akka-docs/src/test/scala/docs/stream/io/StreamTcpDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/io/StreamTcpDocSpec.scala
@@ -6,7 +6,6 @@ package docs.stream.io
 
 import java.util.concurrent.atomic.AtomicReference
 
-import akka.stream._
 import akka.stream.scaladsl.Tcp._
 import akka.stream.scaladsl._
 import akka.testkit.AkkaSpec
@@ -19,7 +18,6 @@ import akka.testkit.SocketUtil
 class StreamTcpDocSpec extends AkkaSpec {
 
   implicit val ec = system.dispatcher
-  implicit val materializer = ActorMaterializer()
 
   // silence sysout
   def println(s: String) = ()

--- a/akka-docs/src/test/scala/docs/stream/operators/SourceOperators.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/SourceOperators.scala
@@ -5,7 +5,6 @@
 package docs.stream.operators
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
 
 object SourceOperators {
@@ -21,7 +20,6 @@ object SourceOperators {
     import scala.concurrent.Future
 
     implicit val system: ActorSystem = ActorSystem()
-    implicit val materializer: ActorMaterializer = ActorMaterializer()
 
     val source: Source[Int, NotUsed] = Source.fromFuture(Future.successful(10))
     val sink: Sink[Int, Future[Done]] = Sink.foreach((i: Int) => println(i))
@@ -40,7 +38,6 @@ object SourceOperators {
     import akka.stream.scaladsl._
 
     implicit val system: ActorSystem = ActorSystem()
-    implicit val materializer: ActorMaterializer = ActorMaterializer()
     val bufferSize = 100
 
     val source: Source[Any, ActorRef] = Source.actorRef[Any](bufferSize, OverflowStrategy.dropHead)
@@ -63,7 +60,6 @@ object SourceOperators {
     import akka.stream.scaladsl._
 
     implicit val system: ActorSystem = ActorSystem()
-    implicit val materializer: ActorMaterializer = ActorMaterializer()
     val probe = TestProbe()
 
     val source: Source[Any, ActorRef] = Source.actorRefWithAck[Any]("ack")

--- a/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/Scan.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/Scan.scala
@@ -11,7 +11,6 @@ object Scan {
     import akka.stream.ActorMaterializer
 
     implicit val system: ActorSystem = ActorSystem()
-    implicit val materializer: ActorMaterializer = ActorMaterializer()
 
     //#scan
     val source = Source(1 to 5)

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/ScriptedTest.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/ScriptedTest.scala
@@ -17,6 +17,8 @@ import scala.annotation.tailrec
 import scala.concurrent.duration._
 import java.util.concurrent.ThreadLocalRandom
 
+import akka.stream.SystemMaterializer
+
 trait ScriptedTest extends Matchers {
 
   class ScriptException(msg: String) extends RuntimeException(msg)
@@ -227,6 +229,10 @@ trait ScriptedTest extends Matchers {
     }
 
   }
+
+  def runScript[In, Out, M](script: Script[In, Out])(op: Flow[In, In, NotUsed] => Flow[In, Out, M])(
+      implicit system: ActorSystem): Unit =
+    runScript(script, SystemMaterializer(system).materializer.settings)(op)(system)
 
   def runScript[In, Out, M](
       script: Script[In, Out],

--- a/akka-stream-tests/src/test/java/akka/stream/StreamTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/StreamTest.java
@@ -4,33 +4,14 @@
 
 package akka.stream;
 
-import akka.stream.testkit.javadsl.StreamTestKit;
-import org.junit.After;
-import org.junit.Before;
-import org.scalatest.junit.JUnitSuite;
-
 import akka.actor.ActorSystem;
 import akka.testkit.AkkaJUnitActorSystemResource;
+import org.scalatest.junit.JUnitSuite;
 
 public abstract class StreamTest extends JUnitSuite {
   protected final ActorSystem system;
-  private final ActorMaterializerSettings settings;
-
-  protected ActorMaterializer materializer;
 
   protected StreamTest(AkkaJUnitActorSystemResource actorSystemResource) {
     system = actorSystemResource.getSystem();
-    settings = ActorMaterializerSettings.create(system);
-  }
-
-  @Before
-  public void setUp() {
-    materializer = ActorMaterializer.create(settings, system);
-  }
-
-  @After
-  public void tearDown() {
-    StreamTestKit.assertAllStagesStopped(materializer);
-    materializer.shutdown();
   }
 }

--- a/akka-stream-tests/src/test/java/akka/stream/io/InputStreamSinkTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/io/InputStreamSinkTest.java
@@ -41,7 +41,7 @@ public class InputStreamSinkTest extends StreamTest {
 
     final Sink<ByteString, InputStream> sink = StreamConverters.asInputStream(timeout);
     final List<ByteString> list = Collections.singletonList(ByteString.fromString("a"));
-    final InputStream stream = Source.from(list).runWith(sink, materializer);
+    final InputStream stream = Source.from(list).runWith(sink, system);
 
     byte[] a = new byte[1];
     stream.read(a);

--- a/akka-stream-tests/src/test/java/akka/stream/io/OutputStreamSinkTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/io/OutputStreamSinkTest.java
@@ -53,7 +53,7 @@ public class OutputStreamSinkTest extends StreamTest {
         };
     final CompletionStage<IOResult> resultFuture =
         Source.single(ByteString.fromString("123456"))
-            .runWith(StreamConverters.fromOutputStream(() -> os), materializer);
+            .runWith(StreamConverters.fromOutputStream(() -> os), system);
     try {
       resultFuture.toCompletableFuture().get(3, TimeUnit.SECONDS);
       Assert.fail("expected IOIncompleteException");

--- a/akka-stream-tests/src/test/java/akka/stream/io/OutputStreamSourceTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/io/OutputStreamSourceTest.java
@@ -49,7 +49,7 @@ public class OutputStreamSourceTest extends StreamTest {
                         probe.getRef().tell(elem, ActorRef.noSender());
                       }
                     }))
-            .run(materializer);
+            .run(system);
 
     s.write("a".getBytes());
 

--- a/akka-stream-tests/src/test/java/akka/stream/io/SinkAsJavaSourceTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/io/SinkAsJavaSourceTest.java
@@ -33,8 +33,7 @@ public class SinkAsJavaSourceTest extends StreamTest {
   public void mustBeAbleToUseAsJavaStream() throws Exception {
     final List<Integer> list = Arrays.asList(1, 2, 3);
     final Sink<Integer, Stream<Integer>> streamSink = StreamConverters.asJavaStream();
-    java.util.stream.Stream<Integer> javaStream =
-        Source.from(list).runWith(streamSink, materializer);
+    java.util.stream.Stream<Integer> javaStream = Source.from(list).runWith(streamSink, system);
     assertEquals(list, javaStream.collect(Collectors.toList()));
   }
 }

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowThrottleTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowThrottleTest.java
@@ -35,7 +35,7 @@ public class FlowThrottleTest extends StreamTest {
             .throttle(1, java.time.Duration.ofDays(1), 1, ThrottleMode.enforcing());
 
     CompletionStage<List<Integer>> result1 =
-        Source.single(1).via(sharedThrottle).via(sharedThrottle).runWith(Sink.seq(), materializer);
+        Source.single(1).via(sharedThrottle).via(sharedThrottle).runWith(Sink.seq(), system);
 
     // If there is accidental shared state then we would not be able to pass through the single
     // element
@@ -44,7 +44,7 @@ public class FlowThrottleTest extends StreamTest {
 
     // It works with a new stream, too
     CompletionStage<List<Integer>> result2 =
-        Source.single(1).via(sharedThrottle).via(sharedThrottle).runWith(Sink.seq(), materializer);
+        Source.single(1).via(sharedThrottle).via(sharedThrottle).runWith(Sink.seq(), system);
 
     assertEquals(
         result2.toCompletableFuture().get(3, TimeUnit.SECONDS), Collections.singletonList(1));

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowWithContextTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowWithContextTest.java
@@ -37,7 +37,7 @@ public class FlowWithContextTest extends StreamTest {
     final CompletionStage<List<Pair<Integer, String>>> result =
         Source.single(new Pair<>(1, "context"))
             .via(flow.map(n -> n + 1).mapContext(ctx -> ctx + "-mapped"))
-            .runWith(Sink.seq(), materializer);
+            .runWith(Sink.seq(), system);
     final List<Pair<Integer, String>> pairs = result.toCompletableFuture().get(3, TimeUnit.SECONDS);
     assertEquals(1, pairs.size());
     assertEquals(Integer.valueOf(2), pairs.get(0).first());
@@ -54,9 +54,7 @@ public class FlowWithContextTest extends StreamTest {
     final FlowWithContext<Integer, NotUsed, String, NotUsed, NotUsed> flow3 = flow1.via(flow2);
 
     final CompletionStage<List<Pair<String, NotUsed>>> result =
-        Source.single(new Pair<>(1, notUsed()))
-            .via(flow3.asFlow())
-            .runWith(Sink.seq(), materializer);
+        Source.single(new Pair<>(1, notUsed())).via(flow3.asFlow()).runWith(Sink.seq(), system);
 
     List<Pair<String, NotUsed>> pairs = result.toCompletableFuture().get(3, TimeUnit.SECONDS);
 

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/FramingTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/FramingTest.java
@@ -27,6 +27,6 @@ public class FramingTest extends StreamTest {
     in.via(
             Framing.delimiter(
                 ByteString.fromString(","), Integer.MAX_VALUE, FramingTruncation.ALLOW))
-        .runWith(Sink.ignore(), materializer);
+        .runWith(Sink.ignore(), system);
   }
 }

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/GraphDslTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/GraphDslTest.java
@@ -67,8 +67,7 @@ public class GraphDslTest extends StreamTest {
                   return ClosedShape.getInstance();
                 }));
     // #simple-graph-dsl
-    final List<String> list =
-        result.run(materializer).toCompletableFuture().get(3, TimeUnit.SECONDS);
+    final List<String> list = result.run(system).toCompletableFuture().get(3, TimeUnit.SECONDS);
     final String[] res = list.toArray(new String[] {});
     Arrays.sort(res, null);
     assertArrayEquals(
@@ -128,7 +127,7 @@ public class GraphDslTest extends StreamTest {
                   return ClosedShape.getInstance();
                 }));
     // #graph-dsl-reusing-a-flow
-    final Pair<CompletionStage<Integer>, CompletionStage<Integer>> pair = g.run(materializer);
+    final Pair<CompletionStage<Integer>, CompletionStage<Integer>> pair = g.run(system);
     assertEquals(Integer.valueOf(2), pair.first().toCompletableFuture().get(3, TimeUnit.SECONDS));
     assertEquals(Integer.valueOf(2), pair.second().toCompletableFuture().get(3, TimeUnit.SECONDS));
   }
@@ -209,7 +208,7 @@ public class GraphDslTest extends StreamTest {
 
                   return ClosedShape.getInstance();
                 }));
-    List<CompletionStage<String>> result = g.run(materializer);
+    List<CompletionStage<String>> result = g.run(system);
     // #graph-from-list
 
     assertEquals(3, result.size());

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/JsonFramingTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/JsonFramingTest.java
@@ -44,7 +44,7 @@ public class JsonFramingTest extends StreamTest {
                   acc.add(entry.utf8String());
                   return acc;
                 },
-                materializer);
+                system);
     // #using-json-framing
 
     List<String> frames = result.toCompletableFuture().get(5, TimeUnit.SECONDS);

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/KillSwitchTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/KillSwitchTest.java
@@ -39,10 +39,10 @@ public class KillSwitchTest extends StreamTest {
         Source.fromPublisher(upstream)
             .viaMat(killSwitch.flow(), Keep.right())
             .to(Sink.fromSubscriber(downstream))
-            .run(materializer);
+            .run(system);
 
     final CompletionStage<Done> completionStage =
-        Source.single(1).via(killSwitch.flow()).runWith(Sink.ignore(), materializer);
+        Source.single(1).via(killSwitch.flow()).runWith(Sink.ignore(), system);
 
     downstream.request(1);
     upstream.sendNext(1);
@@ -66,7 +66,7 @@ public class KillSwitchTest extends StreamTest {
 
     Source.fromPublisher(upstream)
         .viaMat(killSwitch.flow(), Keep.right())
-        .runWith(Sink.fromSubscriber(downstream), materializer);
+        .runWith(Sink.fromSubscriber(downstream), system);
 
     downstream.request(1);
     upstream.sendNext(1);
@@ -92,7 +92,7 @@ public class KillSwitchTest extends StreamTest {
         Source.fromPublisher(upstream)
             .viaMat(killSwitchFlow, Keep.right())
             .to(Sink.fromSubscriber(downstream))
-            .run(materializer);
+            .run(system);
 
     downstream.request(1);
     upstream.sendNext(1);

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/RunnableGraphTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/RunnableGraphTest.java
@@ -6,6 +6,7 @@ package akka.stream.javadsl;
 
 import akka.NotUsed;
 import akka.stream.StreamTest;
+import akka.stream.SystemMaterializer;
 import akka.testkit.AkkaJUnitActorSystemResource;
 import akka.testkit.AkkaSpec;
 import org.junit.ClassRule;
@@ -26,7 +27,8 @@ public class RunnableGraphTest extends StreamTest {
   public void beAbleToConvertFromJavaToScala() {
     final RunnableGraph<NotUsed> javaRunnable = Source.empty().to(Sink.ignore());
     final akka.stream.scaladsl.RunnableGraph<NotUsed> scalaRunnable = javaRunnable.asScala();
-    assertEquals(NotUsed.getInstance(), scalaRunnable.run(materializer));
+    assertEquals(
+        NotUsed.getInstance(), scalaRunnable.run(SystemMaterializer.get(system).materializer()));
   }
 
   @Test
@@ -34,6 +36,6 @@ public class RunnableGraphTest extends StreamTest {
     final akka.stream.scaladsl.RunnableGraph<NotUsed> scalaRunnable =
         akka.stream.scaladsl.Source.empty().to(akka.stream.scaladsl.Sink.ignore());
     final RunnableGraph<NotUsed> javaRunnable = scalaRunnable.asJava();
-    assertEquals(NotUsed.getInstance(), javaRunnable.run(materializer));
+    assertEquals(NotUsed.getInstance(), javaRunnable.run(system));
   }
 }

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/SetupTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/SetupTest.java
@@ -35,7 +35,7 @@ public class SetupTest extends StreamTest {
 
     assertEquals(
         Pair.create(false, false),
-        source.runWith(Sink.head(), materializer).toCompletableFuture().get(5, TimeUnit.SECONDS));
+        source.runWith(Sink.head(), system).toCompletableFuture().get(5, TimeUnit.SECONDS));
   }
 
   @Test
@@ -51,7 +51,7 @@ public class SetupTest extends StreamTest {
         Pair.create(false, false),
         Source.empty()
             .via(flow)
-            .runWith(Sink.head(), materializer)
+            .runWith(Sink.head(), system)
             .toCompletableFuture()
             .get(5, TimeUnit.SECONDS));
   }
@@ -67,7 +67,7 @@ public class SetupTest extends StreamTest {
     assertEquals(
         Pair.create(false, false),
         Source.empty()
-            .runWith(sink, materializer)
+            .runWith(sink, system)
             .thenCompose(c -> c)
             .toCompletableFuture()
             .get(5, TimeUnit.SECONDS));

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java
@@ -57,7 +57,7 @@ public class TcpTest extends StreamTest {
       Sink.foreach(
           new Procedure<IncomingConnection>() {
             public void apply(IncomingConnection conn) {
-              conn.handleWith(Flow.of(ByteString.class), materializer);
+              conn.handleWith(Flow.of(ByteString.class), system);
             }
           });
 
@@ -76,7 +76,7 @@ public class TcpTest extends StreamTest {
     final Source<IncomingConnection, CompletionStage<ServerBinding>> binding =
         Tcp.get(system).bind(serverAddress.getHostString(), serverAddress.getPort());
 
-    final CompletionStage<ServerBinding> future = binding.to(echoHandler).run(materializer);
+    final CompletionStage<ServerBinding> future = binding.to(echoHandler).run(system);
     final ServerBinding b = future.toCompletableFuture().get(5, TimeUnit.SECONDS);
     assertEquals(b.localAddress().getPort(), serverAddress.getPort());
 
@@ -92,7 +92,7 @@ public class TcpTest extends StreamTest {
                     return acc.concat(elem);
                   }
                 },
-                materializer);
+                system);
 
     final byte[] result = resultFuture.toCompletableFuture().get(5, TimeUnit.SECONDS).toArray();
     for (int i = 0; i < testInput.size(); i++) {
@@ -109,7 +109,7 @@ public class TcpTest extends StreamTest {
     final Source<IncomingConnection, CompletionStage<ServerBinding>> binding =
         Tcp.get(system).bind(serverAddress.getHostString(), serverAddress.getPort());
 
-    final CompletionStage<ServerBinding> future = binding.to(echoHandler).run(materializer);
+    final CompletionStage<ServerBinding> future = binding.to(echoHandler).run(system);
     final ServerBinding b = future.toCompletableFuture().get(5, TimeUnit.SECONDS);
     assertEquals(b.localAddress().getPort(), serverAddress.getPort());
 
@@ -122,7 +122,7 @@ public class TcpTest extends StreamTest {
                   try {
                     binding
                         .to(echoHandler)
-                        .run(materializer)
+                        .run(system)
                         .toCompletableFuture()
                         .get(5, TimeUnit.SECONDS);
                     assertTrue("Expected BindFailedException, but nothing was reported", false);
@@ -152,7 +152,7 @@ public class TcpTest extends StreamTest {
                     .outgoingConnection(serverAddress.getHostString(), serverAddress.getPort()),
                 Keep.right())
             .to(Sink.<ByteString>ignore())
-            .run(materializer)
+            .run(system)
             .toCompletableFuture()
             .get(5, TimeUnit.SECONDS);
         assertTrue("Expected StreamTcpException, but nothing was reported", false);

--- a/akka-stream-tests/src/test/java/akka/stream/stage/StageTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/stage/StageTest.java
@@ -36,10 +36,7 @@ public class StageTest extends StreamTest {
     final JavaIdentityStage<Integer> identity = new JavaIdentityStage<Integer>();
 
     final CompletionStage<List<Integer>> result =
-        ints.via(identity)
-            .via(identity)
-            .grouped(1000)
-            .runWith(Sink.<List<Integer>>head(), materializer);
+        ints.via(identity).via(identity).grouped(1000).runWith(Sink.<List<Integer>>head(), system);
 
     assertEquals(
         Arrays.asList(0, 1, 2, 3, 4, 5), result.toCompletableFuture().get(3, TimeUnit.SECONDS));

--- a/akka-stream-tests/src/test/scala-jdk9-only/akka/stream/scaladsl/FlowPublisherSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala-jdk9-only/akka/stream/scaladsl/FlowPublisherSinkSpec.scala
@@ -5,7 +5,7 @@
 package akka.stream.scaladsl
 
 import akka.stream.testkit.StreamSpec
-import akka.stream.{ ClosedShape, ActorMaterializer }
+import akka.stream.{ ClosedShape,  }
 
 import akka.stream.testkit.Utils._
 import akka.stream.testkit.scaladsl.StreamTestKit._
@@ -14,8 +14,6 @@ import scala.concurrent.duration._
 import scala.concurrent.Await
 
 class FlowPublisherSinkSpec extends StreamSpec {
-
-  implicit val materializer = ActorMaterializer()
 
   "A FlowPublisherSink" must {
 

--- a/akka-stream-tests/src/test/scala-jdk9-only/akka/stream/scaladsl/FlowPublisherSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala-jdk9-only/akka/stream/scaladsl/FlowPublisherSinkSpec.scala
@@ -5,7 +5,7 @@
 package akka.stream.scaladsl
 
 import akka.stream.testkit.StreamSpec
-import akka.stream.{ ClosedShape,  }
+import akka.stream.ClosedShape
 
 import akka.stream.testkit.Utils._
 import akka.stream.testkit.scaladsl.StreamTestKit._

--- a/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
@@ -10,8 +10,6 @@ import akka.stream.testkit.StreamSpec
 
 class FusingSpec extends StreamSpec {
 
-  implicit val materializer = ActorMaterializer()
-
   def actorRunningStage = {
     GraphInterpreter.currentInterpreter.context
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/SystemMaterializerSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/SystemMaterializerSpec.scala
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.stream
+
+class SystemMaterializerSpec {}

--- a/akka-stream-tests/src/test/scala/akka/stream/SystemMaterializerSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/SystemMaterializerSpec.scala
@@ -1,6 +1,34 @@
 /*
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.stream
 
-class SystemMaterializerSpec {}
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.stream.testkit.StreamSpec
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.Future
+
+class SystemMaterializerSpec extends StreamSpec with ScalaFutures {
+
+  def compileOnly(): Unit = {
+    Source(1 to 3).to(Sink.ignore).run()
+    Source(1 to 3).runWith(Sink.ignore)
+    Source(1 to 3).runFold(0)((acc, elem) => acc + elem)
+    Source(1 to 3).runFoldAsync(0)((acc, elem) => Future.successful(acc + elem))
+    Source(1 to 3).runForeach(_ => ())
+    Source(1 to 3).runReduce(_ + _)
+  }
+
+  "The SystemMaterializer" must {
+
+    "be implicitly provided when implicit actor system is in scope" in {
+      val result = Source(1 to 3).toMat(Sink.seq)(Keep.right).run()
+      result.futureValue should ===(Seq(1, 2, 3))
+    }
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/FanoutProcessorSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/FanoutProcessorSpec.scala
@@ -4,16 +4,15 @@
 
 package akka.stream.impl
 
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{ Keep, Sink, Source }
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
 import akka.stream.testkit.StreamSpec
 import akka.stream.testkit.Utils.TE
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.testkit.TestProbe
 
 class FanoutProcessorSpec extends StreamSpec {
-
-  implicit val mat = ActorMaterializer()
 
   "The FanoutProcessor" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/GraphStageLogicSpec.scala
@@ -19,8 +19,6 @@ import scala.concurrent.duration.Duration
 
 class GraphStageLogicSpec extends StreamSpec with GraphInterpreterSpecKit with ScalaFutures {
 
-  implicit val materializer = ActorMaterializer()
-
   object emit1234 extends GraphStage[FlowShape[Int, Int]] {
     val in = Inlet[Int]("in")
     val out = Outlet[Int]("out")

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/TimeoutsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/TimeoutsSpec.scala
@@ -18,7 +18,6 @@ import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 
 class TimeoutsSpec extends StreamSpec {
-  implicit val materializer = ActorMaterializer()
 
   "InitialTimeout" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/ActorGraphInterpreterSpec.scala
@@ -22,8 +22,6 @@ import scala.concurrent.duration._
 import org.reactivestreams.{ Publisher, Subscriber, Subscription }
 
 class ActorGraphInterpreterSpec extends StreamSpec {
-  implicit val materializer = ActorMaterializer()
-
   "ActorGraphInterpreter" must {
 
     "be able to interpret a simple identity graph stage" in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/KeepGoingStageSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/KeepGoingStageSpec.scala
@@ -4,20 +4,27 @@
 
 package akka.stream.impl.fusing
 
-import akka.actor.{ ActorRef, NoSerializationVerificationNeeded }
-import akka.stream.scaladsl.{ Keep, Source }
+import akka.actor.ActorRef
+import akka.actor.NoSerializationVerificationNeeded
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Source
+import akka.stream.stage.AsyncCallback
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.GraphStageWithMaterializedValue
+import akka.stream.stage.InHandler
 import akka.stream.testkit.StreamSpec
-import akka.stream.{ ActorMaterializer, Attributes, Inlet, SinkShape }
-import akka.stream.stage.{ AsyncCallback, GraphStageLogic, GraphStageWithMaterializedValue, InHandler }
 import akka.stream.testkit.Utils._
 import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.stream.Attributes
+import akka.stream.Inlet
+import akka.stream.SinkShape
 
-import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.Promise
 
 class KeepGoingStageSpec extends StreamSpec {
-
-  implicit val materializer = ActorMaterializer()
 
   trait PingCmd extends NoSerializationVerificationNeeded
   case class Register(probe: ActorRef) extends PingCmd

--- a/akka-stream-tests/src/test/scala/akka/stream/io/ByteStringParserSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/ByteStringParserSpec.scala
@@ -5,18 +5,23 @@
 package akka.stream.io
 
 import akka.stream.impl.io.ByteStringParser
-import akka.stream.impl.io.ByteStringParser.{ ByteReader, ParseResult, ParseStep }
-import akka.stream.scaladsl.{ Sink, Source }
+import akka.stream.impl.io.ByteStringParser.ByteReader
+import akka.stream.impl.io.ByteStringParser.ParseResult
+import akka.stream.impl.io.ByteStringParser.ParseStep
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
 import akka.stream.stage.GraphStageLogic
-import akka.stream.testkit.{ StreamSpec, TestPublisher, TestSubscriber }
-import akka.stream.{ ActorMaterializer, Attributes, ThrottleMode }
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.TestSubscriber
+import akka.stream.Attributes
+import akka.stream.ThrottleMode
 import akka.util.ByteString
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class ByteStringParserSpec extends StreamSpec {
-  implicit val materializer = ActorMaterializer()
 
   "ByteStringParser" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
@@ -96,7 +96,6 @@ class TlsSpec extends StreamSpec(TlsSpec.configOverrides) with WithLogCapturing 
   import TlsSpec._
 
   import system.dispatcher
-  implicit val materializer = ActorMaterializer()
 
   import GraphDSL.Implicits._
 

--- a/akka-stream-tests/src/test/scala/akka/stream/io/compression/CodecSpecSupport.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/compression/CodecSpecSupport.scala
@@ -5,10 +5,11 @@
 package akka.stream.io.compression
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import akka.util.ByteString
-import org.scalatest.{ BeforeAndAfterAll, Matchers, Suite }
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.Matchers
+import org.scalatest.Suite
 
 trait CodecSpecSupport extends Matchers with BeforeAndAfterAll { self: Suite =>
 
@@ -73,7 +74,6 @@ est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscin
       "\n")
 
   implicit val system = ActorSystem(getClass.getSimpleName)
-  implicit val materializer = ActorMaterializer()
 
   override def afterAll() = TestKit.shutdownActorSystem(system)
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSinkSpec.scala
@@ -51,7 +51,6 @@ object ActorRefBackpressureSinkSpec {
 
 class ActorRefBackpressureSinkSpec extends StreamSpec {
   import ActorRefBackpressureSinkSpec._
-  implicit val mat = ActorMaterializer()
 
   def createActor[T](c: Class[T]) =
     system.actorOf(Props(c, testActor).withDispatcher("akka.test.stream-dispatcher"))

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSourceSpec.scala
@@ -8,7 +8,6 @@ import akka.actor.Status
 import akka.stream.testkit.Utils.TE
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
-import akka.stream.ActorMaterializer
 import akka.stream.testkit.StreamSpec
 import akka.testkit.TestProbe
 
@@ -20,8 +19,6 @@ private object ActorRefBackpressureSourceSpec {
 
 class ActorRefBackpressureSourceSpec extends StreamSpec {
   import ActorRefBackpressureSourceSpec._
-
-  private implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   "An Source.actorRefWithAck" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefSinkSpec.scala
@@ -5,7 +5,6 @@
 package akka.stream.scaladsl
 
 import akka.actor.{ Actor, ActorRef, Props }
-import akka.stream.ActorMaterializer
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.scaladsl._
@@ -25,7 +24,6 @@ object ActorRefSinkSpec {
 
 class ActorRefSinkSpec extends StreamSpec {
   import ActorRefSinkSpec._
-  implicit val materializer = ActorMaterializer()
 
   "A ActorRefSink" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefSourceSpec.scala
@@ -17,7 +17,6 @@ import akka.actor.ActorRef
 import org.reactivestreams.Publisher
 
 class ActorRefSourceSpec extends StreamSpec {
-  private implicit val materializer = ActorMaterializer()
 
   "A ActorRefSource" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
@@ -420,7 +420,7 @@ class AttributesSpec
           // this is now just for map since there already is one in-between stage and map
           .async
           .addAttributes(ActorAttributes.dispatcher("my-dispatcher"))
-          .runWith(javadsl.Sink.head(), materializer)
+          .runWith(javadsl.Sink.head[String](), materializer)
 
       val dispatcher = dispatcherF.toCompletableFuture.get(remainingOrDefault.toMillis, TimeUnit.MILLISECONDS)
 
@@ -433,7 +433,7 @@ class AttributesSpec
           .fromGraph(new ThreadNameSnitchingStage(ActorAttributes.IODispatcher.dispatcher))
           .async
           .withAttributes(ActorAttributes.dispatcher("my-dispatcher"))
-          .runWith(javadsl.Sink.head(), materializer)
+          .runWith(javadsl.Sink.head[String](), materializer)
 
       val dispatcher = dispatcherF.toCompletableFuture.get(remainingOrDefault.toMillis, TimeUnit.MILLISECONDS)
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/BidiFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/BidiFlowSpec.scala
@@ -20,8 +20,6 @@ class BidiFlowSpec extends StreamSpec {
   import Attributes._
   import GraphDSL.Implicits._
 
-  implicit val materializer = ActorMaterializer()
-
   val bidi = BidiFlow.fromFlows(
     Flow[Int].map(x => x.toLong + 2).withAttributes(name("top")),
     Flow[ByteString].map(_.decodeString("UTF-8")).withAttributes(name("bottom")))

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/CompressionSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/CompressionSpec.scala
@@ -6,14 +6,12 @@ package akka.stream.scaladsl
 
 import java.nio.charset.StandardCharsets
 
-import akka.stream.impl.io.compression.{ DeflateCompressor, GzipCompressor }
+import akka.stream.impl.io.compression.DeflateCompressor
+import akka.stream.impl.io.compression.GzipCompressor
 import akka.stream.testkit.StreamSpec
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
 import akka.util.ByteString
 
 class CompressionSpec extends StreamSpec {
-  val settings = ActorMaterializerSettings(system)
-  implicit val materializer = ActorMaterializer(settings)
 
   def gzip(s: String): ByteString = new GzipCompressor().compressAndFinish(ByteString(s))
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FailedSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FailedSourceSpec.scala
@@ -4,15 +4,13 @@
 
 package akka.stream.scaladsl
 
-import akka.stream.ActorMaterializer
-import akka.stream.testkit.{ StreamSpec, TestSubscriber }
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.TestSubscriber
 import akka.testkit.DefaultTimeout
 
 import scala.util.control.NoStackTrace
 
 class FailedSourceSpec extends StreamSpec with DefaultTimeout {
-
-  implicit val materializer = ActorMaterializer()
 
   "The Failed Source" must {
     "emit error immediately" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowAppendSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowAppendSpec.scala
@@ -5,16 +5,12 @@
 package akka.stream.scaladsl
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.ActorMaterializerSettings
-import akka.stream.testkit.{ StreamSpec, TestSubscriber }
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.TestSubscriber
 import org.reactivestreams.Subscriber
 import org.scalatest.Matchers
 
 class FlowAppendSpec extends StreamSpec with River {
-
-  val settings = ActorMaterializerSettings(system)
-  implicit val materializer = ActorMaterializer(settings)
 
   "Flow" should {
     "append Flow" in riverOf[String] { subscriber =>

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowAskSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowAskSpec.scala
@@ -6,16 +6,22 @@ package akka.stream.scaladsl
 
 import java.util.concurrent.ThreadLocalRandom
 
-import akka.actor.{ Actor, ActorRef, PoisonPill, Props }
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.actor.PoisonPill
+import akka.actor.Props
 import akka.stream.ActorAttributes.supervisionStrategy
-import akka.stream.{ ActorAttributes, ActorMaterializer, Supervision }
 import akka.stream.Supervision.resumingDecider
-import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit._
-import akka.testkit.{ TestActors, TestProbe }
+import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.stream.ActorAttributes
+import akka.stream.Supervision
+import akka.testkit.TestActors
+import akka.testkit.TestProbe
 
-import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
+import scala.concurrent.Await
+import scala.concurrent.Future
 import scala.reflect.ClassTag
 
 object FlowAskSpec {
@@ -72,8 +78,6 @@ object FlowAskSpec {
 
 class FlowAskSpec extends StreamSpec {
   import FlowAskSpec._
-
-  implicit val materializer = ActorMaterializer()
 
   "A Flow with ask" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowCollectSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowCollectSpec.scala
@@ -4,20 +4,16 @@
 
 package akka.stream.scaladsl
 
+import java.util.concurrent.ThreadLocalRandom.{ current => random }
+
 import akka.stream.ActorAttributes._
 import akka.stream.Supervision._
+import akka.stream.testkit.ScriptedTest
+import akka.stream.testkit.StreamSpec
 import akka.stream.testkit.Utils.TE
 import akka.stream.testkit.scaladsl.TestSink
 
-import java.util.concurrent.ThreadLocalRandom.{ current => random }
-
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
-import akka.stream.testkit.{ ScriptedTest, StreamSpec }
-
 class FlowCollectSpec extends StreamSpec with ScriptedTest {
-
-  val settings = ActorMaterializerSettings(system)
-  implicit val materializer = ActorMaterializer(settings)
 
   "A Collect" must {
 
@@ -28,7 +24,9 @@ class FlowCollectSpec extends StreamSpec with ScriptedTest {
           Seq(x) -> (if ((x & 1) == 0) Seq((x * x).toString) else Seq.empty[String])
         }: _*)
       TestConfig.RandomTestRange.foreach(_ =>
-        runScript(script, settings)(_.collect { case x if x % 2 == 0 => (x * x).toString }))
+        runScript(script)(_.collect {
+          case x if x % 2 == 0 => (x * x).toString
+        }))
     }
 
     "restart when Collect throws" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowCollectTypeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowCollectTypeSpec.scala
@@ -5,12 +5,8 @@
 package akka.stream.scaladsl
 
 import akka.stream.testkit.StreamSpec
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
 
 class FlowCollectTypeSpec extends StreamSpec {
-
-  val settings = ActorMaterializerSettings(system)
-  implicit val materializer = ActorMaterializer(settings)
 
   sealed class Fruit
   class Orange extends Fruit

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowCompileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowCompileSpec.scala
@@ -6,13 +6,11 @@ package akka.stream.scaladsl
 
 import akka.NotUsed
 import akka.stream.testkit.StreamSpec
+import com.github.ghik.silencer.silent
 import org.reactivestreams.Publisher
 
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
-import akka.stream.ActorMaterializer
-import akka.stream.ActorMaterializerSettings
-import com.github.ghik.silencer.silent
 
 @silent // unused vars are used in shouldNot compile tests
 class FlowCompileSpec extends StreamSpec {
@@ -22,7 +20,6 @@ class FlowCompileSpec extends StreamSpec {
 
   import scala.concurrent.ExecutionContext.Implicits.global
   val intFut = Source.fromFuture(Future { 3 })
-  implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system))
 
   "Flow" should {
     "not run" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDelaySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDelaySpec.scala
@@ -7,21 +7,22 @@ package akka.stream.scaladsl
 import akka.Done
 import akka.stream.Attributes._
 import akka.stream.OverflowStrategies.EmitEarly
+import akka.stream._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.scaladsl.TestSink
-import akka.stream.testkit.{ StreamSpec, TestPublisher, TestSubscriber }
-import akka.stream._
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.TestSubscriber
 import akka.testkit.TimingTest
 import org.scalatest.concurrent.PatienceConfiguration
-import org.scalatest.time.{ Milliseconds, Span }
+import org.scalatest.time.Milliseconds
+import org.scalatest.time.Span
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
 class FlowDelaySpec extends StreamSpec {
-
-  implicit val materializer = ActorMaterializer()
 
   "A Delay" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDetacherSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDetacherSpec.scala
@@ -4,16 +4,14 @@
 
 package akka.stream.scaladsl
 
-import akka.stream._
-import scala.concurrent.Await
-import scala.concurrent.duration._
-import akka.stream.testkit.scaladsl.TestSink
 import akka.stream.testkit.StreamSpec
 import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.stream.testkit.scaladsl.TestSink
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class FlowDetacherSpec extends StreamSpec {
-
-  implicit val materializer = ActorMaterializer()
 
   "A Detacher" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDropWhileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDropWhileSpec.scala
@@ -7,17 +7,11 @@ package akka.stream.scaladsl
 import akka.stream.ActorAttributes._
 import akka.stream.Supervision._
 import akka.stream.testkit.Utils._
-import akka.stream.testkit.scaladsl.StreamTestKit._
-import akka.stream.ActorMaterializer
-import akka.stream.ActorMaterializerSettings
 import akka.stream.testkit._
+import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.scaladsl.TestSink
 
 class FlowDropWhileSpec extends StreamSpec {
-
-  val settings = ActorMaterializerSettings(system)
-
-  implicit val materializer = ActorMaterializer(settings)
 
   "A DropWhile" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDropWithinSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDropWithinSpec.scala
@@ -4,13 +4,11 @@
 
 package akka.stream.scaladsl
 
-import scala.concurrent.duration._
-import akka.stream.ActorMaterializer
 import akka.stream.testkit._
 
-class FlowDropWithinSpec extends StreamSpec {
+import scala.concurrent.duration._
 
-  implicit val materializer = ActorMaterializer()
+class FlowDropWithinSpec extends StreamSpec {
 
   "A DropWithin" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlattenMergeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlattenMergeSpec.scala
@@ -5,24 +5,25 @@
 package akka.stream.scaladsl
 
 import akka.NotUsed
-import akka.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
 import akka.stream._
+import akka.stream.impl.TraversalBuilder
+import akka.stream.impl.fusing.GraphStages.SingleSource
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.OutHandler
 import akka.stream.testkit.Utils.TE
 import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.TestPublisher
+import akka.testkit.TestLatch
+import akka.util.OptionVal
+import org.scalatest.exceptions.TestFailedException
 
 import scala.concurrent._
 import scala.concurrent.duration._
 
-import akka.stream.impl.TraversalBuilder
-import akka.stream.impl.fusing.GraphStages.SingleSource
-import akka.stream.testkit.{ StreamSpec, TestPublisher }
-import org.scalatest.exceptions.TestFailedException
-import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.TestLatch
-import akka.util.OptionVal
-
 class FlowFlattenMergeSpec extends StreamSpec {
-  implicit val materializer = ActorMaterializer()
   import system.dispatcher
 
   def src10(i: Int) = Source(i until (i + 10))

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFoldAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFoldAsyncSpec.scala
@@ -6,22 +6,23 @@ package akka.stream.scaladsl
 
 import akka.NotUsed
 import akka.stream.ActorAttributes.supervisionStrategy
-import akka.stream.ActorMaterializer
-import akka.stream.Supervision.{ restartingDecider, resumingDecider }
+import akka.stream.Supervision.restartingDecider
+import akka.stream.Supervision.resumingDecider
 import akka.stream.impl.ReactiveStreamsCompliance
 import akka.stream.testkit.Utils._
-import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit._
+import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.testkit.LongRunningTest
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.Await
+import scala.concurrent.Future
 import scala.util.control.NoStackTrace
-import akka.testkit.LongRunningTest
 
 class FlowFoldAsyncSpec extends StreamSpec {
-  implicit val materializer = ActorMaterializer()
-  implicit def ec = materializer.executionContext
+
+  implicit def ec = system.dispatcher
   val timeout = Timeout(3.seconds)
 
   "A FoldAsync" must {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFoldSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFoldSpec.scala
@@ -6,16 +6,15 @@ package akka.stream.scaladsl
 
 import akka.NotUsed
 import akka.stream.testkit.StreamSpec
-
-import scala.concurrent.Await
-import akka.stream.{ ActorAttributes, ActorMaterializer, Supervision }
 import akka.stream.testkit.Utils._
 import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.stream.ActorAttributes
+import akka.stream.Supervision
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class FlowFoldSpec extends StreamSpec {
-  implicit val materializer = ActorMaterializer()
 
   "A Fold" must {
     val input = 1 to 100

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowForeachSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowForeachSpec.scala
@@ -4,17 +4,16 @@
 
 package akka.stream.scaladsl
 
-import scala.util.control.NoStackTrace
-import akka.stream.ActorMaterializer
-import akka.stream.testkit._
 import akka.stream.testkit.Utils._
+import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
 
 class FlowForeachSpec extends StreamSpec {
 
-  implicit val materializer = ActorMaterializer()
   import system.dispatcher
 
   "A runForeach" must {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFromFutureSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFromFutureSpec.scala
@@ -4,19 +4,15 @@
 
 package akka.stream.scaladsl
 
-import scala.concurrent.{ Future, Promise }
-import scala.concurrent.duration._
-import scala.util.control.NoStackTrace
-import akka.stream.ActorMaterializer
-import akka.stream.ActorMaterializerSettings
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 
+import scala.concurrent.duration._
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.control.NoStackTrace
+
 class FlowFromFutureSpec extends StreamSpec {
-
-  val settings = ActorMaterializerSettings(system)
-
-  implicit val materializer = ActorMaterializer(settings)
 
   "A Flow based on a Future" must {
     "produce one element from already successful Future" in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupedWithinSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowGroupedWithinSpec.scala
@@ -4,22 +4,18 @@
 
 package akka.stream.scaladsl
 
-import scala.collection.immutable
-import scala.concurrent.duration._
 import java.util.concurrent.ThreadLocalRandom.{ current => random }
 
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings, ThrottleMode }
+import akka.stream.ThrottleMode
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
-
 import akka.testkit.TimingTest
 import akka.util.ConstantFun
 
+import scala.collection.immutable
+import scala.concurrent.duration._
+
 class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
-
-  val settings = ActorMaterializerSettings(system)
-
-  implicit val materializer = ActorMaterializer()
 
   "A GroupedWithin" must {
 
@@ -168,7 +164,7 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
         Script(TestConfig.RandomTestRange.map { _ =>
           val x, y, z = random.nextInt(); Seq(x, y, z) -> Seq(immutable.Seq(x, y, z))
         }: _*)
-      TestConfig.RandomTestRange.foreach(_ => runScript(script, settings)(_.groupedWithin(3, 10.minutes)))
+      TestConfig.RandomTestRange.foreach(_ => runScript(script)(_.groupedWithin(3, 10.minutes)))
     }
 
     "group with rest" taggedAs TimingTest in {
@@ -177,7 +173,7 @@ class FlowGroupedWithinSpec extends StreamSpec with ScriptedTest {
           val x, y, z = random.nextInt(); Seq(x, y, z) -> Seq(immutable.Seq(x, y, z))
         }
         :+ { val x = random.nextInt(); Seq(x) -> Seq(immutable.Seq(x)) }): _*)
-      TestConfig.RandomTestRange.foreach(_ => runScript(script, settings)(_.groupedWithin(3, 10.minutes)))
+      TestConfig.RandomTestRange.foreach(_ => runScript(script)(_.groupedWithin(3, 10.minutes)))
     }
 
     "group with small groups with backpressure" taggedAs TimingTest in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowKillSwitchSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowKillSwitchSpec.scala
@@ -6,16 +6,16 @@ package akka.stream.scaladsl
 
 import akka.Done
 import akka.stream.testkit.StreamSpec
-import akka.stream.{ ActorMaterializer, ClosedShape, KillSwitches }
-import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
-import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.Utils.TE
+import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.testkit.scaladsl.TestSource
+import akka.stream.ClosedShape
+import akka.stream.KillSwitches
 
 import scala.concurrent.duration._
 
 class FlowKillSwitchSpec extends StreamSpec {
-
-  implicit val mat = ActorMaterializer()
 
   "A UniqueKillSwitch" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLogSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowLogSpec.scala
@@ -22,8 +22,6 @@ class FlowLogSpec extends StreamSpec("""
      akka.actor.serialize-messages = off
      """) with ScriptedTest {
 
-  implicit val mat: Materializer = ActorMaterializer()
-
   val logProbe = {
     val p = TestProbe()
     system.eventStream.subscribe(p.ref, classOf[Logging.LogEvent])
@@ -32,7 +30,7 @@ class FlowLogSpec extends StreamSpec("""
 
   "A Log" must {
 
-    val supervisorPath = ActorMaterializerHelper.downcast(mat).supervisor.path
+    val supervisorPath = ActorMaterializerHelper.downcast(SystemMaterializer(system).materializer).supervisor.path
     val LogSrc = s"akka.stream.Log($supervisorPath)"
     val LogClazz = classOf[Materializer]
 
@@ -70,7 +68,7 @@ class FlowLogSpec extends StreamSpec("""
           .log("log-3", new akka.japi.function.Function[Integer, Integer] { def apply(i: Integer) = i }, log)
           .log("log-4", log)
 
-        javadsl.Source.single[Integer](1).via(debugging).runWith(javadsl.Sink.ignore(), mat)
+        javadsl.Source.single[Integer](1).via(debugging).runWith(javadsl.Sink.ignore[Integer](), system)
 
         var counter = 0
         var finishCounter = 0
@@ -163,7 +161,7 @@ class FlowLogSpec extends StreamSpec("""
           .log("log-2", new akka.japi.function.Function[Integer, Integer] { def apply(i: Integer) = i })
           .log("log-3", new akka.japi.function.Function[Integer, Integer] { def apply(i: Integer) = i }, log)
           .log("log-4", log)
-          .runWith(javadsl.Sink.ignore(), mat)
+          .runWith(javadsl.Sink.ignore[Integer](), system)
 
         var counter = 1
         import scala.concurrent.duration._

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncSpec.scala
@@ -4,27 +4,30 @@
 
 package akka.stream.scaladsl
 
-import java.util.concurrent.{ LinkedBlockingQueue, ThreadLocalRandom }
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadLocalRandom
 
 import akka.stream.ActorAttributes.supervisionStrategy
-import akka.stream.{ ActorAttributes, ActorMaterializer, Supervision }
 import akka.stream.Supervision.resumingDecider
 import akka.stream.testkit.Utils._
-import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit._
+import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.{ TestLatch, TestProbe }
+import akka.stream.ActorAttributes
+import akka.stream.Supervision
+import akka.testkit.TestLatch
+import akka.testkit.TestProbe
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
 import scala.annotation.tailrec
-import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.Promise
 import scala.util.control.NoStackTrace
 
 class FlowMapAsyncSpec extends StreamSpec {
-
-  implicit val materializer = ActorMaterializer()
 
   "A Flow with mapAsync" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncUnorderedSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncUnorderedSpec.scala
@@ -4,29 +4,26 @@
 
 package akka.stream.scaladsl
 
-import scala.concurrent.Await
-import scala.concurrent.Future
-import scala.concurrent.duration._
-import scala.util.control.NoStackTrace
-import akka.stream.ActorMaterializer
-import akka.stream.testkit._
-import akka.stream.testkit.scaladsl._
-import akka.stream.testkit.scaladsl.StreamTestKit._
-import akka.testkit.TestLatch
-import akka.testkit.TestProbe
-import akka.stream.ActorAttributes.supervisionStrategy
-import akka.stream.Supervision.resumingDecider
+import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.concurrent.Promise
-import java.util.concurrent.LinkedBlockingQueue
+import akka.stream.ActorAttributes.supervisionStrategy
+import akka.stream.Supervision.resumingDecider
+import akka.stream.testkit._
+import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.stream.testkit.scaladsl._
+import akka.testkit.TestLatch
+import akka.testkit.TestProbe
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 
 import scala.annotation.tailrec
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
 
 class FlowMapAsyncUnorderedSpec extends StreamSpec {
-
-  implicit val materializer = ActorMaterializer()
 
   "A Flow with mapAsyncUnordered" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMonitorSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMonitorSpec.scala
@@ -4,18 +4,16 @@
 
 package akka.stream.scaladsl
 
-import akka.stream.testkit.StreamSpec
-import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings, FlowMonitorState }
 import akka.stream.FlowMonitorState._
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.testkit.scaladsl.TestSource
+import akka.stream.ActorMaterializer
+import akka.stream.FlowMonitorState
 
 import scala.concurrent.duration._
 
 class FlowMonitorSpec extends StreamSpec {
-
-  val settings = ActorMaterializerSettings(system)
-
-  implicit val materializer = ActorMaterializer(settings)
 
   "A FlowMonitor" must {
     "return Finished when stream is completed" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowOrElseSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowOrElseSpec.scala
@@ -4,22 +4,15 @@
 
 package akka.stream.scaladsl
 
-//#or-else
-
-//#or-else
-import scala.concurrent.duration._
 import akka.stream.testkit.Utils.TE
-import akka.stream.testkit.{ TestPublisher, TestSubscriber }
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.TestSubscriber
 import akka.testkit.AkkaSpec
 
 import scala.collection.immutable.Seq
+import scala.concurrent.duration._
 
 class FlowOrElseSpec extends AkkaSpec {
-
-  val settings = ActorMaterializerSettings(system)
-
-  implicit val materializer = ActorMaterializer(settings)
 
   "An OrElse flow" should {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrependSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrependSpec.scala
@@ -4,7 +4,6 @@
 
 package akka.stream.scaladsl
 
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
 import akka.testkit.AkkaSpec
 import com.github.ghik.silencer.silent
 
@@ -12,14 +11,8 @@ import com.github.ghik.silencer.silent
 class FlowPrependSpec extends AkkaSpec {
 
 //#prepend
-  import akka.stream.scaladsl.Source
-  import akka.stream.scaladsl.Sink
 
 //#prepend
-
-  val settings = ActorMaterializerSettings(system)
-
-  implicit val materializer = ActorMaterializer(settings)
 
   "An Prepend flow" should {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowReduceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowReduceSpec.scala
@@ -5,16 +5,15 @@
 package akka.stream.scaladsl
 
 import akka.stream.testkit.StreamSpec
-
-import scala.concurrent.Await
-import akka.stream.{ ActorAttributes, ActorMaterializer, Supervision }
 import akka.stream.testkit.Utils._
 import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.stream.ActorAttributes
+import akka.stream.Supervision
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class FlowReduceSpec extends StreamSpec {
-  implicit val materializer = ActorMaterializer()
 
   "A Reduce" must {
     val input = 1 to 100

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowScanAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowScanAsyncSpec.scala
@@ -5,23 +5,25 @@
 package akka.stream.scaladsl
 
 import akka.pattern
-import akka.stream.{ ActorAttributes, ActorMaterializer, Supervision }
 import akka.stream.impl.ReactiveStreamsCompliance
 import akka.stream.testkit.TestSubscriber.Probe
 import akka.stream.testkit.Utils.TE
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl._
 import org.scalatest.Matchers
+import akka.stream.ActorAttributes
+import akka.stream.Supervision
 
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Future, Promise }
+import scala.concurrent.Future
+import scala.concurrent.Promise
 import scala.util.Failure
 
 class FlowScanAsyncSpec extends StreamSpec with Matchers {
 
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
-  implicit val executionContext = materializer.executionContext
+  implicit val executionContext = system.dispatcher
 
   "A ScanAsync" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSectionSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSectionSpec.scala
@@ -4,11 +4,10 @@
 
 package akka.stream.scaladsl
 
-import akka.stream.Attributes._
-import akka.stream.ActorAttributes._
-import akka.stream.ActorMaterializer
-import akka.stream.testkit.StreamSpec
 import akka.actor.ActorRef
+import akka.stream.ActorAttributes._
+import akka.stream.Attributes._
+import akka.stream.testkit.StreamSpec
 import akka.testkit.TestProbe
 
 object FlowSectionSpec {
@@ -20,8 +19,6 @@ object FlowSectionSpec {
 }
 
 class FlowSectionSpec extends StreamSpec(FlowSectionSpec.config) {
-
-  implicit val materializer = ActorMaterializer()
 
   "A flow".can {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSupervisionSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSupervisionSpec.scala
@@ -4,21 +4,19 @@
 
 package akka.stream.scaladsl
 
-import scala.collection.immutable
-import scala.concurrent.duration._
-import akka.stream.ActorMaterializer
-import akka.stream.testkit._
-import scala.util.control.NoStackTrace
-import scala.concurrent.Await
+import akka.NotUsed
+import akka.stream.ActorAttributes
 import akka.stream.Supervision
 import akka.stream.impl.ReactiveStreamsCompliance
-import akka.stream.ActorAttributes
-import akka.NotUsed
+import akka.stream.testkit._
+
+import scala.collection.immutable
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
 
 class FlowSupervisionSpec extends StreamSpec {
   import ActorAttributes.supervisionStrategy
-
-  implicit val materializer = ActorMaterializer()(system)
 
   val exc = new RuntimeException("simulated exc") with NoStackTrace
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowTakeWhileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowTakeWhileSpec.scala
@@ -6,18 +6,13 @@ package akka.stream.scaladsl
 
 import akka.stream.ActorAttributes._
 import akka.stream.Supervision._
-import akka.stream.testkit.scaladsl.StreamTestKit._
-import akka.stream.ActorMaterializer
-import akka.stream.ActorMaterializerSettings
 import akka.stream.testkit._
+import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.scaladsl.TestSink
+
 import scala.util.control.NoStackTrace
 
 class FlowTakeWhileSpec extends StreamSpec {
-
-  val settings = ActorMaterializerSettings(system)
-
-  implicit val materializer = ActorMaterializer(settings)
 
   "A TakeWhile" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowTakeWithinSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowTakeWithinSpec.scala
@@ -4,14 +4,12 @@
 
 package akka.stream.scaladsl
 
-import scala.concurrent.duration._
-import akka.stream.ActorMaterializer
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 
-class FlowTakeWithinSpec extends StreamSpec {
+import scala.concurrent.duration._
 
-  implicit val materializer = ActorMaterializer()
+class FlowTakeWithinSpec extends StreamSpec {
 
   "A TakeWithin" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWatchSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWatchSpec.scala
@@ -4,10 +4,11 @@
 
 package akka.stream.scaladsl
 
-import akka.actor.{ Actor, PoisonPill, Props }
-import akka.stream.ActorMaterializer
-import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.actor.Actor
+import akka.actor.PoisonPill
+import akka.actor.Props
 import akka.stream.testkit._
+import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.testkit.TestActors
 
 import scala.concurrent.Await
@@ -26,8 +27,6 @@ object FlowWatchSpec {
 
 class FlowWatchSpec extends StreamSpec {
   import FlowWatchSpec._
-
-  implicit val materializer = ActorMaterializer()
 
   "A Flow with watch" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWatchTerminationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWatchTerminationSpec.scala
@@ -9,16 +9,13 @@ import akka.pattern.pipe
 import akka.stream._
 import akka.stream.testkit.StreamSpec
 import akka.stream.testkit.scaladsl.StreamTestKit._
-import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
+import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.testkit.scaladsl.TestSource
 
-import scala.util.control.NoStackTrace
 import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
 
 class FlowWatchTerminationSpec extends StreamSpec {
-
-  val settings = ActorMaterializerSettings(system)
-
-  implicit val materializer = ActorMaterializer(settings)
 
   "A WatchTermination" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWireTapSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWireTapSpec.scala
@@ -5,15 +5,14 @@
 package akka.stream.scaladsl
 
 import akka.Done
-import akka.stream.ActorMaterializer
 import akka.stream.testkit.Utils._
-import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit._
+import akka.stream.testkit.scaladsl.StreamTestKit._
 
 import scala.util.control.NoStackTrace
 
 class FlowWireTapSpec extends StreamSpec("akka.stream.materializer.debug.fuzzing-mode = off") {
-  implicit val materializer = ActorMaterializer()
+
   import system.dispatcher
 
   "A wireTap" must {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWithContextLogSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWithContextLogSpec.scala
@@ -6,16 +6,15 @@ package akka.stream.scaladsl
 
 import akka.event.Logging
 import akka.stream.Attributes.LogLevels
-import akka.stream.testkit.{ ScriptedTest, StreamSpec }
 import akka.stream._
+import akka.stream.testkit.ScriptedTest
+import akka.stream.testkit.StreamSpec
 import akka.testkit.TestProbe
 
 class FlowWithContextLogSpec extends StreamSpec("""
      akka.loglevel = DEBUG # test verifies logging
      akka.actor.serialize-messages = off
      """) with ScriptedTest {
-
-  implicit val mat: Materializer = ActorMaterializer()
 
   val logProbe = {
     val p = TestProbe()
@@ -25,7 +24,7 @@ class FlowWithContextLogSpec extends StreamSpec("""
 
   "log() from FlowWithContextOps" must {
 
-    val supervisorPath = ActorMaterializerHelper.downcast(mat).supervisor.path
+    val supervisorPath = ActorMaterializerHelper.downcast(SystemMaterializer(system).materializer).supervisor.path
     val LogSrc = s"akka.stream.Log($supervisorPath)"
     val LogClazz = classOf[Materializer]
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWithContextSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowWithContextSpec.scala
@@ -4,14 +4,10 @@
 
 package akka.stream.scaladsl
 
-import akka.stream.testkit.scaladsl.TestSink
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
 import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.scaladsl.TestSink
 
 class FlowWithContextSpec extends StreamSpec {
-
-  val settings = ActorMaterializerSettings(system)
-  implicit val materializer = ActorMaterializer(settings)
 
   "A FlowWithContext" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FramingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FramingSpec.scala
@@ -9,9 +9,14 @@ import java.util.concurrent.ThreadLocalRandom
 
 import akka.stream._
 import akka.stream.scaladsl.Framing.FramingException
-import akka.stream.stage.{ GraphStage, _ }
-import akka.stream.testkit.{ StreamSpec, TestPublisher, TestSubscriber }
-import akka.util.{ unused, ByteString, ByteStringBuilder }
+import akka.stream.stage.GraphStage
+import akka.stream.stage._
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.TestSubscriber
+import akka.util.ByteString
+import akka.util.ByteStringBuilder
+import akka.util.unused
 
 import scala.collection.immutable
 import scala.concurrent.Future
@@ -19,9 +24,6 @@ import scala.concurrent.duration._
 import scala.util.Random
 
 class FramingSpec extends StreamSpec {
-
-  val settings = ActorMaterializerSettings(system)
-  implicit val materializer = ActorMaterializer(settings)
 
   class Rechunker extends GraphStage[FlowShape[ByteString, ByteString]] {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FutureFlattenSourceSpec.scala
@@ -17,7 +17,6 @@ import scala.concurrent.{ Await, Future, Promise }
 
 class FutureFlattenSourceSpec extends StreamSpec {
 
-  implicit val materializer = ActorMaterializer()
   implicit def ec = system.dispatcher
 
   "Future source" must {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphDSLCompileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphDSLCompileSpec.scala
@@ -19,8 +19,6 @@ object GraphDSLCompileSpec {
 class GraphDSLCompileSpec extends StreamSpec {
   import GraphDSLCompileSpec._
 
-  implicit val materializer = ActorMaterializer()
-
   def op[In, Out] = new GraphStage[FlowShape[In, Out]] {
     val in = Inlet[In]("op.in")
     val out = Outlet[Out]("op.out")

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphStageTimersSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphStageTimersSpec.scala
@@ -5,17 +5,19 @@
 package akka.stream.scaladsl
 
 import akka.actor.ActorRef
-import akka.stream.{ ActorMaterializer, Attributes }
+import akka.stream.Attributes
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
-import akka.stream.stage.{ AsyncCallback, InHandler, OutHandler, TimerGraphStageLogic }
+import akka.stream.stage.AsyncCallback
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+import akka.stream.stage.TimerGraphStageLogic
+import akka.stream.testkit.Utils._
+import akka.stream.testkit._
+import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.testkit.TestDuration
 
 import scala.concurrent.Promise
 import scala.concurrent.duration._
-
-import akka.stream.testkit._
-import akka.stream.testkit.Utils._
-import akka.stream.testkit.scaladsl.StreamTestKit._
 
 object GraphStageTimersSpec {
   case object TestSingleTimer
@@ -39,8 +41,6 @@ object GraphStageTimersSpec {
 
 class GraphStageTimersSpec extends StreamSpec {
   import GraphStageTimersSpec._
-
-  implicit val materializer = ActorMaterializer()
 
   class TestStage(probe: ActorRef, sideChannel: SideChannel) extends SimpleLinearGraphStage[Int] {
     override def createLogic(inheritedAttributes: Attributes) = new TimerGraphStageLogic(shape) {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphZipLatestSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphZipLatestSpec.scala
@@ -4,11 +4,14 @@
 
 package akka.stream.scaladsl
 
+import akka.stream.ClosedShape
 import akka.stream.testkit.TestPublisher.Probe
-import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
-import akka.stream.testkit.{ StreamSpec, TestPublisher, TestSubscriber }
-import akka.stream.{ ActorMaterializer, ClosedShape }
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.testkit.scaladsl.TestSource
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.TestSubscriber
 import org.scalacheck.Gen
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -23,8 +26,6 @@ object GraphZipLatestSpec {
 
 class GraphZipLatestSpec extends StreamSpec with ScalaCheckPropertyChecks with ScalaFutures {
   import GraphZipLatestSpec._
-
-  implicit val materializer = ActorMaterializer()
 
   "ZipLatest" must {
     "only emit when at least one pair is available" in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
@@ -4,11 +4,15 @@
 
 package akka.stream.scaladsl
 
-import akka.stream.{ ActorMaterializer, KillSwitches, ThrottleMode }
-import akka.stream.testkit.{ StreamSpec, TestPublisher, TestSubscriber }
 import akka.stream.testkit.Utils.TE
-import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
 import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.testkit.scaladsl.TestSource
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.TestSubscriber
+import akka.stream.KillSwitches
+import akka.stream.ThrottleMode
 import akka.testkit.EventFilter
 
 import scala.collection.immutable
@@ -16,8 +20,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class HubSpec extends StreamSpec {
-
-  implicit val mat = ActorMaterializer()
 
   "MergeHub" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/JsonFramingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/JsonFramingSpec.scala
@@ -4,11 +4,11 @@
 
 package akka.stream.scaladsl
 
-import akka.stream.ActorMaterializer
 import akka.stream.impl.JsonObjectParser
 import akka.stream.scaladsl.Framing.FramingException
-import akka.stream.testkit.{ TestPublisher, TestSubscriber }
 import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.TestSubscriber
 import akka.testkit.AkkaSpec
 import akka.util.ByteString
 
@@ -17,8 +17,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class JsonFramingSpec extends AkkaSpec {
-
-  implicit val mat = ActorMaterializer()
 
   "collecting multiple json" should {
     "parse json array" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LastSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LastSinkSpec.scala
@@ -4,18 +4,15 @@
 
 package akka.stream.scaladsl
 
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.Await
+import scala.concurrent.Future
 
 class LastSinkSpec extends StreamSpec with ScriptedTest {
 
-  val settings = ActorMaterializerSettings(system)
-
-  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
   implicit val ec = system.dispatcher
 
   "A Flow with Sink.last" must {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LazilyAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LazilyAsyncSpec.scala
@@ -7,9 +7,9 @@ package akka.stream.scaladsl
 import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.Done
-import akka.stream.ActorMaterializer
-import akka.stream.testkit.{ StreamSpec, TestSubscriber }
 import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.TestSubscriber
 import akka.testkit.DefaultTimeout
 import org.scalatest.concurrent.ScalaFutures
 
@@ -17,9 +17,7 @@ import scala.concurrent.Future
 
 class LazilyAsyncSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
 
-  private implicit val mat: ActorMaterializer = ActorMaterializer()
-
-  import mat.executionContext
+  import system.dispatcher
 
   "A lazy async source" should {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LazySourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LazySourceSpec.scala
@@ -8,11 +8,16 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.Done
 import akka.stream.impl.LazySource
-import akka.stream.stage.{ GraphStage, GraphStageLogic }
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
 import akka.stream.testkit.Utils.TE
 import akka.stream.testkit.scaladsl.StreamTestKit._
-import akka.stream.testkit.{ StreamSpec, TestPublisher, TestSubscriber }
-import akka.stream.{ ActorMaterializer, Attributes, Outlet, SourceShape }
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.TestSubscriber
+import akka.stream.Attributes
+import akka.stream.Outlet
+import akka.stream.SourceShape
 import akka.testkit.DefaultTimeout
 import org.scalatest.concurrent.ScalaFutures
 
@@ -20,8 +25,6 @@ import scala.collection.immutable.Seq
 import scala.concurrent.Future
 
 class LazySourceSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
-
-  implicit val materializer = ActorMaterializer()
 
   "A lazy source" should {
     "work like a normal source, happy path" in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/MaybeSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/MaybeSourceSpec.scala
@@ -4,17 +4,17 @@
 
 package akka.stream.scaladsl
 
-import akka.stream.{ AbruptStageTerminationException, ActorMaterializer }
-import akka.stream.testkit.{ StreamSpec, TestSubscriber }
 import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.TestSubscriber
+import akka.stream.AbruptStageTerminationException
+import akka.stream.ActorMaterializer
 import akka.testkit.DefaultTimeout
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
 class MaybeSourceSpec extends StreamSpec with DefaultTimeout {
-
-  implicit val materializer = ActorMaterializer()
 
   "The Maybe Source" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/PublisherSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/PublisherSinkSpec.scala
@@ -4,17 +4,14 @@
 
 package akka.stream.scaladsl
 
+import akka.stream.ClosedShape
 import akka.stream.testkit.StreamSpec
-import akka.stream.{ ActorMaterializer, ClosedShape }
-
 import akka.stream.testkit.scaladsl.StreamTestKit._
-import scala.concurrent.duration._
 
 import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class PublisherSinkSpec extends StreamSpec {
-
-  implicit val materializer = ActorMaterializer()
 
   "A PublisherSink" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/QueueSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/QueueSinkSpec.scala
@@ -7,17 +7,17 @@ package akka.stream.scaladsl
 import akka.actor.Status
 import akka.pattern.pipe
 import akka.stream.Attributes.inputBuffer
-import akka.stream.{ ActorMaterializer, StreamDetachedException }
-import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.stream.StreamDetachedException
 import akka.stream.testkit._
+import akka.stream.testkit.scaladsl.StreamTestKit._
 
-import scala.concurrent.{ Await, Promise }
 import scala.concurrent.duration._
+import scala.concurrent.Await
+import scala.concurrent.Promise
 import scala.util.control.NoStackTrace
 
 class QueueSinkSpec extends StreamSpec {
   implicit val ec = system.dispatcher
-  implicit val materializer = ActorMaterializer()
 
   val ex = new RuntimeException("ex") with NoStackTrace
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
@@ -7,21 +7,26 @@ package akka.stream.scaladsl
 import java.util.concurrent.atomic.AtomicInteger
 
 import akka.stream.scaladsl.RestartWithBackoffFlow.Delay
-import akka.stream.testkit.{ StreamSpec, TestPublisher, TestSubscriber }
 import akka.stream.testkit.Utils.TE
-import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
 import akka.stream.testkit.scaladsl.StreamTestKit._
-import akka.stream.{ ActorMaterializer, Attributes, OverflowStrategy }
-import akka.testkit.{ DefaultTimeout, TestDuration }
-import akka.{ Done, NotUsed }
+import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.testkit.scaladsl.TestSource
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.TestSubscriber
+import akka.stream.Attributes
+import akka.stream.OverflowStrategy
+import akka.testkit.DefaultTimeout
+import akka.testkit.TestDuration
+import akka.Done
+import akka.NotUsed
 
 import scala.concurrent.Promise
 import scala.concurrent.duration._
-import scala.util.{ Failure, Success }
+import scala.util.Failure
+import scala.util.Success
 
 class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "10s")) with DefaultTimeout {
-
-  implicit val mat = ActorMaterializer()
 
   import system.dispatcher
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ReverseArrowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ReverseArrowSpec.scala
@@ -4,15 +4,15 @@
 
 package akka.stream.scaladsl
 
-import akka.stream.testkit._
 import akka.stream._
+import akka.stream.testkit._
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class ReverseArrowSpec extends StreamSpec {
   import GraphDSL.Implicits._
 
-  implicit val materializer = ActorMaterializer()
   val source = Source(List(1, 2, 3))
   val sink = Flow[Int].limit(10).toMat(Sink.seq)(Keep.right)
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RunnableGraphSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RunnableGraphSpec.scala
@@ -5,13 +5,11 @@
 package akka.stream.scaladsl
 
 import akka.NotUsed
-import akka.stream.{ ActorMaterializer, Attributes }
-import akka.stream.testkit.StreamSpec
+import akka.stream.Attributes
 import akka.stream.javadsl
+import akka.stream.testkit.StreamSpec
 
 class RunnableGraphSpec extends StreamSpec {
-
-  implicit val materializer = ActorMaterializer()
 
   "A RunnableGraph" must {
 
@@ -26,7 +24,7 @@ class RunnableGraphSpec extends StreamSpec {
 
     "allow conversion from scala to java" in {
       val runnable: javadsl.RunnableGraph[NotUsed] = Source.empty.to(Sink.ignore).asJava
-      runnable.run(materializer) shouldBe NotUsed
+      runnable.run(system) shouldBe NotUsed
     }
 
     "allow conversion from java to scala" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
@@ -5,12 +5,10 @@
 package akka.stream.scaladsl
 
 import akka.NotUsed
-import akka.stream.ActorMaterializer
 import akka.stream.testkit.StreamSpec
 
 class SetupSpec extends StreamSpec {
 
-  implicit val materializer = ActorMaterializer()
   import system.dispatcher
 
   "Source.setup" should {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkForeachAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkForeachAsyncSpec.scala
@@ -4,23 +4,27 @@
 
 package akka.stream.scaladsl
 
-import java.util.concurrent.{ CountDownLatch, Executors, TimeUnit }
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 import akka.Done
 import akka.stream.ActorAttributes.supervisionStrategy
-import akka.stream.ActorMaterializer
-import akka.stream.Supervision.{ resumingDecider, stoppingDecider }
+import akka.stream.Supervision.resumingDecider
+import akka.stream.Supervision.stoppingDecider
 import akka.stream.testkit.StreamSpec
 import akka.stream.testkit.scaladsl.StreamTestKit._
-import akka.testkit.{ TestLatch, TestProbe }
+import akka.testkit.TestLatch
+import akka.testkit.TestProbe
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.language.postfixOps
 import scala.util.control.NoStackTrace
 
 class SinkForeachAsyncSpec extends StreamSpec {
-  implicit val materializer = ActorMaterializer()
 
   "A foreachAsync" must {
     "handle empty source" in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkForeachParallelSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkForeachParallelSpec.scala
@@ -4,14 +4,15 @@
 
 package akka.stream.scaladsl
 
-import java.util.concurrent.{ CountDownLatch, TimeUnit }
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
-import akka.stream.ActorMaterializer
 import akka.stream.ActorAttributes._
 import akka.stream.Supervision._
 import akka.stream.testkit.StreamSpec
 import akka.stream.testkit.scaladsl.StreamTestKit._
-import akka.testkit.{ TestLatch, TestProbe }
+import akka.testkit.TestLatch
+import akka.testkit.TestProbe
 import com.github.ghik.silencer.silent
 
 import scala.concurrent.Await
@@ -20,8 +21,6 @@ import scala.util.control.NoStackTrace
 
 @silent // tests deprecated APIs
 class SinkForeachParallelSpec extends StreamSpec {
-
-  implicit val materializer = ActorMaterializer()
 
   "A ForeachParallel" must {
     "produce elements in the order they are ready" in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
@@ -20,8 +20,6 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
 
   import GraphDSL.Implicits._
 
-  implicit val materializer = ActorMaterializer()
-
   "A Sink" must {
     "be composable without importing modules" in {
       val probes = Array.fill(3)(TestSubscriber.manualProbe[Int])

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
@@ -4,27 +4,27 @@
 
 package akka.stream.scaladsl
 
+import akka.stream.testkit.Utils.TE
 import akka.testkit.DefaultTimeout
-import org.scalatest.time.{ Millis, Span }
+import com.github.ghik.silencer.silent
+import org.scalatest.time.Millis
+import org.scalatest.time.Span
 
 import scala.concurrent.Future
-import akka.stream.testkit.Utils.TE
-import com.github.ghik.silencer.silent
 //#imports
 import akka.stream._
 
 //#imports
-import akka.stream.testkit._
 import akka.NotUsed
-import akka.testkit.EventFilter
-import scala.collection.immutable
-
+import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.EventFilter
+
+import scala.collection.immutable
 
 @silent // tests assigning to typed val
 class SourceSpec extends StreamSpec with DefaultTimeout {
 
-  implicit val materializer = ActorMaterializer()
   implicit val config = PatienceConfig(timeout = Span(timeout.duration.toMillis, Millis))
 
   "Single Source" must {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceWithContextSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceWithContextSpec.scala
@@ -4,16 +4,12 @@
 
 package akka.stream.scaladsl
 
-import akka.stream.testkit.scaladsl.TestSink
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
 import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.scaladsl.TestSink
 
 case class Message(data: String, offset: Long)
 
 class SourceWithContextSpec extends StreamSpec {
-
-  val settings = ActorMaterializerSettings(system)
-  implicit val materializer = ActorMaterializer(settings)
 
   "A SourceWithContext" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StageActorRefSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StageActorRefSpec.scala
@@ -4,19 +4,26 @@
 
 package akka.stream.scaladsl
 
-import akka.actor.{ ActorRef, Kill, NoSerializationVerificationNeeded, PoisonPill }
+import akka.actor.ActorRef
+import akka.actor.Kill
+import akka.actor.NoSerializationVerificationNeeded
+import akka.actor.PoisonPill
 import akka.event.Logging
 import akka.stream._
-import akka.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, InHandler }
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.GraphStageWithMaterializedValue
+import akka.stream.stage.InHandler
 import akka.stream.testkit.StreamSpec
-import akka.testkit.{ EventFilter, ImplicitSender, TestEvent, TestProbe }
+import akka.testkit.EventFilter
+import akka.testkit.ImplicitSender
+import akka.testkit.TestEvent
+import akka.testkit.TestProbe
 
-import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration._
+import scala.concurrent.Future
+import scala.concurrent.Promise
 
 class StageActorRefSpec extends StreamSpec with ImplicitSender {
-  implicit val materializer = ActorMaterializer()
-
   import StageActorRefSpec._
   import ControlProtocol._
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamConvertersSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamConvertersSpec.scala
@@ -5,27 +5,33 @@
 package akka.stream.scaladsl
 
 import java.util
-import java.util.function.{ BiConsumer, BinaryOperator, Supplier, ToIntFunction }
+import java.util.function.BiConsumer
+import java.util.function.BinaryOperator
+import java.util.function.Supplier
+import java.util.function.ToIntFunction
 import java.util.stream.Collector.Characteristics
-import java.util.stream.{ BaseStream, Collector, Collectors }
+import java.util.stream.BaseStream
+import java.util.stream.Collector
+import java.util.stream.Collectors
 
-import akka.stream.ActorMaterializer
 import akka.stream.testkit.StreamSpec
 import akka.stream.testkit.Utils.TE
 import akka.testkit.DefaultTimeout
-import org.scalatest.time.{ Millis, Span }
+import org.scalatest.time.Millis
+import org.scalatest.time.Span
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class StreamConvertersSpec extends StreamSpec with DefaultTimeout {
 
-  implicit val materializer = ActorMaterializer()
   implicit val config = PatienceConfig(timeout = Span(timeout.duration.toMillis, Millis))
 
   "Java Stream source" must {
+    import java.util.stream.IntStream
+    import java.util.stream.Stream
+
     import scala.compat.java8.FunctionConverters._
-    import java.util.stream.{ IntStream, Stream }
 
     def javaStreamInts =
       IntStream.iterate(1, { i: Int =>

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamRefsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamRefsSpec.scala
@@ -5,21 +5,32 @@
 package akka.stream.scaladsl
 
 import akka.NotUsed
+import akka.actor.Actor
+import akka.actor.ActorIdentity
+import akka.actor.ActorLogging
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.ActorSystemImpl
+import akka.actor.Identify
+import akka.actor.Props
 import akka.actor.Status.Failure
-import akka.actor.{ Actor, ActorIdentity, ActorLogging, ActorRef, ActorSystem, ActorSystemImpl, Identify, Props }
 import akka.pattern._
-import akka.stream.testkit.TestPublisher
-import akka.stream.testkit.scaladsl._
 import akka.stream._
 import akka.stream.impl.streamref.SinkRefImpl
 import akka.stream.impl.streamref.SourceRefImpl
-import akka.testkit.{ AkkaSpec, ImplicitSender, TestKit, TestProbe }
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.scaladsl._
+import akka.testkit.AkkaSpec
+import akka.testkit.ImplicitSender
+import akka.testkit.TestKit
+import akka.testkit.TestProbe
 import akka.util.ByteString
 import com.typesafe.config._
 
 import scala.collection.immutable
+import scala.concurrent.Await
+import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
 import scala.util.control.NoStackTrace
 
 object StreamRefsSpec {
@@ -30,7 +41,8 @@ object StreamRefsSpec {
   }
 
   class DataSourceActor(probe: ActorRef) extends Actor with ActorLogging {
-    implicit val mat = ActorMaterializer()
+
+    import context.system
 
     def receive = {
       case "give" =>
@@ -177,7 +189,6 @@ class StreamRefsSpec extends AkkaSpec(StreamRefsSpec.config()) with ImplicitSend
   import StreamRefsSpec._
 
   val remoteSystem = ActorSystem("RemoteSystem", StreamRefsSpec.config())
-  implicit val mat = ActorMaterializer()
 
   override protected def beforeTermination(): Unit =
     TestKit.shutdownActorSystem(remoteSystem)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SubscriberSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SubscriberSourceSpec.scala
@@ -4,16 +4,12 @@
 
 package akka.stream.scaladsl
 
-import akka.stream.ActorMaterializer
 import akka.stream.testkit.StreamSpec
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import scala.concurrent.Await
-
 class SubscriberSourceSpec extends StreamSpec {
-
-  implicit val materializer = ActorMaterializer()
 
   "A SubscriberSource" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/TickSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/TickSourceSpec.scala
@@ -4,15 +4,14 @@
 
 package akka.stream.scaladsl
 
-import scala.concurrent.duration._
-import akka.stream.{ ActorMaterializer, ClosedShape }
+import akka.stream.ClosedShape
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.testkit.TimingTest
 
-class TickSourceSpec extends StreamSpec {
+import scala.concurrent.duration._
 
-  implicit val materializer = ActorMaterializer()
+class TickSourceSpec extends StreamSpec {
 
   "A Flow based on tick publisher" must {
     "produce ticks" taggedAs TimingTest in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/WithContextUsageSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/WithContextUsageSpec.scala
@@ -4,17 +4,14 @@
 
 package akka.stream.scaladsl
 
-import scala.collection.immutable
 import akka.NotUsed
-import akka.stream.testkit.scaladsl.TestSink
-import akka.stream.testkit.TestSubscriber.Probe
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
 import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.TestSubscriber.Probe
+import akka.stream.testkit.scaladsl.TestSink
+
+import scala.collection.immutable
 
 class WithContextUsageSpec extends StreamSpec {
-
-  val settings = ActorMaterializerSettings(system)
-  implicit val materializer = ActorMaterializer(settings)
 
   "Context propagation used for committing offsets" must {
 

--- a/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorFlowSpec.scala
+++ b/akka-stream-typed/src/test/scala/akka/stream/typed/scaladsl/ActorFlowSpec.scala
@@ -27,8 +27,6 @@ object ActorFlowSpec {
 class ActorFlowSpec extends ScalaTestWithActorTestKit with WordSpecLike {
   import ActorFlowSpec._
 
-  implicit val mat = ActorMaterializer()
-
   "ActorFlow" should {
 
     val replier = spawn(Behaviors.receiveMessage[Asking] {

--- a/akka-stream-typed/src/test/scala/docs/akka/stream/typed/ActorSourceSinkExample.scala
+++ b/akka-stream-typed/src/test/scala/docs/akka/stream/typed/ActorSourceSinkExample.scala
@@ -7,13 +7,10 @@ package docs.akka.stream.typed
 import akka.NotUsed
 import akka.actor.typed.{ ActorRef, ActorSystem }
 import akka.actor.typed.scaladsl.Behaviors
-import akka.stream.typed.scaladsl.ActorMaterializer
 
 object ActorSourceSinkExample {
 
-  val system: ActorSystem[_] = ActorSystem(Behaviors.empty, "ActorSourceSinkExample")
-
-  implicit val mat: ActorMaterializer = ActorMaterializer()(system)
+  implicit val system: ActorSystem[_] = ActorSystem(Behaviors.empty, "ActorSourceSinkExample")
 
   {
     // #actor-source-ref

--- a/akka-stream/src/main/scala/akka/stream/Materializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/Materializer.scala
@@ -4,6 +4,7 @@
 
 package akka.stream
 
+import akka.actor.ActorSystem
 import akka.actor.Cancellable
 import akka.annotation.InternalApi
 import com.github.ghik.silencer.silent
@@ -142,6 +143,16 @@ abstract class Materializer {
     "scheduleAtFixedRate, but scheduleWithFixedDelay is often preferred.",
     since = "2.6.0")
   def schedulePeriodically(initialDelay: FiniteDuration, interval: FiniteDuration, task: Runnable): Cancellable
+
+}
+
+object Materializer {
+
+  /**
+   * Implicitly provides the system wide materializer
+   */
+  implicit def matFromSystem(implicit system: ActorSystem): Materializer =
+    SystemMaterializer(system).materializer
 
 }
 

--- a/akka-stream/src/main/scala/akka/stream/Materializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/Materializer.scala
@@ -4,7 +4,7 @@
 
 package akka.stream
 
-import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.actor.Cancellable
 import akka.annotation.InternalApi
 import com.github.ghik.silencer.silent
@@ -149,10 +149,10 @@ abstract class Materializer {
 object Materializer {
 
   /**
-   * Implicitly provides the system wide materializer
+   * Implicitly provides the system wide materializer from a classic or typed `ActorSystem`
    */
-  implicit def matFromSystem(implicit system: ActorSystem): Materializer =
-    SystemMaterializer(system).materializer
+  implicit def matFromSystem(implicit provider: ClassicActorSystemProvider): Materializer =
+    SystemMaterializer(provider.classicSystem).materializer
 
 }
 

--- a/akka-stream/src/main/scala/akka/stream/SystemMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/SystemMaterializer.scala
@@ -25,14 +25,9 @@ object SystemMaterializer extends ExtensionId[SystemMaterializer] with Extension
     new SystemMaterializer(system)
 }
 
-final class SystemMaterializer(_system: ExtendedActorSystem) extends Extension {
+final class SystemMaterializer(system: ExtendedActorSystem) extends Extension {
   val materializer = {
-    val settings = ActorMaterializerSettings(_system)
-    ActorMaterializer.systemMaterializer(settings, "default", _system)
+    val settings = ActorMaterializerSettings(system)
+    ActorMaterializer.systemMaterializer(settings, "default", system)
   }
-  // FIXME not 100% sure about this, it will anyways stop when the system stops the actors
-  _system.registerOnTermination {
-    materializer.shutdown()
-  }
-
 }

--- a/akka-stream/src/main/scala/akka/stream/SystemMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/SystemMaterializer.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream
+
+import akka.actor.ActorSystem
+import akka.actor.ExtendedActorSystem
+import akka.actor.Extension
+import akka.actor.ExtensionId
+import akka.actor.ExtensionIdProvider
+
+/**
+ * The system materializer is a default materializer to use for most cases running streams, it is a single instance
+ * per actor system that is tied to the lifecycle of that system.
+ *
+ * Not intended to be manually used in user code.
+ */
+object SystemMaterializer extends ExtensionId[SystemMaterializer] with ExtensionIdProvider {
+  override def get(system: ActorSystem): SystemMaterializer = super.get(system)
+
+  override def lookup = SystemMaterializer
+
+  override def createExtension(system: ExtendedActorSystem): SystemMaterializer =
+    new SystemMaterializer(system)
+}
+
+final class SystemMaterializer(_system: ExtendedActorSystem) extends Extension {
+  val materializer = {
+    val settings = ActorMaterializerSettings(_system)
+    ActorMaterializer.systemMaterializer(settings, "default", _system)
+  }
+  // FIXME not 100% sure about this, it will anyways stop when the system stops the actors
+  _system.registerOnTermination {
+    materializer.shutdown()
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -4,28 +4,33 @@
 
 package akka.stream.javadsl
 
-import akka.util.{ ConstantFun, Timeout }
-import akka.{ Done, NotUsed }
-import akka.event.LoggingAdapter
-import akka.japi.{ function, Pair, Util }
-import akka.stream._
-import org.reactivestreams.Processor
-
-import scala.concurrent.duration.FiniteDuration
-import java.util.{ Comparator, Optional }
 import java.util.concurrent.CompletionStage
-import java.util.function.{ BiFunction, Supplier }
+import java.util.function.BiFunction
+import java.util.function.Supplier
+import java.util.Comparator
+import java.util.Optional
 
-import akka.util.JavaDurationConverters._
 import akka.actor.ActorRef
-import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.dispatch.ExecutionContexts
+import akka.event.LoggingAdapter
+import akka.japi.Pair
+import akka.japi.Util
+import akka.japi.function
+import akka.stream._
 import akka.stream.impl.fusing.LazyFlow
+import akka.util.JavaDurationConverters._
 import akka.util.unused
+import akka.util.ConstantFun
+import akka.util.Timeout
+import akka.Done
+import akka.NotUsed
 import com.github.ghik.silencer.silent
+import org.reactivestreams.Processor
 
 import scala.annotation.unchecked.uncheckedVariance
 import scala.compat.java8.FutureConverters._
+import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
 
 object Flow {
@@ -500,8 +505,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
   def runWith[T, U](
       source: Graph[SourceShape[In], T],
       sink: Graph[SinkShape[Out], U],
-      system: ActorSystem): akka.japi.Pair[T, U] = {
-    val (som, sim) = delegate.runWith(source, sink)(SystemMaterializer(system).materializer)
+      systemProvider: ClassicActorSystemProvider): akka.japi.Pair[T, U] = {
+    val (som, sim) = delegate.runWith(source, sink)(SystemMaterializer(systemProvider.classicSystem).materializer)
     akka.japi.Pair(som, sim)
   }
 
@@ -3603,8 +3608,8 @@ abstract class RunnableGraph[+Mat] extends Graph[ClosedShape, Mat] {
    *
    * Uses the system materializer.
    */
-  def run(system: ActorSystem): Mat = {
-    run(SystemMaterializer(system).materializer)
+  def run(systemProvider: ClassicActorSystemProvider): Mat = {
+    run(SystemMaterializer(systemProvider.classicSystem).materializer)
   }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -5,26 +5,30 @@
 package akka.stream.javadsl
 
 import java.util.Optional
-
-import akka.{ japi, Done, NotUsed }
-import akka.actor.ActorRef
-import akka.dispatch.ExecutionContexts
-import akka.japi.function
-import akka.stream.impl.LinearTraversalBuilder
-import akka.stream.{ javadsl, scaladsl, _ }
-import org.reactivestreams.{ Publisher, Subscriber }
-
-import scala.compat.java8.OptionConverters._
-import scala.concurrent.ExecutionContext
-import scala.util.Try
 import java.util.concurrent.CompletionStage
 import java.util.function.BiFunction
 
+import akka.actor.ActorRef
 import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
+import akka.dispatch.ExecutionContexts
+import akka.japi.function
+import akka.stream.impl.LinearTraversalBuilder
+import akka.stream.javadsl
+import akka.stream.scaladsl
+import akka.stream._
+import akka.Done
+import akka.NotUsed
+import akka.japi
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
 
-import scala.collection.immutable
 import scala.annotation.unchecked.uncheckedVariance
+import scala.collection.immutable
 import scala.compat.java8.FutureConverters._
+import scala.compat.java8.OptionConverters._
+import scala.concurrent.ExecutionContext
+import scala.util.Try
 
 /** Java API */
 object Sink {
@@ -384,8 +388,8 @@ final class Sink[In, Mat](delegate: scaladsl.Sink[In, Mat]) extends Graph[SinkSh
   /**
    * Connect this `Sink` to a `Source` and run it.
    */
-  def runWith[M](source: Graph[SourceShape[In], M], system: ActorSystem): M =
-    asScala.runWith(source)(SystemMaterializer(system).materializer)
+  def runWith[M](source: Graph[SourceShape[In], M], systemProvider: ClassicActorSystemProvider): M =
+    asScala.runWith(source)(SystemMaterializer(systemProvider.classicSystem).materializer)
 
   /**
    * Connect this `Sink` to a `Source` and run it.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -419,9 +419,12 @@ final class Sink[In, Mat](delegate: scaladsl.Sink[In, Mat]) extends Graph[SinkSh
    * that can be consume elements 'into' the pre-materialized one.
    *
    * Useful for when you need a materialized value of a Sink when handing it out to someone to materialize it for you.
+   *
+   * Note that the `ActorSystem` can be used as the `systemProvider` parameter.
    */
-  def preMaterialize(system: ActorSystem): japi.Pair[Mat @uncheckedVariance, Sink[In @uncheckedVariance, NotUsed]] = {
-    val (mat, sink) = delegate.preMaterialize()(SystemMaterializer(system).materializer)
+  def preMaterialize(systemProvider: ClassicActorSystemProvider)
+      : japi.Pair[Mat @uncheckedVariance, Sink[In @uncheckedVariance, NotUsed]] = {
+    val (mat, sink) = delegate.preMaterialize()(SystemMaterializer(systemProvider.classicSystem).materializer)
     akka.japi.Pair(mat, sink.asJava)
   }
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -8,18 +8,17 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 import java.util.function.BiFunction
 
+import akka.Done
+import akka.NotUsed
 import akka.actor.ActorRef
-import akka.actor.ActorSystem
 import akka.actor.ClassicActorSystemProvider
 import akka.dispatch.ExecutionContexts
+import akka.japi
 import akka.japi.function
+import akka.stream._
 import akka.stream.impl.LinearTraversalBuilder
 import akka.stream.javadsl
 import akka.stream.scaladsl
-import akka.stream._
-import akka.Done
-import akka.NotUsed
-import akka.japi
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -382,7 +382,7 @@ object Source {
       second: Source[T, _ <: Any],
       rest: java.util.List[Source[T, _ <: Any]],
       strategy: function.Function[java.lang.Integer, _ <: Graph[UniformFanInShape[T, U], NotUsed]])
-    : Source[U, NotUsed] = {
+      : Source[U, NotUsed] = {
     val seq = if (rest != null) Util.immutableSeq(rest).map(_.asScala) else immutable.Seq()
     new Source(scaladsl.Source.combine(first.asScala, second.asScala, seq: _*)(num => strategy.apply(num)))
   }
@@ -571,7 +571,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * Note that the `ActorSystem` can be used as the `systemProvider` parameter.
    */
   def preMaterialize(systemProvider: ClassicActorSystemProvider)
-    : Pair[Mat @uncheckedVariance, Source[Out @uncheckedVariance, NotUsed]] = {
+      : Pair[Mat @uncheckedVariance, Source[Out @uncheckedVariance, NotUsed]] = {
     val (mat, src) = delegate.preMaterialize()(SystemMaterializer(systemProvider.classicSystem).materializer)
     Pair(mat, new Source(src))
   }
@@ -1758,8 +1758,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
   def statefulMapConcat[T](f: function.Creator[function.Function[Out, java.lang.Iterable[T]]]): javadsl.Source[T, Mat] =
     new Source(delegate.statefulMapConcat { () =>
       val fun = f.create()
-      elem =>
-        Util.immutableSeq(fun(elem))
+      elem => Util.immutableSeq(fun(elem))
     })
 
   /**
@@ -2751,7 +2750,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * @see [[#expand]]
    */
   def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]])
-    : Source[Out, Mat] =
+      : Source[Out, Mat] =
     new Source(delegate.extrapolate(in => extrapolator(in).asScala))
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -382,7 +382,7 @@ object Source {
       second: Source[T, _ <: Any],
       rest: java.util.List[Source[T, _ <: Any]],
       strategy: function.Function[java.lang.Integer, _ <: Graph[UniformFanInShape[T, U], NotUsed]])
-      : Source[U, NotUsed] = {
+    : Source[U, NotUsed] = {
     val seq = if (rest != null) Util.immutableSeq(rest).map(_.asScala) else immutable.Seq()
     new Source(scaladsl.Source.combine(first.asScala, second.asScala, seq: _*)(num => strategy.apply(num)))
   }
@@ -571,7 +571,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * Note that the `ActorSystem` can be used as the `systemProvider` parameter.
    */
   def preMaterialize(systemProvider: ClassicActorSystemProvider)
-      : Pair[Mat @uncheckedVariance, Source[Out @uncheckedVariance, NotUsed]] = {
+    : Pair[Mat @uncheckedVariance, Source[Out @uncheckedVariance, NotUsed]] = {
     val (mat, src) = delegate.preMaterialize()(SystemMaterializer(systemProvider.classicSystem).materializer)
     Pair(mat, new Source(src))
   }
@@ -580,7 +580,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * Materializes this Source, immediately returning (1) its materialized value, and (2) a new Source
    * that can be used to consume elements from the newly materialized Source.
    *
-   * Prefer the method taking an `ActorSystem`/`ClassicActorSystemProvider` unless you have special requirements.
+   * Prefer the method taking an `ActorSystem` unless you have special requirements.
    */
   def preMaterialize(
       materializer: Materializer): Pair[Mat @uncheckedVariance, Source[Out @uncheckedVariance, NotUsed]] = {
@@ -687,7 +687,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * Connect this `Source` to a `Sink` and run it. The returned value is the materialized value
    * of the `Sink`, e.g. the `Publisher` of a `Sink.asPublisher`.
    *
-   * Prefer the method taking an `ActorSystemProvider` unless you have special requirements.
+   * Prefer the method taking an `ActorSystem` unless you have special requirements
    */
   def runWith[M](sink: Graph[SinkShape[Out], M], materializer: Materializer): M =
     delegate.runWith(sink)(materializer)
@@ -744,7 +744,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * function evaluation when the input stream ends, or completed with `Failure`
    * if there is a failure is signaled in the stream.
    *
-   * Prefer the method taking an `ActorSystemProvider` unless you have special requirements.
+   * Prefer the method taking an `ActorSystem` unless you have special requirements
    */
   def runFoldAsync[U](
       zero: U,
@@ -784,7 +784,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * which is semantically in-line with that Scala's standard library collections
    * do in such situations.
    *
-   * Prefer the method taking an `ActorSystemProvider` unless you have special requirements.
+   * Prefer the method taking an `ActorSystem` unless you have special requirements
    */
   def runReduce(f: function.Function2[Out, Out, Out], materializer: Materializer): CompletionStage[Out] =
     runWith(Sink.reduce(f), materializer)
@@ -1483,7 +1483,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * normal end of the stream, or completed exceptionally if there is a failure is signaled in
    * the stream.
    *
-   * Prefer the method taking an `ActorSystemProvider` unless you have special requirements.
+   * Prefer the method taking an `ActorSystem` unless you have special requirements
    */
   def runForeach(f: function.Procedure[Out], materializer: Materializer): CompletionStage[Done] =
     runWith(Sink.foreach(f), materializer)
@@ -1758,7 +1758,8 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
   def statefulMapConcat[T](f: function.Creator[function.Function[Out, java.lang.Iterable[T]]]): javadsl.Source[T, Mat] =
     new Source(delegate.statefulMapConcat { () =>
       val fun = f.create()
-      elem => Util.immutableSeq(fun(elem))
+      elem =>
+        Util.immutableSeq(fun(elem))
     })
 
   /**
@@ -2750,7 +2751,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * @see [[#expand]]
    */
   def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]])
-      : Source[Out, Mat] =
+    : Source[Out, Mat] =
     new Source(delegate.extrapolate(in => extrapolator(in).asScala))
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -29,6 +29,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.function.{ BiFunction, Supplier }
 
 import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.util.unused
 import com.github.ghik.silencer.silent
 
@@ -675,8 +676,8 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * Connect this `Source` to a `Sink` and run it. The returned value is the materialized value
    * of the `Sink`, e.g. the `Publisher` of a `Sink.asPublisher`.
    */
-  def runWith[M](sink: Graph[SinkShape[Out], M], system: ActorSystem): M =
-    delegate.runWith(sink)(SystemMaterializer(system).materializer)
+  def runWith[M](sink: Graph[SinkShape[Out], M], systemProvider: ClassicActorSystemProvider): M =
+    delegate.runWith(sink)(SystemMaterializer(systemProvider.classicSystem).materializer)
 
   /**
    * Connect this `Source` to a `Sink` and run it. The returned value is the materialized value

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SourceWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SourceWithContext.scala
@@ -4,17 +4,18 @@
 
 package akka.stream.javadsl
 
-import akka.japi.{ function, Pair, Util }
-import akka.stream._
-import akka.event.LoggingAdapter
-import akka.util.ConstantFun
-
-import scala.annotation.unchecked.uncheckedVariance
-import akka.util.ccompat.JavaConverters._
 import java.util.concurrent.CompletionStage
 
-import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
+import akka.event.LoggingAdapter
+import akka.japi.Pair
+import akka.japi.Util
+import akka.japi.function
+import akka.stream._
+import akka.util.ConstantFun
+import akka.util.ccompat.JavaConverters._
 
+import scala.annotation.unchecked.uncheckedVariance
 import scala.compat.java8.FutureConverters._
 
 object SourceWithContext {
@@ -234,8 +235,8 @@ final class SourceWithContext[+Out, +Ctx, +Mat](delegate: scaladsl.SourceWithCon
    */
   def runWith[M](
       sink: Graph[SinkShape[Pair[Out @uncheckedVariance, Ctx @uncheckedVariance]], M],
-      system: ActorSystem): M =
-    toMat(sink, Keep.right[Mat, M]).run(system)
+      systemProvider: ClassicActorSystemProvider): M =
+    toMat(sink, Keep.right[Mat, M]).run(systemProvider.classicSystem)
 
   /**
    * Connect this [[akka.stream.javadsl.SourceWithContext]] to a [[akka.stream.javadsl.Sink]] and run it.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SourceWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SourceWithContext.scala
@@ -13,6 +13,8 @@ import scala.annotation.unchecked.uncheckedVariance
 import akka.util.ccompat.JavaConverters._
 import java.util.concurrent.CompletionStage
 
+import akka.actor.ActorSystem
+
 import scala.compat.java8.FutureConverters._
 
 object SourceWithContext {
@@ -229,6 +231,17 @@ final class SourceWithContext[+Out, +Ctx, +Mat](delegate: scaladsl.SourceWithCon
   /**
    * Connect this [[akka.stream.javadsl.SourceWithContext]] to a [[akka.stream.javadsl.Sink]] and run it.
    * The returned value is the materialized value of the `Sink`.
+   */
+  def runWith[M](
+      sink: Graph[SinkShape[Pair[Out @uncheckedVariance, Ctx @uncheckedVariance]], M],
+      system: ActorSystem): M =
+    toMat(sink, Keep.right[Mat, M]).run(system)
+
+  /**
+   * Connect this [[akka.stream.javadsl.SourceWithContext]] to a [[akka.stream.javadsl.Sink]] and run it.
+   * The returned value is the materialized value of the `Sink`.
+   *
+   * Prefer the method taking an ActorSystem unless you have special requirements.
    */
   def runWith[M](
       sink: Graph[SinkShape[Pair[Out @uncheckedVariance, Ctx @uncheckedVariance]], M],

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletionStage
 
 import javax.net.ssl.SSLContext
 import akka.annotation.InternalApi
+import akka.stream.SystemMaterializer
 import akka.stream.TLSProtocol.NegotiateNewSession
 import com.github.ghik.silencer.silent
 
@@ -79,6 +80,17 @@ object Tcp extends ExtensionId[Tcp] with ExtensionIdProvider {
      * materialized value is returned.
      *
      * Convenience shortcut for: `flow.join(handler).run()`.
+     */
+    def handleWith[Mat](handler: Flow[ByteString, ByteString, Mat], system: ActorSystem): Mat =
+      delegate.handleWith(handler.asScala)(SystemMaterializer(system).materializer)
+
+    /**
+     * Handles the connection using the given flow, which is materialized exactly once and the respective
+     * materialized value is returned.
+     *
+     * Convenience shortcut for: `flow.join(handler).run()`.
+     *
+     * Prefer the method taking an ActorSystem unless you have special requirements.
      */
     def handleWith[Mat](handler: Flow[ByteString, ByteString, Mat], materializer: Materializer): Mat =
       delegate.handleWith(handler.asScala)(materializer)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
@@ -93,7 +93,7 @@ object Tcp extends ExtensionId[Tcp] with ExtensionIdProvider {
      *
      * Convenience shortcut for: `flow.join(handler).run()`.
      *
-     * Prefer the method taking an `ActorSystemProvider` unless you have special requirements.
+     * Prefer the method taking an `ActorSystem` unless you have special requirements
      */
     def handleWith[Mat](handler: Flow[ByteString, ByteString, Mat], materializer: Materializer): Mat =
       delegate.handleWith(handler.asScala)(materializer)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
@@ -26,6 +26,7 @@ import scala.compat.java8.OptionConverters._
 import scala.compat.java8.FutureConverters._
 import java.util.concurrent.CompletionStage
 
+import akka.actor.ClassicActorSystemProvider
 import javax.net.ssl.SSLContext
 import akka.annotation.InternalApi
 import akka.stream.SystemMaterializer
@@ -80,9 +81,11 @@ object Tcp extends ExtensionId[Tcp] with ExtensionIdProvider {
      * materialized value is returned.
      *
      * Convenience shortcut for: `flow.join(handler).run()`.
+     *
+     * Note that the classic or typed `ActorSystem` can be used as the `systemProvider` parameter.
      */
-    def handleWith[Mat](handler: Flow[ByteString, ByteString, Mat], system: ActorSystem): Mat =
-      delegate.handleWith(handler.asScala)(SystemMaterializer(system).materializer)
+    def handleWith[Mat](handler: Flow[ByteString, ByteString, Mat], systemProvider: ClassicActorSystemProvider): Mat =
+      delegate.handleWith(handler.asScala)(SystemMaterializer(systemProvider.classicSystem).materializer)
 
     /**
      * Handles the connection using the given flow, which is materialized exactly once and the respective
@@ -90,7 +93,7 @@ object Tcp extends ExtensionId[Tcp] with ExtensionIdProvider {
      *
      * Convenience shortcut for: `flow.join(handler).run()`.
      *
-     * Prefer the method taking an ActorSystem unless you have special requirements.
+     * Prefer the method taking an `ActorSystemProvider` unless you have special requirements.
      */
     def handleWith[Mat](handler: Flow[ByteString, ByteString, Mat], materializer: Materializer): Mat =
       delegate.handleWith(handler.asScala)(materializer)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -287,6 +287,9 @@ final class Flow[-In, +Out, +Mat](
    * Connect the `Source` to this `Flow` and then connect it to the `Sink` and run it. The returned tuple contains
    * the materialized values of the `Source` and `Sink`, e.g. the `Subscriber` of a of a [[Source#subscriber]] and
    * and `Publisher` of a [[Sink#publisher]].
+   *
+   * Note that the `ActorSystem` can be used as the implicit `materializer` parameter to use the
+   * [[akka.stream.SystemMaterializer]] for running the stream.
    */
   def runWith[Mat1, Mat2](source: Graph[SourceShape[In], Mat1], sink: Graph[SinkShape[Out], Mat2])(
       implicit materializer: Materializer): (Mat1, Mat2) =
@@ -622,6 +625,9 @@ final case class RunnableGraph[+Mat](override val traversalBuilder: TraversalBui
 
   /**
    * Run this flow and return the materialized instance from the flow.
+   *
+   * Note that the `ActorSystem` can be used as the implicit `materializer` parameter to use the
+   * [[akka.stream.SystemMaterializer]] for running the stream.
    */
   def run()(implicit materializer: Materializer): Mat = materializer.materialize(this)
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -52,6 +52,9 @@ final class Sink[-In, +Mat](override val traversalBuilder: LinearTraversalBuilde
   /**
    * Connect this `Sink` to a `Source` and run it. The returned value is the materialized value
    * of the `Source`, e.g. the `Subscriber` of a [[Source#subscriber]].
+   *
+   * Note that the `ActorSystem` can be used as the implicit `materializer` parameter to use the
+   * [[akka.stream.SystemMaterializer]] for running the stream.
    */
   def runWith[Mat2](source: Graph[SourceShape[In], Mat2])(implicit materializer: Materializer): Mat2 =
     Source.fromGraph(source).to(this).run()

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -4,24 +4,30 @@
 
 package akka.stream.scaladsl
 
-import akka.{ Done, NotUsed }
-import akka.dispatch.ExecutionContexts
-import akka.actor.{ ActorRef, Status }
+import akka.actor.ActorRef
+import akka.actor.Status
 import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
 import akka.stream.impl.Stages.DefaultAttributes
 import akka.stream.impl._
 import akka.stream.impl.fusing.GraphStages
 import akka.stream.stage._
-import akka.stream.{ javadsl, _ }
-import org.reactivestreams.{ Publisher, Subscriber }
+import akka.stream.javadsl
+import akka.stream._
+import akka.util.ccompat._
+import akka.Done
+import akka.NotUsed
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
 
 import scala.annotation.tailrec
-import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.{ Failure, Success, Try }
-import scala.collection.immutable
-import akka.util.ccompat._
-
 import scala.annotation.unchecked.uncheckedVariance
+import scala.collection.immutable
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 
 /**
  * A `Sink` is a set of stream processing steps that has one open input.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -100,6 +100,9 @@ final class Source[+Out, +Mat](
   /**
    * Connect this `Source` to a `Sink` and run it. The returned value is the materialized value
    * of the `Sink`, e.g. the `Publisher` of a [[akka.stream.scaladsl.Sink#publisher]].
+   *
+   * Note that the `ActorSystem` can be used as the implicit `materializer` parameter to use the
+   * [[akka.stream.SystemMaterializer]] for running the stream.
    */
   def runWith[Mat2](sink: Graph[SinkShape[Out], Mat2])(implicit materializer: Materializer): Mat2 =
     toMat(sink)(Keep.right).run()
@@ -111,6 +114,9 @@ final class Source[+Out, +Mat](
    * The returned [[scala.concurrent.Future]] will be completed with value of the final
    * function evaluation when the input stream ends, or completed with `Failure`
    * if there is a failure signaled in the stream.
+   *
+   * Note that the `ActorSystem` can be used as the implicit `materializer` parameter to use the
+   * [[akka.stream.SystemMaterializer]] for running the stream.
    */
   def runFold[U](zero: U)(f: (U, Out) => U)(implicit materializer: Materializer): Future[U] =
     runWith(Sink.fold(zero)(f))
@@ -122,6 +128,9 @@ final class Source[+Out, +Mat](
    * The returned [[scala.concurrent.Future]] will be completed with value of the final
    * function evaluation when the input stream ends, or completed with `Failure`
    * if there is a failure signaled in the stream.
+   *
+   * Note that the `ActorSystem` can be used as the implicit `materializer` parameter to use the
+   * [[akka.stream.SystemMaterializer]] for running the stream.
    */
   def runFoldAsync[U](zero: U)(f: (U, Out) => Future[U])(implicit materializer: Materializer): Future[U] =
     runWith(Sink.foldAsync(zero)(f))
@@ -138,6 +147,9 @@ final class Source[+Out, +Mat](
    * the reduce operator will fail its downstream with a [[NoSuchElementException]],
    * which is semantically in-line with that Scala's standard library collections
    * do in such situations.
+   *
+   * Note that the `ActorSystem` can be used as the implicit `materializer` parameter to use the
+   * [[akka.stream.SystemMaterializer]] for running the stream.
    */
   def runReduce[U >: Out](f: (U, U) => U)(implicit materializer: Materializer): Future[U] =
     runWith(Sink.reduce(f))
@@ -148,6 +160,9 @@ final class Source[+Out, +Mat](
    * The returned [[scala.concurrent.Future]] will be completed with `Success` when reaching the
    * normal end of the stream, or completed with `Failure` if there is a failure signaled in
    * the stream.
+   *
+   * Note that the `ActorSystem` can be used as the implicit `materializer` parameter to use the
+   * [[akka.stream.SystemMaterializer]] for running the stream.
    */
   // FIXME: Out => Unit should stay, right??
   def runForeach(f: Out => Unit)(implicit materializer: Materializer): Future[Done] = runWith(Sink.foreach(f))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/SourceWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/SourceWithContext.scala
@@ -70,6 +70,9 @@ final class SourceWithContext[+Out, +Ctx, +Mat] private[stream] (delegate: Sourc
   /**
    * Connect this [[akka.stream.scaladsl.SourceWithContext]] to a [[akka.stream.scaladsl.Sink]] and run it.
    * The returned value is the materialized value of the `Sink`.
+   *
+   * Note that the `ActorSystem` can be used as the implicit `materializer` parameter to use the
+   * [[akka.stream.SystemMaterializer]] for running the stream.
    */
   def runWith[Mat2](sink: Graph[SinkShape[(Out, Ctx)], Mat2])(implicit materializer: Materializer): Mat2 =
     delegate.runWith(sink)

--- a/akka-stream/src/main/scala/akka/stream/snapshot/MaterializerState.scala
+++ b/akka-stream/src/main/scala/akka/stream/snapshot/MaterializerState.scala
@@ -4,10 +4,12 @@
 
 package akka.stream.snapshot
 
+import akka.actor.ActorSystem
 import akka.actor.{ ActorPath, ActorRef }
 import akka.annotation.{ ApiMayChange, DoNotInherit, InternalApi }
 import akka.stream.impl.{ PhasedFusingActorMaterializer, StreamSupervisor }
 import akka.pattern.ask
+import akka.stream.SystemMaterializer
 import akka.stream.impl.fusing.ActorGraphInterpreter
 import akka.stream.{ Attributes, Materializer }
 import akka.util.Timeout
@@ -25,6 +27,17 @@ import scala.concurrent.duration._
  * of the running streams.
  */
 object MaterializerState {
+
+  /**
+   * Dump stream snapshots of all streams of the default system materializer.
+   */
+  @ApiMayChange
+  def streamSnapshots(system: ActorSystem): Future[immutable.Seq[StreamSnapshot]] = {
+    SystemMaterializer(system).materializer match {
+      case impl: PhasedFusingActorMaterializer =>
+        requestFromSupervisor(impl.supervisor)(impl.system.dispatchers.internalDispatcher)
+    }
+  }
 
   /**
    * Dump stream snapshots of all streams of the given materializer.


### PR DESCRIPTION
## Purpose
Most use cases of Akka Streams does not really need/want the overhead of creating materializers and would instead be better if they shared a single system wide materialiser whose lifecycle is bound to the ActorSystem.

We may even want to deprecate and do more changes to the materializer hierarchy, this PR is intentionally limited to using and recommending using a default materializer.

## References
Refs #25559 

## Changes
 * New extension housing a system wide materializer
 * New `run` methods for the Java API taking an `ActorSystem` or a typed `ActorSystem[_]`
 * Implicit conversion from an implicit `ActorSystem` or typed `ActorSystem[_]` to the default `Materializer` for the Scala API
 * Updated docs to not show the `Materializer` unless strictly needed.
