### PR TITLE
Add support for applying effects on future completion

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -230,4 +230,5 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
   final case class SnapshotterResponse(msg: akka.persistence.SnapshotProtocol.Response) extends InternalProtocol
   final case class RecoveryTickEvent(snapshot: Boolean) extends InternalProtocol
   final case class IncomingCommand[C](c: C) extends InternalProtocol
+  final case class ApplyEffect[E, S](effect: Effect[E, S]) extends InternalProtocol
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -230,5 +230,5 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
   final case class SnapshotterResponse(msg: akka.persistence.SnapshotProtocol.Response) extends InternalProtocol
   final case class RecoveryTickEvent(snapshot: Boolean) extends InternalProtocol
   final case class IncomingCommand[C](c: C) extends InternalProtocol
-  final case class ApplyEffect[E, S](effect: Effect[E, S]) extends InternalProtocol
+  final case class ApplyEffect[E, S](f: S => Effect[E, S]) extends InternalProtocol
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingEvents.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingEvents.scala
@@ -87,6 +87,7 @@ private[akka] final class ReplayingEvents[C, E, S](
 
   override def onMessage(msg: InternalProtocol): Behavior[InternalProtocol] = {
     msg match {
+      case ApplyEffect(_)          => Behaviors.unhandled
       case JournalResponse(r)      => onJournalResponse(r)
       case SnapshotterResponse(r)  => onSnapshotterResponse(r)
       case RecoveryTickEvent(snap) => onRecoveryTick(snap)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -56,6 +56,7 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
     def stay(receivedPoisonPill: Boolean): Behavior[InternalProtocol] = {
       Behaviors
         .receiveMessage[InternalProtocol] {
+          case ApplyEffect(_)              => Behaviors.unhandled
           case SnapshotterResponse(r)      => onSnapshotterResponse(r, receivedPoisonPill)
           case JournalResponse(r)          => onJournalResponse(r)
           case RecoveryTickEvent(snapshot) => onRecoveryTick(snapshot)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -100,6 +100,7 @@ private[akka] object Running {
       with WithSeqNrAccessible {
 
     def onMessage(msg: InternalProtocol): Behavior[InternalProtocol] = msg match {
+      case ApplyEffect(effect)              => applyEffects(msg, state, effect.asInstanceOf[EffectImpl[E, S]])
       case IncomingCommand(c: C @unchecked) => onCommand(state, c)
       case JournalResponse(r)               => onDeleteEventsJournalResponse(r, state.state)
       case SnapshotterResponse(r)           => onDeleteSnapshotResponse(r, state.state)
@@ -233,6 +234,7 @@ private[akka] object Running {
 
     override def onMessage(msg: InternalProtocol): Behavior[InternalProtocol] = {
       msg match {
+        case ApplyEffect(_)                    => Behaviors.unhandled
         case JournalResponse(r)                => onJournalResponse(r)
         case in: IncomingCommand[C @unchecked] => onCommand(in)
         case SnapshotterResponse(r)            => onDeleteSnapshotResponse(r, visibleState.state)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -100,7 +100,7 @@ private[akka] object Running {
       with WithSeqNrAccessible {
 
     def onMessage(msg: InternalProtocol): Behavior[InternalProtocol] = msg match {
-      case ApplyEffect(effect)              => applyEffects(msg, state, effect.asInstanceOf[EffectImpl[E, S]])
+      case ae @ ApplyEffect(_)              => applyEffects(msg, state, ae.f(state.state).asInstanceOf[EffectImpl[E, S]])
       case IncomingCommand(c: C @unchecked) => onCommand(state, c)
       case JournalResponse(r)               => onDeleteEventsJournalResponse(r, state.state)
       case SnapshotterResponse(r)           => onDeleteSnapshotResponse(r, state.state)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/FutureEffect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/FutureEffect.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.scaladsl
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.Try
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.ActorRef
+import akka.persistence.typed.internal.InternalProtocol.ApplyEffect
+
+/**
+ * Importing [[FutureEffect]] will extend [[ActorContext]] with the [[effectOnComplete]] method.
+ */
+object FutureEffect {
+  implicit class RichActorContext(val ctx: ActorContext[_]) extends AnyVal {
+
+    /**
+     * Will run the supplied `g` method on the result of the `f` future once it has been completed.
+     * Any [[Effect]] returned will be applied to the actor contexts `self` actor.
+     * The `g` callback will be executed by the execution context provided by `ec`.
+     * @param f the future to run g on once completed
+     * @param g the onComplete callback to execute
+     * @param ec the execution context to execute `g` on
+     * @tparam T the type of the result of the future `f`
+     * @tparam E the event type of the actor
+     * @tparam S the state type of the actor
+     * @return the [[Effect]] to apply to the actor
+     */
+    def effectOnComplete[T, E, S](f: Future[T])(g: Try[T] => Effect[E, S])(
+        implicit ec: ExecutionContext): ReplyEffect[E, S] = {
+      f.onComplete { t =>
+        ctx.self.asInstanceOf[ActorRef[Any]] ! ApplyEffect(g(t))
+      }
+      Effect.noReply
+    }
+  }
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/FutureEffect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/FutureEffect.scala
@@ -28,7 +28,7 @@ object FutureEffect {
      * @tparam S the state type of the actor
      * @return the [[Effect]] to apply to the actor
      */
-    def effectOnComplete[T, E, S](f: Future[T])(g: Try[T] => Effect[E, S])(
+    def effectOnComplete[T, E, S](f: Future[T])(g: Try[T] => S => Effect[E, S])(
         implicit ec: ExecutionContext): ReplyEffect[E, S] = {
       f.onComplete { t =>
         ctx.self.asInstanceOf[ActorRef[Any]] ! ApplyEffect(g(t))

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -450,7 +450,7 @@ class EventSourcedBehaviorSpec
       c ! Increment
       c ! GetValue(probe.ref)
       probe.expectMessage(State(4, Vector(0, 1, 2, 3)))
-      Thread.sleep(1000)
+      Thread.sleep(1500)
       c ! GetValue(probe.ref)
       probe.expectMessage(State(8, Vector(0, 1, 2, 3, 4, 5, 6, 7)))
       c ! Increment


### PR DESCRIPTION
This allows the following kind of code:
```scala
case Increment =>
  import FutureEffect._
  implicit val ec: ExecutionContext = ...
  val f: Future[Int] = fetchHowMuchToIncrement()
  ctx.effectOnComplete(f) {
    case Success(n) => Effect.persist(Incremented(n))
    case Failure(t) => Effect.none
  }
``` 
There is no need for the user to define any internal commands to handle the callback, instead an Akka internal `ApplyEffect` message captures the effect generated in the user supplied callback. The effect will then be applied automatically by Akka as part of the pre command interception handling. 
