### PR TITLE
[DOC] Fix a GraphDSL example code to compile

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphOpsIntegrationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphOpsIntegrationSpec.scala
@@ -42,7 +42,6 @@ object GraphOpsIntegrationSpec {
 class GraphOpsIntegrationSpec extends StreamSpec("""
     akka.stream.materializer.initial-input-buffer-size = 2
   """) {
-  import GraphDSL.Implicits._
   import akka.stream.scaladsl.GraphOpsIntegrationSpec._
 
   "GraphDSLs" must {
@@ -50,6 +49,7 @@ class GraphOpsIntegrationSpec extends StreamSpec("""
     "support broadcast - merge layouts" in {
       val resultFuture = RunnableGraph
         .fromGraph(GraphDSL.create(Sink.head[Seq[Int]]) { implicit b => (sink) =>
+          import GraphDSL.Implicits._
           val bcast = b.add(Broadcast[Int](2))
           val merge = b.add(Merge[Int](2))
 
@@ -68,6 +68,7 @@ class GraphOpsIntegrationSpec extends StreamSpec("""
       val elements = 0 to 10
       val out = RunnableGraph
         .fromGraph(GraphDSL.create(Sink.head[Seq[Int]]) { implicit b => (sink) =>
+          import GraphDSL.Implicits._
           val balance = b.add(Balance[Int](5))
           val merge = b.add(Merge[Int](5))
 
@@ -89,6 +90,7 @@ class GraphOpsIntegrationSpec extends StreamSpec("""
 
       val (resultFuture2, resultFuture9, resultFuture10) = RunnableGraph
         .fromGraph(GraphDSL.create(seqSink, seqSink, seqSink)(Tuple3.apply) { implicit b => (sink2, sink9, sink10) =>
+          import GraphDSL.Implicits._
           val b3 = b.add(Broadcast[Int](2))
           val b7 = b.add(Broadcast[Int](2))
           val b11 = b.add(Broadcast[Int](3))
@@ -137,6 +139,7 @@ class GraphOpsIntegrationSpec extends StreamSpec("""
 
       val resultFuture = RunnableGraph
         .fromGraph(GraphDSL.create(Sink.head[Seq[Int]]) { implicit b => (sink) =>
+          import GraphDSL.Implicits._
           val bcast = b.add(Broadcast[Int](2))
           val merge = b.add(Merge[Int](2))
 
@@ -157,6 +160,7 @@ class GraphOpsIntegrationSpec extends StreamSpec("""
       val flow = Flow[Int].map(_ * 2)
       RunnableGraph
         .fromGraph(GraphDSL.create() { implicit builder =>
+          import GraphDSL.Implicits._
           Source.fromPublisher(p) ~> flow ~> Sink.fromSubscriber(s)
           ClosedShape
         })
@@ -175,6 +179,7 @@ class GraphOpsIntegrationSpec extends StreamSpec("""
       val f: Future[Seq[Int]] = RunnableGraph
         .fromGraph(GraphDSL.create(shuffler, shuffler, shuffler, Sink.head[Seq[Int]])((_, _, _, fut) => fut) {
           implicit b => (s1, s2, s3, sink) =>
+            import GraphDSL.Implicits._
             val merge = b.add(Merge[Int](2))
 
             Source(List(1, 2, 3)) ~> s1.in1
@@ -209,6 +214,7 @@ class GraphOpsIntegrationSpec extends StreamSpec("""
 
       val g: RunnableGraph[Seq[Future[String]]] = RunnableGraph.fromGraph(GraphDSL.create(sinks) {
         implicit b => sinkList =>
+          import GraphDSL.Implicits._
           val broadcast = b.add(Broadcast[String](sinkList.size))
 
           Source(List("ax", "bx", "cx")) ~> broadcast
@@ -235,6 +241,7 @@ class GraphOpsIntegrationSpec extends StreamSpec("""
 
       val g: RunnableGraph[Seq[Future[immutable.Seq[Int]]]] = RunnableGraph.fromGraph(GraphDSL.create(sinks) {
         implicit b => sinkList =>
+          import GraphDSL.Implicits._
           val broadcast = b.add(Broadcast[Int](sinkList.size))
 
           Source(List(1, 2, 3)) ~> broadcast


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
## Purpose
Fix an [example code](https://github.com/akka/akka/tree/v2.6.4/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphOpsIntegrationSpec.scala#L206-L220), which does not compile by itself, to work.

## Changes
Inserted import clauses for `GraphDSL.Implicits._` into each test case.
Since it seems each of the other test codes cited in the doc has the import clause inside it to compile by itself, I also inserted the import clause into each test case of `GraphOpsIntegrationSpec`.

## Reference
The third example code in https://doc.akka.io/docs/akka/current/stream/stream-graphs.html is the one.

