### PR TITLE
EventsourcedBehaviorRetentionSpec race fix

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ExternalInteractions.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ExternalInteractions.scala
@@ -143,9 +143,10 @@ private[akka] trait JournalInteractions[C, E, S] {
     if (toSequenceNr > 0) {
       val self = setup.selfClassic
 
-      if (toSequenceNr == Long.MaxValue || toSequenceNr <= lastSequenceNr)
+      if (toSequenceNr == Long.MaxValue || toSequenceNr <= lastSequenceNr) {
+        setup.log.debug("Deleting events up to sequenceNr [{}]", toSequenceNr)
         setup.journal ! JournalProtocol.DeleteMessagesTo(setup.persistenceId.id, toSequenceNr, self)
-      else
+      } else
         self ! DeleteMessagesFailure(
           new RuntimeException(
             s"toSequenceNr [$toSequenceNr] must be less than or equal to lastSequenceNr [$lastSequenceNr]"),

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
@@ -66,7 +66,7 @@ object EventSourcedBehaviorRetentionSpec extends Matchers {
       probe: Option[ActorRef[(State, Event)]] = None,
       snapshotSignalProbe: Option[ActorRef[WrappedSignal]] = None,
       eventSignalProbe: Option[ActorRef[Try[EventSourcedSignal]]] = None)
-    : EventSourcedBehavior[Command, Event, State] = {
+      : EventSourcedBehavior[Command, Event, State] = {
     EventSourcedBehavior[Command, Event, State](
       persistenceId,
       emptyState = State(0, Vector.empty),
@@ -85,13 +85,13 @@ object EventSourcedBehaviorRetentionSpec extends Matchers {
           case StopIt =>
             Effect.none.thenStop()
 
-      },
+        },
       eventHandler = (state, evt) =>
         evt match {
           case Incremented(delta) =>
             probe.foreach(_ ! ((state, evt)))
             State(state.value + delta, state.history :+ state.value)
-      }).receiveSignal {
+        }).receiveSignal {
       case (_, RecoveryCompleted) => ()
       case (_, sc: SnapshotCompleted) =>
         snapshotSignalProbe.foreach(_ ! WrappedSignal(sc))
@@ -245,7 +245,7 @@ class EventSourcedBehaviorRetentionSpec
       val snapshotAtTwo = Behaviors.setup[Command](ctx =>
         counter(ctx, pid, snapshotSignalProbe = Some(snapshotSignalProbe.ref)).snapshotWhen { (s, _, _) =>
           s.value == 2
-      })
+        })
       val c: ActorRef[Command] = spawn(snapshotAtTwo)
 
       val replyProbe = TestProbe[State]()

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
@@ -62,7 +62,7 @@ object EventSourcedBehaviorRetentionSpec extends Matchers {
       probe: Option[ActorRef[(State, Event)]] = None,
       snapshotSignalProbe: Option[ActorRef[WrappedSignal]] = None,
       eventSignalProbe: Option[ActorRef[Try[EventSourcedSignal]]] = None)
-    : EventSourcedBehavior[Command, Event, State] = {
+      : EventSourcedBehavior[Command, Event, State] = {
     EventSourcedBehavior[Command, Event, State](
       persistenceId,
       emptyState = State(0, Vector.empty),
@@ -81,13 +81,13 @@ object EventSourcedBehaviorRetentionSpec extends Matchers {
           case StopIt =>
             Effect.none.thenStop()
 
-      },
+        },
       eventHandler = (state, evt) =>
         evt match {
           case Incremented(delta) =>
             probe.foreach(_ ! ((state, evt)))
             State(state.value + delta, state.history :+ state.value)
-      }).receiveSignal {
+        }).receiveSignal {
       case (_, RecoveryCompleted) => ()
       case (_, sc: SnapshotCompleted) =>
         snapshotSignalProbe.foreach(_ ! WrappedSignal(sc))
@@ -241,7 +241,7 @@ class EventSourcedBehaviorRetentionSpec
       val snapshotAtTwo = Behaviors.setup[Command](ctx =>
         counter(ctx, pid, snapshotSignalProbe = Some(snapshotSignalProbe.ref)).snapshotWhen { (s, _, _) =>
           s.value == 2
-      })
+        })
       val c: ActorRef[Command] = spawn(snapshotAtTwo)
 
       val replyProbe = TestProbe[State]()

--- a/akka-remote/src/test/java/akka/remote/protobuf/v3/ProtobufProtocolV3.java
+++ b/akka-remote/src/test/java/akka/remote/protobuf/v3/ProtobufProtocolV3.java
@@ -123,9 +123,10 @@ public final class ProtobufProtocolV3 {
     protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return akka.remote.protobuf.v3.ProtobufProtocolV3
-          .internal_static_MyMessageV3_fieldAccessorTable.ensureFieldAccessorsInitialized(
-          akka.remote.protobuf.v3.ProtobufProtocolV3.MyMessageV3.class,
-          akka.remote.protobuf.v3.ProtobufProtocolV3.MyMessageV3.Builder.class);
+          .internal_static_MyMessageV3_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              akka.remote.protobuf.v3.ProtobufProtocolV3.MyMessageV3.class,
+              akka.remote.protobuf.v3.ProtobufProtocolV3.MyMessageV3.Builder.class);
     }
 
     public static final int QUERY_FIELD_NUMBER = 1;
@@ -364,9 +365,10 @@ public final class ProtobufProtocolV3 {
       protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return akka.remote.protobuf.v3.ProtobufProtocolV3
-            .internal_static_MyMessageV3_fieldAccessorTable.ensureFieldAccessorsInitialized(
-            akka.remote.protobuf.v3.ProtobufProtocolV3.MyMessageV3.class,
-            akka.remote.protobuf.v3.ProtobufProtocolV3.MyMessageV3.Builder.class);
+            .internal_static_MyMessageV3_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                akka.remote.protobuf.v3.ProtobufProtocolV3.MyMessageV3.class,
+                akka.remote.protobuf.v3.ProtobufProtocolV3.MyMessageV3.Builder.class);
       }
 
       // Construct using akka.remote.protobuf.v3.ProtobufProtocolV3.MyMessageV3.newBuilder()


### PR DESCRIPTION
Refs #27507 
Refs #26895
And also somewhat #26535

 * EventSourcedBehaviorRetentionSpec used the same testprobe for both signals from the journal and the snapshot plugin so ordering was not deterministic
 * Having event deletion and snapshot deletion enabled leads to a switch to runnable after a snapshot is successfully seen written to the delete of events completing which could cause tests testing that which where sending batches of messages to see non deterministic results - changed to send exact sets of messages and then asserting outcome instead
 * Failing the typed TestProbe if one tries to `expect` a signal, which does not work
 * Some added/improved debug logging in the EventSourcedBehavior impl