### PR TITLE
Last sequence number fix

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Snappshotting.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Snappshotting.scala
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.persistence.typed.internal
+
+class Snappshotting {}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Snappshotting.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Snappshotting.scala
@@ -1,6 +1,0 @@
-/*
- * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
- */
-package akka.persistence.typed.internal
-
-class Snappshotting {}

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedSequenceNumberSpec.scala
@@ -18,6 +18,8 @@ object EventSourcedSequenceNumberSpec {
   private val conf = ConfigFactory.parseString(s"""
       akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
       akka.persistence.journal.inmem.test-serialization = on
+      akka.persistence.snapshot-store.plugin = "slow-snapshot-store"
+      slow-snapshot-store.class = "${classOf[SlowInMemorySnapshotStore].getName}"
     """)
 
 }
@@ -28,17 +30,40 @@ class EventSourcedSequenceNumberSpec
     with LogCapturing {
 
   private def behavior(pid: PersistenceId, probe: ActorRef[String]): Behavior[String] =
-    Behaviors.setup(ctx =>
-      EventSourcedBehavior[String, String, String](pid, "", { (_, command) =>
-        probe ! s"${EventSourcedBehavior.lastSequenceNumber(ctx)} onCommand"
-        Effect.persist(command).thenRun(_ => probe ! s"${EventSourcedBehavior.lastSequenceNumber(ctx)} thenRun")
-      }, { (state, evt) =>
-        probe ! s"${EventSourcedBehavior.lastSequenceNumber(ctx)} eventHandler"
-        state + evt
-      }).receiveSignal {
-        case (_, RecoveryCompleted) =>
-          probe ! s"${EventSourcedBehavior.lastSequenceNumber(ctx)} onRecoveryComplete"
-      })
+    Behaviors.setup(
+      ctx =>
+        EventSourcedBehavior[String, String, String](pid, "", {
+          (state, command) =>
+            state match {
+              case "stashing" =>
+                command match {
+                  case "unstash" =>
+                    probe ! s"${EventSourcedBehavior.lastSequenceNumber(ctx)} unstash"
+                    Effect.persist("normal").thenUnstashAll()
+                  case _ =>
+                    Effect.stash()
+                }
+              case _ =>
+                command match {
+                  case "cmd" =>
+                    probe ! s"${EventSourcedBehavior.lastSequenceNumber(ctx)} onCommand"
+                    Effect
+                      .persist(command)
+                      .thenRun(_ => probe ! s"${EventSourcedBehavior.lastSequenceNumber(ctx)} thenRun")
+                  case "stash" =>
+                    probe ! s"${EventSourcedBehavior.lastSequenceNumber(ctx)} stash"
+                    Effect.persist("stashing")
+                  case "snapshot" =>
+                    Effect.persist("snapshot")
+                }
+            }
+        }, { (_, evt) =>
+          probe ! s"${EventSourcedBehavior.lastSequenceNumber(ctx)} eventHandler"
+          evt
+        }).snapshotWhen((_, event, _) => event == "snapshot").receiveSignal {
+          case (_, RecoveryCompleted) =>
+            probe ! s"${EventSourcedBehavior.lastSequenceNumber(ctx)} onRecoveryComplete"
+        })
 
   "The sequence number" must {
 
@@ -47,10 +72,51 @@ class EventSourcedSequenceNumberSpec
       val ref = spawn(behavior(PersistenceId("ess-1"), probe.ref))
       probe.expectMessage("0 onRecoveryComplete")
 
-      ref ! "cmd1"
+      ref ! "cmd"
       probe.expectMessage("0 onCommand")
       probe.expectMessage("0 eventHandler")
       probe.expectMessage("1 thenRun")
+    }
+
+    "be available while replaying stash" in {
+      val probe = TestProbe[String]()
+      val ref = spawn(behavior(PersistenceId("ess-2"), probe.ref))
+      probe.expectMessage("0 onRecoveryComplete")
+
+      ref ! "stash"
+      ref ! "cmd"
+      ref ! "cmd"
+      ref ! "cmd"
+      ref ! "unstash"
+      probe.expectMessage("0 stash")
+      probe.expectMessage("0 eventHandler")
+      probe.expectMessage("1 unstash")
+      probe.expectMessage("1 eventHandler")
+      probe.expectMessage("2 onCommand")
+      probe.expectMessage("2 eventHandler")
+      probe.expectMessage("3 thenRun")
+      probe.expectMessage("3 onCommand")
+      probe.expectMessage("3 eventHandler")
+      probe.expectMessage("4 thenRun")
+    }
+
+    // reproducer for #27935
+    "not fail when snapshotting" in {
+      val probe = TestProbe[String]()
+      val ref = spawn(behavior(PersistenceId("ess-3"), probe.ref))
+      probe.expectMessage("0 onRecoveryComplete")
+
+      ref ! "cmd"
+      ref ! "snapshot"
+      ref ! "cmd"
+
+      probe.expectMessage("0 onCommand") // first command
+      probe.expectMessage("0 eventHandler")
+      probe.expectMessage("1 thenRun")
+      probe.expectMessage("1 eventHandler") // snapshot
+      probe.expectMessage("2 onCommand") // second command
+      probe.expectMessage("2 eventHandler")
+      probe.expectMessage("3 thenRun")
     }
   }
 }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SlowInMemorySnapshotStore.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SlowInMemorySnapshotStore.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.scaladsl
+
+import akka.persistence.SelectedSnapshot
+import akka.persistence.snapshot.SnapshotStore
+import akka.persistence.typed.scaladsl.SnapshotMutableStateSpec.MutableState
+import akka.persistence.{ SnapshotSelectionCriteria => ClassicSnapshotSelectionCriteria }
+import akka.persistence.{ SnapshotMetadata => ClassicSnapshotMetadata }
+
+import scala.concurrent.Future
+
+class SlowInMemorySnapshotStore extends SnapshotStore {
+
+  private var state = Map.empty[String, (Any, ClassicSnapshotMetadata)]
+
+  def loadAsync(persistenceId: String, criteria: ClassicSnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
+    Future.successful(state.get(persistenceId).map {
+      case (snap, meta) => SelectedSnapshot(meta, snap)
+    })
+  }
+
+  def saveAsync(metadata: ClassicSnapshotMetadata, snapshot: Any): Future[Unit] = {
+    val snapshotState = snapshot.asInstanceOf[MutableState]
+    val value1 = snapshotState.value
+    Thread.sleep(50)
+    val value2 = snapshotState.value
+    // it mustn't have been modified by another command/event
+    if (value1 != value2)
+      Future.failed(new IllegalStateException(s"State changed from $value1 to $value2"))
+    else {
+      // copy to simulate serialization, and subsequent recovery shouldn't get same instance
+      state = state.updated(metadata.persistenceId, (new MutableState(snapshotState.value), metadata))
+      Future.successful(())
+    }
+  }
+
+  override def deleteAsync(metadata: ClassicSnapshotMetadata): Future[Unit] = {
+    state = state.filterNot {
+      case (pid, (_, meta)) => pid == metadata.persistenceId && meta.sequenceNr == metadata.sequenceNr
+    }
+    Future.successful(())
+  }
+
+  override def deleteAsync(persistenceId: String, criteria: ClassicSnapshotSelectionCriteria): Future[Unit] = {
+    state = state.filterNot {
+      case (pid, (_, meta)) => pid == persistenceId && criteria.matches(meta)
+    }
+    Future.successful(())
+  }
+}

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotMutableStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/SnapshotMutableStateSpec.scala
@@ -7,66 +7,18 @@ package akka.persistence.typed.scaladsl
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.concurrent.Future
-
 import akka.actor.testkit.typed.scaladsl._
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
-import akka.persistence.SelectedSnapshot
-import akka.persistence.snapshot.SnapshotStore
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.SnapshotCompleted
 import akka.persistence.typed.SnapshotFailed
-import akka.persistence.{ SnapshotSelectionCriteria => ClassicSnapshotSelectionCriteria }
-import akka.persistence.{ SnapshotMetadata => ClassicSnapshotMetadata }
 import akka.serialization.jackson.CborSerializable
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.WordSpecLike
 
 object SnapshotMutableStateSpec {
-
-  class SlowInMemorySnapshotStore extends SnapshotStore {
-
-    private var state = Map.empty[String, (Any, ClassicSnapshotMetadata)]
-
-    def loadAsync(
-        persistenceId: String,
-        criteria: ClassicSnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {
-      Future.successful(state.get(persistenceId).map {
-        case (snap, meta) => SelectedSnapshot(meta, snap)
-      })
-    }
-
-    def saveAsync(metadata: ClassicSnapshotMetadata, snapshot: Any): Future[Unit] = {
-      val snapshotState = snapshot.asInstanceOf[MutableState]
-      val value1 = snapshotState.value
-      Thread.sleep(50)
-      val value2 = snapshotState.value
-      // it mustn't have been modified by another command/event
-      if (value1 != value2)
-        Future.failed(new IllegalStateException(s"State changed from $value1 to $value2"))
-      else {
-        // copy to simulate serialization, and subsequent recovery shouldn't get same instance
-        state = state.updated(metadata.persistenceId, (new MutableState(snapshotState.value), metadata))
-        Future.successful(())
-      }
-    }
-
-    override def deleteAsync(metadata: ClassicSnapshotMetadata): Future[Unit] = {
-      state = state.filterNot {
-        case (pid, (_, meta)) => pid == metadata.persistenceId && meta.sequenceNr == metadata.sequenceNr
-      }
-      Future.successful(())
-    }
-
-    override def deleteAsync(persistenceId: String, criteria: ClassicSnapshotSelectionCriteria): Future[Unit] = {
-      state = state.filterNot {
-        case (pid, (_, meta)) => pid == persistenceId && criteria.matches(meta)
-      }
-      Future.successful(())
-    }
-  }
 
   def conf: Config = ConfigFactory.parseString(s"""
     akka.loglevel = INFO


### PR DESCRIPTION
Refs #27935

When a snapshot write was in progress this switched from the internal EventSourcedEntity state machine `AbstracBehavior with WithSeqNrAccessible` to a `Behaviors.receiveMessage` which would make user calls to `EventSourcedBehavior.lastSequenceNumber` fail.
