### PR TITLE
Akka Stream log operator documentation fix

### DIFF
--- a/akka-docs/src/test/java/jdocs/stream/operators/SourceOrFlow.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/SourceOrFlow.java
@@ -35,7 +35,7 @@ import java.util.Arrays;
 
 // #log
 import akka.stream.Attributes;
-import akka.stream.javadsl.Source;
+
 // #log
 
 import java.time.Duration;
@@ -52,8 +52,8 @@ class SourceOrFlow {
         .addAttributes(
             Attributes.createLogLevels(
                 Attributes.logLevelOff(), // onElement
-                Attributes.logLevelError(), // onFailure
-                Attributes.logLevelInfo())) // onFinish
+                Attributes.logLevelInfo(), // onFinish
+                Attributes.logLevelError())) // onFailure
     // #log
     ;
   }

--- a/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/Log.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/Log.scala
@@ -18,8 +18,8 @@ object Log {
       .addAttributes(
         Attributes.logLevels(
           onElement = Attributes.LogLevels.Off,
-          onFailure = Attributes.LogLevels.Error,
-          onFinish = Attributes.LogLevels.Info))
+          onFinish = Attributes.LogLevels.Info,
+          onFailure = Attributes.LogLevels.Error))
     //#log
   }
 }


### PR DESCRIPTION
## Purpose
Improve Akka documentation

## References
/

## Changes
- Fix Akka Stream log operator documentation example
- Keep Scala documentation example in sync with the updated Java example

## Background Context
/