### PR TITLE
fix wrong logging of REACHABLE, #28393

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -1458,7 +1458,7 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef, joinConfigCompatCh
             logInfo(
               "Marking exiting node(s) as UNREACHABLE [{}]. This is expected and they will be removed.",
               exiting.mkString(", "))
-          nonExiting.foreach { node =>
+          newlyDetectedReachableMembers.foreach { node =>
             logInfo(ClusterLogMarker.reachable(node.address), "Marking node as REACHABLE [{}].", node)
           }
 


### PR DESCRIPTION
Refs #28393

Can be compared with https://github.com/akka/akka/blob/97c5305e0d692675681525da58cfc9429f5153a5/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala#L1423-L1427