### PR TITLE
Automatically enable eventStream Slf4jLogger for Typed, #26537

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
@@ -65,9 +65,7 @@ object ActorSpecMessages {
 
 }
 
-abstract class ActorContextSpec extends ScalaTestWithActorTestKit("""
-    akka.loggers = [akka.event.slf4j.Slf4jLogger]
-  """) with WordSpecLike {
+abstract class ActorContextSpec extends ScalaTestWithActorTestKit with WordSpecLike {
 
   import ActorSpecMessages._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -31,7 +31,6 @@ object AskSpec {
 
 class AskSpec extends ScalaTestWithActorTestKit("""
   akka.loglevel=warning
-  akka.loggers = [akka.event.slf4j.Slf4jLogger]
   """) with WordSpecLike {
 
   import AskSpec._

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
@@ -30,9 +30,7 @@ object DeferredSpec {
       })
 }
 
-class DeferredSpec extends ScalaTestWithActorTestKit("""
-    akka.loggers = [akka.event.slf4j.Slf4jLogger]
-    """) with WordSpecLike {
+class DeferredSpec extends ScalaTestWithActorTestKit with WordSpecLike {
 
   import DeferredSpec._
   implicit val testSettings = TestKitSettings(system)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/InterceptSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/InterceptSpec.scala
@@ -74,9 +74,7 @@ object InterceptSpec {
   }
 }
 
-class InterceptSpec extends ScalaTestWithActorTestKit("""
-      akka.loggers = [akka.event.slf4j.Slf4jLogger]
-    """) with WordSpecLike {
+class InterceptSpec extends ScalaTestWithActorTestKit with WordSpecLike {
   import BehaviorInterceptor._
   import InterceptSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
@@ -24,7 +24,6 @@ class MailboxSelectorSpec extends ScalaTestWithActorTestKit("""
       mailbox-type = "akka.dispatch.NonBlockingBoundedMailbox"
       mailbox-capacity = 4 
     }
-    akka.loggers = [akka.event.slf4j.Slf4jLogger]
   """) with WordSpecLike {
 
   case class WhatsYourMailbox(replyTo: ActorRef[MessageQueue])

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -252,7 +252,6 @@ class StubbedSupervisionSpec extends WordSpec with Matchers {
 }
 
 class SupervisionSpec extends ScalaTestWithActorTestKit("""
-    akka.loggers = [akka.event.slf4j.Slf4jLogger]
     akka.log-dead-letters = off
     """) with WordSpecLike {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
@@ -21,9 +21,7 @@ import akka.actor.typed.scaladsl.TimerScheduler
 import akka.testkit.TimingTest
 import org.scalatest.WordSpecLike
 
-class TimerSpec extends ScalaTestWithActorTestKit("""
-    akka.loggers = [akka.event.slf4j.Slf4jLogger]
-  """) with WordSpecLike {
+class TimerSpec extends ScalaTestWithActorTestKit with WordSpecLike {
 
   sealed trait Command
   case class Tick(n: Int) extends Command

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TransformMessagesSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TransformMessagesSpec.scala
@@ -32,9 +32,7 @@ object TransformMessagesSpec {
       }
 }
 
-class TransformMessagesSpec extends ScalaTestWithActorTestKit("""
-    akka.loggers = [akka.event.slf4j.Slf4jLogger]
-    """) with WordSpecLike {
+class TransformMessagesSpec extends ScalaTestWithActorTestKit with WordSpecLike {
 
   implicit val untypedSystem = system.toUntyped
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
@@ -15,13 +15,9 @@ import scala.concurrent.duration._
 import akka.actor.testkit.typed.TestException
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import com.typesafe.config.ConfigFactory
 import org.scalatest.WordSpecLike
 
 object WatchSpec {
-  val config = ConfigFactory.parseString("""
-       akka.loggers = [akka.event.slf4j.Slf4jLogger]
-    """.stripMargin)
 
   case object Stop
 
@@ -44,7 +40,7 @@ object WatchSpec {
   case class StartWatchingWith(watchee: ActorRef[Stop.type], message: CustomTerminationMessage) extends Message
 }
 
-class WatchSpec extends ScalaTestWithActorTestKit(WatchSpec.config) with WordSpecLike {
+class WatchSpec extends ScalaTestWithActorTestKit with WordSpecLike {
 
   implicit def untypedSystem = system.toUntyped
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
@@ -18,7 +18,6 @@ import org.scalatest.WordSpecLike
 
 object ActorContextAskSpec {
   val config = ConfigFactory.parseString("""
-      akka.loggers = [akka.event.slf4j.Slf4jLogger]
       ping-pong-dispatcher {
         executor = thread-pool-executor
         type = PinnedDispatcher

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
@@ -19,7 +19,6 @@ import org.scalatest.WordSpecLike
 
 object MessageAdapterSpec {
   val config = ConfigFactory.parseString("""
-      akka.loggers = [akka.event.slf4j.Slf4jLogger]
       akka.log-dead-letters = off
       ping-pong-dispatcher {
         executor = thread-pool-executor

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/RoutersSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/RoutersSpec.scala
@@ -21,7 +21,6 @@ import org.scalatest.Matchers
 import org.scalatest.WordSpecLike
 
 class RoutersSpec extends ScalaTestWithActorTestKit("""
-    akka.loggers = [akka.event.slf4j.Slf4jLogger]
     akka.loglevel=debug
   """) with WordSpecLike with Matchers {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashSpec.scala
@@ -255,9 +255,7 @@ abstract class AbstractStashSpec extends ScalaTestWithActorTestKit with WordSpec
 
 }
 
-class UnstashingSpec extends ScalaTestWithActorTestKit("""
-  akka.loggers = [akka.event.slf4j.Slf4jLogger]
-  """) with WordSpecLike {
+class UnstashingSpec extends ScalaTestWithActorTestKit with WordSpecLike {
 
   private def slowStoppingChild(latch: CountDownLatch): Behavior[String] =
     Behaviors.receiveSignal {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/AdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/AdapterSpec.scala
@@ -162,9 +162,7 @@ object AdapterSpec {
 
 }
 
-class AdapterSpec extends AkkaSpec("""
-   akka.loggers = [akka.event.slf4j.Slf4jLogger]
-  """) {
+class AdapterSpec extends AkkaSpec {
   import AdapterSpec._
 
   "ActorSystem adaption" must {

--- a/akka-actor-typed/src/main/resources/reference.conf
+++ b/akka-actor-typed/src/main/resources/reference.conf
@@ -45,3 +45,17 @@ akka.actor {
     "akka.actor.typed.internal.receptionist.DefaultServiceKey" = service-key
   }
 }
+
+# When using Akka Typed (having akka-actor-typed in classpath) the
+# akka.event.slf4j.Slf4jLogger is enabled instead of the DefaultLogger
+# even though it has not been explicitly defined in `akka.loggers`
+# configuration.
+#
+# Slf4jLogger will be used for all Akka classic logging via eventStream,
+# including logging from Akka internals. The Slf4jLogger is then using
+# an ordinary org.slf4j.Logger to emit the log events.
+#
+# The Slf4jLoggingFilter is also enabled automatically.
+#
+# This behavior can be disabled by setting this property to `off`.
+akka.use-slf4j = on

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -271,12 +271,6 @@ object ActorSystem {
  * This class is immutable.
  */
 final class Settings(val config: Config, val untypedSettings: untyped.ActorSystem.Settings, val name: String) {
-  def this(classLoader: ClassLoader, config: Config, name: String) =
-    this({
-      val cfg = config.withFallback(ConfigFactory.defaultReference(classLoader))
-      cfg.checkValid(ConfigFactory.defaultReference(classLoader), "akka")
-      cfg
-    }, new untyped.ActorSystem.Settings(classLoader, config, name), name)
 
   def this(settings: untyped.ActorSystem.Settings) = this(settings.config, settings, settings.name)
 

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/LoggerSourceTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/LoggerSourceTest.java
@@ -24,8 +24,7 @@ public class LoggerSourceTest extends JUnitSuite {
 
   private static final Config config =
       ConfigFactory.parseString(
-          "akka.loggers = [akka.event.slf4j.Slf4jLogger] \n"
-              + "akka.persistence.journal.plugin = \"akka.persistence.journal.inmem\" \n"
+          "akka.persistence.journal.plugin = \"akka.persistence.journal.inmem\" \n"
               + "akka.persistence.journal.inmem.test-serialization = on \n");
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource(config);

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -46,8 +46,7 @@ import static org.junit.Assert.assertEquals;
 public class PersistentActorJavaDslTest extends JUnitSuite {
 
   public static final Config config =
-      ConfigFactory.parseString("akka.loggers = [akka.event.slf4j.Slf4jLogger]")
-          .withFallback(EventSourcedBehaviorSpec.conf().withFallback(ConfigFactory.load()));
+      EventSourcedBehaviorSpec.conf().withFallback(ConfigFactory.load());
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
@@ -48,7 +48,6 @@ object ManyRecoveriesSpec {
 }
 
 class ManyRecoveriesSpec extends ScalaTestWithActorTestKit(s"""
-    akka.loggers = [akka.event.slf4j.Slf4jLogger]
     akka.actor.default-dispatcher {
       type = Dispatcher
       executor = "thread-pool-executor"

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
@@ -67,7 +67,6 @@ object RecoveryPermitterSpec {
 }
 
 class RecoveryPermitterSpec extends ScalaTestWithActorTestKit(s"""
-      akka.loggers = [akka.event.slf4j.Slf4jLogger]
       akka.persistence.max-concurrent-recoveries = 3
       akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
       akka.persistence.journal.inmem.test-serialization = on

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorFailureSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorFailureSpec.scala
@@ -72,7 +72,6 @@ object EventSourcedBehaviorFailureSpec {
 
   val conf: Config = ConfigFactory.parseString(s"""
       akka.loglevel = INFO
-      akka.loggers = [akka.event.slf4j.Slf4jLogger]
       akka.persistence.journal.plugin = "failure-journal"
       failure-journal = $${akka.persistence.journal.inmem}
       failure-journal {

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorInterceptorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorInterceptorSpec.scala
@@ -23,7 +23,6 @@ object EventSourcedBehaviorInterceptorSpec {
 
   def config: Config = ConfigFactory.parseString(s"""
         akka.loglevel = INFO
-        akka.loggers = [akka.event.slf4j.Slf4jLogger]
         akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
         akka.persistence.journal.inmem.test-serialization = on
         """)

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRecoveryTimeoutSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRecoveryTimeoutSpec.scala
@@ -33,7 +33,6 @@ object EventSourcedBehaviorRecoveryTimeoutSpec {
         """))
       .withFallback(ConfigFactory.parseString(s"""
         akka.loglevel = INFO
-        akka.loggers = [akka.event.slf4j.Slf4jLogger]
         """))
 
   def testBehavior(persistenceId: PersistenceId, probe: ActorRef[AnyRef]): Behavior[String] =

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
@@ -38,7 +38,6 @@ object EventSourcedBehaviorRetentionSpec {
 
   def conf: Config = ConfigFactory.parseString(s"""
     akka.loglevel = INFO
-    akka.loggers = [akka.event.slf4j.Slf4jLogger]
     # akka.persistence.typed.log-stashing = on
     akka.persistence.journal.leveldb.dir = "target/typed-persistence-${UUID.randomUUID().toString}"
     akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -79,7 +79,6 @@ object EventSourcedBehaviorSpec {
   // also used from PersistentActorTest
   def conf: Config = ConfigFactory.parseString(s"""
     akka.loglevel = INFO
-    akka.loggers = [akka.event.slf4j.Slf4jLogger]
     # akka.persistence.typed.log-stashing = on
     akka.persistence.journal.leveldb.dir = "target/typed-persistence-${UUID.randomUUID().toString}"
     akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
@@ -563,11 +562,7 @@ class EventSourcedBehaviorSpec extends ScalaTestWithActorTestKit(EventSourcedBeh
 
     "fail fast if default journal plugin is not defined" in {
       // new ActorSystem without persistence config
-      val testkit2 = ActorTestKit(
-        ActorTestKitBase.testNameFromCallStack(),
-        ConfigFactory.parseString("""
-          akka.loggers = [akka.event.slf4j.Slf4jLogger]
-          """))
+      val testkit2 = ActorTestKit(ActorTestKitBase.testNameFromCallStack(), ConfigFactory.parseString(""))
       try {
         LoggingEventFilter[ActorInitializationException](
           start = "Default journal plugin is not configured",
@@ -583,11 +578,7 @@ class EventSourcedBehaviorSpec extends ScalaTestWithActorTestKit(EventSourcedBeh
 
     "fail fast if given journal plugin is not defined" in {
       // new ActorSystem without persistence config
-      val testkit2 = ActorTestKit(
-        ActorTestKitBase.testNameFromCallStack(),
-        ConfigFactory.parseString("""
-          akka.loggers = [akka.event.slf4j.Slf4jLogger]
-          """))
+      val testkit2 = ActorTestKit(ActorTestKitBase.testNameFromCallStack(), ConfigFactory.parseString(""))
       try {
         LoggingEventFilter[ActorInitializationException](
           start = "Journal plugin [missing] configuration doesn't exist",
@@ -606,7 +597,6 @@ class EventSourcedBehaviorSpec extends ScalaTestWithActorTestKit(EventSourcedBeh
       val testkit2 = ActorTestKit(
         ActorTestKitBase.testNameFromCallStack(),
         ConfigFactory.parseString(s"""
-          akka.loggers = [akka.event.slf4j.Slf4jLogger]
           akka.persistence.journal.leveldb.dir = "target/typed-persistence-${UUID.randomUUID().toString}"
           akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
           """))
@@ -630,7 +620,6 @@ class EventSourcedBehaviorSpec extends ScalaTestWithActorTestKit(EventSourcedBeh
       val testkit2 = ActorTestKit(
         ActorTestKitBase.testNameFromCallStack(),
         ConfigFactory.parseString(s"""
-          akka.loggers = [akka.event.slf4j.Slf4jLogger]
           akka.persistence.journal.leveldb.dir = "target/typed-persistence-${UUID.randomUUID().toString}"
           akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
           """))

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
@@ -34,7 +34,6 @@ import org.scalatest.WordSpecLike
 object EventSourcedBehaviorStashSpec {
   def conf: Config = ConfigFactory.parseString(s"""
     #akka.loglevel = DEBUG
-    akka.loggers = [akka.event.slf4j.Slf4jLogger]
     #akka.persistence.typed.log-stashing = on
     akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
     akka.persistence.journal.plugin = "failure-journal"

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorTimersSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorTimersSpec.scala
@@ -24,7 +24,6 @@ object EventSourcedBehaviorTimersSpec {
 
   def config: Config = ConfigFactory.parseString(s"""
         akka.loglevel = INFO
-        akka.loggers = [akka.event.slf4j.Slf4jLogger]
         akka.persistence.journal.leveldb.dir = "target/typed-persistence-${UUID.randomUUID().toString}"
         akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
         """)

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedEventAdapterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedEventAdapterSpec.scala
@@ -28,7 +28,6 @@ import org.scalatest.WordSpecLike
 object EventSourcedEventAdapterSpec {
 
   private val conf = ConfigFactory.parseString(s"""
-      akka.loggers = [akka.event.slf4j.Slf4jLogger]
       akka.persistence.journal.leveldb.dir = "target/typed-persistence-${UUID.randomUUID().toString}"
       akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
     """)

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
@@ -15,7 +15,6 @@ import org.scalatest.WordSpecLike
 object EventSourcedSequenceNumberSpec {
 
   private val conf = ConfigFactory.parseString(s"""
-      akka.loggers = [akka.event.slf4j.Slf4jLogger]
       akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
       akka.persistence.journal.inmem.test-serialization = on
     """)

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/LoggerSourceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/LoggerSourceSpec.scala
@@ -13,17 +13,11 @@ import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.RecoveryCompleted
 import akka.persistence.typed.SnapshotCompleted
 import akka.persistence.typed.SnapshotFailed
-import com.typesafe.config.ConfigFactory
 import org.scalatest.WordSpecLike
 
 // Note that the spec name here is important since there are heuristics in place to avoid names
 // starting with EventSourcedBehavior
-class LoggerSourceSpec
-    extends ScalaTestWithActorTestKit(
-      ConfigFactory
-        .parseString("akka.loggers = [akka.event.slf4j.Slf4jLogger]")
-        .withFallback(EventSourcedBehaviorSpec.conf))
-    with WordSpecLike {
+class LoggerSourceSpec extends ScalaTestWithActorTestKit(EventSourcedBehaviorSpec.conf) with WordSpecLike {
 
   private val pidCounter = new AtomicInteger(0)
   private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/NullEmptyStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/NullEmptyStateSpec.scala
@@ -16,7 +16,6 @@ import org.scalatest.WordSpecLike
 object NullEmptyStateSpec {
 
   private val conf = ConfigFactory.parseString(s"""
-      akka.loggers = [akka.event.slf4j.Slf4jLogger]
       akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
       akka.persistence.journal.inmem.test-serialization = on
     """)

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
@@ -41,7 +41,6 @@ object OptionalSnapshotStoreSpec {
 }
 
 class OptionalSnapshotStoreSpec extends ScalaTestWithActorTestKit(s"""
-    akka.loggers = [akka.event.slf4j.Slf4jLogger]
     akka.persistence.publish-plugin-commands = on
     akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
     akka.persistence.journal.inmem.test-serialization = on

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
@@ -15,7 +15,6 @@ import org.scalatest.WordSpecLike
 object PrimitiveStateSpec {
 
   private val conf = ConfigFactory.parseString(s"""
-      akka.loggers = [akka.event.slf4j.Slf4jLogger]
       akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
       akka.persistence.journal.inmem.test-serialization = on
     """)


### PR DESCRIPTION
* amend the ActorSystem config on startup when config akka.use-slf4j=on
  and akka-slf4j in classpath
* akka.use-slf4j is defined in akka-actor-typed reference.conf
* also enable the Slf4jLoggingFilter automatically
* remove config in tests

On top of https://github.com/akka/akka/pull/27552. Thought it was worth reviewing this separately.

Refs #26537