### PR TITLE
Increase logger startup timeout in cluster metric tests 

### DIFF
--- a/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/ClusterMetricsExtensionSpec.scala
+++ b/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/ClusterMetricsExtensionSpec.scala
@@ -43,7 +43,10 @@ trait ClusterMetricsCommonConfig extends MultiNodeConfig {
     """)
 
   // Activate slf4j logging along with test listener.
-  def customLogging = parseString("""akka.loggers=["akka.testkit.TestEventListener","akka.event.slf4j.Slf4jLogger"]""")
+  def customLogging = parseString("""
+      akka.loggers=["akka.testkit.TestEventListener","akka.event.slf4j.Slf4jLogger"]
+      akka.logger-startup-timeout = 15s
+    """)
 }
 
 object ClusterMetricsDisabledConfig extends ClusterMetricsCommonConfig {


### PR DESCRIPTION
Refs #27955


Both cases was in the `ClusterMetricsDisabledSpec`, which sets up two loggers : `akka.loggers=["akka.testkit.TestEventListener","akka.event.slf4j.Slf4jLogger"]`, the timeout is applied separately for each though. Another clue could be the `akka.cluster.metrics.RedirectLogging` which does some interaction with Slf4j and JUL.

This just increases the logger init, I don't think this one is worth spending more time on given that it doesn't seem to happen in other tests. If it is a deadlock of some kind we'll notice with the longer timeout.
