### PR TITLE
Include host and port in BindException message (#27785)

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -29,7 +29,7 @@ import akka.stream.scaladsl._
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.testkit.EventFilter
-import akka.testkit.SocketUtil.temporaryServerAddress
+import akka.testkit.SocketUtil.{ temporaryServerAddress, temporaryServerHostnameAndPort }
 import akka.testkit.TestKit
 import akka.testkit.TestLatch
 import akka.testkit.TestProbe
@@ -829,6 +829,25 @@ class TcpSpec extends StreamSpec("""
       } finally sys2.terminate()
     }
 
+    "show host and port in bind exception message" in EventFilter[BindException](occurrences = 1).intercept {
+      val (host, port) = temporaryServerHostnameAndPort()
+      val bind = Tcp(system).bind(host, port)
+
+      val probe1 = TestSubscriber.manualProbe[Tcp.IncomingConnection]()
+      val binding1 = bind.to(Sink.fromSubscriber(probe1)).run().futureValue
+
+      probe1.expectSubscription()
+
+      val probe2 = TestSubscriber.manualProbe[Tcp.IncomingConnection]()
+      val binding2 = bind.to(Sink.fromSubscriber(probe2)).run()
+
+      val thrown = the[BindFailedException] thrownBy Await.result(binding2, 3.seconds)
+      thrown.getMessage should include(host)
+      thrown.getMessage should include(port.toString)
+
+      // clean up
+      binding1.unbind().futureValue
+    }
   }
 
   "TLS client and server convenience methods with SSLEngine setup" should {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Purpose

Include `host` and `port` information in the error message when there is a binding error.

## References

References #27785

## Changes

When `java.net.BindException` is found, `host` and `port` information will be added to the original error message `Address already in use`, eg, `[localhost:12345] Address already in use`.

However, since `Exception` is immutable, so a new `java.net.BindException` with the updated message will be returned.

## Background Context

The approach was discussed in #27785 .
