### PR TITLE
Fix ExplicitlyTriggeredScheduler cancellation

### DIFF
--- a/akka-testkit/src/main/mima-filters/2.6.3.backwards.excludes/28604-fix-ExplicitlyTriggeredScheduler-cancellation.excludes
+++ b/akka-testkit/src/main/mima-filters/2.6.3.backwards.excludes/28604-fix-ExplicitlyTriggeredScheduler-cancellation.excludes
@@ -1,11 +1,8 @@
 # #28604 changes in the akka.testkit.ExplicitlyTriggeredScheduler internal implementation.
 # Removal of the `time` field from the internal Item case class in ExplicitlyTriggeredScheduler.
-ProblemFilters.exclude[MissingTypesProblem]("akka.testkit.ExplicitlyTriggeredScheduler$Item$")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.apply")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.apply")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.copy")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.this")
 ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.unapply")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.time")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.copy")
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.copy$default$1")
-ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.copy$default$2")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.copy$default$3")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.this")

--- a/akka-testkit/src/main/mima-filters/2.6.3.backwards.excludes/28604-fix-ExplicitlyTriggeredScheduler-cancellation.excludes
+++ b/akka-testkit/src/main/mima-filters/2.6.3.backwards.excludes/28604-fix-ExplicitlyTriggeredScheduler-cancellation.excludes
@@ -1,8 +1,5 @@
 # #28604 changes in the akka.testkit.ExplicitlyTriggeredScheduler internal implementation.
 # Removal of the `time` field from the internal Item case class in ExplicitlyTriggeredScheduler.
-ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.apply")
-ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.copy")
-ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.this")
-ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.unapply")
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.time")
-ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.copy$default$1")
+ProblemFilters.exclude[MissingClassProblem]("akka.testkit.ExplicitlyTriggeredScheduler$Item$")
+ProblemFilters.exclude[MissingTypesProblem]("akka.testkit.ExplicitlyTriggeredScheduler$Item")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.*")

--- a/akka-testkit/src/main/mima-filters/2.6.3.backwards.excludes/28604-fix-ExplicitlyTriggeredScheduler-cancellation.excludes
+++ b/akka-testkit/src/main/mima-filters/2.6.3.backwards.excludes/28604-fix-ExplicitlyTriggeredScheduler-cancellation.excludes
@@ -1,0 +1,11 @@
+# #28604 changes in the akka.testkit.ExplicitlyTriggeredScheduler internal implementation.
+# Removal of the `time` field from the internal Item case class in ExplicitlyTriggeredScheduler.
+ProblemFilters.exclude[MissingTypesProblem]("akka.testkit.ExplicitlyTriggeredScheduler$Item$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.time")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.copy")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.copy$default$1")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.copy$default$2")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.copy$default$3")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.testkit.ExplicitlyTriggeredScheduler#Item.this")

--- a/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
@@ -13,7 +13,7 @@ import scala.annotation.tailrec
 import akka.util.ccompat.JavaConverters._
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.util.Try
 import akka.actor.Cancellable
 import akka.actor.Scheduler

--- a/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
@@ -70,7 +70,13 @@ class ExplicitlyTriggeredScheduler(@unused config: Config, log: LoggingAdapter, 
   }
 
   private def scheduledTasks(runTo: Long): Seq[(Item, Long)] =
-    scheduled.entrySet().asScala.map(s => (s.getKey, s.getValue)).toSeq.filter { case (_, v) => v <= runTo }.sortBy(_._2)
+    scheduled
+      .entrySet()
+      .asScala
+      .map(s => (s.getKey, s.getValue))
+      .toSeq
+      .filter { case (_, v) => v <= runTo }
+      .sortBy(_._2)
 
   @tailrec
   private[testkit] final def executeTasks(runTo: Long): Unit = {

--- a/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
@@ -33,10 +33,10 @@ import com.typesafe.config.Config
 class ExplicitlyTriggeredScheduler(@unused config: Config, log: LoggingAdapter, @unused tf: ThreadFactory)
     extends Scheduler {
 
-  private case class Item(time: Long, interval: Option[FiniteDuration], runnable: Runnable)
+  private case class Item(interval: Option[FiniteDuration], runnable: Runnable)
 
   private val currentTime = new AtomicLong()
-  private val scheduled = new ConcurrentHashMap[Item, Unit]()
+  private val scheduled = new ConcurrentHashMap[Item, Long]()
 
   override def schedule(initialDelay: FiniteDuration, interval: FiniteDuration, runnable: Runnable)(
       implicit executor: ExecutionContext): Cancellable =
@@ -69,19 +69,19 @@ class ExplicitlyTriggeredScheduler(@unused config: Config, log: LoggingAdapter, 
     currentTime.set(newTime)
   }
 
-  private def scheduledTasks(runTo: Long): Seq[Item] =
-    scheduled.keySet().asScala.filter(_.time <= runTo).toList.sortBy(_.time)
+  private def scheduledTasks(runTo: Long): Seq[(Item, Long)] =
+    scheduled.entrySet().asScala.map(s => (s.getKey, s.getValue)).toSeq.filter { case (_, v) => v <= runTo }.sortBy(_._2)
 
   @tailrec
   private[testkit] final def executeTasks(runTo: Long): Unit = {
     scheduledTasks(runTo).headOption match {
-      case Some(task) =>
-        currentTime.set(task.time)
+      case Some((task, time)) =>
+        currentTime.set(time)
         val runResult = Try(task.runnable.run())
         scheduled.remove(task)
 
         if (runResult.isSuccess)
-          task.interval.foreach(i => scheduled.put(task.copy(time = task.time + i.toMillis), ()))
+          task.interval.foreach(i => scheduled.put(task, time + i.toMillis))
 
         // running the runnable might have scheduled new events
         executeTasks(runTo)
@@ -94,9 +94,9 @@ class ExplicitlyTriggeredScheduler(@unused config: Config, log: LoggingAdapter, 
       interval: Option[FiniteDuration],
       runnable: Runnable): Cancellable = {
     val firstTime = currentTime.get + initialDelay.toMillis
-    val item = Item(firstTime, interval, runnable)
+    val item = Item(interval, runnable)
     log.debug("Scheduled item for {}: {}", firstTime, item)
-    scheduled.put(item, ())
+    scheduled.put(item, firstTime)
 
     if (initialDelay <= Duration.Zero)
       executeTasks(currentTime.get)

--- a/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
@@ -4,7 +4,6 @@
 
 package akka.testkit
 
-import java.util.UUID
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
@@ -34,7 +33,7 @@ import com.typesafe.config.Config
 class ExplicitlyTriggeredScheduler(@unused config: Config, log: LoggingAdapter, @unused tf: ThreadFactory)
     extends Scheduler {
 
-  private case class Item(id: UUID, interval: Option[FiniteDuration], runnable: Runnable)
+  private class Item(val interval: Option[FiniteDuration], val runnable: Runnable)
 
   private val currentTime = new AtomicLong()
   private val scheduled = new ConcurrentHashMap[Item, Long]()
@@ -101,7 +100,7 @@ class ExplicitlyTriggeredScheduler(@unused config: Config, log: LoggingAdapter, 
       interval: Option[FiniteDuration],
       runnable: Runnable): Cancellable = {
     val firstTime = currentTime.get + initialDelay.toMillis
-    val item = Item(UUID.randomUUID(), interval, runnable)
+    val item = new Item(interval, runnable)
     log.debug("Scheduled item for {}: {}", firstTime, item)
     scheduled.put(item, firstTime)
 

--- a/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/ExplicitlyTriggeredScheduler.scala
@@ -4,16 +4,17 @@
 
 package akka.testkit
 
+import java.util.UUID
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
 import scala.annotation.tailrec
 import akka.util.ccompat.JavaConverters._
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.{ Duration, FiniteDuration }
-import scala.util.Try
 
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.util.Try
 import akka.actor.Cancellable
 import akka.actor.Scheduler
 import akka.event.LoggingAdapter
@@ -33,7 +34,7 @@ import com.typesafe.config.Config
 class ExplicitlyTriggeredScheduler(@unused config: Config, log: LoggingAdapter, @unused tf: ThreadFactory)
     extends Scheduler {
 
-  private case class Item(interval: Option[FiniteDuration], runnable: Runnable)
+  private case class Item(id: UUID, interval: Option[FiniteDuration], runnable: Runnable)
 
   private val currentTime = new AtomicLong()
   private val scheduled = new ConcurrentHashMap[Item, Long]()
@@ -100,7 +101,7 @@ class ExplicitlyTriggeredScheduler(@unused config: Config, log: LoggingAdapter, 
       interval: Option[FiniteDuration],
       runnable: Runnable): Cancellable = {
     val firstTime = currentTime.get + initialDelay.toMillis
-    val item = Item(interval, runnable)
+    val item = Item(UUID.randomUUID(), interval, runnable)
     log.debug("Scheduled item for {}: {}", firstTime, item)
     scheduled.put(item, firstTime)
 

--- a/akka-testkit/src/test/scala/akka/testkit/ExplicitlyTriggeredSchedulerSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/ExplicitlyTriggeredSchedulerSpec.scala
@@ -14,6 +14,7 @@ class ExplicitlyTriggeredSchedulerSpec extends AkkaSpec {
 
     "execute a scheduled task" in new TestScope {
       scheduler.schedule(0.seconds, 5.seconds, runnable)(system.dispatcher)
+
       scheduler.timePasses(12.seconds)
 
       counter.get() shouldBe 3
@@ -21,9 +22,28 @@ class ExplicitlyTriggeredSchedulerSpec extends AkkaSpec {
 
     "execute a scheduled task with initial delay" in new TestScope {
       scheduler.schedule(5.seconds, 5.seconds, runnable)(system.dispatcher)
+
       scheduler.timePasses(12.seconds)
 
       counter.get() shouldBe 2
+    }
+
+    "execute a scheduled task only once" in new TestScope {
+      scheduler.scheduleOnce(5.seconds, runnable)(system.dispatcher)
+
+      scheduler.timePasses(100.seconds)
+
+      counter.get() shouldBe 1
+    }
+
+    "schedule multiple identical tasks" in new TestScope {
+      scheduler.scheduleOnce(1.seconds, runnable)(system.dispatcher)
+      scheduler.scheduleOnce(1.seconds, runnable)(system.dispatcher)
+      scheduler.scheduleOnce(1.seconds, runnable)(system.dispatcher)
+
+      scheduler.timePasses(2.seconds)
+
+      counter.get() shouldBe 3
     }
 
     "cancel scheduled task" in new TestScope {
@@ -39,6 +59,30 @@ class ExplicitlyTriggeredSchedulerSpec extends AkkaSpec {
       counter.get() shouldBe 1
     }
 
+    "cancel one out of many scheduled tasks" in new TestScope {
+      scheduler.schedule(5.seconds, 5.seconds, runnable)(system.dispatcher)
+      val task = scheduler.schedule(5.seconds, 5.seconds, runnable)(system.dispatcher)
+      scheduler.schedule(5.seconds, 5.seconds, runnable)(system.dispatcher)
+
+      scheduler.timePasses(7.seconds) // 7s
+      counter.get() shouldBe 3
+
+      val cancellationResult = task.cancel()
+      cancellationResult shouldBe true
+
+      scheduler.timePasses(4.seconds) // 11s
+      counter.get() shouldBe 5
+    }
+
+    "not execute task if cancelled immediately" in new TestScope {
+      val task = scheduler.schedule(5.seconds, 5.seconds, runnable)(system.dispatcher)
+      task.cancel()
+
+      scheduler.timePasses(7.seconds)
+
+      counter.get() shouldBe 0
+    }
+
     "allow to move in time many times" in new TestScope {
       scheduler.schedule(5.seconds, 5.seconds, runnable)(system.dispatcher)
 
@@ -51,18 +95,11 @@ class ExplicitlyTriggeredSchedulerSpec extends AkkaSpec {
       scheduler.timePasses(10.seconds) // 18s
       counter.get() shouldBe 3
     }
-
-    "execute a scheduled task only once" in new TestScope {
-      scheduler.scheduleOnce(5.seconds, runnable)(system.dispatcher)
-      scheduler.timePasses(100.seconds)
-
-      counter.get() shouldBe 1
-    }
   }
 
   trait TestScope {
     val counter = new AtomicInteger()
-    def runnable: Runnable = () => counter.incrementAndGet()
+    val runnable: Runnable = () => counter.incrementAndGet()
     val scheduler = new ExplicitlyTriggeredScheduler(config = null, log = log, tf = null)
   }
 

--- a/akka-testkit/src/test/scala/akka/testkit/ExplicitlyTriggeredSchedulerSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/ExplicitlyTriggeredSchedulerSpec.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.duration.DurationInt
 
-class TestExplicitlyTriggeredScheduler extends AkkaSpec {
+class ExplicitlyTriggeredSchedulerSpec extends AkkaSpec {
 
   "ExplicitlyTriggeredScheduler" must {
 

--- a/akka-testkit/src/test/scala/akka/testkit/TestExplicitlyTriggeredScheduler.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestExplicitlyTriggeredScheduler.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.testkit
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.duration.DurationInt
+
+class TestExplicitlyTriggeredScheduler extends AkkaSpec {
+
+  "ExplicitlyTriggeredScheduler" must {
+
+    "execute a scheduled task" in new TestScope {
+      scheduler.schedule(0.seconds, 5.seconds, runnable)(system.dispatcher)
+      scheduler.timePasses(12.seconds)
+
+      counter.get() shouldBe 3
+    }
+
+    "execute a scheduled task with initial delay" in new TestScope {
+      scheduler.schedule(5.seconds, 5.seconds, runnable)(system.dispatcher)
+      scheduler.timePasses(12.seconds)
+
+      counter.get() shouldBe 2
+    }
+
+    "cancel scheduled task" in new TestScope {
+      val task = scheduler.schedule(5.seconds, 5.seconds, runnable)(system.dispatcher)
+
+      scheduler.timePasses(7.seconds) // 7s
+      counter.get() shouldBe 1
+
+      val cancellationResult = task.cancel()
+      cancellationResult shouldBe true
+
+      scheduler.timePasses(4.seconds) // 11s
+      counter.get() shouldBe 1
+    }
+
+    "allow to move in time many times" in new TestScope {
+      scheduler.schedule(5.seconds, 5.seconds, runnable)(system.dispatcher)
+
+      scheduler.timePasses(7.seconds) // 7s
+      counter.get() shouldBe 1
+
+      scheduler.timePasses(1.seconds) // 8s
+      counter.get() shouldBe 1
+
+      scheduler.timePasses(10.seconds) // 18s
+      counter.get() shouldBe 3
+    }
+
+    "execute a scheduled task only once" in new TestScope {
+      scheduler.scheduleOnce(5.seconds, runnable)(system.dispatcher)
+      scheduler.timePasses(100.seconds)
+
+      counter.get() shouldBe 1
+    }
+  }
+
+  trait TestScope {
+    val counter = new AtomicInteger()
+    def runnable: Runnable = () => counter.incrementAndGet()
+    val scheduler = new ExplicitlyTriggeredScheduler(config = null, log = log, tf = null)
+  }
+
+}


### PR DESCRIPTION
Fixes https://github.com/akka/akka/issues/28604

This also needs to be backported to 2.5.x (PR for 2.5.x: https://github.com/akka/akka/pull/28618)