### PR TITLE
Step two of the CBOR serialization issue, #28927

### DIFF
--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -179,9 +179,6 @@ akka.serialization.jackson {
   # Akka 2.6.4 or earlier, which was plain JSON format.
   jackson-cbor-264 = ${akka.serialization.jackson.jackson-cbor}
 
-  # Issue #28918 temporary in Akka 2.6.5 to support rolling update to 2.6.6.
-  jackson-cbor-265 = ${akka.serialization.jackson.jackson-cbor}
-
 }
 #//#features
 
@@ -202,23 +199,19 @@ akka.serialization.jackson.jackson-json.compression {
 akka.actor {
   serializers {
     jackson-json = "akka.serialization.jackson.JacksonJsonSerializer"
-    jackson-cbor = "akka.serialization.jackson.JacksonJsonSerializer"
+    jackson-cbor = "akka.serialization.jackson.JacksonCborSerializer"
 
     # Issue #28918 for compatibility with data serialized with JacksonCborSerializer in
     # Akka 2.6.4 or earlier, which was plain JSON format.
     jackson-cbor-264 = "akka.serialization.jackson.JacksonJsonSerializer"
-    # Issue #28918 temporary in Akka 2.6.5 to support rolling update to 2.6.6.
-    jackson-cbor-265 = "akka.serialization.jackson.JacksonCborSerializer"
   }
   serialization-identifiers {
     jackson-json = 31
-    jackson-cbor = 32
+    jackson-cbor = 33
 
     # Issue #28918 for compatibility with data serialized with JacksonCborSerializer in
     # Akka 2.6.4 or earlier, which was plain JSON format.
     jackson-cbor-264 = 32
-    # Issue #28918 temporary in Akka 2.6.5 to support rolling update to 2.6.6.
-    jackson-cbor-265 = 33
   }
   serialization-bindings {
     # Define bindings for classes or interfaces use Jackson serializer, e.g.


### PR DESCRIPTION
* Configuration changes to enable toBinary by default for jackson-cbor
* Must be in second step to support rolling updates

References #28927

I have tested this in akka-upgrade-testing https://github.com/akka/akka-upgrade-testing/pull/11 (also negative test to see that it fails if skipping step 1)