### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -400,7 +400,7 @@ lazy val persistenceTyped = akkaModule("akka-persistence-typed")
     persistence % "compile->compile;test->test",
     persistenceQuery % "test",
     actorTypedTests % "test->test",
-    actorTestkitTyped % "compile->compile;test->test",
+    actorTestkitTyped % "test->test",
     jackson % "test->test")
   .settings(javacOptions += "-parameters") // for Jackson
   .settings(Dependencies.persistenceShared)


### PR DESCRIPTION
It looks like an extra `compile -> compile` scope got in the way so `akka-actor-testkit-typed` becomes a transitive dependency. Then, users depending on `akka-cluster-sharding-typed` get:

```
[info] com.typesafe.akka:akka-actor-testkit-typed_2.12:2.6.0-M7 [S]
[info]   +-com.typesafe.akka:akka-persistence-typed_2.12:2.6.0-M7 [S]
[info]     +-com.typesafe.akka:akka-cluster-sharding-typed_2.12:2.6.0-M7 [S]
```

in compile scope. 