### PR TITLE
build: remove scala-2.13+ / scala-2.13- directories for now

### DIFF
--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -117,16 +117,6 @@ object AkkaBuild {
 
     crossVersion := CrossVersion.binary,
 
-    // Adds a `src/main/scala-2.13+` source directory for Scala 2.13 and newer
-    // and a `src/main/scala-2.13-` source directory for Scala version older than 2.13
-    unmanagedSourceDirectories in Compile += {
-      val sourceDir = (sourceDirectory in Compile).value
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, n)) if n >= 13 => sourceDir / "scala-2.13+"
-        case _                       => sourceDir / "scala-2.13-"
-      }
-    },
-
     ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet,
 
     licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))),


### PR DESCRIPTION
For the time being, we'll probably only support 2.12 and 2.13 so these special
directories might not be needed right now.

Follow up to #28888