### PR TITLE
Add omitted `logPrefixSkipList` in getting logger class in `EventSourcedBehavior`

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/EventSourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/EventSourcedBehavior.scala
@@ -63,7 +63,7 @@ object EventSourcedBehavior {
       emptyState: State,
       commandHandler: (State, Command) => ReplyEffect[Event, State],
       eventHandler: (State, Event) => State): EventSourcedBehavior[Command, Event, State] = {
-    val loggerClass = LoggerClass.detectLoggerClassFromStack(classOf[EventSourcedBehavior[_, _, _]])
+    val loggerClass = LoggerClass.detectLoggerClassFromStack(classOf[EventSourcedBehavior[_, _, _]], logPrefixSkipList)
     EventSourcedBehaviorImpl(persistenceId, emptyState, commandHandler, eventHandler, loggerClass)
   }
 


### PR DESCRIPTION
In `EventSourcedBehavior.apply`, `logPrefixSkipList` is used. But in `EventSourcedBehavior.withEnforcedReplies`, it doesn't be used now. So, I added omitted `logPrefixSkipList` in `EventSourcedBehavior.withEnforcedReplies`.