### PR TITLE
Notify Receptionist subscribers when node added and removed, #28792

### DIFF
--- a/akka-cluster-typed/src/main/java/akka/cluster/typed/internal/protobuf/ClusterMessages.java
+++ b/akka-cluster-typed/src/main/java/akka/cluster/typed/internal/protobuf/ClusterMessages.java
@@ -49,6 +49,17 @@ public final class ClusterMessages {
      * @return The systemUid.
      */
     long getSystemUid();
+
+    /**
+     * <code>optional int64 createdTimestamp = 3;</code>
+     * @return Whether the createdTimestamp field is set.
+     */
+    boolean hasCreatedTimestamp();
+    /**
+     * <code>optional int64 createdTimestamp = 3;</code>
+     * @return The createdTimestamp.
+     */
+    long getCreatedTimestamp();
   }
   /**
    * Protobuf type {@code akka.cluster.typed.ReceptionistEntry}
@@ -106,6 +117,11 @@ public final class ClusterMessages {
             case 16: {
               bitField0_ |= 0x00000002;
               systemUid_ = input.readUInt64();
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000004;
+              createdTimestamp_ = input.readInt64();
               break;
             }
             default: {
@@ -203,6 +219,23 @@ public final class ClusterMessages {
       return systemUid_;
     }
 
+    public static final int CREATEDTIMESTAMP_FIELD_NUMBER = 3;
+    private long createdTimestamp_;
+    /**
+     * <code>optional int64 createdTimestamp = 3;</code>
+     * @return Whether the createdTimestamp field is set.
+     */
+    public boolean hasCreatedTimestamp() {
+      return ((bitField0_ & 0x00000004) != 0);
+    }
+    /**
+     * <code>optional int64 createdTimestamp = 3;</code>
+     * @return The createdTimestamp.
+     */
+    public long getCreatedTimestamp() {
+      return createdTimestamp_;
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -231,6 +264,9 @@ public final class ClusterMessages {
       if (((bitField0_ & 0x00000002) != 0)) {
         output.writeUInt64(2, systemUid_);
       }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        output.writeInt64(3, createdTimestamp_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -246,6 +282,10 @@ public final class ClusterMessages {
       if (((bitField0_ & 0x00000002) != 0)) {
         size += akka.protobufv3.internal.CodedOutputStream
           .computeUInt64Size(2, systemUid_);
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += akka.protobufv3.internal.CodedOutputStream
+          .computeInt64Size(3, createdTimestamp_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -272,6 +312,11 @@ public final class ClusterMessages {
         if (getSystemUid()
             != other.getSystemUid()) return false;
       }
+      if (hasCreatedTimestamp() != other.hasCreatedTimestamp()) return false;
+      if (hasCreatedTimestamp()) {
+        if (getCreatedTimestamp()
+            != other.getCreatedTimestamp()) return false;
+      }
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -291,6 +336,11 @@ public final class ClusterMessages {
         hash = (37 * hash) + SYSTEMUID_FIELD_NUMBER;
         hash = (53 * hash) + akka.protobufv3.internal.Internal.hashLong(
             getSystemUid());
+      }
+      if (hasCreatedTimestamp()) {
+        hash = (37 * hash) + CREATEDTIMESTAMP_FIELD_NUMBER;
+        hash = (53 * hash) + akka.protobufv3.internal.Internal.hashLong(
+            getCreatedTimestamp());
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -429,6 +479,8 @@ public final class ClusterMessages {
         bitField0_ = (bitField0_ & ~0x00000001);
         systemUid_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000002);
+        createdTimestamp_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -464,6 +516,10 @@ public final class ClusterMessages {
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.systemUid_ = systemUid_;
           to_bitField0_ |= 0x00000002;
+        }
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.createdTimestamp_ = createdTimestamp_;
+          to_bitField0_ |= 0x00000004;
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -521,6 +577,9 @@ public final class ClusterMessages {
         }
         if (other.hasSystemUid()) {
           setSystemUid(other.getSystemUid());
+        }
+        if (other.hasCreatedTimestamp()) {
+          setCreatedTimestamp(other.getCreatedTimestamp());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -675,6 +734,43 @@ public final class ClusterMessages {
       public Builder clearSystemUid() {
         bitField0_ = (bitField0_ & ~0x00000002);
         systemUid_ = 0L;
+        onChanged();
+        return this;
+      }
+
+      private long createdTimestamp_ ;
+      /**
+       * <code>optional int64 createdTimestamp = 3;</code>
+       * @return Whether the createdTimestamp field is set.
+       */
+      public boolean hasCreatedTimestamp() {
+        return ((bitField0_ & 0x00000004) != 0);
+      }
+      /**
+       * <code>optional int64 createdTimestamp = 3;</code>
+       * @return The createdTimestamp.
+       */
+      public long getCreatedTimestamp() {
+        return createdTimestamp_;
+      }
+      /**
+       * <code>optional int64 createdTimestamp = 3;</code>
+       * @param value The createdTimestamp to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCreatedTimestamp(long value) {
+        bitField0_ |= 0x00000004;
+        createdTimestamp_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 createdTimestamp = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearCreatedTimestamp() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        createdTimestamp_ = 0L;
         onChanged();
         return this;
       }
@@ -1394,11 +1490,12 @@ public final class ClusterMessages {
   static {
     java.lang.String[] descriptorData = {
       "\n\025ClusterMessages.proto\022\022akka.cluster.ty" +
-      "ped\032\026ContainerFormats.proto\"8\n\021Reception" +
+      "ped\032\026ContainerFormats.proto\"R\n\021Reception" +
       "istEntry\022\020\n\010actorRef\030\001 \002(\t\022\021\n\tsystemUid\030" +
-      "\002 \002(\004\"3\n\026PubSubMessagePublished\022\031\n\007messa" +
-      "ge\030\001 \002(\0132\010.PayloadB(\n$akka.cluster.typed" +
-      ".internal.protobufH\001"
+      "\002 \002(\004\022\030\n\020createdTimestamp\030\003 \001(\003\"3\n\026PubSu" +
+      "bMessagePublished\022\031\n\007message\030\001 \002(\0132\010.Pay" +
+      "loadB(\n$akka.cluster.typed.internal.prot" +
+      "obufH\001"
     };
     descriptor = akka.protobufv3.internal.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -1410,7 +1507,7 @@ public final class ClusterMessages {
     internal_static_akka_cluster_typed_ReceptionistEntry_fieldAccessorTable = new
       akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
         internal_static_akka_cluster_typed_ReceptionistEntry_descriptor,
-        new java.lang.String[] { "ActorRef", "SystemUid", });
+        new java.lang.String[] { "ActorRef", "SystemUid", "CreatedTimestamp", });
     internal_static_akka_cluster_typed_PubSubMessagePublished_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_akka_cluster_typed_PubSubMessagePublished_fieldAccessorTable = new

--- a/akka-cluster-typed/src/main/mima-filters/2.6.4.backwards.excludes/issue-28792-ClusterReceptionist.excludes
+++ b/akka-cluster-typed/src/main/mima-filters/2.6.4.backwards.excludes/issue-28792-ClusterReceptionist.excludes
@@ -1,0 +1,3 @@
+# #28792 Changes to internals of ClusterReceptionist
+ProblemFilters.exclude[Problem]("akka.cluster.typed.internal.receptionist.*")
+ProblemFilters.exclude[Problem]("akka.cluster.typed.internal.protobuf.*")

--- a/akka-cluster-typed/src/main/protobuf/ClusterMessages.proto
+++ b/akka-cluster-typed/src/main/protobuf/ClusterMessages.proto
@@ -14,6 +14,7 @@ import "ContainerFormats.proto";
 message ReceptionistEntry {
   required string actorRef = 1;
   required uint64 systemUid = 2;
+  optional int64 createdTimestamp = 3;
 }
 
 message PubSubMessagePublished {

--- a/akka-cluster-typed/src/main/resources/reference.conf
+++ b/akka-cluster-typed/src/main/resources/reference.conf
@@ -14,6 +14,11 @@ akka.cluster.typed.receptionist {
   # in case of abrupt termination.
   pruning-interval = 3 s
 
+  # The periodic task to remove actor references that are hosted by removed nodes
+  # will only remove entries older than this duration. The reason for this
+  # is to avoid removing entries of nodes that haven't been visible as joining.
+  prune-removed-older-than = 60 s
+
   # Shard the services over this many Distributed Data keys, with large amounts of different
   # service keys storing all of them in the same Distributed Data entry would lead to large updates
   # etc. instead the keys are sharded across this number of keys. This must be the same on all nodes

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializer.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializer.scala
@@ -61,13 +61,17 @@ private[akka] final class AkkaClusterTypedSerializer(override val system: Extend
       .toByteArray
   }
 
-  private def receptionistEntryToBinary(e: Entry): Array[Byte] =
-    ClusterMessages.ReceptionistEntry
+  private def receptionistEntryToBinary(e: Entry): Array[Byte] = {
+    val b = ClusterMessages.ReceptionistEntry
       .newBuilder()
       .setActorRef(resolver.toSerializationFormat(e.ref))
       .setSystemUid(e.systemUid)
-      .build()
-      .toByteArray
+
+    if (e.createdTimestamp != 0L)
+      b.setCreatedTimestamp(e.createdTimestamp)
+
+    b.build().toByteArray
+  }
 
   private def pubSubMessageFromBinary(bytes: Array[Byte]): TopicImpl.MessagePublished[_] = {
     val parsed = ClusterMessages.PubSubMessagePublished.parseFrom(bytes)
@@ -77,6 +81,7 @@ private[akka] final class AkkaClusterTypedSerializer(override val system: Extend
 
   private def receptionistEntryFromBinary(bytes: Array[Byte]): Entry = {
     val re = ClusterMessages.ReceptionistEntry.parseFrom(bytes)
-    Entry(resolver.resolveActorRef(re.getActorRef), re.getSystemUid)
+    val createdTimestamp = if (re.hasCreatedTimestamp) re.getCreatedTimestamp else 0L
+    Entry(resolver.resolveActorRef(re.getActorRef), re.getSystemUid)(createdTimestamp)
   }
 }

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
@@ -481,7 +481,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
           }
 
         case NodeAdded(uniqueAddress) =>
-          if (state.registry.nodes(uniqueAddress)) {
+          if (state.registry.nodes.contains(uniqueAddress)) {
             Behaviors.same
           } else {
             val newState = state.copy(registry = state.registry.addNode(uniqueAddress))
@@ -505,7 +505,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
             // If self cluster node is shutting down our own entries should have been removed via
             // watch-Terminated or will be removed by other nodes. This point is anyway too late.
             Behaviors.stopped
-          } else if (state.registry.nodes(uniqueAddress)) {
+          } else if (state.registry.nodes.contains(uniqueAddress)) {
 
             val keysForNode = state.registry.keysFor(uniqueAddress)
             val newState = state.copy(registry = state.registry.removeNode(uniqueAddress))

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSettings.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSettings.scala
@@ -40,6 +40,7 @@ private[akka] object ClusterReceptionistSettings {
     ClusterReceptionistSettings(
       writeConsistency,
       pruningInterval = config.getDuration("pruning-interval", MILLISECONDS).millis,
+      pruneRemovedOlderThan = config.getDuration("prune-removed-older-than", MILLISECONDS).millis,
       config.getInt("distributed-key-count"),
       replicatorSettings)
   }
@@ -52,5 +53,6 @@ private[akka] object ClusterReceptionistSettings {
 private[akka] case class ClusterReceptionistSettings(
     writeConsistency: WriteConsistency,
     pruningInterval: FiniteDuration,
+    pruneRemovedOlderThan: FiniteDuration,
     distributedKeyCount: Int,
     replicatorSettings: ReplicatorSettings)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializerSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/AkkaClusterTypedSerializerSpec.scala
@@ -21,7 +21,7 @@ class AkkaClusterTypedSerializerSpec extends ScalaTestWithActorTestKit with AnyW
 
   "AkkaClusterTypedSerializer" must {
 
-    Seq("ReceptionistEntry" -> ClusterReceptionist.Entry(ref, 666L)).foreach {
+    Seq("ReceptionistEntry" -> ClusterReceptionist.Entry(ref, 666L)(System.currentTimeMillis())).foreach {
       case (scenario, item) =>
         s"resolve serializer for $scenario" in {
           val serializer = SerializationExtension(classicSystem)


### PR DESCRIPTION
* If the change from ddata arrives before the join information
* One difficulty is that that the removal tick may trigger removal
  for entries that are in the ddata state but not in the membership yet.
  Added a delay to solve that.

References #28792
