### PR TITLE
Docs: Scala binary verison in Maven and gradle dependencies

### DIFF
--- a/akka-docs/src/main/paradox/actors.md
+++ b/akka-docs/src/main/paradox/actors.md
@@ -8,7 +8,7 @@ To use Classic Actors, add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/additional/osgi.md
+++ b/akka-docs/src/main/paradox/additional/osgi.md
@@ -6,7 +6,7 @@ To use Akka in OSGi, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-osgi_$scala.binary_version$
+  artifact=akka-osgi_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/cluster-client.md
+++ b/akka-docs/src/main/paradox/cluster-client.md
@@ -15,7 +15,7 @@ To use Cluster Client, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-tools_$scala.binary_version$
+  artifact=akka-cluster-tools_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/cluster-metrics.md
+++ b/akka-docs/src/main/paradox/cluster-metrics.md
@@ -6,7 +6,7 @@ To use Cluster Metrics Extension, you must add the following dependency in your 
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-metrics_$scala.binary_version$
+  artifact=akka-cluster-metrics_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/cluster-routing.md
+++ b/akka-docs/src/main/paradox/cluster-routing.md
@@ -33,7 +33,7 @@ To use Cluster aware routers, you must add the following dependency in your proj
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-cluster_$scala.binary_version$"
+  artifact="akka-cluster_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/cluster-sharding.md
@@ -9,7 +9,7 @@ To use Cluster Sharding, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-sharding_$scala.binary_version$
+  artifact=akka-cluster-sharding_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/cluster-singleton.md
+++ b/akka-docs/src/main/paradox/cluster-singleton.md
@@ -9,7 +9,7 @@ To use Cluster Singleton, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-tools_$scala.binary_version$
+  artifact=akka-cluster-tools_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/cluster-usage.md
+++ b/akka-docs/src/main/paradox/cluster-usage.md
@@ -25,7 +25,7 @@ To use Akka Cluster add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-cluster_$scala.binary_version$"
+  artifact="akka-cluster_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/coordination.md
+++ b/akka-docs/src/main/paradox/coordination.md
@@ -9,7 +9,7 @@ Akka Coordination is a set of tools for distributed coordination.
 
 @@dependency[sbt,Gradle,Maven] {
   group="com.typesafe.akka"
-  artifact="akka-coordination_$scala.binary_version$"
+  artifact="akka-coordination_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/discovery/index.md
+++ b/akka-docs/src/main/paradox/discovery/index.md
@@ -35,7 +35,7 @@ See @ref:[Migration hints](#migrating-from-akka-management-discovery-before-1-0-
 
 @@dependency[sbt,Gradle,Maven] {
   group="com.typesafe.akka"
-  artifact="akka-discovery_$scala.binary_version$"
+  artifact="akka-discovery_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/dispatchers.md
+++ b/akka-docs/src/main/paradox/dispatchers.md
@@ -9,7 +9,7 @@ Dispatchers are part of core Akka, which means that they are part of the akka-ac
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/distributed-data.md
+++ b/akka-docs/src/main/paradox/distributed-data.md
@@ -9,7 +9,7 @@ To use Akka Distributed Data, you must add the following dependency in your proj
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-distributed-data_$scala.binary_version$"
+  artifact="akka-distributed-data_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/distributed-pub-sub.md
+++ b/akka-docs/src/main/paradox/distributed-pub-sub.md
@@ -9,7 +9,7 @@ To use Distributed Publish Subscribe you must add the following dependency in yo
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-cluster-tools_$scala.binary_version$"
+  artifact="akka-cluster-tools_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/fault-tolerance.md
+++ b/akka-docs/src/main/paradox/fault-tolerance.md
@@ -9,7 +9,7 @@ The concept of fault tolerance relates to actors, so in order to use these make 
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/fsm.md
+++ b/akka-docs/src/main/paradox/fsm.md
@@ -9,7 +9,7 @@ To use Finite State Machine actors, you must add the following dependency in you
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/index-actors.md
+++ b/akka-docs/src/main/paradox/index-actors.md
@@ -8,7 +8,7 @@ To use Classic Akka Actors, you must add the following dependency in your projec
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/index-utilities-classic.md
+++ b/akka-docs/src/main/paradox/index-utilities-classic.md
@@ -6,7 +6,7 @@ To use Utilities, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/io-tcp.md
+++ b/akka-docs/src/main/paradox/io-tcp.md
@@ -9,7 +9,7 @@ To use TCP, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/io-udp.md
+++ b/akka-docs/src/main/paradox/io-udp.md
@@ -9,7 +9,7 @@ To use UDP, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/io.md
+++ b/akka-docs/src/main/paradox/io.md
@@ -6,7 +6,7 @@ To use I/O, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/logging.md
+++ b/akka-docs/src/main/paradox/logging.md
@@ -9,7 +9,7 @@ To use Logging, you must at least use the Akka actors dependency in your project
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 
@@ -339,7 +339,7 @@ It has a single dependency: the slf4j-api jar. In your runtime, you also need a 
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-slf4j_$scala.binary_version$"
+  artifact="akka-slf4j_$scala.binary.version$"
   version="$akka.version$"
   group2="ch.qos.logback"
   artifact2="logback-classic"

--- a/akka-docs/src/main/paradox/mailboxes.md
+++ b/akka-docs/src/main/paradox/mailboxes.md
@@ -9,7 +9,7 @@ To use Mailboxes, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/multi-node-testing.md
+++ b/akka-docs/src/main/paradox/multi-node-testing.md
@@ -9,7 +9,7 @@ To use Multi Node Testing, you must add the following dependency in your project
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-multi-node-testkit_$scala.binary_version$
+  artifact=akka-multi-node-testkit_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/persistence-fsm.md
+++ b/akka-docs/src/main/paradox/persistence-fsm.md
@@ -8,7 +8,7 @@ Persistent FSMs are part of Akka persistence, you must add the following depende
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-persistence_$scala.binary_version$"
+  artifact="akka-persistence_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/persistence-journals.md
+++ b/akka-docs/src/main/paradox/persistence-journals.md
@@ -103,7 +103,7 @@ The TCK is usable from Java as well as Scala projects. To test your implementati
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-persistence-tck_$scala.binary_version$"
+  artifact="akka-persistence-tck_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/persistence-query-leveldb.md
+++ b/akka-docs/src/main/paradox/persistence-query-leveldb.md
@@ -6,7 +6,7 @@ To use Persistence Query, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-persistence-query_$scala.binary_version$
+  artifact=akka-persistence-query_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/persistence-query.md
+++ b/akka-docs/src/main/paradox/persistence-query.md
@@ -9,7 +9,7 @@ To use Persistence Query, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-persistence-query_$scala.binary_version$
+  artifact=akka-persistence-query_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/persistence-schema-evolution.md
+++ b/akka-docs/src/main/paradox/persistence-schema-evolution.md
@@ -6,7 +6,7 @@ This documentation page touches upon @ref[Akka Persistence](persistence.md), so 
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-persistence_$scala.binary_version$"
+  artifact="akka-persistence_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/persistence.md
+++ b/akka-docs/src/main/paradox/persistence.md
@@ -12,7 +12,7 @@ To use Akka Persistence, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-persistence_$scala.binary_version$"
+  artifact="akka-persistence_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/project/links.md
+++ b/akka-docs/src/main/paradox/project/links.md
@@ -57,7 +57,7 @@ Define the library dependencies with the timestamp as version. For example:
 
 @@@vars
 ```
-libraryDependencies += "com.typesafe.akka" % "akka-remote_$scala.binary_version$" % "2.5-20170510-230859"
+libraryDependencies += "com.typesafe.akka" % "akka-remote_$scala.binary.version$" % "2.5-20170510-230859"
 ```
 @@@
 
@@ -83,7 +83,7 @@ Define the library dependencies with the timestamp as version. For example:
 <dependencies>
   <dependency>
     <groupId>com.typesafe.akka</groupId>
-    <artifactId>akka-remote_$scala.binary_version$</artifactId>
+    <artifactId>akka-remote_$scala.binary.version$</artifactId>
     <version>2.5-20170510-230859</version>
   </dependency>
 </dependencies>

--- a/akka-docs/src/main/paradox/remoting-artery.md
+++ b/akka-docs/src/main/paradox/remoting-artery.md
@@ -22,7 +22,7 @@ To use Artery Remoting, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-remote_$scala.binary_version$
+  artifact=akka-remote_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/remoting.md
+++ b/akka-docs/src/main/paradox/remoting.md
@@ -26,7 +26,7 @@ To use Akka Remoting, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-remote_$scala.binary_version$
+  artifact=akka-remote_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/routing.md
+++ b/akka-docs/src/main/paradox/routing.md
@@ -9,7 +9,7 @@ To use Routing, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/scheduler.md
+++ b/akka-docs/src/main/paradox/scheduler.md
@@ -12,7 +12,7 @@ To use Scheduler, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/serialization-classic.md
+++ b/akka-docs/src/main/paradox/serialization-classic.md
@@ -11,7 +11,7 @@ To use Serialization, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/serialization-jackson.md
+++ b/akka-docs/src/main/paradox/serialization-jackson.md
@@ -9,7 +9,7 @@ To use Jackson Serialization, you must add the following dependency in your proj
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-serialization-jackson_$scala.binary_version$"
+  artifact="akka-serialization-jackson_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/serialization.md
+++ b/akka-docs/src/main/paradox/serialization.md
@@ -9,7 +9,7 @@ To use Serialization, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor_$scala.binary_version$"
+  artifact="akka-actor_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/actor-interop.md
+++ b/akka-docs/src/main/paradox/stream/actor-interop.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/futures-interop.md
+++ b/akka-docs/src/main/paradox/stream/futures-interop.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/index.md
+++ b/akka-docs/src/main/paradox/stream/index.md
@@ -9,7 +9,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/operators/ActorFlow/ask.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorFlow/ask.md
@@ -10,7 +10,7 @@ This operator is included in:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream-typed_$scala.binary_version$"
+  artifact="akka-stream-typed_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/operators/ActorSink/actorRef.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorSink/actorRef.md
@@ -10,7 +10,7 @@ This operator is included in:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream-typed_$scala.binary_version$"
+  artifact="akka-stream-typed_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/operators/ActorSink/actorRefWithBackpressure.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorSink/actorRefWithBackpressure.md
@@ -10,7 +10,7 @@ This operator is included in:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream-typed_$scala.binary_version$"
+  artifact="akka-stream-typed_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/operators/ActorSource/actorRef.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorSource/actorRef.md
@@ -10,7 +10,7 @@ This operator is included in:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream-typed_$scala.binary_version$"
+  artifact="akka-stream-typed_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/operators/ActorSource/actorRefWithBackpressure.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorSource/actorRefWithBackpressure.md
@@ -10,7 +10,7 @@ This operator is included in:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream-typed_$scala.binary_version$"
+  artifact="akka-stream-typed_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/range.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/range.md
@@ -8,7 +8,7 @@ Emit each integer in a range, with an option to take bigger steps than 1.
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/reactive-streams-interop.md
+++ b/akka-docs/src/main/paradox/stream/reactive-streams-interop.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/stream-composition.md
+++ b/akka-docs/src/main/paradox/stream/stream-composition.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/stream-cookbook.md
+++ b/akka-docs/src/main/paradox/stream/stream-cookbook.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/stream-customize.md
+++ b/akka-docs/src/main/paradox/stream/stream-customize.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/stream-dynamic.md
+++ b/akka-docs/src/main/paradox/stream/stream-dynamic.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/stream-error.md
+++ b/akka-docs/src/main/paradox/stream/stream-error.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
+++ b/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/stream-graphs.md
+++ b/akka-docs/src/main/paradox/stream/stream-graphs.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/stream-io.md
+++ b/akka-docs/src/main/paradox/stream/stream-io.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/stream-parallelism.md
+++ b/akka-docs/src/main/paradox/stream/stream-parallelism.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/stream-quickstart.md
+++ b/akka-docs/src/main/paradox/stream/stream-quickstart.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/stream-rate.md
+++ b/akka-docs/src/main/paradox/stream/stream-rate.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/stream-refs.md
+++ b/akka-docs/src/main/paradox/stream/stream-refs.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/stream-substream.md
+++ b/akka-docs/src/main/paradox/stream/stream-substream.md
@@ -6,7 +6,7 @@ To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream_$scala.binary_version$"
+  artifact="akka-stream_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/stream/stream-testkit.md
+++ b/akka-docs/src/main/paradox/stream/stream-testkit.md
@@ -6,7 +6,7 @@ To use Akka Stream TestKit, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-stream-testkit_$scala.binary_version$"
+  artifact="akka-stream-testkit_$scala.binary.version$"
   version="$akka.version$"
   scope="test"
 }

--- a/akka-docs/src/main/paradox/testing.md
+++ b/akka-docs/src/main/paradox/testing.md
@@ -9,7 +9,7 @@ To use Akka Testkit, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-testkit_$scala.binary_version$"
+  artifact="akka-testkit_$scala.binary.version$"
   version="$akka.version$"
   scope="test"
 }

--- a/akka-docs/src/main/paradox/typed/actor-discovery.md
+++ b/akka-docs/src/main/paradox/typed/actor-discovery.md
@@ -8,7 +8,7 @@ To use Akka Actor Typed, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-actor-typed_$scala.binary_version$
+  artifact=akka-actor-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/actor-lifecycle.md
+++ b/akka-docs/src/main/paradox/typed/actor-lifecycle.md
@@ -11,7 +11,7 @@ To use Akka Actor Typed, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-actor-typed_$scala.binary_version$
+  artifact=akka-actor-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/actors.md
+++ b/akka-docs/src/main/paradox/typed/actors.md
@@ -11,7 +11,7 @@ To use Akka Actors, add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-actor-typed_$scala.binary_version$
+  artifact=akka-actor-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/cluster-dc.md
+++ b/akka-docs/src/main/paradox/typed/cluster-dc.md
@@ -20,7 +20,7 @@ To use Akka Cluster add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-typed_$scala.binary_version$
+  artifact=akka-cluster-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/cluster-sharded-daemon-process.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharded-daemon-process.md
@@ -15,7 +15,7 @@ To use Akka Sharded Daemon Process, you must add the following dependency in you
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-sharding-typed_$scala.binary_version$
+  artifact=akka-cluster-sharding-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -11,7 +11,7 @@ To use Akka Cluster Sharding, you must add the following dependency in your proj
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-sharding-typed_$scala.binary_version$
+  artifact=akka-cluster-sharding-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/cluster-singleton.md
+++ b/akka-docs/src/main/paradox/typed/cluster-singleton.md
@@ -8,7 +8,7 @@ To use Cluster Singleton, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-typed_$scala.binary_version$
+  artifact=akka-cluster-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/cluster.md
+++ b/akka-docs/src/main/paradox/typed/cluster.md
@@ -25,7 +25,7 @@ To use Akka Cluster add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-typed_$scala.binary_version$
+  artifact=akka-cluster-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/coexisting.md
+++ b/akka-docs/src/main/paradox/typed/coexisting.md
@@ -6,7 +6,7 @@ To use Akka Actor Typed, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-actor-typed_$scala.binary_version$
+  artifact=akka-actor-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/dispatchers.md
+++ b/akka-docs/src/main/paradox/typed/dispatchers.md
@@ -12,7 +12,7 @@ page describes how to use dispatchers with `akka-actor-typed`, which has depende
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor-typed_$scala.binary_version$"
+  artifact="akka-actor-typed_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/typed/distributed-data.md
+++ b/akka-docs/src/main/paradox/typed/distributed-data.md
@@ -11,7 +11,7 @@ To use Akka Cluster Distributed Data, you must add the following dependency in y
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-typed_$scala.binary_version$
+  artifact=akka-cluster-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/distributed-pub-sub.md
+++ b/akka-docs/src/main/paradox/typed/distributed-pub-sub.md
@@ -9,7 +9,7 @@ when used in a clustered application:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-cluster-typed_$scala.binary_version$"
+  artifact="akka-cluster-typed_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/typed/from-classic.md
+++ b/akka-docs/src/main/paradox/typed/from-classic.md
@@ -27,7 +27,7 @@ For example `akka-cluster-typed`:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-typed_$scala.binary_version$
+  artifact=akka-cluster-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/guide/modules.md
+++ b/akka-docs/src/main/paradox/typed/guide/modules.md
@@ -36,7 +36,7 @@ This page does not list all available modules, but overviews the main functional
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-actor-typed_$scala.binary_version$
+  artifact=akka-actor-typed_$scala.binary.version$
   version=$akka.version$
 }
 
@@ -61,7 +61,7 @@ Challenges that actors solve include the following:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-remote_$scala.binary_version$
+  artifact=akka-remote_$scala.binary.version$
   version=$akka.version$
 }
 
@@ -84,7 +84,7 @@ Challenges Remoting solves include the following:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-typed_$scala.binary_version$
+  artifact=akka-cluster-typed_$scala.binary.version$
   version=$akka.version$
 }
 
@@ -107,7 +107,7 @@ Challenges the Cluster module solves include the following:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-sharding-typed_$scala.binary_version$
+  artifact=akka-cluster-sharding-typed_$scala.binary.version$
   version=$akka.version$
 }
 
@@ -126,7 +126,7 @@ Challenges that Sharding solves include the following:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-singleton_$scala.binary_version$
+  artifact=akka-cluster-singleton_$scala.binary.version$
   version=$akka.version$
 }
 
@@ -147,7 +147,7 @@ The Singleton module can be used to solve these challenges:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-persistence-typed_$scala.binary_version$
+  artifact=akka-persistence-typed_$scala.binary.version$
   version=$akka.version$
 }
 
@@ -169,7 +169,7 @@ Persistence tackles the following challenges:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-typed_$scala.binary_version$
+  artifact=akka-cluster-typed_$scala.binary.version$
   version=$akka.version$
 }
 
@@ -188,7 +188,7 @@ Distributed Data is intended to solve the following challenges:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-stream-typed_$scala.binary_version$
+  artifact=akka-stream-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/guide/tutorial_1.md
+++ b/akka-docs/src/main/paradox/typed/guide/tutorial_1.md
@@ -6,7 +6,7 @@ Add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor-typed_$scala.binary_version$"
+  artifact="akka-actor-typed_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/typed/interaction-patterns.md
+++ b/akka-docs/src/main/paradox/typed/interaction-patterns.md
@@ -8,7 +8,7 @@ To use Akka Actor Typed, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-actor-typed_$scala.binary_version$
+  artifact=akka-actor-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/logging.md
+++ b/akka-docs/src/main/paradox/typed/logging.md
@@ -12,7 +12,7 @@ via the SLF4J backend, such as Logback configuration.
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor-typed_$scala.binary_version$"
+  artifact="akka-actor-typed_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/typed/mailboxes.md
+++ b/akka-docs/src/main/paradox/typed/mailboxes.md
@@ -9,7 +9,7 @@ page describes how to use mailboxes with `akka-actor-typed`, which has dependenc
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-actor-typed_$scala.binary_version$"
+  artifact="akka-actor-typed_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/typed/persistence-testing.md
+++ b/akka-docs/src/main/paradox/typed/persistence-testing.md
@@ -6,10 +6,10 @@ To use Akka Persistence TestKit, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group1=com.typesafe.akka
-  artifact1=akka-persistence-typed_$scala.binary_version$
+  artifact1=akka-persistence-typed_$scala.binary.version$
   version1=$akka.version$
   group2=com.typesafe.akka
-  artifact2=akka-persistence-testkit_$scala.binary_version$
+  artifact2=akka-persistence-testkit_$scala.binary.version$
   version2=$akka.version$
   scope2=test
 }
@@ -61,7 +61,7 @@ To use the testkit you need to add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-persistence-testkit_$scala.binary_version$"
+  artifact="akka-persistence-testkit_$scala.binary.version$"
   version="$akka.version$"
 }
 
@@ -195,7 +195,7 @@ the plugins at the same time. To coordinate initialization you can use the `Pers
 
 @@dependency[sbt,Maven,Gradle] {
   group="com.typesafe.akka"
-  artifact="akka-persistence-testkit_$scala.binary_version$"
+  artifact="akka-persistence-testkit_$scala.binary.version$"
   version="$akka.version$"
 }
 

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -11,7 +11,7 @@ To use Akka Persistence, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-persistence-typed_$scala.binary_version$
+  artifact=akka-persistence-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/reliable-delivery.md
+++ b/akka-docs/src/main/paradox/typed/reliable-delivery.md
@@ -19,7 +19,7 @@ To use reliable delivery, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-actor-typed_$scala.binary_version$
+  artifact=akka-actor-typed_$scala.binary.version$
   version=$akka.version$
 }
 
@@ -249,7 +249,7 @@ To use reliable delivery with Cluster Sharding, add the following module to your
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-cluster-sharding-typed_$scala.binary_version$
+  artifact=akka-cluster-sharding-typed_$scala.binary.version$
   version=$akka.version$
 }
 
@@ -355,7 +355,7 @@ When using the `EventSourcedProducerQueue` the following dependency is needed:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-persistence-typed_$scala.binary_version$
+  artifact=akka-persistence-typed_$scala.binary.version$
   version=$akka.version$
 } 
 

--- a/akka-docs/src/main/paradox/typed/routers.md
+++ b/akka-docs/src/main/paradox/typed/routers.md
@@ -8,7 +8,7 @@ To use Akka Actor Typed, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-actor-typed_$scala.binary_version$
+  artifact=akka-actor-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/stash.md
+++ b/akka-docs/src/main/paradox/typed/stash.md
@@ -8,7 +8,7 @@ To use Akka Actor Typed, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-actor-typed_$scala.binary_version$
+  artifact=akka-actor-typed_$scala.binary.version$
   version=$akka.version$
 }
 

--- a/akka-docs/src/main/paradox/typed/testing.md
+++ b/akka-docs/src/main/paradox/typed/testing.md
@@ -8,7 +8,7 @@ To use Actor TestKit add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group=com.typesafe.akka
-  artifact=akka-actor-testkit-typed_$scala.binary_version$
+  artifact=akka-actor-testkit-typed_$scala.binary.version$
   version=$akka.version$
   scope=test
 }
@@ -19,7 +19,7 @@ We recommend using Akka TestKit with ScalaTest:
 
 @@dependency[sbt,Maven,Gradle] {
   group=org.scalatest
-  artifact=scalatest_$scala.binary_version$
+  artifact=scalatest_$scala.binary.version$
   version=$scalatest.version$
   scope=test
 }

--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -33,7 +33,7 @@ object Paradox {
         "javadoc.akka.http.base_url" -> "https://doc.akka.io/japi/akka-http/current",
         "javadoc.akka.http.link_style" -> "frames",
         "scala.version" -> scalaVersion.value,
-        "scala.binary_version" -> scalaBinaryVersion.value,
+        "scala.binary.version" -> scalaBinaryVersion.value,
         "akka.version" -> version.value,
         "scalatest.version" -> Dependencies.scalaTestVersion,
         "sigar_loader.version" -> "1.6.6-rev002",


### PR DESCRIPTION
The Paradox `@dependencies` directive relies on a magic string to show the Scala binary version as value in Maven and gradle listings.

See https://github.com/lightbend/paradox/pull/429

References https://github.com/akka/akka/pull/28983
