### PR TITLE
Improve error message when coordinator not found

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -899,9 +899,18 @@ private[akka] class ShardRegion(
           shardBuffers.totalSize,
           coordinatorMessage)
       } else {
+        // Members start off as "Removed"
+        val partOfCluster = cluster.selfMember.status != MemberStatus.Removed
+        val possibleReason =
+          if (partOfCluster)
+            "Has Cluster Sharding been started on every node and nodes been configured with the correct role(s)?"
+          else
+            "Probably, no seed-nodes configured and manual cluster or bootstrap join not performed?"
+
         log.warning(
-          "{}: No coordinator found to register. Probably, no seed-nodes configured and manual cluster join not performed? Total [{}] buffered messages.",
+          "{}: No coordinator found to register. {} Total [{}] buffered messages.",
           typeName,
+          possibleReason,
           shardBuffers.totalSize)
       }
     }


### PR DESCRIPTION
Led users to think that the node had left the cluster when not starting
sharding on every node with the correct roles.

