### PR TITLE
Add missing word Map to tutorial_4.md

### DIFF
--- a/akka-docs/src/main/paradox/typed/guide/tutorial_4.md
+++ b/akka-docs/src/main/paradox/typed/guide/tutorial_4.md
@@ -85,7 +85,7 @@ A group actor has some work to do when it comes to registrations, including:
 
 ### Handling the registration request
 
-A device group actor must either reply to the request with the `ActorRef` of an existing child, or it should create one. To look up child actors by their device IDs we will use a .
+A device group actor must either reply to the request with the `ActorRef` of an existing child, or it should create one. To look up child actors by their device IDs we will use a `Map`.
 
 Add the following to your source file:
 


### PR DESCRIPTION
## Purpose
Fix documentation

## References

N/A

## Changes

- Added the word `Map`

## Background Context
N/A