### PR TITLE
Support cancellation propagation in StreamRefs

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamRefsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamRefsSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.scaladsl
 
-import akka.NotUsed
+import akka.{ Done, NotUsed }
 import akka.actor.{ Actor, ActorIdentity, ActorLogging, ActorRef, ActorSystem, ActorSystemImpl, Identify, Props }
 import akka.pattern._
 import akka.stream._
@@ -42,6 +42,26 @@ object StreamRefsSpec {
         val ref: SourceRef[String] = source.runWith(StreamRefs.sourceRef())
 
         sender() ! ref
+
+      case "give-nothing-watch" =>
+        val source: Source[String, NotUsed] = Source.future(Future.never.mapTo[String])
+        val (done: Future[Done], ref: SourceRef[String]) =
+          source.watchTermination()(Keep.right).toMat(StreamRefs.sourceRef())(Keep.both).run()
+
+        sender() ! ref
+
+        import context.dispatcher
+        done.pipeTo(sender())
+
+      case "give-only-one-watch" =>
+        val source: Source[String, NotUsed] = Source.single("hello").concat(Source.future(Future.never))
+        val (done: Future[Done], ref: SourceRef[String]) =
+          source.watchTermination()(Keep.right).toMat(StreamRefs.sourceRef())(Keep.both).run()
+
+        sender() ! ref
+
+        import context.dispatcher
+        done.pipeTo(sender())
 
       case "give-infinite" =>
         val source: Source[String, NotUsed] = Source.fromIterator(() => Iterator.from(1)).map("ping-" + _)
@@ -85,6 +105,27 @@ object StreamRefsSpec {
         val sink =
           StreamRefs.sinkRef[String]().to(Sink.actorRef(probe, "<COMPLETE>", f => "<FAILED>: " + f.getMessage)).run()
         sender() ! sink
+
+      case "receive-one-shutdown" =>
+        // will shutdown the stream after the first element using a kill switch
+        val (sink, done) =
+          StreamRefs
+            .sinkRef[String]()
+            .viaMat(KillSwitches.single)(Keep.both)
+            .alsoToMat(Sink.head)(Keep.both)
+            .mapMaterializedValue {
+              case ((sink, ks), firstF) =>
+                // shutdown the stream after first element
+                firstF.foreach(_ => ks.shutdown())(context.dispatcher)
+                sink
+            }
+            .watchTermination()(Keep.both)
+            .to(Sink.actorRef(probe, "<COMPLETE>", f => "<FAILED>: " + f.getMessage))
+            .run()
+
+        sender() ! sink
+        import context.dispatcher
+        done.pipeTo(sender())
 
       case "receive-ignore" =>
         val sink =
@@ -294,6 +335,32 @@ class StreamRefsSpec extends AkkaSpec(StreamRefsSpec.config()) with ImplicitSend
 
       Await.result(done, 8.seconds)
     }
+
+    "local shutdown should trigger remote shutdown" in {
+      remoteActor ! "give-only-one-watch"
+      val sourceRef = expectMsgType[SourceRef[String]]
+
+      val ks =
+        sourceRef.viaMat(KillSwitches.single)(Keep.right).to(Sink.actorRef(p.ref, "<COMPLETE>", _ => "<FAILED>")).run()
+
+      p.expectMsg("hello")
+      ks.shutdown()
+      p.expectMsg("<COMPLETE>")
+      expectMsg(Done)
+    }
+
+    "local shutdown should trigger remote shutdown when no elements have been emitted" in {
+      remoteActor ! "give-nothing-watch"
+      val sourceRef = expectMsgType[SourceRef[String]]
+
+      val ks =
+        sourceRef.viaMat(KillSwitches.single)(Keep.right).to(Sink.actorRef(p.ref, "<COMPLETE>", _ => "<FAILED>")).run()
+
+      ks.shutdown()
+      p.expectMsg("<COMPLETE>")
+      expectMsg(Done)
+    }
+
   }
 
   "A SinkRef" must {
@@ -393,6 +460,19 @@ class StreamRefsSpec extends AkkaSpec(StreamRefsSpec.config()) with ImplicitSend
 
       // if we get this message, it means no checks in the request/expect semantics were broken, good!
       p.expectMsg("<COMPLETED>")
+    }
+
+    "remote shutdown should trigger local shutdown" in {
+      remoteActor ! "receive-one-shutdown"
+      val remoteSink: SinkRef[String] = expectMsgType[SinkRef[String]]
+
+      val done =
+        Source.single("hello").concat(Source.future(Future.never)).watchTermination()(Keep.right).to(remoteSink).run()
+
+      p.expectMsg("hello")
+      p.expectMsg("<COMPLETE>")
+      expectMsg(Done)
+      Await.result(done, 5.seconds) shouldBe Done
     }
 
     "not allow materializing multiple times" in {

--- a/akka-stream/src/main/scala/akka/stream/impl/streamref/SourceRefImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/streamref/SourceRefImpl.scala
@@ -332,7 +332,7 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
           }
         case (sender, msg) =>
           // should never happen but keep the compiler happy (stage actor receive is total)
-          throw new IllegalArgumentException(s"[$stageActorName] Unexpected message $msg from $sender")
+          throw new IllegalStateException(s"[$stageActorName] Unexpected message in state $state: $msg from $sender")
       }
 
       override protected def onTimer(timerKey: Any): Unit = timerKey match {

--- a/akka-stream/src/main/scala/akka/stream/impl/streamref/StreamRefsProtocol.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/streamref/StreamRefsProtocol.scala
@@ -39,13 +39,19 @@ private[akka] object StreamRefsProtocol {
       with DeadLetterSuppression
 
   /**
-   * INTERNAL API: Sent to a the receiver side of a stream ref, once the sending side of the SinkRef gets signalled a Failure.
+   * INTERNAL API
+   *
+   * Sent to a the receiver side of a stream ref, once the sending side of the SinkRef gets signalled a Failure.
+   * Sent to the sender of a stream if receiver downstream failed.
    */
   @InternalApi
   private[akka] final case class RemoteStreamFailure(msg: String) extends StreamRefsProtocol
 
   /**
-   * INTERNAL API: Sent to a the receiver side of a stream ref, once the sending side of the SinkRef gets signalled a completion.
+   * INTERNAL API
+   *
+   * Sent to a the receiver side of a stream ref, once the sending side of the SinkRef gets signalled a completion.
+   * Sent to the sender of a stream ref if receiver downstream cancelled.
    */
   @InternalApi
   private[akka] final case class RemoteStreamCompleted(seqNr: Long) extends StreamRefsProtocol
@@ -59,5 +65,13 @@ private[akka] object StreamRefsProtocol {
   private[akka] final case class CumulativeDemand(seqNr: Long) extends StreamRefsProtocol with DeadLetterSuppression {
     if (seqNr <= 0) throw ReactiveStreamsCompliance.numberOfElementsInRequestMustBePositiveException
   }
+
+  /**
+   * INTERNAL API
+   *
+   * Ack that failure or completion has been seen and the remote side can stop
+   */
+  @InternalApi
+  private[akka] final case object Ack extends StreamRefsProtocol with DeadLetterSuppression
 
 }

--- a/akka-stream/src/main/scala/akka/stream/serialization/StreamRefSerializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/serialization/StreamRefSerializer.scala
@@ -26,6 +26,7 @@ private[akka] final class StreamRefSerializer(val system: ExtendedActorSystem)
   private[this] val SourceRefManifest = "E"
   private[this] val SinkRefManifest = "F"
   private[this] val OnSubscribeHandshakeManifest = "G"
+  private[this] val AckManifest = "H"
 
   override def manifest(o: AnyRef): String = o match {
     // protocol
@@ -41,6 +42,7 @@ private[akka] final class StreamRefSerializer(val system: ExtendedActorSystem)
     //    case _: MaterializedSourceRef[_]                 => SourceRefManifest
     case _: SinkRefImpl[_] => SinkRefManifest
     //    case _: MaterializedSinkRef[_]                   => SinkRefManifest
+    case StreamRefsProtocol.Ack => AckManifest
   }
 
   override def toBinary(o: AnyRef): Array[Byte] = o match {
@@ -57,6 +59,7 @@ private[akka] final class StreamRefSerializer(val system: ExtendedActorSystem)
     //    case ref: MaterializedSinkRef[_]                 => ??? // serializeSinkRef(ref).toByteArray
     case ref: SourceRefImpl[_] => serializeSourceRef(ref).toByteArray
     //    case ref: MaterializedSourceRef[_]               => serializeSourceRef(ref.).toByteArray
+    case StreamRefsProtocol.Ack => Array.emptyByteArray
   }
 
   override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = manifest match {
@@ -69,6 +72,7 @@ private[akka] final class StreamRefSerializer(val system: ExtendedActorSystem)
     // refs
     case SinkRefManifest   => deserializeSinkRef(bytes)
     case SourceRefManifest => deserializeSourceRef(bytes)
+    case AckManifest       => StreamRefsProtocol.Ack
   }
 
   // -----


### PR DESCRIPTION
Refs #28317 

## Purpose
Adds propagation of failure and cancellation upstream across remoting for StreamRefs.
This was not a regression but actually something that wasn't implemented earlier.

## Changes

 * Updated the `StreamRefSpec` to use explicit senders to be clear which system is which
 * Quite some restructuring of the `SourceRef` with a state machine to make it feasible to figure out all corner cases and get some help from the compiler.
 * Much increased debug logging to be able to figure out corner cases.
 * There is now a cancel/fail - ack message exchange for cancellation. (For rolling updates all cases _should_ be covered by timeouts and at least fail.)


<img width="783" alt="Screenshot 2019-12-11 at 09 08 31" src="https://user-images.githubusercontent.com/666915/70602978-e91ab300-1bf5-11ea-87b4-98681e2d2842.png">

Loss of cancellation message or ack is covered by timeout (and remote watch). Loss of messages during setup is trickier but should be covered by sub timeout and or cancellation timeout.

