### PR TITLE
Don't rely on logs in pubsub spec 

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/pubsub/LocalPubSubSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/pubsub/LocalPubSubSpec.scala
@@ -7,7 +7,9 @@ package akka.actor.typed.pubsub
 import akka.actor.testkit.typed.scaladsl.LoggingTestKit
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.internal.pubsub.TopicImpl
 import org.scalatest.wordspec.AnyWordSpecLike
+
 import scala.concurrent.duration._
 
 class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
@@ -25,10 +27,15 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
         val probe2 = testKit.createTestProbe[String]()
         val probe3 = testKit.createTestProbe[String]()
 
-        LoggingTestKit.debug("Topic list updated").expect {
-          fruitTopic ! Topic.Subscribe(probe1.ref)
-          fruitTopic ! Topic.Subscribe(probe2.ref)
-          fruitTopic ! Topic.Subscribe(probe3.ref)
+        fruitTopic ! Topic.Subscribe(probe1.ref)
+        fruitTopic ! Topic.Subscribe(probe2.ref)
+        fruitTopic ! Topic.Subscribe(probe3.ref)
+
+        // the subscriber registration of all 3 completed
+        val statsProbe = testKit.createTestProbe[TopicImpl.TopicStats]()
+        statsProbe.awaitAssert {
+          fruitTopic ! TopicImpl.GetTopicStats(statsProbe.ref)
+          statsProbe.receiveMessage().localSubscriberCount should ===(3)
         }
 
         fruitTopic ! Topic.Publish("banana")
@@ -43,13 +50,10 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
 
     "publish to all subscriber actors across several instances of the same topic" in {
       val fruitTopic1 =
-        LoggingTestKit.debug("Topic list updated").expect {
-          testKit.spawn(Topic[String]("fruit"))
-        }
+        testKit.spawn(Topic[String]("fruit"))
+
       val fruitTopic2 =
-        LoggingTestKit.debug("Topic list updated").expect {
-          testKit.spawn(Topic[String]("fruit"))
-        }
+        testKit.spawn(Topic[String]("fruit"))
 
       try {
         val probe1 = testKit.createTestProbe[String]()
@@ -66,6 +70,18 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
             fruitTopic2 ! Topic.Subscribe(probe3.ref)
           }
 
+        // the subscriber registration of all 3 completed
+        val statsProbe = testKit.createTestProbe[Any]()
+        statsProbe.awaitAssert {
+          fruitTopic2 ! TopicImpl.GetTopicStats(statsProbe.ref)
+          statsProbe.expectMessageType[TopicImpl.TopicStats].localSubscriberCount should ===(3)
+        }
+        // and the other topic knows about it
+        statsProbe.awaitAssert {
+          fruitTopic1 ! TopicImpl.GetTopicStats(statsProbe.ref)
+          statsProbe.expectMessageType[TopicImpl.TopicStats].topicInstanceCount should ===(1)
+        }
+
         fruitTopic1 ! Topic.Publish("banana")
         probe1.expectMessage("banana")
         probe2.expectMessage("banana")
@@ -79,19 +95,26 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
 
     "doesn't publish across topics unsubscribe" in {
       val fruitTopic =
-        LoggingTestKit.debug("Topic list updated").expect {
-          testKit.spawn(Topic[String]("fruit"))
-        }
+        testKit.spawn(Topic[String]("fruit"))
+
       val veggieTopic =
-        LoggingTestKit.debug("Topic list updated").expect {
-          testKit.spawn(Topic[String]("veggies"))
-        }
+        testKit.spawn(Topic[String]("veggies"))
 
       try {
         val probe1 = testKit.createTestProbe[String]()
 
-        LoggingTestKit.debug("Topic list updated").expect {
-          fruitTopic ! Topic.Subscribe(probe1.ref)
+        fruitTopic ! Topic.Subscribe(probe1.ref)
+        // the subscriber registration of all 3 completed
+        val statsProbe = testKit.createTestProbe[Any]()
+        statsProbe.awaitAssert {
+          fruitTopic ! TopicImpl.GetTopicStats(statsProbe.ref)
+          statsProbe.expectMessageType[TopicImpl.TopicStats].localSubscriberCount should ===(1)
+        }
+
+        // the other topic should not know about it
+        statsProbe.awaitAssert {
+          veggieTopic ! TopicImpl.GetTopicStats(statsProbe.ref)
+          statsProbe.expectMessageType[TopicImpl.TopicStats].topicInstanceCount should ===(0)
         }
 
         veggieTopic ! Topic.Publish("carrot")
@@ -111,11 +134,18 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
       try {
         val probe1 = testKit.createTestProbe[String]()
 
-        LoggingTestKit.debug("Topic list updated").expect {
-          fruitTopic ! Topic.Subscribe(probe1.ref)
+        fruitTopic ! Topic.Subscribe(probe1.ref)
+        // the subscriber registration of completed
+        val statsProbe = testKit.createTestProbe[Any]()
+        statsProbe.awaitAssert {
+          fruitTopic ! TopicImpl.GetTopicStats(statsProbe.ref)
+          statsProbe.expectMessageType[TopicImpl.TopicStats].localSubscriberCount should ===(1)
         }
-        LoggingTestKit.debug("Topic list updated").expect {
-          fruitTopic ! Topic.Unsubscribe(probe1.ref)
+
+        fruitTopic ! Topic.Unsubscribe(probe1.ref)
+        statsProbe.awaitAssert {
+          fruitTopic ! TopicImpl.GetTopicStats(statsProbe.ref)
+          statsProbe.expectMessageType[TopicImpl.TopicStats].localSubscriberCount should ===(0)
         }
 
         fruitTopic ! Topic.Publish("banana")


### PR DESCRIPTION
Was failing in the community build, better use the internal inspection message to make sure subscriptions has completed before asserting message passing works.

References #28885

