### PR TITLE
avoid touching MDC for context.log.trace in reliable delivery

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/actor/typed/delivery/ReliableDeliveryBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/typed/delivery/ReliableDeliveryBenchmark.scala
@@ -60,13 +60,15 @@ object Consumer {
 
   def apply(consumerController: ActorRef[ConsumerController.Command[Command]]): Behavior[Command] = {
     Behaviors.setup { context =>
+      val traceEnabled = context.log.isTraceEnabled
       val deliveryAdapter =
         context.messageAdapter[ConsumerController.Delivery[Command]](WrappedDelivery(_))
       consumerController ! ConsumerController.Start(deliveryAdapter)
 
       Behaviors.receiveMessagePartial {
         case WrappedDelivery(d @ ConsumerController.Delivery(_, confirmTo)) =>
-          context.log.trace("Processed {}", d.seqNr)
+          if (traceEnabled)
+            context.log.trace("Processed {}", d.seqNr)
           confirmTo ! ConsumerController.Confirmed
           Behaviors.same
       }


### PR DESCRIPTION
Accessing `context.log` will set things in MDC.

We might remove the trace logging completely later and only use flight recorder for that, but can still be useful to have the possibility now for debugging.

JMH results.
before:
```
[info] Benchmark                                                        (window)   Mode  Cnt       Score       Error   Units
[info] ReliableDeliveryBenchmark.echo                                         50  thrpt   10  139694,808 ± 16519,354   ops/s
[info] ReliableDeliveryBenchmark.echo:·gc.alloc.rate                          50  thrpt   10     344,303 ±   187,958  MB/sec
[info] ReliableDeliveryBenchmark.echo:·gc.alloc.rate.norm                     50  thrpt   10    2729,098 ±  1449,338    B/op
```

after:
```
[info] Benchmark                                                        (window)   Mode  Cnt       Score      Error   Units
[info] ReliableDeliveryBenchmark.echo                                         50  thrpt   10  165082,370 ± 4680,406   ops/s
[info] ReliableDeliveryBenchmark.echo:·gc.alloc.rate                          50  thrpt   10     288,025 ±  153,060  MB/sec
[info] ReliableDeliveryBenchmark.echo:·gc.alloc.rate.norm                     50  thrpt   10    1911,120 ± 1014,838    B/op
``` 

I also suspected `withMDC`, but couldn't see any significant difference so leaving that as is.