### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,7 +260,7 @@ All wire protocol changes that may concern rolling upgrades should be documented
 ## Protobuf
 
 Akka includes a shaded version of protobuf `3.9.0` that is used for internal communication. To generate files
-run `protobufGenerate`. The generated files are put in the `src/main/java` of each project and need to be commited. 
+run `protobufGenerate`. The generated files are put in the `src/main/java` of each project and need to be committed. 
 The generated files are automatically transformed to use the shaded version of protobuf.
 
 Generation depends on protoc `3.9.0` being on the path. Old versions of

--- a/akka-actor-tests/src/test/scala/akka/routing/ResizerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ResizerSpec.scala
@@ -193,7 +193,7 @@ class ResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultTimeout with 
         }
       }
 
-      // 2 more should go thru without triggering more
+      // 2 more should go through without triggering more
       loop(2, 200 millis)
       routeeSize(router) should ===(resizer.lowerBound)
 

--- a/akka-actor/src/main/scala/akka/io/SimpleDnsCache.scala
+++ b/akka-actor/src/main/scala/akka/io/SimpleDnsCache.scala
@@ -39,7 +39,7 @@ class SimpleDnsCache extends Dns with PeriodicCacheCleanup with NoSerializationV
    * To get Srv or just one type use DnsProtocol
    *
    * This method is deprecated and involves a copy from the new protocol to
-   * remain compatable
+   * remain compatible
    */
   @silent("deprecated")
   override def cached(name: String): Option[Dns.Resolved] = {

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
@@ -419,7 +419,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
 
       Behaviors.receive[Command] { (_, msg) =>
         msg match {
-          // support two heterogenous types of messages without union types
+          // support two heterogeneous types of messages without union types
           case cmd: InternalCommand => onInternalCommand(cmd)
           case cmd: Command         => onCommand(cmd)
           case _                    => Behaviors.unhandled

--- a/akka-docs/src/main/paradox/persistence-journals.md
+++ b/akka-docs/src/main/paradox/persistence-journals.md
@@ -79,7 +79,7 @@ A snapshot store plugin can be activated with the following minimal configuratio
 
 The snapshot store instance is an actor so the methods corresponding to requests from persistent actors
 are executed sequentially. It may delegate to asynchronous libraries, spawn futures, or delegate to other
-actors to achive parallelism.
+actors to achieve parallelism.
 
 The snapshot store plugin class must have a constructor with one of these signatures:
 

--- a/akka-docs/src/main/paradox/stream/actor-interop.md
+++ b/akka-docs/src/main/paradox/stream/actor-interop.md
@@ -170,7 +170,7 @@ at a rate that is faster than the stream can consume. You should consider using 
 if you want a backpressured actor interface.
 
 The stream can be completed successfully by sending `akka.actor.Status.Success` to the actor reference.
-If the content is `akka.stream.CompletionStrategy.immediately` the completion will be signaled immidiately.
+If the content is `akka.stream.CompletionStrategy.immediately` the completion will be signaled immediately.
 If the content is `akka.stream.CompletionStrategy.draining` already buffered elements will be signaled before siganling completion.
 Any other content will be ignored and fall back to the draining behaviour. 
 

--- a/akka-docs/src/test/java/jdocs/actor/typed/BlockingActor.java
+++ b/akka-docs/src/test/java/jdocs/actor/typed/BlockingActor.java
@@ -24,7 +24,7 @@ public class BlockingActor extends AbstractBehavior<Integer> {
             Integer.class,
             i -> {
               // DO NOT DO THIS HERE: this is an example of incorrect code,
-              // better alternatives are described futher on.
+              // better alternatives are described further on.
 
               // block for 5 seconds, representing blocking I/O, etc
               Thread.sleep(5000);

--- a/akka-docs/src/test/scala/docs/actor/typed/BlockingActor.scala
+++ b/akka-docs/src/test/scala/docs/actor/typed/BlockingActor.scala
@@ -12,7 +12,7 @@ object BlockingActor {
   def apply(): Behavior[Int] =
     Behaviors.receiveMessage { i =>
       // DO NOT DO THIS HERE: this is an example of incorrect code,
-      // better alternatives are described futher on.
+      // better alternatives are described further on.
 
       //block for 5 seconds, representing blocking I/O, etc
       Thread.sleep(5000)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Effect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/Effect.scala
@@ -131,7 +131,7 @@ import akka.actor.typed.ActorRef
    * Run the given callback. Callbacks are run sequentially.
    *
    * @tparam NewState The type of the state after the event is persisted, when not specified will be the same as `State`
-   *                  but if a known subtype of `State` is expected that can be specified instead (preferrably by
+   *                  but if a known subtype of `State` is expected that can be specified instead (preferably by
    *                  explicitly typing the lambda parameter like so: `thenRun((SubState state) -> { ... })`).
    *                  If the state is not of the expected type an [[java.lang.ClassCastException]] is thrown.
    *

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/SignalHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/SignalHandler.scala
@@ -45,7 +45,7 @@ final class SignalHandlerBuilder[State] {
   private var handler: PartialFunction[(State, Signal), Unit] = PartialFunction.empty
 
   /**
-   * If the behavior recieves a signal of type `T`, `callback` is invoked with the signal instance as input.
+   * If the behavior receives a signal of type `T`, `callback` is invoked with the signal instance as input.
    */
   def onSignal[T <: Signal](signalType: Class[T], callback: BiConsumer[State, T]): SignalHandlerBuilder[State] = {
     val newPF: PartialFunction[(State, Signal), Unit] = {

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -579,7 +579,7 @@ object Source {
    * The stream will complete with failure if a message is sent before the acknowledgement has been replied back.
    *
    * The stream can be completed successfully by sending the actor reference a [[akka.actor.Status.Success]].
-   * If the content is [[akka.stream.CompletionStrategy.immediately]] the completion will be signaled immidiately,
+   * If the content is [[akka.stream.CompletionStrategy.immediately]] the completion will be signaled immediately,
    * otherwise if the content is [[akka.stream.CompletionStrategy.draining]] (or anything else)
    * already buffered element will be signaled before siganling completion.
    *

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -710,7 +710,7 @@ object Source {
    * The stream will complete with failure if a message is sent before the acknowledgement has been replied back.
    *
    * The stream can be completed successfully by sending the actor reference a [[akka.actor.Status.Success]].
-   * If the content is [[akka.stream.CompletionStrategy.immediately]] the completion will be signaled immidiately,
+   * If the content is [[akka.stream.CompletionStrategy.immediately]] the completion will be signaled immediately,
    * otherwise if the content is [[akka.stream.CompletionStrategy.draining]] (or anything else)
    * already buffered element will be signaled before siganling completion.
    *


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.