### PR TITLE
-5 pads out the max level of a logger, remove when using []

### DIFF
--- a/akka-actor-typed-tests/src/test/resources/logback-doc-dev.xml
+++ b/akka-actor-typed-tests/src/test/resources/logback-doc-dev.xml
@@ -6,14 +6,14 @@
             <level>INFO</level>
         </filter>
         <encoder>
-            <pattern>[%date{ISO8601}] [%-5level] [%logger] [%thread] [%X{akkaSource}] - %msg%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%thread] [%X{akkaSource}] - %msg%n</pattern>
         </encoder>
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>target/myapp-dev.log</file>
         <encoder>
-            <pattern>[%date{ISO8601}] [%-5level] [%logger] [%thread] [%X{akkaSource}] - %msg%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%thread] [%X{akkaSource}] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-actor-typed-tests/src/test/resources/logback-doc-prod.xml
+++ b/akka-actor-typed-tests/src/test/resources/logback-doc-prod.xml
@@ -8,7 +8,7 @@
             <fileNamePattern>myapp_%d{yyyy-MM-dd}.log</fileNamePattern>
         </rollingPolicy>
         <encoder>
-            <pattern>[%date{ISO8601}] [%-5level] [%logger] [%thread] [%X{akkaSource}] - %msg%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%thread] [%X{akkaSource}] - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-actor-typed-tests/src/test/resources/logback-doc-test.xml
+++ b/akka-actor-typed-tests/src/test/resources/logback-doc-test.xml
@@ -6,7 +6,7 @@
             <level>INFO</level>
         </filter>
         <encoder>
-            <pattern>[%date{ISO8601}] [%-5level] [%logger] [%thread] [%X{akkaSource}] - %msg%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%thread] [%X{akkaSource}] - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
When we use [] around the level it adds a space which then means
searching for [INFO] doesn't work. Left it in for the examples
that don't surround logger with []