### PR TITLE
only check config relation image-liveness-timeout if aeron-upd transport

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
@@ -211,7 +211,8 @@ private[akka] final class ArterySettings private (config: Config) {
       val ImageLivenessTimeout: FiniteDuration = config
         .getMillisDuration("image-liveness-timeout")
         .requiring(interval => interval > Duration.Zero, "image-liveness-timeout must be more than zero")
-      require(ImageLivenessTimeout < HandshakeTimeout, "image-liveness-timeout must be less than handshake-timeout")
+      if (Transport == AeronUpd)
+        require(ImageLivenessTimeout < HandshakeTimeout, "image-liveness-timeout must be less than handshake-timeout")
       val DriverTimeout: FiniteDuration = config
         .getMillisDuration("driver-timeout")
         .requiring(interval => interval > Duration.Zero, "driver-timeout must be more than zero")


### PR DESCRIPTION
when using tcp and changing the handshake-timeout one should not have to care about image-liveness-timeout