### PR TITLE
Typo in "Basics and working with Flows"

### DIFF
--- a/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
+++ b/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
@@ -77,7 +77,7 @@ RunnableGraph
 
 
 It is possible to attach a `Flow` to a `Source` resulting in a composite source, and it is also possible to prepend
-a `Flow` to a `Sink` to get a new sink. After a stream is properly terminated by having both a source and a sink,
+a `Flow` to a `Sink` to get a new sink. After a stream is properly constructed by having both a source and a sink,
 it will be represented by the `RunnableGraph` type, indicating that it is ready to be executed.
 
 It is important to remember that even after constructing the `RunnableGraph` by connecting all the source, sink and


### PR DESCRIPTION
[Defining and running streams](https://doc.akka.io/docs/akka/current/stream/stream-flows-and-basics.html#defining-and-running-streams) says:
> It is possible to attach a `Flow` to a `Source` resulting in a composite source, and it is also possible to prepend a `Flow` to a `Sink` to get a new sink. After a stream is properly **terminated** by having both a source and a sink, it will be represented by the `RunnableGraph` type, indicating that it is ready to be executed.

The word "terminated" confuses since the doc is using it when it says about "terminal" states of a stream, like cancelled or stopped. For instance:
>When the materializer is shut down before the streams have run to completion, they will be **terminated** abruptly. This is a little different than the usual way to **terminate** streams, which is by cancelling/completing them.

A better word would be "constructed". The doc is using it when it explains materializing a newly created stream. For example:
> It is important to remember that even after **constructing** the `RunnableGraph` by connecting all the source, sink and different operators, no data will flow through it until it is materialized.