### PR TITLE
Use japi lambdas where it makes sense

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/EffectfulActorContext.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/EffectfulActorContext.scala
@@ -5,7 +5,6 @@
 package akka.actor.testkit.typed.internal
 
 import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.function
 
 import akka.actor.{ ActorPath, Cancellable }
 import akka.actor.typed.{ ActorRef, Behavior, Props }
@@ -15,7 +14,6 @@ import akka.actor.testkit.typed.Effect._
 
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
-import scala.compat.java8.FunctionConverters._
 
 /**
  * INTERNAL API
@@ -47,9 +45,9 @@ import scala.compat.java8.FunctionConverters._
     effectQueue.offer(MessageAdapter(implicitly[ClassTag[U]].runtimeClass.asInstanceOf[Class[U]], f))
     ref
   }
-  override def messageAdapter[U](messageClass: Class[U], f: function.Function[U, T]): ActorRef[U] = {
+  override def messageAdapter[U](messageClass: Class[U], f: akka.japi.function.Function[U, T]): ActorRef[U] = {
     val ref = super.messageAdapter(messageClass, f)
-    effectQueue.offer(MessageAdapter[U, T](messageClass, f.asScala))
+    effectQueue.offer(MessageAdapter[U, T](messageClass, f.apply))
     ref
   }
   override def spawn[U](behavior: Behavior[U], name: String, props: Props = Props.empty): ActorRef[U] = {

--- a/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/BehaviorTestKitTest.java
+++ b/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/BehaviorTestKitTest.java
@@ -70,10 +70,10 @@ public class BehaviorTestKitTest extends JUnitSuite {
 
   public static class CreateMessageAdapter implements Command {
     private final Class<Object> clazz;
-    private final Function<Object, Command> f;
+    private final akka.japi.function.Function<Object, Command> f;
 
     @SuppressWarnings("unchecked")
-    public CreateMessageAdapter(Class clazz, Function<Object, Command> f) {
+    public CreateMessageAdapter(Class clazz, akka.japi.function.Function<Object, Command> f) {
       this.clazz = clazz;
       this.f = f;
     }

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorCompile.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ActorCompile.java
@@ -170,4 +170,50 @@ public class ActorCompile {
                     .onFailure(IllegalStateException.class, strategy6))
             .onFailure(RuntimeException.class, strategy1);
   }
+
+  // actor context
+  {
+    final ActorRef<Object> otherActor = null;
+    Behavior<String> behavior =
+        Behaviors.setup(
+            context -> {
+              context.ask(
+                  String.class,
+                  otherActor,
+                  Duration.ofSeconds(10),
+                  (ActorRef<String> respRef) -> new Object(),
+                  (String res, Throwable failure) -> {
+                    // checked exception should be ok
+                    if (failure != null) throw new Exception(failure);
+                    else return "success";
+                  });
+
+              ActorRef<Integer> adapter =
+                  context.messageAdapter(
+                      Integer.class,
+                      (number) -> {
+                        // checked exception should be ok
+                        if (number < 10) throw new Exception("too small number");
+                        else return number.toString();
+                      });
+
+              return Behaviors.empty();
+            });
+  }
+
+  // stash buffer
+  {
+    Behavior<String> behavior =
+        Behaviors.withStash(
+            5,
+            stash -> {
+              stash.forEach(
+                  msg -> {
+                    // checked is ok
+                    throw new Exception("checked");
+                  });
+
+              return Behaviors.empty();
+            });
+  }
 }

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ReceiveBuilderTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/ReceiveBuilderTest.java
@@ -8,6 +8,7 @@ import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
+import akka.actor.typed.PostStop;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -138,5 +139,43 @@ public class ReceiveBuilderTest extends JUnitSuite {
     ActorRef<Object> ref = testKit.spawn(behavior);
     ref.tell("message");
     probe.expectMessage("message");
+  }
+
+  public void compileOnlyHandlerAllowedToThrowCheckedException() {
+    Behavior<Object> behavior =
+        ReceiveBuilder.create()
+            .onMessageEquals(
+                "exactly",
+                () -> {
+                  throw new Exception("checked");
+                })
+            .onMessage(
+                String.class,
+                msg -> {
+                  throw new Exception("checked");
+                })
+            .onMessage(
+                Integer.class,
+                msg -> true,
+                msg -> {
+                  throw new Exception("checked");
+                })
+            .onSignalEquals(
+                PostStop.instance(),
+                () -> {
+                  throw new Exception("checked");
+                })
+            .onSignal(
+                PostStop.class,
+                (signal) -> {
+                  throw new Exception("checked");
+                })
+            .onSignal(
+                PostStop.class,
+                signal -> true,
+                signal -> {
+                  throw new Exception("checked");
+                })
+            .build();
   }
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorRefResolver.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorRefResolver.scala
@@ -81,9 +81,7 @@ abstract class ActorRefResolver extends Extension {
 
 object ActorRefResolverSetup {
   def apply[T <: Extension](createExtension: ActorSystem[_] => ActorRefResolver): ActorRefResolverSetup =
-    new ActorRefResolverSetup(new java.util.function.Function[ActorSystem[_], ActorRefResolver] {
-      override def apply(sys: ActorSystem[_]): ActorRefResolver = createExtension(sys)
-    }) // TODO can be simplified when compiled only with Scala >= 2.12
+    new ActorRefResolverSetup(sys => createExtension(sys))
 
 }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Extensions.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Extensions.scala
@@ -174,6 +174,4 @@ abstract class ExtensionSetup[T <: Extension](
  * extension with stub/mock implementations.
  */
 abstract class AbstractExtensionSetup[T <: Extension](extId: ExtensionId[T], createExtension: ActorSystem[_] => T)
-    extends ExtensionSetup[T](extId, new java.util.function.Function[ActorSystem[_], T] {
-      override def apply(sys: ActorSystem[_]): T = createExtension.apply(sys)
-    }) // TODO can be simplified when compiled only with Scala >= 2.12
+    extends ExtensionSetup[T](extId, createExtension.apply)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
@@ -4,7 +4,6 @@
 
 package akka.actor.typed.internal
 
-import java.util.function.Consumer
 import java.util.function.{ Function => JFunction }
 
 import akka.actor.DeadLetter
@@ -18,6 +17,7 @@ import akka.actor.typed.javadsl
 import akka.actor.typed.scaladsl
 import akka.actor.typed.scaladsl.ActorContext
 import akka.annotation.{ InternalApi, InternalStableApi }
+import akka.japi.function.Procedure
 import akka.util.{ unused, ConstantFun }
 
 /**
@@ -107,7 +107,7 @@ import akka.util.{ unused, ConstantFun }
     }
   }
 
-  override def forEach(f: Consumer[T]): Unit = foreach(f.accept)
+  override def forEach(f: Procedure[T]): Unit = foreach(f.apply)
 
   override def unstashAll(behavior: Behavior[T]): Behavior[T] = {
     val behav = unstash(behavior, size, ConstantFun.scalaIdentityFunction[T])

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ActorContext.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/ActorContext.scala
@@ -5,7 +5,6 @@
 package akka.actor.typed.javadsl
 
 import java.time.Duration
-import java.util.function.{ BiFunction, Function => JFunction }
 
 import akka.annotation.DoNotInherit
 import akka.actor.ClassicActorContextProvider
@@ -267,7 +266,7 @@ trait ActorContext[T] extends TypedActorContext[T] with ClassicActorContextProvi
    * *Warning*: This method is not thread-safe and must not be accessed from threads other
    * than the ordinary actor message processing thread, such as [[java.util.concurrent.CompletionStage]] callbacks.
    */
-  def messageAdapter[U](messageClass: Class[U], f: JFunction[U, T]): ActorRef[U]
+  def messageAdapter[U](messageClass: Class[U], f: akka.japi.function.Function[U, T]): ActorRef[U]
 
   /**
    * Perform a single request-response message interaction with another actor, and transform the messages back to
@@ -299,8 +298,8 @@ trait ActorContext[T] extends TypedActorContext[T] with ClassicActorContextProvi
       resClass: Class[Res],
       target: RecipientRef[Req],
       responseTimeout: Duration,
-      createRequest: java.util.function.Function[ActorRef[Res], Req],
-      applyToResponse: BiFunction[Res, Throwable, T]): Unit
+      createRequest: akka.japi.function.Function[ActorRef[Res], Req],
+      applyToResponse: akka.japi.function.Function2[Res, Throwable, T]): Unit
 
   /**
    * Sends the result of the given `CompletionStage` to this Actor (“`self`”), after adapted it with
@@ -309,6 +308,8 @@ trait ActorContext[T] extends TypedActorContext[T] with ClassicActorContextProvi
    * This method is thread-safe and can be called from other threads than the ordinary
    * actor message processing thread, such as [[java.util.concurrent.CompletionStage]] callbacks.
    */
-  def pipeToSelf[Value](future: CompletionStage[Value], applyToResult: BiFunction[Value, Throwable, T]): Unit
+  def pipeToSelf[Value](
+      future: CompletionStage[Value],
+      applyToResult: akka.japi.function.Function2[Value, Throwable, T]): Unit
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AskPattern.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AskPattern.scala
@@ -37,8 +37,8 @@ object AskPattern {
    */
   def ask[Req, Res](
       actor: RecipientRef[Req],
-      message: JFunction[ActorRef[Res], Req],
+      messageFactory: JFunction[ActorRef[Res], Req],
       timeout: Duration,
       scheduler: Scheduler): CompletionStage[Res] =
-    (actor.ask(message.apply)(timeout.asScala, scheduler)).toJava
+    (actor.ask(messageFactory.apply)(timeout.asScala, scheduler)).toJava
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/StashBuffer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/StashBuffer.scala
@@ -4,12 +4,12 @@
 
 package akka.actor.typed.javadsl
 
-import java.util.function.Consumer
 import java.util.function.{ Function => JFunction }
 
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl
 import akka.annotation.DoNotInherit
+import akka.japi.function.Procedure
 
 /**
  * A non thread safe mutable message buffer that can be used to buffer messages inside actors
@@ -72,7 +72,7 @@ import akka.annotation.DoNotInherit
    *
    * @param f the function to apply to each element
    */
-  def forEach(f: Consumer[T]): Unit
+  def forEach(f: Procedure[T]): Unit
 
   /**
    * Process all stashed messages with the `behavior` and the returned

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/ReplicatorMessageAdapter.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/ReplicatorMessageAdapter.scala
@@ -64,7 +64,7 @@ class ReplicatorMessageAdapter[A, B <: ReplicatedData](
    * the replicator are transformed to the message protocol of the requesting actor with
    * the given `responseAdapter` function.
    */
-  def subscribe(key: Key[B], responseAdapter: JFunction[Replicator.SubscribeResponse[B], A]): Unit = {
+  def subscribe(key: Key[B], responseAdapter: akka.japi.function.Function[Replicator.SubscribeResponse[B], A]): Unit = {
     // unsubscribe in case it's called more than once per key
     unsubscribe(key)
     changedMessageAdapters.get(key).foreach { subscriber =>


### PR DESCRIPTION
In quite a few places in the Java APIs throwing a checked exception is fine, for example when handling a message in an actor - it will fail the actor, therefore it is better to use the Akka lambda types which allow that than the Java lambda types that does not (and would require a `try-catch-rethrow-unchecked` for such cases).

This covers the receive builder, message adapters and ask response adaption. Also contains some additional small internal cleanups.