### PR TITLE
Eliminate race in multi node StreamRefSpec 

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StreamRefSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StreamRefSpec.scala
@@ -27,6 +27,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
+import akka.util.JavaDurationConverters._
 
 object StreamRefSpec extends MultiNodeConfig {
   val first = role("first")
@@ -244,7 +245,14 @@ abstract class StreamRefSpec extends MultiNodeSpec(StreamRefSpec) with MultiNode
         streamLifecycle1.expectMsg("failed-system-42-tmp")
       }
       runOn(third) {
-        streamLifecycle3.expectMsg("failed-system-42-tmp")
+        // there's a race here, we know the SourceRef actor was started but we don't know if it
+        // got the remote actor ref and watched it terminate or if we cut connection before that
+        // and it triggered the subscription timeout. Therefore we must wait more than the
+        // the subscription timeout for a failure
+        val timeout = system.settings.config
+            .getDuration("akka.stream.materializer.subscription-timeout.timeout")
+            .asScala + 2.seconds
+        streamLifecycle3.expectMsg(timeout, "failed-system-42-tmp")
       }
 
       enterBarrier("after-3")


### PR DESCRIPTION
Refs #26392

The cause of the failure is described in [the issue](https://github.com/akka/akka/issues/26392#issuecomment-532214194).

Fixes the issue by making sure the test expects either a failure because of remote watch-observed removal of the stream ref actor _or_ a subscription timeout (by waiting more than the subscription timeout in case it didn't fail fast from watching)