### PR TITLE
Check that ActorIdentity is from the expected ActorPath

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteSendConsistencySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteSendConsistencySpec.scala
@@ -4,12 +4,20 @@
 
 package akka.remote.artery
 
+import java.util.UUID
+
 import scala.concurrent.duration._
-
 import com.typesafe.config.{ Config, ConfigFactory }
-
-import akka.actor.{ Actor, ActorIdentity, ActorRef, Deploy, Identify, PoisonPill, Props, RootActorPath }
+import akka.actor.Actor
+import akka.actor.ActorIdentity
+import akka.actor.ActorPath
+import akka.actor.ActorRef
 import akka.actor.ActorSelection
+import akka.actor.Deploy
+import akka.actor.Identify
+import akka.actor.PoisonPill
+import akka.actor.Props
+import akka.actor.RootActorPath
 import akka.testkit.{ ImplicitSender, TestActors, TestProbe }
 
 class ArteryUpdSendConsistencyWithOneLaneSpec
@@ -62,6 +70,17 @@ abstract class AbstractRemoteSendConsistencySpec(config: Config)
   val addressB = address(systemB)
   val rootB = RootActorPath(addressB)
 
+  private def actorRefBySelection(path: ActorPath) = {
+
+    val correlationId = Some(UUID.randomUUID().toString)
+    system.actorSelection(path) ! Identify(correlationId)
+
+    val actorIdentity = expectMsgType[ActorIdentity](5.seconds)
+    actorIdentity.correlationId shouldBe correlationId
+
+    actorIdentity.ref.get
+  }
+
   "Artery" must {
 
     "be able to identify a remote actor and ping it" in {
@@ -71,11 +90,9 @@ abstract class AbstractRemoteSendConsistencySpec(config: Config)
         }
       }), "echo")
 
-      val echoSel = system.actorSelection(rootB / "user" / "echo")
-      val echoRef = {
-        system.actorSelection(rootB / "user" / "echo") ! Identify(None)
-        expectMsgType[ActorIdentity](5.seconds).ref.get
-      }
+      val actorPath = rootB / "user" / "echo"
+      val echoSel = system.actorSelection(actorPath)
+      val echoRef = actorRefBySelection(actorPath)
 
       echoRef ! "ping"
       expectMsg("pong")
@@ -119,18 +136,9 @@ abstract class AbstractRemoteSendConsistencySpec(config: Config)
       systemB.actorOf(TestActors.echoActorProps, "echoB")
       systemB.actorOf(TestActors.echoActorProps, "echoC")
 
-      val remoteRefA = {
-        system.actorSelection(rootB / "user" / "echoA") ! Identify(None)
-        expectMsgType[ActorIdentity].ref.get
-      }
-      val remoteRefB = {
-        system.actorSelection(rootB / "user" / "echoB") ! Identify(None)
-        expectMsgType[ActorIdentity].ref.get
-      }
-      val remoteRefC = {
-        system.actorSelection(rootB / "user" / "echoC") ! Identify(None)
-        expectMsgType[ActorIdentity].ref.get
-      }
+      val remoteRefA = actorRefBySelection(rootB / "user" / "echoA")
+      val remoteRefB = actorRefBySelection(rootB / "user" / "echoB")
+      val remoteRefC = actorRefBySelection(rootB / "user" / "echoC")
 
       def senderProps(remoteRef: ActorRef) =
         Props(new Actor {


### PR DESCRIPTION
This is not a fix for #27954, but will gives us better visibility on what's happening.

As explained [here](https://github.com/akka/akka/issues/27954#issuecomment-620539197), I suspect that we are receiving an `ActorIdentity` message from previous tests and that's creating a cascading failure.
