### PR TITLE
Implicit conversion ClassicActorSystemProvider to ActorSystem

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ClassicActorSystemProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ClassicActorSystemProvider.scala
@@ -7,6 +7,21 @@ package akka.actor
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
 
+object ClassicActorSystemProvider {
+// FIXME Works, but I'm not sure if this is too magic (wide) since a Typed ActorSystem suddenly can be used everywhere
+//       when a Classic is requested
+
+  import scala.language.implicitConversions
+
+  /**
+   * Implicit conversion from [[ClassicActorSystemProvider]] to [[ActorSystem]]
+   * Useful to be able to use a `akka.actor.typed.ActorSystem` when a `akka.actor.ActorSystem` is
+   * requested, such as [[ExtensionId.apply]].
+   */
+  implicit def toClassicActorSystem(provider: ClassicActorSystemProvider): ActorSystem =
+    provider.classicSystem
+}
+
 /**
  * Glue API introduced to allow minimal user effort integration between classic and typed for example for streams.
  *

--- a/akka-actor/src/main/scala/akka/serialization/SerializationExtension.scala
+++ b/akka-actor/src/main/scala/akka/serialization/SerializationExtension.scala
@@ -4,6 +4,7 @@
 
 package akka.serialization
 
+import akka.actor.ClassicActorSystemProvider
 import akka.actor.{ ActorSystem, ExtendedActorSystem, ExtensionId, ExtensionIdProvider }
 
 /**
@@ -11,7 +12,15 @@ import akka.actor.{ ActorSystem, ExtendedActorSystem, ExtensionId, ExtensionIdPr
  * that is built into Akka
  */
 object SerializationExtension extends ExtensionId[Serialization] with ExtensionIdProvider {
+  override def apply(system: ActorSystem): Serialization = super.apply(system)
   override def get(system: ActorSystem): Serialization = super.get(system)
   override def lookup = SerializationExtension
   override def createExtension(system: ExtendedActorSystem): Serialization = new Serialization(system)
+
+  /**
+   * Returns an instance of the [[Serialization]] extension.
+   * @param system You can pass either a Classic or Typed `ActorSystem`.
+   */
+  def get(system: ClassicActorSystemProvider): Serialization = super.get(system.classicSystem)
+
 }

--- a/akka-docs/src/test/scala/docs/serialization/SerializationDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/serialization/SerializationDocSpec.scala
@@ -6,6 +6,7 @@ package docs.serialization {
 
   //#imports
   import akka.actor._
+  import akka.actor.typed.scaladsl.Behaviors
   import akka.cluster.Cluster
   import akka.serialization._
 
@@ -185,7 +186,32 @@ package docs.serialization {
       shutdown(a)
     }
 
-    "demonstrate the programmatic API" in {
+    "demonstrate the programmatic API with Typed ActorSystem" in {
+      //#programmatic
+      val system = akka.actor.typed.ActorSystem[Nothing](Behaviors.empty, "example")
+
+      // Get the Serialization Extension
+      val serialization = SerializationExtension(system)
+
+      // Have something to serialize
+      val original = "woohoo"
+
+      // Turn it into bytes, and retrieve the serializerId and manifest, which are needed for deserialization
+      val bytes = serialization.serialize(original).get
+      val serializerId = serialization.findSerializerFor(original).identifier
+      val manifest = Serializers.manifestFor(serialization.findSerializerFor(original), original)
+
+      // Turn it back into an object
+      val back = serialization.deserialize(bytes, serializerId, manifest).get
+      //#programmatic
+
+      // Voilá!
+      back should be(original)
+
+      shutdown(system)
+    }
+
+    "demonstrate the programmatic API with Classic ActorSystem" in {
       //#programmatic
       val system = ActorSystem("example")
 


### PR DESCRIPTION
I was about to cleanup serialization docs and started thinking about if we can use the extensions (e.g. Serialization) without `.toClassic`.

I'm not sure this is a good idea, since it might be too magic (wide) implicit conversion. Tried to place it closer to ExtensionId and also SerializationExtension but didn't find a place where it would use it there.