### PR TITLE
doc: separate page for reference.conf listing, #27798

### DIFF
--- a/akka-docs/src/main/paradox/actors.md
+++ b/akka-docs/src/main/paradox/actors.md
@@ -1067,7 +1067,7 @@ is only used for debugging/logging.
 Tasks added to the same phase are executed in parallel without any ordering assumptions.
 Next phase will not start until all tasks of previous phase have been completed.
 
-If tasks are not completed within a configured timeout (see @ref:[reference.conf](general/configuration.md#config-akka-actor))
+If tasks are not completed within a configured timeout (see @ref:[reference.conf](general/configuration-reference.md#config-akka-actor))
 the next phase will be started anyway. It is possible to configure `recover=off` for a phase
 to abort the rest of the shutdown process if a task fails or is not completed within the timeout.
 

--- a/akka-docs/src/main/paradox/cluster-routing.md
+++ b/akka-docs/src/main/paradox/cluster-routing.md
@@ -80,7 +80,7 @@ Scala
 Java
 :  @@snip [StatsService.java](/akka-docs/src/test/java/jdocs/cluster/StatsService.java) { #router-lookup-in-code }
 
-See @ref:[reference configuration](general/configuration.md#config-akka-cluster) for further descriptions of the settings.
+See @ref:[reference configuration](general/configuration-reference.md#config-akka-cluster) for further descriptions of the settings.
 
 ### Router Example with Group of Routees
 
@@ -185,7 +185,7 @@ Scala
 Java
 :  @@snip [StatsService.java](/akka-docs/src/test/java/jdocs/cluster/StatsService.java) { #router-deploy-in-code }
 
-See @ref:[reference configuration](general/configuration.md#config-akka-cluster) for further descriptions of the settings.
+See @ref:[reference configuration](general/configuration-reference.md#config-akka-cluster) for further descriptions of the settings.
 
 When using a pool of remote deployed routees you must ensure that all parameters of the `Props` can
 be @ref:[serialized](serialization.md).

--- a/akka-docs/src/main/paradox/cluster-usage.md
+++ b/akka-docs/src/main/paradox/cluster-usage.md
@@ -439,4 +439,4 @@ Make sure you understand the security implications of enabling remote monitoring
 ## Configuration
 
 There are several @ref:[configuration](typed/cluster.md#configuration) properties for the cluster,
-and the full @ref:[reference configuration](general/configuration.md#config-akka-cluster) for complete information. 
+and the full @ref:[reference configuration](general/configuration-reference.md#config-akka-cluster) for complete information. 

--- a/akka-docs/src/main/paradox/general/configuration-reference.md
+++ b/akka-docs/src/main/paradox/general/configuration-reference.md
@@ -1,0 +1,114 @@
+# Default configuration
+
+Each Akka module has a `reference.conf` file with the default values.
+
+Make your edits/overrides in your `application.conf`. Don't override default values if
+you are not sure of the implications. [Akka Config Checker](https://doc.akka.io/docs/akka-enhancements/current/config-checker.html)
+is a useful tool for finding potential configuration issues.
+
+The purpose of `reference.conf` files is for libraries, like Akka, to define default values that are used if
+an application doesn't define a more specific value. It's also a good place to document the existence and
+meaning of the configuration properties. One library must not try to override properties in its own `reference.conf`
+for properties originally defined by another library's `reference.conf`, because the effective value would be
+nondeterministic when loading the configuration.`
+
+<a id="config-akka-actor"></a>
+### akka-actor
+
+@@snip [reference.conf](/akka-actor/src/main/resources/reference.conf)
+
+<a id="config-akka-actor-typed"></a>
+### akka-actor-typed
+
+@@snip [reference.conf](/akka-actor-typed/src/main/resources/reference.conf)
+
+<a id="config-akka-cluster-typed"></a>
+### akka-cluster-typed
+
+@@snip [reference.conf](/akka-cluster-typed/src/main/resources/reference.conf)
+
+<a id="config-akka-cluster"></a>
+### akka-cluster
+
+@@snip [reference.conf](/akka-cluster/src/main/resources/reference.conf)
+
+<a id="config-akka-discovery"></a>
+### akka-discovery
+
+@@snip [reference.conf](/akka-discovery/src/main/resources/reference.conf)
+
+<a id="config-akka-coordination"></a>
+### akka-coordination
+
+@@snip [reference.conf](/akka-coordination/src/main/resources/reference.conf)
+
+<a id="config-akka-multi-node-testkit"></a>
+### akka-multi-node-testkit
+
+@@snip [reference.conf](/akka-multi-node-testkit/src/main/resources/reference.conf)
+
+<a id="config-akka-persistence-typed"></a>
+### akka-persistence-typed
+
+@@snip [reference.conf](/akka-persistence-typed/src/main/resources/reference.conf)
+
+<a id="config-akka-persistence"></a>
+### akka-persistence
+
+@@snip [reference.conf](/akka-persistence/src/main/resources/reference.conf)
+
+<a id="config-akka-persistence-query"></a>
+### akka-persistence-query
+
+@@snip [reference.conf](/akka-persistence-query/src/main/resources/reference.conf)
+
+<a id="config-akka-remote-artery"></a>
+### akka-remote artery
+
+@@snip [reference.conf](/akka-remote/src/main/resources/reference.conf) { #shared #artery type=none }
+
+<a id="config-akka-remote"></a>
+### akka-remote classic (deprecated)
+
+@@snip [reference.conf](/akka-remote/src/main/resources/reference.conf) { #shared #classic type=none }
+
+<a id="config-akka-testkit"></a>
+### akka-testkit
+
+@@snip [reference.conf](/akka-testkit/src/main/resources/reference.conf)
+
+<a id="config-cluster-metrics"></a>
+### akka-cluster-metrics
+
+@@snip [reference.conf](/akka-cluster-metrics/src/main/resources/reference.conf)
+
+<a id="config-cluster-tools"></a>
+### akka-cluster-tools
+
+@@snip [reference.conf](/akka-cluster-tools/src/main/resources/reference.conf)
+
+<a id="config-cluster-sharding-typed"></a>
+### akka-cluster-sharding-typed
+
+@@snip [reference.conf](/akka-cluster-sharding-typed/src/main/resources/reference.conf)
+
+<a id="config-cluster-sharding"></a>
+### akka-cluster-sharding
+
+@@snip [reference.conf](/akka-cluster-sharding/src/main/resources/reference.conf)
+
+<a id="config-distributed-data"></a>
+### akka-distributed-data
+
+@@snip [reference.conf](/akka-distributed-data/src/main/resources/reference.conf)
+
+<a id="config-akka-stream"></a>
+### akka-stream
+
+@@snip [reference.conf](/akka-stream/src/main/resources/reference.conf)
+
+<a id="config-akka-stream-testkit"></a>
+### akka-stream-testkit
+
+@@snip [reference.conf](/akka-stream-testkit/src/main/resources/reference.conf)
+

--- a/akka-docs/src/main/paradox/general/configuration.md
+++ b/akka-docs/src/main/paradox/general/configuration.md
@@ -5,10 +5,10 @@ are provided. Later on you might need to amend the settings to change the defaul
 or adapt for specific runtime environments. Typical examples of settings that you
 might amend:
 
- * log level and logger backend for the Akka internals
- * enable remoting
- * message serializers
- * tuning of dispatchers
+ * @ref:[log level and logger backend](../typed/logging.md)
+ * @ref:[enable Cluster](../typed/cluster.md)
+ * @ref:[message serializers](../serialization.md)
+ * @ref:[tuning of dispatchers](../typed/dispatchers.md)
 
 Akka uses the [Typesafe Config Library](https://github.com/lightbend/config), which might also be a good choice
 for the configuration of your own application or library built with or without
@@ -348,104 +348,4 @@ override the earlier stuff.
 ## Listing of the Reference Configuration
 
 Each Akka module has a reference configuration file with the default values.
-
-<a id="config-akka-actor"></a>
-### akka-actor
-
-@@snip [reference.conf](/akka-actor/src/main/resources/reference.conf)
-
-<a id="config-akka-actor-typed"></a>
-### akka-actor-typed
-
-@@snip [reference.conf](/akka-actor-typed/src/main/resources/reference.conf)
-
-<a id="config-akka-cluster-typed"></a>
-### akka-cluster-typed
-
-@@snip [reference.conf](/akka-cluster-typed/src/main/resources/reference.conf)
-
-<a id="config-akka-cluster"></a>
-### akka-cluster
-
-@@snip [reference.conf](/akka-cluster/src/main/resources/reference.conf)
-
-<a id="config-akka-discovery"></a>
-### akka-discovery
-
-@@snip [reference.conf](/akka-discovery/src/main/resources/reference.conf)
-
-<a id="config-akka-coordination"></a>
-### akka-coordination
-
-@@snip [reference.conf](/akka-coordination/src/main/resources/reference.conf)
-
-<a id="config-akka-multi-node-testkit"></a>
-### akka-multi-node-testkit
-
-@@snip [reference.conf](/akka-multi-node-testkit/src/main/resources/reference.conf)
-
-<a id="config-akka-persistence-typed"></a>
-### akka-persistence-typed
-
-@@snip [reference.conf](/akka-persistence-typed/src/main/resources/reference.conf)
-
-<a id="config-akka-persistence"></a>
-### akka-persistence
-
-@@snip [reference.conf](/akka-persistence/src/main/resources/reference.conf)
-
-<a id="config-akka-persistence-query"></a>
-### akka-persistence-query
-
-@@snip [reference.conf](/akka-persistence-query/src/main/resources/reference.conf)
-
-<a id="config-akka-remote-artery"></a>
-### akka-remote artery
-
-@@snip [reference.conf](/akka-remote/src/main/resources/reference.conf) { #shared #artery type=none }
-
-<a id="config-akka-remote"></a>
-### akka-remote classic (deprecated)
-
-@@snip [reference.conf](/akka-remote/src/main/resources/reference.conf) { #shared #classic type=none }
-
-<a id="config-akka-testkit"></a>
-### akka-testkit
-
-@@snip [reference.conf](/akka-testkit/src/main/resources/reference.conf)
-
-<a id="config-cluster-metrics"></a>
-### akka-cluster-metrics
-
-@@snip [reference.conf](/akka-cluster-metrics/src/main/resources/reference.conf)
-
-<a id="config-cluster-tools"></a>
-### akka-cluster-tools
-
-@@snip [reference.conf](/akka-cluster-tools/src/main/resources/reference.conf)
-
-<a id="config-cluster-sharding-typed"></a>
-### akka-cluster-sharding-typed
-
-@@snip [reference.conf](/akka-cluster-sharding-typed/src/main/resources/reference.conf)
-
-<a id="config-cluster-sharding"></a>
-### akka-cluster-sharding
-
-@@snip [reference.conf](/akka-cluster-sharding/src/main/resources/reference.conf)
-
-<a id="config-distributed-data"></a>
-### akka-distributed-data
-
-@@snip [reference.conf](/akka-distributed-data/src/main/resources/reference.conf)
-
-<a id="config-akka-stream"></a>
-### akka-stream
-
-@@snip [reference.conf](/akka-stream/src/main/resources/reference.conf)
-
-<a id="config-akka-stream-testkit"></a>
-### akka-stream-testkit
-
-@@snip [reference.conf](/akka-stream-testkit/src/main/resources/reference.conf)
-
+Those `reference.conf` files are listed in @ref[Default configuration](configuration-reference.md)

--- a/akka-docs/src/main/paradox/general/index.md
+++ b/akka-docs/src/main/paradox/general/index.md
@@ -13,5 +13,6 @@
 * [jmm](jmm.md)
 * [message-delivery-reliability](message-delivery-reliability.md)
 * [configuration](configuration.md)
+* [configuration-reference](configuration-reference.md)
 
 @@@

--- a/akka-docs/src/main/paradox/multi-node-testing.md
+++ b/akka-docs/src/main/paradox/multi-node-testing.md
@@ -207,4 +207,4 @@ thread. This also means that you shouldn't use them from inside an actor, a futu
 ## Configuration
 
 There are several configuration properties for the Multi-Node Testing module, please refer
-to the @ref:[reference configuration](general/configuration.md#config-akka-multi-node-testkit).
+to the @ref:[reference configuration](general/configuration-reference.md#config-akka-multi-node-testkit).

--- a/akka-docs/src/main/paradox/persistence.md
+++ b/akka-docs/src/main/paradox/persistence.md
@@ -851,7 +851,7 @@ When testing Persistence based projects always rely on @ref:[asynchronous messag
 ## Configuration
 
 There are several configuration properties for the persistence module, please refer
-to the @ref:[reference configuration](general/configuration.md#config-akka-persistence).
+to the @ref:[reference configuration](general/configuration-reference.md#config-akka-persistence).
 
 The @ref:[journal and snapshot store plugins](persistence-plugins.md) have specific configuration, see
 reference documentation of the chosen plugin.

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -230,7 +230,7 @@ For TCP:
 
 Classic remoting is deprecated but can be used in `2.6.` Explicitly disable Artery by setting property `akka.remote.artery.enabled` to `false`. Further, any configuration under `akka.remote` that is
 specific to classic remoting needs to be moved to `akka.remote.classic`. To see which configuration options
-are specific to classic search for them in: @ref:[`akka-remote/reference.conf`](../general/configuration.md#config-akka-remote).
+are specific to classic search for them in: @ref:[`akka-remote/reference.conf`](../general/configuration-reference.md#config-akka-remote).
 
 ## Java Serialization
 

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -178,8 +178,8 @@ akka.remote.artery.canonical.port = 2552
 ```
 
 The configuration for Artery is different, so you might have to revisit any custom configuration. See the full
-@ref:[reference configuration for Artery](../general/configuration.md#config-akka-remote-artery) and
-@ref:[reference configuration for classic remoting](../general/configuration.md#config-akka-remote).
+@ref:[reference configuration for Artery](../general/configuration-reference.md#config-akka-remote-artery) and
+@ref:[reference configuration for classic remoting](../general/configuration-reference.md#config-akka-remote).
 
 @@@ note
 

--- a/akka-docs/src/main/paradox/remoting-artery.md
+++ b/akka-docs/src/main/paradox/remoting-artery.md
@@ -652,7 +652,7 @@ Note that lowest latency can be achieved with `inbound-lanes=1` and `outbound-la
 
 Also note that the total amount of parallel tasks are bound by the `remote-dispatcher` and the thread pool size should not exceed the number of CPU cores minus headroom for actually processing the messages in the application, i.e. in practice the the pool size should be less than half of the number of cores.
 
-See `inbound-lanes` and `outbound-lanes` in the @ref:[reference configuration](general/configuration.md#config-akka-remote-artery) for default values.
+See `inbound-lanes` and `outbound-lanes` in the @ref:[reference configuration](general/configuration-reference.md#config-akka-remote-artery) for default values.
 
 ### Dedicated subchannel for large messages
 
@@ -797,7 +797,7 @@ the system might have less latency than at low message rates.
 ## Remote Configuration
 
 There are lots of configuration properties that are related to remoting in Akka. We refer to the
-@ref:[reference configuration](general/configuration.md#config-akka-remote-artery) for more information.
+@ref:[reference configuration](general/configuration-reference.md#config-akka-remote-artery) for more information.
 
 @@@ note
 

--- a/akka-docs/src/main/paradox/remoting.md
+++ b/akka-docs/src/main/paradox/remoting.md
@@ -584,7 +584,7 @@ marking them `PossiblyHarmful` so that a client cannot forge them.
 ## Remote Configuration
 
 There are lots of configuration properties that are related to remoting in Akka. We refer to the
-@ref:[reference configuration](general/configuration.md#config-akka-remote) for more information.
+@ref:[reference configuration](general/configuration-reference.md#config-akka-remote) for more information.
 
 @@@ note
 

--- a/akka-docs/src/main/paradox/testing.md
+++ b/akka-docs/src/main/paradox/testing.md
@@ -317,7 +317,7 @@ His full example is also available @ref:[here](testing.md#example).
 The tight timeouts you use during testing on your lightning-fast notebook will
 invariably lead to spurious test failures on the heavily loaded Jenkins server
 (or similar). To account for this situation, all maximum durations are
-internally scaled by a factor taken from the @ref:[Configuration](general/configuration.md#config-akka-testkit),
+internally scaled by a factor taken from the @ref:[Configuration](general/configuration-reference.md#config-akka-testkit),
 `akka.test.timefactor`, which defaults to 1.
 
 You can scale other durations with the same factor by using the @scala[implicit conversion
@@ -712,13 +712,13 @@ options:
 
 @@@ div { .group-scala }
 * *Logging of message invocations on certain actors*
-   This is enabled by a setting in the @ref:[Configuration](general/configuration.md#config-akka-actor) — namely
+   This is enabled by a setting in the @ref:[Configuration](general/configuration-reference.md#config-akka-actor) — namely
 `akka.actor.debug.receive` — which enables the `loggable`
 statement to be applied to an actor’s `receive` function:
 
 @@snip [TestkitDocSpec.scala](/akka-docs/src/test/scala/docs/testkit/TestkitDocSpec.scala) { #logging-receive }
 
-If the aforementioned setting is not given in the @ref:[Configuration](general/configuration.md#config-akka-actor), this method will
+If the aforementioned setting is not given in the @ref:[Configuration](general/configuration-reference.md#config-akka-actor), this method will
 pass through the given `Receive` function unmodified, meaning that
 there is no runtime cost unless actually enabled.
 
@@ -807,7 +807,7 @@ when writing the tests or alternatively the `sequential` keyword.
 ## Configuration
 
 There are several configuration properties for the TestKit module, please refer
-to the @ref:[reference configuration](general/configuration.md#config-akka-testkit).
+to the @ref:[reference configuration](general/configuration-reference.md#config-akka-testkit).
 
 @@@ div { .group-scala }
 

--- a/akka-docs/src/main/paradox/typed/cluster.md
+++ b/akka-docs/src/main/paradox/typed/cluster.md
@@ -367,7 +367,7 @@ Akka comes with and uses several types of testing strategies:
 ## Configuration
 
 There are several configuration properties for the cluster. Refer to the 
-@ref:[reference configuration](../general/configuration.md#config-akka-cluster) for full
+@ref:[reference configuration](../general/configuration-reference.md#config-akka-cluster) for full
 configuration descriptions, default values and options.
 
 ### How To Startup when a Cluster size is reached

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -618,7 +618,7 @@ supports active-active persistent entities across data centers.
 ## Configuration
 
 There are several configuration properties for the persistence module, please refer
-to the @ref:[reference configuration](../general/configuration.md#config-akka-persistence).
+to the @ref:[reference configuration](../general/configuration-reference.md#config-akka-persistence).
 
 The @ref:[journal and snapshot store plugins](../persistence-plugins.md) have specific configuration, see
 reference documentation of the chosen plugin.


### PR DESCRIPTION
Place the listings of reference.conf in separate page.

Also some additional clarification of application.conf vs reference.conf, and libraries.

Not exactly as suggested in ticket, but I think there is an advantage of having all of them listed in one place.

Refs #27798