### PR TITLE
Fix memory leak of restarting Artery outbound stream, #28390

### DIFF
--- a/akka-remote/src/main/mima-filters/2.5.27.backwards.excludes
+++ b/akka-remote/src/main/mima-filters/2.5.27.backwards.excludes
@@ -1,0 +1,2 @@
+# #28390 rewrite of AssociationState due to memory leak
+ProblemFilters.exclude[Problem]("akka.remote.artery.AssociationState*")

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -16,11 +16,10 @@ import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
-import scala.util.Failure
-import scala.util.Success
 import scala.util.Try
 import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
+
 import akka.Done
 import akka.NotUsed
 import akka.actor.Actor
@@ -97,15 +96,19 @@ private[remote] object AssociationState {
   def apply(): AssociationState =
     new AssociationState(
       incarnation = 1,
-      uniqueRemoteAddressPromise = Promise(),
       lastUsedTimestamp = new AtomicLong(System.nanoTime()),
       controlIdleKillSwitch = OptionVal.None,
-      quarantined = ImmutableLongMap.empty[QuarantinedTimestamp])
+      quarantined = ImmutableLongMap.empty[QuarantinedTimestamp],
+      new AtomicReference(UniqueRemoteAddressValue(None, Nil)))
 
   final case class QuarantinedTimestamp(nanoTime: Long) {
     override def toString: String =
       s"Quarantined ${TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - nanoTime)} seconds ago"
   }
+
+  private final case class UniqueRemoteAddressValue(
+      uniqueRemoteAddress: Option[UniqueAddress],
+      listeners: List[UniqueAddress => Unit])
 }
 
 /**
@@ -113,59 +116,73 @@ private[remote] object AssociationState {
  */
 private[remote] final class AssociationState(
     val incarnation: Int,
-    val uniqueRemoteAddressPromise: Promise[UniqueAddress],
     val lastUsedTimestamp: AtomicLong, // System.nanoTime timestamp
     val controlIdleKillSwitch: OptionVal[SharedKillSwitch],
-    val quarantined: ImmutableLongMap[AssociationState.QuarantinedTimestamp]) {
+    val quarantined: ImmutableLongMap[AssociationState.QuarantinedTimestamp],
+    _uniqueRemoteAddress: AtomicReference[AssociationState.UniqueRemoteAddressValue]) {
 
   import AssociationState.QuarantinedTimestamp
-
-  // doesn't have to be volatile since it's only a cache changed once
-  private var uniqueRemoteAddressValueCache: Option[UniqueAddress] = null
+  import AssociationState.UniqueRemoteAddressValue
 
   /**
    * Full outbound address with UID for this association.
-   * Completed when by the handshake.
+   * Completed by the handshake.
    */
-  def uniqueRemoteAddress: Future[UniqueAddress] = uniqueRemoteAddressPromise.future
+  def uniqueRemoteAddress(): Option[UniqueAddress] = _uniqueRemoteAddress.get().uniqueRemoteAddress
 
-  def uniqueRemoteAddressValue(): Option[UniqueAddress] = {
-    if (uniqueRemoteAddressValueCache ne null)
-      uniqueRemoteAddressValueCache
-    else {
-      uniqueRemoteAddress.value match {
-        case Some(Success(peer)) =>
-          uniqueRemoteAddressValueCache = Some(peer)
-          uniqueRemoteAddressValueCache
-        case _ => None
-      }
+  @tailrec def completeUniqueRemoteAddress(peer: UniqueAddress): Unit = {
+    val current = _uniqueRemoteAddress.get()
+    if (current.uniqueRemoteAddress.isEmpty) {
+      val newValue = UniqueRemoteAddressValue(Some(peer), Nil)
+      if (_uniqueRemoteAddress.compareAndSet(current, newValue))
+        current.listeners.foreach(_.apply(peer))
+      else
+        completeUniqueRemoteAddress(peer) // cas failed, retry
     }
   }
 
-  def newIncarnation(remoteAddressPromise: Promise[UniqueAddress]): AssociationState =
+  @tailrec def addUniqueRemoteAddressListener(callback: UniqueAddress => Unit): Unit = {
+    val current = _uniqueRemoteAddress.get
+    current.uniqueRemoteAddress match {
+      case Some(peer) => callback(peer)
+      case None =>
+        val newValue = UniqueRemoteAddressValue(None, callback :: current.listeners)
+        if (!_uniqueRemoteAddress.compareAndSet(current, newValue))
+          addUniqueRemoteAddressListener(callback) // cas failed, retry
+    }
+  }
+
+  @tailrec def removeUniqueRemoteAddressListener(callback: UniqueAddress => Unit): Unit = {
+    val current = _uniqueRemoteAddress.get
+    val newValue = UniqueRemoteAddressValue(current.uniqueRemoteAddress, current.listeners.filterNot(_ == callback))
+    if (!_uniqueRemoteAddress.compareAndSet(current, newValue))
+      removeUniqueRemoteAddressListener(callback) // cas failed, retry
+  }
+
+  def newIncarnation(remoteAddress: UniqueAddress): AssociationState =
     new AssociationState(
       incarnation + 1,
-      remoteAddressPromise,
       lastUsedTimestamp = new AtomicLong(System.nanoTime()),
       controlIdleKillSwitch,
-      quarantined)
+      quarantined,
+      new AtomicReference(UniqueRemoteAddressValue(Some(remoteAddress), Nil)))
 
   def newQuarantined(): AssociationState =
-    uniqueRemoteAddressPromise.future.value match {
-      case Some(Success(a)) =>
+    uniqueRemoteAddress() match {
+      case Some(a) =>
         new AssociationState(
           incarnation,
-          uniqueRemoteAddressPromise,
           lastUsedTimestamp = new AtomicLong(System.nanoTime()),
           controlIdleKillSwitch,
-          quarantined = quarantined.updated(a.uid, QuarantinedTimestamp(System.nanoTime())))
-      case _ => this
+          quarantined = quarantined.updated(a.uid, QuarantinedTimestamp(System.nanoTime())),
+          _uniqueRemoteAddress)
+      case None => this
     }
 
   def isQuarantined(): Boolean = {
-    uniqueRemoteAddressValue match {
+    uniqueRemoteAddress() match {
       case Some(a) => isQuarantined(a.uid)
-      case _       => false // handshake not completed yet
+      case None    => false // handshake not completed yet
     }
   }
 
@@ -174,16 +191,15 @@ private[remote] final class AssociationState(
   def withControlIdleKillSwitch(killSwitch: OptionVal[SharedKillSwitch]): AssociationState =
     new AssociationState(
       incarnation,
-      uniqueRemoteAddressPromise,
       lastUsedTimestamp,
       controlIdleKillSwitch = killSwitch,
-      quarantined)
+      quarantined,
+      _uniqueRemoteAddress)
 
   override def toString(): String = {
-    val a = uniqueRemoteAddressPromise.future.value match {
-      case Some(Success(a)) => a
-      case Some(Failure(e)) => s"Failure($e)"
-      case None             => "unknown"
+    val a = uniqueRemoteAddress() match {
+      case Some(a) => a
+      case None    => "unknown"
     }
     s"AssociationState($incarnation, $a)"
   }
@@ -266,7 +282,7 @@ private[remote] class FlushOnShutdown(
     try {
       associations.foreach { a =>
         val acksExpected = a.sendTerminationHint(self)
-        a.associationState.uniqueRemoteAddressValue() match {
+        a.associationState.uniqueRemoteAddress() match {
           case Some(address) => remaining += address -> acksExpected
           case None          => // Ignore, handshake was not completed on this association
         }
@@ -558,7 +574,7 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
                     log.debug("Incoming ActorRef compression advertisement from [{}], table: [{}]", from, table)
                     val a = association(from.address)
                     // make sure uid is same for active association
-                    if (a.associationState.uniqueRemoteAddressValue().contains(from)) {
+                    if (a.associationState.uniqueRemoteAddress().contains(from)) {
                       import system.dispatcher
                       a.changeActorRefCompression(table).foreach { _ =>
                         a.sendControl(ActorRefCompressionAdvertisementAck(localAddress, table.version))
@@ -589,7 +605,7 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
                     log.debug("Incoming Class Manifest compression advertisement from [{}], table: [{}]", from, table)
                     val a = association(from.address)
                     // make sure uid is same for active association
-                    if (a.associationState.uniqueRemoteAddressValue().contains(from)) {
+                    if (a.associationState.uniqueRemoteAddress().contains(from)) {
                       import system.dispatcher
                       a.changeClassManifestCompression(table).foreach { _ =>
                         a.sendControl(ClassManifestCompressionAdvertisementAck(localAddress, table.version))

--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -274,7 +274,6 @@ private[remote] class Association(
       case _ =>
         // clear outbound compression, it's safe to do that several times if someone else
         // completes handshake at same time, but it's important to clear it before
-        // we signal that the handshake is completed (uniqueRemoteAddressPromise.trySuccess)
         import transport.system.dispatcher
         clearOutboundCompression().map { _ =>
           current.completeUniqueRemoteAddress(peer)

--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -14,7 +14,6 @@ import java.util.concurrent.atomic.AtomicReference
 
 import scala.annotation.tailrec
 import scala.concurrent.Future
-import scala.concurrent.Promise
 import scala.concurrent.duration._
 import akka.{ Done, NotUsed }
 import akka.actor.ActorRef
@@ -268,7 +267,7 @@ private[remote] class Association(
       s"wrong remote address in completeHandshake, got ${peer.address}, expected $remoteAddress")
     val current = associationState
 
-    current.uniqueRemoteAddressValue() match {
+    current.uniqueRemoteAddress() match {
       case Some(`peer`) =>
         // handshake already completed
         Future.successful(Done)
@@ -278,14 +277,14 @@ private[remote] class Association(
         // we signal that the handshake is completed (uniqueRemoteAddressPromise.trySuccess)
         import transport.system.dispatcher
         clearOutboundCompression().map { _ =>
-          current.uniqueRemoteAddressPromise.trySuccess(peer)
-          current.uniqueRemoteAddressValue() match {
+          current.completeUniqueRemoteAddress(peer)
+          current.uniqueRemoteAddress() match {
             case Some(`peer`) =>
             // our value
             case _ =>
-              val newState = current.newIncarnation(Promise.successful(peer))
+              val newState = current.newIncarnation(peer)
               if (swapState(current, newState)) {
-                current.uniqueRemoteAddressValue() match {
+                current.uniqueRemoteAddress() match {
                   case Some(old) =>
                     cancelStopQuarantinedTimer()
                     log.debug(
@@ -466,7 +465,7 @@ private[remote] class Association(
 
   // OutboundContext
   override def quarantine(reason: String): Unit = {
-    val uid = associationState.uniqueRemoteAddressValue().map(_.uid)
+    val uid = associationState.uniqueRemoteAddress().map(_.uid)
     quarantine(reason, uid, harmless = false)
   }
 
@@ -474,7 +473,7 @@ private[remote] class Association(
     uid match {
       case Some(u) =>
         val current = associationState
-        current.uniqueRemoteAddressValue() match {
+        current.uniqueRemoteAddress() match {
           case Some(peer) if peer.uid == u =>
             if (!current.isQuarantined(u)) {
               val newState = current.newQuarantined()

--- a/akka-remote/src/main/scala/akka/remote/artery/Handshake.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Handshake.scala
@@ -77,6 +77,7 @@ private[remote] class OutboundHandshake(
             pull(in)
         }
       }
+      // this must be a `val` because function equality is used when removing in postStop
       private val uniqueRemoteAddressListener: UniqueAddress => Unit =
         peer => uniqueRemoteAddressAsyncCallback.invoke(peer)
 
@@ -135,7 +136,7 @@ private[remote] class OutboundHandshake(
               case Some(_) =>
                 handshakeCompleted()
               case None =>
-                // will pull when handshake reply is received (uniqueRemoteAddress completed)
+                // will pull when handshake reply is received (uniqueRemoteAddress populated)
                 handshakeState = ReqInProgress
                 schedulePeriodically(HandshakeRetryTick, retryInterval)
 

--- a/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/SystemMessageDelivery.scala
@@ -99,7 +99,7 @@ import akka.util.OptionVal
       private def localAddress = outboundContext.localAddress
       private def remoteAddress = outboundContext.remoteAddress
       private def remoteAddressLogParam: String =
-        outboundContext.associationState.uniqueRemoteAddressValue().getOrElse(remoteAddress).toString
+        outboundContext.associationState.uniqueRemoteAddress().getOrElse(remoteAddress).toString
 
       override protected def logSource: Class[_] = classOf[SystemMessageDelivery]
 

--- a/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
@@ -8,8 +8,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ThreadLocalRandom
 import scala.concurrent.Future
-import scala.concurrent.Promise
-import scala.util.Success
 import akka.Done
 import akka.actor.ActorRef
 import akka.actor.Address
@@ -80,11 +78,11 @@ private[remote] class TestOutboundContext(
   }
 
   def completeHandshake(peer: UniqueAddress): Future[Done] = synchronized {
-    _associationState.uniqueRemoteAddressPromise.trySuccess(peer)
-    _associationState.uniqueRemoteAddress.value match {
-      case Some(Success(`peer`)) => // our value
+    _associationState.completeUniqueRemoteAddress(peer)
+    _associationState.uniqueRemoteAddress() match {
+      case Some(`peer`) => // our value
       case _ =>
-        _associationState = _associationState.newIncarnation(Promise.successful(peer))
+        _associationState = _associationState.newIncarnation(peer)
     }
     Future.successful(Done)
   }


### PR DESCRIPTION
* If the handshake doesn't complete the Promise in AssociationState was
  not completed and each new restarted stream added future callback to
  it OutboundHandshake stage. Those references are kept in the promise
  and therefore old OutboundHandshake (and probably entire stream) couldn't
  be garbage collected.
* Using own notification mechanism to have control of listener deregistration
  from postStop instead of using Promise/Future.
* Trying to create new Promise after failure/restart would be difficult due
  to that the same AssociationState Promise is accessed from several outbound
  streams, all possibly restarted individually. Therefore easier to cleanup
  from postStop.

Refs #28390

<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #xxxx

## Changes

<!-- Bullets for important changes in this PR -->

## Background Context

<!-- Why did you take this approach? -->
