### PR TITLE
Use CrossVersion.patch for Silencer plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
     - $HOME/.jabba/jdk
 
 script:
-  - jabba use "adopt@~1.8.202-08"
+  - jabba use "adopt@~1.8.0-222"
   # need to override as the default is to test
   - sbt -jvm-opts .jvmopts-travis -Dakka.build.scalaVersion=$TRAVIS_SCALA_VERSION ";update ;mimaReportBinaryIssues ;test:compile ;validateCompile"
   # make 'git branch' work again

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -46,8 +46,8 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
     val silencerVersion = "1.4.1"
     Seq(
       libraryDependencies ++= Seq(
-          compilerPlugin("com.github.ghik" %% "silencer-plugin" % silencerVersion),
-          "com.github.ghik" %% "silencer-lib" % silencerVersion % Provided))
+          compilerPlugin(("com.github.ghik" %% "silencer-plugin" % silencerVersion).cross(CrossVersion.patch)),
+          ("com.github.ghik" %% "silencer-lib" % silencerVersion % Provided).cross(CrossVersion.patch)))
   }
 
   lazy val disciplineSettings =

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -43,7 +43,7 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
     })
 
   lazy val silencerSettings = {
-    val silencerVersion = "1.4.1"
+    val silencerVersion = "1.4.4"
     Seq(
       libraryDependencies ++= Seq(
           compilerPlugin(("com.github.ghik" %% "silencer-plugin" % silencerVersion).cross(CrossVersion.patch)),


### PR DESCRIPTION
Backport of https://github.com/akka/akka/pull/28267

For details on how these differ see:
https://www.scala-sbt.org/1.x/docs/Cross-Build.html#More+about+using+cross-built+libraries

The motivaton for this is so this part of the build doesn't need to be
(ironically) patched when running with a binary-compatible build of the
next patch release of Scala (e.g. Scala 2.13.2-bin-SHA).

Ideally this could be backported to the release-2.5 branch so it would
be immediately of use, otherwise it'll only be available in the
community builds that track Akka 2.6.

(cherry picked from commit bcfa1b85862643a5e92d6407e7687a7284a62880)
