### PR TITLE
28206 adding address typed

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -21,11 +21,10 @@ import akka.annotation.InternalApi
 import akka.{ actor => classic }
 import akka.Done
 import com.typesafe.config.ConfigFactory
+
 import scala.compat.java8.FutureConverters
 import scala.concurrent._
-
-import akka.actor.ActorRefProvider
-import akka.actor.ReflectiveDynamicAccess
+import akka.actor.{ ActorPath, ActorRefProvider, Address, ReflectiveDynamicAccess }
 import akka.actor.typed.internal.InternalRecipientRef
 import com.github.ghik.silencer.silent
 import org.slf4j.Logger
@@ -41,7 +40,9 @@ import org.slf4j.LoggerFactory
     with ActorRefImpl[Nothing]
     with InternalRecipientRef[Nothing] {
 
-  override val path: classic.ActorPath = classic.RootActorPath(classic.Address("akka", name)) / "user"
+  private val rootPath: ActorPath = classic.RootActorPath(classic.Address("akka", name))
+
+  override val path: classic.ActorPath = rootPath / "user"
 
   override val settings: Settings = {
     val classLoader = getClass.getClassLoader
@@ -113,4 +114,8 @@ import org.slf4j.LoggerFactory
     throw new UnsupportedOperationException("ActorSystemStub cannot register extensions")
 
   override def log: Logger = LoggerFactory.getLogger(getClass)
+
+  def getExternalAddressFor(addr: Address): Option[Address] = if (addr == rootPath.address) Some(addr) else None
+
+  def getDefaultAddress: Address = rootPath.address
 }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -115,7 +115,5 @@ import org.slf4j.LoggerFactory
 
   override def log: Logger = LoggerFactory.getLogger(getClass)
 
-  def getExternalAddressFor(addr: Address): Option[Address] = if (addr == rootPath.address) Some(addr) else None
-
-  def getDefaultAddress: Address = rootPath.address
+  def address: Address = rootPath.address
 }

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
@@ -200,17 +200,7 @@ class BehaviorTestKitSpec extends WordSpec with Matchers with LogCapturing {
 
     "return default address" in {
       val testkit = BehaviorTestKit[Parent.Command](Parent.init)
-      testkit.context.asScala.system.getDefaultAddress shouldBe testKitAddress
-    }
-
-    "return None external address for parameter other than rootPath" in {
-      val testkit = BehaviorTestKit[Parent.Command](Parent.init)
-      testkit.context.asScala.system.getExternalAddressFor(Address("akka", "somethingelse")) shouldBe None
-    }
-
-    "return rootPath address for parameter other than rootPath" in {
-      val testkit = BehaviorTestKit[Parent.Command](Parent.init)
-      testkit.context.asScala.system.getExternalAddressFor(testKitAddress) shouldBe Some(testKitAddress)
+      testkit.context.asScala.system.address shouldBe testKitAddress
     }
   }
 

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
@@ -5,6 +5,7 @@
 package akka.actor.testkit.typed.scaladsl
 
 import akka.Done
+import akka.actor.Address
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ ActorRef, Behavior, Props }
 import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
@@ -12,8 +13,8 @@ import akka.actor.testkit.typed.Effect._
 import akka.actor.testkit.typed.scaladsl.BehaviorTestKitSpec.{ Child, Parent }
 import akka.actor.testkit.typed.scaladsl.BehaviorTestKitSpec.Parent._
 import org.scalatest.{ Matchers, WordSpec }
-import scala.reflect.ClassTag
 
+import scala.reflect.ClassTag
 import org.slf4j.event.Level
 
 object BehaviorTestKitSpec {
@@ -125,6 +126,8 @@ class BehaviorTestKitSpec extends WordSpec with Matchers with LogCapturing {
 
   private val props = Props.empty.withDispatcherFromConfig("cat")
 
+  private val testKitAddress = Address("akka", "StubbedActorContext")
+
   "BehaviorTestKit" must {
 
     "allow assertions on effect type" in {
@@ -193,6 +196,21 @@ class BehaviorTestKitSpec extends WordSpec with Matchers with LogCapturing {
       testkit.logEntries() shouldBe Seq(CapturedLogEvent(Level.INFO, what))
       testkit.clearLog()
       testkit.logEntries() shouldBe Seq.empty
+    }
+
+    "return default address" in {
+      val testkit = BehaviorTestKit[Parent.Command](Parent.init)
+      testkit.context.asScala.system.getDefaultAddress shouldBe testKitAddress
+    }
+
+    "return None external address for parameter other than rootPath" in {
+      val testkit = BehaviorTestKit[Parent.Command](Parent.init)
+      testkit.context.asScala.system.getExternalAddressFor(Address("akka", "somethingelse")) shouldBe None
+    }
+
+    "return rootPath address for parameter other than rootPath" in {
+      val testkit = BehaviorTestKit[Parent.Command](Parent.init)
+      testkit.context.asScala.system.getExternalAddressFor(testKitAddress) shouldBe Some(testKitAddress)
     }
   }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorRefResolverSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorRefResolverSpec.scala
@@ -34,7 +34,7 @@ class ActorRefResolverSpec extends WordSpec with ScalaFutures with Matchers {
 
         val minRef1: akka.actor.ActorRef = new MinimalActorRef {
           override def provider: ActorRefProvider = system1.toClassic.asInstanceOf[ActorSystemImpl].provider
-          override def path: ActorPath = RootActorPath(system1.getDefaultAddress) / "minRef1"
+          override def path: ActorPath = RootActorPath(system1.address) / "minRef1"
         }
 
         val minRef1Serialized = ActorRefResolver(system2).toSerializationFormat(minRef1)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorRefResolverSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/ActorRefResolverSpec.scala
@@ -34,7 +34,7 @@ class ActorRefResolverSpec extends WordSpec with ScalaFutures with Matchers {
 
         val minRef1: akka.actor.ActorRef = new MinimalActorRef {
           override def provider: ActorRefProvider = system1.toClassic.asInstanceOf[ActorSystemImpl].provider
-          override def path: ActorPath = RootActorPath(provider.getDefaultAddress) / "minRef1"
+          override def path: ActorPath = RootActorPath(system1.getDefaultAddress) / "minRef1"
         }
 
         val minRef1Serialized = ActorRefResolver(system2).toSerializationFormat(minRef1)

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
@@ -161,19 +161,7 @@ class ActorSystemSpec
 
     "return default address " in {
       withSystem("address", Behaviors.empty[String]) { sys =>
-        sys.getDefaultAddress shouldBe Address("akka", "adapter-address")
-      }
-    }
-
-    "return empty external address for argument other than rootPath" in {
-      withSystem("no-address", Behaviors.empty[String]) { sys =>
-        sys.getExternalAddressFor(Address("akka", "other")) shouldBe None
-      }
-    }
-
-    "return external address for argument equal to rootPath" in {
-      withSystem("some-address", Behaviors.empty[String]) { sys =>
-        sys.getExternalAddressFor(sys.getDefaultAddress) shouldBe Some(sys.getDefaultAddress)
+        sys.address shouldBe Address("akka", "adapter-address")
       }
     }
   }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
@@ -9,10 +9,8 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
-
 import akka.Done
-import akka.actor.CoordinatedShutdown
-import akka.actor.InvalidMessageException
+import akka.actor.{ Address, CoordinatedShutdown, InvalidMessageException }
 import akka.actor.testkit.typed.scaladsl.TestInbox
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.typed.scaladsl.Behaviors
@@ -158,6 +156,24 @@ class ActorSystemSpec
         intercept[InvalidMessageException] {
           sys ! null
         }
+      }
+    }
+
+    "return default address " in {
+      withSystem("address", Behaviors.empty[String]) { sys =>
+        sys.getDefaultAddress shouldBe Address("akka", "adapter-address")
+      }
+    }
+
+    "return empty external address for argument other than rootPath" in {
+      withSystem("no-address", Behaviors.empty[String]) { sys =>
+        sys.getExternalAddressFor(Address("akka", "other")) shouldBe None
+      }
+    }
+
+    "return external address for argument equal to rootPath" in {
+      withSystem("some-address", Behaviors.empty[String]) { sys =>
+        sys.getExternalAddressFor(sys.getDefaultAddress) shouldBe Some(sys.getDefaultAddress)
       }
     }
   }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/routing/RoutingLogicSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/routing/RoutingLogicSpec.scala
@@ -5,11 +5,11 @@
 package akka.actor.typed.internal.routing
 
 import akka.actor.Address
-import akka.actor.testkit.typed.scaladsl.{LogCapturing, ScalaTestWithActorTestKit, TestProbe}
+import akka.actor.testkit.typed.scaladsl.{ LogCapturing, ScalaTestWithActorTestKit, TestProbe }
 import akka.actor.typed.internal.routing.RoutingLogics.ConsistentHashingLogic
 import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.{ActorSystem, Behavior}
-import org.scalatest.{Matchers, WordSpecLike}
+import akka.actor.typed.{ ActorSystem, Behavior }
+import org.scalatest.{ Matchers, WordSpecLike }
 
 class RoutingLogicSpec extends ScalaTestWithActorTestKit with WordSpecLike with Matchers with LogCapturing {
 
@@ -144,7 +144,7 @@ class RoutingLogicSpec extends ScalaTestWithActorTestKit with WordSpecLike with 
   "The consistent hashing logic" must {
     val behavior: Behavior[Int] = Behaviors.empty[Int]
     val typedSystem: ActorSystem[Int] = ActorSystem(behavior, "testSystem")
-    val selfAddress: Address = typedSystem.getDefaultAddress
+    val selfAddress: Address = typedSystem.address
     val modulo10Mapping: Int => String = (in: Int) => (in % 10).toString
     val messages: Map[Any, Seq[Int]] = (1 to 1000).groupBy(modulo10Mapping.apply)
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/routing/RoutingLogicSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/routing/RoutingLogicSpec.scala
@@ -4,12 +4,12 @@
 
 package akka.actor.typed.internal.routing
 
-import akka.actor.{ Address, ExtendedActorSystem }
-import akka.actor.testkit.typed.scaladsl.{ LogCapturing, ScalaTestWithActorTestKit, TestProbe }
+import akka.actor.Address
+import akka.actor.testkit.typed.scaladsl.{LogCapturing, ScalaTestWithActorTestKit, TestProbe}
 import akka.actor.typed.internal.routing.RoutingLogics.ConsistentHashingLogic
 import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.{ ActorSystem, Behavior }
-import org.scalatest.{ Matchers, WordSpecLike }
+import akka.actor.typed.{ActorSystem, Behavior}
+import org.scalatest.{Matchers, WordSpecLike}
 
 class RoutingLogicSpec extends ScalaTestWithActorTestKit with WordSpecLike with Matchers with LogCapturing {
 
@@ -142,10 +142,9 @@ class RoutingLogicSpec extends ScalaTestWithActorTestKit with WordSpecLike with 
   }
 
   "The consistent hashing logic" must {
-    import akka.actor.typed.scaladsl.adapter._
     val behavior: Behavior[Int] = Behaviors.empty[Int]
     val typedSystem: ActorSystem[Int] = ActorSystem(behavior, "testSystem")
-    val selfAddress: Address = typedSystem.toClassic.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
+    val selfAddress: Address = typedSystem.getDefaultAddress
     val modulo10Mapping: Int => String = (in: Int) => (in % 10).toString
     val messages: Map[Any, Seq[Int]] = (1 to 1000).groupBy(modulo10Mapping.apply)
 

--- a/akka-actor-typed/src/main/mima-filters/2.6.0.backwards.excludes/issue-28206-address.excludes
+++ b/akka-actor-typed/src/main/mima-filters/2.6.0.backwards.excludes/issue-28206-address.excludes
@@ -1,0 +1,2 @@
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.ActorSystem.getExternalAddressFor")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.ActorSystem.getDefaultAddress")

--- a/akka-actor-typed/src/main/mima-filters/2.6.0.backwards.excludes/issue-28206-address.excludes
+++ b/akka-actor-typed/src/main/mima-filters/2.6.0.backwards.excludes/issue-28206-address.excludes
@@ -1,2 +1,1 @@
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.ActorSystem.getExternalAddressFor")
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.ActorSystem.getDefaultAddress")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.ActorSystem.address")

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorRefResolver.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorRefResolver.scala
@@ -53,7 +53,7 @@ abstract class ActorRefResolver extends Extension {
   override def toSerializationFormat[T](ref: ActorRef[T]): String = {
 
     def toSerializationFormatWithAddress =
-      ref.path.toSerializationFormatWithAddress(classicSystem.provider.getDefaultAddress)
+      ref.path.toSerializationFormatWithAddress(system.getDefaultAddress)
 
     ref.toClassic match {
       case a: ActorRefWithCell =>

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorRefResolver.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorRefResolver.scala
@@ -53,7 +53,7 @@ abstract class ActorRefResolver extends Extension {
   override def toSerializationFormat[T](ref: ActorRef[T]): String = {
 
     def toSerializationFormatWithAddress =
-      ref.path.toSerializationFormatWithAddress(system.getDefaultAddress)
+      ref.path.toSerializationFormatWithAddress(system.address)
 
     ref.toClassic match {
       case a: ActorRefWithCell =>

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -6,8 +6,7 @@ package akka.actor.typed
 
 import java.util.concurrent.{ CompletionStage, ThreadFactory }
 
-import akka.actor.ClassicActorSystemProvider
-import akka.actor.BootstrapSetup
+import akka.actor.{ Address, BootstrapSetup, ClassicActorSystemProvider }
 import akka.actor.setup.ActorSystemSetup
 import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.internal.{ EventStreamExtension, InternalRecipientRef }
@@ -18,6 +17,7 @@ import akka.util.Helpers.Requiring
 import akka.{ Done, actor => classic }
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.slf4j.Logger
+
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 
 /**
@@ -164,6 +164,19 @@ abstract class ActorSystem[-T] extends ActorRef[T] with Extensions with ClassicA
    */
   def eventStream: ActorRef[EventStream.Command] =
     EventStreamExtension(this).ref
+
+  /**
+   * Obtain the address which is to be used within sender references when
+   * sending to the given other address or none if the other address cannot be
+   * reached from this system (i.e. no means of communication known; no
+   * attempt is made to verify actual reachability).
+   */
+  def getExternalAddressFor(addr: Address): Option[Address]
+
+  /**
+   * Obtain the external address of the default transport.
+   */
+  def getDefaultAddress: Address
 
 }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -166,7 +166,12 @@ abstract class ActorSystem[-T] extends ActorRef[T] with Extensions with ClassicA
     EventStreamExtension(this).ref
 
   /**
-   * Obtain the external address of the default transport.
+   * Obtains the external address of the default transport.
+   *
+   * Consider differences in clustered and non-clustered ActorSystems.
+   * For a non-clustered ActorSystem, this will return an address without host and port.
+   * For a clustered ActorSystem, this will return the address that other nodes can use to
+   * communicate with this node.
    */
   def address: Address
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -166,17 +166,9 @@ abstract class ActorSystem[-T] extends ActorRef[T] with Extensions with ClassicA
     EventStreamExtension(this).ref
 
   /**
-   * Obtain the address which is to be used within sender references when
-   * sending to the given other address or none if the other address cannot be
-   * reached from this system (i.e. no means of communication known; no
-   * attempt is made to verify actual reachability).
-   */
-  def getExternalAddressFor(addr: Address): Option[Address]
-
-  /**
    * Obtain the external address of the default transport.
    */
-  def getDefaultAddress: Address
+  def address: Address
 
 }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -108,9 +108,7 @@ import org.slf4j.{ Logger, LoggerFactory }
     ActorRefAdapter(ref)
   }
 
-  override def getExternalAddressFor(addr: Address): Option[Address] = system.provider.getExternalAddressFor(addr)
-
-  override def getDefaultAddress: Address = system.provider.getDefaultAddress
+  override def address: Address = system.provider.getDefaultAddress
 }
 
 private[akka] object ActorSystemAdapter {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -8,12 +8,9 @@ import java.util.concurrent.CompletionStage
 
 import scala.compat.java8.FutureConverters
 import scala.concurrent.ExecutionContextExecutor
-
 import akka.Done
 import akka.actor
-import akka.actor.ActorRefProvider
-import akka.actor.ExtendedActorSystem
-import akka.actor.InvalidMessageException
+import akka.actor.{ ActorRefProvider, Address, ExtendedActorSystem, InvalidMessageException }
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -111,6 +108,9 @@ import org.slf4j.{ Logger, LoggerFactory }
     ActorRefAdapter(ref)
   }
 
+  override def getExternalAddressFor(addr: Address): Option[Address] = system.provider.getExternalAddressFor(addr)
+
+  override def getDefaultAddress: Address = system.provider.getDefaultAddress
 }
 
 private[akka] object ActorSystemAdapter {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/GroupRouterImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/GroupRouterImpl.scala
@@ -41,11 +41,7 @@ private[akka] final case class GroupRouterBuilder[T] private[akka] (
 
   def withConsistentHashingRouting(virtualNodesFactor: Int, mapping: T => String): GroupRouterBuilder[T] = {
     copy(
-      logicFactory = system =>
-        new RoutingLogics.ConsistentHashingLogic[T](
-          virtualNodesFactor,
-          mapping,
-          system.getDefaultAddress))
+      logicFactory = system => new RoutingLogics.ConsistentHashingLogic[T](virtualNodesFactor, mapping, system.address))
   }
 }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/GroupRouterImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/GroupRouterImpl.scala
@@ -6,7 +6,7 @@ package akka.actor.typed.internal.routing
 
 import java.util.function
 
-import akka.actor.{ Dropped, ExtendedActorSystem }
+import akka.actor.Dropped
 import akka.actor.typed._
 import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.receptionist.Receptionist
@@ -40,13 +40,12 @@ private[akka] final case class GroupRouterBuilder[T] private[akka] (
     withConsistentHashingRouting(virtualNodesFactor, mapping.apply(_))
 
   def withConsistentHashingRouting(virtualNodesFactor: Int, mapping: T => String): GroupRouterBuilder[T] = {
-    import akka.actor.typed.scaladsl.adapter._
     copy(
       logicFactory = system =>
         new RoutingLogics.ConsistentHashingLogic[T](
           virtualNodesFactor,
           mapping,
-          system.toClassic.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress))
+          system.getDefaultAddress))
   }
 }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/PoolRouterImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/PoolRouterImpl.scala
@@ -6,7 +6,6 @@ package akka.actor.typed.internal.routing
 
 import java.util.function
 
-import akka.actor.ExtendedActorSystem
 import akka.actor.typed._
 import akka.actor.typed.javadsl.PoolRouter
 import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, Behaviors }
@@ -36,13 +35,12 @@ private[akka] final case class PoolRouterBuilder[T](
     withConsistentHashingRouting(virtualNodesFactor, mapping.apply(_))
 
   def withConsistentHashingRouting(virtualNodesFactor: Int, mapping: T => String): PoolRouterBuilder[T] = {
-    import akka.actor.typed.scaladsl.adapter._
     copy(
       logicFactory = system =>
         new RoutingLogics.ConsistentHashingLogic[T](
           virtualNodesFactor,
           mapping,
-          system.toClassic.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress))
+          system.getDefaultAddress))
   }
 
   def withPoolSize(poolSize: Int): PoolRouterBuilder[T] = copy(poolSize = poolSize)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/PoolRouterImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/PoolRouterImpl.scala
@@ -36,11 +36,7 @@ private[akka] final case class PoolRouterBuilder[T](
 
   def withConsistentHashingRouting(virtualNodesFactor: Int, mapping: T => String): PoolRouterBuilder[T] = {
     copy(
-      logicFactory = system =>
-        new RoutingLogics.ConsistentHashingLogic[T](
-          virtualNodesFactor,
-          mapping,
-          system.getDefaultAddress))
+      logicFactory = system => new RoutingLogics.ConsistentHashingLogic[T](virtualNodesFactor, mapping, system.address))
   }
 
   def withPoolSize(poolSize: Int): PoolRouterBuilder[T] = copy(poolSize = poolSize)


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->
## Purpose

This PR adds Address retrieving methods to typed ActorSystem.

## References

References https://github.com/akka/akka/issues/28206

## Changes

- Added `getExternalAddressFor` and `getDefaultAddress` methods in `akka.actor.typed.ActorSystem`
- Those methods were implemented in `akka.actor.testkit.typed.internal.ActorSystemStub` and `akka.actor.testkit.typed.internal.adapter.ActorSystemAdapter`.
- Appropriate tests were added.
