### PR TITLE
Use MessageBuffer in RecoveryPermitter, #28417

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/MessageBufferSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/MessageBufferSpec.scala
@@ -58,6 +58,77 @@ class MessageBufferSpec extends WordSpec with Matchers {
       buffer.foreach((m, s) => sb2.append(s"$m->$s:"))
       sb2.toString() should ===("m2->s2:m3->s3:")
     }
+
+    "filterNot of first" in {
+      val buffer = MessageBuffer.empty
+      buffer.append("m1", "s1")
+      buffer.append("m2", "s2")
+      buffer.filterNot((m, _) => m == "m1")
+      buffer.head()._1 should ===("m2")
+      buffer.size should ===(1)
+      buffer.filterNot((m, _) => m == "m2")
+      buffer.isEmpty should ===(true)
+    }
+
+    "filterNot of last" in {
+      val buffer = MessageBuffer.empty
+      buffer.append("m1", "s1")
+      buffer.append("m2", "s2")
+      buffer.filterNot((m, _) => m == "m2")
+      buffer.head()._1 should ===("m1")
+      buffer.size should ===(1)
+      buffer.filterNot((m, _) => m == "m1")
+      buffer.isEmpty should ===(true)
+    }
+
+    "filterNot of single entry" in {
+      val buffer = MessageBuffer.empty
+      buffer.append("m1", "s1")
+      buffer.append("m2", "s2")
+      buffer.append("m3", "s3")
+      buffer.append("m4", "s4")
+      buffer.append("m5", "s5")
+      buffer.append("m6", "s6")
+      buffer.head()._1 should ===("m1")
+      buffer.filterNot((m, _) => m == "m1")
+      buffer.head()._1 should ===("m2")
+      buffer.size should ===(5)
+      buffer.filterNot((m, _) => m == "m3")
+      buffer.size should ===(4)
+      buffer.filterNot((m, _) => m == "m4")
+      buffer.size should ===(3)
+      buffer.dropHead()
+      buffer.head()._1 should ===("m5")
+      buffer.size should ===(2)
+      buffer.filterNot((m, _) => m == "m6")
+      buffer.size should ===(1)
+      buffer.append("m7", "s7")
+      buffer.head()._1 should ===("m5")
+      buffer.size should ===(2)
+      buffer.filterNot((m, _) => m == "m5")
+      buffer.size should ===(1)
+      buffer.filterNot((m, _) => m == "m7")
+      buffer.size should ===(0)
+      buffer.isEmpty should ===(true)
+    }
+
+    "filterNot of several entries" in {
+      val buffer = MessageBuffer.empty
+      buffer.append("m1", "s1")
+      buffer.append("m2", "s2")
+      buffer.append("m3", "s3")
+      buffer.append("m4", "s4")
+      buffer.append("m5", "s5")
+      buffer.append("m6", "s6")
+      buffer.filterNot((m, _) => m == "m1" || m == "m2")
+      buffer.head()._1 should ===("m3")
+      buffer.size should ===(4)
+      buffer.filterNot((m, _) => m == "m4" || m == "m5")
+      buffer.size should ===(2)
+      buffer.dropHead()
+      buffer.head()._1 should ===("m6")
+      buffer.size should ===(1)
+    }
   }
 
   "A MessageBufferMap" must {

--- a/akka-actor/src/main/scala/akka/util/MessageBuffer.scala
+++ b/akka-actor/src/main/scala/akka/util/MessageBuffer.scala
@@ -5,6 +5,7 @@
 package akka.util
 
 import akka.actor.ActorRef
+import akka.annotation.InternalApi
 import akka.japi.function.Procedure2
 
 /**
@@ -109,6 +110,42 @@ final class MessageBuffer private (private var _head: MessageBuffer.Node, privat
    * @param f the function to apply to each element
    */
   def forEach(f: Procedure2[Any, ActorRef]): Unit = foreach { case (message, ref) => f(message, ref) }
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] def filterNot(p: (Any, ActorRef) => Boolean): Unit = {
+    // easiest to collect a new list, and then re-link the nodes
+    var result = Vector.empty[Node]
+    var node = _head
+    while (node ne null) {
+      if (!p(node.message, node.ref)) {
+        result :+= node
+      }
+      node = node.next
+    }
+
+    _size = result.size
+    if (_size == 0) {
+      _head = null
+      _tail = null
+    } else if (_size == 1) {
+      _head = result.head
+      _tail = result.head
+      _tail.next = null
+    } else {
+      _head = result.head
+      _tail = result.last
+      _tail.next = null
+      var i = 0
+      while (i < result.size) {
+        val node = result(i)
+        if (node ne _tail)
+          node.next = result(i + 1)
+        i += 1
+      }
+    }
+  }
 }
 
 object MessageBuffer {
@@ -116,6 +153,8 @@ object MessageBuffer {
     def apply(f: (Any, ActorRef) => Unit): Unit = {
       f(message, ref)
     }
+
+    override def toString: String = s"Node($message,$ref)"
   }
 
   /**

--- a/akka-persistence/src/main/scala/akka/persistence/RecoveryPermitter.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/RecoveryPermitter.scala
@@ -4,13 +4,13 @@
 
 package akka.persistence
 
-import java.util.LinkedList
 import akka.annotation.InternalApi
 import akka.actor.Actor
 import akka.actor.ActorLogging
 import akka.actor.ActorRef
 import akka.actor.Props
 import akka.actor.Terminated
+import akka.util.MessageBuffer
 
 /**
  * INTERNAL API
@@ -37,7 +37,7 @@ import akka.actor.Terminated
   import RecoveryPermitter._
 
   private var usedPermits = 0
-  private val pending = new LinkedList[ActorRef]
+  private val pending = MessageBuffer.empty
   private var maxPendingStats = 0
 
   def receive = {
@@ -46,7 +46,7 @@ import akka.actor.Terminated
       if (usedPermits >= maxPermits) {
         if (pending.isEmpty)
           log.debug("Exceeded max-concurrent-recoveries [{}]. First pending {}", maxPermits, sender())
-        pending.offer(sender())
+        pending.append(RequestRecoveryPermit, sender())
         maxPendingStats = math.max(maxPendingStats, pending.size)
       } else {
         recoveryPermitGranted(sender())
@@ -57,8 +57,10 @@ import akka.actor.Terminated
 
     case Terminated(ref) =>
       // pre-mature termination should be rare
-      if (!pending.remove(ref))
-        onReturnRecoveryPermit(ref)
+      val before = pending.size
+      pending.filterNot { case (_, r) => r == ref }
+      if (before == pending.size)
+        onReturnRecoveryPermit(ref) // it wasn't pending, so return permit
   }
 
   private def onReturnRecoveryPermit(ref: ActorRef): Unit = {
@@ -66,7 +68,8 @@ import akka.actor.Terminated
     context.unwatch(ref)
     if (usedPermits < 0) throw new IllegalStateException(s"permits must not be negative (returned by: ${ref})")
     if (!pending.isEmpty) {
-      val ref = pending.poll()
+      val ref = pending.head()._2
+      pending.dropHead()
       recoveryPermitGranted(ref)
     }
     if (pending.isEmpty && maxPendingStats > 0) {


### PR DESCRIPTION
Backport of https://github.com/akka/akka/pull/28418

* to propagate trace context

(cherry picked from commit 44cac83d0fa9aabf722334adc396992dbbfd5750)
