### PR TITLE
StreamRefs spec fail, #27957

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StreamRefSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StreamRefSpec.scala
@@ -37,6 +37,7 @@ object StreamRefSpec extends MultiNodeConfig {
   commonConfig(
     debugConfig(on = false)
       .withFallback(ConfigFactory.parseString("""
+        akka.stream.materializer.stream-ref.subscription-timeout = 10 s
         akka.cluster {
           downing-provider-class = akka.cluster.testkit.AutoDowning
           testkit.auto-down-unreachable-after = 1s
@@ -254,7 +255,7 @@ abstract class StreamRefSpec extends MultiNodeSpec(StreamRefSpec) with MultiNode
         // and it triggered the subscription timeout. Therefore we must wait more than the
         // the subscription timeout for a failure
         val timeout = system.settings.config
-            .getDuration("akka.stream.materializer.subscription-timeout.timeout")
+            .getDuration("akka.stream.materializer.stream-ref.subscription-timeout")
             .asScala + 2.seconds
         streamLifecycle3.expectMsg(timeout, "failed-system-42-tmp")
       }


### PR DESCRIPTION
Forward port of https://github.com/akka/akka/pull/28018

The postStop change not needed in master since no Future any more.

* Wrong timeout used for subscription timeout

(cherry picked from commit 05098eef1d9ecdbb5f0c8c5cda29aa1890ddc9e6)

I have run `multi-jvm:testOnly akka.cluster.StreamRef` locally.
