### PR TITLE
Fail startup if mixed versions are used, #27965

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/config/ConfigSpec.scala
@@ -48,6 +48,9 @@ class ConfigSpec extends AkkaSpec(ConfigFactory.defaultReference(ActorSystem.fin
         settings.JvmExitOnFatalError should ===(true)
         settings.JvmShutdownHooks should ===(true)
 
+        getBoolean("akka.fail-mixed-versions") should ===(true)
+        settings.FailMixedVersions should ===(true)
+
         getInt("akka.actor.deployment.default.virtual-nodes-factor") should ===(10)
         settings.DefaultVirtualNodesFactor should ===(10)
 

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -94,6 +94,11 @@ akka {
   # terminate the ActorSystem itself, with or without using CoordinatedShutdown.
   jvm-shutdown-hooks = on
 
+  # Version must be the same across all modules and if they are different the startup
+  # will fail. It's possible but not recommended, to disable this check, and only log a warning,
+  # by setting this property to `off`.
+  fail-mixed-versions = on
+
   actor {
 
     # Either one of "local", "remote" or "cluster" or the

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -467,6 +467,7 @@ object ActorSystem {
     final val Daemonicity: Boolean = getBoolean("akka.daemonic")
     final val JvmExitOnFatalError: Boolean = getBoolean("akka.jvm-exit-on-fatal-error")
     final val JvmShutdownHooks: Boolean = getBoolean("akka.jvm-shutdown-hooks")
+    final val FailMixedVersions: Boolean = getBoolean("akka.fail-mixed-versions")
 
     final val CoordinatedShutdownTerminateActorSystem: Boolean = getBoolean(
       "akka.coordinated-shutdown.terminate-actor-system")

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -373,7 +373,8 @@ the default dispatcher has been adjusted down to `1.0` which means the number of
 ### Mixed version
 
 Startup will fail if mixed versions of a product family (such as Akka) are accidentally used. This was previously
-only logged as a warning.
+only logged as a warning. There is no guarantee mixed modules will work and it's better to fail early than
+that the application is crashing at a later time than startup.
 
 By defining the following configuration it is possible, but not recommended, to disable this behavior and only log a
 warning if mixed versions are detected:

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -370,6 +370,18 @@ blocking and protect a bit against starving the internal actors. Since the inter
 the default dispatcher has been adjusted down to `1.0` which means the number of threads will be one per core, but at least
 `8` and at most `64`. This can be tuned using the individual settings in `akka.actor.default-dispatcher.fork-join-executor`.
 
+### Mixed version
+
+Startup will fail if mixed versions of a product family (such as Akka) are accidentally used. This was previously
+only logged as a warning.
+
+By defining the following configuration it is possible, but not recommended, to disable this behavior and only log a
+warning if mixed versions are detected:
+
+```
+akka.fail-mixed-versions = off
+``` 
+
 ### Cluster Sharding
 
 #### waiting-for-state-timeout reduced to 2s

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -374,14 +374,7 @@ the default dispatcher has been adjusted down to `1.0` which means the number of
 
 Startup will fail if mixed versions of a product family (such as Akka) are accidentally used. This was previously
 only logged as a warning. There is no guarantee mixed modules will work and it's better to fail early than
-that the application is crashing at a later time than startup.
-
-By defining the following configuration it is possible, but not recommended, to disable this behavior and only log a
-warning if mixed versions are detected:
-
-```
-akka.fail-mixed-versions = off
-``` 
+that the application is crashing at a later time than startup. 
 
 ### Cluster Sharding
 


### PR DESCRIPTION
* good to make it more strict in Akka 2.6.0
* possibility to opt out via config

Refs #27965