### PR TITLE
remove deprecated actorRefWithAck in akka-stream-typed

### DIFF
--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -487,6 +487,7 @@ made before finalizing the APIs. Compared to Akka 2.5.x the source incompatible 
 * Factories for creating a materializer from an `akka.actor.typed.ActorSystem` have been removed.
   A stream can be run with an `akka.actor.typed.ActorSystem` @scala[in implicit scope]@java[parameter]
   and therefore the need for creating a materializer has been reduced.
+* `actorRefWithAck` has been renamed to `actorRefWithBackpressure`
 
 ## Akka Stream changes
 

--- a/akka-stream-typed/src/main/scala/akka/stream/typed/javadsl/ActorSink.scala
+++ b/akka-stream-typed/src/main/scala/akka/stream/typed/javadsl/ActorSink.scala
@@ -66,38 +66,4 @@ object ActorSink {
         onFailureMessage.apply)
       .asJava
 
-  /**
-   * Sends the elements of the stream to the given `ActorRef` that sends back back-pressure signal.
-   * First element is always `onInitMessage`, then stream is waiting for acknowledgement message
-   * `ackMessage` from the given actor which means that it is ready to process
-   * elements. It also requires `ackMessage` message after each stream element
-   * to make backpressure work.
-   *
-   * If the target actor terminates the stream will be canceled.
-   * When the stream is completed successfully the given `onCompleteMessage`
-   * will be sent to the destination actor.
-   * When the stream is completed with failure - result of `onFailureMessage(throwable)`
-   * function will be sent to the destination actor.
-   *
-   * @deprecated Use actorRefWithBackpressure instead
-   */
-  @Deprecated
-  @deprecated("Use actorRefWithBackpressure instead", "2.6.0")
-  def actorRefWithAck[T, M, A](
-      ref: ActorRef[M],
-      messageAdapter: akka.japi.function.Function2[ActorRef[A], T, M],
-      onInitMessage: akka.japi.function.Function[ActorRef[A], M],
-      ackMessage: A,
-      onCompleteMessage: M,
-      onFailureMessage: akka.japi.function.Function[Throwable, M]): Sink[T, NotUsed] =
-    typed.scaladsl.ActorSink
-      .actorRefWithBackpressure(
-        ref,
-        messageAdapter.apply,
-        onInitMessage.apply,
-        ackMessage,
-        onCompleteMessage,
-        onFailureMessage.apply)
-      .asJava
-
 }

--- a/akka-stream-typed/src/main/scala/akka/stream/typed/scaladsl/ActorSink.scala
+++ b/akka-stream-typed/src/main/scala/akka/stream/typed/scaladsl/ActorSink.scala
@@ -61,33 +61,4 @@ object ActorSink {
       onCompleteMessage,
       onFailureMessage)
 
-  /**
-   * Sends the elements of the stream to the given `ActorRef` that sends back back-pressure signal.
-   * First element is always `onInitMessage`, then stream is waiting for acknowledgement message
-   * `ackMessage` from the given actor which means that it is ready to process
-   * elements. It also requires `ackMessage` message after each stream element
-   * to make backpressure work.
-   *
-   * If the target actor terminates the stream will be canceled.
-   * When the stream is completed successfully the given `onCompleteMessage`
-   * will be sent to the destination actor.
-   * When the stream is completed with failure - result of `onFailureMessage(throwable)`
-   * function will be sent to the destination actor.
-   */
-  @deprecated("Use actorRefWithBackpressure instead", "2.6.0")
-  def actorRefWithAck[T, M, A](
-      ref: ActorRef[M],
-      messageAdapter: (ActorRef[A], T) => M,
-      onInitMessage: ActorRef[A] => M,
-      ackMessage: A,
-      onCompleteMessage: M,
-      onFailureMessage: Throwable => M): Sink[T, NotUsed] =
-    Sink.actorRefWithAck(
-      ref.toClassic,
-      messageAdapter.curried.compose(actorRefAdapter),
-      onInitMessage.compose(actorRefAdapter),
-      ackMessage,
-      onCompleteMessage,
-      onFailureMessage)
-
 }


### PR DESCRIPTION
* for 2.6.0 we make the final api changes without deprecation, unless
  there is a strong reason

It was deprecated in https://github.com/akka/akka/pull/27519, but I didn't want to drag out the review of that PR