### PR TITLE
fix race condition in WriteAggregatorSpec, #25581

### DIFF
--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/WriteAggregatorSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/WriteAggregatorSpec.scala
@@ -354,9 +354,12 @@ class WriteAggregatorSpec extends AkkaSpec(s"""
       probe.expectMsgType[DeltaPropagation]
       probe.lastSender ! WriteAck
       probe.expectMsgType[DeltaPropagation]
+      // no reply
+      probe.expectMsgType[DeltaPropagation]
       // nack
       probe.lastSender ! DeltaNack
-      probe.expectMsgType[DeltaPropagation]
+      // the nack will triggger an immediate Write
+      probe.expectMsgType[Write]
       // no reply
 
       // only 1 ack so we expect 3 full state Write


### PR DESCRIPTION
* sometimes failed: "WriteAggregator with delta must timeout when less than required acks"
* the DeltaNack will trigger immedediate send of Write
* seems to be a race condition of when the probe is receiving the Write
  from the DeltaNack vs the last expected DeltaPropagation

Refs #25581