### PR TITLE
Discovered that RC comparison was problematic in Akka HTTP

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/AkkaVersionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/AkkaVersionSpec.scala
@@ -18,6 +18,7 @@ class AkkaVersionSpec extends WordSpec with Matchers {
 
     "succeed if version is RC and ok" in {
       AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.7-RC10")
+      AkkaVersion.require("AkkaVersionSpec", "2.6.0-RC1", "2.6.0-RC1")
     }
 
     "fail if version is RC and not ok" in {

--- a/akka-actor/src/main/scala/akka/AkkaVersion.scala
+++ b/akka-actor/src/main/scala/akka/AkkaVersion.scala
@@ -29,24 +29,26 @@ object AkkaVersion {
    */
   @InternalApi
   private[akka] def require(libraryName: String, requiredVersion: String, currentVersion: String): Unit = {
-    val VersionPattern = """(\d+)\.(\d+)\.(\d+)(-(?:M|RC)\d+)?""".r
-    currentVersion match {
-      case VersionPattern(currentMajorStr, currentMinorStr, currentPatchStr, mOrRc) =>
-        requiredVersion match {
-          case requiredVersion @ VersionPattern(requiredMajorStr, requiredMinorStr, requiredPatchStr, _) =>
-            // a M or RC is basically in-between versions, so offset
-            val currentPatch =
-              if (mOrRc ne null) currentPatchStr.toInt - 1
-              else currentPatchStr.toInt
-            if (requiredMajorStr.toInt != currentMajorStr.toInt ||
-                requiredMinorStr.toInt > currentMinorStr.toInt ||
-                (requiredMinorStr == currentMinorStr && requiredPatchStr.toInt > currentPatch))
-              throw new UnsupportedAkkaVersion(
-                s"Current version of Akka is [$currentVersion], but $libraryName requires version [$requiredVersion]")
-          case _ => throw new IllegalArgumentException(s"Required version string is invalid: [$requiredVersion]")
-        }
+    if (requiredVersion != currentVersion) {
+      val VersionPattern = """(\d+)\.(\d+)\.(\d+)(-(?:M|RC)\d+)?""".r
+      currentVersion match {
+        case VersionPattern(currentMajorStr, currentMinorStr, currentPatchStr, mOrRc) =>
+          requiredVersion match {
+            case requiredVersion @ VersionPattern(requiredMajorStr, requiredMinorStr, requiredPatchStr, _) =>
+              // a M or RC is basically in-between versions, so offset
+              val currentPatch =
+                if (mOrRc ne null) currentPatchStr.toInt - 1
+                else currentPatchStr.toInt
+              if (requiredMajorStr.toInt != currentMajorStr.toInt ||
+                  requiredMinorStr.toInt > currentMinorStr.toInt ||
+                  (requiredMinorStr == currentMinorStr && requiredPatchStr.toInt > currentPatch))
+                throw new UnsupportedAkkaVersion(
+                  s"Current version of Akka is [$currentVersion], but $libraryName requires version [$requiredVersion]")
+            case _ => throw new IllegalArgumentException(s"Required version string is invalid: [$requiredVersion]")
+          }
 
-      case _ => // SNAPSHOT or unknown - you're on your own
+        case _ => // SNAPSHOT or unknown - you're on your own
+      }
     }
   }
 


### PR DESCRIPTION
Previously 2.6.0-RC1 wouldn't fulfill 2.6.0-RC1. 