### PR TITLE
Fix race when binding to port '0' in artery tcp (#27525)

### DIFF
--- a/akka-remote/src/main/mima-filters/2.5.25.backwards.excludes
+++ b/akka-remote/src/main/mima-filters/2.5.25.backwards.excludes
@@ -1,0 +1,5 @@
+# #27455, #27525 Bind to arbitrary port in Artery TCP
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.artery.ArteryTransport.runInboundStreams")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.*.runInboundStreams")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.artery.ArteryTransport.bindInboundStreams")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.ArteryTransport.autoSelectPort")

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -4,10 +4,7 @@
 
 package akka.remote.artery
 
-import java.net.InetSocketAddress
-import java.nio.channels.DatagramChannel
 import java.nio.channels.FileChannel
-import java.nio.channels.ServerSocketChannel
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -442,21 +439,6 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
     startTransport()
     topLevelFlightRecorder.loFreq(Transport_Started, NoMetaData)
 
-    val udp = settings.Transport == ArterySettings.AeronUpd
-    val port =
-      if (settings.Canonical.Port == 0) {
-        if (settings.Bind.Port != 0) settings.Bind.Port // if bind port is set, use bind port instead of random
-        else ArteryTransport.autoSelectPort(settings.Canonical.Hostname, udp)
-      } else settings.Canonical.Port
-
-    _localAddress = UniqueAddress(
-      Address(ArteryTransport.ProtocolName, system.name, settings.Canonical.Hostname, port),
-      AddressUidExtension(system).longAddressUid)
-    _addresses = Set(_localAddress.address)
-
-    // TODO: This probably needs to be a global value instead of an event as events might rotate out of the log
-    topLevelFlightRecorder.loFreq(Transport_UniqueAddressSet, _localAddress.toString())
-
     materializer = ActorMaterializer.systemMaterializer(settings.Advanced.MaterializerSettings, "remote", system)
     controlMaterializer =
       ActorMaterializer.systemMaterializer(settings.Advanced.MaterializerSettings, "remoteControl", system)
@@ -464,10 +446,20 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
     messageDispatcher = new MessageDispatcher(system, provider)
     topLevelFlightRecorder.loFreq(Transport_MaterializerStarted, NoMetaData)
 
-    val boundPort = runInboundStreams()
+    val (port, boundPort) = bindInboundStreams()
+
+    _localAddress = UniqueAddress(
+      Address(ArteryTransport.ProtocolName, system.name, settings.Canonical.Hostname, port),
+      AddressUidExtension(system).longAddressUid)
+    _addresses = Set(_localAddress.address)
+
     _bindAddress = UniqueAddress(
       Address(ArteryTransport.ProtocolName, system.name, settings.Bind.Hostname, boundPort),
       AddressUidExtension(system).longAddressUid)
+
+    topLevelFlightRecorder.loFreq(Transport_UniqueAddressSet, _localAddress.toString())
+
+    runInboundStreams(port, boundPort)
 
     topLevelFlightRecorder.loFreq(Transport_StartupFinished, NoMetaData)
 
@@ -490,7 +482,21 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
 
   protected def startTransport(): Unit
 
-  protected def runInboundStreams(): Int
+  /**
+   * Bind to the ports for inbound streams. If '0' is specified, this will also select an
+   * arbitrary free local port. For UDP, we only select the port and leave the actual
+   * binding to Aeron when running the inbound stream.
+   *
+   * After calling this method the 'localAddress' and 'bindAddress' fields can be set.
+   */
+  protected def bindInboundStreams(): (Int, Int)
+
+  /**
+   * Run the inbound streams that have been previously bound.
+   *
+   * Before calling this method the 'localAddress' and 'bindAddress' should have been set.
+   */
+  protected def runInboundStreams(port: Int, bindPort: Int): Unit
 
   private def startRemoveQuarantinedAssociationTask(): Unit = {
     val removeAfter = settings.Advanced.RemoveQuarantinedAssociationAfter
@@ -998,22 +1004,6 @@ private[remote] object ArteryTransport {
   object ShuttingDown extends RuntimeException with NoStackTrace
 
   final case class InboundStreamMatValues[LifeCycle](lifeCycle: LifeCycle, completed: Future[Done])
-
-  def autoSelectPort(hostname: String, udp: Boolean): Int = {
-    if (udp) {
-      val socket = DatagramChannel.open().socket()
-      socket.bind(new InetSocketAddress(hostname, 0))
-      val port = socket.getLocalPort
-      socket.close()
-      port
-    } else {
-      val socket = ServerSocketChannel.open().socket()
-      socket.bind(new InetSocketAddress(hostname, 0))
-      val port = socket.getLocalPort
-      socket.close()
-      port
-    }
-  }
 
   val ControlStreamId = 1
   val OrdinaryStreamId = 2

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -77,8 +77,10 @@ private[remote] class ArteryTcpTransport(
   // may change when inbound streams are restarted
   @volatile private var inboundKillSwitch: SharedKillSwitch = KillSwitches.shared("inboundKillSwitch")
   // may change when inbound streams are restarted
-  @volatile private var inboundStream: OptionVal[Sink[EnvelopeBuffer, NotUsed]] = OptionVal.None
   @volatile private var serverBinding: Option[ServerBinding] = None
+  private val firstConnectionFlow = Promise[Flow[ByteString, ByteString, NotUsed]]()
+  @volatile private var inboundConnectionFlow: Future[Flow[ByteString, ByteString, NotUsed]] =
+    firstConnectionFlow.future
 
   private val sslEngineProvider: OptionVal[SSLEngineProvider] =
     if (tlsEnabled) {
@@ -193,7 +195,61 @@ private[remote] class ArteryTcpTransport(
       .toMat(Sink.ignore)(Keep.right)
   }
 
-  override protected def runInboundStreams(): Int = {
+  override protected def bindInboundStreams(): (Int, Int) = {
+    implicit val sys: ActorSystem = system
+    implicit val mat: Materializer = materializer
+
+    val bindHost = settings.Bind.Hostname
+    val bindPort = settings.Bind.Port
+
+    val connectionSource: Source[Tcp.IncomingConnection, Future[ServerBinding]] =
+      if (tlsEnabled) {
+        val sslProvider = sslEngineProvider.get
+        Tcp().bindTlsWithSSLEngine(
+          interface = bindHost,
+          port = bindPort,
+          createSSLEngine = () => sslProvider.createServerSSLEngine(bindHost, bindPort),
+          verifySession = session => optionToTry(sslProvider.verifyServerSession(bindHost, session)))
+      } else {
+        Tcp().bind(interface = bindHost, port = bindPort, halfClose = false)
+      }
+
+    val binding = serverBinding match {
+      case None =>
+        val afr = createFlightRecorderEventSink()
+        val binding = connectionSource
+          .to(Sink.foreach { connection =>
+            afr.loFreq(
+              TcpInbound_Connected,
+              s"${connection.remoteAddress.getHostString}:${connection.remoteAddress.getPort}")
+            inboundConnectionFlow.map(connection.handleWith(_))(sys.dispatcher)
+          })
+          .run()
+          .recoverWith {
+            case e =>
+              Future.failed(
+                new RemoteTransportException(
+                  s"Failed to bind TCP to [$bindHost:$bindPort] due to: " +
+                  e.getMessage,
+                  e))
+          }(ExecutionContexts.sameThreadExecutionContext)
+
+        // only on initial startup, when ActorSystem is starting
+        val b = Await.result(binding, settings.Bind.BindTimeout)
+        afr.loFreq(TcpInbound_Bound, s"$bindHost:${b.localAddress.getPort}")
+        b
+      case Some(binding) =>
+        // already bound, when restarting
+        binding
+    }
+    serverBinding = Some(binding)
+    if (settings.Canonical.Port == 0)
+      (binding.localAddress.getPort, binding.localAddress.getPort)
+    else
+      (settings.Canonical.Port, binding.localAddress.getPort)
+  }
+
+  override protected def runInboundStreams(port: Int, bindPort: Int): Unit = {
     // Design note: The design of how to run the inbound streams are influenced by the original design
     // for the Aeron streams, and there we can only have one single inbound since everything comes in
     // via the single AeronSource.
@@ -207,9 +263,6 @@ private[remote] class ArteryTcpTransport(
     // However, this would be make the design for Aeron and TCP more different and more things might
     // have to be changed, such as compression advertisements and materialized values. Number of
     // inbound streams would be dynamic, and so on.
-
-    implicit val mat: Materializer = materializer
-    implicit val sys: ActorSystem = system
 
     // These streams are always running, only one instance of each inbound stream, and then the inbound connections
     // are attached to these via a MergeHub.
@@ -232,7 +285,7 @@ private[remote] class ArteryTcpTransport(
     // decide where to attach it based on that byte. Then the streamId wouldn't have to be sent in each
     // frame. That was not chosen because it is more complicated to implement and might have more runtime
     // overhead.
-    inboundStream = OptionVal.Some(Sink.fromGraph(GraphDSL.create() { implicit b =>
+    val inboundStream = Sink.fromGraph(GraphDSL.create() { implicit b =>
       import GraphDSL.Implicits._
       val partition = b.add(Partition[EnvelopeBuffer](3, env => {
         env.streamId match {
@@ -246,68 +299,22 @@ private[remote] class ArteryTcpTransport(
       partition.out(1) ~> ordinaryMessagesStream
       partition.out(2) ~> largeMessagesStream
       SinkShape(partition.in)
-    }))
+    })
 
     // If something in the inboundConnectionFlow fails, e.g. framing, the connection will be teared down,
     // but other parts of the inbound streams don't have to restarted.
-    def inboundConnectionFlow: Flow[ByteString, ByteString, NotUsed] = {
+    val newInboundConnectionFlow = {
       // must create new Flow for each connection because of the FlightRecorder that can't be shared
       val afr = createFlightRecorderEventSink()
       Flow[ByteString]
         .via(inboundKillSwitch.flow)
         .via(new TcpFraming(afr))
-        .alsoTo(inboundStream.get)
+        .alsoTo(inboundStream)
         .filter(_ => false) // don't send back anything in this TCP socket
         .map(_ => ByteString.empty) // make it a Flow[ByteString] again
     }
-
-    val bindHost = settings.Bind.Hostname
-    val bindPort =
-      if (settings.Bind.Port == 0 && settings.Canonical.Port == 0)
-        localAddress.address.port match {
-          case Some(n) => n
-          case _       => 0
-        } else settings.Bind.Port
-
-    val connectionSource: Source[Tcp.IncomingConnection, Future[ServerBinding]] =
-      if (tlsEnabled) {
-        val sslProvider = sslEngineProvider.get
-        Tcp().bindTlsWithSSLEngine(
-          interface = bindHost,
-          port = bindPort,
-          createSSLEngine = () => sslProvider.createServerSSLEngine(bindHost, bindPort),
-          verifySession = session => optionToTry(sslProvider.verifyServerSession(bindHost, session)))
-      } else {
-        Tcp().bind(interface = bindHost, port = bindPort, halfClose = false)
-      }
-
-    serverBinding = serverBinding match {
-      case None =>
-        val afr = createFlightRecorderEventSink()
-        val binding = connectionSource
-          .to(Sink.foreach { connection =>
-            afr.loFreq(
-              TcpInbound_Connected,
-              s"${connection.remoteAddress.getHostString}:${connection.remoteAddress.getPort}")
-            connection.handleWith(inboundConnectionFlow)
-          })
-          .run()
-          .recoverWith {
-            case e =>
-              Future.failed(new RemoteTransportException(
-                s"Failed to bind TCP to [${localAddress.address.host.get}:${localAddress.address.port.get}] due to: " +
-                e.getMessage,
-                e))
-          }(ExecutionContexts.sameThreadExecutionContext)
-
-        // only on initial startup, when ActorSystem is starting
-        val b = Await.result(binding, settings.Bind.BindTimeout)
-        afr.loFreq(TcpInbound_Bound, s"$bindHost:${b.localAddress.getPort}")
-        Some(b)
-      case s @ Some(_) =>
-        // already bound, when restarting
-        s
-    }
+    firstConnectionFlow.trySuccess(newInboundConnectionFlow)
+    inboundConnectionFlow = Future.successful(newInboundConnectionFlow)
 
     // Failures in any of the inbound streams should be extremely rare, probably an unforeseen accident.
     // Tear down everything and start over again. Inbound streams are "stateless" so that should be fine.
@@ -325,12 +332,10 @@ private[remote] class ArteryTcpTransport(
         _ <- if (largeMessageChannelEnabled)
           largeMessagesStreamCompleted.recover { case _ => Done } else Future.successful(Done)
       } yield Done
-      allStopped.foreach(_ => runInboundStreams())
+      allStopped.foreach(_ => runInboundStreams(port, bindPort))
     }
 
     attachInboundStreamRestart("Inbound streams", completed, restart)
-
-    serverBinding.get.localAddress.getPort
   }
 
   private def runInboundControlStream(): (Sink[EnvelopeBuffer, NotUsed], Future[Done]) = {


### PR DESCRIPTION
Splitting the 'binding' and 'starting inbound streams' seems to make
it a bit easier to follow as well

backport of #27525