### PR TITLE
Remove Future from typed.ActorSystem.systemActorOf, #27437

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -19,7 +19,6 @@ import akka.actor.typed.Props
 import akka.actor.typed.Scheduler
 import akka.actor.typed.Settings
 import akka.annotation.InternalApi
-import akka.util.Timeout
 import akka.{ actor => untyped }
 import akka.Done
 import com.typesafe.config.ConfigFactory
@@ -91,19 +90,18 @@ import com.github.ghik.silencer.silent
 
   override def printTree: String = "no tree for ActorSystemStub"
 
-  def systemActorOf[U](behavior: Behavior[U], name: String, props: Props)(
-      implicit timeout: Timeout): Future[ActorRef[U]] = {
-    Future.failed(new UnsupportedOperationException("ActorSystemStub cannot create system actors"))
+  override def systemActorOf[U](behavior: Behavior[U], name: String, props: Props): ActorRef[U] = {
+    throw new UnsupportedOperationException("ActorSystemStub cannot create system actors")
   }
 
-  def registerExtension[T <: Extension](ext: ExtensionId[T]): T =
+  override def registerExtension[T <: Extension](ext: ExtensionId[T]): T =
     throw new UnsupportedOperationException("ActorSystemStub cannot register extensions")
 
-  def extension[T <: Extension](ext: ExtensionId[T]): T =
+  override def extension[T <: Extension](ext: ExtensionId[T]): T =
     throw new UnsupportedOperationException("ActorSystemStub cannot register extensions")
 
-  def hasExtension(ext: ExtensionId[_ <: Extension]): Boolean =
+  override def hasExtension(ext: ExtensionId[_ <: Extension]): Boolean =
     throw new UnsupportedOperationException("ActorSystemStub cannot register extensions")
 
-  def log: Logger = new StubbedLogger
+  override def log: Logger = new StubbedLogger
 }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
@@ -14,7 +14,6 @@ import java.util.{ List => JList }
 import scala.annotation.tailrec
 import akka.util.ccompat.JavaConverters._
 import scala.collection.immutable
-import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
@@ -33,7 +32,6 @@ import akka.annotation.InternalApi
 import akka.util.BoxedType
 import akka.util.JavaDurationConverters._
 import akka.util.PrettyDuration._
-import akka.util.Timeout
 
 @InternalApi
 private[akka] object TestProbeImpl {
@@ -81,13 +79,8 @@ private[akka] final class TestProbeImpl[M](name: String, system: ActorSystem[_])
    */
   private var lastWasNoMessage = false
 
-  private val testActor: ActorRef[M] = {
-    // FIXME arbitrary timeout?
-    implicit val timeout: Timeout = Timeout(3.seconds)
-    val futRef =
-      system.systemActorOf(TestProbeImpl.testActor(queue, terminations), s"$name-${testActorId.incrementAndGet()}")
-    Await.result(futRef, timeout.duration + 1.second)
-  }
+  private val testActor: ActorRef[M] =
+    system.systemActorOf(TestProbeImpl.testActor(queue, terminations), s"$name-${testActorId.incrementAndGet()}")
 
   override def ref: ActorRef[M] = testActor
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -219,9 +219,9 @@ final class ActorTestKit private[akka] (val name: String, val config: Config, se
   // FIXME needed for Akka internal tests but, users shouldn't spawn system actors?
   @InternalApi
   private[akka] def systemActor[T](behavior: Behavior[T], name: String): ActorRef[T] =
-    Await.result(system.systemActorOf(behavior, name), timeout.duration)
+    system.systemActorOf(behavior, name)
 
   @InternalApi
   private[akka] def systemActor[T](behavior: Behavior[T]): ActorRef[T] =
-    Await.result(system.systemActorOf(behavior, childName.next()), timeout.duration)
+    system.systemActorOf(behavior, childName.next())
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -15,7 +15,6 @@ import akka.actor.typed.internal.adapter.{ ActorSystemAdapter, GuardianStartupBe
 import akka.actor.typed.receptionist.Receptionist
 import akka.annotation.DoNotInherit
 import akka.util.Helpers.Requiring
-import akka.util.Timeout
 import akka.{ Done, actor => untyped }
 import com.typesafe.config.{ Config, ConfigFactory }
 
@@ -148,12 +147,10 @@ abstract class ActorSystem[-T] extends ActorRef[T] with Extensions with ClassicA
    * Create an actor in the "/system" namespace. This actor will be shut down
    * during system.terminate only after all user actors have terminated.
    *
-   * The returned Future of [[ActorRef]] may be converted into an [[ActorRef]]
-   * to which messages can immediately be sent by using the `ActorRef.apply`
-   * method.
+   * This is only intended to be used by libraries (and Akka itself).
+   * Applications should use ordinary `spawn`.
    */
-  def systemActorOf[U](behavior: Behavior[U], name: String, props: Props = Props.empty)(
-      implicit timeout: Timeout): Future[ActorRef[U]]
+  def systemActorOf[U](behavior: Behavior[U], name: String, props: Props = Props.empty): ActorRef[U]
 
   /**
    * Return a reference to this system’s [[akka.actor.typed.receptionist.Receptionist]].

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -8,7 +8,6 @@ import java.util.concurrent.CompletionStage
 
 import scala.compat.java8.FutureConverters
 import scala.concurrent.ExecutionContextExecutor
-import scala.concurrent.Future
 
 import akka.Done
 import akka.actor
@@ -33,7 +32,6 @@ import akka.actor.typed.internal.PropsImpl.DispatcherSameAsParent
 import akka.actor.typed.internal.SystemMessage
 import akka.annotation.InternalApi
 import akka.event.LoggingFilterWithMarker
-import akka.util.Timeout
 import akka.{ actor => untyped }
 
 /**
@@ -113,10 +111,9 @@ import akka.{ actor => untyped }
   override lazy val getWhenTerminated: CompletionStage[akka.Done] =
     FutureConverters.toJava(whenTerminated)
 
-  def systemActorOf[U](behavior: Behavior[U], name: String, props: Props)(
-      implicit timeout: Timeout): Future[ActorRef[U]] = {
+  override def systemActorOf[U](behavior: Behavior[U], name: String, props: Props): ActorRef[U] = {
     val ref = untypedSystem.systemActorOf(PropsAdapter(() => behavior, props), name)
-    Future.successful(ActorRefAdapter(ref))
+    ActorRefAdapter(ref)
   }
 
 }

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -697,6 +697,9 @@ abstract class ExtendedActorSystem extends ActorSystem {
   /**
    * Create an actor in the "/system" namespace. This actor will be shut down
    * during system.terminate only after all user actors have terminated.
+   *
+   * This is only intended to be used by libraries (and Akka itself).
+   * Applications should use ordinary `actorOf`.
    */
   def systemActorOf(props: Props, name: String): ActorRef
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -592,7 +592,7 @@ class ClusterReceptionistSpec extends WordSpec with Matchers {
     "not conflict with the ClusterClient receptionist default name" in {
       val testKit = ActorTestKit(s"ClusterReceptionistSpec-test-9", ClusterReceptionistSpec.config)
       try {
-        testKit.system.systemActorOf(Behaviors.ignore, "receptionist")(3.seconds)
+        testKit.system.systemActorOf(Behaviors.ignore, "receptionist")
       } finally {
         testKit.shutdownTestKit()
       }

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -487,6 +487,7 @@ made before finalizing the APIs. Compared to Akka 2.5.x the source incompatible 
 * `StashBuffer`s are now created with `Behaviors.withStash` rather than instantiating directly
 * To align with the Akka Typed style guide `SpawnProtocol` is now created through @scala[`SpawnProtocol()`]@java[`SpawnProtocol.create()`], the special `Spawn` message
   factories has been removed and the top level of the actor protocol is now `SpawnProtocol.Command`
+* `Future` removed from `ActorSystem.systemActorOf`.
 
 #### Akka Typed Stream API changes
 


### PR DESCRIPTION
* The reason for the Future was to "prepare" for a world without classic RepointableActorRef
* We can introduce a Future based one later if needed, the naming is anyway more "classic",
  and we can save spawn for the future.
* This also solves the problem that there is currently no Java API for this (returning CompletionStage)

Refs #27437