### PR TITLE
Don't run scheduled tasks on shutdown, #16495

### DIFF
--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -225,7 +225,7 @@ abstract class MessageDispatcher(val configurator: MessageDispatcherConfigurator
     mailBox.cleanUp()
   }
 
-  private val shutdownAction = new Runnable {
+  private val shutdownAction = new Scheduler.TaskRunOnClose {
     @tailrec
     final def run(): Unit = {
       shutdownSchedule match {

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -402,6 +402,15 @@ and then it will behave as in Akka 2.5.x:
 akka.coordinated-shutdown.run-by-actor-system-terminate = off
 ```
 
+### Scheduler not running tasks when shutdown
+
+When the `ActorSystem` was shutting down and the `Scheduler` was closed all outstanding scheduled tasks were run,
+which was needed for some internals in Akka but a surprising behavior for end users. Therefore this behavior has
+changed in Akka 2.6.x and outstanding tasks are not run when the system is terminated.
+
+Instead, `system.registerOnTermination` or `CoordinatedShutdown` can be used for running such tasks when the shutting
+down.
+
 ### IOSources & FileIO
 
 `FileIO.toPath`, `StreamConverters.fromInputStream`, and `StreamConverters.fromOutputStream` now always fail the materialized value in case of failure. 


### PR DESCRIPTION
Behavior change in `Scheduler.close` that would be nice to do in 2.6.

Refs #16495