### PR TITLE
Extension methods to Logger as workaround for overload and varargs problem, #26537

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
@@ -200,18 +200,18 @@ class ActorLoggingSpec extends ScalaTestWithActorTestKit("""
       LoggingEventFilter
         .custom({
           case _ => true // any is fine, we're just after the right count of statements reaching the listener
-        }, occurrences = 34)
+        }, occurrences = 36)
         .intercept({
           spawn(Behaviors.setup[String] {
             context =>
               context.log.debug("message")
               context.log.debug("{}", "arg1")
-              context.log
-                .debug("{} {}", "arg1", "arg2": Any) //using Int to avoid ambiguous reference to overloaded definition
+              // using `: Any` to avoid "ambiguous reference to overloaded definition", see also LoggerOpsSpec
+              context.log.debug("{} {}", "arg1", "arg2": Any)
               context.log.debug("{} {} {}", "arg1", "arg2", "arg3")
               context.log.debug(marker, "message")
               context.log.debug(marker, "{}", "arg1")
-              context.log.debug(marker, "{} {}", "arg1", "arg2": Any) //using Int to avoid ambiguous reference to overloaded definition
+              context.log.debug(marker, "{} {}", "arg1", "arg2": Any)
               context.log.debug(marker, "{} {} {}", "arg1", "arg2", "arg3")
 
               context.log.info("message")
@@ -237,10 +237,13 @@ class ActorLoggingSpec extends ScalaTestWithActorTestKit("""
               context.log.error("{}", "arg1")
               context.log.error("{} {}", "arg1", "arg2": Any)
               context.log.error("{} {} {}", "arg1", "arg2", "arg3")
+              // using to avoid vararg problem for primitive type, see also LoggerOpsSpec
+              context.log.error("{} {} {}", "arg1", "arg2", 3.asInstanceOf[AnyRef])
               context.log.error(marker, "message")
               context.log.error(marker, "{}", "arg1")
               context.log.error(marker, "{} {}", "arg1", "arg2": Any)
               context.log.error(marker, "{} {} {}", "arg1", "arg2", "arg3")
+              context.log.error(marker, "{} {} {}", "arg1", "arg2", 3.asInstanceOf[AnyRef])
               context.log.error("message", cause)
 
               Behaviors.stopped

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/LoggerOpsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/LoggerOpsSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.scaladsl
+
+import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.scalatest.WordSpecLike
+import org.slf4j.LoggerFactory
+
+object LoggerOpsSpec {
+  case class Value1(i: Int)
+  case class Value2(i: Int)
+  case class Value3(i: Int)
+}
+
+class LoggerOpsSpec extends ScalaTestWithActorTestKit with WordSpecLike {
+  import LoggerOpsSpec._
+
+  val log = LoggerFactory.getLogger(getClass)
+
+  "LoggerOps" must {
+
+    "provide extension method for 2 arguments" in {
+      LoggingEventFilter.info(message = "[template a b]", occurrences = 1).intercept {
+        log.info2("[template {} {}]", "a", "b")
+      }
+      LoggingEventFilter.info(message = "[template a 2]", occurrences = 1).intercept {
+        log.info2("[template {} {}]", "a", 2)
+      }
+      LoggingEventFilter.info(message = "[template 1 2]", occurrences = 1).intercept {
+        log.info2("[template {} {}]", 1, 2)
+      }
+      LoggingEventFilter.info(message = "[template 1 b]", occurrences = 1).intercept {
+        log.info2("[template {} {}]", 1, "b")
+      }
+      LoggingEventFilter.info(message = "[template a Value2(2)]", occurrences = 1).intercept {
+        log.info2("[template {} {}]", "a", Value2(2))
+      }
+      LoggingEventFilter.info(message = "[template Value1(1) Value1(1)]", occurrences = 1).intercept {
+        log.info2("[template {} {}]", Value1(1), Value1(1))
+      }
+      LoggingEventFilter.info(message = "[template Value1(1) Value2(2)]", occurrences = 1).intercept {
+        log.info2("[template {} {}]", Value1(1), Value2(2))
+      }
+    }
+
+    "provide extension method for vararg arguments" in {
+      LoggingEventFilter.info(message = "[template a b c]", occurrences = 1).intercept {
+        log.infoN("[template {} {} {}]", "a", "b", "c")
+      }
+      LoggingEventFilter.info(message = "[template a b 3]", occurrences = 1).intercept {
+        log.infoN("[template {} {} {}]", "a", "b", 3)
+      }
+      LoggingEventFilter.info(message = "[template a 2 c]", occurrences = 1).intercept {
+        log.infoN("[template {} {} {}]", "a", 2, "c")
+      }
+      LoggingEventFilter.info(message = "[template 1 2 3]", occurrences = 1).intercept {
+        log.infoN("[template {} {} {}]", 1, 2, 3)
+      }
+      LoggingEventFilter.info(message = "[template 1 b c]", occurrences = 1).intercept {
+        log.infoN("[template {} {} {}]", 1, "b", "c")
+      }
+      LoggingEventFilter.info(message = "[template a Value2(2) Value3(3)]", occurrences = 1).intercept {
+        log.infoN("[template {} {} {}]", "a", Value2(2), Value3(3))
+      }
+      LoggingEventFilter.info(message = "[template Value1(1) Value1(1) Value1(1)]", occurrences = 1).intercept {
+        log.infoN("[template {} {} {}]", Value1(1), Value1(1), Value1(1))
+      }
+      LoggingEventFilter.info(message = "[template Value1(1) Value2(2) Value3(3)]", occurrences = 1).intercept {
+        log.infoN("[template {} {} {}]", Value1(1), Value2(2), Value3(3))
+      }
+    }
+  }
+}

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
@@ -6,14 +6,19 @@ package docs.akka.typed
 
 import java.net.URI
 
-import akka.NotUsed
-import akka.actor.typed.{ ActorRef, ActorSystem, Behavior }
-import akka.actor.typed.scaladsl.{ Behaviors, TimerScheduler }
-
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.{ Failure, Success }
+import scala.util.Failure
+import scala.util.Success
+
+import akka.NotUsed
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
+import akka.actor.typed.scaladsl.TimerScheduler
 import org.scalatest.WordSpecLike
 
 class InteractionPatternsSpec extends ScalaTestWithActorTestKit with WordSpecLike {
@@ -120,10 +125,10 @@ class InteractionPatternsSpec extends ScalaTestWithActorTestKit with WordSpecLik
                       context.log.info("Started {}", taskId)
                       Behaviors.same
                     case Backend.JobProgress(taskId, progress) =>
-                      context.log.info("Progress {}: {}", taskId, progress)
+                      context.log.info2("Progress {}: {}", taskId, progress)
                       Behaviors.same
                     case Backend.JobCompleted(taskId, result) =>
-                      context.log.info("Completed {}: {}", taskId, result)
+                      context.log.info2("Completed {}: {}", taskId, result)
                       inProgress(taskId) ! result
                       active(inProgress - taskId, count)
                   }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
@@ -7,6 +7,7 @@ package docs.akka.typed
 //#fiddle_code
 //#imports
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
 import akka.actor.typed.{ ActorRef, ActorSystem, Behavior }
 //#imports
 //#fiddle_code
@@ -54,7 +55,7 @@ object IntroSpec {
       Behaviors.receive { (context, message) =>
         val n = greetingCounter + 1
         //#fiddle_code
-        context.log.info("Greeting {} for {}", n, message.whom)
+        context.log.info2("Greeting {} for {}", n, message.whom)
         //#fiddle_code
         //#hello-world-bot
         println(s"Greeting $n for ${message.whom}")
@@ -190,7 +191,7 @@ object IntroSpec {
             handle ! PostMessage("Hello World!")
             Behaviors.same
           case MessagePosted(screenName, message) =>
-            context.log.info("message has been posted by '{}': {}", screenName, message: Any)
+            context.log.info2("message has been posted by '{}': {}", screenName, message)
             Behaviors.stopped
         }
       }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/OOIntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/OOIntroSpec.scala
@@ -7,7 +7,7 @@ package docs.akka.typed
 //#imports
 import akka.Done
 import akka.actor.typed.{ ActorRef, ActorSystem, Behavior }
-import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, Behaviors }
+import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, Behaviors, LoggerOps }
 //#imports
 
 import akka.NotUsed
@@ -104,7 +104,7 @@ object OOIntroSpec {
             handle ! PostMessage("Hello World!")
             Behaviors.same
           case MessagePosted(screenName, message) =>
-            context.log.info("message has been posted by '{}': {}", screenName, message: Any)
+            context.log.info2("message has been posted by '{}': {}", screenName, message)
             Behaviors.stopped
         }
       }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
@@ -17,6 +17,7 @@ import com.github.ghik.silencer.silent
 import akka.actor.typed.Behavior
 import akka.actor.typed.SpawnProtocol
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
 
 //#imports1
 
@@ -67,7 +68,7 @@ class SpawnProtocolDocSpec extends ScalaTestWithActorTestKit with WordSpecLike {
         system.ask(SpawnProtocol.Spawn(behavior = HelloWorld(), name = "greeter", props = Props.empty, _))
 
       val greetedBehavior = Behaviors.receive[HelloWorld.Greeted] { (context, message) =>
-        context.log.info("Greeting for {} from {}", message.whom, message.from: Any)
+        context.log.info2("Greeting for {} from {}", message.whom, message.from)
         Behaviors.stopped
       }
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
@@ -9,6 +9,7 @@ import scala.concurrent.Future
 
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.ActorRef
+import akka.actor.typed.scaladsl.LoggerOps
 import akka.actor.typed.scaladsl.TimerScheduler
 import scala.concurrent.duration.FiniteDuration
 
@@ -126,7 +127,7 @@ object StyleGuideDocExamples {
               Behaviors.same
             case Increment =>
               val newValue = n + 1
-              context.log.debug("[{}] Incremented counter to [{}]", name, newValue)
+              context.log.debug2("[{}] Incremented counter to [{}]", name, newValue)
               counter(name, timers, newValue)
             case GetValue(replyTo) =>
               replyTo ! Value(n)
@@ -160,16 +161,16 @@ object StyleGuideDocExamples {
       private def counter(setup: Setup, n: Int): Behavior[Command] =
         Behaviors.receiveMessage {
           case IncrementRepeatedly(interval) =>
-            setup.context.log.debug(
+            setup.context.log.debugN(
               "[{}] Starting repeated increments with interval [{}], current count is [{}]",
               setup.name,
-              interval.toString,
-              n.toString)
+              interval,
+              n)
             setup.timers.startTimerWithFixedDelay("repeat", Increment, interval)
             Behaviors.same
           case Increment =>
             val newValue = n + 1
-            setup.context.log.debug("[{}] Incremented counter to [{}]", setup.name, newValue)
+            setup.context.log.debug2("[{}] Incremented counter to [{}]", setup.name, newValue)
             counter(setup, newValue)
           case GetValue(replyTo) =>
             replyTo ! Value(n)
@@ -207,16 +208,16 @@ object StyleGuideDocExamples {
       private def counter(n: Int): Behavior[Command] =
         Behaviors.receiveMessage {
           case IncrementRepeatedly(interval) =>
-            context.log.debug(
+            context.log.debugN(
               "[{}] Starting repeated increments with interval [{}], current count is [{}]",
               name,
-              interval.toString,
-              n.toString)
+              interval,
+              n)
             timers.startTimerWithFixedDelay("repeat", Increment, interval)
             Behaviors.same
           case Increment =>
             val newValue = n + 1
-            context.log.debug("[{}] Incremented counter to [{}]", name, newValue)
+            context.log.debug2("[{}] Incremented counter to [{}]", name, newValue)
             counter(newValue)
           case GetValue(replyTo) =>
             replyTo ! Value(n)
@@ -243,16 +244,16 @@ object StyleGuideDocExamples {
             def counter(n: Int): Behavior[Command] =
               Behaviors.receiveMessage {
                 case IncrementRepeatedly(interval) =>
-                  context.log.debug(
+                  context.log.debugN(
                     "[{}] Starting repeated increments with interval [{}], current count is [{}]",
                     name,
-                    interval.toString,
-                    n.toString)
+                    interval,
+                    n)
                   timers.startTimerWithFixedDelay("repeat", Increment, interval)
                   Behaviors.same
                 case Increment =>
                   val newValue = n + 1
-                  context.log.debug("[{}] Incremented counter to [{}]", name, newValue)
+                  context.log.debug2("[{}] Incremented counter to [{}]", name, newValue)
                   counter(newValue)
                 case GetValue(replyTo) =>
                   replyTo ! Value(n)
@@ -353,11 +354,11 @@ object StyleGuideDocExamples {
         Behaviors.receiveMessage {
           case Increment =>
             val newValue = n + 1
-            context.log.debug("[{}] Incremented counter to [{}]", name, newValue)
+            context.log.debug2("[{}] Incremented counter to [{}]", name, newValue)
             counter(newValue)
           case Tick =>
             val newValue = n + 1
-            context.log.debug("[{}] Incremented counter by background tick to [{}]", name, newValue)
+            context.log.debug2("[{}] Incremented counter by background tick to [{}]", name, newValue)
             counter(newValue)
           case GetValue(replyTo) =>
             replyTo ! Value(n)
@@ -404,11 +405,11 @@ object StyleGuideDocExamples {
         Behaviors.receiveMessage {
           case Increment =>
             val newValue = n + 1
-            context.log.debug("[{}] Incremented counter to [{}]", name, newValue)
+            context.log.debug2("[{}] Incremented counter to [{}]", name, newValue)
             counter(newValue)
           case Tick =>
             val newValue = n + 1
-            context.log.debug("[{}] Incremented counter by background tick to [{}]", name, newValue)
+            context.log.debug2("[{}] Incremented counter by background tick to [{}]", name, newValue)
             counter(newValue)
           case GetValue(replyTo) =>
             replyTo ! Value(n)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/TimerSchedulerImpl.scala
@@ -11,6 +11,7 @@ import scala.concurrent.duration.FiniteDuration
 import akka.actor.Cancellable
 import akka.actor.NotInfluenceReceiveTimeout
 import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.LoggerOps
 import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts
 import akka.util.JavaDurationConverters._
@@ -159,9 +160,11 @@ import org.slf4j.Logger
         } else {
           // it was from an old timer that was enqueued in mailbox before canceled
           if (log.isDebugEnabled)
-            log.debug(
+            log.debugN(
               "Received timer [{}] from old generation [{}], expected generation [{}], discarding",
-              Array(timerMsg.key, timerMsg.generation, t.generation))
+              timerMsg.key,
+              timerMsg.generation,
+              t.generation)
           OptionVal.none // message should be ignored
         }
     }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/LocalReceptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/LocalReceptionist.scala
@@ -4,11 +4,14 @@
 
 package akka.actor.typed.internal.receptionist
 
-import akka.actor.typed.{ ActorRef, Behavior, Terminated }
+import akka.actor.typed.ActorRef
+import akka.actor.typed.Behavior
+import akka.actor.typed.Terminated
 import akka.actor.typed.receptionist.Receptionist._
 import akka.actor.typed.receptionist.ServiceKey
-import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
-import akka.actor.typed.scaladsl.Behaviors.{ receive, same }
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
 import akka.annotation.InternalApi
 import akka.util.TypedMultiMap
 
@@ -98,7 +101,7 @@ private[akka] object LocalReceptionist extends ReceptionistBehaviorProvider {
 
     def onCommand(ctx: ActorContext[Any], cmd: Command): Behavior[Any] = cmd match {
       case ReceptionistMessages.Register(key, serviceInstance, maybeReplyTo) =>
-        ctx.log.debug("Actor was registered: {} {}", key, serviceInstance: Any)
+        ctx.log.debug2("Actor was registered: {} {}", key, serviceInstance)
         watchWith(ctx, serviceInstance, RegisteredActorTerminated(key, serviceInstance))
         maybeReplyTo match {
           case Some(replyTo) => replyTo ! ReceptionistMessages.Registered(key, serviceInstance)
@@ -108,7 +111,7 @@ private[akka] object LocalReceptionist extends ReceptionistBehaviorProvider {
 
       case ReceptionistMessages.Find(key, replyTo) =>
         replyWithListing(key, replyTo)
-        same
+        Behaviors.same
 
       case ReceptionistMessages.Subscribe(key, subscriber) =>
         watchWith(ctx, subscriber, SubscriberTerminated(key, subscriber))
@@ -121,14 +124,14 @@ private[akka] object LocalReceptionist extends ReceptionistBehaviorProvider {
 
     def onInternal(ctx: ActorContext[Any], cmd: InternalCommand): Behavior[Any] = cmd match {
       case RegisteredActorTerminated(key, serviceInstance) =>
-        ctx.log.debug("Registered actor terminated: {} {}", key, serviceInstance: Any)
+        ctx.log.debug2("Registered actor terminated: {} {}", key, serviceInstance)
         updateRegistry(Set(key), _.removed(key)(serviceInstance))
 
       case SubscriberTerminated(key, subscriber) =>
         next(newSubscriptions = subscriptions.removed(key)(subscriber))
     }
 
-    receive[Any] { (ctx, msg) =>
+    Behaviors.receive[Any] { (ctx, msg) =>
       msg match {
         case cmd: Command         => onCommand(ctx, cmd)
         case cmd: InternalCommand => onInternal(ctx, cmd)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/package.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/package.scala
@@ -1,0 +1,388 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed
+
+import org.slf4j.Logger
+import org.slf4j.Marker
+
+package object scaladsl {
+
+  /**
+   * Extension methods to [[org.slf4j.Logger]] that are useful because the Scala
+   * compiler can't select the right overloaded methods for some cases when using
+   * 2 template arguments and varargs (>= 3 arguments) with primitive types.
+   *
+   * Enable these extension methods with:
+   *
+   * {{{
+   * import akka.actor.typed.scaladsl.LoggerOps
+   * }}}
+   * or
+   * {{{
+   *import akka.actor.typed.scaladsl._
+   * }}}
+   *
+   * @param log the underlying [[org.slf4j.Logger]]
+   */
+  implicit class LoggerOps(val log: Logger) extends AnyVal {
+
+    /**
+     * Log a message at the TRACE level according to the specified format
+     * and 2 arguments.
+     *
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the TRACE level.
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     */
+    def trace2(format: String, arg1: Any, arg2: Any): Unit =
+      log.trace(format, arg1, arg2)
+
+    /**
+     * Log marker data and message at the TRACE level according to the specified format
+     * and 2 arguments.
+     *
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the TRACE level.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     */
+    def trace2(marker: Marker, format: String, arg1: Any, arg2: Any): Unit =
+      log.trace(marker, format, arg1, arg2)
+
+    /**
+     * Log a message at the TRACE level according to the specified format
+     * and arguments.
+     *
+     * This form avoids superfluous string concatenation when the logger
+     * is disabled for the TRACE level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an `Array[Object]` before invoking the method,
+     * even if this logger is disabled for TRACE. The `trace` variants taking
+     * one and `trace2` taking two arguments exist solely in order to avoid this hidden cost.
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    def traceN(format: String, arguments: Any*): Unit = {
+      val arr = arguments.toArray
+      if (arr.isInstanceOf[Array[Object]])
+        log.trace(format, arr.asInstanceOf[Array[Object]]: _*) // this seems to always be the case
+      else
+        log.trace(format, arr.map(_.asInstanceOf[AnyRef]): _*)
+    }
+
+    /**
+     * Log marker data and message at the TRACE level according to the specified format
+     * and arguments.
+     *
+     * This form avoids superfluous string concatenation when the logger
+     * is disabled for the TRACE level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an `Array[Object]` before invoking the method,
+     * even if this logger is disabled for TRACE. The `trace` variants taking
+     * one and `trace2` taking two arguments exist solely in order to avoid this hidden cost.
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    def traceN(marker: Marker, format: String, arguments: Any*): Unit = {
+      val arr = arguments.toArray
+      if (arr.isInstanceOf[Array[Object]])
+        log.trace(marker, format, arr.asInstanceOf[Array[Object]]: _*) // this seems to always be the case
+      else
+        log.trace(marker, format, arr.map(_.asInstanceOf[AnyRef]): _*)
+    }
+
+    /**
+     * Log a message at the DEBUG level according to the specified format
+     * and 2 arguments.
+     *
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the DEBUG level.
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     */
+    def debug2(format: String, arg1: Any, arg2: Any): Unit =
+      log.debug(format, arg1, arg2)
+
+    /**
+     * Log marker data and message at the DEBUG level according to the specified format
+     * and 2 arguments.
+     *
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the DEBUG level.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     */
+    def debug2(marker: Marker, format: String, arg1: Any, arg2: Any): Unit =
+      log.debug(marker, format, arg1, arg2)
+
+    /**
+     * Log a message at the DEBUG level according to the specified format
+     * and arguments.
+     *
+     * This form avoids superfluous string concatenation when the logger
+     * is disabled for the DEBUG level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an `Array[Object]` before invoking the method,
+     * even if this logger is disabled for DEBUG. The `debug` variants taking
+     * one and `debug2` taking two arguments exist solely in order to avoid this hidden cost.
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    def debugN(format: String, arguments: Any*): Unit = {
+      val arr = arguments.toArray
+      if (arr.isInstanceOf[Array[Object]])
+        log.debug(format, arr.asInstanceOf[Array[Object]]: _*) // this seems to always be the case
+      else
+        log.debug(format, arr.map(_.asInstanceOf[AnyRef]): _*)
+    }
+
+    /**
+     * Log marker data and message at the DEBUG level according to the specified format
+     * and arguments.
+     *
+     * This form avoids superfluous string concatenation when the logger
+     * is disabled for the DEBUG level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an `Array[Object]` before invoking the method,
+     * even if this logger is disabled for DEBUG. The `debug` variants taking
+     * one and `debug2` taking two arguments exist solely in order to avoid this hidden cost.
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    def debugN(marker: Marker, format: String, arguments: Any*): Unit = {
+      val arr = arguments.toArray
+      if (arr.isInstanceOf[Array[Object]])
+        log.debug(marker, format, arr.asInstanceOf[Array[Object]]: _*) // this seems to always be the case
+      else
+        log.debug(marker, format, arr.map(_.asInstanceOf[AnyRef]): _*)
+    }
+
+    /**
+     * Log a message at the INFO level according to the specified format
+     * and 2 arguments.
+     *
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the INFO level.
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     */
+    def info2(format: String, arg1: Any, arg2: Any): Unit =
+      log.info(format, arg1, arg2)
+
+    /**
+     * Log marker data and message at the INFO level according to the specified format
+     * and 2 arguments.
+     *
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the INFO level.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     */
+    def info2(marker: Marker, format: String, arg1: Any, arg2: Any): Unit =
+      log.info(marker, format, arg1, arg2)
+
+    /**
+     * Log a message at the INFO level according to the specified format
+     * and arguments.
+     *
+     * This form avoids superfluous string concatenation when the logger
+     * is disabled for the INFO level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an `Array[Object]` before invoking the method,
+     * even if this logger is disabled for INFO. The `info` variants taking
+     * one and `info2` taking two arguments exist solely in order to avoid this hidden cost.
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    def infoN(format: String, arguments: Any*): Unit = {
+      val arr = arguments.toArray
+      if (arr.isInstanceOf[Array[Object]])
+        log.info(format, arr.asInstanceOf[Array[Object]]: _*) // this seems to always be the case
+      else
+        log.info(format, arr.map(_.asInstanceOf[AnyRef]): _*)
+    }
+
+    /**
+     * Log marker data and message at the INFO level according to the specified format
+     * and arguments.
+     *
+     * This form avoids superfluous string concatenation when the logger
+     * is disabled for the INFO level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an `Array[Object]` before invoking the method,
+     * even if this logger is disabled for INFO. The `info` variants taking
+     * one and `info2` taking two arguments exist solely in order to avoid this hidden cost.
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    def infoN(marker: Marker, format: String, arguments: Any*): Unit = {
+      val arr = arguments.toArray
+      if (arr.isInstanceOf[Array[Object]])
+        log.info(marker, format, arr.asInstanceOf[Array[Object]]: _*) // this seems to always be the case
+      else
+        log.info(marker, format, arr.map(_.asInstanceOf[AnyRef]): _*)
+    }
+
+    /**
+     * Log a message at the WARN level according to the specified format
+     * and 2 arguments.
+     *
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the WARN level.
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     */
+    def warn2(format: String, arg1: Any, arg2: Any): Unit =
+      log.warn(format, arg1, arg2)
+
+    /**
+     * Log marker data and message at the WARN level according to the specified format
+     * and 2 arguments.
+     *
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the WARN level.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     */
+    def warn2(marker: Marker, format: String, arg1: Any, arg2: Any): Unit =
+      log.warn(marker, format, arg1, arg2)
+
+    /**
+     * Log a message at the WARN level according to the specified format
+     * and arguments.
+     *
+     * This form avoids superfluous string concatenation when the logger
+     * is disabled for the WARN level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an `Array[Object]` before invoking the method,
+     * even if this logger is disabled for WARN. The `warn` variants taking
+     * one and `warn2` taking two arguments exist solely in order to avoid this hidden cost.
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    def warnN(format: String, arguments: Any*): Unit = {
+      val arr = arguments.toArray
+      if (arr.isInstanceOf[Array[Object]])
+        log.warn(format, arr.asInstanceOf[Array[Object]]: _*) // this seems to always be the case
+      else
+        log.warn(format, arr.map(_.asInstanceOf[AnyRef]): _*)
+    }
+
+    /**
+     * Log marker data and message at the WARN level according to the specified format
+     * and arguments.
+     *
+     * This form avoids superfluous string concatenation when the logger
+     * is disabled for the WARN level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an `Array[Object]` before invoking the method,
+     * even if this logger is disabled for WARN. The `warn` variants taking
+     * one and `warn2` taking two arguments exist solely in order to avoid this hidden cost.
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    def warnN(marker: Marker, format: String, arguments: Any*): Unit = {
+      val arr = arguments.toArray
+      if (arr.isInstanceOf[Array[Object]])
+        log.warn(marker, format, arr.asInstanceOf[Array[Object]]: _*) // this seems to always be the case
+      else
+        log.warn(marker, format, arr.map(_.asInstanceOf[AnyRef]): _*)
+    }
+
+    /**
+     * Log a message at the ERROR level according to the specified format
+     * and 2 arguments.
+     *
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the ERROR level.
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     */
+    def error2(format: String, arg1: Any, arg2: Any): Unit =
+      log.error(format, arg1, arg2)
+
+    /**
+     * Log marker data and message at the ERROR level according to the specified format
+     * and 2 arguments.
+     *
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the ERROR level.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     */
+    def error2(marker: Marker, format: String, arg1: Any, arg2: Any): Unit =
+      log.error(marker, format, arg1, arg2)
+
+    /**
+     * Log a message at the ERROR level according to the specified format
+     * and arguments.
+     *
+     * This form avoids superfluous string concatenation when the logger
+     * is disabled for the ERROR level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an `Array[Object]` before invoking the method,
+     * even if this logger is disabled for ERROR. The `error` variants taking
+     * one and `error2` taking two arguments exist solely in order to avoid this hidden cost.
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    def errorN(format: String, arguments: Any*): Unit = {
+      val arr = arguments.toArray
+      if (arr.isInstanceOf[Array[Object]])
+        log.error(format, arr.asInstanceOf[Array[Object]]: _*) // this seems to always be the case
+      else
+        log.error(format, arr.map(_.asInstanceOf[AnyRef]): _*)
+    }
+
+    /**
+     * Log marker data and message at the ERROR level according to the specified format
+     * and arguments.
+     *
+     * This form avoids superfluous string concatenation when the logger
+     * is disabled for the ERROR level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an `Array[Object]` before invoking the method,
+     * even if this logger is disabled for ERROR. The `error` variants taking
+     * one and `error2` taking two arguments exist solely in order to avoid this hidden cost.
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    def errorN(marker: Marker, format: String, arguments: Any*): Unit = {
+      val arr = arguments.toArray
+      if (arr.isInstanceOf[Array[Object]])
+        log.error(marker, format, arr.asInstanceOf[Array[Object]]: _*) // this seems to always be the case
+      else
+        log.error(marker, format, arr.map(_.asInstanceOf[AnyRef]): _*)
+    }
+
+  }
+
+}

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/DistributedData.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/DistributedData.scala
@@ -10,6 +10,7 @@ import akka.actor.typed.{ ActorRef, ActorSystem, Extension, ExtensionId, Props }
 import akka.actor.ExtendedActorSystem
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
 import akka.annotation.InternalApi
 import akka.cluster.Cluster
 import akka.cluster.ddata.ReplicatedData
@@ -90,11 +91,11 @@ class DistributedData(system: ActorSystem[_]) extends Extension {
       if (Cluster(untypedSystem).isTerminated)
         log.warn("Replicator points to dead letters, because Cluster is terminated.")
       else
-        log.warn(
+        log.warn2(
           "Replicator points to dead letters. Make sure the cluster node has the proper role. " +
           "Node has roles [{}], Distributed Data is configured for roles [{}].",
           Cluster(untypedSystem).selfRoles.mkString(","),
-          settings.roles.mkString(","): Any)
+          settings.roles.mkString(","))
       system.deadLetters
     } else {
       val underlyingReplicator = dd.DistributedData(untypedSystem).replicator

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
@@ -8,7 +8,7 @@ import akka.actor.typed.internal.receptionist.{ AbstractServiceKey, Receptionist
 import akka.actor.typed.receptionist.Receptionist.Command
 import akka.actor.typed.receptionist.ServiceKey
 import akka.actor.typed.scaladsl.adapter._
-import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, LoggerOps }
 import akka.actor.typed.{ ActorRef, Behavior, Terminated }
 import akka.annotation.InternalApi
 import akka.cluster.ClusterEvent.MemberRemoved
@@ -194,7 +194,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
 
           if (removals.nonEmpty) {
             if (ctx.log.isDebugEnabled)
-              ctx.log.debug(
+              ctx.log.debugN(
                 "ClusterReceptionist [{}] - Node(s) removed [{}], updating registry removing entries: [{}]",
                 cluster.selfAddress,
                 addresses.mkString(","),
@@ -237,7 +237,8 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
         case ReceptionistMessages.Register(key, serviceInstance, maybeReplyTo) =>
           if (serviceInstance.path.address.hasLocalScope) {
             val entry = Entry(serviceInstance, setup.selfSystemUid)
-            ctx.log.debug("ClusterReceptionist [{}] - Actor was registered: [{}] [{}]", cluster.selfAddress, key, entry)
+            ctx.log
+              .debugN("ClusterReceptionist [{}] - Actor was registered: [{}] [{}]", cluster.selfAddress, key, entry)
             watchWith(ctx, serviceInstance, RegisteredActorTerminated(key, serviceInstance))
             maybeReplyTo match {
               case Some(replyTo) => replyTo ! ReceptionistMessages.Registered(key, serviceInstance)
@@ -248,7 +249,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
               ServiceRegistry(registry).addBinding(key, entry).toORMultiMap
             }
           } else {
-            ctx.log.error(s"ClusterReceptionist [{}] - Register of non-local [{}] is not supported", serviceInstance)
+            ctx.log.error("ClusterReceptionist [{}] - Register of non-local [{}] is not supported", serviceInstance)
           }
           Behaviors.same
 
@@ -277,7 +278,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
 
         case RegisteredActorTerminated(key, serviceInstance) =>
           val entry = Entry(serviceInstance, setup.selfSystemUid)
-          ctx.log.debug(
+          ctx.log.debugN(
             "ClusterReceptionist [{}] - Registered actor terminated: [{}] [{}]",
             cluster.selfAddress,
             key.asServiceKey.id,
@@ -297,7 +298,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
           val newRegistry = registry.withServiceRegistry(ddataKey, newState)
           if (changedKeys.nonEmpty) {
             if (ctx.log.isDebugEnabled) {
-              ctx.log.debug(
+              ctx.log.debugN(
                 "ClusterReceptionist [{}] - Change from replicator: [{}], changes: [{}], tombstones [{}]",
                 cluster.selfAddress,
                 newState.entries.entries,
@@ -323,10 +324,10 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
               val tombstonedButReAdded = newRegistry.actorRefsFor(serviceKey).filter(newRegistry.hasTombstone)
               if (tombstonedButReAdded.nonEmpty) {
                 if (ctx.log.isDebugEnabled)
-                  ctx.log.debug(
+                  ctx.log.debug2(
                     "ClusterReceptionist [{}] - Saw ActorRefs that were tomstoned [{}], re-removing.",
                     cluster.selfAddress,
-                    tombstonedButReAdded.mkString(", "): Any)
+                    tombstonedButReAdded.mkString(", "))
 
                 replicator ! Replicator.Update(ddataKey, EmptyORMultiMap, settings.writeConsistency) { registry =>
                   tombstonedButReAdded
@@ -355,10 +356,10 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
           } else {
             // Ok to update from several nodes but more efficient to try to do it from one node.
             if (isLeader) {
-              ctx.log.debug(
+              ctx.log.debug2(
                 "ClusterReceptionist [{}] - Leader node observed removed node [{}]",
                 cluster.selfAddress,
-                uniqueAddress: Any)
+                uniqueAddress)
               nodesRemoved(Set(uniqueAddress))
             }
 
@@ -369,10 +370,10 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
           val keysForNode = registry.keysFor(uniqueAddress)
           val newRegistry = registry.addUnreachable(uniqueAddress)
           if (keysForNode.nonEmpty) {
-            ctx.log.debug(
+            ctx.log.debug2(
               "ClusterReceptionist [{}] - Node with registered services unreachable [{}]",
               cluster.selfAddress,
-              uniqueAddress: Any)
+              uniqueAddress)
             reachabilityChanged(keysForNode, newRegistry)
           }
           next(newRegistry)
@@ -381,10 +382,10 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
           val keysForNode = registry.keysFor(uniqueAddress)
           val newRegistry = registry.removeUnreachable(uniqueAddress)
           if (keysForNode.nonEmpty) {
-            ctx.log.debug(
+            ctx.log.debug2(
               "ClusterReceptionist [{}] - Node with registered services reachable again [{}]",
               cluster.selfAddress,
-              uniqueAddress: Any)
+              uniqueAddress)
             reachabilityChanged(keysForNode, newRegistry)
           }
           next(newRegistry)
@@ -398,10 +399,10 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
             if (notInCluster.isEmpty) Behaviors.same
             else {
               if (ctx.log.isDebugEnabled)
-                ctx.log.debug(
+                ctx.log.debug2(
                   "ClusterReceptionist [{}] - Leader node cleanup tick, removed nodes: [{}]",
                   cluster.selfAddress,
-                  notInCluster.mkString(","): Any)
+                  notInCluster.mkString(","))
               nodesRemoved(notInCluster)
             }
           }

--- a/akka-docs/src/test/scala/typed/tutorial_3/Device.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_3/Device.scala
@@ -12,6 +12,7 @@ import akka.actor.typed.Signal
 import akka.actor.typed.scaladsl.AbstractBehavior
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
 
 object Device {
   def apply(groupId: String, deviceId: String): Behavior[Command] =
@@ -35,12 +36,12 @@ class Device(context: ActorContext[Device.Command], groupId: String, deviceId: S
 
   var lastTemperatureReading: Option[Double] = None
 
-  context.log.info("Device actor {}-{} started", groupId, deviceId: Any)
+  context.log.info2("Device actor {}-{} started", groupId, deviceId)
 
   override def onMessage(msg: Command): Behavior[Command] = {
     msg match {
       case RecordTemperature(id, value, replyTo) =>
-        context.log.info("Recorded temperature reading {} with {}", value, id)
+        context.log.info2("Recorded temperature reading {} with {}", value, id)
         lastTemperatureReading = Some(value)
         replyTo ! TemperatureRecorded(id)
         this
@@ -53,7 +54,7 @@ class Device(context: ActorContext[Device.Command], groupId: String, deviceId: S
 
   override def onSignal: PartialFunction[Signal, Behavior[Command]] = {
     case PostStop =>
-      context.log.info("Device actor {}-{} stopped", groupId, deviceId: Any)
+      context.log.info2("Device actor {}-{} stopped", groupId, deviceId)
       this
   }
 

--- a/akka-docs/src/test/scala/typed/tutorial_3/DeviceInProgress.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_3/DeviceInProgress.scala
@@ -4,9 +4,9 @@
 
 package typed.tutorial_3
 
-import akka.actor.typed.ActorRef
 import akka.actor.typed.PostStop
 import akka.actor.typed.Signal
+import akka.actor.typed.scaladsl.LoggerOps
 
 object DeviceInProgress1 {
 
@@ -48,7 +48,7 @@ object DeviceInProgress2 {
 
     var lastTemperatureReading: Option[Double] = None
 
-    context.log.info("Device actor {}-{} started", groupId, deviceId: Any)
+    context.log.info2("Device actor {}-{} started", groupId, deviceId)
 
     override def onMessage(msg: Command): Behavior[Command] = {
       msg match {
@@ -60,7 +60,7 @@ object DeviceInProgress2 {
 
     override def onSignal: PartialFunction[Signal, Behavior[Command]] = {
       case PostStop =>
-        context.log.info("Device actor {}-{} stopped", groupId, deviceId: Any)
+        context.log.info2("Device actor {}-{} stopped", groupId, deviceId)
         this
     }
 

--- a/akka-docs/src/test/scala/typed/tutorial_4/Device.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_4/Device.scala
@@ -12,6 +12,7 @@ import akka.actor.typed.Signal
 import akka.actor.typed.scaladsl.AbstractBehavior
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
 
 object Device {
   def apply(groupId: String, deviceId: String): Behavior[Command] =
@@ -37,12 +38,12 @@ class Device(context: ActorContext[Device.Command], groupId: String, deviceId: S
 
   var lastTemperatureReading: Option[Double] = None
 
-  context.log.info("Device actor {}-{} started", groupId, deviceId: Any)
+  context.log.info2("Device actor {}-{} started", groupId, deviceId)
 
   override def onMessage(msg: Command): Behavior[Command] = {
     msg match {
       case RecordTemperature(id, value, replyTo) =>
-        context.log.info("Recorded temperature reading {} with {}", value, id)
+        context.log.info2("Recorded temperature reading {} with {}", value, id)
         lastTemperatureReading = Some(value)
         replyTo ! TemperatureRecorded(id)
         this
@@ -58,7 +59,7 @@ class Device(context: ActorContext[Device.Command], groupId: String, deviceId: S
 
   override def onSignal: PartialFunction[Signal, Behavior[Command]] = {
     case PostStop =>
-      context.log.info("Device actor {}-{} stopped", groupId, deviceId: Any)
+      context.log.info2("Device actor {}-{} stopped", groupId, deviceId)
       this
   }
 

--- a/akka-docs/src/test/scala/typed/tutorial_4/DeviceGroup.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_4/DeviceGroup.scala
@@ -11,6 +11,7 @@ import akka.actor.typed.Signal
 import akka.actor.typed.scaladsl.AbstractBehavior
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
 
 //#device-group-full
 //#device-group-register
@@ -55,7 +56,7 @@ class DeviceGroup(context: ActorContext[DeviceGroup.Command], groupId: String)
         this
 
       case RequestTrackDevice(gId, _, _) =>
-        context.log.warn("Ignoring TrackDevice request for {}. This actor is responsible for {}.", gId, groupId: Any)
+        context.log.warn2("Ignoring TrackDevice request for {}. This actor is responsible for {}.", gId, groupId)
         this
       //#device-group-register
       //#device-group-remove

--- a/akka-docs/src/test/scala/typed/tutorial_5/Device.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_5/Device.scala
@@ -12,6 +12,7 @@ import akka.actor.typed.Signal
 import akka.actor.typed.scaladsl.AbstractBehavior
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
 
 object Device {
   def apply(groupId: String, deviceId: String): Behavior[Command] =
@@ -35,12 +36,12 @@ class Device(context: ActorContext[Device.Command], groupId: String, deviceId: S
 
   var lastTemperatureReading: Option[Double] = None
 
-  context.log.info("Device actor {}-{} started", groupId, deviceId: Any)
+  context.log.info2("Device actor {}-{} started", groupId, deviceId)
 
   override def onMessage(msg: Command): Behavior[Command] = {
     msg match {
       case RecordTemperature(id, value, replyTo) =>
-        context.log.info("Recorded temperature reading {} with {}", value, id)
+        context.log.info2("Recorded temperature reading {} with {}", value, id)
         lastTemperatureReading = Some(value)
         replyTo ! TemperatureRecorded(id)
         this
@@ -56,7 +57,7 @@ class Device(context: ActorContext[Device.Command], groupId: String, deviceId: S
 
   override def onSignal: PartialFunction[Signal, Behavior[Command]] = {
     case PostStop =>
-      context.log.info("Device actor {}-{} stopped", groupId, deviceId: Any)
+      context.log.info2("Device actor {}-{} stopped", groupId, deviceId)
       this
   }
 

--- a/akka-docs/src/test/scala/typed/tutorial_5/DeviceGroup.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_5/DeviceGroup.scala
@@ -12,6 +12,7 @@ import akka.actor.typed.Signal
 import akka.actor.typed.scaladsl.AbstractBehavior
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
 
 object DeviceGroup {
   def apply(groupId: String): Behavior[Command] =
@@ -59,7 +60,7 @@ class DeviceGroup(context: ActorContext[DeviceGroup.Command], groupId: String)
         this
 
       case RequestTrackDevice(gId, _, _) =>
-        context.log.warn("Ignoring TrackDevice request for {}. This actor is responsible for {}.", gId, groupId: Any)
+        context.log.warn2("Ignoring TrackDevice request for {}. This actor is responsible for {}.", gId, groupId)
         this
 
       case RequestDeviceList(requestId, gId, replyTo) =>

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -16,6 +16,7 @@ import akka.actor.typed.Signal
 import akka.actor.typed.SupervisorStrategy
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
 import akka.annotation._
 import akka.persistence.JournalProtocol
 import akka.persistence.Recovery
@@ -99,13 +100,13 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
       case (_, DeleteSnapshotsCompleted(DeletionTarget.Criteria(criteria))) =>
         ctx.log.debug("Persistent snapshots given criteria [{}] deleted successfully.", criteria)
       case (_, DeleteSnapshotsFailed(DeletionTarget.Individual(meta), failure)) =>
-        ctx.log.warn("Failed to delete snapshot with meta [{}] due to: {}", meta, failure.getMessage: Any)
+        ctx.log.warn2("Failed to delete snapshot with meta [{}] due to: {}", meta, failure.getMessage)
       case (_, DeleteSnapshotsFailed(DeletionTarget.Criteria(criteria), failure)) =>
-        ctx.log.warn("Failed to delete snapshots given criteria [{}] due to: {}", criteria, failure.getMessage: Any)
+        ctx.log.warn2("Failed to delete snapshots given criteria [{}] due to: {}", criteria, failure.getMessage)
       case (_, DeleteEventsCompleted(toSequenceNr)) =>
         ctx.log.debug("Events successfully deleted to sequence number [{}].", toSequenceNr)
       case (_, DeleteEventsFailed(toSequenceNr, failure)) =>
-        ctx.log.warn("Failed to delete events to sequence number [{}] due to: {}", toSequenceNr, failure.getMessage)
+        ctx.log.warn2("Failed to delete events to sequence number [{}] due to: {}", toSequenceNr, failure.getMessage)
     }
 
     // do this once, even if the actor is restarted

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ExternalInteractions.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ExternalInteractions.scala
@@ -13,6 +13,7 @@ import akka.actor.typed.PreRestart
 import akka.actor.typed.Signal
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
 import akka.annotation.InternalApi
 import akka.annotation.InternalStableApi
 
@@ -100,7 +101,7 @@ private[akka] trait JournalInteractions[C, E, S] {
       @unused repr: immutable.Seq[PersistentRepr]): Unit = ()
 
   protected def replayEvents(fromSeqNr: Long, toSeqNr: Long): Unit = {
-    setup.log.debug("Replaying messages: from: {}, to: {}", fromSeqNr, toSeqNr)
+    setup.log.debug2("Replaying messages: from: {}, to: {}", fromSeqNr, toSeqNr)
     setup.journal ! ReplayMessages(
       fromSeqNr,
       toSeqNr,
@@ -182,7 +183,7 @@ private[akka] trait SnapshotInteractions[C, E, S] {
   protected def internalDeleteSnapshots(fromSequenceNr: Long, toSequenceNr: Long): Unit = {
     if (toSequenceNr > 0) {
       val snapshotCriteria = SnapshotSelectionCriteria(minSequenceNr = fromSequenceNr, maxSequenceNr = toSequenceNr)
-      setup.log.debug("Deleting snapshots from sequenceNr [{}] to [{}]", fromSequenceNr, toSequenceNr)
+      setup.log.debug2("Deleting snapshots from sequenceNr [{}] to [{}]", fromSequenceNr, toSequenceNr)
       setup.snapshotStore
         .tell(SnapshotProtocol.DeleteSnapshots(setup.persistenceId.id, snapshotCriteria), setup.selfUntyped)
     }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingEvents.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingEvents.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 import akka.actor.typed.{ Behavior, Signal }
 import akka.actor.typed.internal.PoisonPill
 import akka.actor.typed.internal.UnstashException
-import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, Behaviors }
+import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, Behaviors, LoggerOps }
 import akka.annotation.{ InternalApi, InternalStableApi }
 import akka.event.Logging
 import akka.persistence.JournalProtocol._
@@ -199,10 +199,10 @@ private[akka] final class ReplayingEvents[C, E, S](
     setup.cancelRecoveryTimer()
     tryReturnRecoveryPermit("on replay failure: " + cause.getMessage)
     if (setup.log.isDebugEnabled) {
-      setup.log.debug(
+      setup.log.debug2(
         "Recovery failure for persistenceId [{}] after {}",
         setup.persistenceId,
-        (System.nanoTime() - state.recoveryStartTime).nanos.pretty: Any)
+        (System.nanoTime() - state.recoveryStartTime).nanos.pretty)
     }
     val sequenceNr = state.seqNr
 
@@ -223,10 +223,10 @@ private[akka] final class ReplayingEvents[C, E, S](
       onRecoveryComplete(setup.context)
       tryReturnRecoveryPermit("replay completed successfully")
       if (setup.log.isDebugEnabled) {
-        setup.log.debug(
+        setup.log.debug2(
           "Recovery for persistenceId [{}] took {}",
           setup.persistenceId,
-          (System.nanoTime() - state.recoveryStartTime).nanos.pretty: Any)
+          (System.nanoTime() - state.recoveryStartTime).nanos.pretty)
       }
       setup.onSignal(state.state, RecoveryCompleted, catchAndLog = false)
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/StashManagement.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/StashManagement.scala
@@ -9,6 +9,7 @@ import akka.actor.Dropped
 import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.scaladsl.StashOverflowException
 import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.LoggerOps
 import akka.actor.typed.scaladsl.StashBuffer
 import akka.annotation.InternalApi
 import akka.util.ConstantFun
@@ -95,23 +96,23 @@ private[akka] trait StashManagement[C, E, S] {
 
   private def logStashMessage(msg: InternalProtocol, buffer: StashBuffer[InternalProtocol]): Unit = {
     if (setup.settings.logOnStashing)
-      setup.log.debug(
+      setup.log.debugN(
         "Stashing message to {} stash: [{}] ",
         if (buffer eq stashState.internalStashBuffer) "internal" else "user",
-        msg: Any)
+        msg)
   }
 
   private def logUnstashMessage(buffer: StashBuffer[InternalProtocol]): Unit = {
     if (setup.settings.logOnStashing)
-      setup.log.debug(
+      setup.log.debugN(
         "Unstashing message from {} stash: [{}]",
         if (buffer eq stashState.internalStashBuffer) "internal" else "user",
-        buffer.head: Any)
+        buffer.head)
   }
 
   private def logUnstashAll(): Unit = {
     if (setup.settings.logOnStashing)
-      setup.log.debug(
+      setup.log.debug2(
         "Unstashing all [{}] messages from user stash, first is: [{}]",
         stashState.userStashBuffer.size,
         stashState.userStashBuffer.head)

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
@@ -9,6 +9,7 @@ import scala.concurrent.duration._
 import akka.actor.typed.Behavior
 import akka.actor.typed.SupervisorStrategy
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
 import akka.persistence.typed.DeleteEventsFailed
 import akka.persistence.typed.DeleteSnapshotsFailed
 import akka.persistence.typed.EventAdapter
@@ -123,7 +124,7 @@ object BasicPersistentBehaviorCompileOnly {
 
   val debugAlwaysSnapshot: Behavior[Command] = Behaviors.setup { context =>
     samplePersistentBehavior.snapshotWhen((state, _, _) => {
-      context.log.info("Snapshot actor {} => state: {}", context.self.path.name, state: Any)
+      context.log.info2("Snapshot actor {} => state: {}", context.self.path.name, state)
       true
     })
   }


### PR DESCRIPTION
On top of https://github.com/akka/akka/pull/27552, but deserves separate review.

* "ambiguous reference to overloaded definition" for 2 arg method
* varargs not supported for primitive types
* providing extension methods info2 and infoN (and friends) via implicit class LoggerOps
  as more convenient workaround for these problems

Examples of "ambiguous reference to overloaded definition" for 2 arg method, and how workaround would look like without the extension methods:
```scala
  log.info("template {} {}", "a", "b") // compiler err
  log.info("template {} {}", "a", "b": Any) // workaround
  log.info("template {} {}", "a", 2)
  log.info("template {} {}", 1, 2)
  log.info("template {} {}", 1, "b")
  log.info("template {} {}", "a", Value2(2)) // compiler err
  log.info("template {} {}", "a", Value2(2): Any) // workaround
  log.info("template {} {}", Value1(1), Value1(1)) // compiler err
  log.info("template {} {}", Value1(1), Value1(1): Any) // workaround
  log.info("template {} {}", Value1(1), Value2(2)) // compiler err
  log.info("template {} {}", Value1(1), Value2(2): Any) // workaround
```

Examples of varargs problem for primitive types, and how workaround would look like without the extension methods:
```scala
log.info("template {} {} {}", "a", "b", "c") // ok
  log.info("template {} {} {}", "a", "b", 3) // compiler err
  log.info("template {} {} {}", "a", "b", 3.asInstanceOf[AnyRef]) // workaround
  log.info("template {} {} {}", "a", 2, "c") // compiler err
  log.info("template {} {} {}", "a", 2.asInstanceOf[AnyRef], "c") // workaround
  //log.info("template {} {} {}", 1, 2, 3) // compiler err
  //log.info("template {} {} {}", 1, "b", "c") // compiler err
  log.info("template {} {} {}", "a", Value2(2), Value3(3)) // ok
  log.info("template {} {} {}", Value1(1), Value1(1), Value1(1)) // ok
  log.info("template {} {} {}", Value1(1), Value2(2), Value3(3)) // ok
```

Refs #26537