### PR TITLE
doc: Show how to fail future of external ask

### DIFF
--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java
@@ -620,7 +620,7 @@ public class InteractionPatternsTest extends JUnitSuite {
 
   interface StandaloneAskSample {
     // #standalone-ask
-    public class CookieFabric {
+    public class CookieFabric extends AbstractBehavior<CookieFabric.Command> {
 
       interface Command {}
 
@@ -650,6 +650,26 @@ public class InteractionPatternsTest extends JUnitSuite {
         public InvalidRequest(String reason) {
           this.reason = reason;
         }
+      }
+
+      public static Behavior<Command> create() {
+        return Behaviors.setup(CookieFabric::new);
+      }
+
+      private CookieFabric(ActorContext<Command> context) {
+        super(context);
+      }
+
+      @Override
+      public Receive<Command> createReceive() {
+        return newReceiveBuilder().onMessage(GiveMeCookies.class, this::onGiveMeCookies).build();
+      }
+
+      private Behavior<Command> onGiveMeCookies(GiveMeCookies request) {
+        if (request.count >= 5) request.replyTo.tell(new InvalidRequest("Too many cookies."));
+        else request.replyTo.tell(new Cookies(request.count));
+
+        return this;
       }
     }
     // #standalone-ask

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala
@@ -391,12 +391,18 @@ class InteractionPatternsSpec extends ScalaTestWithActorTestKit with WordSpecLik
     // #standalone-ask
     object CookieFabric {
       sealed trait Command {}
-      case class GiveMeCookies(replyTo: ActorRef[Cookies]) extends Command
-      case class Cookies(count: Int)
+      case class GiveMeCookies(count: Int, replyTo: ActorRef[Reply]) extends Command
+
+      sealed trait Reply
+      case class Cookies(count: Int) extends Reply
+      case class InvalidRequest(reason: String) extends Reply
 
       def apply(): Behaviors.Receive[CookieFabric.GiveMeCookies] =
         Behaviors.receiveMessage { message =>
-          message.replyTo ! Cookies(5)
+          if (message.count >= 5)
+            message.replyTo ! InvalidRequest("Too many cookies.")
+          else
+            message.replyTo ! Cookies(message.count)
           Behaviors.same
         }
     }
@@ -414,18 +420,34 @@ class InteractionPatternsSpec extends ScalaTestWithActorTestKit with WordSpecLik
     // the ask is failed with a TimeoutException
     implicit val timeout: Timeout = 3.seconds
 
-    val result: Future[CookieFabric.Cookies] = cookieFabric.ask(ref => CookieFabric.GiveMeCookies(ref))
+    val result: Future[CookieFabric.Reply] = cookieFabric.ask(ref => CookieFabric.GiveMeCookies(3, ref))
 
     // the response callback will be executed on this execution context
     implicit val ec = system.executionContext
 
     result.onComplete {
-      case Success(cookies) => println(s"Yay, cookies! $cookies")
-      case Failure(ex)      => println(s"Boo! didn't get cookies: ${ex.getMessage}")
+      case Success(CookieFabric.Cookies(count))         => println(s"Yay, $count cookies!")
+      case Success(CookieFabric.InvalidRequest(reason)) => println(s"No cookies for me. $reason")
+      case Failure(ex)                                  => println(s"Boo! didn't get cookies: ${ex.getMessage}")
     }
     // #standalone-ask
 
-    result.futureValue shouldEqual CookieFabric.Cookies(5)
+    result.futureValue shouldEqual CookieFabric.Cookies(3)
+
+    // #standalone-ask-fail-future
+    val cookies: Future[CookieFabric.Cookies] =
+      cookieFabric.ask[CookieFabric.Reply](ref => CookieFabric.GiveMeCookies(3, ref)).flatMap {
+        case c: CookieFabric.Cookies             => Future.successful(c)
+        case CookieFabric.InvalidRequest(reason) => Future.failed(new IllegalArgumentException(reason))
+      }
+
+    cookies.onComplete {
+      case Success(CookieFabric.Cookies(count)) => println(s"Yay, $count cookies!")
+      case Failure(ex)                          => println(s"Boo! didn't get cookies: ${ex.getMessage}")
+    }
+    // #standalone-ask-fail-future
+
+    cookies.futureValue shouldEqual CookieFabric.Cookies(3)
   }
 
   "contain a sample for pipeToSelf" in {

--- a/akka-docs/src/main/paradox/typed/interaction-patterns.md
+++ b/akka-docs/src/main/paradox/typed/interaction-patterns.md
@@ -206,6 +206,17 @@ Scala
 Java
 :  @@snip [InteractionPatternsTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java) { #standalone-ask }
 
+Note that validation errors are also explicit in the message protocol. The `GiveMeCookies` request can reply
+with `Cookies` or `InvalidRequest`. The requestor has to decide how to handle `InvalidRequest` reply. Sometimes
+that should be treated as a failed @scala[`Future`]@java[`Future`] and for that the reply can be mapped on the
+requestor side.
+
+Scala
+:  @@snip [InteractionPatternsSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/InteractionPatternsSpec.scala) { #standalone-ask-fail-future }
+
+Java
+:  @@snip [InteractionPatternsTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java) { #standalone-ask-fail-future }
+
 **Useful when:**
 
  * Querying an actor from outside of the actor system 


### PR DESCRIPTION
* illustrate that validation errors are also part of
  message protocol
* error messages can be turned into failed future


See #25781, maybe doesn't close the ticket but should be good to document anyhow.