### PR TITLE
Use git from the path instead of jgit/sbt-git

### DIFF
--- a/project/Whitesource.scala
+++ b/project/Whitesource.scala
@@ -6,7 +6,7 @@ import sbt._
 import sbt.Keys._
 import sbtwhitesource.WhiteSourcePlugin.autoImport._
 import sbtwhitesource._
-import com.typesafe.sbt.SbtGit.GitKeys._
+import scala.sys.process._
 
 object Whitesource extends AutoPlugin {
   override def requires = WhiteSourcePlugin
@@ -17,15 +17,15 @@ object Whitesource extends AutoPlugin {
     // do not change the value of whitesourceProduct
     whitesourceProduct := "Lightbend Reactive Platform",
     whitesourceAggregateProjectName := {
-      (moduleName in LocalRootProject).value + "-" + (
-        if (isSnapshot.value)
-          if (gitCurrentBranch.value == "master") "master"
-          else "adhoc"
-        else CrossVersion.partialVersion((version in LocalRootProject).value)
-          .map { case (major,minor) => s"$major.$minor-stable" }
-          .getOrElse("adhoc"))
+      (moduleName in LocalRootProject).value + "-" + (if (isSnapshot.value)
+                                                        if ("git branch --show-current".!!.trim == "master") "master"
+                                                        else "adhoc"
+                                                      else
+                                                        CrossVersion
+                                                          .partialVersion((version in LocalRootProject).value)
+                                                          .map { case (major, minor) => s"$major.$minor-stable" }
+                                                          .getOrElse("adhoc"))
     },
     whitesourceForceCheckAllDependencies := true,
-    whitesourceFailOnError := true,
-  )
+    whitesourceFailOnError := true)
 }

--- a/project/Whitesource.scala
+++ b/project/Whitesource.scala
@@ -17,14 +17,19 @@ object Whitesource extends AutoPlugin {
     // do not change the value of whitesourceProduct
     whitesourceProduct := "Lightbend Reactive Platform",
     whitesourceAggregateProjectName := {
-      (moduleName in LocalRootProject).value + "-" + (if (isSnapshot.value)
-                                                        if ("git branch --show-current".!!.trim == "master") "master"
-                                                        else "adhoc"
-                                                      else
-                                                        CrossVersion
-                                                          .partialVersion((version in LocalRootProject).value)
-                                                          .map { case (major, minor) => s"$major.$minor-stable" }
-                                                          .getOrElse("adhoc"))
+      val name = (moduleName in LocalRootProject).value
+      val wsVersionName =
+        if (isSnapshot.value) {
+          val currentGitBranch = "git rev-parse --abbrev-ref HEAD".!!.trim
+          if (currentGitBranch == "master") "master"
+          else "adhoc"
+        } else
+          CrossVersion
+            .partialVersion((version in LocalRootProject).value)
+            .map { case (major, minor) => s"$major.$minor-stable" }
+            .getOrElse("adhoc")
+
+      s"$name-$wsVersionName"
     },
     whitesourceForceCheckAllDependencies := true,
     whitesourceFailOnError := true)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,6 @@ addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.24")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-apidoc" % "0.2")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.6.5")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.16")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0") // for maintenance of copyright file header
 addSbtPlugin("com.hpe.sbt" % "sbt-pull-request-validator" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")


### PR DESCRIPTION
We potentially had issues with jgit filling heap in our PR-validation, probably caused by the repo being massive + jgit.

We only use sbt-git in one place to know the branch name for whitesource validation, let's try getting rid of the plugin.

Two bonuses:

faster project load,
```
       29.64 real       101.31 user         5.52 sys
```
vs after removing
```
       16.76 real        45.58 user         3.84 sys
```
on my machine just avoiding having jgit parsing the git repo.

And no longer blocking use git worktree, (so indirectly refs #25813 )