### PR TITLE
Docs: set 2.6 release date in project info

### DIFF
--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -57,8 +57,8 @@ project-info {
       }
       {
         readiness: Incubating
-        since: "2019-05-21"
-        since-version: "2.6.0-M1"
+        since: "2017-05-24"
+        since-version: "2.5.2"
       }
     ]
     api-docs: [
@@ -78,13 +78,13 @@ project-info {
     levels: [
       {
         readiness: Supported
-        since: "2019-11-05"
+        since: "2019-11-06"
         since-version: "2.6.0"
       }
       {
         readiness: Incubating
-        since: "2019-05-21"
-        since-version: "2.6.0-M1"
+        since: "2017-05-24"
+        since-version: "2.5.2"
       }
     ]
     api-docs: [
@@ -167,13 +167,13 @@ project-info {
     levels: [
       {
         readiness: Supported
-        since: "2019-11-05"
+        since: "2019-11-06"
         since-version: "2.6.0"
       }
       {
         readiness: Incubating
-        since: "2019-05-21"
-        since-version: "2.6.0-M1"
+        since: "2017-05-24"
+        since-version: "2.5.2"
       }
     ]
     api-docs: [
@@ -214,13 +214,13 @@ project-info {
     levels: [
       {
         readiness: Supported
-        since: "2019-11-05"
+        since: "2019-11-06"
         since-version: "2.6.0"
       }
       {
         readiness: Incubating
-        since: "2019-05-21"
-        since-version: "2.6.0-M1"
+        since: "2017-05-24"
+        since-version: "2.5.2"
       }
     ]
     api-docs: [
@@ -387,13 +387,13 @@ project-info {
     levels: [
       {
         readiness: Supported
-        since: "2019-11-05"
+        since: "2019-11-06"
         since-version: "2.6.0"
       }
       {
         readiness: Incubating
-        since: "2019-05-21"
-        since-version: "2.6.0-M1"
+        since: "2017-05-24"
+        since-version: "2.5.2"
       }
     ]
     api-docs: [
@@ -413,7 +413,7 @@ project-info {
     levels: [
       {
         readiness: Supported
-        since: "2019-11-05"
+        since: "2019-11-06"
         since-version: "2.6.0"
         note: "Classic remoting is deprecated and will be removed in Akka 2.7.0."
       }
@@ -503,13 +503,13 @@ project-info {
     levels: [
       {
         readiness: Supported
-        since: "2019-11-05"
+        since: "2019-11-06"
         since-version: "2.6.0"
       }
       {
         readiness: Incubating
-        since: "2019-05-21"
-        since-version: "2.6.0-M1"
+        since: "2017-05-24"
+        since-version: "2.5.2"
       }
     ]
     api-docs: [

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -52,7 +52,7 @@ project-info {
     levels: [
       {
         readiness: Supported
-        since: "2019-12-31"
+        since: "2019-11-06"
         since-version: "2.6.0"
       }
       {
@@ -78,7 +78,7 @@ project-info {
     levels: [
       {
         readiness: Supported
-        since: "2019-12-31"
+        since: "2019-11-05"
         since-version: "2.6.0"
       }
       {
@@ -167,7 +167,7 @@ project-info {
     levels: [
       {
         readiness: Supported
-        since: "2019-12-31"
+        since: "2019-11-05"
         since-version: "2.6.0"
       }
       {
@@ -214,7 +214,7 @@ project-info {
     levels: [
       {
         readiness: Supported
-        since: "2019-12-31"
+        since: "2019-11-05"
         since-version: "2.6.0"
       }
       {
@@ -387,7 +387,7 @@ project-info {
     levels: [
       {
         readiness: Supported
-        since: "2019-12-31"
+        since: "2019-11-05"
         since-version: "2.6.0"
       }
       {
@@ -413,7 +413,7 @@ project-info {
     levels: [
       {
         readiness: Supported
-        since: "2019-12-31"
+        since: "2019-11-05"
         since-version: "2.6.0"
         note: "Classic remoting is deprecated and will be removed in Akka 2.7.0."
       }
@@ -503,7 +503,7 @@ project-info {
     levels: [
       {
         readiness: Supported
-        since: "2019-12-31"
+        since: "2019-11-05"
         since-version: "2.6.0"
       }
       {


### PR DESCRIPTION
These dates were placeholders until we knew the real release date for Akka 2.6.0