### PR TITLE
Make it obvious a custom serializer is needed

### DIFF
--- a/akka-docs/src/main/paradox/typed/distributed-data.md
+++ b/akka-docs/src/main/paradox/typed/distributed-data.md
@@ -569,8 +569,8 @@ Implement the additional methods of @scala[`DeltaReplicatedData`]@java[`Abstract
 #### Serialization
 
 The data types must be serializable with an @ref:[Akka Serializer](../serialization.md).
-It is highly recommended that you implement  efficient serialization with Protobuf or similar
-for your custom data types. The built in data types are marked with `ReplicatedDataSerialization`
+It is highly recommended that you implement efficient serialization with Protobuf or similar
+for your custom data types, otherwise inefficient Java serialization applies. The built in data types are marked with `ReplicatedDataSerialization`
 and serialized with `akka.cluster.ddata.protobuf.ReplicatedDataSerializer`.
 
 Serialization of the data types are used in remote messages and also for creating message


### PR DESCRIPTION
When I read the doc, I get the impression that if no custom serializer is implemented, akka will figure it out by leveraging `ReplicatedDataSerializer`, since in my use case, I do nothing but combining 2 `GCounter` to build a `FractionCounter`. However, my impression is wrong, and I have to read the source code to understand. Maybe better to make it obvious

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
