### PR TITLE
Make akka-protobuf-v3.jar reproducible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -288,7 +288,7 @@ lazy val protobufV3 = akkaModule("akka-protobuf-v3")
     exportJars := true, // in dependent projects, use assembled and shaded jar
     makePomConfiguration := makePomConfiguration.value
         .withConfigurations(Vector(Compile)), // prevent original dependency to be added to pom as runtime dep
-    packageBin in Compile := (assembly in Compile).value, // package by running assembly
+    packageBin in Compile := ReproducibleBuildsPlugin.postProcessJar((assembly in Compile).value), // package by running assembly
     // Prevent cyclic task dependencies, see https://github.com/sbt/sbt-assembly/issues/365
     fullClasspath in assembly := (managedClasspath in Runtime).value, // otherwise, there's a cyclic dependency between packageBin and assembly
     test in assembly := {}, // assembly runs tests for unknown reason which introduces another cyclic dependency to packageBin via exportedJars


### PR DESCRIPTION
## Purpose

Makes sure akka-protobuf-v3.jar is bit-by-bit reproducible by post-processing the jar.

## Background Context

Special treatment is needed because the akka build overrided `packageBin` for this subproject