### PR TITLE
Avoid deadlock on concurrent extension with materializer init 

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -25,6 +25,7 @@ import scala.collection.immutable
 import scala.compat.java8.FutureConverters
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.Duration
+import scala.concurrent.blocking
 import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, Future, Promise }
 import scala.util.control.{ ControlThrowable, NonFatal }
 import scala.util.{ Failure, Success, Try }
@@ -1125,7 +1126,10 @@ private[akka] class ActorSystemImpl(
   @tailrec
   private def findExtension[T <: Extension](ext: ExtensionId[T]): T = extensions.get(ext) match {
     case c: CountDownLatch =>
-      c.await(); findExtension(ext) //Registration in process, await completion and retry
+      blocking {
+        c.await()
+      }
+      findExtension(ext) //Registration in process, await completion and retry
     case t: Throwable => throw t //Initialization failed, throw same again
     case other =>
       other.asInstanceOf[T] //could be a T or null, in which case we return the null as T

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamTestDefaultMailbox.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamTestDefaultMailbox.scala
@@ -13,6 +13,7 @@ import akka.dispatch.MailboxType
 import akka.actor.ActorRef
 import akka.actor.ActorRefWithCell
 import akka.actor.Actor
+import akka.stream.impl.MaterializerGuardian
 
 /**
  * INTERNAL API
@@ -34,7 +35,7 @@ private[akka] final case class StreamTestDefaultMailbox()
           s"Don't use anonymous actor classes, actor class for $r was [${actorClass.getName}]")
         // StreamTcpManager is allowed to use another dispatcher
         assert(
-          !actorClass.getName.startsWith("akka.stream."),
+          actorClass == classOf[MaterializerGuardian] || !actorClass.getName.startsWith("akka.stream."),
           s"$r with actor class [${actorClass.getName}] must not run on default dispatcher in tests. " +
           "Did you forget to define `props.withDispatcher` when creating the actor? " +
           "Or did you forget to configure the `akka.stream.materializer` setting accordingly or force the " +

--- a/akka-stream/src/main/scala/akka/stream/SystemMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/SystemMaterializer.scala
@@ -11,6 +11,7 @@ import akka.actor.Extension
 import akka.actor.ExtensionId
 import akka.actor.ExtensionIdProvider
 import akka.annotation.InternalApi
+import akka.dispatch.Dispatchers
 import akka.stream.impl.MaterializerGuardian
 
 import scala.concurrent.Await
@@ -52,7 +53,8 @@ final class SystemMaterializer(system: ExtendedActorSystem) extends Extension {
   private val materializerGuardian = system.systemActorOf(
     MaterializerGuardian
       .props(systemMaterializerPromise, materializerSettings)
-      .withDispatcher(materializerSettings.dispatcher)
+      // #28037 run on internal dispatcher to make sure default dispatcher starvation doesn't stop materializer creation
+      .withDispatcher(Dispatchers.InternalDispatcherId)
       .withDeploy(Deploy.local),
     "Materializers")
 

--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -105,8 +105,9 @@ import com.github.ghik.silencer.silent
       attributes: Attributes): PhasedFusingActorMaterializer = {
     val haveShutDown = new AtomicBoolean(false)
 
+    val dispatcher = attributes.mandatoryAttribute[ActorAttributes.Dispatcher].dispatcher
     val supervisorProps =
-      StreamSupervisor.props(attributes, haveShutDown).withDispatcher(context.props.dispatcher).withDeploy(Deploy.local)
+      StreamSupervisor.props(attributes, haveShutDown).withDispatcher(dispatcher).withDeploy(Deploy.local)
 
     // FIXME why do we need a global unique name for the child?
     val streamSupervisor = context.actorOf(supervisorProps, StreamSupervisor.nextName())


### PR DESCRIPTION
Refs #28037

Fixes a case where a starved default dispatcher would deadlock on trying to use the old `ActorMaterializer()(system)`. 

Solution is to run the `MaterializerGuardian` on the internal dispatcher rather than the default (previously it picked up the `akka.stream.materializer.dispatcher` setting)