### PR TITLE
Docs: use ref-links to pages

### DIFF
--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -279,7 +279,7 @@ are specific to classic search for them in: @ref:[`akka-remote/reference.conf`](
 
 ### Persistent mode for Cluster Sharding
 
-Cluster Sharding coordinator and [Remembering Entities](../cluster/cluster-sharding.md#remembering-entities) state could previously be stored in Distributed Data or via Akka Persistence.
+Cluster Sharding coordinator and @ref:[Remembering Entities](../cluster-sharding.md#remembering-entities) state could previously be stored in Distributed Data or via Akka Persistence.
 The Persistence mode has been deprecated in favour of using the Distributed Data mode for the coordinator state. A replacement for the state
 for Remembered Entities is tracked in [issue 27763](https://github.com/akka/akka/issues/27763).
 

--- a/akka-docs/src/main/paradox/project/rolling-update.md
+++ b/akka-docs/src/main/paradox/project/rolling-update.md
@@ -11,7 +11,7 @@ update completely before starting next update.
 
 @@@ note
 
-[Rolling update from classic remoting to Artery](../additional/rolling-updates.md#migrating-from-classic-remoting-to-artery) is not supported since the protocol
+@ref:[Rolling update from classic remoting to Artery](../additional/rolling-updates.md#migrating-from-classic-remoting-to-artery) is not supported since the protocol
 is completely different. It will require a full cluster shutdown and new startup.
 
 @@@

--- a/akka-docs/src/main/paradox/typed/distributed-pub-sub.md
+++ b/akka-docs/src/main/paradox/typed/distributed-pub-sub.md
@@ -1,6 +1,6 @@
 # Distributed Publish Subscribe in Cluster
 
-For the Akka Classic documentation of this feature see [Classic Distributed Publish Subscribe](../distributed-pub-sub.md).
+For the Akka Classic documentation of this feature see @ref:[Classic Distributed Publish Subscribe](../distributed-pub-sub.md).
 Classic Pub Sub can be used by leveraging the `.toClassic` adapters until @github[#26338](#26338).
 
 ## Module info


### PR DESCRIPTION
## Purpose

Use `@ref` to link within the documentation.

## Background Context

A few dead links were reported by our tooling. By using https://github.com/lightbend/paradox/pull/393 I identified these links needing to switch to the `@ref` directive.
