### PR TITLE
Remove allocation of Some from CompressionTable

### DIFF
--- a/akka-remote/src/main/mima-filters/2.6.1.backwards.excludes/CompressionTable.excludes
+++ b/akka-remote/src/main/mima-filters/2.6.1.backwards.excludes/CompressionTable.excludes
@@ -1,0 +1,2 @@
+# Internal changes to CompressionTable
+ProblemFilters.exclude[Problem]("akka.remote.artery.compress.CompressionTable*")

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/CompressionTable.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/CompressionTable.scala
@@ -7,6 +7,7 @@ package akka.remote.artery.compress
 import java.util
 import java.util.Comparator
 
+import akka.util.HashCode
 import org.agrona.collections.Object2IntHashMap
 
 /**
@@ -17,7 +18,7 @@ import org.agrona.collections.Object2IntHashMap
 private[remote] final class CompressionTable[T](
     val originUid: Long,
     val version: Byte,
-    _dictionary: Object2IntHashMap[T]) {
+    private val _dictionary: Object2IntHashMap[T]) {
 
   def dictionary: Map[T, Int] = {
     import akka.util.ccompat.JavaConverters._
@@ -67,6 +68,20 @@ private[remote] final class CompressionTable[T](
     }
 
   override def toString: String = s"CompressionTable($originUid,$version,$dictionary)"
+
+  override def hashCode(): Int = {
+    var result = HashCode.SEED
+    result = HashCode.hash(result, originUid)
+    result = HashCode.hash(result, version)
+    result = HashCode.hash(result, _dictionary)
+    result
+  }
+
+  override def equals(obj: Any): Boolean = obj match {
+    case other: CompressionTable[_] =>
+      originUid == other.originUid && version == other.version && _dictionary == other._dictionary
+    case _ => false
+  }
 }
 
 /** INTERNAL API */

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/CompressionTable.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/CompressionTable.scala
@@ -7,41 +7,52 @@ package akka.remote.artery.compress
 import java.util
 import java.util.Comparator
 
+import org.agrona.collections.Object2IntHashMap
+
 /**
  * INTERNAL API: Versioned compression table to be advertised between systems
  *
  * @param version Either -1 for disabled or a version between 0 and 127
  */
-private[remote] final case class CompressionTable[T](originUid: Long, version: Byte, dictionary: Map[T, Int]) {
-  import CompressionTable.NotCompressedId
+private[remote] final class CompressionTable[T](
+    val originUid: Long,
+    val version: Byte,
+    _dictionary: Object2IntHashMap[T]) {
+
+  def dictionary: Map[T, Int] = {
+    import akka.util.ccompat.JavaConverters._
+    _dictionary.entrySet().iterator().asScala.map(entry => entry.getKey -> entry.getValue.intValue()).toMap
+  }
 
   def compress(value: T): Int =
-    dictionary.get(value) match {
-      case Some(id) => id
-      case None     => NotCompressedId
-    }
+    _dictionary.getValue(value)
 
   def invert: DecompressionTable[T] =
-    if (dictionary.isEmpty) DecompressionTable.empty[T].copy(originUid = originUid, version = version)
+    if (_dictionary.isEmpty) DecompressionTable.empty[T].copy(originUid = originUid, version = version)
     else {
       // TODO: these are some expensive sanity checks, about the numbers being consecutive, without gaps
       // TODO: we can remove them, make them re-map (not needed I believe though)
-      val expectedGaplessSum = Integer.valueOf((dictionary.size * (dictionary.size + 1)) / 2) /* Dirichlet */
+      val expectedGaplessSum = Integer.valueOf((_dictionary.size * (_dictionary.size + 1)) / 2) /* Dirichlet */
+      import akka.util.ccompat.JavaConverters._
       require(
-        dictionary.values.min == 0,
-        "Compression table should start allocating from 0, yet lowest allocated id was " + dictionary.values.min)
+        _dictionary.values.iterator().asScala.min == 0,
+        "Compression table should start allocating from 0, yet lowest allocated id was " + _dictionary.values
+          .iterator()
+          .asScala
+          .min)
       require(
-        dictionary.values.sum + dictionary.size == expectedGaplessSum,
+        _dictionary.values.iterator().asScala.map(_.intValue()).sum + _dictionary.size == expectedGaplessSum,
         "Given compression map does not seem to be gap-less and starting from zero, " +
-        "which makes compressing it into an Array difficult, bailing out! Map was: " + dictionary)
+        "which makes compressing it into an Array difficult, bailing out! Map was: " + _dictionary)
 
-      val tups = new Array[(Object, Int)](dictionary.size).asInstanceOf[Array[(T, Int)]]
-      val ts = new Array[Object](dictionary.size).asInstanceOf[Array[T]]
+      val tups = new Array[(Object, Int)](_dictionary.size).asInstanceOf[Array[(T, Int)]]
+      val ts = new Array[Object](_dictionary.size).asInstanceOf[Array[T]]
 
       var i = 0
-      val mit = dictionary.iterator
+      val mit = _dictionary.entrySet().iterator
       while (i < tups.length) {
-        tups(i) = mit.next()
+        val entry = mit.next()
+        tups(i) = (entry.getKey -> entry.getValue.intValue())
         i += 1
       }
       util.Arrays.sort(tups, CompressionTable.compareBy2ndValue[T])
@@ -54,6 +65,8 @@ private[remote] final case class CompressionTable[T](originUid: Long, version: B
 
       DecompressionTable[T](originUid, version, ts)
     }
+
+  override def toString: String = s"CompressionTable($originUid,$version,$dictionary)"
 }
 
 /** INTERNAL API */
@@ -66,6 +79,13 @@ private[remote] object CompressionTable {
   }
   def compareBy2ndValue[T]: Comparator[Tuple2[T, Int]] = CompareBy2ndValue.asInstanceOf[Comparator[(T, Int)]]
 
-  private[this] val _empty = new CompressionTable[Any](0, 0, Map.empty)
-  def empty[T] = _empty.asInstanceOf[CompressionTable[T]]
+  def empty[T] = new CompressionTable[T](0, 0, new Object2IntHashMap[T](NotCompressedId))
+
+  def apply[T](originUid: Long, version: Byte, dictionary: Map[T, Int]): CompressionTable[T] = {
+    val _dictionary = new Object2IntHashMap[T](NotCompressedId)
+    dictionary.foreach {
+      case (key, value) => _dictionary.put(key, value)
+    }
+    new CompressionTable[T](originUid, version, _dictionary)
+  }
 }

--- a/akka-remote/src/main/scala/akka/remote/serialization/ArteryMessageSerializer.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/ArteryMessageSerializer.scala
@@ -162,7 +162,7 @@ private[akka] final class ArteryMessageSerializer(val system: ExtendedActorSyste
         .map(keyDeserializer)
         .zip(protoAdv.getValuesList.asScala.asInstanceOf[Iterable[Int]] /* to avoid having to call toInt explicitly */ )
 
-    val table = CompressionTable(protoAdv.getOriginUid, protoAdv.getTableVersion.byteValue, kvs.toMap)
+    val table = CompressionTable[T](protoAdv.getOriginUid, protoAdv.getTableVersion.byteValue, kvs.toMap)
     create(deserializeUniqueAddress(protoAdv.getFrom), table)
   }
 

--- a/akka-remote/src/test/scala/akka/remote/artery/compress/OutboundCompressionSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/compress/OutboundCompressionSpec.scala
@@ -24,7 +24,7 @@ class OutboundCompressionSpec extends AkkaSpec {
       table.compress(alice) should ===(1) // compressed
       table.compress(bob) should ===(-1) // not compressed
 
-      val table2 = table.copy(2, dictionary = table.dictionary.updated(bob, 2))
+      val table2 = CompressionTable(table.originUid, table.version, table.dictionary.updated(bob, 2))
       table2.compress(alice) should ===(1) // compressed
       table2.compress(bob) should ===(2) // compressed
     }


### PR DESCRIPTION
* JFR TLAB allocations showed that Some was allocated by the CompressionTable
  in the hot path of outbound stream
* CompressionTable.compress is called several times for each message
* This doesn't matter for the tcp transport since there are so many
  other allocations, but for aeron-udp it's nice to remove since it's
  pretty much the only allocation in the outbound stream
