### PR TITLE
typo, user guardian instead of guardian

### DIFF
--- a/akka-docs/src/main/paradox/typed/guide/tutorial_1.md
+++ b/akka-docs/src/main/paradox/typed/guide/tutorial_1.md
@@ -30,7 +30,7 @@ In fact, before your first actor is started, Akka has already created two actors
 
  - `/` the so-called _root guardian_. This is the parent of all actors in the system, and the last one to stop when the system itself is terminated.
  - `/system` the _system guardian_. Akka or other libraries built on top of Akka may create actors in the _system_ namespace.
- - `/user` the _guardian_. This is the top level actor that you provide to start all other actors in your application.
+ - `/user` the _user guardian_. This is the top level actor that you provide to start all other actors in your application.
  
 The easiest way to see the actor hierarchy in action is to print `ActorRef` instances. In this small experiment, we create an actor, print its reference, create a child of this actor, and print the child's reference. We start with the Hello World project, if you have not downloaded it, download the Quickstart project from the @scala[[Lightbend Tech Hub](http://developer.lightbend.com/start/?group=akka&amp;project=akka-quickstart-scala)]@java[[Lightbend Tech Hub](http://developer.lightbend.com/start/?group=akka&amp;project=akka-quickstart-java)].
 


### PR DESCRIPTION
# Background Context

Reading https://doc.akka.io/docs/akka/current/typed/guide/tutorial_1.html
