### PR TITLE
Make running mima in PrValidation optional (default enabled)

### DIFF
--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -16,6 +16,10 @@ import sbt._
 
 object AkkaValidatePullRequest extends AutoPlugin {
 
+  object CliOptions {
+    val mimaEnabled = CliOption("akka.mima.enabled", true)
+  }
+
   import ValidatePullRequest.autoImport._
 
   override def trigger = allRequirements
@@ -87,9 +91,8 @@ object MimaWithPrValidation extends AutoPlugin {
 
   override def trigger = allRequirements
   override def requires = AkkaValidatePullRequest && MimaPlugin
-  override lazy val projectSettings = Seq(
-    additionalTasks += mimaReportBinaryIssues
-  )
+  override lazy val projectSettings =
+    CliOptions.mimaEnabled.ifTrue(additionalTasks += mimaReportBinaryIssues).toList
 }
 
 /**


### PR DESCRIPTION
So we can run it on travis but skip it on jenkins (refs #27757)

Tested by inspecting `akka-actor/additionalTasks` in sbt