### PR TITLE
Typed testkit: log capture logger initalisation

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/LogbackUtil.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/LogbackUtil.scala
@@ -6,8 +6,9 @@ package akka.actor.testkit.typed.internal
 
 import org.slf4j.LoggerFactory
 import org.slf4j.event.Level
-
 import akka.annotation.InternalApi
+
+import scala.annotation.tailrec
 
 /**
  * INTERNAL API
@@ -16,9 +17,17 @@ import akka.annotation.InternalApi
   def loggerNameOrRoot(loggerName: String): String =
     if (loggerName == "") org.slf4j.Logger.ROOT_LOGGER_NAME else loggerName
 
-  def getLogbackLogger(loggerName: String): ch.qos.logback.classic.Logger = {
+  def getLogbackLogger(loggerName: String): ch.qos.logback.classic.Logger =
+    getLogbackLoggerInternal(loggerName, 50)
+
+  @tailrec
+  private def getLogbackLoggerInternal(loggerName: String, count: Int): ch.qos.logback.classic.Logger = {
     LoggerFactory.getLogger(loggerNameOrRoot(loggerName)) match {
-      case logger: ch.qos.logback.classic.Logger => logger
+      case logger: ch.qos.logback.classic.Logger              => logger
+      case _: org.slf4j.helpers.SubstituteLogger if count > 0 =>
+        // Wait for logging initialisation http://www.slf4j.org/codes.html#substituteLogger
+        Thread.sleep(50)
+        getLogbackLoggerInternal(loggerName, count - 1)
       case null =>
         throw new IllegalArgumentException(s"Couldn't find logger for [$loggerName].")
       case other =>


### PR DESCRIPTION
In rare situations the correct logger is not initialised when the log capturing tries to access it.

A bit of `Thread.sleep` makes it go away...