### PR TITLE
Testing utility to silence logging until failure, #26537

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/CapturingAppender.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/CapturingAppender.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.testkit.typed.internal
+
+import akka.annotation.InternalApi
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object CapturingAppender {
+  import LogbackUtil._
+
+  private val CapturingAppenderName = "CapturingAppender"
+
+  def get(loggerName: String): CapturingAppender = {
+    val logbackLogger = getLogbackLogger(loggerName)
+    logbackLogger.getAppender(CapturingAppenderName) match {
+      case null =>
+        throw new IllegalStateException(
+          s"$CapturingAppenderName not defined for [${loggerNameOrRoot(loggerName)}] in logback-test.xml")
+      case appender: CapturingAppender => appender
+      case other =>
+        throw new IllegalStateException(s"Unexpected $CapturingAppender: $other")
+    }
+  }
+
+}
+
+/**
+ * INTERNAL API
+ *
+ * Logging from tests can be silenced by this appender. When there is a test failure
+ * the captured logging events are flushed to the appenders defined for the
+ * akka.actor.testkit.typed.internal.CapturingAppenderDelegate logger.
+ *
+ * The flushing on test failure is handled by [[WithLogCapturing]] mixin.
+ *
+ * Use something like the following in the logback-test.xml:
+ *
+ * {{{
+ *     <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+ *
+ *     <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+ *       <appender-ref ref="STDOUT"/>
+ *     </logger>
+ *
+ *     <root level="DEBUG">
+ *         <appender-ref ref="CapturingAppender"/>
+ *     </root>
+ * }}}
+ */
+@InternalApi private[akka] class CapturingAppender extends AppenderBase[ILoggingEvent] {
+  import LogbackUtil._
+
+  private var buffer: Vector[ILoggingEvent] = Vector.empty
+
+  // invocations are synchronized via doAppend in AppenderBase
+  override def append(event: ILoggingEvent): Unit = {
+    event.prepareForDeferredProcessing()
+    buffer :+= event
+  }
+
+  /**
+   * Flush buffered logging events to the output appenders
+   * Also clears the buffer..
+   */
+  def flush(): Unit = synchronized {
+    import akka.util.ccompat.JavaConverters._
+    val logbackLogger = getLogbackLogger(classOf[CapturingAppender].getName + "Delegate")
+    val appenders = logbackLogger.iteratorForAppenders().asScala.filterNot(_ == this).toList
+    for (event <- buffer; appender <- appenders) {
+      appender.doAppend(event)
+    }
+    clear()
+  }
+
+  /**
+   * Discards the buffered logging events without output.
+   */
+  def clear(): Unit = synchronized {
+    buffer = Vector.empty
+  }
+
+}

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/CapturingAppender.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/CapturingAppender.scala
@@ -37,7 +37,7 @@ import ch.qos.logback.core.AppenderBase
  * the captured logging events are flushed to the appenders defined for the
  * akka.actor.testkit.typed.internal.CapturingAppenderDelegate logger.
  *
- * The flushing on test failure is handled by [[akka.actor.testkit.typed.scaladsl.WithLogCapturing]]
+ * The flushing on test failure is handled by [[akka.actor.testkit.typed.scaladsl.LogCapturing]]
  * for ScalaTest and [[akka.actor.testkit.typed.javadsl.LogCapturing]] for JUnit.
  *
  * Use configuration like the following the logback-test.xml:

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/CapturingAppender.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/CapturingAppender.scala
@@ -37,9 +37,10 @@ import ch.qos.logback.core.AppenderBase
  * the captured logging events are flushed to the appenders defined for the
  * akka.actor.testkit.typed.internal.CapturingAppenderDelegate logger.
  *
- * The flushing on test failure is handled by [[WithLogCapturing]] mixin.
+ * The flushing on test failure is handled by [[akka.actor.testkit.typed.scaladsl.WithLogCapturing]]
+ * for ScalaTest and [[akka.actor.testkit.typed.javadsl.LogCapturing]] for JUnit.
  *
- * Use something like the following in the logback-test.xml:
+ * Use configuration like the following the logback-test.xml:
  *
  * {{{
  *     <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/LogCapturing.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/LogCapturing.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.testkit.typed.internal
+
+import scala.util.control.NonFatal
+
+import akka.annotation.InternalApi
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import org.slf4j.LoggerFactory
+
+/**
+ * INTERNAL API
+ *
+ * JUnit `TestRule` to make log lines appear only when the test failed.
+ * Requires Logback and configuration of [[CapturingAppender]] in logback-test.xml.
+ *
+ * Use this in test by adding a public field annotated with `@TestRule`:
+ * {{{
+ *   @Rule public final LogCapturing logCapturing = new LogCapturing();
+ * }}}
+ */
+@InternalApi private[akka] class LogCapturing extends TestRule {
+  // eager access of CapturingAppender to fail fast if misconfigured
+  private val capturingAppender = CapturingAppender.get("")
+
+  private val myLogger = LoggerFactory.getLogger(classOf[WithLogCapturing])
+
+  override def apply(base: Statement, description: Description): Statement = {
+    new Statement {
+      override def evaluate(): Unit = {
+        try {
+          myLogger.info(s"Logging started for test [${description.getClassName}: ${description.getMethodName}]")
+          base.evaluate()
+          myLogger.info(
+            s"Logging finished for test [${description.getClassName}: ${description.getMethodName}] that was successful")
+        } catch {
+          case NonFatal(e) =>
+            println(
+              s"--> [${Console.BLUE}${description.getClassName}: ${description.getMethodName}${Console.RESET}] " +
+              s"Start of log messages of test that failed with ${e.getMessage}")
+            capturingAppender.flush()
+            println(
+              s"<-- [${Console.BLUE}${description.getClassName}: ${description.getMethodName}${Console.RESET}] " +
+              s"End of log messages of test that failed with ${e.getMessage}")
+            throw e
+        } finally {
+          capturingAppender.clear()
+        }
+      }
+    }
+  }
+}

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/LogbackUtil.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/LogbackUtil.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.testkit.typed.internal
+
+import akka.annotation.InternalApi
+import org.slf4j.LoggerFactory
+import org.slf4j.event.Level
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object LogbackUtil {
+  def loggerNameOrRoot(loggerName: String): String =
+    if (loggerName == "") org.slf4j.Logger.ROOT_LOGGER_NAME else loggerName
+
+  def getLogbackLogger(loggerName: String): ch.qos.logback.classic.Logger = {
+    LoggerFactory.getLogger(loggerNameOrRoot(loggerName)) match {
+      case logger: ch.qos.logback.classic.Logger => logger
+      case null =>
+        throw new IllegalArgumentException(s"Couldn't find logger for [$loggerName].")
+      case other =>
+        throw new IllegalArgumentException(
+          s"Requires Logback logger for [$loggerName], it was a [${other.getClass.getName}]")
+    }
+  }
+
+  def convertLevel(level: ch.qos.logback.classic.Level): Level = {
+    level.levelInt match {
+      case ch.qos.logback.classic.Level.TRACE_INT => Level.TRACE
+      case ch.qos.logback.classic.Level.DEBUG_INT => Level.DEBUG
+      case ch.qos.logback.classic.Level.INFO_INT  => Level.INFO
+      case ch.qos.logback.classic.Level.WARN_INT  => Level.WARN
+      case ch.qos.logback.classic.Level.ERROR_INT => Level.ERROR
+      case _ =>
+        throw new IllegalArgumentException("Level " + level.levelStr + ", " + level.levelInt + " is unknown.")
+    }
+  }
+}

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/WithLogCapturing.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/WithLogCapturing.scala
@@ -6,16 +6,19 @@ package akka.actor.testkit.typed.internal
 
 import scala.util.control.NonFatal
 
+import akka.annotation.InternalApi
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Outcome
 import org.scalatest.TestSuite
 import org.slf4j.LoggerFactory
 
 /**
+ * INTERNAL API
+ *
  * Mixin this trait to a test to make log lines appear only when the test failed.
  * Requires Logback and configuration of [[CapturingAppender]] in logback-test.xml.
  */
-trait WithLogCapturing extends BeforeAndAfterAll { self: TestSuite =>
+@InternalApi private[akka] trait WithLogCapturing extends BeforeAndAfterAll { self: TestSuite =>
 
   // eager access of CapturingAppender to fail fast if misconfigured
   private val capturingAppender = CapturingAppender.get("")

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/WithLogCapturing.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/WithLogCapturing.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.testkit.typed.internal
+
+import scala.util.control.NonFatal
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.Outcome
+import org.scalatest.TestSuite
+import org.slf4j.LoggerFactory
+
+/**
+ * Mixin this trait to a test to make log lines appear only when the test failed.
+ * Requires Logback and configuration of [[CapturingAppender]] in logback-test.xml.
+ */
+trait WithLogCapturing extends BeforeAndAfterAll { self: TestSuite =>
+
+  // eager access of CapturingAppender to fail fast if misconfigured
+  private val capturingAppender = CapturingAppender.get("")
+
+  private val myLogger = LoggerFactory.getLogger(classOf[WithLogCapturing])
+
+  override protected def afterAll(): Unit = {
+    try {
+      super.afterAll()
+    } catch {
+      case NonFatal(e) =>
+        myLogger.error("Exception from afterAll", e)
+        capturingAppender.flush()
+    } finally {
+      capturingAppender.clear()
+    }
+  }
+
+  abstract override def withFixture(test: NoArgTest): Outcome = {
+    myLogger.info(s"Logging started for test [${self.getClass.getName}: ${test.name}]")
+    val res = test()
+    myLogger.info(s"Logging finished for test [${self.getClass.getName}: ${test.name}] that [$res]")
+
+    if (!(res.isSucceeded || res.isPending)) {
+      println(
+        s"--> [${Console.BLUE}${self.getClass.getName}: ${test.name}${Console.RESET}] Start of log messages of test that [$res]")
+      capturingAppender.flush()
+      println(
+        s"<-- [${Console.BLUE}${self.getClass.getName}: ${test.name}${Console.RESET}] End of log messages of test that [$res]")
+    }
+
+    res
+  }
+  // FIXME #26537 silence stdout debug logging when ActorSystem is started and shutdown
+
+  // FIXME #26537 silence slf4j initialization output (must be some config?)
+}

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/LogCapturing.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/LogCapturing.scala
@@ -7,7 +7,6 @@ package akka.actor.testkit.typed.javadsl
 import scala.util.control.NonFatal
 
 import akka.actor.testkit.typed.internal.CapturingAppender
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -39,7 +38,7 @@ final class LogCapturing extends TestRule {
   // eager access of CapturingAppender to fail fast if misconfigured
   private val capturingAppender = CapturingAppender.get("")
 
-  private val myLogger = LoggerFactory.getLogger(classOf[WithLogCapturing])
+  private val myLogger = LoggerFactory.getLogger(classOf[LogCapturing])
 
   override def apply(base: Statement, description: Description): Statement = {
     new Statement {

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/LogCapturing.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/LogCapturing.scala
@@ -2,28 +2,40 @@
  * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package akka.actor.testkit.typed.internal
+package akka.actor.testkit.typed.javadsl
 
 import scala.util.control.NonFatal
 
-import akka.annotation.InternalApi
+import akka.actor.testkit.typed.internal.CapturingAppender
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import org.slf4j.LoggerFactory
 
 /**
- * INTERNAL API
- *
  * JUnit `TestRule` to make log lines appear only when the test failed.
- * Requires Logback and configuration of [[CapturingAppender]] in logback-test.xml.
  *
  * Use this in test by adding a public field annotated with `@TestRule`:
  * {{{
  *   @Rule public final LogCapturing logCapturing = new LogCapturing();
  * }}}
+ *
+ * Requires Logback and configuration like the following the logback-test.xml:
+ *
+ * {{{
+ *     <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+ *
+ *     <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+ *       <appender-ref ref="STDOUT"/>
+ *     </logger>
+ *
+ *     <root level="DEBUG">
+ *         <appender-ref ref="CapturingAppender"/>
+ *     </root>
+ * }}}
  */
-@InternalApi private[akka] class LogCapturing extends TestRule {
+final class LogCapturing extends TestRule {
   // eager access of CapturingAppender to fail fast if misconfigured
   private val capturingAppender = CapturingAppender.get("")
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/LogCapturing.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/LogCapturing.scala
@@ -29,12 +29,12 @@ import org.slf4j.LoggerFactory
  *     </root>
  * }}}
  */
-trait WithLogCapturing extends BeforeAndAfterAll { self: TestSuite =>
+trait LogCapturing extends BeforeAndAfterAll { self: TestSuite =>
 
   // eager access of CapturingAppender to fail fast if misconfigured
   private val capturingAppender = CapturingAppender.get("")
 
-  private val myLogger = LoggerFactory.getLogger(classOf[WithLogCapturing])
+  private val myLogger = LoggerFactory.getLogger(classOf[LogCapturing])
 
   override protected def afterAll(): Unit = {
     try {

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/WithLogCapturing.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/WithLogCapturing.scala
@@ -2,23 +2,34 @@
  * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package akka.actor.testkit.typed.internal
+package akka.actor.testkit.typed.scaladsl
 
 import scala.util.control.NonFatal
 
-import akka.annotation.InternalApi
+import akka.actor.testkit.typed.internal.CapturingAppender
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Outcome
 import org.scalatest.TestSuite
 import org.slf4j.LoggerFactory
 
 /**
- * INTERNAL API
+ * Mixin this trait to a ScalaTest test to make log lines appear only when the test failed.
  *
- * Mixin this trait to a test to make log lines appear only when the test failed.
- * Requires Logback and configuration of [[CapturingAppender]] in logback-test.xml.
+ * Requires Logback and configuration like the following the logback-test.xml:
+ *
+ * {{{
+ *     <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+ *
+ *     <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+ *       <appender-ref ref="STDOUT"/>
+ *     </logger>
+ *
+ *     <root level="DEBUG">
+ *         <appender-ref ref="CapturingAppender"/>
+ *     </root>
+ * }}}
  */
-@InternalApi private[akka] trait WithLogCapturing extends BeforeAndAfterAll { self: TestSuite =>
+trait WithLogCapturing extends BeforeAndAfterAll { self: TestSuite =>
 
   // eager access of CapturingAppender to fail fast if misconfigured
   private val capturingAppender = CapturingAppender.get("")
@@ -52,7 +63,4 @@ import org.slf4j.LoggerFactory
 
     res
   }
-  // FIXME #26537 silence stdout debug logging when ActorSystem is started and shutdown
-
-  // FIXME #26537 silence slf4j initialization output (must be some config?)
 }

--- a/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/ActorTestKitTest.java
+++ b/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/ActorTestKitTest.java
@@ -7,6 +7,7 @@ package akka.actor.testkit.typed.javadsl;
 import akka.Done;
 import akka.actor.typed.javadsl.Behaviors;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -20,6 +21,8 @@ import static org.junit.Assert.assertEquals;
 public class ActorTestKitTest extends JUnitSuite {
 
   @ClassRule public static TestKitJunitResource testKit = new TestKitJunitResource();
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   @Test
   public void systemNameShouldComeFromTestClassViaJunitResource() {

--- a/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/LoggingEventFilterTest.java
+++ b/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/LoggingEventFilterTest.java
@@ -7,6 +7,7 @@ package akka.actor.testkit.typed.javadsl;
 import akka.actor.testkit.typed.LoggingEvent;
 import akka.actor.testkit.typed.TestException;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import org.slf4j.event.Level;
@@ -20,6 +21,8 @@ import static org.junit.Assert.assertTrue;
 public class LoggingEventFilterTest extends JUnitSuite {
 
   @ClassRule public static TestKitJunitResource testKit = new TestKitJunitResource();
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   private LoggingEvent errorNoCause() {
     return LoggingEvent.create(

--- a/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/TestProbeTest.java
+++ b/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/TestProbeTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import akka.actor.testkit.typed.scaladsl.TestProbeSpec;
 import akka.actor.testkit.typed.scaladsl.TestProbeSpec.*;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -19,6 +20,8 @@ import static org.junit.Assert.*;
 public class TestProbeTest extends JUnitSuite {
 
   @ClassRule public static TestKitJunitResource testKit = new TestKitJunitResource();
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   @Test
   public void testReceiveMessage() {

--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/JunitIntegrationExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/JunitIntegrationExampleTest.java
@@ -9,15 +9,19 @@ import static jdocs.akka.actor.testkit.typed.javadsl.AsyncTestingExampleTest.Pon
 import static jdocs.akka.actor.testkit.typed.javadsl.AsyncTestingExampleTest.echoActor;
 
 // #junit-integration
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class JunitIntegrationExampleTest {
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   @Test
   public void testSomething() {

--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/ManualTimerExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/ManualTimerExampleTest.java
@@ -6,10 +6,12 @@ package jdocs.akka.actor.testkit.typed.javadsl;
 
 // #manual-scheduling-simple
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.typed.Behavior;
 import akka.actor.testkit.typed.javadsl.ManualTime;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.scalatest.junit.JUnitSuite;
 import java.time.Duration;
 
@@ -23,6 +25,8 @@ public class ManualTimerExampleTest extends JUnitSuite {
 
   @ClassRule
   public static final TestKitJunitResource testKit = new TestKitJunitResource(ManualTime.config());
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   private final ManualTime manualTime = ManualTime.get(testKit.system());
 

--- a/akka-actor-testkit-typed/src/test/resources/logback-test.xml
+++ b/akka-actor-testkit-typed/src/test/resources/logback-test.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <!-- Silence initial setup logging from Logback -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>DEBUG</level>

--- a/akka-actor-testkit-typed/src/test/resources/logback-test.xml
+++ b/akka-actor-testkit-typed/src/test/resources/logback-test.xml
@@ -12,7 +12,24 @@
             <pattern>%date{ISO8601} %-5level %logger %X{akkaSource} %X{sourceThread} - %msg%n</pattern>
         </encoder>
     </appender>
-    <root level="DEBUG">
+
+    <!--
+    Logging from tests are silenced by this appender. When there is a test failure
+    the captured logging events are flushed to the appenders defined for the
+    akka.actor.testkit.typed.internal.CapturingAppenderDelegate logger.
+    -->
+    <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+
+    <!--
+    The appenders defined for this CapturingAppenderDelegate logger are used
+    when there is a test failure and all logging events from the test are
+    flushed to these appenders.
+    -->
+    <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
         <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <root level="DEBUG">
+        <appender-ref ref="CapturingAppender"/>
     </root>
 </configuration>

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.Matchers
 import org.scalatest.WordSpec
 import org.scalatest.WordSpecLike
 
-class ActorTestKitSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class ActorTestKitSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   "the Scala testkit" should {
 
@@ -91,7 +91,7 @@ class ActorTestKitSpec extends ScalaTestWithActorTestKit with WordSpecLike with 
 }
 
 // derivative classes should also work fine (esp the naming part
-abstract class MyBaseSpec extends ScalaTestWithActorTestKit with Matchers with WordSpecLike with WithLogCapturing
+abstract class MyBaseSpec extends ScalaTestWithActorTestKit with Matchers with WordSpecLike with LogCapturing
 
 class MyConcreteDerivateSpec extends MyBaseSpec {
   "A derivative test" should {
@@ -116,7 +116,7 @@ class MyConcreteDerivateSpec extends MyBaseSpec {
 
 }
 
-class CompositionSpec extends WordSpec with Matchers with BeforeAndAfterAll with WithLogCapturing {
+class CompositionSpec extends WordSpec with Matchers with BeforeAndAfterAll with LogCapturing {
   val testKit = ActorTestKit()
 
   override def afterAll(): Unit = {

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.Matchers
 import org.scalatest.WordSpec
 import org.scalatest.WordSpecLike
 
-class ActorTestKitSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class ActorTestKitSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   "the Scala testkit" should {
 
@@ -91,7 +91,7 @@ class ActorTestKitSpec extends ScalaTestWithActorTestKit with WordSpecLike {
 }
 
 // derivative classes should also work fine (esp the naming part
-abstract class MyBaseSpec extends ScalaTestWithActorTestKit with Matchers with WordSpecLike
+abstract class MyBaseSpec extends ScalaTestWithActorTestKit with Matchers with WordSpecLike with WithLogCapturing
 
 class MyConcreteDerivateSpec extends MyBaseSpec {
   "A derivative test" should {
@@ -116,7 +116,7 @@ class MyConcreteDerivateSpec extends MyBaseSpec {
 
 }
 
-class CompositionSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+class CompositionSpec extends WordSpec with Matchers with BeforeAndAfterAll with WithLogCapturing {
   val testKit = ActorTestKit()
 
   override def afterAll(): Unit = {

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
@@ -121,7 +121,7 @@ object BehaviorTestKitSpec {
 
 }
 
-class BehaviorTestKitSpec extends WordSpec with Matchers {
+class BehaviorTestKitSpec extends WordSpec with Matchers with WithLogCapturing {
 
   private val props = Props.empty.withDispatcherFromConfig("cat")
 

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
@@ -121,7 +121,7 @@ object BehaviorTestKitSpec {
 
 }
 
-class BehaviorTestKitSpec extends WordSpec with Matchers with WithLogCapturing {
+class BehaviorTestKitSpec extends WordSpec with Matchers with LogCapturing {
 
   private val props = Props.empty.withDispatcherFromConfig("cat")
 

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilterSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilterSpec.scala
@@ -8,7 +8,7 @@ import akka.actor.testkit.typed.LoggingEvent
 import org.scalatest.WordSpecLike
 import org.slf4j.event.Level
 
-class LoggingEventFilterSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class LoggingEventFilterSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   private class AnError extends Exception
   private def errorNoCause =

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilterSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilterSpec.scala
@@ -8,7 +8,7 @@ import akka.actor.testkit.typed.LoggingEvent
 import org.scalatest.WordSpecLike
 import org.slf4j.event.Level
 
-class LoggingEventFilterSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class LoggingEventFilterSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   private class AnError extends Exception
   private def errorNoCause =

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestAppenderSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestAppenderSpec.scala
@@ -10,7 +10,7 @@ import akka.actor.testkit.typed.TestException
 import org.scalatest.WordSpecLike
 import org.slf4j.LoggerFactory
 
-class TestAppenderSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class TestAppenderSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   class AnotherLoggerClass
 

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestAppenderSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestAppenderSpec.scala
@@ -10,7 +10,7 @@ import akka.actor.testkit.typed.TestException
 import org.scalatest.WordSpecLike
 import org.slf4j.LoggerFactory
 
-class TestAppenderSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class TestAppenderSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   class AnotherLoggerClass
 

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestProbeSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestProbeSpec.scala
@@ -10,7 +10,7 @@ import com.typesafe.config.ConfigFactory
 import scala.concurrent.duration._
 import org.scalatest.WordSpecLike
 
-class TestProbeSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class TestProbeSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   import TestProbeSpec._
 
@@ -181,7 +181,10 @@ object TestProbeSpec {
     for (n <- 1 to expected) yield EventT(n)
 }
 
-class TestProbeTimeoutSpec extends ScalaTestWithActorTestKit(TestProbeSpec.timeoutConfig) with WordSpecLike {
+class TestProbeTimeoutSpec
+    extends ScalaTestWithActorTestKit(TestProbeSpec.timeoutConfig)
+    with WordSpecLike
+    with WithLogCapturing {
 
   import TestProbeSpec._
 

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestProbeSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestProbeSpec.scala
@@ -10,7 +10,7 @@ import com.typesafe.config.ConfigFactory
 import scala.concurrent.duration._
 import org.scalatest.WordSpecLike
 
-class TestProbeSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class TestProbeSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   import TestProbeSpec._
 
@@ -184,7 +184,7 @@ object TestProbeSpec {
 class TestProbeTimeoutSpec
     extends ScalaTestWithActorTestKit(TestProbeSpec.timeoutConfig)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   import TestProbeSpec._
 

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala
@@ -4,6 +4,7 @@
 
 package docs.akka.actor.testkit.typed.scaladsl
 
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.Scheduler
 //#test-header
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
@@ -58,7 +59,7 @@ object AsyncTestingExampleSpec {
 }
 
 //#test-header
-class AsyncTestingExampleSpec extends WordSpec with BeforeAndAfterAll with Matchers {
+class AsyncTestingExampleSpec extends WordSpec with BeforeAndAfterAll with Matchers with WithLogCapturing {
   val testKit = ActorTestKit()
   //#test-header
 

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/AsyncTestingExampleSpec.scala
@@ -4,7 +4,7 @@
 
 package docs.akka.actor.testkit.typed.scaladsl
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.Scheduler
 //#test-header
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
@@ -59,7 +59,7 @@ object AsyncTestingExampleSpec {
 }
 
 //#test-header
-class AsyncTestingExampleSpec extends WordSpec with BeforeAndAfterAll with Matchers with WithLogCapturing {
+class AsyncTestingExampleSpec extends WordSpec with BeforeAndAfterAll with Matchers with LogCapturing {
   val testKit = ActorTestKit()
   //#test-header
 

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ManualTimerExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ManualTimerExampleSpec.scala
@@ -10,14 +10,11 @@ import scala.concurrent.duration._
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.ManualTime
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.scaladsl.Behaviors
 import org.scalatest.WordSpecLike
 
-class ManualTimerExampleSpec
-    extends ScalaTestWithActorTestKit(ManualTime.config)
-    with WordSpecLike
-    with WithLogCapturing {
+class ManualTimerExampleSpec extends ScalaTestWithActorTestKit(ManualTime.config) with WordSpecLike with LogCapturing {
 
   val manualTime: ManualTime = ManualTime()
 

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ManualTimerExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ManualTimerExampleSpec.scala
@@ -6,13 +6,18 @@ package docs.akka.actor.testkit.typed.scaladsl
 
 //#manual-scheduling-simple
 import scala.concurrent.duration._
+
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.ManualTime
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.scaladsl.Behaviors
 import org.scalatest.WordSpecLike
 
-class ManualTimerExampleSpec extends ScalaTestWithActorTestKit(ManualTime.config) with WordSpecLike {
+class ManualTimerExampleSpec
+    extends ScalaTestWithActorTestKit(ManualTime.config)
+    with WordSpecLike
+    with WithLogCapturing {
 
   val manualTime: ManualTime = ManualTime()
 

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorContextAskTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorContextAskTest.java
@@ -4,6 +4,7 @@
 
 package akka.actor.typed.javadsl;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
 import akka.testkit.AkkaSpec;
@@ -11,6 +12,7 @@ import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.util.Timeout;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -21,6 +23,8 @@ public class ActorContextAskTest extends JUnitSuite {
 
   @ClassRule
   public static final TestKitJunitResource testKit = new TestKitJunitResource(AkkaSpec.testConf());
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   static class Ping {
     final ActorRef<Pong> respondTo;

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorContextPipeToSelfTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorContextPipeToSelfTest.java
@@ -4,12 +4,14 @@
 
 package akka.actor.typed.javadsl;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.Behavior;
 import akka.actor.typed.Props;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -27,6 +29,8 @@ public final class ActorContextPipeToSelfTest extends JUnitSuite {
           ConfigFactory.parseString(
               "pipe-to-self-spec-dispatcher.executor = thread-pool-executor\n"
                   + "pipe-to-self-spec-dispatcher.type = PinnedDispatcher\n"));
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   static final class Msg {
     final String response;

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorLoggingTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorLoggingTest.java
@@ -22,8 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-
 public class ActorLoggingTest extends JUnitSuite {
 
   @ClassRule

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorLoggingTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorLoggingTest.java
@@ -4,6 +4,7 @@
 
 package akka.actor.typed.javadsl;
 
+import akka.actor.testkit.typed.internal.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
@@ -12,6 +13,7 @@ import akka.japi.pf.PFBuilder;
 import akka.testkit.CustomEventFilter;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.duration.FiniteDuration;
@@ -19,6 +21,8 @@ import scala.concurrent.duration.FiniteDuration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
 
 public class ActorLoggingTest extends JUnitSuite {
 
@@ -43,6 +47,8 @@ public class ActorLoggingTest extends JUnitSuite {
       return transactionId;
     }
   }
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   @Test
   public void loggingProvidesClassWhereLogWasCalled() {
@@ -72,7 +78,7 @@ public class ActorLoggingTest extends JUnitSuite {
         Behaviors.setup(
             context ->
                 Behaviors.withMdc(
-                    null,
+                    Protocol.class,
                     (message) -> {
                       Map<String, String> mdc = new HashMap<>();
                       mdc.put("txId", message.getTransactionId());

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorLoggingTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorLoggingTest.java
@@ -4,7 +4,7 @@
 
 package akka.actor.typed.javadsl;
 
-import akka.actor.testkit.typed.internal.LogCapturing;
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/AdapterTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/AdapterTest.java
@@ -4,7 +4,9 @@
 
 package akka.actor.typed.javadsl;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -239,6 +241,8 @@ public class AdapterTest extends JUnitSuite {
   @ClassRule
   public static AkkaJUnitActorSystemResource actorSystemResource =
       new AkkaJUnitActorSystemResource("ActorSelectionTest", AkkaSpec.testConf());
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   private final ActorSystem system = actorSystemResource.getSystem();
 

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/BehaviorBuilderTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/BehaviorBuilderTest.java
@@ -4,9 +4,11 @@
 
 package akka.actor.typed.javadsl;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -24,6 +26,8 @@ import static org.junit.Assert.assertEquals;
 public class BehaviorBuilderTest extends JUnitSuite {
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   interface Message {}
 

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/InterceptTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/InterceptTest.java
@@ -4,11 +4,13 @@
 
 package akka.actor.typed.javadsl;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.*;
 import akka.testkit.AkkaSpec;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -16,6 +18,8 @@ public class InterceptTest extends JUnitSuite {
 
   @ClassRule
   public static final TestKitJunitResource testKit = new TestKitJunitResource(AkkaSpec.testConf());
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   @Test
   public void interceptMessage() {

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ReceiveBuilderTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ReceiveBuilderTest.java
@@ -4,10 +4,12 @@
 
 package akka.actor.typed.javadsl;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -20,6 +22,8 @@ import static org.junit.Assert.assertEquals;
 public class ReceiveBuilderTest extends JUnitSuite {
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   @Test
   public void testMutableCounter() {

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/WatchTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/WatchTest.java
@@ -8,8 +8,10 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 import akka.Done;
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.scalatest.junit.JUnitSuite;
 import org.junit.Test;
 
@@ -23,6 +25,8 @@ import static akka.actor.typed.javadsl.Behaviors.*;
 public class WatchTest extends JUnitSuite {
 
   @ClassRule public static TestKitJunitResource testKit = new TestKitJunitResource();
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   interface Message {}
 

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/BubblingSampleTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/BubblingSampleTest.java
@@ -4,10 +4,12 @@
 
 package jdocs.akka.typed;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -21,6 +23,8 @@ public class BubblingSampleTest extends JUnitSuite {
   @ClassRule
   public static final TestKitJunitResource testKit =
       new TestKitJunitResource("akka.loglevel = off");
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   @Test
   public void testBubblingSample() throws Exception {

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java
@@ -4,6 +4,7 @@
 
 package jdocs.akka.typed;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.ActorSystem;
@@ -11,6 +12,7 @@ import akka.actor.typed.Behavior;
 import akka.actor.typed.javadsl.*;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -646,6 +648,8 @@ public class InteractionPatternsTest extends JUnitSuite {
   }
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   @Test
   public void fireAndForgetSample() throws Exception {

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/MailboxDocTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/MailboxDocTest.java
@@ -5,6 +5,7 @@
 package jdocs.akka.typed;
 
 import akka.Done;
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
@@ -13,6 +14,7 @@ import akka.actor.typed.MailboxSelector;
 import akka.actor.typed.javadsl.Behaviors;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -21,6 +23,8 @@ public class MailboxDocTest extends JUnitSuite {
   @ClassRule
   public static final TestKitJunitResource testKit =
       new TestKitJunitResource(ConfigFactory.load("mailbox-config-sample.conf"));
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   @Test
   public void startSomeActorsWithDifferentMailboxes() {

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/StashDocTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/StashDocTest.java
@@ -5,10 +5,12 @@
 package jdocs.akka.typed;
 
 import akka.Done;
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -21,6 +23,8 @@ import static jdocs.akka.typed.StashDocSample.DataAccess;
 public class StashDocTest extends JUnitSuite {
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   @Test
   public void stashingExample() throws Exception {

--- a/akka-actor-typed-tests/src/test/resources/logback-test.xml
+++ b/akka-actor-typed-tests/src/test/resources/logback-test.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <!-- FIXME #26537 try to implement something like WithLogCapturing to silence logging output in tests -->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>DEBUG</level>
@@ -10,7 +9,24 @@
             <pattern>%date{ISO8601} %-5level %logger %X{akkaSource} %X{sourceThread} - %msg%n</pattern>
         </encoder>
     </appender>
+
+    <!--
+    Logging from tests are silenced by this appender. When there is a test failure
+    the captured logging events are flushed to the appenders defined for the
+    akka.actor.testkit.typed.internal.CapturingAppenderDelegate logger.
+    -->
+    <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+
+    <!--
+    The appenders defined for this CapturingAppenderDelegate logger are used
+    when there is a test failure and all logging events from the test are
+    flushed to these appenders.
+    -->
+    <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+      <appender-ref ref="STDOUT"/>
+    </logger>
+
     <root level="DEBUG">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="CapturingAppender"/>
     </root>
 </configuration>

--- a/akka-actor-typed-tests/src/test/resources/logback-test.xml
+++ b/akka-actor-typed-tests/src/test/resources/logback-test.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <!-- Silence initial setup logging from Logback -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>DEBUG</level>

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
@@ -14,6 +14,7 @@ import akka.actor.UnhandledMessage
 import akka.actor.testkit.typed.TestException
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.eventstream.EventStream
 import org.scalatest.WordSpecLike
 
@@ -65,7 +66,7 @@ object ActorSpecMessages {
 
 }
 
-abstract class ActorContextSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+abstract class ActorContextSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   import ActorSpecMessages._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
@@ -14,7 +14,7 @@ import akka.actor.UnhandledMessage
 import akka.actor.testkit.typed.TestException
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.eventstream.EventStream
 import org.scalatest.WordSpecLike
 
@@ -66,7 +66,7 @@ object ActorSpecMessages {
 
 }
 
-abstract class ActorContextSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+abstract class ActorContextSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   import ActorSpecMessages._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -21,7 +21,7 @@ import scala.concurrent.Future
 import akka.actor.DeadLetter
 import akka.actor.UnhandledMessage
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.eventstream.EventStream
 
 object AskSpec {
@@ -30,7 +30,7 @@ object AskSpec {
   final case class Stop(replyTo: ActorRef[Unit]) extends Msg
 }
 
-class AskSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class AskSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   import AskSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -21,6 +21,7 @@ import scala.concurrent.Future
 import akka.actor.DeadLetter
 import akka.actor.UnhandledMessage
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.eventstream.EventStream
 
 object AskSpec {
@@ -29,9 +30,7 @@ object AskSpec {
   final case class Stop(replyTo: ActorRef[Unit]) extends Msg
 }
 
-class AskSpec extends ScalaTestWithActorTestKit("""
-  akka.loglevel=warning
-  """) with WordSpecLike {
+class AskSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   import AskSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
@@ -12,6 +12,7 @@ import java.util.function.{ Function => F1 }
 
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.testkit.typed.scaladsl.{ BehaviorTestKit, TestInbox }
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.Matchers
@@ -68,7 +69,7 @@ object BehaviorSpec {
     override def next = StateA
   }
 
-  trait Common extends WordSpecLike with Matchers with TypeCheckedTripleEquals {
+  trait Common extends WordSpecLike with Matchers with TypeCheckedTripleEquals with WithLogCapturing {
     type Aux >: Null <: AnyRef
     def behavior(monitor: ActorRef[Event]): (Behavior[Command], Aux)
     @silent("never used")

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
@@ -12,7 +12,7 @@ import java.util.function.{ Function => F1 }
 
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.{ BehaviorTestKit, TestInbox }
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.Matchers
@@ -69,7 +69,7 @@ object BehaviorSpec {
     override def next = StateA
   }
 
-  trait Common extends WordSpecLike with Matchers with TypeCheckedTripleEquals with WithLogCapturing {
+  trait Common extends WordSpecLike with Matchers with TypeCheckedTripleEquals with LogCapturing {
     type Aux >: Null <: AnyRef
     def behavior(monitor: ActorRef[Event]): (Behavior[Command], Aux)
     @silent("never used")

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
@@ -30,7 +30,7 @@ object DeferredSpec {
       })
 }
 
-class DeferredSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class DeferredSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   import DeferredSpec._
   implicit val testSettings = TestKitSettings(system)
@@ -146,7 +146,7 @@ class DeferredSpec extends ScalaTestWithActorTestKit with WordSpecLike with With
   }
 }
 
-class DeferredStubbedSpec extends WordSpec with Matchers with WithLogCapturing {
+class DeferredStubbedSpec extends WordSpec with Matchers with LogCapturing {
 
   import DeferredSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
@@ -30,7 +30,7 @@ object DeferredSpec {
       })
 }
 
-class DeferredSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class DeferredSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   import DeferredSpec._
   implicit val testSettings = TestKitSettings(system)
@@ -146,7 +146,7 @@ class DeferredSpec extends ScalaTestWithActorTestKit with WordSpecLike {
   }
 }
 
-class DeferredStubbedSpec extends WordSpec with Matchers {
+class DeferredStubbedSpec extends WordSpec with Matchers with WithLogCapturing {
 
   import DeferredSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ExtensionsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ExtensionsSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 import akka.actor.BootstrapSetup
 import akka.actor.setup.ActorSystemSetup
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.receptionist.Receptionist
 import akka.actor.typed.receptionist.ServiceKey
 import akka.actor.typed.scaladsl.Behaviors
@@ -73,7 +73,7 @@ akka.actor.typed {
    """).resolve()
 }
 
-class ExtensionsSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class ExtensionsSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   "The extensions subsystem" must {
     "return the same instance for the same id" in

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ExtensionsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ExtensionsSpec.scala
@@ -12,6 +12,7 @@ import scala.concurrent.Future
 import akka.actor.BootstrapSetup
 import akka.actor.setup.ActorSystemSetup
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.receptionist.Receptionist
 import akka.actor.typed.receptionist.ServiceKey
 import akka.actor.typed.scaladsl.Behaviors
@@ -72,7 +73,7 @@ akka.actor.typed {
    """).resolve()
 }
 
-class ExtensionsSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class ExtensionsSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   "The extensions subsystem" must {
     "return the same instance for the same id" in

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/InterceptSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/InterceptSpec.scala
@@ -14,6 +14,7 @@ import scala.concurrent.duration._
 import akka.actor.ActorInitializationException
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.internal.PoisonPill
 import akka.actor.typed.internal.PoisonPillInterceptor
 
@@ -74,7 +75,7 @@ object InterceptSpec {
   }
 }
 
-class InterceptSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class InterceptSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
   import BehaviorInterceptor._
   import InterceptSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/InterceptSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/InterceptSpec.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration._
 import akka.actor.ActorInitializationException
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.internal.PoisonPill
 import akka.actor.typed.internal.PoisonPillInterceptor
 
@@ -75,7 +75,7 @@ object InterceptSpec {
   }
 }
 
-class InterceptSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class InterceptSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
   import BehaviorInterceptor._
   import InterceptSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/LogMessagesSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/LogMessagesSpec.scala
@@ -7,7 +7,7 @@ package akka.actor.typed
 import akka.actor
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
 import org.scalatest.WordSpecLike
@@ -15,7 +15,7 @@ import org.slf4j.event.Level
 
 class LogMessagesSpec extends ScalaTestWithActorTestKit("""
     akka.loglevel = DEBUG # test verifies debug
-    """) with WordSpecLike with WithLogCapturing {
+    """) with WordSpecLike with LogCapturing {
 
   implicit val classic: actor.ActorSystem = system.toClassic
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/LogMessagesSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/LogMessagesSpec.scala
@@ -7,6 +7,7 @@ package akka.actor.typed
 import akka.actor
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
 import org.scalatest.WordSpecLike
@@ -14,7 +15,7 @@ import org.slf4j.event.Level
 
 class LogMessagesSpec extends ScalaTestWithActorTestKit("""
     akka.loglevel = DEBUG # test verifies debug
-    """) with WordSpecLike {
+    """) with WordSpecLike with WithLogCapturing {
 
   implicit val classic: actor.ActorSystem = system.toClassic
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit
 import akka.actor.ActorCell
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.internal.adapter.ActorContextAdapter
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.scaladsl.Behaviors
@@ -24,7 +25,7 @@ class MailboxSelectorSpec extends ScalaTestWithActorTestKit("""
       mailbox-type = "akka.dispatch.NonBlockingBoundedMailbox"
       mailbox-capacity = 4 
     }
-  """) with WordSpecLike {
+  """) with WordSpecLike with WithLogCapturing {
 
   case class WhatsYourMailbox(replyTo: ActorRef[MessageQueue])
   private def behavior: Behavior[WhatsYourMailbox] =

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit
 import akka.actor.ActorCell
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.internal.adapter.ActorContextAdapter
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.scaladsl.Behaviors
@@ -25,7 +25,7 @@ class MailboxSelectorSpec extends ScalaTestWithActorTestKit("""
       mailbox-type = "akka.dispatch.NonBlockingBoundedMailbox"
       mailbox-capacity = 4 
     }
-  """) with WordSpecLike with WithLogCapturing {
+  """) with WordSpecLike with LogCapturing {
 
   case class WhatsYourMailbox(replyTo: ActorRef[MessageQueue])
   private def behavior: Behavior[WhatsYourMailbox] =

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MonitorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MonitorSpec.scala
@@ -6,10 +6,11 @@ package akka.actor.typed
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.scaladsl.Behaviors
 import org.scalatest.WordSpecLike
 
-class MonitorSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class MonitorSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   "The monitor behavior" should {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MonitorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MonitorSpec.scala
@@ -6,11 +6,11 @@ package akka.actor.typed
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.scaladsl.Behaviors
 import org.scalatest.WordSpecLike
 
-class MonitorSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class MonitorSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   "The monitor behavior" should {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/OrElseSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/OrElseSpec.scala
@@ -183,7 +183,7 @@ object OrElseSpec {
 
 }
 
-class OrElseSpec extends WordSpec with Matchers with WithLogCapturing {
+class OrElseSpec extends WordSpec with Matchers with LogCapturing {
 
   import OrElseSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/OrElseSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/OrElseSpec.scala
@@ -183,7 +183,7 @@ object OrElseSpec {
 
 }
 
-class OrElseSpec extends WordSpec with Matchers {
+class OrElseSpec extends WordSpec with Matchers with WithLogCapturing {
 
   import OrElseSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/PropsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/PropsSpec.scala
@@ -4,10 +4,11 @@
 
 package akka.actor.typed
 
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
 
-class PropsSpec extends WordSpec with Matchers {
+class PropsSpec extends WordSpec with Matchers with WithLogCapturing {
 
   val dispatcherFirst = Props.empty.withDispatcherFromConfig("pool").withDispatcherDefault
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/PropsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/PropsSpec.scala
@@ -4,11 +4,11 @@
 
 package akka.actor.typed
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
 
-class PropsSpec extends WordSpec with Matchers with WithLogCapturing {
+class PropsSpec extends WordSpec with Matchers with LogCapturing {
 
   val dispatcherFirst = Props.empty.withDispatcherFromConfig("pool").withDispatcherDefault
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SpawnProtocolSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SpawnProtocolSpec.scala
@@ -26,7 +26,7 @@ object SpawnProtocolSpec {
     }
 }
 
-class SpawnProtocolSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class SpawnProtocolSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   import SpawnProtocolSpec._
   implicit val testSettings = TestKitSettings(system)
@@ -96,7 +96,7 @@ class SpawnProtocolSpec extends ScalaTestWithActorTestKit with WordSpecLike with
   }
 }
 
-class StubbedSpawnProtocolSpec extends WordSpec with Matchers with WithLogCapturing {
+class StubbedSpawnProtocolSpec extends WordSpec with Matchers with LogCapturing {
 
   import SpawnProtocolSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SpawnProtocolSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SpawnProtocolSpec.scala
@@ -26,7 +26,7 @@ object SpawnProtocolSpec {
     }
 }
 
-class SpawnProtocolSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class SpawnProtocolSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   import SpawnProtocolSpec._
   implicit val testSettings = TestKitSettings(system)
@@ -96,7 +96,7 @@ class SpawnProtocolSpec extends ScalaTestWithActorTestKit with WordSpecLike {
   }
 }
 
-class StubbedSpawnProtocolSpec extends WordSpec with Matchers {
+class StubbedSpawnProtocolSpec extends WordSpec with Matchers with WithLogCapturing {
 
   import SpawnProtocolSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -92,7 +92,7 @@ object SupervisionSpec {
   }
 }
 
-class StubbedSupervisionSpec extends WordSpec with Matchers with WithLogCapturing {
+class StubbedSupervisionSpec extends WordSpec with Matchers with LogCapturing {
 
   import SupervisionSpec._
 
@@ -253,7 +253,7 @@ class StubbedSupervisionSpec extends WordSpec with Matchers with WithLogCapturin
 
 class SupervisionSpec extends ScalaTestWithActorTestKit("""
     akka.log-dead-letters = off
-    """) with WordSpecLike with WithLogCapturing {
+    """) with WordSpecLike with LogCapturing {
 
   import BehaviorInterceptor._
   import SupervisionSpec._

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -92,7 +92,7 @@ object SupervisionSpec {
   }
 }
 
-class StubbedSupervisionSpec extends WordSpec with Matchers {
+class StubbedSupervisionSpec extends WordSpec with Matchers with WithLogCapturing {
 
   import SupervisionSpec._
 
@@ -253,7 +253,7 @@ class StubbedSupervisionSpec extends WordSpec with Matchers {
 
 class SupervisionSpec extends ScalaTestWithActorTestKit("""
     akka.log-dead-letters = off
-    """) with WordSpecLike {
+    """) with WordSpecLike with WithLogCapturing {
 
   import BehaviorInterceptor._
   import SupervisionSpec._

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TerminatedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TerminatedSpec.scala
@@ -5,10 +5,10 @@
 package akka.actor.typed
 
 import akka.actor.testkit.typed.scaladsl.TestInbox
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.{ Matchers, WordSpec }
 
-class TerminatedSpec extends WordSpec with Matchers with WithLogCapturing {
+class TerminatedSpec extends WordSpec with Matchers with LogCapturing {
 
   "Child Failed" must {
     "should be pattern matchable" in {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TerminatedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TerminatedSpec.scala
@@ -5,9 +5,10 @@
 package akka.actor.typed
 
 import akka.actor.testkit.typed.scaladsl.TestInbox
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.{ Matchers, WordSpec }
 
-class TerminatedSpec extends WordSpec with Matchers {
+class TerminatedSpec extends WordSpec with Matchers with WithLogCapturing {
 
   "Child Failed" must {
     "should be pattern matchable" in {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
@@ -21,7 +21,7 @@ import akka.actor.typed.scaladsl.TimerScheduler
 import akka.testkit.TimingTest
 import org.scalatest.WordSpecLike
 
-class TimerSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class TimerSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   sealed trait Command
   case class Tick(n: Int) extends Command

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
@@ -21,7 +21,7 @@ import akka.actor.typed.scaladsl.TimerScheduler
 import akka.testkit.TimingTest
 import org.scalatest.WordSpecLike
 
-class TimerSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class TimerSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   sealed trait Command
   case class Tick(n: Int) extends Command

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TransformMessagesSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TransformMessagesSpec.scala
@@ -15,7 +15,7 @@ import org.scalatest.WordSpecLike
 import scala.concurrent.duration._
 
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 
 object TransformMessagesSpec {
 
@@ -33,7 +33,7 @@ object TransformMessagesSpec {
       }
 }
 
-class TransformMessagesSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class TransformMessagesSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   implicit val classicSystem = system.toClassic
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TransformMessagesSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TransformMessagesSpec.scala
@@ -15,6 +15,7 @@ import org.scalatest.WordSpecLike
 import scala.concurrent.duration._
 
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 
 object TransformMessagesSpec {
 
@@ -32,7 +33,7 @@ object TransformMessagesSpec {
       }
 }
 
-class TransformMessagesSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class TransformMessagesSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   implicit val classicSystem = system.toClassic
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
@@ -15,6 +15,7 @@ import scala.concurrent.duration._
 import akka.actor.testkit.typed.TestException
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 
 object WatchSpec {
@@ -40,7 +41,7 @@ object WatchSpec {
   case class StartWatchingWith(watchee: ActorRef[Stop.type], message: CustomTerminationMessage) extends Message
 }
 
-class WatchSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class WatchSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   implicit def classicSystem = system.toClassic
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 import akka.actor.testkit.typed.TestException
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 
 object WatchSpec {
@@ -41,7 +41,7 @@ object WatchSpec {
   case class StartWatchingWith(watchee: ActorRef[Stop.type], message: CustomTerminationMessage) extends Message
 }
 
-class WatchSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class WatchSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   implicit def classicSystem = system.toClassic
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/coexistence/TypedSupervisingClassicSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/coexistence/TypedSupervisingClassicSpec.scala
@@ -5,7 +5,7 @@
 package akka.actor.typed.coexistence
 import akka.actor.Actor
 import akka.actor.testkit.typed.TestException
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.{ ScalaTestWithActorTestKit, TestProbe }
 import akka.actor.typed.ActorRef
 import akka.actor.typed.scaladsl.Behaviors
@@ -43,7 +43,7 @@ object TypedSupervisingClassicSpec {
 
 class TypedSupervisingClassicSpec extends ScalaTestWithActorTestKit("""
     akka.loglevel = INFO
-  """.stripMargin) with WordSpecLike with WithLogCapturing {
+  """.stripMargin) with WordSpecLike with LogCapturing {
   import TypedSupervisingClassicSpec._
 
   "Typed supervising classic" should {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/coexistence/TypedSupervisingClassicSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/coexistence/TypedSupervisingClassicSpec.scala
@@ -5,6 +5,7 @@
 package akka.actor.typed.coexistence
 import akka.actor.Actor
 import akka.actor.testkit.typed.TestException
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.testkit.typed.scaladsl.{ ScalaTestWithActorTestKit, TestProbe }
 import akka.actor.typed.ActorRef
 import akka.actor.typed.scaladsl.Behaviors
@@ -42,7 +43,7 @@ object TypedSupervisingClassicSpec {
 
 class TypedSupervisingClassicSpec extends ScalaTestWithActorTestKit("""
     akka.loglevel = INFO
-  """.stripMargin) with WordSpecLike {
+  """.stripMargin) with WordSpecLike with WithLogCapturing {
   import TypedSupervisingClassicSpec._
 
   "Typed supervising classic" should {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/eventstream/EventStreamSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/eventstream/EventStreamSpec.scala
@@ -6,10 +6,11 @@ package akka.actor.typed.eventstream
 
 import scala.concurrent.duration._
 
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.testkit.typed.scaladsl.{ ScalaTestWithActorTestKit, TestProbe }
 import org.scalatest.WordSpecLike
 
-class EventStreamSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class EventStreamSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   import EventStreamSpec._
   import EventStream._

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/eventstream/EventStreamSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/eventstream/EventStreamSpec.scala
@@ -6,11 +6,11 @@ package akka.actor.typed.eventstream
 
 import scala.concurrent.duration._
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.{ ScalaTestWithActorTestKit, TestProbe }
 import org.scalatest.WordSpecLike
 
-class EventStreamSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class EventStreamSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   import EventStreamSpec._
   import EventStream._

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorRefSerializationSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorRefSerializationSpec.scala
@@ -9,6 +9,7 @@ import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.ActorRef
 import akka.serialization.{ JavaSerializer, SerializationExtension }
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import com.typesafe.config.ConfigFactory
 import org.scalatest.WordSpecLike
 
@@ -27,7 +28,10 @@ object ActorRefSerializationSpec {
   case class MessageWrappingActorRef(s: String, ref: ActorRef[Unit]) extends java.io.Serializable
 }
 
-class ActorRefSerializationSpec extends ScalaTestWithActorTestKit(ActorRefSerializationSpec.config) with WordSpecLike {
+class ActorRefSerializationSpec
+    extends ScalaTestWithActorTestKit(ActorRefSerializationSpec.config)
+    with WordSpecLike
+    with WithLogCapturing {
 
   val serialization = SerializationExtension(system.toClassic)
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorRefSerializationSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorRefSerializationSpec.scala
@@ -9,7 +9,7 @@ import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.ActorRef
 import akka.serialization.{ JavaSerializer, SerializationExtension }
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import com.typesafe.config.ConfigFactory
 import org.scalatest.WordSpecLike
 
@@ -31,7 +31,7 @@ object ActorRefSerializationSpec {
 class ActorRefSerializationSpec
     extends ScalaTestWithActorTestKit(ActorRefSerializationSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   val serialization = SerializationExtension(system.toClassic)
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
@@ -14,7 +14,7 @@ import akka.Done
 import akka.actor.CoordinatedShutdown
 import akka.actor.InvalidMessageException
 import akka.actor.testkit.typed.scaladsl.TestInbox
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
 import org.scalatest._
@@ -27,7 +27,7 @@ class ActorSystemSpec
     with BeforeAndAfterAll
     with ScalaFutures
     with Eventually
-    with WithLogCapturing {
+    with LogCapturing {
 
   override implicit val patienceConfig = PatienceConfig(1.second)
   def system[T](behavior: Behavior[T], name: String) = ActorSystem(behavior, name)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
@@ -14,13 +14,20 @@ import akka.Done
 import akka.actor.CoordinatedShutdown
 import akka.actor.InvalidMessageException
 import akka.actor.testkit.typed.scaladsl.TestInbox
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
 import org.scalatest._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.ScalaFutures
 
-class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with Eventually {
+class ActorSystemSpec
+    extends WordSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with Eventually
+    with WithLogCapturing {
 
   override implicit val patienceConfig = PatienceConfig(1.second)
   def system[T](behavior: Behavior[T], name: String) = ActorSystem(behavior, name)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/LocalReceptionistSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/LocalReceptionistSpec.scala
@@ -5,10 +5,12 @@
 package akka.actor.typed.internal.receptionist
 
 import scala.concurrent.Future
+
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.BehaviorTestKit
 import akka.actor.testkit.typed.scaladsl.TestInbox
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed._
 import akka.actor.typed.receptionist.Receptionist
 import akka.actor.typed.receptionist.Receptionist._
@@ -36,7 +38,7 @@ object LocalReceptionistSpec {
 
 }
 
-class LocalReceptionistSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class LocalReceptionistSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
   import LocalReceptionistSpec._
 
   abstract class TestSetup {
@@ -128,7 +130,7 @@ class LocalReceptionistSpec extends ScalaTestWithActorTestKit with WordSpecLike 
   }
 }
 
-class LocalReceptionistBehaviorSpec extends WordSpec with Matchers {
+class LocalReceptionistBehaviorSpec extends WordSpec with Matchers with WithLogCapturing {
   import LocalReceptionistSpec._
 
   def assertEmpty(inboxes: TestInbox[_]*): Unit = {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/LocalReceptionistSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/LocalReceptionistSpec.scala
@@ -10,7 +10,7 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.BehaviorTestKit
 import akka.actor.testkit.typed.scaladsl.TestInbox
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed._
 import akka.actor.typed.receptionist.Receptionist
 import akka.actor.typed.receptionist.Receptionist._
@@ -38,7 +38,7 @@ object LocalReceptionistSpec {
 
 }
 
-class LocalReceptionistSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class LocalReceptionistSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
   import LocalReceptionistSpec._
 
   abstract class TestSetup {
@@ -130,7 +130,7 @@ class LocalReceptionistSpec extends ScalaTestWithActorTestKit with WordSpecLike 
   }
 }
 
-class LocalReceptionistBehaviorSpec extends WordSpec with Matchers with WithLogCapturing {
+class LocalReceptionistBehaviorSpec extends WordSpec with Matchers with LogCapturing {
   import LocalReceptionistSpec._
 
   def assertEmpty(inboxes: TestInbox[_]*): Unit = {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/ServiceKeySerializationSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/ServiceKeySerializationSpec.scala
@@ -9,11 +9,13 @@ import akka.actor.typed.receptionist.ServiceKey
 import akka.actor.typed.scaladsl.adapter._
 import akka.serialization.SerializationExtension
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 
 class ServiceKeySerializationSpec
     extends ScalaTestWithActorTestKit(ActorRefSerializationSpec.config)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
 
   val serialization = SerializationExtension(system.toClassic)
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/ServiceKeySerializationSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/receptionist/ServiceKeySerializationSpec.scala
@@ -9,13 +9,13 @@ import akka.actor.typed.receptionist.ServiceKey
 import akka.actor.typed.scaladsl.adapter._
 import akka.serialization.SerializationExtension
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 
 class ServiceKeySerializationSpec
     extends ScalaTestWithActorTestKit(ActorRefSerializationSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   val serialization = SerializationExtension(system.toClassic)
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/routing/RoutingLogicSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/routing/RoutingLogicSpec.scala
@@ -5,11 +5,11 @@
 package akka.actor.typed.internal.routing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.Matchers
 import org.scalatest.WordSpecLike
 
-class RoutingLogicSpec extends ScalaTestWithActorTestKit with WordSpecLike with Matchers with WithLogCapturing {
+class RoutingLogicSpec extends ScalaTestWithActorTestKit with WordSpecLike with Matchers with LogCapturing {
 
   "The round robin routing logic" must {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/routing/RoutingLogicSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/routing/RoutingLogicSpec.scala
@@ -5,10 +5,11 @@
 package akka.actor.typed.internal.routing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.Matchers
 import org.scalatest.WordSpecLike
 
-class RoutingLogicSpec extends ScalaTestWithActorTestKit with WordSpecLike with Matchers {
+class RoutingLogicSpec extends ScalaTestWithActorTestKit with WordSpecLike with Matchers with WithLogCapturing {
 
   "The round robin routing logic" must {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
@@ -14,6 +14,7 @@ import scala.util.{ Failure, Success }
 
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 
 object ActorContextAskSpec {
@@ -29,7 +30,10 @@ object ActorContextAskSpec {
     """)
 }
 
-class ActorContextAskSpec extends ScalaTestWithActorTestKit(ActorContextAskSpec.config) with WordSpecLike {
+class ActorContextAskSpec
+    extends ScalaTestWithActorTestKit(ActorContextAskSpec.config)
+    with WordSpecLike
+    with WithLogCapturing {
 
   "The Scala DSL ActorContext" must {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
@@ -14,7 +14,7 @@ import scala.util.{ Failure, Success }
 
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 
 object ActorContextAskSpec {
@@ -33,7 +33,7 @@ object ActorContextAskSpec {
 class ActorContextAskSpec
     extends ScalaTestWithActorTestKit(ActorContextAskSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   "The Scala DSL ActorContext" must {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextPipeToSelfSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextPipeToSelfSpec.scala
@@ -8,6 +8,7 @@ import scala.concurrent.Future
 import scala.util.control.NoStackTrace
 import scala.util.{ Failure, Success }
 
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.testkit.typed.scaladsl.{ ScalaTestWithActorTestKit, TestProbe }
 import akka.actor.typed.Props
 import com.typesafe.config.ConfigFactory
@@ -24,7 +25,8 @@ object ActorContextPipeToSelfSpec {
 
 final class ActorContextPipeToSelfSpec
     extends ScalaTestWithActorTestKit(ActorContextPipeToSelfSpec.config)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
 
   "The Scala DSL ActorContext pipeToSelf" must {
     "handle success" in { responseFrom(Future.successful("hi")) should ===("ok: hi") }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextPipeToSelfSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextPipeToSelfSpec.scala
@@ -8,7 +8,7 @@ import scala.concurrent.Future
 import scala.util.control.NoStackTrace
 import scala.util.{ Failure, Success }
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.{ ScalaTestWithActorTestKit, TestProbe }
 import akka.actor.typed.Props
 import com.typesafe.config.ConfigFactory
@@ -26,7 +26,7 @@ object ActorContextPipeToSelfSpec {
 final class ActorContextPipeToSelfSpec
     extends ScalaTestWithActorTestKit(ActorContextPipeToSelfSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   "The Scala DSL ActorContext pipeToSelf" must {
     "handle success" in { responseFrom(Future.successful("hi")) should ===("ok: hi") }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 import akka.actor.testkit.typed.TestException
+import akka.actor.testkit.typed.internal.WithLogCapturing
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
@@ -46,7 +47,7 @@ class BehaviorWhereTheLoggerIsUsed(context: ActorContext[String]) extends Abstra
 
 class ActorLoggingSpec extends ScalaTestWithActorTestKit("""
     akka.loglevel = DEBUG # test verifies debug
-    """) with WordSpecLike {
+    """) with WordSpecLike with WithLogCapturing {
 
   val marker = new BasicMarkerFactory().getMarker("marker")
   val cause = TestException("böö")

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 import akka.actor.testkit.typed.TestException
-import akka.actor.testkit.typed.internal.WithLogCapturing
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.adapter._
 import akka.event.DefaultLoggingFilter

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
@@ -11,7 +11,7 @@ import akka.actor.testkit.typed.TestException
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.adapter._
 import akka.event.DefaultLoggingFilter
@@ -47,7 +47,7 @@ class BehaviorWhereTheLoggerIsUsed(context: ActorContext[String]) extends Abstra
 
 class ActorLoggingSpec extends ScalaTestWithActorTestKit("""
     akka.loglevel = DEBUG # test verifies debug
-    """) with WordSpecLike with WithLogCapturing {
+    """) with WordSpecLike with LogCapturing {
 
   val marker = new BasicMarkerFactory().getMarker("marker")
   val cause = TestException("böö")

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/DispatcherSelectorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/DispatcherSelectorSpec.scala
@@ -9,6 +9,7 @@ import akka.actor.setup.ActorSystemSetup
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -39,7 +40,10 @@ object DispatcherSelectorSpec {
 
 }
 
-class DispatcherSelectorSpec extends ScalaTestWithActorTestKit(DispatcherSelectorSpec.config) with WordSpecLike {
+class DispatcherSelectorSpec
+    extends ScalaTestWithActorTestKit(DispatcherSelectorSpec.config)
+    with WordSpecLike
+    with WithLogCapturing {
   import DispatcherSelectorSpec.PingPong
   import DispatcherSelectorSpec.PingPong._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/DispatcherSelectorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/DispatcherSelectorSpec.scala
@@ -9,7 +9,7 @@ import akka.actor.setup.ActorSystemSetup
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -43,7 +43,7 @@ object DispatcherSelectorSpec {
 class DispatcherSelectorSpec
     extends ScalaTestWithActorTestKit(DispatcherSelectorSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
   import DispatcherSelectorSpec.PingPong
   import DispatcherSelectorSpec.PingPong._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/GracefulStopSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/GracefulStopSpec.scala
@@ -9,9 +9,10 @@ import akka.Done
 import akka.NotUsed
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 
-final class GracefulStopSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+final class GracefulStopSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   "Graceful stop" must {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/GracefulStopSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/GracefulStopSpec.scala
@@ -9,10 +9,10 @@ import akka.Done
 import akka.NotUsed
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 
-final class GracefulStopSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+final class GracefulStopSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   "Graceful stop" must {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/LoggerOpsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/LoggerOpsSpec.scala
@@ -6,7 +6,7 @@ package akka.actor.typed.scaladsl
 
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 import org.slf4j.LoggerFactory
 
@@ -16,7 +16,7 @@ object LoggerOpsSpec {
   case class Value3(i: Int)
 }
 
-class LoggerOpsSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class LoggerOpsSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
   import LoggerOpsSpec._
 
   val log = LoggerFactory.getLogger(getClass)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/LoggerOpsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/LoggerOpsSpec.scala
@@ -6,6 +6,7 @@ package akka.actor.typed.scaladsl
 
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 import org.slf4j.LoggerFactory
 
@@ -15,7 +16,7 @@ object LoggerOpsSpec {
   case class Value3(i: Int)
 }
 
-class LoggerOpsSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class LoggerOpsSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
   import LoggerOpsSpec._
 
   val log = LoggerFactory.getLogger(getClass)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
@@ -13,7 +13,7 @@ import akka.actor.typed.Behavior
 import akka.actor.typed.PostStop
 import akka.actor.typed.Props
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.eventstream.EventStream
 import com.typesafe.config.ConfigFactory
 import org.scalatest.WordSpecLike
@@ -35,7 +35,7 @@ object MessageAdapterSpec {
 class MessageAdapterSpec
     extends ScalaTestWithActorTestKit(MessageAdapterSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   "Message adapters" must {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
@@ -13,6 +13,7 @@ import akka.actor.typed.Behavior
 import akka.actor.typed.PostStop
 import akka.actor.typed.Props
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.eventstream.EventStream
 import com.typesafe.config.ConfigFactory
 import org.scalatest.WordSpecLike
@@ -31,7 +32,10 @@ object MessageAdapterSpec {
     """)
 }
 
-class MessageAdapterSpec extends ScalaTestWithActorTestKit(MessageAdapterSpec.config) with WordSpecLike {
+class MessageAdapterSpec
+    extends ScalaTestWithActorTestKit(MessageAdapterSpec.config)
+    with WordSpecLike
+    with WithLogCapturing {
 
   "Message adapters" must {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/OnSignalSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/OnSignalSpec.scala
@@ -8,10 +8,10 @@ package scaladsl
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 
-final class OnSignalSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+final class OnSignalSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   "An Actor.OnSignal behavior" must {
     "must correctly install the signal handler" in {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/OnSignalSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/OnSignalSpec.scala
@@ -8,9 +8,10 @@ package scaladsl
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 
-final class OnSignalSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+final class OnSignalSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   "An Actor.OnSignal behavior" must {
     "must correctly install the signal handler" in {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ReceivePartialSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ReceivePartialSpec.scala
@@ -7,9 +7,10 @@ package scaladsl
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 
-class ReceivePartialSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class ReceivePartialSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   implicit val ec = system.executionContext
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ReceivePartialSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ReceivePartialSpec.scala
@@ -7,10 +7,10 @@ package scaladsl
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 
-class ReceivePartialSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class ReceivePartialSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   implicit val ec = system.executionContext
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/RoutersSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/RoutersSpec.scala
@@ -9,7 +9,7 @@ import akka.actor.Dropped
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
 import akka.actor.typed.eventstream.EventStream
@@ -23,7 +23,7 @@ import org.scalatest.WordSpecLike
 
 class RoutersSpec extends ScalaTestWithActorTestKit("""
     akka.loglevel=debug
-  """) with WordSpecLike with Matchers with WithLogCapturing {
+  """) with WordSpecLike with Matchers with LogCapturing {
 
   // needed for the event filter
   implicit val classicSystem = system.toClassic

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/RoutersSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/RoutersSpec.scala
@@ -9,6 +9,7 @@ import akka.actor.Dropped
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
 import akka.actor.typed.eventstream.EventStream
@@ -22,7 +23,7 @@ import org.scalatest.WordSpecLike
 
 class RoutersSpec extends ScalaTestWithActorTestKit("""
     akka.loglevel=debug
-  """) with WordSpecLike with Matchers {
+  """) with WordSpecLike with Matchers with WithLogCapturing {
 
   // needed for the event filter
   implicit val classicSystem = system.toClassic

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashBufferSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashBufferSpec.scala
@@ -7,10 +7,10 @@ package akka.actor.typed.scaladsl
 import akka.actor.typed.Behavior
 import akka.actor.testkit.typed.internal.StubbedActorContext
 import akka.actor.testkit.typed.scaladsl.TestInbox
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.{ Matchers, WordSpec }
 
-class StashBufferSpec extends WordSpec with Matchers with WithLogCapturing {
+class StashBufferSpec extends WordSpec with Matchers with LogCapturing {
 
   val context = new StubbedActorContext[String](
     "StashBufferSpec",

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashBufferSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashBufferSpec.scala
@@ -7,9 +7,10 @@ package akka.actor.typed.scaladsl
 import akka.actor.typed.Behavior
 import akka.actor.testkit.typed.internal.StubbedActorContext
 import akka.actor.testkit.typed.scaladsl.TestInbox
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.{ Matchers, WordSpec }
 
-class StashBufferSpec extends WordSpec with Matchers {
+class StashBufferSpec extends WordSpec with Matchers with WithLogCapturing {
 
   val context = new StubbedActorContext[String](
     "StashBufferSpec",

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashSpec.scala
@@ -16,7 +16,7 @@ import akka.actor.testkit.typed.TestException
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.eventstream.EventStream
 import org.scalatest.WordSpecLike
 
@@ -201,7 +201,7 @@ class MutableStashSpec extends AbstractStashSpec {
     }
 }
 
-abstract class AbstractStashSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+abstract class AbstractStashSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
   import AbstractStashSpec._
 
   def testQualifier: String
@@ -256,7 +256,7 @@ abstract class AbstractStashSpec extends ScalaTestWithActorTestKit with WordSpec
 
 }
 
-class UnstashingSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class UnstashingSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   private def slowStoppingChild(latch: CountDownLatch): Behavior[String] =
     Behaviors.receiveSignal {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashSpec.scala
@@ -16,6 +16,7 @@ import akka.actor.testkit.typed.TestException
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.eventstream.EventStream
 import org.scalatest.WordSpecLike
 
@@ -200,7 +201,7 @@ class MutableStashSpec extends AbstractStashSpec {
     }
 }
 
-abstract class AbstractStashSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+abstract class AbstractStashSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
   import AbstractStashSpec._
 
   def testQualifier: String
@@ -255,7 +256,7 @@ abstract class AbstractStashSpec extends ScalaTestWithActorTestKit with WordSpec
 
 }
 
-class UnstashingSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class UnstashingSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   private def slowStoppingChild(latch: CountDownLatch): Behavior[String] =
     Behaviors.receiveSignal {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StopSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StopSpec.scala
@@ -7,13 +7,14 @@ package akka.actor.typed.scaladsl
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed
 import akka.actor.typed.Behavior
 import akka.actor.typed.BehaviorInterceptor
 import akka.actor.typed.PostStop
 import org.scalatest.WordSpecLike
 
-class StopSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class StopSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
   import BehaviorInterceptor._
 
   "Stopping an actor" should {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StopSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StopSpec.scala
@@ -7,14 +7,14 @@ package akka.actor.typed.scaladsl
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed
 import akka.actor.typed.Behavior
 import akka.actor.typed.BehaviorInterceptor
 import akka.actor.typed.PostStop
 import org.scalatest.WordSpecLike
 
-class StopSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class StopSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
   import BehaviorInterceptor._
 
   "Stopping an actor" should {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
@@ -9,14 +9,14 @@ import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystemImpl
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.Behaviors
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
 import org.scalatest.concurrent.ScalaFutures
 
-class GuardianStartupSpec extends WordSpec with Matchers with ScalaFutures with WithLogCapturing {
+class GuardianStartupSpec extends WordSpec with Matchers with ScalaFutures with LogCapturing {
 
   "The user guardian" must {
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
@@ -9,13 +9,14 @@ import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystemImpl
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.Behaviors
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
 import org.scalatest.concurrent.ScalaFutures
 
-class GuardianStartupSpec extends WordSpec with Matchers with ScalaFutures {
+class GuardianStartupSpec extends WordSpec with Matchers with ScalaFutures with WithLogCapturing {
 
   "The user guardian" must {
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/DispatchersDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/DispatchersDocSpec.scala
@@ -16,7 +16,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.WordSpecLike
 import scala.concurrent.Future
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 
 object DispatchersDocSpec {
 
@@ -61,7 +61,7 @@ object DispatchersDocSpec {
 class DispatchersDocSpec
     extends ScalaTestWithActorTestKit(DispatchersDocSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   "Actor Dispatchers" should {
     "support default and blocking dispatcher" in {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/DispatchersDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/DispatchersDocSpec.scala
@@ -14,8 +14,9 @@ import DispatchersDocSpec._
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import com.typesafe.config.ConfigFactory
 import org.scalatest.WordSpecLike
-
 import scala.concurrent.Future
+
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 
 object DispatchersDocSpec {
 
@@ -57,7 +58,10 @@ object DispatchersDocSpec {
 
 }
 
-class DispatchersDocSpec extends ScalaTestWithActorTestKit(DispatchersDocSpec.config) with WordSpecLike {
+class DispatchersDocSpec
+    extends ScalaTestWithActorTestKit(DispatchersDocSpec.config)
+    with WordSpecLike
+    with WithLogCapturing {
 
   "Actor Dispatchers" should {
     "support default and blocking dispatcher" in {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/FSMDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/FSMDocSpec.scala
@@ -11,7 +11,7 @@ import scala.collection.immutable
 import scala.concurrent.duration._
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 
 object FSMDocSpec {
@@ -68,7 +68,7 @@ object FSMDocSpec {
   //#test-code
 }
 
-class FSMDocSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class FSMDocSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   import FSMDocSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/FSMDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/FSMDocSpec.scala
@@ -7,10 +7,11 @@ package docs.akka.typed
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ ActorRef, Behavior }
-
 import scala.collection.immutable
 import scala.concurrent.duration._
+
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 
 object FSMDocSpec {
@@ -67,7 +68,7 @@ object FSMDocSpec {
   //#test-code
 }
 
-class FSMDocSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class FSMDocSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   import FSMDocSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/GracefulStopDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/GracefulStopDocSpec.scala
@@ -5,6 +5,7 @@
 package docs.akka.typed
 
 //#imports
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ ActorSystem, PostStop }
@@ -73,7 +74,7 @@ object GracefulStopDocSpec {
 
 }
 
-class GracefulStopDocSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class GracefulStopDocSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   import GracefulStopDocSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/GracefulStopDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/GracefulStopDocSpec.scala
@@ -5,7 +5,7 @@
 package docs.akka.typed
 
 //#imports
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ ActorSystem, PostStop }
@@ -74,7 +74,7 @@ object GracefulStopDocSpec {
 
 }
 
-class GracefulStopDocSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class GracefulStopDocSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   import GracefulStopDocSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
@@ -13,7 +13,7 @@ import scala.util.Success
 
 import akka.NotUsed
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -22,7 +22,7 @@ import akka.actor.typed.scaladsl.LoggerOps
 import akka.actor.typed.scaladsl.TimerScheduler
 import org.scalatest.WordSpecLike
 
-class InteractionPatternsSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class InteractionPatternsSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   "The interaction patterns docs" must {
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
@@ -13,6 +13,7 @@ import scala.util.Success
 
 import akka.NotUsed
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -21,7 +22,7 @@ import akka.actor.typed.scaladsl.LoggerOps
 import akka.actor.typed.scaladsl.TimerScheduler
 import org.scalatest.WordSpecLike
 
-class InteractionPatternsSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class InteractionPatternsSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   "The interaction patterns docs" must {
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
@@ -6,7 +6,7 @@ package docs.akka.typed
 
 //#fiddle_code
 //#imports
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.LoggerOps
 import akka.actor.typed.{ ActorRef, ActorSystem, Behavior }
@@ -223,7 +223,7 @@ object IntroSpec {
 
 }
 
-class IntroSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class IntroSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   import IntroSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
@@ -6,6 +6,7 @@ package docs.akka.typed
 
 //#fiddle_code
 //#imports
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.LoggerOps
 import akka.actor.typed.{ ActorRef, ActorSystem, Behavior }
@@ -222,7 +223,7 @@ object IntroSpec {
 
 }
 
-class IntroSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class IntroSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   import IntroSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/MailboxDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/MailboxDocSpec.scala
@@ -6,6 +6,7 @@ package docs.akka.typed
 
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.Behavior
 import akka.actor.typed.MailboxSelector
 import akka.actor.typed.scaladsl.Behaviors
@@ -14,7 +15,8 @@ import org.scalatest.WordSpecLike
 
 class MailboxDocSpec
     extends ScalaTestWithActorTestKit(ConfigFactory.load("mailbox-config-sample.conf"))
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
 
   "Specifying mailbox through props" must {
     "work" in {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/MailboxDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/MailboxDocSpec.scala
@@ -6,7 +6,7 @@ package docs.akka.typed
 
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.Behavior
 import akka.actor.typed.MailboxSelector
 import akka.actor.typed.scaladsl.Behaviors
@@ -16,7 +16,7 @@ import org.scalatest.WordSpecLike
 class MailboxDocSpec
     extends ScalaTestWithActorTestKit(ConfigFactory.load("mailbox-config-sample.conf"))
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   "Specifying mailbox through props" must {
     "work" in {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/OOIntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/OOIntroSpec.scala
@@ -6,7 +6,7 @@ package docs.akka.typed
 
 //#imports
 import akka.Done
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.{ ActorRef, ActorSystem, Behavior }
 import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, Behaviors, LoggerOps }
 //#imports
@@ -136,7 +136,7 @@ object OOIntroSpec {
 
 }
 
-class OOIntroSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class OOIntroSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   import OOIntroSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/OOIntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/OOIntroSpec.scala
@@ -6,6 +6,7 @@ package docs.akka.typed
 
 //#imports
 import akka.Done
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.{ ActorRef, ActorSystem, Behavior }
 import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, Behaviors, LoggerOps }
 //#imports
@@ -135,7 +136,7 @@ object OOIntroSpec {
 
 }
 
-class OOIntroSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class OOIntroSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   import OOIntroSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala
@@ -6,7 +6,7 @@ package docs.akka.typed
 
 // #pool
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.Behavior
 import akka.actor.typed.SupervisorStrategy
 import akka.actor.typed.receptionist.Receptionist
@@ -40,7 +40,7 @@ object RouterSpec {
   val serviceKey = ServiceKey[Worker.Command]("log-worker")
 }
 
-class RouterSpec extends ScalaTestWithActorTestKit("akka.loglevel=warning") with WordSpecLike with WithLogCapturing {
+class RouterSpec extends ScalaTestWithActorTestKit("akka.loglevel=warning") with WordSpecLike with LogCapturing {
   import RouterSpec._
 
   "The routing sample" must {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala
@@ -6,6 +6,7 @@ package docs.akka.typed
 
 // #pool
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.Behavior
 import akka.actor.typed.SupervisorStrategy
 import akka.actor.typed.receptionist.Receptionist
@@ -39,7 +40,7 @@ object RouterSpec {
   val serviceKey = ServiceKey[Worker.Command]("log-worker")
 }
 
-class RouterSpec extends ScalaTestWithActorTestKit("akka.loglevel=warning") with WordSpecLike {
+class RouterSpec extends ScalaTestWithActorTestKit("akka.loglevel=warning") with WordSpecLike with WithLogCapturing {
   import RouterSpec._
 
   "The routing sample" must {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import docs.akka.typed.IntroSpec.HelloWorld
 import org.scalatest.WordSpecLike
 import com.github.ghik.silencer.silent
@@ -49,7 +49,7 @@ object SpawnProtocolDocSpec {
   //#main
 }
 
-class SpawnProtocolDocSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class SpawnProtocolDocSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   import SpawnProtocolDocSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
@@ -7,8 +7,10 @@ package docs.akka.typed
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
+
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import docs.akka.typed.IntroSpec.HelloWorld
 import org.scalatest.WordSpecLike
 import com.github.ghik.silencer.silent
@@ -47,7 +49,7 @@ object SpawnProtocolDocSpec {
   //#main
 }
 
-class SpawnProtocolDocSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class SpawnProtocolDocSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   import SpawnProtocolDocSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StashDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StashDocSpec.scala
@@ -5,7 +5,7 @@
 package docs.akka.typed
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 
 object StashDocSpec {
@@ -100,7 +100,7 @@ object StashDocSpec {
   // #stashing
 }
 
-class StashDocSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class StashDocSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
   import StashDocSpec.DB
   import StashDocSpec.DataAccess
   import scala.concurrent.Future

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StashDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StashDocSpec.scala
@@ -5,7 +5,7 @@
 package docs.akka.typed
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 
 object StashDocSpec {
@@ -100,7 +100,7 @@ object StashDocSpec {
   // #stashing
 }
 
-class StashDocSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class StashDocSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
   import StashDocSpec.DB
   import StashDocSpec.DataAccess
   import scala.concurrent.Future

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/ClassicWatchingTypedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/ClassicWatchingTypedSpec.scala
@@ -5,7 +5,7 @@
 package docs.akka.typed.coexistence
 
 import akka.actor.ActorLogging
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed._
 import akka.actor.typed.scaladsl.Behaviors
 import akka.testkit.TestKit
@@ -72,7 +72,7 @@ object ClassicWatchingTypedSpec {
   //#typed
 }
 
-class ClassicWatchingTypedSpec extends WordSpec with WithLogCapturing {
+class ClassicWatchingTypedSpec extends WordSpec with LogCapturing {
 
   import ClassicWatchingTypedSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/ClassicWatchingTypedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/ClassicWatchingTypedSpec.scala
@@ -5,6 +5,7 @@
 package docs.akka.typed.coexistence
 
 import akka.actor.ActorLogging
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed._
 import akka.actor.typed.scaladsl.Behaviors
 import akka.testkit.TestKit
@@ -71,7 +72,7 @@ object ClassicWatchingTypedSpec {
   //#typed
 }
 
-class ClassicWatchingTypedSpec extends WordSpec {
+class ClassicWatchingTypedSpec extends WordSpec with WithLogCapturing {
 
   import ClassicWatchingTypedSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingClassicSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingClassicSpec.scala
@@ -4,7 +4,7 @@
 
 package docs.akka.typed.coexistence
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed._
 import akka.actor.typed.scaladsl.Behaviors
 import akka.testkit.TestKit
@@ -68,7 +68,7 @@ object TypedWatchingClassicSpec {
   //#classic
 }
 
-class TypedWatchingClassicSpec extends WordSpec with WithLogCapturing {
+class TypedWatchingClassicSpec extends WordSpec with LogCapturing {
 
   import TypedWatchingClassicSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingClassicSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingClassicSpec.scala
@@ -4,6 +4,7 @@
 
 package docs.akka.typed.coexistence
 
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed._
 import akka.actor.typed.scaladsl.Behaviors
 import akka.testkit.TestKit
@@ -67,7 +68,7 @@ object TypedWatchingClassicSpec {
   //#classic
 }
 
-class TypedWatchingClassicSpec extends WordSpec {
+class TypedWatchingClassicSpec extends WordSpec with WithLogCapturing {
 
   import TypedWatchingClassicSpec._
 

--- a/akka-bench-jmh-typed/src/main/resources/logback-test.xml
+++ b/akka-bench-jmh-typed/src/main/resources/logback-test.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <!-- Silence initial setup logging from Logback -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>DEBUG</level>

--- a/akka-cluster-sharding-typed/src/multi-jvm/resources/logback-test.xml
+++ b/akka-cluster-sharding-typed/src/multi-jvm/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Silence initial setup logging from Logback -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger %X{akkaSource} %X{sourceThread} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/javadsl/ClusterShardingPersistenceTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/javadsl/ClusterShardingPersistenceTest.java
@@ -5,6 +5,7 @@
 package akka.cluster.sharding.typed.javadsl;
 
 import akka.Done;
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
@@ -18,6 +19,7 @@ import akka.util.Timeout;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -35,6 +37,8 @@ public class ClusterShardingPersistenceTest extends JUnitSuite {
               + "akka.persistence.journal.inmem.test-serialization = on \n");
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   interface Command {}
 

--- a/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/javadsl/ShardingEventSourcedEntityWithEnforcedRepliesCompileOnlyTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/javadsl/ShardingEventSourcedEntityWithEnforcedRepliesCompileOnlyTest.java
@@ -4,6 +4,7 @@
 
 package akka.cluster.sharding.typed.javadsl;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.typed.ActorRef;
 import akka.cluster.typed.Cluster;
@@ -11,10 +12,13 @@ import akka.cluster.typed.Join;
 import akka.persistence.typed.ExpectingReply;
 import akka.persistence.typed.javadsl.*;
 import org.junit.ClassRule;
+import org.junit.Rule;
 
 public class ShardingEventSourcedEntityWithEnforcedRepliesCompileOnlyTest {
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   interface Command extends ExpectingReply<String> {}
 

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/AccountExampleTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/AccountExampleTest.java
@@ -4,6 +4,7 @@
 
 package jdocs.akka.cluster.sharding.typed;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
@@ -15,6 +16,7 @@ import akka.cluster.typed.Join;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -39,6 +41,8 @@ public class AccountExampleTest extends JUnitSuite {
               + "akka.persistence.journal.inmem.test-serialization = on \n");
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   private ClusterSharding _sharding = null;
 

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleTest.java
@@ -4,6 +4,7 @@
 
 package jdocs.akka.cluster.sharding.typed;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.cluster.sharding.typed.javadsl.ClusterSharding;
@@ -14,6 +15,7 @@ import akka.cluster.typed.Join;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -32,6 +34,8 @@ public class HelloWorldEventSourcedEntityExampleTest extends JUnitSuite {
               + "akka.persistence.journal.inmem.test-serialization = on \n");
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   private ClusterSharding _sharding = null;
 

--- a/akka-cluster-sharding-typed/src/test/resources/logback-test.xml
+++ b/akka-cluster-sharding-typed/src/test/resources/logback-test.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <!-- Silence initial setup logging from Logback -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>DEBUG</level>

--- a/akka-cluster-sharding-typed/src/test/resources/logback-test.xml
+++ b/akka-cluster-sharding-typed/src/test/resources/logback-test.xml
@@ -12,7 +12,25 @@
             <pattern>%date{ISO8601} %-5level %logger %X{akkaSource} %X{sourceThread} { "persistenceId": "%X{persistenceId}", "persistencePhase": "%X{persistencePhase}" } - %msg%n</pattern>
         </encoder>
     </appender>
-    <root level="DEBUG">
+
+    <!--
+    Logging from tests are silenced by this appender. When there is a test failure
+    the captured logging events are flushed to the appenders defined for the
+    akka.actor.testkit.typed.internal.CapturingAppenderDelegate logger.
+    -->
+    <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+
+    <!--
+    The appenders defined for this CapturingAppenderDelegate logger are used
+    when there is a test failure and all logging events from the test are
+    flushed to these appenders.
+    -->
+    <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
         <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <root level="DEBUG">
+        <appender-ref ref="CapturingAppender"/>
     </root>
+
 </configuration>

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ShardingSerializerSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ShardingSerializerSpec.scala
@@ -8,10 +8,10 @@ import akka.actor.typed.internal.adapter.ActorSystemAdapter
 import akka.cluster.sharding.typed.internal.ShardingSerializer
 import akka.serialization.SerializationExtension
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 
-class ShardingSerializerSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class ShardingSerializerSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   "The typed ShardingSerializer" must {
 

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ShardingSerializerSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ShardingSerializerSpec.scala
@@ -8,9 +8,10 @@ import akka.actor.typed.internal.adapter.ActorSystemAdapter
 import akka.cluster.sharding.typed.internal.ShardingSerializer
 import akka.serialization.SerializationExtension
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 
-class ShardingSerializerSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class ShardingSerializerSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   "The typed ShardingSerializer" must {
 

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration._
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
 import akka.actor.typed.PostStop
@@ -150,7 +150,7 @@ object ClusterShardingPersistenceSpec {
 class ClusterShardingPersistenceSpec
     extends ScalaTestWithActorTestKit(ClusterShardingPersistenceSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
   import ClusterShardingPersistenceSpec._
 
   private var _entityId = 0

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingPersistenceSpec.scala
@@ -12,9 +12,11 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
+
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
 import akka.actor.typed.PostStop
@@ -147,7 +149,8 @@ object ClusterShardingPersistenceSpec {
 
 class ClusterShardingPersistenceSpec
     extends ScalaTestWithActorTestKit(ClusterShardingPersistenceSpec.config)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
   import ClusterShardingPersistenceSpec._
 
   private var _entityId = 0

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -9,10 +9,12 @@ import java.nio.charset.StandardCharsets
 import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
+
 import akka.actor.ExtendedActorSystem
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorRefResolver
 import akka.actor.typed.ActorSystem
@@ -179,7 +181,10 @@ object ClusterShardingSpec {
   }
 }
 
-class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.config) with WordSpecLike {
+class ClusterShardingSpec
+    extends ScalaTestWithActorTestKit(ClusterShardingSpec.config)
+    with WordSpecLike
+    with WithLogCapturing {
 
   import ClusterShardingSpec._
 

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -14,7 +14,7 @@ import akka.actor.ExtendedActorSystem
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorRefResolver
 import akka.actor.typed.ActorSystem
@@ -184,7 +184,7 @@ object ClusterShardingSpec {
 class ClusterShardingSpec
     extends ScalaTestWithActorTestKit(ClusterShardingSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   import ClusterShardingSpec._
 

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingStateSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingStateSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.cluster.sharding.typed.scaladsl
 
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.testkit.typed.scaladsl.{ ScalaTestWithActorTestKit, TestProbe }
 import akka.actor.typed.ActorRef
 import akka.cluster.sharding.ShardRegion.{ CurrentShardRegionState, ShardState }
@@ -12,7 +13,10 @@ import akka.cluster.sharding.typed.{ GetShardRegionState, ShardingMessageExtract
 import akka.cluster.typed.{ Cluster, Join }
 import org.scalatest.WordSpecLike
 
-class ClusterShardingStateSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.config) with WordSpecLike {
+class ClusterShardingStateSpec
+    extends ScalaTestWithActorTestKit(ClusterShardingSpec.config)
+    with WordSpecLike
+    with WithLogCapturing {
 
   val sharding = ClusterSharding(system)
 

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingStateSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingStateSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.cluster.sharding.typed.scaladsl
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.{ ScalaTestWithActorTestKit, TestProbe }
 import akka.actor.typed.ActorRef
 import akka.cluster.sharding.ShardRegion.{ CurrentShardRegionState, ShardState }
@@ -16,7 +16,7 @@ import org.scalatest.WordSpecLike
 class ClusterShardingStateSpec
     extends ScalaTestWithActorTestKit(ClusterShardingSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   val sharding = ClusterSharding(system)
 

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/EntityTypeKeySpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/EntityTypeKeySpec.scala
@@ -4,12 +4,12 @@
 
 package akka.cluster.sharding.typed.scaladsl
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.persistence.typed.PersistenceId
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
 
-class EntityTypeKeySpec extends WordSpec with Matchers with WithLogCapturing {
+class EntityTypeKeySpec extends WordSpec with Matchers with LogCapturing {
 
   "EntityTypeKey" must {
     "use | as default entityIdSeparator for compatibility with Lagom's scaladsl" in {

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/EntityTypeKeySpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/EntityTypeKeySpec.scala
@@ -4,11 +4,12 @@
 
 package akka.cluster.sharding.typed.scaladsl
 
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.persistence.typed.PersistenceId
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
 
-class EntityTypeKeySpec extends WordSpec with Matchers {
+class EntityTypeKeySpec extends WordSpec with Matchers with WithLogCapturing {
 
   "EntityTypeKey" must {
     "use | as default entityIdSeparator for compatibility with Lagom's scaladsl" in {

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/AccountExampleSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/AccountExampleSpec.scala
@@ -8,6 +8,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.cluster.sharding.typed.scaladsl.ClusterSharding
 import akka.cluster.sharding.typed.scaladsl.Entity
 import akka.cluster.typed.Cluster
@@ -29,7 +30,10 @@ object AccountExampleSpec {
 
 }
 
-class AccountExampleSpec extends ScalaTestWithActorTestKit(AccountExampleSpec.config) with WordSpecLike {
+class AccountExampleSpec
+    extends ScalaTestWithActorTestKit(AccountExampleSpec.config)
+    with WordSpecLike
+    with WithLogCapturing {
   import AccountExampleWithEventHandlersInState.AccountEntity
   import AccountExampleWithEventHandlersInState.AccountEntity._
 

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/AccountExampleSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/AccountExampleSpec.scala
@@ -8,7 +8,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.cluster.sharding.typed.scaladsl.ClusterSharding
 import akka.cluster.sharding.typed.scaladsl.Entity
 import akka.cluster.typed.Cluster
@@ -33,7 +33,7 @@ object AccountExampleSpec {
 class AccountExampleSpec
     extends ScalaTestWithActorTestKit(AccountExampleSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
   import AccountExampleWithEventHandlersInState.AccountEntity
   import AccountExampleWithEventHandlersInState.AccountEntity._
 

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleSpec.scala
@@ -5,6 +5,7 @@
 package docs.akka.cluster.sharding.typed
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.cluster.sharding.typed.scaladsl.ClusterSharding
 import akka.cluster.sharding.typed.scaladsl.Entity
 import akka.cluster.typed.Cluster
@@ -27,7 +28,8 @@ object HelloWorldEventSourcedEntityExampleSpec {
 
 class HelloWorldEventSourcedEntityExampleSpec
     extends ScalaTestWithActorTestKit(HelloWorldEventSourcedEntityExampleSpec.config)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
   import HelloWorldPersistentEntityExample.HelloWorld
   import HelloWorldPersistentEntityExample.HelloWorld._
 

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/HelloWorldEventSourcedEntityExampleSpec.scala
@@ -5,7 +5,7 @@
 package docs.akka.cluster.sharding.typed
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.cluster.sharding.typed.scaladsl.ClusterSharding
 import akka.cluster.sharding.typed.scaladsl.Entity
 import akka.cluster.typed.Cluster
@@ -29,7 +29,7 @@ object HelloWorldEventSourcedEntityExampleSpec {
 class HelloWorldEventSourcedEntityExampleSpec
     extends ScalaTestWithActorTestKit(HelloWorldEventSourcedEntityExampleSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
   import HelloWorldPersistentEntityExample.HelloWorld
   import HelloWorldPersistentEntityExample.HelloWorld._
 

--- a/akka-cluster-typed/src/multi-jvm/resources/logback-test.xml
+++ b/akka-cluster-typed/src/multi-jvm/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Silence initial setup logging from Logback -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger %X{akkaSource} %X{sourceThread} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/akka-cluster-typed/src/test/java/akka/cluster/ddata/typed/javadsl/ReplicatorTest.java
+++ b/akka-cluster-typed/src/test/java/akka/cluster/ddata/typed/javadsl/ReplicatorTest.java
@@ -6,12 +6,14 @@ package akka.cluster.ddata.typed.javadsl;
 
 // FIXME move to doc package
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.cluster.ddata.*;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -178,6 +180,8 @@ public class ReplicatorTest extends JUnitSuite {
               + "akka.remote.artery.canonical.hostname = 127.0.0.1 \n");
 
   @ClassRule public static TestKitJunitResource testKit = new TestKitJunitResource(config);
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   @Test
   public void shouldHaveApiForUpdateAndGet() {

--- a/akka-cluster-typed/src/test/resources/logback-test.xml
+++ b/akka-cluster-typed/src/test/resources/logback-test.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <!-- Silence initial setup logging from Logback -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>DEBUG</level>

--- a/akka-cluster-typed/src/test/resources/logback-test.xml
+++ b/akka-cluster-typed/src/test/resources/logback-test.xml
@@ -12,7 +12,25 @@
             <pattern>%date{ISO8601} %-5level %logger %X{akkaSource} %X{sourceThread} - %msg%n</pattern>
         </encoder>
     </appender>
-    <root level="DEBUG">
+
+    <!--
+    Logging from tests are silenced by this appender. When there is a test failure
+    the captured logging events are flushed to the appenders defined for the
+    akka.actor.testkit.typed.internal.CapturingAppenderDelegate logger.
+    -->
+    <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+
+    <!--
+    The appenders defined for this CapturingAppenderDelegate logger are used
+    when there is a test failure and all logging events from the test are
+    flushed to these appenders.
+    -->
+    <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
         <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <root level="DEBUG">
+        <appender-ref ref="CapturingAppender"/>
     </root>
+
 </configuration>

--- a/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
@@ -185,7 +185,7 @@ object ReplicatorSpec {
 
 }
 
-class ReplicatorSpec extends ScalaTestWithActorTestKit(ReplicatorSpec.config) with WordSpecLike with WithLogCapturing {
+class ReplicatorSpec extends ScalaTestWithActorTestKit(ReplicatorSpec.config) with WordSpecLike with LogCapturing {
 
   import ReplicatorSpec._
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/ddata/typed/scaladsl/ReplicatorSpec.scala
@@ -185,7 +185,7 @@ object ReplicatorSpec {
 
 }
 
-class ReplicatorSpec extends ScalaTestWithActorTestKit(ReplicatorSpec.config) with WordSpecLike {
+class ReplicatorSpec extends ScalaTestWithActorTestKit(ReplicatorSpec.config) with WordSpecLike with WithLogCapturing {
 
   import ReplicatorSpec._
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ActorSystemSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ActorSystemSpec.scala
@@ -13,7 +13,7 @@ import akka.Done
 import akka.actor.CoordinatedShutdown
 import akka.actor.InvalidMessageException
 import akka.actor.testkit.typed.scaladsl.TestInbox
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -32,7 +32,7 @@ class ActorSystemSpec
     with BeforeAndAfterAll
     with ScalaFutures
     with Eventually
-    with WithLogCapturing {
+    with LogCapturing {
 
   implicit val patience: PatienceConfig = PatienceConfig(3.seconds, Span(100, org.scalatest.time.Millis))
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ActorSystemSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ActorSystemSpec.scala
@@ -13,6 +13,7 @@ import akka.Done
 import akka.actor.CoordinatedShutdown
 import akka.actor.InvalidMessageException
 import akka.actor.testkit.typed.scaladsl.TestInbox
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -25,7 +26,13 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.Span
 
-class ActorSystemSpec extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures with Eventually {
+class ActorSystemSpec
+    extends WordSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with Eventually
+    with WithLogCapturing {
 
   implicit val patience: PatienceConfig = PatienceConfig(3.seconds, Span(100, org.scalatest.time.Millis))
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
@@ -13,7 +13,7 @@ import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import com.typesafe.config.ConfigFactory
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 
 object ClusterApiSpec {
@@ -36,7 +36,7 @@ object ClusterApiSpec {
     """)
 }
 
-class ClusterApiSpec extends ScalaTestWithActorTestKit(ClusterApiSpec.config) with WordSpecLike with WithLogCapturing {
+class ClusterApiSpec extends ScalaTestWithActorTestKit(ClusterApiSpec.config) with WordSpecLike with LogCapturing {
 
   val testSettings = TestKitSettings(system)
   val clusterNode1 = Cluster(system)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterApiSpec.scala
@@ -13,6 +13,7 @@ import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import com.typesafe.config.ConfigFactory
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 
 object ClusterApiSpec {
@@ -35,7 +36,7 @@ object ClusterApiSpec {
     """)
 }
 
-class ClusterApiSpec extends ScalaTestWithActorTestKit(ClusterApiSpec.config) with WordSpecLike {
+class ClusterApiSpec extends ScalaTestWithActorTestKit(ClusterApiSpec.config) with WordSpecLike with WithLogCapturing {
 
   val testSettings = TestKitSettings(system)
   val clusterNode1 = Cluster(system)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
@@ -14,10 +14,11 @@ import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.{ ActorRef, ActorRefResolver }
 import akka.serialization.SerializerWithStringManifest
 import com.typesafe.config.ConfigFactory
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
+
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 
 object ClusterSingletonApiSpec {
@@ -85,7 +86,10 @@ object ClusterSingletonApiSpec {
   }
 }
 
-class ClusterSingletonApiSpec extends ScalaTestWithActorTestKit(ClusterSingletonApiSpec.config) with WordSpecLike {
+class ClusterSingletonApiSpec
+    extends ScalaTestWithActorTestKit(ClusterSingletonApiSpec.config)
+    with WordSpecLike
+    with WithLogCapturing {
   import ClusterSingletonApiSpec._
 
   implicit val testSettings = TestKitSettings(system)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
@@ -18,7 +18,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 
 object ClusterSingletonApiSpec {
@@ -89,7 +89,7 @@ object ClusterSingletonApiSpec {
 class ClusterSingletonApiSpec
     extends ScalaTestWithActorTestKit(ClusterSingletonApiSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
   import ClusterSingletonApiSpec._
 
   implicit val testSettings = TestKitSettings(system)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
@@ -8,7 +8,7 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.typed.{ ActorRef, Behavior }
 import akka.persistence.typed.scaladsl.{ Effect, EventSourcedBehavior }
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.persistence.typed.PersistenceId
 import com.typesafe.config.ConfigFactory
 import org.scalatest.WordSpecLike
@@ -54,7 +54,7 @@ object ClusterSingletonPersistenceSpec {
 class ClusterSingletonPersistenceSpec
     extends ScalaTestWithActorTestKit(ClusterSingletonPersistenceSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
   import ClusterSingletonPersistenceSpec._
   import akka.actor.typed.scaladsl.adapter._
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
@@ -8,6 +8,7 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.typed.{ ActorRef, Behavior }
 import akka.persistence.typed.scaladsl.{ Effect, EventSourcedBehavior }
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.persistence.typed.PersistenceId
 import com.typesafe.config.ConfigFactory
 import org.scalatest.WordSpecLike
@@ -52,7 +53,8 @@ object ClusterSingletonPersistenceSpec {
 
 class ClusterSingletonPersistenceSpec
     extends ScalaTestWithActorTestKit(ClusterSingletonPersistenceSpec.config)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
   import ClusterSingletonPersistenceSpec._
   import akka.actor.typed.scaladsl.adapter._
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPoisonPillSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPoisonPillSpec.scala
@@ -12,8 +12,9 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
 import akka.cluster.typed.ClusterSingletonPoisonPillSpec.GetSelf
 import org.scalatest.WordSpecLike
-
 import scala.concurrent.duration._
+
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 
 object ClusterSingletonPoisonPillSpec {
 
@@ -27,7 +28,8 @@ object ClusterSingletonPoisonPillSpec {
 
 class ClusterSingletonPoisonPillSpec
     extends ScalaTestWithActorTestKit(ClusterSingletonApiSpec.config)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
 
   implicit val testSettings = TestKitSettings(system)
   val clusterNode1 = Cluster(system)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPoisonPillSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPoisonPillSpec.scala
@@ -14,7 +14,7 @@ import akka.cluster.typed.ClusterSingletonPoisonPillSpec.GetSelf
 import org.scalatest.WordSpecLike
 import scala.concurrent.duration._
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 
 object ClusterSingletonPoisonPillSpec {
 
@@ -29,7 +29,7 @@ object ClusterSingletonPoisonPillSpec {
 class ClusterSingletonPoisonPillSpec
     extends ScalaTestWithActorTestKit(ClusterSingletonApiSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   implicit val testSettings = TestKitSettings(system)
   val clusterNode1 = Cluster(system)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
@@ -16,10 +16,11 @@ import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.scaladsl.adapter._
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
-
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
+
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 
 class RemoteContextAskSpecSerializer(system: ExtendedActorSystem) extends SerializerWithStringManifest {
@@ -83,7 +84,10 @@ object RemoteContextAskSpec {
 
 }
 
-class RemoteContextAskSpec extends ScalaTestWithActorTestKit(RemoteContextAskSpec.config) with WordSpecLike {
+class RemoteContextAskSpec
+    extends ScalaTestWithActorTestKit(RemoteContextAskSpec.config)
+    with WordSpecLike
+    with WithLogCapturing {
 
   import RemoteContextAskSpec._
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 
 class RemoteContextAskSpecSerializer(system: ExtendedActorSystem) extends SerializerWithStringManifest {
@@ -87,7 +87,7 @@ object RemoteContextAskSpec {
 class RemoteContextAskSpec
     extends ScalaTestWithActorTestKit(RemoteContextAskSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   import RemoteContextAskSpec._
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteDeployNotAllowedSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteDeployNotAllowedSpec.scala
@@ -8,10 +8,11 @@ import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import com.typesafe.config.ConfigFactory
-
 import scala.concurrent.duration._
+
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 
 object RemoteDeployNotAllowedSpec {
@@ -44,7 +45,8 @@ object RemoteDeployNotAllowedSpec {
 
 class RemoteDeployNotAllowedSpec
     extends ScalaTestWithActorTestKit(RemoteDeployNotAllowedSpec.config)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
 
   "Typed cluster" must {
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteDeployNotAllowedSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteDeployNotAllowedSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 
 object RemoteDeployNotAllowedSpec {
@@ -46,7 +46,7 @@ object RemoteDeployNotAllowedSpec {
 class RemoteDeployNotAllowedSpec
     extends ScalaTestWithActorTestKit(RemoteDeployNotAllowedSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   "Typed cluster" must {
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializerSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializerSpec.scala
@@ -9,11 +9,11 @@ import akka.actor.typed.scaladsl.adapter._
 import akka.cluster.typed.internal.receptionist.ClusterReceptionist
 import akka.serialization.SerializationExtension
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.scaladsl.Behaviors
 import org.scalatest.WordSpecLike
 
-class AkkaClusterTypedSerializerSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class AkkaClusterTypedSerializerSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   val ref = spawn(Behaviors.empty[String])
   val classicSystem = system.toClassic

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializerSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializerSpec.scala
@@ -9,10 +9,11 @@ import akka.actor.typed.scaladsl.adapter._
 import akka.cluster.typed.internal.receptionist.ClusterReceptionist
 import akka.serialization.SerializationExtension
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.scaladsl.Behaviors
 import org.scalatest.WordSpecLike
 
-class AkkaClusterTypedSerializerSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class AkkaClusterTypedSerializerSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   val ref = spawn(Behaviors.empty[String])
   val classicSystem = system.toClassic

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.{ Matchers, WordSpec }
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.cluster.typed.Down
 import akka.cluster.typed.JoinSeedNodes
 import akka.cluster.typed.Leave
@@ -100,7 +100,7 @@ object ClusterReceptionistSpec {
   val PingKey = ServiceKey[PingProtocol]("pingy")
 }
 
-class ClusterReceptionistSpec extends WordSpec with Matchers with WithLogCapturing {
+class ClusterReceptionistSpec extends WordSpec with Matchers with LogCapturing {
 
   import ClusterReceptionistSpec._
   import Receptionist._

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -21,6 +21,7 @@ import org.scalatest.{ Matchers, WordSpec }
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.cluster.typed.Down
 import akka.cluster.typed.JoinSeedNodes
 import akka.cluster.typed.Leave
@@ -99,7 +100,7 @@ object ClusterReceptionistSpec {
   val PingKey = ServiceKey[PingProtocol]("pingy")
 }
 
-class ClusterReceptionistSpec extends WordSpec with Matchers {
+class ClusterReceptionistSpec extends WordSpec with Matchers with WithLogCapturing {
 
   import ClusterReceptionistSpec._
   import Receptionist._

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
@@ -4,7 +4,7 @@
 
 package docs.akka.cluster.typed
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.testkit.SocketUtil
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{ Matchers, WordSpec }
@@ -50,7 +50,7 @@ akka {
      """).withFallback(configSystem1)
 }
 
-class BasicClusterConfigSpec extends WordSpec with ScalaFutures with Eventually with Matchers with WithLogCapturing {
+class BasicClusterConfigSpec extends WordSpec with ScalaFutures with Eventually with Matchers with LogCapturing {
   import BasicClusterExampleSpec._
 
   implicit override val patienceConfig =
@@ -104,7 +104,7 @@ akka {
 
 }
 
-class BasicClusterManualSpec extends WordSpec with ScalaFutures with Eventually with Matchers with WithLogCapturing {
+class BasicClusterManualSpec extends WordSpec with ScalaFutures with Eventually with Matchers with LogCapturing {
 
   import BasicClusterManualSpec._
 

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
@@ -4,6 +4,7 @@
 
 package docs.akka.cluster.typed
 
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.testkit.SocketUtil
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{ Matchers, WordSpec }
@@ -49,7 +50,7 @@ akka {
      """).withFallback(configSystem1)
 }
 
-class BasicClusterConfigSpec extends WordSpec with ScalaFutures with Eventually with Matchers {
+class BasicClusterConfigSpec extends WordSpec with ScalaFutures with Eventually with Matchers with WithLogCapturing {
   import BasicClusterExampleSpec._
 
   implicit override val patienceConfig =
@@ -103,7 +104,7 @@ akka {
 
 }
 
-class BasicClusterManualSpec extends WordSpec with ScalaFutures with Eventually with Matchers {
+class BasicClusterManualSpec extends WordSpec with ScalaFutures with Eventually with Matchers with WithLogCapturing {
 
   import BasicClusterManualSpec._
 

--- a/akka-docs/src/test/resources/logback-test.xml
+++ b/akka-docs/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Silence initial setup logging from Logback -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>DEBUG</level>
+            <onMatch>DENY</onMatch>
+        </filter>
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger %X{akkaSource} %X{sourceThread} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/EventSourcedActorFailureTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/EventSourcedActorFailureTest.java
@@ -5,6 +5,7 @@
 package akka.persistence.typed.javadsl;
 
 import akka.actor.testkit.typed.TestException;
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
@@ -16,6 +17,7 @@ import akka.persistence.typed.RecoveryFailed;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -84,6 +86,8 @@ public class EventSourcedActorFailureTest extends JUnitSuite {
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
 
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
+
   public static Behavior<String> fail(
       PersistenceId pid, ActorRef<String> probe, ActorRef<Throwable> recoveryFailureProbe) {
     return new FailingEventSourcedActor(pid, probe, recoveryFailureProbe);
@@ -91,25 +95,6 @@ public class EventSourcedActorFailureTest extends JUnitSuite {
 
   public static Behavior<String> fail(PersistenceId pid, ActorRef<String> probe) {
     return fail(pid, probe, testKit.<Throwable>createTestProbe().ref());
-  }
-
-  public EventSourcedActorFailureTest() {
-    // FIXME #26537 #24348 silence logging in a proper way
-    //    akka.actor.typed.javadsl.Adapter.toUntyped(testKit.system())
-    //        .eventStream()
-    //        .publish(
-    //            new TestEvent.Mute(
-    //                akka.japi.Util.immutableSeq(
-    //                    new EventFilter[] {
-    //                      EventFilter.warning(null, null, "No default snapshot store", null, 1)
-    //                    })));
-    //    akka.actor.typed.javadsl.Adapter.toUntyped(testKit.system())
-    //        .eventStream()
-    //        .publish(
-    //            new TestEvent.Mute(
-    //                akka.japi.Util.immutableSeq(
-    //                    new EventFilter[] {EventFilter.error(null, null, "", ".*saw failure.*",
-    // 1)})));
   }
 
   @Test

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/LoggerSourceTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/LoggerSourceTest.java
@@ -4,6 +4,7 @@
 
 package akka.persistence.typed.javadsl;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.LoggingEventFilter;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
@@ -16,6 +17,7 @@ import akka.persistence.typed.RecoveryCompleted;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -31,6 +33,8 @@ public class LoggerSourceTest extends JUnitSuite {
               + "akka.persistence.journal.inmem.test-serialization = on \n");
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   private static final AtomicInteger idCounter = new AtomicInteger(0);
 

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/NullEmptyStateTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/NullEmptyStateTest.java
@@ -4,6 +4,7 @@
 
 package akka.persistence.typed.javadsl;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
@@ -14,6 +15,7 @@ import akka.persistence.typed.RecoveryCompleted;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -25,6 +27,8 @@ public class NullEmptyStateTest extends JUnitSuite {
               + "akka.persistence.journal.inmem.test-serialization = on \n");
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   static class NullEmptyState extends EventSourcedBehavior<String, String, String> {
 

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -5,6 +5,7 @@
 package akka.persistence.typed.javadsl;
 
 import akka.Done;
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.LoggingEventFilter;
 import akka.actor.typed.*;
 import akka.actor.typed.javadsl.ActorContext;
@@ -33,6 +34,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import org.slf4j.event.Level;
@@ -50,6 +52,8 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
       EventSourcedBehaviorSpec.conf().withFallback(ConfigFactory.load());
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   private LeveldbReadJournal queries =
       PersistenceQuery.get(Adapter.toClassic(testKit.system()))

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PrimitiveStateTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PrimitiveStateTest.java
@@ -4,6 +4,7 @@
 
 package akka.persistence.typed.javadsl;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
@@ -14,6 +15,7 @@ import akka.persistence.typed.RecoveryCompleted;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
@@ -25,6 +27,8 @@ public class PrimitiveStateTest extends JUnitSuite {
               + "akka.persistence.journal.inmem.test-serialization = on \n");
 
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
   static class PrimitiveState extends EventSourcedBehavior<Integer, Integer, Integer> {
 

--- a/akka-persistence-typed/src/test/resources/logback-test.xml
+++ b/akka-persistence-typed/src/test/resources/logback-test.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <!-- Silence initial setup logging from Logback -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>DEBUG</level>

--- a/akka-persistence-typed/src/test/resources/logback-test.xml
+++ b/akka-persistence-typed/src/test/resources/logback-test.xml
@@ -12,7 +12,25 @@
             <pattern>%date{ISO8601} %-5level %logger %X{akkaSource} %X{sourceThread} { "persistenceId": "%X{persistenceId}", "persistencePhase": "%X{persistencePhase}" } - %msg%n</pattern>
         </encoder>
     </appender>
-    <root level="DEBUG">
+
+    <!--
+    Logging from tests are silenced by this appender. When there is a test failure
+    the captured logging events are flushed to the appenders defined for the
+    akka.actor.testkit.typed.internal.CapturingAppenderDelegate logger.
+    -->
+    <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+
+    <!--
+    The appenders defined for this CapturingAppenderDelegate logger are used
+    when there is a test failure and all logging events from the test are
+    flushed to these appenders.
+    -->
+    <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
         <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <root level="DEBUG">
+        <appender-ref ref="CapturingAppender"/>
     </root>
+
 </configuration>

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
@@ -14,7 +14,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.WordSpecLike
 
 object ManyRecoveriesSpec {
@@ -58,7 +58,7 @@ class ManyRecoveriesSpec extends ScalaTestWithActorTestKit(s"""
     }
     akka.persistence.max-concurrent-recoveries = 3
     akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
-    """) with WordSpecLike with WithLogCapturing {
+    """) with WordSpecLike with LogCapturing {
 
   import ManyRecoveriesSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
@@ -14,6 +14,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import org.scalatest.WordSpecLike
 
 object ManyRecoveriesSpec {
@@ -57,7 +58,7 @@ class ManyRecoveriesSpec extends ScalaTestWithActorTestKit(s"""
     }
     akka.persistence.max-concurrent-recoveries = 3
     akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
-    """) with WordSpecLike {
+    """) with WordSpecLike with WithLogCapturing {
 
   import ManyRecoveriesSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/StashingWhenSnapshottingSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/StashingWhenSnapshottingSpec.scala
@@ -24,7 +24,7 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.util.Success
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 
 object StashingWhenSnapshottingSpec {
   object ControllableSnapshotStoreExt extends ExtensionId[ControllableSnapshotStoreExt] {
@@ -87,7 +87,7 @@ object StashingWhenSnapshottingSpec {
 class StashingWhenSnapshottingSpec
     extends ScalaTestWithActorTestKit(StashingWhenSnapshottingSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
   "A persistent actor" should {
     "stash messages and automatically replay when snapshot is in progress" in {
       val eventProbe = TestProbe[String]()

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/StashingWhenSnapshottingSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/StashingWhenSnapshottingSpec.scala
@@ -20,10 +20,11 @@ import akka.persistence.typed.StashingWhenSnapshottingSpec.ControllableSnapshotS
 import akka.persistence.typed.scaladsl.Effect
 import akka.persistence.typed.scaladsl.EventSourcedBehavior
 import org.scalatest.WordSpecLike
-
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.util.Success
+
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 
 object StashingWhenSnapshottingSpec {
   object ControllableSnapshotStoreExt extends ExtensionId[ControllableSnapshotStoreExt] {
@@ -85,7 +86,8 @@ object StashingWhenSnapshottingSpec {
 
 class StashingWhenSnapshottingSpec
     extends ScalaTestWithActorTestKit(StashingWhenSnapshottingSpec.config)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
   "A persistent actor" should {
     "stash messages and automatically replay when snapshot is in progress" in {
       val eventProbe = TestProbe[String]()

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
@@ -18,6 +18,7 @@ import scala.util.control.NoStackTrace
 
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.RecoveryCompleted
 import org.scalatest.WordSpecLike
@@ -71,7 +72,7 @@ class RecoveryPermitterSpec extends ScalaTestWithActorTestKit(s"""
       akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
       akka.persistence.journal.inmem.test-serialization = on
       akka.loggers = ["akka.testkit.TestEventListener"]
-      """) with WordSpecLike {
+      """) with WordSpecLike with WithLogCapturing {
 
   import RecoveryPermitterSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
@@ -18,7 +18,7 @@ import scala.util.control.NoStackTrace
 
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.RecoveryCompleted
 import org.scalatest.WordSpecLike
@@ -72,7 +72,7 @@ class RecoveryPermitterSpec extends ScalaTestWithActorTestKit(s"""
       akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
       akka.persistence.journal.inmem.test-serialization = on
       akka.loggers = ["akka.testkit.TestEventListener"]
-      """) with WordSpecLike with WithLogCapturing {
+      """) with WordSpecLike with LogCapturing {
 
   import RecoveryPermitterSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RetentionCriteriaSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RetentionCriteriaSpec.scala
@@ -4,12 +4,13 @@
 
 package akka.persistence.typed.internal
 
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.persistence.typed.scaladsl.RetentionCriteria
 import org.scalatest.Matchers
 import org.scalatest.TestSuite
 import org.scalatest.WordSpecLike
 
-class RetentionCriteriaSpec extends TestSuite with Matchers with WordSpecLike {
+class RetentionCriteriaSpec extends TestSuite with Matchers with WordSpecLike with WithLogCapturing {
 
   "RetentionCriteria" must {
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RetentionCriteriaSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RetentionCriteriaSpec.scala
@@ -4,13 +4,13 @@
 
 package akka.persistence.typed.internal
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.persistence.typed.scaladsl.RetentionCriteria
 import org.scalatest.Matchers
 import org.scalatest.TestSuite
 import org.scalatest.WordSpecLike
 
-class RetentionCriteriaSpec extends TestSuite with Matchers with WordSpecLike with WithLogCapturing {
+class RetentionCriteriaSpec extends TestSuite with Matchers with WordSpecLike with LogCapturing {
 
   "RetentionCriteria" must {
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/StashStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/StashStateSpec.scala
@@ -8,13 +8,14 @@ import scala.concurrent.duration._
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
 import akka.persistence.typed.internal.InternalProtocol.IncomingCommand
 import akka.persistence.typed.internal.InternalProtocol.RecoveryPermitGranted
 import org.scalatest.WordSpecLike
 
-class StashStateSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+class StashStateSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
 
   "StashState" should {
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/StashStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/StashStateSpec.scala
@@ -8,14 +8,14 @@ import scala.concurrent.duration._
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
 import akka.persistence.typed.internal.InternalProtocol.IncomingCommand
 import akka.persistence.typed.internal.InternalProtocol.RecoveryPermitGranted
 import org.scalatest.WordSpecLike
 
-class StashStateSpec extends ScalaTestWithActorTestKit with WordSpecLike with WithLogCapturing {
+class StashStateSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
 
   "StashState" should {
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorFailureSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorFailureSpec.scala
@@ -83,7 +83,7 @@ object EventSourcedBehaviorFailureSpec {
 class EventSourcedBehaviorFailureSpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorFailureSpec.conf)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   implicit val testSettings: TestKitSettings = TestKitSettings(system)
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorFailureSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorFailureSpec.scala
@@ -82,7 +82,8 @@ object EventSourcedBehaviorFailureSpec {
 
 class EventSourcedBehaviorFailureSpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorFailureSpec.conf)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
 
   implicit val testSettings: TestKitSettings = TestKitSettings(system)
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorInterceptorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorInterceptorSpec.scala
@@ -45,7 +45,7 @@ object EventSourcedBehaviorInterceptorSpec {
 class EventSourcedBehaviorInterceptorSpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorTimersSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   import EventSourcedBehaviorInterceptorSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorInterceptorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorInterceptorSpec.scala
@@ -44,7 +44,8 @@ object EventSourcedBehaviorInterceptorSpec {
 
 class EventSourcedBehaviorInterceptorSpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorTimersSpec.config)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
 
   import EventSourcedBehaviorInterceptorSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRecoveryTimeoutSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRecoveryTimeoutSpec.scala
@@ -52,7 +52,7 @@ object EventSourcedBehaviorRecoveryTimeoutSpec {
 class EventSourcedBehaviorRecoveryTimeoutSpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorRecoveryTimeoutSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   import EventSourcedBehaviorRecoveryTimeoutSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRecoveryTimeoutSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRecoveryTimeoutSpec.scala
@@ -51,7 +51,8 @@ object EventSourcedBehaviorRecoveryTimeoutSpec {
 
 class EventSourcedBehaviorRecoveryTimeoutSpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorRecoveryTimeoutSpec.config)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
 
   import EventSourcedBehaviorRecoveryTimeoutSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorReplySpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorReplySpec.scala
@@ -76,7 +76,8 @@ object EventSourcedBehaviorReplySpec {
 
 class EventSourcedBehaviorReplySpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorReplySpec.conf)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
 
   import EventSourcedBehaviorReplySpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorReplySpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorReplySpec.scala
@@ -77,7 +77,7 @@ object EventSourcedBehaviorReplySpec {
 class EventSourcedBehaviorReplySpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorReplySpec.conf)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   import EventSourcedBehaviorReplySpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
@@ -144,7 +144,8 @@ object EventSourcedBehaviorRetentionSpec {
 
 class EventSourcedBehaviorRetentionSpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorRetentionSpec.conf)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
 
   import EventSourcedBehaviorRetentionSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
@@ -145,7 +145,7 @@ object EventSourcedBehaviorRetentionSpec {
 class EventSourcedBehaviorRetentionSpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorRetentionSpec.conf)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   import EventSourcedBehaviorRetentionSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -283,7 +283,7 @@ object EventSourcedBehaviorSpec {
 class EventSourcedBehaviorSpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorSpec.conf)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   import EventSourcedBehaviorSpec._
   import akka.actor.typed.scaladsl.adapter._

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -280,7 +280,10 @@ object EventSourcedBehaviorSpec {
   }
 }
 
-class EventSourcedBehaviorSpec extends ScalaTestWithActorTestKit(EventSourcedBehaviorSpec.conf) with WordSpecLike {
+class EventSourcedBehaviorSpec
+    extends ScalaTestWithActorTestKit(EventSourcedBehaviorSpec.conf)
+    with WordSpecLike
+    with WithLogCapturing {
 
   import EventSourcedBehaviorSpec._
   import akka.actor.typed.scaladsl.adapter._

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
@@ -168,7 +168,7 @@ object EventSourcedBehaviorStashSpec {
 class EventSourcedBehaviorStashSpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorStashSpec.conf)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   import EventSourcedBehaviorStashSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
@@ -167,7 +167,8 @@ object EventSourcedBehaviorStashSpec {
 
 class EventSourcedBehaviorStashSpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorStashSpec.conf)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
 
   import EventSourcedBehaviorStashSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorTimersSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorTimersSpec.scala
@@ -74,7 +74,8 @@ object EventSourcedBehaviorTimersSpec {
 
 class EventSourcedBehaviorTimersSpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorTimersSpec.config)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
 
   import EventSourcedBehaviorTimersSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorTimersSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorTimersSpec.scala
@@ -75,7 +75,7 @@ object EventSourcedBehaviorTimersSpec {
 class EventSourcedBehaviorTimersSpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorTimersSpec.config)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   import EventSourcedBehaviorTimersSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedEventAdapterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedEventAdapterSpec.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.scaladsl.Behaviors
 import akka.persistence.query.EventEnvelope
@@ -81,7 +82,8 @@ object EventSourcedEventAdapterSpec {
 
 class EventSourcedEventAdapterSpec
     extends ScalaTestWithActorTestKit(EventSourcedEventAdapterSpec.conf)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
   import EventSourcedEventAdapterSpec._
   import EventSourcedBehaviorSpec.{
     counter,

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedEventAdapterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedEventAdapterSpec.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.scaladsl.Behaviors
 import akka.persistence.query.EventEnvelope
@@ -83,7 +83,7 @@ object EventSourcedEventAdapterSpec {
 class EventSourcedEventAdapterSpec
     extends ScalaTestWithActorTestKit(EventSourcedEventAdapterSpec.conf)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
   import EventSourcedEventAdapterSpec._
   import EventSourcedBehaviorSpec.{
     counter,

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.persistence.typed.scaladsl
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.{ ScalaTestWithActorTestKit, TestProbe }
 import akka.actor.typed.{ ActorRef, Behavior }
 import akka.actor.typed.scaladsl.Behaviors
@@ -25,7 +25,7 @@ object EventSourcedSequenceNumberSpec {
 class EventSourcedSequenceNumberSpec
     extends ScalaTestWithActorTestKit(EventSourcedSequenceNumberSpec.conf)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   private def behavior(pid: PersistenceId, probe: ActorRef[String]): Behavior[String] =
     Behaviors.setup(ctx =>

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.persistence.typed.scaladsl
 
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.testkit.typed.scaladsl.{ ScalaTestWithActorTestKit, TestProbe }
 import akka.actor.typed.{ ActorRef, Behavior }
 import akka.actor.typed.scaladsl.Behaviors
@@ -23,7 +24,8 @@ object EventSourcedSequenceNumberSpec {
 
 class EventSourcedSequenceNumberSpec
     extends ScalaTestWithActorTestKit(EventSourcedSequenceNumberSpec.conf)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
 
   private def behavior(pid: PersistenceId, probe: ActorRef[String]): Behavior[String] =
     Behaviors.setup(ctx =>

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSnapshotAdapterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSnapshotAdapterSpec.scala
@@ -7,6 +7,7 @@ package akka.persistence.typed.scaladsl
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.ActorRef
@@ -34,7 +35,8 @@ object EventSourcedSnapshotAdapterSpec {
 
 class EventSourcedSnapshotAdapterSpec
     extends ScalaTestWithActorTestKit(EventSourcedSnapshotAdapterSpec.conf)
-    with WordSpecLike {
+    with WordSpecLike
+    with WithLogCapturing {
   import EventSourcedSnapshotAdapterSpec._
   import akka.actor.typed.scaladsl.adapter._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSnapshotAdapterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSnapshotAdapterSpec.scala
@@ -7,7 +7,7 @@ package akka.persistence.typed.scaladsl
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.ActorRef
@@ -36,7 +36,7 @@ object EventSourcedSnapshotAdapterSpec {
 class EventSourcedSnapshotAdapterSpec
     extends ScalaTestWithActorTestKit(EventSourcedSnapshotAdapterSpec.conf)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
   import EventSourcedSnapshotAdapterSpec._
   import akka.actor.typed.scaladsl.adapter._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/LoggerSourceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/LoggerSourceSpec.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
 import akka.persistence.typed.PersistenceId
@@ -22,7 +22,7 @@ import org.slf4j.event.Level
 class LoggerSourceSpec
     extends ScalaTestWithActorTestKit(EventSourcedBehaviorSpec.conf)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   private val pidCounter = new AtomicInteger(0)
   private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/LoggerSourceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/LoggerSourceSpec.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
 import akka.persistence.typed.PersistenceId
@@ -18,7 +19,10 @@ import org.slf4j.event.Level
 
 // Note that the spec name here is important since there are heuristics in place to avoid names
 // starting with EventSourcedBehavior
-class LoggerSourceSpec extends ScalaTestWithActorTestKit(EventSourcedBehaviorSpec.conf) with WordSpecLike {
+class LoggerSourceSpec
+    extends ScalaTestWithActorTestKit(EventSourcedBehaviorSpec.conf)
+    with WordSpecLike
+    with WithLogCapturing {
 
   private val pidCounter = new AtomicInteger(0)
   private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/NullEmptyStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/NullEmptyStateSpec.scala
@@ -24,7 +24,7 @@ object NullEmptyStateSpec {
 class NullEmptyStateSpec
     extends ScalaTestWithActorTestKit(NullEmptyStateSpec.conf)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   implicit val testSettings = TestKitSettings(system)
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/NullEmptyStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/NullEmptyStateSpec.scala
@@ -21,7 +21,10 @@ object NullEmptyStateSpec {
     """)
 }
 
-class NullEmptyStateSpec extends ScalaTestWithActorTestKit(NullEmptyStateSpec.conf) with WordSpecLike {
+class NullEmptyStateSpec
+    extends ScalaTestWithActorTestKit(NullEmptyStateSpec.conf)
+    with WordSpecLike
+    with WithLogCapturing {
 
   implicit val testSettings = TestKitSettings(system)
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
@@ -9,6 +9,7 @@ import java.util.UUID
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.scaladsl.EventSourcedBehavior.CommandHandler
 import akka.serialization.jackson.CborSerializable
@@ -47,7 +48,7 @@ class OptionalSnapshotStoreSpec extends ScalaTestWithActorTestKit(s"""
 
     # snapshot store plugin is NOT defined, things should still work
     akka.persistence.snapshot-store.local.dir = "target/snapshots-${classOf[OptionalSnapshotStoreSpec].getName}/"
-    """) with WordSpecLike {
+    """) with WordSpecLike with WithLogCapturing {
 
   import OptionalSnapshotStoreSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
@@ -9,7 +9,7 @@ import java.util.UUID
 import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.scaladsl.EventSourcedBehavior.CommandHandler
 import akka.serialization.jackson.CborSerializable
@@ -48,7 +48,7 @@ class OptionalSnapshotStoreSpec extends ScalaTestWithActorTestKit(s"""
 
     # snapshot store plugin is NOT defined, things should still work
     akka.persistence.snapshot-store.local.dir = "target/snapshots-${classOf[OptionalSnapshotStoreSpec].getName}/"
-    """) with WordSpecLike with WithLogCapturing {
+    """) with WordSpecLike with LogCapturing {
 
   import OptionalSnapshotStoreSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 import akka.actor.testkit.typed.TestException
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.SupervisorStrategy
 import akka.actor.typed.scaladsl.Behaviors
@@ -119,7 +119,7 @@ class PerformanceSpec extends ScalaTestWithActorTestKit(ConfigFactory.parseStrin
       akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
       akka.persistence.snapshot-store.local.dir = "target/snapshots-PerformanceSpec/"
       akka.test.single-expect-default = 10s
-      """).withFallback(ConfigFactory.parseString(PerformanceSpec.config))) with WordSpecLike with WithLogCapturing {
+      """).withFallback(ConfigFactory.parseString(PerformanceSpec.config))) with WordSpecLike with LogCapturing {
 
   import PerformanceSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
@@ -11,6 +11,7 @@ import scala.concurrent.duration._
 import akka.actor.testkit.typed.TestException
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 import akka.actor.typed.ActorRef
 import akka.actor.typed.SupervisorStrategy
 import akka.actor.typed.scaladsl.Behaviors
@@ -118,7 +119,7 @@ class PerformanceSpec extends ScalaTestWithActorTestKit(ConfigFactory.parseStrin
       akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
       akka.persistence.snapshot-store.local.dir = "target/snapshots-PerformanceSpec/"
       akka.test.single-expect-default = 10s
-      """).withFallback(ConfigFactory.parseString(PerformanceSpec.config))) with WordSpecLike {
+      """).withFallback(ConfigFactory.parseString(PerformanceSpec.config))) with WordSpecLike with WithLogCapturing {
 
   import PerformanceSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
@@ -23,7 +23,7 @@ object PrimitiveStateSpec {
 class PrimitiveStateSpec
     extends ScalaTestWithActorTestKit(PrimitiveStateSpec.conf)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   def primitiveState(persistenceId: PersistenceId, probe: ActorRef[String]): Behavior[Int] =
     EventSourcedBehavior[Int, Int, Int](

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
@@ -20,7 +20,10 @@ object PrimitiveStateSpec {
     """)
 }
 
-class PrimitiveStateSpec extends ScalaTestWithActorTestKit(PrimitiveStateSpec.conf) with WordSpecLike {
+class PrimitiveStateSpec
+    extends ScalaTestWithActorTestKit(PrimitiveStateSpec.conf)
+    with WordSpecLike
+    with WithLogCapturing {
 
   def primitiveState(persistenceId: PersistenceId, probe: ActorRef[String]): Behavior[Int] =
     EventSourcedBehavior[Int, Int, Int](

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotMutableStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotMutableStateSpec.scala
@@ -120,7 +120,7 @@ object SnapshotMutableStateSpec {
 class SnapshotMutableStateSpec
     extends ScalaTestWithActorTestKit(SnapshotMutableStateSpec.conf)
     with WordSpecLike
-    with WithLogCapturing {
+    with LogCapturing {
 
   import SnapshotMutableStateSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotMutableStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotMutableStateSpec.scala
@@ -117,7 +117,10 @@ object SnapshotMutableStateSpec {
 
 }
 
-class SnapshotMutableStateSpec extends ScalaTestWithActorTestKit(SnapshotMutableStateSpec.conf) with WordSpecLike {
+class SnapshotMutableStateSpec
+    extends ScalaTestWithActorTestKit(SnapshotMutableStateSpec.conf)
+    with WordSpecLike
+    with WithLogCapturing {
 
   import SnapshotMutableStateSpec._
 

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/PersistentFsmToTypedMigrationSpec.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/PersistentFsmToTypedMigrationSpec.scala
@@ -34,7 +34,7 @@ import org.scalatest.WordSpec
 import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.duration._
 
-import akka.actor.testkit.typed.scaladsl.WithLogCapturing
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 
 object PersistentFsmToTypedMigrationSpec {
   val config = ConfigFactory.parseString(s"""
@@ -206,7 +206,7 @@ object ShoppingCartBehavior {
 
 }
 
-class PersistentFsmToTypedMigrationSpec extends WordSpec with ScalaFutures with WithLogCapturing {
+class PersistentFsmToTypedMigrationSpec extends WordSpec with ScalaFutures with LogCapturing {
 
   import akka.persistence.fsm.PersistentFSMSpec._
 

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/PersistentFsmToTypedMigrationSpec.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/PersistentFsmToTypedMigrationSpec.scala
@@ -32,8 +32,9 @@ import akka.persistence.typed.SnapshotAdapter
 import com.typesafe.config.ConfigFactory
 import org.scalatest.WordSpec
 import org.scalatest.concurrent.ScalaFutures
-
 import scala.concurrent.duration._
+
+import akka.actor.testkit.typed.scaladsl.WithLogCapturing
 
 object PersistentFsmToTypedMigrationSpec {
   val config = ConfigFactory.parseString(s"""
@@ -205,7 +206,7 @@ object ShoppingCartBehavior {
 
 }
 
-class PersistentFsmToTypedMigrationSpec extends WordSpec with ScalaFutures {
+class PersistentFsmToTypedMigrationSpec extends WordSpec with ScalaFutures with WithLogCapturing {
 
   import akka.persistence.fsm.PersistentFSMSpec._
 


### PR DESCRIPTION
On top of #27552, but deserves a separate review.

* Logback appender that captures all log events and can flush them
  later to other appenders
* WithLogCapturing mixin for ScalaTest that flush the captured logging events
  when a test fails. Also clears the captured events after all tests.
* Configuration in logback-test.xml

Refs #26537

TODO in this PR:
- [x] change all tests to use WithLogCapturing, and change all logback-test.xml
- [ ] think about what to do for multi-jvm tests
- [x] utility for junit, and use it in junit tests
- [x] silence stdout debug logging when ActorSystem is started and shutdown
- [x] silence slf4j initialization output (must be some config?)