### PR TITLE
rename the new Materializer.create to createMaterializer, #27642

### DIFF
--- a/akka-docs/src/test/java/jdocs/stream/FlowDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/FlowDocTest.java
@@ -295,7 +295,7 @@ public class FlowDocTest extends AbstractJavaTest {
   // #materializer-from-actor-context
   final class RunWithMyself extends AbstractActor {
 
-    Materializer mat = Materializer.create(context());
+    Materializer mat = Materializer.createMaterializer(context());
 
     @Override
     public void preStart() throws Exception {

--- a/akka-docs/src/test/java/jdocs/stream/HubDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/HubDocTest.java
@@ -62,7 +62,7 @@ public class HubDocTest extends AbstractJavaTest {
   @Test
   public void dynamicBroadcast() {
     // Used to be able to clean up the running stream
-    Materializer materializer = Materializer.create(system);
+    Materializer materializer = Materializer.createMaterializer(system);
 
     // #broadcast-hub
     // A simple producer that publishes a new "message" every second
@@ -134,7 +134,7 @@ public class HubDocTest extends AbstractJavaTest {
   @Test
   public void dynamicPartition() {
     // Used to be able to clean up the running stream
-    Materializer materializer = Materializer.create(system);
+    Materializer materializer = Materializer.createMaterializer(system);
 
     // #partition-hub
     // A simple producer that publishes a new "message-n" every second
@@ -182,7 +182,7 @@ public class HubDocTest extends AbstractJavaTest {
   @Test
   public void dynamicStatefulPartition() {
     // Used to be able to clean up the running stream
-    Materializer materializer = Materializer.create(system);
+    Materializer materializer = Materializer.createMaterializer(system);
 
     // #partition-hub-stateful
     // A simple producer that publishes a new "message-n" every second
@@ -215,7 +215,7 @@ public class HubDocTest extends AbstractJavaTest {
   @Test
   public void dynamicFastestPartition() {
     // Used to be able to clean up the running stream
-    Materializer materializer = Materializer.create(system);
+    Materializer materializer = Materializer.createMaterializer(system);
 
     // #partition-hub-fastest
     Source<Integer, NotUsed> producer = Source.range(0, 100);

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkAsJavaStreamSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkAsJavaStreamSpec.scala
@@ -63,7 +63,7 @@ class SinkAsJavaStreamSpec extends StreamSpec(UnboundedMailboxConfig) {
     }
 
     "work in separate IO dispatcher" in assertAllStagesStopped {
-      val materializer = Materializer.create(system)
+      val materializer = Materializer.createMaterializer(system)
       TestSource.probe[ByteString].runWith(StreamConverters.asJavaStream())(materializer)
       materializer.asInstanceOf[PhasedFusingActorMaterializer].supervisor.tell(StreamSupervisor.GetChildren, testActor)
       val ref = expectMsgType[Children].children.find(_.path.toString contains "asJavaStream").get

--- a/akka-stream-typed/src/test/java/akka/stream/typed/javadsl/CustomGuardianAndMaterializerTest.java
+++ b/akka-stream-typed/src/test/java/akka/stream/typed/javadsl/CustomGuardianAndMaterializerTest.java
@@ -5,15 +5,12 @@
 package akka.stream.typed.javadsl;
 
 import akka.Done;
-import akka.actor.AbstractActor;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
-import akka.actor.typed.TimerSpec;
 import akka.actor.typed.javadsl.Behaviors;
 import akka.stream.AbruptStageTerminationException;
-import akka.stream.AbruptTerminationException;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
@@ -39,7 +36,7 @@ public class CustomGuardianAndMaterializerTest extends JUnitSuite {
 
   @Test
   public void createCustomSystemLevelMaterialiser() throws Exception {
-    Materializer materializer = Materializer.create(testKit.system());
+    Materializer materializer = Materializer.createMaterializer(testKit.system());
 
     CompletionStage<String> result = Source.single("hello").runWith(Sink.head(), materializer);
 
@@ -49,7 +46,7 @@ public class CustomGuardianAndMaterializerTest extends JUnitSuite {
   private static Behavior<String> actorStreamBehavior(ActorRef<Object> probe) {
     return Behaviors.setup(
         (context) -> {
-          Materializer materializer = Materializer.create(context);
+          Materializer materializer = Materializer.createMaterializer(context);
 
           CompletionStage<Done> done = Source.repeat("hello").runWith(Sink.ignore(), materializer);
           done.whenComplete(

--- a/akka-stream/src/main/scala/akka/stream/Materializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/Materializer.scala
@@ -212,7 +212,7 @@ object Materializer {
    *
    * You can pass either a classic actor context or a typed actor context.
    */
-  def create(contextProvider: ClassicActorContextProvider): Materializer = apply(contextProvider)
+  def createMaterializer(contextProvider: ClassicActorContextProvider): Materializer = apply(contextProvider)
 
   /**
    * Scala API: Create a new materializer that will stay alive as long as the system does or until it is explicitly stopped.
@@ -235,7 +235,7 @@ object Materializer {
    * lifecycle of the materializer to an actor, use the factory that takes an [[ActorContext]] instead.
    */
   @silent("deprecated")
-  def create(systemProvider: ClassicActorSystemProvider): Materializer =
+  def createMaterializer(systemProvider: ClassicActorSystemProvider): Materializer =
     apply(systemProvider)
 
 }


### PR DESCRIPTION
* because static methods are resolved by looking at extended class too,
  and that results in ambigious method clash with existing create in
  ActorMaterializer

Compilation failed in akka-http.

More details in the issue.

Refs  #27642