### PR TITLE
Push that DeprecatedTlsSpec timeout a bit up 

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/io/DeprecatedTlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/DeprecatedTlsSpec.scala
@@ -58,7 +58,7 @@ object DeprecatedTlsSpec {
   def initSslContext(): SSLContext = initWithTrust("/truststore")
 
   /**
-   * This is an operator that fires a TimeoutException failure 2 seconds after it was started,
+   * This is an operator that fires a TimeoutException failure after it was started,
    * independent of the traffic going through. The purpose is to include the last seen
    * element in the exception message to help in figuring out what went wrong.
    */
@@ -389,11 +389,11 @@ class DeprecatedTlsSpec extends StreamSpec(DeprecatedTlsSpec.configOverrides) wi
             .collect { case SessionBytes(_, b) => b }
             .scan(ByteString.empty)(_ ++ _)
             .filter(_.nonEmpty)
-            .via(new Timeout(6.seconds))
+            .via(new Timeout(8.seconds))
             .dropWhile(_.size < scenario.output.size)
             .runWith(Sink.headOption)
 
-        Await.result(output, 8.seconds).getOrElse(ByteString.empty).utf8String should be(scenario.output.utf8String)
+        Await.result(output, 10.seconds).getOrElse(ByteString.empty).utf8String should be(scenario.output.utf8String)
 
         commPattern.cleanup()
       }

--- a/akka-stream-tests/src/test/scala/akka/stream/io/DeprecatedTlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/DeprecatedTlsSpec.scala
@@ -25,6 +25,7 @@ import akka.stream.stage._
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.testkit.WithLogCapturing
+import akka.testkit.TestDuration
 import akka.util.ByteString
 import akka.util.JavaVersion
 import com.github.ghik.silencer.silent
@@ -389,11 +390,12 @@ class DeprecatedTlsSpec extends StreamSpec(DeprecatedTlsSpec.configOverrides) wi
             .collect { case SessionBytes(_, b) => b }
             .scan(ByteString.empty)(_ ++ _)
             .filter(_.nonEmpty)
-            .via(new Timeout(10.seconds))
+            .via(new Timeout(10.seconds.dilated))
             .dropWhile(_.size < scenario.output.size)
             .runWith(Sink.headOption)
 
-        Await.result(output, 12.seconds).getOrElse(ByteString.empty).utf8String should be(scenario.output.utf8String)
+        Await.result(output, 12.seconds.dilated).getOrElse(ByteString.empty).utf8String should be(
+          scenario.output.utf8String)
 
         commPattern.cleanup()
       }

--- a/akka-stream-tests/src/test/scala/akka/stream/io/DeprecatedTlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/DeprecatedTlsSpec.scala
@@ -389,11 +389,11 @@ class DeprecatedTlsSpec extends StreamSpec(DeprecatedTlsSpec.configOverrides) wi
             .collect { case SessionBytes(_, b) => b }
             .scan(ByteString.empty)(_ ++ _)
             .filter(_.nonEmpty)
-            .via(new Timeout(8.seconds))
+            .via(new Timeout(10.seconds))
             .dropWhile(_.size < scenario.output.size)
             .runWith(Sink.headOption)
 
-        Await.result(output, 10.seconds).getOrElse(ByteString.empty).utf8String should be(scenario.output.utf8String)
+        Await.result(output, 12.seconds).getOrElse(ByteString.empty).utf8String should be(scenario.output.utf8String)
 
         commPattern.cleanup()
       }

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
@@ -419,11 +419,11 @@ class TlsSpec extends StreamSpec(TlsSpec.configOverrides) with WithLogCapturing 
             .collect { case SessionBytes(_, b) => b }
             .scan(ByteString.empty)(_ ++ _)
             .filter(_.nonEmpty)
-            .via(new Timeout(6.seconds))
+            .via(new Timeout(10.seconds))
             .dropWhile(_.size < scenario.output.size)
             .runWith(Sink.headOption)
 
-        Await.result(output, 8.seconds).getOrElse(ByteString.empty).utf8String should be(scenario.output.utf8String)
+        Await.result(output, 12.seconds).getOrElse(ByteString.empty).utf8String should be(scenario.output.utf8String)
 
         commPattern.cleanup()
       }

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TlsSpec.scala
@@ -23,6 +23,7 @@ import akka.stream.scaladsl._
 import akka.stream.stage._
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
+import akka.testkit.TestDuration
 import akka.util.{ ByteString, JavaVersion }
 import javax.net.ssl._
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
@@ -518,7 +519,7 @@ class TlsSpec extends StreamSpec(TlsSpec.configOverrides) with WithLogCapturing 
       val inFlow = Flow[SslTlsInbound]
         .collect { case SessionBytes(_, b) => b }
         .scan(ByteString.empty)(_ ++ _)
-        .via(new Timeout(6.seconds))
+        .via(new Timeout(6.seconds.dilated))
         .dropWhile(_.size < scenario.output.size)
 
       val f =
@@ -530,7 +531,7 @@ class TlsSpec extends StreamSpec(TlsSpec.configOverrides) with WithLogCapturing 
           })
           .runWith(Sink.last)
 
-      Await.result(f, 8.second).utf8String should be(scenario.output.utf8String)
+      Await.result(f, 8.second.dilated).utf8String should be(scenario.output.utf8String)
     }
 
     "verify hostname" in assertAllStagesStopped {


### PR DESCRIPTION
References #28449

Failures seem to be only for LargeMessage so I think it could be a too tight timeout. Since it passes most of the time I think it is enough with a small increase (although perhaps a large timeout wouldn't hurt either given that it only hits in the fail case).