### PR TITLE
doc: fix Persistence ToC

### DIFF
--- a/akka-docs/src/main/paradox/index.md
+++ b/akka-docs/src/main/paradox/index.md
@@ -9,7 +9,7 @@
 * [general/index](general/index.md)
 * [index-actors](typed/index.md)
 * [index-cluster](typed/index-cluster.md)
-* [persistence](typed/persistence.md)
+* [index-persistence](typed/index-persistence.md)
 * [stream/index](stream/index.md)
 * [discovery](discovery/index.md)
 * [index-utilities](index-utilities.md)

--- a/akka-docs/src/main/paradox/typed/index-persistence.md
+++ b/akka-docs/src/main/paradox/typed/index-persistence.md
@@ -1,0 +1,21 @@
+---
+project.description: Event Sourcing with Akka Persistence enables actors to persist your events for recovery on failure or when migrated within a cluster.
+---
+
+# Persistence
+
+@@toc { depth=2 }
+
+@@@ index
+
+* [persistence](persistence.md)
+* [persistence-style](persistence-style.md)
+* [persistence-snapshot](persistence-snapshot.md)
+* [persistence-testing.md](persistence-testing.md)
+* [persistence-schema-evolution](../persistence-schema-evolution.md)
+* [persistence-query](../persistence-query.md)
+* [persistence-query-leveldb](../persistence-query-leveldb.md)
+* [persistence-plugins](../persistence-plugins.md)
+* [persistence-journals](../persistence-journals.md)
+
+@@@

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -3,19 +3,6 @@ project.description: Event Sourcing with Akka Persistence enables actors to pers
 ---
 # Event Sourcing
 
-@@@ index
-
-* [Persistence coding style](persistence-style.md)
-* [Persistence snapshotting](persistence-snapshot.md)
-* [Persistence testing](persistence-testing.md)
-* [Persistence schema evolution](../persistence-schema-evolution.md)
-* [Persistence query](../persistence-query.md)
-* [Persistence query LevelDB](../persistence-query-leveldb.md)
-* [Persistence Journals](../persistence-plugins.md)
-* [Persistence Journals](../persistence-journals.md)
-
-@@@
-
 @@@ note
 For the Akka Classic documentation of this feature see @ref:[Classic Akka Persistence](../persistence.md).
 @@@


### PR DESCRIPTION
* index was inlined in persistence.md, and that doesn't work well
  because all headings from persistence.md are always visible to the left
  when browsing the other persistence pages

