### PR TITLE
Don't include event in PersistentRepr.toString

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistent.scala
@@ -232,4 +232,8 @@ private[persistence] final case class PersistentImpl(
     case _ => false
   }
 
+  override def toString: String = {
+    s"PersistentRepr($persistenceId,$sequenceNr,$writerUuid,$timestamp)"
+  }
+
 }


### PR DESCRIPTION
* Logging of toString of unknown classes should be avoided, since it could be huge
* Logging for EventSourcedBehaviorImpl includes the PersistentRepr,
  for example:

```
Received Journal response: WriteMessageSuccess(PersistentImpl(Confirmed(2,q1,1583924066958),6,pid-6),,false,null,831cd256-9bc5-40e3-b84c-4a2d34dde643,0),9)
```
