### PR TITLE
Travis: cache coursier library directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ before_cache:
 
 cache:
   directories:
+    - $HOME/.cache/coursier
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot
+    - $HOME/.sbt
     - $HOME/.jabba/jdk
 
 # script for the default 'test' stage:


### PR DESCRIPTION
Travis should cache the library directory for coursier now that the build uses sbt 1.3.2.

https://www.scala-sbt.org/release/docs/Travis-CI-with-sbt.html#Caching