### PR TITLE
Silence another close error in multi-jvm tests

### DIFF
--- a/akka-multi-node-testkit/src/main/mima-filters/2.6.4.backwards.excludes/RemoteConnection-shutdown.excludes
+++ b/akka-multi-node-testkit/src/main/mima-filters/2.6.4.backwards.excludes/RemoteConnection-shutdown.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.remote.testconductor.RemoteConnection.shutdown")

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/RemoteConnection.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/RemoteConnection.scala
@@ -16,6 +16,9 @@ import org.jboss.netty.bootstrap.{ ClientBootstrap, ServerBootstrap }
 import org.jboss.netty.handler.codec.frame.{ LengthFieldBasedFrameDecoder, LengthFieldPrepender }
 import java.net.InetSocketAddress
 import java.util.concurrent.Executors
+
+import scala.util.control.NonFatal
+
 import akka.event.Logging
 import akka.util.Helpers
 import org.jboss.netty.handler.codec.oneone.{ OneToOneDecoder, OneToOneEncoder }
@@ -109,8 +112,14 @@ private[akka] object RemoteConnection {
     case _                    => "[unknown]"
   }
 
-  def shutdown(channel: Channel) =
-    try channel.close()
-    finally try channel.getFactory.shutdown()
-    finally channel.getFactory.releaseExternalResources()
+  def shutdown(channel: Channel) = {
+    try {
+      try channel.close()
+      finally try channel.getFactory.shutdown()
+      finally channel.getFactory.releaseExternalResources()
+    } catch {
+      case NonFatal(_) =>
+      // silence this one to not make tests look like they failed, it's not really critical
+    }
+  }
 }

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/RemoteConnection.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/RemoteConnection.scala
@@ -112,7 +112,7 @@ private[akka] object RemoteConnection {
     case _                    => "[unknown]"
   }
 
-  def shutdown(channel: Channel) = {
+  def shutdown(channel: Channel): Unit = {
     try {
       try channel.close()
       finally try channel.getFactory.shutdown()


### PR DESCRIPTION
Similar was fixed in https://github.com/akka/akka/pull/28692 but I still see them occasionally.
