### PR TITLE
Receptionist: support for actor de-registration #28123

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistMessages.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/receptionist/ReceptionistMessages.scala
@@ -27,8 +27,26 @@ private[akka] object ReceptionistMessages {
       replyTo: Option[ActorRef[Receptionist.Registered]])
       extends Command
 
+  final case class Unregister[T] private[akka] (
+       key: ServiceKey[T],
+       serviceInstance: ActorRef[T],
+       replyTo: Option[ActorRef[Receptionist.Unregistered]]) extends Command
+
   final case class Registered[T] private[akka] (key: ServiceKey[T], _serviceInstance: ActorRef[T])
       extends Receptionist.Registered {
+    def isForKey(key: ServiceKey[_]): Boolean = key == this.key
+    def serviceInstance[M](key: ServiceKey[M]): ActorRef[M] = {
+      if (key != this.key)
+        throw new IllegalArgumentException(s"Wrong key [$key] used, must use listing key [${this.key}]")
+      _serviceInstance.asInstanceOf[ActorRef[M]]
+    }
+
+    def getServiceInstance[M](key: ServiceKey[M]): ActorRef[M] =
+      serviceInstance(key)
+  }
+
+  final case class Unregistered[T] private[akka] (key: ServiceKey[T], _serviceInstance: ActorRef[T])
+    extends Receptionist.Unregistered {
     def isForKey(key: ServiceKey[_]): Boolean = key == this.key
     def serviceInstance[M](key: ServiceKey[M]): ActorRef[M] = {
       if (key != this.key)


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Add support for actor de-registration from recetionist (for now: De-registration is implied by the end of the referenced Actor’s lifecycle).

## References

References #28123


