### PR TITLE
don't crossPaths for akka-protobuf-v3, #27921

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -292,6 +292,7 @@ lazy val protobufV3 = akkaModule("akka-protobuf-v3")
           .rename("com.google.protobuf.**" -> "akka.protobufv3.internal.@1")
           .inLibrary(Dependencies.Compile.protobufRuntime)),
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false, includeBin = false),
+    crossPaths := false,
     autoScalaLibrary := false, // do not include scala dependency in pom
     exportJars := true, // in dependent projects, use assembled and shaded jar
     makePomConfiguration := makePomConfiguration.value


### PR DESCRIPTION
* otherwise akka-bench-jmh doesn't work
* and there are no Scala dependencies in there, as far as I know

Refs #27921
