### PR TITLE
more useful JavaDoc for javadsl Flow

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -370,7 +370,9 @@ object Flow {
 
 }
 
-/** Create a `Flow` which can process elements of type `T`. */
+/**
+ * A `Flow` is a set of stream processing steps that has one open input and one open output.
+ */
 final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Graph[FlowShape[In, Out], Mat] {
   import akka.util.ccompat.JavaConverters._
 


### PR DESCRIPTION
The JavaDoc for `javadsl.Flow` is a bit off. First of all, it specifies `T` instead of `In`, but the constructor cannot be used directly from Java anyway, so it would make more sense to use the class-level documentation from `scaladsl.Flow`.