### PR TITLE
Use CrossVersion.patch for Silencer plugin

### DIFF
--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -27,8 +27,8 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
     val silencerVersion = "1.4.4"
     Seq(
       libraryDependencies ++= Seq(
-          compilerPlugin("com.github.ghik" %% "silencer-plugin" % silencerVersion cross CrossVersion.full),
-          "com.github.ghik" %% "silencer-lib" % silencerVersion % Provided cross CrossVersion.full))
+          compilerPlugin("com.github.ghik" %% "silencer-plugin" % silencerVersion cross CrossVersion.patch),
+          "com.github.ghik" %% "silencer-lib" % silencerVersion % Provided cross CrossVersion.patch))
   }
 
   lazy val disciplineSettings =


### PR DESCRIPTION
For details on how these differ see:
https://www.scala-sbt.org/1.x/docs/Cross-Build.html#More+about+using+cross-built+libraries

The motivaton for this is so this part of the build doesn't need to be
(ironically) patched when running with a binary-compatible build of the
next patch release of Scala (e.g. Scala 2.13.2-bin-SHA).

Ideally this could be backported to the release-2.5 branch so it would
be immediately of use, otherwise it'll only be available in the
community builds that track Akka 2.6.