### PR TITLE
[2.6 Docs Cleanup] Move things to new Package/Deploy/Run section

### DIFF
--- a/akka-docs/src/main/paradox/additional/deploying.md
+++ b/akka-docs/src/main/paradox/additional/deploying.md
@@ -44,3 +44,27 @@ to see what this looks like in practice.
 ### Resource limits
 
 To avoid CFS scheduler limits, it is best not to use `resources.limits.cpu` limits, but use `resources.requests.cpu` configuration instead.
+
+## When Shutdown/Startup Is Required
+ 
+There are a few instances when a full shutdown and startup is required versus being able to do a rolling update.
+
+### Migrating from PersistentFSM to EventSourcedBehavior
+
+If you've migrated from `PersistentFSM` to `EventSourcedBehavior`
+and are using persistence with Cluster Sharding, a full shutdown is required as shards can move between new and old nodes.
+
+### Migrating from classic remoting to Artery
+
+If you've migrated from classic remoting to Artery
+which has a completely different protocol, a rolling update is not supported.
+For more details on this migration
+see @ref:[the migration guide](../project/migration-guide-2.5.x-2.6.x.md#migrating-from-classic-remoting-to-artery).
+
+### Migrating from Akka 2.5 to 2.6
+
+#### Akka Typed with Receptionist or Cluster Receptionist
+
+If you are using the `Receptionist` or `Cluster Receptionist` with Akka Typed, information will not be disseminated between 2.5 and 2.6 nodes during a
+rolling update from 2.5 to 2.6. When all old nodes have been shutdown it will work properly again.
+ 

--- a/akka-docs/src/main/paradox/additional/deploying.md
+++ b/akka-docs/src/main/paradox/additional/deploying.md
@@ -44,27 +44,3 @@ to see what this looks like in practice.
 ### Resource limits
 
 To avoid CFS scheduler limits, it is best not to use `resources.limits.cpu` limits, but use `resources.requests.cpu` configuration instead.
-
-## When Shutdown/Startup Is Required
- 
-There are a few instances when a full shutdown and startup is required versus being able to do a rolling update.
-
-### Migrating from PersistentFSM to EventSourcedBehavior
-
-If you've migrated from `PersistentFSM` to `EventSourcedBehavior`
-and are using persistence with Cluster Sharding, a full shutdown is required as shards can move between new and old nodes.
-
-### Migrating from classic remoting to Artery
-
-If you've migrated from classic remoting to Artery
-which has a completely different protocol, a rolling update is not supported.
-For more details on this migration
-see @ref:[the migration guide](../project/migration-guide-2.5.x-2.6.x.md#migrating-from-classic-remoting-to-artery).
-
-### Migrating from Akka 2.5 to 2.6
-
-#### Akka Typed with Receptionist or Cluster Receptionist
-
-If you are using the `Receptionist` or `Cluster Receptionist` with Akka Typed, information will not be disseminated between 2.5 and 2.6 nodes during a
-rolling update from 2.5 to 2.6. When all old nodes have been shutdown it will work properly again.
- 

--- a/akka-docs/src/main/paradox/additional/rolling-updates.md
+++ b/akka-docs/src/main/paradox/additional/rolling-updates.md
@@ -117,6 +117,12 @@ The procedure for changing from Java serialization to Jackson would look like:
     
 A similar approach can be used when changing between other serializers, for example between Jackson and Protobuf.    
 
+### Akka Typed with Receptionist or Cluster Receptionist
+
+If you are migrating from Akka 2.5 to 2.6, and use the `Receptionist` or `Cluster Receptionist` with Akka Typed, 
+during a rolling update information will not be disseminated between 2.5 and 2.6 nodes.
+However once all old nodes have been phased out during the rolling update it will work properly again.
+
 ## When Shutdown Startup Is Required
  
 There are a few instances when a full shutdown and startup is required versus being able to do a rolling update.
@@ -140,8 +146,3 @@ If you've migrated from classic remoting to Artery
 which has a completely different protocol, a rolling update is not supported.
 For more details on this migration
 see @ref:[the migration guide](../project/migration-guide-2.5.x-2.6.x.md#migrating-from-classic-remoting-to-artery).
-
-### Akka Typed with Receptionist or Cluster Receptionist
-
-If you are migrating from Akka 2.5 to 2.6, using the `Receptionist` or `Cluster Receptionist` with Akka Typed, information will not be disseminated between 2.5 and 2.6 nodes during a
-rolling update from 2.5 to 2.6. When all old nodes have been shutdown it will work properly again.

--- a/akka-docs/src/main/paradox/additional/rolling-updates.md
+++ b/akka-docs/src/main/paradox/additional/rolling-updates.md
@@ -2,7 +2,7 @@
 
 @@@ note
 
-There are a few instances [when a full cluster restart is required](deploying.md#when-shutdownstartup-is-required)
+There are a few instances @ref:[when a full cluster restart is required](#when-shutdown-startup-is-required)
 versus being able to do a rolling update.
 
 @@@
@@ -42,7 +42,7 @@ When an old node is stopped the shards that were running on it are moved to one 
 other old nodes remaining in the cluster. The `ShardCoordinator` is itself a cluster singleton. 
 To minimize downtime of the shard coordinator, see the strategies about @ref[ClusterSingleton](#cluster-singleton) rolling upgrades below.
 
-A few specific changes to sharding configuration require @ref:[a full cluster restart](#cluster-sharding).
+A few specific changes to sharding configuration require @ref:[a full cluster restart](#cluster-sharding-configuration-change).
 
 ## Cluster Singleton
 
@@ -117,11 +117,11 @@ The procedure for changing from Java serialization to Jackson would look like:
     
 A similar approach can be used when changing between other serializers, for example between Jackson and Protobuf.    
 
-## When Shutdown/Startup Is Required
+## When Shutdown Startup Is Required
  
 There are a few instances when a full shutdown and startup is required versus being able to do a rolling update.
 
-### Cluster Sharding
+### Cluster Sharding configuration change
 
 If you need to change any of the following aspects of sharding it will require a full cluster restart versus a rolling update:
 

--- a/akka-docs/src/main/paradox/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/cluster-sharding.md
@@ -285,8 +285,7 @@ themselves it is more convenient to use the Distributed Data mode, since then yo
 setup and operate a separate data store (e.g. Cassandra) for persistence. Aside from that, there are
 no major reasons for using one mode over the the other.
 
-It's important to use the same mode on all nodes in the cluster, i.e. it's not possible to perform
-a rolling upgrade to change this setting.
+Changing persistence mode requires @ref:[a full cluster restart](additional/rolling-updates.md#cluster-sharding).
 
 ### Distributed Data Mode
 
@@ -308,6 +307,7 @@ Cluster Sharding is using its own Distributed Data `Replicator` per node role. I
 all nodes for some entity types and another subset for other entity types. Each such replicator has a name
 that contains the node role and therefore the role configuration must be the same on all nodes in the
 cluster, i.e. you can't change the roles when performing a rolling upgrade.
+Changing roles requires @ref:[a full cluster restart](additional/rolling-updates.md#cluster-sharding).
 
 The settings for Distributed Data is configured in the the section
 `akka.cluster.sharding.distributed-data`. It's not possible to have different
@@ -531,17 +531,6 @@ The type names of all started shards can be acquired via @scala[`ClusterSharding
 
 The purpose of these messages is testing and monitoring, they are not provided to give access to
 directly sending messages to the individual entities.
-
-## Rolling upgrades
-
-When doing rolling upgrades special care must be taken to not change any of the following aspects of sharding:
-
- * the `extractShardId` function
- * the role that the shard regions run on
- * the persistence mode
-
- If any one of these needs a change it will require a full cluster restart.
- 
 
 ## Lease
 

--- a/akka-docs/src/main/paradox/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/cluster-sharding.md
@@ -285,7 +285,7 @@ themselves it is more convenient to use the Distributed Data mode, since then yo
 setup and operate a separate data store (e.g. Cassandra) for persistence. Aside from that, there are
 no major reasons for using one mode over the the other.
 
-Changing persistence mode requires @ref:[a full cluster restart](additional/rolling-updates.md#cluster-sharding).
+Changing persistence mode requires @ref:[a full cluster restart](additional/rolling-updates.md#cluster-sharding-configuration-change).
 
 ### Distributed Data Mode
 
@@ -307,7 +307,7 @@ Cluster Sharding is using its own Distributed Data `Replicator` per node role. I
 all nodes for some entity types and another subset for other entity types. Each such replicator has a name
 that contains the node role and therefore the role configuration must be the same on all nodes in the
 cluster, i.e. you can't change the roles when performing a rolling upgrade.
-Changing roles requires @ref:[a full cluster restart](additional/rolling-updates.md#cluster-sharding).
+Changing roles requires @ref:[a full cluster restart](additional/rolling-updates.md#cluster-sharding-configuration-change).
 
 The settings for Distributed Data is configured in the the section
 `akka.cluster.sharding.distributed-data`. It's not possible to have different

--- a/akka-docs/src/main/paradox/persistence-fsm.md
+++ b/akka-docs/src/main/paradox/persistence-fsm.md
@@ -210,7 +210,7 @@ you can not roll back as the PersistentFSM will not be able to read data written
 
 @@@ note 
 
-There is one case where @ref:[a full shutdown and startup is required](additional/deploying.md#migrating-from-persistentfsm-to-eventsourcedbehavior).
+There is one case where @ref:[a full shutdown and startup is required](additional/rolling-updates.md#migrating-from-persistentfsm-to-eventsourcedbehavior).
 
 @@@
 

--- a/akka-docs/src/main/paradox/persistence-fsm.md
+++ b/akka-docs/src/main/paradox/persistence-fsm.md
@@ -206,7 +206,11 @@ Java
 :  @@snip [PersistentFsmToTypedMigrationCompileOnlyTest.java](/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/PersistentFsmToTypedMigrationCompileOnlyTest.java) { #snapshot-adapter }
 
 That concludes all the steps to allow an @apidoc[EventSourcedBehavior] to read a `PersistentFSM`'s data. Once the new code has been running
-you can not roll back as the PersistentFSM will not be able to read data written by Persistence Typed. This means that if using persistence
-with Cluster Sharding a full shutdown is required as shards can move between new and old nodes.
+you can not roll back as the PersistentFSM will not be able to read data written by Persistence Typed. 
 
+@@@ note 
+
+There is one case where @ref:[a full shutdown and startup is required](additional/deploying.md#migrating-from-persistentfsm-to-eventsourcedbehavior).
+
+@@@
 

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -151,13 +151,16 @@ The configuration for Artery is different, so you might have to revisit any cust
 @ref:[reference configuration for Artery](../general/configuration.md#config-akka-remote-artery) and
 @ref:[reference configuration for classic remoting](../general/configuration.md#config-akka-remote).
 
+@@@ note
+
+For more details on rolling updates with this migration see the @ref:[shutdown and startup](../additional/deploying.md#migrating-from-classic-remoting-to-artery) section.
+
+@@@
+
 Configuration that is likely required to be ported:
 
 * `akka.remote.netty.tcp.hostname` => `akka.remote.artery.canonical.hostname`
 * `akka.remote.netty.tcp.port`=> `akka.remote.artery.canonical.port`
-
-One thing to be aware of is that rolling update from classic remoting to Artery is not supported since the protocol
-is completely different. It will require a full cluster shutdown and new startup.
 
 If using SSL then `tcp-tls` needs to be enabled and setup. See @ref[Artery docs for SSL](../remoting-artery.md#configuring-ssl-tls-for-akka-remoting)
 for how to do this.
@@ -222,35 +225,7 @@ akka.actor.warn-about-java-serializer-usage = off
 
 ### Rolling update
 
-You can replace Java serialization, if you use that, with for example the new
-@ref:[Serialization with Jackson](../serialization-jackson.md) and still be able to perform a rolling updates
-without bringing down the entire cluster.
-
-The procedure for changing from Java serialization to Jackson would look like:
-
-1. Rolling update from 2.5.24 (or later) to 2.6.0
-    * Use config `allow-java-serialization=on`.
-    * Roll out the change.
-    * Java serialization will be used as before.
-    * This step is optional and you could combine it with next step if you like, but could be good to
-      make one change at a time.
-1. Rolling update to support deserialization but not enable serialization
-    * Change message classes by adding the marker interface and possibly needed annotations as
-      described in @ref:[Serialization with Jackson](../serialization-jackson.md).
-    * Test the system with the new serialization in a new test cluster (no rolling update).
-    * Remove the binding for the marker interface, so that Jackson is not used for serialization yet.
-    * Roll out the change.
-    * Java serialization is still used, but this version is prepared for next roll out.
-1. Rolling update to enable serialization with Jackson.
-    * Add the binding to the marker interface to the Jackson serializer.
-    * Roll out the change.
-    * Old nodes will still send messages with Java serialization, and that can still be deserialized by new nodes.
-    * New nodes will send messages with Jackson serialization, and old node can deserialize those because they were
-      prepared in previous roll out.
-1. Rolling update to disable Java serialization
-    * Remove `allow-java-serialization` config, to use the default `allow-java-serialization=off`.
-    * Remove `.warn-about-java-serializer-usage` config if you had changed that, to use the default `.warn-about-java-serializer-usage=on`.
-    * Roll out the change.
+Please see the @ref:[rolling update procedure from Java serialization to Jackson](../additional/rolling-updates.md#from-java-serialization-to-jackson).
 
 ### Java serialization in consistent hashing
 
@@ -353,8 +328,8 @@ the default dispatcher has been adjusted down to `1.0` which means the number of
 #### waiting-for-state-timeout reduced to 2s
 
 This has been reduced to speed up ShardCoordinator initialization in smaller clusters.
-The read from ddata is a ReadMajority, for small clusters (< majority-min-cap) every node needs to respond
-so is more likely to timeout if there are nodes restarting e.g. when there is a rolling re-deploy happening.
+The read from ddata is a ReadMajority. For small clusters (< majority-min-cap) every node needs to respond
+so it is more likely to timeout if there are nodes restarting, for example when there is a rolling re-deploy happening.
 
 #### Passivate idle entity
 
@@ -452,9 +427,7 @@ The materialized value for `StreamRefs.sinkRef` and `StreamRefs.sourceRef` is no
 The receptionist had a name clash with the default Cluster Client Receptionist at `/system/receptionist` and will now 
 instead either run under `/system/localReceptionist` or `/system/clusterReceptionist`.
 
-The path change means that the receptionist information will not be disseminated between 2.5 and 2.6 nodes during a
-rolling update from 2.5 to 2.6 if you use Akka Typed. When all old nodes have been shutdown
-it will work properly again.
+@ref:[A full cluster shutdown and startup is required](../additional/deploying.md#akka-typed-with-receptionist-or-cluster-receptionist).
 
 ### Cluster Receptionist using own Distributed Data
 
@@ -463,10 +436,7 @@ undesired configuration changes if the application was also using that and chang
 configuration.
 
 In 2.6 the Cluster Receptionist is using it's own independent instance of Distributed Data.
-
-This means that the receptionist information will not be disseminated between 2.5 and 2.6 nodes during a
-rolling update from 2.5 to 2.6 if you use Akka Typed. When all old nodes have been shutdown
-it will work properly again.
+@ref:[A full cluster shutdown and startup is required](../additional/deploying.md#akka-typed-with-receptionist-or-cluster-receptionist).
 
 ### Akka Typed API changes
 

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -153,7 +153,7 @@ The configuration for Artery is different, so you might have to revisit any cust
 
 @@@ note
 
-For more details on rolling updates with this migration see the @ref:[shutdown and startup](../additional/deploying.md#migrating-from-classic-remoting-to-artery) section.
+For more details on rolling updates with this migration see the @ref:[shutdown and startup](../additional/rolling-updates.md#migrating-from-classic-remoting-to-artery) section.
 
 @@@
 
@@ -427,7 +427,9 @@ The materialized value for `StreamRefs.sinkRef` and `StreamRefs.sourceRef` is no
 The receptionist had a name clash with the default Cluster Client Receptionist at `/system/receptionist` and will now 
 instead either run under `/system/localReceptionist` or `/system/clusterReceptionist`.
 
-@ref:[A full cluster shutdown and startup is required](../additional/deploying.md#akka-typed-with-receptionist-or-cluster-receptionist).
+The path change means that the receptionist information will not be disseminated between 2.5 and 2.6 nodes during a
+rolling update from 2.5 to 2.6 if you use Akka Typed. When all old nodes have been shutdown
+it will work properly again.
 
 ### Cluster Receptionist using own Distributed Data
 
@@ -436,7 +438,10 @@ undesired configuration changes if the application was also using that and chang
 configuration.
 
 In 2.6 the Cluster Receptionist is using it's own independent instance of Distributed Data.
-@ref:[A full cluster shutdown and startup is required](../additional/deploying.md#akka-typed-with-receptionist-or-cluster-receptionist).
+
+This means that the receptionist information will not be disseminated between 2.5 and 2.6 nodes during a
+rolling update from 2.5 to 2.6 if you use Akka Typed. When all old nodes have been shutdown
+it will work properly again.
 
 ### Akka Typed API changes
 

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -428,8 +428,7 @@ The receptionist had a name clash with the default Cluster Client Receptionist a
 instead either run under `/system/localReceptionist` or `/system/clusterReceptionist`.
 
 The path change means that the receptionist information will not be disseminated between 2.5 and 2.6 nodes during a
-rolling update from 2.5 to 2.6 if you use Akka Typed. When all old nodes have been shutdown
-it will work properly again.
+rolling update from 2.5 to 2.6 if you use Akka Typed. See @ref:[rolling updates with typed Receptionist](../additional/rolling-updates.md#akka-typed-with-receptionist-or-cluster-receptionist)
 
 ### Cluster Receptionist using own Distributed Data
 
@@ -440,8 +439,7 @@ configuration.
 In 2.6 the Cluster Receptionist is using it's own independent instance of Distributed Data.
 
 This means that the receptionist information will not be disseminated between 2.5 and 2.6 nodes during a
-rolling update from 2.5 to 2.6 if you use Akka Typed. When all old nodes have been shutdown
-it will work properly again.
+rolling update from 2.5 to 2.6 if you use Akka Typed. See @ref:[rolling updates with typed Cluster Receptionist](../additional/rolling-updates.md#akka-typed-with-receptionist-or-cluster-receptionist)
 
 ### Akka Typed API changes
 

--- a/akka-docs/src/main/paradox/project/rolling-update.md
+++ b/akka-docs/src/main/paradox/project/rolling-update.md
@@ -9,6 +9,13 @@ For example it's possible to update from 2.5.14 to 2.5.16 without intermediate 2
 It's not supported to have a cluster with more than two different versions. Roll out the first
 update completely before starting next update.
 
+@@@ note
+
+[Rolling update from classic remoting to Artery](../additional/rolling-updates.md#migrating-from-classic-remoting-to-artery) is not supported since the protocol
+is completely different. It will require a full cluster shutdown and new startup.
+
+@@@
+
 ## Change log
 
 ### 2.5.0 Several changes in minor release

--- a/akka-docs/src/main/paradox/project/rolling-update.md
+++ b/akka-docs/src/main/paradox/project/rolling-update.md
@@ -9,13 +9,6 @@ For example it's possible to update from 2.5.14 to 2.5.16 without intermediate 2
 It's not supported to have a cluster with more than two different versions. Roll out the first
 update completely before starting next update.
 
-@@@ note
-
-Rolling update from classic remoting to Artery is not supported since the protocol
-is completely different. It will require a full cluster shutdown and new startup.
-
-@@@
-
 ## Change log
 
 ### 2.5.0 Several changes in minor release


### PR DESCRIPTION
* Part of https://github.com/akka/akka/issues/27223 with crossover for 2.6 and Typed
* Further re-org
* Additionally, this adds a new consolidation section of when the cases when a full shutdown/restart is required vs rolling update
<img width="995" alt="Screen Shot 2019-08-23 at 2 21 19 PM" src="https://user-images.githubusercontent.com/406103/63624483-50621800-c5b1-11e9-8960-5886aecce05f.png">
