### PR TITLE
remove obsolete PersistenceSettings.view

### DIFF
--- a/akka-persistence/src/main/mima-filters/2.6.3.backwards.excludes/28331-timestamp-PersistentRepr.excludes
+++ b/akka-persistence/src/main/mima-filters/2.6.3.backwards.excludes/28331-timestamp-PersistentRepr.excludes
@@ -1,0 +1,3 @@
+# PersistenceSettings.view
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.PersistenceSettings.view")
+ProblemFilters.exclude[MissingClassProblem]("akka.persistence.PersistenceSettings$view$")

--- a/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
@@ -11,7 +11,7 @@ import scala.collection.immutable
 /**
  * INTERNAL API.
  *
- * Messages exchanged between persistent actors, views and a journal.
+ * Messages exchanged between persistent actors and a journal.
  */
 private[persistence] object JournalProtocol {
 

--- a/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
@@ -26,20 +26,6 @@ import akka.annotation.InternalApi
  */
 final class PersistenceSettings(config: Config) {
 
-  object view {
-    val autoUpdate: Boolean =
-      config.getBoolean("view.auto-update")
-
-    val autoUpdateInterval: FiniteDuration =
-      config.getMillisDuration("view.auto-update-interval")
-
-    val autoUpdateReplayMax: Long =
-      posMax(config.getLong("view.auto-update-replay-max"))
-
-    private def posMax(v: Long) =
-      if (v < 0) Long.MaxValue else v
-  }
-
   object atLeastOnceDelivery {
 
     val redeliverInterval: FiniteDuration =

--- a/akka-persistence/src/main/scala/akka/persistence/Protocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Protocol.scala
@@ -9,7 +9,7 @@ import akka.actor.NoSerializationVerificationNeeded
 /**
  * INTERNAL API.
  *
- * Messages exchanged between persistent actors, views and a journal/snapshot-store.
+ * Messages exchanged between persistent actors and a journal/snapshot-store.
  */
 private[persistence] object Protocol {
 


### PR DESCRIPTION
Archeology finding...

* removing without deprecation because this can't be used anywhere
* persistence view has been removed years ago, and those config properties
  don't even exist in reference.conf so accessing this would throw exception
