### PR TITLE
Fix state.nonEmpty check when starting HandOffStopper#27647 (#27860)

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -359,8 +359,9 @@ private[akka] class Shard(
     case None =>
       log.debug("HandOff shard [{}]", shardId)
 
-      if (state.entities.nonEmpty) {
+      if (idByRef.nonEmpty) {
         val entityHandOffTimeout = (settings.tuningParameters.handOffTimeout - 5.seconds).max(1.seconds)
+        log.debug("Starting HandOffStopper for shard [{}] to terminate [{}] entities.", shardId, idByRef.keySet.size)
         handOffStopper = Some(
           context.watch(context.actorOf(
             handOffStopperProps(shardId, replyTo, idByRef.keySet, handOffStopMessage, entityHandOffTimeout))))

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -439,10 +439,12 @@ object ShardRegion {
     def receive: Receive = {
       case ReceiveTimeout =>
         log.warning(
-          "HandOffStopMessage[{}] is not handled by some of the entities of the `{}` shard, " +
-          "stopping the remaining entities.",
+          "HandOffStopMessage[{}] is not handled by some of the entities of the [{}] shard after [{}], " +
+          "stopping the remaining [{}] entities.",
           stopMessage.getClass.getName,
-          shard)
+          shard,
+          handoffTimeout.toCoarsest,
+          remaining.size)
 
         remaining.foreach { ref =>
           context.stop(ref)


### PR DESCRIPTION
Forward port of https://github.com/akka/akka/pull/27860

* Shard state.entities and idByRef properties incosistency in case of HandOffStopper creation
* Additional sharding debugging logs

(cherry picked from commit 70c2b571b9759e0441529fe107b8e8bf42825415)
