### PR TITLE
Eliminate logging race condition in ActorSystemSpec

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -181,7 +181,6 @@ class ActorSystemSpec extends AkkaSpec(ActorSystemSpec.config) with ImplicitSend
         a.tell("run", probe.ref)
         probe.expectTerminated(a)
 
-        a.tell("boom", ActorRef.noSender)
         EventFilter
           .info(pattern = ".*not delivered", occurrences = 1)
           .intercept {

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -181,6 +181,7 @@ class ActorSystemSpec extends AkkaSpec(ActorSystemSpec.config) with ImplicitSend
         a.tell("run", probe.ref)
         probe.expectTerminated(a)
 
+        // Expecting two log entries: one from the actor system at info level and one at warning level from the logging testkit
         EventFilter
           .info(pattern = ".*not delivered", occurrences = 1)
           .intercept {


### PR DESCRIPTION
Refs #28648

Runaway logging from before the EventFilter would sometimes leak into the expect.