### PR TITLE
change %mdc examples, and tests

### DIFF
--- a/akka-actor-testkit-typed/src/test/resources/logback-test.xml
+++ b/akka-actor-testkit-typed/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@
             <level>INFO</level>
         </filter>
         <encoder>
-            <pattern>%date{ISO8601} %-5level %logger %marker - %msg {%mdc}%n</pattern>
+            <pattern>%date{ISO8601} %-5level %logger %marker - %msg MDC: {%mdc}%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-actor-typed-tests/src/test/resources/logback-doc-dev.xml
+++ b/akka-actor-typed-tests/src/test/resources/logback-doc-dev.xml
@@ -6,14 +6,14 @@
             <level>INFO</level>
         </filter>
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
         </encoder>
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>target/myapp-dev.log</file>
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-actor-typed-tests/src/test/resources/logback-doc-prod.xml
+++ b/akka-actor-typed-tests/src/test/resources/logback-doc-prod.xml
@@ -8,7 +8,7 @@
             <fileNamePattern>myapp_%d{yyyy-MM-dd}.log</fileNamePattern>
         </rollingPolicy>
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-actor-typed-tests/src/test/resources/logback-doc-test.xml
+++ b/akka-actor-typed-tests/src/test/resources/logback-doc-test.xml
@@ -6,7 +6,7 @@
             <level>INFO</level>
         </filter>
         <encoder>
-            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg {%mdc}%n</pattern>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-actor-typed-tests/src/test/resources/logback-test.xml
+++ b/akka-actor-typed-tests/src/test/resources/logback-test.xml
@@ -5,7 +5,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{ISO8601} %-5level %logger %marker - %msg {%mdc}%n</pattern>
+            <pattern>%date{ISO8601} %-5level %logger %marker - %msg MDC: {%mdc}%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-bench-jmh/src/main/resources/logback.xml
+++ b/akka-bench-jmh/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{ISO8601} %-5level %logger %marker - %msg {%mdc}%n</pattern>
+            <pattern>%date{ISO8601} %-5level %logger %marker - %msg MDC: {%mdc}%n</pattern>
         </encoder>
     </appender>
     <root level="INFO">

--- a/akka-cluster-metrics/src/test/resources/logback-test.xml
+++ b/akka-cluster-metrics/src/test/resources/logback-test.xml
@@ -3,7 +3,7 @@
 
 	<!-- Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com> -->
 
-	<variable name="pattern" value="%date{ISO8601} %-5level %logger %marker - %msg {%mdc}%n" />
+	<variable name="pattern" value="%date{ISO8601} %-5level %logger %marker - %msg MDC: {%mdc}%n" />
 
 	<variable name="folder" value="${user.dir}/target/metrics" />
 

--- a/akka-cluster-sharding-typed/src/multi-jvm/resources/logback-test.xml
+++ b/akka-cluster-sharding-typed/src/multi-jvm/resources/logback-test.xml
@@ -5,7 +5,7 @@
     
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{ISO8601} %-5level %logger %marker - %msg {%mdc}%n</pattern>
+            <pattern>%date{ISO8601} %-5level %logger %marker - %msg MDC: {%mdc}%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-cluster-sharding-typed/src/test/resources/logback-test.xml
+++ b/akka-cluster-sharding-typed/src/test/resources/logback-test.xml
@@ -5,7 +5,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{ISO8601} %-5level %logger %marker - %msg {%mdc}%n</pattern>
+            <pattern>%date{ISO8601} %-5level %logger %marker - %msg MDC: {%mdc}%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-cluster-typed/src/multi-jvm/resources/logback-test.xml
+++ b/akka-cluster-typed/src/multi-jvm/resources/logback-test.xml
@@ -5,7 +5,7 @@
     
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{ISO8601} %-5level %logger %marker - %msg {%mdc}%n</pattern>
+            <pattern>%date{ISO8601} %-5level %logger %marker - %msg MDC: {%mdc}%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-cluster-typed/src/test/resources/logback-test.xml
+++ b/akka-cluster-typed/src/test/resources/logback-test.xml
@@ -5,7 +5,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{ISO8601} %-5level %logger %marker - %msg {%mdc}%n</pattern>
+            <pattern>%date{ISO8601} %-5level %logger %marker - %msg MDC: {%mdc}%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-docs/src/main/paradox/logging.md
+++ b/akka-docs/src/main/paradox/logging.md
@@ -445,7 +445,7 @@ All MDC properties as key-value entries can be included with `%mdc`:
 
 ```
   <encoder>
-    <pattern>%date{ISO8601} %-5level %logger{36} - %msg {%mdc}%n</pattern>
+    <pattern>%date{ISO8601} %-5level %logger{36} - %msg MDC: {%mdc}%n</pattern>
   </encoder>
 ```
 
@@ -544,7 +544,7 @@ All MDC properties as key-value entries can be included with `%mdc`:
 
 ```
   <encoder>
-    <pattern>%date{ISO8601} %-5level %logger{36} - %msg {%mdc}%n</pattern>
+    <pattern>%date{ISO8601} %-5level %logger{36} - %msg MDC: {%mdc}%n</pattern>
   </encoder>
 ```
 
@@ -574,7 +574,7 @@ The marker can be included in the Logback output with `%marker` and all MDC prop
 
 ```
   <encoder>
-    <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg {%mdc}%n</pattern>
+    <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
   </encoder>
 ```
 

--- a/akka-docs/src/main/paradox/typed/logging.md
+++ b/akka-docs/src/main/paradox/typed/logging.md
@@ -241,7 +241,7 @@ All MDC properties as key-value entries can be included with `%mdc`:
 
 ```
   <encoder>
-    <pattern>%date{ISO8601} %-5level %logger{36} - %msg {%mdc}%n</pattern>
+    <pattern>%date{ISO8601} %-5level %logger{36} - %msg MDC: {%mdc}%n</pattern>
   </encoder>
 ```
 
@@ -426,7 +426,7 @@ All MDC properties as key-value entries can be included with `%mdc`:
 
 ```
   <encoder>
-    <pattern>%date{ISO8601} %-5level %logger{36} - %msg {%mdc}%n</pattern>
+    <pattern>%date{ISO8601} %-5level %logger{36} - %msg MDC: {%mdc}%n</pattern>
   </encoder>
 ```
 
@@ -446,7 +446,7 @@ The marker can be included in the Logback output with `%marker` and all MDC prop
 
 ```
   <encoder>
-    <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg {%mdc}%n</pattern>
+    <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
   </encoder>
 ```
 

--- a/akka-docs/src/test/resources/logback-test.xml
+++ b/akka-docs/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@
             <level>INFO</level>
         </filter>
         <encoder>
-            <pattern>%date{ISO8601} %-5level %logger %marker - %msg {%mdc}%n</pattern>
+            <pattern>%date{ISO8601} %-5level %logger %marker - %msg MDC: {%mdc}%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-osgi/src/test/resources/logback-test.xml
+++ b/akka-osgi/src/test/resources/logback-test.xml
@@ -4,7 +4,7 @@
 
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>%date{ISO8601} %-5level %logger %marker - %msg {%mdc}%n</pattern>
+			<pattern>%date{ISO8601} %-5level %logger %marker - %msg MDC: {%mdc}%n</pattern>
 		</encoder>
 	</appender>
 
@@ -12,7 +12,7 @@
         <file>target/akka-osgi.log</file>
         <append>true</append>
         <encoder>
-			<pattern>%date{ISO8601} %-5level %logger %marker - %msg {%mdc}%n</pattern>
+			<pattern>%date{ISO8601} %-5level %logger %marker - %msg MDC: {%mdc}%n</pattern>
         </encoder>
     </appender>
 

--- a/akka-persistence-typed/src/test/resources/logback-test.xml
+++ b/akka-persistence-typed/src/test/resources/logback-test.xml
@@ -5,7 +5,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%date{ISO8601} %-5level %logger %marker - %msg {%mdc}%n</pattern>
+            <pattern>%date{ISO8601} %-5level %logger %marker - %msg MDC: {%mdc}%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
* if MDC is empty it's confusing with {} because it can be misunderstood
  to be a missing log template parameter

