### PR TITLE
ByteString performance regression toArray on 2.13

### DIFF
--- a/akka-actor/src/main/mima-filters/2.6.1.backwards.excludes/pr-28419-byte-string-perf-2.13.excludes
+++ b/akka-actor/src/main/mima-filters/2.6.1.backwards.excludes/pr-28419-byte-string-perf-2.13.excludes
@@ -1,0 +1,3 @@
+# Fix for 2.13 performance regression #28419
+ProblemFilters.exclude[FinalMethodProblem]("akka.util.ByteString.copyToArray")
+ProblemFilters.exclude[FinalMethodProblem]("akka.util.ByteString.toArray")

--- a/akka-actor/src/main/scala-2.13+/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala-2.13+/akka/util/ByteString.scala
@@ -253,7 +253,7 @@ object ByteString {
     }
 
     override def copyToArray[B >: Byte](dest: Array[B], start: Int, len: Int): Int = {
-      val copied = math.max(math.min(math.min(len, bytes.length), dest.length - start), 0)
+      val copied = math.min(math.min(len, bytes.length), dest.length - start)
       if (copied > 0) {
         System.arraycopy(bytes, 0, dest, start, copied)
       }
@@ -648,13 +648,13 @@ object ByteString {
       if (isCompact) bytestrings.head.copyToArray(dest, start, len)
       else {
         // min of the bytes available top copy, bytes there is room for in dest and the requested number of bytes
-        val copied = math.max(math.min(math.min(len, length), dest.length - start), 0)
+        val copied = math.min(math.min(len, length), dest.length - start)
         if (copied > 0) {
           val bsIterator = bytestrings.iterator
           var pos = 0
           while (pos < copied) {
             val current = bsIterator.next()
-            val copied = current.copyToArray(dest, pos, len)
+            val copied = current.copyToArray(dest, pos, len - pos)
             pos += copied
           }
         }

--- a/akka-actor/src/main/scala-2.13+/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala-2.13+/akka/util/ByteString.scala
@@ -16,8 +16,6 @@ import scala.collection.immutable.{ IndexedSeq, IndexedSeqOps, StrictOptimizedSe
 import scala.reflect.ClassTag
 import com.github.ghik.silencer.silent
 
-import akka.annotation.InternalApi
-
 object ByteString {
 
   /**
@@ -391,7 +389,6 @@ object ByteString {
     }
 
     override def copyToArray[B >: Byte](xs: Array[B], start: Int, len: Int): Int = {
-      val actualSrcPos = startIndex
       // min of the bytes available top copy, bytes there is room for in dest and the requested number of bytes
       val bytesToCopy = length.min(len).min(xs.length - start)
       if (bytesToCopy > 0) {
@@ -798,7 +795,7 @@ sealed abstract class ByteString
 
   // optimized in all subclasses, avoiding usage of the iterator to save allocations/transformations
   override def copyToArray[B >: Byte](xs: Array[B], start: Int, len: Int): Int =
-    throw new UnsupportedOperationException("Method dropRight is not implemented in ByteString")
+    throw new UnsupportedOperationException("Method copyToArray is not implemented in ByteString")
 
   override def foreach[@specialized U](f: Byte => U): Unit = iterator.foreach(f)
 

--- a/akka-actor/src/main/scala-2.13+/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala-2.13+/akka/util/ByteString.scala
@@ -389,7 +389,7 @@ object ByteString {
     }
 
     override def copyToArray[B >: Byte](xs: Array[B], start: Int, len: Int): Int = {
-      // min of the bytes available top copy, bytes there is room for in dest and the requested number of bytes
+      // min of the bytes available to copy, bytes there is room for in dest and the requested number of bytes
       val bytesToCopy = length.min(len).min(xs.length - start)
       if (bytesToCopy > 0) {
         Array.copy(bytes, startIndex, xs, start, bytesToCopy)

--- a/akka-actor/src/main/scala-2.13+/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala-2.13+/akka/util/ByteString.scala
@@ -255,7 +255,7 @@ object ByteString {
     override def copyToArray[B >: Byte](dest: Array[B], start: Int, len: Int): Int = {
       val copied = math.max(math.min(math.min(len, bytes.length), dest.length - start), 0)
       if (copied > 0) {
-        System.arraycopy(bytes, 0, dest, start, len)
+        System.arraycopy(bytes, 0, dest, start, copied)
       }
       copied
     }
@@ -397,7 +397,7 @@ object ByteString {
       // min of the bytes available to copy, bytes there is room for in dest and the requested number of bytes
       val copied = math.max(math.min(math.min(len, length), dest.length - start), 0)
       if (copied > 0) {
-        Array.copy(bytes, startIndex, dest, start, copied)
+        System.arraycopy(bytes, 0, dest, start, copied)
       }
       copied
     }

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
@@ -21,30 +21,33 @@ class ByteString_toArray_Benchmark {
   var kb = 0
 
   /*
-    akka-bench-jmh/jmh:run -f 1 -wi 3 -i 3 .*ByteString_toArray_Benchmark.*
-    Benchmark             (kb)  Mode   Cnt    Score     Error  Units
+    akka-bench-jmh/jmh:run -f 1 -wi 5 -i 5 .*ByteString_toArray_Benchmark.*
+
+
+    Benchmark             (kb)   Mode  Cnt        Score       Error  Units
     2.12
-    composed_bs_to_array    10  thrpt    3    4,658 ±  14,923  ops/s
-    composed_bs_to_array   100  thrpt    3    5,341 ±   0,384  ops/s
-    composed_bs_to_array  1000  thrpt    3    5,362 ±   1,020  ops/s
-    single_bs_to_array      10  thrpt    3  527,457 ± 279,643  ops/s
-    single_bs_to_array     100  thrpt    3  520,702 ±  50,317  ops/s
-    single_bs_to_array    1000  thrpt    3  523,216 ± 108,398  ops/s
+    composed_bs_to_array    10  thrpt    5     5625.395 ±   145.999  ops/s
+    composed_bs_to_array   100  thrpt    5      464.893 ±    33.579  ops/s
+    composed_bs_to_array  1000  thrpt    5       45.482 ±     4.217  ops/s
+    single_bs_to_array      10  thrpt    5  1450077.491 ± 27964.993  ops/s
+    single_bs_to_array     100  thrpt    5    72201.806 ±   637.800  ops/s
+    single_bs_to_array    1000  thrpt    5     5491.724 ±   178.696  ops/s
+
     2.13 before (second) fix
-    Benchmark             (kb)   Mode  Cnt    Score     Error  Units
-    composed_bs_to_array    10  thrpt    3    0,099 ±   0,012  ops/s
-    composed_bs_to_array   100  thrpt    3    0,101 ±   0,074  ops/s
-    composed_bs_to_array  1000  thrpt    3    0,101 ±   0,059  ops/s
-    single_bs_to_array      10  thrpt    3  515,178 ± 461,701  ops/s
-    single_bs_to_array     100  thrpt    3  515,013 ± 162,183  ops/s
-    single_bs_to_array    1000  thrpt    3  508,825 ± 182,691  ops/s
+    composed_bs_to_array    10  thrpt    5      128.706 ±      4.590  ops/s
+    composed_bs_to_array   100  thrpt    5       13.147 ±      0.435  ops/s
+    composed_bs_to_array  1000  thrpt    5        1.255 ±      0.057  ops/s
+    single_bs_to_array      10  thrpt    5  1336977.040 ± 719295.197  ops/s
+    single_bs_to_array     100  thrpt    5    70202.111 ±    522.435  ops/s
+    single_bs_to_array    1000  thrpt    5     5444.186 ±    224.677  ops/s
+
     2.13 with (second) fix
-    composed_bs_to_array    10  thrpt    3    5,586 ±    0,992  ops/s
-    composed_bs_to_array   100  thrpt    3    5,335 ±    1,976  ops/s
-    composed_bs_to_array  1000  thrpt    3    5,434 ±    0,917  ops/s
-    single_bs_to_array      10  thrpt    3  500,953 ± 1411,704  ops/s
-    single_bs_to_array     100  thrpt    3  531,516 ±   99,146  ops/s
-    single_bs_to_array    1000  thrpt    3  530,254 ±  177,647  ops/s
+    composed_bs_to_array    10  thrpt    5     5970.395 ±   348.356  ops/s
+    composed_bs_to_array   100  thrpt    5      479.762 ±    15.819  ops/s
+    composed_bs_to_array  1000  thrpt    5       45.940 ±     1.306  ops/s
+    single_bs_to_array      10  thrpt    5  1468430.822 ± 38730.696  ops/s
+    single_bs_to_array     100  thrpt    5    71313.855 ±   983.643  ops/s
+    single_bs_to_array    1000  thrpt    5     5526.564 ±   143.654  ops/s
    */
 
   @Setup

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
@@ -19,7 +19,8 @@ class ByteString_toArray_Benchmark {
   var kb = 0
 
   /*
-    Benchmark                                  Mode  Cnt    Score    Error  Units
+    akka-bench-jmh/jmh:run -f 1 -wi 3 -i 3 .*ByteString_toArray_Benchmark.*
+    Benchmark             (kb)  Mode   Cnt    Score     Error  Units
     2.12
     composed_bs_to_array    10  thrpt    3    4,658 ±  14,923  ops/s
     composed_bs_to_array   100  thrpt    3    5,341 ±   0,384  ops/s
@@ -35,13 +36,13 @@ class ByteString_toArray_Benchmark {
     single_bs_to_array      10  thrpt    3  515,178 ± 461,701  ops/s
     single_bs_to_array     100  thrpt    3  515,013 ± 162,183  ops/s
     single_bs_to_array    1000  thrpt    3  508,825 ± 182,691  ops/s
-    2.13 with half good fix
-    composed_bs_to_array    10  thrpt    3    2,570 ±   0,837  ops/s
-    composed_bs_to_array   100  thrpt    3    2,678 ±   0,426  ops/s
-    composed_bs_to_array  1000  thrpt    3    2,674 ±   0,844  ops/s
-    single_bs_to_array      10  thrpt    3  527,974 ± 363,850  ops/s
-    single_bs_to_array     100  thrpt    3  541,335 ± 208,655  ops/s
-    single_bs_to_array    1000  thrpt    3  504,734 ± 319,081  ops/s
+    2.13 with (second) fix
+    composed_bs_to_array    10  thrpt    3    5,297 ±   1,649  ops/s
+    composed_bs_to_array   100  thrpt    3    5,379 ±   2,397  ops/s
+    composed_bs_to_array  1000  thrpt    3    5,462 ±   0,908  ops/s
+    single_bs_to_array      10  thrpt    3  552,889 ± 531,326  ops/s
+    single_bs_to_array     100  thrpt    3  531,280 ± 290,192  ops/s
+    single_bs_to_array    1000  thrpt    3  516,088 ± 190,787  ops/s
    */
 
   @Setup

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
@@ -37,12 +37,12 @@ class ByteString_toArray_Benchmark {
     single_bs_to_array     100  thrpt    3  515,013 ± 162,183  ops/s
     single_bs_to_array    1000  thrpt    3  508,825 ± 182,691  ops/s
     2.13 with (second) fix
-    composed_bs_to_array    10  thrpt    3    5,297 ±   1,649  ops/s
-    composed_bs_to_array   100  thrpt    3    5,379 ±   2,397  ops/s
-    composed_bs_to_array  1000  thrpt    3    5,462 ±   0,908  ops/s
-    single_bs_to_array      10  thrpt    3  552,889 ± 531,326  ops/s
-    single_bs_to_array     100  thrpt    3  531,280 ± 290,192  ops/s
-    single_bs_to_array    1000  thrpt    3  516,088 ± 190,787  ops/s
+    composed_bs_to_array    10  thrpt    3    5,586 ±    0,992  ops/s
+    composed_bs_to_array   100  thrpt    3    5,335 ±    1,976  ops/s
+    composed_bs_to_array  1000  thrpt    3    5,434 ±    0,917  ops/s
+    single_bs_to_array      10  thrpt    3  500,953 ± 1411,704  ops/s
+    single_bs_to_array     100  thrpt    3  531,516 ±   99,146  ops/s
+    single_bs_to_array    1000  thrpt    3  530,254 ±  177,647  ops/s
    */
 
   @Setup

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
@@ -51,7 +51,7 @@ class ByteString_toArray_Benchmark {
   def setup(): Unit = {
     val bytes = Array.ofDim[Byte](1024 * kb)
     bs = ByteString(bytes)
-    var composed = ByteString.empty
+    composed = ByteString.empty
     for (_ <- 0 to 100) {
       composed = composed ++ bs
     }

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
@@ -15,6 +15,8 @@ class ByteString_toArray_Benchmark {
 
   var bs: ByteString = _
 
+  var composed: ByteString = _
+
   @Param(Array("10", "100", "1000"))
   var kb = 0
 
@@ -49,24 +51,20 @@ class ByteString_toArray_Benchmark {
   def setup(): Unit = {
     val bytes = Array.ofDim[Byte](1024 * kb)
     bs = ByteString(bytes)
+    var composed = ByteString.empty
+    for (_ <- 0 to 100) {
+      composed = composed ++ bs
+    }
   }
 
   @Benchmark
-  @OperationsPerInvocation(100)
   def single_bs_to_array(blackhole: Blackhole): Unit = {
-
-    for (_ <- 0 to 100)
-      blackhole.consume(bs.toArray[Byte])
-
+    blackhole.consume(bs.toArray[Byte])
   }
 
   @Benchmark
   def composed_bs_to_array(blackhole: Blackhole): Unit = {
-    var b = ByteString.empty
-    for (_ <- 0 to 100) {
-      b = b ++ bs
-    }
-    blackhole.consume(b.toArray[Byte])
+    blackhole.consume(composed.toArray[Byte])
   }
 
 }

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
@@ -27,7 +27,7 @@ class ByteString_toArray_Benchmark {
     single_bs_to_array      10  thrpt    3  527,457 ± 279,643  ops/s
     single_bs_to_array     100  thrpt    3  520,702 ±  50,317  ops/s
     single_bs_to_array    1000  thrpt    3  523,216 ± 108,398  ops/s
-    2.13 before fix
+    2.13 before (second) fix
     Benchmark             (kb)   Mode  Cnt    Score     Error  Units
     composed_bs_to_array    10  thrpt    3    0,099 ±   0,012  ops/s
     composed_bs_to_array   100  thrpt    3    0,101 ±   0,074  ops/s
@@ -35,8 +35,13 @@ class ByteString_toArray_Benchmark {
     single_bs_to_array      10  thrpt    3  515,178 ± 461,701  ops/s
     single_bs_to_array     100  thrpt    3  515,013 ± 162,183  ops/s
     single_bs_to_array    1000  thrpt    3  508,825 ± 182,691  ops/s
-    2.13 with fix
-    ---
+    2.13 with half good fix
+    composed_bs_to_array    10  thrpt    3    2,570 ±   0,837  ops/s
+    composed_bs_to_array   100  thrpt    3    2,678 ±   0,426  ops/s
+    composed_bs_to_array  1000  thrpt    3    2,674 ±   0,844  ops/s
+    single_bs_to_array      10  thrpt    3  527,974 ± 363,850  ops/s
+    single_bs_to_array     100  thrpt    3  541,335 ± 208,655  ops/s
+    single_bs_to_array    1000  thrpt    3  504,734 ± 319,081  ops/s
    */
 
   @Setup

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
@@ -47,7 +47,7 @@ class ByteString_toArray_Benchmark {
 
   @Setup
   def setup(): Unit = {
-    val bytes = Array.ofDim[Byte](1024 * 10244)
+    val bytes = Array.ofDim[Byte](1024 * kb)
     bs = ByteString(bytes)
   }
 

--- a/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ByteString_toArray_Benchmark.scala
@@ -13,25 +13,54 @@ import org.openjdk.jmh.infra.Blackhole
 @Measurement(timeUnit = TimeUnit.MILLISECONDS)
 class ByteString_toArray_Benchmark {
 
-  val b = Array.ofDim[Byte](1024 * 10244)
-  val bb = ByteString(b)
+  var bs: ByteString = _
+
+  @Param(Array("10", "100", "1000"))
+  var kb = 0
+
   /*
     Benchmark                                  Mode  Cnt    Score    Error  Units
     2.12
-    ByteString_toArray_Benchmark.to_array  thrpt    3  537,116 ± 525,663  ops/s
+    composed_bs_to_array    10  thrpt    3    4,658 ±  14,923  ops/s
+    composed_bs_to_array   100  thrpt    3    5,341 ±   0,384  ops/s
+    composed_bs_to_array  1000  thrpt    3    5,362 ±   1,020  ops/s
+    single_bs_to_array      10  thrpt    3  527,457 ± 279,643  ops/s
+    single_bs_to_array     100  thrpt    3  520,702 ±  50,317  ops/s
+    single_bs_to_array    1000  thrpt    3  523,216 ± 108,398  ops/s
     2.13 before fix
-    ByteString_toArray_Benchmark.to_array  thrpt    3  165,869 ± 243,524  ops/s
-    2.13 with fix #28114
-    ByteString_toArray_Benchmark.to_array  thrpt    3  525,521 ± 346,830  ops/s
+    Benchmark             (kb)   Mode  Cnt    Score     Error  Units
+    composed_bs_to_array    10  thrpt    3    0,099 ±   0,012  ops/s
+    composed_bs_to_array   100  thrpt    3    0,101 ±   0,074  ops/s
+    composed_bs_to_array  1000  thrpt    3    0,101 ±   0,059  ops/s
+    single_bs_to_array      10  thrpt    3  515,178 ± 461,701  ops/s
+    single_bs_to_array     100  thrpt    3  515,013 ± 162,183  ops/s
+    single_bs_to_array    1000  thrpt    3  508,825 ± 182,691  ops/s
+    2.13 with fix
+    ---
    */
 
+  @Setup
+  def setup(): Unit = {
+    val bytes = Array.ofDim[Byte](1024 * 10244)
+    bs = ByteString(bytes)
+  }
+
   @Benchmark
-  @OperationsPerInvocation(1000)
-  def to_array(blackhole: Blackhole) = {
+  @OperationsPerInvocation(100)
+  def single_bs_to_array(blackhole: Blackhole): Unit = {
 
-    for (_ <- 0 to 1000)
-      blackhole.consume(bb.toArray[Byte])
+    for (_ <- 0 to 100)
+      blackhole.consume(bs.toArray[Byte])
 
+  }
+
+  @Benchmark
+  def composed_bs_to_array(blackhole: Blackhole): Unit = {
+    var b = ByteString.empty
+    for (_ <- 0 to 100) {
+      b = b ++ bs
+    }
+    blackhole.consume(b.toArray[Byte])
   }
 
 }


### PR DESCRIPTION
Refs #28137 

## Purpose
On Scala 2.13 calling `toArray` and `copyToArray` would delegate to `ByteIterator` with a `LazyList` causing a severe regression in performance (iterating over individual bytes and hitting a lazy val on every sub-list of a composite `ByteString`). See comment in benchmark for concrete numbers.

## Changes
Introduces a specialized `copyToArray` directly on the 2.13 specific `ByteString` allowing for a single array allocation when turning a composite `ByteString` into an array.
