### PR TITLE
Serializer for tck JournalPerfSpec.Cmd, #28291

### DIFF
--- a/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalPerfSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalPerfSpec.scala
@@ -4,13 +4,24 @@
 
 package akka.persistence.journal
 
-import akka.actor.{ ActorLogging, ActorRef, Props }
-import akka.persistence.journal.JournalPerfSpec.{ BenchActor, Cmd, ResetCounter }
-import akka.persistence.{ PersistentActor }
-import akka.testkit.TestProbe
+import java.nio.charset.StandardCharsets
+
 import scala.collection.immutable
 import scala.concurrent.duration._
+
+import akka.actor.ActorLogging
+import akka.actor.ActorRef
+import akka.actor.ExtendedActorSystem
+import akka.actor.Props
+import akka.annotation.InternalApi
+import akka.persistence.PersistentActor
+import akka.persistence.journal.JournalPerfSpec.BenchActor
+import akka.persistence.journal.JournalPerfSpec.Cmd
+import akka.persistence.journal.JournalPerfSpec.ResetCounter
+import akka.serialization.SerializerWithStringManifest
+import akka.testkit.TestProbe
 import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 
 object JournalPerfSpec {
   class BenchActor(override val persistenceId: String, replyTo: ActorRef, replyAfter: Int)
@@ -61,6 +72,42 @@ object JournalPerfSpec {
 
   case object ResetCounter
   case class Cmd(mode: String, payload: Int)
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] class CmdSerializer(system: ExtendedActorSystem) extends SerializerWithStringManifest {
+    override def identifier: Int = 293562
+
+    system.log.info("hi")
+
+    override def manifest(o: AnyRef): String = ""
+
+    override def toBinary(o: AnyRef): Array[Byte] =
+      o match {
+        case Cmd(mode, payload) =>
+          s"$mode|$payload".getBytes(StandardCharsets.UTF_8)
+        case _ =>
+          throw new IllegalArgumentException(s"Can't serialize object of type ${o.getClass} in [${getClass.getName}]")
+      }
+
+    override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = {
+      val str = new String(bytes, StandardCharsets.UTF_8)
+      val i = str.indexOf('|')
+      Cmd(str.substring(0, i), str.substring(i + 1).toInt)
+    }
+  }
+
+  private val cmdSerializerConfig = ConfigFactory.parseString(s"""
+  akka.actor {
+    serializers {
+      JournalPerfSpec = "${classOf[CmdSerializer].getName}"
+    }
+    serialization-bindings {
+      "${classOf[Cmd].getName}" = JournalPerfSpec
+    }
+  }  
+  """)
 }
 
 /**
@@ -77,7 +124,8 @@ object JournalPerfSpec {
  *
  * @see [[akka.persistence.journal.JournalSpec]]
  */
-abstract class JournalPerfSpec(config: Config) extends JournalSpec(config) {
+abstract class JournalPerfSpec(config: Config)
+    extends JournalSpec(config.withFallback(JournalPerfSpec.cmdSerializerConfig)) {
 
   private val testProbe = TestProbe()
 

--- a/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalPerfSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalPerfSpec.scala
@@ -11,7 +11,6 @@ import scala.concurrent.duration._
 
 import akka.actor.ActorLogging
 import akka.actor.ActorRef
-import akka.actor.ExtendedActorSystem
 import akka.actor.Props
 import akka.annotation.InternalApi
 import akka.persistence.PersistentActor
@@ -76,7 +75,7 @@ object JournalPerfSpec {
   /**
    * INTERNAL API
    */
-  @InternalApi private[akka] class CmdSerializer(system: ExtendedActorSystem) extends SerializerWithStringManifest {
+  @InternalApi private[akka] class CmdSerializer extends SerializerWithStringManifest {
     override def identifier: Int = 293562
 
     override def manifest(o: AnyRef): String = ""

--- a/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalPerfSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/journal/JournalPerfSpec.scala
@@ -79,8 +79,6 @@ object JournalPerfSpec {
   @InternalApi private[akka] class CmdSerializer(system: ExtendedActorSystem) extends SerializerWithStringManifest {
     override def identifier: Int = 293562
 
-    system.log.info("hi")
-
     override def manifest(o: AnyRef): String = ""
 
     override def toBinary(o: AnyRef): Array[Byte] =

--- a/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalJavaSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalJavaSpec.scala
@@ -8,8 +8,15 @@ import akka.persistence.journal.JournalSpec
 import akka.persistence.{ PersistenceSpec, PluginCleanup }
 
 class LeveldbJournalJavaSpec
-    extends JournalSpec(config = PersistenceSpec
-      .config("leveldb", "LeveldbJournalJavaSpec", extraConfig = Some("akka.persistence.journal.leveldb.native = off")))
+    extends JournalSpec(
+      config = PersistenceSpec.config(
+        "leveldb",
+        "LeveldbJournalJavaSpec",
+        extraConfig = Some("""
+        akka.persistence.journal.leveldb.native = off
+        akka.actor.allow-java-serialization = off
+        akka.actor.warn-about-java-serializer-usage = on
+        """)))
     with PluginCleanup {
 
   override def supportsRejectingNonSerializableObjects = true

--- a/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNativePerfSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNativePerfSpec.scala
@@ -4,21 +4,28 @@
 
 package akka.persistence.journal.leveldb
 
-import akka.persistence.journal.{ JournalPerfSpec }
-import akka.persistence.{ PersistenceSpec, PluginCleanup }
-import org.scalatest.DoNotDiscover
+import akka.persistence.journal.JournalPerfSpec
+import akka.persistence.PersistenceSpec
+import akka.persistence.PluginCleanup
 
-@DoNotDiscover // because only checking that compilation is OK with JournalPerfSpec
 class LeveldbJournalNativePerfSpec
     extends JournalPerfSpec(
       config = PersistenceSpec.config(
         "leveldb",
         "LeveldbJournalNativePerfSpec",
-        extraConfig = Some("akka.persistence.journal.leveldb.native = on")))
+        extraConfig = Some("""
+        akka.persistence.journal.leveldb.native = on
+        akka.actor.allow-java-serialization = off
+        akka.actor.warn-about-java-serializer-usage = on
+        """)))
     with PluginCleanup {
 
   override def supportsRejectingNonSerializableObjects = true
 
   override def supportsSerialization = true
+
+  override def measurementIterations: Int = 3
+
+  override def eventsCount: Int = 1000
 
 }

--- a/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNativePerfSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNativePerfSpec.scala
@@ -24,8 +24,10 @@ class LeveldbJournalNativePerfSpec
 
   override def supportsSerialization = true
 
+  // increase for real measurements, low because of slow CI
   override def measurementIterations: Int = 3
 
-  override def eventsCount: Int = 1000
+  // increase for real measurements, low because of slow CI
+  override def eventsCount: Int = 100
 
 }

--- a/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNativeSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNativeSpec.scala
@@ -12,7 +12,11 @@ class LeveldbJournalNativeSpec
       config = PersistenceSpec.config(
         "leveldb",
         "LeveldbJournalNativeSpec",
-        extraConfig = Some("akka.persistence.journal.leveldb.native = on")))
+        extraConfig = Some("""
+        akka.persistence.journal.leveldb.native = on
+        akka.actor.allow-java-serialization = off
+        akka.actor.warn-about-java-serializer-usage = on
+        """)))
     with PluginCleanup {
 
   override def supportsRejectingNonSerializableObjects = true

--- a/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNoAtomicPersistMultipleEventsSpec.scala
+++ b/akka-persistence-tck/src/test/scala/akka/persistence/journal/leveldb/LeveldbJournalNoAtomicPersistMultipleEventsSpec.scala
@@ -12,7 +12,11 @@ class LeveldbJournalNoAtomicPersistMultipleEventsSpec
       config = PersistenceSpec.config(
         "leveldb",
         "LeveldbJournalNoAtomicPersistMultipleEventsSpec",
-        extraConfig = Some("akka.persistence.journal.leveldb.native = off")))
+        extraConfig = Some("""
+        akka.persistence.journal.leveldb.native = off
+        akka.actor.allow-java-serialization = off
+        akka.actor.warn-about-java-serializer-usage = on
+        """)))
     with PluginCleanup {
 
   /**


### PR DESCRIPTION
* was using Java serialization
* a journal may choose another serialization mechanism than Akka serialization,
  but this is needed as fallback for Akka serialization

Refs #28291
