### PR TITLE
Simplifies the importing of package

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/AbstractProps.scala
+++ b/akka-actor/src/main/scala/akka/actor/AbstractProps.scala
@@ -4,12 +4,10 @@
 
 package akka.actor
 
-import java.lang.reflect.{ Modifier, ParameterizedType, TypeVariable }
+import java.lang.reflect.{ Constructor, Modifier, ParameterizedType, TypeVariable }
 import akka.japi.Creator
 import akka.util.Reflect
-import scala.annotation.varargs
-import scala.annotation.tailrec
-import java.lang.reflect.Constructor
+import scala.annotation.{ tailrec, varargs }
 
 /**
  *

--- a/akka-actor/src/main/scala/akka/actor/ActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRef.scala
@@ -13,12 +13,8 @@ import scala.collection.immutable
 import scala.util.control.NonFatal
 import akka.dispatch._
 import akka.dispatch.sysmsg._
-import akka.event.AddressTerminatedTopic
-import akka.event.EventStream
-import akka.event.Logging
-import akka.event.MarkerLoggingAdapter
-import akka.serialization.JavaSerializer
-import akka.serialization.Serialization
+import akka.event.{ AddressTerminatedTopic, EventStream, Logging, MarkerLoggingAdapter }
+import akka.serialization.{ JavaSerializer, Serialization }
 import akka.util.OptionVal
 
 object ActorRef {

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -5,23 +5,19 @@
 package akka.actor
 
 import akka.dispatch.sysmsg._
-import akka.dispatch.{ Mailboxes, RequiresMessageQueue, UnboundedMessageQueueSemantics }
+import akka.dispatch.{ Dispatchers, Mailboxes, RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.routing._
 import akka.event._
-import akka.util.Helpers
+import akka.util.{ Helpers, OptionVal }
 import akka.util.Collections.EmptyImmutableSeq
-import scala.util.control.NonFatal
 import java.util.concurrent.atomic.AtomicLong
 
 import scala.concurrent.{ ExecutionContextExecutor, Future, Promise }
 import scala.annotation.implicitNotFound
-
+import scala.util.control.NonFatal
 import akka.ConfigurationException
-import akka.annotation.DoNotInherit
-import akka.annotation.InternalApi
-import akka.dispatch.Dispatchers
+import akka.annotation.{ DoNotInherit, InternalApi }
 import akka.serialization.Serialization
-import akka.util.OptionVal
 
 /**
  * Interface for all ActorRef providers to implement.

--- a/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
@@ -10,8 +10,7 @@ import java.util.concurrent.CompletionStage
 import scala.language.implicitConversions
 import scala.annotation.tailrec
 import scala.collection.immutable
-import scala.concurrent.Future
-import scala.concurrent.Promise
+import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration._
 import scala.util.Success
 import java.util.regex.Pattern
@@ -19,10 +18,10 @@ import java.util.regex.Pattern
 import akka.pattern.ask
 import akka.routing.MurmurHash
 import akka.util.{ Helpers, JavaDurationConverters, Timeout }
+import akka.util.ccompat._
 import akka.dispatch.ExecutionContexts
 
 import scala.compat.java8.FutureConverters
-import akka.util.ccompat._
 import com.github.ghik.silencer.silent
 
 /**

--- a/akka-actor/src/main/scala/akka/actor/Address.scala
+++ b/akka-actor/src/main/scala/akka/actor/Address.scala
@@ -3,9 +3,8 @@
  */
 
 package akka.actor
-import java.net.URI
-import java.net.URISyntaxException
-import java.net.MalformedURLException
+
+import java.net.{ MalformedURLException, URI, URISyntaxException }
 
 import scala.annotation.tailrec
 import scala.collection.immutable

--- a/akka-actor/src/main/scala/akka/actor/ClassicActorSystemProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ClassicActorSystemProvider.scala
@@ -4,8 +4,7 @@
 
 package akka.actor
 
-import akka.annotation.DoNotInherit
-import akka.annotation.InternalApi
+import akka.annotation.{ DoNotInherit, InternalApi }
 
 /**
  * Glue API introduced to allow minimal user effort integration between classic and typed for example for streams.

--- a/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/FaultHandling.scala
@@ -13,9 +13,7 @@ import akka.util.JavaDurationConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.immutable
 import scala.concurrent.duration.Duration
-import akka.event.Logging.LogEvent
-import akka.event.Logging.Error
-import akka.event.Logging.Warning
+import akka.event.Logging.{ Error, LogEvent, Warning }
 import scala.util.control.NonFatal
 import akka.util.ccompat._
 

--- a/akka-actor/src/main/scala/akka/actor/ReflectiveDynamicAccess.scala
+++ b/akka-actor/src/main/scala/akka/actor/ReflectiveDynamicAccess.scala
@@ -10,8 +10,7 @@ import java.lang.reflect.InvocationTargetException
 import akka.annotation.DoNotInherit
 
 import scala.reflect.ClassTag
-import scala.util.Failure
-import scala.util.Try
+import scala.util.{ Failure, Try }
 
 /**
  * This is the default [[akka.actor.DynamicAccess]] implementation used by [[akka.actor.ExtendedActorSystem]]

--- a/akka-actor/src/main/scala/akka/actor/Scheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/Scheduler.scala
@@ -9,7 +9,6 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.tailrec
 
 import akka.util.JavaDurationConverters
-import com.github.ghik.silencer.silent
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
@@ -120,10 +120,11 @@ private[akka] trait Children { this: ActorCell =>
         swapChildrenRefs(c, c.shallDie(ref)) || shallDie(ref)
       }
 
-      if (actor match {
-            case r: RepointableRef => r.isStarted
-            case _                 => true
-          }) shallDie(actor)
+      val needToDie = actor match {
+        case r: RepointableRef => r.isStarted
+        case _                 => true
+      }
+      if (needToDie) shallDie(actor)
     }
     actor.asInstanceOf[InternalActorRef].stop()
   }

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Dispatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Dispatch.scala
@@ -6,7 +6,7 @@ package akka.actor.dungeon
 
 import scala.annotation.tailrec
 import akka.AkkaException
-import akka.dispatch.{ Envelope, Mailbox }
+import akka.dispatch.{ Envelope, Mailbox, MailboxType, ProducesMessageQueue, UnboundedMailbox }
 import akka.dispatch.sysmsg._
 import akka.event.Logging.Error
 import akka.util.Unsafe
@@ -16,9 +16,6 @@ import akka.serialization.{ DisabledJavaSerializer, SerializationExtension, Seri
 
 import scala.util.control.{ NoStackTrace, NonFatal }
 import scala.util.control.Exception.Catcher
-import akka.dispatch.MailboxType
-import akka.dispatch.ProducesMessageQueue
-import akka.dispatch.UnboundedMailbox
 import akka.serialization.Serialization
 import com.github.ghik.silencer.silent
 

--- a/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
@@ -4,20 +4,17 @@
 
 package akka.actor.dungeon
 
-import akka.actor.PostRestartException
-import akka.actor.PreRestartException
-import akka.actor.{ Actor, ActorCell, ActorInterruptedException, ActorRef, InternalActorRef }
+import akka.actor.{ ActorInterruptedException, PostRestartException, PreRestartException }
+import akka.actor.{ Actor, ActorCell, ActorRef, ActorRefScope, InternalActorRef }
 import akka.dispatch._
 import akka.dispatch.sysmsg._
 import akka.event.Logging
-import akka.event.Logging.Debug
-import akka.event.Logging.Error
+import akka.event.Logging.{ Debug, Error }
 
 import scala.collection.immutable
 import scala.concurrent.duration.Duration
 import scala.util.control.Exception._
 import scala.util.control.NonFatal
-import akka.actor.ActorRefScope
 
 private[akka] trait FaultHandling { this: ActorCell =>
 

--- a/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
@@ -4,12 +4,8 @@
 
 package akka.actor.dungeon
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.FiniteDuration
-
-import akka.actor.ActorCell
-import akka.actor.Cancellable
-import akka.actor.NotInfluenceReceiveTimeout
+import scala.concurrent.duration.{ Duration, FiniteDuration }
+import akka.actor.{ ActorCell, Cancellable, NotInfluenceReceiveTimeout }
 
 private[akka] object ReceiveTimeout {
   final val emptyReceiveTimeoutData: (Duration, Cancellable) = (Duration.Undefined, ActorCell.emptyCancellable)

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
@@ -10,8 +10,7 @@ import akka.event.Logging
 import akka.dispatch.sysmsg.SystemMessage
 import java.util.concurrent.{ ExecutorService, RejectedExecutionException }
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
 
 import com.github.ghik.silencer.silent

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -13,8 +13,7 @@ import java.util.{ LinkedList => JLinkedList }
 import java.util.concurrent.{ Callable, Executor, ExecutorService }
 
 import scala.util.{ Failure, Success, Try }
-import java.util.concurrent.CompletionStage
-import java.util.concurrent.CompletableFuture
+import java.util.concurrent.{ CompletableFuture, CompletionStage }
 
 import akka.compat
 import akka.util.unused

--- a/akka-actor/src/main/scala/akka/dispatch/PinnedDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/PinnedDispatcher.scala
@@ -5,8 +5,7 @@
 package akka.dispatch
 
 import akka.actor.ActorCell
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 /**
  * Dedicates a unique thread for each actor passed in as reference. Served through its messageQueue.

--- a/akka-actor/src/main/scala/akka/dispatch/sysmsg/SystemMessage.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/sysmsg/SystemMessage.scala
@@ -5,8 +5,7 @@
 package akka.dispatch.sysmsg
 
 import scala.annotation.tailrec
-import akka.actor.{ ActorInitializationException, ActorRef, InternalActorRef, PossiblyHarmful }
-import akka.actor.DeadLetterSuppression
+import akka.actor.{ ActorInitializationException, ActorRef, DeadLetterSuppression, InternalActorRef, PossiblyHarmful }
 import akka.annotation.InternalStableApi
 
 /**

--- a/akka-actor/src/main/scala/akka/event/LoggingReceive.scala
+++ b/akka-actor/src/main/scala/akka/event/LoggingReceive.scala
@@ -6,11 +6,8 @@ package akka.event
 
 import language.existentials
 import akka.actor.Actor.Receive
-import akka.actor.ActorContext
-import akka.actor.ActorCell
-import akka.actor.DiagnosticActorLogging
+import akka.actor.{ AbstractActor, ActorCell, ActorContext, DiagnosticActorLogging }
 import akka.event.Logging.{ LogEvent, LogLevel }
-import akka.actor.AbstractActor
 import scala.runtime.BoxedUnit
 
 object LoggingReceive {

--- a/akka-actor/src/main/scala/akka/routing/Balancing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Balancing.scala
@@ -5,14 +5,9 @@
 package akka.routing
 
 import scala.collection.immutable
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
-import akka.actor.ActorContext
-import akka.actor.ActorSystem
-import akka.actor.Props
-import akka.actor.SupervisorStrategy
-import akka.dispatch.BalancingDispatcherConfigurator
-import akka.dispatch.Dispatchers
+import com.typesafe.config.{ Config, ConfigFactory }
+import akka.actor.{ ActorContext, ActorSystem, Props, SupervisorStrategy }
+import akka.dispatch.{ BalancingDispatcherConfigurator, Dispatchers }
 import com.github.ghik.silencer.silent
 
 /**

--- a/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
+++ b/akka-actor/src/main/scala/akka/routing/ConsistentHashing.scala
@@ -10,17 +10,13 @@ import akka.dispatch.Dispatchers
 import com.typesafe.config.Config
 import akka.actor.SupervisorStrategy
 import akka.japi.Util.immutableSeq
-import akka.actor.Address
-import akka.actor.ExtendedActorSystem
-import akka.actor.ActorSystem
+import akka.actor.{ ActorPath, ActorSystem, Address, ExtendedActorSystem, WrappedMessage }
 import java.util.concurrent.atomic.AtomicReference
 
 import akka.serialization.SerializationExtension
 import scala.util.control.NonFatal
 
 import akka.event.Logging
-import akka.actor.ActorPath
-import akka.actor.WrappedMessage
 
 object ConsistentHashingRouter {
 

--- a/akka-actor/src/main/scala/akka/util/Helpers.scala
+++ b/akka-actor/src/main/scala/akka/util/Helpers.scala
@@ -4,14 +4,13 @@
 
 package akka.util
 
-import java.util.Comparator
 import scala.annotation.tailrec
-import java.util.regex.Pattern
 import com.typesafe.config.Config
-import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{ Duration, FiniteDuration }
+import java.lang.{ StringBuilder => JStringBuilder }
 import java.util.concurrent.TimeUnit
-import java.util.Locale
+import java.util.{ Comparator, Locale }
+import java.util.regex.Pattern
 import java.time.{ Instant, LocalDateTime, ZoneId }
 import java.time.format.DateTimeFormatter
 
@@ -95,7 +94,7 @@ object Helpers {
   final val base64chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+~"
 
   @tailrec
-  def base64(l: Long, sb: java.lang.StringBuilder = new java.lang.StringBuilder("$")): String = {
+  def base64(l: Long, sb: JStringBuilder = new JStringBuilder("$")): String = {
     sb.append(base64chars.charAt(l.toInt & 63))
     val next = l >>> 6
     if (next == 0) sb.toString

--- a/akka-actor/src/main/scala/akka/util/Reflect.scala
+++ b/akka-actor/src/main/scala/akka/util/Reflect.scala
@@ -3,6 +3,7 @@
  */
 
 package akka.util
+
 import scala.util.control.NonFatal
 import java.lang.reflect.Constructor
 import scala.collection.immutable


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

This PR mainly simplifies some package importing to the simple style(**akka-actor module**), for example
```
  import scala.annotation.varargs
  import scala.annotation.tailrec

  // -->
  import scala.annotation.{ varargs, tailrec }
 
```

In addtion, 

- we removes a redundant import of `import com.github.ghik.silencer.silent`, see `akka-actor/src/main/scala/akka/actor/Scheduler.scala`

- add a local variable `needToDie` to make code more readable, see `akka-actor/src/main/scala/akka/actor/dungeon/Children.scala`

<!-- What does this PR do? -->


<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->

## Changes
- akka-actor module

<!-- Bullets for important changes in this PR -->


