### PR TITLE
Adapted log events for classic and typed coexistence

### DIFF
--- a/akka-slf4j/src/main/scala/akka/event/slf4j/AkkaLogbackClassicAdaptingFilter.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/AkkaLogbackClassicAdaptingFilter.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.event.slf4j
+
+import ch.qos.logback.classic.spi.LoggingEvent
+import ch.qos.logback.core.filter.Filter
+import ch.qos.logback.core.spi.FilterReply
+
+/**
+ * In Akka typed actors the log event timestamp and thread is correct since logging is done directly using SLF4J, much of the
+ * Akka internals however use the classic Akka logging api which is asynchronous and passes over the message bus, and for that
+ * source thread and timestamp has special handling, ending up in two MDC entries.
+ *
+ * This filter adapts classic log events by picking up the `sourceThread` and `akkaTimestampMillis` MDC values
+ * and puts those in the respective fields of the log event.
+ */
+class AkkaLogbackClassicAdaptingFilter extends Filter[LoggingEvent] {
+
+  def decide(event: LoggingEvent): FilterReply = {
+    val mdc = event.getMDCPropertyMap
+
+    // FIXME what about thread safety modifying the events? needs to be synchronized?
+    if (mdc.containsKey("sourceThread")) {
+      // classic emitted event, try to convert to
+      event.setThreadName(mdc.get("sourceThread"))
+
+      if (mdc.containsKey("akkaTimestampMillis")) {
+        event.setTimeStamp(mdc.get("akkaTimestampMillis").toLong)
+      }
+    }
+
+    FilterReply.NEUTRAL
+  }
+
+}

--- a/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
@@ -58,6 +58,7 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
   val mdcActorSystemAttributeName = "sourceActorSystem"
   val mdcAkkaSourceAttributeName = "akkaSource"
   val mdcAkkaTimestamp = "akkaTimestamp"
+  val mdcAkkaTimestampMillis = "akkaTimestampMillis"
   val mdcAkkaAddressAttributeName = "akkaAddress"
 
   private def akkaAddress = context.system.asInstanceOf[ExtendedActorSystem].provider.addressString
@@ -119,6 +120,7 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
     MDC.put(mdcAkkaSourceAttributeName, logSource)
     MDC.put(mdcThreadAttributeName, logEvent.thread.getName)
     MDC.put(mdcAkkaTimestamp, formatTimestamp(logEvent.timestamp))
+    MDC.put(mdcAkkaTimestampMillis, logEvent.timestamp.toString)
     MDC.put(mdcActorSystemAttributeName, context.system.name)
     MDC.put(mdcAkkaAddressAttributeName, akkaAddress)
     logEvent.mdc.foreach { case (k, v) => MDC.put(k, String.valueOf(v)) }

--- a/akka-slf4j/src/test/resources/logback-test.xml
+++ b/akka-slf4j/src/test/resources/logback-test.xml
@@ -10,6 +10,13 @@
       <pattern>%date{ISO8601} level=[%level] marker=[%marker] logger=[%logger] mdc=[%mdc] - msg=[%msg]%n----%n</pattern>
     </encoder>
   </appender>
+  <appender name="ADAPTER-TEST" class="akka.event.slf4j.AkkaLogbackClassicAdaptingFilterSpec$TestAppender">
+    <filter class="akka.event.slf4j.AkkaLogbackClassicAdaptingFilter" />
+    <encoder>
+      <pattern>thread=[%thread] sourceThread=[%X{sourceThread}] timestamp=[%date{yyyyMMdd'T'hh:mm:ss.SSS'Z'}] akkaTimestampMillis=[%X{akkaTimestampMillis}] msg=[%msg]----%n</pattern>
+    </encoder>
+  </appender>
+
   <logger name="akka.event.slf4j.Slf4jLoggingFilterSpec$DebugLevelProducer"
     level="debug" additivity="false">
     <appender-ref ref="STDOUT" />
@@ -21,6 +28,10 @@
   <logger name="akka.event.slf4j.Slf4jLoggerSpec" level="info"
     additivity="false">
     <appender-ref ref="TEST" />
+  </logger>
+  <logger name="akka.event.slf4j.AkkaLogbackClassicAdaptingFilterSpec" level="info"
+          additivity="false">
+    <appender-ref ref="ADAPTER-TEST" />
   </logger>
   <root level="info">
     <appender-ref ref="STDOUT" />

--- a/akka-slf4j/src/test/scala/akka/event/slf4j/AkkaLogbackClassicAdaptingFilterSpec.scala
+++ b/akka-slf4j/src/test/scala/akka/event/slf4j/AkkaLogbackClassicAdaptingFilterSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.event.slf4j
+
+import java.io.ByteArrayOutputStream
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.TimeZone
+
+import akka.actor.Actor
+import akka.actor.ActorLogging
+import akka.actor.Props
+import akka.testkit.AkkaSpec
+import ch.qos.logback.core.OutputStreamAppender
+
+import scala.concurrent.duration._
+
+object AkkaLogbackClassicAdaptingFilterSpec {
+
+  val config = """
+    akka {
+      loglevel = INFO
+      loggers = ["akka.event.slf4j.Slf4jLogger"]
+      logger-startup-timeout = 30s
+    }
+    """
+
+  def loggingActorProps = Props(new LoggingActor)
+  class LoggingActor extends Actor with ActorLogging {
+    def receive = {
+      case _ =>
+        log.info(Thread.currentThread().getName)
+    }
+  }
+  val output = new ByteArrayOutputStream
+  def outputString: String = output.toString("UTF-8")
+
+  class TestAppender extends OutputStreamAppender {
+
+    override def start(): Unit = {
+      setOutputStream(output)
+      super.start()
+    }
+  }
+}
+
+class AkkaLogbackClassicAdaptingFilterSpec extends AkkaSpec(AkkaLogbackClassicAdaptingFilterSpec.config) {
+
+  import AkkaLogbackClassicAdaptingFilterSpec._
+
+  "The Akka classic logback adapting filter" must {
+
+    "put source thread in entries" in {
+      val ref = system.actorOf(loggingActorProps, "LoggingActor")
+
+      ref ! "log!"
+      awaitCond(outputString.contains("----"), 5.seconds)
+      val keyValue = outputString
+        .dropRight(5)
+        .split(' ')
+        .toList
+        .map(_.split('='))
+        .map { case Array(key, value) => key -> value }
+        .toMap
+      // we put current thread as message in log entry
+      keyValue("thread") should ===(keyValue("msg"))
+
+      // not watertight but better than nothing - compare that the event timestamp is the same as the
+      // akkaTimestampMillis when rendered to string with millis
+      val akkaTimestampMillis = LocalDateTime.ofInstant(
+        Instant.ofEpochMilli(keyValue("akkaTimestampMillis").drop(1).dropRight(1).toLong),
+        TimeZone.getDefault.toZoneId)
+      val formattedAkkaTimestamp = DateTimeFormatter.ofPattern("yyyyMMdd'T'hh:mm:ss.SSS'Z'").format(akkaTimestampMillis)
+      keyValue("timestamp").drop(1).dropRight(1) should ===(formattedAkkaTimestamp)
+
+    }
+
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -214,7 +214,7 @@ object Dependencies {
 
   val distributedData = l ++= Seq(lmdb, Test.junit, Test.scalatest.value)
 
-  val slf4j = l ++= Seq(slf4jApi, Test.logback)
+  val slf4j = l ++= Seq(slf4jApi, Provided.logback)
 
   val persistence = l ++= Seq(
         Provided.levelDB,


### PR DESCRIPTION
Provide a logback filter (hack) to modify the log event by copying mdc values into fields for classic so that the regular `%date` and `%thread` patterns will give the right thread and timestamp for both typed and classic actors.

Refs #28153 

