### PR TITLE
Don't include protobuf settings for all projects

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/extensions/ExtensionDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/extensions/ExtensionDocSpec.scala
@@ -9,7 +9,6 @@ import akka.actor.typed.Behavior
 import akka.actor.typed.Extension
 import akka.actor.typed.ExtensionId
 import akka.actor.typed.scaladsl.Behaviors
-import akka.protobufv3.internal.Any
 import com.github.ghik.silencer.silent
 import com.typesafe.config.ConfigFactory
 

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -129,8 +129,6 @@ object AkkaBuild {
   lazy val defaultSettings: Seq[Setting[_]] = Def.settings(
     resolverSettings,
     TestExtras.Filter.settings,
-    Protobuf.settings,
-
     // compile options
     scalacOptions in Compile ++= DefaultScalacOptions,
     scalacOptions in Compile ++=


### PR DESCRIPTION
Only akka-actor got the protobuf files due to the assembled jar being
added to the unmanaged jars for ease of use when importing into
Intellij. Removing that from default settings seems to have fixed it.

Fixes #28227