### PR TITLE
remove ScalaTest 3.1.x Matchers mixin in ScalaTestWithActorTestKit

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ScalaTestWithActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ScalaTestWithActorTestKit.scala
@@ -11,7 +11,7 @@ import org.scalatest.{ BeforeAndAfterAll, TestSuite }
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.Span
-import org.scalatest.matchers.should.Matchers
+
 
 /**
  * A ScalaTest base class for the [[ActorTestKit]], making it possible to have ScalaTest manage the lifecycle of the testkit.
@@ -29,7 +29,6 @@ import org.scalatest.matchers.should.Matchers
 abstract class ScalaTestWithActorTestKit(testKit: ActorTestKit)
     extends ActorTestKitBase(testKit)
     with TestSuite
-    with Matchers
     with BeforeAndAfterAll
     with ScalaFutures
     with Eventually {


### PR DESCRIPTION
The matchers from scalatest 3.1 are creating ClassNotFound Exceptions in SBT, 
especially when scalatestplus-play 5.0.0 is in the project (which is still on scalatest 3.0.8). 
As this class does not need the matchers anyway, I've removed them

see https://github.com/scalatest/scalatest/issues/1734 
and https://github.com/playframework/scalatestplus-play/issues/214
