### PR TITLE
extend JacksonSerializer with ByteBufferSerializer

### DIFF
--- a/akka-actor/src/main/scala/akka/serialization/Serialization.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serialization.scala
@@ -149,7 +149,7 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
   @InternalApi private[akka] def serializationInformation: Serialization.Information =
     system.provider.serializationInformation
 
-  private def withTransportInformation[T](f: () => T): T = {
+  private[akka] def withTransportInformation[T](f: () => T): T = {
     val oldInfo = Serialization.currentTransportInformation.value
     try {
       if (oldInfo eq null)

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.serialization.jackson
 
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.time.Instant
@@ -691,6 +692,13 @@ abstract class JacksonSerializerSpec(serializerName: String)
 
     val deserialized = deserializeFromBinary(blob, serializerId, manifest, sys)
     deserialized should ===(obj)
+
+    val buffer = ByteBuffer.allocate(blob.size)
+    serialization(sys).withTransportInformation { () =>
+      serializer.toBinary(obj, buffer)
+    }
+    val deserializedFromBuffer = serialization(sys).deserializeByteBuffer(buffer, serializerId, manifest)
+    deserializedFromBuffer should ===(obj)
   }
 
   def serializeToBinary(obj: AnyRef, sys: ActorSystem = system): Array[Byte] =


### PR DESCRIPTION
reference: https://github.com/akka/akka/issues/27107

I didn't implemented ByteBufferSerializer with ByteBufferBackedOutputStream/ByteBufferBackedInputStream yet. Because it is particularly awkward to use gzip to transform the io stream. I can make a new output stream and transform the input stream to gzipped/ungzipped version, but the resulting stream has became a output stream. I can not read it. I have not good way to circumvent this issue. Any ideas?