### PR TITLE
Document and fix getAsyncCallback thread safety issues 

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
@@ -106,6 +106,7 @@ import akka.util.OptionVal
       override def preStart(): Unit = {
         implicit val ec = materializer.executionContext
         outboundContext.controlSubject.attach(this).foreach {
+          // FIXME potentially unsafe getAsyncCallback usage
           getAsyncCallback[Done] { _ =>
             replyObserverAttached = true
             if (isAvailable(out))
@@ -151,7 +152,7 @@ import akka.util.OptionVal
         }
       }
 
-      // ControlMessageObserver, external call
+      // ControlMessageObserver, external call but on graph logic machinery thread (getAsyncCallback safe)
       override def controlSubjectCompleted(signal: Try[Done]): Unit = {
         getAsyncCallback[Try[Done]] {
           case Success(_)     => completeStage()

--- a/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
@@ -12,7 +12,6 @@ import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-
 import akka.Done
 import akka.remote.UniqueAddress
 import akka.remote.artery.InboundControlJunction.ControlMessageObserver
@@ -28,9 +27,10 @@ import akka.stream.stage.TimerGraphStageLogic
 import akka.remote.artery.OutboundHandshake.HandshakeReq
 import akka.actor.ActorRef
 import akka.dispatch.sysmsg.SystemMessage
-import scala.util.control.NoStackTrace
 
+import scala.util.control.NoStackTrace
 import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
 import akka.event.Logging
 import akka.stream.stage.StageLogging
 import akka.util.OptionVal
@@ -104,15 +104,14 @@ import akka.util.OptionVal
       override protected def logSource: Class[_] = classOf[SystemMessageDelivery]
 
       override def preStart(): Unit = {
-        implicit val ec = materializer.executionContext
-        outboundContext.controlSubject.attach(this).foreach {
-          // FIXME potentially unsafe getAsyncCallback usage
-          getAsyncCallback[Done] { _ =>
-            replyObserverAttached = true
-            if (isAvailable(out))
-              pull(in) // onPull from downstream already called
-          }.invoke
+        val callback = getAsyncCallback[Done] { _ =>
+          replyObserverAttached = true
+          if (isAvailable(out))
+            pull(in) // onPull from downstream already called
         }
+        outboundContext.controlSubject
+          .attach(this)
+          .foreach(callback.invoke)(ExecutionContexts.sameThreadExecutionContext)
       }
 
       override def postStop(): Unit = {

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -1407,14 +1407,12 @@ private[stream] object Collect {
     new GraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
       override protected def logSource: Class[_] = classOf[Watch[_]]
 
-      private lazy val self = getStageActor {
-        case (_, Terminated(`targetRef`)) =>
-          failStage(new WatchedActorTerminatedException("Watch", targetRef))
-        case (_, _) => // keep the compiler happy (stage actor receive is total)
-      }
-
       override def preStart(): Unit = {
-        // initialize self, and watch the target
+        val self = getStageActor {
+          case (_, Terminated(`targetRef`)) =>
+            failStage(new WatchedActorTerminatedException("Watch", targetRef))
+          case (_, _) => // keep the compiler happy (stage actor receive is total)
+        }
         self.watch(targetRef)
       }
 


### PR DESCRIPTION
Refs #27999


Changes and things checked
* `getAsyncCallback` indirectly used through `getStageActor` and `getEagerStageActor`
  * all use sites ok
  * one small (unrelated) optimization for `Watch` skipping `lazy` field
* unsafe use in `TimerGraphStageLogic`
    * fixed
    * also TimerGraphStage is not thread safe because mutable map, so added a note to the class
        * all usage of `TimerGraphStage` methods ok
* indirectly used in `SubSourceOutlet`
    * added scaladoc about thread safety
    * all use ok (`RestartFlow`, `StreamOfStreams`, `SetupStage`, `LazySink`)
* indirectly used in `SubSinkInlet`
    * added scaladoc about thread safety
    * all use seem ok (`RestartFlow`, `LazySource`, `SetupStage`, `FutureFlattenSource`, `RecoverWith`, `LazyFlow`, `FlattenMerge`, `RestartWithBackoffLogic`)
* Artery
    * `Handshake` fixed
    * `SystemMessageDelivery` ok, added comment
