### PR TITLE
Re enable stress spec artery

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -127,10 +127,6 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
     akka.loglevel = INFO
     akka.remote.log-remote-lifecycle-events = off
 
-    akka.remote.artery.advanced.aeron {
-      idle-cpu-level = 1
-    }
-
     akka.actor.default-dispatcher.fork-join-executor {
       parallelism-min = 8
       parallelism-max = 8
@@ -1168,10 +1164,6 @@ abstract class StressSpec
       }
       enterBarrier("after-" + step)
     }
-
-    // FIXME issue #21810
-    // note: there must be one test step before pending, otherwise afterTermination will not run
-    if (isArteryEnabled) pending
 
     "join seed nodes" taggedAs LongRunningTest in within(30 seconds) {
 

--- a/akka-remote/src/main/scala/akka/remote/artery/RemotingFlightRecorder.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/RemotingFlightRecorder.scala
@@ -32,8 +32,7 @@ object RemotingFlightRecorder extends ExtensionId[RemotingFlightRecorder] with E
         (classOf[ExtendedActorSystem], system) :: Nil) match {
         case Success(jfr) => jfr
         case Failure(ex) =>
-          system.log
-            .warning("Failed to load JFR remoting flight recorder, falling back to noop. Exception: {}", ex.getMessage)
+          system.log.warning("Failed to load JFR remoting flight recorder, falling back to noop. Exception: {}", ex)
           NoOpRemotingFlightRecorder
       } // fallback if not possible to dynamically load for some reason
     } else


### PR DESCRIPTION
Refs #28344

Only enables for artery without aeron as I couldn't figure out a way to make the tests pass with the embedded driver. artery-tcp seems to pass just fine both locally and in jenkins repeat job