### PR TITLE
use CBOR in some tests instead of custom serializers

### DIFF
--- a/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/PingSerializerExampleTest.java
+++ b/akka-cluster-typed/src/test/java/jdocs/akka/cluster/typed/PingSerializerExampleTest.java
@@ -48,7 +48,13 @@ public class PingSerializerExampleTest {
     public String manifest(Object obj) {
       if (obj instanceof Ping) return PING_MANIFEST;
       else if (obj instanceof Pong) return PONG_MANIFEST;
-      else throw new IllegalArgumentException("Unknown type: " + obj);
+      else
+        throw new IllegalArgumentException(
+            "Can't serialize object of type "
+                + obj.getClass()
+                + " in ["
+                + getClass().getName()
+                + "]");
     }
 
     @Override
@@ -58,11 +64,17 @@ public class PingSerializerExampleTest {
             .toSerializationFormat(((Ping) obj).replyTo)
             .getBytes(StandardCharsets.UTF_8);
       else if (obj instanceof Pong) return new byte[0];
-      else throw new IllegalArgumentException("Unknown type: " + obj);
+      else
+        throw new IllegalArgumentException(
+            "Can't serialize object of type "
+                + obj.getClass()
+                + " in ["
+                + getClass().getName()
+                + "]");
     }
 
     @Override
-    public Object fromBinary(byte[] bytes, String manifest) throws NotSerializableException {
+    public Object fromBinary(byte[] bytes, String manifest) {
       if (PING_MANIFEST.equals(manifest)) {
         String str = new String(bytes, StandardCharsets.UTF_8);
         ActorRef<Pong> ref = actorRefResolver.resolveActorRef(str);
@@ -70,7 +82,7 @@ public class PingSerializerExampleTest {
       } else if (PONG_MANIFEST.equals(manifest)) {
         return new Pong();
       } else {
-        throw new NotSerializableException("Unable to handle manifest: " + manifest);
+        throw new IllegalArgumentException("Unable to handle manifest: " + manifest);
       }
     }
   }

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ActorSystemSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ActorSystemSpec.scala
@@ -4,6 +4,8 @@
 
 package akka.cluster.typed
 
+import java.nio.charset.StandardCharsets
+
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
@@ -11,20 +13,46 @@ import scala.util.control.NonFatal
 
 import akka.Done
 import akka.actor.CoordinatedShutdown
+import akka.actor.ExtendedActorSystem
 import akka.actor.InvalidMessageException
 import akka.actor.testkit.typed.scaladsl.TestInbox
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorRefResolver
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
 import akka.actor.typed.PostStop
 import akka.actor.typed.scaladsl.adapter._
 import akka.actor.typed.scaladsl.Behaviors
+import akka.serialization.SerializerWithStringManifest
 import com.typesafe.config.ConfigFactory
 import org.scalatest._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.Span
+
+object ActorSystemSpec {
+
+  class TestSerializer(system: ExtendedActorSystem) extends SerializerWithStringManifest {
+    // Reproducer of issue #24620, by eagerly creating the ActorRefResolver in serializer
+    private val actorRefResolver = ActorRefResolver(system.toTyped)
+
+    def identifier: Int = 47
+    def manifest(o: AnyRef): String =
+      "a"
+
+    def toBinary(o: AnyRef): Array[Byte] = o match {
+      case TestMessage(ref) => actorRefResolver.toSerializationFormat(ref).getBytes(StandardCharsets.UTF_8)
+    }
+
+    def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = manifest match {
+      case "a" => TestMessage(actorRefResolver.resolveActorRef(new String(bytes, StandardCharsets.UTF_8)))
+    }
+  }
+
+  final case class TestMessage(ref: ActorRef[String])
+
+}
 
 class ActorSystemSpec
     extends WordSpec
@@ -41,6 +69,13 @@ class ActorSystemSpec
       akka.remote.classic.netty.tcp.port = 0
       akka.remote.artery.canonical.port = 0
       akka.remote.artery.canonical.hostname = 127.0.0.1
+      
+      serializers {
+          test = "akka.cluster.typed.ActorSystemSpec$$TestSerializer"
+        }
+        serialization-bindings {
+          "akka.cluster.typed.ActorSystemSpec$$TestMessage" = test
+        }
     """)
   def system[T](behavior: Behavior[T], name: String) = ActorSystem(behavior, name, config)
   def suite = "adapter"

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ActorSystemSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ActorSystemSpec.scala
@@ -43,10 +43,13 @@ object ActorSystemSpec {
 
     def toBinary(o: AnyRef): Array[Byte] = o match {
       case TestMessage(ref) => actorRefResolver.toSerializationFormat(ref).getBytes(StandardCharsets.UTF_8)
+      case _ =>
+        throw new IllegalArgumentException(s"Can't serialize object of type ${o.getClass} in [${getClass.getName}]")
     }
 
     def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = manifest match {
       case "a" => TestMessage(actorRefResolver.resolveActorRef(new String(bytes, StandardCharsets.UTF_8)))
+      case _   => throw new IllegalArgumentException(s"Unknown manifest [$manifest]")
     }
   }
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -4,42 +4,35 @@
 
 package akka.cluster.typed.internal.receptionist
 
-import java.nio.charset.StandardCharsets
-
-import akka.actor.{ ExtendedActorSystem, RootActorPath }
-import akka.actor.typed.receptionist.{ Receptionist, ServiceKey }
-import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.scaladsl.adapter._
-import akka.actor.typed.{ ActorRef, ActorRefResolver }
-import akka.cluster.MemberStatus
-import akka.cluster.typed.{ Cluster, Join }
-import akka.serialization.SerializerWithStringManifest
-import akka.actor.testkit.typed.FishingOutcome
-import akka.actor.testkit.typed.scaladsl.{ ActorTestKit, FishingOutcomes, TestProbe }
-import com.typesafe.config.ConfigFactory
-import org.scalatest.{ Matchers, WordSpec }
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
+import akka.actor.RootActorPath
+import akka.actor.testkit.typed.FishingOutcome
+import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import akka.actor.testkit.typed.scaladsl.FishingOutcomes
 import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.typed.ActorRef
+import akka.actor.typed.receptionist.Receptionist
+import akka.actor.typed.receptionist.ServiceKey
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter._
+import akka.cluster.MemberStatus
+import akka.cluster.typed.Cluster
 import akka.cluster.typed.Down
+import akka.cluster.typed.Join
 import akka.cluster.typed.JoinSeedNodes
 import akka.cluster.typed.Leave
+import akka.serialization.jackson.CborSerializable
+import com.typesafe.config.ConfigFactory
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
 
 object ClusterReceptionistSpec {
   val config = ConfigFactory.parseString(s"""
       akka.loglevel = DEBUG # issue #24960
-      akka.actor {
-        provider = cluster
-        serializers {
-          test = "akka.cluster.typed.internal.receptionist.ClusterReceptionistSpec$$PingSerializer"
-        }
-        serialization-bindings {
-          "akka.cluster.typed.internal.receptionist.ClusterReceptionistSpec$$Ping" = test
-          "akka.cluster.typed.internal.receptionist.ClusterReceptionistSpec$$Pong$$" = test
-          "akka.cluster.typed.internal.receptionist.ClusterReceptionistSpec$$Perish$$" = test
-        }
-      }
+      akka.actor.provider = cluster
       akka.remote.classic.netty.tcp.port = 0
       akka.remote.classic.netty.tcp.host = 127.0.0.1
       akka.remote.artery.canonical.port = 0
@@ -57,10 +50,10 @@ object ClusterReceptionistSpec {
       }
     """)
 
-  case object Pong
+  case object Pong extends CborSerializable
   trait PingProtocol
-  case class Ping(respondTo: ActorRef[Pong.type]) extends PingProtocol
-  case object Perish extends PingProtocol
+  case class Ping(respondTo: ActorRef[Pong.type]) extends PingProtocol with CborSerializable
+  case object Perish extends PingProtocol with CborSerializable
 
   val pingPongBehavior = Behaviors.receive[PingProtocol] { (_, msg) =>
     msg match {
@@ -70,28 +63,6 @@ object ClusterReceptionistSpec {
 
       case Perish =>
         Behaviors.stopped
-    }
-  }
-
-  class PingSerializer(system: ExtendedActorSystem) extends SerializerWithStringManifest {
-    def identifier: Int = 47
-    def manifest(o: AnyRef): String = o match {
-      case _: Ping => "a"
-      case Pong    => "b"
-      case Perish  => "c"
-    }
-
-    def toBinary(o: AnyRef): Array[Byte] = o match {
-      case p: Ping =>
-        ActorRefResolver(system.toTyped).toSerializationFormat(p.respondTo).getBytes(StandardCharsets.UTF_8)
-      case Pong   => Array.emptyByteArray
-      case Perish => Array.emptyByteArray
-    }
-
-    def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = manifest match {
-      case "a" => Ping(ActorRefResolver(system.toTyped).resolveActorRef(new String(bytes, StandardCharsets.UTF_8)))
-      case "b" => Pong
-      case "c" => Perish
     }
   }
 

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/PingSerializer.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/PingSerializer.scala
@@ -24,6 +24,8 @@ class PingSerializer(system: ExtendedActorSystem) extends SerializerWithStringMa
   override def manifest(msg: AnyRef) = msg match {
     case _: PingService.Ping => PingManifest
     case PingService.Pong    => PongManifest
+    case _ =>
+      throw new IllegalArgumentException(s"Can't serialize object of type ${msg.getClass} in [${getClass.getName}]")
   }
 
   override def toBinary(msg: AnyRef) = msg match {
@@ -31,6 +33,8 @@ class PingSerializer(system: ExtendedActorSystem) extends SerializerWithStringMa
       actorRefResolver.toSerializationFormat(who).getBytes(StandardCharsets.UTF_8)
     case PingService.Pong =>
       Array.emptyByteArray
+    case _ =>
+      throw new IllegalArgumentException(s"Can't serialize object of type ${msg.getClass} in [${getClass.getName}]")
   }
 
   override def fromBinary(bytes: Array[Byte], manifest: String) = {
@@ -41,6 +45,8 @@ class PingSerializer(system: ExtendedActorSystem) extends SerializerWithStringMa
         PingService.Ping(ref)
       case PongManifest =>
         PingService.Pong
+      case _ =>
+        throw new IllegalArgumentException(s"Unknown manifest [$manifest]")
     }
   }
 }


### PR DESCRIPTION
* those were created before we had Jackson in place
