### PR TITLE
Fixed incorrect routing sample comment

### DIFF
--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java
@@ -94,10 +94,8 @@ public class RouterTest {
           GroupRouter<Worker.Command> group = Routers.group(serviceKey);
           ActorRef<Worker.Command> router = context.spawn(group, "worker-group");
 
-          // note that since registration of workers goes through the receptionist there is no
-          // guarantee the router has seen any workers yet if we hit it directly like this and
-          // these messages may end up in dead letters - in a real application you would not use
-          // a group router immediately like this - it is to keep the sample simple
+          // the group router will stash messages until it sees the first listing of registered
+          // services from the receptionist, so it is safe to send messages right away
           for (int i = 0; i < 10; i++) {
             router.tell(new Worker.DoLog("msg " + i));
           }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala
@@ -99,10 +99,8 @@ class RouterSpec extends ScalaTestWithActorTestKit("akka.loglevel=warning") with
         val group = Routers.group(serviceKey);
         val router = ctx.spawn(group, "worker-group");
 
-        // note that since registration of workers goes through the receptionist there is no
-        // guarantee the router has seen any workers yet if we hit it directly like this and
-        // these messages may end up in dead letters - in a real application you would not use
-        // a group router immediately like this - it is to keep the sample simple
+        // the group router will stash messages until it sees the first listing of registered
+        // services from the receptionist, so it is safe to send messages right away
         (0 to 10).foreach { n =>
           router ! Worker.DoLog(s"msg $n")
         }


### PR DESCRIPTION
Behavior was changed since the comment was placed in the sample.