### PR TITLE
Adding a clarification to the Akka Classic stash documentation about what happens when an actor is restarted.

### DIFF
--- a/akka-docs/src/main/paradox/actors.md
+++ b/akka-docs/src/main/paradox/actors.md
@@ -1283,9 +1283,16 @@ callback. This means it's not possible to write
 
 Note that the stash is part of the ephemeral actor state, unlike the
 mailbox. Therefore, it should be managed like other parts of the
-actor's state which have the same property. The @scala[`Stash` trait’s] @java[`AbstractActorWithStash`]
-implementation of `preRestart` will call `unstashAll()`, which is
-usually the desired behavior.
+actor's state which have the same property.
+
+However, the @scala[`Stash` trait’s] @java[`AbstractActorWithStash`]
+implementation of `preRestart` will call `unstashAll()`. This means
+that prior to the actor restarting, it will transfer all stashed 
+messages back to the actor's mailbox.
+
+The result of this is that when an actor is restarted, any stashed 
+messages will be delivered to the new incarnation of the actor. 
+This is usually the desired behavior.
 
 @@@ note
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Updates the Stash documentation for Akka Classic to provide clarifications about what happens to the stash on restart of the actor.

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->

## Changes

- Updated the Akka Classic Stash documentation.

## Background Context

While reading the docs I found it difficult to understand that the Stashed messages aren't lost if the actor is restarted. That wasn't clear. I had to build an experiment to demonstrate this before I could understand it. Hopefully this will make it more clear for future users.
