### PR TITLE
Cluster sharding with remember entities (persistence) must setup shared journal

### DIFF
--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingRememberEntitiesSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingRememberEntitiesSpec.scala
@@ -46,63 +46,95 @@ object ClusterShardingRememberEntitiesSpec {
 
 }
 
-abstract class ClusterShardingRememberEntitiesSpecConfig(val mode: String) extends MultiNodeConfig {
+abstract class ClusterShardingRememberEntitiesSpecConfig(val mode: String, val rememberEntities: Boolean)
+    extends MultiNodeConfig {
   val first = role("first")
   val second = role("second")
   val third = role("third")
 
+  val targetDir = s"target/ClusterShardingRememberEntitiesSpec-$mode-remember-$rememberEntities"
+
+  val modeConfig =
+    if (mode == ClusterShardingSettings.StateStoreModeDData) ConfigFactory.empty
+    else ConfigFactory.parseString(s"""
+      akka.persistence.journal.plugin = "akka.persistence.journal.leveldb-shared"
+      akka.persistence.journal.leveldb-shared.timeout = 5s
+      akka.persistence.journal.leveldb-shared.store.native = off
+      akka.persistence.journal.leveldb-shared.store.dir = "$targetDir/journal"
+      akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
+      akka.persistence.snapshot-store.local.dir = "$targetDir/snapshots"
+      akka.cluster.sharding.journal-plugin-id = "akka.persistence.journal.inmem"
+      """)
+
   commonConfig(
-    ConfigFactory
-      .parseString(s"""
-    akka.loglevel = DEBUG
-    akka.actor.provider = "cluster"
-    akka.cluster.auto-down-unreachable-after = 0s
-    akka.remote.log-remote-lifecycle-events = off
-    akka.persistence.journal.plugin = "akka.persistence.journal.leveldb-shared"
-    akka.persistence.journal.leveldb-shared {
-      timeout = 5s
-      store {
-        native = off
-        dir = "target/ShardingRememberEntitiesSpec/journal"
+    modeConfig
+      .withFallback(ConfigFactory.parseString(s"""
+      akka.loglevel = DEBUG
+      akka.actor.provider = "cluster"
+      akka.cluster.auto-down-unreachable-after = 0s
+      akka.remote.log-remote-lifecycle-events = off
+      akka.cluster.sharding.state-store-mode = "$mode"
+      akka.cluster.sharding.distributed-data.durable.lmdb {
+        dir = $targetDir/sharding-ddata
+        map-size = 10 MiB
       }
-    }
-    akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
-    akka.persistence.snapshot-store.local.dir = "target/ShardingRememberEntitiesSpec/snapshots"
-    akka.cluster.sharding.state-store-mode = "$mode"
-    akka.cluster.sharding.distributed-data.durable.lmdb {
-      dir = target/ShardingRememberEntitiesSpec/sharding-ddata
-      map-size = 10 MiB
-    }
-    """)
+      # FIXME temporary while sanity-checking persistence enabled
+      # waiting for `Started` from restarted entity
+      akka.testconductor.barrier-timeout = 60 s
+      akka.test.single-expect-default = 60 s # defaults to 3s
+      """))
       .withFallback(SharedLeveldbJournal.configToEnableJavaSerializationForTest)
       .withFallback(MultiNodeClusterSpec.clusterConfig))
 
   nodeConfig(third)(ConfigFactory.parseString(s"""
     akka.cluster.sharding.distributed-data.durable.lmdb {
       # use same directory when starting new node on third (not used at same time)
-      dir = target/ShardingRememberEntitiesSpec/sharding-third
+      dir = $targetDir/sharding-third
     }
     """))
+
 }
 
-object PersistentClusterShardingRememberEntitiesSpecConfig
-    extends ClusterShardingRememberEntitiesSpecConfig(ClusterShardingSettings.StateStoreModePersistence)
-object DDataClusterShardingRememberEntitiesSpecConfig
-    extends ClusterShardingRememberEntitiesSpecConfig(ClusterShardingSettings.StateStoreModeDData)
+object PersistentClusterShardingRememberEntitiesEnabledSpecConfig
+    extends ClusterShardingRememberEntitiesSpecConfig(ClusterShardingSettings.StateStoreModePersistence, true)
+object PersistentClusterShardingRememberEntitiesDefaultSpecConfig
+    extends ClusterShardingRememberEntitiesSpecConfig(ClusterShardingSettings.StateStoreModePersistence, false)
+object DDataClusterShardingRememberEntitiesEnabledSpecConfig
+    extends ClusterShardingRememberEntitiesSpecConfig(ClusterShardingSettings.StateStoreModeDData, true)
+object DDataClusterShardingRememberEntitiesDefaultSpecConfig
+    extends ClusterShardingRememberEntitiesSpecConfig(ClusterShardingSettings.StateStoreModeDData, false)
 
-class PersistentClusterShardingRememberEntitiesSpec
-    extends ClusterShardingRememberEntitiesSpec(PersistentClusterShardingRememberEntitiesSpecConfig)
+class PersistentClusterShardingRememberEntitiesEnabledSpec
+    extends ClusterShardingRememberEntitiesSpec(PersistentClusterShardingRememberEntitiesEnabledSpecConfig)
+class PersistentClusterShardingRememberEntitiesDefaultSpec
+    extends ClusterShardingRememberEntitiesSpec(PersistentClusterShardingRememberEntitiesDefaultSpecConfig)
 
-class PersistentClusterShardingRememberEntitiesMultiJvmNode1 extends PersistentClusterShardingRememberEntitiesSpec
-class PersistentClusterShardingRememberEntitiesMultiJvmNode2 extends PersistentClusterShardingRememberEntitiesSpec
-class PersistentClusterShardingRememberEntitiesMultiJvmNode3 extends PersistentClusterShardingRememberEntitiesSpec
+class PersistentClusterShardingRememberEntitiesEnabledMultiJvmNode1
+    extends PersistentClusterShardingRememberEntitiesEnabledSpec
+class PersistentClusterShardingRememberEntitiesEnabledMultiJvmNode2
+    extends PersistentClusterShardingRememberEntitiesEnabledSpec
+class PersistentClusterShardingRememberEntitiesEnabledMultiJvmNode3
+    extends PersistentClusterShardingRememberEntitiesEnabledSpec
 
-class DDataClusterShardingRememberEntitiesSpec
-    extends ClusterShardingRememberEntitiesSpec(DDataClusterShardingRememberEntitiesSpecConfig)
+class PersistentClusterShardingRememberEntitiesDefaultMultiJvmNode1
+    extends PersistentClusterShardingRememberEntitiesDefaultSpec
+class PersistentClusterShardingRememberEntitiesDefaultMultiJvmNode2
+    extends PersistentClusterShardingRememberEntitiesDefaultSpec
+class PersistentClusterShardingRememberEntitiesDefaultMultiJvmNode3
+    extends PersistentClusterShardingRememberEntitiesDefaultSpec
 
-class DDataClusterShardingRememberEntitiesMultiJvmNode1 extends DDataClusterShardingRememberEntitiesSpec
-class DDataClusterShardingRememberEntitiesMultiJvmNode2 extends DDataClusterShardingRememberEntitiesSpec
-class DDataClusterShardingRememberEntitiesMultiJvmNode3 extends DDataClusterShardingRememberEntitiesSpec
+class DDataClusterShardingRememberEntitiesEnabledSpec
+    extends ClusterShardingRememberEntitiesSpec(DDataClusterShardingRememberEntitiesEnabledSpecConfig)
+class DDataClusterShardingRememberEntitiesDefaultSpec
+    extends ClusterShardingRememberEntitiesSpec(DDataClusterShardingRememberEntitiesEnabledSpecConfig)
+
+class DDataClusterShardingRememberEntitiesEnabledMultiJvmNode1 extends DDataClusterShardingRememberEntitiesEnabledSpec
+class DDataClusterShardingRememberEntitiesEnabledMultiJvmNode2 extends DDataClusterShardingRememberEntitiesEnabledSpec
+class DDataClusterShardingRememberEntitiesEnabledMultiJvmNode3 extends DDataClusterShardingRememberEntitiesEnabledSpec
+
+class DDataClusterShardingRememberEntitiesDisabledMultiJvmNode1 extends DDataClusterShardingRememberEntitiesEnabledSpec
+class DDataClusterShardingRememberEntitiesDisabledMultiJvmNode2 extends DDataClusterShardingRememberEntitiesEnabledSpec
+class DDataClusterShardingRememberEntitiesDisabledMultiJvmNode3 extends DDataClusterShardingRememberEntitiesEnabledSpec
 
 abstract class ClusterShardingRememberEntitiesSpec(config: ClusterShardingRememberEntitiesSpecConfig)
     extends MultiNodeSpec(config)
@@ -111,7 +143,9 @@ abstract class ClusterShardingRememberEntitiesSpec(config: ClusterShardingRememb
   import ClusterShardingRememberEntitiesSpec._
   import config._
 
-  override def initialParticipants = roles.size
+  override def initialParticipants: Int = roles.size
+
+  val dataType = "Entity"
 
   val storageLocations = List(
     new File(system.settings.config.getString("akka.cluster.sharding.distributed-data.durable.lmdb.dir")).getParentFile)
@@ -128,24 +162,35 @@ abstract class ClusterShardingRememberEntitiesSpec(config: ClusterShardingRememb
   def join(from: RoleName, to: RoleName): Unit = {
     runOn(from) {
       Cluster(system).join(node(to).address)
+      awaitAssert {
+        Cluster(system).state.isMemberUp(node(from).address)
+      }
     }
     enterBarrier(from.name + "-joined")
   }
 
   val cluster = Cluster(system)
 
-  def startSharding(sys: ActorSystem = system, probe: ActorRef = testActor): Unit = {
+  def startSharding(sys: ActorSystem, probe: ActorRef): ActorRef = {
     ClusterSharding(sys).start(
-      typeName = "Entity",
+      typeName = dataType,
       entityProps = ClusterShardingRememberEntitiesSpec.props(probe),
-      settings = ClusterShardingSettings(system).withRememberEntities(true),
+      settings = ClusterShardingSettings(sys).withRememberEntities(rememberEntities),
       extractEntityId = extractEntityId,
       extractShardId = extractShardId)
   }
 
-  lazy val region = ClusterSharding(system).shardRegion("Entity")
+  lazy val region = ClusterSharding(system).shardRegion(dataType)
 
   def isDdataMode: Boolean = mode == ClusterShardingSettings.StateStoreModeDData
+
+  def setStoreIfNotDdata(sys: ActorSystem): Unit =
+    if (!isDdataMode) {
+      val probe = TestProbe()(sys)
+      sys.actorSelection(node(first) / "user" / "store").tell(Identify(None), probe.ref)
+      val sharedStore = probe.expectMsgType[ActorIdentity](20.seconds).ref.get
+      SharedLeveldbJournal.setStore(sharedStore, sys)
+    }
 
   s"Cluster sharding with remember entities ($mode)" must {
 
@@ -156,12 +201,10 @@ abstract class ClusterShardingRememberEntitiesSpec(config: ClusterShardingRememb
         runOn(first) {
           system.actorOf(Props[SharedLeveldbStore], "store")
         }
-        enterBarrier("peristence-started")
+        enterBarrier("persistence-started")
 
         runOn(first, second, third) {
-          system.actorSelection(node(first) / "user" / "store") ! Identify(None)
-          val sharedStore = expectMsgType[ActorIdentity](10.seconds).ref.get
-          SharedLeveldbJournal.setStore(sharedStore, system)
+          setStoreIfNotDdata(system)
         }
 
         enterBarrier("after-1")
@@ -171,7 +214,7 @@ abstract class ClusterShardingRememberEntitiesSpec(config: ClusterShardingRememb
     "start remembered entities when coordinator fail over" in within(30.seconds) {
       join(second, second)
       runOn(second) {
-        startSharding()
+        startSharding(system, testActor)
         region ! 1
         expectMsgType[Started]
       }
@@ -179,7 +222,7 @@ abstract class ClusterShardingRememberEntitiesSpec(config: ClusterShardingRememb
 
       join(third, second)
       runOn(third) {
-        startSharding()
+        startSharding(system, testActor)
       }
       runOn(second, third) {
         within(remaining) {
@@ -203,7 +246,21 @@ abstract class ClusterShardingRememberEntitiesSpec(config: ClusterShardingRememb
       enterBarrier("crash-second")
 
       runOn(third) {
-        expectMsgType[Started](remaining)
+        if (!rememberEntities) {
+          ClusterSharding(system).shardRegion(dataType) ! 1
+        }
+        // FIXME This is where we fail if remember=true, mode=persistence.
+        // What is curious is after node 'second' stops
+        // the ShardCoordinator does correctly restart on node 'third',
+        // however the entity does not get re-created automatically as it should, even though:
+        // the ShardRegion
+        // - does get registered: [Actor[akka://ClusterShardingRememberEntitiesSpec/system/sharding/Entity#380407716]]
+        // - is in the ShardCoordinator's 'aliveRegion'
+        // - does receive the RegisterAck
+        expectMsgType[Started](20.seconds)
+        if (!rememberEntities) {
+          expectMsg(1)
+        }
       }
 
       enterBarrier("after-2")
@@ -222,15 +279,18 @@ abstract class ClusterShardingRememberEntitiesSpec(config: ClusterShardingRememb
         val sys2 = ActorSystem(system.name, system.settings.config)
         val probe2 = TestProbe()(sys2)
 
-        if (!isDdataMode) {
-          sys2.actorSelection(node(first) / "user" / "store").tell(Identify(None), probe2.ref)
-          val sharedStore = probe2.expectMsgType[ActorIdentity](10.seconds).ref.get
-          SharedLeveldbJournal.setStore(sharedStore, sys2)
-        }
+        setStoreIfNotDdata(sys2)
 
         Cluster(sys2).join(Cluster(sys2).selfAddress)
         startSharding(sys2, probe2.ref)
+
+        if (!rememberEntities) {
+          probe2.send(ClusterSharding(sys2).shardRegion(dataType), 1)
+        }
         probe2.expectMsgType[Started](20.seconds)
+        if (!rememberEntities) {
+          probe2.expectMsg(1)
+        }
 
         shutdown(sys2)
       }


### PR DESCRIPTION
* Fixes https://github.com/akka/akka/issues/27548
* Additionally adds more test coverage for multi-jvm testing of all combinations:
   - both `ddata` and `persistence` modes against both enabled or default `rememberEntities`
* Run against a jenkins akka-multi-node-repeat