### PR TITLE
Add CQRS page to docs

### DIFF
--- a/akka-docs/src/main/paradox/typed/cqrs.md
+++ b/akka-docs/src/main/paradox/typed/cqrs.md
@@ -1,0 +1,11 @@
+# CQRS
+
+@ref:[EventSourcedBehavior](persistence.md)s along with @ref:[Persistence Query](../persistence-query.md)'s `EventsByTag` query can be used to implement
+ Command Query Responsibility Segregation (CQRS).
+ 
+The @java[@extref[CQRS example project](samples:akka-samples-cqrs-java)]@scala[@extref[CQRS example project](samples:akka-samples-cqrs-scala)]
+shows how to do this, including scaling read side processors for building projections.
+In the sample the events are tagged to be consumed by even processors to build other representations
+from the events, or publish the events to other services.
+
+ 

--- a/akka-docs/src/main/paradox/typed/index-persistence.md
+++ b/akka-docs/src/main/paradox/typed/index-persistence.md
@@ -9,6 +9,7 @@ project.description: Event Sourcing with Akka Persistence enables actors to pers
 @@@ index
 
 * [persistence](persistence.md)
+* [cqrs](cqrs.md)
 * [persistence-style](persistence-style.md)
 * [persistence-snapshot](persistence-snapshot.md)
 * [persistence-testing.md](persistence-testing.md)


### PR DESCRIPTION
To highlight the cqrs sample in the index and make it more clear you can
use akka persistence for CQRS.