### PR TITLE
Backport of LogMarker.properties

### DIFF
--- a/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
@@ -104,6 +104,15 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
 
   @inline
   final def withMdc(logSource: String, logEvent: LogEvent)(logStatement: => Unit): Unit = {
+    logEvent match {
+      case m: LogEventWithMarker if m.marker ne null =>
+        val properties = m.marker.properties
+        if (properties.nonEmpty) {
+          properties.foreach { case (k, v) => MDC.put(k, String.valueOf(v)) }
+        }
+      case _ =>
+    }
+
     MDC.put(mdcAkkaSourceAttributeName, logSource)
     MDC.put(mdcThreadAttributeName, logEvent.thread.getName)
     MDC.put(mdcAkkaTimestamp, formatTimestamp(logEvent.timestamp))
@@ -111,11 +120,7 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
     logEvent.mdc.foreach { case (k, v) => MDC.put(k, String.valueOf(v)) }
     try logStatement
     finally {
-      MDC.remove(mdcAkkaSourceAttributeName)
-      MDC.remove(mdcThreadAttributeName)
-      MDC.remove(mdcAkkaTimestamp)
-      MDC.remove(mdcActorSystemAttributeName)
-      logEvent.mdc.keys.foreach(k => MDC.remove(k))
+      MDC.clear()
     }
   }
 
@@ -175,7 +180,7 @@ class Slf4jLoggingFilter(@unused settings: ActorSystem.Settings, eventStream: Ev
 }
 
 /** Wraps [[org.slf4j.Marker]] */
-final class Slf4jLogMarker(val marker: org.slf4j.Marker) extends LogMarker(name = marker.getName)
+final class Slf4jLogMarker(val marker: org.slf4j.Marker) extends LogMarker(name = marker.getName, Map.empty)
 
 /** Factory for creating [[LogMarker]] that wraps [[org.slf4j.Marker]] */
 object Slf4jLogMarker {

--- a/akka-slf4j/src/test/resources/logback-test.xml
+++ b/akka-slf4j/src/test/resources/logback-test.xml
@@ -7,7 +7,7 @@
   </appender>
   <appender name="TEST" class="akka.event.slf4j.Slf4jLoggerSpec$TestAppender">
     <encoder>
-      <pattern>%date{ISO8601} level=[%level] marker=[%marker] logger=[%logger] akkaSource=[%X{akkaSource}] sourceActorSystem=[%X{sourceActorSystem}] sourceThread=[%X{sourceThread}] mdc=[ticket-#%X{ticketNumber}: %X{ticketDesc}] - msg=[%msg]%n----%n</pattern>
+      <pattern>%date{ISO8601} level=[%level] marker=[%marker] logger=[%logger] akkaSource=[%X{akkaSource}] sourceActorSystem=[%X{sourceActorSystem}] sourceThread=[%X{sourceThread}] mdc=[ticket-#%X{ticketNumber}: %X{ticketDesc} p1: %X{p1} p2: %X{p2}] - msg=[%msg]%n----%n</pattern>
     </encoder>
   </appender>
   <logger name="akka.event.slf4j.Slf4jLoggingFilterSpec$DebugLevelProducer"

--- a/akka-slf4j/src/test/scala/akka/event/slf4j/Slf4jLoggerSpec.scala
+++ b/akka-slf4j/src/test/scala/akka/event/slf4j/Slf4jLoggerSpec.scala
@@ -120,6 +120,16 @@ class Slf4jLoggerSpec extends AkkaSpec(Slf4jLoggerSpec.config) with BeforeAndAft
       s should include("msg=[security-wise interesting message]")
     }
 
+    "log info with marker and properties" in {
+      producer ! StringWithMarker("interesting message", LogMarker("testMarker", Map("p1" -> 1, "p2" -> "B")))
+
+      awaitCond(outputString.contains("----"), 5 seconds)
+      val s = outputString
+      s should include("marker=[testMarker]")
+      s should include("p1: 1 p2: B")
+      s should include("msg=[interesting message]")
+    }
+
     "log info with slf4j marker" in {
       val slf4jMarker = MarkerFactory.getMarker("SLF")
       slf4jMarker.add(MarkerFactory.getMarker("ADDED")) // slf4j markers can have children
@@ -141,7 +151,7 @@ class Slf4jLoggerSpec extends AkkaSpec(Slf4jLoggerSpec.config) with BeforeAndAft
       awaitCond(outputString.contains("----"), 5 seconds)
       val s = outputString
       s should include("marker=[SLF [ ADDED ]]")
-      s should include("mdc=[ticket-#3671: Custom MDC Values]")
+      s should include("mdc=[ticket-#3671: Custom MDC Values")
       s should include("msg=[security-wise interesting message]")
     }
 
@@ -156,7 +166,7 @@ class Slf4jLoggerSpec extends AkkaSpec(Slf4jLoggerSpec.config) with BeforeAndAft
       s should include("level=[INFO]")
       s should include("logger=[akka.event.slf4j.Slf4jLoggerSpec$LogProducer]")
       (s should include).regex(sourceThreadRegex)
-      s should include("mdc=[ticket-#3671: Custom MDC Values]")
+      s should include("mdc=[ticket-#3671: Custom MDC Values")
       s should include("msg=[Message with custom MDC values]")
     }
 
@@ -177,7 +187,7 @@ class Slf4jLoggerSpec extends AkkaSpec(Slf4jLoggerSpec.config) with BeforeAndAft
       s should include("level=[INFO]")
       s should include("logger=[akka.event.slf4j.Slf4jLoggerSpec$LogProducer]")
       (s should include).regex(sourceThreadRegex)
-      s should include("mdc=[ticket-#3671: null]")
+      s should include("mdc=[ticket-#3671: null")
       s should include("msg=[Message with null custom MDC values]")
     }
 


### PR DESCRIPTION
Only backporting the `LogMarker.properties` api and `Slf4Logger` changes, so we can start using it in Akka Management.

Refs #28207 