### PR TITLE
Remove mentions of Typed - replaces @@@note of classic/typed with an includes

### DIFF
--- a/akka-docs/src/main/paradox/actors.md
+++ b/akka-docs/src/main/paradox/actors.md
@@ -1,15 +1,6 @@
 # Classic Actors
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
-For the new API see @ref[actors](typed/actors.md).
-
-@@@
+@@include[includes.md](includes.md) { #actor-api }
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/cluster-client.md
+++ b/akka-docs/src/main/paradox/cluster-client.md
@@ -1,15 +1,7 @@
 # Classic Cluster Client
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
+@@include[includes.md](includes.md) { #actor-api }
 Instead of the cluster client we recommend Akka gRPC (FIXME https://github.com/akka/akka/issues/26175)
-
-@@@
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/cluster-routing.md
+++ b/akka-docs/src/main/paradox/cluster-routing.md
@@ -1,15 +1,7 @@
 # Classic Cluster Aware Routers
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
+@@include[includes.md](includes.md) { #actor-api }
 For the new API see @ref[routers](typed/routers.md).
-
-@@@
 
 All @ref:[routers](routing.md) can be made aware of member nodes in the cluster, i.e.
 deploying new routees or looking up routees on nodes in the cluster.

--- a/akka-docs/src/main/paradox/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/cluster-sharding.md
@@ -1,15 +1,7 @@
 # Classic Cluster Sharding
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
-For the new API see @ref[cluster-sharding](typed/cluster-sharding.md).
-
-@@@
+@@include[includes.md](includes.md) { #actor-api }
+For the new API see @ref:[cluster-sharding](typed/cluster-sharding.md).
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/cluster-singleton.md
+++ b/akka-docs/src/main/paradox/cluster-singleton.md
@@ -1,15 +1,7 @@
 # Classic Cluster Singleton
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
+@@include[includes.md](includes.md) { #actor-api }
 For the new API see @ref[cluster-singleton](typed/cluster-singleton.md).
-
-@@@
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/dispatchers.md
+++ b/akka-docs/src/main/paradox/dispatchers.md
@@ -1,6 +1,6 @@
 # Classic Dispatchers
 
-@@include[includes.md](includes.md) { #actor-api }s
+@@include[includes.md](includes.md) { #actor-api }
 For the new API see @ref:[Dispatchers](typed/dispatchers.md).
 
 For more details on advanced dispatcher config and options, see @ref[Dispatchers](typed/dispatchers.md).

--- a/akka-docs/src/main/paradox/dispatchers.md
+++ b/akka-docs/src/main/paradox/dispatchers.md
@@ -1,15 +1,7 @@
 # Classic Dispatchers
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
-For the new API see @ref[Dispatchers](typed/dispatchers.md).
-
-@@@
+@@include[includes.md](includes.md) { #actor-api }s
+For the new API see @ref:[Dispatchers](typed/dispatchers.md).
 
 For more details on advanced dispatcher config and options, see @ref[Dispatchers](typed/dispatchers.md).
 

--- a/akka-docs/src/main/paradox/distributed-data.md
+++ b/akka-docs/src/main/paradox/distributed-data.md
@@ -1,16 +1,8 @@
 # Classic Distributed Data
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
-For the new API see @ref[distributed-data](typed/distributed-data.md).
-
-@@@
-
+@@include[includes.md](includes.md) { #actor-api }
+For the new API see @ref:[distributed-data](typed/distributed-data.md).
+ 
 ## Dependency
 
 To use Akka Distributed Data, you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/distributed-pub-sub.md
+++ b/akka-docs/src/main/paradox/distributed-pub-sub.md
@@ -1,15 +1,7 @@
 # Classic Distributed Publish Subscribe in Cluster
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
-For the new API see FIXME https://github.com/akka/akka/issues/26338
-
-@@@
+@@include[includes.md](includes.md) { #actor-api }
+For the new API see FIXME https://github.com/akka/akka/issues/26338.
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/fault-tolerance.md
+++ b/akka-docs/src/main/paradox/fault-tolerance.md
@@ -1,15 +1,7 @@
 # Classic Fault Tolerance
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
-For the new API see @ref[fault tolerance](typed/fault-tolerance.md).
-
-@@@
+@@include[includes.md](includes.md) { #actor-api }
+For the new API see @ref:[fault tolerance](typed/fault-tolerance.md).
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/fsm.md
+++ b/akka-docs/src/main/paradox/fsm.md
@@ -1,15 +1,7 @@
 # Classic FSM
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
+@@include[includes.md](includes.md) { #actor-api }
 For the new API see @ref[fsm](typed/fsm.md).
-
-@@@
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/includes.md
+++ b/akka-docs/src/main/paradox/includes.md
@@ -1,0 +1,11 @@
+
+<!--- #actor-api --->
+@@@ note
+
+Akka Classic pertains to the original Actor APIs, which have been improved by more type safe and guided Actor APIs. 
+Akka Classic is still fully supported and existing applications can continue to use the classic APIs. It is also
+possible to use the new Actor APIs together with classic actors in the same ActorSystem, see @ref:[coexistence](typed/coexisting.md).
+For new projects we recommend using @ref:[the new Actor API](typed/actors.md).
+       
+@@@
+<!--- #actor-api --->

--- a/akka-docs/src/main/paradox/index-actors.md
+++ b/akka-docs/src/main/paradox/index-actors.md
@@ -1,15 +1,6 @@
 # Classic Actors
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
-For the new API see @ref[Actors](typed/actors.md).
-
-@@@
+@@include[includes.md](includes.md) { #actor-api }
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/index-classic.md
+++ b/akka-docs/src/main/paradox/index-classic.md
@@ -1,13 +1,6 @@
 # Akka Classic
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
-@@@
+@@include[includes.md](includes.md) { #actor-api }
 
 @@toc { depth=2 }
 

--- a/akka-docs/src/main/paradox/index-cluster.md
+++ b/akka-docs/src/main/paradox/index-cluster.md
@@ -1,15 +1,7 @@
 # Classic Clustering
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
+@@include[includes.md](includes.md) { #actor-api }
 For the new API see @ref[Cluster](typed/index-cluster.md). 
-
-@@@
 
 @@toc { depth=2 }
 

--- a/akka-docs/src/main/paradox/index-network.md
+++ b/akka-docs/src/main/paradox/index-network.md
@@ -1,15 +1,7 @@
 # Classic Networking
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
+@@include[includes.md](includes.md) { #actor-api }
 FIXME https://github.com/akka/akka/issues/27263
-
-@@@
 
 @@toc { depth=2 }
 

--- a/akka-docs/src/main/paradox/mailboxes.md
+++ b/akka-docs/src/main/paradox/mailboxes.md
@@ -1,7 +1,7 @@
 # Classic Mailboxes
 
 @@include[includes.md](includes.md) { #actor-api }
-For the new API see (FIXME https://github.com/akka/akka/issues/27124).
+For the new API see @ref:[mailboxes](typed/mailboxes.md).
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/mailboxes.md
+++ b/akka-docs/src/main/paradox/mailboxes.md
@@ -1,15 +1,7 @@
 # Classic Mailboxes
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
+@@include[includes.md](includes.md) { #actor-api }
 For the new API see (FIXME https://github.com/akka/akka/issues/27124).
-
-@@@
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/persistence-fsm.md
+++ b/akka-docs/src/main/paradox/persistence-fsm.md
@@ -1,13 +1,6 @@
 # Classic Persistent FSM
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
-@@@
+@@include[includes.md](includes.md) { #actor-api }
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/persistence.md
+++ b/akka-docs/src/main/paradox/persistence.md
@@ -1,15 +1,7 @@
 # Classic Persistence
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
+@@include[includes.md](includes.md) { #actor-api }
 For the new API see @ref[persistence](typed/persistence.md).
-
-@@@
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/routing.md
+++ b/akka-docs/src/main/paradox/routing.md
@@ -1,15 +1,7 @@
 # Classic Routing
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
+@@include[includes.md](includes.md) { #actor-api }
 For the new API see @ref[routers](typed/routers.md).
-
-@@@
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/scheduler.md
+++ b/akka-docs/src/main/paradox/scheduler.md
@@ -1,15 +1,7 @@
 # Classic Scheduler
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
-For the new API see @ref[typed scheduling](typed/interaction-patterns.md#typed-scheduling).
-
-@@@
+@@include[includes.md](includes.md) { #actor-api }
+For the new API see @ref:[typed scheduling](typed/interaction-patterns.md#typed-scheduling).
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/testing.md
+++ b/akka-docs/src/main/paradox/testing.md
@@ -1,15 +1,7 @@
 # Testing Classic Actors
 
-@@@ note
-
-Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
-known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
-the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
-ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.
-
+@@include[includes.md](includes.md) { #actor-api }
 For the new API see @ref[testing](typed/testing.md).
-
-@@@
 
 ## Dependency
 

--- a/build.sbt
+++ b/build.sbt
@@ -239,7 +239,12 @@ lazy val docs = akkaModule("akka-docs")
       // Page that recommends Alpakka:
       "camel.html",
       // TODO seems like an orphan?
-      "fault-tolerance-sample.html"
+      "fault-tolerance-sample.html",
+      // FIXME https://github.com/lightbend/paradox/issues/350
+      // for subdirs you can add an /includes/page.html to add snippets
+      // but from a root page.md it can't resolve a typed/page.html from /subdir/page
+      // other include options are however possible from an /includes
+      "includes.html"
     ),
     resolvers += Resolver.jcenterRepo,
     apidocRootPackage := "akka",

--- a/build.sbt
+++ b/build.sbt
@@ -241,9 +241,8 @@ lazy val docs = akkaModule("akka-docs")
       // TODO seems like an orphan?
       "fault-tolerance-sample.html",
       // FIXME https://github.com/lightbend/paradox/issues/350
-      // for subdirs you can add an /includes/page.html to add snippets
-      // but from a root page.md it can't resolve a typed/page.html from /subdir/page
-      // other include options are however possible from an /includes
+      // Links in a snippet are interpreted relative to the page the snippet is included in,
+      // instead of relative to the place where the snippet is declared.
       "includes.html"
     ),
     resolvers += Resolver.jcenterRepo,


### PR DESCRIPTION
## References
https://github.com/akka/akka/issues/24717

## Changes
Replaces all of these scattered in most of the /paradox root markup files with an includes

```
@@@ note

Akka Classic is the original Actor APIs, which have been improved by more type safe and guided Actor APIs, 
known as Akka Typed. Akka Classic is still fully supported and existing applications can continue to use 
the classic APIs. It is also possible to use Akka Typed together with classic actors within the same 
ActorSystem, see @ref[coexistence](typed/coexisting.md). For new projects we recommend using the new Actor APIs.

@@@
```

