### PR TITLE
attempt to fix v1.class does not exist

### DIFF
--- a/akka-docs/src/test/java/jdocs/persistence/PersistenceSchemaEvolutionDocTest.java
+++ b/akka-docs/src/test/java/jdocs/persistence/PersistenceSchemaEvolutionDocTest.java
@@ -246,15 +246,15 @@ public class PersistenceSchemaEvolutionDocTest {
   }
 
   // #split-events-during-recovery
-  interface V1 {};
+  interface Version1 {};
 
-  interface V2 {}
+  interface Version2 {}
 
   // #split-events-during-recovery
   public
   // #split-events-during-recovery
   // V1 event:
-  static class UserDetailsChanged implements V1 {
+  static class UserDetailsChanged implements Version1 {
     public final String name;
     public final String address;
 
@@ -268,7 +268,7 @@ public class PersistenceSchemaEvolutionDocTest {
   public
   // #split-events-during-recovery
   // corresponding V2 events:
-  static class UserNameChanged implements V2 {
+  static class UserNameChanged implements Version2 {
     public final String name;
 
     public UserNameChanged(String name) {
@@ -278,7 +278,7 @@ public class PersistenceSchemaEvolutionDocTest {
   // #split-events-during-recovery
   public
   // #split-events-during-recovery
-  static class UserAddressChanged implements V2 {
+  static class UserAddressChanged implements Version2 {
     public final String address;
 
     public UserAddressChanged(String address) {

--- a/akka-docs/src/test/scala/docs/persistence/PersistenceSchemaEvolutionDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/persistence/PersistenceSchemaEvolutionDocSpec.scala
@@ -235,15 +235,15 @@ class PersonSerializerSettingsBox {
 final case class SamplePayload(p: Any)
 
 //#split-events-during-recovery
-trait V1
-trait V2
+trait Version1
+trait Version2
 
 // V1 event:
-final case class UserDetailsChanged(name: String, address: String) extends V1
+final case class UserDetailsChanged(name: String, address: String) extends Version1
 
 // corresponding V2 events:
-final case class UserNameChanged(name: String) extends V2
-final case class UserAddressChanged(address: String) extends V2
+final case class UserNameChanged(name: String) extends Version2
+final case class UserAddressChanged(address: String) extends Version2
 
 // event splitting adapter:
 class UserEventsAdapter extends EventAdapter {
@@ -254,7 +254,7 @@ class UserEventsAdapter extends EventAdapter {
     case UserDetailsChanged(name, null)    => EventSeq(UserNameChanged(name))
     case UserDetailsChanged(name, address) =>
       EventSeq(UserNameChanged(name), UserAddressChanged(address))
-    case event: V2 => EventSeq(event)
+    case event: Version2 => EventSeq(event)
   }
 
   override def toJournal(event: Any): Any = event


### PR DESCRIPTION
* sometimes I see v1.class does not exist error from incremental compiler
* could be because we have `object v1` and `trait V1` in same package

