### PR TITLE
Fix incorrect exception names in fault tolerance doc

### DIFF
--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/BubblingSample.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/BubblingSample.java
@@ -94,7 +94,7 @@ public class BubblingSample {
     public Receive<Protocol.Command> createReceive() {
       // here we don't handle Terminated at all which means that
       // when the child fails or stops gracefully this actor will
-      // fail with a DeathWatchException
+      // fail with a DeathPactException
       return newReceiveBuilder().onMessage(Protocol.Command.class, this::onCommand).build();
     }
 
@@ -125,7 +125,7 @@ public class BubblingSample {
     @Override
     public Receive<Protocol.Command> createReceive() {
       // here we don't handle Terminated at all which means that
-      // when middle management fails with a DeathWatchException
+      // when middle management fails with a DeathPactException
       // this actor will also fail
       return newReceiveBuilder().onMessage(Protocol.Command.class, this::onCommand).build();
     }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/FaultToleranceDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/FaultToleranceDocSpec.scala
@@ -47,7 +47,7 @@ object FaultToleranceDocSpec {
 
         // here we don't handle Terminated at all which means that
         // when the child fails or stops gracefully this actor will
-        // fail with a DeathWatchException
+        // fail with a DeathPactException
         Behaviors.receiveMessage { message =>
           child ! message
           Behaviors.same
@@ -65,7 +65,7 @@ object FaultToleranceDocSpec {
           context.watch(middleManagement)
 
           // here we don't handle Terminated at all which means that
-          // when middle management fails with a DeathWatchException
+          // when middle management fails with a DeathPactException
           // this actor will also fail
           Behaviors.receiveMessage[Command] { message =>
             middleManagement ! message


### PR DESCRIPTION
Just tiny PR for fixing incorrect exception name in fault tolerance doc