### PR TITLE
Remove microkernel leftovers in ActorSystem

### DIFF
--- a/akka-actor/src/main/mima-filters/2.6.4.backwards.excludes/kernel-legacy.excludes
+++ b/akka-actor/src/main/mima-filters/2.6.4.backwards.excludes/kernel-legacy.excludes
@@ -1,0 +1,5 @@
+# leftover from microkernel, removed in Akka 2.4
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.ActorSystem.GlobalHome")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.ActorSystem.SystemHome")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.ActorSystem.EnvHome")
+

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -170,18 +170,6 @@ object ActorSystem {
 
   val Version: String = akka.Version.current // generated file
 
-  val EnvHome: Option[String] = System.getenv("AKKA_HOME") match {
-    case null | "" | "." => None
-    case value           => Some(value)
-  }
-
-  val SystemHome: Option[String] = System.getProperty("akka.home") match {
-    case null | "" => None
-    case value     => Some(value)
-  }
-
-  val GlobalHome: Option[String] = SystemHome.orElse(EnvHome)
-
   /**
    * Creates a new ActorSystem with the name "default",
    * obtains the current ClassLoader by first inspecting the current threads' getContextClassLoader,


### PR DESCRIPTION
* Microkernel removed in Akka 2.4 so removing this without deprecation
  should be alright

See https://discuss.lightbend.com/t/what-is-akka-home-configuration/6268
