### PR TITLE
Review defaults for TLS algorithms defaults

### DIFF
--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -661,12 +661,18 @@ akka {
         # https://blogs.oracle.com/java-platform-group/entry/java_8_will_use_tls
         protocol = "TLSv1.2"
 
-        # Example: ["TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"]
+        # Example: ["TLS_DHE_RSA_WITH_AES_128_GCM_SHA256", 
+        #   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        #   "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+        #   "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"]
+        # When doing rolling upgrades, make sure to include both the algorithm used 
+        # by old nodes and the preferred algorithm.
         # If you use a JDK 8 prior to 8u161 you need to install
         # the JCE Unlimited Strength Jurisdiction Policy Files to use AES 256.
         # More info here:
         # https://www.oracle.com/java/technologies/javase-jce-all-downloads.html
-        enabled-algorithms = ["TLS_RSA_WITH_AES_128_CBC_SHA"]
+        enabled-algorithms = ["TLS_RSA_WITH_AES_128_CBC_SHA",
+        "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"]
 
         # There are two options, and the default SecureRandom is recommended:
         # "" or "SecureRandom" => (default)
@@ -1133,12 +1139,18 @@ akka {
           # https://blogs.oracle.com/java-platform-group/entry/java_8_will_use_tls
           protocol = "TLSv1.2"
 
-          # Example: ["TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_RSA_WITH_AES_256_CBC_SHA"]
+          # Example: ["TLS_DHE_RSA_WITH_AES_128_GCM_SHA256", 
+          #   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+          #   "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+          #   "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"]
+          # When doing rolling upgrades, make sure to include both the algorithm used 
+          # by old nodes and the preferred algorithm.
           # If you use a JDK 8 prior to 8u161 you need to install
           # the JCE Unlimited Strength Jurisdiction Policy Files to use AES 256.
           # More info here:
           # https://www.oracle.com/java/technologies/javase-jce-all-downloads.html
-          enabled-algorithms = ["TLS_RSA_WITH_AES_128_CBC_SHA"]
+          enabled-algorithms = ["TLS_RSA_WITH_AES_128_CBC_SHA",
+          "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"]
 
           # There are two options, and the default SecureRandom is recommended:
           # "" or "SecureRandom" => (default)

--- a/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
@@ -130,7 +130,8 @@ class RemoteConfigSpec extends AkkaSpec("""
       sslSettings.SSLTrustStore should ===("truststore")
       sslSettings.SSLTrustStorePassword should ===("changeme")
       sslSettings.SSLProtocol should ===("TLSv1.2")
-      sslSettings.SSLEnabledAlgorithms should ===(Set("TLS_RSA_WITH_AES_128_CBC_SHA"))
+      sslSettings.SSLEnabledAlgorithms should ===(
+        Set("TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"))
       sslSettings.SSLRandomNumberGenerator should ===("")
     }
 

--- a/akka-remote/src/test/scala/akka/remote/Ticket1978ConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/Ticket1978ConfigSpec.scala
@@ -23,7 +23,8 @@ class Ticket1978ConfigSpec extends AkkaSpec("""
       settings.SSLTrustStore should ===("truststore")
       settings.SSLTrustStorePassword should ===("changeme")
       settings.SSLProtocol should ===("TLSv1.2")
-      settings.SSLEnabledAlgorithms should ===(Set("TLS_RSA_WITH_AES_128_CBC_SHA"))
+      settings.SSLEnabledAlgorithms should ===(
+        Set("TLS_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"))
       settings.SSLRandomNumberGenerator should ===("SecureRandom")
     }
   }


### PR DESCRIPTION
Default values and comments in `reference.conf` don't align with recommendations in [the docs](https://doc.akka.io/docs/akka/current/remoting-artery.html#configuring-ssl-tls-for-akka-remoting).

This sets a new default given JDK8u161 (including Java Crypto Extensions by default) was released over [4 years ago](https://en.wikipedia.org/wiki/Java_version_history).

Keeps the old default for rolling upgrades.