### PR TITLE
persistence: fix premature reset of the 'writeInProgress' flag in cas…

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -307,7 +307,7 @@ private[akka] object Running {
           // ignore
           this
 
-        case WriteMessagesFailed(_) =>
+        case WriteMessagesFailed(_, _) =>
           // ignore
           this // it will be stopped by the first WriteMessageFailure message; not applying side effects
 

--- a/akka-persistence/src/main/mima-filters/2.6.4.backwards.excludes/28629-writeInProgress-race.excludes
+++ b/akka-persistence/src/main/mima-filters/2.6.4.backwards.excludes/28629-writeInProgress-race.excludes
@@ -1,0 +1,6 @@
+#Add writeCount field to WriteMessagesFailed, safe to exclude since the message is internal
+ProblemFilters.exclude[MissingTypesProblem]("akka.persistence.JournalProtocol$WriteMessagesFailed$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.JournalProtocol#WriteMessagesFailed.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.JournalProtocol#WriteMessagesFailed.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.JournalProtocol#WriteMessagesFailed.this")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.JournalProtocol#WriteMessagesFailed.unapply")

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -873,9 +873,10 @@ private[persistence] trait Eventsourced
         writeInProgress = false
         flushJournalBatch()
 
-      case WriteMessagesFailed(_) =>
-        writeInProgress = false
-        () // it will be stopped by the first WriteMessageFailure message
+      case WriteMessagesFailed(_, writeCount) =>
+        // if writeCount > 0 then WriteMessageFailure will follow that will stop the actor
+        if (writeCount == 0) writeInProgress = false
+        ()
 
       case _: RecoveryTick =>
       // we may have one of these in the mailbox before the scheduled timeout

--- a/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
@@ -55,8 +55,9 @@ private[persistence] object JournalProtocol {
    * before all subsequent [[WriteMessageFailure]] replies.
    *
    * @param cause failure cause.
+   * @param writeCount the number of atomic writes that failed.
    */
-  final case class WriteMessagesFailed(cause: Throwable) extends Response
+  final case class WriteMessagesFailed(cause: Throwable, writeCount: Int) extends Response
 
   /**
    * Reply message to a successful [[WriteMessages]] request. For each contained [[PersistentRepr]] message

--- a/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteJournal.scala
@@ -122,7 +122,7 @@ trait AsyncWriteJournal extends Actor with WriteJournalBase with AsyncRecovery {
             }
 
           case Failure(e) =>
-            resequencer ! Desequenced(WriteMessagesFailed(e), cctr, persistentActor, self)
+            resequencer ! Desequenced(WriteMessagesFailed(e, atomicWriteCount), cctr, persistentActor, self)
             var n = cctr + 1
             messages.foreach {
               case a: AtomicWrite =>

--- a/akka-persistence/src/main/scala/akka/persistence/journal/PersistencePluginProxy.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/PersistencePluginProxy.scala
@@ -189,7 +189,8 @@ final class PersistencePluginProxy(config: Config) extends Actor with Stash with
     case req: JournalProtocol.Request =>
       req match { // exhaustive match
         case WriteMessages(messages, persistentActor, actorInstanceId) =>
-          persistentActor ! WriteMessagesFailed(timeoutException)
+          val atomicWriteCount = messages.count(_.isInstanceOf[AtomicWrite])
+          persistentActor ! WriteMessagesFailed(timeoutException, atomicWriteCount)
           messages.foreach {
             case a: AtomicWrite =>
               a.payload.foreach { p =>


### PR DESCRIPTION
A fix for
>Possible race condition in Akka Persistence that can lead to lost events when using persistAsync() #28629

The idea is not to reset the `writeInProgress` flag prematurely before the actor gets stopped by `WriteMessageFailure`.
