### PR TITLE
LoggingFSM adds itself to the debug log

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/FSMActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMActorSpec.scala
@@ -281,7 +281,7 @@ class FSMActorSpec extends AkkaSpec(Map("akka.actor.debug.fsm" -> true)) with Im
             fsm ! "go"
             expectMsgPF(1 second, hint = "processing Event(go,null)") {
               case Logging.Debug(`name`, `fsmClass`, s: String)
-                  if s.startsWith("processing Event(go,null) from Actor[") =>
+                  if s.startsWith(s"${fsm} is processing Event(go,null) from Actor[") =>
                 true
             }
             expectMsg(1 second, Logging.Debug(name, fsmClass, "setting timer 't'/1500 milliseconds: Shutdown"))
@@ -289,7 +289,7 @@ class FSMActorSpec extends AkkaSpec(Map("akka.actor.debug.fsm" -> true)) with Im
             fsm ! "stop"
             expectMsgPF(1 second, hint = "processing Event(stop,null)") {
               case Logging.Debug(`name`, `fsmClass`, s: String)
-                  if s.startsWith("processing Event(stop,null) from Actor[") =>
+                  if s.startsWith(s"${fsm} is processing Event(stop,null) from Actor[") =>
                 true
             }
             expectMsgAllOf(1 second, Logging.Debug(name, fsmClass, "canceling timer 't'"), FSM.Normal)

--- a/akka-actor/src/main/scala/akka/actor/FSM.scala
+++ b/akka-actor/src/main/scala/akka/actor/FSM.scala
@@ -928,7 +928,7 @@ trait LoggingFSM[S, D] extends FSM[S, D] { this: Actor =>
         case a: ActorRef             => a.toString
         case _                       => "unknown"
       }
-      log.debug("processing {} from {} in state {}", event, srcstr, stateName)
+      log.debug("{} is processing {} from {} in state {}", self, event, srcstr, stateName)
     }
 
     if (logDepth > 0) {


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [Y] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [Y] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [No needed ] Have you updated the documentation?
* [Y] Have you added tests for any changed functionality?
-->
## Purpose

Added string representation of FSM actor in the debug log for `LoggingFSM` which will help in case if you have more than one instance of the same type of FSM.

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #xxxx

## Changes

<!-- Bullets for important changes in this PR -->

## Background Context

<!-- Why did you take this approach? -->
