### PR TITLE
Do not cache PromiseActorRef 

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
@@ -62,8 +62,11 @@ private[remote] class Encoder(
 
   override def createLogicAndMaterializedValue(
       inheritedAttributes: Attributes): (GraphStageLogic, OutboundCompressionAccess) = {
-    val logic = new GraphStageLogic(shape) with InHandler with OutHandler with StageLogging
-    with OutboundCompressionAccess {
+    val logic = new GraphStageLogic(shape)
+      with InHandler
+      with OutHandler
+      with StageLogging
+      with OutboundCompressionAccess {
 
       private val headerBuilder = HeaderBuilder.out()
       headerBuilder.setVersion(version)
@@ -354,8 +357,11 @@ private[remote] class Decoder(
   val shape: FlowShape[EnvelopeBuffer, InboundEnvelope] = FlowShape(in, out)
 
   def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, InboundCompressionAccess) = {
-    val logic = new TimerGraphStageLogic(shape) with InboundCompressionAccessImpl with InHandler with OutHandler
-    with StageLogging {
+    val logic = new TimerGraphStageLogic(shape)
+      with InboundCompressionAccessImpl
+      with InHandler
+      with OutHandler
+      with StageLogging {
       import Decoder.RetryResolveRemoteDeployedRecipient
 
       override val compressions = inboundCompressions


### PR DESCRIPTION
... since that is a one off ref that won't be reused, and keeping it referenced also keeps the response from getting GC:d after it has gotten a response

Refs #28521