### PR TITLE
Fixes intermittent "Could not create directory" issue

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -11,6 +11,8 @@ import java.time.format.DateTimeFormatter
 import java.time.ZonedDateTime
 import java.time.ZoneOffset
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys._
+import com.typesafe.sbt.MultiJvmPlugin.autoImport.MultiJvm
+import sbtassembly.AssemblyPlugin.autoImport._
 
 import sbt.Keys._
 import sbt._
@@ -251,6 +253,14 @@ object AkkaBuild {
     mavenLocalResolverSettings,
     docLintingSettings,
     JdkOptions.targetJdkSettings,
+
+    // a workaround for https://github.com/akka/akka/issues/27661
+    // see also project/Protobuf.scala that introduces /../ to make "intellij happy"
+    MultiJvm / assembly / fullClasspath := {
+      val old = (MultiJvm / assembly / fullClasspath).value.toVector
+      val files = old.map(_.data.getCanonicalFile).distinct
+      files map { x => Attributed.blank(x) }
+    },
   )
 
   lazy val docLintingSettings = Seq(


### PR DESCRIPTION
Fixes #27661
This was a collaboration work with @helena 

I saw that MultiJVM's assembly/fullClasspath contains a bunch of duplicates in the form of:

```
[info] * Attributed(/Users/eed3si9n/work/akka/akka-cluster-sharding/../akka-protobuf-v3/target/akka-protobuf-v3-assembly-2.6-SNAPSHOT.jar)
[info] * Attributed(/Users/eed3si9n/work/akka/akka-cluster/../akka-protobuf-v3/target/akka-protobuf-v3-assembly-2.6-SNAPSHOT.jar)
```

Helena pointed out to me that project/Protobuf.scala introduces `/../` in the middle of an unmaged JAR path:

```
    // this keeps intellij happy for files that use the shaded protobuf
    Compile / unmanagedJars ++= Seq(
        baseDirectory.value / ".." / "akka-protobuf-v3" / "target" / s"akka-protobuf-v3-assembly-${version.value}.jar"),
```

While that may keep IntelliJ, sbt-assembly is not very happy with the duplicated protobuf jars.

This works around the issue by calling `getCanonicalFile` to make the path canonical.
