### PR TITLE
Failed: MultiDcClusterSharding #27663

### DIFF
--- a/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/MultiDcClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/MultiDcClusterShardingSpec.scala
@@ -69,7 +69,7 @@ abstract class MultiDcClusterShardingSpec
       val shardRegion: ActorRef[ShardingEnvelope[PingProtocol]] = sharding.init(Entity(typeKey, _ => multiDcPinger))
       val probe = TestProbe[Pong]
       shardRegion ! ShardingEnvelope(entityId, Ping(probe.ref))
-      probe.expectMessage(max = 10.seconds, Pong(cluster.selfMember.dataCenter))
+      probe.expectMessage(max = 15.seconds, Pong(cluster.selfMember.dataCenter))
       enterBarrier("sharding-initialized")
     }
 


### PR DESCRIPTION
References https://github.com/akka/akka/issues/27663

My initial theory is that because the test sets this so low
```
# First is likely to be ignored as shard coordinator not ready
 retry-interval = 0.2s
```
CI runs need a few seconds more for retries to complete sharding initialization and receive the first message response.
