### PR TITLE
Docs: Javadoc links in project info

### DIFF
--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -1,7 +1,7 @@
 project-info {
   version: "current"
   scaladoc: "https://doc.akka.io/api/akka/"${project-info.version}"/akka/"
-  javadoc: "https://doc.akka.io/japi/akka/"${project-info.version}"/index.html"
+  javadoc: "https://doc.akka.io/japi/akka/"${project-info.version}"/akka/"
   shared-info {
     jdk-versions: ["Adopt OpenJDK 8", "Adopt OpenJDK 11"]
     // snapshots: { }
@@ -41,7 +41,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/actor/package-summary.html"
+        url: ${project-info.javadoc}"actor/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -67,7 +67,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/actor/testkit/typed/package-summary.html"
+        url: ${project-info.javadoc}"actor/testkit/typed/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -93,7 +93,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/actor/typed/package-summary.html"
+        url: ${project-info.javadoc}"actor/typed/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -114,7 +114,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/cluster/package-summary.html"
+        url: ${project-info.javadoc}"cluster/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -135,7 +135,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/cluster/metrics/package-summary.html"
+        url: ${project-info.javadoc}"cluster/metrics/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -156,7 +156,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/cluster/sharding/package-summary.html"
+        url: ${project-info.javadoc}"cluster/sharding/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -182,7 +182,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/cluster/sharding/typed/package-summary.html"
+        url: ${project-info.javadoc}"cluster/sharding/typed/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -203,7 +203,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/cluster/tools/package-summary.html"
+        url: ${project-info.javadoc}"cluster/tools/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -229,7 +229,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/cluster/typed/package-summary.html"
+        url: ${project-info.javadoc}"cluster/typed/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -250,7 +250,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/coordination/package-summary.html"
+        url: ${project-info.javadoc}"coordination/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -271,7 +271,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/discovery/package-summary.html"
+        url: ${project-info.javadoc}"discovery/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -292,7 +292,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/discovery/package-summary.html"
+        url: ${project-info.javadoc}"discovery/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -313,7 +313,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/remote/testkit/package-summary.html"
+        url: ${project-info.javadoc}"remote/testkit/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -334,7 +334,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/osgi/package-summary.html"
+        url: ${project-info.javadoc}"osgi/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -355,7 +355,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/persistence/package-summary.html"
+        url: ${project-info.javadoc}"persistence/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -376,7 +376,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/persistence/query/package-summary.html"
+        url: ${project-info.javadoc}"persistence/query/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -402,7 +402,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/persistence/typed/package-summary.html"
+        url: ${project-info.javadoc}"persistence/typed/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -423,7 +423,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/persistence/testkit/javadsl/package-summary.html"
+        url: ${project-info.javadoc}"persistence/testkit/javadsl/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -450,7 +450,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/remote/package-summary.html"
+        url: ${project-info.javadoc}"remote/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -471,7 +471,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/event/slf4j/package-summary.html"
+        url: ${project-info.javadoc}"event/slf4j/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -492,7 +492,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/stream/package-summary.html"
+        url: ${project-info.javadoc}"stream/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -513,7 +513,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/stream/testkit/package-summary.html"
+        url: ${project-info.javadoc}"stream/testkit/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -539,7 +539,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/stream/package-summary.html"
+        url: ${project-info.javadoc}"stream/package-summary.html"
         text: "API (Javadoc)"
       }
     ]
@@ -560,7 +560,7 @@ project-info {
         text: "API (Scaladoc)"
       }
       {
-        url: ${project-info.javadoc}"?akka/testkit/package-summary.html"
+        url: ${project-info.javadoc}"testkit/package-summary.html"
         text: "API (Javadoc)"
       }
     ]


### PR DESCRIPTION
The links broke when we changed to non-frames style Javadoc.

Fixes #28996