### PR TITLE
[2.5 backport] Fix assertion in dns tests wrt changed docker json API

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/dns/DockerBindDnsService.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/DockerBindDnsService.scala
@@ -70,7 +70,7 @@ trait DockerBindDnsService extends Eventually { self: AkkaSpec =>
       })
 
     val creation = client.createContainer(containerConfig, containerName)
-    creation.warnings() should be(null)
+    creation.warnings() should be(null).or(have(size(0)))
     id = Some(creation.id())
 
     client.startContainer(creation.id())


### PR DESCRIPTION
(cherry picked from commit a19bd1597a5c0de27c88558eaa94cdf21905b8e8)

Backport for #27490 to make 2.5 nightlies succeed again