### PR TITLE
Convert 2.5.x MiMa excludes to subdirectory style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,7 +227,11 @@ an error like this:
 [error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowOps.foldAsync")
 ```
 
-In such situations it's good to consult with a core team member if the violation can be safely ignored (by adding the above snippet to `<module>/src/main/mima-filters/<last-version>.backwards.excludes`), or if it would indeed break binary compatibility.
+In such situations it's good to consult with a core team member whether the violation can be safely ignored or if it would indeed
+break binary compatibility. If the violation can be ignored add exclude statements from the mima output to
+a new file named `<module>/src/main/mima-filters/<last-version>.backwards.excludes/<pr-or-issue>-<issue-number>-<description>.excludes`,
+e.g. `akka-actor/src/main/mima-filters/2.5.x.backwards.excludes/pr-12345-rename-internal-classes.excludes`. Make sure to add a comment
+in the file that describes briefly why the incompatibility can be ignored.
 
 Situations when it may be fine to ignore a MiMa issued warning include:
 

--- a/akka-actor/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-actor/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -1,3 +1,4 @@
+# This file contains all excludes added before changing to the subdirectory style
 # excludes for 2.6
 
 ProblemFilters.exclude[MissingClassProblem]("akka.actor.Inbox$")

--- a/akka-cluster-metrics/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-cluster-metrics/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -1,3 +1,4 @@
+# This file contains all excludes added before changing to the subdirectory style
 # Upgrade to protobuf 3
 ProblemFilters.exclude[Problem]("akka.cluster.metrics.protobuf.msg.ClusterMetricsMessages*")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.metrics.protobuf.MessageSerializer.compress")

--- a/akka-cluster-sharding/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -1,3 +1,4 @@
+# This file contains all excludes added before changing to the subdirectory style
 # #26877 Performance improvements of DDataShard
 ProblemFilters.exclude[Problem]("akka.cluster.sharding.Shard.*")
 

--- a/akka-cluster-tools/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-cluster-tools/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -1,3 +1,4 @@
+# This file contains all excludes added before changing to the subdirectory style
 # Protobuf 3
 ProblemFilters.exclude[Problem]("akka.cluster.client.protobuf.msg.*")
 ProblemFilters.exclude[Problem]("akka.cluster.pubsub.protobuf.msg.*")

--- a/akka-cluster/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-cluster/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -1,3 +1,4 @@
+# This file contains all excludes added before changing to the subdirectory style
 # 26757 add timings to cluster heart beat messages
 ProblemFilters.exclude[MissingTypesProblem]("akka.cluster.ClusterHeartbeatSender$Heartbeat$")
 ProblemFilters.exclude[MissingTypesProblem]("akka.cluster.ClusterHeartbeatSender$HeartbeatRsp$")

--- a/akka-coordination/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-coordination/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -1,2 +1,3 @@
+# This file contains all excludes added before changing to the subdirectory style
 # Made final when removing api may change
 ProblemFilters.exclude[FinalClassProblem]("akka.coordination.lease.LeaseUsageSettings")

--- a/akka-distributed-data/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-distributed-data/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -1,2 +1,3 @@
+# This file contains all excludes added before changing to the subdirectory style
 # Upgrade to protobuf 3
 ProblemFilters.exclude[Problem]("akka.cluster.ddata.protobuf.*")

--- a/akka-multi-node-testkit/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-multi-node-testkit/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -1,3 +1,4 @@
+# This file contains all excludes added before changing to the subdirectory style
 # Protobuf 3
 ProblemFilters.exclude[Problem]("akka.remote.testconductor.TestConductorProtocol*")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.remote.testconductor.ProtobufDecoder.this")

--- a/akka-persistence-query/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-persistence-query/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -1,3 +1,4 @@
+# This file contains all excludes added before changing to the subdirectory style
 # Remove ActorPublisher/Subscriber
 
 ProblemFilters.exclude[MissingClassProblem]("akka.persistence.query.journal.leveldb.LiveEventsByTagPublisher")

--- a/akka-persistence/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-persistence/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -1,3 +1,4 @@
+# This file contains all excludes added before changing to the subdirectory style
 # excludes for 2.6
 
 # Remove deprecated features since 2.5.0 https://github.com/akka/akka/issues/26492

--- a/akka-remote/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-remote/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -1,3 +1,4 @@
+# This file contains all excludes added before changing to the subdirectory style
 # #26190 remove actorFor
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.remote.RemoteActorRefProvider.actorFor")
 

--- a/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -1,3 +1,4 @@
+# This file contains all excludes added before changing to the subdirectory style
 # Java9 RS APIs and more that was missed in a few earlier versions
 ProblemFilters.exclude[MissingClassProblem]("akka.stream.javadsl.JavaFlowSupport$Source")
 ProblemFilters.exclude[MissingClassProblem]("akka.stream.javadsl.JavaFlowSupport")

--- a/akka-testkit/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-testkit/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -1,3 +1,4 @@
+# This file contains all excludes added before changing to the subdirectory style
 # Remove JavaTestKit https://github.com/akka/akka/issues/26189
 ProblemFilters.exclude[MissingClassProblem]("akka.testkit.JavaTestKit")
 ProblemFilters.exclude[MissingClassProblem]("akka.testkit.JavaTestKit$*")


### PR DESCRIPTION
Using this script:

```sh

set -ex

FILE=$1
DIR=`dirname $FILE`
TMP_FILE=$DIR/_existing.excludes
FINAL_FILE=$DIR/2.5.x.backwards.excludes/_existing.excludes

mv $FILE $TMP_FILE
mkdir $DIR/2.5.x.backwards.excludes
(echo "# This file contains all excludes added before changing to the subdirectory style" && cat $TMP_FILE) > $FINAL_FILE
rm $TMP_FILE
git add $FINAL_FILE
```

And yes, this will add lot of conflicts with existing PRs. The upside: it will be the last time for mima excludes.