### PR TITLE
Docs: add project info boxes

### DIFF
--- a/akka-docs/src/main/paradox/actors.md
+++ b/akka-docs/src/main/paradox/actors.md
@@ -2,6 +2,8 @@
 
 @@include[includes.md](includes.md) { #actor-api }
 
+@@project-info{ projectId="akka-actor" }
+
 ## Dependency
 
 To use Classic Actors, you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/cluster-client.md
+++ b/akka-docs/src/main/paradox/cluster-client.md
@@ -9,6 +9,8 @@ It is not advised to build new applications with Cluster Client, and existing us
 
 @@include[includes.md](includes.md) { #actor-api }
 
+@@project-info{ projectId="akka-cluster-tools" }
+
 ## Dependency
 
 To use Cluster Client, you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/cluster-metrics.md
+++ b/akka-docs/src/main/paradox/cluster-metrics.md
@@ -1,5 +1,7 @@
 # Classic Cluster Metrics Extension
 
+@@project-info{ projectId="akka-cluster-metrics" }
+
 ## Dependency
 
 To use Cluster Metrics Extension, you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/cluster-sharding.md
@@ -3,6 +3,8 @@
 @@include[includes.md](includes.md) { #actor-api }
 For the full documentation of this feature and for new projects see @ref:[Cluster Sharding](typed/cluster-sharding.md).
 
+@@project-info{ projectId="akka-cluster-sharding" }
+
 ## Dependency
 
 To use Cluster Sharding, you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/cluster-singleton.md
+++ b/akka-docs/src/main/paradox/cluster-singleton.md
@@ -3,6 +3,8 @@
 @@include[includes.md](includes.md) { #actor-api }
 For the full documentation of this feature and for new projects see @ref:[Cluster Singleton](typed/cluster-singleton.md).
 
+@@project-info{ projectId="akka-cluster-tools" }
+
 ## Dependency
 
 To use Cluster Singleton, you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/cluster-usage.md
+++ b/akka-docs/src/main/paradox/cluster-usage.md
@@ -19,6 +19,8 @@ recommendation if you don't have other preferences or constraints.
 
 @@@
 
+@@project-info{ projectId="akka-cluster" }
+
 ## Dependency
 
 To use Akka Cluster add the following dependency in your project:

--- a/akka-docs/src/main/paradox/coordination.md
+++ b/akka-docs/src/main/paradox/coordination.md
@@ -5,6 +5,8 @@ project.description: A distributed lock with Akka Coordination using a pluggable
 
 Akka Coordination is a set of tools for distributed coordination.
 
+@@project-info{ projectId="akka-coordination" }
+
 ## Dependency
 
 @@dependency[sbt,Gradle,Maven] {

--- a/akka-docs/src/main/paradox/discovery/index.md
+++ b/akka-docs/src/main/paradox/discovery/index.md
@@ -31,6 +31,8 @@ See @ref:[Migration hints](#migrating-from-akka-management-discovery-before-1-0-
 
 @@@
 
+@@project-info{ projectId="akka-discovery" }
+
 ## Dependency
 
 @@dependency[sbt,Gradle,Maven] {

--- a/akka-docs/src/main/paradox/distributed-pub-sub.md
+++ b/akka-docs/src/main/paradox/distributed-pub-sub.md
@@ -3,6 +3,8 @@
 @@include[includes.md](includes.md) { #actor-api }
 For the new API see FIXME https://github.com/akka/akka/issues/26338.
 
+@@project-info{ projectId="akka-cluster-tools" }
+
 ## Dependency
 
 To use Distributed Publish Subscribe you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/logging.md
+++ b/akka-docs/src/main/paradox/logging.md
@@ -3,6 +3,8 @@
 @@include[includes.md](includes.md) { #actor-api }
 For the new API see @ref[Logging](typed/logging.md).
 
+@@project-info{ projectId="akka-slf4j" }
+
 ## Dependency
 
 To use Logging, you must at least use the Akka actors dependency in your project, and will most likely want to configure logging via the SLF4J module (@ref:[see below](#slf4j)), or use `java.util.logging` (@ref:[see below](#java-util-logging)).

--- a/akka-docs/src/main/paradox/multi-node-testing.md
+++ b/akka-docs/src/main/paradox/multi-node-testing.md
@@ -3,6 +3,8 @@ project.description: Multi node testing of distributed systems built with Akka.
 ---
 # Multi Node Testing
 
+@@project-info{ projectId="akka-multi-node-testkit" }
+
 ## Dependency
 
 To use Multi Node Testing, you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/persistence.md
+++ b/akka-docs/src/main/paradox/persistence.md
@@ -6,6 +6,8 @@ project.description: Akka Persistence Classic, event sourcing with Akka, At-Leas
 @@include[includes.md](includes.md) { #actor-api }
 For the full documentation of this feature and for new projects see @ref:[persistence](typed/persistence.md).
 
+@@project-info{ projectId="akka-persistence" }
+
 ## Dependency
 
 To use Akka Persistence, you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/remoting.md
+++ b/akka-docs/src/main/paradox/remoting.md
@@ -20,6 +20,8 @@ such as [HTTP](https://doc.akka.io/docs/akka-http/current/),
 
 @@@
 
+@@project-info{ projectId="akka-remote" }
+
 ## Dependency
 
 To use Akka Remoting, you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/stream/index.md
+++ b/akka-docs/src/main/paradox/stream/index.md
@@ -3,6 +3,8 @@ project.description: An intuitive and safe way to do asynchronous, non-blocking 
 ---
 # Streams
 
+@@project-info{ projectId="akka-stream" }
+
 ## Dependency
 
 To use Akka Streams, add the module to your project:

--- a/akka-docs/src/main/paradox/testing.md
+++ b/akka-docs/src/main/paradox/testing.md
@@ -3,6 +3,8 @@
 @@include[includes.md](includes.md) { #actor-api }
 For the new API see @ref[testing](typed/testing.md).
 
+@@project-info{ projectId="akka-testkit" }
+
 ## Dependency
 
 To use Akka Testkit, you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/typed/actors.md
+++ b/akka-docs/src/main/paradox/typed/actors.md
@@ -7,6 +7,8 @@ project.description: The Actor model, managing internal state and changing behav
 For the Akka Classic documentation of this feature see @ref:[Classic Actors](../actors.md).
 @@@
 
+@@project-info{ projectId="akka-actor-typed" }
+
 ## Dependency
 
 To use Akka Actor Typed, you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -7,6 +7,8 @@ project.description: Shard a clustered compute process across the network with l
 For the Akka Classic documentation of this feature see @ref:[Classic Cluster Sharding](../cluster-sharding.md)
 @@@
 
+@@project-info{ projectId="akka-cluster-sharding-typed" }
+
 ## Dependency
 
 To use Akka Cluster Sharding, you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/typed/cluster-singleton.md
+++ b/akka-docs/src/main/paradox/typed/cluster-singleton.md
@@ -4,6 +4,8 @@
 For the Akka Classic documentation of this feature see @ref:[Classic Cluster Singleton](../cluster-singleton.md).
 @@@
 
+@@project-info{ projectId="akka-cluster-typed" }
+
 ## Dependency
 
 To use Cluster Singleton, you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/typed/cluster.md
+++ b/akka-docs/src/main/paradox/typed/cluster.md
@@ -21,6 +21,8 @@ You have to enable @ref:[serialization](../serialization.md)  to send messages b
 @ref:[Serialization with Jackson](../serialization-jackson.md) is a good choice in many cases, and our
 recommendation if you don't have other preferences or constraints.
 
+@@project-info{ projectId="akka-cluster-typed" }
+
 ## Dependency
 
 To use Akka Cluster add the following dependency in your project:

--- a/akka-docs/src/main/paradox/typed/distributed-data.md
+++ b/akka-docs/src/main/paradox/typed/distributed-data.md
@@ -7,6 +7,8 @@ project.description: Share data between nodes and perform updates without coordi
 For the Akka Classic documentation of this feature see @ref:[Classic Distributed Data](../distributed-data.md).
 @@@
 
+@@project-info{ projectId="akka-cluster-typed" }
+
 ## Dependency
 
 To use Akka Cluster Distributed Data Typed, you must add the following dependency in your project:

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -19,6 +19,8 @@ project.description: Event Sourcing with Akka Persistence enables actors to pers
 For the Akka Classic documentation of this feature see @ref:[Classic Akka Persistence](../persistence.md).
 @@@
 
+@@project-info{ projectId="akka-persistence-typed" }
+
 ## Dependency
 
 To use Akka Persistence Typed, add the module to your project:

--- a/akka-docs/src/main/paradox/typed/stream.md
+++ b/akka-docs/src/main/paradox/typed/stream.md
@@ -1,5 +1,7 @@
 # Streams
 
+@@project-info{ projectId="akka-stream-typed" }
+
 ## Dependency
 
 To use Akka Streams Typed, add the module to your project:

--- a/akka-docs/src/main/paradox/typed/testing.md
+++ b/akka-docs/src/main/paradox/typed/testing.md
@@ -4,6 +4,8 @@
 For the Akka Classic documentation of this feature see @ref:[Classic Testing](../testing.md).
 @@@
 
+@@project-info{ projectId="akka-actor-testkit-typed" }
+
 ## Dependency
 
 To use Akka TestKit add the module to your project:

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -10,10 +10,10 @@ import java.util.Properties
 import java.time.format.DateTimeFormatter
 import java.time.ZonedDateTime
 import java.time.ZoneOffset
+import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys._
 
 import sbt.Keys._
 import sbt._
-
 import JdkOptions.autoImport._
 import scala.collection.breakOut
 
@@ -64,7 +64,9 @@ object AkkaBuild {
     UnidocRoot.akkaSettings,
     Protobuf.settings,
     parallelExecution in GlobalScope := System.getProperty("akka.parallelExecution", parallelExecutionByDefault.toString).toBoolean,
-      version in ThisBuild := akkaVersion
+    version in ThisBuild := akkaVersion,
+    // used for linking to API docs (overwrites `project-info.version`)
+    ThisBuild / projectInfoVersion := { if (isSnapshot.value) "snapshot" else version.value }
   )
 
   lazy val mayChangeSettings = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,6 +17,7 @@ addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.2")
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.24")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-apidoc" % "0.2")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-project-info" % "1.1.2")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.6.5")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.17")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0") // for maintenance of copyright file header

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -4,20 +4,16 @@ project-info {
   javadoc: "https://doc.akka.io/japi/akka/"${project-info.version}"/index.html"
   shared-info {
     jdk-versions: ["Adopt OpenJDK 8", "Adopt OpenJDK 11"]
-//    snapshots: {
-//      url: "other-docs/snapshots.html"
-//      text: "Snapshots are available"
-//      new-tab: false
-//    }
+    // snapshots: { }
     issues: {
       url: "https://github.com/akka/akka/issues"
       text: "Github issues"
     }
-//    release-notes: {
-//      url: "https://doc.akka.io/docs/alpakka/current/release-notes/index.html"
-//      text: "In the documentation"
-//      new-tab: false
-//    }
+    release-notes: {
+      url: "https://akka.io/blog/news-archive.html"
+      text: "akka.io blog"
+      new-tab: false
+    }
     forums: [
       {
         text: "Lightbend Discuss"

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -1,0 +1,551 @@
+project-info {
+  version: "current"
+  scaladoc: "https://doc.akka.io/api/akka/"${project-info.version}"/akka/"
+  javadoc: "https://doc.akka.io/japi/akka/"${project-info.version}"/index.html"
+  shared-info {
+    jdk-versions: ["Adopt OpenJDK 8", "Adopt OpenJDK 11"]
+//    snapshots: {
+//      url: "other-docs/snapshots.html"
+//      text: "Snapshots are available"
+//      new-tab: false
+//    }
+    issues: {
+      url: "https://github.com/akka/akka/issues"
+      text: "Github issues"
+    }
+//    release-notes: {
+//      url: "https://doc.akka.io/docs/alpakka/current/release-notes/index.html"
+//      text: "In the documentation"
+//      new-tab: false
+//    }
+    forums: [
+      {
+        text: "Lightbend Discuss"
+        url: "https://discuss.akka.io"
+      }
+      {
+        text: "akka/akka Gitter channel"
+        url: "https://gitter.im/akka/akka"
+      }
+    ]
+  }
+  akka-actor: ${project-info.shared-info} {
+    title: "Akka Actors (classic)"
+    jpms-name: "akka.actor"
+    levels: [
+      {
+        readiness: Supported
+        since: "2012-03-06"
+        since-version: "2.0"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"actor/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/actor/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-actor-testkit-typed: ${project-info.shared-info} {
+    title: "Akka Actor Testkit (typed)"
+    jpms-name: "akka.actor.testkit.typed"
+    levels: [
+      {
+        readiness: Supported
+        since: "2019-12-31"
+        since-version: "2.6.0"
+      }
+      {
+        readiness: Incubating
+        since: "2019-05-21"
+        since-version: "2.6.0-M1"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"actor/testkit/typed/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/actor/testkit/typed/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-actor-typed: ${project-info.shared-info} {
+    title: "Akka Actors (typed)"
+    jpms-name: "akka.actor.typed"
+    levels: [
+      {
+        readiness: Supported
+        since: "2019-12-31"
+        since-version: "2.6.0"
+      }
+      {
+        readiness: Incubating
+        since: "2019-05-21"
+        since-version: "2.6.0-M1"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"actor/typed/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/actor/typed/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-cluster: ${project-info.shared-info} {
+    title: "Akka Cluster (classic)"
+    jpms-name: "akka.cluster"
+    levels: [
+      {
+        readiness: Supported
+        since: "2013-07-09"
+        since-version: "2.2.0"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"cluster/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/cluster/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-cluster-metrics: ${project-info.shared-info} {
+    title: "Akka Cluster Metrics (classic)"
+    jpms-name: "akka.cluster.metrics"
+    levels: [
+      {
+        readiness: Supported
+        since: "2014-03-05"
+        since-version: "2.3.0"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"cluster/metrics/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/cluster/metrics/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-cluster-sharding: ${project-info.shared-info} {
+    title: "Akka Cluster Sharding (classic)"
+    jpms-name: "akka.cluster.sharding"
+    levels: [
+      {
+        readiness: Supported
+        since: "2014-03-05"
+        since-version: "2.3.0"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"cluster/sharding/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/cluster/sharding/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-cluster-sharding-typed: ${project-info.shared-info} {
+    title: "Akka Cluster Sharding (typed)"
+    jpms-name: "akka.cluster.sharding.typed"
+    levels: [
+      {
+        readiness: Supported
+        since: "2019-12-31"
+        since-version: "2.6.0"
+      }
+      {
+        readiness: Incubating
+        since: "2019-05-21"
+        since-version: "2.6.0-M1"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"cluster/sharding/typed/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/cluster/sharding/typed/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-cluster-tools: ${project-info.shared-info} {
+    title: "Akka Cluster Tools (classic)"
+    jpms-name: "akka.cluster.tools"
+    levels: [
+      {
+        readiness: Supported
+        since: "2014-03-05"
+        since-version: "2.3.0"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"cluster/tools/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/cluster/tools/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-cluster-typed: ${project-info.shared-info} {
+    title: "Akka Cluster (typed)"
+    jpms-name: "akka.cluster.typed"
+    levels: [
+      {
+        readiness: Supported
+        since: "2019-12-31"
+        since-version: "2.6.0"
+      }
+      {
+        readiness: Incubating
+        since: "2019-05-21"
+        since-version: "2.6.0-M1"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"cluster/typed/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/cluster/typed/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-coordination: ${project-info.shared-info} {
+    title: "Akka Coordination"
+    jpms-name: "akka.coordination"
+    levels: [
+      {
+        readiness: Supported
+        since: "2019-04-03"
+        since-version: "2.5.22"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"coordination/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/coordination/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-discovery: ${project-info.shared-info} {
+    title: "Akka Discovery"
+    jpms-name: "akka.discovery"
+    levels: [
+      {
+        readiness: Supported
+        since: "2018-12-07"
+        since-version: "2.5.19"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"discovery/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/discovery/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-distributed-data: ${project-info.shared-info} {
+    title: "Akka Distributed Data (classic)"
+    jpms-name: "akka.cluster.ddata"
+    levels: [
+      {
+        readiness: Supported
+        since: "2018-12-07"
+        since-version: "2.5.19"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"discovery/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/discovery/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-multi-node-testkit: ${project-info.shared-info} {
+    title: "Akka Multi-node Testkit"
+    jpms-name: "akka.remote.testkit"
+    levels: [
+      {
+        readiness: Supported
+        since: "2017-04-13"
+        since-version: "before 2.5.0"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"remote/testkit/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/remote/testkit/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-osgi: ${project-info.shared-info} {
+    title: "Akka OSGi"
+    jpms-name: "akka.osgi"
+    levels: [
+      {
+        readiness: CommunityDriven
+        since: "2017-04-13"
+        since-version: "before 2.5.0"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"osgi/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/osgi/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-persistence: ${project-info.shared-info} {
+    title: "Akka Persistence (classic)"
+    jpms-name: "akka.persistence"
+    levels: [
+      {
+        readiness: Supported
+        since: "2014-03-05"
+        since-version: "2.3.0"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"persistence/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/persistence/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-persistence-query: ${project-info.shared-info} {
+    title: "Akka Persistence Query"
+    jpms-name: "akka.persistence.query"
+    levels: [
+      {
+        readiness: Supported
+        since: "2017-04-13"
+        since-version: "before 2.5.0"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"persistence/query/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/persistence/query/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-persistence-typed: ${project-info.shared-info} {
+    title: "Akka Event Sourcing (typed)"
+    jpms-name: "akka.persistence.typed"
+    levels: [
+      {
+        readiness: Supported
+        since: "2019-12-31"
+        since-version: "2.6.0"
+      }
+      {
+        readiness: Incubating
+        since: "2019-05-21"
+        since-version: "2.6.0-M1"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"persistence/typed/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/persistence/typed/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-remote: ${project-info.shared-info} {
+    title: "Akka Remoting"
+    jpms-name: "akka.remote"
+    levels: [
+      {
+        readiness: Supported
+        since: "2019-12-31"
+        since-version: "2.6.0"
+        note: "Classic remoting is deprecated and will be removed in Akka 2.7.0."
+      }
+      {
+        readiness: Supported
+        since: "2013-07-09"
+        since-version: "2.2.0"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"remote/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/remote/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-slf4j: ${project-info.shared-info} {
+    title: "Akka Logging (classic)"
+    jpms-name: "akka.slf4j"
+    levels: [
+      {
+        readiness: Supported
+        since: "2015-09-30"
+        since-version: "2.4.0"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"slf4j/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/slf4j/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-stream: ${project-info.shared-info} {
+    title: "Akka Streams"
+    jpms-name: "akka.stream"
+    levels: [
+      {
+        readiness: Supported
+        since: "2017-04-13"
+        since-version: "2.5.0"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"stream/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/stream/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-stream-testkit: ${project-info.shared-info} {
+    title: "Akka Stream Testkit"
+    jpms-name: "akka.stream.testkit"
+    levels: [
+      {
+        readiness: Supported
+        since: "2017-04-13"
+        since-version: "2.5.0"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"stream/testkit/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/stream/testkit/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-stream-typed: ${project-info.shared-info} {
+    title: "Akka Stream (typed)"
+    jpms-name: "akka.stream"
+    levels: [
+      {
+        readiness: Supported
+        since: "2019-12-31"
+        since-version: "2.6.0"
+      }
+      {
+        readiness: Incubating
+        since: "2019-05-21"
+        since-version: "2.6.0-M1"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"stream/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/stream/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+  akka-testkit: ${project-info.shared-info} {
+    title: "Akka Actor Testkit (classic)"
+    jpms-name: "akka.actor.testkit"
+    levels: [
+      {
+        readiness: Supported
+        since: "2012-03-06"
+        since-version: "2.0"
+      }
+    ]
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"testkit/index.html"
+        text: "API (Scaladoc)"
+      }
+      {
+        url: ${project-info.javadoc}"?akka/testkit/package-summary.html"
+        text: "API (Javadoc)"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Purpose

Adds project-info boxes for all modules with the [sbt-paradox-project-info](https://github.com/lightbend/sbt-paradox-project-info/) plugin.

## References

Issue https://github.com/akka/akka/issues/27601

## Changes

* Add the `sbt-paradox-project-info` plugin
* Use the `project-info` directive in the main page of each module
* Add project-info configuration

Most "Supported Since" dates and versions are conservative guesses.