### PR TITLE
Update sbt-java-formatter to 0.5.1 and disable javafmt on compile

### DIFF
--- a/project/JavaFormatter.scala
+++ b/project/JavaFormatter.scala
@@ -4,7 +4,7 @@
 
 import akka.ProjectFileIgnoreSupport
 import com.lightbend.sbt.JavaFormatterPlugin
-import sbt.{AutoPlugin, PluginTrigger, Plugins}
+import sbt.{ AutoPlugin, PluginTrigger, Plugins }
 
 object JavaFormatter extends AutoPlugin {
 
@@ -15,6 +15,8 @@ object JavaFormatter extends AutoPlugin {
   private val ignoreConfigFileName: String = ".sbt-java-formatter.conf"
   private val descriptor: String = "sbt-java-formatter"
 
+  private val formatOnCompile = !sys.props.contains("akka.no.discipline")
+
   import JavaFormatterPlugin.autoImport._
   import sbt.Keys._
   import sbt._
@@ -23,9 +25,10 @@ object JavaFormatter extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     //below is for sbt java formatter
     (excludeFilter in javafmt) := {
-      val ignoreSupport = new ProjectFileIgnoreSupport((baseDirectory in ThisBuild).value / ignoreConfigFileName, descriptor)
+      val ignoreSupport =
+        new ProjectFileIgnoreSupport((baseDirectory in ThisBuild).value / ignoreConfigFileName, descriptor)
       val simpleFileFilter = new SimpleFileFilter(file => ignoreSupport.isIgnoredByFileOrPackages(file))
       simpleFileFilter || (excludeFilter in javafmt).value
-    }
-  )
+    },
+    javafmtOnCompile := formatOnCompile)
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ libraryDependencies += Defaults.sbtPluginExtra(
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 //#sbt-multi-jvm
 
-addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.5.0")
+addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.5.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.6")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.14")
 // sbt-osgi 0.9.5 is available but breaks including jdk9-only classes


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/akka/akka/issues/28951

sbt-java-formatter `0.5.1` introduces configuration for on compile formatting, thought about adding a flag that would allow toggling it, similar to what's done with discipline plugin, but then figured that maybe disabling it all together is a better solution, makes it uniform with how Scala sources are formatted.
