### PR TITLE
RestartShard should only be sent to the local ShardRegion #27782

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -11,6 +11,7 @@ import scala.concurrent.duration._
 
 import akka.actor.Actor
 import akka.actor.ActorLogging
+import akka.actor.ActorPath
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.actor.DeadLetterSuppression
@@ -33,6 +34,7 @@ import akka.coordination.lease.scaladsl.Lease
 import akka.coordination.lease.scaladsl.LeaseProvider
 import akka.pattern.pipe
 import akka.persistence._
+import akka.util.ByteString
 import akka.util.MessageBufferMap
 import akka.util.PrettyDuration._
 import akka.util.unused
@@ -152,6 +154,19 @@ private[akka] object Shard {
   }
 
   case object PassivateIdleTick extends NoSerializationVerificationNeeded
+
+  private[sharding] def name(id: ShardRegion.ShardId): String =
+    URLEncoder.encode(id, ByteString.UTF_8)
+
+  /**
+   * INTERNAL API
+   *
+   * Use to determine whether an `ActorRef` is a shard.
+   * Returns true if the `path` is for a shard, meaning the name was encoded from the `shardId`.
+   * Region and region proxy names are encoded from their `typeName`, the coordinator name is derived from the encoded region name.
+   */
+  private[sharding] def isShard(typeName: String, shardId: ShardRegion.ShardId, path: ActorPath): Boolean =
+    path.parent.name.contains(typeName) && path.name == shardId // match parent: region or proxy
 
 }
 

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/MultiNodeClusterShardingConfig.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/MultiNodeClusterShardingConfig.scala
@@ -5,9 +5,9 @@
 package akka.cluster.sharding
 
 import akka.cluster.MultiNodeClusterSpec
+import akka.cluster.sharding.testkit.ClusterShardingConfig
 import akka.persistence.journal.leveldb.SharedLeveldbJournal
 import akka.remote.testkit.MultiNodeConfig
-import akka.testkit.AkkaSpec
 import com.typesafe.config.{ Config, ConfigFactory }
 
 /**
@@ -19,13 +19,12 @@ import com.typesafe.config.{ Config, ConfigFactory }
  * @param loglevel defaults to INFO
  */
 abstract class MultiNodeClusterShardingConfig(
-    val mode: String = ClusterShardingSettings.StateStoreModeDData,
-    val rememberEntities: Boolean = false,
+    override val mode: String = ClusterShardingSettings.StateStoreModeDData,
+    override val rememberEntities: Boolean = false,
     overrides: Config = ConfigFactory.empty,
     loglevel: String = "INFO")
-    extends MultiNodeConfig {
-
-  val targetDir = s"target/ClusterSharding${AkkaSpec.getCallerName(getClass)}Spec-$mode-remember-$rememberEntities"
+    extends MultiNodeConfig
+    with ClusterShardingConfig {
 
   val modeConfig =
     if (mode == ClusterShardingSettings.StateStoreModeDData) ConfigFactory.empty
@@ -41,16 +40,9 @@ abstract class MultiNodeClusterShardingConfig(
   commonConfig(
     overrides
       .withFallback(modeConfig)
+      .withFallback(baseConfig)
       .withFallback(ConfigFactory.parseString(s"""
-      akka.loglevel = $loglevel
-      akka.actor.provider = "cluster"
       akka.cluster.auto-down-unreachable-after = 0s
-      akka.remote.log-remote-lifecycle-events = off
-      akka.cluster.sharding.state-store-mode = "$mode"
-      akka.cluster.sharding.distributed-data.durable.lmdb {
-        dir = $targetDir/sharding-ddata
-        map-size = 10 MiB
-      }
       """))
       .withFallback(SharedLeveldbJournal.configToEnableJavaSerializationForTest)
       .withFallback(MultiNodeClusterSpec.clusterConfig))

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ShardRegionSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ShardRegionSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import scala.concurrent.duration._
+
+import akka.actor.{ Actor, ActorLogging, ActorRef, ActorSystem, Props }
+import akka.cluster.ClusterEvent.CurrentClusterState
+import akka.cluster.{ Cluster, MemberStatus }
+import akka.cluster.sharding.testkit.ClusterShardingConfig
+import akka.testkit.TestActors.EchoActor
+import akka.testkit.{ AkkaSpec, TestProbe }
+import org.scalatest.concurrent.ScalaFutures
+
+object ShardRegionSpec extends ClusterShardingConfig {
+
+  val shardTypeName = "Caat"
+
+  val extractEntityId: ShardRegion.ExtractEntityId = {
+    case msg: Int => (msg.toString, msg)
+  }
+
+  val extractShardId: ShardRegion.ExtractShardId = {
+    case msg: Int => (msg % 10).toString
+  }
+
+  class EntityActor extends Actor with ActorLogging {
+    override def receive: Receive = {
+      case msg => sender() ! s"ack ${msg}"
+    }
+  }
+}
+
+class ShardRegionSpec extends AkkaSpec(ShardRegionSpec.baseConfig) with ScalaFutures {
+  import ShardRegionSpec._
+
+  private val sysA = system
+  private val sysB = ActorSystem(system.name, system.settings.config)
+
+  private val region1 = startShard(sysA)
+  private val region2 = startShard(sysB)
+
+  private val regionProbes = Set((region1, TestProbe()(sysA)), (region2, TestProbe()(sysB)))
+  private val events = Set(1, 2)
+
+  override def beforeTermination(): Unit = shutdown(sysB)
+
+  def startShard(sys: ActorSystem): ActorRef =
+    ClusterSharding(sys).start(
+      shardTypeName,
+      Props[EchoActor](),
+      ClusterShardingSettings(system),
+      extractEntityId,
+      extractShardId)
+
+  def startProxy(sys: ActorSystem): ActorRef =
+    ClusterSharding(sys).startProxy(shardTypeName, None, extractEntityId, extractShardId)
+
+  "Cluster ShardRegion" must {
+
+    "initialize cluster and allocate sharded actors" in {
+      Cluster(sysA).join(Cluster(sysA).selfAddress) // coordinator on A
+      awaitAssert(Cluster(sysA).selfMember.status shouldEqual MemberStatus.Up)
+      Cluster(sysB).join(Cluster(sysA).selfAddress)
+
+      within(10.seconds) {
+        awaitAssert {
+          Set(sysA, sysB).foreach { s =>
+            Cluster(s).sendCurrentClusterState(testActor)
+            expectMsgType[CurrentClusterState].members.size shouldEqual 2
+          }
+        }
+      }
+
+      within(10.seconds) {
+        awaitAssert {
+          for ((region, probe) <- regionProbes; event <- events) {
+            region.tell(event, probe.ref)
+            probe.expectMsg(1.seconds, event)
+          }
+        }
+      }
+    }
+
+    "determine whether the ref to deliver buffered RestartShard events to should receive them" in {
+      within(15.seconds) {
+        awaitAssert {
+          regionProbes.foreach {
+            case (region, probe) =>
+              region.tell(ShardRegion.GetShardRegionState, probe.ref)
+              val states = probe.receiveWhile(messages = 2) {
+                case msg: ShardRegion.CurrentShardRegionState => msg
+              }
+              val shardIds = for {
+                state <- states
+                shard <- state.shards
+              } yield shard.shardId
+
+              shardIds.forall { sid =>
+                !Shard.isShard(shardTypeName, sid, region.path) &&
+                Shard.isShard(shardTypeName, sid, region.path / sid)
+              } shouldEqual true
+          }
+        }
+      }
+    }
+
+    "only deliver RestartShard to the local region" in {
+      // TODO set rememberEntities = on, stop then restart the shard to trigger event/buffering/delivery
+    }
+
+  }
+}

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ShardSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ShardSpec.scala
@@ -6,7 +6,7 @@ package akka.cluster.sharding
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import akka.actor.{ Actor, ActorLogging, PoisonPill, Props }
+import akka.actor.{ Actor, ActorLogging, PoisonPill, Props, RootActorPath }
 import akka.cluster.TestLeaseExt
 import akka.cluster.sharding.ShardRegion.ShardInitialized
 import akka.coordination.lease.LeaseUsageSettings
@@ -92,6 +92,13 @@ class ShardSpec extends AkkaSpec(ShardSpec.config) with ImplicitSender {
       parent.expectMsg(ShardInitialized(shardId))
       lease.getCurrentCallback().apply(Some(BadLease("bye bye lease")))
       probe.expectTerminated(shard)
+    }
+
+    "be differentiated by its ShardId-encoded name from other ActorRefs" in new Setup {
+      val name = Shard.name(shardId)
+      val regionPath = RootActorPath(parent.ref.path.address) / "system" / "sharding" / typeName
+      Shard.isShard(typeName, shardId, regionPath) shouldEqual false
+      Shard.isShard(typeName, shardId, regionPath / name) shouldEqual true
     }
   }
 

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/testkit/ClusterShardingConfig.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/testkit/ClusterShardingConfig.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding.testkit
+
+import akka.cluster.sharding.ClusterShardingSettings
+import akka.testkit.AkkaSpec
+import com.typesafe.config.{ Config, ConfigFactory }
+
+trait ClusterShardingConfig {
+
+  val mode: String = ClusterShardingSettings.StateStoreModeDData
+
+  val rememberEntities: Boolean = false
+
+  val loglevel: String = "INFO"
+
+  val targetDir = s"target/ClusterSharding${AkkaSpec.getCallerName(getClass)}Spec-$mode-remember-$rememberEntities"
+
+  val baseConfig: Config =
+    ConfigFactory.parseString(s"""
+          akka.loglevel = $loglevel
+          akka.actor.provider = "cluster"
+          akka.remote.log-remote-lifecycle-events = off
+          akka.cluster.jmx.enabled = off
+          akka.cluster.sharding.state-store-mode = "$mode"
+          akka.cluster.sharding.distributed-data.durable.lmdb {
+            dir = $targetDir/sharding-ddata
+            map-size = 10 MiB
+          }
+          akka.remote.classic.netty.tcp.port = 0
+          akka.remote.artery.canonical.port = 0
+          """)
+}


### PR DESCRIPTION
 https://github.com/akka/akka/issues/27782

TODO
- [ ] [Clarify and implement the behavior needed when not delivering a buffered RestartShard for a `shardId`](https://github.com/akka/akka/compare/master...helena:restart-shard-ser-issue?expand=1#diff-9d06486133d0565a63482bccb91579c0R956-R969)
- [ ] Complete the last test with the above
