### PR TITLE
Final touch for the SLF4J PR

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/LoggingEventFilterImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/LoggingEventFilterImpl.scala
@@ -77,6 +77,7 @@ import org.slf4j.event.Level
 
   override def intercept[T](code: => T)(implicit system: ActorSystem[_]): T = {
     val effectiveLoggerName = loggerName.getOrElse("")
+    checkLogback(system)
     TestAppender.setupTestAppender(effectiveLoggerName)
     TestAppender.addFilter(effectiveLoggerName, this)
     val leeway = TestKitSettings(system).FilterLeeway
@@ -91,6 +92,12 @@ import org.slf4j.event.Level
     } finally {
       todo = occurrences
       TestAppender.removeFilter(effectiveLoggerName, this)
+    }
+  }
+
+  private def checkLogback(system: ActorSystem[_]): Unit = {
+    if (!system.dynamicAccess.classIsOnClasspath("ch.qos.logback.classic.spi.ILoggingEvent")) {
+      throw new IllegalStateException("LoggingEventFilter requires logback-classic dependency in classpath.")
     }
   }
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
@@ -187,7 +187,9 @@ private[akka] final class FunctionRef[-T](override val path: ActorPath, send: (T
 
   override def log: Logger = logger
 
-  override def setLoggerClass(clazz: Class[_]): Unit = () // nop as we don't track logger class
+  override def setLoggerName(name: String): Unit = () // nop as we don't track logger
+
+  override def setLoggerName(clazz: Class[_]): Unit = () // nop as we don't track logger
 
   /**
    * The log entries logged through context.log.{debug, info, warn, error} are captured and can be inspected through

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestAppender.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestAppender.scala
@@ -24,9 +24,6 @@ import ch.qos.logback.core.AppenderBase
 
   private val TestAppenderName = "AkkaTestAppender"
 
-  // FIXME #26537 detect if logback is not in classpath and fail more friendly,
-  // also detect if other slf4j impl is used and fail friendly
-
   def setupTestAppender(loggerName: String): Unit = {
     val logbackLogger = getLogbackLogger(loggerName)
     logbackLogger.getAppender(TestAppenderName) match {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
@@ -319,7 +319,8 @@ class ActorLoggingSpec extends ScalaTestWithActorTestKit("""
       // mdc on defer is empty
       val ref = LoggingEventFilter
         .info("Starting")
-        .withCustom(logEvent => logEvent.mdc.filterKeys(!_.startsWith("akka")).isEmpty)
+        // not counting for example "akkaSource", but it shouldn't have any other entries
+        .withCustom(logEvent => logEvent.mdc.keysIterator.forall(_.startsWith("akka")))
         .intercept {
           spawn(behaviors)
         }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
@@ -77,7 +77,7 @@ class ActorLoggingSpec extends ScalaTestWithActorTestKit("""
 
     "log with custom Logger class" in {
       val behavior: Behavior[String] = Behaviors.setup[String] { context =>
-        context.setLoggerClass(classOf[AnotherLoggerClass])
+        context.setLoggerName(classOf[AnotherLoggerClass])
         context.log.info("Started")
 
         Behaviors.receive { (context, message) =>

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
@@ -88,7 +88,7 @@ import org.slf4j.LoggerFactory
       case OptionVal.Some(l) => l
       case OptionVal.None =>
         val logClass = LoggerClass.detectLoggerClassFromStack(classOf[Behavior[_]])
-        initLoggerWithClass(logClass)
+        initLoggerWithName(logClass.getName)
     }
     // avoid access to MDC ThreadLocal if not needed
     mdcUsed = true
@@ -98,9 +98,11 @@ import org.slf4j.LoggerFactory
 
   override def getLog: Logger = log
 
-  override def setLoggerClass(clazz: Class[_]): Unit = {
-    initLoggerWithClass(clazz)
-  }
+  override def setLoggerName(name: String): Unit =
+    initLoggerWithName(name)
+
+  override def setLoggerName(clazz: Class[_]): Unit =
+    setLoggerName(clazz.getName)
 
   // MDC is cleared (if used) from aroundReceive in ActorAdapter after processing each message
   override private[akka] def clearMdc(): Unit = {
@@ -111,8 +113,8 @@ import org.slf4j.LoggerFactory
     }
   }
 
-  private def initLoggerWithClass(logClass: Class[_]): Logger = {
-    val l = LoggerFactory.getLogger(logClass)
+  private def initLoggerWithName(name: String): Logger = {
+    val l = LoggerFactory.getLogger(name)
     logger = OptionVal.Some(l)
     l
   }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/LocalReceptionist.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/LocalReceptionist.scala
@@ -48,7 +48,7 @@ private[akka] object LocalReceptionist extends ReceptionistBehaviorProvider {
       extends InternalCommand
 
   override def behavior: Behavior[Command] = Behaviors.setup { ctx =>
-    ctx.setLoggerClass(classOf[LocalReceptionist])
+    ctx.setLoggerName(classOf[LocalReceptionist])
     behavior(TypedMultiMap.empty[AbstractServiceKey, KV], TypedMultiMap.empty[AbstractServiceKey, SubscriptionsKV])
       .narrow[Command]
   }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ActorContext.scala
@@ -68,7 +68,11 @@ trait ActorContext[T] extends TypedActorContext[T] with ClassicActorContextProvi
   def getSystem: ActorSystem[Void]
 
   /**
-   * An actor specific logger
+   * An actor specific logger.
+   *
+   * The logger name will be an estimated source class for the actor which is calculated when the
+   * logger is first used (the logger is lazily created upon first use). If this yields the wrong
+   * class or another class is preferred this can be changed with `setLoggerName`.
    *
    * *Warning*: This method is not thread-safe and must not be accessed from threads other
    * than the ordinary actor message processing thread, such as [[java.util.concurrent.CompletionStage]] callbacks.
@@ -77,12 +81,21 @@ trait ActorContext[T] extends TypedActorContext[T] with ClassicActorContextProvi
 
   /**
    * Replace the current logger (or initialize a new logger if the logger was not touched before) with one that
-   * has ghe given class as logging class. Logger source will be actor path.
+   * has ghe given name as logger name. Logger source MDC entry "akkaSource" will be the actor path.
    *
    * *Warning*: This method is not thread-safe and must not be accessed from threads other
    * than the ordinary actor message processing thread, such as [[java.util.concurrent.CompletionStage]] callbacks.
    */
-  def setLoggerClass(clazz: Class[_]): Unit
+  def setLoggerName(name: String): Unit
+
+  /**
+   * Replace the current logger (or initialize a new logger if the logger was not touched before) with one that
+   * has ghe given class name as logger name. Logger source MDC entry "akkaSource" will be the actor path.
+   *
+   * *Warning*: This method is not thread-safe and must not be accessed from threads other
+   * than the ordinary actor message processing thread, such as [[java.util.concurrent.CompletionStage]] callbacks.
+   */
+  def setLoggerName(clazz: Class[_]): Unit
 
   /**
    * The list of child Actors created by this Actor during its lifetime that

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/ActorContext.scala
@@ -68,10 +68,9 @@ trait ActorContext[T] extends TypedActorContext[T] with ClassicActorContextProvi
   /**
    * An actor specific logger.
    *
-   * The logger will have the actor path as `logSource` and will an estimated source class for the actor
-   * which is calculated when the logger is first used (the logger is lazily created upon first use). If this
-   * yields the wrong class or another class is preferred this can be achieved through `Logger.withLoggerClass`
-   * or `setLoggerClass`.
+   * The logger name will be an estimated source class for the actor which is calculated when the
+   * logger is first used (the logger is lazily created upon first use). If this yields the wrong
+   * class or another class is preferred this can be changed with `setLoggerName`.
    *
    * *Warning*: This method is not thread-safe and must not be accessed from threads other
    * than the ordinary actor message processing thread, such as [[scala.concurrent.Future]] callbacks.
@@ -80,12 +79,21 @@ trait ActorContext[T] extends TypedActorContext[T] with ClassicActorContextProvi
 
   /**
    * Replace the current logger (or initialize a new logger if the logger was not touched before) with one that
-   * has ghe given class as logging class. Logger source will be actor path.
+   * has ghe given name as logger name. Logger source MDC entry "akkaSource" will be the actor path.
+   *
+   * *Warning*: This method is not thread-safe and must not be accessed from threads other
+   * than the ordinary actor message processing thread, such as [[java.util.concurrent.CompletionStage]] callbacks.
+   */
+  def setLoggerName(name: String): Unit
+
+  /**
+   * Replace the current logger (or initialize a new logger if the logger was not touched before) with one that
+   * has ghe given class name as logger name. Logger source MDC entry "akkaSource" will be the actor path.
    *
    * *Warning*: This method is not thread-safe and must not be accessed from threads other
    * than the ordinary actor message processing thread, such as [[scala.concurrent.Future]] callbacks.
    */
-  def setLoggerClass(clazz: Class[_]): Unit // FIXME #26537 rename this to setLoggerName (could have class as convenience param), see ClusterReceptionist that doesn't have a class
+  def setLoggerName(clazz: Class[_]): Unit
 
   /**
    * The list of child Actors created by this Actor during its lifetime that

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
@@ -92,7 +92,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
 
   override def behavior: Behavior[Command] =
     Behaviors.setup { ctx =>
-      ctx.setLoggerClass(classOf[ClusterReceptionist])
+      ctx.setLoggerName(classOf[ClusterReceptionist])
       Behaviors.withTimers { timers =>
         val setup = new Setup(ctx)
         // include selfUniqueAddress so that it can be used locally before joining cluster

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -473,12 +473,16 @@ made before finalizing the APIs. Compared to Akka 2.5.x the source incompatible 
 * To align with the Akka Typed style guide `SpawnProtocol` is now created through @scala[`SpawnProtocol()`]@java[`SpawnProtocol.create()`], the special `Spawn` message
   factories has been removed and the top level of the actor protocol is now `SpawnProtocol.Command`
 * `Future` removed from `ActorSystem.systemActorOf`.
+* `toUntyped` has been renamed to `toClassic`.
+* Akka Typed is now using SLF4J as the logging API. @scala[`ActorContext.log`]@java[`ActorContext.getLog`] returns
+  an `org.slf4j.Logger`. MDC has been changed to only support `String` values.
 
 #### Akka Typed Stream API changes
 
 * `ActorSource.actorRef` relying on `PartialFunction` has been replaced in the Java API with a variant more suitable to be called by Java.
-* `toUntyped` has been renamed to `toClassic`.
-
+* Factories for creating a materializer from an `akka.actor.typed.ActorSystem` have been removed.
+  A stream can be run with an `akka.actor.typed.ActorSystem` @scala[in implicit scope]@java[parameter]
+  and therefore the need for creating a materializer has been reduced.
 
 ## Akka Stream changes
 

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -476,6 +476,7 @@ made before finalizing the APIs. Compared to Akka 2.5.x the source incompatible 
 * `toUntyped` has been renamed to `toClassic`.
 * Akka Typed is now using SLF4J as the logging API. @scala[`ActorContext.log`]@java[`ActorContext.getLog`] returns
   an `org.slf4j.Logger`. MDC has been changed to only support `String` values.
+* `setLoggerClass` in `ActorContext` has been renamed to `setLoggerName`.
 
 #### Akka Typed Stream API changes
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -83,7 +83,7 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
 
   override def apply(context: typed.TypedActorContext[Command]): Behavior[Command] = {
     val ctx = context.asScala
-    ctx.setLoggerClass(loggerClass)
+    ctx.setLoggerName(loggerClass)
     val settings = EventSourcedSettings(ctx.system, journalPluginId.getOrElse(""), snapshotPluginId.getOrElse(""))
 
     // stashState outside supervise because StashState should survive restarts due to persist failures


### PR DESCRIPTION
On top of https://github.com/akka/akka/pull/27552

Just a few minor things...
* mention in migration guide
* rename setLoggerClass to setLoggerName
* check for logback dependency to give nicer error message