### PR TITLE
doc: reword routing link to new API

### DIFF
--- a/akka-docs/src/main/paradox/fsm.md
+++ b/akka-docs/src/main/paradox/fsm.md
@@ -1,7 +1,7 @@
 # Classic FSM
 
 @@include[includes.md](includes.md) { #actor-api }
-For the full documentation of this feature and for new projects see @ref:[fsm](typed/fsm.md).
+For the documentation of the new API of this feature and for new projects see @ref:[fsm](typed/fsm.md).
 
 ## Dependency
 

--- a/akka-docs/src/main/paradox/routing.md
+++ b/akka-docs/src/main/paradox/routing.md
@@ -1,7 +1,7 @@
 # Classic Routing
 
 @@include[includes.md](includes.md) { #actor-api }
-For the full documentation of this feature and for new projects see @ref:[routers](typed/routers.md).
+For the documentation of the new API of this feature and for new projects see @ref:[routers](typed/routers.md).
 
 ## Dependency
 


### PR DESCRIPTION
* routing is so different so it doesn't make sense to use "full documentation"
* similar with fsm
