### PR TITLE
Improve grammar

### DIFF
--- a/akka-docs/src/main/paradox/typed/distributed-data.md
+++ b/akka-docs/src/main/paradox/typed/distributed-data.md
@@ -270,8 +270,8 @@ better safety for small clusters.
 #### Consistency and response types
 
 When using `ReadLocal`, you will never receive a `GetFailure` response, since the local replica is always available to
-local readers. `WriteLocal` however may still reply with `UpdateFailure` messages, in the event that the `modify` function
-threw an exception, or, if using @ref:[durable storage](#durable-storage), if storing failed.
+local readers. `WriteLocal` however may still reply with `UpdateFailure` messages when the `modify` function
+throws an exception, or if storing failed when using @ref:[durable storage](#durable-storage).
 
 #### Examples
 

--- a/akka-docs/src/main/paradox/typed/distributed-data.md
+++ b/akka-docs/src/main/paradox/typed/distributed-data.md
@@ -270,8 +270,8 @@ better safety for small clusters.
 #### Consistency and response types
 
 When using `ReadLocal`, you will never receive a `GetFailure` response, since the local replica is always available to
-local readers. `WriteLocal` however may still reply with `UpdateFailure` messages when the `modify` function
-throws an exception, or if storing failed when using @ref:[durable storage](#durable-storage).
+local readers. `WriteLocal` however may still reply with `UpdateFailure` messages if the `modify` function
+throws an exception, or if it fails to persist to @ref:[durable storage](#durable-storage).
 
 #### Examples
 


### PR DESCRIPTION
"threw" -> "throw" is the fix, the rest are slight improvements

