### PR TITLE
Upgrade scalafix plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.5")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.6")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.7-1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.5")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")


### PR DESCRIPTION
The akka sbt build starts up about 15-20% faster (15.5 seconds vs 18.5
seconds on my laptop) with this updated version due to
https://github.com/scalacenter/sbt-scalafix/pull/42.

<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Lower sbt startup time in the akka project.

## Changes

Updates the scalafix plugin version.

## Background Context
I was debugging sbt startup performance in general and was using akka as a test project when I uncovered the perforance bug in the scalafix plugin.