### PR TITLE
[WIP] Reimplementation of mapAsync on top of simpler components

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncSpec.scala
@@ -78,7 +78,9 @@ class FlowMapAsyncSpec extends StreamSpec {
         .to(Sink.fromSubscriber(c))
         .run()
       val sub = c.expectSubscription()
-      probe.expectNoMessage(500.millis)
+      // This wait here was a curious detail of the previous version : we wouldn't start executing the first thunk
+      // after the stage was pulled first but afterwards we would pull eagerly
+      // probe.expectNoMessage(500.millis)
       sub.request(1)
       probe.receiveN(9).toSet should be((1 to 9).toSet)
       probe.expectNoMessage(500.millis)

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/AsyncStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/AsyncStages.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.impl.fusing
+
+import akka.dispatch.ExecutionContexts
+import akka.stream.ActorAttributes.SupervisionStrategy
+import akka.stream.Attributes
+import akka.stream.FlowShape
+import akka.stream.Inlet
+import akka.stream.Outlet
+import akka.stream.Supervision
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+class LimitUncompleted[T](parallelism: Int) extends GraphStage[FlowShape[Future[T], Future[T]]] {
+  require(parallelism > 0)
+
+  val in = Inlet[Future[T]]("LimitUncompleted.in")
+  val out = Outlet[Future[T]]("LimitUncompleted.out")
+  def shape: FlowShape[Future[T], Future[T]] = FlowShape(in, out)
+  def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+      lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
+      setHandlers(in, out, this)
+
+      var inFlight: Long = 0L
+
+      val callback = getAsyncCallback[Try[T]] { result =>
+        inFlight -= 1
+        handleResult(result, () => ())
+        pullIfNecessary()
+      }
+
+      override def onPush(): Unit = {
+        val ele = grab(in)
+
+        if (ele.isCompleted)
+          handleResult(ele.value.get, () => push(out, ele))
+        else {
+          inFlight += 1
+          ele.onComplete(callback.invoke)(ExecutionContexts.sameThreadExecutionContext)
+          push(out, ele)
+        }
+
+        pullIfNecessary()
+      }
+      override def onPull(): Unit = pullIfNecessary()
+
+      private def handleResult(result: Try[T], whenSuccess: () => Unit): Unit =
+        // result handling only needed to be able to fail fast when futures fail
+        result match {
+          case Success(_) => whenSuccess()
+          case Failure(ex) =>
+            decider(ex) match {
+              case Supervision.Stop => failStage(ex)
+              case _                => // skip further handling
+            }
+        }
+
+      private def pullIfNecessary(): Unit =
+        if (inFlight < parallelism && !hasBeenPulled(in) && isAvailable(out)) tryPull(in)
+    }
+}
+
+class WaitForCompletion[T] extends GraphStage[FlowShape[Future[T], T]] {
+  val in = Inlet[Future[T]]("WaitForCompletion.in")
+  val out = Outlet[T]("WaitForCompletion.out")
+  def shape: FlowShape[Future[T], T] = FlowShape(in, out)
+  def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+      lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
+
+      setHandlers(in, out, this)
+      var inFlight: Boolean = false
+
+      val callback = getAsyncCallback[Try[T]](handleResult)
+
+      override def onPush(): Unit = {
+        val ele = grab(in)
+        ele.value match {
+          case Some(result) =>
+            handleResult(result)
+          case None =>
+            require(!inFlight)
+            inFlight = true
+            ele.onComplete(callback.invoke)(ExecutionContexts.sameThreadExecutionContext)
+        }
+      }
+
+      override def onPull(): Unit = pull(in)
+
+      private def handleResult(result: Try[T]): Unit = {
+        inFlight = false
+        result match {
+          case Success(null) => // ignore
+          case Success(t)    => push(out, t)
+          case Failure(ex) =>
+            decider(ex) match {
+              case Supervision.Stop => failStage(ex)
+              case _                => // throw result away
+            }
+        }
+        if (isClosed(in)) completeStage()
+        else if (isAvailable(out) && !hasBeenPulled(in)) pull(in)
+      }
+
+      override def onUpstreamFinish(): Unit =
+        if (!inFlight) completeStage()
+    }
+}


### PR DESCRIPTION
The idea is that one can break up the implementations like this:

mapAsync:
 * map(f)
 * LimitUncompleted Flow[Future[T], Future[T]]
 * simple buffer
 * WaitForCompletion Flow[Future[T], T]

LimitUncompleted just passes the futures through but only let's a maximum number of uncompleted futures through.

WaitForCompletion just waits for a single future to complete.

One important observation was that the `parallelism` setting has two meanings:
 * How many thunks should possibly be running in parallel?
 * How large should the buffer be on the outgoing side when there's either backpressure from downstream or (for mapAsync) head-of-line blocking.

The first question is one of how many resources your stream should use while the second question is mostly a tuning parameter of that stream.

E.g. with mapAsync you want to avoid head-of-line blocking so you want to set a  high parallelism setting (like 1000) to hide latency outliers. But that might put extra strain on you backend systems (REST Apis, DBs, CPU cores, etc).

With the new setup, there could be another operator (or a combination of the ones here) where you keep the parallelism setting at something that makes sense with your resources (e.g. number of cores for CPU-bottlenecked tasks) but increase the buffer size to whatever is necessary to hide tail latency (of course, keeping additional memory usage in mind).
