### PR TITLE
Reafactor shard to have a state for each entity

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -147,7 +147,7 @@ private[akka] object Shard {
 
     private val entities: java.util.Map[EntityId, EntityState] = new util.HashMap[EntityId, EntityState]()
     // needed to look up entity by reg when a Passivating is received
-    private var byRef = new util.HashMap[ActorRef, EntityId]()
+    private val byRef = new util.HashMap[ActorRef, EntityId]()
 
     def alreadyRemembered(set: Set[EntityId]): Unit = {
       set.foreach { id =>

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/EventSourcedRememberEntities.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/EventSourcedRememberEntities.scala
@@ -30,7 +30,7 @@ import akka.persistence.SnapshotSelectionCriteria
 private[akka] final class EventSourcedRememberEntitiesProvider(typeName: String, settings: ClusterShardingSettings)
     extends RememberEntitiesProvider {
 
-  // this is backed by an actor using the same events, at the serailisation level, as the now removed PersistentShard when state-store-mode=persistence
+  // this is backed by an actor using the same events, at the serialization level, as the now removed PersistentShard when state-store-mode=persistence
   // new events can be added but the old events should continue to be handled
   override def shardStoreProps(shardId: ShardId): Props =
     EventSourcedRememberEntitiesStore.props(typeName, shardId, settings)
@@ -97,7 +97,7 @@ private[akka] final class EventSourcedRememberEntitiesStore(
   override def snapshotPluginId: String = settings.snapshotPluginId
 
   override def receiveRecover: Receive = {
-    case EntitiesStarted(ids)              => state = state.copy(state.entities ++ ids)
+    case EntitiesStarted(ids)              => state = state.copy(state.entities.union(ids))
     case EntityStopped(id)                 => state = state.copy(state.entities - id)
     case SnapshotOffer(_, snapshot: State) => state = snapshot
     case RecoveryCompleted =>

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/EntitiesSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/EntitiesSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+import akka.actor.ActorRef
+import akka.cluster.sharding
+import akka.cluster.sharding.Shard.{ Active, Passivating, RememberedButNotCreated, Remembering, Stopped }
+import akka.event.NoLogging
+import akka.util.OptionVal
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class EntitiesSpec extends AnyWordSpec with Matchers {
+
+  "Entities" should {
+    "start empty" in {
+      val entities = new sharding.Shard.Entities(NoLogging)
+      entities.activeEntityIds() shouldEqual Set.empty
+      entities.size shouldEqual 0
+      entities.activeEntities() shouldEqual Set.empty
+    }
+    "set already remembered entities to state RememberedButNotStarted" in {
+      val entities = new sharding.Shard.Entities(NoLogging)
+      val ids = Set("a", "b", "c")
+      entities.alreadyRemembered(ids)
+      entities.activeEntities() shouldEqual Set.empty
+      entities.size shouldEqual 3
+      ids.foreach { id =>
+        entities.entityState(id) shouldEqual OptionVal.Some(RememberedButNotCreated)
+      }
+    }
+    "set state to terminating" in {
+      val entities = new sharding.Shard.Entities(NoLogging)
+      val ref = ActorRef.noSender
+      entities.addEntity("a", ref)
+      entities.terminated(ref)
+      entities.entityState("a") shouldEqual OptionVal.Some(Stopped)
+    }
+
+    "set state to remembering" in {
+      val entities = new sharding.Shard.Entities(NoLogging)
+      entities.remembering("a")
+      entities.entityState("a") shouldEqual OptionVal.Some(Remembering)
+    }
+    "fully remove an entity" in {
+      val entities = new sharding.Shard.Entities(NoLogging)
+      val ref = ActorRef.noSender
+      entities.addEntity("a", ref)
+      entities.removeEntity("a")
+      entities.entityState("a") shouldEqual OptionVal.None
+      entities.activeEntities() shouldEqual Set.empty
+
+    }
+    "add an entity as active" in {
+      val entities = new sharding.Shard.Entities(NoLogging)
+      val ref = ActorRef.noSender
+      entities.addEntity("a", ref)
+      entities.entityState("a") shouldEqual OptionVal.Some(Active(ref))
+    }
+    "look up actor ref by id" in {
+      val entities = new sharding.Shard.Entities(NoLogging)
+      val ref = ActorRef.noSender
+      entities.addEntity("a", ref)
+      entities.entityId(ref) shouldEqual OptionVal.Some("a")
+    }
+    "set state to passivating" in {
+      val entities = new sharding.Shard.Entities(NoLogging)
+      val ref = ActorRef.noSender
+      entities.addEntity("a", ref)
+      entities.entityPassivating("a")
+      entities.entityState("a") shouldEqual OptionVal.Some(Passivating(ref))
+    }
+  }
+
+}

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/EntitiesSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/EntitiesSpec.scala
@@ -36,6 +36,7 @@ class EntitiesSpec extends AnyWordSpec with Matchers {
       entities.addEntity("a", ref)
       entities.terminated(ref)
       entities.entityState("a") shouldEqual OptionVal.Some(Stopped)
+      entities.activeEntities() shouldEqual Set.empty
     }
 
     "set state to remembering" in {


### PR DESCRIPTION
Rather than inferred from various maps and sets.

Unfortunately, we still have the by actor ref and by id but have moved
them to a class so they are always updated together.

