### PR TITLE
Add .withRouteeProps(props) to pool router builder API (akka typed)

### DIFF
--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java
@@ -8,6 +8,7 @@ package jdocs.akka.typed;
  */
 
 import akka.actor.typed.ActorSystem;
+import akka.actor.typed.DispatcherSelector;
 // #pool
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.Behavior;
@@ -71,6 +72,14 @@ public class RouterTest {
             router.tell(new Worker.DoLog("msg " + i));
           }
           // #pool
+
+          // #pool-dispatcher
+          // make sure workers use the default blocking IO dispatcher
+          PoolRouter<Worker.Command> blockingPool = pool.withRouteeProps(DispatcherSelector.blocking());
+          // spawn head router using the same executor as the parent
+          ActorRef<Worker.Command> blockingRouter = context.spawn(
+                  blockingPool, "blocking-pool", DispatcherSelector.sameAsParent());
+          // #pool-dispatcher
 
           // #strategy
           PoolRouter<Worker.Command> alternativePool = pool.withPoolSize(2).withRoundRobinRouting();

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java
@@ -75,10 +75,11 @@ public class RouterTest {
 
           // #pool-dispatcher
           // make sure workers use the default blocking IO dispatcher
-          PoolRouter<Worker.Command> blockingPool = pool.withRouteeProps(DispatcherSelector.blocking());
+          PoolRouter<Worker.Command> blockingPool =
+              pool.withRouteeProps(DispatcherSelector.blocking());
           // spawn head router using the same executor as the parent
-          ActorRef<Worker.Command> blockingRouter = context.spawn(
-                  blockingPool, "blocking-pool", DispatcherSelector.sameAsParent());
+          ActorRef<Worker.Command> blockingRouter =
+              context.spawn(blockingPool, "blocking-pool", DispatcherSelector.sameAsParent());
           // #pool-dispatcher
 
           // #strategy

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/routing/PoolRouterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/routing/PoolRouterSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.internal.routing
+
+import akka.actor.testkit.typed.scaladsl.{ LogCapturing, ScalaTestWithActorTestKit }
+import akka.actor.typed.{ ActorRef, Behavior, DispatcherSelector }
+import akka.actor.typed.scaladsl.{ Behaviors, Routers }
+import org.scalatest.WordSpecLike
+
+object PoolRouterSpec {
+
+  object RouteeBehavior {
+
+    final case class WhichDispatcher(replyTo: ActorRef[String])
+
+    def apply(): Behavior[WhichDispatcher] = Behaviors.receiveMessage {
+      case WhichDispatcher(replyTo) =>
+        replyTo ! Thread.currentThread.getName
+        Behaviors.same
+    }
+  }
+}
+
+class PoolRouterSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapturing {
+  import PoolRouterSpec.RouteeBehavior
+  import RouteeBehavior.WhichDispatcher
+
+  "PoolRouter" must {
+
+    "use the default dispatcher per default for its routees" in {
+      val probe = createTestProbe[String]()
+      val pool = spawn(Routers.pool(1)(RouteeBehavior()), "default-pool")
+      pool ! WhichDispatcher(probe.ref)
+
+      val response = probe.receiveMessage()
+      response should startWith("PoolRouterSpec-akka.actor.default-dispatcher")
+    }
+
+    "use the specified dispatcher for its routees" in {
+      val probe = createTestProbe[String]()
+      val pool = spawn(
+        Routers.pool(1)(RouteeBehavior()).withRouteeProps(DispatcherSelector.blocking()),
+        "pool-with-blocking-routees")
+      pool ! WhichDispatcher(probe.ref)
+
+      val response = probe.receiveMessage()
+      response should startWith("PoolRouterSpec-akka.actor.default-blocking-io-dispatcher")
+    }
+  }
+}

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala
@@ -4,6 +4,7 @@
 
 package docs.akka.typed
 
+import akka.actor.typed.DispatcherSelector
 // #pool
 import akka.actor.testkit.typed.scaladsl.{ LogCapturing, ScalaTestWithActorTestKit }
 import akka.actor.typed.{ Behavior, SupervisorStrategy }
@@ -65,6 +66,15 @@ class RouterSpec extends ScalaTestWithActorTestKit("akka.loglevel=warning") with
         }
         // #pool
 
+        // #pool-dispatcher
+        // make sure workers use the default blocking IO dispatcher
+        val blockingPool = pool.withRouteeProps(routeeProps = DispatcherSelector.blocking())
+        // spawn head router using the same executor as the parent
+        val blockingRouter = ctx.spawn(blockingPool, "blocking-pool", DispatcherSelector.sameAsParent())
+        // #pool-dispatcher
+
+        blockingRouter ! Worker.DoLog("msg")
+
         // #strategy
         val alternativePool = pool.withPoolSize(2).withRoundRobinRouting()
         // #strategy
@@ -75,7 +85,7 @@ class RouterSpec extends ScalaTestWithActorTestKit("akka.loglevel=warning") with
         Behaviors.empty
       })
 
-      probe.receiveMessages(10)
+      probe.receiveMessages(11)
     }
 
     "show group routing" in {

--- a/akka-actor-typed/src/main/mima-filters/2.6.1.backwards.excludes/pr-28384-pool-routee-props.excludes
+++ b/akka-actor-typed/src/main/mima-filters/2.6.1.backwards.excludes/pr-28384-pool-routee-props.excludes
@@ -1,0 +1,12 @@
+# New methods on PoolRouterBuilder to set routee props
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.javadsl.PoolRouter.withRouteeProps")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.scaladsl.PoolRouter.withRouteeProps")
+
+# pool router builder now includes routeeProps, but it is still an internal API
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.typed.internal.routing.PoolRouterBuilder.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.typed.internal.routing.PoolRouterBuilder.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.actor.typed.internal.routing.PoolRouterBuilder.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.typed.internal.routing.PoolRouterBuilder.copy")
+
+# constructor changed to include routeeProps, but it is still an internal API
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.typed.internal.routing.PoolRouterImpl.this")

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Routers.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Routers.scala
@@ -4,7 +4,7 @@
 
 package akka.actor.typed.javadsl
 
-import akka.actor.typed.Behavior
+import akka.actor.typed.{ Behavior, Props }
 import akka.actor.typed.internal.BehaviorImpl.DeferredBehavior
 import akka.actor.typed.internal.routing.{ GroupRouterBuilder, PoolRouterBuilder }
 import akka.actor.typed.receptionist.ServiceKey
@@ -176,4 +176,9 @@ abstract class PoolRouter[T] extends DeferredBehavior[T] {
    * Set a new pool size from the one set at construction
    */
   def withPoolSize(poolSize: Int): PoolRouter[T]
+
+  /**
+   * Set the props used to spawn the pool's routees
+   */
+  def withRouteeProps(routeeProps: Props): PoolRouter[T]
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Routers.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Routers.scala
@@ -3,7 +3,7 @@
  */
 
 package akka.actor.typed.scaladsl
-import akka.actor.typed.Behavior
+import akka.actor.typed.{ Behavior, Props }
 import akka.actor.typed.internal.routing.{ GroupRouterBuilder, PoolRouterBuilder }
 import akka.actor.typed.receptionist.ServiceKey
 import akka.annotation.DoNotInherit
@@ -166,4 +166,9 @@ trait PoolRouter[T] extends Behavior[T] {
    * Set a new pool size from the one set at construction
    */
   def withPoolSize(poolSize: Int): PoolRouter[T]
+
+  /**
+   * Set the props used to spawn the pool's routees
+   */
+  def withRouteeProps(routeeProps: Props): PoolRouter[T]
 }

--- a/akka-docs/src/main/paradox/typed/routers.md
+++ b/akka-docs/src/main/paradox/typed/routers.md
@@ -36,6 +36,17 @@ Scala
 Java
 :  @@snip [RouterTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java) { #pool }
 
+### Configuring Dispatchers
+
+Since the router itself is spawned as an actor the dispatcher used for it can be configured directly in the call to `spawn`.
+The routees, however, are spawned by the router.
+Therefore, the `PoolRouter` has a property to configure the `Props` of its routees:
+
+Scala
+:  @@snip [RouterSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala) { #pool-dispatcher }
+
+Java
+:  @@snip [RouterTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java) { #pool-dispatcher }
 
 ## Group Router
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->
## Purpose

Introduces `.withRouteeProps(props)` on the pool router builders (scala and java DSL) to allow setting the dispatcher used to spawn the routees explicitly.

## References

References #28370

## Changes

- add `.withRouteeProps(props)` to scaladsl
- add `.withRouteeProps(props)` to javadsl
- use `Props.empty` as default props for the pool router's routees
- add subsection to [Routers / Pool Router](https://doc.akka.io/docs/akka/current/typed/routers.html#pool-router) documentation section that describes how to configure dispatchers for the pool router and the routees

## Background Context

Previously, it was not possible to use a pool router that spawns its routees with a different dispatcher. This is useful if the routees perform work that should not be executed on the default dispatcher (CPU heavy or blockig).
