### PR TITLE
Expose entityId on PersistenceId

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/PersistenceId.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/PersistenceId.scala
@@ -68,7 +68,7 @@ object PersistenceId {
           s"entityTypeHint [$entityTypeHint] contains [$separator] which is a reserved character")
     }
 
-    new PersistenceId(entityTypeHint + separator + entityId)
+    new PersistenceId(entityId, Some(entityTypeHint), separator)
   }
 
   /**
@@ -131,12 +131,22 @@ object PersistenceId {
  * Unique identifier in the backend data store (journal and snapshot store) of the
  * persistent actor.
  */
-final class PersistenceId private (val id: String) {
-  if (id eq null)
+final class PersistenceId private (
+    val entityId: String,
+    maybeHint: Option[String] = None,
+    separator: String = PersistenceId.DefaultSeparator) {
+  if (entityId eq null)
     throw new IllegalArgumentException("persistenceId must not be null")
 
-  if (id.trim.isEmpty)
+  if (entityId.trim.isEmpty)
     throw new IllegalArgumentException("persistenceId must not be empty")
+
+  val id =
+    maybeHint
+      .map { hint =>
+        hint + separator + entityId
+      }
+      .getOrElse(entityId)
 
   override def toString: String = s"PersistenceId($id)"
 

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/EventSourcedActorFailureTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/EventSourcedActorFailureTest.java
@@ -102,7 +102,10 @@ public class EventSourcedActorFailureTest extends JUnitSuite {
     TestProbe<String> probe = testKit.createTestProbe();
     TestProbe<Throwable> recoveryFailureProbe = testKit.createTestProbe();
     Behavior<String> p1 =
-        fail(new PersistenceId("fail-recovery-once"), probe.ref(), recoveryFailureProbe.ref());
+        fail(
+            PersistenceId.ofUniqueId("fail-recovery-once"),
+            probe.ref(),
+            recoveryFailureProbe.ref());
     testKit.spawn(p1);
     recoveryFailureProbe.expectMessageClass(TestException.class);
   }
@@ -110,7 +113,7 @@ public class EventSourcedActorFailureTest extends JUnitSuite {
   @Test
   public void persistEvents() throws Exception {
     TestProbe<String> probe = testKit.createTestProbe();
-    Behavior<String> p1 = fail(new PersistenceId("fail-first-2"), probe.ref());
+    Behavior<String> p1 = fail(PersistenceId.ofUniqueId("fail-first-2"), probe.ref());
     ActorRef<String> c = testKit.spawn(p1);
     probe.expectMessage("starting");
     // fail

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/LoggerSourceTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/LoggerSourceTest.java
@@ -39,7 +39,7 @@ public class LoggerSourceTest extends JUnitSuite {
   private static final AtomicInteger idCounter = new AtomicInteger(0);
 
   public static PersistenceId nextId() {
-    return new PersistenceId("" + idCounter.incrementAndGet());
+    return PersistenceId.ofUniqueId("" + idCounter.incrementAndGet());
   }
 
   static class LoggingBehavior extends EventSourcedBehavior<String, String, String> {

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/NullEmptyStateTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/NullEmptyStateTest.java
@@ -85,7 +85,7 @@ public class NullEmptyStateTest extends JUnitSuite {
   public void handleNullState() throws Exception {
     TestProbe<String> probe = testKit.createTestProbe();
     Behavior<String> b =
-        Behaviors.setup(ctx -> new NullEmptyState(new PersistenceId("a"), probe.ref()));
+        Behaviors.setup(ctx -> new NullEmptyState(PersistenceId.ofUniqueId("a"), probe.ref()));
 
     ActorRef<String> ref1 = testKit.spawn(b);
     probe.expectMessage("onRecoveryCompleted:null");

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorCompileOnlyTest.java
@@ -94,7 +94,8 @@ public class PersistentActorCompileOnlyTest {
     }
 
     public static EventSourcedBehavior<SimpleCommand, SimpleEvent, SimpleState> pb =
-        new EventSourcedBehavior<SimpleCommand, SimpleEvent, SimpleState>(new PersistenceId("p1")) {
+        new EventSourcedBehavior<SimpleCommand, SimpleEvent, SimpleState>(
+            PersistenceId.ofUniqueId("p1")) {
 
           @Override
           public SimpleState emptyState() {
@@ -139,7 +140,7 @@ public class PersistentActorCompileOnlyTest {
         extends EventSourcedBehavior<SimpleCommand, SimpleEvent, SimpleState> {
 
       public AdditionalSettings(PersistenceId persistenceId) {
-        super(new PersistenceId("p1"));
+        super(PersistenceId.ofUniqueId("p1"));
       }
 
       @Override
@@ -211,7 +212,7 @@ public class PersistentActorCompileOnlyTest {
     // #commonChainedEffects
 
     private EventSourcedBehavior<MyCommand, MyEvent, ExampleState> pa =
-        new EventSourcedBehavior<MyCommand, MyEvent, ExampleState>(new PersistenceId("pa")) {
+        new EventSourcedBehavior<MyCommand, MyEvent, ExampleState>(PersistenceId.ofUniqueId("pa")) {
 
           @Override
           public ExampleState emptyState() {

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PersistentActorJavaDslTest.java
@@ -292,7 +292,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
 
   @Test
   public void persistEvents() {
-    ActorRef<Command> c = testKit.spawn(counter(new PersistenceId("c1")));
+    ActorRef<Command> c = testKit.spawn(counter(PersistenceId.ofUniqueId("c1")));
     TestProbe<State> probe = testKit.createTestProbe();
     c.tell(Increment.INSTANCE);
     c.tell(new GetValue(probe.ref()));
@@ -301,7 +301,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
 
   @Test
   public void replyStoredEvents() {
-    ActorRef<Command> c = testKit.spawn(counter(new PersistenceId("c2")));
+    ActorRef<Command> c = testKit.spawn(counter(PersistenceId.ofUniqueId("c2")));
     TestProbe<State> probe = testKit.createTestProbe();
     c.tell(Increment.INSTANCE);
     c.tell(Increment.INSTANCE);
@@ -309,7 +309,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     c.tell(new GetValue(probe.ref()));
     probe.expectMessage(new State(3, Arrays.asList(0, 1, 2)));
 
-    ActorRef<Command> c2 = testKit.spawn(counter(new PersistenceId("c2")));
+    ActorRef<Command> c2 = testKit.spawn(counter(PersistenceId.ofUniqueId("c2")));
     c2.tell(new GetValue(probe.ref()));
     probe.expectMessage(new State(3, Arrays.asList(0, 1, 2)));
     c2.tell(Increment.INSTANCE);
@@ -319,7 +319,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
 
   @Test
   public void thenReplyEffect() {
-    ActorRef<Command> c = testKit.spawn(counter(new PersistenceId("c1b")));
+    ActorRef<Command> c = testKit.spawn(counter(PersistenceId.ofUniqueId("c1b")));
     TestProbe<Done> probe = testKit.createTestProbe();
     c.tell(new IncrementWithConfirmation(probe.ref()));
     probe.expectMessage(Done.getInstance());
@@ -331,7 +331,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     Behavior<Command> counter =
         Behaviors.setup(
             ctx ->
-                new CounterBehavior(new PersistenceId("c3"), ctx) {
+                new CounterBehavior(PersistenceId.ofUniqueId("c3"), ctx) {
                   @Override
                   protected State applyIncremented(State state, Incremented event) {
                     eventHandlerProbe.ref().tell(Pair.create(state, event));
@@ -352,7 +352,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     Behavior<Command> counter =
         Behaviors.setup(
             ctx ->
-                new CounterBehavior(new PersistenceId("c4"), ctx) {
+                new CounterBehavior(PersistenceId.ofUniqueId("c4"), ctx) {
                   @Override
                   protected State applyIncremented(State state, Incremented event) {
                     eventHandlerProbe.ref().tell(Pair.create(state, event));
@@ -370,7 +370,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     Behavior<Command> counter =
         Behaviors.setup(
             ctx ->
-                new CounterBehavior(new PersistenceId("c5"), ctx) {
+                new CounterBehavior(PersistenceId.ofUniqueId("c5"), ctx) {
                   @Override
                   protected void log() {
                     loggingProbe.ref().tell("logged");
@@ -384,7 +384,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
   @Test
   public void workWhenWrappedInOtherBehavior() {
     Behavior<Command> behavior =
-        Behaviors.supervise(counter(new PersistenceId("c6")))
+        Behaviors.supervise(counter(PersistenceId.ofUniqueId("c6")))
             .onFailure(
                 SupervisorStrategy.restartWithBackoff(
                     Duration.ofSeconds(1), Duration.ofSeconds(10), 0.1));
@@ -403,7 +403,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     Behavior<Command> snapshoter =
         Behaviors.setup(
             ctx ->
-                new CounterBehavior(new PersistenceId("snapshot"), ctx) {
+                new CounterBehavior(PersistenceId.ofUniqueId("snapshot"), ctx) {
                   @Override
                   public boolean shouldSnapshot(State state, Event event, long sequenceNr) {
                     return state.value % 2 == 0;
@@ -439,7 +439,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     Behavior<Command> recovered =
         Behaviors.setup(
             ctx ->
-                new CounterBehavior(new PersistenceId("snapshot"), ctx) {
+                new CounterBehavior(PersistenceId.ofUniqueId("snapshot"), ctx) {
                   @Override
                   protected State applyIncremented(State state, Incremented event) {
                     eventHandlerProbe.ref().tell(Pair.create(state, event));
@@ -457,7 +457,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
   @Test
   public void stopThenLog() {
     TestProbe<State> probe = testKit.createTestProbe();
-    ActorRef<Command> c = testKit.spawn(counter(new PersistenceId("c12")));
+    ActorRef<Command> c = testKit.spawn(counter(PersistenceId.ofUniqueId("c12")));
     c.tell(StopThenLog.INSTANCE);
     probe.expectTerminated(c);
   }
@@ -468,7 +468,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     Behavior<Command> counter =
         Behaviors.setup(
             ctx ->
-                new CounterBehavior(new PersistenceId("c5"), ctx) {
+                new CounterBehavior(PersistenceId.ofUniqueId("c5"), ctx) {
 
                   @Override
                   public SignalHandler<State> signalHandler() {
@@ -508,7 +508,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
           }
         };
     ActorRef<Command> c =
-        testKit.spawn(Behaviors.intercept(() -> tap, counter(new PersistenceId("tap1"))));
+        testKit.spawn(Behaviors.intercept(() -> tap, counter(PersistenceId.ofUniqueId("tap1"))));
     c.tell(Increment.INSTANCE);
     interceptProbe.expectMessage(Increment.INSTANCE);
     signalProbe.expectNoMessage();
@@ -519,7 +519,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     Behavior<Command> tagger =
         Behaviors.setup(
             ctx ->
-                new CounterBehavior(new PersistenceId("tagging"), ctx) {
+                new CounterBehavior(PersistenceId.ofUniqueId("tagging"), ctx) {
                   @Override
                   public Set<String> tagsFor(Event incremented) {
                     return Sets.newHashSet("tag1", "tag2");
@@ -549,7 +549,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     Behavior<Command> transformer =
         Behaviors.setup(
             ctx ->
-                new CounterBehavior(new PersistenceId("transform"), ctx) {
+                new CounterBehavior(PersistenceId.ofUniqueId("transform"), ctx) {
                   private final EventAdapter<Event, ?> adapter = new WrapperEventAdapter();
 
                   public EventAdapter<Event, ?> eventAdapter() {
@@ -688,7 +688,8 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
     TestProbe<String> probe = testKit.createTestProbe();
     ActorRef<String> c =
         testKit.spawn(
-            new IncorrectExpectedStateForThenRun(probe.getRef(), new PersistenceId("foiesftr")));
+            new IncorrectExpectedStateForThenRun(
+                probe.getRef(), PersistenceId.ofUniqueId("foiesftr")));
 
     probe.expectMessage("started!");
 
@@ -767,7 +768,7 @@ public class PersistentActorJavaDslTest extends JUnitSuite {
             Behaviors.<String>setup(
                 context ->
                     new SequenceNumberBehavior(
-                        new PersistenceId("seqnr1"), probe.getRef(), context)));
+                        PersistenceId.ofUniqueId("seqnr1"), probe.getRef(), context)));
 
     probe.expectMessage("0 onRecoveryCompleted");
     ref.tell("cmd");

--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PrimitiveStateTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PrimitiveStateTest.java
@@ -76,7 +76,7 @@ public class PrimitiveStateTest extends JUnitSuite {
   public void handleIntegerState() throws Exception {
     TestProbe<String> probe = testKit.createTestProbe();
     Behavior<Integer> b =
-        Behaviors.setup(ctx -> new PrimitiveState(new PersistenceId("a"), probe.ref()));
+        Behaviors.setup(ctx -> new PrimitiveState(PersistenceId.ofUniqueId("a"), probe.ref()));
     ActorRef<Integer> ref1 = testKit.spawn(b);
     probe.expectMessage("onRecoveryCompleted:0");
     ref1.tell(1);

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
@@ -46,7 +46,7 @@ public class BasicPersistentBehaviorTest {
       public static class State {}
 
       public static Behavior<Command> create() {
-        return new MyPersistentBehavior(new PersistenceId("pid"));
+        return new MyPersistentBehavior(PersistenceId.ofUniqueId("pid"));
       }
 
       private MyPersistentBehavior(PersistenceId persistenceId) {

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/MovieWatchList.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/MovieWatchList.java
@@ -84,7 +84,7 @@ public class MovieWatchList
   }
 
   public static Behavior<Command> behavior(String userId) {
-    return new MovieWatchList(new PersistenceId("movies-" + userId));
+    return new MovieWatchList(PersistenceId.ofUniqueId("movies-" + userId));
   }
 
   public MovieWatchList(PersistenceId persistenceId) {

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/auction/AuctionEntity.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/auction/AuctionEntity.java
@@ -27,7 +27,7 @@ public class AuctionEntity
   private final UUID entityUUID;
 
   public AuctionEntity(String entityId) {
-    super(new PersistenceId("Auction|" + entityId));
+    super(PersistenceId.ofUniqueId("Auction|" + entityId));
     this.entityUUID = UUID.fromString(entityId);
   }
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/PersistenceIdSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/PersistenceIdSpec.scala
@@ -46,6 +46,12 @@ class PersistenceIdSpec extends WordSpec with Matchers with LogCapturing {
         PersistenceId("SomeType", "A#B", "#")
       }
     }
+
+    "expose the entityId used for the PersistenceId" in {
+      PersistenceId("MyType", "abc", "#/#").entityId should ===("abc")
+      PersistenceId("MyType", "abc", "#/#").id should ===("MyType#/#abc")
+    }
+
   }
 
 }


### PR DESCRIPTION
I took a conservative approach and only exposed `entityId` (not the `entityTypeHint` or `separator`).

Fixes #28082 

There were multiple tests using the `private` constructor which I've refactored to use the `ofUniqueId` factory method (which is `public`).