### PR TITLE
Don't warn about discarded return values

### DIFF
--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -19,7 +19,28 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
   // We allow warnings in docs to get the 'snippets' right
   val nonFatalWarningsFor = Set("akka-docs")
 
-  val strictProjects = Set("akka-discovery", "akka-protobuf", "akka-coordination")
+  val looseProjects = Set(
+    "akka-actor",
+    "akka-actor-testkit-typed",
+    "akka-actor-tests",
+    "akka-actor-typed",
+    "akka-actor-typed-tests",
+    "akka-bench-jmh",
+    "akka-cluster",
+    "akka-cluster-metrics",
+    "akka-distributed-data",
+    "akka-persistence",
+    "akka-persistence-tck",
+    "akka-persistence-typed",
+    "akka-persistence-query",
+    "akka-remote",
+    "akka-remote-tests",
+    "akka-stream",
+    "akka-stream-testkit",
+    "akka-stream-tests",
+    "akka-stream-tests-tck",
+    "akka-testkit",
+  )
 
   lazy val scalaFixSettings = Seq(Compile / scalacOptions += "-Yrangepos")
 
@@ -54,8 +75,8 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
             Nil
         }).toSeq,
       Compile / scalacOptions --=
-        (if (strictProjects.contains(name.value)) Seq.empty
-         else undisciplineScalacOptions.toSeq),
+        (if (looseProjects.contains(name.value)) undisciplineScalacOptions.toSeq
+         else Seq.empty),
       // Discipline is not needed for the docs compilation run (which uses
       // different compiler phases from the regular run), and in particular
       // '-Ywarn-unused:explicits' breaks 'sbt ++2.13.0-M5 akka-actor/doc'
@@ -65,22 +86,18 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
       Compile / console / scalacOptions --= disciplineScalacOptions.toSeq)
 
   val testUndicipline = Seq(
-    "-Ywarn-dead-code", // ??? used in compile only specs
-    "-Ywarn-value-discard" // Ignoring returned assertions
+    "-Ywarn-dead-code", // '???' used in compile only specs
   )
 
   /**
    * Remain visibly filtered for future code quality work and removing.
    */
-  val undisciplineScalacOptions = Set("-Ywarn-value-discard", "-Ywarn-numeric-widen")
+  val undisciplineScalacOptions = Set("-Ywarn-numeric-widen")
 
   /** These options are desired, but some are excluded for the time being*/
   val disciplineScalacOptions = Set(
-    // start: must currently remove, version regardless
-    "-Ywarn-value-discard",
     "-Ywarn-numeric-widen",
     "-Yno-adapted-args",
-    // end
     "-deprecation",
     "-Xlint",
     "-Ywarn-dead-code",

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -28,6 +28,7 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
     "akka-bench-jmh",
     "akka-cluster",
     "akka-cluster-metrics",
+    "akka-cluster-sharding",
     "akka-distributed-data",
     "akka-persistence",
     "akka-persistence-tck",


### PR DESCRIPTION
Since we have and use many API's where the return value can be safely
ignored.

Also switched around the logic so that projects are 'strictly' checked
by default, and only loosely checked when we add an exception.