### PR TITLE
[WIP] 2.5 backport of stream cancellation modes

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/Attributes.scala
+++ b/akka-stream/src/main/scala/akka/stream/Attributes.scala
@@ -293,6 +293,16 @@ object Attributes {
       extends Attribute
   final case object AsyncBoundary extends Attribute
 
+  final case class CancellationBehavior(behavior: CancellationBehavior.Behavior) extends Attribute
+  object CancellationBehavior {
+    val Default: CancellationBehavior = CancellationBehavior(CompleteStage)
+
+    sealed trait Behavior
+    case object CompleteStage extends Behavior
+    case object FailStage extends Behavior
+    case class AfterDelay(delay: FiniteDuration, behavior: Behavior) extends Behavior
+  }
+
   object LogLevels {
 
     /** Use to disable logging on certain operations when configuring [[Attributes#logLevels]] */


### PR DESCRIPTION
That's not the final thing but rather a first try of providing a minimal backport of new stream cancellation features in 2.6. The idea is not backport stream cancellation causes but still provide the possibility to configure stream cancellation modes (as suggested in #27594). We cannot provide the new `PropagateFailures` mode (because there are no causes to propagate in 2.5). In akka-http we can still use the `AfterDelay` mode to introduce a general cancellation delay stages which seems to be enough to fix the so far elusive cancellation race conditions.