### PR TITLE
Avoid dead letter for rebalance timeout msg

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -434,15 +434,15 @@ object ShardCoordinator {
       regions: Set[ActorRef],
       shuttingDownRegions: Set[ActorRef])
       extends Actor
-      with ActorLogging {
+      with ActorLogging
+      with Timers {
     import Internal._
 
     shuttingDownRegions.foreach(context.watch)
     regions.foreach(_ ! BeginHandOff(shard))
     var remaining = regions
 
-    import context.dispatcher
-    context.system.scheduler.scheduleOnce(handOffTimeout, self, ReceiveTimeout)
+    timers.startSingleTimer("hand-off-timeout", ReceiveTimeout, handOffTimeout)
 
     def receive = {
       case BeginHandOffAck(`shard`) =>


### PR DESCRIPTION
E.g.

```
Message [akka.actor.ReceiveTimeout$] from Actor[akka://KafkaToSharding/system/sharding/user-processingCoordinator/singleton/coordinator/$d#-955782993] to Actor[akka://KafkaToSharding/system/sharding/user-processingCoordinator/singleton/coordinator/$d#-955782993] was not delivered. [10] dead letters encountered, no more dead letters will be logged in next [5.000 min]. If this is not an expected behavior then Actor[akka://KafkaToSharding/system/sharding/user-processingCoordinator/singleton/coordinator/$d#-955782993] may have terminated unexpectedly. This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' and 'akka.log-dead-letters-during-shutdown'.
```