### PR TITLE
Update 'managing blocking' examples

### DIFF
--- a/akka-docs/src/test/java/jdocs/actor/typed/BlockingDispatcherTest.java
+++ b/akka-docs/src/test/java/jdocs/actor/typed/BlockingDispatcherTest.java
@@ -13,12 +13,9 @@ public class BlockingDispatcherTest {
     Behavior<Void> root =
         Behaviors.setup(
             context -> {
-              ActorRef<Integer> actor1 = context.spawn(BlockingActor.create(), "BlockingActor");
-              ActorRef<Integer> actor2 = context.spawn(PrintActor.create(), "PrintActor");
-
               for (int i = 0; i < 100; i++) {
-                actor1.tell(i);
-                actor2.tell(i);
+                context.spawn(BlockingActor.create(), "BlockingActor-" + i).tell(i);
+                context.spawn(PrintActor.create(), "PrintActor-" + i).tell(i);
               }
               return Behaviors.ignore();
             });

--- a/akka-docs/src/test/scala/docs/actor/typed/BlockingDispatcherSample.scala
+++ b/akka-docs/src/test/scala/docs/actor/typed/BlockingDispatcherSample.scala
@@ -59,12 +59,9 @@ object BlockingDispatcherSample {
   def main(args: Array[String]): Unit = {
     // #blocking-main
     val root = Behaviors.setup[Nothing] { context =>
-      val actor1 = context.spawn(BlockingFutureActor(), "futureActor")
-      val actor2 = context.spawn(PrintActor(), "printActor")
-
       for (i <- 1 to 100) {
-        actor1 ! i
-        actor2 ! i
+        context.spawn(BlockingFutureActor(), s"futureActor-$i") ! i
+        context.spawn(PrintActor(), s"printActor-$i") ! i
       }
       Behaviors.empty
     }
@@ -91,12 +88,9 @@ object SeparateDispatcherSample {
 
     // #separate-dispatcher-main
     val root = Behaviors.setup[Nothing] { context =>
-      val actor1 = context.spawn(SeparateDispatcherFutureActor(), "futureActor")
-      val actor2 = context.spawn(PrintActor(), "printActor")
-
       for (i <- 1 to 100) {
-        actor1 ! i
-        actor2 ! i
+        context.spawn(SeparateDispatcherFutureActor(), s"futureActor-$i") ! i
+        context.spawn(PrintActor(), s"printActor-$i") ! i
       }
       Behaviors.ignore
     }


### PR DESCRIPTION
Having only one blocking actor is not enough, since then only one dispatcher
thread will be blocked at a time.