### PR TITLE
fix deprecation warning for protobuf enum

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -400,7 +400,7 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem)
       cm.Member.newBuilder
         .setAddressIndex(mapUniqueAddress(member.uniqueAddress))
         .setUpNumber(member.upNumber)
-        .setStatus(cm.MemberStatus.valueOf(memberStatusToInt(member.status)))
+        .setStatus(cm.MemberStatus.forNumber(memberStatusToInt(member.status)))
         .addAllRolesIndexes(member.roles.map(mapRole).asJava)
 
     def reachabilityToProto(reachability: Reachability): Iterable[cm.ObserverReachability.Builder] = {
@@ -413,7 +413,7 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem)
                 cm.SubjectReachability
                   .newBuilder()
                   .setAddressIndex(mapUniqueAddress(r.subject))
-                  .setStatus(cm.ReachabilityStatus.valueOf(reachabilityStatusToInt(r.status)))
+                  .setStatus(cm.ReachabilityStatus.forNumber(reachabilityStatusToInt(r.status)))
                   .setVersion(r.version))
           cm.ObserverReachability
             .newBuilder()


### PR DESCRIPTION
This fails the build `test:compile` for me on master. Not sure why it started to fail. Haven't seen problem in any of the CI jobs.

```
[error] src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala:403:36: method valueOf in Java enum MemberStatus is deprecated: see corresponding Javadoc for more information.
[error]         .setStatus(cm.MemberStatus.valueOf(memberStatusToInt(member.status)))
[error]                                    ^
[error] src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala:416:52: method valueOf in Java enum ReachabilityStatus is deprecated: see corresponding Javadoc for more information.
[error]                   .setStatus(cm.ReachabilityStatus.valueOf(reachabilityStatusToInt(r.status)))
[error]
```