### PR TITLE
Fixing typo - "timej" to "time"

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
@@ -47,7 +47,7 @@ object Behaviors {
     BehaviorImpl.DeferredBehavior(ctx => factory.apply(ctx.asJava))
 
   /**
-   * Support for stashing messages to unstash at a later timej.
+   * Support for stashing messages to unstash at a later time.
    */
   def withStash[T](capacity: Int, factory: java.util.function.Function[StashBuffer[T], Behavior[T]]): Behavior[T] =
     setup(ctx => {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Behaviors.scala
@@ -30,7 +30,7 @@ object Behaviors {
     BehaviorImpl.DeferredBehavior(factory)
 
   /**
-   * Support for stashing messages to unstash at a later timej.
+   * Support for stashing messages to unstash at a later time.
    */
   def withStash[T](capacity: Int)(factory: StashBuffer[T] => Behavior[T]): Behavior[T] =
     setup(ctx => {


### PR DESCRIPTION
## Purpose

I found a typo in rather - what I consider to be - important class/object `Behaviors`. A made a little fix and I hope it can be merged and can make people who read the source and docs a bit happier.

Thanks for building Akka and good luck to you all!

- Oto