### PR TITLE
Avoid publication of duplicate UnreachableDataCenter, #24955

### DIFF
--- a/akka-cluster/src/main/mima-filters/2.5.x.backwards.excludes
+++ b/akka-cluster/src/main/mima-filters/2.5.x.backwards.excludes
@@ -22,3 +22,7 @@ ProblemFilters.exclude[MissingTypesProblem]("akka.cluster.protobuf.msg.ClusterMe
 # Upgrade to protobuf 3
 ProblemFilters.exclude[Problem]("akka.cluster.protobuf.msg.ClusterMessages*")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.protobuf.ClusterMessageSerializer.compress")
+
+# #24955 publish of UnreachableDataCenter and ReachableDataCenter
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterEvent.isReachable")
+


### PR DESCRIPTION
* see scenario in added test, extracted from debug logs "New gossip published"
  from MultiDcSplitBrainSpec,https://jenkins.akka.io:8498/job/akka-nightly/6884/consoleText
* it publised UnreachableDataCenter even though it had already published that,
  when a new cross link is added as unreachable in the reachability table
* don't know why the implementation of diffUnreachableDataCenter/isReachable was
  so complicated, but no tests are failing for the changed implementation

Refs #24955
