### PR TITLE
First step of rolling update cluster serlializer no classmanifests

### DIFF
--- a/akka-cluster/src/main/mima-filters/2.6.1.backwards.excludes/issue-13654-no-class-manifests-for-cluster-serializer-step1.excludes
+++ b/akka-cluster/src/main/mima-filters/2.6.1.backwards.excludes/issue-13654-no-class-manifests-for-cluster-serializer-step1.excludes
@@ -1,0 +1,5 @@
+# internals changed
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.protobuf.ClusterMessageSerializer.HeartBeatRspManifest")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.protobuf.ClusterMessageSerializer.HeartBeatManifest")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.protobuf.ClusterMessageSerializer.HeartBeatManifest")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.protobuf.ClusterMessageSerializer.HeartBeatRspManifest")

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -59,8 +59,8 @@ private[akka] object ClusterMessageSerializer {
   val InitJoinManifest = "IJ"
   val InitJoinAckManifest = "IJA"
   val InitJoinNackManifest = "IJN"
-  val HeartBeatManifest = "HB"
-  val HeartBeatRspManifest = "HBR"
+  val HeartbeatManifest = "HB"
+  val HeartbeatRspManifest = "HBR"
   val ExitingConfirmedManifest = "EC"
   val GossipStatusManifest = "GS"
   val GossipEnvelopeManifest = "GE"
@@ -120,8 +120,8 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem)
   def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = manifest match {
     case HeartBeatManifestPre2523     => deserializeHeartBeatAsAddress(bytes)
     case HeartBeatRspManifest2523     => deserializeHeartBeatRspAsUniqueAddress(bytes)
-    case HeartBeatManifest            => deserializeHeartBeat(bytes)
-    case HeartBeatRspManifest         => deserializeHeartBeatResponse(bytes)
+    case HeartbeatManifest            => deserializeHeartBeat(bytes)
+    case HeartbeatRspManifest         => deserializeHeartBeatResponse(bytes)
     case OldGossipStatusManifest      => deserializeGossipStatus(bytes)
     case OldGossipEnvelopeManifest    => deserializeGossipEnvelope(bytes)
     case OldInitJoinManifest          => deserializeInitJoin(bytes)

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -31,27 +31,40 @@ import com.typesafe.config.{ Config, ConfigFactory, ConfigRenderOptions }
 @InternalApi
 @ccompatUsedUntil213
 private[akka] object ClusterMessageSerializer {
-  // FIXME use short manifests when we can break wire compatibility
+  // Kept for one version iteration from 2.6.2 to allow rolling migration to short manifests
+  // will be removed in 2.6.3
   // needs to be full class names for backwards compatibility
-  val JoinManifest = s"akka.cluster.InternalClusterAction$$Join"
-  val WelcomeManifest = s"akka.cluster.InternalClusterAction$$Welcome"
-  val LeaveManifest = s"akka.cluster.ClusterUserAction$$Leave"
-  val DownManifest = s"akka.cluster.ClusterUserAction$$Down"
+  val OldJoinManifest = s"akka.cluster.InternalClusterAction$$Join"
+  val OldWelcomeManifest = s"akka.cluster.InternalClusterAction$$Welcome"
+  val OldLeaveManifest = s"akka.cluster.ClusterUserAction$$Leave"
+  val OldDownManifest = s"akka.cluster.ClusterUserAction$$Down"
   // #24622 wire compatibility
   // we need to use this object name rather than classname to be able to join a 2.5.9 cluster during rolling upgrades
-  val InitJoinManifest = s"akka.cluster.InternalClusterAction$$InitJoin$$"
-  val InitJoinAckManifest = s"akka.cluster.InternalClusterAction$$InitJoinAck"
-  val InitJoinNackManifest = s"akka.cluster.InternalClusterAction$$InitJoinNack"
+  val OldInitJoinManifest = s"akka.cluster.InternalClusterAction$$InitJoin$$"
+  val OldInitJoinAckManifest = s"akka.cluster.InternalClusterAction$$InitJoinAck"
+  val OldInitJoinNackManifest = s"akka.cluster.InternalClusterAction$$InitJoinNack"
   // FIXME, remove in a later version (2.6?) and make 2.5.24+ a mandatory step for rolling upgrade
   val HeartBeatManifestPre2523 = s"akka.cluster.ClusterHeartbeatSender$$Heartbeat"
   val HeartBeatRspManifest2523 = s"akka.cluster.ClusterHeartbeatSender$$HeartbeatRsp"
+  val OldExitingConfirmedManifest = s"akka.cluster.InternalClusterAction$$ExitingConfirmed"
+  val OldGossipStatusManifest = "akka.cluster.GossipStatus"
+  val OldGossipEnvelopeManifest = "akka.cluster.GossipEnvelope"
+  val OldClusterRouterPoolManifest = "akka.cluster.routing.ClusterRouterPool"
 
+  // is handled on the deserializing side in 2.6.2 and then on the serializing side in 2.6.3
+  val JoinManifest = "J"
+  val WelcomeManifest = "W"
+  val LeaveManifest = "L"
+  val DownManifest = "D"
+  val InitJoinManifest = "IJ"
+  val InitJoinAckManifest = "IJA"
+  val InitJoinNackManifest = "IJN"
   val HeartBeatManifest = "HB"
   val HeartBeatRspManifest = "HBR"
-  val ExitingConfirmedManifest = s"akka.cluster.InternalClusterAction$$ExitingConfirmed"
-  val GossipStatusManifest = "akka.cluster.GossipStatus"
-  val GossipEnvelopeManifest = "akka.cluster.GossipEnvelope"
-  val ClusterRouterPoolManifest = "akka.cluster.routing.ClusterRouterPool"
+  val ExitingConfirmedManifest = "EC"
+  val GossipStatusManifest = "GS"
+  val GossipEnvelopeManifest = "GE"
+  val ClusterRouterPoolManifest = "CRP"
 
   private final val BufferSize = 1024 * 4
 }
@@ -69,19 +82,19 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem)
   private lazy val GossipTimeToLive = Cluster(system).settings.GossipTimeToLive
 
   def manifest(o: AnyRef): String = o match {
-    case _: InternalClusterAction.Join          => JoinManifest
-    case _: InternalClusterAction.Welcome       => WelcomeManifest
-    case _: ClusterUserAction.Leave             => LeaveManifest
-    case _: ClusterUserAction.Down              => DownManifest
-    case _: InternalClusterAction.InitJoin      => InitJoinManifest
-    case _: InternalClusterAction.InitJoinAck   => InitJoinAckManifest
-    case _: InternalClusterAction.InitJoinNack  => InitJoinNackManifest
+    case _: InternalClusterAction.Join          => OldJoinManifest
+    case _: InternalClusterAction.Welcome       => OldWelcomeManifest
+    case _: ClusterUserAction.Leave             => OldLeaveManifest
+    case _: ClusterUserAction.Down              => OldDownManifest
+    case _: InternalClusterAction.InitJoin      => OldInitJoinManifest
+    case _: InternalClusterAction.InitJoinAck   => OldInitJoinAckManifest
+    case _: InternalClusterAction.InitJoinNack  => OldInitJoinNackManifest
     case _: ClusterHeartbeatSender.Heartbeat    => HeartBeatManifestPre2523
     case _: ClusterHeartbeatSender.HeartbeatRsp => HeartBeatRspManifest2523
-    case _: ExitingConfirmed                    => ExitingConfirmedManifest
-    case _: GossipStatus                        => GossipStatusManifest
-    case _: GossipEnvelope                      => GossipEnvelopeManifest
-    case _: ClusterRouterPool                   => ClusterRouterPoolManifest
+    case _: ExitingConfirmed                    => OldExitingConfirmedManifest
+    case _: GossipStatus                        => OldGossipStatusManifest
+    case _: GossipEnvelope                      => OldGossipEnvelopeManifest
+    case _: ClusterRouterPool                   => OldClusterRouterPoolManifest
     case _ =>
       throw new IllegalArgumentException(s"Can't serialize object of type ${o.getClass} in [${getClass.getName}]")
   }
@@ -105,22 +118,33 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem)
   }
 
   def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = manifest match {
-    case HeartBeatManifestPre2523  => deserializeHeartBeatAsAddress(bytes)
-    case HeartBeatRspManifest2523  => deserializeHeartBeatRspAsUniqueAddress(bytes)
-    case HeartBeatManifest         => deserializeHeartBeat(bytes)
-    case HeartBeatRspManifest      => deserializeHeartBeatResponse(bytes)
-    case GossipStatusManifest      => deserializeGossipStatus(bytes)
-    case GossipEnvelopeManifest    => deserializeGossipEnvelope(bytes)
-    case InitJoinManifest          => deserializeInitJoin(bytes)
-    case InitJoinAckManifest       => deserializeInitJoinAck(bytes)
-    case InitJoinNackManifest      => deserializeInitJoinNack(bytes)
-    case JoinManifest              => deserializeJoin(bytes)
-    case WelcomeManifest           => deserializeWelcome(bytes)
-    case LeaveManifest             => deserializeLeave(bytes)
-    case DownManifest              => deserializeDown(bytes)
-    case ExitingConfirmedManifest  => deserializeExitingConfirmed(bytes)
-    case ClusterRouterPoolManifest => deserializeClusterRouterPool(bytes)
-    case _                         => throw new IllegalArgumentException(s"Unknown manifest [${manifest}]")
+    case HeartBeatManifestPre2523     => deserializeHeartBeatAsAddress(bytes)
+    case HeartBeatRspManifest2523     => deserializeHeartBeatRspAsUniqueAddress(bytes)
+    case HeartBeatManifest            => deserializeHeartBeat(bytes)
+    case HeartBeatRspManifest         => deserializeHeartBeatResponse(bytes)
+    case OldGossipStatusManifest      => deserializeGossipStatus(bytes)
+    case OldGossipEnvelopeManifest    => deserializeGossipEnvelope(bytes)
+    case OldInitJoinManifest          => deserializeInitJoin(bytes)
+    case OldInitJoinAckManifest       => deserializeInitJoinAck(bytes)
+    case OldInitJoinNackManifest      => deserializeInitJoinNack(bytes)
+    case OldJoinManifest              => deserializeJoin(bytes)
+    case OldWelcomeManifest           => deserializeWelcome(bytes)
+    case OldLeaveManifest             => deserializeLeave(bytes)
+    case OldDownManifest              => deserializeDown(bytes)
+    case OldExitingConfirmedManifest  => deserializeExitingConfirmed(bytes)
+    case OldClusterRouterPoolManifest => deserializeClusterRouterPool(bytes)
+    case GossipStatusManifest         => deserializeGossipStatus(bytes)
+    case GossipEnvelopeManifest       => deserializeGossipEnvelope(bytes)
+    case InitJoinManifest             => deserializeInitJoin(bytes)
+    case InitJoinAckManifest          => deserializeInitJoinAck(bytes)
+    case InitJoinNackManifest         => deserializeInitJoinNack(bytes)
+    case JoinManifest                 => deserializeJoin(bytes)
+    case WelcomeManifest              => deserializeWelcome(bytes)
+    case LeaveManifest                => deserializeLeave(bytes)
+    case DownManifest                 => deserializeDown(bytes)
+    case ExitingConfirmedManifest     => deserializeExitingConfirmed(bytes)
+    case ClusterRouterPoolManifest    => deserializeClusterRouterPool(bytes)
+    case _                            => throw new IllegalArgumentException(s"Unknown manifest [${manifest}]")
   }
 
   def compress(msg: MessageLite): Array[Byte] = {

--- a/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
@@ -110,7 +110,7 @@ class ClusterMessageSerializerSpec extends AkkaSpec("akka.actor.provider = clust
       val serializedInitJoinAckPre2510 = serializer.addressToProto(initJoinAck.address).build().toByteArray
 
       val deserialized =
-        serializer.fromBinary(serializedInitJoinAckPre2510, ClusterMessageSerializer.InitJoinAckManifest)
+        serializer.fromBinary(serializedInitJoinAckPre2510, ClusterMessageSerializer.OldInitJoinAckManifest)
       deserialized shouldEqual initJoinAck
     }
 

--- a/akka-docs/src/main/paradox/project/rolling-update.md
+++ b/akka-docs/src/main/paradox/project/rolling-update.md
@@ -73,3 +73,16 @@ versions 2.5.18, 2.5.19, 2.5.20 or 2.5.21.
 ### 2.6.0 Several changes in minor release
 
 See @ref:[migration guide](migration-guide-2.5.x-2.6.x.md) when updating from 2.5.x to 2.6.x.
+
+### 2.6.2 ClusterMessageSerializer manifests change
+
+Issue: [#23654](https://github.com/akka/akka/issues/13654)
+
+In preparation of switching away from class based manifests to more efficient letter codes the `ClusterMessageSerializer`
+has been prepared to accept those shorter forms but still emits the old long manifests.
+
+* 2.6.2 - shorter manifests accepted
+* 2.6.3 - shorter manifests emitted (not released yet)
+
+This means that a rolling upgrade will have to go through 2.6.2 and 2.6.3 when upgrading to 2.6.3 or higher or else
+cluster nodes will not be able to communicate during the rolling upgrade.


### PR DESCRIPTION
Refs #13654

First we add short manifests and handle both those and the old class based ones in deserialization for 2.6.2

Then in a next step for 2.6.3 we start emitting the new ones and remove the old ones.

I renamed all the old full class name manifest constants with an `Old` prefix to make them easy to sppot in the next step.