### PR TITLE
Use unique name for typed and untyped testprobes

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
@@ -22,7 +22,6 @@ import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.javadsl.{ TestProbe => JavaTestProbe }
 import akka.actor.testkit.typed.scaladsl.TestDuration
 import akka.actor.testkit.typed.scaladsl.{ TestProbe => ScalaTestProbe }
-import akka.testkit.TestKit.testActorId
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -66,6 +65,9 @@ private[akka] final class TestProbeImpl[M](name: String, system: ActorSystem[_])
     with ScalaTestProbe[M] {
 
   import TestProbeImpl._
+
+  // have to use same global counter as Classic TestKit to ensure unique names
+  private def testActorId = akka.testkit.TestKit.testActorId
   protected implicit val settings: TestKitSettings = TestKitSettings(system)
   private val queue = new LinkedBlockingDeque[M]
   private val terminations = new LinkedBlockingDeque[Terminated]

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
@@ -7,7 +7,6 @@ package akka.actor.testkit.typed.internal
 import java.time.{ Duration => JDuration }
 import java.util.concurrent.BlockingDeque
 import java.util.concurrent.LinkedBlockingDeque
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Supplier
 import java.util.{ List => JList }
 
@@ -23,6 +22,7 @@ import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.javadsl.{ TestProbe => JavaTestProbe }
 import akka.actor.testkit.typed.scaladsl.TestDuration
 import akka.actor.testkit.typed.scaladsl.{ TestProbe => ScalaTestProbe }
+import akka.testkit.TestKit.testActorId
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -36,8 +36,6 @@ import akka.util.PrettyDuration._
 
 @InternalApi
 private[akka] object TestProbeImpl {
-  private val testActorId = new AtomicInteger(0)
-
   private final case class WatchActor[U](actor: ActorRef[U])
   private case object Stop
 

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/ActorTestKitSpec.scala
@@ -85,6 +85,13 @@ class ActorTestKitSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wi
       scalaTestWithActorTestKit2.testKit.system.settings.config.hasPath("test.from-application") should ===(false)
     }
 
+    "have unique names for probes across untyped testkit" in {
+      import akka.actor.typed.scaladsl.adapter._
+      createTestProbe()
+      akka.testkit.TestProbe()(system.toClassic)
+      // not throw
+    }
+
   }
 
 }

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -20,6 +20,7 @@ import akka.util.{ BoxedType, Timeout }
 import akka.actor.IllegalActorStateException
 import akka.actor.DeadLetter
 import akka.actor.Terminated
+import akka.annotation.InternalApi
 import com.github.ghik.silencer.silent
 
 object TestActor {
@@ -928,7 +929,12 @@ trait TestKitBase {
 class TestKit(_system: ActorSystem) extends { implicit val system = _system } with TestKitBase
 
 object TestKit {
-  private[testkit] val testActorId = new AtomicInteger(0)
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private[akka] val testActorId = new AtomicInteger(0)
 
   /**
    * Await until the given condition evaluates to `true` or the timeout


### PR DESCRIPTION
Fixes https://github.com/akka/akka/issues/28509