### PR TITLE
Ignore length field value when provided computeFrameSize (#27884)

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
@@ -421,7 +421,7 @@ object Framing {
             if (frameSize > maximumFrameLength) {
               failStage(new FramingException(
                 s"Maximum allowed frame size is $maximumFrameLength but decoded frame header reported size $frameSize"))
-            } else if (parsedLength < 0) {
+            } else if (computeFrameSize.isEmpty && parsedLength < 0) {
               failStage(new FramingException(s"Decoded frame header reported negative size $parsedLength"))
             } else if (frameSize < minimumChunkSize) {
               failStage(


### PR DESCRIPTION
* Add test for computed frame sizes from negative length field values

* Skip check for length field value < 0 when using computeFrameSize

## Purpose

Skip the check for negative length field values when using computed frame sizes. 

## References

References #27884

## Changes

Added a new test to `FramingSpec` to check that `Framing.lengthField()` will allow for negative field values if it is provided a `computeFrameSize` function.

Modified an existing `if()` statement inside `Framing.LengthFieldFramingStage.tryPushFrame()` so the check for a negative parsed field value is skipped if there is a `computeFrameSize()` function present.
