### PR TITLE
lastSequenceNr should reflect the snapshot sequence and not start with 0 when journal is empty

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -744,9 +744,10 @@ private[persistence] trait Eventsourced
                 finally context.stop(self)
                 returnRecoveryPermit()
             }
-          case RecoverySuccess(highestSeqNr) =>
+          case RecoverySuccess(highestJournalSeqNr) =>
             timeoutCancellable.cancel()
             onReplaySuccess() // callback for subclass implementation
+            val highestSeqNr = Math.max(highestJournalSeqNr, lastSequenceNr)
             sequenceNr = highestSeqNr
             setLastSequenceNr(highestSeqNr)
             _recoveryRunning = false

--- a/akka-persistence/src/test/scala/akka/persistence/SnapshotRecoveryWithEmptyJournalSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/SnapshotRecoveryWithEmptyJournalSpec.scala
@@ -104,5 +104,4 @@ class SnapshotRecoveryWithEmptyJournalSpec
       expectMsgAllOf(givenSnapshotSequenceNr + 1)
     }
   }
-
 }

--- a/akka-persistence/src/test/scala/akka/persistence/SnapshotRecoveryWithEmptyJournalSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/SnapshotRecoveryWithEmptyJournalSpec.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence
+
+import akka.actor._
+import akka.testkit._
+
+object SnapshotRecoveryWithEmptyJournalSpec {
+  case class TakeSnapshot(deleteMessages: Boolean)
+
+  class SaveSnapshotTestPersistentActor(name: String, probe: ActorRef) extends NamedPersistentActor(name) {
+    var deleteMessages = false
+    var state = List.empty[String]
+
+    override def receiveRecover: Receive = {
+      case payload: String                     => state = s"${payload}-${lastSequenceNr}" :: state
+      case SnapshotOffer(_, snapshot: List[_]) => state = snapshot.asInstanceOf[List[String]]
+    }
+
+    override def receiveCommand = {
+      case payload: String =>
+        persist(payload) { _ =>
+          state = s"${payload}-${lastSequenceNr}" :: state
+        }
+      case TakeSnapshot(deleteMsgs) =>
+        deleteMessages = deleteMsgs
+        saveSnapshot(state)
+      case SaveSnapshotSuccess(md) =>
+        if (deleteMessages) {
+          deleteMessages(md.sequenceNr)
+          deleteMessages = false
+        }
+        probe ! md.sequenceNr
+      case GetState                 => probe ! state.reverse
+      case o: DeleteMessagesSuccess => probe ! o
+    }
+  }
+
+  class LoadSnapshotTestPersistentActor(name: String, _recovery: Recovery, probe: ActorRef)
+    extends NamedPersistentActor(name) {
+    override def recovery: Recovery = _recovery
+
+    override def receiveRecover: Receive = {
+      case payload: String      => probe ! s"${payload}-${lastSequenceNr}"
+      case offer: SnapshotOffer => probe ! offer
+      case other                => probe ! other
+    }
+
+    override def receiveCommand = {
+      case "done" => probe ! "done"
+      case payload: String =>
+        persist(payload) { _ =>
+          probe ! s"${payload}-${lastSequenceNr}"
+        }
+      case offer: SnapshotOffer => probe ! offer
+      case other                => probe ! other
+    }
+  }
+}
+
+class SnapshotRecoveryWithEmptyJournalSpec extends PersistenceSpec(PersistenceSpec.config(
+  "inmem", // with leveldb the error cannot be reproduced (counterKey is not reset after deleteMessages() )
+  "SnapshotRecoveryWithEmptyJournalSpec")) with ImplicitSender {
+  import SnapshotRecoveryWithEmptyJournalSpec._
+
+  "A persistentActor" must {
+    "recover state starting from the most recent snapshot and use subsequent sequence numbers to persist events to the journal" in {
+      val persistenceId = name
+      val persistentActor = system.actorOf(Props(classOf[SaveSnapshotTestPersistentActor], name, testActor))
+      persistentActor ! "a"
+      persistentActor ! "b"
+      persistentActor ! TakeSnapshot(true)
+      expectMsgAllOf(DeleteMessagesSuccess(2), 2L)
+
+      system.actorOf(Props(classOf[LoadSnapshotTestPersistentActor], name, Recovery(), testActor))
+      expectMsgPF() {
+        case SnapshotOffer(SnapshotMetadata(`persistenceId`, 2, timestamp), state) =>
+          state should ===(List("a-1", "b-2").reverse)
+          timestamp should be > (0L)
+      }
+      expectMsg(RecoveryCompleted)
+
+      val persistentActor1 = system.actorOf(Props(classOf[SaveSnapshotTestPersistentActor], name, testActor))
+      persistentActor1 ! "c"
+      persistentActor1 ! TakeSnapshot(true)
+      expectMsgAllOf(DeleteMessagesSuccess(3), 3L)
+    }
+  }
+}

--- a/akka-persistence/src/test/scala/akka/persistence/SnapshotRecoveryWithEmptyJournalSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/SnapshotRecoveryWithEmptyJournalSpec.scala
@@ -25,7 +25,7 @@ object SnapshotRecoveryWithEmptyJournalSpec {
       case SnapshotOffer(_, snapshot: List[_]) => state = snapshot.asInstanceOf[List[String]]
     }
 
-    override def receiveCommand = {
+    override def receiveCommand: PartialFunction[Any, Unit] = {
       case payload: String =>
         persist(payload) { _ =>
           state = s"${payload}-${lastSequenceNr}" :: state
@@ -47,7 +47,7 @@ object SnapshotRecoveryWithEmptyJournalSpec {
       case other                => probe ! other
     }
 
-    override def receiveCommand = {
+    override def receiveCommand: PartialFunction[Any, Unit] = {
       case "done" => probe ! "done"
       case payload: String =>
         persist(payload) { _ =>

--- a/akka-persistence/src/test/scala/akka/persistence/SnapshotRecoveryWithEmptyJournalSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/SnapshotRecoveryWithEmptyJournalSpec.scala
@@ -8,7 +8,7 @@ import java.io.File
 
 import akka.actor._
 import akka.persistence.serialization.Snapshot
-import akka.serialization.{Serialization, SerializationExtension}
+import akka.serialization.{ Serialization, SerializationExtension }
 import akka.testkit._
 import org.apache.commons.io.FileUtils
 
@@ -38,7 +38,7 @@ object SnapshotRecoveryWithEmptyJournalSpec {
   }
 
   class LoadSnapshotTestPersistentActor(name: String, _recovery: Recovery, probe: ActorRef)
-    extends NamedPersistentActor(name) {
+      extends NamedPersistentActor(name) {
     override def recovery: Recovery = _recovery
 
     override def receiveRecover: Receive = {


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [-] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->
disclaimer: I'm really new to the internals, so I'm happy to learn and improve this PR :-)
## Purpose
When a journal log is non-existent but a snapshot can be found (let's say with sequence 42), the state is correctly offered, however, the lastSequenceNr (which contains 42)  is overwritten with the highest sequence number that was found during journal recovery (which is 0). When a snapshot is taken now, its snapshot sequence will be most probably lower (let's say 10).  When the actor recovers anew, the snapshot with sequence 42 will be found, hiding the more recent changes in the snapshot with 10.
## Changes

- My proposed change is to use either the lastSequenceNr (which is already set to the value from the snapshot) or the one found from the journal, whichever is higher (see the change in Eventsourced).

- SnapshotRecoveryWithEmptyJournalSpec simulates the described problem above

## Background Context
In one of our projects we can live with a transient but fast journal. That led us to a really simple k8s pod setup with 1 jvm, running 1 actor system, LeveldbJournal, LocalSnapshotStore & no akka cluster needed.  We store the journal on the local node but keep snapshots on a persistent volume. The pod is rescheduled to a different node from time to time. Because we leave the journal on local storage, the journal will be empty when the pod is restarted on the new node (which is fine and expected in our case).