### PR TITLE
Improved docs for some queries

### DIFF
--- a/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/CurrentEventsByTagQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/CurrentEventsByTagQuery.scala
@@ -15,8 +15,11 @@ trait CurrentEventsByTagQuery extends ReadJournal {
 
   /**
    * Same type of query as [[EventsByTagQuery#eventsByTag]] but the event stream
-   * is completed immediately when it reaches the end of the "result set". Events that are
-   * stored after the query is completed are not included in the event stream.
+   * is completed immediately when it reaches the end of the "result set". Depending
+   * on journal implementation, this may mean all events up to when the query is
+   * started, or it may include events that are persisted while the query is still
+   * streaming results. For eventually consistent stores, it may only include all
+   * events up to some point before the query is started.
    */
   def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed]
 }

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/EventsByPersistenceIdQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/EventsByPersistenceIdQuery.scala
@@ -17,7 +17,8 @@ trait EventsByPersistenceIdQuery extends ReadJournal {
    * Query events for a specific `PersistentActor` identified by `persistenceId`.
    *
    * You can retrieve a subset of all events by specifying `fromSequenceNr` and `toSequenceNr`
-   * or use `0L` and `Long.MaxValue` respectively to retrieve all events.
+   * or use `0L` and `Long.MAX_VALUE` respectively to retrieve all events. The query will
+   * return all the events inclusive of the `fromSequenceNr` and `toSequenceNr` values.
    *
    * The returned event stream should be ordered by sequence number.
    *

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/EventsByTagQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/EventsByTagQuery.scala
@@ -30,7 +30,7 @@ trait EventsByTagQuery extends ReadJournal {
    * In strongly consistent stores, where the `offset` is unique and strictly ordered, the
    * stream should start from the next event after the `offset`. Otherwise, the read journal
    * should ensure that between an invocation that returned an event with the given
-   * `offset`, and this invocation, no events are missed, and, depending on the journal
+   * `offset` and this invocation, no events are missed. Depending on the journal
    * implementation, this may mean that this invocation will return events that were already
    * returned by the previous invocation, including the event with the passed in `offset`.
    *

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/EventsByTagQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/EventsByTagQuery.scala
@@ -27,6 +27,13 @@ trait EventsByTagQuery extends ReadJournal {
    * timestamp (taken when the event was created or stored). Timestamps are not unique and
    * not strictly ordered, since clocks on different machines may not be synchronized.
    *
+   * In strongly consistent stores, where the `offset` is unique and strictly ordered, the
+   * stream should start from the next event after the `offset`. Otherwise, the read journal
+   * should ensure that between an invocation that returned an event with the given
+   * `offset`, and this invocation, no events are missed, and, depending on the journal
+   * implementation, this may mean that this invocation will return events that were already
+   * returned by the previous invocation, including the event with the passed in `offset`.
+   *
    * The returned event stream should be ordered by `offset` if possible, but this can also be
    * difficult to fulfill for a distributed data store. The order must be documented by the
    * read journal plugin.

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/CurrentEventsByTagQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/CurrentEventsByTagQuery.scala
@@ -15,8 +15,11 @@ trait CurrentEventsByTagQuery extends ReadJournal {
 
   /**
    * Same type of query as [[EventsByTagQuery#eventsByTag]] but the event stream
-   * is completed immediately when it reaches the end of the "result set". Events that are
-   * stored after the query is completed are not included in the event stream.
+   * is completed immediately when it reaches the end of the "result set". Depending
+   * on journal implementation, this may mean all events up to when the query is
+   * started, or it may include events that are persisted while the query is still
+   * streaming results. For eventually consistent stores, it may only include all
+   * events up to some point before the query is started.
    */
   def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed]
 

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/EventsByPersistenceIdQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/EventsByPersistenceIdQuery.scala
@@ -17,7 +17,8 @@ trait EventsByPersistenceIdQuery extends ReadJournal {
    * Query events for a specific `PersistentActor` identified by `persistenceId`.
    *
    * You can retrieve a subset of all events by specifying `fromSequenceNr` and `toSequenceNr`
-   * or use `0L` and `Long.MaxValue` respectively to retrieve all events.
+   * or use `0L` and `Long.MaxValue` respectively to retrieve all events. The query will
+   * return all the events inclusive of the `fromSequenceNr` and `toSequenceNr` values.
    *
    * The returned event stream should be ordered by sequence number.
    *

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/EventsByTagQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/EventsByTagQuery.scala
@@ -30,7 +30,7 @@ trait EventsByTagQuery extends ReadJournal {
    * In strongly consistent stores, where the `offset` is unique and strictly ordered, the
    * stream should start from the next event after the `offset`. Otherwise, the read journal
    * should ensure that between an invocation that returned an event with the given
-   * `offset`, and this invocation, no events are missed, and, depending on the journal
+   * `offset`, and this invocation, no events are missed. Depending on the journal
    * implementation, this may mean that this invocation will return events that were already
    * returned by the previous invocation, including the event with the passed in `offset`.
    *

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/EventsByTagQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/EventsByTagQuery.scala
@@ -27,6 +27,13 @@ trait EventsByTagQuery extends ReadJournal {
    * timestamp (taken when the event was created or stored). Timestamps are not unique and
    * not strictly ordered, since clocks on different machines may not be synchronized.
    *
+   * In strongly consistent stores, where the `offset` is unique and strictly ordered, the
+   * stream should start from the next event after the `offset`. Otherwise, the read journal
+   * should ensure that between an invocation that returned an event with the given
+   * `offset`, and this invocation, no events are missed, and, depending on the journal
+   * implementation, this may mean that this invocation will return events that were already
+   * returned by the previous invocation, including the event with the passed in `offset`.
+   *
    * The returned event stream should be ordered by `offset` if possible, but this can also be
    * difficult to fulfill for a distributed data store. The order must be documented by the
    * read journal plugin.


### PR DESCRIPTION
I found myself having to look into the implementation of a plugin to find out whether `EventsByPersistenceIdQuery` is inclusive of the sequence numbers or not, it's not mentioned in the docs, so I've updated.

And then, after working out that the events by peristence id query was inclusive, I assumed events by tag was also inclusive (again it's not mentioned), and so I was incrementing the offset and missing events as a result. So I updated the `EventsByTagQuery` docs to make it clear that the intention is for it to be exclusive, so you always pass in the last offset you received to get the next, but that that shouldn't be relied on and less consistent stores may return duplicates.