### PR TITLE
Fixed register a callback on termination

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -1030,7 +1030,7 @@ private[akka] class ActorSystemImpl(
         "Please report at https://github.com/akka/akka/issues.")
   private lazy val _start: this.type = try {
 
-    registerOnTermination(stopScheduler())
+    registerOnTermination(stopScheduler)
     // the provider is expected to start default loggers, LocalActorRefProvider does this
     provider.init(this)
     // at this point it should be initialized "enough" for most extensions that we might want to guard against otherwise


### PR DESCRIPTION
I guess this was a typo because now it just terminated scheduler on start and register `Unit` as a callback.

I believe that the original idea was to register `stopScheduler` as callback on termination of the Akka system.

Without it, at some rare case, it was possible to have infinity loop inside `AbstractNodeQueue` like this:

```
"System-scheduler-1" #42 prio=5 os_prio=0 tid=0x00007f900dd820d0 nid=0x3d runnable [0x00007f8f6fffe000]
   java.lang.Thread.State: RUNNABLE
        at akka.dispatch.AbstractNodeQueue.pollNode(AbstractNodeQueue.java:163)
        at akka.actor.LightArrayRevolverScheduler$$anon$3.executeBucket$1(LightArrayRevolverScheduler.scala:277)
        at akka.actor.LightArrayRevolverScheduler$$anon$3.nextTick(LightArrayRevolverScheduler.scala:289)
        at akka.actor.LightArrayRevolverScheduler$$anon$3.run(LightArrayRevolverScheduler.scala:241)
        at java.lang.Thread.run(Thread.java:748)
```