### PR TITLE
Updates external serialization documentation #27886

### DIFF
--- a/akka-docs/src/main/paradox/serialization.md
+++ b/akka-docs/src/main/paradox/serialization.md
@@ -257,9 +257,7 @@ It must still be possible to deserialize the events that were stored with the ol
 
 ## External Akka Serializers
 
-* [Akka-quickser by Roman Levenstein](https://github.com/romix/akka-quickser-serialization)
-
-* [Akka-kryo by Roman Levenstein](https://github.com/romix/akka-kryo-serialization)
+* [Kryo serializer for Akka](https://github.com/altoo-ag/akka-kryo-serialization)
 
 * [Twitter Chill Scala extensions for Kryo](https://github.com/twitter/chill)
 


### PR DESCRIPTION
Akka-kryo-serialization has not been maintained for quite some time. As Twitter's Chill is not available for Scala 2.13 as well we switched to akka-kryo-serialization ourselves and took over the project from romix.