### PR TITLE
The parasitic marked internal stable and further docs on the annotation

### DIFF
--- a/akka-actor/src/main/java/akka/annotation/InternalStableApi.java
+++ b/akka-actor/src/main/java/akka/annotation/InternalStableApi.java
@@ -11,8 +11,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks internal members that shouldn't be changed without considering possible usage outside of
+ * Marks APIs that are considered internal to Akka and should not be accessed by user code but that are used
+ * across Akka project boundaries and therefore shouldn't be changed without considering possible usage outside of
  * the Akka core modules.
+ *
+ * <p>If a method/class annotated with this annotation is part of a public API and has the Scala {@code private[akka]} access
+ * restriction, which leads to a public method from Java,  there should be a javadoc/scaladoc comment where the first line
+ * MUST include {@code INTERNAL API} in order to be easily identifiable from generated
+ * documentation. Additional information may be put on the same line as the INTERNAL API comment in
+ * order to clarify further.
  */
 @Documented
 @Retention(RetentionPolicy.CLASS) // to be accessible by MiMa

--- a/akka-actor/src/main/java/akka/annotation/InternalStableApi.java
+++ b/akka-actor/src/main/java/akka/annotation/InternalStableApi.java
@@ -11,15 +11,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks APIs that are considered internal to Akka and should not be accessed by user code but that are used
- * across Akka project boundaries and therefore shouldn't be changed without considering possible usage outside of
- * the Akka core modules.
+ * Marks APIs that are considered internal to Akka and should not be accessed by user code but that
+ * are used across Akka project boundaries and therefore shouldn't be changed without considering
+ * possible usage outside of the Akka core modules.
  *
- * <p>If a method/class annotated with this annotation is part of a public API and has the Scala {@code private[akka]} access
- * restriction, which leads to a public method from Java,  there should be a javadoc/scaladoc comment where the first line
- * MUST include {@code INTERNAL API} in order to be easily identifiable from generated
- * documentation. Additional information may be put on the same line as the INTERNAL API comment in
- * order to clarify further.
+ * <p>If a method/class annotated with this annotation is part of a public API and has the Scala
+ * {@code private[akka]} access restriction, which leads to a public method from Java, there should
+ * be a javadoc/scaladoc comment where the first line MUST include {@code INTERNAL API} in order to
+ * be easily identifiable from generated documentation. Additional information may be put on the
+ * same line as the INTERNAL API comment in order to clarify further.
  */
 @Documented
 @Retention(RetentionPolicy.CLASS) // to be accessible by MiMa

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -17,6 +17,7 @@ import java.util.concurrent.CompletionStage
 import java.util.concurrent.CompletableFuture
 
 import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
 import akka.compat
 import akka.dispatch.internal.SameThreadExecutionContext
 import akka.util.unused
@@ -86,7 +87,7 @@ object ExecutionContexts {
    * INTERNAL API
    */
   // Once Scala 2.12 is no longer supported this can be dropped in favour of directly using [[ExecutionContext.parasitic]]
-  @InternalApi
+  @InternalStableApi
   private[akka] val parasitic: ExecutionContext = SameThreadExecutionContext()
 
   /**


### PR DESCRIPTION
`ExecutionContexts.parasitic` is internal but expected to be used in at least Akka HTTP