### PR TITLE
unmoored doc comment in PhasedFusingActorMaterializer

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -387,20 +387,19 @@ private final case class SavedIslandData(
 
 /**
  * INTERNAL API
+ *
+ * `defaultAttributes` for the materializer, based on the [[ActorMaterializerSettings]] and
+ * are always seen as least specific, so any attribute specified in the graph "wins" over these.
+ * In addition to that this also guarantees that the attributes `InputBuffer`, `SupervisionStrategy`,
+ * and `Dispatcher` is _always_ present in the attributes and can be accessed through `Attributes.mandatoryAttribute`
+ *
+ * When these attributes are needed later in the materialization process it is important that
+ * they are gotten through the attributes and not through the [[ActorMaterializerSettings]]
  */
 @InternalApi private[akka] case class PhasedFusingActorMaterializer(
     system: ActorSystem,
     override val settings: ActorMaterializerSettings,
-    /**
-     * Default attributes for the materializer, based on the [[ActorMaterializerSettings]] and
-     * are always seen as least specific, so any attribute specified in the graph "wins" over these.
-     * In addition to that this also guarantees that the attributes `InputBuffer`, `SupervisionStrategy`,
-     * and `Dispatcher` is _always_ present in the attributes and can be accessed through `Attributes.mandatoryAttribute`
-     *
-     * When these attributes are needed later in the materialization process it is important that
-     * they are gotten through the attributes and not through the [[ActorMaterializerSettings]]
-     */
-    defaultAttributes: Attributes,
+    defaultAttributes: Attributes, // see description above
     dispatchers: Dispatchers,
     supervisor: ActorRef,
     haveShutDown: AtomicBoolean,


### PR DESCRIPTION
Failing the akka-publish-nightly

```
[error] /localhome/jenkinsakka/workspace/akka-publish-nightly/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala:394:5: discarding unmoored doc comment
[error]     /**
[error]     ^
```

https://jenkins.akka.io:8498/job/akka-publish-nightly/1215/consoleFull