### PR TITLE
Unstash one instead of all in ConsumerController, #28718

### DIFF
--- a/akka-actor-typed-tests/src/test/resources/logback-test.xml
+++ b/akka-actor-typed-tests/src/test/resources/logback-test.xml
@@ -25,7 +25,7 @@
       <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="DEBUG">
+    <root level="TRACE">
         <appender-ref ref="CapturingAppender"/>
     </root>
 </configuration>

--- a/akka-actor-typed/src/main/scala-jdk-9/akka/actor/typed/internal/jfr/Events.scala
+++ b/akka-actor-typed/src/main/scala-jdk-9/akka/actor/typed/internal/jfr/Events.scala
@@ -159,3 +159,10 @@ final class DeliveryConsumerSentRequest(val producerId: String, val requestedSeq
 @StackTrace(false)
 @Category(Array("Akka", "Delivery", "ConsumerController")) @Label("Delivery ConsumerController producer changed")
 final class DeliveryConsumerChangedProducer(val producerId: String) extends Event
+
+/** INTERNAL API */
+@InternalApi
+@Enabled(true)
+@StackTrace(false)
+@Category(Array("Akka", "Delivery", "ConsumerController")) @Label("Delivery ConsumerController stash is full")
+final class DeliveryConsumerStashFull(val producerId: String, val seqNr: Long) extends Event

--- a/akka-actor-typed/src/main/scala-jdk-9/akka/actor/typed/internal/jfr/JFRActorFlightRecorder.scala
+++ b/akka-actor-typed/src/main/scala-jdk-9/akka/actor/typed/internal/jfr/JFRActorFlightRecorder.scala
@@ -64,5 +64,7 @@ private[akka] final class JFRActorFlightRecorder(val system: ActorSystem[_]) ext
     new DeliveryConsumerSentRequest(producerId, requestedSeqNr).commit()
   override def consumerChangedProducer(producerId: String): Unit =
     new DeliveryConsumerChangedProducer(producerId).commit()
+  override def consumerStashFull(producerId: String, seqNr: Long): Unit =
+    new DeliveryConsumerStashFull(producerId, seqNr).commit()
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/internal/ConsumerControllerImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/internal/ConsumerControllerImpl.scala
@@ -18,6 +18,7 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.LoggerOps
 import akka.actor.typed.scaladsl.StashBuffer
 import akka.actor.typed.scaladsl.TimerScheduler
+import akka.util.ConstantFun.scalaIdentityFunction
 import akka.annotation.InternalApi
 
 /**
@@ -115,12 +116,12 @@ import akka.annotation.InternalApi
             }
             Behaviors.withTimers { timers =>
               // wait for the `Start` message from the consumer, SequencedMessage will be stashed
-              def waitForStart(
-                  registering: Option[ActorRef[ProducerController.Command[A]]]): Behavior[InternalCommand] = {
+              def waitForStart(registering: Option[ActorRef[ProducerController.Command[A]]], stopping: Boolean)
+                  : Behavior[InternalCommand] = {
                 Behaviors.receiveMessagePartial {
                   case reg: RegisterToProducerController[A] @unchecked =>
                     reg.producerController ! ProducerController.RegisterConsumer(context.self)
-                    waitForStart(Some(reg.producerController))
+                    waitForStart(Some(reg.producerController), stopping)
 
                   case s: Start[A] @unchecked =>
                     ConsumerControllerImpl.enforceLocalConsumer(s.deliverTo)
@@ -129,20 +130,30 @@ import akka.annotation.InternalApi
                     flightRecorder.consumerStarted(context.self.path)
                     val activeBehavior =
                       new ConsumerControllerImpl[A](context, timers, stashBuffer, settings)
-                        .active(initialState(context, s, registering))
+                        .active(initialState(context, s, registering, stopping))
                     context.log.debug("Received Start, unstash [{}] messages.", stashBuffer.size)
-                    stashBuffer.unstashAll(activeBehavior)
+                    stashBuffer.unstash(activeBehavior, 1, scalaIdentityFunction)
 
                   case seqMsg: SequencedMessage[A] @unchecked =>
+                    if (stashBuffer.isFull) {
+                      flightRecorder.consumerStashFull(seqMsg.producerId, seqMsg.seqNr)
+                      context.log.debug(
+                        "Received SequencedMessage seqNr [{}], stashing before Start, discarding message because stash is full.",
+                        seqMsg.seqNr)
+                    } else {
+                      context.log.trace(
+                        "Received SequencedMessage seqNr [{}], stashing before Start, stashed size [{}].",
+                        seqMsg.seqNr,
+                        stashBuffer.size + 1)
+                    }
                     stashBuffer.stash(seqMsg)
                     Behaviors.same
 
-                  case d: DeliverThenStop[_] =>
+                  case _: DeliverThenStop[_] =>
                     if (stashBuffer.isEmpty) {
                       Behaviors.stopped
                     } else {
-                      stashBuffer.stash(d)
-                      Behaviors.same
+                      waitForStart(registering, stopping = true)
                     }
 
                   case Retry =>
@@ -161,7 +172,7 @@ import akka.annotation.InternalApi
               }
 
               timers.startTimerWithFixedDelay(Retry, Retry, settings.resendInterval)
-              waitForStart(None)
+              waitForStart(None, stopping = false)
             }
           }
         }
@@ -179,7 +190,8 @@ import akka.annotation.InternalApi
   private def initialState[A](
       context: ActorContext[InternalCommand],
       start: Start[A],
-      registering: Option[ActorRef[ProducerController.Command[A]]]): State[A] = {
+      registering: Option[ActorRef[ProducerController.Command[A]]],
+      stopping: Boolean): State[A] = {
     State(
       producerController = context.system.deadLetters,
       "n/a",
@@ -188,7 +200,7 @@ import akka.annotation.InternalApi
       confirmedSeqNr = 0,
       requestedSeqNr = 0,
       registering,
-      stopping = false)
+      stopping)
   }
 
   def enforceLocalConsumer(ref: ActorRef[_]): Unit = {
@@ -235,12 +247,12 @@ private class ConsumerControllerImpl[A](
           if (s.isProducerChanged(seqMsg)) {
             if (seqMsg.first)
               context.log.trace("Received first SequencedMessage seqNr [{}], delivering to consumer.", seqNr)
-            receiveChangedProducer(s, seqMsg)
+            receiveChangedProducer(s, seqMsg, () => active(s))
           } else if (s.registering.isDefined) {
             context.log.debug(
               "Received SequencedMessage seqNr [{}], discarding message because registering to new ProducerController.",
               seqNr)
-            Behaviors.same
+            stashBuffer.unstash(active(s), 1, scalaIdentityFunction)
           } else if (s.isNextExpected(seqMsg)) {
             context.log.trace("Received SequencedMessage seqNr [{}], delivering to consumer.", seqNr)
             deliver(s.copy(receivedSeqNr = seqNr), seqMsg)
@@ -253,18 +265,18 @@ private class ConsumerControllerImpl[A](
               if (resendLost) "requesting resend from expected seqNr" else "delivering to consumer anyway")
             if (resendLost) {
               seqMsg.producerController ! Resend(fromSeqNr = expectedSeqNr)
+              clearStashBuffer()
               resending(s)
             } else {
-              s.consumer ! Delivery(seqMsg.message, context.self, pid, seqNr)
-              waitingForConfirmation(s.copy(receivedSeqNr = seqNr), seqMsg)
+              deliver(s.copy(receivedSeqNr = seqNr), seqMsg)
             }
           } else { // seqNr < expectedSeqNr
             flightRecorder.consumerDuplicate(pid, expectedSeqNr, seqNr)
             context.log.debug2("Received duplicate SequencedMessage seqNr [{}], expected [{}].", seqNr, expectedSeqNr)
             if (seqMsg.first)
-              active(retryRequest(s))
+              stashBuffer.unstash(active(retryRequest(s)), 1, scalaIdentityFunction)
             else
-              Behaviors.same
+              stashBuffer.unstash(active(s), 1, scalaIdentityFunction)
           }
 
         case Retry =>
@@ -293,7 +305,10 @@ private class ConsumerControllerImpl[A](
       }
   }
 
-  private def receiveChangedProducer(s: State[A], seqMsg: SequencedMessage[A]): Behavior[InternalCommand] = {
+  private def receiveChangedProducer(
+      s: State[A],
+      seqMsg: SequencedMessage[A],
+      nextBehaviorIfUnexpectedProducer: () => Behavior[InternalCommand]): Behavior[InternalCommand] = {
     val seqNr = seqMsg.seqNr
 
     if (seqMsg.first || !resendLost) {
@@ -320,6 +335,7 @@ private class ConsumerControllerImpl[A](
         seqMsg.producerController)
       // request resend of all unconfirmed, and mark first
       seqMsg.producerController ! Resend(0)
+      clearStashBuffer()
       resending(s)
     } else {
       context.log.warnN(
@@ -328,7 +344,7 @@ private class ConsumerControllerImpl[A](
         seqNr,
         seqMsg.producerController,
         s.producerController)
-      Behaviors.same
+      stashBuffer.unstash(nextBehaviorIfUnexpectedProducer(), 1, scalaIdentityFunction)
     }
 
   }
@@ -353,6 +369,8 @@ private class ConsumerControllerImpl[A](
   // ProducerController with the missing seqNr. Other SequencedMessage with different seqNr will be
   // discarded since they were in flight before the Resend request and will anyway be sent again.
   private def resending(s: State[A]): Behavior[InternalCommand] = {
+    if (stashBuffer.nonEmpty)
+      throw new IllegalStateException("StashBuffer should be cleared before resending.")
     Behaviors
       .receiveMessage[InternalCommand] {
         case seqMsg: SequencedMessage[A] =>
@@ -361,7 +379,7 @@ private class ConsumerControllerImpl[A](
           if (s.isProducerChanged(seqMsg)) {
             if (seqMsg.first)
               context.log.trace("Received first SequencedMessage seqNr [{}], delivering to consumer.", seqNr)
-            receiveChangedProducer(s, seqMsg)
+            receiveChangedProducer(s, seqMsg, () => resending(s))
           } else if (s.registering.isDefined) {
             context.log.debug(
               "Received SequencedMessage seqNr [{}], discarding message because registering to new ProducerController.",
@@ -414,6 +432,10 @@ private class ConsumerControllerImpl[A](
       }
   }
 
+  private def clearStashBuffer(): Unit = {
+    stashBuffer.unstashAll(Behaviors.ignore)
+  }
+
   private def deliver(s: State[A], seqMsg: SequencedMessage[A]): Behavior[InternalCommand] = {
     s.consumer ! Delivery(seqMsg.message, context.self, seqMsg.producerId, seqMsg.seqNr)
     waitingForConfirmation(s, seqMsg)
@@ -464,8 +486,10 @@ private class ConsumerControllerImpl[A](
               s.producerController ! Ack(seqNr)
             }
           } else {
-            // FIXME #28718 can we use unstashOne instead of all?
-            stashBuffer.unstashAll(active(s.copy(confirmedSeqNr = seqNr, requestedSeqNr = newRequestedSeqNr)))
+            stashBuffer.unstash(
+              active(s.copy(confirmedSeqNr = seqNr, requestedSeqNr = newRequestedSeqNr)),
+              1,
+              scalaIdentityFunction)
           }
 
         case msg: SequencedMessage[A] =>
@@ -476,14 +500,17 @@ private class ConsumerControllerImpl[A](
           } else if (stashBuffer.isFull) {
             // possible that the stash is full if ProducerController resends unconfirmed (duplicates)
             // dropping them since they can be resent
+            flightRecorder.consumerStashFull(seqMsg.producerId, seqMsg.seqNr)
             context.log.debug(
               "Received SequencedMessage seqNr [{}], discarding message because stash is full.",
               msg.seqNr)
           } else {
-            context.log.trace(
-              "Received SequencedMessage seqNr [{}], stashing while waiting for consumer to confirm [{}].",
-              msg.seqNr,
-              seqMsg.seqNr)
+            if (context.log.isTraceEnabled())
+              context.log.traceN(
+                "Received SequencedMessage seqNr [{}], stashing while waiting for consumer to confirm [{}], stashed size [{}].",
+                msg.seqNr,
+                seqMsg.seqNr,
+                stashBuffer.size + 1)
             stashBuffer.stash(msg)
           }
           Behaviors.same

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/internal/ConsumerControllerImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/internal/ConsumerControllerImpl.scala
@@ -265,7 +265,7 @@ private class ConsumerControllerImpl[A](
               if (resendLost) "requesting resend from expected seqNr" else "delivering to consumer anyway")
             if (resendLost) {
               seqMsg.producerController ! Resend(fromSeqNr = expectedSeqNr)
-              clearStashBuffer()
+              stashBuffer.clear()
               resending(s)
             } else {
               deliver(s.copy(receivedSeqNr = seqNr), seqMsg)
@@ -335,7 +335,7 @@ private class ConsumerControllerImpl[A](
         seqMsg.producerController)
       // request resend of all unconfirmed, and mark first
       seqMsg.producerController ! Resend(0)
-      clearStashBuffer()
+      stashBuffer.clear()
       resending(s)
     } else {
       context.log.warnN(
@@ -430,10 +430,6 @@ private class ConsumerControllerImpl[A](
       .receiveSignal {
         case (_, PostStop) => postStop(s)
       }
-  }
-
-  private def clearStashBuffer(): Unit = {
-    stashBuffer.unstashAll(Behaviors.ignore)
   }
 
   private def deliver(s: State[A], seqMsg: SequencedMessage[A]): Behavior[InternalCommand] = {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/internal/ConsumerControllerImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/internal/ConsumerControllerImpl.scala
@@ -247,12 +247,12 @@ private class ConsumerControllerImpl[A](
           if (s.isProducerChanged(seqMsg)) {
             if (seqMsg.first)
               context.log.trace("Received first SequencedMessage seqNr [{}], delivering to consumer.", seqNr)
-            receiveChangedProducer(s, seqMsg, () => active(s))
+            receiveChangedProducer(s, seqMsg)
           } else if (s.registering.isDefined) {
             context.log.debug(
               "Received SequencedMessage seqNr [{}], discarding message because registering to new ProducerController.",
               seqNr)
-            stashBuffer.unstash(active(s), 1, scalaIdentityFunction)
+            stashBuffer.unstash(Behaviors.same, 1, scalaIdentityFunction)
           } else if (s.isNextExpected(seqMsg)) {
             context.log.trace("Received SequencedMessage seqNr [{}], delivering to consumer.", seqNr)
             deliver(s.copy(receivedSeqNr = seqNr), seqMsg)
@@ -276,7 +276,7 @@ private class ConsumerControllerImpl[A](
             if (seqMsg.first)
               stashBuffer.unstash(active(retryRequest(s)), 1, scalaIdentityFunction)
             else
-              stashBuffer.unstash(active(s), 1, scalaIdentityFunction)
+              stashBuffer.unstash(Behaviors.same, 1, scalaIdentityFunction)
           }
 
         case Retry =>
@@ -305,10 +305,7 @@ private class ConsumerControllerImpl[A](
       }
   }
 
-  private def receiveChangedProducer(
-      s: State[A],
-      seqMsg: SequencedMessage[A],
-      nextBehaviorIfUnexpectedProducer: () => Behavior[InternalCommand]): Behavior[InternalCommand] = {
+  private def receiveChangedProducer(s: State[A], seqMsg: SequencedMessage[A]): Behavior[InternalCommand] = {
     val seqNr = seqMsg.seqNr
 
     if (seqMsg.first || !resendLost) {
@@ -344,7 +341,7 @@ private class ConsumerControllerImpl[A](
         seqNr,
         seqMsg.producerController,
         s.producerController)
-      stashBuffer.unstash(nextBehaviorIfUnexpectedProducer(), 1, scalaIdentityFunction)
+      stashBuffer.unstash(Behaviors.same, 1, scalaIdentityFunction)
     }
 
   }
@@ -379,7 +376,7 @@ private class ConsumerControllerImpl[A](
           if (s.isProducerChanged(seqMsg)) {
             if (seqMsg.first)
               context.log.trace("Received first SequencedMessage seqNr [{}], delivering to consumer.", seqNr)
-            receiveChangedProducer(s, seqMsg, () => resending(s))
+            receiveChangedProducer(s, seqMsg)
           } else if (s.registering.isDefined) {
             context.log.debug(
               "Received SequencedMessage seqNr [{}], discarding message because registering to new ProducerController.",

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/internal/ConsumerControllerImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/internal/ConsumerControllerImpl.scala
@@ -145,8 +145,8 @@ import akka.annotation.InternalApi
                         "Received SequencedMessage seqNr [{}], stashing before Start, stashed size [{}].",
                         seqMsg.seqNr,
                         stashBuffer.size + 1)
+                      stashBuffer.stash(seqMsg)
                     }
-                    stashBuffer.stash(seqMsg)
                     Behaviors.same
 
                   case _: DeliverThenStop[_] =>

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorFlightRecorder.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorFlightRecorder.scala
@@ -72,6 +72,7 @@ private[akka] trait ActorFlightRecorder extends Extension {
   def consumerReceivedResend(seqNr: Long): Unit
   def consumerSentRequest(producerId: String, requestedSeqNr: Long): Unit
   def consumerChangedProducer(producerId: String): Unit
+  def consumerStashFull(producerId: String, seqNr: Long): Unit
 }
 
 /**
@@ -111,5 +112,6 @@ private[akka] case object NoOpActorFlightRecorder extends ActorFlightRecorder {
   override def consumerReceivedResend(seqNr: Long): Unit = ()
   override def consumerSentRequest(producerId: String, requestedSeqNr: Long): Unit = ()
   override def consumerChangedProducer(producerId: String): Unit = ()
+  override def consumerStashFull(producerId: String, seqNr: Long): Unit = ()
 
 }


### PR DESCRIPTION
The old bench results for flow control window of 10 and 50:
```
[info] Benchmark                       (window)   Mode  Cnt       Score      Error  Units
[info] ReliableDeliveryBenchmark.echo        10  thrpt    5  149123,705 ± 9050,765  ops/s
[info] ReliableDeliveryBenchmark.echo        50  thrpt    5  105514,340 ± 5432,436  ops/s
```

Much lower for larger window can be explained by that messages are stashed and then all are unstashed even though only one can be delivered, resulting in that all but one are stashed again.

This PR fixes that. Bench results with this PR:
```
[info] Benchmark                       (window)   Mode  Cnt       Score       Error  Units
[info] ReliableDeliveryBenchmark.echo        10  thrpt    5  147510,237 ± 14949,517  ops/s
[info] ReliableDeliveryBenchmark.echo        50  thrpt    5  160423,531 ±  8052,905  ops/s
```

Refs #28718