### PR TITLE
Docs: Sink.foreach

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/Sink/foreach.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/foreach.md
@@ -4,22 +4,33 @@ Invoke a given procedure for each element received.
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #forEach }
-
-@@@
+@apidoc[Sink.foreach](Sink$) { java="#foreach(akka.japi.function.Procedure)" scala="#foreach[T](f:T=%3EUnit):akka.stream.scaladsl.Sink[T,scala.concurrent.Future[akka.Done]]" }
 
 ## Description
 
 Invoke a given procedure for each element received. Note that it is not safe to mutate shared state from the procedure.
 
-The sink materializes into a  @scala[`Future[Option[Done]]`] @java[`CompletionStage<Optional<Done>`] which completes when the
+The sink materializes into a  @scala[`Future[Done]`] @java[`CompletionStage<Done>`] which completes when the
 stream completes, or fails if the stream fails.
 
 Note that it is not safe to mutate state from the procedure.
+
+See also:
+
+* @ref[`foreachAsync`](foreachAsync.md) Invoke a given procedure asynchronously for each element received.
+* @ref[`actorRef`](actorRef.md) Send the elements from the stream to an `ActorRef`.
+
+## Example
+
+This prints out every element to standard out.
+
+Scala
+:   @@snip [snip](/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala) { #foreach }
+
+Java
+:   @@snip [snip](/akka-stream-tests/src/test/java/akka/stream/javadsl/SinkTest.java) { #foreach }
 
 ## Reactive Streams semantics
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/foreach.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/foreach.md
@@ -12,7 +12,7 @@ Invoke a given procedure for each element received.
 
 Invoke a given procedure for each element received. Note that it is not safe to mutate shared state from the procedure.
 
-The sink materializes into a  @scala[`Future[Done]`] @java[`CompletionStage<Done>`] which completes when the
+The sink materializes into a @scala[`Future[Done]`] @java[`CompletionStage<Done>`] which completes when the
 stream completes, or fails if the stream fails.
 
 Note that it is not safe to mutate state from the procedure.

--- a/akka-docs/src/main/paradox/stream/operators/Sink/foreachAsync.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/foreachAsync.md
@@ -19,6 +19,11 @@ Invoke a given procedure asynchronously for each element received. Note that if 
 The sink materializes into a  @scala[`Future[Done]`] @java[`CompletionStage<Done>`] which completes when the
 stream completes, or fails if the stream fails.
 
+See also:
+
+* @ref[`foreach`](foreach.md) Invoke a given procedure for each element received.
+* @ref[`actorRef`](actorRef.md) Send the elements from the stream to an `ActorRef`.
+
 ## Example
 
 Scala

--- a/akka-docs/src/main/paradox/stream/operators/Sink/foreachParallel.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/foreachParallel.md
@@ -4,17 +4,11 @@ Like `foreach` but allows up to `parallellism` procedure calls to happen in para
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
+@@@warning { title="Deprecated" }
 
-## Signature
-
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #foreachParallel }
+Use @ref[`foreachAsync`](foreachAsync.md) instead (this is deprecated since Akka 2.5.17).
 
 @@@
-
-## Description
-
-Like `foreach` but allows up to `parallellism` procedure calls to happen in parallel.
 
 ## Reactive Streams semantics
 

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/SinkTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/SinkTest.java
@@ -153,16 +153,19 @@ public class SinkTest extends StreamTest {
     Sink<Integer, NotUsed> javaSink = scalaSink.asJava();
   }
 
+  @Test
   public void sinkForeachMustBeDocumented()
       throws InterruptedException, ExecutionException, TimeoutException {
     // #foreach
     Sink<Integer, CompletionStage<Done>> printlnSink = Sink.foreach(System.out::println);
     CompletionStage<Done> cs = Source.from(Arrays.asList(1, 2, 3, 4)).runWith(printlnSink, system);
+    Done done = cs.toCompletableFuture().get(100, TimeUnit.MILLISECONDS);
+    // will print
     // 1
     // 2
     // 3
     // 4
     // #foreach
-    assertEquals(Done.done(), cs.toCompletableFuture().get(1, TimeUnit.SECONDS));
+    assertEquals(Done.done(), done);
   }
 }

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/SinkTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/SinkTest.java
@@ -9,11 +9,10 @@ import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.stream.Collectors;
 
+import akka.Done;
 import akka.NotUsed;
 import akka.japi.Pair;
 import akka.japi.function.Function;
@@ -152,5 +151,18 @@ public class SinkTest extends StreamTest {
     final akka.stream.scaladsl.Sink<Integer, NotUsed> scalaSink =
         akka.stream.scaladsl.Sink.cancelled();
     Sink<Integer, NotUsed> javaSink = scalaSink.asJava();
+  }
+
+  public void sinkForeachMustBeDocumented()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    // #foreach
+    Sink<Integer, CompletionStage<Done>> printlnSink = Sink.foreach(System.out::println);
+    CompletionStage<Done> cs = Source.from(Arrays.asList(1, 2, 3, 4)).runWith(printlnSink, system);
+    // 1
+    // 2
+    // 3
+    // 4
+    // #foreach
+    assertEquals(Done.done(), cs.toCompletableFuture().get(1, TimeUnit.SECONDS));
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.stream.scaladsl
 
+import akka.Done
 import akka.stream._
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.TestSink
@@ -15,7 +16,7 @@ import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-@silent("deprecated")
+@silent("deprecated") // attributes.getFirst
 class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
 
   import GraphDSL.Implicits._
@@ -187,7 +188,6 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
     "given multiple attributes of a class when getting first attribute with default value should get first attribute" in {
       import Attributes._
       val s: Sink[Int, Future[Int]] = Sink.head[Int].withAttributes(none).async.named("name").named("another_name")
-
       s.traversalBuilder.attributes.getFirst[Name](Name("default")) shouldEqual Name("name")
     }
 
@@ -206,6 +206,7 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
   "The ignore sink" should {
 
     "fail its materialized value on abrupt materializer termination" in {
+      @silent("deprecated")
       val mat = ActorMaterializer()
 
       val matVal = Source.maybe[Int].runWith(Sink.ignore)(mat)
@@ -240,6 +241,20 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
       // 3
       // #seq-operator-example
       assert(seq == Vector(1, 2, 3))
+    }
+  }
+
+  "The foreach sink" must {
+    "illustrate println" in {
+      // #foreach
+      val printlnSink: Sink[Any, Future[Done]] = Sink.foreach(println)
+      val f = Source(1 to 4).runWith(printlnSink)
+      // 1
+      // 2
+      // 3
+      // 4
+      // #foreach
+      f.futureValue shouldBe Done
     }
   }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
@@ -13,7 +13,7 @@ import com.github.ghik.silencer.silent
 import org.reactivestreams.Publisher
 import org.scalatest.concurrent.ScalaFutures
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
 class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {


### PR DESCRIPTION
Stream operator example for `Sink.foreach` and updates to related operators.

Refs #25468 