### PR TITLE
Configure Autolabler

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,0 +1,5 @@
+# configuration for https://github.com/probot/autolabeler
+
+dependency-change: "/project/Dependencies.scala"
+
+'t:stream': ["/akka-stream", "/akka-stream-testkit", "/akka-stream-tests", "/akka-stream-tests-tck", "/akka-stream-typed"]


### PR DESCRIPTION
So that Akka Stream-related PRs automatically get the `t:stream` label and changes to dependencies get a label.