### PR TITLE
Link to replicator case object

### DIFF
--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/Replicator.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/Replicator.scala
@@ -332,6 +332,7 @@ object Replicator {
 
   /**
    * INTERNAL API
+   * Obtain the instance of this class with the [[#flushChanges]] method.
    */
   @InternalApi private[akka] case object FlushChanges extends Command
 

--- a/akka-docs/src/main/paradox/typed/distributed-data.md
+++ b/akka-docs/src/main/paradox/typed/distributed-data.md
@@ -40,12 +40,11 @@ out-of-date value.
 
 ## Using the Replicator
 
-The @apidoc[typed.*.Replicator$]
-actor provides the API for interacting with the data and is accessed through the extension 
-@apidoc[typed.*.DistributedData].
+You can interact with the data through the replicator actor which can be
+accessed through the @apidoc[typed.*.DistributedData] extension.
 
-The messages for the replicator, such as `Replicator.Update` are defined in
-@scala[`akka.cluster.ddata.typed.scaladsl.Replicator`]@java[`akka.cluster.ddata.typed.javaadsl.Replicator`]
+The messages for the replicator, such as @apidoc[typed.*Replicator.Update] are defined as
+subclasses of @apidoc[typed.*Replicator.Command]
 and the actual CRDTs are defined in the `akka.cluster.ddata` package, for example
 @apidoc[akka.cluster.ddata.GCounter]. It requires a @scala[implicit] `akka.cluster.ddata.SelfUniqueAddress`,
 available from:

--- a/akka-docs/src/main/paradox/typed/distributed-data.md
+++ b/akka-docs/src/main/paradox/typed/distributed-data.md
@@ -40,7 +40,7 @@ out-of-date value.
 
 ## Using the Replicator
 
-The @apidoc[typed.*.Replicator]
+The @apidoc[typed.*.Replicator$]
 actor provides the API for interacting with the data and is accessed through the extension 
 @apidoc[typed.*.DistributedData].
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.28")
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.29")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.18")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.3.1") // for maintenance of copyright file header
 addSbtPlugin("com.hpe.sbt" % "sbt-pull-request-validator" % "1.0.0")


### PR DESCRIPTION
Refs #28427

Unfortunately apidoc cannot detect when you link to a class but only the
corresponding object exists in the scaladoc, not the class itself.