### PR TITLE
[#28822] Don't advertise temporary references in the compression table

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
@@ -471,15 +471,15 @@ private[remote] class Decoder(
                 case OptionVal.Some(assoc) =>
                   val remoteAddress = assoc.remoteAddress
                   sender match {
-                    case OptionVal.Some(snd) =>
+                    case OptionVal.Some(snd) if shouldCount(snd) =>
                       compressions.hitActorRef(originUid, remoteAddress, snd, 1)
-                    case OptionVal.None =>
+                    case _ => // ignore
                   }
 
                   recipient match {
-                    case OptionVal.Some(rcp) =>
+                    case OptionVal.Some(rcp) if shouldCount(rcp) =>
                       compressions.hitActorRef(originUid, remoteAddress, rcp, 1)
-                    case OptionVal.None =>
+                    case _ => // ignore
                   }
 
                   compressions.hitClassManifest(originUid, remoteAddress, classManifest, 1)
@@ -619,6 +619,10 @@ private[remote] class Decoder(
 
     (logic, logic)
   }
+
+  protected def shouldCount(v: InternalActorRef): Boolean =
+    // don't count temporary refs
+    !v.path.elements.headOption.contains("temp")
 
 }
 

--- a/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
@@ -472,17 +472,13 @@ private[remote] class Decoder(
                   val remoteAddress = assoc.remoteAddress
                   sender match {
                     case OptionVal.Some(snd) =>
-                      if (shouldCount(snd)) {
-                        compressions.hitActorRef(originUid, remoteAddress, snd, 1)
-                      }
+                      compressions.hitActorRef(originUid, remoteAddress, snd, 1)
                     case OptionVal.None =>
                   }
 
                   recipient match {
                     case OptionVal.Some(rcp) =>
-                      if (shouldCount(rcp)) {
-                        compressions.hitActorRef(originUid, remoteAddress, rcp, 1)
-                      }
+                      compressions.hitActorRef(originUid, remoteAddress, rcp, 1)
                     case OptionVal.None =>
                   }
 
@@ -623,13 +619,6 @@ private[remote] class Decoder(
 
     (logic, logic)
   }
-
-  protected def shouldCount(v: InternalActorRef): Boolean =
-    if (v.isLocal) {
-      !v.isInstanceOf[PromiseActorRef]
-    } else {
-      !(v.path.root.name == "temp")
-    }
 
 }
 

--- a/akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/compress/InboundCompressions.scala
@@ -7,12 +7,10 @@ package akka.remote.artery.compress
 import java.util.function.LongFunction
 
 import scala.annotation.tailrec
-
-import akka.actor.ActorRef
-import akka.actor.ActorSystem
-import akka.actor.Address
+import akka.actor.{ ActorRef, ActorSystem, Address, InternalActorRef }
 import akka.event.Logging
 import akka.event.LoggingAdapter
+import akka.pattern.PromiseActorRef
 import akka.remote.artery._
 import akka.util.{ unused, OptionVal }
 import org.agrona.collections.Long2ObjectHashMap
@@ -191,6 +189,21 @@ private[remote] final class InboundActorRefCompression(
       originUid)
     outboundContext.sendControl(
       CompressionProtocol.ActorRefCompressionAdvertisement(inboundContext.localAddress, table))
+  }
+
+  override protected def buildTableForAdvertisement(elements: Iterator[ActorRef]): Map[ActorRef, Int] = {
+    val mb = Map.newBuilder[ActorRef, Int]
+    var idx = 0
+    elements.foreach {
+      case ref: InternalActorRef =>
+        val isTemporaryRef = (ref.isLocal && ref.isInstanceOf[PromiseActorRef]) ||
+          (!ref.isLocal && ref.path.elements.head == "temp")
+        if (!isTemporaryRef) {
+          mb += ref -> idx
+          idx += 1
+        }
+    }
+    mb.result()
   }
 }
 
@@ -493,13 +506,15 @@ private[remote] abstract class InboundCompression[T >: Null](
   protected def advertiseCompressionTable(association: OutboundContext, table: CompressionTable[T]): Unit
 
   private def prepareCompressionAdvertisement(nextTableVersion: Byte): CompressionTable[T] = {
-    // TODO optimised somewhat, check if still to heavy; could be encoded into simple array
-    val mappings: Map[T, Int] = {
-      val mb = Map.newBuilder[T, Int]
-      mb ++= heavyHitters.iterator.zipWithIndex
-      mb.result()
-    }
+    val mappings: Map[T, Int] = buildTableForAdvertisement(heavyHitters.iterator)
     CompressionTable(originUid, nextTableVersion, mappings)
+  }
+
+  protected def buildTableForAdvertisement(elements: Iterator[T]): Map[T, Int] = {
+    // TODO optimised somewhat, check if still to heavy; could be encoded into simple array
+    val mb = Map.newBuilder[T, Int]
+    mb ++= elements.zipWithIndex
+    mb.result()
   }
 
   override def toString =


### PR DESCRIPTION
Fix based on the path, not sure if there's a cleaner way

References #28822