### PR TITLE
Revert: Harden DowningProviderSpec, and detect terminated before initialized, #27840

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -1043,20 +1043,14 @@ private[akka] class ActorSystemImpl(
     case NonFatal(e) =>
       try terminate()
       catch { case NonFatal(_) => Try(stopScheduler()) }
-      if (terminating)
-        throw new IllegalStateException("ActorSystem was terminated before it was fully initialized.", e)
-      else
-        throw e
+      throw e
   }
 
   def start(): this.type = _start
   def registerOnTermination[T](code: => T): Unit = { registerOnTermination(new Runnable { def run = code }) }
   def registerOnTermination(code: Runnable): Unit = { terminationCallbacks.add(code) }
 
-  @volatile private var terminating = false
-
   override def terminate(): Future[Terminated] = {
-    terminating = true
     if (settings.CoordinatedShutdownRunByActorSystemTerminate && !aborting) {
       // Note that the combination CoordinatedShutdownRunByActorSystemTerminate==true &&
       // CoordinatedShutdownTerminateActorSystem==false is disallowed, checked in Settings.


### PR DESCRIPTION
The attempt in https://github.com/akka/akka/pull/27911 was wrong. Have to think some more about this, but let's revert so master is back.

This reverts commit f2466cad49f0eb413d74532af205aa34a4386505.

* and temporary pending of DowningProviderSpec

