### PR TITLE
rename PersistenceId.apply to PersistenceId.ofUniqueId, #27924

### DIFF
--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPersistenceSpec.scala
@@ -33,7 +33,7 @@ object ClusterSingletonPersistenceSpec {
 
   val persistentActor: Behavior[Command] =
     EventSourcedBehavior[Command, String, String](
-      persistenceId = PersistenceId("TheSingleton"),
+      persistenceId = PersistenceId.ofUniqueId("TheSingleton"),
       emptyState = "",
       commandHandler = (state, cmd) =>
         cmd match {

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -597,6 +597,7 @@ made before finalizing the APIs. Compared to Akka 2.5.x the source incompatible 
 * `EventSourcedEntity` removed in favor using plain `EventSourcedBehavior` because the alternative way was
   causing more confusion than adding value. Construction of `PersistentId` for the `EventSourcedBehavior` is
   facilitated by factory methods in `PersistenceId`.
+* `PersistenceId.apply(String)` renamed to `PersistenceId.ofUniqueId(String)`  
 * `akka.cluster.sharding.typed.scaladsl.Entity.apply` changed to use two parameter lists because the new
   `EntityContext.entityTypeKey` required additional type parameter that is inferred better with a secondary
   parameter list.

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -102,7 +102,7 @@ that there is only one active entity for each `PersistenceId` (`entityId`).
 
 The `entityId` in Cluster Sharding is the business domain identifier of the entity. The `entityId` might not
 be unique enough to be used as the `PersistenceId` by itself. For example two different types of
-entities may have the same `entityId`. To create a unique `PersistenceId` the `entityId` is can be prefixed
+entities may have the same `entityId`. To create a unique `PersistenceId` the `entityId` should be prefixed
 with a stable name of the entity type, which typically is the same as the `EntityTypeKey.name` that
 is used in Cluster Sharding. There are @scala[`PersistenceId.apply`]@java[`PersistenceId.of`] factory methods
 to help with constructing such `PersistenceId` from a `entityTypeHint` and `entityId`.

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -122,6 +122,8 @@ The @ref:[Persistence example in the Cluster Sharding documentation](cluster-sha
 illustrates how to construct the `PersistenceId` from the `entityTypeKey` and `entityId` provided by the
 `EntityContext`.
 
+A custom identifier can be created with `PersistenceId.ofUniqueId`.  
+
 ### Command handler
 
 The command handler is a function with 2 parameters, the current `State` and the incoming `Command`.

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/PersistenceId.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/PersistenceId.scala
@@ -68,7 +68,7 @@ object PersistenceId {
           s"entityTypeHint [$entityTypeHint] contains [$separator] which is a reserved character")
     }
 
-    PersistenceId(entityTypeHint + separator + entityId)
+    new PersistenceId(entityTypeHint + separator + entityId)
   }
 
   /**
@@ -122,18 +122,28 @@ object PersistenceId {
   /**
    * Constructs a [[PersistenceId]] with `id` as the full unique identifier.
    */
-  def of(id: String): PersistenceId =
-    PersistenceId(id)
+  def ofUniqueId(id: String): PersistenceId =
+    new PersistenceId(id)
+
 }
 
 /**
  * Unique identifier in the backend data store (journal and snapshot store) of the
  * persistent actor.
  */
-final case class PersistenceId(id: String) {
+final class PersistenceId private (val id: String) {
   if (id eq null)
     throw new IllegalArgumentException("persistenceId must not be null")
 
   if (id.trim.isEmpty)
     throw new IllegalArgumentException("persistenceId must not be empty")
+
+  override def toString: String = s"PersistenceId($id)"
+
+  override def hashCode(): Int = id.hashCode
+
+  override def equals(obj: Any): Boolean = obj match {
+    case other: PersistenceId => id == other.id
+    case _                    => false
+  }
 }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
@@ -28,7 +28,7 @@ object ManyRecoveriesSpec {
       probe: TestProbe[String],
       latch: Option[TestLatch]): EventSourcedBehavior[Cmd, Evt, String] =
     EventSourcedBehavior[Cmd, Evt, String](
-      persistenceId = PersistenceId(name),
+      persistenceId = PersistenceId.ofUniqueId(name),
       emptyState = "",
       commandHandler = CommandHandler.command {
         case Cmd(s) => Effect.persist(Evt(s)).thenRun(_ => probe.ref ! s"$name-$s")

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/PersistenceIdSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/PersistenceIdSpec.scala
@@ -12,15 +12,15 @@ class PersistenceIdSpec extends WordSpec with Matchers with LogCapturing {
 
   "PersistenceId" must {
     "use | as default entityIdSeparator for compatibility with Lagom's scaladsl" in {
-      PersistenceId("MyType", "abc") should ===(PersistenceId("MyType|abc"))
+      PersistenceId("MyType", "abc") should ===(PersistenceId.ofUniqueId("MyType|abc"))
     }
 
     "support custom separator for compatibility with Lagom's javadsl" in {
-      PersistenceId("MyType", "abc", "") should ===(PersistenceId("MyTypeabc"))
+      PersistenceId("MyType", "abc", "") should ===(PersistenceId.ofUniqueId("MyTypeabc"))
     }
 
     "support custom entityIdSeparator for compatibility with other naming" in {
-      PersistenceId("MyType", "abc", "#/#") should ===(PersistenceId("MyType#/#abc"))
+      PersistenceId("MyType", "abc", "#/#") should ===(PersistenceId.ofUniqueId("MyType#/#abc"))
     }
 
     "not allow | in entityTypeName because it's the default separator" in {

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/StashingWhenSnapshottingSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/StashingWhenSnapshottingSpec.scala
@@ -91,7 +91,8 @@ class StashingWhenSnapshottingSpec
   "A persistent actor" should {
     "stash messages and automatically replay when snapshot is in progress" in {
       val eventProbe = TestProbe[String]()
-      val persistentActor = spawn(StashingWhenSnapshottingSpec.persistentTestBehavior(PersistenceId("1"), eventProbe))
+      val persistentActor =
+        spawn(StashingWhenSnapshottingSpec.persistentTestBehavior(PersistenceId.ofUniqueId("1"), eventProbe))
       persistentActor ! "one"
       eventProbe.expectMessage("one")
       persistentActor ! "snap"

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
@@ -47,7 +47,7 @@ object RecoveryPermitterSpec {
       eventProbe: TestProbe[Any],
       throwOnRecovery: Boolean = false): Behavior[Command] =
     EventSourcedBehavior[Command, Event, State](
-      persistenceId = PersistenceId(name),
+      persistenceId = PersistenceId.ofUniqueId(name),
       emptyState = EmptyState,
       commandHandler = CommandHandler.command {
         case StopActor => Effect.stop()

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorFailureSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorFailureSpec.scala
@@ -124,7 +124,7 @@ class EventSourcedBehaviorFailureSpec
       LoggingEventFilter.error[JournalFailureException].intercept {
         val probe = TestProbe[String]()
         val excProbe = TestProbe[Throwable]()
-        spawn(failingPersistentActor(PersistenceId("fail-recovery"), probe.ref, {
+        spawn(failingPersistentActor(PersistenceId.ofUniqueId("fail-recovery"), probe.ref, {
           case (_, RecoveryFailed(t)) =>
             excProbe.ref ! t
         }))
@@ -136,7 +136,7 @@ class EventSourcedBehaviorFailureSpec
 
     "handle exceptions from RecoveryFailed signal handler" in {
       val probe = TestProbe[String]()
-      val pa = spawn(failingPersistentActor(PersistenceId("fail-recovery-twice"), probe.ref, {
+      val pa = spawn(failingPersistentActor(PersistenceId.ofUniqueId("fail-recovery-twice"), probe.ref, {
         case (_, RecoveryFailed(_)) =>
           throw TestException("recovery call back failure")
       }))
@@ -150,7 +150,7 @@ class EventSourcedBehaviorFailureSpec
     "signal RecoveryFailure when event handler throws during replay" in {
       val probe = TestProbe[String]()
       val excProbe = TestProbe[Throwable]()
-      val pid = PersistenceId("wrong-event-1")
+      val pid = PersistenceId.ofUniqueId("wrong-event-1")
       val ref = spawn(failingPersistentActor(pid, probe.ref))
 
       ref ! "malicious"
@@ -176,11 +176,13 @@ class EventSourcedBehaviorFailureSpec
       LoggingEventFilter.error[JournalFailureException].intercept {
         spawn(
           Behaviors
-            .supervise(failingPersistentActor(PersistenceId("recovery-ok"), probe.ref, {
-              case (_, RecoveryCompleted) =>
-                probe.ref.tell("starting")
-                throw TestException("recovery call back failure")
-            }))
+            .supervise(failingPersistentActor(
+              PersistenceId.ofUniqueId("recovery-ok"),
+              probe.ref, {
+                case (_, RecoveryCompleted) =>
+                  probe.ref.tell("starting")
+                  throw TestException("recovery call back failure")
+              }))
             // since recovery fails restart supervision is not supposed to be used
             .onFailure(SupervisorStrategy.restart))
         probe.expectMessage("starting")
@@ -190,7 +192,7 @@ class EventSourcedBehaviorFailureSpec
 
     "restart with backoff" in {
       val probe = TestProbe[String]()
-      val behav = failingPersistentActor(PersistenceId("fail-first-2"), probe.ref).onPersistFailure(
+      val behav = failingPersistentActor(PersistenceId.ofUniqueId("fail-first-2"), probe.ref).onPersistFailure(
         SupervisorStrategy.restartWithBackoff(1.milli, 10.millis, 0.1).withLoggingEnabled(enabled = false))
       val c = spawn(behav)
       probe.expectMessage("starting")
@@ -217,7 +219,7 @@ class EventSourcedBehaviorFailureSpec
 
     "restart with backoff for recovery" in {
       val probe = TestProbe[String]()
-      val behav = failingPersistentActor(PersistenceId("fail-recovery-once"), probe.ref).onPersistFailure(
+      val behav = failingPersistentActor(PersistenceId.ofUniqueId("fail-recovery-once"), probe.ref).onPersistFailure(
         SupervisorStrategy.restartWithBackoff(1.milli, 10.millis, 0.1).withLoggingEnabled(enabled = false))
       spawn(behav)
       // First time fails, second time should work and call onRecoveryComplete
@@ -230,7 +232,7 @@ class EventSourcedBehaviorFailureSpec
       val probe = TestProbe[String]()
       val behav =
         Behaviors
-          .supervise(failingPersistentActor(PersistenceId("reject-first"), probe.ref))
+          .supervise(failingPersistentActor(PersistenceId.ofUniqueId("reject-first"), probe.ref))
           .onFailure[EventRejectedException](
             SupervisorStrategy.restartWithBackoff(1.milli, 5.millis, 0.1).withLoggingEnabled(enabled = false))
       val c = spawn(behav)
@@ -252,7 +254,7 @@ class EventSourcedBehaviorFailureSpec
     "stop (default supervisor strategy) if command handler throws" in {
       LoggingEventFilter.error[TestException].intercept {
         val probe = TestProbe[String]()
-        val behav = failingPersistentActor(PersistenceId("wrong-command-1"), probe.ref)
+        val behav = failingPersistentActor(PersistenceId.ofUniqueId("wrong-command-1"), probe.ref)
         val c = spawn(behav)
         probe.expectMessage("starting")
         c ! "wrong"
@@ -264,7 +266,7 @@ class EventSourcedBehaviorFailureSpec
       LoggingEventFilter.error[TestException].intercept {
         val probe = TestProbe[String]()
         val behav = Behaviors
-          .supervise(failingPersistentActor(PersistenceId("wrong-command-2"), probe.ref))
+          .supervise(failingPersistentActor(PersistenceId.ofUniqueId("wrong-command-2"), probe.ref))
           .onFailure[TestException](SupervisorStrategy.restart)
         val c = spawn(behav)
         probe.expectMessage("starting")
@@ -276,7 +278,7 @@ class EventSourcedBehaviorFailureSpec
     "stop (default supervisor strategy) if side effect callback throws" in {
       LoggingEventFilter.error[TestException].intercept {
         val probe = TestProbe[String]()
-        val behav = failingPersistentActor(PersistenceId("wrong-command-3"), probe.ref)
+        val behav = failingPersistentActor(PersistenceId.ofUniqueId("wrong-command-3"), probe.ref)
         val c = spawn(behav)
         probe.expectMessage("starting")
         c ! "wrong-callback"
@@ -291,7 +293,7 @@ class EventSourcedBehaviorFailureSpec
       case object SomeSignal extends Signal
       LoggingEventFilter.error[TestException].intercept {
         val probe = TestProbe[String]()
-        val behav = failingPersistentActor(PersistenceId("wrong-signal-handler"), probe.ref, {
+        val behav = failingPersistentActor(PersistenceId.ofUniqueId("wrong-signal-handler"), probe.ref, {
           case (_, SomeSignal) => throw TestException("from signal")
         })
         val c = spawn(behav)
@@ -304,7 +306,7 @@ class EventSourcedBehaviorFailureSpec
     "not accept wrong event, before persisting it" in {
       LoggingEventFilter.error[TestException].intercept {
         val probe = TestProbe[String]()
-        val behav = failingPersistentActor(PersistenceId("wrong-event-2"), probe.ref)
+        val behav = failingPersistentActor(PersistenceId.ofUniqueId("wrong-event-2"), probe.ref)
         val c = spawn(behav)
         probe.expectMessage("starting")
         // event handler will throw for this event

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorInterceptorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorInterceptorSpec.scala
@@ -50,7 +50,7 @@ class EventSourcedBehaviorInterceptorSpec
   import EventSourcedBehaviorInterceptorSpec._
 
   val pidCounter = new AtomicInteger(0)
-  private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()})")
 
   "EventSourcedBehavior interceptor" must {
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRecoveryTimeoutSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRecoveryTimeoutSpec.scala
@@ -57,7 +57,7 @@ class EventSourcedBehaviorRecoveryTimeoutSpec
   import EventSourcedBehaviorRecoveryTimeoutSpec._
 
   val pidCounter = new AtomicInteger(0)
-  private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()})")
 
   import akka.actor.typed.scaladsl.adapter._
   // needed for SteppingInmemJournal.step

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorReplySpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorReplySpec.scala
@@ -81,7 +81,7 @@ class EventSourcedBehaviorReplySpec
   import EventSourcedBehaviorReplySpec._
 
   val pidCounter = new AtomicInteger(0)
-  private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()})")
 
   "A typed persistent actor with commands that are expecting replies" must {
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
@@ -132,7 +132,7 @@ class EventSourcedBehaviorRetentionSpec
   import EventSourcedBehaviorRetentionSpec._
 
   val pidCounter = new AtomicInteger(0)
-  private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()})")
 
   "EventSourcedBehavior with retention" must {
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -289,7 +289,7 @@ class EventSourcedBehaviorSpec
     PersistenceQuery(system.toClassic).readJournalFor[LeveldbReadJournal](LeveldbReadJournal.Identifier)
 
   val pidCounter = new AtomicInteger(0)
-  private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()})")
 
   "A typed persistent actor" must {
 
@@ -531,14 +531,14 @@ class EventSourcedBehaviorSpec
 
     "fail fast if persistenceId is null" in {
       intercept[IllegalArgumentException] {
-        PersistenceId(null)
+        PersistenceId.ofUniqueId(null)
       }
       val probe = TestProbe[AnyRef]
       LoggingEventFilter
         .error[ActorInitializationException]
         .withMessageContains("persistenceId must not be null")
         .intercept {
-          val ref = spawn(Behaviors.setup[Command](counter(_, persistenceId = PersistenceId(null))))
+          val ref = spawn(Behaviors.setup[Command](counter(_, persistenceId = PersistenceId.ofUniqueId(null))))
           probe.expectTerminated(ref)
         }
       LoggingEventFilter
@@ -552,14 +552,14 @@ class EventSourcedBehaviorSpec
 
     "fail fast if persistenceId is empty" in {
       intercept[IllegalArgumentException] {
-        PersistenceId("")
+        PersistenceId.ofUniqueId("")
       }
       val probe = TestProbe[AnyRef]
       LoggingEventFilter
         .error[ActorInitializationException]
         .withMessageContains("persistenceId must not be empty")
         .intercept {
-          val ref = spawn(Behaviors.setup[Command](counter(_, persistenceId = PersistenceId(""))))
+          val ref = spawn(Behaviors.setup[Command](counter(_, persistenceId = PersistenceId.ofUniqueId(""))))
           probe.expectTerminated(ref)
         }
     }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
@@ -171,7 +171,7 @@ class EventSourcedBehaviorStashSpec
   import EventSourcedBehaviorStashSpec._
 
   val pidCounter = new AtomicInteger(0)
-  private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()})")
 
   "A typed persistent actor that is stashing commands" must {
 
@@ -447,7 +447,7 @@ class EventSourcedBehaviorStashSpec
     }
 
     "preserve internal stash when persist failed" in {
-      val c = spawn(counter(PersistenceId("fail-fifth-a")))
+      val c = spawn(counter(PersistenceId.ofUniqueId("fail-fifth-a")))
       val ackProbe = TestProbe[Ack]
       val stateProbe = TestProbe[State]
 
@@ -465,7 +465,7 @@ class EventSourcedBehaviorStashSpec
     }
 
     "preserve user stash when persist failed" in {
-      val c = spawn(counter(PersistenceId("fail-fifth-b")))
+      val c = spawn(counter(PersistenceId.ofUniqueId("fail-fifth-b")))
       val ackProbe = TestProbe[Ack]
       val stateProbe = TestProbe[State]
 
@@ -502,7 +502,7 @@ class EventSourcedBehaviorStashSpec
       system.toClassic.eventStream.subscribe(probe.ref.toClassic, classOf[Dropped])
       val behavior = Behaviors.setup[String] { context =>
         EventSourcedBehavior[String, String, Boolean](
-          persistenceId = PersistenceId("stash-is-full-drop"),
+          persistenceId = PersistenceId.ofUniqueId("stash-is-full-drop"),
           emptyState = false,
           commandHandler = { (state, command) =>
             state match {
@@ -570,13 +570,17 @@ class EventSourcedBehaviorStashSpec
       try {
         val probe = failStashTestKit.createTestProbe[AnyRef]()
         val behavior =
-          EventSourcedBehavior[String, String, String](PersistenceId("stash-is-full-fail"), "", commandHandler = {
-            case (_, "ping") =>
-              probe.ref ! "pong"
-              Effect.none
-            case (_, _) =>
-              Effect.stash()
-          }, (state, _) => state)
+          EventSourcedBehavior[String, String, String](
+            PersistenceId.ofUniqueId("stash-is-full-fail"),
+            "",
+            commandHandler = {
+              case (_, "ping") =>
+                probe.ref ! "pong"
+                Effect.none
+              case (_, _) =>
+                Effect.stash()
+            },
+            (state, _) => state)
 
         val c = failStashTestKit.spawn(behavior)
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorTimersSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorTimersSpec.scala
@@ -80,7 +80,7 @@ class EventSourcedBehaviorTimersSpec
   import EventSourcedBehaviorTimersSpec._
 
   val pidCounter = new AtomicInteger(0)
-  private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()})")
 
   "EventSourcedBehavior withTimers" must {
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedEventAdapterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedEventAdapterSpec.scala
@@ -99,7 +99,7 @@ class EventSourcedEventAdapterSpec
   import akka.actor.typed.scaladsl.adapter._
 
   val pidCounter = new AtomicInteger(0)
-  private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()})")
 
   val queries: LeveldbReadJournal =
     PersistenceQuery(system.toClassic).readJournalFor[LeveldbReadJournal](LeveldbReadJournal.Identifier)

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
@@ -44,7 +44,7 @@ class EventSourcedSequenceNumberSpec
 
     "be accessible in the handlers" in {
       val probe = TestProbe[String]()
-      val ref = spawn(behavior(PersistenceId("ess-1"), probe.ref))
+      val ref = spawn(behavior(PersistenceId.ofUniqueId("ess-1"), probe.ref))
       probe.expectMessage("0 onRecoveryComplete")
 
       ref ! "cmd1"

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSnapshotAdapterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSnapshotAdapterSpec.scala
@@ -41,7 +41,7 @@ class EventSourcedSnapshotAdapterSpec
   import akka.actor.typed.scaladsl.adapter._
 
   val pidCounter = new AtomicInteger(0)
-  private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()})")
 
   val queries: LeveldbReadJournal =
     PersistenceQuery(system.toClassic).readJournalFor[LeveldbReadJournal](LeveldbReadJournal.Identifier)

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/LoggerSourceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/LoggerSourceSpec.scala
@@ -25,7 +25,7 @@ class LoggerSourceSpec
     with LogCapturing {
 
   private val pidCounter = new AtomicInteger(0)
-  private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()})")
 
   def behavior: Behavior[String] = Behaviors.setup { ctx =>
     ctx.log.info("setting-up-behavior")

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/NullEmptyStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/NullEmptyStateSpec.scala
@@ -49,7 +49,7 @@ class NullEmptyStateSpec
   "A typed persistent actor with primitive state" must {
     "persist events and update state" in {
       val probe = TestProbe[String]()
-      val b = primitiveState(PersistenceId("a"), probe.ref)
+      val b = primitiveState(PersistenceId.ofUniqueId("a"), probe.ref)
       val ref1 = spawn(b)
       probe.expectMessage("onRecoveryCompleted:null")
       ref1 ! "one"

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/OptionalSnapshotStoreSpec.scala
@@ -27,7 +27,7 @@ object OptionalSnapshotStoreSpec {
 
   def persistentBehavior(probe: TestProbe[State], name: String = UUID.randomUUID().toString) =
     EventSourcedBehavior[Command, Event, State](
-      persistenceId = PersistenceId(name),
+      persistenceId = PersistenceId.ofUniqueId(name),
       emptyState = State(),
       commandHandler = CommandHandler.command { _ =>
         Effect.persist(Event()).thenRun(probe.ref ! _)

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
@@ -74,7 +74,7 @@ object PerformanceSpec {
       .supervise({
         val parameters = Parameters()
         EventSourcedBehavior[Command, String, String](
-          persistenceId = PersistenceId(name),
+          persistenceId = PersistenceId.ofUniqueId(name),
           "",
           commandHandler = CommandHandler.command {
             case StopMeasure =>

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
@@ -33,7 +33,7 @@ object PersistentActorCompileOnlyTest {
     case class ExampleState(events: List[String] = Nil)
 
     EventSourcedBehavior[MyCommand, MyEvent, ExampleState](
-      persistenceId = PersistenceId("sample-id-1"),
+      persistenceId = PersistenceId.ofUniqueId("sample-id-1"),
       emptyState = ExampleState(Nil),
       commandHandler = CommandHandler.command {
         case Cmd(data, sender) =>
@@ -77,7 +77,7 @@ object PersistentActorCompileOnlyTest {
       Behaviors.setup(
         ctx =>
           EventSourcedBehavior[Command, Event, EventsInFlight](
-            persistenceId = PersistenceId("recovery-complete-id"),
+            persistenceId = PersistenceId.ofUniqueId("recovery-complete-id"),
             emptyState = EventsInFlight(0, Map.empty),
             commandHandler = (state, cmd) =>
               cmd match {
@@ -118,7 +118,7 @@ object PersistentActorCompileOnlyTest {
     case class MoodChanged(to: Mood) extends Event
 
     val b: Behavior[Command] = EventSourcedBehavior[Command, Event, Mood](
-      persistenceId = PersistenceId("myPersistenceId"),
+      persistenceId = PersistenceId.ofUniqueId("myPersistenceId"),
       emptyState = Happy,
       commandHandler = { (state, command) =>
         state match {
@@ -162,7 +162,7 @@ object PersistentActorCompileOnlyTest {
     case class State(tasksInFlight: List[Task])
 
     EventSourcedBehavior[Command, Event, State](
-      persistenceId = PersistenceId("asdf"),
+      persistenceId = PersistenceId.ofUniqueId("asdf"),
       emptyState = State(Nil),
       commandHandler = CommandHandler.command {
         case RegisterTask(task) => Effect.persist(TaskRegistered(task))
@@ -195,7 +195,7 @@ object PersistentActorCompileOnlyTest {
     val behavior: Behavior[Command] = Behaviors.setup(
       ctx =>
         EventSourcedBehavior[Command, Event, State](
-          persistenceId = PersistenceId("asdf"),
+          persistenceId = PersistenceId.ofUniqueId("asdf"),
           emptyState = State(Nil),
           commandHandler = (_, cmd) =>
             cmd match {
@@ -257,7 +257,7 @@ object PersistentActorCompileOnlyTest {
         Effect.persist[Event, List[Id]](ItemAdded(id)).thenRun(_ => metadataRegistry ! GetMetaData(id, adapt))
 
       EventSourcedBehavior[Command, Event, List[Id]](
-        persistenceId = PersistenceId("basket-1"),
+        persistenceId = PersistenceId("basket", "1"),
         emptyState = Nil,
         commandHandler = { (state, cmd) =>
           if (isFullyHydrated(basket, state))
@@ -351,7 +351,7 @@ object PersistentActorCompileOnlyTest {
     }
 
     EventSourcedBehavior[Command, Event, Mood](
-      persistenceId = PersistenceId("myPersistenceId"),
+      persistenceId = PersistenceId.ofUniqueId("myPersistenceId"),
       emptyState = Sad,
       commandHandler,
       eventHandler)
@@ -377,7 +377,7 @@ object PersistentActorCompileOnlyTest {
     }
 
     EventSourcedBehavior[Command, Event, State](
-      persistenceId = PersistenceId("myPersistenceId"),
+      persistenceId = PersistenceId.ofUniqueId("myPersistenceId"),
       emptyState = new State,
       commandHandler,
       eventHandler)
@@ -389,7 +389,7 @@ object PersistentActorCompileOnlyTest {
     class Second extends State
 
     EventSourcedBehavior[String, String, State](
-      persistenceId = PersistenceId("myPersistenceId"),
+      persistenceId = PersistenceId.ofUniqueId("myPersistenceId"),
       emptyState = new First,
       commandHandler = CommandHandler.command { cmd =>
         Effect.persist(cmd).thenRun {

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
@@ -46,7 +46,7 @@ class PrimitiveStateSpec
   "A typed persistent actor with primitive state" must {
     "persist primitive events and update state" in {
       val probe = TestProbe[String]()
-      val b = primitiveState(PersistenceId("a"), probe.ref)
+      val b = primitiveState(PersistenceId.ofUniqueId("a"), probe.ref)
       val ref1 = spawn(b)
       probe.expectMessage("onRecoveryCompleted:0")
       ref1 ! 1

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotMutableStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotMutableStateSpec.scala
@@ -125,7 +125,7 @@ class SnapshotMutableStateSpec
   import SnapshotMutableStateSpec._
 
   val pidCounter = new AtomicInteger(0)
-  private def nextPid(): PersistenceId = PersistenceId(s"c${pidCounter.incrementAndGet()})")
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()})")
 
   "A typed persistent actor with mutable state" must {
 

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
@@ -81,7 +81,7 @@ object BasicPersistentBehaviorCompileOnly {
     //#behavior
     def apply(id: String): Behavior[Command] =
       EventSourcedBehavior[Command, Event, State](
-        persistenceId = PersistenceId(id),
+        persistenceId = PersistenceId.ofUniqueId(id),
         emptyState = State(Nil),
         commandHandler = commandHandler,
         eventHandler = eventHandler)
@@ -97,7 +97,7 @@ object BasicPersistentBehaviorCompileOnly {
 
     def apply(): Behavior[Command] =
       EventSourcedBehavior[Command, Event, State](
-        persistenceId = PersistenceId("abc"),
+        persistenceId = PersistenceId.ofUniqueId("abc"),
         emptyState = State(),
         commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"),
         eventHandler = (state, evt) => throw new NotImplementedError("TODO: process the event return the next state"))
@@ -110,7 +110,7 @@ object BasicPersistentBehaviorCompileOnly {
     def apply(): Behavior[Command] =
       //#recovery
       EventSourcedBehavior[Command, Event, State](
-        persistenceId = PersistenceId("abc"),
+        persistenceId = PersistenceId.ofUniqueId("abc"),
         emptyState = State(),
         commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"),
         eventHandler = (state, evt) => throw new NotImplementedError("TODO: process the event return the next state"))
@@ -125,7 +125,7 @@ object BasicPersistentBehaviorCompileOnly {
     def apply(): Behavior[Command] =
       //#tagging
       EventSourcedBehavior[Command, Event, State](
-        persistenceId = PersistenceId("abc"),
+        persistenceId = PersistenceId.ofUniqueId("abc"),
         emptyState = State(),
         commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"),
         eventHandler = (state, evt) => throw new NotImplementedError("TODO: process the event return the next state"))
@@ -163,7 +163,7 @@ object BasicPersistentBehaviorCompileOnly {
       //#wrapPersistentBehavior
       Behaviors.setup[Command] { context =>
         EventSourcedBehavior[Command, Event, State](
-          persistenceId = PersistenceId("abc"),
+          persistenceId = PersistenceId.ofUniqueId("abc"),
           emptyState = State(),
           commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"),
           eventHandler = (state, evt) => throw new NotImplementedError("TODO: process the event return the next state"))
@@ -179,7 +179,7 @@ object BasicPersistentBehaviorCompileOnly {
     def apply(): Behavior[Command] =
       //#supervision
       EventSourcedBehavior[Command, Event, State](
-        persistenceId = PersistenceId("abc"),
+        persistenceId = PersistenceId.ofUniqueId("abc"),
         emptyState = State(),
         commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"),
         eventHandler = (state, evt) => throw new NotImplementedError("TODO: process the event return the next state"))
@@ -196,7 +196,7 @@ object BasicPersistentBehaviorCompileOnly {
     def apply(): Behavior[String] =
       Behaviors.setup { context =>
         EventSourcedBehavior[String, String, State](
-          persistenceId = PersistenceId("myPersistenceId"),
+          persistenceId = PersistenceId.ofUniqueId("myPersistenceId"),
           emptyState = State(),
           commandHandler = CommandHandler.command { cmd =>
             context.log.info("Got command {}", cmd)
@@ -216,7 +216,7 @@ object BasicPersistentBehaviorCompileOnly {
   //#snapshottingEveryN
 
   EventSourcedBehavior[Command, Event, State](
-    persistenceId = PersistenceId("abc"),
+    persistenceId = PersistenceId.ofUniqueId("abc"),
     emptyState = State(),
     commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"),
     eventHandler = (state, evt) => throw new NotImplementedError("TODO: process the event return the next state"))
@@ -225,7 +225,7 @@ object BasicPersistentBehaviorCompileOnly {
 
   //#snapshottingPredicate
   EventSourcedBehavior[Command, Event, State](
-    persistenceId = PersistenceId("abc"),
+    persistenceId = PersistenceId.ofUniqueId("abc"),
     emptyState = State(),
     commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"),
     eventHandler = (state, evt) => throw new NotImplementedError("TODO: process the event return the next state"))
@@ -239,7 +239,7 @@ object BasicPersistentBehaviorCompileOnly {
   import akka.persistence.typed.SnapshotSelectionCriteria
 
   EventSourcedBehavior[Command, Event, State](
-    persistenceId = PersistenceId("abc"),
+    persistenceId = PersistenceId.ofUniqueId("abc"),
     emptyState = State(),
     commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"),
     eventHandler = (state, evt) => throw new NotImplementedError("TODO: process the event return the next state"))
@@ -251,7 +251,7 @@ object BasicPersistentBehaviorCompileOnly {
   import akka.persistence.typed.scaladsl.Effect
 
   EventSourcedBehavior[Command, Event, State](
-    persistenceId = PersistenceId("abc"),
+    persistenceId = PersistenceId.ofUniqueId("abc"),
     emptyState = State(),
     commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"),
     eventHandler = (state, evt) => state) // do something based on a particular state
@@ -265,7 +265,7 @@ object BasicPersistentBehaviorCompileOnly {
   //#snapshotAndEventDeletes
 
   EventSourcedBehavior[Command, Event, State](
-    persistenceId = PersistenceId("abc"),
+    persistenceId = PersistenceId.ofUniqueId("abc"),
     emptyState = State(),
     commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"),
     eventHandler = (state, evt) => throw new NotImplementedError("TODO: process the event return the next state"))
@@ -280,7 +280,7 @@ object BasicPersistentBehaviorCompileOnly {
   //#retentionCriteriaWithSignals
 
   EventSourcedBehavior[Command, Event, State](
-    persistenceId = PersistenceId("abc"),
+    persistenceId = PersistenceId.ofUniqueId("abc"),
     emptyState = State(),
     commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"),
     eventHandler = (state, evt) => throw new NotImplementedError("TODO: process the event return the next state"))
@@ -302,7 +302,7 @@ object BasicPersistentBehaviorCompileOnly {
 
   //#install-event-adapter
   EventSourcedBehavior[Command, Event, State](
-    persistenceId = PersistenceId("abc"),
+    persistenceId = PersistenceId.ofUniqueId("abc"),
     emptyState = State(),
     commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"),
     eventHandler = (state, evt) => throw new NotImplementedError("TODO: process the event return the next state"))

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/MovieWatchList.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/MovieWatchList.scala
@@ -44,7 +44,7 @@ object MovieWatchList {
 
   def behavior(userId: String): Behavior[Command] = {
     EventSourcedBehavior[Command, Event, MovieList](
-      persistenceId = PersistenceId(s"movies-$userId"),
+      persistenceId = PersistenceId("movies", userId),
       emptyState = MovieList(Set.empty),
       commandHandler,
       eventHandler = (state, event) => state.applyEvent(event))

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/PersistentFsmToTypedMigrationSpec.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/PersistentFsmToTypedMigrationSpec.scala
@@ -239,7 +239,7 @@ class PersistentFsmToTypedMigrationSpec extends WordSpec with ScalaFutures with 
       try {
         import typedTestKit._
         val typedProbe = akka.actor.testkit.typed.scaladsl.TestProbe[ShoppingCart]()
-        val typedReplacement = spawn(ShoppingCartBehavior(PersistenceId(pid)))
+        val typedReplacement = spawn(ShoppingCartBehavior(PersistenceId.ofUniqueId(pid)))
         typedReplacement ! ShoppingCartBehavior.AddItem(coat)
         typedReplacement ! ShoppingCartBehavior.GetCurrentCart(typedProbe.ref)
         typedProbe.expectMessage(NonEmptyShoppingCart(List(shirt, shoes, coat)))
@@ -277,7 +277,7 @@ class PersistentFsmToTypedMigrationSpec extends WordSpec with ScalaFutures with 
       try {
         import typedTestKit._
         val typedProbe = akka.actor.testkit.typed.scaladsl.TestProbe[ShoppingCart]()
-        val typedReplacement = spawn(ShoppingCartBehavior(PersistenceId(pid)))
+        val typedReplacement = spawn(ShoppingCartBehavior(PersistenceId.ofUniqueId(pid)))
         typedReplacement ! ShoppingCartBehavior.GetCurrentCart(typedProbe.ref)
         typedProbe.expectMessage(NonEmptyShoppingCart(Seq(shirt)))
       } finally {


### PR DESCRIPTION
* to make the entityTypeHint, entityId the more prominent choice, and
  avoid that only the entityId is used as the uniqueId

Refs #27924