### PR TITLE
Remoting docs config snippet should clarify provider 

### DIFF
--- a/akka-docs/src/main/paradox/remoting-artery.md
+++ b/akka-docs/src/main/paradox/remoting-artery.md
@@ -42,14 +42,14 @@ If migrating from classic remoting see @ref:[what's new in Artery](#what-is-new-
 
 ## Configuration
 
+We recommend using @ref:[Akka Cluster](cluster-usage.md) over using remoting directly. Therefore
+`akka.actor.provider = cluster` should be configured.
+  
 To enable remote capabilities in your Akka project you should, at a minimum, add the following changes
 to your `application.conf` file:
 
 ```
 akka {
-  actor {
-    provider = remote 
-  }
   remote {
     artery {
       transport = tcp # See Selecting a transport below
@@ -60,9 +60,8 @@ akka {
 }
 ```
 
-As you can see in the example above there are four things you need to add to get started:
+As you can see in the example above there are three things you need to add to get started:
 
- * Change provider from `local` to `remote`. Note: we recommend using @ref:[Akka Cluster](cluster-usage.md) over using remoting directly.
  * Enable Artery to use it as the remoting implementation
  * Add host name - the machine you want to run the actor system on; this host
 name is exactly what is passed to remote systems in order to identify this
@@ -70,7 +69,7 @@ system and consequently used for connecting back to this system if need be,
 hence set it to a reachable IP address or resolvable name in case you want to
 communicate across the network.
  * Add port number - the port the actor system should listen on, set to 0 to have it chosen automatically
-
+  
 @@@ note
 
 The port number needs to be unique for each actor system on the same machine even if the actor

--- a/akka-docs/src/main/paradox/remoting-artery.md
+++ b/akka-docs/src/main/paradox/remoting-artery.md
@@ -48,7 +48,7 @@ to your `application.conf` file:
 ```
 akka {
   actor {
-    provider = cluster 
+    provider = remote 
   }
   remote {
     artery {
@@ -62,7 +62,7 @@ akka {
 
 As you can see in the example above there are four things you need to add to get started:
 
- * Change provider from `local` to `cluster`
+ * Change provider from `local` to `remote`. Note: we recommend using @ref:[Akka Cluster](cluster-usage.md) over using remoting directly.
  * Enable Artery to use it as the remoting implementation
  * Add host name - the machine you want to run the actor system on; this host
 name is exactly what is passed to remote systems in order to identify this

--- a/akka-docs/src/main/paradox/remoting-artery.md
+++ b/akka-docs/src/main/paradox/remoting-artery.md
@@ -42,14 +42,15 @@ If migrating from classic remoting see @ref:[what's new in Artery](#what-is-new-
 
 ## Configuration
 
-We recommend using @ref:[Akka Cluster](cluster-usage.md) over using remoting directly. Therefore
-`akka.actor.provider = cluster` should be configured.
-  
 To enable remote capabilities in your Akka project you should, at a minimum, add the following changes
 to your `application.conf` file:
 
 ```
 akka {
+  actor {
+    # provider=remote is possible, but prefer cluster
+    provider = cluster 
+  }
   remote {
     artery {
       transport = tcp # See Selecting a transport below
@@ -60,8 +61,9 @@ akka {
 }
 ```
 
-As you can see in the example above there are three things you need to add to get started:
+As you can see in the example above there are four things you need to add to get started:
 
+Change provider from `local`. We recommend using @ref:[Akka Cluster](cluster-usage.md) over using remoting directly.
  * Enable Artery to use it as the remoting implementation
  * Add host name - the machine you want to run the actor system on; this host
 name is exactly what is passed to remote systems in order to identify this
@@ -69,7 +71,7 @@ system and consequently used for connecting back to this system if need be,
 hence set it to a reachable IP address or resolvable name in case you want to
 communicate across the network.
  * Add port number - the port the actor system should listen on, set to 0 to have it chosen automatically
-  
+
 @@@ note
 
 The port number needs to be unique for each actor system on the same machine even if the actor

--- a/akka-docs/src/main/paradox/remoting.md
+++ b/akka-docs/src/main/paradox/remoting.md
@@ -64,7 +64,7 @@ akka {
 
 As you can see in the example above there are five things you need to add to get started:
 
- * Change provider from `local` to `remote`
+ * Change provider from `local` to `remote`. Note: we recommend using @ref:[Akka Cluster](cluster-usage.md) over using remoting directly.
  * Disable artery remoting. Artery is the default remoting implementation since `2.6.0`
  * Add host name - the machine you want to run the actor system on; this host
 name is exactly what is passed to remote systems in order to identify this

--- a/akka-docs/src/main/paradox/remoting.md
+++ b/akka-docs/src/main/paradox/remoting.md
@@ -43,14 +43,15 @@ not using classic remoting do not have to have Netty on the classpath:
 
 ## Configuration
 
-We recommend using @ref:[Akka Cluster](cluster-usage.md) over using remoting directly. Therefore
-`akka.actor.provider = cluster` should be configured.
-
 To enable classic remoting in your Akka project you should, at a minimum, add the following changes
 to your `application.conf` file:
 
 ```
 akka {
+  actor {
+    # provider=remote is possible, but prefer cluster
+    provider = cluster
+  }
   remote.artery.enabled = false
   remote.classic {
     enabled-transports = ["akka.remote.classic.netty.tcp"]
@@ -62,8 +63,9 @@ akka {
 }
 ```
 
-As you can see in the example above there are four things you need to add to get started:
+As you can see in the example above there are five things you need to add to get started:
 
+ * Change provider from `local`. We recommend using @ref:[Akka Cluster](cluster-usage.md) over using remoting directly.
  * Disable artery remoting. Artery is the default remoting implementation since `2.6.0`
  * Add host name - the machine you want to run the actor system on; this host
 name is exactly what is passed to remote systems in order to identify this
@@ -71,7 +73,7 @@ system and consequently used for connecting back to this system if need be,
 hence set it to a reachable IP address or resolvable name in case you want to
 communicate across the network.
  * Add port number - the port the actor system should listen on, set to 0 to have it chosen automatically
-  
+
 @@@ note
 
 The port number needs to be unique for each actor system on the same machine even if the actor

--- a/akka-docs/src/main/paradox/remoting.md
+++ b/akka-docs/src/main/paradox/remoting.md
@@ -43,14 +43,14 @@ not using classic remoting do not have to have Netty on the classpath:
 
 ## Configuration
 
+We recommend using @ref:[Akka Cluster](cluster-usage.md) over using remoting directly. Therefore
+`akka.actor.provider = cluster` should be configured.
+
 To enable classic remoting in your Akka project you should, at a minimum, add the following changes
 to your `application.conf` file:
 
 ```
 akka {
-  actor {
-    provider = remote
-  }
   remote.artery.enabled = false
   remote.classic {
     enabled-transports = ["akka.remote.classic.netty.tcp"]
@@ -62,9 +62,8 @@ akka {
 }
 ```
 
-As you can see in the example above there are five things you need to add to get started:
+As you can see in the example above there are four things you need to add to get started:
 
- * Change provider from `local` to `remote`. Note: we recommend using @ref:[Akka Cluster](cluster-usage.md) over using remoting directly.
  * Disable artery remoting. Artery is the default remoting implementation since `2.6.0`
  * Add host name - the machine you want to run the actor system on; this host
 name is exactly what is passed to remote systems in order to identify this
@@ -72,7 +71,7 @@ system and consequently used for connecting back to this system if need be,
 hence set it to a reachable IP address or resolvable name in case you want to
 communicate across the network.
  * Add port number - the port the actor system should listen on, set to 0 to have it chosen automatically
-
+  
 @@@ note
 
 The port number needs to be unique for each actor system on the same machine even if the actor


### PR DESCRIPTION
Should be backported as well.