### PR TITLE
dead scaladoc links to log markers

### DIFF
--- a/akka-docs/src/main/paradox/logging.md
+++ b/akka-docs/src/main/paradox/logging.md
@@ -561,10 +561,10 @@ The slf4j bridge provided by Akka in `akka-slf4j` will automatically pick up thi
 Akka is logging some events with markers. Some of these events also include structured MDC properties. 
 
 * The "SECURITY" marker is used for highlighting security related events or incidents.
-* Akka Actor is using the markers defined in @apidoc[akka.actor.ActorLogMarker].
-* Akka Cluster is using the markers defined in @apidoc[akka.cluster.ClusterLogMarker].
-* Akka Remoting is using the markers defined in @apidoc[akka.remote.RemoteLogMarker].
-* Akka Cluster Sharding is using the markers defined in @apidoc[akka.cluster.sharding.ShardingLogMarker].
+* Akka Actor is using the markers defined in @apidoc[akka.actor.ActorLogMarker$].
+* Akka Cluster is using the markers defined in @apidoc[akka.cluster.ClusterLogMarker$].
+* Akka Remoting is using the markers defined in @apidoc[akka.remote.RemoteLogMarker$].
+* Akka Cluster Sharding is using the markers defined in @apidoc[akka.cluster.sharding.ShardingLogMarker$].
 
 Markers and MDC properties are automatically picked up by the [Logstash Logback encoder](https://github.com/logstash/logstash-logback-encoder).
 

--- a/akka-docs/src/main/paradox/typed/logging.md
+++ b/akka-docs/src/main/paradox/typed/logging.md
@@ -435,10 +435,10 @@ All MDC properties as key-value entries can be included with `%mdc`:
 Akka is logging some events with markers. Some of these events also include structured MDC properties. 
 
 * The "SECURITY" marker is used for highlighting security related events or incidents.
-* Akka Actor is using the markers defined in @scala[@apidoc[akka.actor.ActorLogMarker$]]@java[@apidoc[akka.actor.ActorLogMarker]].
-* Akka Cluster is using the markers defined in @scala[@apidoc[akka.cluster.ClusterLogMarker$]]@java[@apidoc[akka.cluster.ClusterLogMarker]].
-* Akka Remoting is using the markers defined in @scala[@apidoc[akka.remote.RemoteLogMarker$]]@java[@apidoc[akka.remote.RemoteLogMarker]].
-* Akka Cluster Sharding is using the markers defined in @scala[@apidoc[akka.cluster.sharding.ShardingLogMarker$]]@java[@apidoc[akka.cluster.sharding.ShardingLogMarker]].
+* Akka Actor is using the markers defined in @apidoc[akka.actor.ActorLogMarker$].
+* Akka Cluster is using the markers defined in @apidoc[akka.cluster.ClusterLogMarker$].
+* Akka Remoting is using the markers defined in @apidoc[akka.remote.RemoteLogMarker$].
+* Akka Cluster Sharding is using the markers defined in @apidoc[akka.cluster.sharding.ShardingLogMarker$].
 
 Markers and MDC properties are automatically picked up by the [Logstash Logback encoder](https://github.com/logstash/logstash-logback-encoder).
 

--- a/akka-docs/src/main/paradox/typed/logging.md
+++ b/akka-docs/src/main/paradox/typed/logging.md
@@ -435,10 +435,10 @@ All MDC properties as key-value entries can be included with `%mdc`:
 Akka is logging some events with markers. Some of these events also include structured MDC properties. 
 
 * The "SECURITY" marker is used for highlighting security related events or incidents.
-* Akka Actor is using the markers defined in @apidoc[akka.actor.ActorLogMarker].
-* Akka Cluster is using the markers defined in @apidoc[akka.cluster.ClusterLogMarker].
-* Akka Remoting is using the markers defined in @apidoc[akka.remote.RemoteLogMarker].
-* Akka Cluster Sharding is using the markers defined in @apidoc[akka.cluster.sharding.ShardingLogMarker].
+* Akka Actor is using the markers defined in @scala[@apidoc[akka.actor.ActorLogMarker$]]@java[@apidoc[akka.actor.ActorLogMarker]].
+* Akka Cluster is using the markers defined in @scala[@apidoc[akka.cluster.ClusterLogMarker$]]@java[@apidoc[akka.cluster.ClusterLogMarker]].
+* Akka Remoting is using the markers defined in @scala[@apidoc[akka.remote.RemoteLogMarker$]]@java[@apidoc[akka.remote.RemoteLogMarker]].
+* Akka Cluster Sharding is using the markers defined in @scala[@apidoc[akka.cluster.sharding.ShardingLogMarker$]]@java[@apidoc[akka.cluster.sharding.ShardingLogMarker]].
 
 Markers and MDC properties are automatically picked up by the [Logstash Logback encoder](https://github.com/logstash/logstash-logback-encoder).
 


### PR DESCRIPTION
Linking to `object` should end with `$`