### PR TITLE
adjust dependencies to akka-protobuf-v3, #27661

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -244,7 +244,7 @@ lazy val osgi = akkaModule("akka-osgi")
   .settings(parallelExecution in Test := false)
 
 lazy val persistence = akkaModule("akka-persistence")
-  .dependsOn(actor, testkit % "test->test", protobufV3)
+  .dependsOn(actor, stream, testkit % "test->test")
   .settings(Dependencies.persistence)
   .settings(AutomaticModuleName.settings("akka.persistence"))
   .settings(OSGi.persistence)
@@ -260,7 +260,7 @@ lazy val persistenceQuery = akkaModule("akka-persistence-query")
   .enablePlugins(ScaladocNoVerificationOfDiagrams)
 
 lazy val persistenceShared = akkaModule("akka-persistence-shared")
-  .dependsOn(persistence % "test->test", testkit % "test->test", remote % "test", protobufV3)
+  .dependsOn(persistence % "test->test", testkit % "test->test", remote % "test")
   .settings(Dependencies.persistenceShared)
   .settings(AutomaticModuleName.settings("akka.persistence.shared"))
   .settings(fork in Test := true)
@@ -307,7 +307,6 @@ lazy val remote =
     .dependsOn(
       actor,
       stream,
-      protobufV3,
       protobuf % "test",
       actorTests % "test->test",
       testkit % "test->test",
@@ -415,7 +414,6 @@ lazy val clusterTyped = akkaModule("akka-cluster-typed")
     distributedData,
     persistence % "test->test",
     persistenceTyped % "test->test",
-    protobufV3,
     actorTestkitTyped % "test->test",
     actorTypedTests % "test->test",
     remoteTests % "test->test",


### PR DESCRIPTION
* attempt to fix the mysterious "Could not create directory,
  file exists and is not a directory" problem in multi-node tests
* only depend on protobufV3 from akka-stream, all others dependen
  on stream
* adding dependency from akka-persistence to akka-stream that is
  not needed but in practise it shouldn't hurt since akka-stream
  is very likely used anyway (also from persistence plugins)

Started a full multi-node repeat job on this branch

Refs #27661
