### PR TITLE
Handle Replicator.Unsubscribe in Typed scaladsl, #28061

### DIFF
--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/internal/ReplicatorBehavior.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/internal/ReplicatorBehavior.scala
@@ -48,11 +48,11 @@ import akka.actor.typed.Terminated
 
       def withState(
           subscribeAdapters: Map[
-            ActorRef[JReplicator.Changed[ReplicatedData]],
-            ActorRef[dd.Replicator.Changed[ReplicatedData]]]): Behavior[SReplicator.Command] = {
+            ActorRef[JReplicator.SubscribeResponse[ReplicatedData]],
+            ActorRef[dd.Replicator.SubscribeResponse[ReplicatedData]]]): Behavior[SReplicator.Command] = {
 
         def stopSubscribeAdapter(
-            subscriber: ActorRef[JReplicator.Changed[ReplicatedData]]): Behavior[SReplicator.Command] = {
+            subscriber: ActorRef[JReplicator.SubscribeResponse[ReplicatedData]]): Behavior[SReplicator.Command] = {
           subscribeAdapters.get(subscriber) match {
             case Some(adapter) =>
               // will be unsubscribed from classicReplicator via Terminated
@@ -122,14 +122,14 @@ import akka.actor.typed.Terminated
                 Behaviors.same
 
               case cmd: SReplicator.Subscribe[_] =>
-                // For the Scala API the Changed messages can be sent directly to the subscriber
+                // For the Scala API the SubscribeResponse messages can be sent directly to the subscriber
                 classicReplicator.tell(
                   dd.Replicator.Subscribe(cmd.key, cmd.subscriber.toClassic),
                   sender = cmd.subscriber.toClassic)
                 Behaviors.same
 
               case cmd: JReplicator.Subscribe[ReplicatedData] @unchecked =>
-                // For the Java API the Changed messages must be mapped to the JReplicator.Changed class.
+                // For the Java API the Changed/Deleted messages must be mapped to the JReplicator.Changed/Deleted class.
                 // That is done with an adapter, and we have to keep track of the lifecycle of the original
                 // subscriber and stop the adapter when the original subscriber is stopped.
                 val adapter: ActorRef[dd.Replicator.SubscribeResponse[ReplicatedData]] = ctx.spawnMessageAdapter {
@@ -150,6 +150,12 @@ import akka.actor.typed.Terminated
                   case chg: dd.Replicator.Changed[_] => subscriber ! JReplicator.Changed(chg.key)(chg.dataValue)
                   case del: dd.Replicator.Deleted[_] => subscriber ! JReplicator.Deleted(del.key)
                 }
+                Behaviors.same
+
+              case cmd: SReplicator.Unsubscribe[_] =>
+                classicReplicator.tell(
+                  dd.Replicator.Unsubscribe(cmd.key, cmd.subscriber.toClassic),
+                  sender = cmd.subscriber.toClassic)
                 Behaviors.same
 
               case cmd: JReplicator.Unsubscribe[ReplicatedData] @unchecked =>
@@ -202,7 +208,7 @@ import akka.actor.typed.Terminated
             }
           }
           .receiveSignal {
-            case (_, Terminated(ref: ActorRef[JReplicator.Changed[ReplicatedData]] @unchecked)) =>
+            case (_, Terminated(ref: ActorRef[JReplicator.SubscribeResponse[ReplicatedData]] @unchecked)) =>
               stopSubscribeAdapter(ref)
           }
       }

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/Replicator.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/scaladsl/Replicator.scala
@@ -250,14 +250,16 @@ object Replicator {
    * If the key is deleted the subscriber is notified with a [[Deleted]]
    * message.
    */
-  final case class Subscribe[A <: ReplicatedData](key: Key[A], subscriber: ActorRef[Changed[A]]) extends Command
+  final case class Subscribe[A <: ReplicatedData](key: Key[A], subscriber: ActorRef[SubscribeResponse[A]])
+      extends Command
 
   /**
    * Unregister a subscriber.
    *
    * @see [[Subscribe]]
    */
-  final case class Unsubscribe[A <: ReplicatedData](key: Key[A], subscriber: ActorRef[Changed[A]]) extends Command
+  final case class Unsubscribe[A <: ReplicatedData](key: Key[A], subscriber: ActorRef[SubscribeResponse[A]])
+      extends Command
 
   /**
    * @see [[Subscribe]]

--- a/akka-cluster-typed/src/test/java/jdocs/akka/cluster/ddata/typed/javadsl/ReplicatorDocSample.java
+++ b/akka-cluster-typed/src/test/java/jdocs/akka/cluster/ddata/typed/javadsl/ReplicatorDocSample.java
@@ -45,6 +45,10 @@ interface ReplicatorDocSample {
       }
     }
 
+    enum Unsubscribe implements Command {
+      INSTANCE
+    }
+
     private interface InternalCommand extends Command {}
 
     private static class InternalUpdateResponse implements InternalCommand {
@@ -115,6 +119,7 @@ interface ReplicatorDocSample {
           .onMessage(InternalUpdateResponse.class, msg -> Behaviors.same())
           .onMessage(GetValue.class, this::onGetValue)
           .onMessage(GetCachedValue.class, this::onGetCachedValue)
+          .onMessage(Unsubscribe.class, this::onUnsubscribe)
           .onMessage(InternalGetResponse.class, this::onInternalGetResponse)
           .onMessage(InternalSubscribeResponse.class, this::onInternalSubscribeResponse)
           .build();
@@ -144,6 +149,11 @@ interface ReplicatorDocSample {
 
     private Behavior<Command> onGetCachedValue(GetCachedValue cmd) {
       cmd.replyTo.tell(cachedValue);
+      return this;
+    }
+
+    private Behavior<Command> onUnsubscribe(Unsubscribe cmd) {
+      replicatorAdapter.unsubscribe(key);
       return this;
     }
 


### PR DESCRIPTION
* scaladsl.Unsubscribe was missing in ReplicatorBehavior
* also noticed a Changed vs SubscribeResponse leftover from
  previous api change


Refs #28061
