### PR TITLE
Create a new flightrecorder instance per connection (backport)

### DIFF
--- a/akka-remote/src/main/mima-filters/2.5.25.backwards.excludes
+++ b/akka-remote/src/main/mima-filters/2.5.25.backwards.excludes
@@ -1,5 +1,7 @@
 # #27455, #27525 Bind to arbitrary port in Artery TCP
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.artery.ArteryTransport.runInboundStreams")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.remote.artery.*.runInboundStreams")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.artery.*.runInboundStreams")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.*.runInboundStreams")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.remote.artery.ArteryTransport.bindInboundStreams")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.artery.ArteryTransport.autoSelectPort")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.remote.artery.tcp.TcpFraming.this")

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -304,11 +304,10 @@ private[remote] class ArteryTcpTransport(
     // If something in the inboundConnectionFlow fails, e.g. framing, the connection will be teared down,
     // but other parts of the inbound streams don't have to restarted.
     val newInboundConnectionFlow = {
-      // must create new Flow for each connection because of the FlightRecorder that can't be shared
-      val afr = createFlightRecorderEventSink()
       Flow[ByteString]
         .via(inboundKillSwitch.flow)
-        .via(new TcpFraming(afr))
+        // must create new FlightRecorder event sink for each connection because they can't be shared
+        .via(new TcpFraming(() => createFlightRecorderEventSink(false)))
         .alsoTo(inboundStream)
         .filter(_ => false) // don't send back anything in this TCP socket
         .map(_ => ByteString.empty) // make it a Flow[ByteString] again

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/TcpFraming.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/TcpFraming.scala
@@ -59,8 +59,11 @@ import akka.util.ByteString
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] class TcpFraming(flightRecorder: EventSink) extends ByteStringParser[EnvelopeBuffer] {
+@InternalApi private[akka] class TcpFraming(flightRecorderSupplier: () => EventSink)
+    extends ByteStringParser[EnvelopeBuffer] {
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new ParsingLogic {
+    val flightRecorder = flightRecorderSupplier()
+
     abstract class Step extends ParseStep[EnvelopeBuffer]
     startWith(ReadMagic)
 

--- a/akka-remote/src/test/scala/akka/remote/artery/tcp/TcpFramingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/tcp/TcpFramingSpec.scala
@@ -27,7 +27,7 @@ class TcpFramingSpec extends AkkaSpec with ImplicitSender {
 
   private val afr = IgnoreEventSink
 
-  private val framingFlow = Flow[ByteString].via(new TcpFraming(afr))
+  private val framingFlow = Flow[ByteString].via(new TcpFraming(() => afr))
 
   private val payload5 = ByteString((1 to 5).map(_.toByte).toArray)
 


### PR DESCRIPTION
From https://github.com/akka/akka/pull/27577

(cherry picked from commit bc4a4a5837e9d79a491edae6c75143a817ff6c26)

Refs #27574