### PR TITLE
Publish snapshots to gustav with 'publish'

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -41,7 +41,7 @@ object Publish extends AutoPlugin {
 
   private def akkaPublishTo = Def.setting {
     val key = new java.io.File(
-      Option(System.getProperty("akka.gustav.key", null)).getOrElse(sys.env("HOME") + "/.ssh/id_rsa_gustav.pem"))
+      Option(System.getProperty("akka.gustav.key")).getOrElse(System.getProperty("user.home") + "/.ssh/id_rsa_gustav.pem"))
     if (isSnapshot.value)
       Resolver.sftp("Akka snapshots", "gustav.akka.io", "/home/akkarepo/www/snapshots").as("akkarepo", key)
     else
@@ -49,7 +49,7 @@ object Publish extends AutoPlugin {
   }
 
   private def akkaCredentials: Seq[Credentials] =
-    Option(System.getProperty("akka.publish.credentials", null)).map(f => Credentials(new File(f))).toSeq
+    Option(System.getProperty("akka.publish.credentials")).map(f => Credentials(new File(f))).toSeq
 }
 
 /**

--- a/project/scripts/release
+++ b/project/scripts/release
@@ -64,7 +64,12 @@
 # 3.2) Install your public ssh key to avoid typing in your password.
 #      From the command line:
 #        shell> cat ~/.ssh/id_rsa.pub | ssh akkarepo@gustav.akka.io "cat >> ~/.ssh/authorized_keys"
-##
+#
+# 3.3) Also make it available for publishing snapshots.
+#      From the command line:
+#        shell> cp ~/.ssh/id_rsa.pub ~/.ssh/id_rsa_gustav.pem
+#        shell> ssh-keygen -p -f ~/.ssh/id_rsa_gustav.pem -m pem
+#
 # 4) Have access to github.com/akka/akka. This should be a given.
 #
 # Now you should be all set to run the script


### PR DESCRIPTION
This removes the need to publish to a 'predictable' directory and then
'manually' rsyncing the locally-created repository from jenkins to gustav.

This is not needed for anything, it just simplifies the build a bit. We
could eventually use it for the paradox and api docs as well, replacing
the current custom `DeployRsync`.