### PR TITLE
exercise expected code path in test

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RetryFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RetryFlowSpec.scala
@@ -63,7 +63,7 @@ class RetryFlowSpec extends StreamSpec("""
 
     "send elements through" in {
       val sink =
-        Source(List(13, 17, 19, 23, 27))
+        Source(List(13, 17, 19, 23, 26))
           .via(
             RetryFlow.withBackoff(10.millis, 5.second, 0d, maxRetries = 3, failEvenValuesFlow)(incrementFailedValues))
           .runWith(Sink.seq)


### PR DESCRIPTION
In the existing test, the code path that "element is even -> the original flow will return Failure -> RetryFlow retries on failure" is not exercised. Change the input list from all odds into odds + 1 even to exercise such a code path.
