### PR TITLE
Remove the default reschedule=true arg to internal checkReceiveTimeout

### DIFF
--- a/akka-actor/src/main/mima-filters/2.6.1.backwards.excludes/28399-remove-default-arg.excludes
+++ b/akka-actor/src/main/mima-filters/2.6.1.backwards.excludes/28399-remove-default-arg.excludes
@@ -1,0 +1,5 @@
+# Remove the default reschedule=true arg to internal checkReceiveTimeout #28399
+# class akka.actor.ActorCell does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.ActorCell.checkReceiveTimeout$default$1")
+# interface akka.actor.dungeon.ReceiveTimeout does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.dungeon.ReceiveTimeout.checkReceiveTimeout$default$1")

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -635,7 +635,7 @@ private[akka] class ActorCell(
       val created = newActor()
       actor = created
       created.aroundPreStart()
-      checkReceiveTimeout()
+      checkReceiveTimeout(reschedule = true)
       if (system.settings.DebugLifecycle)
         publish(Debug(self.path.toString, clazz(created), "started (" + created + ")"))
     } catch {

--- a/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
@@ -244,7 +244,7 @@ private[akka] trait FaultHandling { this: ActorCell =>
       if (freshActor eq failedActor) setActorFields(freshActor, this, self) // If the creator returns the same instance, we need to restore our nulled out fields.
 
       freshActor.aroundPostRestart(cause)
-      checkReceiveTimeout() // user may have set a receive timeout in preStart which is called from postRestart
+      checkReceiveTimeout(reschedule = true) // user may have set a receive timeout in preStart which is called from postRestart
       if (system.settings.DebugLifecycle) publish(Debug(self.path.toString, clazz(freshActor), "restarted"))
 
       // only after parent is up and running again do restart the children which were not stopped

--- a/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/ReceiveTimeout.scala
@@ -31,11 +31,11 @@ private[akka] trait ReceiveTimeout { this: ActorCell =>
     if (hasTimeoutData || receiveTimeoutChanged(beforeReceive))
       checkReceiveTimeout(!message.isInstanceOf[NotInfluenceReceiveTimeout] || receiveTimeoutChanged(beforeReceive))
 
-  final def checkReceiveTimeout(reschedule: Boolean = true): Unit = {
+  final def checkReceiveTimeout(reschedule: Boolean): Unit = {
     val (recvTimeout, task) = receiveTimeoutData
     recvTimeout match {
       case f: FiniteDuration =>
-        // The fact that timeout is FiniteDuration and task is emptyCancellable
+        // The fact that recvTimeout is FiniteDuration and task is emptyCancellable
         // means that a user called `context.setReceiveTimeout(...)`
         // while sending the ReceiveTimeout message is not scheduled yet.
         // We have to handle the case and schedule sending the ReceiveTimeout message


### PR DESCRIPTION
While reviewing https://github.com/akka/akka/pull/28385 it struck me as unnecessary to use a default argument for `ReceiveTimeout.checkReceiveTimeout` even though it is internal. It is only called from `ActorCell` where passing the explicit reschedule = true is clearer.
 