### PR TITLE
dotty phase 1

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,9 +1,14 @@
 // .scalafix.conf
 rules = [
   RemoveUnused
+  ExplicitResultTypes
   "github:ohze/scalafix-rules/ConstructorProcedureSyntax"
   "github:ohze/scalafix-rules/FinalObject"
 ]
+ExplicitResultTypes {
+  memberVisibility = [] # only rewrite implicit members
+  skipSimpleDefinitions = []
+}
 RemoveUnused.imports = true
 RemoveUnused.privates = false
 RemoveUnused.locals = false

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -4,6 +4,7 @@ rules = [
   ExplicitResultTypes
   "github:ohze/scalafix-rules/ConstructorProcedureSyntax"
   "github:ohze/scalafix-rules/FinalObject"
+  "github:ohze/scalafix-rules/Any2StringAdd"
 ]
 ExplicitResultTypes {
   memberVisibility = [] # only rewrite implicit members

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -2,6 +2,7 @@
 rules = [
   RemoveUnused
   "github:ohze/scalafix-rules/ConstructorProcedureSyntax"
+  "github:ohze/scalafix-rules/FinalObject"
 ]
 RemoveUnused.imports = true
 RemoveUnused.privates = false

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,6 +1,7 @@
 // .scalafix.conf
 rules = [
   RemoveUnused
+  "github:ohze/scalafix-rules/ConstructorProcedureSyntax"
 ]
 RemoveUnused.imports = true
 RemoveUnused.privates = false

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/CapturedLogEvent.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/CapturedLogEvent.scala
@@ -28,37 +28,32 @@ final case class CapturedLogEvent(level: Level, message: String, cause: Option[T
       message: String,
       errorCause: Optional[Throwable],
       marker: Optional[Marker],
-      mdc: java.util.Map[String, Any]) {
+      mdc: java.util.Map[String, Any]) =
     this(level, message, errorCause.asScala, marker.asScala)
-  }
 
   /**
    * Constructor for Java API
    */
-  def this(level: Level, message: String) {
+  def this(level: Level, message: String) =
     this(level, message, Option.empty, Option.empty)
-  }
 
   /**
    * Constructor for Java API
    */
-  def this(level: Level, message: String, errorCause: Throwable) {
+  def this(level: Level, message: String, errorCause: Throwable) =
     this(level, message, Some(errorCause), Option.empty[Marker])
-  }
 
   /**
    * Constructor for Java API
    */
-  def this(level: Level, message: String, marker: Marker) {
+  def this(level: Level, message: String, marker: Marker) =
     this(level, message, Option.empty[Throwable], Some(marker))
-  }
 
   /**
    * Constructor for Java API
    */
-  def this(level: Level, message: String, errorCause: Throwable, marker: Marker) {
+  def this(level: Level, message: String, errorCause: Throwable, marker: Marker) =
     this(level, message, Some(errorCause), Some(marker))
-  }
 
   def getErrorCause: Optional[Throwable] = cause.asJava
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/Effect.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/Effect.scala
@@ -191,7 +191,7 @@ object Effect {
     def duration(): java.time.Duration = d.asJava
   }
 
-  final case object ReceiveTimeoutCancelled extends ReceiveTimeoutCancelled
+  case object ReceiveTimeoutCancelled extends ReceiveTimeoutCancelled
 
   sealed abstract class ReceiveTimeoutCancelled extends Effect
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestKitUtils.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestKitUtils.scala
@@ -30,7 +30,7 @@ private[akka] object ActorTestKitGuardian {
   final case class StopActor[T](ref: ActorRef[T], replyTo: ActorRef[Ack.type]) extends TestKitCommand
   final case class ActorStopped[T](replyTo: ActorRef[Ack.type]) extends TestKitCommand
 
-  final case object Ack
+  case object Ack
 
   val testKitGuardian: Behavior[TestKitCommand] = Behaviors.receive[TestKitCommand] {
     case (context, SpawnActor(name, behavior, reply, props)) =>

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSelectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSelectionSpec.scala
@@ -355,7 +355,7 @@ class ActorSelectionSpec extends AkkaSpec with DefaultTimeout {
 
     "identify actors with wildcard selection correctly" in {
       val creator = TestProbe()
-      implicit def self = creator.ref
+      implicit def self: ActorRef = creator.ref
       val top = system.actorOf(p, "a")
       val b1 = Await.result((top ? Create("b1")).mapTo[ActorRef], timeout.duration)
       val b2 = Await.result((top ? Create("b2")).mapTo[ActorRef], timeout.duration)

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -263,7 +263,7 @@ class ActorSystemSpec extends AkkaSpec(ActorSystemSpec.config) with ImplicitSend
 
     "reliably create waves of actors" in {
       import system.dispatcher
-      implicit val timeout = Timeout((20 seconds).dilated)
+      implicit val timeout: Timeout = Timeout((20 seconds).dilated)
       val waves = for (_ <- 1 to 3) yield system.actorOf(Props[ActorSystemSpec.Waves]) ? 50000
       Await.result(Future.sequence(waves), timeout.duration + 5.seconds) should ===(Vector("done", "done", "done"))
     }

--- a/akka-actor-tests/src/test/scala/akka/actor/DeathWatchSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/DeathWatchSpec.scala
@@ -83,7 +83,7 @@ trait DeathWatchSpec { this: AkkaSpec with ImplicitSender with DefaultTimeout =>
 
   "The Death Watch" must {
     def expectTerminationOf(actorRef: ActorRef) =
-      expectMsgPF(5 seconds, actorRef + ": Stopped or Already terminated when linking") {
+      expectMsgPF(5 seconds, "" + actorRef + ": Stopped or Already terminated when linking") {
         case WrappedTerminated(Terminated(`actorRef`)) => true
       }
 

--- a/akka-actor-tests/src/test/scala/akka/actor/ForwardActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ForwardActorSpec.scala
@@ -9,6 +9,7 @@ import language.postfixOps
 import akka.testkit._
 import scala.concurrent.duration._
 import akka.pattern.{ ask, pipe }
+import scala.concurrent.ExecutionContextExecutor
 
 object ForwardActorSpec {
   val ExpectedMessage = "FOO"
@@ -29,7 +30,7 @@ object ForwardActorSpec {
 
 class ForwardActorSpec extends AkkaSpec {
   import ForwardActorSpec._
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
   "A Forward Actor" must {
 
     "forward actor reference when invoking forward on tell" in {

--- a/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
@@ -130,7 +130,7 @@ class LocalActorRefProviderSpec extends AkkaSpec(LocalActorRefProviderSpec.confi
 
       for (i <- 0 until 100) {
         val address = "new-actor" + i
-        implicit val timeout = Timeout(5 seconds)
+        implicit val timeout: Timeout = Timeout(5 seconds)
         val actors =
           for (_ <- 1 to 4)
             yield Future(system.actorOf(Props(new Actor { def receive = { case _ => } }), address))

--- a/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
@@ -496,7 +496,7 @@ class LightArrayRevolverSchedulerSpec extends AkkaSpec(SchedulerSpec.testConfRev
 
       "execute multiple jobs at once when expiring multiple buckets" taggedAs TimingTest in {
         withScheduler() { (sched, driver) =>
-          implicit def ec = localEC
+          implicit def ec: ExecutionContext = localEC
           import driver._
           val start = step / 2
           (0 to 3).foreach(i => sched.scheduleOnce(start + step * i, testActor, "hello"))
@@ -511,7 +511,7 @@ class LightArrayRevolverSchedulerSpec extends AkkaSpec(SchedulerSpec.testConfRev
 
       "properly defer jobs even when the timer thread oversleeps" taggedAs TimingTest in {
         withScheduler() { (sched, driver) =>
-          implicit def ec = localEC
+          implicit def ec: ExecutionContext = localEC
           import driver._
           sched.scheduleOnce(step * 3, probe.ref, "hello")
           wakeUp(step * 5)
@@ -526,7 +526,7 @@ class LightArrayRevolverSchedulerSpec extends AkkaSpec(SchedulerSpec.testConfRev
 
       "correctly wrap around wheel rounds" taggedAs TimingTest in {
         withScheduler(config = ConfigFactory.parseString("akka.scheduler.ticks-per-wheel=2")) { (sched, driver) =>
-          implicit def ec = localEC
+          implicit def ec: ExecutionContext = localEC
           import driver._
           val start = step / 2
           (0 to 3).foreach(i => sched.scheduleOnce(start + step * i, probe.ref, "hello"))
@@ -553,7 +553,7 @@ class LightArrayRevolverSchedulerSpec extends AkkaSpec(SchedulerSpec.testConfRev
 
       "correctly execute jobs when clock wraps around" taggedAs TimingTest in {
         withScheduler(Long.MaxValue - 200000000L) { (sched, driver) =>
-          implicit def ec = localEC
+          implicit def ec: ExecutionContext = localEC
           import driver._
           val start = step / 2
           (0 to 3).foreach(i => sched.scheduleOnce(start + step * i, testActor, "hello"))
@@ -583,7 +583,7 @@ class LightArrayRevolverSchedulerSpec extends AkkaSpec(SchedulerSpec.testConfRev
         val targetTicks = Int.MaxValue - numEvents + 20
 
         withScheduler(_startTick = Int.MaxValue - 100) { (sched, driver) =>
-          implicit def ec = localEC
+          implicit def ec: ExecutionContext = localEC
           import driver._
 
           val start = step / 2

--- a/akka-actor-tests/src/test/scala/akka/dataflow/Future2Actor.scala
+++ b/akka-actor-tests/src/test/scala/akka/dataflow/Future2Actor.scala
@@ -7,6 +7,7 @@ package akka.dataflow
 import language.postfixOps
 
 import akka.actor.{ Actor, Props }
+import akka.actor.ActorRef
 import scala.concurrent.Future
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -25,7 +26,7 @@ class Future2ActorSpec extends AkkaSpec with DefaultTimeout {
     }
 
     "support convenient sending to multiple destinations with implicit sender" in {
-      implicit val someActor = system.actorOf(Props(new Actor { def receive = Actor.emptyBehavior }))
+      implicit val someActor: ActorRef = system.actorOf(Props(new Actor { def receive = Actor.emptyBehavior }))
       Future(42).pipeTo(testActor).pipeTo(testActor)
       expectMsgAllOf(1 second, 42, 42)
       lastSender should ===(someActor)

--- a/akka-actor-tests/src/test/scala/akka/dataflow/Future2Actor.scala
+++ b/akka-actor-tests/src/test/scala/akka/dataflow/Future2Actor.scala
@@ -13,9 +13,10 @@ import scala.concurrent.duration._
 import akka.testkit.{ AkkaSpec, DefaultTimeout }
 import akka.pattern.{ ask, pipe }
 import scala.concurrent.ExecutionException
+import scala.concurrent.ExecutionContextExecutor
 
 class Future2ActorSpec extends AkkaSpec with DefaultTimeout {
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
   "The Future2Actor bridge" must {
 
     "support convenient sending to multiple destinations" in {

--- a/akka-actor-tests/src/test/scala/akka/event/EventBusSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/EventBusSpec.scala
@@ -172,9 +172,8 @@ class ActorEventBusSpec(conf: Config) extends EventBusSpec("ActorEventBus", conf
   import akka.event.ActorEventBusSpec._
   import EventBusSpec.TestActorWrapperActor
 
-  def this() {
+  def this() =
     this(ConfigFactory.parseString("akka.actor.debug.event-stream = on").withFallback(AkkaSpec.testConf))
-  }
 
   type BusType = MyActorEventBus
   def createNewEventBus(): BusType = new MyActorEventBus(system)

--- a/akka-actor-tests/src/test/scala/akka/io/dns/AsyncDnsResolverIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/AsyncDnsResolverIntegrationSpec.scala
@@ -33,7 +33,7 @@ class AsyncDnsResolverIntegrationSpec extends AkkaSpec(s"""
     akka.io.dns.async-dns.ndots = 2
   """) with DockerBindDnsService with WithLogCapturing {
   val duration = 10.seconds
-  implicit val timeout = Timeout(duration)
+  implicit val timeout: Timeout = Timeout(duration)
 
   val hostPort = AsyncDnsResolverIntegrationSpec.dockerDnsServerPort
 

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsResolverSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsResolverSpec.scala
@@ -39,7 +39,7 @@ class AsyncDnsResolverSpec extends AkkaSpec("""
     val dnsClient2 = TestProbe()
     val r = resolver(List(dnsClient1.ref, dnsClient2.ref), defaultConfig)
     val senderProbe = TestProbe()
-    implicit val sender = senderProbe.ref
+    implicit val sender: ActorRef = senderProbe.ref
   }
 
   "Async DNS Resolver" must {

--- a/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
@@ -19,7 +19,7 @@ class AskSpec extends AkkaSpec {
 
   "The “ask” pattern" must {
     "send request to actor and wrap the answer in Future" in {
-      implicit val timeout = Timeout(5.seconds)
+      implicit val timeout: Timeout = Timeout(5.seconds)
       val echo = system.actorOf(Props(new Actor { def receive = { case x => sender() ! x } }))
       val f = echo ? "ping"
       f.futureValue should ===("ping")
@@ -35,7 +35,7 @@ class AskSpec extends AkkaSpec {
     }
 
     "return broken promises on EmptyLocalActorRefs" in {
-      implicit val timeout = Timeout(5 seconds)
+      implicit val timeout: Timeout = Timeout(5 seconds)
       val empty = system.asInstanceOf[ExtendedActorSystem].provider.resolveActorRef("/user/unknown")
       val f = empty ? 3.14
       f.isCompleted should ===(true)
@@ -46,7 +46,7 @@ class AskSpec extends AkkaSpec {
     }
 
     "return broken promises on unsupported ActorRefs" in {
-      implicit val timeout = Timeout(5 seconds)
+      implicit val timeout: Timeout = Timeout(5 seconds)
       val f = ask(null: ActorRef, 3.14)
       f.isCompleted should ===(true)
 
@@ -57,7 +57,7 @@ class AskSpec extends AkkaSpec {
     }
 
     "return broken promises on 0 timeout" in {
-      implicit val timeout = Timeout(0 seconds)
+      implicit val timeout: Timeout = Timeout(0 seconds)
       val echo = system.actorOf(Props(new Actor { def receive = { case x => sender() ! x } }))
       val f = echo ? "foo"
       val expectedMsg =
@@ -68,7 +68,7 @@ class AskSpec extends AkkaSpec {
     }
 
     "return broken promises on < 0 timeout" in {
-      implicit val timeout = Timeout(-1000 seconds)
+      implicit val timeout: Timeout = Timeout(-1000 seconds)
       val echo = system.actorOf(Props(new Actor { def receive = { case x => sender() ! x } }))
       val f = echo ? "foo"
       val expectedMsg =
@@ -79,7 +79,7 @@ class AskSpec extends AkkaSpec {
     }
 
     "include target information in AskTimeout" in {
-      implicit val timeout = Timeout(0.5 seconds)
+      implicit val timeout: Timeout = Timeout(0.5 seconds)
       val silentOne = system.actorOf(Props.empty, "silent")
       val f = silentOne ? "noreply"
       intercept[AskTimeoutException] {
@@ -88,7 +88,7 @@ class AskSpec extends AkkaSpec {
     }
 
     "include timeout information in AskTimeout" in {
-      implicit val timeout = Timeout(0.5 seconds)
+      implicit val timeout: Timeout = Timeout(0.5 seconds)
       val f = system.actorOf(Props.empty) ? "noreply"
       intercept[AskTimeoutException] {
         Await.result(f, 1 second)
@@ -96,8 +96,8 @@ class AskSpec extends AkkaSpec {
     }
 
     "include sender information in AskTimeout" in {
-      implicit val timeout = Timeout(0.5 seconds)
-      implicit val sender = system.actorOf(Props.empty)
+      implicit val timeout: Timeout = Timeout(0.5 seconds)
+      implicit val sender: ActorRef = system.actorOf(Props.empty)
       val f = system.actorOf(Props.empty) ? "noreply"
       intercept[AskTimeoutException] {
         Await.result(f, 1 second)
@@ -105,7 +105,7 @@ class AskSpec extends AkkaSpec {
     }
 
     "include message class information in AskTimeout" in {
-      implicit val timeout = Timeout(0.5 seconds)
+      implicit val timeout: Timeout = Timeout(0.5 seconds)
       val f = system.actorOf(Props.empty) ? Integer.valueOf(17)
       intercept[AskTimeoutException] {
         Await.result(f, 1 second)
@@ -113,7 +113,7 @@ class AskSpec extends AkkaSpec {
     }
 
     "work for ActorSelection" in {
-      implicit val timeout = Timeout(5 seconds)
+      implicit val timeout: Timeout = Timeout(5 seconds)
       import system.dispatcher
       val echo = system.actorOf(Props(new Actor { def receive = { case x => sender() ! x } }), "select-echo")
       val identityFuture =
@@ -123,7 +123,7 @@ class AskSpec extends AkkaSpec {
     }
 
     "work when reply uses actor selection" in {
-      implicit val timeout = Timeout(5 seconds)
+      implicit val timeout: Timeout = Timeout(5 seconds)
       val deadListener = TestProbe()
       system.eventStream.subscribe(deadListener.ref, classOf[DeadLetter])
 
@@ -138,7 +138,7 @@ class AskSpec extends AkkaSpec {
     }
 
     "throw AskTimeoutException on using *" in {
-      implicit val timeout = Timeout(0.5 seconds)
+      implicit val timeout: Timeout = Timeout(0.5 seconds)
       val deadListener = TestProbe()
       system.eventStream.subscribe(deadListener.ref, classOf[DeadLetter])
 
@@ -154,7 +154,7 @@ class AskSpec extends AkkaSpec {
     }
 
     "throw AskTimeoutException on using .." in {
-      implicit val timeout = Timeout(0.5 seconds)
+      implicit val timeout: Timeout = Timeout(0.5 seconds)
       val deadListener = TestProbe()
       system.eventStream.subscribe(deadListener.ref, classOf[DeadLetter])
 
@@ -175,7 +175,7 @@ class AskSpec extends AkkaSpec {
     }
 
     "send to DeadLetter when child does not exist" in {
-      implicit val timeout = Timeout(0.5 seconds)
+      implicit val timeout: Timeout = Timeout(0.5 seconds)
       val deadListener = TestProbe()
       system.eventStream.subscribe(deadListener.ref, classOf[DeadLetter])
 
@@ -194,7 +194,7 @@ class AskSpec extends AkkaSpec {
     }
 
     "send DeadLetter when answering to grandchild" in {
-      implicit val timeout = Timeout(0.5 seconds)
+      implicit val timeout: Timeout = Timeout(0.5 seconds)
       val deadListener = TestProbe()
       system.eventStream.subscribe(deadListener.ref, classOf[DeadLetter])
 
@@ -212,7 +212,7 @@ class AskSpec extends AkkaSpec {
     }
 
     "allow watching the promiseActor and send Terminated() when completes" in {
-      implicit val timeout = Timeout(300 millis)
+      implicit val timeout: Timeout = Timeout(300 millis)
       val p = TestProbe()
 
       val act = system.actorOf(Props(new Actor {

--- a/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
@@ -30,7 +30,7 @@ class AskSpec extends AkkaSpec {
       f.isCompleted should ===(true)
       f.value.get match {
         case Failure(_: AskTimeoutException) =>
-        case v                               => fail(v + " was not Failure(AskTimeoutException)")
+        case v                               => fail("" + v + " was not Failure(AskTimeoutException)")
       }
     }
 
@@ -41,7 +41,7 @@ class AskSpec extends AkkaSpec {
       f.isCompleted should ===(true)
       f.value.get match {
         case Failure(_: AskTimeoutException) =>
-        case v                               => fail(v + " was not Failure(AskTimeoutException)")
+        case v                               => fail("" + v + " was not Failure(AskTimeoutException)")
       }
     }
 

--- a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerMTSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerMTSpec.scala
@@ -8,9 +8,10 @@ import akka.testkit._
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
+import scala.concurrent.ExecutionContextExecutor
 
 class CircuitBreakerMTSpec extends AkkaSpec {
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
   "A circuit breaker being called by many threads" must {
     val callTimeout = 2.second.dilated
     val resetTimeout = 3.seconds.dilated

--- a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
@@ -16,6 +16,7 @@ import scala.language.postfixOps
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+import scala.concurrent.ExecutionContextExecutor
 
 object CircuitBreakerSpec {
 
@@ -83,7 +84,7 @@ object CircuitBreakerSpec {
 
 class CircuitBreakerSpec extends AkkaSpec {
   import CircuitBreakerSpec._
-  implicit def ec = system.dispatcher
+  implicit def ec: ExecutionContextExecutor = system.dispatcher
 
   val awaitTimeout = 2.seconds.dilated
 

--- a/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
@@ -10,6 +10,7 @@ import akka.testkit.{ AkkaSpec, TestLatch }
 import akka.actor.{ Actor, Props }
 import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContextExecutor
 
 object PatternSpec {
   final case class Work(duration: Duration)
@@ -22,7 +23,7 @@ object PatternSpec {
 }
 
 class PatternSpec extends AkkaSpec {
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
   import PatternSpec._
 
   "pattern.gracefulStop" must {

--- a/akka-actor-tests/src/test/scala/akka/pattern/extended/ExplicitAskSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/extended/ExplicitAskSpec.scala
@@ -19,7 +19,7 @@ class ExplicitAskSpec extends AkkaSpec {
 
   "The “ask” pattern with explicit sender" must {
     "allow to access an explicit reference to actor to respond to" in {
-      implicit val timeout = Timeout(5.seconds)
+      implicit val timeout: Timeout = Timeout(5.seconds)
 
       val target = system.actorOf(Props(new Actor {
         def receive = {
@@ -32,7 +32,7 @@ class ExplicitAskSpec extends AkkaSpec {
     }
 
     "work for ActorSelection" in {
-      implicit val timeout = Timeout(5.seconds)
+      implicit val timeout: Timeout = Timeout(5.seconds)
 
       val target = system.actorOf(Props(new Actor {
         def receive = {

--- a/akka-actor-tests/src/test/scala/akka/routing/ConsistentHashingRouterSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ConsistentHashingRouterSpec.scala
@@ -14,6 +14,7 @@ import akka.routing.ConsistentHashingRouter.ConsistentHashableEnvelope
 import akka.routing.ConsistentHashingRouter.ConsistentHashMapping
 import akka.testkit.AkkaSpec
 import akka.testkit._
+import scala.concurrent.ExecutionContextExecutor
 
 object ConsistentHashingRouterSpec {
 
@@ -56,7 +57,7 @@ class ConsistentHashingRouterSpec
     with DefaultTimeout
     with ImplicitSender {
   import ConsistentHashingRouterSpec._
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
 
   val router1 = system.actorOf(FromConfig.props(Props[Echo]), "router1")
 

--- a/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RoutingSpec.scala
@@ -14,6 +14,7 @@ import scala.concurrent.Await
 import akka.ConfigurationException
 import com.typesafe.config.ConfigFactory
 import akka.pattern.{ ask, pipe }
+import scala.concurrent.ExecutionContextExecutor
 
 object RoutingSpec {
 
@@ -47,7 +48,7 @@ object RoutingSpec {
 }
 
 class RoutingSpec extends AkkaSpec(RoutingSpec.config) with DefaultTimeout with ImplicitSender {
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
   import RoutingSpec._
 
   muteDeadLetters(classOf[akka.dispatch.sysmsg.DeathWatchNotification])(system)

--- a/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
@@ -276,7 +276,7 @@ class SerializeSpec extends AkkaSpec(SerializationTests.serializeConf) {
 }
 
 class VerifySerializabilitySpec extends AkkaSpec(SerializationTests.verifySerializabilityConf) {
-  implicit val timeout = Timeout(5 seconds)
+  implicit val timeout: Timeout = Timeout(5 seconds)
 
   "verify config" in {
     system.settings.SerializeAllCreators should ===(true)

--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -23,7 +23,8 @@ import scala.collection.mutable.Builder
 
 class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
 
-  implicit val betterGeneratorDrivenConfig = PropertyCheckConfiguration().copy(minSuccessful = 1000)
+  implicit val betterGeneratorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration().copy(minSuccessful = 1000)
 
   def genSimpleByteString(min: Int, max: Int) =
     for {
@@ -57,7 +58,7 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
 
   case class ByteStringGrouped(bs: ByteString, size: Int)
 
-  implicit val arbitraryByteStringGrouped = Arbitrary {
+  implicit val arbitraryByteStringGrouped: Arbitrary[ByteStringGrouped] = Arbitrary {
     for {
       xs <- arbitraryByteString.arbitrary
       size <- Gen.choose(1, 1 max xs.length)

--- a/akka-actor-tests/src/test/scala/akka/util/IndexSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/IndexSpec.scala
@@ -11,9 +11,10 @@ import scala.concurrent.Await
 import scala.util.Random
 import akka.testkit.DefaultTimeout
 import org.scalatest.matchers.should.Matchers
+import scala.concurrent.ExecutionContextExecutor
 
 class IndexSpec extends AkkaSpec with Matchers with DefaultTimeout {
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
   private def emptyIndex =
     new Index[String, Int](100, new Comparator[Int] {
       override def compare(a: Int, b: Int): Int = Integer.compare(a, b)

--- a/akka-actor-tests/src/test/scala/akka/util/ReflectSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ReflectSpec.scala
@@ -16,8 +16,8 @@ object ReflectSpec {
   class Two(@unused a: A, @unused b: B)
 
   class MultipleOne(a: A, b: B) {
-    def this(a: A) { this(a, null) }
-    def this(b: B) { this(null, b) }
+    def this(a: A) = this(a, null)
+    def this(b: B) = this(null, b)
   }
 }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/DeferredSpec.scala
@@ -34,7 +34,7 @@ object DeferredSpec {
 class DeferredSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
 
   import DeferredSpec._
-  implicit val testSettings = TestKitSettings(system)
+  implicit val testSettings: TestKitSettings = TestKitSettings(system)
 
   "Deferred behavior" must {
     "must create underlying" in {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SpawnProtocolSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SpawnProtocolSpec.scala
@@ -48,7 +48,7 @@ class SpawnProtocolSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike w
     "have nice API for ask" in {
       val parent = spawn(SpawnProtocol(), "parent2")
       import akka.actor.typed.scaladsl.AskPattern._
-      implicit val timeout = Timeout(5.seconds)
+      implicit val timeout: Timeout = Timeout(5.seconds)
       val parentReply: Future[ActorRef[Ping]] =
         parent.ask(SpawnProtocol.Spawn(target, "child", Props.empty, _))
       val child = parentReply.futureValue

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SpawnProtocolSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/SpawnProtocolSpec.scala
@@ -30,7 +30,7 @@ object SpawnProtocolSpec {
 class SpawnProtocolSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
 
   import SpawnProtocolSpec._
-  implicit val testSettings = TestKitSettings(system)
+  implicit val testSettings: TestKitSettings = TestKitSettings(system)
 
   "Spawn behavior" must {
     "spawn child actor" in {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TransformMessagesSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/TransformMessagesSpec.scala
@@ -16,6 +16,7 @@ import scala.concurrent.duration._
 import akka.actor.testkit.typed.scaladsl.LoggingTestKit
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.wordspec.AnyWordSpecLike
+import akka.actor
 
 object TransformMessagesSpec {
 
@@ -35,7 +36,7 @@ object TransformMessagesSpec {
 
 class TransformMessagesSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
 
-  implicit val classicSystem = system.toClassic
+  implicit val classicSystem: actor.ActorSystem = system.toClassic
 
   def intToString(probe: ActorRef[String]): Behavior[Int] = {
     Behaviors

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/WatchSpec.scala
@@ -17,6 +17,7 @@ import akka.actor.testkit.typed.scaladsl.LoggingTestKit
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.wordspec.AnyWordSpecLike
+import akka.actor
 
 object WatchSpec {
 
@@ -45,7 +46,7 @@ object WatchSpec {
 
 class WatchSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
 
-  implicit def classicSystem = system.toClassic
+  implicit def classicSystem: actor.ActorSystem = system.toClassic
 
   import WatchSpec._
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/coexistence/ClassicSupervisingTypedSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/coexistence/ClassicSupervisingTypedSpec.scala
@@ -56,7 +56,7 @@ class ClassicSupervisingTypedSpec extends AnyWordSpecLike with LogCapturing with
       akka.actor.testkit.typed.expect-no-message-default = 50 ms
       """))
   val classicTestKit = new akka.testkit.TestKit(classicSystem)
-  implicit val classicSender = classicTestKit.testActor
+  implicit val classicSender: u.ActorRef = classicTestKit.testActor
   import classicTestKit._
 
   "A classic actor system that spawns typed actors" should {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/delivery/TestProducer.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/delivery/TestProducer.scala
@@ -17,7 +17,7 @@ object TestProducer {
 
   trait Command
   final case class RequestNext(sendTo: ActorRef[TestConsumer.Job]) extends Command
-  private final case object Tick extends Command
+  private case object Tick extends Command
 
   val defaultProducerDelay: FiniteDuration = 20.millis
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/delivery/TestProducerWorkPulling.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/delivery/TestProducerWorkPulling.scala
@@ -14,7 +14,7 @@ object TestProducerWorkPulling {
 
   trait Command
   final case class RequestNext(sendTo: ActorRef[TestConsumer.Job]) extends Command
-  private final case object Tick extends Command
+  private case object Tick extends Command
 
   def apply(
       delay: FiniteDuration,

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
@@ -28,7 +28,7 @@ class ActorSystemSpec
     with Eventually
     with LogCapturing {
 
-  override implicit val patienceConfig = PatienceConfig(1.second)
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(1.second)
   def system[T](behavior: Behavior[T], name: String) = ActorSystem(behavior, name)
   def suite = "adapter"
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorLoggingSpec.scala
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.slf4j.helpers.BasicMarkerFactory
 import org.scalatest.wordspec.AnyWordSpecLike
+import akka.actor.ActorSystem
 
 class SomeClass
 
@@ -57,7 +58,7 @@ class ActorLoggingSpec extends ScalaTestWithActorTestKit("""
   val marker = new BasicMarkerFactory().getMarker("marker")
   val cause = TestException("böö")
 
-  implicit val classic = system.toClassic
+  implicit val classic: ActorSystem = system.toClassic
 
   class AnotherLoggerClass
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ReceivePartialSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ReceivePartialSpec.scala
@@ -9,10 +9,11 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import org.scalatest.wordspec.AnyWordSpecLike
+import scala.concurrent.ExecutionContextExecutor
 
 class ReceivePartialSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with LogCapturing {
 
-  implicit val ec = system.executionContext
+  implicit val ec: ExecutionContextExecutor = system.executionContext
 
   "An immutable partial" must {
     "correctly install the receiveMessage handler" in {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/AdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/adapter/AdapterSpec.scala
@@ -184,7 +184,7 @@ object AdapterSpec {
 class AdapterSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with LogCapturing {
   import AdapterSpec._
 
-  implicit val system = akka.actor.ActorSystem("AdapterSpec")
+  implicit val system: classic.ActorSystem = akka.actor.ActorSystem("AdapterSpec")
   def typedSystem: ActorSystem[Nothing] = system.toTyped
 
   "ActorSystem adaption" must {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/GracefulStopDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/GracefulStopDocSpec.scala
@@ -28,7 +28,7 @@ object GracefulStopDocSpec {
   object MasterControlProgram {
     sealed trait Command
     final case class SpawnJob(name: String) extends Command
-    final case object GracefulShutdown extends Command
+    case object GracefulShutdown extends Command
 
     // Predefined cleanup operation
     def cleanup(log: Logger): Unit = log.info("Cleaning up!")

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StashDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StashDocSpec.scala
@@ -31,7 +31,7 @@ object StashDocSpec {
     final case class Save(value: String, replyTo: ActorRef[Done]) extends Command
     final case class Get(replyTo: ActorRef[String]) extends Command
     private final case class InitialState(value: String) extends Command
-    private final case object SaveSuccess extends Command
+    private case object SaveSuccess extends Command
     private final case class DBError(cause: Throwable) extends Command
 
     def apply(id: String, db: DB): Behavior[Command] = {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
@@ -428,7 +428,7 @@ object StyleGuideDocExamples {
     import akka.actor.typed.scaladsl.AskPattern._
     import akka.util.Timeout
 
-    implicit val timeout = Timeout(3.seconds)
+    implicit val timeout: Timeout = Timeout(3.seconds)
     val counter: ActorRef[Command] = ???
 
     val result: Future[OperationResult] = counter.ask(replyTo => Increment(delta = 2, replyTo))

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/internal/ConsumerControllerImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/internal/ConsumerControllerImpl.scala
@@ -73,7 +73,7 @@ import akka.annotation.InternalApi
   /** For commands defined in public ConsumerController */
   trait UnsealedInternalCommand extends InternalCommand
 
-  private final case object Retry extends InternalCommand
+  private case object Retry extends InternalCommand
 
   private final case class ConsumerTerminated(consumer: ActorRef[_]) extends InternalCommand
 

--- a/akka-actor/src/main/scala/akka/actor/Actor.scala
+++ b/akka-actor/src/main/scala/akka/actor/Actor.scala
@@ -500,7 +500,7 @@ trait Actor {
    * self ! message
    * </pre>
    */
-  implicit final val self = context.self //MUST BE A VAL, TRUST ME
+  implicit final val self: ActorRef = context.self //MUST BE A VAL, TRUST ME
 
   /**
    * The reference sender Actor of the last received message.

--- a/akka-actor/src/main/scala/akka/actor/FSM.scala
+++ b/akka-actor/src/main/scala/akka/actor/FSM.scala
@@ -13,6 +13,7 @@ import akka.routing.{ Deafen, Listen, Listeners }
 import akka.annotation.InternalApi
 import akka.util.{ unused, JavaDurationConverters }
 import com.github.ghik.silencer.silent
+import scala.concurrent.ExecutionContextExecutor
 
 object FSM {
 
@@ -121,7 +122,7 @@ object FSM {
       extends NoSerializationVerificationNeeded {
     private var ref: Option[Cancellable] = _
     private val scheduler = context.system.scheduler
-    private implicit val executionContext = context.dispatcher
+    private implicit val executionContext: ExecutionContextExecutor = context.dispatcher
 
     def schedule(actor: ActorRef, timeout: FiniteDuration): Unit = {
       val timerMsg = msg match {

--- a/akka-actor/src/main/scala/akka/actor/TypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/TypedActor.scala
@@ -24,6 +24,7 @@ import java.io.ObjectStreamException
 import java.lang.reflect.{ InvocationHandler, InvocationTargetException, Method, Proxy }
 
 import com.github.ghik.silencer.silent
+import scala.concurrent.ExecutionContextExecutor
 
 /**
  * A TypedActorFactory is something that can created TypedActor instances.
@@ -252,7 +253,7 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
   /**
    * Returns the default dispatcher (for a TypedActor) when inside a method call in a TypedActor.
    */
-  implicit def dispatcher = context.dispatcher
+  implicit def dispatcher: ExecutionContextExecutor = context.dispatcher
 
   /**
    * INTERNAL API

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -75,7 +75,7 @@ private[akka] object MessageDispatcher {
     if (debug) {
       for {
         d <- actors.keys
-        a <- { println(d + " inhabitants: " + d.inhabitants); actors.valueIterator(d) }
+        a <- { println("" + d + " inhabitants: " + d.inhabitants); actors.valueIterator(d) }
       } {
         val status = if (a.isTerminated) " (terminated)" else " (alive)"
         val messages = a match {

--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -265,7 +265,7 @@ private[akka] abstract class Mailbox(val messageQueue: MessageQueue)
     if (shouldProcessMessage) {
       val next = dequeue()
       if (next ne null) {
-        if (Mailbox.debug) println(actor.self + " processing message " + next)
+        if (Mailbox.debug) println("" + actor.self + " processing message " + next)
         actor.invoke(next)
         if (Thread.interrupted())
           throw new InterruptedException("Interrupted while processing actor messages")
@@ -289,7 +289,7 @@ private[akka] abstract class Mailbox(val messageQueue: MessageQueue)
       val msg = messageList.head
       messageList = messageList.tail
       msg.unlink()
-      if (debug) println(actor.self + " processing system message " + msg + " with " + actor.childrenRefs)
+      if (debug) println("" + actor.self + " processing system message " + msg + " with " + actor.childrenRefs)
       // we know here that systemInvoke ensures that only "fatal" exceptions get rethrown
       actor.systemInvoke(msg)
       if (Thread.interrupted())
@@ -468,7 +468,7 @@ private[akka] trait DefaultSystemMessageQueue { self: Mailbox =>
   @tailrec
   final def systemEnqueue(receiver: ActorRef, message: SystemMessage): Unit = {
     assert(message.unlinked)
-    if (Mailbox.debug) println(receiver + " having enqueued " + message)
+    if (Mailbox.debug) println("" + receiver + " having enqueued " + message)
     val currentList = systemQueueGet
     if (currentList.head == NoMessage) {
       if (actor ne null) actor.dispatcher.mailboxes.deadLetterMailbox.systemEnqueue(receiver, message)

--- a/akka-actor/src/main/scala/akka/event/EventStream.scala
+++ b/akka-actor/src/main/scala/akka/event/EventStream.scala
@@ -32,7 +32,7 @@ class EventStream(sys: ActorSystem, private val debug: Boolean) extends LoggingB
   /** Either the list of subscribed actors, or a ref to an [[akka.event.EventStreamUnsubscriber]] */
   private val initiallySubscribedOrUnsubscriber = new AtomicReference[Either[Set[ActorRef], ActorRef]](Left(Set.empty))
 
-  protected implicit val subclassification = new Subclassification[Class[_]] {
+  protected implicit val subclassification: Subclassification[Classifier] = new Subclassification[Class[_]] {
     def isEqual(x: Class[_], y: Class[_]) = x == y
     def isSubclass(x: Class[_], y: Class[_]) = y.isAssignableFrom(x)
   }

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -22,6 +22,7 @@ import scala.collection.immutable
 import scala.concurrent.Await
 import scala.language.existentials
 import scala.util.control.{ NoStackTrace, NonFatal }
+import akka.util.Timeout
 
 /**
  * This trait brings log level handling to the EventStream: it reads the log
@@ -198,7 +199,7 @@ trait LoggingBus extends ActorEventBus {
       logName: String): ActorRef = {
     val name = "log" + LogExt(system).id() + "-" + simpleName(clazz)
     val actor = system.systemActorOf(Props(clazz).withDispatcher(system.settings.LoggersDispatcher), name)
-    implicit def timeout = system.settings.LoggerStartTimeout
+    implicit def timeout: Timeout = system.settings.LoggerStartTimeout
     import akka.pattern.ask
     val response = try Await.result(actor ? InitializeLogger(this), timeout.duration)
     catch {

--- a/akka-actor/src/main/scala/akka/io/dns/DnsProtocol.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/DnsProtocol.scala
@@ -30,7 +30,7 @@ object DnsProtocol {
 
   sealed trait RequestType
   final case class Ip(ipv4: Boolean = true, ipv6: Boolean = true) extends RequestType
-  final case object Srv extends RequestType
+  case object Srv extends RequestType
 
   /**
    * Java API

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
@@ -20,6 +20,7 @@ import com.github.ghik.silencer.silent
 import com.typesafe.config.Config
 
 import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContextExecutor
 
 /**
  * INTERNAL API
@@ -62,10 +63,10 @@ private[io] final class AsyncDnsManager(
       ext.Settings.Dispatcher,
       ext.provider)
 
-  implicit val ec = context.dispatcher
+  implicit val ec: ExecutionContextExecutor = context.dispatcher
 
   val settings = new DnsSettings(system, resolverConfig)
-  implicit val timeout = Timeout(settings.ResolveTimeout)
+  implicit val timeout: Timeout = Timeout(settings.ResolveTimeout)
 
   private val resolver = {
     val props: Props = FromConfig.props(

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
@@ -22,6 +22,7 @@ import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.Try
 import scala.util.control.NonFatal
+import scala.concurrent.ExecutionContextExecutor
 
 /**
  * INTERNAL API
@@ -36,10 +37,10 @@ private[io] final class AsyncDnsResolver(
 
   import AsyncDnsResolver._
 
-  implicit val ec = context.dispatcher
+  implicit val ec: ExecutionContextExecutor = context.dispatcher
 
   // For ask to DNS Client
-  implicit val timeout = Timeout(settings.ResolveTimeout)
+  implicit val timeout: Timeout = Timeout(settings.ResolveTimeout)
 
   val nameServers = settings.NameServers
 

--- a/akka-actor/src/main/scala/akka/pattern/Backoff.scala
+++ b/akka-actor/src/main/scala/akka/pattern/Backoff.scala
@@ -635,5 +635,5 @@ private final case class BackoffOptionsImpl(
 }
 
 private sealed trait BackoffType
-private final case object StopImpliesFailure extends BackoffType
-private final case object RestartImpliesFailure extends BackoffType
+private case object StopImpliesFailure extends BackoffType
+private case object RestartImpliesFailure extends BackoffType

--- a/akka-actor/src/main/scala/akka/pattern/BackoffOptions.scala
+++ b/akka-actor/src/main/scala/akka/pattern/BackoffOptions.scala
@@ -424,5 +424,5 @@ private final case class BackoffOnFailureOptionsImpl[T](
 }
 
 private[akka] sealed trait BackoffReset
-private[akka] final case object ManualReset extends BackoffReset
+private[akka] case object ManualReset extends BackoffReset
 private[akka] final case class AutoReset(resetBackoff: FiniteDuration) extends BackoffReset

--- a/akka-actor/src/main/scala/akka/pattern/BackoffSupervisor.scala
+++ b/akka-actor/src/main/scala/akka/pattern/BackoffSupervisor.scala
@@ -246,7 +246,7 @@ object BackoffSupervisor {
    * Send this message to the `BackoffSupervisor` and it will reply with
    * [[BackoffSupervisor.CurrentChild]] containing the `ActorRef` of the current child, if any.
    */
-  final case object GetCurrentChild
+  case object GetCurrentChild
 
   /**
    * Java API: Send this message to the `BackoffSupervisor` and it will reply with
@@ -270,7 +270,7 @@ object BackoffSupervisor {
    * Send this message to the `BackoffSupervisor` and it will reset the back-off.
    * This should be used in conjunction with `withManualReset` in [[BackoffOptions]].
    */
-  final case object Reset
+  case object Reset
 
   /**
    * Java API: Send this message to the `BackoffSupervisor` and it will reset the back-off.
@@ -282,7 +282,7 @@ object BackoffSupervisor {
    * Send this message to the `BackoffSupervisor` and it will reply with
    * [[BackoffSupervisor.RestartCount]] containing the current restart count.
    */
-  final case object GetRestartCount
+  case object GetRestartCount
 
   /**
    * Java API: Send this message to the `BackoffSupervisor` and it will reply with

--- a/akka-bench-jmh/src/main/scala/akka/actor/TellOnlyBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/TellOnlyBenchmark.scala
@@ -97,7 +97,7 @@ object TellOnlyBenchmark {
 
   class Echo extends Actor {
     def receive = {
-      case s @ `stop` =>
+      case `stop` =>
         context.stop(self)
       case m => sender ! m
     }

--- a/akka-bench-jmh/src/main/scala/akka/actor/typed/TypedActorBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/typed/TypedActorBenchmark.scala
@@ -47,7 +47,7 @@ class TypedActorBenchmark {
 
   implicit var system: ActorSystem[Start] = _
 
-  implicit val askTimeout = akka.util.Timeout(timeout)
+  implicit val askTimeout: akka.util.Timeout = akka.util.Timeout(timeout)
 
   @Setup(Level.Trial)
   def setup(): Unit = {

--- a/akka-bench-jmh/src/main/scala/akka/actor/typed/TypedBenchmarkActors.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/typed/TypedBenchmarkActors.scala
@@ -16,7 +16,7 @@ object TypedBenchmarkActors {
 
   // to avoid benchmark to be dominated by allocations of message
   // we pass the respondTo actor ref into the behavior
-  final case object Message
+  case object Message
 
   private def echoBehavior(respondTo: ActorRef[Message.type]): Behavior[Message.type] = Behaviors.receive { (_, _) =>
     respondTo ! Message

--- a/akka-bench-jmh/src/main/scala/akka/actor/typed/delivery/ReliableDeliveryBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/typed/delivery/ReliableDeliveryBenchmark.scala
@@ -206,7 +206,7 @@ class ReliableDeliveryBenchmark {
 
   implicit var system: ActorSystem[Guardian.Command] = _
 
-  implicit val askTimeout = akka.util.Timeout(timeout)
+  implicit val askTimeout: akka.util.Timeout = akka.util.Timeout(timeout)
 
   @Setup(Level.Trial)
   def setup(): Unit = {

--- a/akka-bench-jmh/src/main/scala/akka/dispatch/NodeQueueBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/dispatch/NodeQueueBenchmark.scala
@@ -39,7 +39,7 @@ mailbox {
   mailbox-capacity = 1000000
 }
 """).withFallback(ConfigFactory.load())
-  implicit val sys = ActorSystem("ANQ", config)
+  implicit val sys: ActorSystem = ActorSystem("ANQ", config)
   val ref = sys.actorOf(Props(new Actor {
     def receive = {
       case Stop => sender() ! Stop

--- a/akka-bench-jmh/src/main/scala/akka/remote/artery/SendQueueBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/remote/artery/SendQueueBenchmark.scala
@@ -31,7 +31,7 @@ class SendQueueBenchmark {
   val config = ConfigFactory.parseString("""
     """)
 
-  implicit val system = ActorSystem("SendQueueBenchmark", config)
+  implicit val system: ActorSystem = ActorSystem("SendQueueBenchmark", config)
 
   @Setup
   def setup(): Unit = {

--- a/akka-bench-jmh/src/main/scala/akka/stream/AskBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/AskBenchmark.scala
@@ -42,14 +42,14 @@ class AskBenchmark {
     }
     """)
 
-  implicit val system = ActorSystem("MapAsyncBenchmark", config)
+  implicit val system: ActorSystem = ActorSystem("MapAsyncBenchmark", config)
   import system.dispatcher
 
   var testSource: Source[java.lang.Integer, NotUsed] = _
 
   var actor: ActorRef = _
 
-  implicit val timeout = Timeout(10.seconds)
+  implicit val timeout: Timeout = Timeout(10.seconds)
 
   @Param(Array("1", "4"))
   var parallelism = 0

--- a/akka-bench-jmh/src/main/scala/akka/stream/EmptySourceBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/EmptySourceBenchmark.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration._
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @BenchmarkMode(Array(Mode.Throughput))
 class EmptySourceBenchmark {
-  implicit val system = ActorSystem("EmptySourceBenchmark")
+  implicit val system: ActorSystem = ActorSystem("EmptySourceBenchmark")
 
   @TearDown
   def shutdown(): Unit = {

--- a/akka-bench-jmh/src/main/scala/akka/stream/FlatMapMergeBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FlatMapMergeBenchmark.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration._
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @BenchmarkMode(Array(Mode.Throughput))
 class FlatMapMergeBenchmark {
-  implicit val system = ActorSystem("FlatMapMergeBenchmark")
+  implicit val system: ActorSystem = ActorSystem("FlatMapMergeBenchmark")
 
   val NumberOfElements = 100000
 

--- a/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FlowMapBenchmark.scala
@@ -48,7 +48,7 @@ class FlowMapBenchmark {
         }
       }""".stripMargin).withFallback(ConfigFactory.load())
 
-  implicit val system = ActorSystem("test", config)
+  implicit val system: ActorSystem = ActorSystem("test", config)
 
   @Param(Array("true", "false"))
   var UseGraphStageIdentity = false

--- a/akka-bench-jmh/src/main/scala/akka/stream/FusedGraphsBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FusedGraphsBenchmark.scala
@@ -96,7 +96,7 @@ class IdentityStage extends GraphStage[FlowShape[MutableElement, MutableElement]
 class FusedGraphsBenchmark {
   import FusedGraphsBenchmark._
 
-  implicit val system = ActorSystem(
+  implicit val system: ActorSystem = ActorSystem(
     "test",
     ConfigFactory.parseString(s"""
       akka.stream.materializer.sync-processing-limit = ${Int.MaxValue}

--- a/akka-bench-jmh/src/main/scala/akka/stream/InvokeWithFeedbackBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/InvokeWithFeedbackBenchmark.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration._
 @OutputTimeUnit(TimeUnit.SECONDS)
 @BenchmarkMode(Array(Mode.Throughput))
 class InvokeWithFeedbackBenchmark {
-  implicit val system = ActorSystem("InvokeWithFeedbackBenchmark")
+  implicit val system: ActorSystem = ActorSystem("InvokeWithFeedbackBenchmark")
 
   var sourceQueue: SourceQueueWithComplete[Int] = _
   var sinkQueue: SinkQueueWithCancel[Int] = _

--- a/akka-bench-jmh/src/main/scala/akka/stream/MapAsyncBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/MapAsyncBenchmark.scala
@@ -39,7 +39,7 @@ class MapAsyncBenchmark {
     }
     """)
 
-  implicit val system = ActorSystem("MapAsyncBenchmark", config)
+  implicit val system: ActorSystem = ActorSystem("MapAsyncBenchmark", config)
   import system.dispatcher
 
   var testSource: Source[java.lang.Integer, NotUsed] = _

--- a/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/MaterializationBenchmark.scala
@@ -96,7 +96,7 @@ class MaterializationBenchmark {
 
   import MaterializationBenchmark._
 
-  implicit val system = ActorSystem("MaterializationBenchmark")
+  implicit val system: ActorSystem = ActorSystem("MaterializationBenchmark")
 
   var flowWithMap: RunnableGraph[NotUsed] = _
   var graphWithJunctionsGradual: RunnableGraph[NotUsed] = _

--- a/akka-bench-jmh/src/main/scala/akka/stream/PartitionHubBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/PartitionHubBenchmark.scala
@@ -40,7 +40,7 @@ class PartitionHubBenchmark {
     }
     """)
 
-  implicit val system = ActorSystem("PartitionHubBenchmark", config)
+  implicit val system: ActorSystem = ActorSystem("PartitionHubBenchmark", config)
 
   @Param(Array("2", "5", "10", "20", "30"))
   var NumberOfStreams = 0

--- a/akka-bench-jmh/src/main/scala/akka/stream/SourceRefBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/SourceRefBenchmark.scala
@@ -33,7 +33,7 @@ class SourceRefBenchmark {
         loglevel = "WARNING"
       }""".stripMargin).withFallback(ConfigFactory.load())
 
-  implicit val system = ActorSystem("test", config)
+  implicit val system: ActorSystem = ActorSystem("test", config)
 
   final val successMarker = Success(1)
   final val successFailure = Success(new Exception)

--- a/akka-bench-jmh/src/main/scala/akka/stream/impl/OutputStreamSourceStageBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/impl/OutputStreamSourceStageBenchmark.scala
@@ -24,7 +24,7 @@ object OutputStreamSourceStageBenchmark {
 @BenchmarkMode(Array(Mode.Throughput))
 class OutputStreamSourceStageBenchmark {
   import OutputStreamSourceStageBenchmark.WritesPerBench
-  implicit val system = ActorSystem("OutputStreamSourceStageBenchmark")
+  implicit val system: ActorSystem = ActorSystem("OutputStreamSourceStageBenchmark")
 
   private val bytes: Array[Byte] = Array.emptyByteArray
 

--- a/akka-bench-jmh/src/main/scala/akka/stream/io/FileSourcesBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/io/FileSourcesBenchmark.scala
@@ -31,7 +31,7 @@ import scala.concurrent.Promise
 @BenchmarkMode(Array(Mode.AverageTime))
 class FileSourcesBenchmark {
 
-  implicit val system = ActorSystem("file-sources-benchmark")
+  implicit val system: ActorSystem = ActorSystem("file-sources-benchmark")
 
   val file: Path = {
     val line = ByteString("x" * 2048 + "\n")

--- a/akka-bench-jmh/src/main/scala/akka/stream/io/FileSourcesScaleBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/io/FileSourcesScaleBenchmark.scala
@@ -34,7 +34,7 @@ class FileSourcesScaleBenchmark {
    * FileSourcesScaleBenchmark.flatMapMerge       2048  avgt   10  1.587 ± 0.118   s/op
    * FileSourcesScaleBenchmark.mapAsync           2048  avgt   10  0.899 ± 0.103   s/op
    */
-  implicit val system = ActorSystem("file-sources-benchmark")
+  implicit val system: ActorSystem = ActorSystem("file-sources-benchmark")
 
   val FILES_NUMBER = 40
   val files: Seq[Path] = {

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
@@ -104,8 +104,8 @@ object ClusterShardingSettings {
       else
         throw new IllegalArgumentException("Not recognized StateStoreMode, only 'ddata' is supported.")
   }
-  final case object StateStoreModePersistence extends StateStoreMode { override def name = "persistence" }
-  final case object StateStoreModeDData extends StateStoreMode { override def name = "ddata" }
+  case object StateStoreModePersistence extends StateStoreMode { override def name = "persistence" }
+  case object StateStoreModeDData extends StateStoreMode { override def name = "ddata" }
 
   // generated using kaze-class
   final class TuningParameters private (

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
@@ -127,7 +127,7 @@ object ClusterShardingSettings {
       val updatingStateTimeout: FiniteDuration,
       val waitingForStateTimeout: FiniteDuration) {
 
-    def this(classic: ClassicShardingSettings.TuningParameters) {
+    def this(classic: ClassicShardingSettings.TuningParameters) =
       this(
         bufferSize = classic.bufferSize,
         coordinatorFailureBackoff = classic.coordinatorFailureBackoff,
@@ -146,8 +146,6 @@ object ClusterShardingSettings {
         entityRecoveryStrategy = classic.entityRecoveryStrategy,
         entityRecoveryConstantRateStrategyFrequency = classic.entityRecoveryConstantRateStrategyFrequency,
         entityRecoveryConstantRateStrategyNumberOfEntities = classic.entityRecoveryConstantRateStrategyNumberOfEntities)
-
-    }
 
     require(
       entityRecoveryStrategy == "all" || entityRecoveryStrategy == "constant",

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/delivery/ReliableDeliveryShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/delivery/ReliableDeliveryShardingSpec.scala
@@ -42,7 +42,7 @@ object ReliableDeliveryShardingSpec {
     trait Command
     final case class RequestNext(sendToRef: ActorRef[ShardingEnvelope[TestConsumer.Job]]) extends Command
 
-    private final case object Tick extends Command
+    private case object Tick extends Command
 
     def apply(producerController: ActorRef[ShardingProducerController.Start[TestConsumer.Job]]): Behavior[Command] = {
       Behaviors.setup { context =>

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -96,7 +96,7 @@ private[akka] object Shard {
   final case class LeaseAcquireResult(acquired: Boolean, reason: Option[Throwable]) extends DeadLetterSuppression
   final case class LeaseLost(reason: Option[Throwable]) extends DeadLetterSuppression
 
-  final case object LeaseRetry extends DeadLetterSuppression
+  case object LeaseRetry extends DeadLetterSuppression
   private val LeaseRetryTimer = "lease-retry"
 
   object State {

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -780,8 +780,8 @@ private[akka] class DDataShard(
   private val writeMajority = WriteMajority(settings.tuningParameters.updatingStateTimeout, majorityMinCap)
   private val maxUpdateAttempts = 3
 
-  implicit private val node = Cluster(context.system)
-  implicit private val selfUniqueAddress = SelfUniqueAddress(node.selfUniqueAddress)
+  implicit private val node: Cluster = Cluster(context.system)
+  implicit private val selfUniqueAddress: SelfUniqueAddress = SelfUniqueAddress(node.selfUniqueAddress)
 
   // The default maximum-frame-size is 256 KiB with Artery.
   // When using entity identifiers with 36 character strings (e.g. UUID.randomUUID).

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -1100,8 +1100,8 @@ class DDataShardCoordinator(
   private val readMajority = ReadMajority(settings.tuningParameters.waitingForStateTimeout, majorityMinCap)
   private val writeMajority = WriteMajority(settings.tuningParameters.updatingStateTimeout, majorityMinCap)
 
-  implicit val node = Cluster(context.system)
-  private implicit val selfUniqueAddress = SelfUniqueAddress(node.selfUniqueAddress)
+  implicit val node: Cluster = Cluster(context.system)
+  private implicit val selfUniqueAddress: SelfUniqueAddress = SelfUniqueAddress(node.selfUniqueAddress)
   val CoordinatorStateKey = LWWRegisterKey[State](s"${typeName}CoordinatorState")
   val initEmptyState = State.empty.withRememberEntities(settings.rememberEntities)
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -203,7 +203,7 @@ object ShardRegion {
    * the `ShardRegion` and then the `ShardRegion` actor will be stopped. You can `watch`
    * it to know when it is completed.
    */
-  @SerialVersionUID(1L) final case object GracefulShutdown extends ShardRegionCommand
+  @SerialVersionUID(1L) case object GracefulShutdown extends ShardRegionCommand
 
   /**
    * We must be sure that a shard is initialized before to start send messages to it.
@@ -226,7 +226,7 @@ object ShardRegion {
    * Intended for testing purpose to see when cluster sharding is "ready" or to monitor
    * the state of the shard regions.
    */
-  @SerialVersionUID(1L) final case object GetCurrentRegions extends ShardRegionQuery with ClusterShardingSerializable
+  @SerialVersionUID(1L) case object GetCurrentRegions extends ShardRegionQuery with ClusterShardingSerializable
 
   /**
    * Java API:

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/external/ExternalShardAllocationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/external/ExternalShardAllocationStrategy.scala
@@ -36,7 +36,7 @@ object ExternalShardAllocationStrategy {
 
   // local only messages
   private[akka] final case class GetShardLocation(shard: ShardId)
-  private[akka] final case object GetShardLocations
+  private[akka] case object GetShardLocations
   private[akka] final case class GetShardLocationsResponse(desiredAllocations: Map[ShardId, Address])
   private[akka] final case class GetShardLocationResponse(address: Option[Address])
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/external/internal/ExternalShardAllocationClientImpl.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/external/internal/ExternalShardAllocationClientImpl.scala
@@ -37,6 +37,7 @@ import akka.pattern.ask
 import scala.concurrent.Future
 import scala.compat.java8.FutureConverters._
 import akka.util.JavaDurationConverters._
+import akka.dispatch.MessageDispatcher
 
 /**
  * INTERNAL API
@@ -55,8 +56,8 @@ final private[external] class ExternalShardAllocationClientImpl(system: ActorSys
     system.settings.config
       .getDuration("akka.cluster.sharding.external-shard-allocation-strategy.client-timeout")
       .asScala
-  private implicit val askTimeout = Timeout(timeout * 2)
-  private implicit val ec = system.dispatchers.internalDispatcher
+  private implicit val askTimeout: Timeout = Timeout(timeout * 2)
+  private implicit val ec: MessageDispatcher = system.dispatchers.internalDispatcher
 
   private val Key = ExternalShardAllocationStrategy.ddataKey(typeName)
 

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingCustomShardAllocationSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingCustomShardAllocationSpec.scala
@@ -43,7 +43,7 @@ object ClusterShardingCustomShardAllocationSpec {
   }
 
   case class TestAllocationStrategy(ref: ActorRef) extends ShardAllocationStrategy {
-    implicit val timeout = Timeout(3.seconds)
+    implicit val timeout: Timeout = Timeout(3.seconds)
     override def allocateShard(
         requester: ActorRef,
         shardId: ShardRegion.ShardId,

--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
@@ -104,7 +104,7 @@ final class DistributedPubSubSettings(
       routingLogic: RoutingLogic,
       gossipInterval: FiniteDuration,
       removedTimeToLive: FiniteDuration,
-      maxDeltaElements: Int) {
+      maxDeltaElements: Int) =
     this(
       role,
       routingLogic,
@@ -112,7 +112,6 @@ final class DistributedPubSubSettings(
       removedTimeToLive,
       maxDeltaElements,
       sendToDeadLettersWhenNoSubscribers = true)
-  }
 
   require(
     !routingLogic.isInstanceOf[ConsistentHashingRoutingLogic],

--- a/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/singleton/ClusterSingletonManager.scala
@@ -217,7 +217,7 @@ object ClusterSingletonManager {
 
     final case class HandOverRetry(count: Int)
     final case class TakeOverRetry(count: Int)
-    final case object LeaseRetry
+    case object LeaseRetry
     case object Cleanup
     case object StartOldestChangedBuffer
 

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/TestLeaseActor.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/TestLeaseActor.scala
@@ -102,7 +102,7 @@ class TestLeaseActorClient(settings: LeaseSettings, system: ExtendedActorSystem)
   log.info("lease created {}", settings)
   leaseActor ! Create(settings.leaseName, settings.ownerName)
 
-  private implicit val timeout = Timeout(100.seconds)
+  private implicit val timeout: Timeout = Timeout(100.seconds)
 
   override def acquire(): Future[Boolean] = {
     (leaseActor ? Acquire(settings.ownerName)).mapTo[Boolean]

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/TestLeaseActor.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/TestLeaseActor.scala
@@ -35,7 +35,7 @@ object TestLeaseActor {
   final case class Release(owner: String) extends LeaseRequest
   final case class Create(leaseName: String, ownerName: String) extends JavaSerializable
 
-  final case object GetRequests extends JavaSerializable
+  case object GetRequests extends JavaSerializable
   final case class LeaseRequests(requests: List[LeaseRequest]) extends JavaSerializable
   final case class ActionRequest(request: LeaseRequest, result: Any) extends JavaSerializable // boolean of Failure
 }

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionist.scala
@@ -184,7 +184,7 @@ private[typed] object ClusterReceptionist extends ReceptionistBehaviorProvider {
     val cluster = Cluster(classicSystem)
     // don't use DistributedData.selfUniqueAddress here, because that will initialize extension, which
     // isn't used otherwise by the ClusterReceptionist
-    implicit val selfNodeAddress = SelfUniqueAddress(cluster.selfUniqueAddress)
+    implicit val selfNodeAddress: SelfUniqueAddress = SelfUniqueAddress(cluster.selfUniqueAddress)
 
     val replicator = ctx.actorOf(Replicator.props(settings.replicatorSettings), "replicator")
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
@@ -54,7 +54,7 @@ class ClusterSingletonApiSpec
     with LogCapturing {
   import ClusterSingletonApiSpec._
 
-  implicit val testSettings = TestKitSettings(system)
+  implicit val testSettings: TestKitSettings = TestKitSettings(system)
   val clusterNode1 = Cluster(system)
   val classicSystem1 = system.toClassic
 

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPoisonPillSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonPoisonPillSpec.scala
@@ -31,7 +31,7 @@ class ClusterSingletonPoisonPillSpec
     with AnyWordSpecLike
     with LogCapturing {
 
-  implicit val testSettings = TestKitSettings(system)
+  implicit val testSettings: TestKitSettings = TestKitSettings(system)
   val clusterNode1 = Cluster(system)
   clusterNode1.manager ! Join(clusterNode1.selfMember.address)
   val classicSystem1 = system.toClassic

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/ddata/typed/scaladsl/ReplicatorDocSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/ddata/typed/scaladsl/ReplicatorDocSpec.scala
@@ -34,7 +34,7 @@ object ReplicatorDocSpec {
   // #sample
   object Counter {
     sealed trait Command
-    final case object Increment extends Command
+    case object Increment extends Command
     final case class GetValue(replyTo: ActorRef[Int]) extends Command
     final case class GetCachedValue(replyTo: ActorRef[Int]) extends Command
     case object Unsubscribe extends Command

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/ReceptionistExample.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/ReceptionistExample.scala
@@ -18,7 +18,7 @@ object PingPongExample {
     val PingServiceKey = ServiceKey[Ping]("pingService")
 
     final case class Ping(replyTo: ActorRef[Pong.type])
-    final case object Pong
+    case object Pong
 
     def apply(): Behavior[Ping] = {
       Behaviors.setup { context =>

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -177,7 +177,7 @@ private[cluster] object InternalClusterAction {
   final case class PublishChanges(state: MembershipState) extends PublishMessage
   final case class PublishEvent(event: ClusterDomainEvent) extends PublishMessage
 
-  final case object ExitingCompleted
+  case object ExitingCompleted
 
 }
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
@@ -337,7 +337,7 @@ object ClusterEvent {
    * This event is published when the cluster node is shutting down,
    * before the final [[MemberRemoved]] events are published.
    */
-  final case object ClusterShuttingDown extends ClusterDomainEvent
+  case object ClusterShuttingDown extends ClusterDomainEvent
 
   /**
    * Java API: get the singleton instance of `ClusterShuttingDown` event

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StreamRefSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StreamRefSpec.scala
@@ -56,7 +56,7 @@ object StreamRefSpec extends MultiNodeConfig {
 
   class DataSource(streamLifecycleProbe: ActorRef) extends Actor with ActorLogging {
     import context.dispatcher
-    implicit val mat = Materializer(context)
+    implicit val mat: Materializer = Materializer(context)
 
     def receive = {
       case RequestLogs(streamId) =>
@@ -102,7 +102,7 @@ object StreamRefSpec extends MultiNodeConfig {
   class DataReceiver(streamLifecycleProbe: ActorRef) extends Actor with ActorLogging {
 
     import context.dispatcher
-    implicit val mat = Materializer(context)
+    implicit val mat: Materializer = Materializer(context)
 
     def receive = {
       case PrepareUpload(nodeId) =>

--- a/akka-discovery/src/main/scala/akka/discovery/aggregate/AggregateServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/aggregate/AggregateServiceDiscovery.scala
@@ -17,6 +17,7 @@ import akka.util.ccompat.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
+import akka.dispatch.MessageDispatcher
 
 /**
  * INTERNAL API
@@ -55,7 +56,7 @@ private[akka] final class AggregateServiceDiscovery(system: ExtendedActorSystem)
     val serviceDiscovery = Discovery(system)
     settings.discoveryMethods.map(mech => (mech, serviceDiscovery.loadServiceDiscovery(mech)))
   }
-  private implicit val ec = system.dispatchers.internalDispatcher
+  private implicit val ec: MessageDispatcher = system.dispatchers.internalDispatcher
 
   /**
    * Each discovery method is given the resolveTimeout rather than reducing it each time between methods.

--- a/akka-discovery/src/main/scala/akka/discovery/dns/DnsServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/dns/DnsServiceDiscovery.scala
@@ -30,6 +30,7 @@ import akka.io.dns.internal.AsyncDnsManager
 import akka.pattern.AskTimeoutException
 import akka.util.OptionVal
 import akka.util.Timeout
+import akka.dispatch.MessageDispatcher
 
 /**
  * INTERNAL API
@@ -91,7 +92,7 @@ private[akka] class DnsServiceDiscovery(system: ExtendedActorSystem) extends Ser
   // (eventually visible)
   private var asyncDnsCache: OptionVal[SimpleDnsCache] = OptionVal.None
 
-  private implicit val ec = system.dispatchers.internalDispatcher
+  private implicit val ec: MessageDispatcher = system.dispatchers.internalDispatcher
 
   dns.ask(AsyncDnsManager.GetCache)(Timeout(30.seconds)).onComplete {
     case Success(cache: SimpleDnsCache) =>

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
@@ -781,7 +781,7 @@ object Replicator {
    * Get current number of replicas, including the local replica.
    * Will reply to sender with [[ReplicaCount]].
    */
-  final case object GetReplicaCount
+  case object GetReplicaCount
 
   /**
    * Java API: The `GetReplicaCount` instance

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurableDataSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurableDataSpec.scala
@@ -84,7 +84,7 @@ abstract class DurableDataSpec(multiNodeConfig: DurableDataSpecConfig)
   override def initialParticipants = roles.size
 
   val cluster = Cluster(system)
-  implicit val selfUniqueAddress = DistributedData(system).selfUniqueAddress
+  implicit val selfUniqueAddress: SelfUniqueAddress = DistributedData(system).selfUniqueAddress
   val timeout = 14.seconds.dilated // initialization of lmdb can be very slow in CI environment
   val writeTwo = WriteTo(2, timeout)
   val readTwo = ReadFrom(2, timeout)

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurablePruningSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurablePruningSpec.scala
@@ -46,7 +46,7 @@ class DurablePruningSpec extends MultiNodeSpec(DurablePruningSpec) with STMultiN
   override def initialParticipants = roles.size
 
   val cluster = Cluster(system)
-  implicit val selfUniqueAddress = DistributedData(system).selfUniqueAddress
+  implicit val selfUniqueAddress: SelfUniqueAddress = DistributedData(system).selfUniqueAddress
   val maxPruningDissemination = 3.seconds
 
   def startReplicator(sys: ActorSystem): ActorRef =

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/JepsenInspiredInsertSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/JepsenInspiredInsertSpec.scala
@@ -53,7 +53,7 @@ class JepsenInspiredInsertSpec
   override def initialParticipants = roles.size
 
   val cluster = Cluster(system)
-  implicit val selfUniqueAddress = DistributedData(system).selfUniqueAddress
+  implicit val selfUniqueAddress: SelfUniqueAddress = DistributedData(system).selfUniqueAddress
   val replicator = DistributedData(system).replicator
   val nodes = roles.drop(1) // controller not part of active nodes
   val nodeCount = nodes.size

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/PerformanceSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/PerformanceSpec.scala
@@ -69,7 +69,7 @@ class PerformanceSpec extends MultiNodeSpec(PerformanceSpec) with STMultiNodeSpe
   override def initialParticipants = roles.size
 
   val cluster = Cluster(system)
-  implicit val selfUniqueAddress = DistributedData(system).selfUniqueAddress
+  implicit val selfUniqueAddress: SelfUniqueAddress = DistributedData(system).selfUniqueAddress
   val replicator = DistributedData(system).replicator
   val timeout = 3.seconds.dilated
   val factor = 1 // use 3 here for serious tuning

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorChaosSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorChaosSpec.scala
@@ -44,7 +44,7 @@ class ReplicatorChaosSpec extends MultiNodeSpec(ReplicatorChaosSpec) with STMult
   override def initialParticipants = roles.size
 
   val cluster = Cluster(system)
-  implicit val selfUniqueAddress = DistributedData(system).selfUniqueAddress
+  implicit val selfUniqueAddress: SelfUniqueAddress = DistributedData(system).selfUniqueAddress
   val replicator = system.actorOf(
     Replicator.props(ReplicatorSettings(system).withRole("backend").withGossipInterval(1.second)),
     "replicator")

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorDeltaSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorDeltaSpec.scala
@@ -146,7 +146,7 @@ class ReplicatorDeltaSpec extends MultiNodeSpec(ReplicatorDeltaSpec) with STMult
   override def initialParticipants = roles.size
 
   val cluster = Cluster(system)
-  implicit val selfUniqueAddress = DistributedData(system).selfUniqueAddress
+  implicit val selfUniqueAddress: SelfUniqueAddress = DistributedData(system).selfUniqueAddress
   val fullStateReplicator = system.actorOf(
     Replicator.props(ReplicatorSettings(system).withGossipInterval(1.second).withDeltaCrdtEnabled(false)),
     "fullStateReplicator")

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorMapDeltaSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorMapDeltaSpec.scala
@@ -186,7 +186,7 @@ class ReplicatorMapDeltaSpec extends MultiNodeSpec(ReplicatorMapDeltaSpec) with 
   override def initialParticipants = roles.size
 
   val cluster = Cluster(system)
-  implicit val selfUniqueAddress = DistributedData(system).selfUniqueAddress
+  implicit val selfUniqueAddress: SelfUniqueAddress = DistributedData(system).selfUniqueAddress
   val fullStateReplicator = system.actorOf(
     Replicator.props(ReplicatorSettings(system).withGossipInterval(1.second).withDeltaCrdtEnabled(false)),
     "fullStateReplicator")

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorORSetDeltaSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorORSetDeltaSpec.scala
@@ -42,7 +42,7 @@ class ReplicatorORSetDeltaSpec
   override def initialParticipants = roles.size
 
   val cluster = Cluster(system)
-  implicit val selfUniqueAddress = DistributedData(system).selfUniqueAddress
+  implicit val selfUniqueAddress: SelfUniqueAddress = DistributedData(system).selfUniqueAddress
   val replicator =
     system.actorOf(Replicator.props(ReplicatorSettings(system).withGossipInterval(1.second)), "replicator")
   val timeout = 3.seconds.dilated

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorPruningSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorPruningSpec.scala
@@ -42,7 +42,7 @@ class ReplicatorPruningSpec extends MultiNodeSpec(ReplicatorPruningSpec) with ST
   override def initialParticipants = roles.size
 
   val cluster = Cluster(system)
-  implicit val selfUniqueAddress = DistributedData(system).selfUniqueAddress
+  implicit val selfUniqueAddress: SelfUniqueAddress = DistributedData(system).selfUniqueAddress
   val maxPruningDissemination = 3.seconds
   val replicator = system.actorOf(
     Replicator.props(

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/ReplicatorSpec.scala
@@ -44,7 +44,7 @@ class ReplicatorSpec extends MultiNodeSpec(ReplicatorSpec) with STMultiNodeSpec 
   override def initialParticipants = roles.size
 
   val cluster = Cluster(system)
-  implicit val selfUniqueAddress = DistributedData(system).selfUniqueAddress
+  implicit val selfUniqueAddress: SelfUniqueAddress = DistributedData(system).selfUniqueAddress
   val replicator = system.actorOf(
     Replicator.props(ReplicatorSettings(system).withGossipInterval(1.second).withMaxDeltaElements(10)),
     "replicator")

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/LocalConcurrencySpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/LocalConcurrencySpec.scala
@@ -45,7 +45,7 @@ class LocalConcurrencySpec(_system: ActorSystem)
     with ImplicitSender {
   import LocalConcurrencySpec._
 
-  def this() {
+  def this() =
     this(
       ActorSystem(
         "LocalConcurrencySpec",
@@ -54,7 +54,6 @@ class LocalConcurrencySpec(_system: ActorSystem)
       akka.remote.classic.netty.tcp.port=0
       akka.remote.artery.canonical.port = 0
       """)))
-  }
 
   override def afterAll(): Unit = {
     shutdown(system)

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/LocalConcurrencySpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/LocalConcurrencySpec.scala
@@ -25,7 +25,7 @@ object LocalConcurrencySpec {
 
   class Updater extends Actor with Stash {
 
-    implicit val selfUniqueAddress = DistributedData(context.system).selfUniqueAddress
+    implicit val selfUniqueAddress: SelfUniqueAddress = DistributedData(context.system).selfUniqueAddress
 
     val replicator = DistributedData(context.system).replicator
 

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/LotsOfDataBot.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/LotsOfDataBot.scala
@@ -69,7 +69,7 @@ class LotsOfDataBot extends Actor with ActorLogging {
   import LotsOfDataBot._
   import Replicator._
 
-  implicit val selfUniqueAddress = DistributedData(context.system).selfUniqueAddress
+  implicit val selfUniqueAddress: SelfUniqueAddress = DistributedData(context.system).selfUniqueAddress
   val replicator = DistributedData(context.system).replicator
 
   import context.dispatcher

--- a/akka-docs/src/test/scala/docs/stream/IntegrationDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/IntegrationDocSpec.scala
@@ -85,7 +85,7 @@ object IntegrationDocSpec {
   }
 
   final case class Save(tweet: Tweet)
-  final case object SaveDone
+  case object SaveDone
 
   class DatabaseService(probe: ActorRef) extends Actor {
     override def receive = {

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Conductor.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Conductor.scala
@@ -277,7 +277,7 @@ trait Conductor { this: TestConductorExt =>
 private[akka] class ConductorHandler(_createTimeout: Timeout, controller: ActorRef, log: LoggingAdapter)
     extends SimpleChannelUpstreamHandler {
 
-  implicit val createTimeout = _createTimeout
+  implicit val createTimeout: Timeout = _createTimeout
   val clients = new ConcurrentHashMap[Channel, ActorRef]()
 
   override def channelConnected(ctx: ChannelHandlerContext, event: ChannelStateEvent) = {

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Extension.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Extension.scala
@@ -62,8 +62,8 @@ class TestConductorExt(val system: ExtendedActorSystem) extends Extension with C
     val ClientReconnects = config.getInt("client-reconnects")
     val ReconnectBackoff = config.getMillisDuration("reconnect-backoff")
 
-    implicit val BarrierTimeout = Timeout(config.getMillisDuration("barrier-timeout"))
-    implicit val QueryTimeout = Timeout(config.getMillisDuration("query-timeout"))
+    implicit val BarrierTimeout: Timeout = Timeout(config.getMillisDuration("barrier-timeout"))
+    implicit val QueryTimeout: Timeout = Timeout(config.getMillisDuration("query-timeout"))
     val PacketSplitThreshold = config.getMillisDuration("packet-split-threshold")
 
     private def computeWPS(config: Config): Int =

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/Offset.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/Offset.scala
@@ -52,7 +52,7 @@ final case class TimeBasedUUID(value: UUID) extends Offset with Ordered[TimeBase
 /**
  * Used when retrieving all events.
  */
-final case object NoOffset extends Offset {
+case object NoOffset extends Offset {
 
   /**
    * Java API:

--- a/akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala
+++ b/akka-persistence-tck/src/main/scala/akka/persistence/snapshot/SnapshotStoreSpec.scala
@@ -44,7 +44,8 @@ abstract class SnapshotStoreSpec(config: Config)
     with MayVerb
     with OptionalTests
     with SnapshotStoreCapabilityFlags {
-  implicit lazy val system = ActorSystem("SnapshotStoreSpec", config.withFallback(SnapshotStoreSpec.config))
+  implicit lazy val system: ActorSystem =
+    ActorSystem("SnapshotStoreSpec", config.withFallback(SnapshotStoreSpec.config))
 
   private var senderProbe: TestProbe = _
   private var metadata: Seq[SnapshotMetadata] = Nil

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ClusterSingletonPersistenceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ClusterSingletonPersistenceSpec.scala
@@ -15,6 +15,8 @@ import akka.persistence.typed.scaladsl.Effect
 import akka.persistence.typed.scaladsl.EventSourcedBehavior
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
+import akka.actor
+import akka.actor.typed.ActorSystem
 
 object ClusterSingletonPersistenceSpec {
   val config = ConfigFactory.parseString("""
@@ -57,9 +59,9 @@ class ClusterSingletonPersistenceSpec
   import ClusterSingletonPersistenceSpec._
   import akka.actor.typed.scaladsl.adapter._
 
-  implicit val s = system
+  implicit val s: ActorSystem[Nothing] = system
 
-  implicit val classicSystem = system.toClassic
+  implicit val classicSystem: actor.ActorSystem = system.toClassic
   private val classicCluster = akka.cluster.Cluster(classicSystem)
 
   "A typed cluster singleton with persistent actor" must {

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ClusterSingletonPersistenceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ClusterSingletonPersistenceSpec.scala
@@ -32,7 +32,7 @@ object ClusterSingletonPersistenceSpec {
   sealed trait Command
   final case class Add(s: String) extends Command
   final case class Get(replyTo: ActorRef[String]) extends Command
-  private final case object StopPlz extends Command
+  private case object StopPlz extends Command
 
   val persistentActor: Behavior[Command] =
     EventSourcedBehavior[Command, String, String](

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
@@ -22,6 +22,7 @@ import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.RecoveryCompleted
 import org.scalatest.wordspec.AnyWordSpecLike
+import akka.actor.ActorSystem
 
 object RecoveryPermitterSpec {
 
@@ -76,7 +77,7 @@ class RecoveryPermitterSpec extends ScalaTestWithActorTestKit(s"""
 
   import RecoveryPermitterSpec._
 
-  implicit val classicSystem = system.toClassic
+  implicit val classicSystem: ActorSystem = system.toClassic
 
   private val permitter = Persistence(classicSystem).recoveryPermitter
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
@@ -44,10 +44,10 @@ object EventSourcedBehaviorRetentionSpec extends Matchers {
     """)
 
   sealed trait Command extends CborSerializable
-  final case object Increment extends Command
+  case object Increment extends Command
   final case class IncrementWithPersistAll(nr: Int) extends Command
   final case class GetValue(replyTo: ActorRef[State]) extends Command
-  final case object StopIt extends Command
+  case object StopIt extends Command
 
   final case class WrappedSignal(signal: EventSourcedSignal)
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -91,22 +91,22 @@ object EventSourcedBehaviorSpec {
     """)
 
   sealed trait Command extends CborSerializable
-  final case object Increment extends Command
-  final case object IncrementThenLogThenStop extends Command
-  final case object IncrementTwiceThenLogThenStop extends Command
+  case object Increment extends Command
+  case object IncrementThenLogThenStop extends Command
+  case object IncrementTwiceThenLogThenStop extends Command
   final case class IncrementWithPersistAll(nr: Int) extends Command
-  final case object IncrementLater extends Command
-  final case object IncrementAfterReceiveTimeout extends Command
-  final case object IncrementTwiceAndThenLog extends Command
+  case object IncrementLater extends Command
+  case object IncrementAfterReceiveTimeout extends Command
+  case object IncrementTwiceAndThenLog extends Command
   final case class IncrementWithConfirmation(replyTo: ActorRef[Done]) extends Command
-  final case object DoNothingAndThenLog extends Command
-  final case object EmptyEventsListAndThenLog extends Command
+  case object DoNothingAndThenLog extends Command
+  case object EmptyEventsListAndThenLog extends Command
   final case class GetValue(replyTo: ActorRef[State]) extends Command
-  final case object DelayFinished extends Command
+  case object DelayFinished extends Command
   private case object Timeout extends Command
-  final case object LogThenStop extends Command
-  final case object Fail extends Command
-  final case object StopIt extends Command
+  case object LogThenStop extends Command
+  case object Fail extends Command
+  case object StopIt extends Command
 
   sealed trait Event extends CborSerializable
   final case class Incremented(delta: Int) extends Event

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/NullEmptyStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/NullEmptyStateSpec.scala
@@ -26,7 +26,7 @@ class NullEmptyStateSpec
     with AnyWordSpecLike
     with LogCapturing {
 
-  implicit val testSettings = TestKitSettings(system)
+  implicit val testSettings: TestKitSettings = TestKitSettings(system)
 
   def primitiveState(persistenceId: PersistenceId, probe: ActorRef[String]): Behavior[String] =
     EventSourcedBehavior[String, String, String](

--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
@@ -17,6 +17,7 @@ import scala.annotation.varargs
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
+import scala.concurrent.ExecutionContextExecutor
 
 /**
  * SnapshotAfter Extension Id and factory for creating SnapshotAfter extension
@@ -331,7 +332,7 @@ object PersistentFSM {
       extends NoSerializationVerificationNeeded {
     private var ref: Option[Cancellable] = _
     private val scheduler = context.system.scheduler
-    private implicit val executionContext = context.dispatcher
+    private implicit val executionContext: ExecutionContextExecutor = context.dispatcher
 
     def schedule(actor: ActorRef, timeout: FiniteDuration): Unit = {
       val timerMsg = msg match {

--- a/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteProxy.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/AsyncWriteProxy.scala
@@ -98,7 +98,7 @@ private[persistence] trait AsyncWriteProxy extends AsyncWriteJournal with Stash 
  */
 private[persistence] object AsyncWriteProxy {
   final case class SetStore(ref: ActorRef)
-  final case object InitTimeout
+  case object InitTimeout
 }
 
 /**

--- a/akka-persistence/src/main/scala/akka/persistence/journal/EventAdapter.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/EventAdapter.scala
@@ -105,14 +105,14 @@ final case class SingleEventSeq(event: Any) extends EventSeq { // TODO try to ma
 }
 
 sealed trait EmptyEventSeq extends EventSeq
-final object EmptyEventSeq extends EmptyEventSeq {
+object EmptyEventSeq extends EmptyEventSeq {
   override def events = Nil
 }
 
 final case class EventsSeq[E](events: immutable.Seq[E]) extends EventSeq
 
 /** No-op model adapter which passes through the incoming events as-is. */
-final case object IdentityEventAdapter extends EventAdapter {
+case object IdentityEventAdapter extends EventAdapter {
   override def toJournal(event: Any): Any = event
   override def fromJournal(event: Any, manifest: String): EventSeq = EventSeq.single(event)
   override def manifest(event: Any): String = ""

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbJournal.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbJournal.scala
@@ -92,7 +92,7 @@ private[persistence] object LeveldbJournal {
    * subscriber followed by [[PersistenceIdAdded]] messages when new persistenceIds
    * are created.
    */
-  final case object SubscribeAllPersistenceIds extends SubscriptionCommand
+  case object SubscribeAllPersistenceIds extends SubscriptionCommand
   final case class CurrentPersistenceIds(allPersistenceIds: Set[String]) extends DeadLetterSuppression
   final case class PersistenceIdAdded(persistenceId: String) extends DeadLetterSuppression
 

--- a/akka-persistence/src/test/scala/akka/persistence/EventAdapterSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/EventAdapterSpec.scala
@@ -101,7 +101,7 @@ abstract class EventAdapterSpec(journalName: String, journalConfig: Config, adap
 
   import EventAdapterSpec._
 
-  def this(journalName: String) {
+  def this(journalName: String) =
     this(
       "inmem",
       PersistenceSpec.config("inmem", "InmemPersistentTaggingSpec"),
@@ -150,7 +150,6 @@ abstract class EventAdapterSpec(journalName: String, journalConfig: Config, adap
          |  }
          |}
       """.stripMargin))
-  }
 
   def persister(name: String, journalId: String = journalName) =
     system.actorOf(Props(classOf[PersistAllIncomingActor], name, "akka.persistence.journal." + journalId))

--- a/akka-persistence/src/test/scala/akka/persistence/OptimizedRecoverySpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/OptimizedRecoverySpec.scala
@@ -14,7 +14,7 @@ object OptimizedRecoverySpec {
     case object TakeSnapshot
     final case class Save(s: String)
     final case class Saved(s: String, seqNr: Long)
-    final case object PersistFromRecoveryCompleted
+    case object PersistFromRecoveryCompleted
 
     def props(name: String, recovery: Recovery, probe: ActorRef): Props = {
       Props(new TestPersistentActor(name, recovery, probe))

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/LatencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/LatencySpec.scala
@@ -63,7 +63,7 @@ object LatencySpec extends MultiNodeConfig {
        }
        """)).withFallback(RemotingMultiNodeSpec.commonConfig))
 
-  final case object Reset extends CborSerializable
+  case object Reset extends CborSerializable
 
   def echoProps(): Props =
     Props(new Echo).withDispatcher(Dispatchers.InternalDispatcherId)

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/MaxThroughputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/MaxThroughputSpec.scala
@@ -86,9 +86,9 @@ object MaxThroughputSpec extends MultiNodeConfig {
 
   case object Run
   sealed trait Echo extends DeadLetterSuppression with CborSerializable
-  final case object StartAck extends Echo
+  case object StartAck extends Echo
   final case class Start(correspondingReceiver: ActorRef) extends Echo
-  final case object End extends Echo
+  case object End extends Echo
   final case class Warmup(payload: AnyRef) extends CborSerializable
   final case class EndResult(totalReceived: Long) extends CborSerializable
   final case class FlowControl(id: Int, burstStartTime: Long) extends Echo

--- a/akka-remote/src/main/scala/akka/remote/FailureDetector.scala
+++ b/akka-remote/src/main/scala/akka/remote/FailureDetector.scala
@@ -40,7 +40,7 @@ object FailureDetector {
   // Abstract class to be able to extend it from Java
   abstract class Clock extends (() => Long)
 
-  implicit val defaultClock = new Clock {
+  implicit val defaultClock: Clock = new Clock {
     def apply() = NANOSECONDS.toMillis(System.nanoTime)
   }
 }

--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -34,6 +34,7 @@ import akka.actor.ActorInitializationException
 import akka.annotation.InternalStableApi
 import akka.util.ccompat._
 import com.github.ghik.silencer.silent
+import akka.dispatch.MessageDispatcher
 
 /**
  * INTERNAL API
@@ -149,7 +150,7 @@ private[remote] class Remoting(_system: ExtendedActorSystem, _provider: RemoteAc
 
   import provider.remoteSettings._
 
-  private implicit val ec = system.dispatchers.lookup(Dispatcher)
+  private implicit val ec: MessageDispatcher = system.dispatchers.lookup(Dispatcher)
 
   val transportSupervisor = system.systemActorOf(configureDispatcher(Props[TransportSupervisor]), "transports")
 

--- a/akka-remote/src/main/scala/akka/remote/transport/AbstractTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AbstractTransportAdapter.scala
@@ -160,7 +160,7 @@ object ActorTransportAdapter {
       extends TransportOperation
       with DeadLetterSuppression
 
-  implicit val AskTimeout = Timeout(5.seconds)
+  implicit val AskTimeout: Timeout = Timeout(5.seconds)
 }
 
 @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")

--- a/akka-remote/src/test/scala/akka/remote/artery/compress/HandshakeShouldDropCompressionTableSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/compress/HandshakeShouldDropCompressionTableSpec.scala
@@ -39,7 +39,7 @@ class HandshakeShouldDropCompressionTableSpec
     with ImplicitSender
     with BeforeAndAfter {
 
-  implicit val t = Timeout(3.seconds)
+  implicit val t: Timeout = Timeout(3.seconds)
   var systemB: ActorSystem = null
   val portB = freePort()
 

--- a/akka-remote/src/test/scala/akka/remote/classic/RemotingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/RemotingSpec.scala
@@ -226,7 +226,7 @@ class RemotingSpec extends AkkaSpec(RemotingSpec.cfg) with ImplicitSender with D
     "support ask" in {
       Await.result(here ? "ping", timeout.duration) match {
         case ("pong", _: akka.pattern.PromiseActorRef) => // good
-        case m                                         => fail(m + " was not (pong, AskActorRef)")
+        case m                                         => fail("" + m + " was not (pong, AskActorRef)")
       }
     }
 

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -35,7 +35,7 @@ object TestPublisher {
   final case class CancelSubscription(subscription: Subscription, cause: Throwable) extends PublisherEvent
   final case class RequestMore(subscription: Subscription, elements: Long) extends PublisherEvent
 
-  final object SubscriptionDone extends NoSerializationVerificationNeeded
+  object SubscriptionDone extends NoSerializationVerificationNeeded
 
   /**
    * Publisher that signals complete to subscribers, after handing a void subscription.

--- a/akka-stream-tests/src/test/scala/akka/stream/ActorMaterializerSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/ActorMaterializerSpec.scala
@@ -34,7 +34,7 @@ object IndirectMaterializerCreation extends ExtensionId[IndirectMaterializerCrea
 @silent
 class IndirectMaterializerCreation(ex: ExtendedActorSystem) extends Extension {
   // extension instantiation blocked on materializer (which has Await.result inside)
-  implicit val mat = ActorMaterializer()(ex)
+  implicit val mat: ActorMaterializer = ActorMaterializer()(ex)
 
   def futureThing(n: Int): Future[Int] = {
     Source.single(n).runWith(Sink.head)
@@ -160,7 +160,7 @@ object ActorMaterializerSpec {
   class ActorWithMaterializer(p: TestProbe) extends Actor {
     private val settings: ActorMaterializerSettings =
       ActorMaterializerSettings(context.system).withDispatcher("akka.test.stream-dispatcher")
-    implicit val mat = ActorMaterializer(settings)(context)
+    implicit val mat: ActorMaterializer = ActorMaterializer(settings)(context)
 
     Source
       .repeat("hello")

--- a/akka-stream-tests/src/test/scala/akka/stream/io/FileSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/FileSinkSpec.scala
@@ -29,7 +29,7 @@ import scala.util.Success
 class FileSinkSpec extends StreamSpec(UnboundedMailboxConfig) with ScalaFutures {
 
   val settings = ActorMaterializerSettings(system).withDispatcher("akka.actor.default-dispatcher")
-  implicit val materializer = ActorMaterializer(settings)
+  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
   val fs = Jimfs.newFileSystem("FileSinkSpec", Configuration.unix())
 
   val TestLines = {

--- a/akka-stream-tests/src/test/scala/akka/stream/io/FileSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/FileSourceSpec.scala
@@ -35,7 +35,7 @@ object FileSourceSpec {
 class FileSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
 
   val settings = ActorMaterializerSettings(system).withDispatcher("akka.actor.default-dispatcher")
-  implicit val materializer = ActorMaterializer(settings)
+  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
 
   val fs = Jimfs.newFileSystem("FileSourceSpec", Configuration.unix())
 

--- a/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSourceSpec.scala
@@ -23,7 +23,7 @@ import com.github.ghik.silencer.silent
 class InputStreamSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
 
   val settings = ActorMaterializerSettings(system).withDispatcher("akka.actor.default-dispatcher")
-  implicit val materializer = ActorMaterializer(settings)
+  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
 
   private def inputStreamFor(bytes: Array[Byte]): InputStream =
     new ByteArrayInputStream(bytes)

--- a/akka-stream-tests/src/test/scala/akka/stream/io/OutputStreamSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/OutputStreamSinkSpec.scala
@@ -23,7 +23,7 @@ import scala.util.Success
 class OutputStreamSinkSpec extends StreamSpec(UnboundedMailboxConfig) with ScalaFutures {
 
   val settings = ActorMaterializerSettings(system).withDispatcher("akka.actor.default-dispatcher")
-  implicit val materializer = ActorMaterializer(settings)
+  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
 
   "OutputStreamSink" must {
     "write bytes to void OutputStream" in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/io/compression/CodecSpecSupport.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/compression/CodecSpecSupport.scala
@@ -73,7 +73,7 @@ est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscin
       "\r\n",
       "\n")
 
-  implicit val system = ActorSystem(getClass.getSimpleName)
+  implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
 
   override def afterAll() = TestKit.shutdownActorSystem(system)
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
@@ -125,7 +125,7 @@ class AttributesSpec
 
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = ActorMaterializer(settings)
+  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
 
   "an attributes instance" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFoldAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFoldAsyncSpec.scala
@@ -19,10 +19,11 @@ import scala.concurrent.duration._
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.util.control.NoStackTrace
+import scala.concurrent.ExecutionContextExecutor
 
 class FlowFoldAsyncSpec extends StreamSpec {
 
-  implicit def ec = system.dispatcher
+  implicit def ec: ExecutionContextExecutor = system.dispatcher
   val timeout = Timeout(3.seconds)
 
   "A FoldAsync" must {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowJoinSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowJoinSpec.scala
@@ -17,7 +17,7 @@ class FlowJoinSpec extends StreamSpec("""
     akka.stream.materializer.initial-input-buffer-size = 2
   """) {
 
-  implicit val defaultPatience =
+  implicit val defaultPatience: PatienceConfig =
     PatienceConfig(timeout = Span(2, Seconds), interval = Span(200, Millis))
 
   "A Flow using join" must {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowRecoverWithSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowRecoverWithSpec.scala
@@ -19,7 +19,7 @@ class FlowRecoverWithSpec extends StreamSpec {
 
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 1, maxSize = 1)
 
-  implicit val materializer = ActorMaterializer(settings)
+  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
 
   val ex = new RuntimeException("ex") with NoStackTrace
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowScanAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowScanAsyncSpec.scala
@@ -19,10 +19,11 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.util.Failure
 import org.scalatest.matchers.should.Matchers
+import scala.concurrent.ExecutionContextExecutor
 
 class FlowScanAsyncSpec extends StreamSpec with Matchers {
 
-  implicit val executionContext = system.dispatcher
+  implicit val executionContext: ExecutionContextExecutor = system.dispatcher
 
   "A ScanAsync" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSlidingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSlidingSpec.scala
@@ -17,7 +17,7 @@ class FlowSlidingSpec extends StreamSpec with ScalaCheckPropertyChecks {
   import system.dispatcher
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = ActorMaterializer(settings)
+  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
 
   "Sliding" must {
     import org.scalacheck.Shrink.shrinkAny

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSpec.scala
@@ -40,7 +40,7 @@ class FlowSpec extends StreamSpec(ConfigFactory.parseString("akka.actor.debug.re
 
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 2, maxSize = 2)
 
-  implicit val materializer = ActorMaterializer(settings)
+  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
 
   val identity: Flow[Any, Any, NotUsed] => Flow[Any, Any, NotUsed] = in => in.map(e => e)
   val identity2: Flow[Any, Any, NotUsed] => Flow[Any, Any, NotUsed] = in => identity(in)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBackedFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBackedFlowSpec.scala
@@ -44,7 +44,7 @@ class GraphFlowSpec extends StreamSpec {
 
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = ActorMaterializer(settings)
+  implicit val materializer: ActorMaterializer = ActorMaterializer(settings)
 
   def validateProbe(probe: TestSubscriber.ManualProbe[Int], requests: Int, result: Set[Int]): Unit = {
     val subscription = probe.expectSubscription()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedSpec.scala
@@ -24,7 +24,8 @@ class GraphMergeSortedSpec extends TwoStreamsSetup with ScalaCheckPropertyChecks
     override def out: Outlet[Outputs] = merge.out
   }
 
-  implicit def noShrink[T] = Shrink[T](_ => Stream.empty) // do not shrink failures, it only destroys evidence
+  implicit def noShrink[T]: Shrink[T] =
+    Shrink[T](_ => Stream.empty) // do not shrink failures, it only destroys evidence
 
   "MergeSorted" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LastSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LastSinkSpec.scala
@@ -10,10 +10,11 @@ import akka.stream.testkit.scaladsl.StreamTestKit._
 import scala.concurrent.duration._
 import scala.concurrent.Await
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContextExecutor
 
 class LastSinkSpec extends StreamSpec with ScriptedTest {
 
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
 
   "A Flow with Sink.last" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/QueueSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/QueueSinkSpec.scala
@@ -16,9 +16,10 @@ import scala.concurrent.Await
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
+import scala.concurrent.ExecutionContextExecutor
 
 class QueueSinkSpec extends StreamSpec {
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
 
   val ex = new RuntimeException("ex") with NoStackTrace
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/QueueSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/QueueSourceSpec.scala
@@ -22,11 +22,11 @@ import scala.concurrent._
 import scala.concurrent.duration._
 
 class QueueSourceSpec extends StreamSpec {
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
   val pause = 300.millis
 
   // more frequent checks than defaults from AkkaSpec
-  implicit val testPatience =
+  implicit val testPatience: PatienceConfig =
     PatienceConfig(testKitSettings.DefaultTimeout.duration, Span(5, org.scalatest.time.Millis))
 
   def assertSuccess(f: Future[QueueOfferResult]): Unit = {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
@@ -26,7 +26,7 @@ import scala.collection.immutable
 @silent // tests assigning to typed val
 class SourceSpec extends StreamSpec with DefaultTimeout {
 
-  implicit val config = PatienceConfig(timeout = Span(timeout.duration.toMillis, Millis))
+  implicit val config: PatienceConfig = PatienceConfig(timeout = Span(timeout.duration.toMillis, Millis))
 
   "Single Source" must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamConvertersSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamConvertersSpec.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration._
 
 class StreamConvertersSpec extends StreamSpec with DefaultTimeout {
 
-  implicit val config = PatienceConfig(timeout = Span(timeout.duration.toMillis, Millis))
+  implicit val config: PatienceConfig = PatienceConfig(timeout = Span(timeout.duration.toMillis, Millis))
 
   "Java Stream source" must {
     import java.util.stream.IntStream

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/TakeLastSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/TakeLastSinkSpec.scala
@@ -16,7 +16,7 @@ class TakeLastSinkSpec extends StreamSpec {
 
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val mat = ActorMaterializer(settings)
+  implicit val mat: ActorMaterializer = ActorMaterializer(settings)
 
   "Sink.takeLast" must {
     "return the last 3 elements" in {

--- a/akka-stream/src/main/scala/akka/stream/Attributes.scala
+++ b/akka-stream/src/main/scala/akka/stream/Attributes.scala
@@ -310,7 +310,7 @@ object Attributes {
 
   final case class LogLevels(onElement: Logging.LogLevel, onFinish: Logging.LogLevel, onFailure: Logging.LogLevel)
       extends Attribute
-  final case object AsyncBoundary extends Attribute
+  case object AsyncBoundary extends Attribute
 
   /**
    * Cancellation strategies provide a way to configure the behavior of a stage when `cancelStage` is called.

--- a/akka-stream/src/main/scala/akka/stream/QueueOfferResult.scala
+++ b/akka-stream/src/main/scala/akka/stream/QueueOfferResult.scala
@@ -14,7 +14,7 @@ object QueueOfferResult {
   /**
    * Type is used to indicate that stream is successfully enqueued an element
    */
-  final case object Enqueued extends QueueOfferResult
+  case object Enqueued extends QueueOfferResult
 
   /**
    * Java API: The `Enqueued` singleton instance
@@ -24,7 +24,7 @@ object QueueOfferResult {
   /**
    * Type is used to indicate that stream is dropped an element
    */
-  final case object Dropped extends QueueOfferResult
+  case object Dropped extends QueueOfferResult
 
   /**
    * Java API: The `Dropped` singleton instance

--- a/akka-stream/src/main/scala/akka/stream/SubstreamCancelStrategy.scala
+++ b/akka-stream/src/main/scala/akka/stream/SubstreamCancelStrategy.scala
@@ -16,12 +16,12 @@ private[akka] object SubstreamCancelStrategies {
   /**
    * INTERNAL API
    */
-  private[akka] final case object Propagate extends SubstreamCancelStrategy
+  private[akka] case object Propagate extends SubstreamCancelStrategy
 
   /**
    * INTERNAL API
    */
-  private[akka] final case object Drain extends SubstreamCancelStrategy
+  private[akka] case object Drain extends SubstreamCancelStrategy
 }
 
 object SubstreamCancelStrategy {

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
@@ -225,7 +225,7 @@ private[akka] class SubFusingActorMaterializerImpl(
  */
 @InternalApi private[akka] class StreamSupervisor(haveShutDown: AtomicBoolean) extends Actor {
   import akka.stream.impl.StreamSupervisor._
-  implicit val ec = context.dispatcher
+  implicit val ec: ExecutionContextExecutor = context.dispatcher
   override def supervisorStrategy: SupervisorStrategy = SupervisorStrategy.stoppingStrategy
 
   def receive: Receive = {

--- a/akka-stream/src/main/scala/akka/stream/impl/EmptySource.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/EmptySource.scala
@@ -12,7 +12,7 @@ import akka.stream.stage._
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] final object EmptySource extends GraphStage[SourceShape[Nothing]] {
+@InternalApi private[akka] object EmptySource extends GraphStage[SourceShape[Nothing]] {
   val out = Outlet[Nothing]("EmptySource.out")
   override val shape = SourceShape(out)
 

--- a/akka-stream/src/main/scala/akka/stream/impl/MaterializerGuardian.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/MaterializerGuardian.scala
@@ -22,7 +22,7 @@ import scala.concurrent.Promise
 @InternalApi
 private[akka] object MaterializerGuardian {
 
-  final case object StartMaterializer
+  case object StartMaterializer
   final case class MaterializerStarted(materializer: Materializer)
 
   // this is available to keep backwards compatibility with ActorMaterializer and should

--- a/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
@@ -180,7 +180,7 @@ import akka.util.unused
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] final case object PopAttributes extends Traversal
+@InternalApi private[akka] case object PopAttributes extends Traversal
 
 /**
  * INTERNAL API
@@ -190,7 +190,7 @@ import akka.util.unused
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] final case object ExitIsland extends Traversal
+@InternalApi private[akka] case object ExitIsland extends Traversal
 
 /**
  * INTERNAL API

--- a/akka-stream/src/main/scala/akka/stream/impl/streamref/StreamRefsProtocol.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/streamref/StreamRefsProtocol.scala
@@ -72,6 +72,6 @@ private[akka] object StreamRefsProtocol {
    * Ack that failure or completion has been seen and the remote side can stop
    */
   @InternalApi
-  private[akka] final case object Ack extends StreamRefsProtocol with DeadLetterSuppression
+  private[akka] case object Ack extends StreamRefsProtocol with DeadLetterSuppression
 
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
@@ -371,9 +371,8 @@ object Framing {
       extends GraphStage[FlowShape[ByteString, ByteString]] {
 
     //for the sake of binary compatibility
-    def this(lengthFieldLength: Int, lengthFieldOffset: Int, maximumFrameLength: Int, byteOrder: ByteOrder) {
+    def this(lengthFieldLength: Int, lengthFieldOffset: Int, maximumFrameLength: Int, byteOrder: ByteOrder) =
       this(lengthFieldLength, lengthFieldOffset, maximumFrameLength, byteOrder, None)
-    }
 
     private val minimumChunkSize = lengthFieldOffset + lengthFieldLength
     private val intDecoder = byteOrder match {

--- a/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/util/AkkaLoggerBridge.scala
+++ b/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/util/AkkaLoggerBridge.scala
@@ -17,7 +17,7 @@ final class AkkaLoggerFactory(system: ActorSystem) extends LoggerFactory {
 }
 
 class AkkaLoggerBridge(bus: EventStream, logSource: String, logClass: Class[_]) extends NoDepsLogger {
-  def this(bus: EventStream, clazz: Class[_]) { this(bus, clazz.getCanonicalName, clazz) }
+  def this(bus: EventStream, clazz: Class[_]) = this(bus, clazz.getCanonicalName, clazz)
 
   override def isDebugEnabled: Boolean = true
 

--- a/akka-testkit/src/main/scala/akka/testkit/CallingThreadDispatcher.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/CallingThreadDispatcher.scala
@@ -276,7 +276,7 @@ class CallingThreadDispatcher(_configurator: MessageDispatcherConfigurator) exte
         }
         if (handle ne null) {
           try {
-            if (Mailbox.debug) println(mbox.actor.self + " processing message " + handle)
+            if (Mailbox.debug) println("" + mbox.actor.self + " processing message " + handle)
             mbox.actor.invoke(handle)
             intex = checkThreadInterruption(intex)
             true

--- a/akka-testkit/src/main/scala/akka/testkit/SocketUtil.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/SocketUtil.scala
@@ -30,9 +30,9 @@ object SocketUtil {
   }
 
   sealed trait Protocol
-  final case object Tcp extends Protocol
-  final case object Udp extends Protocol
-  final case object Both extends Protocol
+  case object Tcp extends Protocol
+  case object Udp extends Protocol
+  case object Both extends Protocol
 
   /** @return A port on 'localhost' that is currently available */
   def temporaryLocalPort(udp: Boolean = false): Int = temporaryServerAddress("localhost", udp).getPort

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -964,7 +964,7 @@ trait TestKitBase {
  * @since 1.1
  */
 @silent // 'early initializers' are deprecated on 2.13 and will be replaced with trait parameters on 2.14. https://github.com/akka/akka/issues/26753
-class TestKit(_system: ActorSystem) extends { implicit val system = _system } with TestKitBase
+class TestKit(_system: ActorSystem) extends { implicit val system: ActorSystem = _system } with TestKitBase
 
 object TestKit {
 
@@ -1071,7 +1071,7 @@ object TestProbe {
 }
 
 trait ImplicitSender { this: TestKitBase =>
-  implicit def self = testActor
+  implicit def self: ActorRef = testActor
 }
 
 trait DefaultTimeout { this: TestKitBase =>

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -102,7 +102,7 @@ abstract class AkkaSpec(_system: ActorSystem)
     with TypeCheckedTripleEquals
     with ScalaFutures {
 
-  implicit val patience = PatienceConfig(testKitSettings.DefaultTimeout.duration, Span(100, Millis))
+  implicit val patience: PatienceConfig = PatienceConfig(testKitSettings.DefaultTimeout.duration, Span(100, Millis))
 
   def this(config: Config) =
     this(

--- a/akka-testkit/src/test/scala/akka/testkit/DefaultTimeoutSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/DefaultTimeoutSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class DefaultTimeoutSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with TestKitBase with DefaultTimeout {
 
-  implicit lazy val system = ActorSystem("AkkaCustomSpec")
+  implicit lazy val system: ActorSystem = ActorSystem("AkkaCustomSpec")
 
   override def afterAll = system.terminate
 

--- a/akka-testkit/src/test/scala/akka/testkit/ImplicitSenderSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/ImplicitSenderSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class ImplicitSenderSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with TestKitBase with ImplicitSender {
 
-  implicit lazy val system = ActorSystem("AkkaCustomSpec")
+  implicit lazy val system: ActorSystem = ActorSystem("AkkaCustomSpec")
 
   override def afterAll = system.terminate
 

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -142,7 +142,7 @@ object AkkaBuild {
          |implicit def _system = system
          |def startSystem(remoting: Boolean = false) { system = ActorSystem("repl", if(remoting) remoteConfig else config); println("don’t forget to system.terminate()!") }
          |implicit def ec = system.dispatcher
-         |implicit val timeout = Timeout(5 seconds)
+         |implicit val timeout: Timeout = Timeout(5 seconds)
          |""".stripMargin,
 
     /**

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -8,12 +8,10 @@ import sbt._
 import Keys.{ scalacOptions, _ }
 import sbt.plugins.JvmPlugin
 
-object AkkaDisciplinePlugin extends AutoPlugin with ScalafixSupport {
-
-  import scalafix.sbt.ScalafixPlugin
+object AkkaDisciplinePlugin extends AutoPlugin {
 
   override def trigger: PluginTrigger = allRequirements
-  override def requires: Plugins = JvmPlugin && ScalafixPlugin
+  override def requires: Plugins = JvmPlugin
   override lazy val projectSettings = disciplineSettings
 
   // allow toggling for pocs/exploration of ideas without discpline

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,7 @@ package akka
 
 import sbt._
 import Keys._
+import scala.language.implicitConversions
 
 object Dependencies {
   import DependencyHelpers._

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,7 +69,7 @@ object Dependencies {
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion // CC0
 
     // ssl-config
-    val sslConfigCore = Def.setting { "com.typesafe" %% "ssl-config-core" % sslConfigVersion } // ApacheV2
+    val sslConfigCore = "com.typesafe" %% "ssl-config-core" % sslConfigVersion // ApacheV2
 
     val lmdb = "org.lmdbjava" % "lmdbjava" % "0.7.0" // ApacheV2, OpenLDAP Public License
 
@@ -275,7 +275,7 @@ object Dependencies {
 
   // akka stream
 
-  lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, sslConfigCore.value, Test.scalatest)
+  lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, sslConfigCore, Test.scalatest)
 
   lazy val streamTestkit = l ++= Seq(Test.scalatest, Test.scalacheck, Test.junit)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.5.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.6")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.11")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.14")
 // sbt-osgi 0.9.5 is available but breaks including jdk9-only classes
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.4")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.7.0")


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #28835, #28837

I split #28837 to some PRs.
This is the first PR & only:
+ Add dotty support to sbt.
Sbt settings are only changed if `scalaVersion` is dotty, ex by adding `-Dakka.build.scalaVersion=0.24.0-bin-20200408-4cc224b-NIGHTLY` when running sbt.
+ Source & binary compatible changes

**EDIT: I change this PR to only include changes by running scalafix rules**
_(and some obvious sbt changes)_
