### PR TITLE
Docs: sink seq operator examples

### DIFF
--- a/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
+++ b/akka-docs/src/main/paradox/project/migration-guide-2.5.x-2.6.x.md
@@ -280,6 +280,8 @@ Explicitly disable Artery by setting property `akka.remote.artery.enabled` to `f
 specific to classic remoting needs to be moved to `akka.remote.classic`. To see which configuration options
 are specific to classic search for them in: @ref:[`akka-remote/reference.conf`](../general/configuration-reference.md#config-akka-remote).
 
+If you have a [Lightbend Platform Subscription](https://www.lightbend.com/lightbend-platform-subscription) you can use our [Config Checker](https://doc.akka.io/docs/akka-enhancements/current/config-checker.html) enhancement to flag any settings that have not been properly migrated.
+
 ### Persistent mode for Cluster Sharding
 
 Cluster Sharding coordinator and @ref:[Remembering Entities](../cluster-sharding.md#remembering-entities) state could previously be stored in Distributed Data or via Akka Persistence.

--- a/akka-docs/src/main/paradox/stream/operators/Sink/seq.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/seq.md
@@ -18,6 +18,16 @@ Collect values emitted from the stream into a collection, the collection is avai
 which completes when the stream completes. Note that the collection is bounded to @scala[`Int.MaxValue`] @java[`Integer.MAX_VALUE`],
 if more element are emitted the sink will cancel the stream
 
+## Example
+
+Given a stream of numbers we can collect the numbers into a collection with the `seq` operator
+
+Scala
+:   @@snip [SinkSpec.scala](/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala) { #seq-operator-example }
+
+Java
+:   @@snip [SinkDocExamples.java](/akka-docs/src/test/java/jdocs/stream/operators/SinkDocExamples.java) { #seq-operator-example }
+
 ## Reactive Streams semantics
 
 @@@div { .callout }

--- a/akka-docs/src/test/java/jdocs/stream/operators/SinkDocExamples.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/SinkDocExamples.java
@@ -21,7 +21,7 @@ public class SinkDocExamples {
 
   private static final ActorSystem system = ActorSystem.create("SourceFromExample");
 
-  static void reduceExample() throws InterruptedException, ExecutionException, TimeoutException {
+  static void reduceExample() {
 
     // #reduce-operator-example
     Source<Integer, NotUsed> ints = Source.from(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
@@ -31,7 +31,18 @@ public class SinkDocExamples {
     // #reduce-operator-example
   }
 
-  static void takeLastExample() throws InterruptedException, ExecutionException, TimeoutException {
+  static void seqExample() {
+    // #seq-operator-example
+    Source<Integer, NotUsed> ints = Source.from(Arrays.asList(1, 2, 3));
+    CompletionStage<List<Integer>> result = ints.runWith(Sink.seq(), system);
+    result.thenAccept(list -> list.forEach(System.out::println));
+    // 1
+    // 2
+    // 3
+    // #seq-operator-example
+  }
+
+  static void takeLastExample() {
     // #takeLast-operator-example
     // pair of (Name, GPA)
     List<Pair> sortedStudents =
@@ -64,7 +75,7 @@ public class SinkDocExamples {
     // #takeLast-operator-example
   }
 
-  static void lastExample() throws InterruptedException, ExecutionException, TimeoutException {
+  static void lastExample() {
     // #last-operator-example
     Source<Integer, NotUsed> source = Source.from(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
     CompletionStage<Integer> result = source.runWith(Sink.last(), system);
@@ -73,8 +84,7 @@ public class SinkDocExamples {
     // #last-operator-example
   }
 
-  static void lastOptionExample()
-      throws InterruptedException, ExecutionException, TimeoutException {
+  static void lastOptionExample() {
     // #lastOption-operator-example
     Source<Integer, NotUsed> source = Source.empty();
     CompletionStage<Optional<Integer>> result = source.runWith(Sink.lastOption(), system);

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
@@ -228,6 +228,21 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
     }
   }
 
+  "The seq sink" must {
+    "collect the streamed elements into a sequence" in {
+      // #seq-operator-example
+      val source = Source(1 to 3)
+      val result = source.runWith(Sink.seq[Int])
+      val seq = result.futureValue
+      seq.foreach(println)
+      // 1
+      // 2
+      // 3
+      // #seq-operator-example
+      assert(seq == Vector(1, 2, 3))
+    }
+  }
+
   "Sink pre-materialization" must {
     "materialize the sink and wrap its exposed publisher in a Source" in {
       val publisherSink: Sink[String, Publisher[String]] = Sink.asPublisher[String](false)


### PR DESCRIPTION
- Added unit test, examples in java and scala, cleaned up not thrown exceptions

References #25468

