### PR TITLE
sbt option to explicitly specify the jdk8 jdk to use

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -264,7 +264,12 @@ object AkkaBuild {
   )
 
   private def optionalDir(path: String): Option[File] =
-    Option(path).filter(_.nonEmpty).map(new File(_))
+    Option(path).filter(_.nonEmpty).map { path =>
+      val dir = new File(path)
+      if (!dir.exists)
+        throw new IllegalArgumentException(s"Path [$path] not found")
+      dir
+    }
 
   lazy val docLintingSettings = Seq(
     javacOptions in compile ++= Seq("-Xdoclint:none"),

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -134,14 +134,14 @@ object AkkaBuild {
     // compile options
     scalacOptions in Compile ++= DefaultScalacOptions,
     scalacOptions in Compile ++=
-      JdkOptions.targetJdkScalacOptions(targetSystemJdk.value, fullJavaHomes.value),
+      JdkOptions.targetJdkScalacOptions(targetSystemJdk.value, optionalDir(jdk8home.value), fullJavaHomes.value),
     scalacOptions in Compile ++= (if (allWarnings) Seq("-deprecation") else Nil),
     scalacOptions in Test := (scalacOptions in Test).value.filterNot(opt =>
       opt == "-Xlog-reflective-calls" || opt.contains("genjavadoc")),
     javacOptions in compile ++= DefaultJavacOptions ++
-      JdkOptions.targetJdkJavacOptions(targetSystemJdk.value, fullJavaHomes.value),
+      JdkOptions.targetJdkJavacOptions(targetSystemJdk.value, optionalDir(jdk8home.value), fullJavaHomes.value),
     javacOptions in test ++= DefaultJavacOptions ++
-      JdkOptions.targetJdkJavacOptions(targetSystemJdk.value, fullJavaHomes.value),
+      JdkOptions.targetJdkJavacOptions(targetSystemJdk.value, optionalDir(jdk8home.value), fullJavaHomes.value),
     javacOptions in compile ++= (if (allWarnings) Seq("-Xlint:deprecation") else Nil),
     javacOptions in doc ++= Seq(),
 
@@ -262,6 +262,9 @@ object AkkaBuild {
       files map { x => Attributed.blank(x) }
     },
   )
+
+  private def optionalDir(path: String): Option[File] =
+    Option(path).filter(_.nonEmpty).map(new File(_))
 
   lazy val docLintingSettings = Seq(
     javacOptions in compile ++= Seq("-Xdoclint:none"),

--- a/project/JdkOptions.scala
+++ b/project/JdkOptions.scala
@@ -67,6 +67,6 @@ object JdkOptions extends AutoPlugin {
 
   val targetJdkSettings = Seq(
     targetSystemJdk := false,
-    jdk8home := "",
+    jdk8home := sys.env.get("JAVA_8_HOME").getOrElse(""),
   )
 }

--- a/project/JdkOptions.scala
+++ b/project/JdkOptions.scala
@@ -14,6 +14,7 @@ import sbt.librarymanagement.VersionNumber
 
 object JdkOptions extends AutoPlugin {
   object autoImport {
+    val jdk8home = settingKey[String]("JDK 8 home. Only needs to be set when it cannot be auto-detected by sbt");
     val targetSystemJdk = settingKey[Boolean]("Target the system JDK instead of building against JDK 8. When this is enabled resulting artifacts may not work on JDK 8!")
   }
   import autoImport._
@@ -27,9 +28,10 @@ object JdkOptions extends AutoPlugin {
 
   def notOnJdk8[T](values: Seq[T]): Seq[T] = if (isJdk8) Seq.empty[T] else values
 
-  def targetJdkScalacOptions(targetSystemJdk: Boolean, fullJavaHomes: Map[String, File]): Seq[String] =
+  def targetJdkScalacOptions(targetSystemJdk: Boolean, jdk8home: Option[File], fullJavaHomes: Map[String, File]): Seq[String] =
     selectOptions(
       targetSystemJdk,
+      jdk8home,
       fullJavaHomes,
       Seq("-target:jvm-1.8"),
       // '-release 8' is not enough, for some reason we need the 8 rt.jar
@@ -40,9 +42,10 @@ object JdkOptions extends AutoPlugin {
       // "java/nio/ByteBuffer.clear:()Ljava/nio/ByteBuffer". Issue #27079
       (java8home: File) => Seq("-release", "8", "-javabootclasspath", java8home + "/jre/lib/rt.jar")
     )
-  def targetJdkJavacOptions(targetSystemJdk: Boolean, fullJavaHomes: Map[String, File]): Seq[String] =
+  def targetJdkJavacOptions(targetSystemJdk: Boolean, jdk8home: Option[File], fullJavaHomes: Map[String, File]): Seq[String] =
     selectOptions(
       targetSystemJdk,
+      jdk8home,
       fullJavaHomes,
       Nil,
       // '-release 8' would be a neater option here, but is currently not an
@@ -50,19 +53,20 @@ object JdkOptions extends AutoPlugin {
       (java8home: File) => Seq("-source", "8", "-target", "8", "-bootclasspath", java8home + "/jre/lib/rt.jar")
   )
 
-  private def selectOptions(targetSystemJdk: Boolean, fullJavaHomes: Map[String, File], jdk8options: Seq[String], jdk11options: File => Seq[String]): Seq[String] =
+  private def selectOptions(targetSystemJdk: Boolean, jdk8home: Option[File], fullJavaHomes: Map[String, File], jdk8options: Seq[String], jdk11options: File => Seq[String]): Seq[String] =
     if (targetSystemJdk)
       Nil
     else if (isJdk8)
       jdk8options
-    else fullJavaHomes.get("8") match {
+    else jdk8home.orElse(fullJavaHomes.get("8")) match {
       case Some(java8home) =>
         jdk11options(java8home)
       case None =>
-        throw new MessageOnlyException("A JDK 8 installation was not found, but is required to build Akka. To target your system JDK, use the \"set every targetSystemJdk := true\" sbt command. Resulting artifacts may not work on JDK 8")
+        throw new MessageOnlyException("A JDK 8 installation was not found, but is required to build Akka. To manually specify a JDK 8 installation, use the \"set every jdk8home := \\\"/path/to/jdk\\\" sbt command. If you have no JDK 8 installation, target your system JDK with the \"set every targetSystemJdk := true\" sbt command, but beware resulting artifacts will not work on JDK 8")
     }
 
   val targetJdkSettings = Seq(
     targetSystemJdk := false,
+    jdk8home := "",
   )
 }


### PR DESCRIPTION
## Purpose

Add an sbt option to the Akka build to specify the JDK8 JDK to use

## References

This is also an improved approach for some of the use cases where you'd previously have to use #27083

## Background Context

This is useful when sbt cannot discover the jdk8 jdk to use, or discovers the wrong one.