### PR TITLE
Log warning when typed message adapters return null

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextPipeToSelfSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextPipeToSelfSpec.scala
@@ -7,12 +7,14 @@ package akka.actor.typed.scaladsl
 import scala.concurrent.Future
 import scala.util.control.NoStackTrace
 import scala.util.{ Failure, Success }
-
+import akka.actor.testkit.typed.scaladsl.LoggingTestKit
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.{ ScalaTestWithActorTestKit, TestProbe }
 import akka.actor.typed.Props
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
+
+import scala.concurrent.Promise
 
 object ActorContextPipeToSelfSpec {
   val config = ConfigFactory.parseString("""
@@ -31,6 +33,31 @@ final class ActorContextPipeToSelfSpec
   "The Scala DSL ActorContext pipeToSelf" must {
     "handle success" in { responseFrom(Future.successful("hi")) should ===("ok: hi") }
     "handle failure" in { responseFrom(Future.failed(Fail)) should ===(s"ko: $Fail") }
+    "handle adapted null" in {
+      val probe = testKit.createTestProbe[String]()
+      val promise = Promise[String]()
+      testKit.spawn(Behaviors.setup[String] { ctx =>
+        ctx.pipeToSelf(promise.future) {
+          case Success(value) =>
+            probe.ref ! "adapting"
+            value // we're passing on null here
+          case Failure(ex) => throw ex
+        }
+
+        Behaviors.receiveMessage {
+          case msg =>
+            probe.ref ! msg
+            Behaviors.same
+
+        }
+      })
+
+      LoggingTestKit.warn("Adapter function returned null which is not valid as an actor message, ignoring").expect {
+        // (probably more likely to happen in Java)
+        promise.success(null.asInstanceOf[String])
+      }
+
+    }
   }
 
   object Fail extends NoStackTrace

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
@@ -220,9 +220,9 @@ import org.slf4j.LoggerFactory
       future: CompletionStage[Value],
       applyToResult: akka.japi.function.Function2[Value, Throwable, T]): Unit = {
     future.whenComplete { (value, ex) =>
-      if (value != null) self.unsafeUpcast ! AdaptMessage(value, applyToResult.apply(_: Value, null))
       if (ex != null)
         self.unsafeUpcast ! AdaptMessage(ex, applyToResult.apply(null.asInstanceOf[Value], _: Throwable))
+      else self.unsafeUpcast ! AdaptMessage(value, applyToResult.apply(_: Value, null))
     }
   }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
@@ -14,13 +14,13 @@ import akka.actor.typed.internal.BehaviorImpl.DeferredBehavior
 import akka.actor.typed.internal.BehaviorImpl.StoppedBehavior
 import akka.actor.typed.internal.adapter.ActorAdapter.TypedActorFailedException
 import akka.annotation.InternalApi
+
 import scala.annotation.tailrec
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 import scala.util.control.Exception.Catcher
 import scala.annotation.switch
-
 import akka.actor.typed.internal.TimerSchedulerImpl.TimerMsg
 import akka.util.OptionVal
 
@@ -92,7 +92,7 @@ import akka.util.OptionVal
         case classic.ReceiveTimeout =>
           handleMessage(ctx.receiveTimeoutMsg)
         case wrapped: AdaptMessage[Any, T] @unchecked =>
-          withSafelyAdapted(() => wrapped.adapt()) {
+          withSafelyAdapted(wrapped.adapt) {
             case AdaptWithRegisteredMessageAdapter(msg) =>
               adaptAndHandle(msg)
             case msg: T @unchecked =>
@@ -182,6 +182,9 @@ import akka.util.OptionVal
 
   private def withSafelyAdapted[U, V](adapt: () => U)(body: U => V): Unit = {
     Try(adapt()) match {
+      case Success(null) =>
+        ctx.log.warn(
+          "Adapter function returned null which is not valid as an actor message, ignoring. This can happen for example when using pipeToSelf and returning null from the adapt function. Null value is ignored and not passed on to actor.")
       case Success(a) =>
         body(a)
       case Failure(ex) =>

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
@@ -92,7 +92,7 @@ import akka.util.OptionVal
         case classic.ReceiveTimeout =>
           handleMessage(ctx.receiveTimeoutMsg)
         case wrapped: AdaptMessage[Any, T] @unchecked =>
-          withSafelyAdapted(wrapped.adapt) {
+          withSafelyAdapted(() => wrapped.adapt()) {
             case AdaptWithRegisteredMessageAdapter(msg) =>
               adaptAndHandle(msg)
             case msg: T @unchecked =>


### PR DESCRIPTION
Refs #28587

Can happen if

 * pipeToSelf adapt function returns null (can easily happen in Java with two param adapt
   when completion stage is completed with null and check is for exception non-null)
 * messageAdapter returns null (less likely)