### PR TITLE
Fix typo depredated, change to deprecated

### DIFF
--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -144,7 +144,8 @@ akka {
 
     # TypedActor deprecated since 2.6.0.
     typed {
-      # Default timeout for the depredated TypedActor (not the new actor APIs in 2.6) methods with non-void return type
+      # Default timeout for the deprecated TypedActor (not the new actor APIs in 2.6)
+      # methods with non-void return type.
       timeout = 5s
     }
 


### PR DESCRIPTION
This is just a typo fix. Change _depre**d**ated_ to _depre**c**ated_.
