### PR TITLE
Fix ByteStringSpec for Scala 2.13.1

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -950,7 +950,7 @@ class ByteStringSpec extends WordSpec with Matchers with Checkers {
       }
       "calling length" in {
         check { a: ByteString =>
-          likeVecIt(a) { _.length }
+          likeVecIt(a)(_.length, strict = false)
         }
       }
       "calling duplicate" in {


### PR DESCRIPTION
Backport of #27655