### PR TITLE
No more Predef.getClass

### DIFF
--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamSpec.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamSpec.scala
@@ -16,13 +16,13 @@ import scala.concurrent.duration._
 
 class StreamSpec(_system: ActorSystem) extends AkkaSpec(_system) {
   def this(config: Config) =
-    this(ActorSystem(AkkaSpec.getCallerName(getClass), ConfigFactory.load(config.withFallback(AkkaSpec.testConf))))
+    this(ActorSystem(AkkaSpec.getCallerName(classOf[StreamSpec]), ConfigFactory.load(config.withFallback(AkkaSpec.testConf))))
 
   def this(s: String) = this(ConfigFactory.parseString(s))
 
   def this(configMap: Map[String, _]) = this(AkkaSpec.mapToConfig(configMap))
 
-  def this() = this(ActorSystem(AkkaSpec.getCallerName(getClass), AkkaSpec.testConf))
+  def this() = this(ActorSystem(AkkaSpec.getCallerName(classOf[StreamSpec]), AkkaSpec.testConf))
 
   override def withFixture(test: NoArgTest) = {
     super.withFixture(test) match {

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamSpec.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamSpec.scala
@@ -16,7 +16,10 @@ import scala.concurrent.duration._
 
 class StreamSpec(_system: ActorSystem) extends AkkaSpec(_system) {
   def this(config: Config) =
-    this(ActorSystem(AkkaSpec.getCallerName(classOf[StreamSpec]), ConfigFactory.load(config.withFallback(AkkaSpec.testConf))))
+    this(
+      ActorSystem(
+        AkkaSpec.getCallerName(classOf[StreamSpec]),
+        ConfigFactory.load(config.withFallback(AkkaSpec.testConf))))
 
   def this(s: String) = this(ConfigFactory.parseString(s))
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->
The Scala community build noticed that a test class accidentally uses the root import of `Predef.getClass`, which is no longer supported, so this class did not compile.

## References

https://github.com/scala/scala-dev/issues/660
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->

## Changes

<!-- Bullets for important changes in this PR -->

## Background Context

<!-- Why did you take this approach? -->
