### PR TITLE
Docs and related naming & content: Change Untyped to Classic

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -57,7 +57,7 @@ import com.github.ghik.silencer.silent
 
   // stream materialization etc. using stub not supported
   override private[akka] def classicSystem =
-    throw new UnsupportedOperationException("no untyped actor system available")
+    throw new UnsupportedOperationException("No classic actor system available.")
 
   // impl InternalRecipientRef
   def isTerminated: Boolean = whenTerminated.isCompleted

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ManualTime.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/ManualTime.scala
@@ -42,7 +42,7 @@ object ManualTime {
         }
       case s =>
         throw new IllegalArgumentException(
-          s"ActorSystem.scheduler is not an untyped SchedulerAdapter but a ${s.getClass.getName}, this is not supported")
+          s"ActorSystem.scheduler is not a classic SchedulerAdapter but a ${s.getClass.getName}, this is not supported")
     }
 
 }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ManualTime.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ManualTime.scala
@@ -41,7 +41,7 @@ object ManualTime {
         }
       case s =>
         throw new IllegalArgumentException(
-          s"ActorSystem.scheduler is not an untyped SchedulerAdapter but a ${s.getClass.getName}, this is not supported")
+          s"ActorSystem.scheduler is not a classic SchedulerAdapter but a ${s.getClass.getName}, this is not supported.")
     }
 
 }

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/ClassicWatchingTypedTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/ClassicWatchingTypedTest.java
@@ -10,7 +10,7 @@ import akka.actor.typed.ActorSystem;
 import akka.actor.typed.Behavior;
 import akka.actor.typed.javadsl.Behaviors;
 // #adapter-import
-// In java use the static methods on Adapter to convert from typed to untyped
+// In java use the static methods on Adapter to convert from typed to classic
 import akka.actor.typed.javadsl.Adapter;
 // #adapter-import
 import akka.testkit.TestProbe;
@@ -21,12 +21,12 @@ import scala.concurrent.duration.Duration;
 
 import static akka.actor.typed.javadsl.Behaviors.same;
 
-public class UntypedWatchingTypedTest extends JUnitSuite {
+public class ClassicWatchingTypedTest extends JUnitSuite {
 
-  // #untyped-watch
-  public static class Untyped extends AbstractActor {
+  // #classic-watch
+  public static class Classic extends AbstractActor {
     public static akka.actor.Props props() {
-      return akka.actor.Props.create(Untyped.class);
+      return akka.actor.Props.create(Classic.class);
     }
 
     private final akka.actor.typed.ActorRef<Typed.Command> second =
@@ -54,7 +54,7 @@ public class UntypedWatchingTypedTest extends JUnitSuite {
           .build();
     }
   }
-  // #untyped-watch
+  // #classic-watch
 
   // #typed
   public abstract static class Typed {
@@ -85,22 +85,22 @@ public class UntypedWatchingTypedTest extends JUnitSuite {
 
   @Test
   public void testItWorks() {
-    // #create-untyped
+    // #create-classic
     akka.actor.ActorSystem as = akka.actor.ActorSystem.create();
-    akka.actor.ActorRef untyped = as.actorOf(Untyped.props());
-    // #create-untyped
+    akka.actor.ActorRef classic = as.actorOf(Classic.props());
+    // #create-classic
     TestProbe probe = new TestProbe(as);
-    probe.watch(untyped);
-    probe.expectTerminated(untyped, Duration.create(1, "second"));
+    probe.watch(classic);
+    probe.expectTerminated(classic, Duration.create(1, "second"));
     TestKit.shutdownActorSystem(as);
   }
 
   @Test
-  public void testConversionFromUnTypedSystemToTyped() {
-    // #convert-untyped
-    akka.actor.ActorSystem untypedActorSystem = akka.actor.ActorSystem.create();
-    ActorSystem<Void> typedActorSystem = Adapter.toTyped(untypedActorSystem);
-    // #convert-untyped
-    TestKit.shutdownActorSystem(untypedActorSystem);
+  public void testConversionFromClassicSystemToTyped() {
+    // #convert-classic
+    akka.actor.ActorSystem classicActorSystem = akka.actor.ActorSystem.create();
+    ActorSystem<Void> typedActorSystem = Adapter.toTyped(classicActorSystem);
+    // #convert-classic
+    TestKit.shutdownActorSystem(classicActorSystem);
   }
 }

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingClassicTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingClassicTest.java
@@ -9,7 +9,7 @@ import akka.actor.ActorSystem;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
 // #adapter-import
-// in Java use the static methods on Adapter to convert from untyped to typed
+// in Java use the static methods on Adapter to convert from classic to typed
 import akka.actor.typed.javadsl.Adapter;
 // #adapter-import
 import akka.actor.typed.javadsl.AbstractBehavior;
@@ -20,7 +20,7 @@ import akka.testkit.javadsl.TestKit;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 
-public class TypedWatchingUntypedTest extends JUnitSuite {
+public class TypedWatchingClassicTest extends JUnitSuite {
 
   // #typed
   public static class Typed extends AbstractBehavior<Typed.Command> {
@@ -50,7 +50,7 @@ public class TypedWatchingUntypedTest extends JUnitSuite {
     public static Behavior<Command> create() {
       return akka.actor.typed.javadsl.Behaviors.setup(
           context -> {
-            akka.actor.ActorRef second = Adapter.actorOf(context, Untyped.props(), "second");
+            akka.actor.ActorRef second = Adapter.actorOf(context, Classic.props(), "second");
 
             Adapter.watch(context, second);
 
@@ -76,10 +76,10 @@ public class TypedWatchingUntypedTest extends JUnitSuite {
   }
   // #typed
 
-  // #untyped
-  public static class Untyped extends AbstractActor {
+  // #classic
+  public static class Classic extends AbstractActor {
     public static akka.actor.Props props() {
-      return akka.actor.Props.create(Untyped.class);
+      return akka.actor.Props.create(Classic.class);
     }
 
     @Override
@@ -91,7 +91,7 @@ public class TypedWatchingUntypedTest extends JUnitSuite {
       message.replyTo.tell(Typed.Pong.INSTANCE);
     }
   }
-  // #untyped
+  // #classic
 
   @Test
   public void testItWorks() {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ExtensionsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ExtensionsSpec.scala
@@ -188,7 +188,7 @@ class ExtensionsSpec extends ScalaTestWithActorTestKit with WordSpecLike {
       (instance1 should be).theSameInstanceAs(instance2)
     }
 
-    "load registered typed extensions eagerly even for untyped system" in {
+    "load registered typed extensions eagerly even for classic system" in {
       import akka.actor.typed.scaladsl.adapter._
       val beforeCreation = InstanceCountingExtension.createCount.get()
       val untypedSystem = akka.actor.ActorSystem("as", ExtensionsSpec.config)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/coexistence/TypedSupervisingUntypedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/coexistence/TypedSupervisingUntypedSpec.scala
@@ -45,7 +45,7 @@ class TypedSupervisingUntypedSpec extends ScalaTestWithActorTestKit("""
   """.stripMargin) with WordSpecLike {
   import TypedSupervisingUntypedSpec._
 
-  "Typed supervising untyped" should {
+  "Typed supervising classic" should {
     "default to restart" in {
       val ref: ActorRef[Protocol] = spawn(untypedActorOf())
       val lifecycleProbe = TestProbe[String]
@@ -55,7 +55,7 @@ class TypedSupervisingUntypedSpec extends ScalaTestWithActorTestKit("""
       lifecycleProbe.expectMessage("preStart")
       spawnedUntyped ! "throw"
       lifecycleProbe.expectMessage("postStop")
-      // should be restarted because it is an untyped actor
+      // should be restarted because it is a classic actor
       lifecycleProbe.expectMessage("preStart")
     }
   }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/coexistence/UntypedSupervisingTypedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/coexistence/UntypedSupervisingTypedSpec.scala
@@ -54,7 +54,7 @@ class UntypedSupervisingTypedSpec
 
   implicit val typedActorSystem: ActorSystem[Nothing] = system.toTyped
 
-  "An untyped actor system that spawns typed actors" should {
+  "A classic actor system that spawns typed actors" should {
     "default to stop for supervision" in {
       val probe = TestProbe()
       val underTest = system.spawn(ProbedBehavior.behavior(probe.ref), "a1")
@@ -87,9 +87,9 @@ class UntypedSupervisingTypedSpec
     }
 
     "default to stop supervision (from context)" in {
-      val untyped = system.actorOf(u.Props(new UntypedToTyped()))
+      val classic = system.actorOf(u.Props(new UntypedToTyped()))
       val probe = TestProbe()
-      untyped ! SpawnFromUntyped(ProbedBehavior.behavior(probe.ref), "a3")
+      classic ! SpawnFromUntyped(ProbedBehavior.behavior(probe.ref), "a3")
       val underTest = expectMsgType[TypedSpawnedFromUntypedConext].actorRef
       watch(underTest.toUntyped)
       underTest ! "throw"
@@ -99,10 +99,10 @@ class UntypedSupervisingTypedSpec
     }
 
     "allow overriding the default (from context)" in {
-      val untyped = system.actorOf(u.Props(new UntypedToTyped()))
+      val classic = system.actorOf(u.Props(new UntypedToTyped()))
       val probe = TestProbe()
       val behavior = Behaviors.supervise(ProbedBehavior.behavior(probe.ref)).onFailure(SupervisorStrategy.restart)
-      untyped ! SpawnFromUntyped(behavior, "a4")
+      classic ! SpawnFromUntyped(behavior, "a4")
       val underTest = expectMsgType[TypedSpawnedFromUntypedConext].actorRef
       watch(underTest.toUntyped)
       underTest ! "throw"
@@ -112,9 +112,9 @@ class UntypedSupervisingTypedSpec
     }
 
     "default to stop supervision for spawn anonymous (from context)" in {
-      val untyped = system.actorOf(u.Props(new UntypedToTyped()))
+      val classic = system.actorOf(u.Props(new UntypedToTyped()))
       val probe = TestProbe()
-      untyped ! SpawnAnonFromUntyped(ProbedBehavior.behavior(probe.ref))
+      classic ! SpawnAnonFromUntyped(ProbedBehavior.behavior(probe.ref))
       val underTest = expectMsgType[TypedSpawnedFromUntypedConext].actorRef
       watch(underTest.toUntyped)
       underTest ! "throw"

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
@@ -38,7 +38,7 @@ class GuardianStartupSpec extends WordSpec with Matchers with ScalaFutures {
       }
     }
 
-    "not start before untyped system initialization is complete" in {
+    "not start before classic system initialization is complete" in {
       var system: ActorSystem[String] = null
       val initialized = new CountDownLatch(1)
       val guardianBehavior = Behaviors.setup[String] { ctx =>

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingClassicSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingClassicSpec.scala
@@ -7,19 +7,19 @@ package docs.akka.typed.coexistence
 import akka.actor.typed._
 import akka.actor.typed.scaladsl.Behaviors
 import akka.testkit.TestKit
-import docs.akka.typed.coexistence.TypedWatchingUntypedSpec.Typed
+import docs.akka.typed.coexistence.TypedWatchingClassicSpec.Typed
 //#adapter-import
-// adds support for typed actors to an untyped actor system and context
+// adds support for typed actors to a classic actor system and context
 import akka.actor.typed.scaladsl.adapter._
 //#adapter-import
 import akka.testkit.TestProbe
 //#import-alias
-import akka.{ actor => untyped }
+import akka.{ actor => classic }
 //#import-alias
 import org.scalatest.WordSpec
 import scala.concurrent.duration._
 
-object TypedWatchingUntypedSpec {
+object TypedWatchingClassicSpec {
 
   //#typed
   object Typed {
@@ -30,20 +30,20 @@ object TypedWatchingUntypedSpec {
     val behavior: Behavior[Command] =
       Behaviors.setup { context =>
         // context.actorOf is an implicit extension method
-        val untyped = context.actorOf(Untyped.props(), "second")
+        val classic = context.actorOf(Classic.props(), "second")
 
         // context.watch is an implicit extension method
-        context.watch(untyped)
+        context.watch(classic)
 
         // illustrating how to pass sender, toUntyped is an implicit extension method
-        untyped.tell(Typed.Ping(context.self), context.self.toUntyped)
+        classic.tell(Typed.Ping(context.self), context.self.toUntyped)
 
         Behaviors
           .receivePartial[Command] {
             case (context, Pong) =>
               // it's not possible to get the sender, that must be sent in message
               // context.stop is an implicit extension method
-              context.stop(untyped)
+              context.stop(classic)
               Behaviors.same
           }
           .receiveSignal {
@@ -54,27 +54,27 @@ object TypedWatchingUntypedSpec {
   }
   //#typed
 
-  //#untyped
-  object Untyped {
-    def props(): untyped.Props = untyped.Props(new Untyped)
+  //#classic
+  object Classic {
+    def props(): classic.Props = classic.Props(new Classic)
   }
-  class Untyped extends untyped.Actor {
+  class Classic extends classic.Actor {
     override def receive = {
       case Typed.Ping(replyTo) =>
         replyTo ! Typed.Pong
     }
   }
-  //#untyped
+  //#classic
 }
 
-class TypedWatchingUntypedSpec extends WordSpec {
+class TypedWatchingClassicSpec extends WordSpec {
 
-  import TypedWatchingUntypedSpec._
+  import TypedWatchingClassicSpec._
 
-  "Typed -> Untyped" must {
+  "Typed -> Classic" must {
     "support creating, watching and messaging" in {
       //#create
-      val system = untyped.ActorSystem("TypedWatchingUntyped")
+      val system = classic.ActorSystem("TypedWatchingClassic")
       val typed = system.spawn(Typed.behavior, "Typed")
       //#create
       val probe = TestProbe()(system)

--- a/akka-actor-typed/src/main/resources/reference.conf
+++ b/akka-actor-typed/src/main/resources/reference.conf
@@ -25,7 +25,7 @@ akka.actor.typed {
   restart-stash-capacity = 1000
 }
 
-# Load typed extensions by an untyped unextension.
+# Load typed extensions by a classic unextension.
 akka.library-extensions += "akka.actor.typed.internal.adapter.ActorSystemAdapter$LoadTypedExtensions"
 
 akka.actor {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -227,9 +227,9 @@ object ActorSystem {
     create(guardianBehavior, name, ActorSystemSetup.create(bootstrapSetup))
 
   /**
-   * Create an ActorSystem based on the untyped [[akka.actor.ActorSystem]]
+   * Create an ActorSystem based on the classic [[akka.actor.ActorSystem]]
    * which runs Akka Typed [[Behavior]] on an emulation layer. In this
-   * system typed and untyped actors can coexist.
+   * system typed and classic actors can coexist.
    */
   private def createInternal[T](
       name: String,
@@ -259,7 +259,7 @@ object ActorSystem {
   }
 
   /**
-   * Wrap an untyped [[akka.actor.ActorSystem]] such that it can be used from
+   * Wrap a classic [[akka.actor.ActorSystem]] such that it can be used from
    * Akka Typed [[Behavior]].
    */
   def wrap(system: untyped.ActorSystem): ActorSystem[Nothing] =

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/SpawnProtocol.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/SpawnProtocol.scala
@@ -16,7 +16,7 @@ import akka.annotation.DoNotInherit
  * The typical usage of this is to use it as the guardian actor of the [[ActorSystem]], possibly combined with
  * `Behaviors.setup` to starts some initial tasks or actors. Child actors can then be started from the outside
  * by telling or asking [[SpawnProtocol#Spawn]] to the actor reference of the system. When using `ask` this is
- * similar to how [[akka.actor.ActorSystem#actorOf]] can be used in untyped actors with the difference that
+ * similar to how [[akka.actor.ActorSystem#actorOf]] can be used in classic actors with the difference that
  * a `Future` / `CompletionStage` of the `ActorRef` is returned.
  *
  * Stopping children is done through specific support in the protocol of the children, or stopping the entire

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/MiscMessageSerializer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/MiscMessageSerializer.scala
@@ -17,7 +17,7 @@ class MiscMessageSerializer(val system: akka.actor.ExtendedActorSystem)
     extends SerializerWithStringManifest
     with BaseSerializer {
 
-  // Serializers are initialized early on. `toTyped` might then try to initialize the untyped ActorSystemAdapter extension.
+  // Serializers are initialized early on. `toTyped` might then try to initialize the classic ActorSystemAdapter extension.
   private lazy val resolver = ActorRefResolver(system.toTyped)
   private val ActorRefManifest = "a"
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/PoisonPill.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/PoisonPill.scala
@@ -14,7 +14,7 @@ import akka.annotation.InternalApi
 /**
  * INTERNAL API
  *
- * Note that this is a `Signal` poison pill, not a universal poison pill like the untyped actor one.
+ * Note that this is a `Signal` poison pill, not a universal poison pill like the classic actor one.
  * This requires special handling on the receiving side where it is used (for example with the interceptor below).
  */
 @InternalApi private[akka] sealed abstract class PoisonPill extends Signal

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
@@ -64,7 +64,7 @@ import akka.util.OptionVal
   }
 
   /**
-   * Failures from failed children, that were stopped through untyped supervision, this is what allows us to pass
+   * Failures from failed children, that were stopped through classic supervision, this is what allows us to pass
    * child exception in Terminated for direct children.
    */
   private var failures: Map[untyped.ActorRef, Throwable] = Map.empty
@@ -73,7 +73,7 @@ import akka.util.OptionVal
 
   override protected[akka] def aroundReceive(receive: Receive, msg: Any): Unit = {
     // as we know we never become in "normal" typed actors, it is just the current behavior that
-    // changes, we can avoid some overhead with the partial function/behavior stack of untyped entirely
+    // changes, we can avoid some overhead with the partial function/behavior stack of classic entirely
     // we also know that the receive is total, so we can avoid the orElse part as well.
     msg match {
       case untyped.Terminated(ref) =>
@@ -146,7 +146,7 @@ import akka.util.OptionVal
         unhandled(msg)
       case BehaviorTags.FailedBehavior =>
         val f = b.asInstanceOf[BehaviorImpl.FailedBehavior]
-        // For the parent untyped supervisor to pick up the exception
+        // For the parent classic supervisor to pick up the exception
         if (rethrowTypedFailure) throw TypedActorFailedException(f.cause)
         else context.stop(self)
       case BehaviorTags.StoppedBehavior =>

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorContextAdapter.scala
@@ -23,7 +23,7 @@ private[akka] object ActorContextAdapter {
       case adapter: ActorContextAdapter[_] => adapter.untypedContext
       case _ =>
         throw new UnsupportedOperationException(
-          "only adapted untyped ActorContext permissible " +
+          "only adapted classic ActorContext permissible " +
           s"($context of class ${context.getClass.getName})")
     }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala
@@ -51,7 +51,7 @@ private[akka] object ActorRefAdapter {
       case system: ActorSystemAdapter[_] => system.untypedSystem.guardian
       case _ =>
         throw new UnsupportedOperationException(
-          "only adapted untyped ActorRefs permissible " +
+          "only adapted classic ActorRefs permissible " +
           s"($ref of class ${ref.getClass.getName})")
     }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/PropsAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/PropsAdapter.scala
@@ -32,7 +32,7 @@ import akka.dispatch.Mailboxes
     val p2 = deploy.firstOrElse[MailboxSelector](MailboxSelector.default()) match {
       case _: DefaultMailboxSelector           => p1
       case BoundedMailboxSelector(capacity, _) =>
-        // specific support in untyped Mailboxes
+        // specific support in classic Mailboxes
         p1.withMailbox(s"${Mailboxes.BoundedCapacityPrefix}$capacity")
       case MailboxFromConfigSelector(path, _) =>
         props.withMailbox(path)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Adapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Adapter.scala
@@ -14,23 +14,23 @@ import akka.actor.typed.internal.adapter.ActorContextAdapter
 import akka.japi.Creator
 
 /**
- * Java API: Adapters between typed and untyped actors and actor systems.
- * The underlying `ActorSystem` is the untyped [[akka.actor.ActorSystem]]
+ * Java API: Adapters between typed and classic actors and actor systems.
+ * The underlying `ActorSystem` is the classic [[akka.actor.ActorSystem]]
  * which runs Akka Typed [[akka.actor.typed.Behavior]] on an emulation layer. In this
- * system typed and untyped actors can coexist.
+ * system typed and classic actors can coexist.
  *
- * These methods make it possible to create typed child actor from untyped
- * parent actor, and the opposite untyped child from typed parent.
+ * These methods make it possible to create typed child actor from classic
+ * parent actor, and the opposite classic child from typed parent.
  * `watch` is also supported in both directions.
  *
- * There are also converters (`toTyped`, `toUntyped`) between untyped
- * [[akka.actor.ActorRef]] and typed [[akka.actor.typed.ActorRef]], and between untyped
+ * There are also converters (`toTyped`, `toUntyped`) between classic
+ * [[akka.actor.ActorRef]] and typed [[akka.actor.typed.ActorRef]], and between classic
  * [[akka.actor.ActorSystem]] and typed [[akka.actor.typed.ActorSystem]].
  */
 object Adapter {
 
   /**
-   *  Spawn the given behavior as a child of the user actor in an untyped ActorSystem.
+   *  Spawn the given behavior as a child of the user actor in a classic ActorSystem.
    *  Typed actors default supervision strategy is to stop. Can be overridden with
    *  `Behaviors.supervise`.
    */
@@ -38,7 +38,7 @@ object Adapter {
     spawnAnonymous(sys, behavior, Props.empty)
 
   /**
-   *  Spawn the given behavior as a child of the user actor in an untyped ActorSystem.
+   *  Spawn the given behavior as a child of the user actor in a classic ActorSystem.
    *  Typed actors default supervision strategy is to stop. Can be overridden with
    *  `Behaviors.supervise`.
    */
@@ -46,7 +46,7 @@ object Adapter {
     sys.spawnAnonymous(behavior, props)
 
   /**
-   *  Spawn the given behavior as a child of the user actor in an untyped ActorSystem.
+   *  Spawn the given behavior as a child of the user actor in a classic ActorSystem.
    *  Typed actors default supervision strategy is to stop. Can be overridden with
    *  `Behaviors.supervise`.
    */
@@ -54,7 +54,7 @@ object Adapter {
     spawn(sys, behavior, name, Props.empty)
 
   /**
-   *  Spawn the given behavior as a child of the user actor in an untyped ActorSystem.
+   *  Spawn the given behavior as a child of the user actor in a classic ActorSystem.
    *  Typed actors default supervision strategy is to stop. Can be overridden with
    *  `Behaviors.supervise`.
    */
@@ -62,7 +62,7 @@ object Adapter {
     sys.spawn(behavior, name, props)
 
   /**
-   *  Spawn the given behavior as a child of the user actor in an untyped ActorContext.
+   *  Spawn the given behavior as a child of the user actor in a classic ActorContext.
    *  Typed actors default supervision strategy is to stop. Can be overridden with
    *  `Behaviors.supervise`.
    */
@@ -70,7 +70,7 @@ object Adapter {
     spawnAnonymous(ctx, behavior, Props.empty)
 
   /**
-   *  Spawn the given behavior as a child of the user actor in an untyped ActorContext.
+   *  Spawn the given behavior as a child of the user actor in a classic ActorContext.
    *  Typed actors default supervision strategy is to stop. Can be overridden with
    *  `Behaviors.supervise`.
    */
@@ -78,7 +78,7 @@ object Adapter {
     ctx.spawnAnonymous(behavior, props)
 
   /**
-   *  Spawn the given behavior as a child of the user actor in an untyped ActorContext.
+   *  Spawn the given behavior as a child of the user actor in a classic ActorContext.
    *  Typed actors default supervision strategy is to stop. Can be overridden with
    *  `Behaviors.supervise`.
    */
@@ -86,7 +86,7 @@ object Adapter {
     spawn(ctx, behavior, name, Props.empty)
 
   /**
-   *  Spawn the given behavior as a child of the user actor in an untyped ActorContext.
+   *  Spawn the given behavior as a child of the user actor in a classic ActorContext.
    *  Typed actors default supervision strategy is to stop. Can be overridden with
    *  `Behaviors.supervise`.
    */
@@ -133,24 +133,24 @@ object Adapter {
     ref
 
   /**
-   * Wrap [[akka.actor.typed.Behavior]] in an untyped [[akka.actor.Props]], i.e. when
-   * spawning a typed child actor from an untyped parent actor.
+   * Wrap [[akka.actor.typed.Behavior]] in a classic [[akka.actor.Props]], i.e. when
+   * spawning a typed child actor from a classic parent actor.
    * This is normally not needed because you can use the extension methods
-   * `spawn` and `spawnAnonymous` with an untyped `ActorContext`, but it's needed
+   * `spawn` and `spawnAnonymous` with a classic `ActorContext`, but it's needed
    * when using typed actors with an existing library/tool that provides an API that
-   * takes an untyped [[akka.actor.Props]] parameter. Cluster Sharding is an
+   * takes a classic [[akka.actor.Props]] parameter. Cluster Sharding is an
    * example of that.
    */
   def props[T](behavior: Creator[Behavior[T]], deploy: Props): akka.actor.Props =
     akka.actor.typed.internal.adapter.PropsAdapter(() => behavior.create(), deploy)
 
   /**
-   * Wrap [[akka.actor.typed.Behavior]] in an untyped [[akka.actor.Props]], i.e. when
-   * spawning a typed child actor from an untyped parent actor.
+   * Wrap [[akka.actor.typed.Behavior]] in a classic [[akka.actor.Props]], i.e. when
+   * spawning a typed child actor from a classic parent actor.
    * This is normally not needed because you can use the extension methods
-   * `spawn` and `spawnAnonymous` with an untyped `ActorContext`, but it's needed
+   * `spawn` and `spawnAnonymous` with a classic `ActorContext`, but it's needed
    * when using typed actors with an existing library/tool that provides an API that
-   * takes an untyped [[akka.actor.Props]] parameter. Cluster Sharding is an
+   * takes a classic [[akka.actor.Props]] parameter. Cluster Sharding is an
    * example of that.
    */
   def props[T](behavior: Creator[Behavior[T]]): akka.actor.Props =

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/adapter/PropsAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/adapter/PropsAdapter.scala
@@ -8,12 +8,12 @@ import akka.actor.typed.Behavior
 import akka.actor.typed.Props
 
 /**
- * Wrap [[akka.actor.typed.Behavior]] in an untyped [[akka.actor.Props]], i.e. when
- * spawning a typed child actor from an untyped parent actor.
+ * Wrap [[akka.actor.typed.Behavior]] in a classic [[akka.actor.Props]], i.e. when
+ * spawning a typed child actor from a classic parent actor.
  * This is normally not needed because you can use the extension methods
- * `spawn` and `spawnAnonymous` on an untyped `ActorContext`, but it's needed
+ * `spawn` and `spawnAnonymous` on a classic `ActorContext`, but it's needed
  * when using typed actors with an existing library/tool that provides an API that
- * takes an untyped [[akka.actor.Props]] parameter. Cluster Sharding is an
+ * takes a classic [[akka.actor.Props]] parameter. Cluster Sharding is an
  * example of that.
  */
 object PropsAdapter {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/adapter/package.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/adapter/package.scala
@@ -10,23 +10,23 @@ import akka.actor.typed.internal.adapter.{ PropsAdapter => _, _ }
 import akka.annotation.InternalApi
 
 /**
- * Scala API: Adapters between typed and untyped actors and actor systems.
- * The underlying `ActorSystem` is the untyped [[akka.actor.ActorSystem]]
+ * Scala API: Adapters between typed and classic actors and actor systems.
+ * The underlying `ActorSystem` is the classic [[akka.actor.ActorSystem]]
  * which runs Akka Typed [[akka.actor.typed.Behavior]] on an emulation layer. In this
- * system typed and untyped actors can coexist.
+ * system typed and classic actors can coexist.
  *
  * Use these adapters with `import akka.actor.typed.scaladsl.adapter._`.
  *
- * Implicit extension methods are added to untyped and typed `ActorSystem`,
+ * Implicit extension methods are added to classic and typed `ActorSystem`,
  * `ActorContext`. Such methods make it possible to create typed child actor
- * from untyped parent actor, and the opposite untyped child from typed parent.
+ * from classic parent actor, and the opposite classic child from typed parent.
  * `watch` is also supported in both directions.
  *
- * There is an implicit conversion from untyped [[akka.actor.ActorRef]] to
+ * There is an implicit conversion from classic [[akka.actor.ActorRef]] to
  * typed [[akka.actor.typed.ActorRef]].
  *
  * There are also converters (`toTyped`, `toUntyped`) from typed
- * [[akka.actor.typed.ActorRef]] to untyped [[akka.actor.ActorRef]], and between untyped
+ * [[akka.actor.typed.ActorRef]] to classic [[akka.actor.ActorRef]], and between classic
  * [[akka.actor.ActorSystem]] and typed [[akka.actor.typed.ActorSystem]].
  */
 package object adapter {
@@ -39,7 +39,7 @@ package object adapter {
   implicit class UntypedActorSystemOps(val sys: akka.actor.ActorSystem) extends AnyVal {
 
     /**
-     *  Spawn the given behavior as a child of the user actor in an untyped ActorSystem.
+     *  Spawn the given behavior as a child of the user actor in a classic ActorSystem.
      *
      *  Typed actors default supervision strategy is to stop. Can be overridden with
      *  `Behaviors.supervise`.
@@ -53,7 +53,7 @@ package object adapter {
     }
 
     /**
-     *  Spawn the given behavior as a child of the user actor in an untyped ActorSystem.
+     *  Spawn the given behavior as a child of the user actor in a classic ActorSystem.
      *
      *  Typed actors default supervision strategy is to stop. Can be overridden with
      *  `Behaviors.supervise`.
@@ -93,7 +93,7 @@ package object adapter {
   implicit class UntypedActorContextOps(val ctx: akka.actor.ActorContext) extends AnyVal {
 
     /**
-     *  Spawn the given behavior as a child of the user actor in an untyped ActorContext.
+     *  Spawn the given behavior as a child of the user actor in a classic ActorContext.
      *
      *  Typed actors default supervision strategy is to stop. Can be overridden with
      *  `Behaviors.supervise`.
@@ -106,7 +106,7 @@ package object adapter {
         rethrowTypedFailure = false)
 
     /**
-     *  Spawn the given behavior as a child of the user actor in an untyped ActorContext.
+     *  Spawn the given behavior as a child of the user actor in a classic ActorContext.
      *
      *  Typed actors default supervision strategy is to stop. Can be overridden with
      *  `Behaviors.supervise`.
@@ -154,7 +154,7 @@ package object adapter {
   implicit class UntypedActorRefOps(val ref: akka.actor.ActorRef) extends AnyVal {
 
     /**
-     * Adapt the untyped `ActorRef` to typed `ActorRef[T]`. There is also an
+     * Adapt the classic `ActorRef` to typed `ActorRef[T]`. There is also an
      * automatic implicit conversion for this, but this more explicit variant might
      * sometimes be preferred.
      */
@@ -162,7 +162,7 @@ package object adapter {
   }
 
   /**
-   * Implicit conversion from untyped [[akka.actor.ActorRef]] to typed [[akka.actor.typed.ActorRef]].
+   * Implicit conversion from classic [[akka.actor.ActorRef]] to typed [[akka.actor.typed.ActorRef]].
    */
   implicit def actorRefAdapter[T](ref: akka.actor.ActorRef): ActorRef[T] = ActorRefAdapter(ref)
 

--- a/akka-actor/src/main/scala/akka/actor/AbstractActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/AbstractActor.scala
@@ -321,7 +321,7 @@ abstract class AbstractActor extends Actor {
  * of `AbstractActor`. The partial functions created by the `ReceiveBuilder` consist of multiple lambda
  * expressions for every match statement, where each lambda is referencing the code to be run. This is something
  * that the JVM can have problems optimizing and the resulting code might not be as performant as the
- * untyped version. When extending `UntypedAbstractActor` each message is received as an untyped
+ * classic version. When extending `UntypedAbstractActor` each message is received as a classic
  * `Object` and you have to inspect and cast it to the actual message type in other ways (instanceof checks).
  */
 abstract class UntypedAbstractActor extends AbstractActor {

--- a/akka-docs/src/main/paradox/actors.md
+++ b/akka-docs/src/main/paradox/actors.md
@@ -837,7 +837,7 @@ actors you can consider to implement it at lower level by extending `UntypedAbst
 of `AbstractActor`. The partial functions created by the `ReceiveBuilder` consist of multiple lambda
 expressions for every match statement, where each lambda is referencing the code to be run. This is something
 that the JVM can have problems optimizing and the resulting code might not be as performant as the
-untyped version. When extending `UntypedAbstractActor` each message is received as an untyped
+classic version. When extending `UntypedAbstractActor` each message is received as a classic
 `Object` and you have to inspect and cast it to the actual message type in other ways, like this:
 
 @@snip [ActorDocTest.java](/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java) { #optimized }

--- a/akka-docs/src/main/paradox/mailboxes.md
+++ b/akka-docs/src/main/paradox/mailboxes.md
@@ -33,7 +33,7 @@ Scala
 :   @@snip [DispatcherDocSpec.scala](/akka-docs/src/test/scala/docs/dispatcher/DispatcherDocSpec.scala) { #required-mailbox-class }
 
 Java
-:   @@snip [MyBoundedActor.java](/akka-docs/src/test/java/jdocs/actor/MyBoundedActor.java) { #my-bounded-untyped-actor }
+:   @@snip [MyBoundedActor.java](/akka-docs/src/test/java/jdocs/actor/MyBoundedActor.java) { #my-bounded-classic-actor }
 
 The type parameter to the `RequiresMessageQueue` @scala[trait]@java[interface] needs to be mapped to a mailbox in
 configuration like this:

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -51,9 +51,9 @@ Classic remoting over UDP has been deprecated since `2.5.0` and now has been rem
 To continue to use UDP configure @ref[Artery UDP](../remoting-artery.md#configuring-ssl-tls-for-akka-remoting) or migrate to Artery TCP.
 A full cluster restart is required to change to Artery.
 
-### Untyped actor removed
+### Classic actor removed
 
-`UntypedActor` has been depcated since `2.5.0`. Use `AbstractActor` instead.
+`UntypedActor` has been deprecated since `2.5.0`. Use `AbstractActor` instead.
 
 ### UntypedPersistentActor removed
 
@@ -65,7 +65,7 @@ Use @apidoc[AbstractPersistentActorWithAtLeastOnceDelivery] instead.
 
 ### Various removed methods
 
-* `Logging.getLogger(UntypedActor)` Untyped actor has been removed, use AbstractActor instead.
+* `Logging.getLogger(UntypedActor)` classic actor has been removed, use AbstractActor instead.
 * `LoggingReceive.create(Receive, ActorContext)` use `AbstractActor.Receive` instead.
 * `ActorMaterialzierSettings.withAutoFusing` disabling fusing is no longer possible.
 * `AbstractActor.getChild` use `findChild` instead.
@@ -467,7 +467,7 @@ made before finalizing the APIs. Compared to Akka 2.5.x the source incompatible 
 * Factory method `Entity.ofPersistentEntity` is renamed to `Entity.ofEventSourcedEntity` in the Java API for Akka Cluster Sharding Typed.
 * New abstract class `EventSourcedEntityWithEnforcedReplies` in Java API for Akka Cluster Sharding Typed and corresponding factory method `Entity.ofEventSourcedEntityWithEnforcedReplies` to ease the creation of `EventSourcedBehavior` with enforced replies.
 * New method `EventSourcedEntity.withEnforcedReplies` added to Scala API to ease the creation of `EventSourcedBehavior` with enforced replies.
-* `ActorSystem.scheduler` previously gave access to the untyped `akka.actor.Scheduler` but now returns a typed specific `akka.actor.typed.Scheduler`.
+* `ActorSystem.scheduler` previously gave access to the classic `akka.actor.Scheduler` but now returns a typed specific `akka.actor.typed.Scheduler`.
   Additionally `schedule` method has been replaced by `scheduleWithFixedDelay` and `scheduleAtFixedRate`. Actors that needs to schedule tasks should
   prefer `Behaviors.withTimers`.
 * `TimerScheduler.startPeriodicTimer`, replaced by `startTimerWithFixedDelay` or `startTimerAtFixedRate`

--- a/akka-docs/src/main/paradox/typed/actor-discovery.md
+++ b/akka-docs/src/main/paradox/typed/actor-discovery.md
@@ -12,7 +12,7 @@ To use Akka Actor Typed, you must add the following dependency in your project:
 
 ## Introduction
 
-With @ref:[untyped actors](../general/addressing.md) you would use `ActorSelection` to "lookup" actors. Given an actor path with
+With @ref:[classic actors](../general/addressing.md) you would use `ActorSelection` to "lookup" actors. Given an actor path with
 address information you can get hold of an `ActorRef` to any actor. `ActorSelection` does not exist in Akka Typed, 
 so how do you get the actor references? You can send refs in messages but you need something to bootstrap the interaction.
 

--- a/akka-docs/src/main/paradox/typed/actor-lifecycle.md
+++ b/akka-docs/src/main/paradox/typed/actor-lifecycle.md
@@ -64,7 +64,7 @@ Java
 
 @@@ Note
 
-In the untyped counter part, the @apidoc[akka.actor.ActorSystem], the root actor was provided out of the box and you
+In the classic counter part, the @apidoc[akka.actor.ActorSystem], the root actor was provided out of the box and you
 could spawn top-level actors from the outside of the `ActorSystem` using `actorOf`. @ref:[SpawnProtocol](#spawnprotocol)
 is a tool that mimics the old style of starting up actors.
 
@@ -105,7 +105,7 @@ That is not difficult to implement in your behavior, but since this is a common 
 message protocol and implementation of a behavior for this. It can be used as the guardian actor of the `ActorSystem`,
 possibly combined with `Behaviors.setup` to start some initial tasks or actors. Child actors can then be started from
 the outside by telling or asking `SpawnProtocol.Spawn` to the actor reference of the system. When using `ask` this is
-similar to how `ActorSystem.actorOf` can be used in untyped actors with the difference that a
+similar to how `ActorSystem.actorOf` can be used in classic actors with the difference that a
 @scala[`Future`]@java[`CompletionStage`] of the `ActorRef` is returned.
 
 The guardian behavior can be defined as:

--- a/akka-docs/src/main/paradox/typed/coexisting.md
+++ b/akka-docs/src/main/paradox/typed/coexisting.md
@@ -13,114 +13,114 @@ To use Akka Actor Typed, you must add the following dependency in your project:
 ## Introduction
 
 We believe Akka Typed will be adopted in existing systems gradually and therefore it's important to be able to use typed
-and untyped actors together, within the same `ActorSystem`. Also, we will not be able to integrate with all existing modules in one big bang release and that is another reason for why these two ways of writing actors must be able to coexist.
+and classic actors together, within the same `ActorSystem`. Also, we will not be able to integrate with all existing modules in one big bang release and that is another reason for why these two ways of writing actors must be able to coexist.
 
 There are two different `ActorSystem`s: `akka.actor.ActorSystem` and `akka.actor.typed.ActorSystem`. 
 
-Currently the typed actor system is implemented using an untyped actor system under the hood. This may change in the future.
+Currently the typed actor system is implemented using the classic actor system under the hood. This may change in the future.
 
-Typed and untyped can interact the following ways:
+Typed and classic can interact the following ways:
 
-* untyped actor systems can create typed actors
-* typed actors can send messages to untyped actors, and opposite
-* spawn and supervise typed child from untyped parent, and opposite
-* watch typed from untyped, and opposite
-* untyped actor system can be converted to a typed actor system
+* classic actor systems can create typed actors
+* typed actors can send messages to classic actors, and opposite
+* spawn and supervise typed child from classic parent, and opposite
+* watch typed from classic, and opposite
+* classic actor system can be converted to a typed actor system
 
 @@@ div { .group-scala }
-In the examples the `akka.actor` package is aliased to `untyped`.
+In the examples the `akka.actor` package is aliased to `classic`.
 
 Scala
-:  @@snip [UntypedWatchingTypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala) { #import-alias }
+:  @@snip [ClassicWatchingTypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/ClassicWatchingTypedSpec.scala) { #import-alias }
 
 @@@
 
-@java[The examples use fully qualified class names for the untyped classes to distinguish between typed and untyped classes with the same name.]
+@java[The examples use fully qualified class names for the classic classes to distinguish between typed and classic classes with the same name.]
 
-## Untyped to typed 
+## Classic to typed 
 
-While coexisting your application will likely still have an untyped ActorSystem. This can be converted to a typed ActorSystem
-so that new code and migrated parts don't rely on the untyped system:
+While coexisting your application will likely still have a classic ActorSystem. This can be converted to a typed ActorSystem
+so that new code and migrated parts don't rely on the classic system:
 
 Scala
-:  @@snip [UntypedWatchingTypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala) { #adapter-import #convert-untyped }
+:  @@snip [ClassicWatchingTypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/ClassicWatchingTypedSpec.scala) { #adapter-import #convert-classic }
 
 Java
-:  @@snip [UntypedWatchingTypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/UntypedWatchingTypedTest.java) { #adapter-import #convert-untyped }
+:  @@snip [ClassicWatchingTypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/ClassicWatchingTypedTest.java) { #adapter-import #convert-classic }
 
 Then for new typed actors here's how you create, watch and send messages to
-it from an untyped actor.
+it from a classic actor.
 
 Scala
-:  @@snip [UntypedWatchingTypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala) { #typed }
+:  @@snip [ClassicWatchingTypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/ClassicWatchingTypedSpec.scala) { #typed }
 
 Java
-:  @@snip [UntypedWatchingTypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/UntypedWatchingTypedTest.java) { #typed }
+:  @@snip [ClassicWatchingTypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/ClassicWatchingTypedTest.java) { #typed }
 
-The top level untyped actor is created in the usual way:
+The top level classic actor is created in the usual way:
 
 Scala
-:  @@snip [UntypedWatchingTypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala) { #create-untyped }
+:  @@snip [ClassicWatchingTypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/ClassicWatchingTypedSpec.scala) { #create-classic }
 
 Java
-:  @@snip [UntypedWatchingTypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/UntypedWatchingTypedTest.java) { #create-untyped }
+:  @@snip [ClassicWatchingTypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/ClassicWatchingTypedTest.java) { #create-classic }
 
 Then it can create a typed actor, watch it, and send a message to it:
 
 Scala
-:  @@snip [UntypedWatchingTypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala) { #untyped-watch }
+:  @@snip [ClassicWatchingTypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/ClassicWatchingTypedSpec.scala) { #classic-watch }
 
 Java
-:  @@snip [UntypedWatchingTypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/UntypedWatchingTypedTest.java) { #untyped-watch }
+:  @@snip [ClassicWatchingTypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/ClassicWatchingTypedTest.java) { #classic-watch }
 
 @scala[There is one `import` that is needed to make that work.] @java[We import the Adapter class and
 call static methods for conversion.]
 
 Scala
-:  @@snip [UntypedWatchingTypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/UntypedWatchingTypedSpec.scala) { #adapter-import }
+:  @@snip [ClassicWatchingTypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/ClassicWatchingTypedSpec.scala) { #adapter-import }
 
 Java
-:  @@snip [UntypedWatchingTypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/UntypedWatchingTypedTest.java) { #adapter-import }
+:  @@snip [ClassicWatchingTypedSpec.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/ClassicWatchingTypedTest.java) { #adapter-import }
 
 
-@scala[That adds some implicit extension methods that are added to untyped and typed `ActorSystem` and `ActorContext` in both directions.]
-@java[To convert between typed and untyped there are adapter methods in `akka.actor.typed.javadsl.Adapter`.] Note the inline comments in the example above.
+@scala[That adds some implicit extension methods that are added to classic and typed `ActorSystem` and `ActorContext` in both directions.]
+@java[To convert between typed and classic there are adapter methods in `akka.actor.typed.javadsl.Adapter`.] Note the inline comments in the example above.
 
-## Typed to untyped
+## Typed to classic
 
-Let's turn the example upside down and first start the typed actor and then the untyped as a child.
+Let's turn the example upside down and first start the typed actor and then the classic as a child.
 
 The following will show how to create, watch and send messages back and forth from a typed actor to this
-untyped actor:
+classic actor:
 
 Scala
-:  @@snip [TypedWatchingUntypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingUntypedSpec.scala) { #untyped }
+:  @@snip [TypedWatchingClassicSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingClassicSpec.scala) { #classic }
 
 Java
-:  @@snip [TypedWatchingUntypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingUntypedTest.java) { #untyped }
+:  @@snip [TypedWatchingClassicSpec.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingClassicTest.java) { #classic }
 
 Creating the actor system and the typed actor:
 
 Scala
-:  @@snip [TypedWatchingUntypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingUntypedSpec.scala) { #create }
+:  @@snip [TypedWatchingClassicSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingClassicSpec.scala) { #create }
 
 Java
-:  @@snip [TypedWatchingUntypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingUntypedTest.java) { #create }
+:  @@snip [TypedWatchingClassicSpec.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingClassicTest.java) { #create }
 
-Then the typed actor creates the untyped actor, watches it and sends and receives a response:
+Then the typed actor creates the classic actor, watches it and sends and receives a response:
 
 Scala
-:  @@snip [TypedWatchingUntypedSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingUntypedSpec.scala) { #typed }
+:  @@snip [TypedWatchingClassicSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingClassicSpec.scala) { #typed }
 
 Java
-:  @@snip [TypedWatchingUntypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingUntypedTest.java) { #typed }
+:  @@snip [TypedWatchingClassicSpec.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingClassicTest.java) { #typed }
 
 ## Supervision
 
-The default supervision for untyped actors is to restart whereas for typed it is to stop.
-When combining untyped and typed actors the default supervision is based on the default behavior of
-the child i.e. if an untyped actor creates a typed child, its default supervision will be to stop. If a typed
-actor creates an untyped child, its default supervision will be to restart.
+The default supervision for classic actors is to restart whereas for typed it is to stop.
+When combining classic and typed actors the default supervision is based on the default behavior of
+the child i.e. if a classic actor creates a typed child, its default supervision will be to stop. If a typed
+actor creates a classic child, its default supervision will be to restart.
 
 
 

--- a/akka-docs/src/main/paradox/typed/distributed-data.md
+++ b/akka-docs/src/main/paradox/typed/distributed-data.md
@@ -39,7 +39,7 @@ actor provides the API for interacting with the data and is accessed through the
 
 The messages for the replicator, such as `Replicator.Update` are defined in @apidoc[typed.*.Replicator]
 but the actual CRDTs are the 
-same as in untyped, for example `akka.cluster.ddata.GCounter`. This will require a @scala[implicit] `akka.cluster.ddata.SelfUniqueAddress.SelfUniqueAddress`,
+same as in classic, for example `akka.cluster.ddata.GCounter`. This will require a @scala[implicit] `akka.cluster.ddata.SelfUniqueAddress.SelfUniqueAddress`,
 available from @scala[`implicit val node = DistributedData(system).selfUniqueAddress`]@java[SelfUniqueAddress node = DistributedData.get(system).selfUniqueAddress();].
 
 The replicator can contain multiple entries each containing a replicated data type, we therefore need to create a 
@@ -79,7 +79,7 @@ the extra interaction with the replicator using the `GetCachedValue` command.
 The example also supports asking the replicator using the `GetValue` command. Note how the `replyTo` from the
 incoming message can be used when the `GetSuccess` response from the replicator is received.
 
-See the @ref[the untyped Distributed Data documentation](../distributed-data.md#using-the-replicator)
+See the @ref[the classic Distributed Data documentation](../distributed-data.md#using-the-replicator)
 for more details about `Get`, `Update` and `Delete` interactions with the replicator.
 
 @@@ div { .group-scala }
@@ -98,15 +98,15 @@ Scala
 ### Replicated data types
 
 Akka contains a set of useful replicated data types and it is fully possible to implement custom replicated data types. 
-For more details, read @ref[the untyped Distributed Data documentation](../distributed-data.md#data-types)
+For more details, read @ref[the classic Distributed Data documentation](../distributed-data.md#data-types)
 
 ### Running separate instances of the replicator
 
 For some use cases, for example when limiting the replicator to certain roles, or using different subsets on different roles,
 it makes sense to start separate replicators, this needs to be done on all nodes, or 
 the group of nodes tagged with a specific role. To do this with the Typed Distributed Data you will first
-have to start an untyped `Replicator` and pass it to the `Replicator.behavior` method that takes an untyped
-actor ref. All such `Replicator`s must run on the same path in the untyped actor hierarchy.
+have to start a classic `Replicator` and pass it to the `Replicator.behavior` method that takes a classic
+actor ref. All such `Replicator`s must run on the same path in the classic actor hierarchy.
 
 A standalone `ReplicatorMessageAdapter` can also be created for a given `Replicator` instead of creating
 one via the `DistributedData` extension.

--- a/akka-docs/src/main/paradox/typed/fault-tolerance.md
+++ b/akka-docs/src/main/paradox/typed/fault-tolerance.md
@@ -5,8 +5,8 @@ will by default be stopped.
 
 @@@ note
 
-An important difference between Typed and Untyped actors is that Typed actors are by default stopped if
-an exception is thrown and no supervision strategy is defined while in Untyped they are restarted.
+An important difference between Typed and Classic actors is that Typed actors are by default stopped if
+an exception is thrown and no supervision strategy is defined while in Classic they are restarted.
 
 @@@
 
@@ -114,7 +114,7 @@ restarted.
 ## Bubble failures up through the hierarchy
 
 In some scenarios it may be useful to push the decision about what to do on a failure upwards in the Actor hierarchy
- and let the parent actor handle what should happen on failures (in untyped Akka Actors this is how it works by default).
+ and let the parent actor handle what should happen on failures (in classic Akka Actors this is how it works by default).
 
 For a parent to be notified when a child is terminated it has to `watch` the child. If the child was stopped because of
 a failure the `ChildFailed` signal will be received which will contain the cause. `ChildFailed` extends `Terminated` so if

--- a/akka-docs/src/main/paradox/typed/fsm.md
+++ b/akka-docs/src/main/paradox/typed/fsm.md
@@ -1,10 +1,10 @@
 # Behaviors as Finite state machines
 
-With untyped actors there is explicit support for building @ref[Finite State Machines](../fsm.md). No support
+With classic actors there is explicit support for building @ref[Finite State Machines](../fsm.md). No support
 is needed in Akka Typed as it is straightforward to represent FSMs with behaviors. 
 
 To see how the Akka Typed API can be used to model FSMs here's the Buncher example ported from
-the @ref[untyped actor FSM docs](../fsm.md). It demonstrates how to:
+the @ref[classic actor FSM docs](../fsm.md). It demonstrates how to:
 
 * Model states using different behaviors
 * Model storing data at each state by representing the behavior as a method 
@@ -22,7 +22,7 @@ Java
 `Batches` to be passed on; `Queue` will add to the internal queue while
 `Flush` will mark the end of a burst.
 
-Untyped `FSM`s also have a `D` (data) type parameter. Akka Typed doesn't need to be aware of this and it can be stored
+Classic `FSM`s also have a `D` (data) type parameter. Akka Typed doesn't need to be aware of this and it can be stored
 via defining your behaviors as methods.
 
 Scala

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -24,7 +24,7 @@ To use Akka Persistence Typed, add the module to your project:
 ## Introduction
 
 Akka Persistence is a library for building event sourced actors. For background about how it works
-see the @ref:[untyped Akka Persistence section](../persistence.md). This documentation shows how the typed API for persistence
+see the @ref:[classic Akka Persistence section](../persistence.md). This documentation shows how the typed API for persistence
 works and assumes you know what is meant by `Command`, `Event` and `State`.
 
 ## Example
@@ -323,7 +323,7 @@ command or the reply will be sent later, perhaps after some asynchronous interac
 
 ## Serialization
 
-The same @ref:[serialization](../serialization.md) mechanism as for untyped
+The same @ref:[serialization](../serialization.md) mechanism as for classic
 actors is also used in Akka Typed, also for persistent actors. When picking serialization solution for the events
 you should also consider that it must be possible read old events when the application has evolved.
 Strategies for that can be found in the @ref:[schema evolution](../persistence-schema-evolution.md).

--- a/akka-docs/src/main/paradox/typed/testing.md
+++ b/akka-docs/src/main/paradox/typed/testing.md
@@ -117,7 +117,7 @@ run the other actors it depends on. Instead, you might want to create mock behav
 messages in the same way the other actor would do but without executing any actual logic.
 In addition to this it can also be useful to observe those interactions to assert that the component under test did send
 the expected messages.
-This allows the same kinds of tests as untyped `TestActor`/`Autopilot`.
+This allows the same kinds of tests as classic `TestActor`/`Autopilot`.
 
 As an example, let's assume we'd like to test the following component:
 

--- a/akka-docs/src/test/java/jdocs/actor/MyBoundedActor.java
+++ b/akka-docs/src/test/java/jdocs/actor/MyBoundedActor.java
@@ -4,10 +4,10 @@
 
 package jdocs.actor;
 
-// #my-bounded-untyped-actor
+// #my-bounded-classic-actor
 import akka.dispatch.BoundedMessageQueueSemantics;
 import akka.dispatch.RequiresMessageQueue;
 
 public class MyBoundedActor extends MyActor
     implements RequiresMessageQueue<BoundedMessageQueueSemantics> {}
-// #my-bounded-untyped-actor
+// #my-bounded-classic-actor

--- a/akka-testkit/src/test/scala/akka/testkit/TestEventListenerSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestEventListenerSpec.scala
@@ -10,7 +10,7 @@ import akka.event.Logging.Warning
 
 class TestEventListenerSpec extends AkkaSpec with ImplicitSender {
 
-  "The untyped EventFilter.error" must {
+  "The classic EventFilter.error" must {
     "filter errors without cause" in {
       val filter = EventFilter.error()
       filter(errorNoCause) should ===(true)
@@ -53,7 +53,7 @@ class TestEventListenerSpec extends AkkaSpec with ImplicitSender {
     }
   }
 
-  "The untyped EventFilter.warning" must {
+  "The classic EventFilter.warning" must {
     "filter warnings without cause" in {
       val filter = EventFilter.warning()
       filter(warningNoCause) should ===(true)


### PR DESCRIPTION
## References
https://github.com/akka/akka/issues/24717
I kind of went to town on this one, moving away from the untyped since tests are also documentation (akka-typed-test* and friends) where some are referenced in the docs.

## Changes
Docs: Change "Untyped" to "Classic"