### PR TITLE
wait for async excess events when occurrences 0

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/LoggingEventFilter.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/LoggingEventFilter.scala
@@ -26,6 +26,13 @@ import org.slf4j.event.Level
 
   /**
    * Number of events the filter is supposed to match. By default 1.
+   *
+   * When occurrences > 0 it will not look for excess messages that are logged asynchronously
+   * outside (after) the `intercept` thunk and it has already found expected number.
+   *
+   * When occurrences is 0 it will look for unexpected matching events, and then it will
+   * also look for excess messages during the configured `akka.actor.testkit.typed.expect-no-message-default`
+   * duration.
    */
   def withOccurrences(newOccurrences: Int): LoggingEventFilter
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilter.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/LoggingEventFilter.scala
@@ -26,6 +26,13 @@ import org.slf4j.event.Level
 
   /**
    * Number of events the filter is supposed to match. By default 1.
+   *
+   * When occurrences > 0 it will not look for excess messages that are logged asynchronously
+   * outside (after) the `intercept` thunk and it has already found expected number.
+   *
+   * When occurrences is 0 it will look for unexpected matching events, and then it will
+   * also look for excess messages during the configured `akka.actor.testkit.typed.expect-no-message-default`
+   * duration.
    */
   def withOccurrences(newOccurrences: Int): LoggingEventFilter
 


### PR DESCRIPTION
* otherwise withOccurrences(0) testing is typically not testing
  anything since logging is typically async from some actor
* but don't want to slow down by always waiting when occurrences > 0
