### PR TITLE
Avoid falling back to IterableOnceOps.copyToArray

### DIFF
--- a/akka-actor/src/main/scala-2.13+/akka/util/ByteIterator.scala
+++ b/akka-actor/src/main/scala-2.13+/akka/util/ByteIterator.scala
@@ -99,6 +99,12 @@ object ByteIterator {
       this
     }
 
+    override def copyToArray[B >: Byte](xs: Array[B], start: Int): Int =
+      this.copyToArray(xs, start, xs.length)
+
+    override def copyToArray[B >: Byte](xs: Array[B]): Int =
+      this.copyToArray(xs, 0, xs.length)
+
     final override def copyToArray[B >: Byte](xs: Array[B], start: Int, len: Int): Int = {
       val n = 0 max ((xs.length - start) min this.len min len)
       Array.copy(this.array, from, xs, start, n)

--- a/akka-actor/src/main/scala-2.13+/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala-2.13+/akka/util/ByteString.scala
@@ -755,8 +755,9 @@ sealed abstract class ByteString
   protected[ByteString] def toArray: Array[Byte] = toArray[Byte]
 
   override def toArray[B >: Byte](implicit arg0: ClassTag[B]): Array[B] = iterator.toArray
-  // override def copyToArray[B >: Byte](xs: Array[B], start: Int, len: Int): Unit =
-  //   iterator.copyToArray(xs, start, len)
+
+  override def copyToArray[B >: Byte](xs: Array[B], start: Int, len: Int): Int =
+    iterator.copyToArray(xs, start, len)
 
   override def foreach[@specialized U](f: Byte => U): Unit = iterator.foreach(f)
 

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2014-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+@State(Scope.Benchmark)
+@Measurement(timeUnit = TimeUnit.MILLISECONDS)
+class ByteString_toArray_Benchmark {
+
+  val b = Array.ofDim[Byte](1024 * 10244)
+  val bb = ByteString(b)
+  /*
+    Benchmark                                  Mode  Cnt    Score    Error  Units
+    2.12
+    ByteString_toArray_Benchmark.to_array  thrpt    3  537,116 ± 525,663  ops/s
+    2.13 before fix
+    ByteString_toArray_Benchmark.to_array  thrpt    3  165,869 ± 243,524  ops/s
+    2.13 with fix #28114
+    ByteString_toArray_Benchmark.to_array  thrpt    3  525,521 ± 346,830  ops/s
+   */
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def to_array(blackhole: Blackhole) = {
+
+    for (_ <- 0 to 1000)
+      blackhole.consume(bb.toArray[Byte])
+
+  }
+
+}


### PR DESCRIPTION
Backport of #28116 
Refs #28114 