### PR TITLE
Fix compiling javadoc jar

### DIFF
--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -24,7 +24,7 @@ object Scaladoc extends AutoPlugin {
   }
 
   override def trigger = allRequirements
-  override def requires = plugins.JvmPlugin && DeployRsync
+  override def requires = plugins.JvmPlugin
 
   val validateDiagrams = settingKey[Boolean]("Validate generated scaladoc diagrams")
 


### PR DESCRIPTION
Refs #28848

This dependency wasn't needed and somehow broke setting the scalacSettings
for the doc target...