### PR TITLE
Unstash to correct Beahviors.same when unstash in progress, #28831

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
@@ -7,9 +7,9 @@ package akka.actor.typed.internal
 import java.util.function.{ Function => JFunction }
 
 import akka.actor.DeadLetter
-
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
+
 import akka.actor.typed.Behavior
 import akka.actor.typed.Signal
 import akka.actor.typed.TypedActorContext
@@ -18,6 +18,7 @@ import akka.actor.typed.scaladsl
 import akka.actor.typed.scaladsl.ActorContext
 import akka.annotation.{ InternalApi, InternalStableApi }
 import akka.japi.function.Procedure
+import akka.util.OptionVal
 import akka.util.{ unused, ConstantFun }
 
 /**
@@ -46,6 +47,8 @@ import akka.util.{ unused, ConstantFun }
   import StashBufferImpl.Node
 
   private var _size: Int = if (_first eq null) 0 else 1
+
+  private var currentBehaviorWhenUnstashInProgress: OptionVal[Behavior[T]] = OptionVal.None
 
   override def isEmpty: Boolean = _first eq null
 
@@ -128,15 +131,24 @@ import akka.util.{ unused, ConstantFun }
     if (isEmpty)
       behavior // optimization
     else {
-      val iter = new Iterator[Node[T]] {
-        override def hasNext: Boolean = StashBufferImpl.this.nonEmpty
-        override def next(): Node[T] = {
-          val next = StashBufferImpl.this.dropHeadForUnstash()
-          unstashed(ctx, next)
-          next
-        }
-      }.take(math.min(numberOfMessages, size))
-      interpretUnstashedMessages(behavior, ctx, iter, wrap)
+      // currentBehaviorWhenUnstashInProgress is needed to keep track of current Behavior for Behaviors.same
+      // when unstash is called when a previous unstash is already in progress (in same call stack)
+      val unstashAlreadyInProgress = currentBehaviorWhenUnstashInProgress.isDefined
+      try {
+        val iter = new Iterator[Node[T]] {
+          override def hasNext: Boolean = StashBufferImpl.this.nonEmpty
+
+          override def next(): Node[T] = {
+            val next = StashBufferImpl.this.dropHeadForUnstash()
+            unstashed(ctx, next)
+            next
+          }
+        }.take(math.min(numberOfMessages, size))
+        interpretUnstashedMessages(behavior, ctx, iter, wrap)
+      } finally {
+        if (!unstashAlreadyInProgress)
+          currentBehaviorWhenUnstashInProgress = OptionVal.None
+      }
     }
   }
 
@@ -147,6 +159,7 @@ import akka.util.{ unused, ConstantFun }
       wrap: T => T): Behavior[T] = {
     @tailrec def interpretOne(b: Behavior[T]): Behavior[T] = {
       val b2 = Behavior.start(b, ctx)
+      currentBehaviorWhenUnstashInProgress = OptionVal.Some(b2)
       if (!Behavior.isAlive(b2) || !messages.hasNext) b2
       else {
         val node = messages.next()
@@ -183,7 +196,10 @@ import akka.util.{ unused, ConstantFun }
       if (Behavior.isUnhandled(started))
         throw new IllegalArgumentException("Cannot unstash with unhandled as starting behavior")
       else if (started == BehaviorImpl.same) {
-        ctx.asScala.currentBehavior
+        currentBehaviorWhenUnstashInProgress match {
+          case OptionVal.None    => ctx.asScala.currentBehavior
+          case OptionVal.Some(c) => c
+        }
       } else started
 
     if (Behavior.isAlive(actualInitialBehavior)) {


### PR DESCRIPTION
* When unstashing one message the currentBehavior from the context
  is stale.
* While unstash is in progress we can keep track of currentBehavior
  inside StashBufferImpl.

References #28831
