### PR TITLE
[Only] Deprecate Persistent mode of Cluster Sharding 

### DIFF
--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
@@ -106,6 +106,7 @@ object ClusterShardingSettings {
         throw new IllegalArgumentException(
           "Not recognized StateStoreMode, only 'persistence' and 'ddata' are supported.")
   }
+
   final case object StateStoreModePersistence extends StateStoreMode { override def name = "persistence" }
   final case object StateStoreModeDData extends StateStoreMode { override def name = "ddata" }
 

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
@@ -104,9 +104,8 @@ object ClusterShardingSettings {
       else if (name == StateStoreModeDData.name) StateStoreModeDData
       else
         throw new IllegalArgumentException(
-          "Not recognized StateStoreMode, only 'persistence' and 'ddata' are supported.")
+          "Not recognized StateStoreMode, only 'ddata' is supported.")
   }
-
   final case object StateStoreModePersistence extends StateStoreMode { override def name = "persistence" }
   final case object StateStoreModeDData extends StateStoreMode { override def name = "ddata" }
 

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
@@ -103,8 +103,7 @@ object ClusterShardingSettings {
       if (name == StateStoreModePersistence.name) StateStoreModePersistence
       else if (name == StateStoreModeDData.name) StateStoreModeDData
       else
-        throw new IllegalArgumentException(
-          "Not recognized StateStoreMode, only 'ddata' is supported.")
+        throw new IllegalArgumentException("Not recognized StateStoreMode, only 'ddata' is supported.")
   }
   final case object StateStoreModePersistence extends StateStoreMode { override def name = "persistence" }
   final case object StateStoreModeDData extends StateStoreMode { override def name = "ddata" }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -281,6 +281,9 @@ class ClusterSharding(system: ExtendedActorSystem) extends Extension {
       allocationStrategy: ShardAllocationStrategy,
       handOffStopMessage: Any): ActorRef = {
 
+    if (settings.stateStoreMode == ClusterShardingSettings.StateStoreModePersistence)
+      log.warning("Cluster Sharding has been set to use the deprecated `persistence` state store mode.")
+
     if (settings.shouldHostShard(cluster)) {
       regions.get(typeName) match {
         case null =>

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -4,16 +4,17 @@
 
 package akka.cluster.sharding
 
-import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
+
 import akka.actor.ActorSystem
 import akka.actor.NoSerializationVerificationNeeded
 import akka.annotation.InternalApi
-import com.typesafe.config.Config
 import akka.cluster.Cluster
 import akka.cluster.singleton.ClusterSingletonManagerSettings
 import akka.coordination.lease.LeaseUsageSettings
 import akka.util.JavaDurationConverters._
+import com.typesafe.config.Config
 
 object ClusterShardingSettings {
 
@@ -299,7 +300,8 @@ final class ClusterShardingSettings(
       tuningParameters,
       coordinatorSingletonSettings)
 
-  import ClusterShardingSettings.{ StateStoreModeDData, StateStoreModePersistence }
+  import ClusterShardingSettings.StateStoreModeDData
+  import ClusterShardingSettings.StateStoreModePersistence
   require(
     stateStoreMode == StateStoreModePersistence || stateStoreMode == StateStoreModeDData,
     s"Unknown 'state-store-mode' [$stateStoreMode], valid values are '$StateStoreModeDData' or '$StateStoreModePersistence'")

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -36,7 +36,6 @@ import akka.persistence._
 import akka.util.MessageBufferMap
 import akka.util.PrettyDuration._
 import akka.util.unused
-import com.github.ghik.silencer.silent
 
 /**
  * INTERNAL API
@@ -125,27 +124,28 @@ private[akka] object Shard {
       handOffStopMessage: Any,
       replicator: ActorRef,
       majorityMinCap: Int): Props = {
-
     (if (settings.rememberEntities && settings.stateStoreMode == ClusterShardingSettings.StateStoreModeDData) {
-       DDataShard.props(
-         typeName,
-         shardId,
-         entityProps,
-         settings,
-         extractEntityId,
-         extractShardId,
-         handOffStopMessage,
-         replicator,
-         majorityMinCap)
+       Props(
+         new DDataShard(
+           typeName,
+           shardId,
+           entityProps,
+           settings,
+           extractEntityId,
+           extractShardId,
+           handOffStopMessage,
+           replicator,
+           majorityMinCap))
      } else if (settings.rememberEntities && settings.stateStoreMode == ClusterShardingSettings.StateStoreModePersistence)
-       PersistentShard.props(
-         typeName,
-         shardId,
-         entityProps,
-         settings,
-         extractEntityId,
-         extractShardId,
-         handOffStopMessage)
+       Props(
+         new PersistentShard(
+           typeName,
+           shardId,
+           entityProps,
+           settings,
+           extractEntityId,
+           extractShardId,
+           handOffStopMessage))
      else {
        Props(new Shard(typeName, shardId, entityProps, settings, extractEntityId, extractShardId, handOffStopMessage))
      }).withDeploy(Deploy.local)
@@ -649,29 +649,6 @@ private[akka] trait RememberingShard {
   }
 }
 
-/** INTERNAL API */
-private[akka] object PersistentShard {
-
-  @silent("deprecated")
-  def props(
-      typeName: String,
-      shardId: ShardRegion.ShardId,
-      entityProps: String => Props,
-      settings: ClusterShardingSettings,
-      extractEntityId: ShardRegion.ExtractEntityId,
-      extractShardId: ShardRegion.ExtractShardId,
-      handOffStopMessage: Any): Props =
-    Props(
-      new PersistentShard(
-        typeName,
-        shardId,
-        entityProps,
-        settings,
-        extractEntityId,
-        extractShardId,
-        handOffStopMessage))
-}
-
 /**
  * INTERNAL API
  *
@@ -681,7 +658,6 @@ private[akka] object PersistentShard {
  *
  * @see [[ClusterSharding$ ClusterSharding extension]]
  */
-@deprecated("Use `ddata` mode, persistence mode is deprecated.", "2.6.0")
 private[akka] class PersistentShard(
     typeName: String,
     shardId: ShardRegion.ShardId,
@@ -769,32 +745,6 @@ private[akka] class PersistentShard(
 
     }: Receive).orElse(super.receiveCommand)
 
-}
-
-/** INTERNAL API */
-private[akka] object DDataShard {
-
-  def props(
-      typeName: String,
-      shardId: ShardRegion.ShardId,
-      entityProps: String => Props,
-      settings: ClusterShardingSettings,
-      extractEntityId: ShardRegion.ExtractEntityId,
-      extractShardId: ShardRegion.ExtractShardId,
-      handOffStopMessage: Any,
-      replicator: ActorRef,
-      majorityMinCap: Int): Props =
-    Props(
-      new DDataShard(
-        typeName,
-        shardId,
-        entityProps,
-        settings,
-        extractEntityId,
-        extractShardId,
-        handOffStopMessage,
-        replicator,
-        majorityMinCap))
 }
 
 /**

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -5,11 +5,11 @@
 package akka.cluster.sharding
 
 import akka.util.Timeout
-
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Success
+
 import akka.actor._
 import akka.actor.DeadLetterSuppression
 import akka.cluster.Cluster
@@ -26,6 +26,7 @@ import akka.cluster.ddata.GSetKey
 import akka.cluster.ddata.Key
 import akka.cluster.ddata.ReplicatedData
 import akka.cluster.ddata.SelfUniqueAddress
+import com.github.ghik.silencer.silent
 
 /**
  * @see [[ClusterSharding$ ClusterSharding extension]]
@@ -38,6 +39,7 @@ object ShardCoordinator {
    * INTERNAL API
    * Factory method for the [[akka.actor.Props]] of the [[ShardCoordinator]] actor.
    */
+  @silent("deprecated")
   private[akka] def props(
       typeName: String,
       settings: ClusterShardingSettings,
@@ -920,6 +922,7 @@ abstract class ShardCoordinator(
  *
  * @see [[ClusterSharding$ ClusterSharding extension]]
  */
+@deprecated("Use `ddata` mode, persistence mode is deprecated.", "2.6.0")
 class PersistentShardCoordinator(
     typeName: String,
     settings: ClusterShardingSettings,

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -4,12 +4,10 @@
 
 package akka.cluster.sharding
 
-import akka.util.Timeout
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Success
-
 import akka.actor._
 import akka.actor.DeadLetterSuppression
 import akka.cluster.Cluster
@@ -26,6 +24,7 @@ import akka.cluster.ddata.GSetKey
 import akka.cluster.ddata.Key
 import akka.cluster.ddata.ReplicatedData
 import akka.cluster.ddata.SelfUniqueAddress
+import akka.util.Timeout
 import com.github.ghik.silencer.silent
 
 /**

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/PersistentShardSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/PersistentShardSpec.scala
@@ -30,11 +30,11 @@ class PersistentShardSpec extends AkkaSpec(PersistentShardSpec.config) with Word
 
     "remember entities started with StartEntity" in {
       val props =
-        Props(new PersistentShard("cats", "shard-1", _ => Props(new EntityActor), ClusterShardingSettings(system), {
+        PersistentShard.props("cats", "shard-1", _ => Props(new EntityActor), ClusterShardingSettings(system), {
           case _ => ("entity-1", "msg")
         }, { _ =>
           "shard-1"
-        }, PoisonPill))
+        }, PoisonPill)
       val persistentShard = system.actorOf(props)
       watch(persistentShard)
 

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/PersistentShardSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/PersistentShardSpec.scala
@@ -30,11 +30,11 @@ class PersistentShardSpec extends AkkaSpec(PersistentShardSpec.config) with Word
 
     "remember entities started with StartEntity" in {
       val props =
-        PersistentShard.props("cats", "shard-1", _ => Props(new EntityActor), ClusterShardingSettings(system), {
+        Props(new PersistentShard("cats", "shard-1", _ => Props(new EntityActor), ClusterShardingSettings(system), {
           case _ => ("entity-1", "msg")
         }, { _ =>
           "shard-1"
-        }, PoisonPill)
+        }, PoisonPill))
       val persistentShard = system.actorOf(props)
       watch(persistentShard)
 

--- a/akka-docs/src/main/paradox/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/cluster-sharding.md
@@ -226,7 +226,7 @@ will stop all entities in that shard by sending the specified `stopMessage`
 (default `PoisonPill`) to them. When all entities have been terminated the `ShardRegion`
 owning the entities will acknowledge the handoff as completed to the coordinator.
 Thereafter the coordinator will reply to requests for the location of
-the shard and thereby allocate a new home for the shard and then buffered messages in the
+the shard, thereby allocating a new home for the shard, and then buffered messages in the
 `ShardRegion` actors are delivered to the new location. This means that the state of the entities
 are not transferred or migrated. If the state of the entities are of importance it should be
 persistent (durable), e.g. with @ref:[Persistence](persistence.md), so that it can be recovered at the new
@@ -251,10 +251,12 @@ the number of shards (and therefore load) between different nodes may be signifi
 ### ShardCoordinator State
 
 The state of shard locations in the `ShardCoordinator` is persistent (durable) with
-@ref:[Distributed Data](distributed-data.md) or @ref:[Persistence](persistence.md) to survive failures. When a crashed or
+@ref:[Distributed Data](distributed-data.md) or @ref:[Persistence](persistence.md) to survive failures. 
+
+When a crashed or
 unreachable coordinator node has been removed (via down) from the cluster a new `ShardCoordinator` singleton
 actor will take over and the state is recovered. During such a failure period shards
-with known location are still available, while messages for new (unknown) shards
+with a known location are still available, while messages for new (unknown) shards
 are buffered until the new `ShardCoordinator` becomes available.
 
 ### Message ordering
@@ -263,7 +265,7 @@ As long as a sender uses the same `ShardRegion` actor to deliver messages to an 
 actor the order of the messages is preserved. As long as the buffer limit is not reached
 messages are delivered on a best effort basis, with at-most once delivery semantics,
 in the same way as ordinary message sending. Reliable end-to-end messaging, with
-at-least-once semantics can be added by using `AtLeastOnceDelivery`  in @ref:[Persistence](persistence.md).
+at-least-once semantics can be added by using `AtLeastOnceDelivery` in @ref:[Persistence](persistence.md).
 
 ### Overhead
 
@@ -274,16 +276,19 @@ shard resolution, e.g. to avoid too fine grained shards. Once a shard's location
 the only overhead is sending a message via the `ShardRegion` rather than directly.
 
 <a id="cluster-sharding-mode"></a>
-## Distributed Data vs. Persistence Mode
+## Sharding State Store Modes
 
-The state of the coordinator and the state of [Remembering Entities](#cluster-sharding-remembering) of the shards
-are persistent (durable) to survive failures. @ref:[Distributed Data](distributed-data.md) or @ref:[Persistence](persistence.md)
-can be used for the storage. Distributed Data is used by default.
+There are two cluster sharding states managed:
+1. @ref:[ShardCoordinator State](#shardcoordinator-state) - the `Shard` locations
+1. @ref:[Remembering Entities](#remembering-entities) - the entities in each `Shard`, which is optional, and disabled by default
+ 
+For these, there are currently two modes which define how these states are stored:
+* @ref:[Distributed Data Mode](#distributed-data-mode) - uses Akka @ref:[Distributed Data](distributed-data.md) (CRDTs) (the default)
+* @ref:[Persistence Mode](#persistence-mode) - uses Akka @ref:[Persistence](persistence.md) (Event Sourcing)
 
-The functionality when using the two modes is the same. If your sharded entities are not using Akka Persistence
-themselves it is more convenient to use the Distributed Data mode, since then you don't have to
-setup and operate a separate data store (e.g. Cassandra) for persistence. Aside from that, there are
-no major reasons for using one mode over the other.
+Functionally the two modes are the same. If your sharded entities are not using Akka Persistence
+themselves it is more convenient to use Distributed Data mode to not additionally
+connect a separate data store (e.g. Cassandra) for persistence.
 
 Changing persistence mode requires @ref:[a full cluster restart](additional/rolling-updates.md#cluster-sharding-configuration-change).
 
@@ -299,10 +304,10 @@ The state of the `ShardCoordinator` is replicated across the cluster but is not 
 The `ShardCoordinator` state replication is handled by @ref:[Distributed Data](distributed-data.md) with `WriteMajority`/`ReadMajority` consistency.
 When all nodes in the cluster have been stopped, the state is no longer needed and dropped.
 
-The state of [Remembering Entities](#cluster-sharding-remembering) is durable and stored to
+The state of @ref:[Remembering Entities](#remembering-entities) is durable and stored to
 disk. This means remembered entities are restarted even after a complete (non-rolling) cluster restart when the disk is still available.
 
-Cluster Sharding is using its own Distributed Data `Replicator` per node. 
+Cluster Sharding uses its own Distributed Data `Replicator` per node. 
 If using roles with sharding there is one `Replicator` per role, which enables a subset of
 all nodes for some entity types and another subset for other entity types. Each such replicator has a name
 that contains the node role and therefore the role configuration must be the same on all nodes in the
@@ -322,6 +327,14 @@ akka.cluster.sharding.state-store-mode = persistence
 ```
 
 Since it is running in a cluster @ref:[Persistence](persistence.md) must be configured with a distributed journal.
+
+@@@ note
+
+Persistence mode will be replaced by a pluggable data access API with storage implementations.
+New sharding applications should no longer choose persistence mode. Existing users of persistence mode
+can eventually migrate to the replacement options. 
+
+@@@
 
 ## Startup after minimum number of members
 
@@ -368,6 +381,11 @@ It is always disabled if @ref:[Remembering Entities](#remembering-entities) is e
 <a id="cluster-sharding-remembering"></a>
 ## Remembering Entities
 
+Remembering entities pertains to restarting entities after a rebalance or recovering from a crash.
+Enabling or disabling it (the default) drives the behavior of the restart. Note that the state of
+the entities themselves will not be restored unless they have been made persistent,
+for example with @ref:[Event Sourcing](persistence.md).
+
 The list of entities in each `Shard` can be made persistent (durable) by setting
 the `rememberEntities` flag to true in `ClusterShardingSettings` when calling
 `ClusterSharding.start` and making sure the `shardIdExtractor` handles
@@ -380,13 +398,21 @@ Scala
 Java
 :  @@snip [ClusterShardingTest.java](/akka-docs/src/test/java/jdocs/sharding/ClusterShardingTest.java) { #extractShardId-StartEntity }
 
-When configured to remember entities, whenever a `Shard` is rebalanced onto another
+This can also be configured by setting `akka.cluster.sharding.remember-entities = on`.
+
+The performance cost of `rememberEntities` is rather high when starting/stopping entities and when
+shards are rebalanced. This cost increases with number of entities per shard, thus it is not
+recommended with more than 10000 active (non passivated) entities per shard.
+
+### Behavior When Enabled 
+
+When `rememberEntities` is enabled, whenever a `Shard` is rebalanced onto another
 node or recovers after a crash it will recreate all the entities which were previously
 running in that `Shard`. To permanently stop entities, a `Passivate` message must be
 sent to the parent of the entity actor, otherwise the entity will be automatically
 restarted after the entity restart backoff specified in the configuration.
 
-When [Distributed Data mode](#cluster-sharding-mode) is used the identifiers of the entities are
+When [Distributed Data mode](#distributed-data-mode) is used the identifiers of the entities are
 stored in @ref:[Durable Storage](distributed-data.md#ddata-durable) of Distributed Data. You may want to change the
 configuration of the `akka.cluster.sharding.distributed-data.durable.lmdb.dir`, since
 the default directory contains the remote port of the actor system. If using a dynamically
@@ -401,17 +427,12 @@ you can disable durable storage and benefit from better performance by using the
 akka.cluster.sharding.distributed-data.durable.keys = []
 ```
 
-When `rememberEntities` is set to false, a `Shard` will not automatically restart any entities
-after a rebalance or recovering from a crash. Entities will only be started once the first message
+### Behavior When Not Enabled 
+
+When `rememberEntities` is disabled (the default), a `Shard` will not automatically restart any entities
+after a rebalance or recovering from a crash. Instead, entities are started once the first message
 for that entity has been received in the `Shard`. Entities will not be restarted if they stop without
 using a `Passivate`.
-
-Note that the state of the entities themselves will not be restored unless they have been made persistent,
-e.g. with @ref:[Persistence](persistence.md).
-
-The performance cost of `rememberEntities` is rather high when starting/stopping entities and when
-shards are rebalanced. This cost increases with number of entities per shard and we currently don't
-recommend using it with more than 10000 active (non passivated) entities per shard.
 
 ## Supervision
 
@@ -451,9 +472,9 @@ graceful leaving process of a cluster member.
 <a id="removeinternalclustershardingdata"></a>
 ## Removal of Internal Cluster Sharding Data
 
-The Cluster Sharding coordinator stores the locations of the shards using Akka Persistence.
-This data can safely be removed when restarting the whole Akka Cluster.
-Note that this is not application data.
+The Cluster Sharding `ShardCoordinator` stores locations of the shards.
+This data is safely be removed when restarting the whole Akka Cluster.
+Note that this does not include application data.
 
 There is a utility program `akka.cluster.sharding.RemoveInternalClusterShardingData`
 that removes this data.

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -132,20 +132,6 @@ Scala
 Java
 :  @@snip [BasicPersistentBehaviorTest.java](/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java) { #behavior }
 
-## Cluster Sharding and persistence
-
-In a use case where the number of persistent actors needed are higher than what would fit in the memory of one node or
-where resilience is important so that if a node crashes the persistent actors are quickly started on a new node and can
-resume operations @ref:[Cluster Sharding](cluster-sharding.md) is an excellent fit to spread persistent actors over a
-cluster and address them by id.
-
-The `EventSourcedBehavior` can then be run as with any plain typed actor as described in @ref:[actors documentation](actors.md),
-but since Akka Persistence is based on the single-writer principle the persistent actors are typically used together
-with Cluster Sharding. For a particular `persistenceId` only one persistent actor instance should be active at one time.
-If multiple instances were to persist events at the same time, the events would be interleaved and might not be
-interpreted correctly on replay. Cluster Sharding ensures that there is only one active entity for each id. The
-@ref:[Cluster Sharding example](cluster-sharding.md#persistence-example) illustrates this common combination.
-
 ## Accessing the ActorContext
 
 If the @apidoc[EventSourcedBehavior] needs to use the @apidoc[typed.*.ActorContext], for example to spawn child actors, it can be obtained by

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -132,6 +132,20 @@ Scala
 Java
 :  @@snip [BasicPersistentBehaviorTest.java](/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java) { #behavior }
 
+## Cluster Sharding and EventSourcedBehavior
+
+In a use case where the number of persistent actors needed are higher than what would fit in the memory of one node or
+where resilience is important so that if a node crashes the persistent actors are quickly started on a new node and can
+resume operations @ref:[Cluster Sharding](cluster-sharding.md) is an excellent fit to spread persistent actors over a
+cluster and address them by id.
+
+The `EventSourcedBehavior` can then be run as with any plain typed actor as described in @ref:[actors documentation](actors.md),
+but since Akka Persistence is based on the single-writer principle the persistent actors are typically used together
+with Cluster Sharding. For a particular `persistenceId` only one persistent actor instance should be active at one time.
+If multiple instances were to persist events at the same time, the events would be interleaved and might not be
+interpreted correctly on replay. Cluster Sharding ensures that there is only one active entity for each id. The
+@ref:[Cluster Sharding example](cluster-sharding.md#persistence-example) illustrates this common combination.
+
 ## Accessing the ActorContext
 
 If the @apidoc[EventSourcedBehavior] needs to use the @apidoc[typed.*.ActorContext], for example to spawn child actors, it can be obtained by


### PR DESCRIPTION
## References 
#27528 
## Background
Because we want to deprecate persistence mode for Cluster Sharding, but the replacement is non-trivial and we prefer to not allocate the time in order to get 2.6, and the alternative is wait until 2.7 to do this all at once, we decided to push the deprecation in for 2.6 and the replacement in post-2.6.

This includes deprecation and modification of the docs where it makes sense - the rest of the doc changes belong in the replacement PR.

Note: I went back and forth on removing this section https://doc.akka.io/docs/akka/snapshot/typed/cluster-sharding.html#persistence-example to not encourage new users of sharding to choose/learn to use persistence mode. Finally decided it is worth being in until the replacement to support existing users wanting a reference.

There are quite a few doc updates to do in the later PR. I tried to do only what made sense, along with some cleanup and clarification.