### PR TITLE
API changes related to DataDeleted, #27371

### DIFF
--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/ReplicatorMessageAdapter.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/ReplicatorMessageAdapter.scala
@@ -57,21 +57,21 @@ class ReplicatorMessageAdapter[A, B <: ReplicatedData](
 
   private implicit val askTimeout: Timeout = Timeout(unexpectedAskTimeout.asScala)
 
-  private var changedMessageAdapters: Map[Key[B], ActorRef[Replicator.Changed[B]]] = Map.empty
+  private var changedMessageAdapters: Map[Key[B], ActorRef[Replicator.SubscribeResponse[B]]] = Map.empty
 
   /**
-   * Subscribe to changes of the given `key`. The [[Replicator.Changed]] messages from
+   * Subscribe to changes of the given `key`. The [[Replicator.Changed]] and [[Replicator.Deleted]] messages from
    * the replicator are transformed to the message protocol of the requesting actor with
    * the given `responseAdapter` function.
    */
-  def subscribe(key: Key[B], responseAdapter: JFunction[Replicator.Changed[B], A]): Unit = {
+  def subscribe(key: Key[B], responseAdapter: JFunction[Replicator.SubscribeResponse[B], A]): Unit = {
     // unsubscribe in case it's called more than once per key
     unsubscribe(key)
     changedMessageAdapters.get(key).foreach { subscriber =>
       replicator ! Replicator.Unsubscribe(key, subscriber)
     }
-    val replyTo: ActorRef[Replicator.Changed[B]] =
-      context.messageAdapter(classOf[Replicator.Changed[B]], responseAdapter)
+    val replyTo: ActorRef[Replicator.SubscribeResponse[B]] =
+      context.messageAdapter(classOf[Replicator.SubscribeResponse[B]], responseAdapter)
     changedMessageAdapters = changedMessageAdapters.updated(key, replyTo)
     replicator ! Replicator.Subscribe(key, replyTo)
   }

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/Replicator.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/Replicator.scala
@@ -86,6 +86,15 @@ object Replicator {
     def unapply[A <: ReplicatedData](rsp: GetFailure[A]): Option[Key[A]] = Some(rsp.key)
   }
 
+  /**
+   * The [[Get]] request couldn't be performed because the entry has been deleted.
+   */
+  type GetDataDeleted[A <: ReplicatedData] = dd.Replicator.GetDataDeleted[A]
+  object GetDataDeleted {
+    def unapply[A <: ReplicatedData](rsp: GetDataDeleted[A]): Option[Key[A]] =
+      Some(rsp.key)
+  }
+
   object Update {
 
     /**
@@ -166,6 +175,15 @@ object Replicator {
   }
 
   /**
+   * The [[Update]] couldn't be performed because the entry has been deleted.
+   */
+  type UpdateDataDeleted[A <: ReplicatedData] = dd.Replicator.UpdateDataDeleted[A]
+  object UpdateDataDeleted {
+    def unapply[A <: ReplicatedData](rsp: UpdateDataDeleted[A]): Option[Key[A]] =
+      Some(rsp.key)
+  }
+
+  /**
    * If the `modify` function of the [[Update]] throws an exception the reply message
    * will be this `ModifyFailure` message. The original exception is included as `cause`.
    */
@@ -214,6 +232,16 @@ object Replicator {
    */
   final case class Unsubscribe[A <: ReplicatedData](key: Key[A], subscriber: ActorRef[Changed[A]]) extends Command
 
+  /**
+   * @see [[Replicator.Subscribe]]
+   */
+  type SubscribeResponse[A <: ReplicatedData] = dd.Replicator.SubscribeResponse[A]
+
+  /**
+   * The data value is retrieved with [[#get]] using the typed key.
+   *
+   * @see [[Replicator.Subscribe]]
+   */
   object Changed {
     def unapply[A <: ReplicatedData](chg: Changed[A]): Option[Key[A]] = Some(chg.key)
   }
@@ -224,6 +252,15 @@ object Replicator {
    * @see [[Replicator.Subscribe]]
    */
   type Changed[A <: ReplicatedData] = dd.Replicator.Changed[A]
+
+  object Deleted {
+    def unapply[A <: ReplicatedData](del: Deleted[A]): Option[Key[A]] = Some(del.key)
+  }
+
+  /**
+   * @see [[Replicator.Subscribe]]
+   */
+  type Deleted[A <: ReplicatedData] = dd.Replicator.Deleted[A]
 
   object Delete {
 
@@ -253,9 +290,9 @@ object Replicator {
     def unapply[A <: ReplicatedData](rsp: DeleteSuccess[A]): Option[Key[A]] =
       Some(rsp.key)
   }
-  type ReplicationDeleteFailure[A <: ReplicatedData] = dd.Replicator.ReplicationDeleteFailure[A]
-  object ReplicationDeleteFailure {
-    def unapply[A <: ReplicatedData](rsp: ReplicationDeleteFailure[A]): Option[Key[A]] =
+  type DeleteFailure[A <: ReplicatedData] = dd.Replicator.ReplicationDeleteFailure[A]
+  object DeleteFailure {
+    def unapply[A <: ReplicatedData](rsp: DeleteFailure[A]): Option[Key[A]] =
       Some(rsp.key)
   }
   type DataDeleted[A <: ReplicatedData] = dd.Replicator.DataDeleted[A]

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorMessageAdapter.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorMessageAdapter.scala
@@ -61,20 +61,21 @@ class ReplicatorMessageAdapter[A, B <: ReplicatedData](
 
   private implicit val askTimeout: Timeout = Timeout(unexpectedAskTimeout)
 
-  private var changedMessageAdapters: Map[Key[B], ActorRef[Replicator.Changed[B]]] = Map.empty
+  private var changedMessageAdapters: Map[Key[B], ActorRef[Replicator.SubscribeResponse[B]]] = Map.empty
 
   /**
-   * Subscribe to changes of the given `key`. The [[Replicator.Changed]] messages from
+   * Subscribe to changes of the given `key`. The [[Replicator.Changed]] and [[Replicator.Deleted]] messages from
    * the replicator are transformed to the message protocol of the requesting actor with
    * the given `responseAdapter` function.
    */
-  def subscribe(key: Key[B], responseAdapter: Replicator.Changed[B] => A): Unit = {
+  def subscribe(key: Key[B], responseAdapter: Replicator.SubscribeResponse[B] => A): Unit = {
     // unsubscribe in case it's called more than once per key
     unsubscribe(key)
     changedMessageAdapters.get(key).foreach { subscriber =>
       replicator ! Replicator.Unsubscribe(key, subscriber)
     }
-    val replyTo: ActorRef[Replicator.Changed[B]] = context.messageAdapter[Replicator.Changed[B]](responseAdapter)
+    val replyTo: ActorRef[Replicator.SubscribeResponse[B]] =
+      context.messageAdapter[Replicator.SubscribeResponse[B]](responseAdapter)
     changedMessageAdapters = changedMessageAdapters.updated(key, replyTo)
     replicator ! Replicator.Subscribe(key, replyTo)
   }

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorChaosSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorChaosSpec.scala
@@ -86,7 +86,7 @@ class ReplicatorChaosSpec extends MultiNodeSpec(ReplicatorChaosSpec) with STMult
     within(5.seconds) {
       awaitAssert {
         replicator ! Get(key, ReadLocal)
-        expectMsg(DataDeleted(key, None))
+        expectMsg(GetDataDeleted(key, None))
       }
     }
 


### PR DESCRIPTION
* The reason for this change is that `DataDeleted` didn't extend the
  `UpdateResponse` and `GetResponse` types and could therefore cause problems
  when `Update` and `Get` were used with `ask`. This was also a problem for
  Akka Typed.
* Introduce new messages types UpdateDataDeleted and GetDataDeleted
* Introduce SubscribeResponse because the responses can be both `Changed`
  and `Deleted` are responses to subscriptions. Important for Typed.

Refs #27371
