### PR TITLE
fix DispatcherSameAsParent when using ClusterActorRefProvider, #28842

### DIFF
--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterDispatcherSelectorSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterDispatcherSelectorSpec.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.typed
+
+import akka.actor.typed.scaladsl.DispatcherSelectorSpec
+import com.typesafe.config.ConfigFactory
+
+class ClusterDispatcherSelectorSpec
+    extends DispatcherSelectorSpec(ConfigFactory.parseString("""
+    akka.actor.provider = cluster
+    """).withFallback(DispatcherSelectorSpec.config)) {
+
+  // same tests as in DispatcherSelectorSpec
+
+}

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -372,9 +372,6 @@ private[akka] class RemoteActorRefProvider(
     if (systemService) local.actorOf(system, props, supervisor, path, systemService, deploy, lookupDeploy, async)
     else {
 
-      if (!system.dispatchers.hasDispatcher(props.dispatcher))
-        throw new ConfigurationException(s"Dispatcher [${props.dispatcher}] not configured for path $path")
-
       /*
        * This needs to deal with “mangled” paths, which are created by remote
        * deployment, also in this method. The scheme is the following:


### PR DESCRIPTION
* add test
* the check for valid config is not needed in RemoteActorRefProvider,
  since it is delegating to LocalActorRefProvider for all cases but the
  remote deployment case

Refs #28842