### PR TITLE
Upgrade scalafmt but keep defaults from 2.1.0

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,7 @@
-version = 2.1.0
+version = 2.3.2
+
+# Use the 2.1.0 default settings
+edition = 2019-09
 
 style = defaultWithAlign
 

--- a/akka-actor-tests/src/test/scala/akka/routing/MetricsBasedResizerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/MetricsBasedResizerSpec.scala
@@ -134,9 +134,8 @@ class MetricsBasedResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultT
 
     "stop an underutilizationStreak when fully utilized" in {
       val resizer = DefaultOptimalSizeExploringResizer()
-      resizer.record = ResizeRecord(
-        underutilizationStreak =
-          Some(UnderUtilizationStreak(start = LocalDateTime.now.minusHours(1), highestUtilization = 1)))
+      resizer.record = ResizeRecord(underutilizationStreak =
+        Some(UnderUtilizationStreak(start = LocalDateTime.now.minusHours(1), highestUtilization = 1)))
 
       val router = TestRouter(routees(2))
       router.sendToAll(await = true)
@@ -159,8 +158,8 @@ class MetricsBasedResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultT
 
     "leave the underutilizationStreak highestUtilization unchanged if current utilization is lower" in {
       val resizer = DefaultOptimalSizeExploringResizer()
-      resizer.record = ResizeRecord(
-        underutilizationStreak = Some(UnderUtilizationStreak(start = LocalDateTime.now, highestUtilization = 2)))
+      resizer.record = ResizeRecord(underutilizationStreak =
+        Some(UnderUtilizationStreak(start = LocalDateTime.now, highestUtilization = 2)))
 
       val router = TestRouter(routees(2))
       router.mockSend(await = true)
@@ -173,8 +172,8 @@ class MetricsBasedResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultT
 
     "update the underutilizationStreak highestUtilization if current utilization is higher" in {
       val resizer = DefaultOptimalSizeExploringResizer()
-      resizer.record = ResizeRecord(
-        underutilizationStreak = Some(UnderUtilizationStreak(start = LocalDateTime.now, highestUtilization = 1)))
+      resizer.record = ResizeRecord(underutilizationStreak =
+        Some(UnderUtilizationStreak(start = LocalDateTime.now, highestUtilization = 1)))
 
       val router = TestRouter(routees(3))
       router.mockSend(await = true, routeeIdx = 0)
@@ -294,9 +293,8 @@ class MetricsBasedResizerSpec extends AkkaSpec(ResizerSpec.config) with DefaultT
     "downsize to close to the highest retention when a streak of underutilization started downsizeAfterUnderutilizedFor" in {
       val resizer = DefaultOptimalSizeExploringResizer(downsizeAfterUnderutilizedFor = 72.hours, downsizeRatio = 0.5)
 
-      resizer.record = ResizeRecord(
-        underutilizationStreak =
-          Some(UnderUtilizationStreak(start = LocalDateTime.now.minusHours(73), highestUtilization = 8)))
+      resizer.record = ResizeRecord(underutilizationStreak =
+        Some(UnderUtilizationStreak(start = LocalDateTime.now.minusHours(73), highestUtilization = 8)))
       resizer.resize(routees(20)) should be(4 - 20)
     }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SupervisionSpec.scala
@@ -551,8 +551,8 @@ class SupervisionSpec extends ScalaTestWithActorTestKit("""
     }
 
     "optionally NOT stop children when backoff" in {
-      testNotStopChildren(
-        strategy = SupervisorStrategy.restartWithBackoff(10.millis, 10.millis, 0).withStopChildren(enabled = false))
+      testNotStopChildren(strategy =
+        SupervisorStrategy.restartWithBackoff(10.millis, 10.millis, 0).withStopChildren(enabled = false))
     }
 
     def testNotStopChildren(strategy: SupervisorStrategy): Unit = {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/PoolRouterImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/PoolRouterImpl.scala
@@ -36,8 +36,8 @@ private[akka] final case class PoolRouterBuilder[T](
     withConsistentHashingRouting(virtualNodesFactor, mapping.apply(_))
 
   def withConsistentHashingRouting(virtualNodesFactor: Int, mapping: T => String): PoolRouterBuilder[T] = {
-    copy(
-      logicFactory = system => new RoutingLogics.ConsistentHashingLogic[T](virtualNodesFactor, mapping, system.address))
+    copy(logicFactory = system =>
+      new RoutingLogics.ConsistentHashingLogic[T](virtualNodesFactor, mapping, system.address))
   }
 
   def withPoolSize(poolSize: Int): PoolRouterBuilder[T] = copy(poolSize = poolSize)

--- a/akka-actor/src/main/scala/akka/actor/ActorPath.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorPath.scala
@@ -126,7 +126,8 @@ object ActorPath {
             case '%' if pos + 2 < len && isHexChar(s.charAt(pos + 1)) && isHexChar(s.charAt(pos + 2)) =>
               validate(pos + 3)
             case _ => pos
-          } else ValidPathCode
+          }
+        else ValidPathCode
 
       if (len > 0 && s.charAt(0) != '$') validate(0) else 0
     }

--- a/akka-actor/src/main/scala/akka/actor/TypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/TypedActor.scala
@@ -749,5 +749,6 @@ class TypedActorExtension(val system: ExtendedActorSystem) extends TypedActorFac
           case handler: TypedActorInvocationHandler => handler
           case _                                    => null
         }
-    } else null
+    }
+    else null
 }

--- a/akka-actor/src/main/scala/akka/actor/dungeon/ChildrenContainer.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/ChildrenContainer.scala
@@ -173,7 +173,8 @@ private[akka] object ChildrenContainer {
       if (t.isEmpty) reason match {
         case Termination => TerminatedChildrenContainer
         case _           => NormalChildrenContainer(c - child.path.name)
-      } else copy(c - child.path.name, t)
+      }
+      else copy(c - child.path.name, t)
     }
 
     override def getByName(name: String): Option[ChildStats] = c.get(name)

--- a/akka-actor/src/main/scala/akka/pattern/Backoff.scala
+++ b/akka-actor/src/main/scala/akka/pattern/Backoff.scala
@@ -586,9 +586,8 @@ private final case class BackoffOptionsImpl(
   def withManualReset = copy(reset = Some(ManualReset))
   def withSupervisorStrategy(supervisorStrategy: OneForOneStrategy) = copy(supervisorStrategy = supervisorStrategy)
   def withDefaultStoppingStrategy =
-    copy(
-      supervisorStrategy =
-        OneForOneStrategy(supervisorStrategy.maxNrOfRetries)(SupervisorStrategy.stoppingStrategy.decider))
+    copy(supervisorStrategy =
+      OneForOneStrategy(supervisorStrategy.maxNrOfRetries)(SupervisorStrategy.stoppingStrategy.decider))
   def withReplyWhileStopped(replyWhileStopped: Any) = copy(replyWhileStopped = Some(replyWhileStopped))
   def withMaxNrOfRetries(maxNrOfRetries: Int) =
     copy(supervisorStrategy = supervisorStrategy.withMaxNrOfRetries(maxNrOfRetries))

--- a/akka-actor/src/main/scala/akka/pattern/BackoffOptions.scala
+++ b/akka-actor/src/main/scala/akka/pattern/BackoffOptions.scala
@@ -350,9 +350,8 @@ private final case class BackoffOnStopOptionsImpl[T](
 
   // additional
   def withDefaultStoppingStrategy =
-    copy(
-      supervisorStrategy =
-        OneForOneStrategy(supervisorStrategy.maxNrOfRetries)(SupervisorStrategy.stoppingStrategy.decider))
+    copy(supervisorStrategy =
+      OneForOneStrategy(supervisorStrategy.maxNrOfRetries)(SupervisorStrategy.stoppingStrategy.decider))
   def withFinalStopMessage(action: Any => Boolean) = copy(finalStopMessage = Some(action))
 
   def props: Props = {

--- a/akka-actor/src/main/scala/akka/pattern/BackoffSupervisor.scala
+++ b/akka-actor/src/main/scala/akka/pattern/BackoffSupervisor.scala
@@ -323,7 +323,7 @@ object BackoffSupervisor {
   }
 }
 
-final class BackoffSupervisor @deprecated("Use `BackoffSupervisor.props` method instead", since = "2.5.22")(
+final class BackoffSupervisor @deprecated("Use `BackoffSupervisor.props` method instead", since = "2.5.22") (
     override val childProps: Props,
     override val childName: String,
     minBackoff: FiniteDuration,

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/Metric.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/Metric.scala
@@ -37,7 +37,8 @@ final case class Metric private[metrics] (name: String, value: Number, average: 
       case Some(avg)                        => copy(value = latest.value, average = Some(avg :+ latest.value.doubleValue))
       case None if latest.average.isDefined => copy(value = latest.value, average = latest.average)
       case _                                => copy(value = latest.value)
-    } else this
+    }
+    else this
 
   /**
    * The numerical value of the average, if defined, otherwise the latest value

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -1056,10 +1056,9 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef, joinConfigCompatCh
       // Don't mark gossip state as seen while exiting is in progress, e.g.
       // shutting down singleton actors. This delays removal of the member until
       // the exiting tasks have been completed.
-      membershipState = membershipState.copy(
-        latestGossip =
-          if (exitingTasksInProgress) winningGossip
-          else winningGossip.seen(selfUniqueAddress))
+      membershipState = membershipState.copy(latestGossip =
+        if (exitingTasksInProgress) winningGossip
+        else winningGossip.seen(selfUniqueAddress))
       assertLatestGossip()
 
       // for all new nodes we remove them from the failure detector

--- a/akka-cluster/src/test/scala/akka/cluster/CrossDcHeartbeatSenderSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/CrossDcHeartbeatSenderSpec.scala
@@ -38,10 +38,9 @@ class CrossDcHeartbeatSenderSpec extends AkkaSpec("""
       Cluster(system).join(Cluster(system).selfMember.address)
       awaitAssert(Cluster(system).selfMember.status == MemberStatus.Up)
       val underTest = system.actorOf(Props(new TestCrossDcHeartbeatSender(probe)))
-      underTest ! CurrentClusterState(
-        members = SortedSet(
-          Cluster(system).selfMember,
-          Member(UniqueAddress(Address("akka", system.name), 2L), Set("dc-dc2")).copy(status = MemberStatus.Up)))
+      underTest ! CurrentClusterState(members = SortedSet(
+        Cluster(system).selfMember,
+        Member(UniqueAddress(Address("akka", system.name), 2L), Set("dc-dc2")).copy(status = MemberStatus.Up)))
 
       probe.expectMsgType[Heartbeat].sequenceNr shouldEqual 1
       probe.expectMsgType[Heartbeat].sequenceNr shouldEqual 2

--- a/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/GossipSpec.scala
@@ -217,10 +217,9 @@ class GossipSpec extends WordSpec with Matchers {
       state(g1).youngestMember should ===(b1)
       val g2 = Gossip(
         members = SortedSet(a2, b1.copyUp(3), e1),
-        overview = GossipOverview(
-          reachability = Reachability.empty
-            .unreachable(a2.uniqueAddress, b1.uniqueAddress)
-            .unreachable(a2.uniqueAddress, e1.uniqueAddress)))
+        overview = GossipOverview(reachability = Reachability.empty
+          .unreachable(a2.uniqueAddress, b1.uniqueAddress)
+          .unreachable(a2.uniqueAddress, e1.uniqueAddress)))
       state(g2).youngestMember should ===(b1)
       val g3 = Gossip(members = SortedSet(a2, b1.copyUp(3), e2.copyUp(4)))
       state(g3).youngestMember should ===(e2)
@@ -355,10 +354,9 @@ class GossipSpec extends WordSpec with Matchers {
     "clear out a bunch of stuff when removing a node" in {
       val g = Gossip(
         members = SortedSet(dc1a1, dc1b1, dc2d2),
-        overview = GossipOverview(
-          reachability = Reachability.empty
-            .unreachable(dc1b1.uniqueAddress, dc2d2.uniqueAddress)
-            .unreachable(dc2d2.uniqueAddress, dc1b1.uniqueAddress)))
+        overview = GossipOverview(reachability = Reachability.empty
+          .unreachable(dc1b1.uniqueAddress, dc2d2.uniqueAddress)
+          .unreachable(dc2d2.uniqueAddress, dc1b1.uniqueAddress)))
         .:+(VectorClock.Node(Gossip.vclockName(dc1b1.uniqueAddress)))
         .:+(VectorClock.Node(Gossip.vclockName(dc2d2.uniqueAddress)))
         .remove(dc1b1.uniqueAddress, System.currentTimeMillis())

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMultiMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMultiMap.scala
@@ -95,8 +95,9 @@ final class ORMultiMap[A, B] private[akka] (
    */
   def entries: Map[A, Set[B]] =
     if (withValueDeltas)
-      underlying.entries.collect { case (k, v) if underlying.keys.elements.contains(k) => k -> v.elements } else
-      underlying.entries.map { case (k, v)                                             => k -> v.elements }
+      underlying.entries.collect { case (k, v) if underlying.keys.elements.contains(k) => k -> v.elements }
+    else
+      underlying.entries.map { case (k, v) => k -> v.elements }
 
   /**
    * Java API: All entries of a multimap where keys are strings and values are sets.
@@ -107,7 +108,8 @@ final class ORMultiMap[A, B] private[akka] (
     if (withValueDeltas)
       underlying.entries.foreach {
         case (k, v) => if (underlying.keys.elements.contains(k)) result.put(k, v.elements.asJava)
-      } else
+      }
+    else
       underlying.entries.foreach { case (k, v) => result.put(k, v.elements.asJava) }
     result
   }

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORSet.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORSet.scala
@@ -439,7 +439,8 @@ final class ORSet[A] private[akka] (
     val entries00 = ORSet.mergeCommonKeys(commonKeys, this, that)
     val entries0 =
       if (addDeltaOp)
-        entries00 ++ this.elementsMap.filter { case (elem, _) => !that.elementsMap.contains(elem) } else {
+        entries00 ++ this.elementsMap.filter { case (elem, _) => !that.elementsMap.contains(elem) }
+      else {
         val thisUniqueKeys = this.elementsMap.keysIterator.filterNot(that.elementsMap.contains)
         ORSet.mergeDisjointKeys(thisUniqueKeys, this.elementsMap, that.vvector, entries00)
       }

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurableDataSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurableDataSpec.scala
@@ -54,7 +54,8 @@ object DurableDataSpec {
         if (failStore) reply match {
           case Some(StoreReply(_, failureMsg, replyTo)) => replyTo ! failureMsg
           case None                                     =>
-        } else
+        }
+        else
           reply match {
             case Some(StoreReply(successMsg, _, replyTo)) => replyTo ! successMsg
             case None                                     =>

--- a/akka-docs/src/test/scala/docs/persistence/PersistenceDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/persistence/PersistenceDocSpec.scala
@@ -179,8 +179,7 @@ object PersistenceDocSpec {
 
       //#snapshot-criteria
       override def recovery =
-        Recovery(
-          fromSnapshot = SnapshotSelectionCriteria(maxSequenceNr = 457L, maxTimestamp = System.currentTimeMillis))
+        Recovery(fromSnapshot = SnapshotSelectionCriteria(maxSequenceNr = 457L, maxTimestamp = System.currentTimeMillis))
       //#snapshot-criteria
 
       //#snapshot-offer

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
@@ -272,7 +272,8 @@ object PersistentActorCompileOnlyTest {
               case GetTotalPrice(sender) =>
                 sender ! basket.items.map(_.price).sum
                 Effect.none
-            } else
+            }
+          else
             cmd match {
               case AddItem(id)    => addItem(id, ctx.self)
               case RemoveItem(id) => Effect.persist(ItemRemoved(id))

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -245,7 +245,8 @@ private[akka] class RemoteActorRefProvider(
         case ArterySettings.AeronUpd => new ArteryAeronUdpTransport(system, this)
         case ArterySettings.Tcp      => new ArteryTcpTransport(system, this, tlsEnabled = false)
         case ArterySettings.TlsTcp   => new ArteryTcpTransport(system, this, tlsEnabled = true)
-      } else new Remoting(system, this))
+      }
+      else new Remoting(system, this))
     _internals = internals
     remotingTerminator ! internals
 
@@ -416,7 +417,8 @@ private[akka] class RemoteActorRefProvider(
             case "user" | "system" => deployer.lookup(elems.drop(1))
             case "remote"          => lookupRemotes(elems)
             case _                 => None
-          } else None
+          }
+        else None
 
       val deployment = {
         deploy.toList ::: lookup.toList match {

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -373,9 +373,8 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
 
   private val inboundEnvelopePool = ReusableInboundEnvelope.createObjectPool(capacity = 16)
   // The outboundEnvelopePool is shared among all outbound associations
-  private val outboundEnvelopePool = ReusableOutboundEnvelope.createObjectPool(
-    capacity =
-      settings.Advanced.OutboundMessageQueueSize * settings.Advanced.OutboundLanes * 3)
+  private val outboundEnvelopePool = ReusableOutboundEnvelope.createObjectPool(capacity =
+    settings.Advanced.OutboundMessageQueueSize * settings.Advanced.OutboundLanes * 3)
 
   private val associationRegistry = new AssociationRegistry(
     remoteAddress =>

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -364,7 +364,8 @@ private[remote] class ArteryTcpTransport(
         _ <- controlStreamCompleted.recover { case _          => Done }
         _ <- ordinaryMessagesStreamCompleted.recover { case _ => Done }
         _ <- if (largeMessageChannelEnabled)
-          largeMessagesStreamCompleted.recover { case _ => Done } else Future.successful(Done)
+          largeMessagesStreamCompleted.recover { case _ => Done }
+        else Future.successful(Done)
       } yield Done
       allStopped.foreach(_ => runInboundStreams(port, bindPort))
     }

--- a/akka-stream-tests-tck/src/test/scala/akka/stream/tck/AkkaPublisherVerification.scala
+++ b/akka-stream-tests-tck/src/test/scala/akka/stream/tck/AkkaPublisherVerification.scala
@@ -37,6 +37,7 @@ abstract class AkkaPublisherVerification[T](val env: TestEnvironment, publisherS
 
   def iterable(elements: Long): immutable.Iterable[Int] =
     if (elements > Int.MaxValue)
-      new immutable.Iterable[Int] { override def iterator = Iterator.from(0) } else
+      new immutable.Iterable[Int] { override def iterator = Iterator.from(0) }
+    else
       0 until elements.toInt
 }

--- a/akka-stream-tests-tck/src/test/scala/akka/stream/tck/FanoutPublisherTest.scala
+++ b/akka-stream-tests-tck/src/test/scala/akka/stream/tck/FanoutPublisherTest.scala
@@ -13,7 +13,8 @@ class FanoutPublisherTest extends AkkaPublisherVerification[Int] {
 
   def createPublisher(elements: Long): Publisher[Int] = {
     val iterable: immutable.Iterable[Int] =
-      if (elements == 0) new immutable.Iterable[Int] { override def iterator = Iterator.from(0) } else
+      if (elements == 0) new immutable.Iterable[Int] { override def iterator = Iterator.from(0) }
+      else
         0 until elements.toInt
 
     Source(iterable).runWith(Sink.asPublisher(true))

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RetryFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RetryFlowSpec.scala
@@ -83,11 +83,10 @@ class RetryFlowSpec extends StreamSpec("""
       // #withBackoff-demo
 
       val retryFlow: Flow[Int, Int, NotUsed] =
-        RetryFlow.withBackoff(minBackoff = 10.millis, maxBackoff = 5.seconds, randomFactor = 0d, maxRetries = 3, flow)(
-          decideRetry = {
-            case (_, result) if result > 0 => Some(result)
-            case _                         => None
-          })
+        RetryFlow.withBackoff(minBackoff = 10.millis, maxBackoff = 5.seconds, randomFactor = 0d, maxRetries = 3, flow)(decideRetry = {
+          case (_, result) if result > 0 => Some(result)
+          case _                         => None
+        })
       // #withBackoff-demo
 
       val (source, sink) = TestSource.probe[Int].via(retryFlow).toMat(TestSink.probe)(Keep.both).run()
@@ -111,11 +110,10 @@ class RetryFlowSpec extends StreamSpec("""
 
       // The retry flow will retry on negative input values
       val retryFlow: Flow[Int, Int, NotUsed] =
-        RetryFlow.withBackoff(minBackoff = 10.millis, maxBackoff = 100.millis, randomFactor = 0d, maxRetries = 5, flow)(
-          decideRetry = {
-            case (x, result) if result < 0 => Some(x)
-            case (_, _)                    => None
-          })
+        RetryFlow.withBackoff(minBackoff = 10.millis, maxBackoff = 100.millis, randomFactor = 0d, maxRetries = 5, flow)(decideRetry = {
+          case (x, result) if result < 0 => Some(x)
+          case (_, _)                    => None
+        })
 
       val (source, sink) = TestSource.probe[Int].via(retryFlow).toMat(TestSink.probe)(Keep.both).run()
 

--- a/akka-stream/src/main/scala/akka/stream/Attributes.scala
+++ b/akka-stream/src/main/scala/akka/stream/Attributes.scala
@@ -169,7 +169,8 @@ final case class Attributes(attributeList: List[Attributes.Attribute] = Nil) {
               concatNames(i, null, b.append(first).append('-').append(n))
             } else concatNames(i, n, null)
           case _ => concatNames(i, first, buf)
-        } else if (buf eq null) first
+        }
+      else if (buf eq null) first
       else buf.toString
 
     Option(concatNames(attributeList.reverseIterator, null, null))

--- a/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
@@ -871,8 +871,8 @@ import akka.util.unused
     if (toAppend.isEmpty) {
       copy(traversalSoFar = PushNotUsed.concat(LinearTraversalBuilder.addMatCompose(traversalSoFar, matCompose)))
     } else if (this.isEmpty) {
-      toAppend.copy(
-        traversalSoFar = toAppend.traversalSoFar.concat(LinearTraversalBuilder.addMatCompose(traversal, matCompose)))
+      toAppend.copy(traversalSoFar =
+        toAppend.traversalSoFar.concat(LinearTraversalBuilder.addMatCompose(traversal, matCompose)))
     } else {
       if (outPort.isDefined) {
         if (toAppend.inPort.isEmpty)

--- a/akka-stream/src/main/scala/akka/stream/impl/streamref/SourceRefImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/streamref/SourceRefImpl.scala
@@ -145,8 +145,8 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
 
       private val receiveBuffer = FixedSizeBuffer[Out](bufferCapacity)
 
-      private val requestStrategy: WatermarkRequestStrategy = WatermarkRequestStrategy(
-        highWatermark = receiveBuffer.capacity)
+      private val requestStrategy: WatermarkRequestStrategy =
+        WatermarkRequestStrategy(highWatermark = receiveBuffer.capacity)
       // end of demand management ---
 
       // initialized with the originRef if present, that means we're the "remote" for an already active Source on the other side (the "origin")

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -595,11 +595,13 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
         connection.slot match {
           case Empty | _ @(_: Cancelled) => false // cancelled (element is discarded when cancelled)
           case _                         => true // completed but element still there to grab
-        } else if ((connection.portState & (InReady | InFailed)) == (InReady | InFailed))
+        }
+      else if ((connection.portState & (InReady | InFailed)) == (InReady | InFailed))
         connection.slot match {
           case Failed(_, elem) => elem.asInstanceOf[AnyRef] ne Empty // failed but element still there to grab
           case _               => false
-        } else false
+        }
+      else false
     }
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 //#sbt-multi-jvm
 
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.5.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.11")
 // sbt-osgi 0.9.5 is available but breaks including jdk9-only classes
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.4")


### PR DESCRIPTION
The `edition`, to preserve existing behavior while upgrading to latest for perf upgrades, mainly works but some bugs have been fixed e.g.
https://github.com/scalameta/scalafmt/issues/1509 that cause 
formatting changes

For me this makes clean;scalafmtAll 3x faster