### PR TITLE
Report UDP connection error for negatively-cached hostnames

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/UdpConnectedIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpConnectedIntegrationSpec.scala
@@ -48,6 +48,15 @@ class UdpConnectedIntegrationSpec extends AkkaSpec("""
       commander.expectMsg(6.seconds, UdpConnected.CommandFailed(command))
     }
 
+    "report error if can not resolve (cached)" in {
+      val serverAddress = "doesnotexist.local"
+      val commander = TestProbe()
+      val handler = TestProbe()
+      val command = UdpConnected.Connect(handler.ref, InetSocketAddress.createUnresolved(serverAddress, 1234), None)
+      commander.send(IO(UdpConnected), command)
+      commander.expectMsg(6.seconds, UdpConnected.CommandFailed(command))
+    }
+
     "be able to send and receive without binding" in {
       val serverAddress = addresses(0)
       val server = bindUdp(serverAddress, testActor)

--- a/akka-actor/src/main/scala/akka/io/InetAddressDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/InetAddressDnsResolver.scala
@@ -121,6 +121,7 @@ class InetAddressDnsResolver(cache: SimpleDnsCache, config: Config) extends Acto
       val answer = cache.cached(r) match {
         case Some(a) => a
         case None =>
+          log.debug("Request for [{}] was not yet cached", name)
           try {
             val addresses: Array[InetAddress] = InetAddress.getAllByName(name)
             val records = addressToRecords(name, addresses.toList, ipv4, ipv6)

--- a/akka-actor/src/main/scala/akka/io/UdpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnection.scala
@@ -43,9 +43,11 @@ private[io] class UdpConnection(
   if (remoteAddress.isUnresolved) {
     Dns.resolve(DnsProtocol.Resolve(remoteAddress.getHostName), context.system, self) match {
       case Some(r) =>
-        doConnect(new InetSocketAddress(r.address(), remoteAddress.getPort))
+        reportConnectFailure {
+          doConnect(new InetSocketAddress(r.address(), remoteAddress.getPort))
+        }
       case None =>
-        context.become(resolving(), discardOld = true)
+        context.become(resolving())
     }
   } else {
     doConnect(remoteAddress)


### PR DESCRIPTION
When creating an UDP connection for a hostname for which we already have a
'negative cache' saying it cannot be resolved, report that as an error
as well.

Noticed while looking at #28133, but looking closer at the logs that seems
like a different problem. Added logging that might make it easier to diagnose.