### PR TITLE
Manifest-less Jackson serializers

### DIFF
--- a/akka-docs/src/main/paradox/serialization-jackson.md
+++ b/akka-docs/src/main/paradox/serialization-jackson.md
@@ -404,6 +404,12 @@ this to be useful, generally that single type must be a
 @ref:[Polymorphic type](#polymorphic-types), with all type information necessary to deserialize to
 the various sub types contained in the JSON message.
 
+When switching serializers, for example, if doing a rolling update as described
+@ref:[here](additional/rolling-updates.md#from-java-serialization-to-jackson), there will be
+periods of time when you may have no serialization bindings declared for the type. In such
+circumstances, you must use the `deserialization-type` configuration attribute to specify which
+type should be used to deserialize messages.
+
 Since this configuration can only be applied to a single root type, you will usually only want to
 apply it to a per binding configuration, not to the regular `jackson-json` or `jackson-cbor`
 configurations.

--- a/akka-docs/src/main/paradox/serialization-jackson.md
+++ b/akka-docs/src/main/paradox/serialization-jackson.md
@@ -391,6 +391,29 @@ different settings for remote messages and persisted events.
 
 @@snip [config](/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala) { #several-config }
 
+### Manifest-less serialization
+
+When using the Jackson serializer for persistence, given that the fully qualified class name is
+stored in the manifest, this can result in a lot of wasted disk and IO used, especially when the
+events are small. To address this, a `type-in-manifest` flag can be turned off, which will result
+in the class name not appearing in the manifest.
+
+When deserializing, the Jackson serializer will use the type defined in `deserialization-type`, if
+present, otherwise it will look for exactly one serialization binding class, and use that. For
+this to be useful, generally that single type must be a 
+@ref:[Polymorphic type](#polymorphic-types), with all type information necessary to deserialize to
+the various sub types contained in the JSON message.
+
+Since this configuration can only be applied to a single root type, you will usually only want to
+apply it to a per binding configuration, not to the regular `jackson-json` or `jackson-cbor`
+configurations.
+
+@@snip [config](/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala) { #manifestless }
+
+Note that Akka remoting already implements manifest compression, and so this optimization will have
+no significant impact for messages sent over remoting. It's only useful for messages serialized for
+other purposes, such as persistence or distributed data.
+
 ## Additional features
 
 Additional Jackson serialization features can be enabled/disabled in configuration. The default values from

--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -144,6 +144,29 @@ akka.serialization.jackson {
     compress-larger-than = 0 KiB
   }
 
+  # Whether the type should be written to the manifest.
+  # If this is off, then either deserialization-type must be defined, or there must be exactly
+  # one serialization binding declared for this serializer, and the type in that binding will be
+  # used as the deserialization type. This featuer will only work if that type either is a
+  # concrete class, or if it is a supertype that uses Jackson polymorphism (ie, the
+  # @JsonTypeInfo annotation) to store type information in the JSON itself. The intention behind
+  # disabling this is to remove extraneous type information (ie, fully qualified class names) when
+  # serialized objects are persisted in Akka persistence or replicated using Akka distributed
+  # data. Note that Akka remoting already has manifest compression optimizations that address this,
+  # so for types that just get sent over remoting, this offers no optimization.
+  type-in-manifest = on
+
+  # The type to use for deserialization.
+  # This is only used if type-in-manifest is disabled. If set, this type will be used to
+  # deserialize all messages. This is useful if the binding configuration you want to use when
+  # disabling type in manifest cannot be expressed as a single type. Examples of when you might
+  # use this include when change serializers, so you don't want this serializer used for
+  # serialization and you haven't declared any bindings for it, but you still want to be able to
+  # deserialize messages that were serialized with this serializer, as well as situations where
+  # you only want some sub types of a given Jackson polymorphic type to be serialized using this
+  # serializer.
+  deserialization-type = ""
+
   # Specific settings for jackson-json binding can be defined in this section to
   # override the settings in 'akka.serialization.jackson'
   jackson-json {}

--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -147,7 +147,7 @@ akka.serialization.jackson {
   # Whether the type should be written to the manifest.
   # If this is off, then either deserialization-type must be defined, or there must be exactly
   # one serialization binding declared for this serializer, and the type in that binding will be
-  # used as the deserialization type. This featuer will only work if that type either is a
+  # used as the deserialization type. This feature will only work if that type either is a
   # concrete class, or if it is a supertype that uses Jackson polymorphism (ie, the
   # @JsonTypeInfo annotation) to store type information in the JSON itself. The intention behind
   # disabling this is to remove extraneous type information (ie, fully qualified class names) when
@@ -160,7 +160,7 @@ akka.serialization.jackson {
   # This is only used if type-in-manifest is disabled. If set, this type will be used to
   # deserialize all messages. This is useful if the binding configuration you want to use when
   # disabling type in manifest cannot be expressed as a single type. Examples of when you might
-  # use this include when change serializers, so you don't want this serializer used for
+  # use this include when changing serializers, so you don't want this serializer used for
   # serialization and you haven't declared any bindings for it, but you still want to be able to
   # deserialize messages that were serialized with this serializer, as well as situations where
   # you only want some sub types of a given Jackson polymorphic type to be serialized using this

--- a/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonSerializer.scala
+++ b/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonSerializer.scala
@@ -14,7 +14,6 @@ import scala.annotation.tailrec
 import scala.util.Failure
 import scala.util.Success
 import scala.util.control.NonFatal
-
 import akka.actor.ExtendedActorSystem
 import akka.annotation.InternalApi
 import akka.event.LogMarker
@@ -165,9 +164,53 @@ import com.fasterxml.jackson.dataformat.cbor.CBORFactory
     import akka.util.ccompat.JavaConverters._
     conf.getStringList("whitelist-class-prefix").asScala.toVector
   }
+  private val typeInManifest: Boolean = conf.getBoolean("type-in-manifest")
+  // Calculated eagerly so as to fail fast
+  private val configuredDeserializationType: Option[Class[_ <: AnyRef]] = conf.getString("deserialization-type") match {
+    case "" => None
+    case className =>
+      system.dynamicAccess.getClassFor[AnyRef](className) match {
+        case Success(c) => Some(c)
+        case Failure(_) =>
+          throw new IllegalArgumentException(
+            s"Cannot find deserialization-type [$className] for Jackson serializer [$bindingName]")
+      }
+  }
 
   // This must lazy otherwise it will deadlock the ActorSystem creation
   private lazy val serialization = SerializationExtension(system)
+
+  // This must be lazy since it depends on serialization above
+  private lazy val deserializationType: Option[Class[_ <: AnyRef]] = if (typeInManifest) {
+    None
+  } else {
+    configuredDeserializationType.orElse {
+      val bindings = serialization.settings.SerializationBindings.filter(_._2 == bindingName).keys.toList
+      bindings match {
+        case Nil =>
+          throw new IllegalArgumentException(
+            s"Jackson serializer [$bindingName] with type-in-manifest disabled must either declare" +
+            " a deserialization-type or have exactly one binding configured, but none were configured")
+
+        case List(className) =>
+          Some(system.dynamicAccess.getClassFor[AnyRef](className) match {
+            case Success(c) => c
+            case Failure(_) =>
+              // This should not be possible, since serialization should have already validated that this
+              // class exists.
+              throw new NotSerializableException(
+                s"Cannot find deserialization-type [$className] for Jackson serializer [$bindingName]")
+
+          })
+
+        case multiple =>
+          throw new IllegalArgumentException(
+            s"Jackson serializer [$bindingName] with type-in-manifest disabled must either declare" +
+            " a deserialization-type or have exactly one binding configured, but multiple bindings" +
+            s" were configured [${multiple.mkString(", ")}]")
+      }
+    }
+  }
 
   // doesn't have to be volatile, doesn't matter if check is run more than once
   private var serializationBindingsCheckedOk = false
@@ -176,12 +219,20 @@ import com.fasterxml.jackson.dataformat.cbor.CBORFactory
 
   override def manifest(obj: AnyRef): String = {
     checkAllowedSerializationBindings()
-    val className = obj.getClass.getName
-    checkAllowedClassName(className)
-    checkAllowedClass(obj.getClass)
-    migrations.get(className) match {
-      case Some(transformer) => className + "#" + transformer.currentVersion
-      case None              => className
+    deserializationType match {
+      case Some(clazz) =>
+        migrations.get(clazz.getName) match {
+          case Some(transformer) => "#" + transformer.currentVersion
+          case None              => ""
+        }
+      case None =>
+        val className = obj.getClass.getName
+        checkAllowedClassName(className)
+        checkAllowedClass(obj.getClass)
+        migrations.get(className) match {
+          case Some(transformer) => className + "#" + transformer.currentVersion
+          case None              => className
+        }
     }
   }
 
@@ -220,9 +271,9 @@ import com.fasterxml.jackson.dataformat.cbor.CBORFactory
     val startTime = if (isDebugEnabled) System.nanoTime else 0L
 
     val (fromVersion, manifestClassName) = parseManifest(manifest)
-    checkAllowedClassName(manifestClassName)
+    if (typeInManifest) checkAllowedClassName(manifestClassName)
 
-    val migration = migrations.get(manifestClassName)
+    val migration = migrations.get(deserializationType.fold(manifestClassName)(_.getName))
 
     val className = migration match {
       case Some(transformer) if fromVersion < transformer.currentVersion =>
@@ -234,7 +285,7 @@ import com.fasterxml.jackson.dataformat.cbor.CBORFactory
       case _ => manifestClassName
     }
 
-    if (className ne manifestClassName)
+    if (typeInManifest && (className ne manifestClassName))
       checkAllowedClassName(className)
 
     if (isCaseObject(className)) {
@@ -250,13 +301,15 @@ import com.fasterxml.jackson.dataformat.cbor.CBORFactory
       logFromBinaryDuration(bytes, bytes, startTime, clazz)
       result
     } else {
-      val clazz = system.dynamicAccess.getClassFor[AnyRef](className) match {
-        case Success(c) => c
-        case Failure(_) =>
-          throw new NotSerializableException(
-            s"Cannot find manifest class [$className] for serializer [${getClass.getName}].")
+      val clazz = deserializationType.getOrElse {
+        system.dynamicAccess.getClassFor[AnyRef](className) match {
+          case Success(c) => c
+          case Failure(_) =>
+            throw new NotSerializableException(
+              s"Cannot find manifest class [$className] for serializer [${getClass.getName}].")
+        }
       }
-      checkAllowedClass(clazz)
+      if (typeInManifest) checkAllowedClass(clazz)
 
       val decompressedBytes = decompress(bytes)
 

--- a/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala
@@ -101,6 +101,27 @@ object SerializationDocSpec {
     #//#several-config
   """
 
+  val configManifestless = """
+    #//#manifestless
+    akka.actor {
+      serializers {
+        jackson-json-event   = "akka.serialization.jackson.JacksonJsonSerializer"
+      }
+      serialization-identifiers {
+        jackson-json-event = 9001
+      }
+      serialization-bindings {
+        "com.myservice.MyEvent" = jackson-json-event
+      }
+    }
+    akka.serialization.jackson {
+      jackson-json-event {
+        type-in-manifest = off
+      }
+    }
+    #//#manifestless
+  """
+
   //#polymorphism
   final case class Zoo(primaryAttraction: Animal) extends MySerializable
 

--- a/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala
@@ -105,7 +105,7 @@ object SerializationDocSpec {
     #//#manifestless
     akka.actor {
       serializers {
-        jackson-json-event   = "akka.serialization.jackson.JacksonJsonSerializer"
+        jackson-json-event = "akka.serialization.jackson.JacksonJsonSerializer"
       }
       serialization-identifiers {
         jackson-json-event = 9001
@@ -117,6 +117,10 @@ object SerializationDocSpec {
     akka.serialization.jackson {
       jackson-json-event {
         type-in-manifest = off
+        # Since there is exactly one serialization binding declared for this
+        # serializer above, this is optional, but if there were none or many,
+        # this would be mandatory.
+        deserialization-type = "com.myservice.MyEvent"
       }
     }
     #//#manifestless


### PR DESCRIPTION
Implements #28113

This adds the ability to make Jackson serializers not output the class name in the manifest in cases where type information is stored in a more concise format in the JSON itself.

Default usage would be to have exactly one serialization binding for the serializer, and this can be then used to determine the type to be used when deserializing. However, there are scenarios where this may not be practical:

* You might want to change serializers, but you still have old messages that you need to deserialize using the old deserializer. In this case, you will have no serialization bindings.
* You might want more fine grained control over exactly which messages use this serializer, rather than simply using it for all subtypes of the super type.

To address the above scenarios, an additional configuration option, `deserialization-type` has been added to explicitly select the type that should be used when deserializing.

This works with migrations - the migrations must all be declared for the root type, and if they need to know which subtype, it is up to the migration to inspect the embedded type info in the JSON message. The manifest for message with migrations defined will just be a hash followed by the version number.