### PR TITLE
Silencing multi-jvm shutdown error

### DIFF
--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
@@ -5,8 +5,10 @@
 package akka.remote.testconductor
 
 import java.util.concurrent.TimeoutException
+
 import akka.actor._
 import akka.remote.testconductor.RemoteConnection.getAddrString
+
 import scala.collection.immutable
 import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration._
@@ -25,6 +27,8 @@ import org.jboss.netty.channel.{
 import akka.pattern.{ ask, AskTimeoutException }
 import akka.event.{ Logging, LoggingAdapter }
 import java.net.{ ConnectException, InetSocketAddress }
+import java.util.concurrent.RejectedExecutionException
+
 import akka.remote.transport.ThrottlerTransportAdapter.{ Blackhole, SetThrottle, TokenBucket, Unthrottled }
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.util.ccompat._
@@ -300,7 +304,13 @@ private[akka] class ClientFSM(name: RoleName, controllerAddr: InetSocketAddress)
 
   onTermination {
     case StopEvent(_, _, Data(Some(channel), _)) =>
-      channel.close()
+      try {
+        channel.close()
+      } catch {
+        case ex: RejectedExecutionException =>
+          // silence this one to not make tests look like they failed, it's not really critical
+          log.debug(s"Failed closing channel with ${ex.getClass.getName} ${ex.getMessage}")
+      }
   }
 
   initialize()

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Player.scala
@@ -27,11 +27,12 @@ import org.jboss.netty.channel.{
 import akka.pattern.{ ask, AskTimeoutException }
 import akka.event.{ Logging, LoggingAdapter }
 import java.net.{ ConnectException, InetSocketAddress }
-import java.util.concurrent.RejectedExecutionException
 
 import akka.remote.transport.ThrottlerTransportAdapter.{ Blackhole, SetThrottle, TokenBucket, Unthrottled }
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.util.ccompat._
+
+import scala.util.control.NonFatal
 
 @ccompatUsedUntil213
 object Player {
@@ -307,7 +308,7 @@ private[akka] class ClientFSM(name: RoleName, controllerAddr: InetSocketAddress)
       try {
         channel.close()
       } catch {
-        case ex: RejectedExecutionException =>
+        case NonFatal(ex) =>
           // silence this one to not make tests look like they failed, it's not really critical
           log.debug(s"Failed closing channel with ${ex.getClass.getName} ${ex.getMessage}")
       }


### PR DESCRIPTION
Annoying shutdown channel error stacktrace is logged even though tests are actually green.