### PR TITLE
Remove last crossPaths occurrence

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -296,7 +296,6 @@ lazy val protobufV3 = akkaModule("akka-protobuf-v3")
           .rename("com.google.protobuf.**" -> "akka.protobufv3.internal.@1")
           .inLibrary(Dependencies.Compile.protobufRuntime)),
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false, includeBin = false),
-    crossPaths := false,
     autoScalaLibrary := false, // do not include scala dependency in pom
     exportJars := true, // in dependent projects, use assembled and shaded jar
     makePomConfiguration := makePomConfiguration.value

--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -30,7 +30,7 @@ object Protobuf {
     importPath := None,
     // this keeps intellij happy for files that use the shaded protobuf
     Compile / unmanagedJars ++= Seq(
-        baseDirectory.value / ".." / "akka-protobuf-v3" / "target" / s"akka-protobuf-v3-assembly-${version.value}.jar"),
+        baseDirectory.value / ".." / "akka-protobuf-v3" / "target" / s"scala-${scalaBinaryVersion.value}" / s"akka-protobuf-v3-assembly-${version.value}.jar"),
     protoc := "protoc",
     protocVersion := "3.10.0",
     generate := {


### PR DESCRIPTION
We were already not using it for most of the build

Tested that intellij correctly picks up the jar, though this is
very brittle in the first place :(