### PR TITLE
build: fix mima checking for Akka 2.6.0

### DIFF
--- a/akka-actor/src/main/mima-filters/2.6.0.backwards.excludes/28300-fix-2.6.0-mima.excludes
+++ b/akka-actor/src/main/mima-filters/2.6.0.backwards.excludes/28300-fix-2.6.0-mima.excludes
@@ -1,0 +1,2 @@
+# Akka 2.6.0 for Scala 2.13 accidentally contained a copy of the protobuf classes which has now been fixed
+ProblemFilters.exclude[MissingClassProblem]("akka.protobufv3.internal.*")

--- a/akka-remote/src/main/mima-filters/2.6.0.backwards.excludes/28300-fix-2.6.0-mima.excludes
+++ b/akka-remote/src/main/mima-filters/2.6.0.backwards.excludes/28300-fix-2.6.0-mima.excludes
@@ -1,5 +1,4 @@
-# FIXME: Incompatibilities against 2.6.0 / Scala 2.13 is that something we need to look into?
+# Internal incompatibilities introduced in the scala 2.13.0->2.13.1 update
 ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.remote.EndpointManager#Send.unapply")
 ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.remote.artery.Association#OutboundStreamMatValues.unapply")
 ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.remote.transport.AkkaPduCodec#Message.unapply")
-

--- a/akka-remote/src/main/mima-filters/2.6.0.backwards.excludes/28300-fix-2.6.0-mima.excludes
+++ b/akka-remote/src/main/mima-filters/2.6.0.backwards.excludes/28300-fix-2.6.0-mima.excludes
@@ -1,0 +1,5 @@
+# FIXME: Incompatibilities against 2.6.0 / Scala 2.13 is that something we need to look into?
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.remote.EndpointManager#Send.unapply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.remote.artery.Association#OutboundStreamMatValues.unapply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.remote.transport.AkkaPduCodec#Message.unapply")
+

--- a/akka-stream/src/main/mima-filters/2.6.0.backwards.excludes/28300-fix-2.6.0-mima.excludes
+++ b/akka-stream/src/main/mima-filters/2.6.0.backwards.excludes/28300-fix-2.6.0-mima.excludes
@@ -1,0 +1,10 @@
+# Incompatibilities against 2.6.0 / Scala 2.13 in implementation classes
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.impl.CompletedTraversalBuilder.curried")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.impl.CompletedTraversalBuilder.tupled")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.impl.CompletedTraversalBuilder.unapply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.impl.CompositeTraversalBuilder.curried")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.impl.CompositeTraversalBuilder.tupled")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.impl.CompositeTraversalBuilder.unapply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.impl.LinearTraversalBuilder.unapply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.impl.VirtualProcessor#Establishing.unapply")
+

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -33,15 +33,19 @@ object MiMa extends AutoPlugin {
         else if (projectName.contains("coordination")) 22
         else 0
 
-      if (!(projectName.contains("typed") || projectName.contains("jackson"))) {
-        // 2.5.18 is the only release built with Scala 2.12.7, which due to
-        // https://github.com/scala/bug/issues/11207 produced many more
-        // static methods than expected. These are hard to filter out, so
-        // we exclude it here and rely on the checks for 2.5.17 and 2.5.19.
-        expandVersions(2, 5, ((firstPatchOf25 to latestPatchOf25).toSet - 18).toList)
-      } else {
-        Nil
-      } ++ expandVersions(2, 6, 0 to latestPatchOf26)
+      val akka25Previous =
+        if (!(projectName.contains("typed") || projectName.contains("jackson"))) {
+          // 2.5.18 is the only release built with Scala 2.12.7, which due to
+          // https://github.com/scala/bug/issues/11207 produced many more
+          // static methods than expected. These are hard to filter out, so
+          // we exclude it here and rely on the checks for 2.5.17 and 2.5.19.
+          expandVersions(2, 5, ((firstPatchOf25 to latestPatchOf25).toSet - 18).toList)
+        } else {
+          Nil
+        }
+      val akka26Previous = expandVersions(2, 6, 0 to latestPatchOf26)
+
+      akka25Previous ++ akka26Previous
     }
 
     val akka25PromotedArtifacts = Set("akka-distributed-data")


### PR DESCRIPTION
Previously, due to a syntax problem, only typed artifacts were checked against
2.6.0.