### PR TITLE
JournalTCK, put delete tests behind a capability flag

### DIFF
--- a/akka-persistence-tck/src/main/scala/akka/persistence/CapabilityFlags.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/CapabilityFlags.scala
@@ -52,6 +52,11 @@ trait JournalCapabilityFlags extends CapabilityFlags {
    */
   protected def supportsSerialization: CapabilityFlag
 
+  /**
+   * When `true` enables tests which check if the journal supports deletes
+   */
+  protected def supportsDeletes: CapabilityFlag
+
 }
 //#journal-flags
 


### PR DESCRIPTION
Spanner emulator is currently broken for deletes so this will allow running all the other tests in travis against the emulator 