### PR TITLE
Streams TLS and Tcp with SSLEngine, #21753

### DIFF
--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -145,6 +145,15 @@ Akka is now using Protobuf version 3.9.0 for serialization of messages defined b
 Cluster client has been deprecated as of 2.6 in favor of [Akka gRPC](https://doc.akka.io/docs/akka-grpc/current/index.html).
 It is not advised to build new applications with Cluster client, and existing users @ref[should migrate to Akka gRPC](../cluster-client.md#migration-to-akka-grpc).
 
+### AkkaSslConfig
+
+`AkkaSslConfig` has been deprecated in favor of setting up TLS with `javax.net.ssl.SSLEngine` directly.
+
+This also means that methods Akka Streams `TLS` and `Tcp` that take `SSLContext` or `AkkaSslConfig` have been
+deprecated and replaced with corresponding methods that takes a factory function for creating the `SSLEngine`.
+
+See documentation of @ref:[streaming IO with TLS](../stream/stream-io.md#tls).    
+
 ### akka.Main
 
 `akka.Main` is deprecated in favour of starting the `ActorSystem` from a custom main class instead. `akka.Main` was not

--- a/akka-docs/src/main/paradox/stream/stream-io.md
+++ b/akka-docs/src/main/paradox/stream/stream-io.md
@@ -155,7 +155,7 @@ Scala
 :  @@snip [TcpSpec.scala](/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala) { #setting-up-ssl-engine }
 
 Java
-:  @@snip [TcpTest.java](/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java) { #setting-up-ssl-context }
+:  @@snip [TcpTest.java](/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java) { #setting-up-ssl-engine }
 
 
 The `SSLEngine` instance can then be used with the binding or outgoing connection factory methods.

--- a/akka-docs/src/main/paradox/stream/stream-io.md
+++ b/akka-docs/src/main/paradox/stream/stream-io.md
@@ -145,18 +145,20 @@ Java
 
 ### TLS
 
-Similar factories as shown above for raw TCP but where the data is encrypted using TLS are available from `Tcp` through `outgoingTlsConnection`, `bindTls` and `bindAndHandleTls`, see the @scala[@scaladoc[`Tcp Scaladoc`](akka.stream.scaladsl.Tcp)]@java[@javadoc[`Tcp Javadoc`](akka.stream.javadsl.Tcp)]  for details.
+Similar factories as shown above for raw TCP but where the data is encrypted using TLS are available from `Tcp`
+through `outgoingTlsConnectionWithSSLEngine`, `bindTlsWithSSLEngine` and `bindAndHandleTlsWithSSLEngine`,
+see the @scala[@scaladoc[`Tcp Scaladoc`](akka.stream.scaladsl.Tcp)]@java[@javadoc[`Tcp Javadoc`](akka.stream.javadsl.Tcp)]  for details.
 
-Using TLS requires a keystore and a truststore and then a somewhat involved dance of configuring the SSLContext and the details for how the session should be negotiated:
+Using TLS requires a keystore and a truststore and then a somewhat involved dance of configuring the SSLEngine and the details for how the session should be negotiated:
 
 Scala
-:  @@snip [TcpSpec.scala](/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala) { #setting-up-ssl-context }
+:  @@snip [TcpSpec.scala](/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala) { #setting-up-ssl-engine }
 
 Java
 :  @@snip [TcpTest.java](/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java) { #setting-up-ssl-context }
 
 
-The `SslContext` and `NegotiateFirstSession` instances can then be used with the binding or outgoing connection factory methods.
+The `SSLEngine` instance can then be used with the binding or outgoing connection factory methods.
 
 ## Streaming File IO
 

--- a/akka-docs/src/main/paradox/stream/stream-io.md
+++ b/akka-docs/src/main/paradox/stream/stream-io.md
@@ -146,7 +146,7 @@ Java
 ### TLS
 
 Similar factories as shown above for raw TCP but where the data is encrypted using TLS are available from `Tcp`
-through `outgoingTlsConnectionWithSSLEngine`, `bindTlsWithSSLEngine` and `bindAndHandleTlsWithSSLEngine`,
+through `outgoingConnectionWithTls`, `bindWithTls` and `bindAndHandleWithTls`,
 see the @scala[@scaladoc[`Tcp Scaladoc`](akka.stream.scaladsl.Tcp)]@java[@javadoc[`Tcp Javadoc`](akka.stream.javadsl.Tcp)]  for details.
 
 Using TLS requires a keystore and a truststore and then a somewhat involved dance of configuring the SSLEngine and the details for how the session should be negotiated:

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -124,7 +124,7 @@ private[remote] class ArteryTcpTransport(
     def connectionFlow: Flow[ByteString, ByteString, Future[Tcp.OutgoingConnection]] =
       if (tlsEnabled) {
         val sslProvider = sslEngineProvider.get
-        Tcp().outgoingTlsConnectionWithSSLEngine(
+        Tcp().outgoingConnectionWithTls(
           remoteAddress,
           createSSLEngine = () => sslProvider.createClientSSLEngine(host, port),
           connectTimeout = settings.Advanced.Tcp.ConnectionTimeout,
@@ -213,7 +213,7 @@ private[remote] class ArteryTcpTransport(
     val connectionSource: Source[Tcp.IncomingConnection, Future[ServerBinding]] =
       if (tlsEnabled) {
         val sslProvider = sslEngineProvider.get
-        Tcp().bindTlsWithSSLEngine(
+        Tcp().bindWithTls(
           interface = bindHost,
           port = bindPort,
           createSSLEngine = () => sslProvider.createServerSSLEngine(bindHost, bindPort),

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java
@@ -5,12 +5,12 @@
 package akka.stream.javadsl;
 
 import akka.Done;
-import akka.actor.ActorSystem;
 import akka.japi.function.Function2;
 import akka.japi.function.Procedure;
 import akka.stream.BindFailedException;
 import akka.stream.StreamTcpException;
 import akka.stream.StreamTest;
+
 import akka.stream.javadsl.Tcp.IncomingConnection;
 import akka.stream.javadsl.Tcp.ServerBinding;
 import akka.testkit.AkkaJUnitActorSystemResource;
@@ -23,8 +23,14 @@ import static akka.util.ByteString.emptyByteString;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.net.BindException;
 import java.net.InetSocketAddress;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -34,15 +40,17 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-// #setting-up-ssl-context
+// #setting-up-ssl-engine
 // imports
-import akka.stream.TLSClientAuth;
-import akka.stream.TLSProtocol;
-import com.typesafe.sslconfig.akka.AkkaSSLConfig;
 import java.security.KeyStore;
-import javax.net.ssl.*;
 import java.security.SecureRandom;
-// #setting-up-ssl-context
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManagerFactory;
+import akka.stream.TLSRole;
+
+// #setting-up-ssl-engine
 
 public class TcpTest extends StreamTest {
   public TcpTest() {
@@ -165,52 +173,46 @@ public class TcpTest extends StreamTest {
   }
 
   // compile only sample
-  public void constructSslContext() throws Exception {
-    ActorSystem system = null;
+  // #setting-up-ssl-engine
+  public SSLEngine createSSLEngine(TLSRole role) {
+    try {
+      // Don't hardcode your password in actual code
+      char[] password = "abcdef".toCharArray();
 
-    // FIXME #21753 SSLEngine
+      // trust store and keys in one keystore
+      KeyStore keyStore = KeyStore.getInstance("PKCS12");
+      keyStore.load(getClass().getResourceAsStream("/tcp-spec-keystore.p12"), password);
 
-    // #setting-up-ssl-context
+      TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance("SunX509");
+      trustManagerFactory.init(keyStore);
 
-    // -- setup logic ---
+      KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance("SunX509");
+      keyManagerFactory.init(keyStore, password);
 
-    AkkaSSLConfig sslConfig = AkkaSSLConfig.get(system);
+      // initial ssl context
+      SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+      sslContext.init(
+          keyManagerFactory.getKeyManagers(),
+          trustManagerFactory.getTrustManagers(),
+          new SecureRandom());
 
-    // Don't hardcode your password in actual code
-    char[] password = "abcdef".toCharArray();
+      SSLEngine engine = sslContext.createSSLEngine();
 
-    // trust store and keys in one keystore
-    KeyStore keyStore = KeyStore.getInstance("PKCS12");
-    keyStore.load(getClass().getResourceAsStream("/tcp-spec-keystore.p12"), password);
+      engine.setUseClientMode(role.equals(akka.stream.TLSRole.client()));
+      engine.setEnabledCipherSuites(new String[] {"TLS_RSA_WITH_AES_128_CBC_SHA"});
+      engine.setEnabledProtocols(new String[] {"TLSv1.2"});
 
-    TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
-    tmf.init(keyStore);
+      return engine;
 
-    KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance("SunX509");
-    keyManagerFactory.init(keyStore, password);
-
-    // initial ssl context
-    SSLContext sslContext = SSLContext.getInstance("TLS");
-    sslContext.init(keyManagerFactory.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
-
-    // protocols
-    SSLParameters defaultParams = sslContext.getDefaultSSLParameters();
-    String[] defaultProtocols = defaultParams.getProtocols();
-    String[] protocols = sslConfig.configureProtocols(defaultProtocols, sslConfig.config());
-    defaultParams.setProtocols(protocols);
-
-    // ciphers
-    String[] defaultCiphers = defaultParams.getCipherSuites();
-    String[] cipherSuites = sslConfig.configureCipherSuites(defaultCiphers, sslConfig.config());
-    defaultParams.setCipherSuites(cipherSuites);
-
-    TLSProtocol.NegotiateNewSession negotiateNewSession =
-        TLSProtocol.negotiateNewSession()
-            .withCipherSuites(cipherSuites)
-            .withProtocols(protocols)
-            .withParameters(defaultParams)
-            .withClientAuth(TLSClientAuth.none());
-
-    // #setting-up-ssl-context
+    } catch (KeyStoreException
+        | IOException
+        | NoSuchAlgorithmException
+        | CertificateException
+        | UnrecoverableKeyException
+        | KeyManagementException e) {
+      throw new RuntimeException(e);
+    }
   }
+  // #setting-up-ssl-engine
+
 }

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/TcpTest.java
@@ -168,6 +168,8 @@ public class TcpTest extends StreamTest {
   public void constructSslContext() throws Exception {
     ActorSystem system = null;
 
+    // FIXME #21753 SSLEngine
+
     // #setting-up-ssl-context
 
     // -- setup logic ---

--- a/akka-stream-tests/src/test/scala/akka/stream/io/DeprecatedTlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/DeprecatedTlsSpec.scala
@@ -6,6 +6,7 @@ package akka.stream.io
 
 import java.security.KeyStore
 import java.security.SecureRandom
+import java.security.cert.CertificateException
 import java.util.concurrent.TimeoutException
 
 import scala.collection.immutable
@@ -517,7 +518,12 @@ class DeprecatedTlsSpec extends StreamSpec(DeprecatedTlsSpec.configOverrides) wi
       val cause = intercept[Exception] {
         Await.result(run("unknown.example.org"), 3.seconds)
       }
-      cause.getMessage should ===("Hostname verification failed! Expected session to be for unknown.example.org")
+      cause.getClass should ===(classOf[SSLHandshakeException]) //General SSLEngine problem
+      val cause2 = cause.getCause
+      cause2.getClass should ===(classOf[SSLHandshakeException]) //General SSLEngine problem
+      val cause3 = cause2.getCause
+      cause3.getClass should ===(classOf[CertificateException])
+      cause3.getMessage should ===("No name matching unknown.example.org found")
     }
 
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -875,8 +875,8 @@ class TcpSpec extends StreamSpec("""
     import javax.net.ssl.SSLContext
     import akka.stream.TLSRole
 
-    def createSSLEngine(role: TLSRole): SSLEngine = {
-
+    // initialize SSLContext once
+    lazy val sslContext: SSLContext = {
       // Don't hardcode your password in actual code
       val password = "abcdef".toCharArray
 
@@ -890,10 +890,14 @@ class TcpSpec extends StreamSpec("""
       val keyManagerFactory = KeyManagerFactory.getInstance("SunX509")
       keyManagerFactory.init(keyStore, password)
 
-      // initial ssl context
-      val sslContext = SSLContext.getInstance("TLSv1.2")
-      sslContext.init(keyManagerFactory.getKeyManagers, trustManagerFactory.getTrustManagers, new SecureRandom)
+      // init ssl context
+      val context = SSLContext.getInstance("TLSv1.2")
+      context.init(keyManagerFactory.getKeyManagers, trustManagerFactory.getTrustManagers, new SecureRandom)
+      context
+    }
 
+    // create new SSLEngine from the SSLContext, which was initialized once
+    def createSSLEngine(role: TLSRole): SSLEngine = {
       val engine = sslContext.createSSLEngine()
 
       engine.setUseClientMode(role == akka.stream.Client)

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -839,7 +839,7 @@ class TcpSpec extends StreamSpec("""
       val address = temporaryServerAddress()
 
       Tcp()
-        .bindAndHandleTlsWithSSLEngine(
+        .bindAndHandleWithTls(
           // just echo charactes until we reach '\n', then complete stream
           // also - byte is our framing
           Flow[ByteString].mapConcat(_.utf8String.toList).takeWhile(_ != '\n').map(c => ByteString(c)),
@@ -851,7 +851,7 @@ class TcpSpec extends StreamSpec("""
       system.log.info(s"Server bound to ${address.getHostString}:${address.getPort}")
 
       val connectionFlow =
-        Tcp().outgoingTlsConnectionWithSSLEngine(
+        Tcp().outgoingConnectionWithTls(
           address,
           () => createSSLEngine(TLSRole.client),
           verifySession = _ => Success(()))

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -46,7 +46,6 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
-import scala.util.Success
 
 import com.github.ghik.silencer.silent
 
@@ -845,16 +844,12 @@ class TcpSpec extends StreamSpec("""
           Flow[ByteString].mapConcat(_.utf8String.toList).takeWhile(_ != '\n').map(c => ByteString(c)),
           address.getHostName,
           address.getPort,
-          () => createSSLEngine(TLSRole.server),
-          verifySession = _ => Success(()))
+          () => createSSLEngine(TLSRole.server))
         .futureValue
       system.log.info(s"Server bound to ${address.getHostString}:${address.getPort}")
 
       val connectionFlow =
-        Tcp().outgoingConnectionWithTls(
-          address,
-          () => createSSLEngine(TLSRole.client),
-          verifySession = _ => Success(()))
+        Tcp().outgoingConnectionWithTls(address, () => createSSLEngine(TLSRole.client))
 
       val chars = "hello\n".toList.map(_.toString)
       val (connectionF, result) =
@@ -955,6 +950,7 @@ class TcpSpec extends StreamSpec("""
       result.futureValue(PatienceConfiguration.Timeout(10.seconds)) should ===("hello")
     }
 
+    @silent("deprecated")
     def initSslMess() = {
       // #setting-up-ssl-context
       import java.security.KeyStore

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -833,7 +833,7 @@ class TcpSpec extends StreamSpec("""
 
   "TLS client and server convenience methods with SSLEngine setup" should {
 
-    "allow for 'simple' TLS with deprecated SSLContext setup" in {
+    "allow for TLS" in {
       // cert is valid until 2025, so if this tests starts failing after that you need to create a new one
       val address = temporaryServerAddress()
 
@@ -904,8 +904,6 @@ class TcpSpec extends StreamSpec("""
       engine.setEnabledCipherSuites(Array("TLS_RSA_WITH_AES_128_CBC_SHA"))
       engine.setEnabledProtocols(Array("TLSv1.2"))
 
-      // FIXME do we need to show hostnameVerification?
-
       engine
     }
     // #setting-up-ssl-engine
@@ -914,7 +912,7 @@ class TcpSpec extends StreamSpec("""
 
   "TLS client and server convenience methods with deprecated SSLContext setup" should {
 
-    "allow for 'simple' TLS" in {
+    "allow for TLS" in {
       test()
     }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
@@ -124,7 +124,10 @@ class TlsSpec extends StreamSpec(TlsSpec.configOverrides) with WithLogCapturing 
         hostInfo: Option[(String, Int)]): SSLEngine = {
 
       val engine = hostInfo match {
-        case None                   => context.createSSLEngine()
+        case None =>
+          if (hostnameVerification)
+            throw new IllegalArgumentException("hostInfo must be defined for hostnameVerification to work.")
+          context.createSSLEngine()
         case Some((hostname, port)) => context.createSSLEngine(hostname, port)
       }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
@@ -549,7 +549,6 @@ class TlsSpec extends StreamSpec(TlsSpec.configOverrides) with WithLogCapturing 
         Await.result(run("unknown.example.org"), 3.seconds)
       }
 
-      // FIXME #21753 is this hostname verification ok? AkkaSSLConfig is verifying in different way?
       cause.getClass should ===(classOf[SSLHandshakeException]) //General SSLEngine problem
       val cause2 = cause.getCause
       cause2.getClass should ===(classOf[SSLHandshakeException]) //General SSLEngine problem

--- a/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -243,16 +243,3 @@ ProblemFilters.exclude[Problem]("akka.stream.actor.*")
 
 # system materializer guardian #26850
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.ActorMaterializer.systemMaterializer")
-
-# #21753 internal method WithSSLEngine renamed and changed
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$3")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$4")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$5")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$6")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$8")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine$default$4")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine$default$5")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine$default$6")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine$default$8")

--- a/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes/_existing.excludes
@@ -243,3 +243,16 @@ ProblemFilters.exclude[Problem]("akka.stream.actor.*")
 
 # system materializer guardian #26850
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.ActorMaterializer.systemMaterializer")
+
+# #21753 internal method WithSSLEngine renamed and changed
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$3")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$4")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$5")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$6")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$8")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine$default$4")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine$default$5")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine$default$6")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine$default$8")

--- a/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes/issue-21753-sslconfig.excludes
+++ b/akka-stream/src/main/mima-filters/2.5.x.backwards.excludes/issue-21753-sslconfig.excludes
@@ -1,0 +1,12 @@
+# #21753 internal method WithSSLEngine renamed and changed
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$3")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$4")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$5")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$6")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.outgoingTlsConnectionWithSSLEngine$default$8")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine$default$4")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine$default$5")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine$default$6")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Tcp.bindTlsWithSSLEngine$default$8")

--- a/akka-stream/src/main/scala/akka/stream/javadsl/TLS.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/TLS.scala
@@ -158,7 +158,7 @@ object TLS {
   /**
    * Create a StreamTls [[akka.stream.javadsl.BidiFlow]]. This is a low-level interface.
    *
-   * You can specify a constructor `sslEngineCreator` to create an SSLEngine that must already be configured for
+   * You specify a factory `sslEngineCreator` to create an SSLEngine that must already be configured for
    * client and server mode and with all the parameters for the first session.
    *
    * You can specify a verification function `sessionVerifier` that will be called
@@ -176,7 +176,7 @@ object TLS {
   /**
    * Create a StreamTls [[akka.stream.javadsl.BidiFlow]]. This is a low-level interface.
    *
-   * You can specify a constructor `sslEngineCreator` to create an SSLEngine that must already be configured for
+   * You specify a factory `sslEngineCreator` to create an SSLEngine that must already be configured for
    * client and server mode and with all the parameters for the first session.
    *
    * For a description of the `closing` parameter please refer to [[TLSClosing]].

--- a/akka-stream/src/main/scala/akka/stream/javadsl/TLS.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/TLS.scala
@@ -30,10 +30,8 @@ import scala.util.Try
  * documentation. The philosophy of this integration into Akka Streams is to
  * expose all knobs and dials to client code and therefore not limit the
  * configuration possibilities. In particular the client code will have to
- * provide the SSLContext from which the SSLEngine is then created. Handshake
- * parameters are set using [[NegotiateNewSession]] messages, the settings for
- * the initial handshake need to be provided up front using the same class;
- * please refer to the method documentation below.
+ * provide the SSLEngine, which is typically created from a SSLContext. Handshake
+ * parameters and other parameters are defined when creating the SSLEngine.
  *
  * '''IMPORTANT NOTE'''
  *
@@ -66,6 +64,7 @@ object TLS {
    *
    * This method uses the default closing behavior or [[IgnoreComplete]].
    */
+  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "2.6.0")
   def create(
       sslContext: SSLContext,
       sslConfig: Optional[AkkaSSLConfig],
@@ -84,6 +83,7 @@ object TLS {
    *
    * This method uses the default closing behavior or [[IgnoreComplete]].
    */
+  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "2.6.0")
   def create(
       sslContext: SSLContext,
       firstSession: NegotiateNewSession,
@@ -106,6 +106,7 @@ object TLS {
    * The SSLEngine may use this information e.g. when an endpoint identification algorithm was
    * configured using [[javax.net.ssl.SSLParameters.setEndpointIdentificationAlgorithm]].
    */
+  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "2.6.0")
   def create(
       sslContext: SSLContext,
       sslConfig: Optional[AkkaSSLConfig],
@@ -138,6 +139,7 @@ object TLS {
    * The SSLEngine may use this information e.g. when an endpoint identification algorithm was
    * configured using [[javax.net.ssl.SSLParameters.setEndpointIdentificationAlgorithm]].
    */
+  @deprecated("Use create that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "2.6.0")
   def create(
       sslContext: SSLContext,
       firstSession: NegotiateNewSession,

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
@@ -6,9 +6,9 @@ package akka.stream.javadsl
 
 import java.lang.{ Iterable => JIterable }
 import java.util.Optional
+import java.util.function.{ Function => JFunction }
 
 import akka.{ Done, NotUsed }
-
 import scala.concurrent.duration._
 import java.net.InetSocketAddress
 
@@ -21,17 +21,24 @@ import akka.stream.scaladsl
 import akka.util.ByteString
 import akka.japi.Util.immutableSeq
 import akka.io.Inet.SocketOption
-
 import scala.compat.java8.OptionConverters._
 import scala.compat.java8.FutureConverters._
 import java.util.concurrent.CompletionStage
+import java.util.function.Supplier
+
+import scala.util.Failure
+import scala.util.Success
 
 import akka.actor.ClassicActorSystemProvider
 import javax.net.ssl.SSLContext
 import akka.annotation.InternalApi
 import akka.stream.SystemMaterializer
+import akka.stream.TLSClosing
 import akka.stream.TLSProtocol.NegotiateNewSession
+import akka.util.JavaDurationConverters._
 import com.github.ghik.silencer.silent
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.SSLSession
 
 object Tcp extends ExtensionId[Tcp] with ExtensionIdProvider {
 
@@ -161,12 +168,43 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       backlog: Int,
       options: JIterable[SocketOption],
       halfClose: Boolean,
-      idleTimeout: Duration): Source[IncomingConnection, CompletionStage[ServerBinding]] =
+      idleTimeout: Optional[java.time.Duration]): Source[IncomingConnection, CompletionStage[ServerBinding]] =
     Source.fromGraph(
       delegate
-        .bind(interface, port, backlog, immutableSeq(options), halfClose, idleTimeout)
+        .bind(interface, port, backlog, immutableSeq(options), halfClose, optionalDurationToScala(idleTimeout))
         .map(new IncomingConnection(_))
         .mapMaterializedValue(_.map(new ServerBinding(_))(ec).toJava))
+
+  /**
+   * Creates a [[Tcp.ServerBinding]] instance which represents a prospective TCP server binding on the given `endpoint`.
+   *
+   * Please note that the startup of the server is asynchronous, i.e. after materializing the enclosing
+   * [[akka.stream.scaladsl.RunnableGraph]] the server is not immediately available. Only after the materialized future
+   * completes is the server ready to accept client connections.
+   *
+   * @param interface The interface to listen on
+   * @param port      The port to listen on
+   * @param backlog   Controls the size of the connection backlog
+   * @param options   TCP options for the connections, see [[akka.io.Tcp]] for details
+   * @param halfClose
+   *                  Controls whether the connection is kept open even after writing has been completed to the accepted
+   *                  TCP connections.
+   *                  If set to true, the connection will implement the TCP half-close mechanism, allowing the client to
+   *                  write to the connection even after the server has finished writing. The TCP socket is only closed
+   *                  after both the client and server finished writing.
+   *                  If set to false, the connection will immediately closed once the server closes its write side,
+   *                  independently whether the client is still attempting to write. This setting is recommended
+   *                  for servers, and therefore it is the default setting.
+   */
+  @deprecated("Use bind that takes a java.time.Duration parameter instead.", "2.6.0")
+  def bind(
+      interface: String,
+      port: Int,
+      backlog: Int,
+      options: JIterable[SocketOption],
+      halfClose: Boolean,
+      idleTimeout: Duration): Source[IncomingConnection, CompletionStage[ServerBinding]] =
+    bind(interface, port, backlog, options, halfClose, durationToJavaOptional(idleTimeout))
 
   /**
    * Creates a [[Tcp.ServerBinding]] without specifying options.
@@ -208,8 +246,8 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       localAddress: Optional[InetSocketAddress],
       options: JIterable[SocketOption],
       halfClose: Boolean,
-      connectTimeout: Duration,
-      idleTimeout: Duration): Flow[ByteString, ByteString, CompletionStage[OutgoingConnection]] =
+      connectTimeout: Optional[java.time.Duration],
+      idleTimeout: Optional[java.time.Duration]): Flow[ByteString, ByteString, CompletionStage[OutgoingConnection]] =
     Flow.fromGraph(
       delegate
         .outgoingConnection(
@@ -217,9 +255,45 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
           localAddress.asScala,
           immutableSeq(options),
           halfClose,
-          connectTimeout,
-          idleTimeout)
+          optionalDurationToScala(connectTimeout),
+          optionalDurationToScala(idleTimeout))
         .mapMaterializedValue(_.map(new OutgoingConnection(_))(ec).toJava))
+
+  /**
+   * Creates an [[Tcp.OutgoingConnection]] instance representing a prospective TCP client connection to the given endpoint.
+   *
+   * Note that the ByteString chunk boundaries are not retained across the network,
+   * to achieve application level chunks you have to introduce explicit framing in your streams,
+   * for example using the [[Framing]] operators.
+   *
+   * @param remoteAddress The remote address to connect to
+   * @param localAddress  Optional local address for the connection
+   * @param options   TCP options for the connections, see [[akka.io.Tcp]] for details
+   * @param halfClose
+   *                  Controls whether the connection is kept open even after writing has been completed to the accepted
+   *                  TCP connections.
+   *                  If set to true, the connection will implement the TCP half-close mechanism, allowing the server to
+   *                  write to the connection even after the client has finished writing. The TCP socket is only closed
+   *                  after both the client and server finished writing. This setting is recommended for clients and
+   *                  therefore it is the default setting.
+   *                  If set to false, the connection will immediately closed once the client closes its write side,
+   *                  independently whether the server is still attempting to write.
+   */
+  @deprecated("Use bind that takes a java.time.Duration parameter instead.", "2.6.0")
+  def outgoingConnection(
+      remoteAddress: InetSocketAddress,
+      localAddress: Optional[InetSocketAddress],
+      options: JIterable[SocketOption],
+      halfClose: Boolean,
+      connectTimeout: Duration,
+      idleTimeout: Duration): Flow[ByteString, ByteString, CompletionStage[OutgoingConnection]] =
+    outgoingConnection(
+      remoteAddress,
+      localAddress,
+      options,
+      halfClose,
+      durationToJavaOptional(connectTimeout),
+      durationToJavaOptional(idleTimeout))
 
   /**
    * Creates an [[Tcp.OutgoingConnection]] without specifying options.
@@ -242,6 +316,10 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
    *
    * @see [[Tcp.outgoingConnection()]]
    */
+  @deprecated(
+    "Use outgoingConnectionWithTls that takes a SSLEngine factory instead. " +
+    "Setup the SSLEngine with needed parameters.",
+    "2.6.0")
   def outgoingTlsConnection(
       host: String,
       port: Int,
@@ -261,6 +339,10 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
    *
    * Marked API-may-change to leave room for an improvement around the very long parameter list.
    */
+  @deprecated(
+    "Use outgoingConnectionWithTls that takes a SSLEngine factory instead. " +
+    "Setup the SSLEngine with needed parameters.",
+    "2.6.0")
   def outgoingTlsConnection(
       remoteAddress: InetSocketAddress,
       sslContext: SSLContext,
@@ -282,6 +364,61 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
         .mapMaterializedValue(_.map(new OutgoingConnection(_))(ec).toJava))
 
   /**
+   * Creates an [[Tcp.OutgoingConnection]] with TLS.
+   * The returned flow represents a TCP client connection to the given endpoint where all bytes in and
+   * out go through TLS.
+   *
+   * You specify a factory to create an SSLEngine that must already be configured for
+   * client mode and with all the parameters for the first session.
+   *
+   * @see [[Tcp.outgoingConnection()]]
+   */
+  def outgoingConnectionWithTls(
+      remoteAddress: InetSocketAddress,
+      createSSLEngine: Supplier[SSLEngine]): Flow[ByteString, ByteString, CompletionStage[OutgoingConnection]] =
+    Flow.fromGraph(
+      delegate
+        .outgoingConnectionWithTls(remoteAddress, createSSLEngine = () => createSSLEngine.get())
+        .mapMaterializedValue(_.map(new OutgoingConnection(_))(ec).toJava))
+
+  /**
+   * Creates an [[Tcp.OutgoingConnection]] with TLS.
+   * The returned flow represents a TCP client connection to the given endpoint where all bytes in and
+   * out go through TLS.
+   *
+   * You specify a factory to create an SSLEngine that must already be configured for
+   * client mode and with all the parameters for the first session.
+   *
+   * @see [[Tcp.outgoingConnection()]]
+   */
+  def outgoingConnectionWithTls(
+      remoteAddress: InetSocketAddress,
+      createSSLEngine: Supplier[SSLEngine],
+      localAddress: Optional[InetSocketAddress],
+      options: JIterable[SocketOption],
+      connectTimeout: Optional[java.time.Duration],
+      idleTimeout: Optional[java.time.Duration],
+      verifySession: JFunction[SSLSession, Optional[Throwable]],
+      closing: TLSClosing): Flow[ByteString, ByteString, CompletionStage[OutgoingConnection]] = {
+    Flow.fromGraph(
+      delegate
+        .outgoingConnectionWithTls(
+          remoteAddress,
+          createSSLEngine = () => createSSLEngine.get(),
+          localAddress.asScala,
+          immutableSeq(options),
+          optionalDurationToScala(connectTimeout),
+          optionalDurationToScala(idleTimeout),
+          session =>
+            verifySession.apply(session).asScala match {
+              case None    => Success(())
+              case Some(t) => Failure(t)
+            },
+          closing)
+        .mapMaterializedValue(_.map(new OutgoingConnection(_))(ec).toJava))
+  }
+
+  /**
    * Creates a [[Tcp.ServerBinding]] instance which represents a prospective TCP server binding on the given `endpoint`
    * where all incoming and outgoing bytes are passed through TLS.
    *
@@ -290,6 +427,10 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
    *
    * Note: the half close parameter is currently ignored
    */
+  @deprecated(
+    "Use bindWithTls that takes a SSLEngine factory instead. " +
+    "Setup the SSLEngine with needed parameters.",
+    "2.6.0")
   def bindTls(
       interface: String,
       port: Int,
@@ -312,6 +453,10 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
    *
    * @see [[Tcp.bind()]]
    */
+  @deprecated(
+    "Use bindWithTls that takes a SSLEngine factory instead. " +
+    "Setup the SSLEngine with needed parameters.",
+    "2.6.0")
   def bindTls(
       interface: String,
       port: Int,
@@ -323,4 +468,63 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
         .map(new IncomingConnection(_))
         .mapMaterializedValue(_.map(new ServerBinding(_))(ec).toJava))
 
+  /**
+   * Creates a [[Tcp.ServerBinding]] instance which represents a prospective TCP server binding on the given `endpoint`
+   * where all incoming and outgoing bytes are passed through TLS.
+   *
+   * @see [[Tcp.bind()]]
+   */
+  def bindWithTls(
+      interface: String,
+      port: Int,
+      createSSLEngine: Supplier[SSLEngine]): Source[IncomingConnection, CompletionStage[ServerBinding]] = {
+    Source.fromGraph(
+      delegate
+        .bindWithTls(interface, port, createSSLEngine = () => createSSLEngine.get())
+        .map(new IncomingConnection(_))
+        .mapMaterializedValue(_.map(new ServerBinding(_))(ec).toJava))
+  }
+
+  /**
+   * Creates a [[Tcp.ServerBinding]] instance which represents a prospective TCP server binding on the given `endpoint`
+   * where all incoming and outgoing bytes are passed through TLS.
+   *
+   * @see [[Tcp.bind()]]
+   */
+  def bindWithTls(
+      interface: String,
+      port: Int,
+      createSSLEngine: Supplier[SSLEngine],
+      backlog: Int,
+      options: JIterable[SocketOption],
+      idleTimeout: Optional[java.time.Duration],
+      verifySession: JFunction[SSLSession, Optional[Throwable]],
+      closing: TLSClosing): Source[IncomingConnection, CompletionStage[ServerBinding]] = {
+    // FIXME halfClose unused #26689
+    Source.fromGraph(
+      delegate
+        .bindWithTls(
+          interface,
+          port,
+          createSSLEngine = () => createSSLEngine.get(),
+          backlog,
+          immutableSeq(options),
+          optionalDurationToScala(idleTimeout),
+          session =>
+            verifySession.apply(session).asScala match {
+              case None    => Success(())
+              case Some(t) => Failure(t)
+            },
+          closing)
+        .map(new IncomingConnection(_))
+        .mapMaterializedValue(_.map(new ServerBinding(_))(ec).toJava))
+  }
+
+  private def optionalDurationToScala(duration: Optional[java.time.Duration]) = {
+    if (duration.isPresent) duration.get.asScala else Duration.Inf
+  }
+
+  private def durationToJavaOptional(duration: Duration): Optional[java.time.Duration] = {
+    if (duration.isFinite()) Optional.ofNullable(duration.asJava) else Optional.empty()
+  }
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
@@ -525,6 +525,6 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
   }
 
   private def durationToJavaOptional(duration: Duration): Optional[java.time.Duration] = {
-    if (duration.isFinite()) Optional.ofNullable(duration.asJava) else Optional.empty()
+    if (duration.isFinite) Optional.ofNullable(duration.asJava) else Optional.empty()
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
@@ -438,7 +438,7 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       negotiateNewSession: NegotiateNewSession,
       backlog: Int,
       options: JIterable[SocketOption],
-      @silent // FIXME unused #26689
+      @silent // unused #26689
       halfClose: Boolean,
       idleTimeout: Duration): Source[IncomingConnection, CompletionStage[ServerBinding]] =
     Source.fromGraph(
@@ -500,7 +500,6 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       idleTimeout: Optional[java.time.Duration],
       verifySession: JFunction[SSLSession, Optional[Throwable]],
       closing: TLSClosing): Source[IncomingConnection, CompletionStage[ServerBinding]] = {
-    // FIXME halfClose unused #26689
     Source.fromGraph(
       delegate
         .bindWithTls(

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/TLS.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/TLS.scala
@@ -30,10 +30,8 @@ import scala.util.{ Failure, Success, Try }
  * documentation. The philosophy of this integration into Akka Streams is to
  * expose all knobs and dials to client code and therefore not limit the
  * configuration possibilities. In particular the client code will have to
- * provide the SSLContext from which the SSLEngine is then created. Handshake
- * parameters are set using [[NegotiateNewSession]] messages, the settings for
- * the initial handshake need to be provided up front using the same class;
- * please refer to the method documentation below.
+ * provide the SSLEngine, which is typically created from a SSLContext. Handshake
+ * parameters and other parameters are defined when creating the SSLEngine.
  *
  * '''IMPORTANT NOTE'''
  *
@@ -71,6 +69,7 @@ object TLS {
    * The SSLEngine may use this information e.g. when an endpoint identification algorithm was
    * configured using [[javax.net.ssl.SSLParameters.setEndpointIdentificationAlgorithm]].
    */
+  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "2.6.0")
   def apply(
       sslContext: SSLContext,
       sslConfig: Option[AkkaSSLConfig],
@@ -140,6 +139,7 @@ object TLS {
    * The SSLEngine may use this information e.g. when an endpoint identification algorithm was
    * configured using [[javax.net.ssl.SSLParameters.setEndpointIdentificationAlgorithm]].
    */
+  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "2.6.0")
   def apply(
       sslContext: SSLContext,
       firstSession: NegotiateNewSession,
@@ -158,6 +158,7 @@ object TLS {
    * that is not a requirement and depends entirely on the application
    * protocol.
    */
+  @deprecated("Use apply that takes a SSLEngine factory instead. Setup the SSLEngine with needed parameters.", "2.6.0")
   def apply(
       sslContext: SSLContext,
       firstSession: NegotiateNewSession,
@@ -165,7 +166,7 @@ object TLS {
     apply(sslContext, None, firstSession, role, IgnoreComplete, None)
 
   /**
-   * Create a StreamTls [[akka.stream.scaladsl.BidiFlow]]. This is a low-level interface.
+   * Create a StreamTls [[akka.stream.scaladsl.BidiFlow]].
    *
    * You can specify a constructor to create an SSLEngine that must already be configured for
    * client and server mode and with all the parameters for the first session.
@@ -183,7 +184,7 @@ object TLS {
       TlsModule(Attributes.none, _ => createSSLEngine(), (_, session) => verifySession(session), closing))
 
   /**
-   * Create a StreamTls [[akka.stream.scaladsl.BidiFlow]]. This is a low-level interface.
+   * Create a StreamTls [[akka.stream.scaladsl.BidiFlow]].
    *
    * You can specify a constructor to create an SSLEngine that must already be configured for
    * client and server mode and with all the parameters for the first session.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/TLS.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/TLS.scala
@@ -168,7 +168,7 @@ object TLS {
   /**
    * Create a StreamTls [[akka.stream.scaladsl.BidiFlow]].
    *
-   * You can specify a constructor to create an SSLEngine that must already be configured for
+   * You specify a factory to create an SSLEngine that must already be configured for
    * client and server mode and with all the parameters for the first session.
    *
    * You can specify a verification function that will be called after every successful handshake
@@ -186,7 +186,7 @@ object TLS {
   /**
    * Create a StreamTls [[akka.stream.scaladsl.BidiFlow]].
    *
-   * You can specify a constructor to create an SSLEngine that must already be configured for
+   * You specify a factory to create an SSLEngine that must already be configured for
    * client and server mode and with all the parameters for the first session.
    *
    * For a description of the `closing` parameter please refer to [[TLSClosing]].

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
@@ -419,8 +419,6 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
 
     val tls = tlsWrapping.atop(TLS(createSSLEngine, verifySession, closing)).reversed
 
-    // FIXME halfClose true in scaladsl but parameter was not in javadsl #26689
-
     bind(interface, port, backlog, options, halfClose = true, idleTimeout).map { incomingConnection =>
       incomingConnection.copy(flow = incomingConnection.flow.join(tls))
     }

--- a/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/AkkaSSLConfig.scala
+++ b/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/AkkaSSLConfig.scala
@@ -7,9 +7,10 @@ package com.typesafe.sslconfig.akka
 import java.security.KeyStore
 import java.security.cert.CertPathValidatorException
 import java.util.Collections
-import javax.net.ssl._
 
+import javax.net.ssl._
 import akka.actor._
+import akka.annotation.InternalApi
 import akka.event.Logging
 import com.typesafe.sslconfig.akka.util.AkkaLoggerFactory
 import com.typesafe.sslconfig.ssl._
@@ -68,6 +69,15 @@ final class AkkaSSLConfig(system: ExtendedActorSystem, val config: SSLConfigSett
     new AkkaSSLConfig(system, f.apply(config))
 
   val hostnameVerifier = buildHostnameVerifier(config)
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi def useJvmHostnameVerification: Boolean =
+    hostnameVerifier match {
+      case _: DefaultHostnameVerifier | _: NoopHostnameVerifier => true
+      case _                                                    => false
+    }
 
   val sslEngineConfigurator = {
     val sslContext = if (config.default) {

--- a/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/AkkaSSLConfig.scala
+++ b/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/AkkaSSLConfig.scala
@@ -15,7 +15,7 @@ import com.typesafe.sslconfig.akka.util.AkkaLoggerFactory
 import com.typesafe.sslconfig.ssl._
 import com.typesafe.sslconfig.util.LoggerFactory
 
-// TODO: remove again in 2.5.x, see https://github.com/akka/akka/issues/21753
+@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "2.6.0")
 object AkkaSSLConfig extends ExtensionId[AkkaSSLConfig] with ExtensionIdProvider {
 
   //////////////////// EXTENSION SETUP ///////////////////
@@ -36,6 +36,7 @@ object AkkaSSLConfig extends ExtensionId[AkkaSSLConfig] with ExtensionIdProvider
 
 }
 
+@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "2.6.0")
 final class AkkaSSLConfig(system: ExtendedActorSystem, val config: SSLConfigSettings) extends Extension {
 
   private val mkLogger = new AkkaLoggerFactory(system)

--- a/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/SSLEngineConfigurator.scala
+++ b/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/SSLEngineConfigurator.scala
@@ -12,10 +12,12 @@ import com.typesafe.sslconfig.ssl.SSLConfigSettings
  * Gives the chance to configure the SSLContext before it is going to be used.
  * The passed in context will be already set in client mode and provided with hostInfo during initialization.
  */
+@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "2.6.0")
 trait SSLEngineConfigurator {
   def configure(engine: SSLEngine, sslContext: SSLContext): SSLEngine
 }
 
+@deprecated("Use Tcp and TLS with SSLEngine parameters instead. Setup the SSLEngine with needed parameters.", "2.6.0")
 final class DefaultSSLEngineConfigurator(
     config: SSLConfigSettings,
     enabledProtocols: Array[String],

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
 
   val reactiveStreamsVersion = "1.0.3"
 
-  val sslConfigVersion = "0.3.8"
+  val sslConfigVersion = "0.4.0"
 
   val Versions = Seq(
     crossScalaVersions := Seq(scala212Version, scala213Version),


### PR DESCRIPTION
Some details remaining but the approach seems to work.

* SSLEngine factory instead of SSLContext and AkkaSSLConfig parameters
  in TLS and Tcp
* Update TlsSpec to use SSLEngine
* Keep copy of old TlsSpec for test coverage of deprecated methods
* Update doc example of how to setup a SSLEngine

Refs #21753