### PR TITLE
Include actor path as akkaSource in MDC

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilter.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilter.scala
@@ -97,9 +97,6 @@ abstract class LoggingEventFilter(occurrences: Int) {
   protected val message: Either[String, Regex] = Left("")
   protected val complete: Boolean = false
 
-  // FIXME #26537 source not implemented (yet)
-  protected val SourceTodo = "SourceTodo"
-
   /**
    * internal implementation helper, no guaranteed API
    */
@@ -111,6 +108,7 @@ abstract class LoggingEventFilter(occurrences: Int) {
       case Right(p) => p.findFirstIn(msgstr).isDefined
     })
   }
+
 }
 
 /**
@@ -294,8 +292,8 @@ final case class ErrorFilter(
     ((event.message == null && event.throwable
       .map(_.getMessage)
       .isEmpty && event.throwable.map(_.getStackTrace.length).getOrElse(0) == 0) ||
-    doMatch(SourceTodo, event.message) || (event.throwable.nonEmpty && doMatch(
-      SourceTodo,
+    doMatch(event.mdc.getOrElse("akkaSource", ""), event.message) || (event.throwable.nonEmpty && doMatch(
+      event.mdc.getOrElse("akkaSource", ""),
       event.throwable.get.getMessage)))
   }
 
@@ -351,7 +349,7 @@ final case class WarningFilter(
     extends LoggingEventFilter(occurrences) {
 
   def matches(event: LoggingEvent) = {
-    event.level == Level.WARN && doMatch(SourceTodo, event.message)
+    event.level == Level.WARN && doMatch(event.mdc.getOrElse("akkaSource", ""), event.message)
   }
 
   /**
@@ -393,7 +391,7 @@ final case class InfoFilter(
     extends LoggingEventFilter(occurrences) {
 
   def matches(event: LoggingEvent) = {
-    event.level == Level.INFO && doMatch(SourceTodo, event.message)
+    event.level == Level.INFO && doMatch(event.mdc.getOrElse("akkaSource", ""), event.message)
   }
 
   /**
@@ -435,7 +433,7 @@ final case class DebugFilter(
     extends LoggingEventFilter(occurrences) {
 
   def matches(event: LoggingEvent) = {
-    event.level == Level.DEBUG && doMatch(SourceTodo, event.message)
+    event.level == Level.DEBUG && doMatch(event.mdc.getOrElse("akkaSource", ""), event.message)
   }
 
   /**

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilterSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilterSpec.scala
@@ -45,6 +45,16 @@ class LoggingEventFilterSpec extends ScalaTestWithActorTestKit with WordSpecLike
       marker = None,
       throwable = Option(cause),
       mdc = Map.empty)
+  private def warningWithSource(source: String) =
+    LoggingEvent(
+      level = Level.WARN,
+      loggerName = getClass.getName,
+      message = "this is a warning",
+      threadName = Thread.currentThread().getName,
+      timeStamp = System.currentTimeMillis(),
+      marker = None,
+      throwable = None,
+      mdc = Map("akkaSource" -> source))
 
   "The LoggingEventFilter.error" must {
     "filter errors without cause" in {
@@ -99,6 +109,11 @@ class LoggingEventFilterSpec extends ScalaTestWithActorTestKit with WordSpecLike
       LoggingEventFilter.warning(message = "this is a warning").apply(warningWithCause(new AnError)) should ===(true)
       LoggingEventFilter.warning(message = "this is another warning").apply(warningWithCause(new AnError)) should ===(
         false)
+    }
+    "filter warning with matching source" in {
+      val source = "akka://Sys/user/foo"
+      LoggingEventFilter.warning(source = source).apply(warningWithSource(source)) should ===(true)
+      LoggingEventFilter.warning(source = "akka://Sys/user/bar").apply(warningWithSource(source)) should ===(false)
     }
 
   }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/LogMessagesSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/LogMessagesSpec.scala
@@ -25,9 +25,7 @@ class LogMessagesSpec extends ScalaTestWithActorTestKit("""
 
       val ref: ActorRef[String] = spawn(behavior)
 
-      // FIXME #26537 not testing `source = ref.path.toString`
-
-      LoggingEventFilter.debug(s"actor [${ref.path}] received message: Hello", occurrences = 1).intercept {
+      LoggingEventFilter.debug(s"actor [${ref.path.toString}] received message: Hello", occurrences = 1).intercept {
         ref ! "Hello"
       }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorMdc.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorMdc.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.internal
+
+import akka.annotation.InternalApi
+import org.slf4j.MDC
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object ActorMdc {
+  val SourceKey = "akkaSource"
+
+  def setMdc(source: String): Unit = {
+    val mdcAdpater = MDC.getMDCAdapter
+    mdcAdpater.put(SourceKey, source)
+  }
+
+  // MDC is cleared (if used) from aroundReceive in ActorAdapter after processing each message,
+  // via ActorContextImpl.clearMdc()
+  def clearMdc(): Unit =
+    MDC.clear()
+
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
@@ -323,4 +323,10 @@ trait ActorContext[T] extends TypedActorContext[T] {
   @InternalApi
   private[akka] def cancelAllTimers(): Unit
 
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private[akka] def clearMdc(): Unit
+
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -141,34 +141,26 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
                 ctx: typed.TypedActorContext[Any],
                 msg: Any,
                 target: ReceiveTarget[InternalProtocol]): Behavior[InternalProtocol] = {
-              try {
-                val innerMsg = msg match {
-                  case res: JournalProtocol.Response           => InternalProtocol.JournalResponse(res)
-                  case res: SnapshotProtocol.Response          => InternalProtocol.SnapshotterResponse(res)
-                  case RecoveryPermitter.RecoveryPermitGranted => InternalProtocol.RecoveryPermitGranted
-                  case internal: InternalProtocol              => internal // such as RecoveryTickEvent
-                  case cmd: Command @unchecked                 => InternalProtocol.IncomingCommand(cmd)
-                }
-                target(ctx, innerMsg)
-              } finally {
-                eventSourcedSetup.clearMdc()
+              val innerMsg = msg match {
+                case res: JournalProtocol.Response           => InternalProtocol.JournalResponse(res)
+                case res: SnapshotProtocol.Response          => InternalProtocol.SnapshotterResponse(res)
+                case RecoveryPermitter.RecoveryPermitGranted => InternalProtocol.RecoveryPermitGranted
+                case internal: InternalProtocol              => internal // such as RecoveryTickEvent
+                case cmd: Command @unchecked                 => InternalProtocol.IncomingCommand(cmd)
               }
+              target(ctx, innerMsg)
             }
 
             override def aroundSignal(
                 ctx: typed.TypedActorContext[Any],
                 signal: Signal,
                 target: SignalTarget[InternalProtocol]): Behavior[InternalProtocol] = {
-              try {
-                if (signal == PostStop) {
-                  eventSourcedSetup.cancelRecoveryTimer()
-                  // clear stash to be GC friendly
-                  stashState.clearStashBuffers()
-                }
-                target(ctx, signal)
-              } finally {
-                eventSourcedSetup.clearMdc()
+              if (signal == PostStop) {
+                eventSourcedSetup.cancelRecoveryTimer()
+                // clear stash to be GC friendly
+                stashState.clearStashBuffers()
               }
+              target(ctx, signal)
             }
 
             override def toString: String = "EventSourcedBehaviorInterceptor"


### PR DESCRIPTION
On top of https://github.com/akka/akka/pull/27552, but deserves a separate review.

* move logger init to ActorContextImpl since not specific to untyped (ActorContextAdapter)
* careful to not access MDC ThreadLocal if logging isn't used (per message)
* MDC is cleared (if used) from aroundReceive in ActorAdapter after processing each message
* also changed MDC for EventSourcedBehavior to rely on context.log and the outer MDC.clear()
* just removing the MDC values is not enough because the empty Map remains in the ThreadLocal

Refs #26537
