### PR TITLE
Expose capacity property on StashBuffer

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashBufferSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashBufferSpec.scala
@@ -201,5 +201,11 @@ class StashBufferSpec extends AnyWordSpec with Matchers with LogCapturing {
       intercept[IllegalArgumentException](stash.unstashAll(Behaviors.unhandled))
     }
 
+    "answer thruthfully about its capacity" in {
+      val capacity = 42
+      val stash = StashBuffer[String](context, capacity)
+
+      stash.capacity should ===(capacity)
+    }
   }
 }

--- a/akka-actor-typed/src/main/mima-filters/2.6.3.backwards.excludes/pr-28739-expose-stashbuffer-capacity.excludes
+++ b/akka-actor-typed/src/main/mima-filters/2.6.3.backwards.excludes/pr-28739-expose-stashbuffer-capacity.excludes
@@ -1,0 +1,4 @@
+# https://github.com/akka/akka/pull/28739#issuecomment-602527515
+# StashBuffer trait is not meant to be extended by external users, and is marked as such with a @DoNotInherit
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.javadsl.StashBuffer.capacity")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.scaladsl.StashBuffer.capacity")

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/StashBuffer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/StashBuffer.scala
@@ -43,6 +43,13 @@ import akka.japi.function.Procedure
   def size: Int
 
   /**
+   * What is the capacity of this buffer.
+   *
+   * @return the capacity of this buffer
+   */
+  def capacity: Int
+
+  /**
    * @return `true` if no more messages can be added, i.e. size equals the capacity of the stash buffer
    */
   def isFull: Boolean

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/StashBuffer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/StashBuffer.scala
@@ -56,6 +56,13 @@ import akka.annotation.{ DoNotInherit, InternalApi }
   def size: Int
 
   /**
+   * What is the capacity of this buffer.
+   *
+   * @return the capacity of this buffer
+   */
+  def capacity: Int
+
+  /**
    * @return `true` if no more messages can be added, i.e. size equals the capacity of the stash buffer
    */
   def isFull: Boolean


### PR DESCRIPTION
## Summary of changes
Just as `size` is available as a property on `StashBuffer`, I have ran into cases where I needed a capacity as well (mainly for logging/monitoring). Instead of passing stash construction parameter to places where it should not be passed, I believe a `capacity` property would be a better solution.
