### PR TITLE
do not nullify context on actor termination #25040

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
@@ -9,15 +9,16 @@ import org.scalatest.BeforeAndAfterEach
 import akka.actor.Actor._
 import akka.testkit._
 import java.util.concurrent.atomic._
-import scala.concurrent.Await
+import scala.concurrent.{ Await, Future }
 import akka.pattern.ask
 import java.util.UUID.{ randomUUID => newUuid }
+import java.util.concurrent.CountDownLatch
 
 object ActorLifeCycleSpec {
 
   class LifeCycleTestActor(testActor: ActorRef, id: String, generationProvider: AtomicInteger) extends Actor {
     def report(msg: Any) = testActor ! message(msg)
-    def message(msg: Any): Tuple3[Any, String, Int] = (msg, id, currentGen)
+    def message(msg: Any): (Any, String, Int) = (msg, id, currentGen)
     val currentGen = generationProvider.getAndIncrement()
     override def preStart(): Unit = { report("preStart") }
     override def postStop(): Unit = { report("postStop") }
@@ -118,7 +119,7 @@ class ActorLifeCycleSpec
       system.stop(supervisor)
     }
 
-    "log failues in postStop" in {
+    "log failures in postStop" in {
       val a = system.actorOf(Props(new Actor {
         def receive = Actor.emptyBehavior
         override def postStop: Unit = { throw new Exception("hurrah") }
@@ -153,4 +154,34 @@ class ActorLifeCycleSpec
     }
   }
 
+  "have a non null context after termination" in {
+    class StopBeforeFutureFinishes(val latch: CountDownLatch) extends Actor {
+      import context.dispatcher
+      import akka.pattern._
+
+      override def receive: Receive = {
+        case "ping" =>
+          val replyTo = sender()
+
+          context.stop(self)
+
+          Future {
+            latch.await()
+            Thread.sleep(50)
+            "po"
+          }.flatMap(x => Future { x + "ng" }).recover { case _: NullPointerException => "npe" }.pipeTo(replyTo)
+      }
+    }
+
+    val latch = new CountDownLatch(1)
+    val actor = system.actorOf(Props(new StopBeforeFutureFinishes(latch)))
+    watch(actor)
+
+    actor ! "ping"
+
+    expectTerminated(actor)
+    latch.countDown()
+
+    expectMsg("pong")
+  }
 }

--- a/akka-actor-tests/src/test/scala/akka/pattern/PromiseRefSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/PromiseRefSpec.scala
@@ -20,7 +20,6 @@ object PromiseRefSpec {
 
 class PromiseRefSpec extends AkkaSpec with ImplicitSender {
   import PromiseRefSpec._
-  import akka.pattern._
 
   "The PromiseRef" must {
     "complete promise with received message" in {

--- a/akka-actor/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.x.backwards.excludes
@@ -82,3 +82,6 @@ ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.pattern.CircuitBreaker
 
 # streamref serialization #27304
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.DynamicAccess.classIsOnClasspath")
+
+# #25040 Don't clear context
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.ActorCell.clearActorFields")

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -622,7 +622,7 @@ private[akka] class ActorCell(
   protected def create(failure: Option[ActorInitializationException]): Unit = {
     def clearOutActorIfNonNull(): Unit = {
       if (actor != null) {
-        clearActorFields(actor, recreate = false)
+        clearActorFields(actor, clearContext = true, recreate = false)
         actor = null // ensure that we know that we failed during creation
       }
     }
@@ -686,8 +686,11 @@ private[akka] class ActorCell(
       throw new IllegalArgumentException("ActorCell has no props field")
   }
 
-  final protected def clearActorFields(actorInstance: Actor, recreate: Boolean): Unit = {
-    setActorFields(actorInstance, context = null, self = if (recreate) self else system.deadLetters)
+  final protected def clearActorFields(actorInstance: Actor, clearContext: Boolean, recreate: Boolean): Unit = {
+    setActorFields(
+      actorInstance,
+      context = if (clearContext) null else this,
+      self = if (recreate) self else system.deadLetters)
     currentMessage = null
     behaviorStack = emptyBehaviorStack
   }

--- a/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
@@ -70,7 +70,7 @@ private[akka] trait FaultHandling { this: ActorCell =>
           val ex = PreRestartException(self, e, cause, optionalMessage)
           publish(Error(ex, self.path.toString, clazz(failedActor), e.getMessage))
         } finally {
-          clearActorFields(failedActor, recreate = true)
+          clearActorFields(failedActor, clearContext = true, recreate = true)
         }
       }
       assert(mailbox.isSuspended, "mailbox must be suspended during restart, status=" + mailbox.currentStatus)
@@ -225,7 +225,7 @@ private[akka] trait FaultHandling { this: ActorCell =>
       if (system.settings.DebugLifecycle)
         publish(Debug(self.path.toString, clazz(a), "stopped"))
 
-      clearActorFields(a, recreate = false)
+      clearActorFields(a, clearContext = false, recreate = false)
       clearActorCellFields(this)
       actor = null
     }
@@ -254,7 +254,7 @@ private[akka] trait FaultHandling { this: ActorCell =>
             publish(Error(e, self.path.toString, clazz(freshActor), "restarting " + child))
           })
     } catch handleNonFatalOrInterruptedException { e =>
-      clearActorFields(actor, recreate = false) // in order to prevent preRestart() from happening again
+      clearActorFields(actor, clearContext = true, recreate = false) // in order to prevent preRestart() from happening again
       handleInvokeFailure(survivors, PostRestartException(self, e, cause))
     }
   }


### PR DESCRIPTION
* test for non null context on actor termination

Continued from https://github.com/akka/akka/pull/26745

I reduced the changes by removing the `clearActorFieldsOnTerminate`.
However, I don't think this is the final solution. To be discussed inline...

Refs #25040