### PR TITLE
missing auto-down config in JoinConfigCompatCheckerSpec, #27840

### DIFF
--- a/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatCheckerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatCheckerSpec.scala
@@ -260,6 +260,7 @@ class JoinConfigCompatCheckerSpec extends AkkaSpec with ClusterTestKit {
 
               # using explicit downing provider class
               downing-provider-class = "akka.cluster.AutoDowning"
+              auto-down-unreachable-after = 0s
 
               configuration-compatibility-check {
                 enforce-on-join = on


### PR DESCRIPTION
Some timing must have changed on Jenkins since this suddenly started failing frequently.

It's anyway wrong.

We don't need this if #27855 is merged first, because I fixed same thing there.

Refs #27840