### PR TITLE
fix wrong ActorSystem name when using MultiNodeClusterShardingSpec #28953

### DIFF
--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testkit/MultiNodeSpec.scala
@@ -245,15 +245,6 @@ object MultiNodeSpec {
     ConfigFactory.parseMap(map.asJava)
   }
 
-  private def getCallerName(clazz: Class[_]): String = {
-    val pattern = s"(akka\\.remote\\.testkit\\.MultiNodeSpec.*|akka\\.remote\\.RemotingMultiNodeSpec)"
-    val s = Thread.currentThread.getStackTrace.map(_.getClassName).drop(1).dropWhile(_.matches(pattern))
-    val reduced = s.lastIndexWhere(_ == clazz.getName) match {
-      case -1 => s
-      case z  => s.drop(z + 1)
-    }
-    reduced.head.replaceFirst(""".*\.""", "").replaceAll("[^a-zA-Z_0-9]", "_")
-  }
 }
 
 /**
@@ -284,7 +275,7 @@ abstract class MultiNodeSpec(
 
   def this(config: MultiNodeConfig) =
     this(config, {
-      val name = MultiNodeSpec.getCallerName(classOf[MultiNodeSpec])
+      val name = TestKitUtils.testNameFromCallStack(classOf[MultiNodeSpec], "".r)
       config =>
         try {
           ActorSystem(name, config)

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamSpec.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/StreamSpec.scala
@@ -10,22 +10,23 @@ import akka.stream.snapshot.{ MaterializerState, StreamSnapshotImpl }
 import akka.testkit.{ AkkaSpec, TestProbe }
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.Failed
-
 import scala.concurrent.Future
 import scala.concurrent.duration._
+
+import akka.testkit.TestKitUtils
 
 abstract class StreamSpec(_system: ActorSystem) extends AkkaSpec(_system) {
   def this(config: Config) =
     this(
       ActorSystem(
-        AkkaSpec.testNameFromCallStack(classOf[StreamSpec]),
+        TestKitUtils.testNameFromCallStack(classOf[StreamSpec], "".r),
         ConfigFactory.load(config.withFallback(AkkaSpec.testConf))))
 
   def this(s: String) = this(ConfigFactory.parseString(s))
 
   def this(configMap: Map[String, _]) = this(AkkaSpec.mapToConfig(configMap))
 
-  def this() = this(ActorSystem(AkkaSpec.testNameFromCallStack(classOf[StreamSpec]), AkkaSpec.testConf))
+  def this() = this(ActorSystem(TestKitUtils.testNameFromCallStack(classOf[StreamSpec], "".r), AkkaSpec.testConf))
 
   override def withFixture(test: NoArgTest) = {
     super.withFixture(test) match {

--- a/akka-testkit/src/main/scala/akka/testkit/TestKitUtils.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKitUtils.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.testkit
+
+import java.lang.reflect.Modifier
+
+import scala.util.matching.Regex
+
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] object TestKitUtils {
+
+  def testNameFromCallStack(classToStartFrom: Class[_], testKitRegex: Regex): String = {
+
+    def isAbstractClass(className: String): Boolean = {
+      try {
+        Modifier.isAbstract(Class.forName(className).getModifiers)
+      } catch {
+        case _: Throwable => false // yes catch everything, best effort check
+      }
+    }
+
+    val startFrom = classToStartFrom.getName
+    val filteredStack = Thread.currentThread.getStackTrace.iterator
+      .map(_.getClassName)
+      // drop until we find the first occurrence of classToStartFrom
+      .dropWhile(!_.startsWith(startFrom))
+      // then continue to the next entry after classToStartFrom that makes sense
+      .dropWhile {
+        case `startFrom`                            => true
+        case str if str.startsWith(startFrom + "$") => true // lambdas inside startFrom etc
+        case testKitRegex()                         => true // testkit internals
+        case str if isAbstractClass(str)            => true
+        case _                                      => false
+      }
+
+    if (filteredStack.isEmpty)
+      throw new IllegalArgumentException(s"Couldn't find [${classToStartFrom.getName}] in call stack")
+
+    // sanitize for actor system name
+    scrubActorSystemName(filteredStack.next())
+  }
+
+  /**
+   * Sanitize the `name` to be used as valid actor system name by
+   * replacing invalid characters. `name` may for example be a fully qualified
+   * class name and then the short class name will be used.
+   */
+  def scrubActorSystemName(name: String): String = {
+    name
+      .replaceFirst("""^.*\.""", "") // drop package name
+      .replaceAll("""\$\$?\w+""", "") // drop scala anonymous functions/classes
+      .replaceAll("[^a-zA-Z_0-9]", "_")
+  }
+}

--- a/akka-testkit/src/main/scala/akka/testkit/TestKitUtils.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKitUtils.scala
@@ -57,5 +57,6 @@ private[akka] object TestKitUtils {
       .replaceFirst("""^.*\.""", "") // drop package name
       .replaceAll("""\$\$?\w+""", "") // drop scala anonymous functions/classes
       .replaceAll("[^a-zA-Z_0-9]", "_")
+      .replaceAll("""MultiJvmNode\d+""", "") // drop MultiJvm suffix
   }
 }

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -4,8 +4,6 @@
 
 package akka.testkit
 
-import java.lang.reflect.Modifier
-
 import akka.actor.ActorSystem
 import akka.dispatch.Dispatchers
 import akka.event.Logging
@@ -43,54 +41,13 @@ object AkkaSpec {
           }
         }
       }
-                                                    """)
+      """)
 
   def mapToConfig(map: Map[String, Any]): Config = {
     import akka.util.ccompat.JavaConverters._
     ConfigFactory.parseMap(map.asJava)
   }
 
-  def testNameFromCallStack(classToStartFrom: Class[_]): String = {
-
-    def isAbstractClass(className: String): Boolean = {
-      try {
-        Modifier.isAbstract(Class.forName(className).getModifiers)
-      } catch {
-        case _: Throwable => false // yes catch everything, best effort check
-      }
-    }
-
-    val startFrom = classToStartFrom.getName
-    val filteredStack = Thread.currentThread.getStackTrace.iterator
-      .map(_.getClassName)
-      // drop until we find the first occurrence of classToStartFrom
-      .dropWhile(!_.startsWith(startFrom))
-      // then continue to the next entry after classToStartFrom that makes sense
-      .dropWhile {
-        case `startFrom`                            => true
-        case str if str.startsWith(startFrom + "$") => true // lambdas inside startFrom etc
-        case str if isAbstractClass(str)            => true
-        case _                                      => false
-      }
-
-    if (filteredStack.isEmpty)
-      throw new IllegalArgumentException(s"Couldn't find [${classToStartFrom.getName}] in call stack")
-
-    // sanitize for actor system name
-    scrubActorSystemName(filteredStack.next())
-  }
-
-  /**
-   * Sanitize the `name` to be used as valid actor system name by
-   * replacing invalid characters. `name` may for example be a fully qualified
-   * class name and then the short class name will be used.
-   */
-  def scrubActorSystemName(name: String): String = {
-    name
-      .replaceFirst("""^.*\.""", "") // drop package name
-      .replaceAll("""\$\$?\w+""", "") // drop scala anonymous functions/classes
-      .replaceAll("[^a-zA-Z_0-9]", "_")
-  }
 }
 
 abstract class AkkaSpec(_system: ActorSystem)
@@ -107,14 +64,14 @@ abstract class AkkaSpec(_system: ActorSystem)
   def this(config: Config) =
     this(
       ActorSystem(
-        AkkaSpec.testNameFromCallStack(classOf[AkkaSpec]),
+        TestKitUtils.testNameFromCallStack(classOf[AkkaSpec], "".r),
         ConfigFactory.load(config.withFallback(AkkaSpec.testConf))))
 
   def this(s: String) = this(ConfigFactory.parseString(s))
 
   def this(configMap: Map[String, _]) = this(AkkaSpec.mapToConfig(configMap))
 
-  def this() = this(ActorSystem(AkkaSpec.testNameFromCallStack(classOf[AkkaSpec]), AkkaSpec.testConf))
+  def this() = this(ActorSystem(TestKitUtils.testNameFromCallStack(classOf[AkkaSpec], "".r), AkkaSpec.testConf))
 
   val log: LoggingAdapter = Logging(system, this.getClass)
 


### PR DESCRIPTION
* use same testNameFromCallStack everywhere

References #28953
