### PR TITLE
Getting started referred to a package name not present in quickstart

### DIFF
--- a/akka-docs/src/main/paradox/typed/guide/tutorial_1.md
+++ b/akka-docs/src/main/paradox/typed/guide/tutorial_1.md
@@ -32,7 +32,7 @@ In fact, before your first actor is started, Akka has already created two actors
  
 The easiest way to see the actor hierarchy in action is to print `ActorRef` instances. In this small experiment, we create an actor, print its reference, create a child of this actor, and print the child's reference. We start with the Hello World project, if you have not downloaded it, download the Quickstart project from the @scala[[Lightbend Tech Hub](https://developer.lightbend.com/start/?group=akka&amp;project=akka-quickstart-scala)]@java[[Lightbend Tech Hub](https://developer.lightbend.com/start/?group=akka&amp;project=akka-quickstart-java)].
 
-In your Hello World project, navigate to the `com.lightbend.akka.sample` package and create a new @scala[Scala file called `ActorHierarchyExperiments.scala`]@java[Java file called `ActorHierarchyExperiments.java`] here. Copy and paste the code from the snippet below to this new source file. Save your file and run `sbt "runMain com.lightbend.akka.sample.ActorHierarchyExperiments"` to observe the output.
+In your Hello World project, navigate to the `com.example` package and create a new @scala[Scala file called `ActorHierarchyExperiments.scala`]@java[Java file called `ActorHierarchyExperiments.java`] here. Copy and paste the code from the snippet below to this new source file. Save your file and run `sbt "runMain com.example.ActorHierarchyExperiments"` to observe the output.
 
 Scala
 :   @@snip [ActorHierarchyExperiments.scala](/akka-docs/src/test/scala/typed/tutorial_1/ActorHierarchyExperiments.scala) { #print-refs }

--- a/akka-docs/src/main/paradox/typed/guide/tutorial_2.md
+++ b/akka-docs/src/main/paradox/typed/guide/tutorial_2.md
@@ -8,7 +8,7 @@ With an understanding of actor hierarchy and behavior, the remaining question is
 
 We can define the first actor, the IotSupervisor, with a few lines of code. To start your tutorial application:
 
-1. Create a new `IotSupervisor` source file in the `com.lightbend.akka.sample` package.
+1. Create a new `IotSupervisor` source file in the `com.example` package.
 1. Paste the following code into the new file to define the IotSupervisor.
 
 Scala

--- a/akka-docs/src/main/paradox/typed/guide/tutorial_3.md
+++ b/akka-docs/src/main/paradox/typed/guide/tutorial_3.md
@@ -138,7 +138,7 @@ Note in the code that:
 
 ## Testing the actor
 
-Based on the actor above, we could write a test. In the `com.lightbend.akka.sample` package in the test tree of your project, add the following code to a @scala[`DeviceSpec.scala`]@java[`DeviceTest.java`] file.
+Based on the actor above, we could write a test. In the `com.example` package in the test tree of your project, add the following code to a @scala[`DeviceSpec.scala`]@java[`DeviceTest.java`] file.
 @scala[(We use ScalaTest but any other test framework can be used with the Akka Testkit)].
 
 You can run this test @scala[by running `test` at the sbt prompt]@java[by running `mvn test`].

--- a/akka-docs/src/test/scala/typed/tutorial_3/DeviceInProgress.scala
+++ b/akka-docs/src/test/scala/typed/tutorial_3/DeviceInProgress.scala
@@ -6,7 +6,6 @@ package typed.tutorial_3
 
 import akka.actor.typed.PostStop
 import akka.actor.typed.Signal
-import akka.actor.typed.scaladsl.LoggerOps
 
 object DeviceInProgress1 {
 
@@ -30,6 +29,7 @@ object DeviceInProgress2 {
   import akka.actor.typed.scaladsl.AbstractBehavior
   import akka.actor.typed.scaladsl.ActorContext
   import akka.actor.typed.scaladsl.Behaviors
+  import akka.actor.typed.scaladsl.LoggerOps
 
   object Device {
     def apply(groupId: String, deviceId: String): Behavior[Command] =


### PR DESCRIPTION
Noticed during the workshop at Scala usergroup Stockholm yesterday.

Techhub zip has `com.example` and g8 template defaults to com.example so let's refer to that instead of `com.lightbend.something.something` (old quickstart package I guess)
