### PR TITLE
Provide Scheduler implicitly from implicit typed actorsystem

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeoutException
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-
 import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.internal.ActorTestKitGuardian
 import akka.actor.testkit.typed.internal.TestKitUtils
@@ -144,10 +143,11 @@ final class ActorTestKit private[akka] (val name: String, val config: Config, se
 
   implicit def system: ActorSystem[Nothing] = internalSystem
 
-  implicit def scheduler: Scheduler = system.scheduler
   private val childName: Iterator[String] = Iterator.from(0).map(_.toString)
 
   implicit val timeout: Timeout = testKitSettings.DefaultTimeout
+
+  def scheduler: Scheduler = system.scheduler
 
   def shutdownTestKit(): Unit = {
     ActorTestKit.shutdown(

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitBase.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitBase.scala
@@ -9,7 +9,6 @@ import akka.actor.testkit.typed.internal.TestKitUtils
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
-import akka.actor.typed.Scheduler
 import akka.actor.typed.Props
 import akka.util.Timeout
 import com.typesafe.config.Config
@@ -64,11 +63,6 @@ abstract class ActorTestKitBase(val testKit: ActorTestKit) {
    * See corresponding method on [[ActorTestKit]]
    */
   implicit def timeout: Timeout = testKit.timeout
-
-  /**
-   * See corresponding method on [[ActorTestKit]]
-   */
-  implicit def scheduler: Scheduler = testKit.scheduler
 
   /**
    * See corresponding method on [[ActorTestKit]]

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -130,7 +130,6 @@ class AskSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCaptur
         import scaladsl.AskPattern._
         import akka.actor.typed.scaladsl.adapter._
         implicit val timeout: Timeout = 3.seconds
-        implicit val scheduler = classicSystem.toTyped.scheduler
         val typedLegacy: ActorRef[AnyRef] = legacyActor
         (typedLegacy.ask(Ping)).failed.futureValue should ===(ex)
       } finally {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/ReceptionistApiSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/receptionist/ReceptionistApiSpec.scala
@@ -20,8 +20,7 @@ object ReceptionistApiSpec {
     implicit val timeout: Timeout = 3.seconds
     val service: ActorRef[String] = ???
     val key: ServiceKey[String] = ServiceKey[String]("id")
-    val system: ActorSystem[Void] = ???
-    implicit val scheduler = system.scheduler
+    implicit val system: ActorSystem[Void] = ???
     import system.executionContext
 
     // registration from outside, without ack, should be rare

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
@@ -410,10 +410,9 @@ class InteractionPatternsSpec extends ScalaTestWithActorTestKit with WordSpecLik
     import akka.actor.typed.scaladsl.AskPattern._
     import akka.util.Timeout
 
-    // asking someone requires a timeout and a scheduler, if the timeout hits without response
+    // asking someone requires a timeout if the timeout hits without response
     // the ask is failed with a TimeoutException
     implicit val timeout: Timeout = 3.seconds
-    implicit val scheduler = system.scheduler
 
     val result: Future[CookieFabric.Cookies] = cookieFabric.ask(ref => CookieFabric.GiveMeCookies(ref))
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
@@ -64,7 +64,6 @@ class SpawnProtocolDocSpec extends ScalaTestWithActorTestKit with WordSpecLike w
       import akka.actor.typed.scaladsl.AskPattern._
       implicit val ec: ExecutionContext = system.executionContext
       implicit val timeout: Timeout = Timeout(3.seconds)
-      implicit val scheduler: Scheduler = system.scheduler
 
       val greeter: Future[ActorRef[HelloWorld.Greet]] =
         system.ask(SpawnProtocol.Spawn(behavior = HelloWorld(), name = "greeter", props = Props.empty, _))

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
@@ -28,7 +28,6 @@ import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Props
 import akka.util.Timeout
-import akka.actor.typed.Scheduler
 
 //#imports2
 
@@ -57,7 +56,7 @@ class SpawnProtocolDocSpec extends ScalaTestWithActorTestKit with WordSpecLike w
     "be able to spawn actors" in {
       //#system-spawn
 
-      val system: ActorSystem[SpawnProtocol.Command] =
+      implicit val system: ActorSystem[SpawnProtocol.Command] =
         ActorSystem(HelloWorldMain(), "hello")
 
       // needed in implicit scope for ask (?)

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
@@ -422,14 +422,13 @@ object StyleGuideDocExamples {
   object Ask {
     import Messages.CounterProtocol._
 
-    val system: ActorSystem[Nothing] = ???
+    implicit val system: ActorSystem[Nothing] = ???
 
     //#ask-1
     import akka.actor.typed.scaladsl.AskPattern._
     import akka.util.Timeout
 
     implicit val timeout = Timeout(3.seconds)
-    implicit val scheduler = system.scheduler
     val counter: ActorRef[Command] = ???
 
     val result: Future[OperationResult] = counter.ask(replyTo => Increment(delta = 2, replyTo))

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeoutException
 import scala.concurrent.Future
 import akka.actor.{ Address, RootActorPath }
 import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
 import akka.actor.typed.Scheduler
 import akka.actor.typed.internal.{ adapter => adapt }
 import akka.annotation.InternalApi
@@ -24,6 +25,12 @@ import com.github.ghik.silencer.silent
  * See [[AskPattern.Askable.ask]] for details
  */
 object AskPattern {
+
+  /**
+   * Provides a scheduler from an actor system (that will likely already be implicit in the scope) to minimize ask
+   * boilerplate.
+   */
+  implicit def schedulerFromActorSystem(implicit system: ActorSystem[_]): Scheduler = system.scheduler
 
   /**
    * See [[ask]]

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
@@ -60,7 +60,7 @@ object AskPattern {
      * case class Request(msg: String, replyTo: ActorRef[Reply])
      * case class Reply(msg: String)
      *
-     * implicit val scheduler = system.scheduler
+     * implicit val system = ...
      * implicit val timeout = Timeout(3.seconds)
      * val target: ActorRef[Request] = ...
      * val f: Future[Reply] = target ? (replyTo => Request("hello", replyTo))
@@ -93,7 +93,7 @@ object AskPattern {
      * case class Request(msg: String, replyTo: ActorRef[Reply])
      * case class Reply(msg: String)
      *
-     * implicit val scheduler = system.scheduler
+     * implicit val system = ...
      * implicit val timeout = Timeout(3.seconds)
      * val target: ActorRef[Request] = ...
      * val f: Future[Reply] = target.ask(replyTo => Request("hello", replyTo))

--- a/akka-bench-jmh/src/main/scala/akka/actor/typed/TypedActorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/typed/TypedActorBenchmark.scala
@@ -48,7 +48,6 @@ class TypedActorBenchmark {
   implicit var system: ActorSystem[Start] = _
 
   implicit val askTimeout = akka.util.Timeout(timeout)
-  implicit def scheduler = system.scheduler
 
   @Setup(Level.Trial)
   def setup(): Unit = {

--- a/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/internal/ClusterReceptionistUnreachabilitySpec.scala
+++ b/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/internal/ClusterReceptionistUnreachabilitySpec.scala
@@ -58,7 +58,6 @@ abstract class ClusterReceptionistUnreachabilitySpec
   val spawnActor = system.actorOf(PropsAdapter(SpawnProtocol())).toTyped[SpawnProtocol.Command]
   def spawn[T](behavior: Behavior[T], name: String): ActorRef[T] = {
     implicit val timeout: Timeout = 3.seconds
-    implicit val scheduler = typedSystem.scheduler
     val f: Future[ActorRef[T]] = spawnActor.ask(SpawnProtocol.Spawn(behavior, name, Props.empty, _))
 
     Await.result(f, 3.seconds)

--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -618,6 +618,7 @@ made before finalizing the APIs. Compared to Akka 2.5.x the source incompatible 
   The reason is to encourage right usage and detect mistakes like not creating a new instance (via `setup`)
   when the behavior is supervised and restarted.    
 * `LoggingEventFilter` has been renamed to `LoggingTestKit` and its `intercept` method renamed to `assert`
+* Scala `ask` from `AskPattern` now implicitly converts an implicit `ActorSystem[_]` to `Scheduler` to eliminate some boilerplate.
 
 #### Akka Typed Stream API changes
 

--- a/akka-docs/src/test/scala/docs/persistence/query/PersistenceQueryDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/persistence/query/PersistenceQueryDocSpec.scala
@@ -296,7 +296,6 @@ class PersistenceQueryDocSpec(s: String) extends AkkaSpec(s) {
         PersistenceQuery(system.toClassic).readJournalFor[MyScaladslReadJournal](JournalId)
 
       import system.executionContext
-      implicit val scheduler = system.scheduler
       implicit val timeout = Timeout(3.seconds)
 
       val bidProjection = new MyResumableProjection("bid")

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
@@ -64,7 +64,6 @@ object PersistentActorCompileOnlyTest {
     def performSideEffect(sender: ActorRef[AcknowledgeSideEffect], correlationId: Int, data: String): Unit = {
       import akka.actor.typed.scaladsl.AskPattern._
       implicit val timeout: akka.util.Timeout = 1.second
-      implicit val scheduler: akka.actor.typed.Scheduler = ???
       implicit val ec: ExecutionContext = ???
 
       val response: Future[RecoveryComplete.Response] =

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
@@ -4,6 +4,8 @@
 
 package akka.persistence.typed.scaladsl
 
+import akka.actor.typed.ActorSystem
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import akka.actor.typed.{ ActorRef, Behavior }
@@ -64,6 +66,7 @@ object PersistentActorCompileOnlyTest {
     def performSideEffect(sender: ActorRef[AcknowledgeSideEffect], correlationId: Int, data: String): Unit = {
       import akka.actor.typed.scaladsl.AskPattern._
       implicit val timeout: akka.util.Timeout = 1.second
+      implicit val system: ActorSystem[_] = ???
       implicit val ec: ExecutionContext = ???
 
       val response: Future[RecoveryComplete.Response] =


### PR DESCRIPTION
## Purpose
Minimize AskPattern boilerplate by implicitly providing a `Scheduler` when there is an implict `ActorSystem` in context.

## References
Refs #27968