### PR TITLE
harden access to outboundControlIngress, #27732

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -232,8 +232,8 @@ private[remote] class Association(
         _outboundControlIngress match {
           case OptionVal.Some(o) => o
           case OptionVal.None =>
-            if (transport.isShutdown) throw ShuttingDown
-            else throw new IllegalStateException("outboundControlIngress not initialized yet")
+            if (transport.isShutdown || isRemovedAfterQuarantined()) throw ShuttingDown
+            else throw new IllegalStateException(s"outboundControlIngress for [$remoteAddress] not initialized yet")
         }
     }
   }


### PR DESCRIPTION
* _outboundControlIngress is cleared from removedAfterQuarantined via the
  startRemoveQuarantinedAssociationTask
* in sendControl it is checking isRemovedAfterQuarantined but a race condition
  of the clearing at the same time can cause it to access the outboundControlIngress
  anyway, resulting in the IllegalStateException "not initialized yet"
* in the reported case there were severe jvm problems (seen in logs as delayed heartbeats)
* additional check in outboundControlIngress access solves that,
  control messages can be dropped

Refs #27732