### PR TITLE
Try to get root cause of timeout in ReplicatorPruningSpec 

### DIFF
--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorPruningSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorPruningSpec.scala
@@ -22,6 +22,9 @@ object ReplicatorPruningSpec extends MultiNodeConfig {
 
   commonConfig(ConfigFactory.parseString("""
     akka.loglevel = INFO
+    # we use 3s as write timeouts in test, make sure we see that
+    # and not time out the expectMsg at the same time
+    akka.test.single-expect-default = 5s
     akka.actor.provider = "cluster"
     akka.log-dead-letters-during-shutdown = off
     """))


### PR DESCRIPTION
Refs #26957

Doesn't fix anything but should allow us to see a difference between expectMsg timing out and ddata update with `writeAll` timing out.