### PR TITLE
stream: fail eagerly during SubSink/SubSource materialization

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrefixAndTailSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrefixAndTailSpec.scala
@@ -100,8 +100,9 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
       val subscriber2 = TestSubscriber.probe[Int]()
       tail.to(Sink.fromSubscriber(subscriber2)).run()
-      subscriber2.expectSubscriptionAndError().getMessage should ===(
-        "Substream Source cannot be materialized more than once")
+      val ex = subscriber2.expectSubscriptionAndError()
+      ex.getMessage should ===("Substream Source(TailSource) cannot be materialized more than once")
+      ex.getStackTrace.exists(_.getClassName contains "FlowPrefixAndTailSpec") shouldBe true
 
       subscriber1.requestNext(2).expectComplete()
 
@@ -126,7 +127,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
 
       tail.to(Sink.fromSubscriber(subscriber)).run()(tightTimeoutMaterializer)
       subscriber.expectSubscriptionAndError().getMessage should ===(
-        s"Substream Source has not been materialized in ${ms} milliseconds")
+        s"Substream Source(TailSource) has not been materialized in ${ms} milliseconds")
     }
     "not fail the stream if substream has not been subscribed in time and configured subscription timeout is noop" in assertAllStagesStopped {
       @silent("deprecated")

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSplitWhenSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSplitWhenSpec.scala
@@ -275,9 +275,9 @@ class FlowSplitWhenSpec extends StreamSpec("""
       val probe = stream.withAttributes(Attributes.inputBuffer(1, 1)).run()
       probe.request(1)
       val future = probe.requestNext()
-      an[IllegalStateException] mustBe thrownBy {
-        Await.result(future, 3.seconds)
-      }
+      val ex = the[IllegalStateException] thrownBy Await.result(future, 3.seconds)
+      ex.getMessage should ===("Substream Source(TailSource) cannot be materialized more than once")
+      ex.getStackTrace.exists(_.getClassName contains "FlowSplitWhenSpec") shouldBe true
       probe.cancel()
     }
 


### PR DESCRIPTION
This way the stack trace will be more helpful because it contains the stage
that actually triggered the materialization.

Otherwise, we will only fail during `preStart` in the interpreter where the
stage will be failed and the error be propagated through the stream where
it can be hard to figure out what happened.

Also improve the message itself to contain the user provided name of the
sink/source.

(This will probably fail a few tests, so this is Jenkins-fodder for now)