### PR TITLE
actor: use simple comparison in LightArrayRevolverScheduler

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/LightArrayRevolverScheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/LightArrayRevolverScheduler.scala
@@ -186,7 +186,7 @@ class LightArrayRevolverScheduler(config: Config, log: LoggingAdapter, threadFac
   private val queue = new TaskQueue
 
   private def schedule(ec: ExecutionContext, r: Runnable, delay: FiniteDuration): TimerTask =
-    if (delay <= Duration.Zero) {
+    if (delay.length <= 0L) { // use simple comparision instead of Ordering for performance
       if (stopped.get != null) throw SchedulerException("cannot enqueue after timer shutdown")
       ec.execute(r)
       NotCancellable


### PR DESCRIPTION
This turned up in profiling because akka-http's request timeout support
schedules a task per request. Providing `<=` through Ordering.Implicits requires quite some indirection so that it can be a slight performance hit.