### PR TITLE
Use one param list for first two arguments of ActorContext.ask

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -143,7 +143,7 @@ class AskSpec extends ScalaTestWithActorTestKit("""
       val behv =
         Behaviors.receive[String] {
           case (context, "start-ask") =>
-            context.ask[Question, Long](probe.ref)(Question(_)) {
+            context.ask[Question, Long](probe.ref, Question(_)) {
               case Success(42L) =>
                 throw new RuntimeException("Unsupported number")
               case _ => "test"

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/ReceptionistApiSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/ReceptionistApiSpec.scala
@@ -50,7 +50,7 @@ object ReceptionistApiSpec {
 
     Behaviors.setup[Any] { context =>
       // oneoff ask inside of actor, this should be a rare use case
-      context.ask(system.receptionist)(Receptionist.Find(key)) {
+      context.ask(system.receptionist, Receptionist.Find(key)) {
         case Success(key.Listing(services)) => services // Set[ActorRef[String]] !!
         case _                              => "unexpected"
       }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
@@ -51,7 +51,7 @@ class ActorContextAskSpec extends ScalaTestWithActorTestKit(ActorContextAskSpec.
       val snitch = Behaviors.setup[Pong] { context =>
         // Timeout comes from TypedAkkaSpec
 
-        context.ask(pingPong)(Ping) {
+        context.ask(pingPong, Ping) {
           case Success(_)  => Pong(context.self.path.name + "1", Thread.currentThread().getName)
           case Failure(ex) => throw ex
         }
@@ -85,7 +85,7 @@ class ActorContextAskSpec extends ScalaTestWithActorTestKit(ActorContextAskSpec.
         }))
 
       val snitch = Behaviors.setup[AnyRef] { context =>
-        context.ask(pingPong)(Ping) {
+        context.ask(pingPong, Ping) {
           case Success(message) => throw new NotImplementedError(message.toString)
           case Failure(x)       => x
         }
@@ -115,7 +115,7 @@ class ActorContextAskSpec extends ScalaTestWithActorTestKit(ActorContextAskSpec.
     "deal with timeouts in ask" in {
       val probe = TestProbe[AnyRef]()
       val snitch = Behaviors.setup[AnyRef] { context =>
-        context.ask[String, String](system.deadLetters)(_ => "boo") {
+        context.ask[String, String](system.deadLetters, _ => "boo") {
           case Success(m) => m
           case Failure(x) => x
         }(10.millis, implicitly[ClassTag[String]])
@@ -140,7 +140,7 @@ class ActorContextAskSpec extends ScalaTestWithActorTestKit(ActorContextAskSpec.
       val target = spawn(Behaviors.ignore[String])
       val probe = TestProbe[AnyRef]()
       val snitch = Behaviors.setup[AnyRef] { context =>
-        context.ask[String, String](target)(_ => "bar") {
+        context.ask[String, String](target, _ => "bar") {
           case Success(m) => m
           case Failure(x) => x
         }(10.millis, implicitly[ClassTag[String]])

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
@@ -244,7 +244,7 @@ class InteractionPatternsSpec extends ScalaTestWithActorTestKit with WordSpecLik
           // as OpenThePodBayDoorsPlease is a case class it has a factory apply method
           // that is what we are passing as the second parameter here it could also be written
           // as `ref => OpenThePodBayDoorsPlease(ref)`
-          context.ask(hal)(Hal.OpenThePodBayDoorsPlease) {
+          context.ask(hal, Hal.OpenThePodBayDoorsPlease) {
             case Success(Hal.Response(message)) => AdaptedResponse(message)
             case Failure(_)                     => AdaptedResponse("Request failed")
           }
@@ -254,7 +254,7 @@ class InteractionPatternsSpec extends ScalaTestWithActorTestKit with WordSpecLik
           // changed at the time the response arrives and the transformation is done, best is to
           // use immutable state we have closed over like here.
           val requestId = 1
-          context.ask(hal)(Hal.OpenThePodBayDoorsPlease) {
+          context.ask(hal, Hal.OpenThePodBayDoorsPlease) {
             case Success(Hal.Response(message)) => AdaptedResponse(s"$requestId: $message")
             case Failure(_)                     => AdaptedResponse(s"$requestId: Request failed")
           }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
@@ -91,7 +91,7 @@ import akka.util.JavaDurationConverters._
     spawnAnonymous(behavior, Props.empty)
 
   // Scala API impl
-  override def ask[Req, Res](target: RecipientRef[Req])(createRequest: ActorRef[Res] => Req)(
+  override def ask[Req, Res](target: RecipientRef[Req], createRequest: ActorRef[Res] => Req)(
       mapResponse: Try[Res] => T)(implicit responseTimeout: Timeout, classTag: ClassTag[Res]): Unit = {
     import akka.actor.typed.scaladsl.AskPattern._
     pipeToSelf((target.ask(createRequest))(responseTimeout, system.scheduler))(mapResponse)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
@@ -286,7 +286,7 @@ trait ActorContext[T] extends TypedActorContext[T] {
    * @tparam Req The request protocol, what the other actor accepts
    * @tparam Res The response protocol, what the other actor sends back
    */
-  def ask[Req, Res](target: RecipientRef[Req])(createRequest: ActorRef[Res] => Req)(
+  def ask[Req, Res](target: RecipientRef[Req], createRequest: ActorRef[Res] => Req)(
       mapResponse: Try[Res] => T)(implicit responseTimeout: Timeout, classTag: ClassTag[Res]): Unit
 
   /**

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -348,7 +348,7 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
       val p = TestProbe[TheReply]()
 
       spawn(Behaviors.setup[TheReply] { ctx =>
-        ctx.ask(aliceRef)(WhoAreYou) {
+        ctx.ask(aliceRef, WhoAreYou) {
           case Success(name) => TheReply(name)
           case Failure(ex)   => TheReply(ex.getMessage)
         }

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/ReplicatorMessageAdapter.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/ReplicatorMessageAdapter.scala
@@ -16,6 +16,7 @@ import akka.actor.typed.javadsl.ActorContext
 import akka.cluster.ddata.Key
 import akka.cluster.ddata.ReplicatedData
 import akka.util.Timeout
+import com.github.ghik.silencer.silent
 
 /**
  * When interacting with the `Replicator` from an actor this class provides convenient
@@ -97,11 +98,11 @@ class ReplicatorMessageAdapter[A, B <: ReplicatedData](
   def askUpdate(
       createRequest: JFunction[ActorRef[Replicator.UpdateResponse[B]], Replicator.Update[B]],
       responseAdapter: JFunction[Replicator.UpdateResponse[B], A]): Unit = {
-    context.asScala.ask[Replicator.Update[B], Replicator.UpdateResponse[B]](replicator)(askReplyTo =>
-      createRequest(askReplyTo)) {
-      case Success(value) => responseAdapter(value)
-      case Failure(ex)    => throw ex // unexpected ask timeout
-    }
+    context.asScala
+      .ask[Replicator.Update[B], Replicator.UpdateResponse[B]](replicator, askReplyTo => createRequest(askReplyTo)) {
+        case Success(value) => responseAdapter(value)
+        case Failure(ex)    => throw ex // unexpected ask timeout
+      }
   }
 
   /**
@@ -113,14 +114,15 @@ class ReplicatorMessageAdapter[A, B <: ReplicatedData](
    * `ActorRef[GetResponse]` that the the replicator will send the response message back through.
    * Use that `ActorRef[GetResponse]` as the `replyTo` parameter in the `Get` message.
    */
+  @silent
   def askGet(
       createRequest: JFunction[ActorRef[Replicator.GetResponse[B]], Replicator.Get[B]],
       responseAdapter: JFunction[Replicator.GetResponse[B], A]): Unit = {
-    context.asScala.ask[Replicator.Get[B], Replicator.GetResponse[B]](replicator)(askReplyTo =>
-      createRequest(askReplyTo)) {
-      case Success(value) => responseAdapter(value)
-      case Failure(ex)    => throw ex // unexpected ask timeout
-    }
+    context.asScala
+      .ask[Replicator.Get[B], Replicator.GetResponse[B]](replicator, askReplyTo => createRequest(askReplyTo)) {
+        case Success(value) => responseAdapter(value)
+        case Failure(ex)    => throw ex // unexpected ask timeout
+      }
   }
 
   /**
@@ -135,11 +137,11 @@ class ReplicatorMessageAdapter[A, B <: ReplicatedData](
   def askDelete(
       createRequest: JFunction[ActorRef[Replicator.DeleteResponse[B]], Replicator.Delete[B]],
       responseAdapter: JFunction[Replicator.DeleteResponse[B], A]): Unit = {
-    context.asScala.ask[Replicator.Delete[B], Replicator.DeleteResponse[B]](replicator)(askReplyTo =>
-      createRequest(askReplyTo)) {
-      case Success(value) => responseAdapter(value)
-      case Failure(ex)    => throw ex // unexpected ask timeout
-    }
+    context.asScala
+      .ask[Replicator.Delete[B], Replicator.DeleteResponse[B]](replicator, askReplyTo => createRequest(askReplyTo)) {
+        case Success(value) => responseAdapter(value)
+        case Failure(ex)    => throw ex // unexpected ask timeout
+      }
   }
 
   /**
@@ -154,11 +156,11 @@ class ReplicatorMessageAdapter[A, B <: ReplicatedData](
   def askReplicaCount(
       createRequest: JFunction[ActorRef[Replicator.ReplicaCount], Replicator.GetReplicaCount],
       responseAdapter: JFunction[Replicator.ReplicaCount, A]): Unit = {
-    context.asScala.ask[Replicator.GetReplicaCount, Replicator.ReplicaCount](replicator)(askReplyTo =>
-      createRequest(askReplyTo)) {
-      case Success(value) => responseAdapter(value)
-      case Failure(ex)    => throw ex // unexpected ask timeout
-    }
+    context.asScala
+      .ask[Replicator.GetReplicaCount, Replicator.ReplicaCount](replicator, askReplyTo => createRequest(askReplyTo)) {
+        case Success(value) => responseAdapter(value)
+        case Failure(ex)    => throw ex // unexpected ask timeout
+      }
   }
 
 }

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorMessageAdapter.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorMessageAdapter.scala
@@ -101,10 +101,11 @@ class ReplicatorMessageAdapter[A, B <: ReplicatedData](
   def askUpdate(
       createRequest: ActorRef[Replicator.UpdateResponse[B]] => Replicator.Update[B],
       responseAdapter: Replicator.UpdateResponse[B] => A): Unit = {
-    context.ask[Replicator.Update[B], Replicator.UpdateResponse[B]](replicator)(askReplyTo => createRequest(askReplyTo)) {
-      case Success(value) => responseAdapter(value)
-      case Failure(ex)    => throw ex // unexpected ask timeout
-    }
+    context
+      .ask[Replicator.Update[B], Replicator.UpdateResponse[B]](replicator, askReplyTo => createRequest(askReplyTo)) {
+        case Success(value) => responseAdapter(value)
+        case Failure(ex)    => throw ex // unexpected ask timeout
+      }
   }
 
   /**
@@ -119,7 +120,7 @@ class ReplicatorMessageAdapter[A, B <: ReplicatedData](
   def askGet(
       createRequest: ActorRef[Replicator.GetResponse[B]] => Replicator.Get[B],
       responseAdapter: Replicator.GetResponse[B] => A): Unit = {
-    context.ask[Replicator.Get[B], Replicator.GetResponse[B]](replicator)(askReplyTo => createRequest(askReplyTo)) {
+    context.ask[Replicator.Get[B], Replicator.GetResponse[B]](replicator, askReplyTo => createRequest(askReplyTo)) {
       case Success(value) => responseAdapter(value)
       case Failure(ex)    => throw ex // unexpected ask timeout
     }
@@ -137,10 +138,11 @@ class ReplicatorMessageAdapter[A, B <: ReplicatedData](
   def askDelete(
       createRequest: ActorRef[Replicator.DeleteResponse[B]] => Replicator.Delete[B],
       responseAdapter: Replicator.DeleteResponse[B] => A): Unit = {
-    context.ask[Replicator.Delete[B], Replicator.DeleteResponse[B]](replicator)(askReplyTo => createRequest(askReplyTo)) {
-      case Success(value) => responseAdapter(value)
-      case Failure(ex)    => throw ex // unexpected ask timeout
-    }
+    context
+      .ask[Replicator.Delete[B], Replicator.DeleteResponse[B]](replicator, askReplyTo => createRequest(askReplyTo)) {
+        case Success(value) => responseAdapter(value)
+        case Failure(ex)    => throw ex // unexpected ask timeout
+      }
   }
 
   /**
@@ -155,11 +157,11 @@ class ReplicatorMessageAdapter[A, B <: ReplicatedData](
   def askReplicaCount(
       createRequest: ActorRef[Replicator.ReplicaCount] => Replicator.GetReplicaCount,
       responseAdapter: Replicator.ReplicaCount => A): Unit = {
-    context.ask[Replicator.GetReplicaCount, Replicator.ReplicaCount](replicator)(askReplyTo =>
-      createRequest(askReplyTo)) {
-      case Success(value) => responseAdapter(value)
-      case Failure(ex)    => throw ex // unexpected ask timeout
-    }
+    context
+      .ask[Replicator.GetReplicaCount, Replicator.ReplicaCount](replicator, askReplyTo => createRequest(askReplyTo)) {
+        case Success(value) => responseAdapter(value)
+        case Failure(ex)    => throw ex // unexpected ask timeout
+      }
   }
 
 }

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
@@ -111,7 +111,7 @@ class RemoteContextAskSpec extends ScalaTestWithActorTestKit(RemoteContextAskSpe
       spawn(Behaviors.setup[AnyRef] { ctx =>
         implicit val timeout: Timeout = 3.seconds
 
-        ctx.ask(remoteRef)(Ping) {
+        ctx.ask(remoteRef, Ping) {
           case Success(pong) => pong
           case Failure(ex)   => ex
         }


### PR DESCRIPTION
I think it would be better to place the first two parameter, which are both about sending the request, into the first parameter list instead of having separate lists for those.