### PR TITLE
New API for Typed LoggingEventFilter, #26537

### DIFF
--- a/akka-actor-testkit-typed/src/main/resources/reference.conf
+++ b/akka-actor-testkit-typed/src/main/resources/reference.conf
@@ -6,15 +6,15 @@
 # Make your edits/overrides in your application.conf.
 
 akka.actor.testkit.typed {
-  # factor by which to scale timeouts during tests, e.g. to account for shared
-  # build system load
+  # Factor by which to scale timeouts during tests, e.g. to account for shared
+  # build system load.
   timefactor =  1.0
 
-  # duration to wait in expectMsg and friends outside of within() block
+  # Duration to wait in expectMsg and friends outside of within() block
   # by default, will be dilated by the timefactor.
   single-expect-default = 3s
 
-  # duration to wait in expectNoMessage by default,
+  # Duration to wait in expectNoMessage by default,
   # will be dilated by the timefactor.
   expect-no-message-default = 100ms
 
@@ -27,5 +27,9 @@ akka.actor.testkit.typed {
 
   # Throw an exception on shutdown if the timeout is hit, if false an error is printed to stdout instead.
   throw-on-shutdown-timeout=true
+
+  # Duration of LoggingEventFilter.intercept waits after the block is finished until
+  # all required messages are received, will be dilated by the timefactor.
+  filter-leeway = 3s
 
 }

--- a/akka-actor-testkit-typed/src/main/resources/reference.conf
+++ b/akka-actor-testkit-typed/src/main/resources/reference.conf
@@ -11,25 +11,27 @@ akka.actor.testkit.typed {
   timefactor =  1.0
 
   # Duration to wait in expectMsg and friends outside of within() block
-  # by default, will be dilated by the timefactor.
+  # by default.
+  # Dilated by the timefactor.
   single-expect-default = 3s
 
-  # Duration to wait in expectNoMessage by default,
-  # will be dilated by the timefactor.
+  # Duration to wait in expectNoMessage by default.
+  # Dilated by the timefactor.
   expect-no-message-default = 100ms
 
-  # The timeout that is added as an implicit by DefaultTimeout trait, will be dilated by the timefactor.
+  # The timeout that is used as an implicit Timeout.
+  # Dilated by the timefactor.
   default-timeout = 5s
 
-  # Default timeout for shutting down the actor system (used when no explicit timeout specified),
-  # will be dilated by the timefactor.
+  # Default timeout for shutting down the actor system (used when no explicit timeout specified).
+  # Dilated by the timefactor.
   system-shutdown-default=10s
 
   # Throw an exception on shutdown if the timeout is hit, if false an error is printed to stdout instead.
   throw-on-shutdown-timeout=true
 
-  # Duration of LoggingEventFilter.intercept waits after the block is finished until
-  # all required messages are received, will be dilated by the timefactor.
+  # Duration to wait for all required logging events in LoggingEventFilter.intercept.
+  # Dilated by the timefactor.
   filter-leeway = 3s
 
 }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/LoggingEvent.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/LoggingEvent.scala
@@ -5,6 +5,7 @@
 package akka.actor.testkit.typed
 
 import scala.compat.java8.OptionConverters._
+import akka.util.ccompat.JavaConverters._
 
 import java.util.Optional
 
@@ -12,8 +13,32 @@ import org.slf4j.Marker
 import org.slf4j.event.Level
 
 object LoggingEvent {
+
+  /**
+   * Scala API
+   */
   def apply(level: Level, loggerName: String, threadName: String, message: String, timeStamp: Long): LoggingEvent =
     new LoggingEvent(level, loggerName, threadName, message, timeStamp, None, None, Map.empty)
+
+  /**
+   * Java API
+   */
+  def create(level: Level, loggerName: String, threadName: String, message: String, timeStamp: Long): LoggingEvent =
+    apply(level, loggerName, threadName, message, timeStamp)
+
+  /**
+   * Java API
+   */
+  def create(
+      level: Level,
+      loggerName: String,
+      threadName: String,
+      message: String,
+      timeStamp: Long,
+      marker: Optional[Marker],
+      throwable: Optional[Throwable],
+      mdc: java.util.Map[String, String]) =
+    apply(level, loggerName, threadName, message, timeStamp, marker.asScala, throwable.asScala, mdc.asScala.toMap)
 }
 
 /**

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/TestKitSettings.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/TestKitSettings.scala
@@ -59,21 +59,21 @@ final class TestKitSettings(val config: Config) {
     .getDouble("timefactor")
     .requiring(tf => !tf.isInfinite && tf > 0, "timefactor must be positive finite double")
 
-  /** dilated with `TestTimeFactor` */
+  /** Dilated with `TestTimeFactor`. */
   val SingleExpectDefaultTimeout: FiniteDuration = dilated(config.getMillisDuration("single-expect-default"))
 
-  /** dilated with `TestTimeFactor` */
+  /** Dilated with `TestTimeFactor`. */
   val ExpectNoMessageDefaultTimeout: FiniteDuration = dilated(config.getMillisDuration("expect-no-message-default"))
 
-  /** dilated with `TestTimeFactor` */
+  /** Dilated with `TestTimeFactor`. */
   val DefaultTimeout: Timeout = Timeout(dilated(config.getMillisDuration("default-timeout")))
 
-  /** dilated with `TestTimeFactor` */
+  /** Dilated with `TestTimeFactor`. */
   val DefaultActorSystemShutdownTimeout: FiniteDuration = dilated(config.getMillisDuration("system-shutdown-default"))
 
   val ThrowOnShutdownTimeout: Boolean = config.getBoolean("throw-on-shutdown-timeout")
 
-  /** dilated with `TestTimeFactor` */
+  /** Dilated with `TestTimeFactor`. */
   val FilterLeeway: FiniteDuration = dilated(config.getMillisDuration("filter-leeway"))
 
   /**

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/TestKitSettings.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/TestKitSettings.scala
@@ -5,11 +5,13 @@
 package akka.actor.testkit.typed
 
 import com.typesafe.config.Config
-
 import scala.concurrent.duration.{ Duration, FiniteDuration }
+
 import akka.util.JavaDurationConverters._
 import akka.util.Timeout
 import akka.actor.typed.ActorSystem
+import akka.actor.typed.Extension
+import akka.actor.typed.ExtensionId
 
 object TestKitSettings {
 
@@ -17,7 +19,7 @@ object TestKitSettings {
    * Reads configuration settings from `akka.actor.testkit.typed` section.
    */
   def apply(system: ActorSystem[_]): TestKitSettings =
-    apply(system.settings.config.getConfig("akka.actor.testkit.typed"))
+    Ext(system).settings
 
   /**
    * Reads configuration settings from given `Config` that
@@ -38,13 +40,22 @@ object TestKitSettings {
    */
   def create(config: Config): TestKitSettings =
     new TestKitSettings(config)
+
+  private object Ext extends ExtensionId[Ext] {
+    override def createExtension(system: ActorSystem[_]): Ext = new Ext(system)
+    def get(system: ActorSystem[_]): Ext = apply(system)
+  }
+
+  private class Ext(system: ActorSystem[_]) extends Extension {
+    val settings: TestKitSettings = TestKitSettings(system.settings.config.getConfig("akka.actor.testkit.typed"))
+  }
 }
 
 final class TestKitSettings(val config: Config) {
 
   import akka.util.Helpers._
 
-  val TestTimeFactor = config
+  val TestTimeFactor: Double = config
     .getDouble("timefactor")
     .requiring(tf => !tf.isInfinite && tf > 0, "timefactor must be positive finite double")
 
@@ -61,6 +72,9 @@ final class TestKitSettings(val config: Config) {
   val DefaultActorSystemShutdownTimeout: FiniteDuration = dilated(config.getMillisDuration("system-shutdown-default"))
 
   val ThrowOnShutdownTimeout: Boolean = config.getBoolean("throw-on-shutdown-timeout")
+
+  /** dilated with `TestTimeFactor` */
+  val FilterLeeway: FiniteDuration = dilated(config.getMillisDuration("filter-leeway"))
 
   /**
    * Scala API: Scale the `duration` with the configured `TestTimeFactor`

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/LoggingEventFilterImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/LoggingEventFilterImpl.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.testkit.typed.internal
+
+import scala.concurrent.duration.Duration
+import scala.reflect.ClassTag
+import scala.util.matching.Regex
+
+import akka.actor.testkit.typed.LoggingEvent
+import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
+import akka.actor.typed.ActorSystem
+import akka.annotation.InternalApi
+import akka.testkit.TestKit
+import akka.testkit.TestKitExtension
+import org.slf4j.event.Level
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object LoggingEventFilterImpl {
+  def empty: LoggingEventFilterImpl = new LoggingEventFilterImpl(1, None, None, None, None, None, None)
+}
+
+/**
+ * INTERNAL API
+ *
+ * Facilities for selectively filtering out expected events from logging so
+ * that you can keep your test run’s console output clean and do not miss real
+ * error messages.
+ *
+ * See the companion object for convenient factory methods.
+ *
+ * If the `occurrences` is set to Int.MaxValue, no tracking is done.
+ */
+@InternalApi private[akka] final case class LoggingEventFilterImpl(
+    occurrences: Int,
+    logLevel: Option[Level],
+    source: Option[String],
+    messageContains: Option[String],
+    messageRegex: Option[Regex],
+    cause: Option[Class[Throwable]],
+    custom: Option[PartialFunction[LoggingEvent, Boolean]])
+    extends LoggingEventFilter {
+
+  @volatile // JMM does not guarantee visibility for non-final fields
+  private var todo = occurrences
+
+  /**
+   * This method decides whether to filter the event (<code>true</code>) or not
+   * (<code>false</code>).
+   */
+  def matches(event: LoggingEvent): Boolean = {
+    logLevel.forall(_ == event.level) &&
+    source.forall(_ == sourceOrEmpty(event)) &&
+    messageContains.forall(messageOrEmpty(event).contains) &&
+    messageRegex.forall(_.findFirstIn(messageOrEmpty(event)).isDefined) &&
+    cause.forall(c => event.throwable.isDefined && c.isInstance(event.throwable.get)) &&
+    custom.forall(pf => pf.isDefinedAt(event) && pf(event))
+  }
+
+  private def messageOrEmpty(event: LoggingEvent): String =
+    if (event.message == null) "" else event.message
+
+  private def sourceOrEmpty(event: LoggingEvent): String =
+    event.mdc.getOrElse("akkaSource", "")
+
+  def apply(event: LoggingEvent): Boolean = {
+    if (matches(event)) {
+      if (todo != Int.MaxValue) todo -= 1
+      true
+    } else false
+  }
+
+  def awaitDone(max: Duration): Boolean = {
+    if (todo != Int.MaxValue && todo > 0) TestKit.awaitCond(todo <= 0, max, noThrow = true)
+    todo == Int.MaxValue || todo == 0
+  }
+
+  /**
+   * Assert that this filter has matched as often as requested by its
+   * `occurrences` parameter specifies.
+   */
+  def assertDone(max: Duration): Unit =
+    assert(
+      awaitDone(max),
+      if (todo > 0) s"$todo messages outstanding on $this"
+      else s"received ${-todo} excess messages on $this")
+
+  /**
+   * Apply this filter while executing the given code block. Care is taken to
+   * remove the filter when the block is finished or aborted.
+   */
+  override def intercept[T](code: => T)(implicit system: ActorSystem[_]): T = {
+    interceptLogger("")(code)
+  }
+
+  /**
+   * Apply this filter while executing the given code block. Care is taken to
+   * remove the filter when the block is finished or aborted.
+   */
+  override def interceptLogger[T](loggerName: String)(code: => T)(implicit system: ActorSystem[_]): T = {
+    TestAppender.setupTestAppender(loggerName)
+    TestAppender.addFilter(loggerName, this)
+    // FIXME #26537 other setting for leeway
+    import akka.actor.typed.scaladsl.adapter._
+    val leeway = TestKitExtension(system.toUntyped).TestEventFilterLeeway
+    try {
+      val result = code
+      if (!awaitDone(leeway))
+        if (todo > 0)
+          throw new AssertionError(s"timeout ($leeway) waiting for $todo messages on $this")
+        else
+          throw new AssertionError(s"received ${-todo} excess messages on $this")
+      result
+    } finally {
+      todo = occurrences
+      TestAppender.removeFilter(loggerName, this)
+    }
+  }
+
+  override def withOccurrences(newOccurrences: Int): LoggingEventFilter =
+    copy(occurrences = newOccurrences)
+
+  override def withLogLevel(newLogLevel: Level): LoggingEventFilter =
+    copy(logLevel = Option(newLogLevel))
+
+  override def withSource(newSource: String): LoggingEventFilter =
+    copy(source = Option(newSource))
+
+  override def withMessageContains(newMessageContains: String): LoggingEventFilter =
+    copy(messageContains = Option(newMessageContains))
+
+  def withMessageRegex(newMessageRegex: String): LoggingEventFilter =
+    copy(messageRegex = Option(new Regex(newMessageRegex)))
+
+  override def withCause[A <: Throwable: ClassTag]: LoggingEventFilter = {
+    val causeClass = implicitly[ClassTag[A]].runtimeClass.asInstanceOf[Class[Throwable]]
+    copy(cause = Option(causeClass))
+  }
+
+  override def withCustom(newCustom: PartialFunction[LoggingEvent, Boolean]): LoggingEventFilter =
+    copy(custom = Option(newCustom))
+
+}

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/LoggingEventFilterImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/LoggingEventFilterImpl.scala
@@ -84,9 +84,9 @@ import org.slf4j.event.Level
       val result = code
       if (!awaitDone(leeway))
         if (todo > 0)
-          throw new AssertionError(s"timeout ($leeway) waiting for $todo messages on $this")
+          throw new AssertionError(s"Timeout ($leeway) waiting for $todo messages on $this.")
         else
-          throw new AssertionError(s"received ${-todo} excess messages on $this")
+          throw new AssertionError(s"Received ${-todo} excess messages on $this.")
       result
     } finally {
       todo = occurrences

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestAppender.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestAppender.scala
@@ -5,7 +5,6 @@
 package akka.actor.testkit.typed.internal
 
 import akka.actor.testkit.typed.LoggingEvent
-import akka.actor.testkit.typed.scaladsl.LoggingEventFilter
 import akka.annotation.InternalApi
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.spi.ThrowableProxy
@@ -16,7 +15,7 @@ import org.slf4j.event.Level
 /**
  * INTERNAL API
  *
- * The `TestAppender` emits the logging events to the registered [[LoggingEventFilter]], which
+ * The `TestAppender` emits the logging events to the registered [[LoggingEventFilterImpl]], which
  * are added and removed to the appender dynamically from tests.
  *
  * `TestAppender` is currently requiring Logback as SLF4J implementation.
@@ -45,10 +44,10 @@ import org.slf4j.event.Level
     }
   }
 
-  def addFilter(loggerName: String, filter: LoggingEventFilter): Unit =
+  def addFilter(loggerName: String, filter: LoggingEventFilterImpl): Unit =
     getTestAppender(loggerName).addTestFilter(filter)
 
-  def removeFilter(loggerName: String, filter: LoggingEventFilter): Unit =
+  def removeFilter(loggerName: String, filter: LoggingEventFilterImpl): Unit =
     getTestAppender(loggerName).removeTestFilter(filter)
 
   private def loggerNameOrRoot(loggerName: String): String =
@@ -84,7 +83,7 @@ import org.slf4j.event.Level
  */
 @InternalApi private[akka] class TestAppender extends AppenderBase[ILoggingEvent] {
 
-  private var filters: List[LoggingEventFilter] = Nil
+  private var filters: List[LoggingEventFilterImpl] = Nil
 
   // invocations are synchronized via doAppend in AppenderBase
   override def append(event: ILoggingEvent): Unit = {
@@ -130,13 +129,15 @@ import org.slf4j.event.Level
       })
   }
 
-  def addTestFilter(filter: LoggingEventFilter): Unit = synchronized {
+  def addTestFilter(filter: LoggingEventFilterImpl): Unit = synchronized {
     filters ::= filter
   }
 
-  def removeTestFilter(filter: LoggingEventFilter): Unit = synchronized {
+  def removeTestFilter(filter: LoggingEventFilterImpl): Unit = synchronized {
     @scala.annotation.tailrec
-    def removeFirst(list: List[LoggingEventFilter], zipped: List[LoggingEventFilter] = Nil): List[LoggingEventFilter] =
+    def removeFirst(
+        list: List[LoggingEventFilterImpl],
+        zipped: List[LoggingEventFilterImpl] = Nil): List[LoggingEventFilterImpl] =
       list match {
         case head :: tail if head == filter => tail.reverse_:::(zipped)
         case head :: tail                   => removeFirst(tail, head :: zipped)

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/LoggingEventFilter.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/LoggingEventFilter.scala
@@ -5,7 +5,6 @@
 package akka.actor.testkit.typed.javadsl
 
 import java.util.function.Supplier
-import java.util.function.{ Function => JFunction }
 
 import akka.actor.testkit.typed.LoggingEvent
 import akka.actor.testkit.typed.internal.LoggingEventFilterImpl
@@ -58,9 +57,16 @@ import org.slf4j.event.Level
   def withCause(newCause: Class[_ <: Throwable]): LoggingEventFilter
 
   /**
+   * Matching events with MDC containing all entries of the given `Map`.
+   * The event MDC may have more entries than the given `Map`.
+   */
+  def withMdc(newMdc: java.util.Map[String, String]): LoggingEventFilter
+
+  /**
    * Matching events for which the supplied function returns `true`.
    */
-  def withCustom(newCustom: JFunction[LoggingEvent, Boolean]): LoggingEventFilter
+  def withCustom(newCustom: Function[LoggingEvent, Boolean]): LoggingEventFilter
+  // this is a Scala Function, ^ but that can be used with lambda from Java
 
   /**
    * @return `true` if the event matches the conditions of the filter.
@@ -172,8 +178,8 @@ object LoggingEventFilter {
    * Create a custom event filter. The filter will match those events for
    * which for which the supplied function returns `true`.
    */
-  def custom(test: JFunction[LoggingEvent, Boolean]): LoggingEventFilter =
-    empty.withCustom(test)
+  def custom(test: Function[LoggingEvent, Boolean]): LoggingEventFilter =
+    empty.withCustom(test) // this is a Scala Function, but that can be used with lambda from Java
 
   /**
    * Filter for the logging of dead letters.

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/LoggingEventFilter.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/LoggingEventFilter.scala
@@ -18,7 +18,7 @@ import org.slf4j.event.Level
  *
  * Requires Logback.
  *
- * See the companion object for convenient factory methods.
+ * See the static factory methods as starting point for creating `LoggingEventFilter`.
  *
  * Not for user extension.
  */

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/LoggingEventFilter.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/LoggingEventFilter.scala
@@ -35,6 +35,13 @@ import org.slf4j.event.Level
   def withLogLevel(newLogLevel: Level): LoggingEventFilter
 
   /**
+   * Matching events with the given logger name or sub-names in the same way
+   * as configuration loggers are configured in logback.xml.
+   * By default the root logger is used.
+   */
+  def withLoggerName(newLoggerName: String): LoggingEventFilter
+
+  /**
    * Matching events that have "akkaSource" MDC value equal to the given value.
    * "akkaSource" is typically the actor path.
    */
@@ -74,16 +81,14 @@ import org.slf4j.event.Level
   def matches(event: LoggingEvent): Boolean
 
   /**
-   * Apply this filter while executing the given code block. Care is taken to
-   * remove the filter when the block is finished or aborted.
+   * Apply this filter while executing the given code block.
+   * Assert that this filter has matched within the configured `akka.actor.testkit.typed.filter-leeway`
+   * as often as requested by its `occurrences` parameter specifies.
+   *
+   * Care is taken to remove the filter when the block is finished or aborted.
    */
   def intercept[T](system: ActorSystem[_], code: Supplier[T]): T
 
-  /**
-   * Apply this filter while executing the given code block. Care is taken to
-   * remove the filter when the block is finished or aborted.
-   */
-  def interceptLogger[T](system: ActorSystem[_], loggerName: String, code: Supplier[T]): T
 }
 
 /**

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilter.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilter.scala
@@ -1,21 +1,16 @@
 /*
- * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.actor.testkit.typed.scaladsl
 
-import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
-import scala.util.matching.Regex
 
 import akka.actor.testkit.typed.LoggingEvent
-import akka.actor.testkit.typed.internal.TestAppender
+import akka.actor.testkit.typed.internal.LoggingEventFilterImpl
 import akka.actor.typed.ActorSystem
-import akka.testkit.TestKit
-import akka.testkit.TestKitExtension
+import akka.annotation.DoNotInherit
 import org.slf4j.event.Level
-
-// FIXME #26537 this is a close copy of classic EventFilter so far. Design a better scaladsl and javadsl API.
 
 /**
  * Facilities for selectively filtering out expected events from logging so
@@ -25,449 +20,79 @@ import org.slf4j.event.Level
  * See the companion object for convenient factory methods.
  *
  * If the `occurrences` is set to Int.MaxValue, no tracking is done.
+ *
+ * Not for user extension.
  */
-abstract class LoggingEventFilter(occurrences: Int) {
+@DoNotInherit trait LoggingEventFilter {
 
-  @volatile // JMM does not guarantee visibility for non-final fields
-  private var todo = occurrences
+  def withOccurrences(newOccurrences: Int): LoggingEventFilter
 
-  /**
-   * This method decides whether to filter the event (<code>true</code>) or not
-   * (<code>false</code>).
-   */
-  protected def matches(event: LoggingEvent): Boolean
+  def withLogLevel(newLogLevel: Level): LoggingEventFilter
 
-  final def apply(event: LoggingEvent): Boolean = {
-    if (matches(event)) {
-      if (todo != Int.MaxValue) todo -= 1
-      true
-    } else false
-  }
+  def withSource(newSource: String): LoggingEventFilter
 
-  def awaitDone(max: Duration): Boolean = {
-    if (todo != Int.MaxValue && todo > 0) TestKit.awaitCond(todo <= 0, max, noThrow = true)
-    todo == Int.MaxValue || todo == 0
-  }
+  def withMessageContains(newMessageContains: String): LoggingEventFilter
 
-  /**
-   * Assert that this filter has matched as often as requested by its
-   * `occurrences` parameter specifies.
-   */
-  def assertDone(max: Duration): Unit =
-    assert(
-      awaitDone(max),
-      if (todo > 0) s"$todo messages outstanding on $this"
-      else s"received ${-todo} excess messages on $this")
+  def withMessageRegex(newMessageRegex: String): LoggingEventFilter
+
+  def withCause[A <: Throwable: ClassTag]: LoggingEventFilter
+
+  def withCustom(newCustom: PartialFunction[LoggingEvent, Boolean]): LoggingEventFilter
+
+  def matches(event: LoggingEvent): Boolean
 
   /**
    * Apply this filter while executing the given code block. Care is taken to
    * remove the filter when the block is finished or aborted.
    */
-  def intercept[T](code: => T)(implicit system: ActorSystem[_]): T = {
-    interceptLogger("")(code)
-  }
+  def intercept[T](code: => T)(implicit system: ActorSystem[_]): T
 
   /**
    * Apply this filter while executing the given code block. Care is taken to
    * remove the filter when the block is finished or aborted.
    */
-  def interceptLogger[T](loggerName: String)(code: => T)(implicit system: ActorSystem[_]): T = {
-    TestAppender.setupTestAppender(loggerName)
-    TestAppender.addFilter(loggerName, this)
-    // FIXME #26537 other setting for leeway
-    import akka.actor.typed.scaladsl.adapter._
-    val leeway = TestKitExtension(system.toUntyped).TestEventFilterLeeway
-    try {
-      val result = code
-      if (!awaitDone(leeway))
-        if (todo > 0)
-          throw new AssertionError(s"timeout ($leeway) waiting for $todo messages on $this")
-        else
-          throw new AssertionError(s"received ${-todo} excess messages on $this")
-      result
-    } finally {
-      TestAppender.removeFilter(loggerName, this)
-    }
-  }
-
-  /*
-   * these default values are just there for easier subclassing
-   */
-  protected val source: Option[String] = None
-  protected val message: Either[String, Regex] = Left("")
-  protected val complete: Boolean = false
-
-  /**
-   * internal implementation helper, no guaranteed API
-   */
-  protected def doMatch(src: String, msg: Any) = {
-    val msgstr = if (msg != null) msg.toString else "null"
-    (source.isDefined && source.get == src || source.isEmpty) &&
-    (message match {
-      case Left(s)  => if (complete) msgstr == s else msgstr.startsWith(s)
-      case Right(p) => p.findFirstIn(msgstr).isDefined
-    })
-  }
-
+  def interceptLogger[T](loggerName: String)(code: => T)(implicit system: ActorSystem[_]): T
 }
 
 /**
- * Facilities for selectively filtering out expected events from logging so
- * that you can keep your test run’s console output clean and do not miss real
- * error messages.
- *
- * '''Also have a look at the `akka.testkit` package object’s `filterEvents` and
- * `filterException` methods.'''
- *
- * The source filters do accept `Class[_]` arguments, matching any
- * object which is an instance of the given class, e.g.
- *
- * {{{
- * LoggingEventFilter.info(source = classOf[MyActor]) // will match Info events from any MyActor instance
- * }}}
- *
- * The message object will be converted to a string before matching (`"null"` if it is `null`).
+ * Facilities for selectively matching expected events from logging.
  */
 object LoggingEventFilter {
 
-  /**
-   * Create a filter for Error events. Give up to one of <code>start</code> and <code>pattern</code>:
-   *
-   * {{{
-   * LoggingEventFilter[MyException]()                                         // filter only on exception type
-   * LoggingEventFilter[MyException]("message")                                // filter on exactly matching message
-   * LoggingEventFilter[MyException](source = obj)                             // filter on event source
-   * LoggingEventFilter[MyException](start = "Expected")                       // filter on start of message
-   * LoggingEventFilter[MyException](source = obj, pattern = "weird.*message") // filter on pattern and message
-   * }}}
-   *
-   * ''Please note that filtering on the `source` being
-   * `null` does NOT work (passing `null` disables the
-   * source filter).''
-   */
-  def apply[A <: Throwable: ClassTag](
-      message: String = null,
-      source: String = null,
-      start: String = "",
-      pattern: String = null,
-      occurrences: Int = Int.MaxValue): LoggingEventFilter =
-    ErrorFilter(
-      Some(implicitly[ClassTag[A]].runtimeClass),
-      Option(source),
-      if (message ne null) Left(message) else Option(pattern).map(new Regex(_)).toRight(start),
-      message ne null)(occurrences)
+  def empty: LoggingEventFilter = LoggingEventFilterImpl.empty
 
-  /**
-   * Create a filter for Error events. See apply() for more details.
-   */
-  def error(
-      message: String = null,
-      source: String = null,
-      start: String = "",
-      pattern: String = null,
-      occurrences: Int = Int.MaxValue): LoggingEventFilter =
-    ErrorFilter(
-      None,
-      Option(source),
-      if (message ne null) Left(message) else Option(pattern).map(new Regex(_)).toRight(start),
-      message ne null)(occurrences)
+  def messageContains(str: String): LoggingEventFilter =
+    empty.withMessageContains(str)
 
-  /**
-   * Create a filter for Warning events. Give up to one of <code>start</code> and <code>pattern</code>:
-   *
-   * {{{
-   * LoggingEventFilter.warning()                                         // filter only on warning event
-   * LoggingEventFilter.warning(source = obj)                             // filter on event source
-   * LoggingEventFilter.warning(start = "Expected")                       // filter on start of message
-   * LoggingEventFilter.warning(source = obj, pattern = "weird.*message") // filter on pattern and message
-   * }}}
-   *
-   * ''Please note that filtering on the `source` being
-   * `null` does NOT work (passing `null` disables the
-   * source filter).''
-   */
-  def warning(
-      message: String = null,
-      source: String = null,
-      start: String = "",
-      pattern: String = null,
-      occurrences: Int = Int.MaxValue): LoggingEventFilter =
-    WarningFilter(
-      Option(source),
-      if (message ne null) Left(message) else Option(pattern).map(new Regex(_)).toRight(start),
-      message ne null)(occurrences)
+  def trace(messageIncludes: String): LoggingEventFilter =
+    messageContains(messageIncludes).withLogLevel(Level.TRACE)
 
-  /**
-   * Create a filter for Info events. Give up to one of <code>start</code> and <code>pattern</code>:
-   *
-   * {{{
-   * LoggingEventFilter.info()                                         // filter only on info event
-   * LoggingEventFilter.info(source = obj)                             // filter on event source
-   * LoggingEventFilter.info(start = "Expected")                       // filter on start of message
-   * LoggingEventFilter.info(source = obj, pattern = "weird.*message") // filter on pattern and message
-   * }}}
-   *
-   * ''Please note that filtering on the `source` being
-   * `null` does NOT work (passing `null` disables the
-   * source filter).''
-   */
-  def info(
-      message: String = null,
-      source: String = null,
-      start: String = "",
-      pattern: String = null,
-      occurrences: Int = Int.MaxValue): LoggingEventFilter =
-    InfoFilter(
-      Option(source),
-      if (message ne null) Left(message) else Option(pattern).map(new Regex(_)).toRight(start),
-      message ne null)(occurrences)
+  def debug(messageIncludes: String): LoggingEventFilter =
+    messageContains(messageIncludes).withLogLevel(Level.DEBUG)
 
-  /**
-   * Create a filter for Debug events. Give up to one of <code>start</code> and <code>pattern</code>:
-   *
-   * {{{
-   * LoggingEventFilter.debug()                                         // filter only on debug type
-   * LoggingEventFilter.debug(source = obj)                             // filter on event source
-   * LoggingEventFilter.debug(start = "Expected")                       // filter on start of message
-   * LoggingEventFilter.debug(source = obj, pattern = "weird.*message") // filter on pattern and message
-   * }}}
-   *
-   * ''Please note that filtering on the `source` being
-   * `null` does NOT work (passing `null` disables the
-   * source filter).''
-   */
-  def debug(
-      message: String = null,
-      source: String = null,
-      start: String = "",
-      pattern: String = null,
-      occurrences: Int = Int.MaxValue): LoggingEventFilter =
-    DebugFilter(
-      Option(source),
-      if (message ne null) Left(message) else Option(pattern).map(new Regex(_)).toRight(start),
-      message ne null)(occurrences)
+  def info(messageIncludes: String): LoggingEventFilter =
+    messageContains(messageIncludes).withLogLevel(Level.INFO)
+
+  def warn(messageIncludes: String): LoggingEventFilter =
+    messageContains(messageIncludes).withLogLevel(Level.WARN)
+
+  def warn[A <: Throwable: ClassTag]: LoggingEventFilter =
+    empty.withLogLevel(Level.WARN).withCause[A]
+
+  def error(messageIncludes: String): LoggingEventFilter =
+    messageContains(messageIncludes).withLogLevel(Level.ERROR)
+
+  def error[A <: Throwable: ClassTag]: LoggingEventFilter =
+    empty.withLogLevel(Level.ERROR).withCause[A]
 
   /**
    * Create a custom event filter. The filter will affect those events for
    * which the supplied partial function is defined and returns
    * `true`.
-   *
-   * {{{
-   * LoggingEventFilter.custom {
-   *   case Warning(ref, "my warning") if ref == actor || ref == null => true
-   * }
-   * }}}
    */
-  def custom(test: PartialFunction[LoggingEvent, Boolean], occurrences: Int = Int.MaxValue): LoggingEventFilter =
-    CustomEventFilter(test)(occurrences)
+  def custom(test: PartialFunction[LoggingEvent, Boolean]): LoggingEventFilter =
+    empty.withCustom(test)
 
-  def deadLetters(occurrences: Int = Int.MaxValue): LoggingEventFilter =
-    info(pattern = ".*was not delivered.*dead letters encountered.*", occurrences = occurrences)
-}
-
-/**
- * Filter which matches Error events, if they satisfy the given criteria:
- * <ul>
- * <li><code>throwable</code> applies an upper bound on the type of exception contained in the Error event</li>
- * <li><code>source</code>, if given, applies a filter on the event’s origin</li>
- * <li><code>message</code> applies a filter on the event’s message (either
- *   with String.startsWith or Regex.findFirstIn().isDefined); if the message
- *   itself does not match, the match is retried with the contained Exception’s
- *   message; if both are <code>null</code>, the filter always matches if at
- *   the same time the Exception’s stack trace is empty (this catches
- *   JVM-omitted “fast-throw” exceptions)</li>
- * </ul>
- * If you want to match all Error events, the most efficient is to use <code>Left("")</code>.
- */
-final case class ErrorFilter(
-    throwable: Option[Class[_]],
-    override val source: Option[String],
-    override val message: Either[String, Regex],
-    override val complete: Boolean)(occurrences: Int)
-    extends LoggingEventFilter(occurrences) {
-
-  def matches(event: LoggingEvent) = {
-    event.level == Level.ERROR &&
-    (throwable.isEmpty || throwable.get.isInstance(event.throwable.orNull)) &&
-    ((event.message == null && event.throwable
-      .map(_.getMessage)
-      .isEmpty && event.throwable.map(_.getStackTrace.length).getOrElse(0) == 0) ||
-    doMatch(event.mdc.getOrElse("akkaSource", ""), event.message) || (event.throwable.nonEmpty && doMatch(
-      event.mdc.getOrElse("akkaSource", ""),
-      event.throwable.get.getMessage)))
-  }
-
-  /**
-   * Java API: create an ErrorFilter
-   *
-   * @param source
-   *   apply this filter only to events from the given source; do not filter on source if this is given as <code>null</code>
-   * @param message
-   *   apply this filter only to events whose message matches; do not filter on message if this is given as <code>null</code>
-   * @param pattern
-   *   if <code>false</code>, the message string must start with the given
-   *   string, otherwise the <code>message</code> argument is treated as
-   *   regular expression which is matched against the message (may match only
-   *   a substring to filter)
-   * @param complete
-   *   whether the event’s message must match the given message string or pattern completely
-   */
-  def this(
-      throwable: Class[_],
-      source: String,
-      message: String,
-      pattern: Boolean,
-      complete: Boolean,
-      occurrences: Int) =
-    this(
-      Option(throwable),
-      Option(source),
-      if (message eq null) Left("")
-      else if (pattern) Right(new Regex(message))
-      else Left(message),
-      complete)(occurrences)
-
-  /**
-   * Java API: filter only on the given type of exception
-   */
-  def this(throwable: Class[_]) = this(throwable, null, null, false, false, Int.MaxValue)
-
-}
-
-/**
- * Filter which matches Warning events, if they satisfy the given criteria:
- * <ul>
- * <li><code>source</code>, if given, applies a filter on the event’s origin</li>
- * <li><code>message</code> applies a filter on the event’s message (either with String.startsWith or Regex.findFirstIn().isDefined)</li>
- * </ul>
- * If you want to match all Warning events, the most efficient is to use <code>Left("")</code>.
- */
-final case class WarningFilter(
-    override val source: Option[String],
-    override val message: Either[String, Regex],
-    override val complete: Boolean)(occurrences: Int)
-    extends LoggingEventFilter(occurrences) {
-
-  def matches(event: LoggingEvent) = {
-    event.level == Level.WARN && doMatch(event.mdc.getOrElse("akkaSource", ""), event.message)
-  }
-
-  /**
-   * Java API: create a WarningFilter
-   *
-   * @param source
-   *   apply this filter only to events from the given source; do not filter on source if this is given as <code>null</code>
-   * @param message
-   *   apply this filter only to events whose message matches; do not filter on message if this is given as <code>null</code>
-   * @param pattern
-   *   if <code>false</code>, the message string must start with the given
-   *   string, otherwise the <code>message</code> argument is treated as
-   *   regular expression which is matched against the message (may match only
-   *   a substring to filter)
-   * @param complete
-   *   whether the event’s message must match the given message string or pattern completely
-   */
-  def this(source: String, message: String, pattern: Boolean, complete: Boolean, occurrences: Int) =
-    this(
-      Option(source),
-      if (message eq null) Left("")
-      else if (pattern) Right(new Regex(message))
-      else Left(message),
-      complete)(occurrences)
-}
-
-/**
- * Filter which matches Info events, if they satisfy the given criteria:
- * <ul>
- * <li><code>source</code>, if given, applies a filter on the event’s origin</li>
- * <li><code>message</code> applies a filter on the event’s message (either with String.startsWith or Regex.findFirstIn().isDefined)</li>
- * </ul>
- * If you want to match all Info events, the most efficient is to use <code>Left("")</code>.
- */
-final case class InfoFilter(
-    override val source: Option[String],
-    override val message: Either[String, Regex],
-    override val complete: Boolean)(occurrences: Int)
-    extends LoggingEventFilter(occurrences) {
-
-  def matches(event: LoggingEvent) = {
-    event.level == Level.INFO && doMatch(event.mdc.getOrElse("akkaSource", ""), event.message)
-  }
-
-  /**
-   * Java API: create an InfoFilter
-   *
-   * @param source
-   *   apply this filter only to events from the given source; do not filter on source if this is given as <code>null</code>
-   * @param message
-   *   apply this filter only to events whose message matches; do not filter on message if this is given as <code>null</code>
-   * @param pattern
-   *   if <code>false</code>, the message string must start with the given
-   *   string, otherwise the <code>message</code> argument is treated as
-   *   regular expression which is matched against the message (may match only
-   *   a substring to filter)
-   * @param complete
-   *   whether the event’s message must match the given message string or pattern completely
-   */
-  def this(source: String, message: String, pattern: Boolean, complete: Boolean, occurrences: Int) =
-    this(
-      Option(source),
-      if (message eq null) Left("")
-      else if (pattern) Right(new Regex(message))
-      else Left(message),
-      complete)(occurrences)
-}
-
-/**
- * Filter which matches Debug events, if they satisfy the given criteria:
- * <ul>
- * <li><code>source</code>, if given, applies a filter on the event’s origin</li>
- * <li><code>message</code> applies a filter on the event’s message (either with String.startsWith or Regex.findFirstIn().isDefined)</li>
- * </ul>
- * If you want to match all Debug events, the most efficient is to use <code>Left("")</code>.
- */
-final case class DebugFilter(
-    override val source: Option[String],
-    override val message: Either[String, Regex],
-    override val complete: Boolean)(occurrences: Int)
-    extends LoggingEventFilter(occurrences) {
-
-  def matches(event: LoggingEvent) = {
-    event.level == Level.DEBUG && doMatch(event.mdc.getOrElse("akkaSource", ""), event.message)
-  }
-
-  /**
-   * Java API: create a DebugFilter
-   *
-   * @param source
-   *   apply this filter only to events from the given source; do not filter on source if this is given as <code>null</code>
-   * @param message
-   *   apply this filter only to events whose message matches; do not filter on message if this is given as <code>null</code>
-   * @param pattern
-   *   if <code>false</code>, the message string must start with the given
-   *   string, otherwise the <code>message</code> argument is treated as
-   *   regular expression which is matched against the message (may match only
-   *   a substring to filter)
-   * @param complete
-   *   whether the event’s message must match the given message string or pattern completely
-   */
-  def this(source: String, message: String, pattern: Boolean, complete: Boolean, occurrences: Int) =
-    this(
-      Option(source),
-      if (message eq null) Left("")
-      else if (pattern) Right(new Regex(message))
-      else Left(message),
-      complete)(occurrences)
-}
-
-/**
- * Custom event filter when the others do not fit the bill.
- *
- * If the partial function is defined and returns true, filter the event.
- */
-final case class CustomEventFilter(test: PartialFunction[LoggingEvent, Boolean])(occurrences: Int)
-    extends LoggingEventFilter(occurrences) {
-  def matches(event: LoggingEvent) = {
-    test.isDefinedAt(event) && test(event)
-  }
+  def deadLetters(): LoggingEventFilter =
+    empty.withLogLevel(Level.INFO).withMessageRegex(".*was not delivered.*dead letters encountered.*")
 }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilter.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilter.scala
@@ -57,10 +57,15 @@ import org.slf4j.event.Level
   def withCause[A <: Throwable: ClassTag]: LoggingEventFilter
 
   /**
-   * Matching eventsfor which the supplied partial function is defined and returns
-   * `true`.
+   * Matching events with MDC containing all entries of the given `Map`.
+   * The event MDC may have more entries than the given `Map`.
    */
-  def withCustom(newCustom: PartialFunction[LoggingEvent, Boolean]): LoggingEventFilter
+  def withMdc(newMdc: Map[String, String]): LoggingEventFilter
+
+  /**
+   * Matching events for which the supplied function returns`true`.
+   */
+  def withCustom(newCustom: Function[LoggingEvent, Boolean]): LoggingEventFilter
 
   /**
    * @return `true` if the event matches the conditions of the filter.
@@ -170,10 +175,9 @@ object LoggingEventFilter {
 
   /**
    * Create a custom event filter. The filter will match those events for
-   * which the supplied partial function is defined and returns
-   * `true`.
+   * which the supplied function returns `true`.
    */
-  def custom(test: PartialFunction[LoggingEvent, Boolean]): LoggingEventFilter =
+  def custom(test: Function[LoggingEvent, Boolean]): LoggingEventFilter =
     empty.withCustom(test)
 
   /**

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilter.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilter.scala
@@ -35,6 +35,13 @@ import org.slf4j.event.Level
   def withLogLevel(newLogLevel: Level): LoggingEventFilter
 
   /**
+   * Matching events with the given logger name or sub-names in the same way
+   * as configuration loggers are configured in logback.xml.
+   * By default the root logger is used.
+   */
+  def withLoggerName(newLoggerName: String): LoggingEventFilter
+
+  /**
    * Matching events that have "akkaSource" MDC value equal to the given value.
    * "akkaSource" is typically the actor path.
    */
@@ -73,16 +80,14 @@ import org.slf4j.event.Level
   def matches(event: LoggingEvent): Boolean
 
   /**
-   * Apply this filter while executing the given code block. Care is taken to
-   * remove the filter when the block is finished or aborted.
+   * Apply this filter while executing the given code block.
+   * Assert that this filter has matched as often as requested by its
+   * `occurrences` parameter specifies.
+   *
+   * Care is taken to remove the filter when the block is finished or aborted.
    */
   def intercept[T](code: => T)(implicit system: ActorSystem[_]): T
 
-  /**
-   * Apply this filter while executing the given code block. Care is taken to
-   * remove the filter when the block is finished or aborted.
-   */
-  def interceptLogger[T](loggerName: String)(code: => T)(implicit system: ActorSystem[_]): T
 }
 
 /**

--- a/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/LoggingEventFilterTest.java
+++ b/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/LoggingEventFilterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.testkit.typed.javadsl;
+
+import akka.actor.testkit.typed.LoggingEvent;
+import akka.actor.testkit.typed.TestException;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
+import org.slf4j.event.Level;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class LoggingEventFilterTest extends JUnitSuite {
+
+  @ClassRule public static TestKitJunitResource testKit = new TestKitJunitResource();
+
+  private LoggingEvent errorNoCause() {
+    return LoggingEvent.create(
+        Level.ERROR,
+        getClass().getName(),
+        Thread.currentThread().getName(),
+        "this is an error",
+        System.currentTimeMillis(),
+        Optional.empty(),
+        Optional.empty(),
+        Collections.emptyMap());
+  }
+
+  private LoggingEvent errorWithCause(Throwable cause) {
+    return LoggingEvent.create(
+        Level.ERROR,
+        getClass().getName(),
+        Thread.currentThread().getName(),
+        "this is an error",
+        System.currentTimeMillis(),
+        Optional.empty(),
+        Optional.of(cause),
+        Collections.emptyMap());
+  }
+
+  @Test
+  public void filterErrorsWithMatchingMessage() {
+    assertTrue(
+        LoggingEventFilter.error("an error").matches(errorWithCause(new TestException("exc"))));
+    assertTrue(LoggingEventFilter.error("an error").matches(errorNoCause()));
+    assertFalse(LoggingEventFilter.error("another error").matches(errorNoCause()));
+  }
+
+  @Test
+  public void filterErrorsWithMatchingCause() {
+    assertTrue(
+        LoggingEventFilter.error(TestException.class)
+            .matches(errorWithCause(new TestException("exc"))));
+    assertFalse(
+        LoggingEventFilter.error(TestException.class)
+            .matches(errorWithCause(new RuntimeException("exc"))));
+    assertTrue(
+        LoggingEventFilter.error("an error")
+            .withCause(TestException.class)
+            .matches(errorWithCause(new TestException("exc"))));
+    assertFalse(
+        LoggingEventFilter.error("another error")
+            .withCause(TestException.class)
+            .matches(errorWithCause(new TestException("exc"))));
+  }
+
+  @Test
+  public void filterErrorsWithMatchingCustomFunction() {
+    assertTrue(LoggingEventFilter.custom(event -> true).matches(errorNoCause()));
+    assertFalse(
+        LoggingEventFilter.custom(event -> event.getMdc().containsKey("aKey"))
+            .matches(errorNoCause()));
+  }
+}

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilterSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilterSpec.scala
@@ -72,6 +72,21 @@ class LoggingEventFilterSpec extends ScalaTestWithActorTestKit with WordSpecLike
       LoggingEventFilter.error("an error").matches(errorNoCause) should ===(true)
       LoggingEventFilter.error("another error").matches(errorNoCause) should ===(false)
     }
+
+    "filter with matching MDC" in {
+      LoggingEventFilter.empty.withMdc(Map("a" -> "A")).matches(errorNoCause.copy(mdc = Map("a" -> "A"))) should ===(
+        true)
+      LoggingEventFilter.empty
+        .withMdc(Map("a" -> "A", "b" -> "B"))
+        .matches(errorNoCause.copy(mdc = Map("a" -> "A", "b" -> "B"))) should ===(true)
+      LoggingEventFilter.empty
+        .withMdc(Map("a" -> "A"))
+        .matches(errorNoCause.copy(mdc = Map("a" -> "A", "b" -> "B"))) should ===(true)
+      LoggingEventFilter.empty
+        .withMdc(Map("a" -> "A", "b" -> "B"))
+        .matches(errorNoCause.copy(mdc = Map("a" -> "A"))) should ===(false)
+      LoggingEventFilter.empty.withMdc(Map("a" -> "A", "b" -> "B")).matches(errorNoCause) should ===(false)
+    }
   }
 
   "The LoggingEventFilter with cause" must {

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilterSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilterSpec.scala
@@ -58,62 +58,67 @@ class LoggingEventFilterSpec extends ScalaTestWithActorTestKit with WordSpecLike
 
   "The LoggingEventFilter.error" must {
     "filter errors without cause" in {
-      val filter = LoggingEventFilter.error()
-      filter(errorNoCause) should ===(true)
+      val filter = LoggingEventFilter.empty.withLogLevel(Level.ERROR)
+      filter.matches(errorNoCause) should ===(true)
     }
 
     "filter errors with cause" in {
-      val filter = LoggingEventFilter.error()
-      filter(errorWithCause(new AnError)) should ===(true)
+      val filter = LoggingEventFilter.empty.withLogLevel(Level.ERROR)
+      filter.matches(errorWithCause(new AnError)) should ===(true)
     }
 
     "filter error with matching message" in {
-      LoggingEventFilter.error(message = "this is an error").apply(errorWithCause(new AnError)) should ===(true)
-      LoggingEventFilter.error(message = "this is an error").apply(errorNoCause) should ===(true)
-      LoggingEventFilter.error(message = "this is another error").apply(errorNoCause) should ===(false)
+      LoggingEventFilter.error("an error").matches(errorWithCause(new AnError)) should ===(true)
+      LoggingEventFilter.error("an error").matches(errorNoCause) should ===(true)
+      LoggingEventFilter.error("another error").matches(errorNoCause) should ===(false)
     }
   }
 
-  "The LoggingEventFilter[Exc]" must {
+  "The LoggingEventFilter with cause" must {
     "not filter errors without cause" in {
-      val filter = LoggingEventFilter[AnError]()
-      filter(errorNoCause) should ===(false)
+      val filter = LoggingEventFilter.error[AnError]
+      filter.matches(errorNoCause) should ===(false)
     }
 
     "not filter errors with an unrelated cause" in {
       object AnotherError extends Exception
-      val filter = LoggingEventFilter[AnError]()
-      filter(errorWithCause(AnotherError)) should ===(false)
+      val filter = LoggingEventFilter.error[AnError]
+      filter.matches(errorWithCause(AnotherError)) should ===(false)
     }
 
     "filter errors with a matching cause" in {
-      val filter = LoggingEventFilter[AnError]()
-      filter(errorWithCause(new AnError)) should ===(true)
+      val filter = LoggingEventFilter.error[AnError]
+      filter.matches(errorWithCause(new AnError)) should ===(true)
     }
     "filter errors with a matching cause and message" in {
-      val filter = LoggingEventFilter[AnError](message = "this is an error")
-      filter(errorWithCause(new AnError)) should ===(true)
+      val filter = LoggingEventFilter.error("this is an error").withCause[AnError]
+      filter.matches(errorWithCause(new AnError)) should ===(true)
     }
   }
 
-  "The LoggingEventFilter.warning" must {
+  "The LoggingEventFilter.warn" must {
     "filter warnings without cause" in {
-      val filter = LoggingEventFilter.warning()
-      filter(warningNoCause) should ===(true)
+      val filter = LoggingEventFilter.empty.withLogLevel(Level.WARN)
+      filter.matches(warningNoCause) should ===(true)
     }
     "filter warning with cause" in {
-      val filter = LoggingEventFilter.warning()
-      filter(warningWithCause(new AnError)) should ===(true)
+      val filter = LoggingEventFilter.empty.withLogLevel(Level.WARN)
+      filter.matches(warningWithCause(new AnError)) should ===(true)
     }
     "filter warning with matching message" in {
-      LoggingEventFilter.warning(message = "this is a warning").apply(warningWithCause(new AnError)) should ===(true)
-      LoggingEventFilter.warning(message = "this is another warning").apply(warningWithCause(new AnError)) should ===(
-        false)
+      LoggingEventFilter.warn("this is a warning").matches(warningWithCause(new AnError)) should ===(true)
+      LoggingEventFilter.warn("this is another warning").matches(warningWithCause(new AnError)) should ===(false)
     }
     "filter warning with matching source" in {
       val source = "akka://Sys/user/foo"
-      LoggingEventFilter.warning(source = source).apply(warningWithSource(source)) should ===(true)
-      LoggingEventFilter.warning(source = "akka://Sys/user/bar").apply(warningWithSource(source)) should ===(false)
+      LoggingEventFilter.empty
+        .withLogLevel(Level.WARN)
+        .withSource(source)
+        .matches(warningWithSource(source)) should ===(true)
+      LoggingEventFilter.empty
+        .withLogLevel(Level.WARN)
+        .withSource("akka://Sys/user/bar")
+        .matches(warningWithSource(source)) should ===(false)
     }
 
   }

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestAppenderSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestAppenderSpec.scala
@@ -39,7 +39,7 @@ class TestAppenderSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       }
     }
 
-    "only filter events for logger given in interceptLogger" in {
+    "only filter events for given logger name" in {
       val count = new AtomicInteger
       LoggingEventFilter
         .custom({
@@ -48,7 +48,8 @@ class TestAppenderSpec extends ScalaTestWithActorTestKit with WordSpecLike {
             logEvent.message == "Hello from right logger" && logEvent.loggerName == classOf[AnotherLoggerClass].getName
         })
         .withOccurrences(2)
-        .interceptLogger(classOf[AnotherLoggerClass].getName) {
+        .withLoggerName(classOf[AnotherLoggerClass].getName)
+        .intercept {
           LoggerFactory.getLogger(classOf[AnotherLoggerClass]).info("Hello from right logger")
           log.info("Hello wrong logger")
           LoggerFactory.getLogger(classOf[AnotherLoggerClass]).info("Hello from right logger")

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestAppenderSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestAppenderSpec.scala
@@ -18,20 +18,20 @@ class TestAppenderSpec extends ScalaTestWithActorTestKit with WordSpecLike {
 
   "TestAppender and LoggingEventFilter" must {
     "filter errors without cause" in {
-      LoggingEventFilter.error(message = "an error", occurrences = 2).intercept {
+      LoggingEventFilter.error("an error").withOccurrences(2).intercept {
         log.error("an error")
         log.error("an error")
       }
     }
 
     "filter errors with cause" in {
-      LoggingEventFilter[TestException](message = "err", occurrences = 1).intercept {
+      LoggingEventFilter.error("err").withCause[TestException].intercept {
         log.error("err", TestException("an error"))
       }
     }
 
     "filter warnings" in {
-      LoggingEventFilter.warning(message = "a warning", occurrences = 2).intercept {
+      LoggingEventFilter.warn("a warning").withOccurrences(2).intercept {
         log.error("an error")
         log.warn("a warning")
         log.error("an error")
@@ -42,13 +42,12 @@ class TestAppenderSpec extends ScalaTestWithActorTestKit with WordSpecLike {
     "only filter events for logger given in interceptLogger" in {
       val count = new AtomicInteger
       LoggingEventFilter
-        .custom(
-          {
-            case logEvent =>
-              count.incrementAndGet()
-              logEvent.message == "Hello from right logger" && logEvent.loggerName == classOf[AnotherLoggerClass].getName
-          },
-          occurrences = 2)
+        .custom({
+          case logEvent =>
+            count.incrementAndGet()
+            logEvent.message == "Hello from right logger" && logEvent.loggerName == classOf[AnotherLoggerClass].getName
+        })
+        .withOccurrences(2)
         .interceptLogger(classOf[AnotherLoggerClass].getName) {
           LoggerFactory.getLogger(classOf[AnotherLoggerClass]).info("Hello from right logger")
           log.info("Hello wrong logger")

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestAppenderSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestAppenderSpec.scala
@@ -69,14 +69,14 @@ class TestAppenderSpec extends ScalaTestWithActorTestKit with WordSpecLike {
           log.warn("a warning")
           log.warn("another warning")
         }
-      }.getMessage should include("received 1 excess messages")
+      }.getMessage should include("Received 1 excess messages")
 
       intercept[AssertionError] {
         LoggingEventFilter.warn("a warning").withOccurrences(0).intercept {
           log.warn("a warning")
           log.warn("a warning")
         }
-      }.getMessage should include("received 2 excess messages")
+      }.getMessage should include("Received 2 excess messages")
     }
 
   }

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestAppenderSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/TestAppenderSpec.scala
@@ -56,6 +56,28 @@ class TestAppenderSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       count.get should ===(2)
     }
 
+    "find unexpected events withOccurences(0)" in {
+      LoggingEventFilter.warn("a warning").withOccurrences(0).intercept {
+        log.error("an error")
+        log.warn("another warning")
+      }
+
+      intercept[AssertionError] {
+        LoggingEventFilter.warn("a warning").withOccurrences(0).intercept {
+          log.error("an error")
+          log.warn("a warning")
+          log.warn("another warning")
+        }
+      }.getMessage should include("received 1 excess messages")
+
+      intercept[AssertionError] {
+        LoggingEventFilter.warn("a warning").withOccurrences(0).intercept {
+          log.warn("a warning")
+          log.warn("a warning")
+        }
+      }.getMessage should include("received 2 excess messages")
+    }
+
   }
 
 }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorContextSpec.scala
@@ -140,7 +140,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit with WordSpecL
 
       val behavior = Behaviors.supervise(internal).onFailure(SupervisorStrategy.restart)
       val actor = spawn(behavior)
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         actor ! Fail
       }
       probe.expectMessage(ReceivedSignal(PreRestart))
@@ -204,7 +204,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit with WordSpecL
 
       val parentRef = spawn(parent)
       val childRef = probe.expectMessageType[ChildMade].ref
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         childRef ! Fail
       }
       probe.expectMessage(GotChildSignal(PreRestart))
@@ -261,7 +261,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit with WordSpecL
       val actor = spawn(behavior)
       actor ! Ping
       probe.expectMessage(1)
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         actor ! Fail
       }
       actor ! Ping
@@ -287,7 +287,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit with WordSpecL
       val actor = spawn(behavior)
       actor ! Ping
       probe.expectMessage(1)
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         actor ! Fail
       }
       actor ! Ping
@@ -329,7 +329,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit with WordSpecL
       probe.expectMessage(Pong)
       watcher ! Ping
       probe.expectMessage(Pong)
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         actorToWatch ! Fail
       }
       probe.expectMessage(ReceivedSignal(PostStop))
@@ -514,7 +514,7 @@ abstract class ActorContextSpec extends ScalaTestWithActorTestKit with WordSpecL
       val childRef = probe.expectMessageType[ChildMade].ref
       actor ! Inert
       probe.expectMessage(InertEvent)
-      LoggingEventFilter[DeathPactException](occurrences = 1).intercept {
+      LoggingEventFilter.error[DeathPactException].intercept {
         childRef ! Stop
         probe.expectMessage(GotChildSignal(PostStop))
         probe.expectMessage(ReceivedSignal(PostStop))

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -176,11 +176,11 @@ class AskSpec extends ScalaTestWithActorTestKit("""
       ref ! "start-ask"
       val Question(replyRef2) = probe.expectMessageType[Question]
 
-      LoggingEventFilter[RuntimeException](
-        message = "Exception thrown out of adapter. Stopping myself.",
-        occurrences = 1).intercept {
-        replyRef2 ! 42L
-      }(system)
+      LoggingEventFilter
+        .error("Exception thrown out of adapter. Stopping myself.")
+        .intercept {
+          replyRef2 ! 42L
+        }(system)
 
       probe.expectTerminated(ref, probe.remainingOrDefault)
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
@@ -62,7 +62,7 @@ class DeferredSpec extends ScalaTestWithActorTestKit with WordSpecLike {
             Behaviors.stopped
         }
       }
-      LoggingEventFilter[ActorInitializationException](occurrences = 1).intercept {
+      LoggingEventFilter.error[ActorInitializationException].intercept {
         spawn(behv)
         probe.expectMessage(Started)
         probe.expectMessage(Pong)
@@ -138,7 +138,7 @@ class DeferredSpec extends ScalaTestWithActorTestKit with WordSpecLike {
           Behaviors.same
         }
       }
-      LoggingEventFilter[ActorInitializationException](occurrences = 1).intercept {
+      LoggingEventFilter.error[ActorInitializationException].intercept {
         val ref = spawn(behv)
         probe.expectTerminated(ref, probe.remainingOrDefault)
       }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/InterceptSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/InterceptSpec.scala
@@ -281,7 +281,7 @@ class InterceptSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       val probe = TestProbe[String]()
       val interceptor = snitchingInterceptor(probe.ref)
 
-      LoggingEventFilter[ActorInitializationException](occurrences = 1).intercept {
+      LoggingEventFilter.error[ActorInitializationException].intercept {
         val ref = spawn(Behaviors.intercept(() => interceptor)(Behaviors.setup[String] { _ =>
           Behaviors.same[String]
         }))

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/LogMessagesSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/LogMessagesSpec.scala
@@ -25,11 +25,11 @@ class LogMessagesSpec extends ScalaTestWithActorTestKit("""
 
       val ref: ActorRef[String] = spawn(behavior)
 
-      LoggingEventFilter.debug(s"actor [${ref.path.toString}] received message: Hello", occurrences = 1).intercept {
+      LoggingEventFilter.debug(s"actor [${ref.path.toString}] received message: Hello").intercept {
         ref ! "Hello"
       }
 
-      LoggingEventFilter.debug(s"actor [${ref.path}] received signal: PostStop", occurrences = 1).intercept {
+      LoggingEventFilter.debug(s"actor [${ref.path}] received signal: PostStop").intercept {
         testKit.stop(ref)
       }
     }
@@ -40,11 +40,11 @@ class LogMessagesSpec extends ScalaTestWithActorTestKit("""
 
       val ref: ActorRef[String] = spawn(behavior)
 
-      LoggingEventFilter.info(s"actor [${ref.path}] received message: Hello", occurrences = 1).intercept {
+      LoggingEventFilter.info(s"actor [${ref.path}] received message: Hello").intercept {
         ref ! "Hello"
       }
 
-      LoggingEventFilter.info(s"actor [${ref.path}] received signal: PostStop", occurrences = 1).intercept {
+      LoggingEventFilter.info(s"actor [${ref.path}] received signal: PostStop").intercept {
         testKit.stop(ref)
       }
     }
@@ -56,11 +56,11 @@ class LogMessagesSpec extends ScalaTestWithActorTestKit("""
 
       val ref: ActorRef[String] = spawn(behavior)
 
-      LoggingEventFilter.debug(s"actor [${ref.path}] received message: Hello", occurrences = 1).intercept {
+      LoggingEventFilter.debug(s"actor [${ref.path}] received message: Hello").intercept {
         ref ! "Hello"
       }
 
-      LoggingEventFilter.debug(s"actor [${ref.path}] received signal: PostStop", occurrences = 1).intercept {
+      LoggingEventFilter.debug(s"actor [${ref.path}] received signal: PostStop").intercept {
         testKit.stop(ref)
       }
     }
@@ -71,11 +71,11 @@ class LogMessagesSpec extends ScalaTestWithActorTestKit("""
 
       val ref: ActorRef[String] = spawn(behavior)
 
-      LoggingEventFilter.debug(s"actor [${ref.path}] received message: Hello", occurrences = 0).intercept {
+      LoggingEventFilter.debug(s"actor [${ref.path}] received message: Hello").withOccurrences(0).intercept {
         ref ! "Hello"
       }
 
-      LoggingEventFilter.debug(s"actor [${ref.path}] received signal: PostStop", occurrences = 0).intercept {
+      LoggingEventFilter.debug(s"actor [${ref.path}] received signal: PostStop").withOccurrences(0).intercept {
         testKit.stop(ref)
       }
     }
@@ -87,33 +87,13 @@ class LogMessagesSpec extends ScalaTestWithActorTestKit("""
 
       val ref = spawn(behavior)
 
-      LoggingEventFilter
-        .custom(
-          {
-            case logEvent if logEvent.level == Level.DEBUG =>
-              logEvent.message should ===(s"actor [${ref.path}] received message: Hello")
-              logEvent.mdc should ===(mdc)
-              true
-            case other => system.log.error(s"Unexpected log event: {}", other); false
-          },
-          occurrences = 1)
-        .intercept {
-          ref ! "Hello"
-        }
+      LoggingEventFilter.debug(s"actor [${ref.path}] received message: Hello").withMdc(mdc).intercept {
+        ref ! "Hello"
+      }
 
-      LoggingEventFilter
-        .custom(
-          {
-            case logEvent if logEvent.level == Level.DEBUG =>
-              logEvent.message should ===(s"actor [${ref.path}] received signal: PostStop")
-              logEvent.mdc should ===(mdc)
-              true
-            case other => system.log.error(s"Unexpected log event: {}", other); false
-          },
-          occurrences = 1)
-        .intercept {
-          testKit.stop(ref)
-        }
+      LoggingEventFilter.debug(s"actor [${ref.path}] received signal: PostStop").withMdc(mdc).intercept {
+        testKit.stop(ref)
+      }
     }
 
     "log messages with different decorated MDC values in different actors" in {
@@ -125,63 +105,23 @@ class LogMessagesSpec extends ScalaTestWithActorTestKit("""
 
       val ref2 = spawn(behavior2)
 
-      LoggingEventFilter
-        .custom(
-          {
-            case logEvent if logEvent.level == Level.DEBUG =>
-              logEvent.message should ===(s"actor [${ref2.path}] received message: Hello")
-              logEvent.mdc should ===(mdc2)
-              true
-            case other => system.log.error(s"Unexpected log event: {}", other); false
-          },
-          occurrences = 1)
-        .intercept {
-          ref2 ! "Hello"
-        }
+      LoggingEventFilter.debug(s"actor [${ref2.path}] received message: Hello").withMdc(mdc2).intercept {
+        ref2 ! "Hello"
+      }
 
       val ref1 = spawn(behavior1)
 
-      LoggingEventFilter
-        .custom(
-          {
-            case logEvent if logEvent.level == Level.DEBUG =>
-              logEvent.message should ===(s"actor [${ref1.path}] received message: Hello")
-              logEvent.mdc should ===(mdc1)
-              true
-            case other => system.log.error(s"Unexpected log event: {}", other); false
-          },
-          occurrences = 1)
-        .intercept {
-          ref1 ! "Hello"
-        }
+      LoggingEventFilter.debug(s"actor [${ref1.path}] received message: Hello").withMdc(mdc1).intercept {
+        ref1 ! "Hello"
+      }
 
-      LoggingEventFilter
-        .custom(
-          {
-            case logEvent if logEvent.level == Level.DEBUG =>
-              logEvent.message should ===(s"actor [${ref2.path}] received signal: PostStop")
-              logEvent.mdc should ===(mdc2)
-              true
-            case other => system.log.error(s"Unexpected log event: {}", other); false
-          },
-          occurrences = 1)
-        .intercept {
-          testKit.stop(ref2)
-        }
+      LoggingEventFilter.debug(s"actor [${ref2.path}] received signal: PostStop").withMdc(mdc2).intercept {
+        testKit.stop(ref2)
+      }
 
-      LoggingEventFilter
-        .custom(
-          {
-            case logEvent if logEvent.level == Level.DEBUG =>
-              logEvent.message should ===(s"actor [${ref1.path}] received signal: PostStop")
-              logEvent.mdc should ===(mdc1)
-              true
-            case other => system.log.error(s"Unexpected log event: {}", other); false
-          },
-          occurrences = 1)
-        .intercept {
-          testKit.stop(ref1)
-        }
+      LoggingEventFilter.debug(s"actor [${ref1.path}] received signal: PostStop").withMdc(mdc1).intercept {
+        testKit.stop(ref1)
+      }
     }
 
     "log messages of different type" in {
@@ -189,7 +129,7 @@ class LogMessagesSpec extends ScalaTestWithActorTestKit("""
 
       val ref = spawn(behavior)
 
-      LoggingEventFilter.debug(s"actor [${ref.path}] received message: 13", occurrences = 1).intercept {
+      LoggingEventFilter.debug(s"actor [${ref.path}] received message: 13").intercept {
         ref.unsafeUpcast[Any] ! 13
       }
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
@@ -70,7 +70,7 @@ class MailboxSelectorSpec extends ScalaTestWithActorTestKit("""
       }, MailboxSelector.bounded(2))
       actor ! "one" // actor will block here
       actor ! "two"
-      LoggingEventFilter.deadLetters(occurrences = 1).intercept {
+      LoggingEventFilter.deadLetters().intercept {
         // one or both of these doesn't fit in mailbox
         // depending on race with how fast actor consumes
         actor ! "three"

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -313,7 +313,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       val probe = TestProbe[Event]("evt")
       val behv = targetBehavior(probe.ref)
       val ref = spawn(behv)
-      LoggingEventFilter[Exc3](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc3].intercept {
         ref ! Throw(new Exc3)
         probe.expectMessage(ReceivedSignal(PostStop))
         probe.expectTerminated(ref)
@@ -323,7 +323,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       val probe = TestProbe[Event]("evt")
       val behv = Behaviors.supervise(targetBehavior(probe.ref)).onFailure[Throwable](SupervisorStrategy.stop)
       val ref = spawn(behv)
-      LoggingEventFilter[Exc3](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc3].intercept {
         ref ! Throw(new Exc3)
         probe.expectMessage(ReceivedSignal(PostStop))
         probe.expectTerminated(ref)
@@ -337,7 +337,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
         targetBehavior(probe.ref)
       })
       val behv = Behaviors.supervise(failedSetup).onFailure[Throwable](SupervisorStrategy.stop)
-      LoggingEventFilter[Exc3](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc3].intercept {
         spawn(behv)
       }
     }
@@ -350,12 +350,12 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
 
       val ref = spawn(behv)
 
-      LoggingEventFilter[IOException](occurrences = 1).intercept {
+      LoggingEventFilter.error[IOException].intercept {
         ref ! Throw(new IOException())
         probe.expectMessage(ReceivedSignal(PreRestart))
       }
 
-      LoggingEventFilter[IllegalArgumentException](occurrences = 1).intercept {
+      LoggingEventFilter.error[IllegalArgumentException].intercept {
         ref ! Throw(new IllegalArgumentException("cat"))
         probe.expectMessage(ReceivedSignal(PostStop))
       }
@@ -371,7 +371,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
 
       val ref = spawn(behv)
 
-      LoggingEventFilter[Exception](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exception].intercept {
         ref ! Throw(new IOException())
         probe.expectMessage(ReceivedSignal(PreRestart))
       }
@@ -379,7 +379,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       ref ! Ping(1)
       probe.expectMessage(Pong(1))
 
-      LoggingEventFilter[IllegalArgumentException](occurrences = 1).intercept {
+      LoggingEventFilter.error[IllegalArgumentException].intercept {
         ref ! Throw(new IllegalArgumentException("cat"))
         probe.expectMessage(ReceivedSignal(PreRestart))
       }
@@ -397,7 +397,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
 
       val ref = spawn(behv)
 
-      LoggingEventFilter[Exception](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exception].intercept {
         ref ! Throw(new IOException())
         probe.expectMessage(ReceivedSignal(PreRestart))
       }
@@ -405,7 +405,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       ref ! Ping(1)
       probe.expectMessage(Pong(1))
 
-      LoggingEventFilter[IllegalArgumentException](occurrences = 1).intercept {
+      LoggingEventFilter.error[IllegalArgumentException].intercept {
         ref ! Throw(new IllegalArgumentException("cat"))
         probe.expectMessage(ReceivedSignal(PreRestart))
       }
@@ -419,7 +419,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       val probe = TestProbe[Event]("evt")
       val behv = targetBehavior(probe.ref)
       val ref = spawn(behv)
-      LoggingEventFilter[Exc3](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc3].intercept {
         ref ! Throw(new Exc3)
         probe.expectMessage(ReceivedSignal(PostStop))
       }
@@ -429,7 +429,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       val probe = TestProbe[Event]("evt")
       val behv = Behaviors.supervise(targetBehavior(probe.ref)).onFailure[Exc1](SupervisorStrategy.restart)
       val ref = spawn(behv)
-      LoggingEventFilter[Exc3](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc3].intercept {
         ref ! Throw(new Exc3)
         probe.expectMessage(ReceivedSignal(PostStop))
       }
@@ -443,7 +443,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       ref ! GetState
       probe.expectMessage(State(1, Map.empty))
 
-      LoggingEventFilter[Exc2](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc2].intercept {
         ref ! Throw(new Exc2)
         probe.expectMessage(ReceivedSignal(PreRestart))
       }
@@ -462,7 +462,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       ref ! GetState
       probe.expectMessage(State(1, Map.empty))
 
-      LoggingEventFilter[Exc2](occurrences = 3).intercept {
+      LoggingEventFilter.error[Exc2].withOccurrences(3).intercept {
         ref ! Throw(new Exc2)
         probe.expectMessage(ReceivedSignal(PreRestart))
         ref ! Throw(new Exc2)
@@ -485,7 +485,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       ref ! GetState
       probe.expectMessage(State(1, Map.empty))
 
-      LoggingEventFilter[Exc2](occurrences = 3).intercept {
+      LoggingEventFilter.error[Exc2].withOccurrences(3).intercept {
         ref ! Throw(new Exc2)
         probe.expectMessage(ReceivedSignal(PreRestart))
         ref ! Throw(new Exc2)
@@ -525,7 +525,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       ref ! GetState
       parentProbe.expectMessageType[State].children.keySet should ===(Set(child1Name, child2Name))
 
-      LoggingEventFilter[Exc1](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc1].intercept {
         ref ! Throw(new Exc1)
         parentProbe.expectMessage(ReceivedSignal(PreRestart))
         ref ! GetState
@@ -563,7 +563,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       ref ! GetState
       parentProbe.expectMessageType[State].children.keySet should contain(childName)
 
-      LoggingEventFilter[Exc1](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc1].intercept {
         ref ! Throw(new Exc1)
         parentProbe.expectMessage(ReceivedSignal(PreRestart))
         ref ! GetState
@@ -594,7 +594,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
 
       val child2Name = nextName()
 
-      LoggingEventFilter[Exc1](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc1].intercept {
         ref ! Throw(new Exc1)
         parentProbe.expectMessage(ReceivedSignal(PreRestart))
         ref ! GetState
@@ -603,7 +603,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
         ref ! Throw(new Exc1)
       }
 
-      LoggingEventFilter[Exc1](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc1].intercept {
         slowStop.countDown()
         childProbe.expectMessage(ReceivedSignal(PostStop)) // child1
         parentProbe.expectMessageType[State].children.keySet should ===(Set.empty)
@@ -648,7 +648,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
         }
         .onFailure[RuntimeException](strategy)
 
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         val ref = spawn(behv)
         slowStop1.countDown()
         child1Probe.expectMessage(ReceivedSignal(PostStop))
@@ -699,12 +699,12 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
 
       throwFromSetup.set(true)
 
-      LoggingEventFilter[Exc1](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc1].intercept {
         ref ! Throw(new Exc1)
         parentProbe.expectMessage(ReceivedSignal(PreRestart))
       }
 
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         slowStop1.countDown()
         child1Probe.expectMessage(ReceivedSignal(PostStop))
         child1Probe.expectMessage(ReceivedSignal(PostStop))
@@ -725,7 +725,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       ref ! GetState
       probe.expectMessage(State(1, Map.empty))
 
-      LoggingEventFilter[Exc2](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc2].intercept {
         ref ! Throw(new Exc2)
         ref ! GetState
         probe.expectMessage(State(1, Map.empty))
@@ -743,7 +743,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       probe.expectMessage(State(1, Map.empty))
 
       // resume
-      LoggingEventFilter[Exc2](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc2].intercept {
         ref ! Throw(new Exc2)
         probe.expectNoMessage()
         ref ! GetState
@@ -751,7 +751,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       }
 
       // restart
-      LoggingEventFilter[Exc3](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc3].intercept {
         ref ! Throw(new Exc3)
         probe.expectMessage(ReceivedSignal(PreRestart))
         ref ! GetState
@@ -759,7 +759,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       }
 
       // stop
-      LoggingEventFilter[Exc1](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc1].intercept {
         ref ! Throw(new Exc1)
         probe.expectMessage(ReceivedSignal(PostStop))
       }
@@ -781,7 +781,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       val droppedMessagesProbe = TestProbe[Dropped]()
       system.eventStream ! EventStream.Subscribe(droppedMessagesProbe.ref)
       val ref = spawn(behv)
-      LoggingEventFilter[Exc1](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc1].intercept {
         startedProbe.expectMessage(Started)
         ref ! Throw(new Exc1)
         probe.expectMessage(ReceivedSignal(PreRestart))
@@ -817,7 +817,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       val droppedMessagesProbe = TestProbe[Dropped]()
       system.eventStream ! EventStream.Subscribe(droppedMessagesProbe.ref)
 
-      LoggingEventFilter[Exc1](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc1].intercept {
         startedProbe.expectMessage(Started)
         ref ! IncrementState
         ref ! Throw(new Exc1)
@@ -833,7 +833,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       probe.expectMessage(State(0, Map.empty))
 
       // one more time
-      LoggingEventFilter[Exc1](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc1].intercept {
         ref ! IncrementState
         ref ! Throw(new Exc1)
         probe.expectMessage(ReceivedSignal(PreRestart))
@@ -871,8 +871,8 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
         .onFailure[Exception](strategy)
       val ref = spawn(behv)
 
-      LoggingEventFilter[Exc1](occurrences = 1).intercept {
-        LoggingEventFilter[TestException](occurrences = 2).intercept {
+      LoggingEventFilter.error[Exc1].intercept {
+        LoggingEventFilter.error[TestException].withOccurrences(2).intercept {
           startedProbe.expectMessage(Started)
           ref ! Throw(new Exc1)
           probe.expectTerminated(ref, 3.seconds)
@@ -894,7 +894,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       val droppedMessagesProbe = TestProbe[Dropped]()
       system.eventStream ! EventStream.Subscribe(droppedMessagesProbe.ref)
 
-      LoggingEventFilter[Exc1](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc1].intercept {
         ref ! IncrementState
         ref ! Throw(new Exc1)
         probe.expectMessage(ReceivedSignal(PreRestart))
@@ -907,7 +907,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       probe.expectMessage(State(0, Map.empty))
 
       // one more time after the reset timeout
-      LoggingEventFilter[Exc1](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc1].intercept {
         probe.expectNoMessage(strategy.resetBackoffAfter + 100.millis.dilated)
         ref ! IncrementState
         ref ! Throw(new Exc1)
@@ -938,7 +938,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       failCount = 1,
       strategy = SupervisorStrategy.restart) {
 
-      LoggingEventFilter[ActorInitializationException](occurrences = 1).intercept {
+      LoggingEventFilter.error[ActorInitializationException].intercept {
         spawn(behv)
       }
     }
@@ -946,7 +946,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
     "fail to restart when deferred factory throws unhandled" in new FailingUnhandledTestSetup(
       strategy = SupervisorStrategy.restart) {
 
-      LoggingEventFilter[ActorInitializationException](occurrences = 1).intercept {
+      LoggingEventFilter.error[ActorInitializationException].intercept {
         spawn(behv)
       }
     }
@@ -954,8 +954,8 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
     "fail to resume when deferred factory throws" in new FailingDeferredTestSetup(
       failCount = 1,
       strategy = SupervisorStrategy.resume) {
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
-        LoggingEventFilter[ActorInitializationException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
+        LoggingEventFilter.error[ActorInitializationException].intercept {
           spawn(behv)
         }
       }
@@ -965,7 +965,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       failCount = 1,
       strategy = SupervisorStrategy.restartWithBackoff(minBackoff = 100.millis.dilated, maxBackoff = 1.second, 0)) {
 
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         spawn(behv)
 
         probe.expectMessage(StartFailed)
@@ -978,7 +978,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
     "fail instead of restart with exponential backoff when deferred factory throws unhandled" in new FailingUnhandledTestSetup(
       strategy = SupervisorStrategy.restartWithBackoff(minBackoff = 100.millis.dilated, maxBackoff = 1.second, 0)) {
 
-      LoggingEventFilter[ActorInitializationException](occurrences = 1).intercept {
+      LoggingEventFilter.error[ActorInitializationException].intercept {
         spawn(behv)
         probe.expectMessage(StartFailed)
       }
@@ -988,7 +988,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       failCount = 1,
       strategy = SupervisorStrategy.restart.withLimit(3, 1.second)) {
 
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         spawn(behv)
 
         probe.expectMessage(StartFailed)
@@ -1000,8 +1000,8 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       failCount = 20,
       strategy = SupervisorStrategy.restart.withLimit(2, 1.second)) {
 
-      LoggingEventFilter[ActorInitializationException](occurrences = 1).intercept {
-        LoggingEventFilter[TestException](occurrences = 2).intercept {
+      LoggingEventFilter.error[ActorInitializationException].intercept {
+        LoggingEventFilter.error[TestException].withOccurrences(2).intercept {
           spawn(behv)
 
           // first one from initial setup
@@ -1017,7 +1017,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
     "fail instead of restart with limit when deferred factory throws unhandled" in new FailingUnhandledTestSetup(
       strategy = SupervisorStrategy.restart.withLimit(3, 1.second)) {
 
-      LoggingEventFilter[ActorInitializationException](occurrences = 1).intercept {
+      LoggingEventFilter.error[ActorInitializationException].intercept {
         spawn(behv)
         probe.expectMessage(StartFailed)
       }
@@ -1028,7 +1028,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       val behv = supervise(setup[Command](_ => new FailingConstructor(probe.ref)))
         .onFailure[Exception](SupervisorStrategy.restart)
 
-      LoggingEventFilter[ActorInitializationException](occurrences = 1).intercept {
+      LoggingEventFilter.error[ActorInitializationException].intercept {
         spawn(behv)
         probe.expectMessage(Started) // first one before failure
       }
@@ -1073,7 +1073,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       actor ! "ping"
       probe.expectMessage("pong")
 
-      LoggingEventFilter[RuntimeException](occurrences = 1).intercept {
+      LoggingEventFilter.error[RuntimeException].intercept {
         // Should be supervised as resume
         actor ! "boom"
       }
@@ -1121,7 +1121,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       actor ! "ping"
       probe.expectMessage("pong")
 
-      LoggingEventFilter[RuntimeException](occurrences = 1).intercept {
+      LoggingEventFilter.error[RuntimeException].intercept {
         // Should be supervised as resume
         actor ! "boom"
       }
@@ -1165,7 +1165,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       probe.expectMessage("started 1")
       ref ! "ping"
       probe.expectMessage("pong 1")
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         ref ! "boom"
         probe.expectMessage("crashing 1")
         ref ! "ping"
@@ -1175,10 +1175,12 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       probe.expectMessage("pong 2") // from "ping" that was stashed
       ref ! "ping"
       probe.expectMessage("pong 2")
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
-        ref ! "boom" // now we should have replaced supervision with the resuming one
-        probe.expectMessage("crashing 2")
-      }(system)
+      LoggingEventFilter
+        .error[TestException]
+        .intercept {
+          ref ! "boom" // now we should have replaced supervision with the resuming one
+          probe.expectMessage("crashing 2")
+        }(system)
       ref ! "ping"
       probe.expectMessage("pong 2")
     }
@@ -1208,7 +1210,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
           })
           .onFailure[DeathPactException](SupervisorStrategy.restart))
 
-      LoggingEventFilter[DeathPactException](occurrences = 1).intercept {
+      LoggingEventFilter.error[DeathPactException].intercept {
         actor ! "boom"
         val child = probe.expectMessageType[ActorRef[_]]
         probe.expectTerminated(child, 3.seconds)
@@ -1223,7 +1225,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
         .supervise(targetBehavior(probe.ref))
         .onFailure[Exc1](SupervisorStrategy.restart.withLoggingEnabled(true).withLogLevel(Level.INFO))
       val ref = spawn(behv)
-      LoggingEventFilter.info(pattern = "exc-1", occurrences = 1).intercept {
+      LoggingEventFilter.info("exc-1").intercept {
         ref ! Throw(new Exc1)
         probe.expectMessage(ReceivedSignal(PreRestart))
       }
@@ -1235,7 +1237,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
         .supervise(targetBehavior(probe.ref))
         .onFailure[Exc1](SupervisorStrategy.restart.withLoggingEnabled(true).withLogLevel(Level.DEBUG))
       val ref = spawn(behv)
-      LoggingEventFilter.info(pattern = "exc-1", source = ref.path.toString, occurrences = 0).intercept {
+      LoggingEventFilter.info("exc-1").withSource(ref.path.toString).withOccurrences(0).intercept {
         ref ! Throw(new Exc1)
         probe.expectMessage(ReceivedSignal(PreRestart))
       }
@@ -1263,7 +1265,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
       ref ! Ping(1)
       probe.expectMessage(Pong(1))
 
-      LoggingEventFilter[Exc1](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc1].intercept {
         ref.unsafeUpcast ! "boom"
         probe.expectMessage(ReceivedSignal(PreRestart))
       }
@@ -1311,7 +1313,7 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
               })
               .onFailure[TestException](strategy))
 
-          LoggingEventFilter[TestException](occurrences = 1).intercept {
+          LoggingEventFilter.error[TestException].intercept {
             actor ! "boom"
           }
           createTestProbe().expectTerminated(actor, 3.second)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TimerSpec.scala
@@ -175,7 +175,7 @@ class TimerSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       probe.expectMessage(Tock(1))
 
       val latch = new CountDownLatch(1)
-      LoggingEventFilter[Exc](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc].intercept {
         // next Tock(1) is enqueued in mailbox, but should be discarded by new incarnation
         ref ! SlowThenThrow(latch, new Exc)
 
@@ -205,7 +205,7 @@ class TimerSpec extends ScalaTestWithActorTestKit with WordSpecLike {
 
       probe.expectMessage(Tock(2))
 
-      LoggingEventFilter[Exc](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc].intercept {
         val latch = new CountDownLatch(1)
         // next Tock(2) is enqueued in mailbox, but should be discarded by new incarnation
         ref ! SlowThenThrow(latch, new Exc)
@@ -226,7 +226,7 @@ class TimerSpec extends ScalaTestWithActorTestKit with WordSpecLike {
         target(probe.ref, timer, 1)
       }
       val ref = spawn(behv)
-      LoggingEventFilter[Exc](occurrences = 1).intercept {
+      LoggingEventFilter.error[Exc].intercept {
         ref ! Throw(new Exc)
         probe.expectMessage(GotPostStop(false))
       }
@@ -344,7 +344,7 @@ class TimerSpec extends ScalaTestWithActorTestKit with WordSpecLike {
           Behaviors.unhandled
       }
 
-    LoggingEventFilter[TestException](occurrences = 1).intercept {
+    LoggingEventFilter.error[TestException].intercept {
       val ref = spawn(Behaviors.supervise(behv).onFailure[TestException](SupervisorStrategy.restart))
       ref ! Tick(-1)
       probe.expectMessage(Tock(-1))
@@ -379,7 +379,7 @@ class TimerSpec extends ScalaTestWithActorTestKit with WordSpecLike {
         Behaviors.unhandled
     }
 
-    LoggingEventFilter[TestException](occurrences = 1).intercept {
+    LoggingEventFilter.error[TestException].intercept {
       val ref = spawn(Behaviors.supervise(behv).onFailure[TestException](SupervisorStrategy.restart))
       ref ! Tick(-1)
       probe.expectMessage(Tock(-1))

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TransformMessagesSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TransformMessagesSpec.scala
@@ -133,7 +133,7 @@ class TransformMessagesSpec extends ScalaTestWithActorTestKit with WordSpecLike 
           case s => s.toLowerCase
         }
 
-      LoggingEventFilter[ActorInitializationException](occurrences = 1).intercept {
+      LoggingEventFilter.error[ActorInitializationException].intercept {
         val ref = spawn(transform(transform(Behaviors.receiveMessage[String] { _ =>
           Behaviors.same
         })))

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
@@ -106,7 +106,7 @@ class WatchSpec extends ScalaTestWithActorTestKit with WordSpecLike {
         },
         "supervised-child-parent")
 
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         parent ! "boom"
       }
       probe.expectMessageType[ChildHasFailed].t.cause shouldEqual ex
@@ -141,7 +141,7 @@ class WatchSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       }
       val parent = spawn(behavior, "parent")
 
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         parent ! "boom"
       }
       probe.expectMessageType[ChildHasFailed].t.cause shouldEqual ex
@@ -180,8 +180,8 @@ class WatchSpec extends ScalaTestWithActorTestKit with WordSpecLike {
           },
           "grosso-bosso")
 
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
-        LoggingEventFilter[DeathPactException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
+        LoggingEventFilter.error[DeathPactException].intercept {
           grossoBosso ! "boom"
         }
       }
@@ -321,11 +321,12 @@ class WatchSpec extends ScalaTestWithActorTestKit with WordSpecLike {
     "fail when watch is used after watchWith on same subject" in new ErrorTestSetup {
       watcher ! StartWatchingWith(terminator, CustomTerminationMessage)
 
-      LoggingEventFilter[IllegalStateException](
-        pattern = ".*termination message was not overwritten.*",
-        occurrences = 1).intercept {
-        watcher ! StartWatching(terminator)
-      }
+      LoggingEventFilter
+        .error[IllegalStateException]
+        .withMessageContains("termination message was not overwritten")
+        .intercept {
+          watcher ! StartWatching(terminator)
+        }
       // supervisor should have stopped the actor
       expectStopped()
     }
@@ -333,22 +334,24 @@ class WatchSpec extends ScalaTestWithActorTestKit with WordSpecLike {
     "fail when watchWitch is used after watchWith with different termination message" in new ErrorTestSetup {
       watcher ! StartWatchingWith(terminator, CustomTerminationMessage)
 
-      LoggingEventFilter[IllegalStateException](
-        pattern = ".*termination message was not overwritten.*",
-        occurrences = 1).intercept {
-        watcher ! StartWatchingWith(terminator, CustomTerminationMessage2)
-      }
+      LoggingEventFilter
+        .error[IllegalStateException]
+        .withMessageContains("termination message was not overwritten")
+        .intercept {
+          watcher ! StartWatchingWith(terminator, CustomTerminationMessage2)
+        }
       // supervisor should have stopped the actor
       expectStopped()
     }
     "fail when watchWith is used after watch on same subject" in new ErrorTestSetup {
       watcher ! StartWatching(terminator)
 
-      LoggingEventFilter[IllegalStateException](
-        pattern = ".*termination message was not overwritten.*",
-        occurrences = 1).intercept {
-        watcher ! StartWatchingWith(terminator, CustomTerminationMessage)
-      }
+      LoggingEventFilter
+        .error[IllegalStateException]
+        .withMessageContains("termination message was not overwritten")
+        .intercept {
+          watcher ! StartWatchingWith(terminator, CustomTerminationMessage)
+        }
       // supervisor should have stopped the actor
       expectStopped()
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextAskSpec.scala
@@ -100,7 +100,7 @@ class ActorContextAskSpec extends ScalaTestWithActorTestKit(ActorContextAskSpec.
           }
       }
 
-      LoggingEventFilter[NotImplementedError](occurrences = 1, start = "Pong").intercept {
+      LoggingEventFilter.error[NotImplementedError].withMessageContains("Pong").intercept {
         spawn(snitch)
       }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
@@ -86,7 +86,7 @@ class ActorLoggingSpec extends ScalaTestWithActorTestKit("""
       }
 
       val actor =
-        LoggingEventFilter.info("Started").interceptLogger(classOf[AnotherLoggerClass].getName) {
+        LoggingEventFilter.info("Started").withLoggerName(classOf[AnotherLoggerClass].getName).intercept {
           spawn(behavior, "the-other-actor")
         }
 
@@ -99,8 +99,9 @@ class ActorLoggingSpec extends ScalaTestWithActorTestKit("""
           count.incrementAndGet()
           logEvent.message == "got message Hello" && logEvent.loggerName == classOf[AnotherLoggerClass].getName
         }
+        .withLoggerName(classOf[AnotherLoggerClass].getName)
         .withOccurrences(2)
-        .interceptLogger(classOf[AnotherLoggerClass].getName) {
+        .intercept {
           actor ! "Hello"
           LoggerFactory.getLogger(classOf[ActorLoggingSpec]).debug("Hello from other logger")
           actor ! "Hello"

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/LoggerOpsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/LoggerOpsSpec.scala
@@ -23,52 +23,52 @@ class LoggerOpsSpec extends ScalaTestWithActorTestKit with WordSpecLike {
   "LoggerOps" must {
 
     "provide extension method for 2 arguments" in {
-      LoggingEventFilter.info(message = "[template a b]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template a b]").intercept {
         log.info2("[template {} {}]", "a", "b")
       }
-      LoggingEventFilter.info(message = "[template a 2]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template a 2]").intercept {
         log.info2("[template {} {}]", "a", 2)
       }
-      LoggingEventFilter.info(message = "[template 1 2]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template 1 2]").intercept {
         log.info2("[template {} {}]", 1, 2)
       }
-      LoggingEventFilter.info(message = "[template 1 b]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template 1 b]").intercept {
         log.info2("[template {} {}]", 1, "b")
       }
-      LoggingEventFilter.info(message = "[template a Value2(2)]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template a Value2(2)]").intercept {
         log.info2("[template {} {}]", "a", Value2(2))
       }
-      LoggingEventFilter.info(message = "[template Value1(1) Value1(1)]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template Value1(1) Value1(1)]").intercept {
         log.info2("[template {} {}]", Value1(1), Value1(1))
       }
-      LoggingEventFilter.info(message = "[template Value1(1) Value2(2)]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template Value1(1) Value2(2)]").intercept {
         log.info2("[template {} {}]", Value1(1), Value2(2))
       }
     }
 
     "provide extension method for vararg arguments" in {
-      LoggingEventFilter.info(message = "[template a b c]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template a b c]").intercept {
         log.infoN("[template {} {} {}]", "a", "b", "c")
       }
-      LoggingEventFilter.info(message = "[template a b 3]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template a b 3]").intercept {
         log.infoN("[template {} {} {}]", "a", "b", 3)
       }
-      LoggingEventFilter.info(message = "[template a 2 c]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template a 2 c]").intercept {
         log.infoN("[template {} {} {}]", "a", 2, "c")
       }
-      LoggingEventFilter.info(message = "[template 1 2 3]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template 1 2 3]").intercept {
         log.infoN("[template {} {} {}]", 1, 2, 3)
       }
-      LoggingEventFilter.info(message = "[template 1 b c]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template 1 b c]").intercept {
         log.infoN("[template {} {} {}]", 1, "b", "c")
       }
-      LoggingEventFilter.info(message = "[template a Value2(2) Value3(3)]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template a Value2(2) Value3(3)]").intercept {
         log.infoN("[template {} {} {}]", "a", Value2(2), Value3(3))
       }
-      LoggingEventFilter.info(message = "[template Value1(1) Value1(1) Value1(1)]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template Value1(1) Value1(1) Value1(1)]").intercept {
         log.infoN("[template {} {} {}]", Value1(1), Value1(1), Value1(1))
       }
-      LoggingEventFilter.info(message = "[template Value1(1) Value2(2) Value3(3)]", occurrences = 1).intercept {
+      LoggingEventFilter.info("[template Value1(1) Value2(2) Value3(3)]").intercept {
         log.infoN("[template {} {} {}]", Value1(1), Value2(2), Value3(3))
       }
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
@@ -246,7 +246,7 @@ class MessageAdapterSpec extends ScalaTestWithActorTestKit(MessageAdapterSpec.co
       }
 
       // Not expecting "Exception thrown out of adapter. Stopping myself"
-      LoggingEventFilter[TestException](message = "boom", occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].withMessageContains("boom").intercept {
         spawn(snitch)
       }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/RoutersSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/RoutersSpec.scala
@@ -84,7 +84,7 @@ class RoutersSpec extends ScalaTestWithActorTestKit("""
             Behaviors.same
         }))
 
-      LoggingEventFilter.debug(start = "Pool child stopped", occurrences = 2).intercept {
+      LoggingEventFilter.debug("Pool child stopped").withOccurrences(2).intercept {
         pool ! "stop"
         pool ! "stop"
       }
@@ -109,7 +109,7 @@ class RoutersSpec extends ScalaTestWithActorTestKit("""
           Behaviors.stopped
         }))
 
-      LoggingEventFilter.info(start = "Last pool child stopped, stopping pool", occurrences = 1).intercept {
+      LoggingEventFilter.info("Last pool child stopped, stopping pool").intercept {
         (0 to 3).foreach { _ =>
           pool ! "stop"
         }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/AdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/AdapterSpec.scala
@@ -277,10 +277,12 @@ class AdapterSpec extends AkkaSpec {
       val typedRef = system.spawnAnonymous(typed1(ignore, probe.ref))
 
       // only stop supervisorStrategy
-      LoggingEventFilter[AdapterSpec.ThrowIt3.type](occurrences = 1).intercept {
-        typedRef ! "supervise-restart"
-        probe.expectMsg("ok")
-      }(system.toTyped)
+      LoggingEventFilter
+        .error[AdapterSpec.ThrowIt3.type]
+        .intercept {
+          typedRef ! "supervise-restart"
+          probe.expectMsg("ok")
+        }(system.toTyped)
     }
 
     "stop typed child from untyped parent" in {
@@ -302,7 +304,7 @@ class AdapterSpec extends AkkaSpec {
     "log exception if not by handled typed supervisor" in {
       val throwMsg = "sad panda"
       LoggingEventFilter
-        .warning(pattern = ".*sad panda.*")
+        .error("sad panda")
         .intercept {
           system.spawnAnonymous(unhappyTyped(throwMsg))
           Thread.sleep(1000)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
@@ -181,7 +181,7 @@ import akka.util.OptionVal
       case Success(a) =>
         body(a)
       case Failure(ex) =>
-        log.error(ex, "Exception thrown out of adapter. Stopping myself.")
+        log.error(ex, s"Exception thrown out of adapter. Stopping myself. ${ex.getMessage}")
         context.stop(self)
     }
   }

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -5,6 +5,7 @@
 package akka.persistence.typed.javadsl;
 
 import akka.Done;
+import akka.actor.testkit.typed.javadsl.LoggingEventFilter;
 import akka.actor.typed.*;
 import akka.actor.typed.javadsl.ActorContext;
 import akka.actor.typed.javadsl.Adapter;
@@ -35,6 +36,7 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
+import org.slf4j.event.Level;
 
 import java.time.Duration;
 import java.util.*;
@@ -695,20 +697,21 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
   }
 
   @Test
-  @Ignore // FIXME #26537 use LoggingEventFilter when javadsl is ready
   public void failOnIncorrectExpectedStateForThenRun() {
     TestProbe<String> probe = testKit.createTestProbe();
     ActorRef<String> c =
         testKit.spawn(
             new IncorrectExpectedStateForThenRun(probe.getRef(), new PersistenceId("foiesftr")));
 
-    probe.expectMessage("started!"); // workaround for #26256
+    probe.expectMessage("started!");
 
-    new EventFilter(Logging.Error.class, Adapter.toUntyped(testKit.system()))
-        .occurrences(1)
+    LoggingEventFilter.empty()
+        .withLogLevel(Level.ERROR)
         // the error messages slightly changed in later JDKs
-        .matches("(class )?java.lang.Integer cannot be cast to (class )?java.lang.String.*")
+        .withMessageRegex(
+            "(class )?java.lang.Integer cannot be cast to (class )?java.lang.String.*")
         .intercept(
+            testKit.system(),
             () -> {
               c.tell("expect wrong type");
               return null;

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
@@ -188,7 +188,7 @@ class RecoveryPermitterSpec extends ScalaTestWithActorTestKit(s"""
 
       val stopProbe = createTestProbe[ActorRef[Command]]()
       val parent =
-        LoggingEventFilter.error(occurrences = 1, start = "Exception during recovery.").intercept {
+        LoggingEventFilter.error("Exception during recovery.").intercept {
           spawn(Behaviors.setup[Command](ctx => {
             val persistentActor =
               ctx.spawnAnonymous(persistentBehavior("p3", p3, p3, throwOnRecovery = true))

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorFailureSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorFailureSpec.scala
@@ -120,7 +120,7 @@ class EventSourcedBehaviorFailureSpec
   "A typed persistent actor (failures)" must {
 
     "signal RecoveryFailure when replay fails" in {
-      LoggingEventFilter[JournalFailureException](occurrences = 1).intercept {
+      LoggingEventFilter.error[JournalFailureException].intercept {
         val probe = TestProbe[String]()
         val excProbe = TestProbe[Throwable]()
         spawn(failingPersistentActor(PersistenceId("fail-recovery"), probe.ref, {
@@ -158,7 +158,7 @@ class EventSourcedBehaviorFailureSpec
       probe.expectMessage("malicious")
       probe.expectMessage("persisted")
 
-      LoggingEventFilter[JournalFailureException](occurrences = 1).intercept {
+      LoggingEventFilter.error[JournalFailureException].intercept {
         // start again and then the event handler will throw
         spawn(failingPersistentActor(pid, probe.ref, {
           case (_, RecoveryFailed(t)) =>
@@ -172,7 +172,7 @@ class EventSourcedBehaviorFailureSpec
 
     "fail recovery if exception from RecoveryCompleted signal handler" in {
       val probe = TestProbe[String]()
-      LoggingEventFilter[JournalFailureException](occurrences = 1).intercept {
+      LoggingEventFilter.error[JournalFailureException].intercept {
         spawn(
           Behaviors
             .supervise(failingPersistentActor(PersistenceId("recovery-ok"), probe.ref, {
@@ -249,7 +249,7 @@ class EventSourcedBehaviorFailureSpec
     }
 
     "stop (default supervisor strategy) if command handler throws" in {
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         val probe = TestProbe[String]()
         val behav = failingPersistentActor(PersistenceId("wrong-command-1"), probe.ref)
         val c = spawn(behav)
@@ -260,7 +260,7 @@ class EventSourcedBehaviorFailureSpec
     }
 
     "restart supervisor strategy if command handler throws" in {
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         val probe = TestProbe[String]()
         val behav = Behaviors
           .supervise(failingPersistentActor(PersistenceId("wrong-command-2"), probe.ref))
@@ -273,7 +273,7 @@ class EventSourcedBehaviorFailureSpec
     }
 
     "stop (default supervisor strategy) if side effect callback throws" in {
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         val probe = TestProbe[String]()
         val behav = failingPersistentActor(PersistenceId("wrong-command-3"), probe.ref)
         val c = spawn(behav)
@@ -288,7 +288,7 @@ class EventSourcedBehaviorFailureSpec
 
     "stop (default supervisor strategy) if signal handler throws" in {
       case object SomeSignal extends Signal
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         val probe = TestProbe[String]()
         val behav = failingPersistentActor(PersistenceId("wrong-signal-handler"), probe.ref, {
           case (_, SomeSignal) => throw TestException("from signal")
@@ -301,7 +301,7 @@ class EventSourcedBehaviorFailureSpec
     }
 
     "not accept wrong event, before persisting it" in {
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         val probe = TestProbe[String]()
         val behav = failingPersistentActor(PersistenceId("wrong-event-2"), probe.ref)
         val c = spawn(behav)

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRecoveryTimeoutSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRecoveryTimeoutSpec.scala
@@ -84,17 +84,18 @@ class EventSourcedBehaviorRecoveryTimeoutSpec
 
       // now replay, but don't give the journal any tokens to replay events
       // so that we cause the timeout to trigger
-      LoggingEventFilter[JournalFailureException](
-        pattern = "Exception during recovery.*Replay timed out",
-        occurrences = 1).intercept {
-        val replaying = spawn(testBehavior(pid, probe.ref))
+      LoggingEventFilter
+        .error[JournalFailureException]
+        .withMessageRegex("Exception during recovery.*Replay timed out")
+        .intercept {
+          val replaying = spawn(testBehavior(pid, probe.ref))
 
-        // initial read highest
-        SteppingInmemJournal.step(journal)
+          // initial read highest
+          SteppingInmemJournal.step(journal)
 
-        probe.expectMessageType[RecoveryTimedOut]
-        probe.expectTerminated(replaying)
-      }
+          probe.expectMessageType[RecoveryTimedOut]
+          probe.expectTerminated(replaying)
+        }
 
       // avoid having it stuck in the next test from the
       // last read request above

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -498,7 +498,7 @@ class EventSourcedBehaviorSpec extends ScalaTestWithActorTestKit(EventSourcedBeh
     }
 
     "fail after recovery timeout" in {
-      LoggingEventFilter.error(start = "Persistence failure when replaying snapshot", occurrences = 1).intercept {
+      LoggingEventFilter.error("Persistence failure when replaying snapshot").intercept {
         val c = spawn(
           Behaviors.setup[Command](ctx =>
             counter(ctx, nextPid)
@@ -524,7 +524,7 @@ class EventSourcedBehaviorSpec extends ScalaTestWithActorTestKit(EventSourcedBeh
       c ! StopIt
       probe.expectTerminated(c)
 
-      LoggingEventFilter[TestException](occurrences = 1).intercept {
+      LoggingEventFilter.error[TestException].intercept {
         val c2 = spawn(Behaviors.setup[Command](counter(_, pid)))
         c2 ! Fail
         probe.expectTerminated(c2) // should fail
@@ -536,12 +536,16 @@ class EventSourcedBehaviorSpec extends ScalaTestWithActorTestKit(EventSourcedBeh
         PersistenceId(null)
       }
       val probe = TestProbe[AnyRef]
-      LoggingEventFilter[ActorInitializationException](start = "persistenceId must not be null", occurrences = 1)
+      LoggingEventFilter
+        .error[ActorInitializationException]
+        .withMessageContains("persistenceId must not be null")
         .intercept {
           val ref = spawn(Behaviors.setup[Command](counter(_, persistenceId = PersistenceId(null))))
           probe.expectTerminated(ref)
         }
-      LoggingEventFilter[ActorInitializationException](start = "persistenceId must not be null", occurrences = 1)
+      LoggingEventFilter
+        .error[ActorInitializationException]
+        .withMessageContains("persistenceId must not be null")
         .intercept {
           val ref = spawn(Behaviors.setup[Command](counter(_, persistenceId = null)))
           probe.expectTerminated(ref)
@@ -553,7 +557,9 @@ class EventSourcedBehaviorSpec extends ScalaTestWithActorTestKit(EventSourcedBeh
         PersistenceId("")
       }
       val probe = TestProbe[AnyRef]
-      LoggingEventFilter[ActorInitializationException](start = "persistenceId must not be empty", occurrences = 1)
+      LoggingEventFilter
+        .error[ActorInitializationException]
+        .withMessageContains("persistenceId must not be empty")
         .intercept {
           val ref = spawn(Behaviors.setup[Command](counter(_, persistenceId = PersistenceId(""))))
           probe.expectTerminated(ref)
@@ -564,13 +570,14 @@ class EventSourcedBehaviorSpec extends ScalaTestWithActorTestKit(EventSourcedBeh
       // new ActorSystem without persistence config
       val testkit2 = ActorTestKit(ActorTestKitBase.testNameFromCallStack(), ConfigFactory.parseString(""))
       try {
-        LoggingEventFilter[ActorInitializationException](
-          start = "Default journal plugin is not configured",
-          occurrences = 1).intercept {
-          val ref = testkit2.spawn(Behaviors.setup[Command](counter(_, nextPid())))
-          val probe = testkit2.createTestProbe()
-          probe.expectTerminated(ref)
-        }(testkit2.system)
+        LoggingEventFilter
+          .error[ActorInitializationException]
+          .withMessageContains("Default journal plugin is not configured")
+          .intercept {
+            val ref = testkit2.spawn(Behaviors.setup[Command](counter(_, nextPid())))
+            val probe = testkit2.createTestProbe()
+            probe.expectTerminated(ref)
+          }(testkit2.system)
       } finally {
         testkit2.shutdownTestKit()
       }
@@ -580,13 +587,14 @@ class EventSourcedBehaviorSpec extends ScalaTestWithActorTestKit(EventSourcedBeh
       // new ActorSystem without persistence config
       val testkit2 = ActorTestKit(ActorTestKitBase.testNameFromCallStack(), ConfigFactory.parseString(""))
       try {
-        LoggingEventFilter[ActorInitializationException](
-          start = "Journal plugin [missing] configuration doesn't exist",
-          occurrences = 1).intercept {
-          val ref = testkit2.spawn(Behaviors.setup[Command](counter(_, nextPid()).withJournalPluginId("missing")))
-          val probe = testkit2.createTestProbe()
-          probe.expectTerminated(ref)
-        }(testkit2.system)
+        LoggingEventFilter
+          .error[ActorInitializationException]
+          .withMessageContains("Journal plugin [missing] configuration doesn't exist")
+          .intercept {
+            val ref = testkit2.spawn(Behaviors.setup[Command](counter(_, nextPid()).withJournalPluginId("missing")))
+            val probe = testkit2.createTestProbe()
+            probe.expectTerminated(ref)
+          }(testkit2.system)
       } finally {
         testkit2.shutdownTestKit()
       }
@@ -602,7 +610,7 @@ class EventSourcedBehaviorSpec extends ScalaTestWithActorTestKit(EventSourcedBeh
           """))
       try {
         LoggingEventFilter
-          .warning(start = "No default snapshot store configured", occurrences = 1)
+          .warn("No default snapshot store configured")
           .intercept {
             val ref = testkit2.spawn(Behaviors.setup[Command](counter(_, nextPid())))
             val probe = testkit2.createTestProbe[State]()
@@ -624,13 +632,14 @@ class EventSourcedBehaviorSpec extends ScalaTestWithActorTestKit(EventSourcedBeh
           akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
           """))
       try {
-        LoggingEventFilter[ActorInitializationException](
-          start = "Snapshot store plugin [missing] configuration doesn't exist",
-          occurrences = 1).intercept {
-          val ref = testkit2.spawn(Behaviors.setup[Command](counter(_, nextPid()).withSnapshotPluginId("missing")))
-          val probe = testkit2.createTestProbe()
-          probe.expectTerminated(ref)
-        }(testkit2.system)
+        LoggingEventFilter
+          .error[ActorInitializationException]
+          .withMessageContains("Snapshot store plugin [missing] configuration doesn't exist")
+          .intercept {
+            val ref = testkit2.spawn(Behaviors.setup[Command](counter(_, nextPid()).withSnapshotPluginId("missing")))
+            val probe = testkit2.createTestProbe()
+            probe.expectTerminated(ref)
+          }(testkit2.system)
       } finally {
         testkit2.shutdownTestKit()
       }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/LoggerSourceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/LoggerSourceSpec.scala
@@ -14,6 +14,7 @@ import akka.persistence.typed.RecoveryCompleted
 import akka.persistence.typed.SnapshotCompleted
 import akka.persistence.typed.SnapshotFailed
 import org.scalatest.WordSpecLike
+import org.slf4j.event.Level
 
 // Note that the spec name here is important since there are heuristics in place to avoid names
 // starting with EventSourcedBehavior
@@ -43,7 +44,7 @@ class LoggerSourceSpec extends ScalaTestWithActorTestKit(EventSourcedBehaviorSpe
     // one test case leaks to another, the actual log class is what is tested in each individual case
 
     "log from setup" in {
-      LoggingEventFilter.info("recovery-completed", occurrences = 1).intercept {
+      LoggingEventFilter.info("recovery-completed").intercept {
         eventFilterFor("setting-up-behavior").intercept {
           spawn(behavior)
         }
@@ -52,7 +53,7 @@ class LoggerSourceSpec extends ScalaTestWithActorTestKit(EventSourcedBehaviorSpe
     }
 
     "log from recovery completed" in {
-      LoggingEventFilter.info("setting-up-behavior", occurrences = 1).intercept {
+      LoggingEventFilter.info("setting-up-behavior").intercept {
         eventFilterFor("recovery-completed").intercept {
           spawn(behavior)
         }
@@ -60,8 +61,10 @@ class LoggerSourceSpec extends ScalaTestWithActorTestKit(EventSourcedBehaviorSpe
     }
 
     "log from command handler" in {
-      LoggingEventFilter
-        .info(pattern = "(setting-up-behavior|recovery-completed|event-received)", occurrences = 3)
+      LoggingEventFilter.empty
+        .withLogLevel(Level.INFO)
+        .withMessageRegex("(setting-up-behavior|recovery-completed|event-received)")
+        .withOccurrences(3)
         .intercept {
           eventFilterFor("command-received").intercept {
             spawn(behavior) ! "cmd"
@@ -70,8 +73,10 @@ class LoggerSourceSpec extends ScalaTestWithActorTestKit(EventSourcedBehaviorSpe
     }
 
     "log from event handler" in {
-      LoggingEventFilter
-        .info(pattern = "(setting-up-behavior|recovery-completed|command-received)", occurrences = 3)
+      LoggingEventFilter.empty
+        .withLogLevel(Level.INFO)
+        .withMessageRegex("(setting-up-behavior|recovery-completed|command-received)")
+        .withOccurrences(3)
         .intercept {
           eventFilterFor("event-received").intercept {
             spawn(behavior) ! "cmd"
@@ -81,13 +86,8 @@ class LoggerSourceSpec extends ScalaTestWithActorTestKit(EventSourcedBehaviorSpe
   }
 
   def eventFilterFor(logMsg: String) =
-    LoggingEventFilter.custom(
-      {
-        case logEvent if logEvent.message == logMsg =>
-          if (logEvent.loggerName == classOf[LoggerSourceSpec].getName) true
-          else fail(s"Unexpected logger name: ${logEvent.loggerName} for message ${logEvent.message}")
-        case _ => false
-      },
-      occurrences = 1)
+    LoggingEventFilter.custom { logEvent =>
+      logEvent.message == logMsg && logEvent.loggerName == classOf[LoggerSourceSpec].getName
+    }
 
 }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
@@ -53,7 +53,7 @@ class OptionalSnapshotStoreSpec extends ScalaTestWithActorTestKit(s"""
 
   "Persistence extension" must {
     "initialize properly even in absence of configured snapshot store" in {
-      LoggingEventFilter.warning(start = "No default snapshot store configured", occurrences = 1).intercept {
+      LoggingEventFilter.warn("No default snapshot store configured").intercept {
         val stateProbe = TestProbe[State]()
         spawn(persistentBehavior(stateProbe))
         stateProbe.expectNoMessage()
@@ -61,8 +61,8 @@ class OptionalSnapshotStoreSpec extends ScalaTestWithActorTestKit(s"""
     }
 
     "fail if PersistentActor tries to saveSnapshot without snapshot-store available" in {
-      LoggingEventFilter.error(pattern = ".*No snapshot store configured.*", occurrences = 1).intercept {
-        LoggingEventFilter.warning(pattern = ".*Failed to save snapshot.*", occurrences = 1).intercept {
+      LoggingEventFilter.error("No snapshot store configured").intercept {
+        LoggingEventFilter.warn("Failed to save snapshot").intercept {
           val stateProbe = TestProbe[State]()
           val persistentActor = spawn(persistentBehavior(stateProbe))
           persistentActor ! AnyCommand


### PR DESCRIPTION
On top of https://github.com/akka/akka/pull/27552, but deserves separate review

* builder style
* will make it easier to add more conditions
* all conditions are AND:ed together which makes it easier to define custom filters
* simplifies the implementation as a bonus

Refs #26537

TODO:
* [x] convenience for mdc contains, to simplify all the custom filters
* [x] corresponding javadsl
* [x] update all tests