### PR TITLE
Minor typo in documentation.

### DIFF
--- a/akka-docs/src/test/scala/docs/stream/FlowDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/FlowDocSpec.scala
@@ -156,7 +156,7 @@ class FlowDocSpec extends AkkaSpec with CompileOnlySpec {
     })
 
     //#flow-mat-combine
-    // An source that can be signalled explicitly from the outside
+    // A source that can be signalled explicitly from the outside
     val source: Source[Int, Promise[Option[Int]]] = Source.maybe[Int]
 
     // A flow that internally throttles elements to 1/second, and returns a Cancellable


### PR DESCRIPTION
It's just a one-char typo. Thought I'd fix it.