### PR TITLE
Test jackson support for scala enumerations

### DIFF
--- a/akka-docs/src/main/paradox/serialization-jackson.md
+++ b/akka-docs/src/main/paradox/serialization-jackson.md
@@ -173,7 +173,17 @@ This can be solved by implementing a custom serialization for the enums. Annotat
 Scala
 :  @@snip [CustomAdtSerializer.scala](/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/CustomAdtSerializer.scala) { #adt-trait-object }
 
+### Enumerations
 
+Jackson support for Scala Enumerations defaults to serializing a `Value` as a `JsonObject` that includes a 
+field with the `"value"` and a field with the `"type"` whose value is the FQCN of the enumeration. Jackson
+includes the [`@JsonScalaEnumeration`](https://github.com/FasterXML/jackson-module-scala/wiki/Enumerations) to 
+statically specify the type information to a field. When using the `@JsonScalaEnumeration` annotation the enumeration 
+value is serialized as a JsonString.
+
+Scala
+:  @@snip [JacksonSerializerSpec.scala](/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala) { #jackson-scala-enumeration }
+    
 @@@
 
 

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -97,14 +97,19 @@ object ScalaTestMessages {
 
   final case class OldCommandNotInBindings(name: String)
 
+  // #jackson-scala-enumeration
   object Planet extends Enumeration {
     type Planet = Value
     val Mercury, Venus, Earth, Mars, Krypton = Value
   }
+
+  // Uses default Jackson serialization format for Scala Enumerations
   final case class Alien(name:String, planet:Planet.Planet) extends TestMessage
 
+  // Serializes planet values as a JsonString
   class PlanetType extends TypeReference[Planet.type] {}
   final case class Superhero(name:String, @JsonScalaEnumeration(classOf[PlanetType]) planet:Planet.Planet) extends TestMessage
+  // #jackson-scala-enumeration
 
 }
 

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -17,7 +17,6 @@ import java.util.logging.FileHandler
 import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
-
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.actor.Address
@@ -51,7 +50,9 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.StreamReadFeature
 import com.fasterxml.jackson.core.StreamWriteFeature
+import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.scala.JsonScalaEnumeration
 import com.github.ghik.silencer.silent
 
 object ScalaTestMessages {
@@ -95,6 +96,15 @@ object ScalaTestMessages {
   final case class Cockroach(name: String) extends Animal
 
   final case class OldCommandNotInBindings(name: String)
+
+  object Planet extends Enumeration {
+    type Planet = Value
+    val Mercury, Venus, Earth, Mars, Krypton = Value
+  }
+  final case class Alien(name:String, planet:Planet.Planet) extends TestMessage
+
+  class PlanetType extends TypeReference[Planet.type] {}
+  final case class Superhero(name:String, @JsonScalaEnumeration(classOf[PlanetType]) planet:Planet.Planet) extends TestMessage
 
 }
 
@@ -463,6 +473,15 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
       deserializeFromJsonString(json, serializer.identifier, serializer.manifest(expected)) should ===(expected)
     }
 
+    "deserialize Enumerations as String when configured" in {
+      val json = """{"name":"Superman", "planet":"Krypton"}"""
+
+      val expected = Superhero("Superman", Planet.Krypton)
+      val serializer = serializerFor(expected)
+
+      deserializeFromJsonString(json, serializer.identifier, serializer.manifest(expected)) should ===(expected)
+    }
+
     "compress large payload with gzip" in {
       val conf = JacksonObjectMapperProvider.configForBinding("jackson-json", system.settings.config)
       val compressionAlgo = conf.getString("compression.algorithm")
@@ -720,6 +739,14 @@ abstract class JacksonSerializerSpec(serializerName: String)
     "serialize message with boolean property" in {
       checkSerialization(BooleanCommand(true))
       checkSerialization(BooleanCommand(false))
+    }
+
+    "serialize message with Enumeration property (using Jackson legacy format)" in {
+      checkSerialization(Alien("E.T.", Planet.Mars))
+    }
+
+    "serialize message with Enumeration property as a String" in {
+      checkSerialization(Superhero("Kal El", Planet.Krypton))
     }
 
     "serialize message with Optional property" in {

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -104,11 +104,12 @@ object ScalaTestMessages {
   }
 
   // Uses default Jackson serialization format for Scala Enumerations
-  final case class Alien(name:String, planet:Planet.Planet) extends TestMessage
+  final case class Alien(name: String, planet: Planet.Planet) extends TestMessage
 
   // Serializes planet values as a JsonString
   class PlanetType extends TypeReference[Planet.type] {}
-  final case class Superhero(name:String, @JsonScalaEnumeration(classOf[PlanetType]) planet:Planet.Planet) extends TestMessage
+  final case class Superhero(name: String, @JsonScalaEnumeration(classOf[PlanetType]) planet: Planet.Planet)
+      extends TestMessage
   // #jackson-scala-enumeration
 
 }


### PR DESCRIPTION
Akka Jackson support may be used to read data produced by Play-JSON and other libraries.
Scala Enumerations use different default formats. Given this Enumeration and instance:

```scala
object InnerPlanet extends Enumeration {
  type InnerPlanet = Value
  val Mercury, Venus, Earth, Mars = Value
}
val galacticTrip = Seq(Earth, Mars, Venus)
```

Play JSON produces: `["Earth", "Mars", "Venus"]` (a `JsString` per value)

While Jackson still defaults to a legacy format: (formatting mine)

```
[
 {"enumClass":"example.InnerPlanet","value":"Earth"},
 {"enumClass":"example.InnerPlanet","value":"Mars"},
 {"enumClass":"example.InnerPlanet","value":"Venus"},
]
```

Using Jackson's `JsonScalaEnumeration` it is possible to produce `["Earth", "Mars", "Venus"]`.

This PR introduces tests for both formats.
