### PR TITLE
Deprecate EventEnvelope ctor without timestamp

### DIFF
--- a/akka-persistence-query/src/main/scala/akka/persistence/query/EventEnvelope.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/EventEnvelope.scala
@@ -13,6 +13,7 @@ object EventEnvelope extends AbstractFunction4[Offset, String, Long, Any, EventE
   def apply(offset: Offset, persistenceId: String, sequenceNr: Long, event: Any, timestamp: Long): EventEnvelope =
     new EventEnvelope(offset, persistenceId, sequenceNr, event, timestamp)
 
+  @deprecated("for binary compatibility", "2.6.2")
   override def apply(offset: Offset, persistenceId: String, sequenceNr: Long, event: Any): EventEnvelope =
     new EventEnvelope(offset, persistenceId, sequenceNr, event)
 
@@ -37,7 +38,7 @@ final class EventEnvelope(
     extends Product4[Offset, String, Long, Any]
     with Serializable {
 
-  // for binary compatibility
+  @deprecated("for binary compatibility", "2.6.2")
   def this(offset: Offset, persistenceId: String, sequenceNr: Long, event: Any) =
     this(offset, persistenceId, sequenceNr, event, 0L)
 

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/EventsByTagSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/journal/leveldb/EventsByTagSpec.scala
@@ -86,18 +86,18 @@ class EventsByTagSpec extends AkkaSpec(EventsByTagSpec.config) with Cleanup with
       greenSrc
         .runWith(TestSink.probe[Any])
         .request(2)
-        .expectNext(EventEnvelope(Sequence(1L), "a", 2L, "a green apple"))
-        .expectNext(EventEnvelope(Sequence(2L), "a", 3L, "a green banana"))
+        .expectNext(EventEnvelope(Sequence(1L), "a", 2L, "a green apple", 0L))
+        .expectNext(EventEnvelope(Sequence(2L), "a", 3L, "a green banana", 0L))
         .expectNoMessage(500.millis)
         .request(2)
-        .expectNext(EventEnvelope(Sequence(3L), "b", 2L, "a green leaf"))
+        .expectNext(EventEnvelope(Sequence(3L), "b", 2L, "a green leaf", 0L))
         .expectComplete()
 
       val blackSrc = queries.currentEventsByTag(tag = "black", offset = Sequence(0L))
       blackSrc
         .runWith(TestSink.probe[Any])
         .request(5)
-        .expectNext(EventEnvelope(Sequence(1L), "b", 1L, "a black car"))
+        .expectNext(EventEnvelope(Sequence(1L), "b", 1L, "a black car", 0L))
         .expectComplete()
     }
 
@@ -108,8 +108,8 @@ class EventsByTagSpec extends AkkaSpec(EventsByTagSpec.config) with Cleanup with
       val probe = greenSrc
         .runWith(TestSink.probe[Any])
         .request(2)
-        .expectNext(EventEnvelope(Sequence(1L), "a", 2L, "a green apple"))
-        .expectNext(EventEnvelope(Sequence(2L), "a", 3L, "a green banana"))
+        .expectNext(EventEnvelope(Sequence(1L), "a", 2L, "a green apple", 0L))
+        .expectNext(EventEnvelope(Sequence(2L), "a", 3L, "a green banana", 0L))
         .expectNoMessage(100.millis)
 
       c ! "a green cucumber"
@@ -118,7 +118,7 @@ class EventsByTagSpec extends AkkaSpec(EventsByTagSpec.config) with Cleanup with
       probe
         .expectNoMessage(100.millis)
         .request(5)
-        .expectNext(EventEnvelope(Sequence(3L), "b", 2L, "a green leaf"))
+        .expectNext(EventEnvelope(Sequence(3L), "b", 2L, "a green leaf", 0L))
         .expectComplete() // green cucumber not seen
     }
 
@@ -128,8 +128,8 @@ class EventsByTagSpec extends AkkaSpec(EventsByTagSpec.config) with Cleanup with
         .runWith(TestSink.probe[Any])
         .request(10)
         // note that banana is not included, since exclusive offset
-        .expectNext(EventEnvelope(Sequence(3L), "b", 2L, "a green leaf"))
-        .expectNext(EventEnvelope(Sequence(4L), "c", 1L, "a green cucumber"))
+        .expectNext(EventEnvelope(Sequence(3L), "b", 2L, "a green leaf", 0L))
+        .expectNext(EventEnvelope(Sequence(4L), "c", 1L, "a green cucumber", 0L))
         .expectComplete()
     }
 
@@ -145,15 +145,15 @@ class EventsByTagSpec extends AkkaSpec(EventsByTagSpec.config) with Cleanup with
       val pinkSrc = queries.currentEventsByTag(tag = "pink")
       val probe = pinkSrc.runWith(TestSink.probe[Any])
 
-      probe.request(1).expectNext(EventEnvelope(Sequence(1L), "z", 1L, "a pink apple"))
+      probe.request(1).expectNext(EventEnvelope(Sequence(1L), "z", 1L, "a pink apple", 0L))
 
       system.log.info("delay before demand")
 
       probe
         .expectNoMessage(200.millis)
         .request(3)
-        .expectNext(EventEnvelope(Sequence(2L), "z", 2L, "a pink banana"))
-        .expectNext(EventEnvelope(Sequence(3L), "z", 3L, "a pink orange"))
+        .expectNext(EventEnvelope(Sequence(2L), "z", 2L, "a pink banana", 0L))
+        .expectNext(EventEnvelope(Sequence(3L), "z", 3L, "a pink orange", 0L))
         .expectComplete()
 
     }
@@ -179,7 +179,7 @@ class EventsByTagSpec extends AkkaSpec(EventsByTagSpec.config) with Cleanup with
 
       try {
 
-        probe.request(2).expectNext(EventEnvelope(Sequence(1L), "b", 1L, "a black car")).expectNoMessage(100.millis)
+        probe.request(2).expectNext(EventEnvelope(Sequence(1L), "b", 1L, "a black car", 0L)).expectNoMessage(100.millis)
 
         d ! "a black dog"
         expectMsg(s"a black dog-done")
@@ -187,10 +187,10 @@ class EventsByTagSpec extends AkkaSpec(EventsByTagSpec.config) with Cleanup with
         expectMsg(s"a black night-done")
 
         probe
-          .expectNext(EventEnvelope(Sequence(2L), "d", 1L, "a black dog"))
+          .expectNext(EventEnvelope(Sequence(2L), "d", 1L, "a black dog", 0L))
           .expectNoMessage(100.millis)
           .request(10)
-          .expectNext(EventEnvelope(Sequence(3L), "d", 2L, "a black night"))
+          .expectNext(EventEnvelope(Sequence(3L), "d", 2L, "a black night", 0L))
       } finally {
         probe.cancel()
       }
@@ -203,8 +203,8 @@ class EventsByTagSpec extends AkkaSpec(EventsByTagSpec.config) with Cleanup with
         probe
           .request(10)
           // note that banana is not included, since exclusive offset
-          .expectNext(EventEnvelope(Sequence(3L), "b", 2L, "a green leaf"))
-          .expectNext(EventEnvelope(Sequence(4L), "c", 1L, "a green cucumber"))
+          .expectNext(EventEnvelope(Sequence(3L), "b", 2L, "a green leaf", 0L))
+          .expectNext(EventEnvelope(Sequence(4L), "c", 1L, "a green cucumber", 0L))
           .expectNoMessage(100.millis)
       } finally {
         probe.cancel()
@@ -222,7 +222,7 @@ class EventsByTagSpec extends AkkaSpec(EventsByTagSpec.config) with Cleanup with
       val probe = yellowSrc
         .runWith(TestSink.probe[Any])
         .request(2)
-        .expectNext(EventEnvelope(Sequence(1L), "y", 1L, "a yellow car"))
+        .expectNext(EventEnvelope(Sequence(1L), "y", 1L, "a yellow car", 0L))
         .expectNoMessage(100.millis)
 
       d ! "a yellow dog"
@@ -231,10 +231,10 @@ class EventsByTagSpec extends AkkaSpec(EventsByTagSpec.config) with Cleanup with
       expectMsg(s"a yellow night-done")
 
       probe
-        .expectNext(EventEnvelope(Sequence(2L), "y", 2L, "a yellow dog"))
+        .expectNext(EventEnvelope(Sequence(2L), "y", 2L, "a yellow dog", 0L))
         .expectNoMessage(100.millis)
         .request(10)
-        .expectNext(EventEnvelope(Sequence(3L), "y", 3L, "a yellow night"))
+        .expectNext(EventEnvelope(Sequence(3L), "y", 3L, "a yellow night", 0L))
 
       probe.cancel()
     }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -461,7 +461,7 @@ class EventSourcedBehaviorSpec
       replyProbe.expectMessage(State(1, Vector(0)))
 
       val events = queries.currentEventsByTag("tag1").runWith(Sink.seq).futureValue
-      events shouldEqual List(EventEnvelope(Sequence(1), pid.id, 1, Incremented(1)))
+      events shouldEqual List(EventEnvelope(Sequence(1), pid.id, 1, Incremented(1), 0L))
     }
 
     "handle scheduled message arriving before recovery completed " in {

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedEventAdapterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedEventAdapterSpec.scala
@@ -191,7 +191,7 @@ class EventSourcedEventAdapterSpec
       replyProbe.expectMessage(State(1, Vector(0)))
 
       val events = queries.currentEventsByPersistenceId(pid.id).runWith(Sink.seq).futureValue
-      events shouldEqual List(EventEnvelope(Sequence(1), pid.id, 1, GenericWrapper(Incremented(1))))
+      events shouldEqual List(EventEnvelope(Sequence(1), pid.id, 1, GenericWrapper(Incremented(1)), 0L))
 
       val c2 =
         spawn(Behaviors.setup[Command](ctx => counter(ctx, pid).eventAdapter(new GenericWrapperEventAdapter[Event])))
@@ -212,8 +212,8 @@ class EventSourcedEventAdapterSpec
 
       val events = queries.currentEventsByPersistenceId(pid.id).runWith(Sink.seq).futureValue
       events shouldEqual List(
-        EventEnvelope(Sequence(1), pid.id, 1, GenericWrapper(Incremented(1))),
-        EventEnvelope(Sequence(2), pid.id, 2, GenericWrapper(Incremented(1))))
+        EventEnvelope(Sequence(1), pid.id, 1, GenericWrapper(Incremented(1)), 0L),
+        EventEnvelope(Sequence(2), pid.id, 2, GenericWrapper(Incremented(1)), 0L))
 
       val c2 =
         spawn(Behaviors.setup[Command](ctx => counter(ctx, pid).eventAdapter(new GenericWrapperEventAdapter[Event])))
@@ -232,7 +232,7 @@ class EventSourcedEventAdapterSpec
       replyProbe.expectMessage(State(1, Vector(0)))
 
       val events = queries.currentEventsByPersistenceId(pid.id).runWith(Sink.seq).futureValue
-      events shouldEqual List(EventEnvelope(Sequence(1), pid.id, 1, GenericWrapper(Incremented(1))))
+      events shouldEqual List(EventEnvelope(Sequence(1), pid.id, 1, GenericWrapper(Incremented(1)), 0L))
 
       val c2 =
         spawn(Behaviors.setup[Command](ctx => counter(ctx, pid).eventAdapter(new GenericWrapperEventAdapter[Event])))
@@ -240,7 +240,7 @@ class EventSourcedEventAdapterSpec
       replyProbe.expectMessage(State(1, Vector(0)))
 
       val taggedEvents = queries.currentEventsByTag("tag99").runWith(Sink.seq).futureValue
-      taggedEvents shouldEqual List(EventEnvelope(Sequence(1), pid.id, 1, GenericWrapper(Incremented(1))))
+      taggedEvents shouldEqual List(EventEnvelope(Sequence(1), pid.id, 1, GenericWrapper(Incremented(1)), 0L))
     }
   }
 }


### PR DESCRIPTION
Follow-up on #28383. A bit noisier in test, but perhaps safer?