### PR TITLE
A few more apidoc directives

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/RestartFlow/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartFlow/withBackoff.md
@@ -4,13 +4,9 @@ Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it f
 
 @ref[Error handling](../index.md#error-handling)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [RestartFlow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala) { #withBackoff }
-
-@@@
+@apidoc[RestartFlow.withBackoff](RestartFlow$) { scala="#withBackoff[In,Out](minBackoff:scala.concurrent.duration.FiniteDuration,maxBackoff:scala.concurrent.duration.FiniteDuration,randomFactor:Double)(flowFactory:()=&gt;akka.stream.scaladsl.Flow[In,Out,_]):akka.stream.scaladsl.Flow[In,Out,akka.NotUsed]" java="#withBackoff(java.time.Duration,java.time.Duration,double,int,akka.japi.function.Creator)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/RestartSink/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartSink/withBackoff.md
@@ -4,13 +4,10 @@ Wrap the given @apidoc[Sink] with a @apidoc[Sink] that will restart it when it f
 
 @ref[Error handling](../index.md#error-handling)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [RestartSink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSink.scala) { #withBackoff }
+@apidoc[RestartSink.withBackoff](RestartSink$) { scala="#withBackoff[T](minBackoff:scala.concurrent.duration.FiniteDuration,maxBackoff:scala.concurrent.duration.FiniteDuration,randomFactor:Double,maxRestarts:Int)(sinkFactory:()=&gt;akka.stream.scaladsl.Sink[T,_]):akka.stream.scaladsl.Sink[T,akka.NotUsed]"  java="#withBackoff(java.time.Duration,java.time.Duration,double,int,akka.japi.function.Creator)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/RestartSource/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartSource/withBackoff.md
@@ -4,13 +4,9 @@ Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when 
 
 @ref[Error handling](../index.md#error-handling)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [RestartSource.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSource.scala) { #withBackoff }
-
-@@@
+@apidoc[RestartSource.withBackoff](RestartSource$) { scala="#withBackoff[T](minBackoff:scala.concurrent.duration.FiniteDuration,maxBackoff:scala.concurrent.duration.FiniteDuration,randomFactor:Double,maxRestarts:Int)(sourceFactory:()=&gt;akka.stream.scaladsl.Source[T,_]):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#withBackoff(java.time.Duration,java.time.Duration,double,int,akka.japi.function.Creator)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/RetryFlow/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RetryFlow/withBackoff.md
@@ -4,13 +4,9 @@ Wrap the given @apidoc[Flow] and retry individual elements in that stream with a
 
 @ref[Error handling](../index.md#error-handling)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [RetryFlow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/RetryFlow.scala) { #withBackoff }
-
-@@@
+@apidoc[RetryFlow.withBackoff](RetryFlow$) { scala="#withBackoff[In,Out,Mat](minBackoff:scala.concurrent.duration.FiniteDuration,maxBackoff:scala.concurrent.duration.FiniteDuration,randomFactor:Double,maxRetries:Int,flow:akka.stream.scaladsl.Flow[In,Out,Mat])(decideRetry:(In,Out)=&gt;Option[In]):akka.stream.scaladsl.Flow[In,Out,Mat]" java="#withBackoff(java.time.Duration,java.time.Duration,double,int,akka.stream.javadsl.Flow,akka.japi.function.Function2)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/collection.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/collection.md
@@ -4,13 +4,10 @@
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #collection }
+@apidoc[Sink.collection](Sink$) { scala="#collection[T,That](implicitcbf:akka.util.ccompat.Factory[T,Thatwithscala.collection.immutable.Iterable[_]]):akka.stream.scaladsl.Sink[T,scala.concurrent.Future[That]]" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/combine.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/combine.md
@@ -4,13 +4,9 @@ Combine several sinks into one using a user specified strategy
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #combine }
-
-@@@
+@apidoc[Sink.combine](Sink$) { scala="#combine[T,U](first:akka.stream.scaladsl.Sink[U,_],second:akka.stream.scaladsl.Sink[U,_],rest:akka.stream.scaladsl.Sink[U,_]*)(strategy:Int=&gt;akka.stream.Graph[akka.stream.UniformFanOutShape[T,U],akka.NotUsed]):akka.stream.scaladsl.Sink[T,akka.NotUsed]" java="#combine(akka.stream.javadsl.Sink,akka.stream.javadsl.Sink,java.util.List,akka.japi.function.Function)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/queue.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/queue.md
@@ -4,13 +4,10 @@ Materialize a `SinkQueue` that can be pulled to trigger demand through the sink.
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #queue }
+@apidoc[Sink.queue](Sink$) { scala="#queue[T](maxConcurrentPulls:Int):akka.stream.scaladsl.Sink[T,akka.stream.scaladsl.SinkQueueWithCancel[T]]" java="#queue(int)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/setup.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/setup.md
@@ -10,13 +10,9 @@ The `setup` operator has been deprecated, use @ref:[fromMaterializer](./fromMate
 
 @@@
 
-@@@ div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #setup }
-
-@@@
+@apidoc[Sink.setup](Sink$) { scala="#setup[T,M](factory:(akka.stream.ActorMaterializer,akka.stream.Attributes)=&gt;akka.stream.scaladsl.Sink[T,M]):akka.stream.scaladsl.Sink[T,scala.concurrent.Future[M]]" java="#setup(java.util.function.BiFunction)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/alsoTo.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/alsoTo.md
@@ -4,11 +4,11 @@ Attaches the given `Sink` to this `Flow`, meaning that elements that pass throug
 
 @ref[Fan-out operators](../index.md#fan-out-operators)
 
-@@@ div { .group-scala }
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #alsoTo }
-@@@
+@apidoc[Source.alsoTo](Source) { scala="#alsoTo(that:akka.stream.Graph[akka.stream.SinkShape[Out],_]):FlowOps.this.Repr[Out]" java="#alsoTo(akka.stream.Graph)" }
+@apidoc[Flow.alsoTo](Flow) { scala="#alsoTo(that:akka.stream.Graph[akka.stream.SinkShape[Out],_]):FlowOps.this.Repr[Out]" java="#alsoTo(akka.stream.Graph)" }
+
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/batchWeighted.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/batchWeighted.md
@@ -4,11 +4,11 @@ Allow for a slower downstream by passing incoming elements and a summary into an
 
 @ref[Backpressure aware operators](../index.md#backpressure-aware-operators)
 
-@@@ div { .group-scala }
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #batchWeighted }
-@@@
+@apidoc[Source.batchWeighted](Source) { scala="#batchWeighted[S](max:Long,costFn:Out=&gt;Long,seed:Out=&gt;S)(aggregate:(S,Out)=&gt;S):FlowOps.this.Repr[S]" java="#batchWeighted(long,akka.japi.function.Function,akka.japi.function.Function,akka.japi.function.Function2)" }
+@apidoc[Flow.batchWeighted](Flow) { scala="#batchWeighted[S](max:Long,costFn:Out=&gt;Long,seed:Out=&gt;S)(aggregate:(S,Out)=&gt;S):FlowOps.this.Repr[S]" java="#batchWeighted(long,akka.japi.function.Function,akka.japi.function.Function,akka.japi.function.Function2)" }
+
 
 
 ## Description

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/buffer.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/buffer.md
@@ -4,12 +4,10 @@ Allow for a temporarily faster upstream events by buffering `size` elements.
 
 @ref[Backpressure aware operators](../index.md#backpressure-aware-operators)
 
-@@@ div { .group-scala }
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #buffer }
-@@@
-
+@apidoc[Source.buffer](Source) { scala"#buffer(size:Int,overflowStrategy:akka.stream.OverflowStrategy):FlowOps.this.Repr[Out]" java="#buffer(int,akka.stream.OverflowStrategy)" }
+@apidoc[Flow.buffer](Flow) { scala="#buffer(size:Int,overflowStrategy:akka.stream.OverflowStrategy):FlowOps.this.Repr[Out]" java="#buffer(int,akka.stream.OverflowStrategy)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/collect.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/collect.md
@@ -4,13 +4,10 @@ Apply a partial function to each incoming element, if the partial function is de
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #collect }
-
-@@@
+@apidoc[Source.collect](Source) { scala="#collect[T](pf:PartialFunction[Out,T]):FlowOps.this.Repr[T]" java="#collect(scala.PartialFunction)" }
+@apidoc[Flow.collect](Flow) { scala="#collect[T](pf:PartialFunction[Out,T]):FlowOps.this.Repr[T]" java="#collect(scala.PartialFunction)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/completionTimeout.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/completionTimeout.md
@@ -4,13 +4,11 @@ If the completion of the stream does not happen until the provided timeout, the 
 
 @ref[Time aware operators](../index.md#time-aware-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #completionTimeout }
+@apidoc[Source.completionTimeout](Source) { scala="#completionTimeout(timeout:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Out]" java="#completionTimeout(java.time.Duration)" }
+@apidoc[Flow.completionTimeout](Flow) { scala="#completionTimeout(timeout:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Out]" java="#completionTimeout(java.time.Duration)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/concat.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/concat.md
@@ -4,13 +4,11 @@ After completion of the original upstream the elements of the given source will 
 
 @ref[Fan-in operators](../index.md#fan-in-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #concat }
+@apidoc[Source.concat](Source) { scala="#concat[U&gt;:Out,Mat2](that:akka.stream.Graph[akka.stream.SourceShape[U],Mat2]):FlowOps.this.Repr[U]" java="#concat(akka.stream.Graph)" }
+@apidoc[Flow.concat](Flow) { scala="#concat[U&gt;:Out,Mat2](that:akka.stream.Graph[akka.stream.SourceShape[U],Mat2]):FlowOps.this.Repr[U]" java="#concat(akka.stream.Graph)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/idleTimeout.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/idleTimeout.md
@@ -4,13 +4,10 @@ If the time between two processed elements exceeds the provided timeout, the str
 
 @ref[Time aware operators](../index.md#time-aware-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #idleTimeout }
-
-@@@
+@apidoc[Source.idleTimeout](Source) { scala="#idleTimeout(timeout:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Out]" java="#idleTimeout(java.time.Duration)" }
+@apidoc[Flow.idleTimeout](Flow) { scala="#idleTimeout(timeout:scala.concurrent.duration.FiniteDuration):FlowOps.this.Repr[Out]" java="#idleTimeout(java.time.Duration)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/log.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/log.md
@@ -4,13 +4,10 @@ Log elements flowing through the stream as well as completion and erroring.
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #log }
-
-@@@
+@apidoc[Source.log](Source) { scala="#log(name:String,extract:Out=&gt;Any)(implicitlog:akka.event.LoggingAdapter):FlowOps.this.Repr[Out]" java="#log(java.lang.String)" }
+@apidoc[Flow.log](Flow) { scala="#log(name:String,extract:Out=&gt;Any)(implicitlog:akka.event.LoggingAdapter):FlowOps.this.Repr[Out]" java="#log(java.lang.String)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/merge.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/merge.md
@@ -4,13 +4,11 @@ Merge multiple sources.
 
 @ref[Fan-in operators](../index.md#fan-in-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #merge }
+@apidoc[Source.merge](Source) { scala="#merge[U&gt;:Out,M](that:akka.stream.Graph[akka.stream.SourceShape[U],M],eagerComplete:Boolean):FlowOps.this.Repr[U]" java="#merge(akka.stream.Graph)" java="#merge(akka.stream.Graph,boolean)" }
+@apidoc[Flow.merge](Flow) { scala="#merge[U&gt;:Out,M](that:akka.stream.Graph[akka.stream.SourceShape[U],M],eagerComplete:Boolean):FlowOps.this.Repr[U]" java="#merge(akka.stream.Graph)" java="#merge(akka.stream.Graph,boolean)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/setup.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/setup.md
@@ -10,14 +10,10 @@ The `setup` operator has been deprecated, use @ref:[fromMaterializer](./fromMate
 
 @@@
 
-@@@ div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #setup }
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #setup }
-
-@@@
+@apidoc[Source.setup](Source$) { scala="#setup[T,M](factory:(akka.stream.ActorMaterializer,akka.stream.Attributes)=&gt;akka.stream.scaladsl.Source[T,M]):akka.stream.scaladsl.Source[T,scala.concurrent.Future[M]]" java="#setup(java.util.function.BiFunction)" }
+@apidoc[Flow.setup](Flow$) { scala="#setup[T,U,M](factory:(akka.stream.ActorMaterializer,akka.stream.Attributes)=&gt;akka.stream.scaladsl.Flow[T,U,M]):akka.stream.scaladsl.Flow[T,U,scala.concurrent.Future[M]]" java="#setup(java.util.function.BiFunction)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/throttle.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/throttle.md
@@ -4,13 +4,10 @@ Limit the throughput to a specific number of elements per time unit, or a specif
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #throttle }
-
-@@@
+@apidoc[Source.throttle](Source) { scala="#throttle(cost:Int,per:scala.concurrent.duration.FiniteDuration,maximumBurst:Int,costCalculation:Out=&gt;Int,mode:akka.stream.ThrottleMode):FlowOps.this.Repr[Out]" java="#throttle(int,java.time.Duration,int,akka.japi.function.Function,akka.stream.ThrottleMode)" }
+@apidoc[Flow.throttle](Flow) { scala="#throttle(cost:Int,per:scala.concurrent.duration.FiniteDuration,maximumBurst:Int,costCalculation:Out=&gt;Int,mode:akka.stream.ThrottleMode):FlowOps.this.Repr[Out]" java="#throttle(int,java.time.Duration,int,akka.japi.function.Function,akka.stream.ThrottleMode)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/watch.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/watch.md
@@ -4,13 +4,10 @@ Watch a specific `ActorRef` and signal a failure downstream once the actor termi
 
 @ref[Actor interop operators](../index.md#actor-interop-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #watch }
-
-@@@
+@apidoc[Source.watch](Source) { scala="#watch(ref:akka.actor.ActorRef):FlowOps.this.Repr[Out]" java="#watch(akka.actor.ActorRef)" }
+@apidoc[Flow.watch](Flow) { scala="#watch(ref:akka.actor.ActorRef):FlowOps.this.Repr[Out]" java="#watch(akka.actor.ActorRef)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zip.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zip.md
@@ -4,13 +4,10 @@ Combines elements from each of multiple sources into @scala[tuples] @java[*Pair*
 
 @ref[Fan-in operators](../index.md#fan-in-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #zip }
-
-@@@
+@apidoc[Source.zip](Source$) { scala="#zip[U](that:akka.stream.Graph[akka.stream.SourceShape[U],_]):FlowOps.this.Repr[(Out,U)]" java="#zip(akka.stream.Graph)" }
+@apidoc[Flow.zip](Flow) { scala="#zip[U](that:akka.stream.Graph[akka.stream.SourceShape[U],_]):FlowOps.this.Repr[(Out,U)]" java="#zip(akka.stream.Graph)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zipWith.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/zipWith.md
@@ -4,13 +4,11 @@ Combines elements from multiple sources through a `combine` function and passes 
 
 @ref[Fan-in operators](../index.md#fan-in-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #zipWith }
+@apidoc[Source.zipWith](Source) { scala="#zipWith[Out2,Out3](that:akka.stream.Graph[akka.stream.SourceShape[Out2],_])(combine:(Out,Out2)=&gt;Out3):FlowOps.this.Repr[Out3]" java="#zipWith(akka.stream.Graph,akka.japi.function.Function2)" }
+@apidoc[Flow.zipWith](Flow) { scala="#zipWith[Out2,Out3](that:akka.stream.Graph[akka.stream.SourceShape[Out2],_])(combine:(Out,Out2)=&gt;Out3):FlowOps.this.Repr[Out3]" java="#zipWith(akka.stream.Graph,akka.japi.function.Function2)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/combine.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/combine.md
@@ -4,13 +4,10 @@ Combine several sources, using a given strategy such as merge or concat, into on
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #combine }
+@apidoc[Source.combine](Source$) { scala="#combine[T,U](first:akka.stream.scaladsl.Source[T,_],second:akka.stream.scaladsl.Source[T,_],rest:akka.stream.scaladsl.Source[T,_]*)(strategy:Int=&gt;akka.stream.Graph[akka.stream.UniformFanInShape[T,U],akka.NotUsed]):akka.stream.scaladsl.Source[U,akka.NotUsed]" java="#combine(akka.stream.javadsl.Source,akka.stream.javadsl.Source,java.util.List,akka.japi.function.Function)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/queue.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/queue.md
@@ -4,13 +4,10 @@ Materialize a `SourceQueue` onto which elements can be pushed for emitting from 
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #queue }
+@apidoc[Source.queue](Source$) { scala="#queue[T](bufferSize:Int,overflowStrategy:akka.stream.OverflowStrategy):akka.stream.scaladsl.Source[T,akka.stream.scaladsl.SourceQueueWithComplete[T]]" java="#queue(int,akka.stream.OverflowStrategy)" }
 
-@@@
 
 ## Description
 


### PR DESCRIPTION
References #28901 

This is a follow up to #28980. It required a couple of fixes in the automated script and some manual massaging of the output.

With this PR, the number of usages of the `@signature` directive in the operator docs is down to only 11.