### PR TITLE
doc: use ref links

### DIFF
--- a/akka-docs/src/main/paradox/actors.md
+++ b/akka-docs/src/main/paradox/actors.md
@@ -83,7 +83,7 @@ as explained below.
 The result of the @scala[`receive` method is a partial function object, which is]
 @java[`createReceive` method is `AbstractActor.Receive` which is a wrapper around partial 
 scala function object. It is] stored within the actor as its “initial behavior”, 
-see [Become/Unbecome](#become-unbecome) for
+see @ref:[Become/Unbecome](#become-unbecome) for
 further information on changing the behavior of an actor after its
 construction.
 
@@ -382,7 +382,7 @@ are notified of the termination. After the incarnation is stopped, the path can
 be reused again by creating an actor with `actorOf()`. In this case the
 name of the new incarnation will be the same as the previous one but the
 UIDs will differ. An actor can be stopped by the actor itself, another actor
-or the `ActorSystem` (see [Stopping actors](#stopping-actors)).
+or the `ActorSystem` (see @ref:[Stopping actors](#stopping-actors)).
 
 @@@ note
 
@@ -404,7 +404,7 @@ occupying it. `ActorSelection` cannot be watched for this reason. It is
 possible to resolve the current incarnation's `ActorRef` living under the
 path by sending an `Identify` message to the `ActorSelection` which
 will be replied to with an `ActorIdentity` containing the correct reference
-(see [ActorSelection](#actorselection)). This can also be done with the `resolveOne`
+(see @ref:[ActorSelection](#actorselection)). This can also be done with the `resolveOne`
 method of the `ActorSelection`, which returns a `Future` of the matching
 `ActorRef`.
 
@@ -414,7 +414,7 @@ method of the `ActorSelection`, which returns a `Future` of the matching
 In order to be notified when another actor terminates (i.e. stops permanently,
 not temporary failure and restart), an actor may register itself for reception
 of the `Terminated` message dispatched by the other actor upon
-termination (see [Stopping Actors](#stopping-actors)). This service is provided by the
+termination (see @ref:[Stopping Actors](#stopping-actors)). This service is provided by the
 `DeathWatch` component of the actor system.
 
 Registering a monitor is easy:
@@ -935,7 +935,7 @@ Termination of an actor proceeds in two steps: first the actor suspends its
 mailbox processing and sends a stop command to all its children, then it keeps
 processing the internal termination notifications from its children until the last one is
 gone, finally terminating itself (invoking `postStop`, dumping mailbox,
-publishing `Terminated` on the [DeathWatch](#deathwatch), telling
+publishing `Terminated` on the @ref:[DeathWatch](#deathwatch), telling
 its supervisor). This procedure ensures that actor system sub-trees terminate
 in an orderly fashion, propagating the stop command to the leaves and
 collecting their confirmation back to the stopped supervisor. If one of the

--- a/akka-docs/src/main/paradox/additional/operations.md
+++ b/akka-docs/src/main/paradox/additional/operations.md
@@ -4,7 +4,7 @@ project.description: Operating, managing and monitoring Akka and Akka Cluster ap
 # Operating a Cluster
 
 This documentation discusses how to operate a cluster. For related, more specific guides
-see [Packaging](packaging.md), [Deploying](deploying.md) and [Rolling Updates](rolling-updates.md).
+see @ref:[Packaging](packaging.md), @ref:[Deploying](deploying.md) and @ref:[Rolling Updates](rolling-updates.md).
  
 ## Starting 
 

--- a/akka-docs/src/main/paradox/additional/rolling-updates.md
+++ b/akka-docs/src/main/paradox/additional/rolling-updates.md
@@ -140,7 +140,7 @@ If you need to change any of the following aspects of sharding it will require a
  
 ### Migrating from PersistentFSM to EventSourcedBehavior
 
-If you've [migrated from `PersistentFSM` to `EventSourcedBehavior`](../persistence-fsm.md#migration-to-eventsourcedbehavior)
+If you've @ref:[migrated from `PersistentFSM` to `EventSourcedBehavior`](../persistence-fsm.md#migration-to-eventsourcedbehavior)
 and are using PersistenceFSM with Cluster Sharding, a full shutdown is required as shards can move between new and old nodes.
   
 ### Migrating from classic remoting to Artery

--- a/akka-docs/src/main/paradox/cluster-client.md
+++ b/akka-docs/src/main/paradox/cluster-client.md
@@ -144,7 +144,7 @@ Java
 :  @@snip [ClusterClientTest.java](/akka-cluster-tools/src/test/java/akka/cluster/client/ClusterClientTest.java) { #initialContacts }
 
 You will probably define the address information of the initial contact points in configuration or system property.
-See also [Configuration](#cluster-client-config).
+See also @ref:[Configuration](#cluster-client-config).
 
 A more comprehensive sample is available in the tutorial named
 @scala[[Distributed workers with Akka and Scala](https://github.com/typesafehub/activator-akka-distributed-workers).]

--- a/akka-docs/src/main/paradox/cluster-routing.md
+++ b/akka-docs/src/main/paradox/cluster-routing.md
@@ -10,7 +10,7 @@ automatically unregistered from the router. When new nodes join the cluster, add
 routees are added to the router, according to the configuration. Routees are also added
 when a node becomes reachable again, after having been unreachable.
 
-Cluster aware routers make use of members with status [WeaklyUp](#weakly-up) if that feature
+Cluster aware routers make use of members with status @ref:[WeaklyUp](typed/cluster-membership.md#weakly-up) if that feature
 is enabled.
 
 There are two distinct types of routers.

--- a/akka-docs/src/main/paradox/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/cluster-sharding.md
@@ -44,7 +44,7 @@ You may define it another way, but it must be unique.
 When using the sharding extension you are first, typically at system startup on each node
 in the cluster, supposed to register the supported entity types with the `ClusterSharding.start`
 method. `ClusterSharding.start` gives you the reference which you can pass along.
-Please note that `ClusterSharding.start` will start a `ShardRegion` in [proxy only mode](#proxy-only-mode) 
+Please note that `ClusterSharding.start` will start a `ShardRegion` in @ref:[proxy only mode](#proxy-only-mode) 
 when there is no match between the roles of the current cluster node and the role specified in 
 `ClusterShardingSettings`.
 

--- a/akka-docs/src/main/paradox/common/binary-compatibility-rules.md
+++ b/akka-docs/src/main/paradox/common/binary-compatibility-rules.md
@@ -15,7 +15,7 @@ This means that the new JARs are a drop-in replacement for the old one
 
 Binary compatibility is maintained between:
 
- * **minor** and **patch** versions - please note that the meaning of "minor" has shifted to be more restrictive with Akka `2.4.0`, read [Change in versioning scheme](#24versioningchange) for details.
+ * **minor** and **patch** versions - please note that the meaning of "minor" has shifted to be more restrictive with Akka `2.4.0`, read @ref:[Change in versioning scheme](#24versioningchange) for details.
 
 Binary compatibility is **NOT** maintained between:
 
@@ -23,7 +23,7 @@ Binary compatibility is **NOT** maintained between:
  * any versions of **may change** modules – read @ref:[Modules marked "May Change"](may-change.md) for details
  * a few notable exclusions explained below
 
-Specific examples (please read [Change in versioning scheme](#24versioningchange) to understand the difference in "before 2.4 era" and "after 2.4 era"):
+Specific examples (please read @ref:[Change in versioning scheme](#24versioningchange) to understand the difference in "before 2.4 era" and "after 2.4 era"):
 
 ```
 # [epoch.major.minor] era

--- a/akka-docs/src/main/paradox/distributed-pub-sub.md
+++ b/akka-docs/src/main/paradox/distributed-pub-sub.md
@@ -43,7 +43,7 @@ You can send messages via the mediator on any node to registered actors on
 any other node.
 
 There a two different modes of message delivery, explained in the sections
-[Publish](#distributed-pub-sub-publish) and [Send](#distributed-pub-sub-send) below.
+@ref:[Publish](#distributed-pub-sub-publish) and @ref:[Send](#distributed-pub-sub-send) below.
 
 @@@ div { .group-scala }
 

--- a/akka-docs/src/main/paradox/event-bus.md
+++ b/akka-docs/src/main/paradox/event-bus.md
@@ -18,7 +18,7 @@ you have to provide it inside the message.
 
 @@@
 
-This mechanism is used in different places within Akka, e.g. the [Event Stream](#event-stream).
+This mechanism is used in different places within Akka, e.g. the @ref:[Event Stream](#event-stream).
 Implementations can make use of the specific building blocks presented below.
 
 An event bus must define the following three @scala[abstract types]@java[type parameters]:
@@ -155,8 +155,8 @@ all use cases.
 ## Event Stream
 
 The event stream is the main event bus of each actor system: it is used for
-carrying @ref:[log messages](logging.md) and [Dead Letters](#dead-letters) and may be
-used by the user code for other purposes as well. It uses [Subchannel
+carrying @ref:[log messages](logging.md) and @ref:[Dead Letters](#dead-letters) and may be
+used by the user code for other purposes as well. It uses @ref:[Subchannel
 Classification](#subchannel-classification) which enables registering to related sets of channels (as is
 used for `RemotingLifecycleEvent`). The following example demonstrates
 how a simple subscription works. Given a simple actor:
@@ -190,7 +190,7 @@ Scala
 Java
 :  @@snip [LoggingDocTest.java](/akka-docs/src/test/java/jdocs/event/LoggingDocTest.java) { #superclass-subscription-eventstream }
 
-Similarly to [Actor Classification](#actor-classification), `EventStream` will automatically remove subscribers when they terminate.
+Similarly to @ref:[Actor Classification](#actor-classification), `EventStream` will automatically remove subscribers when they terminate.
 
 @@@ note
 

--- a/akka-docs/src/main/paradox/fsm.md
+++ b/akka-docs/src/main/paradox/fsm.md
@@ -288,7 +288,7 @@ Within this handler the state of the FSM may be queried using the
 ### Initiating Transitions
 
 The result of any `stateFunction` must be a definition of the next state
-unless terminating the FSM, which is described in [Termination from Inside](#termination-from-inside).
+unless terminating the FSM, which is described in @ref:[Termination from Inside](#termination-from-inside).
 The state definition can either be the current state, as described by the
 `stay` directive, or it is a different state as given by
 `goto(state)`. The resulting object allows further qualification by way
@@ -307,7 +307,7 @@ use `Duration.Inf`.
  * 
    `using(data)`
    This modifier replaces the old state data with the new data given. If you
-follow the advice [above](#fsm-philosophy), this is the only place where
+follow the advice @ref:[above](#defining-states), this is the only place where
 internal state data are ever modified.
  * 
    `replying(msg)`

--- a/akka-docs/src/main/paradox/general/message-delivery-reliability.md
+++ b/akka-docs/src/main/paradox/general/message-delivery-reliability.md
@@ -192,7 +192,7 @@ will bind your application to local-only deployment: an application may have to
 be designed differently (as opposed to just employing some message exchange
 patterns local to some actors) in order to be fit for running on a cluster of
 machines. Our credo is “design once, deploy any way you wish”, and to achieve
-this you should only rely on [The General Rules](#the-general-rules).
+this you should only rely on @ref:[The General Rules](#the-general-rules).
 
 ### Reliability of Local Message Sends
 
@@ -310,7 +310,7 @@ at the receiving actor’s end in order to handle temporary failures. This
 pattern is mostly useful in the local communication context where delivery
 guarantees are otherwise sufficient to fulfill the application’s requirements.
 
-Please note that the caveats for [The Rules for In-JVM (Local) Message Sends](#the-rules-for-in-jvm-local-message-sends)
+Please note that the caveats for @ref:[The Rules for In-JVM (Local) Message Sends](#the-rules-for-in-jvm-local-message-sends)
 do apply.
 
 <a id="deadletters"></a>

--- a/akka-docs/src/main/paradox/io-tcp.md
+++ b/akka-docs/src/main/paradox/io-tcp.md
@@ -79,7 +79,7 @@ observed in that state. For a discussion on `CommandFailed` see
 [Throttling Reads and Writes](#throttling-reads-and-writes) below. `ConnectionClosed` is a trait,
 which marks the different connection close events. The last line handles all
 connection close events in the same way. It is possible to listen for more
-fine-grained connection close events, see [Closing Connections](#closing-connections) below.
+fine-grained connection close events, see @ref:[Closing Connections](#closing-connections) below.
 
 ## Accepting connections
 
@@ -113,7 +113,7 @@ Java
 :  @@snip [IODocTest.java](/akka-docs/src/test/java/jdocs/io/japi/IODocTest.java) { #simplistic-handler }
 
 For a more complete sample which also takes into account the possibility of
-failures when sending please see [Throttling Reads and Writes](#throttling-reads-and-writes) below.
+failures when sending please see @ref:[Throttling Reads and Writes](#throttling-reads-and-writes) below.
 
 The only difference to outgoing connections is that the internal actor managing
 the listen port—the sender of the `Bound` message—watches the actor

--- a/akka-docs/src/main/paradox/logging.md
+++ b/akka-docs/src/main/paradox/logging.md
@@ -288,7 +288,7 @@ that receives the log events in the same order they were emitted.
 
 The event handler actor does not have a bounded inbox and is run on the default dispatcher. This means
 that logging extreme amounts of data may affect your application badly. This can be somewhat mitigated by
-using an async logging backend though. (See [Using the SLF4J API directly](#slf4j-directly))
+using an async logging backend though. (See @ref:[Using the SLF4J API directly](#slf4j-directly))
 
 @@@
 

--- a/akka-docs/src/main/paradox/multi-node-testing.md
+++ b/akka-docs/src/main/paradox/multi-node-testing.md
@@ -24,10 +24,10 @@ to see what this looks like in practice.
 When we talk about multi node testing in Akka we mean the process of running coordinated tests on multiple actor
 systems in different JVMs. The multi node testing kit consist of three main parts.
 
- * [The Test Conductor](#the-test-conductor). that coordinates and controls the nodes under test.
- * [The Multi Node Spec](#the-multi-node-spec). that is a convenience wrapper for starting the `TestConductor` and letting all
+ * @ref:[The Test Conductor](#the-test-conductor). that coordinates and controls the nodes under test.
+ * @ref:[The Multi Node Spec](#the-multi-node-spec). that is a convenience wrapper for starting the `TestConductor` and letting all
 nodes connect to it.
- * [The SbtMultiJvm Plugin](#the-sbtmultijvm-plugin). that starts tests in multiple JVMs possibly on multiple machines.
+ * @ref:[The SbtMultiJvm Plugin](#the-sbtmultijvm-plugin). that starts tests in multiple JVMs possibly on multiple machines.
 
 ## The Test Conductor
 

--- a/akka-docs/src/main/paradox/persistence-fsm.md
+++ b/akka-docs/src/main/paradox/persistence-fsm.md
@@ -125,7 +125,7 @@ Persistent FSMs can be represented using @ref[Persistence Typed](typed/persisten
 using a snapshot adapter and an event adapter. The adapters are required as Persistent FSM doesn't store snapshots and user data directly, it wraps them in 
 internal types that include state transition information.
 
-Before reading the migration guide it is advised to understand [Persistence Typed](typed/persistence.md). 
+Before reading the migration guide it is advised to understand @ref:[Persistence Typed](typed/persistence.md). 
 
 ### Migration steps
 

--- a/akka-docs/src/main/paradox/persistence-plugins.md
+++ b/akka-docs/src/main/paradox/persistence-plugins.md
@@ -22,8 +22,8 @@ akka.persistence.snapshot-store.plugin = ""
 
 However, these entries are provided as empty "", and require explicit user configuration via override in the user `application.conf`.
 
-* For an example of a journal plugin which writes messages to LevelDB see [Local LevelDB journal](#local-leveldb-journal).
-* For an example of a snapshot store plugin which writes snapshots as individual files to the local filesystem see [Local snapshot store](#local-snapshot-store).
+* For an example of a journal plugin which writes messages to LevelDB see @ref:[Local LevelDB journal](#local-leveldb-journal).
+* For an example of a snapshot store plugin which writes snapshots as individual files to the local filesystem see @ref:[Local snapshot store](#local-snapshot-store).
 
 ## Eager initialization of persistence plugin
 
@@ -108,7 +108,7 @@ purposes.
 @@@
 
 @@@ note
-This plugin has been supplanted by [Persistence Plugin Proxy](#persistence-plugin-proxy).
+This plugin has been supplanted by @ref:[Persistence Plugin Proxy](#persistence-plugin-proxy).
 @@@
 
 A shared LevelDB instance is started by instantiating the `SharedLeveldbStore` actor.

--- a/akka-docs/src/main/paradox/persistence-schema-evolution.md
+++ b/akka-docs/src/main/paradox/persistence-schema-evolution.md
@@ -68,10 +68,10 @@ definition - in a backwards compatible way - such that the new deserialization c
 
 The most common schema changes you will likely are:
 
- * [adding a field to an event type](#add-field),
- * [remove or rename field in event type](#rename-field),
- * [remove event type](#remove-event-class),
- * [split event into multiple smaller events](#split-large-event-into-smaller).
+ * @ref:[adding a field to an event type](#add-field),
+ * @ref:[remove or rename field in event type](#rename-field),
+ * @ref:[remove event type](#remove-event-class),
+ * @ref:[split event into multiple smaller events](#split-large-event-into-smaller).
 
 The following sections will explain some patterns which can be used to safely evolve your schema when facing those changes.
 
@@ -133,7 +133,7 @@ serializers, and the yellow payload indicates the user provided event (by callin
 As you can see, the `PersistentMessage` acts as an envelope around the payload, adding various fields related to the
 origin of the event (`persistenceId`, `sequenceNr` and more).
 
-More advanced techniques (e.g. [Remove event class and ignore events](#remove-event-class)) will dive into using the manifests for increasing the
+More advanced techniques (e.g. @ref:[Remove event class and ignore events](#remove-event-class)) will dive into using the manifests for increasing the
 flexibility of the persisted vs. exposed types even more. However for now we will focus on the simpler evolution techniques,
 concerning only configuring the payload serializers.
 
@@ -430,7 +430,7 @@ Then the serializer can simply convert the bytes do the domain object by using t
 You want to keep your persisted events in a human-readable format, for example JSON.
 
 **Solution:**
-This is a special case of the [Detach domain model from data model](#detach-domain-from-data-model) pattern, and thus requires some co-operation
+This is a special case of the @ref:[Detach domain model from data model](#detach-domain-from-data-model) pattern, and thus requires some co-operation
 from the Journal implementation to achieve this.
 
 An example of a Journal which may implement this pattern is MongoDB, however other databases such as PostgreSQL

--- a/akka-docs/src/main/paradox/persistence.md
+++ b/akka-docs/src/main/paradox/persistence.md
@@ -81,7 +81,7 @@ about successful state changes by publishing events.
 
 When persisting events with `persist` it is guaranteed that the persistent actor will not receive further commands between
 the `persist` call and the execution(s) of the associated event handler. This also holds for multiple `persist`
-calls in context of a single command. Incoming messages are [stashed](#internal-stash) until the `persist`
+calls in context of a single command. Incoming messages are @ref:[stashed](#internal-stash) until the `persist`
 is completed.
 
 If persistence of an event fails, `onPersistFailure` will be invoked (logging the error by default),
@@ -433,7 +433,7 @@ next message.
 If there is a problem with recovering the state of the actor from the journal when the actor is
 started, `onRecoveryFailure` is called (logging the error by default), and the actor will be stopped.
 Note that failure to load snapshot is also treated like this, but you can disable loading of snapshots
-if you for example know that serialization format has changed in an incompatible way, see [Recovery customization](#recovery-custom).
+if you for example know that serialization format has changed in an incompatible way, see @ref:[Recovery customization](#recovery-custom).
 
 ### Atomic writes
 
@@ -501,7 +501,7 @@ For critical failures, such as recovery or persisting events failing, the persis
 handler is invoked. This is because if the underlying journal implementation is signalling persistence failures it is most
 likely either failing completely or overloaded and restarting right-away and trying to persist the event again will most
 likely not help the journal recover – as it would likely cause a [Thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem), as many persistent actors
-would restart and try to persist their events again. Instead, using a `BackoffSupervisor` (as described in [Failures](#failures)) which
+would restart and try to persist their events again. Instead, using a `BackoffSupervisor` (as described in @ref:[Failures](#failures)) which
 implements an exponential-backoff strategy which allows for more breathing room for the journal to recover between
 restarts of the persistent actor.
 
@@ -838,7 +838,7 @@ Also note that for the LevelDB Java port, you will need the following dependenci
 @@@ warning
 
 It is not possible to test persistence provided classes (i.e. `PersistentActor`
-and [AtLeastOnceDelivery](#at-least-once-delivery)) using `TestActorRef` due to its *synchronous* nature.
+and @ref:[AtLeastOnceDelivery](#at-least-once-delivery)) using `TestActorRef` due to its *synchronous* nature.
 These traits need to be able to perform asynchronous tasks in the background in order to handle internal persistence
 related events.
 

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -481,7 +481,7 @@ akka.remote.artery.advanced.materializer = ${akka.stream.materializer}
 The materialized value for `StreamRefs.sinkRef` and `StreamRefs.sourceRef` is no longer wrapped in
 `Future`/`CompletionStage`. It can be sent as reply to `sender()` immediately without using the `pipe` pattern.
 
-`StreamRefs` was marked as [may change](../common/may-change.md).
+`StreamRefs` was marked as @ref:[may change](../common/may-change.md).
 
 ## Akka Typed
 
@@ -512,7 +512,7 @@ rolling update from 2.5 to 2.6 if you use Akka Typed. See @ref:[rolling updates 
 
 ### Akka Typed API changes
 
-Akka Typed APIs are still marked as [may change](../common/may-change.md) and a few changes were
+Akka Typed APIs are still marked as @ref:[may change](../common/may-change.md) and a few changes were
 made before finalizing the APIs. Compared to Akka 2.5.x the source incompatible changes are:
 
 * `Behaviors.intercept` now takes a factory function for the interceptor.
@@ -579,7 +579,7 @@ see below for more details.
 Having a default materializer available means that most, if not all, usages of Java `ActorMaterializer.create()`
 and Scala `implicit val materializer = ActorMaterializer()` should be removed.
 
-Details about the stream materializer can be found in [Actor Materializer Lifecycle](../stream/stream-flows-and-basics.md#actor-materializer-lifecycle)
+Details about the stream materializer can be found in @ref:[Actor Materializer Lifecycle](../stream/stream-flows-and-basics.md#actor-materializer-lifecycle)
 
 When using streams from typed the same factories and methods for creating materializers and running streams as from classic can now be used with typed. The
 `akka.stream.typed.scaladsl.ActorMaterializer` and `akka.stream.typed.javadsl.ActorMaterializerFactory` that previously existed in the `akka-stream-typed` module has been removed.

--- a/akka-docs/src/main/paradox/remoting-artery.md
+++ b/akka-docs/src/main/paradox/remoting-artery.md
@@ -160,7 +160,7 @@ real network.
 
 In cases, where Network Address Translation (NAT) is used or other network bridging is involved, it is important
 to configure the system so that it understands that there is a difference between his externally visible, canonical
-address and between the host-port pair that is used to listen for connections. See [Akka behind NAT or in a Docker container](#remote-configuration-nat-artery)
+address and between the host-port pair that is used to listen for connections. See @ref:[Akka behind NAT or in a Docker container](#remote-configuration-nat-artery)
 for details.
 
 ## Acquiring references to remote actors
@@ -253,7 +253,7 @@ be delivered just fine.
 
 An `ActorSystem` should not be exposed via Akka Remote (Artery) over plain Aeron/UDP or TCP to an untrusted
 network (e.g. Internet). It should be protected by network security, such as a firewall. If that is not considered
-as enough protection [TLS with mutual authentication](#remote-tls) should be enabled.
+as enough protection @ref:[TLS with mutual authentication](#remote-tls) should be enabled.
 
 Best practice is that Akka remoting nodes should only be accessible from the adjacent network. Note that if TLS is
 enabled with mutual authentication there is still a risk that an attacker can gain access to a valid certificate by

--- a/akka-docs/src/main/paradox/remoting.md
+++ b/akka-docs/src/main/paradox/remoting.md
@@ -80,7 +80,7 @@ listening for connections and handling messages as not to interfere with other a
 @@@
 
 The example above only illustrates the bare minimum of properties you have to add to enable remoting.
-All settings are described in [Remote Configuration](#remote-configuration).
+All settings are described in @ref:[Remote Configuration](#remote-configuration).
 
 ## Introduction
 
@@ -315,7 +315,7 @@ Watching a remote actor is not different than watching a local actor, as describ
 Please see:
 
 * @ref:[Phi Accrual Failure Detector](typed/failure-detector.md) implementation for details
-* [Using the Failure Detector](#using-the-failure-detector) below for usage 
+* @ref:[Using the Failure Detector](#using-the-failure-detector) below for usage 
 
 ### Using the Failure Detector
  
@@ -326,7 +326,7 @@ implementing the `akka.remote.FailureDetector` and configuring it:
 akka.remote.watch-failure-detector.implementation-class = "com.example.CustomFailureDetector"
 ``` 
  
-In the [Remote Configuration](#remote-configuration) you may want to adjust these
+In the @ref:[Remote Configuration](#remote-configuration) you may want to adjust these
 depending on you environment:
 
 * When a *phi* value is considered to be a failure `akka.remote.watch-failure-detector.threshold`

--- a/akka-docs/src/main/paradox/routing.md
+++ b/akka-docs/src/main/paradox/routing.md
@@ -21,7 +21,7 @@ routees yourselves or use a self contained router actor with configuration capab
 
 Different routing strategies can be used, according to your application's needs. Akka comes with
 several useful routing strategies right out of the box. But, as you will see in this chapter, it is
-also possible to [create your own](#custom-router).
+also possible to @ref:[create your own](#custom-router).
 
 <a id="simple-router"></a>
 ## A Simple Router
@@ -59,9 +59,9 @@ outside of actors.
 @@@ note
 
 In general, any message sent to a router will be sent onwards to its routees, but there is one exception.
-The special [Broadcast Messages](#broadcast-messages) will send to *all* of a router's routees.
-However, do not use [Broadcast Messages](#broadcast-messages) when you use [BalancingPool](#balancing-pool) for routees
-as described in [Specially Handled Messages](#router-special-messages).
+The special @ref:[Broadcast Messages](#broadcast-messages) will send to *all* of a router's routees.
+However, do not use @ref:[Broadcast Messages](#broadcast-messages) when you use @ref:[BalancingPool](#balancing-pool) for routees
+as described in @ref:[Specially Handled Messages](#router-special-messages).
 
 @@@
 
@@ -91,13 +91,13 @@ original sender, not to the router actor.
 @@@ note
 
 In general, any message sent to a router will be sent onwards to its routees, but there are a
-few exceptions. These are documented in the [Specially Handled Messages](#router-special-messages) section below.
+few exceptions. These are documented in the @ref:[Specially Handled Messages](#router-special-messages) section below.
 
 @@@
 
 ### Pool
 
-The following code and configuration snippets show how to create a [round-robin](#round-robin-router) router that forwards messages to five `Worker` routees. The
+The following code and configuration snippets show how to create a @ref:[round-robin](#round-robin-router) router that forwards messages to five `Worker` routees. The
 routees will be created as the router's children.
 
 @@snip [RouterDocSpec.scala](/akka-docs/src/test/scala/docs/routing/RouterDocSpec.scala) { #config-round-robin-pool }
@@ -349,7 +349,7 @@ right actor in most cases. Therefore you cannot use it for workflows that
 require state to be kept within the routee, you would in this case have to
 include the whole state in the messages.
 
-With a [SmallestMailboxPool](#smallestmailboxpool) you can have a vertically scaling service that
+With a @ref:[SmallestMailboxPool](#smallestmailboxpool) you can have a vertically scaling service that
 can interact in a stateful fashion with other services in the back-end before
 replying to the original client. The other advantage is that it does not place
 a restriction on the message queue implementation as BalancingPool does.
@@ -358,8 +358,8 @@ a restriction on the message queue implementation as BalancingPool does.
 
 @@@ note
 
-Do not use [Broadcast Messages](#broadcast-messages) when you use [BalancingPool](#balancing-pool) for routers,
-as described in [Specially Handled Messages](#router-special-messages).
+Do not use @ref:[Broadcast Messages](#broadcast-messages) when you use @ref:[BalancingPool](#balancing-pool) for routers,
+as described in @ref:[Specially Handled Messages](#router-special-messages).
 
 @@@
 
@@ -684,7 +684,7 @@ However there are a few types of messages that have special behavior.
 
 Note that these special messages, except for the `Broadcast` message, are only handled by 
 self contained router actors and not by the `akka.routing.Router` component described 
-in [A Simple Router](#simple-router).
+in @ref:[A Simple Router](#simple-router).
 
 ### Broadcast Messages
 
@@ -707,8 +707,8 @@ routees. It is up to each routee actor to handle the received payload message.
 
 @@@ note
 
-Do not use [Broadcast Messages](#broadcast-messages) when you use [BalancingPool](#balancing-pool) for routers.
-Routees on [BalancingPool](#balancing-pool) shares the same mailbox instance, thus some routees can
+Do not use @ref:[Broadcast Messages](#broadcast-messages) when you use @ref:[BalancingPool](#balancing-pool) for routers.
+Routees on @ref:[BalancingPool](#balancing-pool) shares the same mailbox instance, thus some routees can
 possibly get the broadcast message multiple times, while other routees get no broadcast message.
 
 @@@
@@ -949,7 +949,7 @@ Java
 :  @@snip [CustomRouterDocTest.java](/akka-docs/src/test/java/jdocs/routing/CustomRouterDocTest.java) { #unit-test-logic }
 
 You could stop here and use the `RedundancyRoutingLogic` with a `akka.routing.Router`
-as described in [A Simple Router](#simple-router).
+as described in @ref:[A Simple Router](#simple-router).
 
 Let us continue and make this into a self contained, configurable, router actor.
 

--- a/akka-docs/src/main/paradox/stream/stream-dynamic.md
+++ b/akka-docs/src/main/paradox/stream/stream-dynamic.md
@@ -175,7 +175,7 @@ Java
 
 The resulting Flow now has a type of `Flow[String, String, UniqueKillSwitch]` representing a publish-subscribe
 channel which can be used any number of times to attach new producers or consumers. In addition, it materializes
-to a `UniqueKillSwitch` (see [UniqueKillSwitch](#unique-kill-switch)) that can be used to deregister a single user externally:
+to a `UniqueKillSwitch` (see @ref:[UniqueKillSwitch](#unique-kill-switch)) that can be used to deregister a single user externally:
 
 Scala
 :   @@snip [HubsDocSpec.scala](/akka-docs/src/test/scala/docs/stream/HubsDocSpec.scala) { #pub-sub-4 }

--- a/akka-docs/src/main/paradox/stream/stream-graphs.md
+++ b/akka-docs/src/main/paradox/stream/stream-graphs.md
@@ -118,7 +118,7 @@ Sometimes it is not possible (or needed) to construct the entire computation gra
 all of its different phases in different places and in the end connect them all into a complete graph and run it.
 
 This can be achieved by @scala[returning a different `Shape` than `ClosedShape`, for example `FlowShape(in, out)`, from the
-function given to `GraphDSL.create`. See [Predefined shapes](#predefined-shapes) for a list of such predefined shapes.
+function given to `GraphDSL.create`. See @ref:[Predefined shapes](#predefined-shapes) for a list of such predefined shapes.
 Making a `Graph` a `RunnableGraph`]@java[using the returned `Graph` from `GraphDSL.create()` rather than
 passing it to `RunnableGraph.fromGraph()` to wrap it in a `RunnableGraph`.The reason of representing it as a different type is that a
 `RunnableGraph`] requires all ports to be connected, and if they are not

--- a/akka-docs/src/main/paradox/stream/stream-quickstart.md
+++ b/akka-docs/src/main/paradox/stream/stream-quickstart.md
@@ -248,7 +248,7 @@ Java
 Streams always start flowing from a @scala[`Source[Out,M1]`]@java[`Source<Out,M1>`] then can continue through @scala[`Flow[In,Out,M2]`]@java[`Flow<In,Out,M2>`] elements or
 more advanced operators to finally be consumed by a @scala[`Sink[In,M3]`]@java[`Sink<In,M3>`] @scala[(ignore the type parameters `M1`, `M2`
 and `M3` for now, they are not relevant to the types of the elements produced/consumed by these classes – they are
-"materialized types", which we'll talk about [below](#materialized-values-quick))]@java[. The first type parameter—`Tweet` in this case—designates the kind of elements produced
+"materialized types", which we'll talk about @ref:[below](#materialized-values-quick))]@java[. The first type parameter—`Tweet` in this case—designates the kind of elements produced
 by the source while the `M` type parameters describe the object that is created during
 materialization ([see below](#materialized-values-quick))—`NotUsed` (from the `scala.runtime`
 package) means that no value is produced, it is the generic equivalent of `void`.]

--- a/akka-docs/src/main/paradox/stream/stream-refs.md
+++ b/akka-docs/src/main/paradox/stream/stream-refs.md
@@ -41,7 +41,7 @@ implement manually.
 @@@
 
 @@@ warning { title=IMPORTANT }
-  Use stream refs with Akka Cluster. The [failure detector can cause quarantining](../typed/cluster-concepts.md#quarantined) if plain Akka remoting is used.
+  Use stream refs with Akka Cluster. The @ref:[failure detector can cause quarantining](../typed/cluster-concepts.md#quarantined) if plain Akka remoting is used.
 @@@
 
 ## Stream References

--- a/akka-docs/src/main/paradox/testing.md
+++ b/akka-docs/src/main/paradox/testing.md
@@ -83,7 +83,7 @@ Java
 In these examples, the maximum durations you will find mentioned below are left
 out, in which case they use the default value from configuration item
 `akka.test.single-expect-default` which itself defaults to 3 seconds (or they
-obey the innermost enclosing `Within` as detailed [below](#testkit-within)). The full signatures are:
+obey the innermost enclosing `Within` as detailed @ref:[below](#testkit-within)). The full signatures are:
 
 * @scala[`expectMsg[T](d: Duration, msg: T): T`]@java[`public <T> T expectMsgEquals(Duration max, T msg)`]
    The given message object must be received within the specified time; the
@@ -93,7 +93,7 @@ object will be returned.
 @scala[partial] function must be defined for that message; the result from applying
 the @scala[partial] function to the received message is returned. @scala[The duration may
 be left unspecified (empty parentheses are required in this case) to use
-the deadline from the innermost enclosing [within](#testkit-within)
+the deadline from the innermost enclosing @ref:[within](#testkit-within)
 block instead.]
 * @scala[`expectMsgClass[T](d: Duration, c: Class[T]): T`]@java[`public <T> T expectMsgClass(Duration max, Class<T> c)`]
    An object which is an instance of the given `Class` must be received
@@ -179,7 +179,7 @@ Collect messages as long as
     * the next message is received within the idle timeout
     * the number of messages has not yet reached the maximum
 All collected messages are returned. @scala[The maximum duration defaults to the
-time remaining in the innermost enclosing [within](#testkit-within)
+time remaining in the innermost enclosing @ref:[within](#testkit-within)
 block and the idle duration defaults to infinity (thereby disabling the
 idle timeout feature). The number of expected messages defaults to
 `Int.MaxValue`, which effectively disables this limit.]
@@ -194,9 +194,9 @@ maximum defaults to the time remaining in the innermost enclosing
 Poll the given assert function every `interval` until it does not throw
 an exception or the `max` duration is used up. If the timeout expires the
 last exception is thrown. @scala[The interval defaults to 100 ms and the maximum defaults
-to the time remaining in the innermost enclosing [within](#testkit-within)
+to the time remaining in the innermost enclosing @ref:[within](#testkit-within)
 block. The interval defaults to 100 ms and the maximum defaults to the time
-remaining in the innermost enclosing [within](#testkit-within) block.] Return an arbitrary value that would be returned from awaitAssert if successful, if not interested in such value you can return null.
+remaining in the innermost enclosing @ref:[within](#testkit-within) block.] Return an arbitrary value that would be returned from awaitAssert if successful, if not interested in such value you can return null.
 
 * @scala[`ignoreMsg(pf: PartialFunction[AnyRef, Boolean])`]@java[`public void ignoreMsg(Function<Object, Boolean> f)`]
 @scala[`ignoreMsg`]@java[`public void ignoreMsg()`]
@@ -466,7 +466,7 @@ in an `Option`; setting it to `None` terminates the auto-pilot].
 
 The behavior of `within` blocks when using test probes might be perceived
 as counter-intuitive: you need to remember that the nicely scoped deadline as
-described [above](#testkit-within) is local to each probe. Hence, probes
+described @ref:[above](#testkit-within) is local to each probe. Hence, probes
 do not react to each other's deadlines or to the deadline set in an enclosing
 `TestKit` instance:
 
@@ -907,7 +907,7 @@ operation to complement the `Actor` testing: it supports all operations
 also valid on normal `ActorRef`. Messages sent to the actor are
 processed synchronously on the current thread and answers may be sent back as
 usual. This trick is made possible by the `CallingThreadDispatcher`
-described below (see [CallingThreadDispatcher](#callingthreaddispatcher)); this dispatcher is set
+described below (see @ref:[CallingThreadDispatcher](#callingthreaddispatcher)); this dispatcher is set
 implicitly for any actor instantiated into a `TestActorRef`.
 
 Scala

--- a/akka-docs/src/main/paradox/typed/cluster-concepts.md
+++ b/akka-docs/src/main/paradox/typed/cluster-concepts.md
@@ -10,7 +10,7 @@ This document describes the design concepts of Akka Cluster. For the guide on us
 
 Akka Cluster provides a fault-tolerant decentralized peer-to-peer based
 @ref:[Cluster Membership Service](cluster-membership.md#cluster-membership-service) with no single point of failure or 
-single point of bottleneck. It does this using [gossip](#gossip) protocols and an automatic [failure detector](#failure-detector).
+single point of bottleneck. It does this using @ref:[gossip](#gossip) protocols and an automatic [failure detector](#failure-detector).
 
 Akka Cluster allows for building distributed applications, where one application or service spans multiple nodes
 (in practice multiple `ActorSystem`s). 

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -272,7 +272,7 @@ running in that `Shard`. To permanently stop entities, a `Passivate` message mus
 sent to the parent of the entity actor, otherwise the entity will be automatically
 restarted after the entity restart backoff specified in the configuration.
 
-When [Distributed Data mode](#distributed-data-mode) is used the identifiers of the entities are
+When @ref:[Distributed Data mode](#distributed-data-mode) is used the identifiers of the entities are
 stored in @ref:[Durable Storage](distributed-data.md#durable-storage) of Distributed Data. You may want to change the
 configuration of the `akka.cluster.sharding.distributed-data.durable.lmdb.dir`, since
 the default directory contains the remote port of the actor system. If using a dynamically

--- a/akka-docs/src/main/paradox/typed/distributed-data.md
+++ b/akka-docs/src/main/paradox/typed/distributed-data.md
@@ -197,7 +197,7 @@ akka.cluster.distributed-data.delta-crdt.enabled=off
 
 ### Consistency
 
-The consistency level that is supplied in the [Update](#update) and [Get](#get)
+The consistency level that is supplied in the @ref:[Update](#update) and @ref:[Get](#get)
 specifies per request how many replicas that must respond successfully to a write and read request.
 
 `WriteAll` and `ReadAll` is the strongest consistency level, but also the slowest and with
@@ -341,7 +341,7 @@ Scala
 Java
 : @@snip [DistributedDataDocTest.java](/akka-docs/src/test/java/jdocs/ddata/DistributedDataDocTest.java) { #pncounter }
 
-`GCounter` and `PNCounter` have support for [delta-CRDT](#delta-crdt) and don't need causal
+`GCounter` and `PNCounter` have support for @ref:[delta-CRDT](#delta-crdt) and don't need causal
 delivery of deltas.
 
 Several related counters can be managed in a map with the `PNCounterMap` data type.
@@ -367,7 +367,7 @@ Scala
 Java
 : @@snip [DistributedDataDocTest.java](/akka-docs/src/test/java/jdocs/ddata/DistributedDataDocTest.java) { #gset }
 
-`GSet` has support for [delta-CRDT](#delta-crdt) and it doesn't require causal delivery of deltas.
+`GSet` has support for @ref:[delta-CRDT](#delta-crdt) and it doesn't require causal delivery of deltas.
 
 If you need add and remove operations you should use the `ORSet` (observed-remove set).
 Elements can be added and removed any number of times. If an element is concurrently added and
@@ -384,7 +384,7 @@ Scala
 Java
 : @@snip [DistributedDataDocTest.java](/akka-docs/src/test/java/jdocs/ddata/DistributedDataDocTest.java) { #orset }
 
-`ORSet` has support for [delta-CRDT](#delta-crdt) and it requires causal delivery of deltas.
+`ORSet` has support for @ref:[delta-CRDT](#delta-crdt) and it requires causal delivery of deltas.
 
 ### Maps
 
@@ -410,7 +410,7 @@ It is a specialized `ORMap` with `PNCounter` values.
 `LWWMap` (last writer wins map) is a specialized `ORMap` with `LWWRegister` (last writer wins register)
 values.
 
-`ORMap`, `ORMultiMap`, `PNCounterMap` and `LWWMap` have support for [delta-CRDT](#delta-crdt) and they require causal
+`ORMap`, `ORMultiMap`, `PNCounterMap` and `LWWMap` have support for @ref:[delta-CRDT](#delta-crdt) and they require causal
 delivery of deltas. Support for deltas here means that the `ORSet` being underlying key type for all those maps
 uses delta propagation to deliver updates. Effectively, the update for map is then a pair, consisting of delta for the `ORSet`
 being the key and full update for the respective value (`ORSet`, `PNCounter` or `LWWRegister`) kept in the map.
@@ -631,7 +631,7 @@ Note that you should be prepared to receive `WriteFailure` as reply to an `Updat
 durable entry if the data could not be stored for some reason. When enabling `write-behind-interval`
 such errors will only be logged and `UpdateSuccess` will still be the reply to the `Update`.
 
-There is one important caveat when it comes pruning of [CRDT Garbage](#crdt-garbage) for durable data.
+There is one important caveat when it comes pruning of @ref:[CRDT Garbage](#crdt-garbage) for durable data.
 If an old data entry that was never pruned is injected and merged with existing data after
 that the pruning markers have been removed the value will not be correct. The time-to-live
 of the markers is defined by configuration
@@ -668,7 +668,7 @@ be able to improve this if needed, but the design is still not intended for bill
 All data is held in memory, which is another reason why it is not intended for *Big Data*.
 
 When a data entry is changed the full state of that entry may be replicated to other nodes
-if it doesn't support [delta-CRDT](#delta-crdt). The full state is also replicated for delta-CRDTs,
+if it doesn't support @ref:[delta-CRDT](#delta-crdt). The full state is also replicated for delta-CRDTs,
 for example when new nodes are added to the cluster or when deltas could not be propagated because
 of network partitions or similar problems. This means that you cannot have too large
 data entries, because then the remote message size will be too large.

--- a/akka-docs/src/main/paradox/typed/guide/actors-motivation.md
+++ b/akka-docs/src/main/paradox/typed/guide/actors-motivation.md
@@ -4,9 +4,9 @@ The actor model was proposed decades ago by @extref[Carl Hewitt](wikipedia:Carl_
 
 Today, the actor model is not only recognized as a highly effective solution &#8212; it has been proven in production for some of the world's most demanding applications. To highlight issues that the actor model addresses, this topic discusses the following mismatches between traditional programming assumptions and the reality of modern multi-threaded, multi-CPU architectures:
 
-* [The challenge of encapsulation](#the-illusion-of-encapsulation)
-* [The illusion of shared memory on modern computer architectures](#The-illusion-of-shared-memory-on-modern-computer-architectures)
-* [The illusion of a call stack](#the-illusion-of-a-call-stack)
+* @ref:[The challenge of encapsulation](#the-challenge-of-encapsulation)
+* @ref:[The illusion of shared memory on modern computer architectures](#the-illusion-of-shared-memory-on-modern-computer-architectures)
+* @ref:[The illusion of a call stack](#the-illusion-of-a-call-stack)
 
 
 ## The challenge of encapsulation

--- a/akka-docs/src/main/paradox/typed/guide/modules.md
+++ b/akka-docs/src/main/paradox/typed/guide/modules.md
@@ -4,15 +4,15 @@ Before delving into some best practices for writing actors, it will be helpful t
 
 The following capabilities are included with Akka OSS and are introduced later on this page:
 
-* [Actor library](#actor-library)
-* [Remoting](#remoting)
-* [Cluster](#cluster)
-* [Cluster Sharding](#cluster-sharding)
-* [Cluster Singleton](#cluster-singleton)
-* [Persistence](#persistence)
-* [Distributed Data](#distributed-data)
-* [Streams](#streams)
-* [HTTP](#http)
+* @ref:[Actor library](#actor-library)
+* @ref:[Remoting](#remoting)
+* @ref:[Cluster](#cluster)
+* @ref:[Cluster Sharding](#cluster-sharding)
+* @ref:[Cluster Singleton](#cluster-singleton)
+* @ref:[Persistence](#persistence)
+* @ref:[Distributed Data](#distributed-data)
+* @ref:[Streams](#streams)
+* @ref:[HTTP](#http)
 
 With a [Lightbend Platform Subscription](https://www.lightbend.com/platform/subscription), you can use [Akka Enhancements](https://doc.akka.io/docs/akka-enhancements/current/) that includes:
 

--- a/akka-docs/src/main/paradox/typed/guide/tutorial_3.md
+++ b/akka-docs/src/main/paradox/typed/guide/tutorial_3.md
@@ -51,8 +51,8 @@ But to further understand the need for flexibility in the protocol, it will help
 
 The following sections discuss this behavior in more detail:
 
-* [Message delivery](#message-delivery)
-* [Message ordering](#message-ordering)
+* @ref:[Message delivery](#message-delivery)
+* @ref:[Message ordering](#message-ordering)
 
 ### Message delivery
 The delivery semantics provided by messaging subsystems typically fall into the following categories:


### PR DESCRIPTION
* always use ref links for internal links, also within same page
* to benefit from link and anchor checking

(skipped cluster.md since I fixed it there in another open pr)