### PR TITLE
Rename Start message in HelloWorld

### DIFF
--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/IntroTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/IntroTest.java
@@ -106,36 +106,36 @@ public interface IntroTest {
 
   // #hello-world-main
   // #hello-world-main-setup
-  public class HelloWorldMain extends AbstractBehavior<HelloWorldMain.Start> {
+  public class HelloWorldMain extends AbstractBehavior<HelloWorldMain.SayHello> {
     // #hello-world-main-setup
 
-    public static class Start {
+    public static class SayHello {
       public final String name;
 
-      public Start(String name) {
+      public SayHello(String name) {
         this.name = name;
       }
     }
 
     // #hello-world-main-setup
-    public static Behavior<Start> create() {
+    public static Behavior<SayHello> create() {
       return Behaviors.setup(HelloWorldMain::new);
     }
 
     private final ActorRef<HelloWorld.Greet> greeter;
 
-    private HelloWorldMain(ActorContext<Start> context) {
+    private HelloWorldMain(ActorContext<SayHello> context) {
       super(context);
       greeter = context.spawn(HelloWorld.create(), "greeter");
     }
     // #hello-world-main-setup
 
     @Override
-    public Receive<Start> createReceive() {
-      return newReceiveBuilder().onMessage(Start.class, this::onStart).build();
+    public Receive<SayHello> createReceive() {
+      return newReceiveBuilder().onMessage(SayHello.class, this::onStart).build();
     }
 
-    private Behavior<Start> onStart(Start command) {
+    private Behavior<SayHello> onStart(SayHello command) {
       ActorRef<HelloWorld.Greeted> replyTo =
           getContext().spawn(HelloWorldBot.create(3), command.name);
       greeter.tell(new HelloWorld.Greet(command.name, replyTo));
@@ -148,35 +148,35 @@ public interface IntroTest {
 
   interface CustomDispatchersExample {
 
-    public static class Start {
+    public static class SayHello {
       public final String name;
 
-      public Start(String name) {
+      public SayHello(String name) {
         this.name = name;
       }
     }
 
     // #hello-world-main-with-dispatchers
-    public class HelloWorldMain extends AbstractBehavior<HelloWorldMain.Start> {
+    public class HelloWorldMain extends AbstractBehavior<HelloWorldMain.SayHello> {
 
       // Start message...
       // #hello-world-main-with-dispatchers
-      public static class Start {
+      public static class SayHello {
         public final String name;
 
-        public Start(String name) {
+        public SayHello(String name) {
           this.name = name;
         }
       }
       // #hello-world-main-with-dispatchers
 
-      public static Behavior<Start> create() {
+      public static Behavior<SayHello> create() {
         return Behaviors.setup(HelloWorldMain::new);
       }
 
       private final ActorRef<HelloWorld.Greet> greeter;
 
-      private HelloWorldMain(ActorContext<Start> context) {
+      private HelloWorldMain(ActorContext<SayHello> context) {
         super(context);
 
         final String dispatcherPath = "akka.actor.default-blocking-io-dispatcher";
@@ -187,7 +187,7 @@ public interface IntroTest {
       // createReceive ...
       // #hello-world-main-with-dispatchers
       @Override
-      public Receive<HelloWorldMain.Start> createReceive() {
+      public Receive<SayHello> createReceive() {
         return null;
       }
       // #hello-world-main-with-dispatchers
@@ -197,11 +197,11 @@ public interface IntroTest {
 
   public static void main(String[] args) throws Exception {
     // #hello-world
-    final ActorSystem<HelloWorldMain.Start> system =
+    final ActorSystem<HelloWorldMain.SayHello> system =
         ActorSystem.create(HelloWorldMain.create(), "hello");
 
-    system.tell(new HelloWorldMain.Start("World"));
-    system.tell(new HelloWorldMain.Start("Akka"));
+    system.tell(new HelloWorldMain.SayHello("World"));
+    system.tell(new HelloWorldMain.SayHello("Akka"));
     // #hello-world
 
     Thread.sleep(3000);

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
@@ -74,9 +74,9 @@ object IntroSpec {
   //#hello-world-main
   object HelloWorldMain {
 
-    final case class Start(name: String)
+    final case class SayHello(name: String)
 
-    def apply(): Behavior[Start] =
+    def apply(): Behavior[SayHello] =
       Behaviors.setup { context =>
         val greeter = context.spawn(HelloWorld(), "greeter")
 
@@ -232,11 +232,11 @@ class IntroSpec extends ScalaTestWithActorTestKit with WordSpecLike with LogCapt
       //#fiddle_code
       //#hello-world
 
-      val system: ActorSystem[HelloWorldMain.Start] =
+      val system: ActorSystem[HelloWorldMain.SayHello] =
         ActorSystem(HelloWorldMain(), "hello")
 
-      system ! HelloWorldMain.Start("World")
-      system ! HelloWorldMain.Start("Akka")
+      system ! HelloWorldMain.SayHello("World")
+      system ! HelloWorldMain.SayHello("Akka")
 
       //#hello-world
       //#fiddle_code

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
@@ -94,10 +94,10 @@ object IntroSpec {
   object CustomDispatchersExample {
     object HelloWorldMain {
 
-      final case class Start(name: String)
+      final case class SayHello(name: String)
 
       //#hello-world-main-with-dispatchers
-      def apply(): Behavior[Start] =
+      def apply(): Behavior[SayHello] =
         Behaviors.setup { context =>
           val dispatcherPath = "akka.actor.default-blocking-io-dispatcher"
 

--- a/akka-docs/src/main/paradox/typed/actors.md
+++ b/akka-docs/src/main/paradox/typed/actors.md
@@ -132,7 +132,7 @@ Scala
 Java
 :  @@snip [IntroSpec.scala](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/IntroTest.java) { #hello-world }
 
-We start an Actor system from the defined `HelloWorldMain` behavior and send two `Start` messages that
+We start an Actor system from the defined `HelloWorldMain` behavior and send two `SayHello` messages that
 will kick-off the interaction between two separate `HelloWorldBot` actors and the single `Greeter` actor.
 
 An application normally consists of a single `ActorSystem`, running many actors, per JVM. 

--- a/akka-persistence/src/test/scala/akka/persistence/journal/inmem/InmemJournalSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/journal/inmem/InmemJournalSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence.journal.inmem


### PR DESCRIPTION
Someone said that the `Start` message could be misleading into the thinking that initialization of an actor should be done with a start message.

I'm not sure what to call it. Suggestions welcome. I'll make changes at more places when we have decided the name.