### PR TITLE
Scaladoc, comments and test: Change untyped to classic - General Typed docs cleanup 

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/GuardianStartupSpec.scala
@@ -38,7 +38,7 @@ class GuardianStartupSpec extends WordSpec with Matchers with ScalaFutures {
       }
     }
 
-    "not start before untyped system initialization is complete" in {
+    "not start before classic system initialization is complete" in {
       var system: ActorSystem[String] = null
       val initialized = new CountDownLatch(1)
       val guardianBehavior = Behaviors.setup[String] { ctx =>

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -134,11 +134,11 @@ private[akka] object ActorSystemAdapter {
   }
 
   /**
-   * An untyped extension to load configured typed extensions. It is loaded via
+   * A classic extension to load configured typed extensions. It is loaded via
    * akka.library-extensions. `loadExtensions` cannot be called from the AdapterExtension
    * directly because the adapter is created too early during typed actor system creation.
    *
-   * When on the classpath typed extensions will be loaded for untyped ActorSystems as well.
+   * When on the classpath typed extensions will be loaded for classic ActorSystems as well.
    */
   class LoadTypedExtensions(system: untyped.ExtendedActorSystem) extends untyped.Extension {
     ActorSystemAdapter.AdapterExtension(system).adapter.loadExtensions()
@@ -155,7 +155,7 @@ private[akka] object ActorSystemAdapter {
       case adapter: ActorSystemAdapter[_] => adapter.untypedSystem
       case _ =>
         throw new UnsupportedOperationException(
-          "only adapted untyped ActorSystem permissible " +
+          "Only adapted classic ActorSystem permissible " +
           s"($sys of class ${sys.getClass.getName})")
     }
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/adapter/package.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/adapter/package.scala
@@ -10,23 +10,23 @@ import akka.actor.typed.internal.adapter.{ PropsAdapter => _, _ }
 import akka.annotation.InternalApi
 
 /**
- * Scala API: Adapters between typed and untyped actors and actor systems.
- * The underlying `ActorSystem` is the untyped [[akka.actor.ActorSystem]]
+ * Scala API: Adapters between typed and classic actors and actor systems.
+ * The underlying `ActorSystem` is the classic [[akka.actor.ActorSystem]]
  * which runs Akka Typed [[akka.actor.typed.Behavior]] on an emulation layer. In this
- * system typed and untyped actors can coexist.
+ * system typed and classic actors can coexist.
  *
  * Use these adapters with `import akka.actor.typed.scaladsl.adapter._`.
  *
- * Implicit extension methods are added to untyped and typed `ActorSystem`,
+ * Implicit extension methods are added to classic and typed `ActorSystem`,
  * `ActorContext`. Such methods make it possible to create typed child actor
- * from untyped parent actor, and the opposite untyped child from typed parent.
+ * from classic parent actor, and the opposite untyped child from typed parent.
  * `watch` is also supported in both directions.
  *
- * There is an implicit conversion from untyped [[akka.actor.ActorRef]] to
+ * There is an implicit conversion from classic [[akka.actor.ActorRef]] to
  * typed [[akka.actor.typed.ActorRef]].
  *
  * There are also converters (`toTyped`, `toUntyped`) from typed
- * [[akka.actor.typed.ActorRef]] to untyped [[akka.actor.ActorRef]], and between untyped
+ * [[akka.actor.typed.ActorRef]] to classic [[akka.actor.ActorRef]], and between classic
  * [[akka.actor.ActorSystem]] and typed [[akka.actor.typed.ActorSystem]].
  */
 package object adapter {

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -129,7 +129,7 @@ import akka.util.Timeout
 
   require(
     system.isInstanceOf[ActorSystemAdapter[_]],
-    "only adapted untyped actor systems can be used for cluster features")
+    "only adapted classic actor systems can be used for cluster features")
 
   private val cluster = Cluster(system)
   private val untypedSystem: ExtendedActorSystem = system.toUntyped.asInstanceOf[ExtendedActorSystem]

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -395,8 +395,8 @@ class ClusterShardingSpec extends ScalaTestWithActorTestKit(ClusterShardingSpec.
       exc.getMessage should include("[10 ms]") // timeout
     }
 
-    "handle untyped StartEntity message" in {
-      // it is normally using envelopes, but the untyped StartEntity message can be sent internally,
+    "handle classic StartEntity message" in {
+      // it is normally using envelopes, but the classic StartEntity message can be sent internally,
       // e.g. for remember entities
 
       val totalCountBefore = totalEntityCount1()

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/DistributedData.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/DistributedData.scala
@@ -65,7 +65,7 @@ object DistributedData extends ExtensionId[DistributedData] {
  *
  * This is using the same underlying `Replicator` instance as
  * [[akka.cluster.ddata.DistributedData]] and that means that typed
- * and untyped actors can share the same data.
+ * and classic actors can share the same data.
  *
  * This class is not intended for user extension other than for test purposes (e.g.
  * stub implementation). More methods may be added in the future and that may break

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/DistributedData.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/DistributedData.scala
@@ -61,7 +61,7 @@ object DistributedData extends ExtensionId[DistributedData] {
  *
  * This is using the same underlying `Replicator` instance as
  * [[akka.cluster.ddata.DistributedData]] and that means that typed
- * and untyped actors can share the same data.
+ * and classic actors can share the same data.
  */
 class DistributedData(system: ActorSystem[_]) extends Extension {
   import akka.actor.typed.scaladsl.adapter._

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializer.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializer.scala
@@ -22,7 +22,7 @@ private[akka] final class AkkaClusterTypedSerializer(override val system: Extend
     extends SerializerWithStringManifest
     with BaseSerializer {
 
-  // Serializers are initialized early on. `toTyped` might then try to initialize the untyped ActorSystemAdapter extension.
+  // Serializers are initialized early on. `toTyped` might then try to initialize the classic ActorSystemAdapter extension.
   private lazy val resolver = ActorRefResolver(system.toTyped)
   private val ReceptionistEntryManifest = "a"
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/DistributedData.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/DistributedData.scala
@@ -62,7 +62,7 @@ class DistributedData(system: ExtendedActorSystem) extends Extension {
 }
 
 /**
- * Cluster non-specific (typed vs untyped) wrapper for [[akka.cluster.UniqueAddress]].
+ * Cluster non-specific (typed vs classic) wrapper for [[akka.cluster.UniqueAddress]].
  */
 @SerialVersionUID(1L)
 final case class SelfUniqueAddress(uniqueAddress: UniqueAddress)

--- a/akka-stream-typed/src/main/scala/akka/stream/typed/scaladsl/ActorFlow.scala
+++ b/akka-stream-typed/src/main/scala/akka/stream/typed/scaladsl/ActorFlow.scala
@@ -110,7 +110,7 @@ object ActorFlow {
         val res = akka.pattern.extended.ask(untypedRef, (replyTo: akka.actor.ActorRef) => makeMessage(el, replyTo))
         // we need to cast manually (yet safely, by construction!) since otherwise we need a ClassTag,
         // which in Scala is fine, but then we would force JavaDSL to create one, which is a hassle in the Akka Typed DSL,
-        // since one may say "but I already specified the type!", and that we have to go via the untyped ask is an implementation detail
+        // since one may say "but I already specified the type!", and that we have to go via the classic ask is an implementation detail
         res.asInstanceOf[Future[A]]
       }
       .mapError {

--- a/akka-stream/src/main/scala/akka/stream/Shape.scala
+++ b/akka-stream/src/main/scala/akka/stream/Shape.scala
@@ -13,7 +13,7 @@ import akka.annotation.InternalApi
 /**
  * An input port of a StreamLayout.Module. This type logically belongs
  * into the impl package but must live here due to how `sealed` works.
- * It is also used in the Java DSL for “untyped Inlets” as a work-around
+ * It is also used in the Java DSL for “classic Inlets” as a work-around
  * for otherwise unreasonable existential types.
  */
 sealed abstract class InPort { self: Inlet[_] =>
@@ -39,7 +39,7 @@ sealed abstract class InPort { self: Inlet[_] =>
 /**
  * An output port of a StreamLayout.Module. This type logically belongs
  * into the impl package but must live here due to how `sealed` works.
- * It is also used in the Java DSL for “untyped Outlets” as a work-around
+ * It is also used in the Java DSL for “classic Outlets” as a work-around
  * for otherwise unreasonable existential types.
  */
 sealed abstract class OutPort { self: Outlet[_] =>


### PR DESCRIPTION
## References
https://github.com/akka/akka/issues/24717

## Changes
Scaladoc, comments etc: Change "Untyped" to "Classic"