### PR TITLE
Shard region registration to more potential oldest, #28416

### DIFF
--- a/akka-cluster-sharding/src/main/mima-filters/2.6.1.backwards.excludes/issue-28416-region-registration.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.6.1.backwards.excludes/issue-28416-region-registration.excludes
@@ -1,0 +1,3 @@
+# #28416 change of coordinatorSelection in internal ShardRegion actor
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.cluster.sharding.ShardRegion.coordinatorSelection")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.ShardRegion.gracefulShutdownCoordinatorSelections")

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -6,6 +6,7 @@ package akka.cluster.sharding
 
 import java.net.URLEncoder
 
+import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.Future
@@ -506,6 +507,9 @@ private[akka] class ShardRegion(
   // sort by age, oldest first
   val ageOrdering = Member.ageOrdering
   var membersByAge: immutable.SortedSet[Member] = immutable.SortedSet.empty(ageOrdering)
+  // membersByAge contains members with these status
+  private val memberStatusOfInterest: Set[MemberStatus] =
+    Set(MemberStatus.Up, MemberStatus.Leaving, MemberStatus.Exiting)
 
   var regions = Map.empty[ActorRef, Set[ShardId]]
   var regionByShard = Map.empty[ShardId, ActorRef]
@@ -568,16 +572,26 @@ private[akka] class ShardRegion(
   def matchingRole(member: Member): Boolean =
     member.hasRole(targetDcRole) && role.forall(member.hasRole)
 
-  def coordinatorSelection: Option[ActorSelection] =
-    membersByAge.headOption.map(m => context.actorSelection(RootActorPath(m.address).toString + coordinatorPath))
-
   /**
    * When leaving the coordinator singleton is started rather quickly on next
-   * oldest node and therefore it is good to send the GracefulShutdownReq to
+   * oldest node and therefore it is good to send the Register and GracefulShutdownReq to
    * the likely locations of the coordinator.
    */
-  def gracefulShutdownCoordinatorSelections: List[ActorSelection] =
-    membersByAge.take(2).toList.map(m => context.actorSelection(RootActorPath(m.address).toString + coordinatorPath))
+  def coordinatorSelection: List[ActorSelection] = {
+    @tailrec def select(result: List[Member], remaining: immutable.SortedSet[Member]): List[Member] = {
+      if (remaining.isEmpty)
+        result
+      else {
+        val m = remaining.head
+        if (m.status == MemberStatus.Up)
+          m :: result
+        else
+          select(m :: result, remaining.tail)
+      }
+    }
+
+    select(Nil, membersByAge).map(m => context.actorSelection(RootActorPath(m.address).toString + coordinatorPath))
+  }
 
   var coordinator: Option[ActorRef] = None
 
@@ -616,14 +630,16 @@ private[akka] class ShardRegion(
     changeMembers(
       immutable.SortedSet
         .empty(ageOrdering)
-        .union(state.members.filter(m => m.status == MemberStatus.Up && matchingRole(m))))
+        .union(state.members.filter(m => memberStatusOfInterest(m.status) && matchingRole(m))))
   }
 
   def receiveClusterEvent(evt: ClusterDomainEvent): Unit = evt match {
     case MemberUp(m) =>
-      if (matchingRole(m))
-        // replace, it's possible that the upNumber is changed
-        changeMembers(membersByAge.filterNot(_.uniqueAddress == m.uniqueAddress) + m)
+      addMember(m)
+    case MemberLeft(m) =>
+      addMember(m)
+    case MemberExited(m) =>
+      addMember(m)
 
     case MemberRemoved(m, _) =>
       if (m.uniqueAddress == cluster.selfUniqueAddress)
@@ -640,6 +656,13 @@ private[akka] class ShardRegion(
     case _: MemberEvent => // these are expected, no need to warn about them
 
     case _ => unhandled(evt)
+  }
+
+  private def addMember(m: Member): Unit = {
+    if (matchingRole(m) && memberStatusOfInterest(m.status)) {
+      // replace, it's possible that the status, or upNumber is changed
+      changeMembers(membersByAge.filterNot(_.uniqueAddress == m.uniqueAddress) + m)
+    }
   }
 
   def receiveCoordinatorMessage(msg: CoordinatorMessage): Unit = msg match {
@@ -862,23 +885,25 @@ private[akka] class ShardRegion(
   }
 
   def register(): Unit = {
-    coordinatorSelection.foreach(_ ! registrationMessage)
-    if (shardBuffers.nonEmpty && retryCount >= 5) coordinatorSelection match {
-      case Some(actorSelection) =>
+    val actorSelections = coordinatorSelection
+    actorSelections.foreach(_ ! registrationMessage)
+    if (shardBuffers.nonEmpty && retryCount >= 5) {
+      if (actorSelections.nonEmpty) {
         val coordinatorMessage =
           if (cluster.state.unreachable(membersByAge.head)) s"Coordinator [${membersByAge.head}] is unreachable."
           else s"Coordinator [${membersByAge.head}] is reachable."
         log.warning(
           "{}: Trying to register to coordinator at [{}], but no acknowledgement. Total [{}] buffered messages. [{}]",
           typeName,
-          actorSelection,
+          actorSelections.mkString(", "),
           shardBuffers.totalSize,
           coordinatorMessage)
-      case None =>
+      } else {
         log.warning(
           "{}: No coordinator found to register. Probably, no seed-nodes configured and manual cluster join not performed? Total [{}] buffered messages.",
           typeName,
           shardBuffers.totalSize)
+      }
     }
   }
 
@@ -1067,6 +1092,6 @@ private[akka] class ShardRegion(
 
   def sendGracefulShutdownToCoordinator(): Unit = {
     if (gracefulShutdownInProgress)
-      gracefulShutdownCoordinatorSelections.foreach(_ ! GracefulShutdownReq(self))
+      coordinatorSelection.foreach(_ ! GracefulShutdownReq(self))
   }
 }

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingRegistrationCoordinatedShutdownSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingRegistrationCoordinatedShutdownSpec.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import akka.Done
+import akka.actor._
+import akka.cluster.Cluster
+import akka.cluster.MemberStatus
+import akka.cluster.MultiNodeClusterSpec
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.remote.testkit.STMultiNodeSpec
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
+
+/**
+ * Test for issue #28416
+ */
+object ClusterShardingRegistrationCoordinatedShutdownSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+
+  commonConfig(ConfigFactory.parseString(s"""
+    akka.loglevel = DEBUG # FIXME
+    """).withFallback(MultiNodeClusterSpec.clusterConfig))
+
+  class Entity extends Actor {
+    def receive = {
+      case id: Int => sender() ! id
+    }
+  }
+
+  val extractEntityId: ShardRegion.ExtractEntityId = {
+    case id: Int => (id.toString, id)
+  }
+
+  val extractShardId: ShardRegion.ExtractShardId = msg =>
+    msg match {
+      case id: Int => id.toString
+    }
+
+}
+
+class ClusterShardingRegistrationCoordinatedShutdownMultiJvmNode1
+    extends ClusterShardingRegistrationCoordinatedShutdownSpec
+class ClusterShardingRegistrationCoordinatedShutdownMultiJvmNode2
+    extends ClusterShardingRegistrationCoordinatedShutdownSpec
+class ClusterShardingRegistrationCoordinatedShutdownMultiJvmNode3
+    extends ClusterShardingRegistrationCoordinatedShutdownSpec
+
+abstract class ClusterShardingRegistrationCoordinatedShutdownSpec
+    extends MultiNodeSpec(ClusterShardingRegistrationCoordinatedShutdownSpec)
+    with STMultiNodeSpec
+    with ImplicitSender {
+  import ClusterShardingRegistrationCoordinatedShutdownSpec._
+
+  override def initialParticipants: Int = roles.size
+
+  private val cluster = Cluster(system)
+  private lazy val region = ClusterSharding(system).shardRegion("Entity")
+
+  def join(from: RoleName, to: RoleName): Unit = {
+    runOn(from) {
+      cluster.join(node(to).address)
+    }
+    runOn(from) {
+      cluster.state.members.exists(m => m.uniqueAddress == cluster.selfUniqueAddress && m.status == MemberStatus.Up)
+    }
+    enterBarrier(from.name + "-joined")
+  }
+
+  def startSharding(): Unit = {
+    ClusterSharding(system).start(
+      typeName = "Entity",
+      entityProps = Props[Entity],
+      settings = ClusterShardingSettings(system),
+      extractEntityId = extractEntityId,
+      extractShardId = extractShardId)
+  }
+
+  s"Region registration during CoordinatedShutdown" must {
+
+    "try next oldest" in within(30.seconds) {
+      // second should be oldest
+      join(second, second)
+      join(first, second)
+      join(third, second)
+
+      awaitAssert {
+        cluster.state.members.count(_.status == MemberStatus.Up) should ===(3)
+      }
+
+      val csTaskDone = TestProbe()
+      runOn(third) {
+        CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseBeforeClusterShutdown, "test")(() => {
+          Thread.sleep(200)
+          region ! 1
+          expectMsg(1)
+          csTaskDone.ref ! Done
+          Future.successful(Done)
+        })
+
+      }
+
+      startSharding()
+
+      enterBarrier("before-shutdown")
+
+      runOn(second) {
+        CoordinatedShutdown(system).run(CoordinatedShutdown.UnknownReason)
+        awaitCond(cluster.isTerminated)
+      }
+
+      runOn(third) {
+        CoordinatedShutdown(system).run(CoordinatedShutdown.UnknownReason)
+        awaitCond(cluster.isTerminated)
+        csTaskDone.expectMsg(Done)
+      }
+
+      enterBarrier("after-shutdown")
+
+      runOn(first) {
+        region ! 2
+        expectMsg(2)
+        lastSender.path.address.hasLocalScope should ===(true)
+      }
+
+      enterBarrier("after-1")
+    }
+  }
+}


### PR DESCRIPTION
* Keep track of Leaving and Exiting members in ShardRegion and
  attempt to register to coordinator at several of the oldest if
  they have status Leaving and Exiting. Include all up to and
  including the first member with status Up.
* Sending to wrong node doesn't matter, will be suppressed deadLetter.
* Same for the GracefulShutdownReq which already had that intention by
  sending to 2 oldest.

Refs #28416
