### PR TITLE
Revert "Remove scalac javabootclasspath hack (#28156)"

### DIFF
--- a/project/JdkOptions.scala
+++ b/project/JdkOptions.scala
@@ -34,7 +34,13 @@ object JdkOptions extends AutoPlugin {
       jdk8home,
       fullJavaHomes,
       Seq("-target:jvm-1.8"),
-      _ => Seq("-release", "8")
+      // '-release 8' is not enough, for some reason we need the 8 rt.jar
+      // explicitly. To test whether this has the desired effect, compile
+      // akka-remote and check the invocation of 'ByteBuffer.clear()' in
+      // EnvelopeBuffer.class with 'javap -c': it should refer to
+      //""java/nio/ByteBuffer.clear:()Ljava/nio/Buffer" and not
+      // "java/nio/ByteBuffer.clear:()Ljava/nio/ByteBuffer". Issue #27079
+      (java8home: File) => Seq("-release", "8", "-javabootclasspath", java8home + "/jre/lib/rt.jar")
     )
   def targetJdkJavacOptions(targetSystemJdk: Boolean, jdk8home: Option[File], fullJavaHomes: Map[String, File]): Seq[String] =
     selectOptions(


### PR DESCRIPTION
Breaks the JDK 11 nightly builds

This reverts commit 2bf43d394cc6e97db3213a59a06638f0b90c5cda.
