### PR TITLE
Build 2.5: Scala 2.12.11; set canonical URL for Scaladoc

### DIFF
--- a/akka-actor/src/main/scala-2.13-/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala-2.13-/akka/util/ByteString.scala
@@ -421,7 +421,7 @@ object ByteString {
 
   private[akka] object ByteStrings extends Companion {
     def apply(bytestrings: Vector[ByteString1]): ByteString =
-      new ByteStrings(bytestrings, (0 /: bytestrings)(_ + _.length))
+      new ByteStrings(bytestrings, bytestrings.foldLeft(0)(_ + _.length))
 
     def apply(bytestrings: Vector[ByteString1], length: Int): ByteString = new ByteStrings(bytestrings, length)
 

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -43,7 +43,7 @@ object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
     })
 
   lazy val silencerSettings = {
-    val silencerVersion = "1.4.4"
+    val silencerVersion = "1.6.0"
     Seq(
       libraryDependencies ++= Seq(
           compilerPlugin(("com.github.ghik" %% "silencer-plugin" % silencerVersion).cross(CrossVersion.patch)),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val aeronVersion = "1.15.1"
 
   val Versions = Seq(
-    crossScalaVersions := Seq("2.12.8", "2.13.0"),
+    crossScalaVersions := Seq("2.12.11", "2.13.0"),
     scalaVersion := System.getProperty("akka.build.scalaVersion", crossScalaVersions.value.head),
     scalaStmVersion := sys.props.get("akka.build.scalaStmVersion").getOrElse("0.9.1"),
     scalaCheckVersion := sys.props

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -30,7 +30,7 @@ object Scaladoc extends AutoPlugin {
   override lazy val projectSettings = {
     inTask(doc)(
       Seq(
-        scalacOptions in Compile ++= scaladocOptions(version.value, (baseDirectory in ThisBuild).value),
+        scalacOptions in Compile ++= scaladocOptions(scalaVersion.value, version.value, (baseDirectory in ThisBuild).value),
         // -release caused build failures when generating javadoc:
         scalacOptions in Compile --= Seq("-release", "8"),
         autoAPIMappings := CliOptions.scaladocAutoAPI.get)) ++
@@ -43,7 +43,7 @@ object Scaladoc extends AutoPlugin {
     })
   }
 
-  def scaladocOptions(ver: String, base: File): List[String] = {
+  def scaladocOptions(scalaVersion: String, ver: String, base: File): List[String] = {
     val urlString = GitHub.url(ver) + "/€{FILE_PATH}.scala"
     val opts = List(
       "-implicits",
@@ -55,7 +55,15 @@ object Scaladoc extends AutoPlugin {
       "-doc-title",
       "Akka",
       "-doc-version",
-      ver)
+      ver) ++
+      (CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, 11)) => Seq()
+      case _ =>
+        Seq(
+          "-doc-canonical-base-url",
+          "https://doc.akka.io/api/akka/current/"
+        )
+    })
     CliOptions.scaladocDiagramsEnabled.ifTrue("-diagrams").toList ::: opts
   }
 

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -182,7 +182,7 @@ object BootstrapGenjavadoc extends AutoPlugin {
 
   override lazy val projectSettings = UnidocRoot.CliOptions.genjavadocEnabled
     .ifTrue(Seq(
-      unidocGenjavadocVersion := "0.13",
+      unidocGenjavadocVersion := "0.16",
       scalacOptions in Compile ++= Seq("-P:genjavadoc:fabricateParams=true", "-P:genjavadoc:suppressSynthetic=false")))
     .getOrElse(Nil)
 }


### PR DESCRIPTION
* Scala 2.12.11 (was 2.12.8)
* Silencer upgrade
* Fix Scala deprecation in `ByteString`
* Set Scaladoc flag only for Scala 2.12 and 2.13.

References #27546 in Akka 2.6