### PR TITLE
OSGi: register ActorSystem under ActorFactoryRef interface

### DIFF
--- a/akka-osgi/src/main/scala/akka/osgi/ActorSystemActivator.scala
+++ b/akka-osgi/src/main/scala/akka/osgi/ActorSystemActivator.scala
@@ -4,13 +4,13 @@
 
 package akka.osgi
 
-import akka.actor.ActorSystem
-import java.util.{ Dictionary, Properties }
+import akka.actor.{ActorRefFactory, ActorSystem}
+import java.util.{Dictionary, Properties}
 
 import akka.util.unused
 import org.osgi.framework._
 import org.osgi.service.log.LogService
-import com.typesafe.config.{ Config, ConfigFactory }
+import com.typesafe.config.{Config, ConfigFactory}
 
 /**
  * Abstract bundle activator implementation to bootstrap and configure an actor system in an
@@ -104,7 +104,7 @@ abstract class ActorSystemActivator extends BundleActivator {
     val properties = new Properties()
     properties.put("name", system.name)
     registration = Some(
-      context.registerService(classOf[ActorSystem].getName, system, properties.asInstanceOf[Dictionary[String, Any]]))
+      context.registerService(Array(classOf[ActorSystem].getName, classOf[ActorRefFactory].getName), system, properties.asInstanceOf[Dictionary[String, Any]]))
   }
 
   /**

--- a/akka-osgi/src/main/scala/akka/osgi/ActorSystemActivator.scala
+++ b/akka-osgi/src/main/scala/akka/osgi/ActorSystemActivator.scala
@@ -4,13 +4,13 @@
 
 package akka.osgi
 
-import akka.actor.{ActorRefFactory, ActorSystem}
-import java.util.{Dictionary, Properties}
+import akka.actor.{ ActorRefFactory, ActorSystem }
+import java.util.{ Dictionary, Properties }
 
 import akka.util.unused
 import org.osgi.framework._
 import org.osgi.service.log.LogService
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 
 /**
  * Abstract bundle activator implementation to bootstrap and configure an actor system in an
@@ -104,7 +104,10 @@ abstract class ActorSystemActivator extends BundleActivator {
     val properties = new Properties()
     properties.put("name", system.name)
     registration = Some(
-      context.registerService(Array(classOf[ActorSystem].getName, classOf[ActorRefFactory].getName), system, properties.asInstanceOf[Dictionary[String, Any]]))
+      context.registerService(
+        Array(classOf[ActorSystem].getName, classOf[ActorRefFactory].getName),
+        system,
+        properties.asInstanceOf[Dictionary[String, Any]]))
   }
 
   /**


### PR DESCRIPTION
By also registering the osgi service under the interface name, it becomes more convenient to retrieve the reference from the osgi registry.

With the current implementation we need to explicitly tell blueprint to allow classes instead of only interfaces to be looked up. eg 
`<reference id="actorSystem" interface="akka.actor.ActorSystem" ext:proxy-method="classes" />` 

could become 

`<reference id="actorSystem" interface="akka.actor.ActorFactoryRef" />`