### PR TITLE
more efficient and correct clear in Slf4jLogger

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorMdc.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorMdc.scala
@@ -18,10 +18,9 @@ import org.slf4j.MDC
    * @param tags empty string for no tags, a single tag or a comma separated list of tags
    */
   def setMdc(source: String, tags: String): Unit = {
-    val mdcAdapter = MDC.getMDCAdapter
-    mdcAdapter.put(SourceKey, source)
+    MDC.put(SourceKey, source)
     if (tags.nonEmpty)
-      mdcAdapter.put(TagsKey, tags)
+      MDC.put(TagsKey, tags)
   }
 
   // MDC is cleared (if used) from aroundReceive in ActorAdapter after processing each message,

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/WithMdcBehaviorInterceptor.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/WithMdcBehaviorInterceptor.scala
@@ -90,12 +90,11 @@ import scala.reflect.ClassTag
   }
 
   private def setMdcValues(dynamicMdc: Map[String, String]): Unit = {
-    val mdcAdapter = MDC.getMDCAdapter
     if (staticMdc.nonEmpty) staticMdc.foreach {
-      case (key, value) => mdcAdapter.put(key, value)
+      case (key, value) => MDC.put(key, value)
     }
     if (dynamicMdc.nonEmpty) dynamicMdc.foreach {
-      case (key, value) => mdcAdapter.put(key, value)
+      case (key, value) => MDC.put(key, value)
     }
   }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
@@ -155,9 +155,8 @@ private[akka] object PersistenceMdc {
   // MDC is cleared (if used) from aroundReceive in ActorAdapter after processing each message,
   // but important to call `context.log` to mark MDC as used
   def setMdc(persistenceId: PersistenceId, phase: String): Unit = {
-    val mdcAdpater = MDC.getMDCAdapter
-    mdcAdpater.put(PersistenceIdKey, persistenceId.id)
-    mdcAdpater.put(PersistencePhaseKey, phase)
+    MDC.put(PersistenceIdKey, persistenceId.id)
+    MDC.put(PersistencePhaseKey, phase)
   }
 
 }

--- a/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
@@ -104,12 +104,11 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
 
   @inline
   final def withMdc(logSource: String, logEvent: LogEvent)(logStatement: => Unit): Unit = {
-    val mdcAdapter = MDC.getMDCAdapter
-    mdcAdapter.put(mdcAkkaSourceAttributeName, logSource)
-    mdcAdapter.put(mdcThreadAttributeName, logEvent.thread.getName)
-    mdcAdapter.put(mdcAkkaTimestamp, formatTimestamp(logEvent.timestamp))
-    mdcAdapter.put(mdcActorSystemAttributeName, actorSystemName)
-    logEvent.mdc.foreach { case (k, v) => mdcAdapter.put(k, String.valueOf(v)) }
+    MDC.put(mdcAkkaSourceAttributeName, logSource)
+    MDC.put(mdcThreadAttributeName, logEvent.thread.getName)
+    MDC.put(mdcAkkaTimestamp, formatTimestamp(logEvent.timestamp))
+    MDC.put(mdcActorSystemAttributeName, actorSystemName)
+    logEvent.mdc.foreach { case (k, v) => MDC.put(k, String.valueOf(v)) }
     try logStatement
     finally {
       MDC.clear()

--- a/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
@@ -104,18 +104,15 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
 
   @inline
   final def withMdc(logSource: String, logEvent: LogEvent)(logStatement: => Unit): Unit = {
-    MDC.put(mdcAkkaSourceAttributeName, logSource)
-    MDC.put(mdcThreadAttributeName, logEvent.thread.getName)
-    MDC.put(mdcAkkaTimestamp, formatTimestamp(logEvent.timestamp))
-    MDC.put(mdcActorSystemAttributeName, actorSystemName)
-    logEvent.mdc.foreach { case (k, v) => MDC.put(k, String.valueOf(v)) }
+    val mdcAdapter = MDC.getMDCAdapter
+    mdcAdapter.put(mdcAkkaSourceAttributeName, logSource)
+    mdcAdapter.put(mdcThreadAttributeName, logEvent.thread.getName)
+    mdcAdapter.put(mdcAkkaTimestamp, formatTimestamp(logEvent.timestamp))
+    mdcAdapter.put(mdcActorSystemAttributeName, actorSystemName)
+    logEvent.mdc.foreach { case (k, v) => mdcAdapter.put(k, String.valueOf(v)) }
     try logStatement
     finally {
-      MDC.remove(mdcAkkaSourceAttributeName)
-      MDC.remove(mdcThreadAttributeName)
-      MDC.remove(mdcAkkaTimestamp)
-      MDC.remove(mdcActorSystemAttributeName)
-      logEvent.mdc.keys.foreach(k => MDC.remove(k))
+      MDC.clear()
     }
   }
 


### PR DESCRIPTION
When reading https://github.com/akka/akka/issues/28077 I saw that we can set and clear the MDC values in a more efficient way in Slf4jLogger.