### PR TITLE
harden ClusterSingletonManagerLeave2Spec, #27555

### DIFF
--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerLeave2Spec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerLeave2Spec.scala
@@ -178,7 +178,7 @@ class ClusterSingletonManagerLeave2Spec
       enterBarrier("stopped")
 
       runOn(third) {
-        expectMsg("preStart")
+        expectMsg(10.seconds, "preStart")
       }
       enterBarrier("third-started")
 


### PR DESCRIPTION
* from logs it can be seen that the singleton actor on third node is started
  after 3 seconds and the expectMsg("preStart") timeout is also 3 seconds
* increasing that timeout

```
[JVM-1] [INFO] [08/22/2019 22:56:40.852] [ClusterSingletonManagerLeave2Spec-akka.actor.internal-dispatcher-15] [akka://ClusterSingletonManagerLeave2Spec@first/user/echo] Self removed, stopping ClusterSingletonManager
[second] [JVM-3] [INFO] [08/22/2019 22:56:40.859] [ClusterSingletonManagerLeave2Spec-akka.actor.internal-dispatcher-15] [akka://ClusterSingletonManagerLeave2Spec@third/user/echo] Retry [3], sending HandOverToMe to [Some(akka://ClusterSingletonManagerLeave2Spec@first)]

[JVM-3] [INFO] [08/22/2019 22:56:43.862] [ClusterSingletonManagerLeave2Spec-akka.actor.internal-dispatcher-15] [akka://ClusterSingletonManagerLeave2Spec@third/user/echo] Member removed [akka://ClusterSingletonManagerLeave2Spec@first], previous oldest [akka://ClusterSingletonManagerLeave2Spec@first]
[JVM-3] [INFO] [08/22/2019 22:56:43.863] [ClusterSingletonManagerLeave2Spec-akka.actor.internal-dispatcher-15] [akka://ClusterSingletonManagerLeave2Spec@third/user/echo] Singleton manager starting singleton actor [akka://ClusterSingletonManagerLeave2Spec/user/echo/singleton]
```

Refs #27555