### PR TITLE
Structured log events, #28207

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorLogMarker.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorLogMarker.scala
@@ -7,6 +7,11 @@ package akka.actor
 import akka.annotation.ApiMayChange
 import akka.event.LogMarker
 
+/**
+ * This is public with the purpose to document the used markers and properties of log events.
+ * No guarantee that it will remain binary compatible, but the marker names and properties
+ * are considered public API and will not be changed without notice.
+ */
 @ApiMayChange
 object ActorLogMarker {
 

--- a/akka-actor/src/main/scala/akka/actor/ActorLogMarker.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorLogMarker.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor
+
+import akka.annotation.ApiMayChange
+import akka.event.LogMarker
+
+@ApiMayChange
+object ActorLogMarker {
+
+  /**
+   * Marker "akkaDeadLetter" of log event for dead letter messages.
+   *
+   * @param messageClass The message class of the DeadLetter. Included as property "akkaMessageClass".
+   */
+  def deadLetter(messageClass: String): LogMarker =
+    LogMarker("akkaDeadLetter", Map(LogMarker.Properties.MessageClass -> messageClass))
+
+}

--- a/akka-actor/src/main/scala/akka/event/DeadLetterListener.scala
+++ b/akka-actor/src/main/scala/akka/event/DeadLetterListener.scala
@@ -8,6 +8,7 @@ import scala.concurrent.duration.Deadline
 import scala.concurrent.duration.FiniteDuration
 
 import akka.actor.Actor
+import akka.actor.ActorLogMarker
 import akka.actor.ActorRef
 import akka.actor.AllDeadLetters
 import akka.actor.DeadLetter
@@ -116,7 +117,9 @@ class DeadLetterListener extends Actor {
         d.recipient.getClass,
         logMessage +
         "This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' " +
-        "and 'akka.log-dead-letters-during-shutdown'."))
+        "and 'akka.log-dead-letters-during-shutdown'.",
+        Logging.emptyMDC,
+        ActorLogMarker.deadLetter(messageStr)))
   }
 
   private def isReal(snd: ActorRef): Boolean = {

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -1634,7 +1634,7 @@ class LogMarker(val name: String, val properties: Map[String, Any]) {
 
   /** Java API */
   def getProperties: java.util.Map[String, Object] = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     properties.map { case (k, v) => (k, v.asInstanceOf[AnyRef]) }.asJava
   }
 }
@@ -1653,7 +1653,7 @@ object LogMarker {
 
   /** Java API */
   def create(name: String, properties: java.util.Map[String, Any]): LogMarker = {
-    import scala.collection.JavaConverters._
+    import akka.util.ccompat.JavaConverters._
     apply(name, properties.asScala.toMap)
   }
 

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -1671,6 +1671,7 @@ object LogMarker {
    * INTERNAL API
    */
   @InternalApi private[akka] object Properties {
+    val MessageClass = "akkaMessageClass"
     val RemoteAddress = "akkaRemoteAddress"
     val RemoteAddressUid = "akkaRemoteAddressUid"
   }

--- a/akka-cluster-sharding/src/main/mima-filters/2.6.0.backwards.excludes/issue-28207-struct-log.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.6.0.backwards.excludes/issue-28207-struct-log.excludes
@@ -1,0 +1,8 @@
+# #28207 logging with markers
+ProblemFilters.exclude[MissingTypesProblem]("akka.cluster.sharding.PersistentShardCoordinator")
+ProblemFilters.exclude[MissingTypesProblem]("akka.cluster.sharding.DDataShardCoordinator")
+ProblemFilters.exclude[MissingTypesProblem]("akka.cluster.sharding.ShardCoordinator")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.cluster.sharding.ShardCoordinator.log")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.sharding.ShardCoordinator.typeName")
+ProblemFilters.exclude[MissingTypesProblem]("akka.cluster.sharding.ShardRegion")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.cluster.sharding.ShardRegion.log")

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -25,6 +25,7 @@ import akka.cluster.MemberStatus
 import akka.cluster.ClusterSettings
 import akka.cluster.ClusterSettings.DataCenter
 import akka.cluster.sharding.Shard.ShardStats
+import akka.event.Logging
 import akka.pattern.{ ask, pipe }
 import akka.util.{ MessageBufferMap, PrettyDuration, Timeout }
 
@@ -490,7 +491,6 @@ private[akka] class ShardRegion(
     replicator: ActorRef,
     majorityMinCap: Int)
     extends Actor
-    with ActorLogging
     with Timers {
 
   import ShardingQueries.ShardsQueryResult
@@ -498,6 +498,8 @@ private[akka] class ShardRegion(
   import ShardRegion._
   import settings._
   import settings.tuningParameters._
+
+  val log = Logging.withMarker(context.system, this)
 
   val cluster = Cluster(context.system)
 
@@ -1033,7 +1035,7 @@ private[akka] class ShardRegion(
         .get(id)
         .orElse(entityProps match {
           case Some(props) if !shardsByRef.values.exists(_ == id) =>
-            log.debug("{}: Starting shard [{}] in region", typeName, id)
+            log.debug(ShardingLogMarker.shardStarted(typeName, id), "{}: Starting shard [{}] in region", typeName, id)
 
             val name = URLEncoder.encode(id, "utf-8")
             val shard = context.watch(

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardingLogMarker.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardingLogMarker.scala
@@ -9,6 +9,11 @@ import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
 import akka.event.LogMarker
 
+/**
+ * This is public with the purpose to document the used markers and properties of log events.
+ * No guarantee that it will remain binary compatible, but the marker names and properties
+ * are considered public API and will not be changed without notice.
+ */
 @ApiMayChange
 object ShardingLogMarker {
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardingLogMarker.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardingLogMarker.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import akka.actor.Address
+import akka.annotation.ApiMayChange
+import akka.annotation.InternalApi
+import akka.event.LogMarker
+
+@ApiMayChange
+object ShardingLogMarker {
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] object Properties {
+    val ShardTypeName = "akkaShardTypeName"
+    val ShardId = "akkaShardId"
+  }
+
+  /**
+   * Marker "akkaShardAllocated" of log event when `ShardCoordinator` allocates a shard to a region.
+   * @param shardTypeName The `typeName` of the shard. Included as property "akkaShardTypeName".
+   * @param shardId The id of the shard. Included as property "akkaShardId".
+   * @param node The address of the node where the shard is allocated. Included as property "akkaRemoteAddress".
+   */
+  def shardAllocated(shardTypeName: String, shardId: String, node: Address): LogMarker =
+    LogMarker(
+      "akkaShardAllocated",
+      Map(
+        Properties.ShardTypeName -> shardTypeName,
+        Properties.ShardId -> shardId,
+        LogMarker.Properties.RemoteAddress -> node))
+
+  /**
+   * Marker "akkaShardStarted" of log event when `ShardRegion` starts a shard.
+   * @param shardTypeName The `typeName` of the shard. Included as property "akkaShardTypeName".
+   * @param shardId The id of the shard. Included as property "akkaShardId".
+   */
+  def shardStarted(shardTypeName: String, shardId: String): LogMarker =
+    LogMarker("akkaShardStarted", Map(Properties.ShardTypeName -> shardTypeName, Properties.ShardId -> shardId))
+
+}

--- a/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
@@ -816,7 +816,7 @@ class ClusterSingletonManager(singletonProps: Props, terminationMessage: Any, se
       }
     case Event(Terminated(ref), AcquiringLeaseData(_, Some(singleton))) if ref == singleton =>
       logInfo(
-        LogMarker("cluster.singleton.terminated"),
+        ClusterLogMarker.singletonTerminated,
         "Singleton actor terminated. Trying to acquire lease again before re-creating.")
       // tryAcquireLease sets the state to None for singleton actor
       tryAcquireLease()
@@ -850,7 +850,7 @@ class ClusterSingletonManager(singletonProps: Props, terminationMessage: Any, se
   @InternalStableApi
   def gotoOldest(): State = {
     logInfo(
-      LogMarker("cluster.singleton.started"),
+      ClusterLogMarker.singletonStarted,
       "Singleton manager starting singleton actor [{}]",
       self.path / singletonName)
     val singleton = context.watch(context.actorOf(singletonProps, singletonName))
@@ -892,7 +892,7 @@ class ClusterSingletonManager(singletonProps: Props, terminationMessage: Any, se
       stay
 
     case Event(Terminated(ref), d @ OldestData(Some(singleton))) if ref == singleton =>
-      logInfo(LogMarker("cluster.singleton.terminated"), "Singleton actor [{}] was terminated", singleton.path)
+      logInfo(ClusterLogMarker.singletonTerminated, "Singleton actor [{}] was terminated", singleton.path)
       stay.using(d.copy(singleton = None))
 
     case Event(SelfExiting, _) =>
@@ -952,7 +952,7 @@ class ClusterSingletonManager(singletonProps: Props, terminationMessage: Any, se
       gotoHandingOver(singleton, None)
 
     case Event(Terminated(ref), d @ WasOldestData(singleton, _)) if singleton.contains(ref) =>
-      logInfo(LogMarker("cluster.singleton.terminated"), "Singleton actor [{}] was terminated", ref.path)
+      logInfo(ClusterLogMarker.singletonTerminated, "Singleton actor [{}] was terminated", ref.path)
       stay.using(d.copy(singleton = None))
 
     case Event(SelfExiting, _) =>
@@ -1003,7 +1003,7 @@ class ClusterSingletonManager(singletonProps: Props, terminationMessage: Any, se
   def handOverDone(handOverTo: Option[ActorRef]): State = {
     val newOldest = handOverTo.map(_.path.address)
     logInfo(
-      LogMarker("cluster.singleton.terminated"),
+      ClusterLogMarker.singletonTerminated,
       "Singleton terminated, hand-over done [{} -> {}]",
       cluster.selfAddress,
       newOldest)

--- a/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
@@ -1026,7 +1026,7 @@ class ClusterSingletonManager(singletonProps: Props, terminationMessage: Any, se
 
   when(Stopping) {
     case Event(Terminated(ref), StoppingData(singleton)) if ref == singleton =>
-      logInfo(LogMarker("cluster.singleton.terminated"), "Singleton actor [{}] was terminated", singleton.path)
+      logInfo(ClusterLogMarker.singletonTerminated, "Singleton actor [{}] was terminated", singleton.path)
       stop()
   }
 

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -474,51 +474,51 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
       log.isDebugEnabled
 
     def logDebug(message: String): Unit =
-      if (LogInfo && log.isDebugEnabled)
+      if (settings.LogInfo && log.isDebugEnabled)
         logAtLevel(Logging.DebugLevel, message)
 
     def logDebug(template: String, arg1: Any): Unit =
-      if (LogInfo && log.isDebugEnabled)
+      if (settings.LogInfo && log.isDebugEnabled)
         logAtLevel(Logging.DebugLevel, log.format(template, arg1))
 
     def logDebug(template: String, arg1: Any, arg2: Any): Unit =
-      if (LogInfo && log.isDebugEnabled)
+      if (settings.LogInfo && log.isDebugEnabled)
         logAtLevel(Logging.DebugLevel, log.format(template, arg1, arg2))
 
     def logDebug(template: String, arg1: Any, arg2: Any, arg3: Any): Unit =
-      if (LogInfo && log.isDebugEnabled)
+      if (settings.LogInfo && log.isDebugEnabled)
         logAtLevel(Logging.DebugLevel, log.format(template, arg1, arg2, arg3))
 
     def logInfo(message: String): Unit =
-      if (LogInfo && log.isInfoEnabled)
+      if (settings.LogInfo && log.isInfoEnabled)
         logAtLevel(Logging.InfoLevel, message)
 
     def logInfo(marker: LogMarker, message: String): Unit =
-      if (LogInfo && log.isInfoEnabled(marker))
+      if (settings.LogInfo && log.isInfoEnabled(marker))
         logAtLevel(marker, Logging.InfoLevel, message)
 
     def logInfo(template: String, arg1: Any): Unit =
-      if (LogInfo && log.isInfoEnabled)
+      if (settings.LogInfo && log.isInfoEnabled)
         logAtLevel(Logging.InfoLevel, log.format(template, arg1))
 
     def logInfo(marker: LogMarker, template: String, arg1: Any): Unit =
-      if (LogInfo && log.isInfoEnabled(marker))
+      if (settings.LogInfo && log.isInfoEnabled(marker))
         logAtLevel(marker, Logging.InfoLevel, log.format(template, arg1))
 
     def logInfo(template: String, arg1: Any, arg2: Any): Unit =
-      if (LogInfo && log.isInfoEnabled)
+      if (settings.LogInfo && log.isInfoEnabled)
         logAtLevel(Logging.InfoLevel, log.format(template, arg1, arg2))
 
     def logInfo(marker: LogMarker, template: String, arg1: Any, arg2: Any): Unit =
-      if (LogInfo && log.isInfoEnabled(marker))
+      if (settings.LogInfo && log.isInfoEnabled(marker))
         logAtLevel(marker, Logging.InfoLevel, log.format(template, arg1, arg2))
 
     def logInfo(template: String, arg1: Any, arg2: Any, arg3: Any): Unit =
-      if (LogInfo && log.isInfoEnabled)
+      if (settings.LogInfo && log.isInfoEnabled)
         logAtLevel(Logging.InfoLevel, log.format(template, arg1, arg2, arg3))
 
     def logInfo(marker: LogMarker, template: String, arg1: Any, arg2: Any, arg3: Any): Unit =
-      if (LogInfo && log.isInfoEnabled(marker))
+      if (settings.LogInfo && log.isInfoEnabled(marker))
         logAtLevel(marker, Logging.InfoLevel, log.format(template, arg1, arg2, arg3))
 
     def logWarning(message: String): Unit =

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -494,7 +494,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
         logAtLevel(Logging.InfoLevel, message)
 
     def logInfo(marker: LogMarker, message: String): Unit =
-      if (LogInfo && log.isInfoEnabled)
+      if (LogInfo && log.isInfoEnabled(marker))
         logAtLevel(marker, Logging.InfoLevel, message)
 
     def logInfo(template: String, arg1: Any): Unit =
@@ -502,7 +502,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
         logAtLevel(Logging.InfoLevel, log.format(template, arg1))
 
     def logInfo(marker: LogMarker, template: String, arg1: Any): Unit =
-      if (LogInfo && log.isInfoEnabled)
+      if (LogInfo && log.isInfoEnabled(marker))
         logAtLevel(marker, Logging.InfoLevel, log.format(template, arg1))
 
     def logInfo(template: String, arg1: Any, arg2: Any): Unit =
@@ -510,7 +510,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
         logAtLevel(Logging.InfoLevel, log.format(template, arg1, arg2))
 
     def logInfo(marker: LogMarker, template: String, arg1: Any, arg2: Any): Unit =
-      if (LogInfo && log.isInfoEnabled)
+      if (LogInfo && log.isInfoEnabled(marker))
         logAtLevel(marker, Logging.InfoLevel, log.format(template, arg1, arg2))
 
     def logInfo(template: String, arg1: Any, arg2: Any, arg3: Any): Unit =
@@ -518,7 +518,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
         logAtLevel(Logging.InfoLevel, log.format(template, arg1, arg2, arg3))
 
     def logInfo(marker: LogMarker, template: String, arg1: Any, arg2: Any, arg3: Any): Unit =
-      if (LogInfo && log.isInfoEnabled)
+      if (LogInfo && log.isInfoEnabled(marker))
         logAtLevel(marker, Logging.InfoLevel, log.format(template, arg1, arg2, arg3))
 
     def logWarning(message: String): Unit =
@@ -530,7 +530,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
         logAtLevel(Logging.WarningLevel, log.format(template, arg1))
 
     def logWarning(marker: LogMarker, template: String, arg1: Any): Unit =
-      if (log.isWarningEnabled)
+      if (log.isWarningEnabled(marker))
         logAtLevel(marker, Logging.WarningLevel, log.format(template, arg1))
 
     def logWarning(template: String, arg1: Any, arg2: Any): Unit =
@@ -538,7 +538,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
         logAtLevel(Logging.WarningLevel, log.format(template, arg1, arg2))
 
     def logWarning(marker: LogMarker, template: String, arg1: Any, arg2: Any): Unit =
-      if (log.isWarningEnabled)
+      if (log.isWarningEnabled(marker))
         logAtLevel(marker, Logging.WarningLevel, log.format(template, arg1, arg2))
 
     def logWarning(template: String, arg1: Any, arg2: Any, arg3: Any): Unit =
@@ -548,6 +548,10 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
     def logError(message: String): Unit =
       if (log.isErrorEnabled)
         logAtLevel(Logging.ErrorLevel, message)
+
+    def logError(marker: LogMarker, message: String): Unit =
+      if (log.isErrorEnabled(marker))
+        logAtLevel(marker, Logging.ErrorLevel, message)
 
     def logError(template: String, arg1: Any): Unit =
       if (log.isErrorEnabled)

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -493,6 +493,10 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
       if (LogInfo && log.isInfoEnabled)
         logAtLevel(Logging.InfoLevel, message)
 
+    def logInfo(marker: LogMarker, message: String): Unit =
+      if (LogInfo && log.isInfoEnabled)
+        logAtLevel(marker, Logging.InfoLevel, message)
+
     def logInfo(template: String, arg1: Any): Unit =
       if (LogInfo && log.isInfoEnabled)
         logAtLevel(Logging.InfoLevel, log.format(template, arg1))

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -509,9 +509,17 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
       if (LogInfo && log.isInfoEnabled)
         logAtLevel(Logging.InfoLevel, log.format(template, arg1, arg2))
 
+    def logInfo(marker: LogMarker, template: String, arg1: Any, arg2: Any): Unit =
+      if (LogInfo && log.isInfoEnabled)
+        logAtLevel(marker, Logging.InfoLevel, log.format(template, arg1, arg2))
+
     def logInfo(template: String, arg1: Any, arg2: Any, arg3: Any): Unit =
       if (LogInfo && log.isInfoEnabled)
         logAtLevel(Logging.InfoLevel, log.format(template, arg1, arg2, arg3))
+
+    def logInfo(marker: LogMarker, template: String, arg1: Any, arg2: Any, arg3: Any): Unit =
+      if (LogInfo && log.isInfoEnabled)
+        logAtLevel(marker, Logging.InfoLevel, log.format(template, arg1, arg2, arg3))
 
     def logWarning(message: String): Unit =
       if (log.isWarningEnabled)

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -1173,7 +1173,7 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef, joinConfigCompatCh
       val periodicNotice = 60
       if (membershipState.convergence(exitingConfirmed)) {
         if (leaderActionCounter >= firstNotice)
-          logInfo(ClusterLogMarker.leaderAllowed, "Leader can perform its duties again")
+          logInfo(ClusterLogMarker.leaderRestored, "Leader can perform its duties again")
         leaderActionCounter = 0
         leaderActionsOnConvergence()
       } else {
@@ -1183,7 +1183,7 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef, joinConfigCompatCh
 
         if (leaderActionCounter == firstNotice || leaderActionCounter % periodicNotice == 0)
           logInfo(
-            ClusterLogMarker.leaderDetained,
+            ClusterLogMarker.leaderIncapacitated,
             "Leader can currently not perform its duties, reachability status: [{}], member status: [{}]",
             membershipState.dcReachabilityExcludingDownedObservers,
             latestGossip.members

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -1777,6 +1777,7 @@ private[cluster] final class JoinSeedNodeProcess(
         context.become(done)
       } else {
         logError(
+          ClusterLogMarker.joinFailed,
           "Couldn't join seed nodes because of incompatible cluster configuration. " +
           "It's recommended to perform a full cluster shutdown in order to deploy this new version." +
           "If a cluster shutdown isn't an option, you may want to disable this protection by setting " +
@@ -1792,6 +1793,7 @@ private[cluster] final class JoinSeedNodeProcess(
     case ReceiveTimeout =>
       if (attempt >= 2)
         logWarning(
+          ClusterLogMarker.joinFailed,
           "Couldn't join seed nodes after [{}] attempts, will try again. seed-nodes=[{}]",
           attempt,
           seedNodes.filterNot(_ == selfAddress).mkString(", "))

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -1155,7 +1155,7 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef, joinConfigCompatCh
       val periodicNotice = 60
       if (membershipState.convergence(exitingConfirmed)) {
         if (leaderActionCounter >= firstNotice)
-          logInfo("Leader can perform its duties again")
+          logInfo(ClusterLogMarker.leaderAllowed, "Leader can perform its duties again")
         leaderActionCounter = 0
         leaderActionsOnConvergence()
       } else {
@@ -1165,6 +1165,7 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef, joinConfigCompatCh
 
         if (leaderActionCounter == firstNotice || leaderActionCounter % periodicNotice == 0)
           logInfo(
+            ClusterLogMarker.leaderDetained,
             "Leader can currently not perform its duties, reachability status: [{}], member status: [{}]",
             membershipState.dcReachabilityExcludingDownedObservers,
             latestGossip.members

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
@@ -19,6 +19,7 @@ import akka.actor.RootActorPath
 import akka.annotation.InternalApi
 import akka.cluster.ClusterEvent._
 import akka.event.ActorWithLogClass
+import akka.event.LogMarker
 import akka.event.Logging
 import akka.remote.FailureDetectorRegistry
 import akka.remote.HeartbeatMessage
@@ -227,6 +228,7 @@ private[cluster] class ClusterHeartbeatSender extends Actor {
     val now = System.nanoTime()
     if ((now - tickTimestamp) >= (HeartbeatInterval.toNanos * 2))
       logWarning(
+        LogMarker("cluster.fd.starvation"),
         "Scheduled sending of heartbeat was delayed. " +
         "Previous heartbeat was sent [{}] ms ago, expected interval is [{}] ms. This may cause failure detection " +
         "to mark members as unreachable. The reason can be thread starvation, e.g. by running blocking tasks on the " +

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterLogMarker.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterLogMarker.scala
@@ -9,6 +9,11 @@ import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
 import akka.event.LogMarker
 
+/**
+ * This is public with the purpose to document the used markers and properties of log events.
+ * No guarantee that it will remain binary compatible, but the marker names and properties
+ * are considered public API and will not be changed without notice.
+ */
 @ApiMayChange
 object ClusterLogMarker {
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterLogMarker.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterLogMarker.scala
@@ -45,16 +45,17 @@ object ClusterLogMarker {
     LogMarker("akkaHeartbeatStarvation")
 
   /**
-   * Marker "akkaClusterLeaderDetained" of log event when leader can't perform its duties.
+   * Marker "akkaClusterLeaderIncapacitated" of log event when leader can't perform its duties.
+   * Typically because there are unreachable nodes that have not been downed.
    */
-  val leaderDetained: LogMarker =
-    LogMarker("akkaClusterLeaderDetained")
+  val leaderIncapacitated: LogMarker =
+    LogMarker("akkaClusterLeaderIncapacitated")
 
   /**
-   * Marker "akkaClusterLeaderAllowed" of log event when leader can perform its duties again.
+   * Marker "akkaClusterLeaderRestored" of log event when leader can perform its duties again.
    */
-  val leaderAllowed: LogMarker =
-    LogMarker("akkaClusterLeaderAllowed")
+  val leaderRestored: LogMarker =
+    LogMarker("akkaClusterLeaderRestored")
 
   /**
    * Marker "akkaJoinFailed" of log event when node couldn't join seed nodes.

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterLogMarker.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterLogMarker.scala
@@ -32,6 +32,18 @@ object ClusterLogMarker {
     LogMarker("akkaHeartbeatStarvation")
 
   /**
+   * Marker "akkaClusterLeaderDetained" of log event when leader can't perform its duties.
+   */
+  val leaderDetained: LogMarker =
+    LogMarker("akkaClusterLeaderDetained")
+
+  /**
+   * Marker "akkaClusterLeaderAllowed" of log event when leader can perform its duties again.
+   */
+  val leaderAllowed: LogMarker =
+    LogMarker("akkaClusterLeaderAllowed")
+
+  /**
    * Marker "akkaClusterSingletonStarted" of log event when Cluster Singleton
    * instance has started.
    */

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterLogMarker.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterLogMarker.scala
@@ -52,6 +52,12 @@ object ClusterLogMarker {
     LogMarker("akkaClusterLeaderAllowed")
 
   /**
+   * Marker "akkaJoinFailed" of log event when node couldn't join seed nodes.
+   */
+  val joinFailed: LogMarker =
+    LogMarker("akkaJoinFailed")
+
+  /**
    * Marker "akkaMemberChanged" of log event when a member's status is changed by the leader.
    * @param node The address of the node that is changed. Included as property "akkaRemoteAddress"
    *             and "akkaRemoteAddressUid".

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterLogMarker.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterLogMarker.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster
+
+import akka.actor.Address
+import akka.annotation.ApiMayChange
+import akka.event.LogMarker
+
+@ApiMayChange
+object ClusterLogMarker {
+
+  /**
+   * Marker "akkaUnreachable" of log event when a node is marked as unreachable based no failure detector observation.
+   * @param node The address of the node that is marked as unreachable. Included as property "akkaRemoteAddress".
+   */
+  def unreachable(node: Address): LogMarker =
+    LogMarker("akkaUnreachable", Map(LogMarker.Properties.RemoteAddress -> node))
+
+  /**
+   * Marker "akkaReachable" of log event when a node is marked as reachable again based no failure detector observation.
+   * @param node The address of the node that is marked as reachable. Included as property "akkaRemoteAddress".
+   */
+  def reachable(node: Address): LogMarker =
+    LogMarker("akkaReachable", Map(LogMarker.Properties.RemoteAddress -> node))
+
+  /**
+   * Marker "akkaHeartbeatStarvation" of log event when scheduled heartbeat was delayed.
+   */
+  val heartbeatStarvation: LogMarker =
+    LogMarker("akkaHeartbeatStarvation")
+
+  /**
+   * Marker "akkaClusterSingletonStarted" of log event when Cluster Singleton
+   * instance has started.
+   */
+  val singletonStarted: LogMarker =
+    LogMarker("akkaClusterSingletonStarted")
+
+  /**
+   * Marker "akkaClusterSingletonTerminated" of log event when Cluster Singleton
+   * instance has terminated.
+   */
+  val singletonTerminated: LogMarker =
+    LogMarker("akkaClusterSingletonTerminated")
+
+}

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterLogMarker.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterLogMarker.scala
@@ -6,10 +6,18 @@ package akka.cluster
 
 import akka.actor.Address
 import akka.annotation.ApiMayChange
+import akka.annotation.InternalApi
 import akka.event.LogMarker
 
 @ApiMayChange
 object ClusterLogMarker {
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] object Properties {
+    val MemberStatus = "akkaMemberStatus"
+  }
 
   /**
    * Marker "akkaUnreachable" of log event when a node is marked as unreachable based no failure detector observation.
@@ -42,6 +50,20 @@ object ClusterLogMarker {
    */
   val leaderAllowed: LogMarker =
     LogMarker("akkaClusterLeaderAllowed")
+
+  /**
+   * Marker "akkaMemberChanged" of log event when a member's status is changed by the leader.
+   * @param node The address of the node that is changed. Included as property "akkaRemoteAddress"
+   *             and "akkaRemoteAddressUid".
+   * @param status New member status. Included as property "akkaMemberStatus".
+   */
+  def memberChanged(node: UniqueAddress, status: MemberStatus): LogMarker =
+    LogMarker(
+      "akkaMemberChanged",
+      Map(
+        LogMarker.Properties.RemoteAddress -> node.address,
+        LogMarker.Properties.RemoteAddressUid -> node.longUid,
+        Properties.MemberStatus -> status))
 
   /**
    * Marker "akkaClusterSingletonStarted" of log event when Cluster Singleton

--- a/akka-cluster/src/main/scala/akka/cluster/CrossDcClusterHeartbeat.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/CrossDcClusterHeartbeat.scala
@@ -47,7 +47,8 @@ private[cluster] class CrossDcHeartbeatSender extends Actor {
   import context.dispatcher
 
   private val clusterLogger =
-    new cluster.ClusterLogger(Logging(context.system, ActorWithLogClass(this, ClusterLogClass.ClusterHeartbeat)))
+    new cluster.ClusterLogger(
+      Logging.withMarker(context.system, ActorWithLogClass(this, ClusterLogClass.ClusterHeartbeat)))
   import clusterLogger._
 
   // For inspecting if in active state; allows avoiding "becoming active" when already active

--- a/akka-docs/src/main/paradox/logging.md
+++ b/akka-docs/src/main/paradox/logging.md
@@ -580,7 +580,8 @@ Akka is logging some events with markers. Some of these events also include stru
 * The "SECURITY" marker is used for highlighting security related events or incidents.
 * Akka Actor is using the markers defined in @apidoc[akka.actor.ActorLogMarker].
 * Akka Cluster is using the markers defined in @apidoc[akka.cluster.ClusterLogMarker].
-* Akka Remoting is using the markers defined in @apidoc[akka.remote.RemoteLogMarker]
+* Akka Remoting is using the markers defined in @apidoc[akka.remote.RemoteLogMarker].
+* Akka Cluster Sharding is using the markers defined in @apidoc[akka.cluster.sharding.ShardingLogMarker].
 
 #### Using SLF4J's Markers
 

--- a/akka-docs/src/main/paradox/logging.md
+++ b/akka-docs/src/main/paradox/logging.md
@@ -575,6 +575,12 @@ A more advanced (including most Akka added information) example pattern would be
 <pattern>%date{ISO8601} level=[%level] marker=[%marker] logger=[%logger] akkaSource=[%X{akkaSource}] sourceActorSystem=[%X{sourceActorSystem}] sourceThread=[%X{sourceThread}] mdc=[ticket-#%X{ticketNumber}: %X{ticketDesc}] - msg=[%msg]%n----%n</pattern>
 ```
 
+Akka is logging some events with markers. Some of these events also include structured MDC properties. 
+
+* The "SECURITY" marker is used for highlighting security related events or incidents.
+* Akka Cluster is using the markers defined in @apidoc[akka.cluster.ClusterLogMarker].
+* Akka Remoting is using the markers defined in @apidoc[akka.remote.RemoteLogMarker]
+
 #### Using SLF4J's Markers
 
 It is also possible to use the `org.slf4j.Marker` with the `LoggingAdapter` when using slf4j.

--- a/akka-docs/src/main/paradox/logging.md
+++ b/akka-docs/src/main/paradox/logging.md
@@ -578,6 +578,7 @@ A more advanced (including most Akka added information) example pattern would be
 Akka is logging some events with markers. Some of these events also include structured MDC properties. 
 
 * The "SECURITY" marker is used for highlighting security related events or incidents.
+* Akka Actor is using the markers defined in @apidoc[akka.actor.ActorLogMarker].
 * Akka Cluster is using the markers defined in @apidoc[akka.cluster.ClusterLogMarker].
 * Akka Remoting is using the markers defined in @apidoc[akka.remote.RemoteLogMarker]
 

--- a/akka-docs/src/main/paradox/typed/logging.md
+++ b/akka-docs/src/main/paradox/typed/logging.md
@@ -433,6 +433,14 @@ With Logback the timestamp is available with `%X{akkaTimestamp}` specifier withi
   </encoder>
 ```
 
+### Markers
+
+Akka is logging some events with markers. Some of these events also include structured MDC properties. 
+
+* The "SECURITY" marker is used for highlighting security related events or incidents.
+* Akka Cluster is using the markers defined in @apidoc[akka.cluster.ClusterLogMarker].
+* Akka Remoting is using the markers defined in @apidoc[akka.remote.RemoteLogMarker]
+
 ### Logger names
 
 It can be useful to enable debug level or other SLF4J backend configuration for certain modules of Akka when

--- a/akka-docs/src/main/paradox/typed/logging.md
+++ b/akka-docs/src/main/paradox/typed/logging.md
@@ -438,6 +438,7 @@ With Logback the timestamp is available with `%X{akkaTimestamp}` specifier withi
 Akka is logging some events with markers. Some of these events also include structured MDC properties. 
 
 * The "SECURITY" marker is used for highlighting security related events or incidents.
+* Akka Actor is using the markers defined in @apidoc[akka.actor.ActorLogMarker].
 * Akka Cluster is using the markers defined in @apidoc[akka.cluster.ClusterLogMarker].
 * Akka Remoting is using the markers defined in @apidoc[akka.remote.RemoteLogMarker]
 

--- a/akka-docs/src/main/paradox/typed/logging.md
+++ b/akka-docs/src/main/paradox/typed/logging.md
@@ -440,7 +440,8 @@ Akka is logging some events with markers. Some of these events also include stru
 * The "SECURITY" marker is used for highlighting security related events or incidents.
 * Akka Actor is using the markers defined in @apidoc[akka.actor.ActorLogMarker].
 * Akka Cluster is using the markers defined in @apidoc[akka.cluster.ClusterLogMarker].
-* Akka Remoting is using the markers defined in @apidoc[akka.remote.RemoteLogMarker]
+* Akka Remoting is using the markers defined in @apidoc[akka.remote.RemoteLogMarker].
+* Akka Cluster Sharding is using the markers defined in @apidoc[akka.cluster.sharding.ShardingLogMarker].
 
 ### Logger names
 

--- a/akka-remote/src/main/scala/akka/remote/PhiAccrualFailureDetector.scala
+++ b/akka-remote/src/main/scala/akka/remote/PhiAccrualFailureDetector.scala
@@ -7,12 +7,16 @@ package akka.remote
 import akka.event.Logging.Warning
 import akka.remote.FailureDetector.Clock
 import java.util.concurrent.atomic.AtomicReference
+
 import scala.annotation.tailrec
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 import scala.collection.immutable
+
 import com.typesafe.config.Config
 import akka.event.EventStream
+import akka.event.LogMarker
+import akka.event.Logging
 import akka.util.Helpers.ConfigOps
 
 /**
@@ -144,7 +148,9 @@ class PhiAccrualFailureDetector(
               Warning(
                 this.toString,
                 getClass,
-                s"heartbeat interval is growing too large for address $address: $interval millis"))
+                s"heartbeat interval is growing too large for address $address: $interval millis",
+                Logging.emptyMDC,
+                LogMarker("cluster.fd.growing", Map(LogMarker.Properties.RemoteAddress -> address))))
           oldState.history :+ interval
         } else oldState.history
     }

--- a/akka-remote/src/main/scala/akka/remote/PhiAccrualFailureDetector.scala
+++ b/akka-remote/src/main/scala/akka/remote/PhiAccrualFailureDetector.scala
@@ -15,7 +15,6 @@ import scala.collection.immutable
 
 import com.typesafe.config.Config
 import akka.event.EventStream
-import akka.event.LogMarker
 import akka.event.Logging
 import akka.util.Helpers.ConfigOps
 
@@ -150,7 +149,7 @@ class PhiAccrualFailureDetector(
                 getClass,
                 s"heartbeat interval is growing too large for address $address: $interval millis",
                 Logging.emptyMDC,
-                LogMarker("cluster.fd.growing", Map(LogMarker.Properties.RemoteAddress -> address))))
+                RemoteLogMarker.failureDetectorGrowing(address)))
           oldState.history :+ interval
         } else oldState.history
     }

--- a/akka-remote/src/main/scala/akka/remote/RemoteLogMarker.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteLogMarker.scala
@@ -8,6 +8,11 @@ import akka.actor.Address
 import akka.annotation.ApiMayChange
 import akka.event.LogMarker
 
+/**
+ * This is public with the purpose to document the used markers and properties of log events.
+ * No guarantee that it will remain binary compatible, but the marker names and properties
+ * are considered public API and will not be changed without notice.
+ */
 @ApiMayChange
 object RemoteLogMarker {
 

--- a/akka-remote/src/main/scala/akka/remote/RemoteLogMarker.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteLogMarker.scala
@@ -34,14 +34,14 @@ object RemoteLogMarker {
         LogMarker.Properties.RemoteAddressUid -> remoteAddressUid.getOrElse("")))
 
   /**
-   * Marker "akkaConnected" of log event when outbound connection is established.
+   * Marker "akkaConnect" of log event when outbound connection is attempted.
    *
    * @param remoteAddress The address of the connected node. Included as property "akkaRemoteAddress".
    * @param remoteAddressUid The address of the connected node. Included as property "akkaRemoteAddressUid".
    */
-  def connected(remoteAddress: Address, remoteAddressUid: Option[Long]): LogMarker =
+  def connect(remoteAddress: Address, remoteAddressUid: Option[Long]): LogMarker =
     LogMarker(
-      "akkaConnected",
+      "akkaConnect",
       Map(
         LogMarker.Properties.RemoteAddress -> remoteAddress,
         LogMarker.Properties.RemoteAddressUid -> remoteAddressUid.getOrElse("")))

--- a/akka-remote/src/main/scala/akka/remote/RemoteLogMarker.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteLogMarker.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.remote
+
+import akka.actor.Address
+import akka.annotation.ApiMayChange
+import akka.event.LogMarker
+
+@ApiMayChange
+object RemoteLogMarker {
+
+  /**
+   * Marker "akkaFailureDetectorGrowing" of log event when failure detector heartbeat interval
+   * is growing too large.
+   *
+   * @param remoteAddress The address of the node that the failure detector is monitoring. Included as property "akkaRemoteAddress".
+   */
+  def failureDetectorGrowing(remoteAddress: String): LogMarker =
+    LogMarker("akkaFailureDetectorGrowing", Map(LogMarker.Properties.RemoteAddress -> remoteAddress))
+
+  /**
+   * Marker "akkaQuarantine" of log event when a node is quarantined.
+   *
+   * @param remoteAddress The address of the node that is quarantined. Included as property "akkaRemoteAddress".
+   * @param remoteAddressUid The address of the node that is quarantined. Included as property "akkaRemoteAddressUid".
+   */
+  def quarantine(remoteAddress: Address, remoteAddressUid: Option[Long]): LogMarker =
+    LogMarker(
+      "akkaQuarantine",
+      Map(
+        LogMarker.Properties.RemoteAddress -> remoteAddress,
+        LogMarker.Properties.RemoteAddressUid -> remoteAddressUid.getOrElse("")))
+
+  /**
+   * Marker "akkaConnected" of log event when outbound connection is established.
+   *
+   * @param remoteAddress The address of the connected node. Included as property "akkaRemoteAddress".
+   * @param remoteAddressUid The address of the connected node. Included as property "akkaRemoteAddressUid".
+   */
+  def connected(remoteAddress: Address, remoteAddressUid: Option[Long]): LogMarker =
+    LogMarker(
+      "akkaConnected",
+      Map(
+        LogMarker.Properties.RemoteAddress -> remoteAddress,
+        LogMarker.Properties.RemoteAddressUid -> remoteAddressUid.getOrElse("")))
+
+  /**
+   * Marker "akkaDisconnected" of log event when outbound connection is closed.
+   *
+   * @param remoteAddress The address of the disconnected node. Included as property "akkaRemoteAddress".
+   * @param remoteAddressUid The address of the disconnected node. Included as property "akkaRemoteAddressUid".
+   */
+  def disconnected(remoteAddress: Address, remoteAddressUid: Option[Long]): LogMarker =
+    LogMarker(
+      "akkaDisconnected",
+      Map(
+        LogMarker.Properties.RemoteAddress -> remoteAddress,
+        LogMarker.Properties.RemoteAddressUid -> remoteAddressUid.getOrElse("")))
+}

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -11,7 +11,7 @@ import akka.{ Done, NotUsed }
 import akka.actor.{ Actor, ActorRef, Address, CoordinatedShutdown, Dropped, ExtendedActorSystem, Props }
 import akka.annotation.InternalStableApi
 import akka.dispatch.Dispatchers
-import akka.event.{ Logging, LoggingAdapter }
+import akka.event.{ Logging, MarkerLoggingAdapter }
 import akka.remote.AddressUidExtension
 import akka.remote.RemoteActorRef
 import akka.remote.RemoteActorRefProvider
@@ -28,7 +28,6 @@ import akka.stream._
 import akka.stream.scaladsl.{ Flow, Keep, Sink }
 import akka.util.{ unused, OptionVal, WildcardIndex }
 import com.github.ghik.silencer.silent
-
 import scala.annotation.tailrec
 import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
@@ -308,7 +307,7 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
   @volatile private[this] var controlSubject: ControlMessageSubject = _
   @volatile private[this] var messageDispatcher: MessageDispatcher = _
 
-  override val log: LoggingAdapter = Logging(system, getClass)
+  override val log: MarkerLoggingAdapter = Logging.withMarker(system, getClass)
 
   /**
    * Compression tables must be created once, such that inbound lane restarts don't cause dropping of the tables.

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -24,9 +24,9 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.actor.ExtendedActorSystem
 import akka.dispatch.ExecutionContexts
-import akka.event.LogMarker
 import akka.event.Logging
 import akka.remote.RemoteActorRefProvider
+import akka.remote.RemoteLogMarker
 import akka.remote.RemoteTransportException
 import akka.remote.artery.Decoder.InboundCompressionAccess
 import akka.remote.artery.compress._
@@ -149,13 +149,9 @@ private[remote] class ArteryTcpTransport(
       def logConnected(): Unit = {
         if (log.isDebugEnabled)
           log.debug(
-            LogMarker(
-              "remote.outbound",
-              Map(
-                LogMarker.Properties.RemoteAddress -> outboundContext.remoteAddress,
-                LogMarker.Properties.RemoteAddressUid -> outboundContext.associationState
-                  .uniqueRemoteAddressValue()
-                  .getOrElse(""))),
+            RemoteLogMarker.connected(
+              outboundContext.remoteAddress,
+              outboundContext.associationState.uniqueRemoteAddressValue().map(_.uid)),
             "Outbound connection opened to [{}]",
             outboundContext.remoteAddress)
       }
@@ -163,13 +159,9 @@ private[remote] class ArteryTcpTransport(
       def logDisconnected(): Unit = {
         if (log.isDebugEnabled)
           log.debug(
-            LogMarker(
-              "remote.outbound",
-              Map(
-                LogMarker.Properties.RemoteAddress -> outboundContext.remoteAddress,
-                LogMarker.Properties.RemoteAddressUid -> outboundContext.associationState
-                  .uniqueRemoteAddressValue()
-                  .getOrElse(""))),
+            RemoteLogMarker.disconnected(
+              outboundContext.remoteAddress,
+              outboundContext.associationState.uniqueRemoteAddressValue().map(_.uid)),
             "Outbound connection closed to [{}]",
             outboundContext.remoteAddress)
       }

--- a/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
@@ -107,12 +107,22 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
 
   @inline
   final def withMdc(logSource: String, logEvent: LogEvent)(logStatement: => Unit): Unit = {
+    logEvent match {
+      case m: LogEventWithMarker =>
+        val properties = m.marker.properties
+        if (properties.nonEmpty) {
+          properties.foreach { case (k, v) => MDC.put(k, String.valueOf(v)) }
+        }
+      case _ =>
+    }
+
     MDC.put(mdcAkkaSourceAttributeName, logSource)
     MDC.put(mdcThreadAttributeName, logEvent.thread.getName)
     MDC.put(mdcAkkaTimestamp, formatTimestamp(logEvent.timestamp))
     MDC.put(mdcActorSystemAttributeName, context.system.name)
     MDC.put(mdcAkkaAddressAttributeName, akkaAddress)
     logEvent.mdc.foreach { case (k, v) => MDC.put(k, String.valueOf(v)) }
+
     try logStatement
     finally {
       MDC.clear()
@@ -174,7 +184,7 @@ class Slf4jLoggingFilter(@unused settings: ActorSystem.Settings, eventStream: Ev
 }
 
 /** Wraps [[org.slf4j.Marker]] */
-final class Slf4jLogMarker(val marker: org.slf4j.Marker) extends LogMarker(name = marker.getName)
+final class Slf4jLogMarker(val marker: org.slf4j.Marker) extends LogMarker(name = marker.getName, Map.empty)
 
 /** Factory for creating [[LogMarker]] that wraps [[org.slf4j.Marker]] */
 object Slf4jLogMarker {

--- a/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
@@ -108,7 +108,7 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
   @inline
   final def withMdc(logSource: String, logEvent: LogEvent)(logStatement: => Unit): Unit = {
     logEvent match {
-      case m: LogEventWithMarker =>
+      case m: LogEventWithMarker if m.marker ne null =>
         val properties = m.marker.properties
         if (properties.nonEmpty) {
           properties.foreach { case (k, v) => MDC.put(k, String.valueOf(v)) }

--- a/akka-slf4j/src/test/resources/logback-test.xml
+++ b/akka-slf4j/src/test/resources/logback-test.xml
@@ -7,7 +7,7 @@
   </appender>
   <appender name="TEST" class="akka.event.slf4j.Slf4jLoggerSpec$TestAppender">
     <encoder>
-      <pattern>%date{ISO8601} level=[%level] marker=[%marker] logger=[%logger] akkaSource=[%X{akkaSource}] akkaAddress=[%X{akkaAddress}] sourceActorSystem=[%X{sourceActorSystem}] sourceThread=[%X{sourceThread}] mdc=[ticket-#%X{ticketNumber}: %X{ticketDesc}] - msg=[%msg]%n----%n</pattern>
+      <pattern>%date{ISO8601} level=[%level] marker=[%marker] logger=[%logger] akkaSource=[%X{akkaSource}] akkaAddress=[%X{akkaAddress}] sourceActorSystem=[%X{sourceActorSystem}] sourceThread=[%X{sourceThread}] mdc=[ticket-#%X{ticketNumber}: %X{ticketDesc} p1: %X{p1} p2: %X{p2}] - msg=[%msg]%n----%n</pattern>
     </encoder>
   </appender>
   <logger name="akka.event.slf4j.Slf4jLoggingFilterSpec$DebugLevelProducer"

--- a/akka-slf4j/src/test/scala/akka/event/slf4j/Slf4jLoggerSpec.scala
+++ b/akka-slf4j/src/test/scala/akka/event/slf4j/Slf4jLoggerSpec.scala
@@ -122,6 +122,16 @@ class Slf4jLoggerSpec extends AkkaSpec(Slf4jLoggerSpec.config) with BeforeAndAft
       s should include("msg=[security-wise interesting message]")
     }
 
+    "log info with marker and properties" in {
+      producer ! StringWithMarker("interesting message", LogMarker("testMarker", Map("p1" -> 1, "p2" -> "B")))
+
+      awaitCond(outputString.contains("----"), 5 seconds)
+      val s = outputString
+      s should include("marker=[testMarker]")
+      s should include("p1: 1 p2: B")
+      s should include("msg=[interesting message]")
+    }
+
     "log info with slf4j marker" in {
       val slf4jMarker = MarkerFactory.getMarker("SLF")
       slf4jMarker.add(MarkerFactory.getMarker("ADDED")) // slf4j markers can have children
@@ -143,7 +153,7 @@ class Slf4jLoggerSpec extends AkkaSpec(Slf4jLoggerSpec.config) with BeforeAndAft
       awaitCond(outputString.contains("----"), 5 seconds)
       val s = outputString
       s should include("marker=[SLF [ ADDED ]]")
-      s should include("mdc=[ticket-#3671: Custom MDC Values]")
+      s should include("mdc=[ticket-#3671: Custom MDC Values")
       s should include("msg=[security-wise interesting message]")
     }
 
@@ -158,7 +168,7 @@ class Slf4jLoggerSpec extends AkkaSpec(Slf4jLoggerSpec.config) with BeforeAndAft
       s should include("level=[INFO]")
       s should include("logger=[akka.event.slf4j.Slf4jLoggerSpec$LogProducer]")
       (s should include).regex(sourceThreadRegex)
-      s should include("mdc=[ticket-#3671: Custom MDC Values]")
+      s should include("mdc=[ticket-#3671: Custom MDC Values")
       s should include("msg=[Message with custom MDC values]")
     }
 
@@ -179,7 +189,7 @@ class Slf4jLoggerSpec extends AkkaSpec(Slf4jLoggerSpec.config) with BeforeAndAft
       s should include("level=[INFO]")
       s should include("logger=[akka.event.slf4j.Slf4jLoggerSpec$LogProducer]")
       (s should include).regex(sourceThreadRegex)
-      s should include("mdc=[ticket-#3671: null]")
+      s should include("mdc=[ticket-#3671: null")
       s should include("msg=[Message with null custom MDC values]")
     }
 


### PR DESCRIPTION
* Expanding the LogMarker to optionally include Map of additional properties
* The name of the marker shows up as `tags` in Kibana
* The properties of the LogMarker are included as MDC entries, which Logstash encoder automatically understands
* Implemented with classic eventStream logging so that it can be used from all places without dependencies to Slf4j
  * also means that it's possible to subscribe to LogEventWithMarker to consume these events via the eventStream

On top of https://github.com/akka/akka/pull/28148 because the akkaAddress is important information.

Refs #28207

