### PR TITLE
[2.5 backport] stream: fail eagerly during SubSink/SubSource material…ization

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrefixAndTailSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrefixAndTailSpec.scala
@@ -99,8 +99,9 @@ class FlowPrefixAndTailSpec extends StreamSpec {
 
       val subscriber2 = TestSubscriber.probe[Int]()
       tail.to(Sink.fromSubscriber(subscriber2)).run()
-      subscriber2.expectSubscriptionAndError().getMessage should ===(
-        "Substream Source cannot be materialized more than once")
+      val ex = subscriber2.expectSubscriptionAndError()
+      ex.getMessage should ===("Substream Source(TailSource) cannot be materialized more than once")
+      ex.getStackTrace.exists(_.getClassName contains "FlowPrefixAndTailSpec") shouldBe true
 
       subscriber1.requestNext(2).expectComplete()
 
@@ -124,7 +125,7 @@ class FlowPrefixAndTailSpec extends StreamSpec {
 
       tail.to(Sink.fromSubscriber(subscriber)).run()(tightTimeoutMaterializer)
       subscriber.expectSubscriptionAndError().getMessage should ===(
-        s"Substream Source has not been materialized in ${ms} milliseconds")
+        s"Substream Source(TailSource) has not been materialized in ${ms} milliseconds")
     }
     "not fail the stream if substream has not been subscribed in time and configured subscription timeout is noop" in assertAllStagesStopped {
       val tightTimeoutMaterializer =


### PR DESCRIPTION
Backport of #28492

This way the stack trace will be more helpful because it contains the stage
that actually triggered the materialization.

Otherwise, we will only fail during `preStart` in the interpreter where the
stage will be failed and the error be propagated through the stream where
it can be hard to figure out what happened.

Also improve the message itself to contain the user provided name of the
sink/source.

(cherry picked from commit 1fbd1d338f8b9303f5d88351e5a67c63e6416aea)