### PR TITLE
Backport of sameThreadExecutionContext replacement method

### DIFF
--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -4,21 +4,22 @@
 
 package akka.dispatch
 
-import scala.runtime.{ AbstractPartialFunction, BoxedUnit }
-import akka.japi.{ Procedure, Function => JFunc, Option => JOption }
+import scala.runtime.{AbstractPartialFunction, BoxedUnit}
+import akka.japi.{Procedure, Function => JFunc, Option => JOption}
 
-import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, ExecutionContextExecutorService, Future, Promise }
-import java.lang.{ Iterable => JIterable }
-import java.util.{ LinkedList => JLinkedList }
-import java.util.concurrent.{ Callable, Executor, ExecutorService }
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, ExecutionContextExecutorService, Future, Promise}
+import java.lang.{Iterable => JIterable}
+import java.util.{LinkedList => JLinkedList}
+import java.util.concurrent.{Callable, Executor, ExecutorService}
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.CompletableFuture
 
 import akka.compat
 import akka.util.unused
 import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
 import com.github.ghik.silencer.silent
 
 /**
@@ -86,7 +87,7 @@ object ExecutionContexts {
    *
    * INTERNAL API
    */
-  @InternalApi
+  @InternalStableApi
   private[akka] val parasitic: ExecutionContext = sameThreadExecutionContext
 
   /**

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -4,15 +4,15 @@
 
 package akka.dispatch
 
-import scala.runtime.{AbstractPartialFunction, BoxedUnit}
-import akka.japi.{Procedure, Function => JFunc, Option => JOption}
+import scala.runtime.{ AbstractPartialFunction, BoxedUnit }
+import akka.japi.{ Procedure, Function => JFunc, Option => JOption }
 
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, ExecutionContextExecutorService, Future, Promise}
-import java.lang.{Iterable => JIterable}
-import java.util.{LinkedList => JLinkedList}
-import java.util.concurrent.{Callable, Executor, ExecutorService}
+import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, ExecutionContextExecutorService, Future, Promise }
+import java.lang.{ Iterable => JIterable }
+import java.util.{ LinkedList => JLinkedList }
+import java.util.concurrent.{ Callable, Executor, ExecutorService }
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.CompletableFuture
 

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -4,18 +4,13 @@
 
 package akka.dispatch
 
-import scala.runtime.{ AbstractPartialFunction, BoxedUnit }
-import akka.japi.{ Procedure, Function => JFunc, Option => JOption }
+import akka.annotation.InternalApi
 
-import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, ExecutionContextExecutorService, Future, Promise }
-import java.lang.{ Iterable => JIterable }
-import java.util.{ LinkedList => JLinkedList }
-import java.util.concurrent.{ Callable, Executor, ExecutorService }
+import scala.runtime.{AbstractPartialFunction, BoxedUnit}
+import akka.japi.{Procedure, Function => JFunc, Option => JOption}
 
-import scala.util.{ Failure, Success, Try }
-import java.util.concurrent.CompletionStage
-import java.util.concurrent.CompletableFuture
-
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, ExecutionContextExecutorService, Future, Promise}
+import scala.util.{Failure, Success, Try}
 import akka.compat
 import akka.util.unused
 import com.github.ghik.silencer.silent
@@ -73,6 +68,20 @@ object ExecutionContexts {
    * @return a reference to the global ExecutionContext
    */
   def global(): ExecutionContextExecutor = ExecutionContext.global
+
+  /**
+   * WARNING: Not A General Purpose ExecutionContext!
+   *
+   * This is an execution context which runs everything on the calling thread.
+   * It is very useful for actions which are known to be non-blocking and
+   * non-throwing in order to save a round-trip to the thread pool.
+   *
+   * Alias for [[sameThreadExecutionContext]], which is deprecated in 2.6, providing cross version non-deprecated access.
+   *
+   * INTERNAL API
+   */
+  @InternalApi
+  private[akka] val parasitic: ExecutionContext = sameThreadExecutionContext
 
   /**
    * WARNING: Not A General Purpose ExecutionContext!

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -4,15 +4,21 @@
 
 package akka.dispatch
 
-import akka.annotation.InternalApi
+import scala.runtime.{ AbstractPartialFunction, BoxedUnit }
+import akka.japi.{ Procedure, Function => JFunc, Option => JOption }
 
-import scala.runtime.{AbstractPartialFunction, BoxedUnit}
-import akka.japi.{Procedure, Function => JFunc, Option => JOption}
+import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, ExecutionContextExecutorService, Future, Promise }
+import java.lang.{ Iterable => JIterable }
+import java.util.{ LinkedList => JLinkedList }
+import java.util.concurrent.{ Callable, Executor, ExecutorService }
 
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, ExecutionContextExecutorService, Future, Promise}
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.CompletableFuture
+
 import akka.compat
 import akka.util.unused
+import akka.annotation.InternalApi
 import com.github.ghik.silencer.silent
 
 /**

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -18,7 +18,6 @@ import java.util.concurrent.CompletableFuture
 
 import akka.compat
 import akka.util.unused
-import akka.annotation.InternalApi
 import akka.annotation.InternalStableApi
 import com.github.ghik.silencer.silent
 


### PR DESCRIPTION
Backport of #28515

Just the non-deprecated method, not the full 2.6 change.