### PR TITLE
Fix race condition in InputStreamSinkSpec

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSinkSpec.scala
@@ -263,10 +263,8 @@ class InputStreamSinkSpec extends StreamSpec(UnboundedMailboxConfig) {
 
     "propagate error to InputStream" in {
       val readTimeout = 3.seconds
-      val (probe, inputStream) =
+      val (probe, inputStream: InputStream) =
         TestSource.probe[ByteString].toMat(StreamConverters.asInputStream(readTimeout))(Keep.both).run()
-
-      probe.sendNext(ByteString("one"))
       val error = new RuntimeException("failure")
       probe.sendError(error)
       val buffer = Array.ofDim[Byte](5)


### PR DESCRIPTION
There's only one read so it was relying on both the Data and the Failed
being in the shared queue when it takes place.

Remove the data so that the poll on the shared queue will wait for the
Failed to be added.

Ref #28829