### PR TITLE
Automated signature-to-apidoc replacement (first batch)

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/FileIO/fromFile.md
+++ b/akka-docs/src/main/paradox/stream/operators/FileIO/fromFile.md
@@ -10,13 +10,10 @@ The `fromFile` operator has been deprecated, use @ref:[fromPath](./fromPath.md) 
 
 @@@
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [FileIO.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/FileIO.scala) { #fromFile }
+@apidoc[FileIO.fromFile](FileIO$) { scala="#fromFile(f:java.io.File,chunkSize:Int):akka.stream.scaladsl.Source[akka.util.ByteString,scala.concurrent.Future[akka.stream.IOResult]]" java="#fromFile(java.io.File)" java="#fromFile(java.io.File,int)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/FileIO/fromPath.md
+++ b/akka-docs/src/main/paradox/stream/operators/FileIO/fromPath.md
@@ -4,13 +4,10 @@ Emits the contents of a file from the given path.
 
 @ref[File IO Sinks and Sources](../index.md#file-io-sinks-and-sources)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [FileIO.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/FileIO.scala) { #fromPath }
+@apidoc[FileIO.fromPath](FileIO$) { scala="#fromPath(f:java.nio.file.Path,chunkSize:Int,startPosition:Long):akka.stream.scaladsl.Source[akka.util.ByteString,scala.concurrent.Future[akka.stream.IOResult]]" java="#fromPath(java.nio.file.Path,int,long)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/FileIO/toFile.md
+++ b/akka-docs/src/main/paradox/stream/operators/FileIO/toFile.md
@@ -10,13 +10,10 @@ The `toFile` operator has been deprecated, use @ref:[toPath](./toPath.md) instea
 
 @@@
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [FileIO.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/FileIO.scala) { #toFile }
+@apidoc[FileIO.toFile](FileIO$) { scala="#toFile(f:java.io.File,options:Set[java.nio.file.OpenOption]):akka.stream.scaladsl.Sink[akka.util.ByteString,scala.concurrent.Future[akka.stream.IOResult]]" java="#toFile(java.io.File,java.util.Set)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/FileIO/toPath.md
+++ b/akka-docs/src/main/paradox/stream/operators/FileIO/toPath.md
@@ -4,13 +4,10 @@ Create a sink which will write incoming `ByteString` s to a given file path.
 
 @ref[File IO Sinks and Sources](../index.md#file-io-sinks-and-sources)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [FileIO.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/FileIO.scala) { #toPath }
+@apidoc[FileIO.toPath](FileIO$) { scala="#toPath(f:java.nio.file.Path,options:Set[java.nio.file.OpenOption],startPosition:Long):akka.stream.scaladsl.Sink[akka.util.ByteString,scala.concurrent.Future[akka.stream.IOResult]]" java="#toPath(java.nio.file.Path,java.util.Set,long)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Flow/asFlowWithContext.md
+++ b/akka-docs/src/main/paradox/stream/operators/Flow/asFlowWithContext.md
@@ -4,13 +4,10 @@ Turns a Flow into a FlowWithContext which can propagate a context per element al
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #asFlowWithContext }
+@apidoc[Flow.asFlowWithContext](Flow) { scala="#asFlowWithContext[U,CtxU,CtxOut](collapseContext:(U,CtxU)=&gt;In)(extractContext:Out=&gt;CtxOut):akka.stream.scaladsl.FlowWithContext[U,CtxU,Out,CtxOut,Mat]" java="#asFlowWithContext(akka.japi.function.Function2,akka.japi.function.Function)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Flow/completionStageFlow.md
+++ b/akka-docs/src/main/paradox/stream/operators/Flow/completionStageFlow.md
@@ -4,13 +4,10 @@ Streams the elements through the given future flow once it successfully complete
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #futureFlow }
+@apidoc[Flow.completionStageFlow](Flow$) { java="#completionStageFlow(java.util.concurrent.CompletionStage)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Flow/futureFlow.md
+++ b/akka-docs/src/main/paradox/stream/operators/Flow/futureFlow.md
@@ -4,13 +4,10 @@ Streams the elements through the given future flow once it successfully complete
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #futureFlow }
+@apidoc[Flow.futureFlow](Flow$) { scala="#futureFlow[I,O,M](flow:scala.concurrent.Future[akka.stream.scaladsl.Flow[I,O,M]]):akka.stream.scaladsl.Flow[I,O,scala.concurrent.Future[M]]" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Flow/lazyFlow.md
+++ b/akka-docs/src/main/paradox/stream/operators/Flow/lazyFlow.md
@@ -4,13 +4,10 @@ Defers creation and materialization of a `Flow` until there is a first element.
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #lazyFlow }
+@apidoc[Flow.lazyFlow](Flow$) { scala="#lazyFlow[I,O,M](create:()=&gt;akka.stream.scaladsl.Flow[I,O,M]):akka.stream.scaladsl.Flow[I,O,scala.concurrent.Future[M]]" java="#lazyFlow(akka.japi.function.Creator)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Flow/lazyFutureFlow.md
+++ b/akka-docs/src/main/paradox/stream/operators/Flow/lazyFutureFlow.md
@@ -4,13 +4,10 @@ Defers creation and materialization of a `Flow` until there is a first element.
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #lazyFlow }
+@apidoc[Flow.lazyFutureFlow](Flow$) { scala="#lazyFutureFlow[I,O,M](create:()=&gt;scala.concurrent.Future[akka.stream.scaladsl.Flow[I,O,M]]):akka.stream.scaladsl.Flow[I,O,scala.concurrent.Future[M]]" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Flow/lazyInitAsync.md
+++ b/akka-docs/src/main/paradox/stream/operators/Flow/lazyInitAsync.md
@@ -4,13 +4,9 @@ Deprecated by @ref:[`Flow.lazyFutureFlow`](lazyFutureFlow.md) in combination wit
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #lazyInitAsync }
-
-@@@
+@apidoc[Flow.lazyInitAsync](Flow$) { scala="#lazyInitAsync[I,O,M](flowFactory:()=&gt;scala.concurrent.Future[akka.stream.scaladsl.Flow[I,O,M]]):akka.stream.scaladsl.Flow[I,O,scala.concurrent.Future[Option[M]]]" java="#lazyInitAsync(akka.japi.function.Creator)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/RestartFlow/onFailuresWithBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartFlow/onFailuresWithBackoff.md
@@ -4,13 +4,10 @@ Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it f
 
 @ref[Error handling](../index.md#error-handling)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [RestartFlow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala) { #onFailuresWithBackoff }
+@apidoc[RestartFlow.onFailuresWithBackoff](RestartFlow$) { scala="#onFailuresWithBackoff[In,Out](minBackoff:scala.concurrent.duration.FiniteDuration,maxBackoff:scala.concurrent.duration.FiniteDuration,randomFactor:Double,maxRestarts:Int)(flowFactory:()=&gt;akka.stream.scaladsl.Flow[In,Out,_]):akka.stream.scaladsl.Flow[In,Out,akka.NotUsed]" java="#onFailuresWithBackoff(java.time.Duration,java.time.Duration,double,int,akka.japi.function.Creator)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/RestartSource/onFailuresWithBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartSource/onFailuresWithBackoff.md
@@ -4,13 +4,9 @@ Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when 
 
 @ref[Error handling](../index.md#error-handling)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [RestartSource.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSource.scala) { #onFailuresWithBackoff }
-
-@@@
+@apidoc[RestartSource.onFailuresWithBackoff](RestartSource$) { scala="#onFailuresWithBackoff[T](minBackoff:scala.concurrent.duration.FiniteDuration,maxBackoff:scala.concurrent.duration.FiniteDuration,randomFactor:Double)(sourceFactory:()=&gt;akka.stream.scaladsl.Source[T,_]):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#onFailuresWithBackoff(java.time.Duration,java.time.Duration,double,int,akka.japi.function.Creator)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/RetryFlow/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RetryFlow/withBackoff.md
@@ -4,17 +4,13 @@ Wrap the given @apidoc[Flow] and retry individual elements in that stream with a
 
 @ref[Error handling](../index.md#error-handling)
 
+@@@div { .group-scala }
+
 ## Signature
 
-Scala
-:   @@signature [RetryFlow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala) { #withBackoff }
+@@signature [RetryFlow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala) { #withBackoff }
 
-Java
-:   @@snip [RetryFlowTest.java](/akka-stream-tests/src/test/java/akka/stream/javadsl/RetryFlowTest.java) { #withBackoff-signature }
-
-## API documentation
-
-@apidoc[RetryFlow$]
+@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/RetryFlow/withBackoffAndContext.md
+++ b/akka-docs/src/main/paradox/stream/operators/RetryFlow/withBackoffAndContext.md
@@ -4,14 +4,13 @@ Wrap the given @apidoc[FlowWithContext] and retry individual elements in that st
 
 @ref[Error handling](../index.md#error-handling)
 
+@@@div { .group-scala }
+
 ## Signature
 
-Scala
-:   @@signature [RetryFlow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala) { #withBackoffAndContext }
+@@signature [RetryFlow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala) { #withBackoffAndContext }
 
-Java
-:   @@snip [RetryFlowTest.java](/akka-stream-tests/src/test/java/akka/stream/javadsl/RetryFlowTest.java) { #signature }
-
+@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/RetryFlow/withBackoffAndContext.md
+++ b/akka-docs/src/main/paradox/stream/operators/RetryFlow/withBackoffAndContext.md
@@ -4,13 +4,10 @@ Wrap the given @apidoc[FlowWithContext] and retry individual elements in that st
 
 @ref[Error handling](../index.md#error-handling)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [RetryFlow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala) { #withBackoffAndContext }
+@apidoc[RetryFlow.withBackoffAndContext](RetryFlow$) { scala="#withBackoffAndContext[In,CtxIn,Out,CtxOut,Mat](minBackoff:scala.concurrent.duration.FiniteDuration,maxBackoff:scala.concurrent.duration.FiniteDuration,randomFactor:Double,maxRetries:Int,flow:akka.stream.scaladsl.FlowWithContext[In,CtxIn,Out,CtxOut,Mat])(decideRetry:((In,CtxIn),(Out,CtxOut))=&gt;Option[(In,CtxIn)]):akka.stream.scaladsl.FlowWithContext[In,CtxIn,Out,CtxOut,Mat]" java="#withBackoffAndContext(java.time.Duration,java.time.Duration,double,int,akka.stream.javadsl.FlowWithContext,akka.japi.function.Function2)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/actorRef.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/actorRef.md
@@ -4,10 +4,11 @@ Send the elements from the stream to an `ActorRef`.
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@ div { .group-scala }
+@@@div { .group-scala }
 ## Signature
 
 @@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #actorRef }
+
 @@@
 
 ## Description

--- a/akka-docs/src/main/paradox/stream/operators/Sink/asPublisher.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/asPublisher.md
@@ -4,13 +4,10 @@ Integration with Reactive Streams, materializes into a `org.reactivestreams.Publ
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@ div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #asPublisher }
+@apidoc[Sink.asPublisher](Sink$) { scala="#asPublisher[T](fanout:Boolean):akka.stream.scaladsl.Sink[T,org.reactivestreams.Publisher[T]]" java="#asPublisher(akka.stream.javadsl.AsPublisher)" }
 
-@@@
 
 
 ## Description

--- a/akka-docs/src/main/paradox/stream/operators/Sink/cancelled.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/cancelled.md
@@ -4,13 +4,10 @@ Immediately cancel the stream
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #cancelled }
+@apidoc[Sink.cancelled](Sink$) { scala="#cancelled[T]:akka.stream.scaladsl.Sink[T,akka.NotUsed]" java="#cancelled()" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/collection.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/collection.md
@@ -10,6 +10,8 @@
 
 @@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #collection }
 
+@@@
+
 ## Description
 
 @scala[Collect values emitted from the stream into an arbitrary collection `That`. The resulting collection is available through a `Future[That]` or when the stream completes. Note that the collection boundaries are those defined in the `CanBuildFrom` associated with the chosen collection. See [The Architecture of Scala 2.13's Collections](https://docs.scala-lang.org/overviews/core/architecture-of-scala-213-collections.html) for more info. The [`seq`](seq.html) operator is a shorthand for `Sink.collection[T, Vector[T]]`.]@java[Operator only available in the Scala API. The closest operator in the Java API is [`Sink.seq`](seq.html).]

--- a/akka-docs/src/main/paradox/stream/operators/Sink/fold.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/fold.md
@@ -4,13 +4,9 @@ Fold over emitted element with a function, where each invocation will get the ne
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #fold }
-
-@@@
+@apidoc[Sink.fold](Sink$) { scala="#fold[U,T](zero:U)(f:(U,T)=&gt;U):akka.stream.scaladsl.Sink[T,scala.concurrent.Future[U]]" java="#fold(java.lang.Object,akka.japi.function.Function2)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/foreachAsync.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/foreachAsync.md
@@ -4,13 +4,10 @@ Invoke a given procedure asynchronously for each element received.
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #foreachAsync }
+@apidoc[Sink.foreachAsync](Sink$) { scala="#foreachAsync[T](parallelism:Int)(f:T=&gt;scala.concurrent.Future[Unit]):akka.stream.scaladsl.Sink[T,scala.concurrent.Future[akka.Done]]" java="#foreachAsync(int,akka.japi.function.Function)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/fromMaterializer.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/fromMaterializer.md
@@ -9,6 +9,7 @@ Defer the creation of a `Sink` until materialization and access `Materializer` a
 ## Signature
 
 @@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #fromMaterializer }
+
 @@@
 
 ## Description

--- a/akka-docs/src/main/paradox/stream/operators/Sink/fromSubscriber.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/fromSubscriber.md
@@ -4,13 +4,10 @@ Integration with Reactive Streams, wraps a `org.reactivestreams.Subscriber` as a
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #fromSubscriber }
+@apidoc[Sink.fromSubscriber](Sink$) { scala="#fromSubscriber[T](subscriber:org.reactivestreams.Subscriber[T]):akka.stream.scaladsl.Sink[T,akka.NotUsed]" java="#fromSubscriber(org.reactivestreams.Subscriber)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/futureSink.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/futureSink.md
@@ -4,13 +4,10 @@ Streams the elements to the given future sink once it successfully completes.
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #futureSink }
+@apidoc[Sink.futureSink](Sink$) { scala="#futureSink[T,M](future:scala.concurrent.Future[akka.stream.scaladsl.Sink[T,M]]):akka.stream.scaladsl.Sink[T,scala.concurrent.Future[M]]" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/head.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/head.md
@@ -4,13 +4,10 @@ Materializes into a @scala[`Future`] @java[`CompletionStage`] which completes wi
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #head }
+@apidoc[Sink.head](Sink$) { scala="#head[T]:akka.stream.scaladsl.Sink[T,scala.concurrent.Future[T]]" java="#head()" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/headOption.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/headOption.md
@@ -4,13 +4,10 @@ Materializes into a @scala[`Future[Option[T]]`] @java[`CompletionStage<Optional<
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #headOption }
+@apidoc[Sink.headOption](Sink$) { scala="#headOption[T]:akka.stream.scaladsl.Sink[T,scala.concurrent.Future[Option[T]]]" java="#headOption()" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/ignore.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/ignore.md
@@ -4,13 +4,10 @@ Consume all elements but discards them.
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #ignore }
+@apidoc[Sink.ignore](Sink$) { java="#ignore()" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/last.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/last.md
@@ -4,13 +4,10 @@ Materializes into a @scala[`Future`] @java[`CompletionStage`] which will complet
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #last }
+@apidoc[Sink.last](Sink$) { scala="#last[T]:akka.stream.scaladsl.Sink[T,scala.concurrent.Future[T]]" java="#last()" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/lastOption.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/lastOption.md
@@ -4,13 +4,10 @@ Materialize a @scala[`Future[Option[T]]`] @java[`CompletionStage<Optional<T>>`] 
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #lastOption }
+@apidoc[Sink.lastOption](Sink$) { scala="#lastOption[T]:akka.stream.scaladsl.Sink[T,scala.concurrent.Future[Option[T]]]" java="#lastOption()" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/lazyFutureSink.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/lazyFutureSink.md
@@ -4,13 +4,10 @@ Defers creation and materialization of a `Sink` until there is a first element.
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #lazySink }
+@apidoc[Sink.lazyFutureSink](Sink$) { scala="#lazyFutureSink[T,M](create:()=&gt;scala.concurrent.Future[akka.stream.scaladsl.Sink[T,M]]):akka.stream.scaladsl.Sink[T,scala.concurrent.Future[M]]" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/lazyInitAsync.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/lazyInitAsync.md
@@ -4,13 +4,11 @@ Deprecated by @ref:[`Sink.lazyFutureSink`](lazyFutureSink.md).
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #lazyInitAsync }
+@apidoc[Flow.lazyInitAsync](Flow$) { scala="#lazyInitAsync[I,O,M](flowFactory:()=&gt;scala.concurrent.Future[akka.stream.scaladsl.Flow[I,O,M]]):akka.stream.scaladsl.Flow[I,O,scala.concurrent.Future[Option[M]]]" java="#lazyInitAsync(akka.japi.function.Creator)" }
+@apidoc[Sink.lazyInitAsync](Sink$) { scala="#lazyInitAsync[T,M](sinkFactory:()=&gt;scala.concurrent.Future[akka.stream.scaladsl.Sink[T,M]]):akka.stream.scaladsl.Sink[T,scala.concurrent.Future[Option[M]]]" java="#lazyInitAsync(akka.japi.function.Creator)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/lazySink.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/lazySink.md
@@ -4,13 +4,10 @@ Defers creation and materialization of a `Sink` until there is a first element.
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #lazySink }
+@apidoc[Sink.lazySink](Sink$) { scala="#lazySink[T,M](create:()=&gt;akka.stream.scaladsl.Sink[T,M]):akka.stream.scaladsl.Sink[T,scala.concurrent.Future[M]]" java="#lazySink(akka.japi.function.Creator)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/onComplete.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/onComplete.md
@@ -4,13 +4,10 @@ Invoke a callback when the stream has completed or failed.
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #onComplete }
+@apidoc[Sink.onComplete](Sink$) { scala="#onComplete[T](callback:scala.util.Try[akka.Done]=&gt;Unit):akka.stream.scaladsl.Sink[T,akka.NotUsed]" java="#onComplete(akka.japi.function.Procedure)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/preMaterialize.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/preMaterialize.md
@@ -4,13 +4,10 @@ Materializes this Sink, immediately returning (1) its materialized value, and (2
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #preMaterialize }
+@apidoc[Sink.preMaterialize](Sink) { scala="#preMaterialize()(implicitmaterializer:akka.stream.Materializer):(Mat,akka.stream.scaladsl.Sink[In,akka.NotUsed])" java="#preMaterialize(akka.actor.ClassicActorSystemProvider)" java="#preMaterialize(akka.stream.Materializer)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/reduce.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/reduce.md
@@ -4,13 +4,10 @@ Apply a reduction function on the incoming elements and pass the result to the n
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #reduce }
+@apidoc[Sink.reduce](Sink$) { scala="#reduce[T](f:(T,T)=&gt;T):akka.stream.scaladsl.Sink[T,scala.concurrent.Future[T]]" java="#reduce(akka.japi.function.Function2)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/seq.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/seq.md
@@ -4,13 +4,10 @@ Collect values emitted from the stream into a collection.
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #seq }
+@apidoc[Sink.seq](Sink$) { scala="#seq[T]:akka.stream.scaladsl.Sink[T,scala.concurrent.Future[scala.collection.immutable.Seq[T]]]" java="#seq()" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/setup.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/setup.md
@@ -15,6 +15,7 @@ The `setup` operator has been deprecated, use @ref:[fromMaterializer](./fromMate
 ## Signature
 
 @@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #setup }
+
 @@@
 
 ## Description

--- a/akka-docs/src/main/paradox/stream/operators/Sink/takeLast.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/takeLast.md
@@ -4,13 +4,10 @@ Collect the last `n` values emitted from the stream into a collection.
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #takeLast }
+@apidoc[Sink.takeLast](Sink$) { scala="#takeLast[T](n:Int):akka.stream.scaladsl.Sink[T,scala.concurrent.Future[scala.collection.immutable.Seq[T]]]" java="#takeLast(int)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/backpressureTimeout.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/backpressureTimeout.md
@@ -4,11 +4,11 @@ If the time between the emission of an element and the following downstream dema
 
 @ref[Time aware operators](../index.md#time-aware-operators)
 
-@@@ div { .group-scala }
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #backpressureTimeout }
-@@@
+@apidoc[Source.backpressureTimeout](Source) { scala="#backpressureTimeout(timeout:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Out]" java="#backpressureTimeout(java.time.Duration)" }
+@apidoc[Flow.backpressureTimeout](Flow) { scala="#backpressureTimeout(timeout:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Out]" java="#backpressureTimeout(java.time.Duration)" }
+
 
 
 ## Description

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/batch.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/batch.md
@@ -4,11 +4,11 @@ Allow for a slower downstream by passing incoming elements and a summary into an
 
 @ref[Backpressure aware operators](../index.md#backpressure-aware-operators)
 
-@@@ div { .group-scala }
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #batch }
-@@@
+@apidoc[Source.batch](Source) { scala="#batch[S](max:Long,seed:Out=&gt;S)(aggregate:(S,Out)=&gt;S):FlowOps.this.Repr[S]" java="#batch(long,akka.japi.function.Function,akka.japi.function.Function2)" }
+@apidoc[Flow.batch](Flow) { scala="#batch[S](max:Long,seed:Out=&gt;S)(aggregate:(S,Out)=&gt;S):FlowOps.this.Repr[S]" java="#batch(long,akka.japi.function.Function,akka.japi.function.Function2)" }
+
 
 
 ## Description

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/collectType.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/collectType.md
@@ -4,13 +4,11 @@ Transform this stream by testing the type of each of the elements on which the e
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #collectType }
+@apidoc[Source.collectType](Source) { scala="#collectType[T](implicittag:scala.reflect.ClassTag[T]):FlowOps.this.Repr[T]" java="#collectType(java.lang.Class)" }
+@apidoc[Flow.collectType](Flow) { scala="#collectType[T](implicittag:scala.reflect.ClassTag[T]):FlowOps.this.Repr[T]" java="#collectType(java.lang.Class)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/conflate.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/conflate.md
@@ -4,13 +4,11 @@ Allow for a slower downstream by passing incoming elements and a summary into an
 
 @ref[Backpressure aware operators](../index.md#backpressure-aware-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #conflate }
+@apidoc[Source.conflate](Source) { scala="#conflate[O2&gt;:Out](aggregate:(O2,O2)=&gt;O2):FlowOps.this.Repr[O2]" java="#conflate(akka.japi.function.Function2)" }
+@apidoc[Flow.conflate](Flow) { scala="#conflate[O2&gt;:Out](aggregate:(O2,O2)=&gt;O2):FlowOps.this.Repr[O2]" java="#conflate(akka.japi.function.Function2)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/conflateWithSeed.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/conflateWithSeed.md
@@ -4,13 +4,11 @@ Allow for a slower downstream by passing incoming elements and a summary into an
 
 @ref[Backpressure aware operators](../index.md#backpressure-aware-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #conflateWithSeed }
+@apidoc[Source.conflateWithSeed](Source) { scala="#conflateWithSeed[S](seed:Out=&gt;S)(aggregate:(S,Out)=&gt;S):FlowOps.this.Repr[S]" java="#conflateWithSeed(akka.japi.function.Function,akka.japi.function.Function2)" }
+@apidoc[Flow.conflateWithSeed](Flow) { scala="#conflateWithSeed[S](seed:Out=&gt;S)(aggregate:(S,Out)=&gt;S):FlowOps.this.Repr[S]" java="#conflateWithSeed(akka.japi.function.Function,akka.japi.function.Function2)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/delay.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/delay.md
@@ -4,13 +4,11 @@ Delay every element passed through with a specific duration.
 
 @ref[Timer driven operators](../index.md#timer-driven-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #delay }
+@apidoc[Source.delay](Source) { scala="#delay(of:scala.concurrent.duration.FiniteDuration,strategy:akka.stream.DelayOverflowStrategy):FlowOps.this.Repr[Out]" java="#delay(java.time.Duration,akka.stream.DelayOverflowStrategy)" }
+@apidoc[Flow.delay](Flow) { scala="#delay(of:scala.concurrent.duration.FiniteDuration,strategy:akka.stream.DelayOverflowStrategy):FlowOps.this.Repr[Out]" java="#delay(java.time.Duration,akka.stream.DelayOverflowStrategy)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/delayWith.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/delayWith.md
@@ -4,13 +4,11 @@ Delay every element passed through with a duration that can be controlled dynami
 
 @ref[Timer driven operators](../index.md#timer-driven-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #delayWith }
+@apidoc[Source.delayWith](Source) { scala="#delayWith(delayStrategySupplier:()=&gt;akka.stream.scaladsl.DelayStrategy[Out],overFlowStrategy:akka.stream.DelayOverflowStrategy):FlowOps.this.Repr[Out]" java="#delayWith(java.util.function.Supplier,akka.stream.DelayOverflowStrategy)" }
+@apidoc[Flow.delayWith](Flow) { scala="#delayWith(delayStrategySupplier:()=&gt;akka.stream.scaladsl.DelayStrategy[Out],overFlowStrategy:akka.stream.DelayOverflowStrategy):FlowOps.this.Repr[Out]" java="#delayWith(java.util.function.Supplier,akka.stream.DelayOverflowStrategy)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/detach.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/detach.md
@@ -4,13 +4,10 @@ Detach upstream demand from downstream demand without detaching the stream rates
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #detach }
-
-@@@
+@apidoc[Source.detach](Source) { scala="#detach:FlowOps.this.Repr[Out]" java="#detach()" }
+@apidoc[Flow.detach](Flow) { scala="#detach:FlowOps.this.Repr[Out]" java="#detach()" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/divertTo.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/divertTo.md
@@ -4,13 +4,11 @@ Each upstream element will either be diverted to the given sink, or the downstre
 
 @ref[Fan-out operators](../index.md#fan-out-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #divertTo }
+@apidoc[Source.divertTo](Source) { scala="#divertTo(that:akka.stream.Graph[akka.stream.SinkShape[Out],_],when:Out=&gt;Boolean):FlowOps.this.Repr[Out]" java="#divertTo(akka.stream.Graph,akka.japi.function.Predicate)" }
+@apidoc[Flow.divertTo](Flow) { scala="#divertTo(that:akka.stream.Graph[akka.stream.SinkShape[Out],_],when:Out=&gt;Boolean):FlowOps.this.Repr[Out]" java="#divertTo(akka.stream.Graph,akka.japi.function.Predicate)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/drop.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/drop.md
@@ -4,13 +4,11 @@ Drop `n` elements and then pass any subsequent element downstream.
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #drop }
+@apidoc[Source.drop](Source) { scala="#drop(n:Long):FlowOps.this.Repr[Out]" java="#drop(long)" }
+@apidoc[Flow.drop](Flow) { scala="#drop(n:Long):FlowOps.this.Repr[Out]" java="#drop(long)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/dropWhile.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/dropWhile.md
@@ -4,13 +4,11 @@ Drop elements as long as a predicate function return true for the element
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #dropWhile }
+@apidoc[Source.dropWhile](Source) { scala="#dropWhile(p:Out=&gt;Boolean):FlowOps.this.Repr[Out]" java="#dropWhile(akka.japi.function.Predicate)" }
+@apidoc[Flow.dropWhile](Flow) { scala="#dropWhile(p:Out=&gt;Boolean):FlowOps.this.Repr[Out]" java="#dropWhile(akka.japi.function.Predicate)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/dropWithin.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/dropWithin.md
@@ -4,13 +4,11 @@ Drop elements until a timeout has fired
 
 @ref[Timer driven operators](../index.md#timer-driven-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #dropWithin }
+@apidoc[Source.dropWithin](Source) { scala="#dropWithin(d:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Out]" java="#dropWithin(java.time.Duration)" }
+@apidoc[Flow.dropWithin](Flow) { scala="#dropWithin(d:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Out]" java="#dropWithin(java.time.Duration)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/expand.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/expand.md
@@ -4,13 +4,11 @@ Like `extrapolate`, but does not have the `initial` argument, and the `Iterator`
 
 @ref[Backpressure aware operators](../index.md#backpressure-aware-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #expand }
+@apidoc[Source.expand](Source) { scala="#expand[U](expander:Out=&gt;Iterator[U]):FlowOps.this.Repr[U]" java="#expand(akka.japi.function.Function)" }
+@apidoc[Flow.expand](Flow) { scala="#expand[U](expander:Out=&gt;Iterator[U]):FlowOps.this.Repr[U]" java="#expand(akka.japi.function.Function)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/extrapolate.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/extrapolate.md
@@ -4,13 +4,11 @@ Allow for a faster downstream by expanding the last emitted element to an `Itera
 
 @ref[Backpressure aware operators](../index.md#backpressure-aware-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #extrapolate }
+@apidoc[Source.extrapolate](Source) { scala="#extrapolate[U&gt;:Out](extrapolator:U=&gt;Iterator[U],initial:Option[U]):FlowOps.this.Repr[U]" java="#extrapolate(akka.japi.function.Function,java.lang.Object)" }
+@apidoc[Flow.extrapolate](Flow) { scala="#extrapolate[U&gt;:Out](extrapolator:U=&gt;Iterator[U],initial:Option[U]):FlowOps.this.Repr[U]" java="#extrapolate(akka.japi.function.Function,java.lang.Object)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/filter.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/filter.md
@@ -4,13 +4,11 @@ Filter the incoming elements using a predicate.
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #filter }
+@apidoc[Source.filter](Source) { scala="#filter(p:Out=&gt;Boolean):FlowOps.this.Repr[Out]" java="#filter(akka.japi.function.Predicate)" }
+@apidoc[Flow.filter](Flow) { scala="#filter(p:Out=&gt;Boolean):FlowOps.this.Repr[Out]" java="#filter(akka.japi.function.Predicate)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/filterNot.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/filterNot.md
@@ -4,13 +4,11 @@ Filter the incoming elements using a predicate.
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #filterNot }
+@apidoc[Source.filterNot](Source) { scala="#filterNot(p:Out=&gt;Boolean):FlowOps.this.Repr[Out]" java="#filterNot(akka.japi.function.Predicate)" }
+@apidoc[Flow.filterNot](Flow) { scala="#filterNot(p:Out=&gt;Boolean):FlowOps.this.Repr[Out]" java="#filterNot(akka.japi.function.Predicate)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/flatMapPrefix.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/flatMapPrefix.md
@@ -4,13 +4,11 @@ Use the first `n` elements from the stream to determine how to process the rest.
 
 @ref[Nesting and flattening operators](../index.md#nesting-and-flattening-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #flatMapPrefix }
+@apidoc[Source.flatMapPrefix](Source) { scala="#flatMapPrefix[Out2,Mat2](n:Int)(f:scala.collection.immutable.Seq[Out]=&gt;akka.stream.scaladsl.Flow[Out,Out2,Mat2]):FlowOps.this.Repr[Out2]" java="#flatMapPrefix(int,akka.japi.function.Function)" }
+@apidoc[Flow.flatMapPrefix](Flow) { scala="#flatMapPrefix[Out2,Mat2](n:Int)(f:scala.collection.immutable.Seq[Out]=&gt;akka.stream.scaladsl.Flow[Out,Out2,Mat2]):FlowOps.this.Repr[Out2]" java="#flatMapPrefix(int,akka.japi.function.Function)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/fold.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/fold.md
@@ -4,13 +4,10 @@ Start with current value `zero` and then apply the current and next value to the
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #fold }
-
-@@@
+@apidoc[Source.fold](Source) { scala="#fold[T](zero:T)(f:(T,Out)=&gt;T):FlowOps.this.Repr[T]" java="#fold(java.lang.Object,akka.japi.function.Function2)" }
+@apidoc[Flow.fold](Flow) { scala="#fold[T](zero:T)(f:(T,Out)=&gt;T):FlowOps.this.Repr[T]" java="#fold(java.lang.Object,akka.japi.function.Function2)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/foldAsync.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/foldAsync.md
@@ -4,13 +4,10 @@ Just like `fold` but receives a function that results in a @scala[`Future`] @jav
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #foldAsync }
-
-@@@
+@apidoc[Source.foldAsync](Source) { scala="#foldAsync[T](zero:T)(f:(T,Out)=&gt;scala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#foldAsync(java.lang.Object,akka.japi.function.Function2)" }
+@apidoc[Flow.foldAsync](Flow) { scala="#foldAsync[T](zero:T)(f:(T,Out)=&gt;scala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#foldAsync(java.lang.Object,akka.japi.function.Function2)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/groupBy.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/groupBy.md
@@ -4,13 +4,11 @@ Demultiplex the incoming stream into separate output streams.
 
 @ref[Nesting and flattening operators](../index.md#nesting-and-flattening-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #groupBy }
+@apidoc[Source.groupBy](Source) { scala="#groupBy[K](maxSubstreams:Int,f:Out=&gt;K):akka.stream.scaladsl.SubFlow[Out,Mat,FlowOps.this.Repr,FlowOps.this.Closed]" java="#groupBy(int,akka.japi.function.Function,boolean)" }
+@apidoc[Flow.groupBy](Flow) { scala="#groupBy[K](maxSubstreams:Int,f:Out=&gt;K):akka.stream.scaladsl.SubFlow[Out,Mat,FlowOps.this.Repr,FlowOps.this.Closed]" java="#groupBy(int,akka.japi.function.Function,boolean)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/grouped.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/grouped.md
@@ -4,13 +4,11 @@ Accumulate incoming events until the specified number of elements have been accu
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #grouped }
+@apidoc[Source.grouped](Source) { scala="#grouped(n:Int):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#grouped(int)" }
+@apidoc[Flow.grouped](Flow) { scala="#grouped(n:Int):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#grouped(int)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWeightedWithin.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWeightedWithin.md
@@ -4,13 +4,11 @@ Chunk up this stream into groups of elements received within a time window, or l
 
 @ref[Timer driven operators](../index.md#timer-driven-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #groupedWeightedWithin }
+@apidoc[Source.groupedWeightedWithin](Source) { scala="#groupedWeightedWithin(maxWeight:Long,d:scala.concurrent.duration.FiniteDuration)(costFn:Out=&gt;Long):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#groupedWeightedWithin(long,akka.japi.function.Function,java.time.Duration)" }
+@apidoc[Flow.groupedWeightedWithin](Flow) { scala="#groupedWeightedWithin(maxWeight:Long,d:scala.concurrent.duration.FiniteDuration)(costFn:Out=&gt;Long):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#groupedWeightedWithin(long,akka.japi.function.Function,java.time.Duration)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWithin.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWithin.md
@@ -4,13 +4,11 @@ Chunk up this stream into groups of elements received within a time window, or l
 
 @ref[Timer driven operators](../index.md#timer-driven-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #groupedWithin }
+@apidoc[Source.groupedWithin](Source) { scala="#groupedWithin(n:Int,d:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#groupedWithin(int,java.time.Duration)" }
+@apidoc[Flow.groupedWithin](Flow) { scala="#groupedWithin(n:Int,d:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[scala.collection.immutable.Seq[Out]]" java="#groupedWithin(int,java.time.Duration)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/initialDelay.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/initialDelay.md
@@ -4,13 +4,11 @@ Delays the initial element by the specified duration.
 
 @ref[Timer driven operators](../index.md#timer-driven-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #initialDelay }
+@apidoc[Source.initialDelay](Source$) { scala="#initialDelay(delay:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Out]" java="#initialDelay(java.time.Duration)" }
+@apidoc[Flow.initialDelay](Flow) { scala="#initialDelay(delay:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Out]" java="#initialDelay(java.time.Duration)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/initialTimeout.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/initialTimeout.md
@@ -4,13 +4,11 @@ If the first element has not passed through this operators before the provided t
 
 @ref[Time aware operators](../index.md#time-aware-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #initialTimeout }
+@apidoc[Source.initialTimeout](Source) { scala="#initialTimeout(timeout:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Out]" java="#initialTimeout(java.time.Duration)" }
+@apidoc[Flow.initialTimeout](Flow) { scala="#initialTimeout(timeout:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Out]" java="#initialTimeout(java.time.Duration)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/interleave.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/interleave.md
@@ -4,13 +4,11 @@ Emits a specifiable number of elements from the original source, then from the p
 
 @ref[Fan-in operators](../index.md#fan-in-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #interleave }
+@apidoc[Source.interleave](Source) { scala="#interleave[U&gt;:Out](that:akka.stream.Graph[akka.stream.SourceShape[U],_],segmentSize:Int,eagerClose:Boolean):FlowOps.this.Repr[U]" java="#interleave(akka.stream.Graph,int,boolean)" }
+@apidoc[Flow.interleave](Flow) { scala="#interleave[U&gt;:Out](that:akka.stream.Graph[akka.stream.SourceShape[U],_],segmentSize:Int,eagerClose:Boolean):FlowOps.this.Repr[U]" java="#interleave(akka.stream.Graph,int,boolean)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/intersperse.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/intersperse.md
@@ -4,13 +4,11 @@ Intersperse stream with provided element similar to `List.mkString`.
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #intersperse }
+@apidoc[Source.intersperse](Source) { scala="#intersperse[T&gt;:Out](start:T,inject:T,end:T):FlowOps.this.Repr[T]" java="#intersperse(java.lang.Object,java.lang.Object,java.lang.Object)" }
+@apidoc[Flow.intersperse](Flow) {  scala="#intersperse[T&gt;:Out](start:T,inject:T,end:T):FlowOps.this.Repr[T]" java="#intersperse(java.lang.Object,java.lang.Object,java.lang.Object)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/keepAlive.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/keepAlive.md
@@ -4,13 +4,11 @@ Injects additional (configured) elements if upstream does not emit for a configu
 
 @ref[Time aware operators](../index.md#time-aware-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #keepAlive }
+@apidoc[Source.keepAlive](Source) { scala="#keepAlive[U&gt;:Out](maxIdle:scala.concurrent.duration.FiniteDuration,injectedElem:()=&gt;U):FlowOps.this.Repr[U]" java="#keepAlive(java.time.Duration,akka.japi.function.Creator)" }
+@apidoc[Flow.keepAlive](Flow) { scala="#keepAlive[U&gt;:Out](maxIdle:scala.concurrent.duration.FiniteDuration,injectedElem:()=&gt;U):FlowOps.this.Repr[U]" java="#keepAlive(java.time.Duration,akka.japi.function.Creator)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/logWithMarker.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/logWithMarker.md
@@ -4,13 +4,11 @@ Log elements flowing through the stream as well as completion and erroring.
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #logWithMarker }
+@apidoc[Source.logWithMarker](Source) { scala="#logWithMarker(name:String,marker:Out=&gt;akka.event.LogMarker,extract:Out=&gt;Any)(implicitlog:akka.event.MarkerLoggingAdapter):FlowOps.this.Repr[Out]" java="#logWithMarker(java.lang.String,akka.japi.function.Function)" }
+@apidoc[Flow.logWithMarker](Flow) { scala="#logWithMarker(name:String,marker:Out=&gt;akka.event.LogMarker,extract:Out=&gt;Any)(implicitlog:akka.event.MarkerLoggingAdapter):FlowOps.this.Repr[Out]" java="#logWithMarker(java.lang.String,akka.japi.function.Function)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/logWithMarker.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/logWithMarker.md
@@ -4,14 +4,13 @@ Log elements flowing through the stream as well as completion and erroring.
 
 @ref[Simple operators](../index.md#simple-operators)
 
+@@@div { .group-scala }
+
 ## Signature
 
+@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #logWithMarker }
 
-Scala
-:   @@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #logWithMarker }
-
-Java
-:   @@snip [FlowLogWithMarkerTest.java](/akka-stream-tests/src/test/java/akka/stream/javadsl/FlowLogWithMarkerTest.java) { #signature }
+@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsync.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsync.md
@@ -4,13 +4,11 @@ Pass incoming elements to a function that return a @scala[`Future`] @java[`Compl
 
 @ref[Asynchronous operators](../index.md#asynchronous-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #mapAsync }
+@apidoc[Source.mapAsync](Source) { scala="#mapAsync[T](parallelism:Int)(f:Out=&gt;scala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#mapAsync(int,akka.japi.function.Function)" }
+@apidoc[Flow.mapAsync](Flow) { scala="#mapAsync[T](parallelism:Int)(f:Out=&gt;scala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#mapAsync(int,akka.japi.function.Function)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncUnordered.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncUnordered.md
@@ -4,13 +4,11 @@ Like `mapAsync` but @scala[`Future`] @java[`CompletionStage`] results are passed
 
 @ref[Asynchronous operators](../index.md#asynchronous-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #mapAsyncUnordered }
+@apidoc[Source.mapAsyncUnordered](Source) { scala="#mapAsyncUnordered[T](parallelism:Int)(f:Out=&gt;scala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#mapAsyncUnordered(int,akka.japi.function.Function)" }
+@apidoc[Flow.mapAsyncUnordered](Flow) { scala="#mapAsyncUnordered[T](parallelism:Int)(f:Out=&gt;scala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#mapAsyncUnordered(int,akka.japi.function.Function)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapConcat.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapConcat.md
@@ -4,13 +4,11 @@ Transform each element into zero or more elements that are individually passed d
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #mapConcat }
+@apidoc[Source.mapConcat](Source) { scala="#mapConcat[T](f:Out=&gt;scala.collection.immutable.Iterable[T]):FlowOps.this.Repr[T]" java="#mapConcat(akka.japi.function.Function)" }
+@apidoc[Flow.mapConcat](Flow) { scala="#mapConcat[T](f:Out=&gt;scala.collection.immutable.Iterable[T]):FlowOps.this.Repr[T]" java="#mapConcat(akka.japi.function.Function)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapError.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapError.md
@@ -4,13 +4,11 @@ While similar to `recover` this operators can be used to transform an error sign
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #mapError }
+@apidoc[Source.mapError](Source) { scala="#mapError(pf:PartialFunction[Throwable,Throwable]):FlowOps.this.Repr[Out]" java="#mapError(java.lang.Class,akka.japi.function.Function)" }
+@apidoc[Flow.mapError](Flow) { scala="#mapError(pf:PartialFunction[Throwable,Throwable]):FlowOps.this.Repr[Out]" java="#mapError(java.lang.Class,akka.japi.function.Function)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mergeSorted.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mergeSorted.md
@@ -4,13 +4,11 @@ Merge multiple sources.
 
 @ref[Fan-in operators](../index.md#fan-in-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #mergeSorted }
+@apidoc[Source.mergeSorted](Source) { scala="#mergeSorted[U&gt;:Out,M](that:akka.stream.Graph[akka.stream.SourceShape[U],M])(implicitord:Ordering[U]):FlowOps.this.Repr[U]" java="#mergeSorted(akka.stream.Graph,java.util.Comparator)" }
+@apidoc[Flow.mergeSorted](Flow) { scala="#mergeSorted[U&gt;:Out,M](that:akka.stream.Graph[akka.stream.SourceShape[U],M])(implicitord:Ordering[U]):FlowOps.this.Repr[U]" java="#mergeSorted(akka.stream.Graph,java.util.Comparator)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/monitor.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/monitor.md
@@ -4,13 +4,11 @@ Materializes to a `FlowMonitor` that monitors messages flowing through or comple
 
 @ref[Watching status operators](../index.md#watching-status-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #monitor }
+@apidoc[Source.monitor](Source) { scala="#monitor[Mat2]()(combine:(Mat,akka.stream.FlowMonitor[Out])=&gt;Mat2):FlowOpsMat.this.ReprMat[Out,Mat2]" java="#monitor(akka.japi.function.Function2)" java="#monitor()" }
+@apidoc[Flow.monitor](Flow) { scala="#monitor[Mat2]()(combine:(Mat,akka.stream.FlowMonitor[Out])=&gt;Mat2):FlowOpsMat.this.ReprMat[Out,Mat2]" java="#monitor(akka.japi.function.Function2)" java="#monitor()" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/orElse.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/orElse.md
@@ -4,13 +4,11 @@ If the primary source completes without emitting any elements, the elements from
 
 @ref[Fan-in operators](../index.md#fan-in-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #orElse }
+@apidoc[Source.orElse](Source) { scala="#orElse[U&gt;:Out,Mat2](secondary:akka.stream.Graph[akka.stream.SourceShape[U],Mat2]):FlowOps.this.Repr[U]" java="#orElse(akka.stream.Graph)" }
+@apidoc[Flow.orElse](Flow) { scala="#orElse[U&gt;:Out,Mat2](secondary:akka.stream.Graph[akka.stream.SourceShape[U],Mat2]):FlowOps.this.Repr[U]" java="#orElse(akka.stream.Graph)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/prefixAndTail.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/prefixAndTail.md
@@ -4,13 +4,11 @@ Take up to *n* elements from the stream (less than *n* only if the upstream comp
 
 @ref[Nesting and flattening operators](../index.md#nesting-and-flattening-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #prefixAndTail }
+@apidoc[Source.prefixAndTail](Source) { scala="#prefixAndTail[U&gt;:Out](n:Int):FlowOps.this.Repr[(scala.collection.immutable.Seq[Out],akka.stream.scaladsl.Source[U,akka.NotUsed])]" java="#prefixAndTail(int)" }
+@apidoc[Flow.prefixAndTail](Flow) { scala="#prefixAndTail[U&gt;:Out](n:Int):FlowOps.this.Repr[(scala.collection.immutable.Seq[Out],akka.stream.scaladsl.Source[U,akka.NotUsed])]" java="#prefixAndTail(int)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/prepend.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/prepend.md
@@ -4,13 +4,11 @@ Prepends the given source to the flow, consuming it until completion before the 
 
 @ref[Fan-in operators](../index.md#fan-in-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #prepend }
+@apidoc[Source.prepend](Source) { scala="#prepend[U&gt;:Out,Mat2](that:akka.stream.Graph[akka.stream.SourceShape[U],Mat2]):FlowOps.this.Repr[U]" java="#prepend(akka.stream.Graph)" }
+@apidoc[Flow.prepend](Flow) { scala="#prepend[U&gt;:Out,Mat2](that:akka.stream.Graph[akka.stream.SourceShape[U],Mat2]):FlowOps.this.Repr[U]" java="#prepend(akka.stream.Graph)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/recover.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/recover.md
@@ -4,13 +4,11 @@ Allow sending of one last element downstream when a failure has happened upstrea
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #recover }
+@apidoc[Source.recover](Source) { scala="#recover[T&gt;:Out](pf:PartialFunction[Throwable,T]):FlowOps.this.Repr[T]" java="#recover(scala.PartialFunction)" java="#recover(java.lang.Class,java.util.function.Supplier)" }
+@apidoc[Flow.recover](Flow) { scala="#recover[T&gt;:Out](pf:PartialFunction[Throwable,T]):FlowOps.this.Repr[T]" java="#recover(scala.PartialFunction)" java="#recover(java.lang.Class,java.util.function.Supplier)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/recoverWith.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/recoverWith.md
@@ -4,13 +4,11 @@ Allow switching to alternative Source when a failure has happened upstream.
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #recoverWith }
+@apidoc[Source.recoverWith](Source) { scala="#recoverWith[T&gt;:Out](pf:PartialFunction[Throwable,akka.stream.Graph[akka.stream.SourceShape[T],akka.NotUsed]]):FlowOps.this.Repr[T]" java="#recoverWith(java.lang.Class,java.util.function.Supplier)" }
+@apidoc[Flow.recoverWith](Flow) { scala="#recoverWith[T&gt;:Out](pf:PartialFunction[Throwable,akka.stream.Graph[akka.stream.SourceShape[T],akka.NotUsed]]):FlowOps.this.Repr[T]" java="#recoverWith(java.lang.Class,java.util.function.Supplier)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/recoverWithRetries.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/recoverWithRetries.md
@@ -4,13 +4,11 @@ RecoverWithRetries allows to switch to alternative Source on flow failure.
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #recoverWithRetries }
+@apidoc[Source.recoverWithRetries](Source) { scala="#recoverWithRetries[T&gt;:Out](attempts:Int,pf:PartialFunction[Throwable,akka.stream.Graph[akka.stream.SourceShape[T],akka.NotUsed]]):FlowOps.this.Repr[T]" java="#recoverWithRetries(int,java.lang.Class,java.util.function.Supplier)" }
+@apidoc[Flow.recoverWithRetries](Flow) { scala="#recoverWithRetries[T&gt;:Out](attempts:Int,pf:PartialFunction[Throwable,akka.stream.Graph[akka.stream.SourceShape[T],akka.NotUsed]]):FlowOps.this.Repr[T]" java="#recoverWithRetries(int,java.lang.Class,java.util.function.Supplier)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/reduce.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/reduce.md
@@ -4,13 +4,11 @@ Start with first element and then apply the current and next value to the given 
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #reduce }
+@apidoc[Source.reduce](Source) { scala="#reduce[T&gt;:Out](f:(T,T)=&gt;T):FlowOps.this.Repr[T]" java="#reduce(akka.japi.function.Function2)" }
+@apidoc[Flow.reduce](Flow) { scala="#reduce[T&gt;:Out](f:(T,T)=&gt;T):FlowOps.this.Repr[T]" java="#reduce(akka.japi.function.Function2)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/scan.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/scan.md
@@ -4,13 +4,11 @@ Emit its current value, which starts at `zero`, and then apply the current and n
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #scan }
+@apidoc[Source.scan](Source) { scala="#scan[T](zero:T)(f:(T,Out)=&gt;T):FlowOps.this.Repr[T]" java="#scan(java.lang.Object,akka.japi.function.Function2)" }
+@apidoc[Flow.scan](Flow) { scala="#scan[T](zero:T)(f:(T,Out)=&gt;T):FlowOps.this.Repr[T]" java="#scan(java.lang.Object,akka.japi.function.Function2)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/scanAsync.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/scanAsync.md
@@ -4,13 +4,11 @@ Just like @ref[`scan`](./scan.md) but receives a function that results in a @sca
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #scanAsync }
+@apidoc[Source.scanAsync](Source) { scala="#scanAsync[T](zero:T)(f:(T,Out)=&gt;scala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#scanAsync(java.lang.Object,akka.japi.function.Function2)" }
+@apidoc[Flow.scanAsync](Flow) { scala="#scanAsync[T](zero:T)(f:(T,Out)=&gt;scala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#scanAsync(java.lang.Object,akka.japi.function.Function2)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/splitAfter.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/splitAfter.md
@@ -4,13 +4,11 @@ End the current substream whenever a predicate returns `true`, starting a new su
 
 @ref[Nesting and flattening operators](../index.md#nesting-and-flattening-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #splitAfter }
+@apidoc[Source.splitAfter](Source) { scala="#splitAfter(substreamCancelStrategy:akka.stream.SubstreamCancelStrategy)(p:Out=&gt;Boolean):akka.stream.scaladsl.SubFlow[Out,Mat,FlowOps.this.Repr,FlowOps.this.Closed]" java="#splitAfter(akka.stream.SubstreamCancelStrategy,akka.japi.function.Predicate)" }
+@apidoc[Flow.splitAfter](Flow) { scala="#splitAfter(substreamCancelStrategy:akka.stream.SubstreamCancelStrategy)(p:Out=&gt;Boolean):akka.stream.scaladsl.SubFlow[Out,Mat,FlowOps.this.Repr,FlowOps.this.Closed]" java="#splitAfter(akka.stream.SubstreamCancelStrategy,akka.japi.function.Predicate)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/splitWhen.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/splitWhen.md
@@ -4,13 +4,11 @@ Split off elements into a new substream whenever a predicate function return `tr
 
 @ref[Nesting and flattening operators](../index.md#nesting-and-flattening-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #splitWhen }
+@apidoc[Source.splitWhen](Source) { scala="#splitWhen(substreamCancelStrategy:akka.stream.SubstreamCancelStrategy)(p:Out=&gt;Boolean):akka.stream.scaladsl.SubFlow[Out,Mat,FlowOps.this.Repr,FlowOps.this.Closed]" java="#splitWhen(akka.stream.SubstreamCancelStrategy,akka.japi.function.Predicate)" }
+@apidoc[Flow.splitWhen](Flow) { scala="#splitWhen(substreamCancelStrategy:akka.stream.SubstreamCancelStrategy)(p:Out=&gt;Boolean):akka.stream.scaladsl.SubFlow[Out,Mat,FlowOps.this.Repr,FlowOps.this.Closed]" java="#splitWhen(akka.stream.SubstreamCancelStrategy,akka.japi.function.Predicate)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/take.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/take.md
@@ -4,13 +4,11 @@ Pass `n` incoming elements downstream and then complete
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #take }
+@apidoc[Source.take](Source) { scala="#take(n:Long):FlowOps.this.Repr[Out]" java="#take(long)" }
+@apidoc[Flow.take](Flow) { scala="#take(n:Long):FlowOps.this.Repr[Out]" java="#take(long)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/takeWhile.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/takeWhile.md
@@ -4,13 +4,11 @@ Pass elements downstream as long as a predicate function returns true and then c
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #takeWhile }
+@apidoc[Source.takeWhile](Source) { scala="#takeWhile(p:Out=&gt;Boolean,inclusive:Boolean):FlowOps.this.Repr[Out]" java="#takeWhile(akka.japi.function.Predicate)" }
+@apidoc[Flow.takeWhile](Flow) { scala="#takeWhile(p:Out=&gt;Boolean,inclusive:Boolean):FlowOps.this.Repr[Out]" java="#takeWhile(akka.japi.function.Predicate)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/takeWithin.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/takeWithin.md
@@ -4,13 +4,11 @@ Pass elements downstream within a timeout and then complete.
 
 @ref[Timer driven operators](../index.md#timer-driven-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #takeWithin }
+@apidoc[Source.takeWithin](Source) { scala="#takeWithin(d:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Out]" java="#takeWithin(java.time.Duration)" }
+@apidoc[Flow.takeWithin](Flow) { scala="#takeWithin(d:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Out]" java="#takeWithin(java.time.Duration)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/watchTermination.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/watchTermination.md
@@ -4,13 +4,11 @@ Materializes to a @scala[`Future`] @java[`CompletionStage`] that will be complet
 
 @ref[Watching status operators](../index.md#watching-status-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #watchTermination }
+@apidoc[Source.watchTermination](Source) { scala="#watchTermination[Mat2]()(matF:(Mat,scala.concurrent.Future[akka.Done])=&gt;Mat2):FlowOpsMat.this.ReprMat[Out,Mat2]" java="#watchTermination(akka.japi.function.Function2)" }
+@apidoc[Flow.watchTermination](Flow) { scala="#watchTermination[Mat2]()(matF:(Mat,scala.concurrent.Future[akka.Done])=&gt;Mat2):FlowOpsMat.this.ReprMat[Out,Mat2]" java="#watchTermination(akka.japi.function.Function2)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/wireTap.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/wireTap.md
@@ -4,13 +4,11 @@ Attaches the given `Sink` to this `Flow` as a wire tap, meaning that elements th
 
 @ref[Fan-out operators](../index.md#fan-out-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #wireTap }
+@apidoc[Source.wireTap](Source) { scala="#wireTap(f:Out=&gt;Unit):FlowOps.this.Repr[Out]" java="#wireTap(akka.japi.function.Procedure)" }
+@apidoc[Flow.wireTap](Flow) { scala="#wireTap(f:Out=&gt;Unit):FlowOps.this.Repr[Out]" java="#wireTap(akka.japi.function.Procedure)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zipAll.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zipAll.md
@@ -4,13 +4,11 @@ Combines elements from two sources into @scala[tuples] @java[*Pair*] handling ea
 
 @ref[Fan-in operators](../index.md#fan-in-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #zipAll }
+@apidoc[Source.zipAll](Source) { scala="#zipAll[U,A&gt;:Out](that:akka.stream.Graph[akka.stream.SourceShape[U],_],thisElem:A,thatElem:U):FlowOps.this.Repr[(A,U)]" java="#zipAll(akka.stream.Graph,java.lang.Object,java.lang.Object)" }
+@apidoc[Flow.zipAll](Flow) { scala="#zipAll[U,A&gt;:Out](that:akka.stream.Graph[akka.stream.SourceShape[U],_],thisElem:A,thatElem:U):FlowOps.this.Repr[(A,U)]" java="#zipAll(akka.stream.Graph,java.lang.Object,java.lang.Object)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zipLatest.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zipLatest.md
@@ -4,13 +4,11 @@ Combines elements from each of multiple sources into @scala[tuples] @java[*Pair*
 
 @ref[Fan-in operators](../index.md#fan-in-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #zipLatest }
+@apidoc[Source.zipLatest](Source) { scala="#zipLatest[U](that:akka.stream.Graph[akka.stream.SourceShape[U],_]):FlowOps.this.Repr[(Out,U)]" java="#zipLatest(akka.stream.Graph)" }
+@apidoc[Flow.zipLatest](Flow) { scala="#zipLatest[U](that:akka.stream.Graph[akka.stream.SourceShape[U],_]):FlowOps.this.Repr[(Out,U)]" java="#zipLatest(akka.stream.Graph)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zipLatestWith.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zipLatestWith.md
@@ -4,13 +4,11 @@ Combines elements from multiple sources through a `combine` function and passes 
 
 @ref[Fan-in operators](../index.md#fan-in-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #zipLatestWith }
+@apidoc[Source.zipLatestWith](Source) { scala="#zipLatestWith[Out2,Out3](that:akka.stream.Graph[akka.stream.SourceShape[Out2],_])(combine:(Out,Out2)=&gt;Out3):FlowOps.this.Repr[Out3]" java="#zipLatestWith(akka.stream.Graph,akka.japi.function.Function2)" }
+@apidoc[Flow.zipLatestWith](Flow) { scala="#zipLatestWith[Out2,Out3](that:akka.stream.Graph[akka.stream.SourceShape[Out2],_])(combine:(Out,Out2)=&gt;Out3):FlowOps.this.Repr[Out3]" java="#zipLatestWith(akka.stream.Graph,akka.japi.function.Function2)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zipWithIndex.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zipWithIndex.md
@@ -4,13 +4,10 @@ Zips elements of current flow with its indices.
 
 @ref[Fan-in operators](../index.md#fan-in-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #zipWithIndex }
-
-@@@
+@apidoc[Source.zipWithIndex](Source) { scala="#zipWithIndex:FlowOps.this.Repr[(Out,Long)]" java="#zipWithIndex()" }
+@apidoc[Flow.zipWithIndex](Flow) { scala="#zipWithIndex:FlowOps.this.Repr[(Out,Long)]" java="#zipWithIndex()" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/asSourceWithContext.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/asSourceWithContext.md
@@ -4,13 +4,10 @@ Turns a Source into a SourceWithContext which can propagate a context per elemen
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #asSourceWithContext }
+@apidoc[Source.asSourceWithContext](Source) { scala="#asSourceWithContext[Ctx](f:Out=&gt;Ctx):akka.stream.scaladsl.SourceWithContext[Out,Ctx,Mat]" java="#asSourceWithContext(akka.japi.function.Function)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/completionStage.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/completionStage.md
@@ -4,13 +4,10 @@ Send the single value of the `CompletionStage` when it completes and there is de
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-java }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #completionStage }
+@apidoc[Source.completionStage](Source$) { scala="#completionStage[T](completionStage:java.util.concurrent.CompletionStage[T]):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#completionStage(java.util.concurrent.CompletionStage)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/cycle.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/cycle.md
@@ -4,13 +4,10 @@ Stream iterator in cycled manner.
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #cycle }
+@apidoc[Source.cycle](Source$) { scala="#cycle[T](f:()=&gt;Iterator[T]):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#cycle(akka.japi.function.Creator)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/empty.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/empty.md
@@ -4,13 +4,10 @@ Complete right away without ever emitting any elements.
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #empty }
+@apidoc[Source.empty](Source$) { scala="#empty[T]:akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#empty()" java="#empty(java.lang.Class)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/failed.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/failed.md
@@ -4,13 +4,10 @@ Fail directly with a user specified exception.
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #failed }
+@apidoc[Source.failed](Source$) { scala="#failed[T](cause:Throwable):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#failed(java.lang.Throwable)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/fromCompletionStage.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/fromCompletionStage.md
@@ -4,13 +4,10 @@ Deprecated by @ref:[`Source.completionStage`](completionStage.md).
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #fromCompletionStage }
+@apidoc[Source.fromCompletionStage](Source$) { scala="#fromCompletionStage[T](future:java.util.concurrent.CompletionStage[T]):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#fromCompletionStage(java.util.concurrent.CompletionStage)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/fromFuture.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/fromFuture.md
@@ -4,13 +4,10 @@ Deprecated by @ref[`Source.future`](future.md).
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #fromFuture }
+@apidoc[Source.fromFuture](Source$) { scala="#fromFuture[T](future:scala.concurrent.Future[T]):akka.stream.scaladsl.Source[T,akka.NotUsed]" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/fromFutureSource.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/fromFutureSource.md
@@ -4,13 +4,10 @@ Deprecated by @ref:[`Source.futureSource`](futureSource.md).
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #fromFutureSource }
+@apidoc[Source.fromFutureSource](Source$) { scala="#fromFutureSource[T,M](future:scala.concurrent.Future[akka.stream.Graph[akka.stream.SourceShape[T],M]]):akka.stream.scaladsl.Source[T,scala.concurrent.Future[M]]" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/fromIterator.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/fromIterator.md
@@ -4,13 +4,10 @@ Stream the values from an `Iterator`, requesting the next value when there is de
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #fromIterator }
+@apidoc[Source.fromIterator](Source$) { scala="#fromIterator[T](f:()=&gt;Iterator[T]):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#fromIterator(akka.japi.function.Creator)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/fromJavaStream.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/fromJavaStream.md
@@ -4,13 +4,10 @@ Stream the values from a Java 8 `Stream`, requesting the next value when there i
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #fromJavaStream }
+@apidoc[StreamConverters.fromJavaStream](StreamConverters$) { scala="#fromJavaStream[T,S&lt;:java.util.stream.BaseStream[T,S]](stream:()=&gt;java.util.stream.BaseStream[T,S]):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#fromJavaStream(akka.japi.function.Creator)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/future.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/future.md
@@ -4,13 +4,9 @@ Send the single value of the `Future` when it completes and there is demand.
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #future }
-
-@@@
+@apidoc[Source.future](Source$) { scala="#future[T](futureElement:scala.concurrent.Future[T]):akka.stream.scaladsl.Source[T,akka.NotUsed]" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/futureSource.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/futureSource.md
@@ -4,13 +4,10 @@ Streams the elements of the given future source once it successfully completes.
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #futureSource }
+@apidoc[Source.futureSource](Source$) { scala="#futureSource[T,M](futureSource:scala.concurrent.Future[akka.stream.scaladsl.Source[T,M]]):akka.stream.scaladsl.Source[T,scala.concurrent.Future[M]]" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/lazily.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/lazily.md
@@ -4,13 +4,10 @@ Deprecated by @ref:[`Source.lazySource`](lazySource.md).
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #lazily }
+@apidoc[Source.lazily](Source$) { scala="#lazily[T,M](create:()=&gt;akka.stream.scaladsl.Source[T,M]):akka.stream.scaladsl.Source[T,scala.concurrent.Future[M]]" java="#lazily(akka.japi.function.Creator)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/lazyFuture.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/lazyFuture.md
@@ -4,13 +4,9 @@ Defers creation of a future of a single element source until there is demand.
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #lazyFuture }
-
-@@@
+@apidoc[Source.lazyFuture](Source$) { scala="#lazyFuture[T](create:()=&gt;scala.concurrent.Future[T]):akka.stream.scaladsl.Source[T,akka.NotUsed]" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/lazyFutureSource.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/lazyFutureSource.md
@@ -4,13 +4,10 @@ Defers creation and materialization of a `Source` until there is demand.
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #lazyFutureSource }
+@apidoc[Source.lazyFutureSource](Source$) { scala="#lazyFutureSource[T,M](create:()=&gt;scala.concurrent.Future[akka.stream.scaladsl.Source[T,M]]):akka.stream.scaladsl.Source[T,scala.concurrent.Future[M]]" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/lazySingle.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/lazySingle.md
@@ -4,13 +4,10 @@ Defers creation of a single element source until there is demand.
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #lazySingle }
+@apidoc[Source.lazySingle](Source$) { scala="#lazySingle[T](create:()=&gt;T):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#lazySingle(akka.japi.function.Creator)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/lazySource.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/lazySource.md
@@ -4,13 +4,10 @@ Defers creation and materialization of a `Source` until there is demand.
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #lazySource }
+@apidoc[Source.lazySource](Source$) { scala="#lazySource[T,M](create:()=&gt;akka.stream.scaladsl.Source[T,M]):akka.stream.scaladsl.Source[T,scala.concurrent.Future[M]]" java="#lazySource(akka.japi.function.Creator)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/maybe.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/maybe.md
@@ -4,13 +4,13 @@ Create a source that emits once the materialized @scala[`Promise`] @java[`Comple
 
 @ref[Source operators](../index.md#source-operators)
 
+@@@div { .group-scala }
+
 ## Signature
 
-Scala
- :   @@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #maybe }
+@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #maybe }
 
-Java
-:   @@snip [SourceDocExamples.java](/akka-docs/src/test/java/jdocs/stream/operators/SourceDocExamples.java) { #maybe-signature }
+@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/maybe.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/maybe.md
@@ -4,13 +4,10 @@ Create a source that emits once the materialized @scala[`Promise`] @java[`Comple
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #maybe }
+@apidoc[Source.maybe](Source$) { scala="#maybe[T]:akka.stream.scaladsl.Source[T,scala.concurrent.Promise[Option[T]]]" java="#maybe()" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/tick.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/tick.md
@@ -4,13 +4,10 @@ A periodical repetition of an arbitrary object.
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #tick }
+@apidoc[Source.tick](Source$) { scala="#tick[T](initialDelay:scala.concurrent.duration.FiniteDuration,interval:scala.concurrent.duration.FiniteDuration,tick:T):akka.stream.scaladsl.Source[T,akka.actor.Cancellable]" java="#tick(java.time.Duration,java.time.Duration,java.lang.Object)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/unfold.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/unfold.md
@@ -4,13 +4,10 @@ Stream the result of a function as long as it returns a @scala[`Some`] @java[non
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #unfold }
+@apidoc[Source.unfold](Source$) { scala="#unfold[S,E](s:S)(f:S=&gt;Option[(S,E)]):akka.stream.scaladsl.Source[E,akka.NotUsed]" java="#unfold(java.lang.Object,akka.japi.function.Function)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/unfold.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/unfold.md
@@ -4,13 +4,13 @@ Stream the result of a function as long as it returns a @scala[`Some`] @java[non
 
 @ref[Source operators](../index.md#source-operators)
 
+@@@div { .group-scala }
+
 ## Signature
 
-Scala
-:   @@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #unfold }
+@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #unfold }
 
-Java
-:   @@snip [SourceUnfoldTest.java](/akka-stream-tests/src/test/java/akka/stream/javadsl/SourceUnfoldTest.java) { #signature }
+@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/unfoldAsync.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/unfoldAsync.md
@@ -4,13 +4,10 @@ Just like `unfold` but the fold function returns a @scala[`Future`] @java[`Compl
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #unfoldAsync }
+@apidoc[Source.unfoldAsync](Source$) { scala="#unfoldAsync[S,E](s:S)(f:S=&gt;scala.concurrent.Future[Option[(S,E)]]):akka.stream.scaladsl.Source[E,akka.NotUsed]" java="#unfoldAsync(java.lang.Object,akka.japi.function.Function)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/unfoldResource.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/unfoldResource.md
@@ -4,13 +4,10 @@ Wrap any resource that can be opened, queried for next element (in a blocking wa
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #unfoldResource }
+@apidoc[Source.unfoldResource](Source$) { scala="#unfoldResource[T,S](create:()=&gt;S,read:S=&gt;Option[T],close:S=&gt;Unit):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#unfoldResource(akka.japi.function.Creator,akka.japi.function.Function,akka.japi.function.Procedure)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/unfoldResourceAsync.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/unfoldResourceAsync.md
@@ -4,13 +4,10 @@ Wrap any resource that can be opened, queried for next element and closed in an 
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #unfoldResourceAsync }
+@apidoc[Source.unfoldResourceAsync](Source$) { scala="#unfoldResourceAsync[T,S](create:()=&gt;scala.concurrent.Future[S],read:S=&gt;scala.concurrent.Future[Option[T]],close:S=&gt;scala.concurrent.Future[akka.Done]):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#unfoldResourceAsync(akka.japi.function.Creator,akka.japi.function.Function,akka.japi.function.Function)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/StreamConverters/asInputStream.md
+++ b/akka-docs/src/main/paradox/stream/operators/StreamConverters/asInputStream.md
@@ -4,11 +4,10 @@ Create a sink which materializes into an `InputStream` that can be read to trigg
 
 @ref[Additional Sink and Source converters](../index.md#additional-sink-and-source-converters)
 
-@@@ div { .group-scala }
 ## Signature
 
-@@signature [StreamConverters.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/StreamConverters.scala) { #asInputStream }
-@@@
+@apidoc[StreamConverters.asInputStream](StreamConverters$) { scala="#asInputStream(readTimeout:scala.concurrent.duration.FiniteDuration):akka.stream.scaladsl.Sink[akka.util.ByteString,java.io.InputStream]" java="#asInputStream()" }
+
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/StreamConverters/asOutputStream.md
+++ b/akka-docs/src/main/paradox/stream/operators/StreamConverters/asOutputStream.md
@@ -4,11 +4,9 @@ Create a source that materializes into an `OutputStream`.
 
 @ref[Additional Sink and Source converters](../index.md#additional-sink-and-source-converters)
 
-@@@ div { .group-scala }
 ## Signature
 
-@@signature [StreamConverters.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/StreamConverters.scala) { #asOutputStream }
-@@@
+@apidoc[StreamConverters.asOutputStream](StreamConverters$) { scala="#asOutputStream(writeTimeout:scala.concurrent.duration.FiniteDuration):akka.stream.scaladsl.Source[akka.util.ByteString,java.io.OutputStream]" java="#asOutputStream(java.time.Duration)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/StreamConverters/javaCollector.md
+++ b/akka-docs/src/main/paradox/stream/operators/StreamConverters/javaCollector.md
@@ -4,13 +4,10 @@ Create a sink which materializes into a @scala[`Future`] @java[`CompletionStage`
 
 @ref[Additional Sink and Source converters](../index.md#additional-sink-and-source-converters)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [StreamConverters.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/StreamConverters.scala) { #javaCollector }
+@apidoc[StreamConverters.javaCollector](StreamConverters$) { scala="#javaCollector[T,R](collectorFactory:()=&gt;java.util.stream.Collector[T,_,R]):akka.stream.scaladsl.Sink[T,scala.concurrent.Future[R]]" java="#javaCollector(akka.japi.function.Creator)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/StreamConverters/javaCollectorParallelUnordered.md
+++ b/akka-docs/src/main/paradox/stream/operators/StreamConverters/javaCollectorParallelUnordered.md
@@ -4,13 +4,10 @@ Create a sink which materializes into a @scala[`Future`] @java[`CompletionStage`
 
 @ref[Additional Sink and Source converters](../index.md#additional-sink-and-source-converters)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [StreamConverters.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/StreamConverters.scala) { #javaCollectorParallelUnordered }
+@apidoc[StreamConverters.javaCollectorParallelUnordered](StreamConverters$) { scala="#javaCollectorParallelUnordered[T,R](parallelism:Int)(collectorFactory:()=&gt;java.util.stream.Collector[T,_,R]):akka.stream.scaladsl.Sink[T,scala.concurrent.Future[R]]" java="#javaCollectorParallelUnordered(int,akka.japi.function.Creator)" }
 
-@@@
 
 ## Description
 


### PR DESCRIPTION
References #28901 

when moving from `@reference` to `@apidoc` directives there's a bit of a mechanical work such as locating the correct type, the signatures for java and scala, etc...

I put together a replacement tool so the rewrite is simpler (edit/remove suggestions). 
