### PR TITLE
Final signature to apidoc review

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/ActorSink/actorRef.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorSink/actorRef.md
@@ -14,13 +14,9 @@ This operator is included in:
   version="$akka.version$"
 }
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [ActorSink.scala](/akka-stream-typed/src/main/scala/akka/stream/typed/scaladsl/ActorSink.scala) { #actorRef }
-
-@@@
+@apidoc[ActorSink.actorRef](ActorSink$) { scala="#actorRef[T](ref:akka.actor.typed.ActorRef[T],onCompleteMessage:T,onFailureMessage:Throwable=&gt;T):akka.stream.scaladsl.Sink[T,akka.NotUsed]" java="#actorRef(akka.actor.typed.ActorRef,java.lang.Object,akka.japi.function.Function)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/ActorSink/actorRefWithBackpressure.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorSink/actorRefWithBackpressure.md
@@ -14,13 +14,9 @@ This operator is included in:
   version="$akka.version$"
 }
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [ActorSink.scala](/akka-stream-typed/src/main/scala/akka/stream/typed/scaladsl/ActorSink.scala) { #actorRefWithBackpressure }
-
-@@@
+@apidoc[ActorSink.actorRefWithBackpressure](ActorSink$) { scala="#actorRefWithBackpressure[T,M,A](ref:akka.actor.typed.ActorRef[M],messageAdapter:(akka.actor.typed.ActorRef[A],T)=&gt;M,onInitMessage:akka.actor.typed.ActorRef[A]=&gt;M,ackMessage:A,onCompleteMessage:M,onFailureMessage:Throwable=&gt;M):akka.stream.scaladsl.Sink[T,akka.NotUsed]" java="#actorRefWithBackpressure(akka.actor.typed.ActorRef,akka.japi.function.Function2,akka.japi.function.Function,java.lang.Object,java.lang.Object,akka.japi.function.Function)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/ActorSource/actorRef.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorSource/actorRef.md
@@ -14,13 +14,9 @@ This operator is included in:
   version="$akka.version$"
 }
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [ActorSource.scala](/akka-stream-typed/src/main/scala/akka/stream/typed/scaladsl/ActorSource.scala) { #actorRef }
-
-@@@
+@apidoc[ActorSource.actorRef](ActorSource$) { scala="#actorRef[T](completionMatcher:PartialFunction[T,Unit],failureMatcher:PartialFunction[T,Throwable],bufferSize:Int,overflowStrategy:akka.stream.OverflowStrategy):akka.stream.scaladsl.Source[T,akka.actor.typed.ActorRef[T]]" java="#actorRef(java.util.function.Predicate,akka.japi.function.Function,int,akka.stream.OverflowStrategy)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/ActorSource/actorRefWithBackpressure.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorSource/actorRefWithBackpressure.md
@@ -14,12 +14,9 @@ This operator is included in:
   version="$akka.version$"
 }
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [ActorSource.scala](/akka-stream-typed/src/main/scala/akka/stream/typed/scaladsl/ActorSource.scala) { #actorRefWithBackpressure }
-@@@
+@apidoc[ActorSource.actorRefWithBackpressure](ActorSource$) { scala="#actorRefWithBackpressure[T,Ack](ackTo:akka.actor.typed.ActorRef[Ack],ackMessage:Ack,completionMatcher:PartialFunction[T,akka.stream.CompletionStrategy],failureMatcher:PartialFunction[T,Throwable]):akka.stream.scaladsl.Source[T,akka.actor.typed.ActorRef[T]]" java="#actorRefWithBackpressure(akka.actor.typed.ActorRef,java.lang.Object,akka.japi.function.Function,akka.japi.function.Function)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/actorRef.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/actorRef.md
@@ -4,12 +4,9 @@ Send the elements from the stream to an `ActorRef`.
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@div { .group-scala }
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #actorRef }
-
-@@@
+@apidoc[Sink.actorRef](Sink$) { scala="#actorRef[T](ref:akka.actor.ActorRef,onCompleteMessage:Any,onFailureMessage:Throwable=&gt;Any):akka.stream.scaladsl.Sink[T,akka.NotUsed]" java="#actorRef(akka.actor.ActorRef,java.lang.Object)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Sink/actorRefWithBackpressure.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/actorRefWithBackpressure.md
@@ -4,6 +4,10 @@ Send the elements from the stream to an `ActorRef` which must then acknowledge r
 
 @ref[Sink operators](../index.md#sink-operators)
 
+## Signature
+
+@apidoc[Sink.actorRefWithBackpressure](Sink$) { scala="#actorRefWithBackpressure[T](ref:akka.actor.ActorRef,onInitMessage:Any,ackMessage:Any,onCompleteMessage:Any,onFailureMessage:Throwable=&gt;Any):akka.stream.scaladsl.Sink[T,akka.NotUsed]" java="#actorRefWithBackpressure(akka.actor.ActorRef,java.lang.Object,java.lang.Object,java.lang.Object,akka.japi.function.Function)" }
+
 ## Description
 
 Send the elements from the stream to an `ActorRef` which must then acknowledge reception after completing a message,

--- a/akka-docs/src/main/paradox/stream/operators/Sink/fromMaterializer.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/fromMaterializer.md
@@ -4,13 +4,9 @@ Defer the creation of a `Sink` until materialization and access `Materializer` a
 
 @ref[Sink operators](../index.md#sink-operators)
 
-@@@ div { .group-scala }
-
 ## Signature
 
-@@signature [Sink.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala) { #fromMaterializer }
-
-@@@
+@apidoc[Sink.fromMaterializer](Sink$) { scala="#fromMaterializer[T,M](factory:(akka.stream.Materializer,akka.stream.Attributes)=&gt;akka.stream.scaladsl.Sink[T,M]):akka.stream.scaladsl.Sink[T,scala.concurrent.Future[M]]" java="#fromMaterializer(java.util.function.BiFunction)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/ask.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/ask.md
@@ -6,6 +6,7 @@ Use the "Ask Pattern" to send a request-reply message to the target `ref` actor 
 
 ## Signature
 
+@apidoc[Source.ask](Source) {scala="#ask[S](ref:akka.actor.ActorRef)(implicittimeout:akka.util.Timeout,implicittag:scala.reflect.ClassTag[S]):FlowOps.this.Repr[S]" java="#ask(akka.actor.ActorRef,java.lang.Class,akka.util.Timeout)" }
 @apidoc[Flow.ask](Flow$) { scala="#ask%5BS](ref:akka.actor.ActorRef)(implicittimeout:akka.util.Timeout,implicittag:scala.reflect.ClassTag%5BS]):FlowOps.this.Repr%5BS]" java="#ask(akka.actor.ActorRef,java.lang.Class,akka.util.Timeout)" }
 
 ## Description

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/fromMaterializer.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/fromMaterializer.md
@@ -4,14 +4,11 @@ Defer the creation of a `Source/Flow` until materialization and access `Material
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@ div { .group-scala }
-
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #fromMaterializer }
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #fromMaterializer }
+@apidoc[Source.fromMaterializer](Source$) { scala="#fromMaterializer[T,M](factory:(akka.stream.Materializer,akka.stream.Attributes)=&gt;akka.stream.scaladsl.Source[T,M]):akka.stream.scaladsl.Source[T,scala.concurrent.Future[M]]" java="#fromMaterializer(java.util.function.BiFunction)" }
+@apidoc[Flow.fromMaterializer](Flow$) { scala="#fromMaterializer[T,U,M](factory:(akka.stream.Materializer,akka.stream.Attributes)=&gt;akka.stream.scaladsl.Flow[T,U,M]):akka.stream.scaladsl.Flow[T,U,scala.concurrent.Future[M]]" java="#fromMaterializer(java.util.function.BiFunction)" }
 
-@@@
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/map.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/map.md
@@ -4,13 +4,10 @@ Transform each element in the stream by calling a mapping function with it and p
 
 @ref[Simple operators](../index.md#simple-operators)
 
-@@@div { .group-scala }
-
 ## Signature
 
-@@signature [Flow.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala) { #map }
-
-@@@
+@apidoc[Source.map](Source) { scala="#map[T](f:Out=&gt;T):FlowOps.this.Repr[T]" java="#map(akka.japi.function.Function)" }
+@apidoc[Flow.map](Flow) { scala="#map[T](f:Out=&gt;T):FlowOps.this.Repr[T]" java="#map(akka.japi.function.Function)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/actorRefWithBackpressure.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/actorRefWithBackpressure.md
@@ -4,11 +4,9 @@ Materialize an `ActorRef`; sending messages to it will emit them on the stream. 
 
 @ref[Source operators](../index.md#source-operators)
 
-@@@ div { .group-scala }
 ## Signature
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #actorRefWithBackpressure }
-@@@
+@apidoc[Source.actorRefWithBackpressure](Source$) { scala="#actorRefWithBackpressure[T](ackMessage:Any,completionMatcher:PartialFunction[Any,akka.stream.CompletionStrategy],failureMatcher:PartialFunction[Any,Throwable]):akka.stream.scaladsl.Source[T,akka.actor.ActorRef]" java="#actorRefWithBackpressure(java.lang.Object,akka.japi.function.Function,akka.japi.function.Function)" }
 
 ## Description
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/from.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/from.md
@@ -4,14 +4,19 @@ Stream the values of an @scala[`immutable.Seq`]@java[`Iterable`].
 
 @ref[Source operators](../index.md#source-operators)
 
+## Signature
 
 @@@div { .group-scala }
 
-## Signature
+@apidoc[Source.apply](Source$) { scala="#apply[T](iterable:scala.collection.immutable.Iterable[T]):akka.stream.scaladsl.Source[T,akka.NotUsed]"  }
 
-@@signature [Source.scala](/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala) { #apply }
+@@@ 
 
-@@@
+@@@div { .group-java }
+
+@apidoc[Source.from](Source$) { java="#from(java.lang.Iterable)" }
+
+@@@ 
 
 ## Description
 


### PR DESCRIPTION
Completes the migration from the `@signature` to `@apidoc` directive in operators docs.

References #28901
