### PR TITLE
RetrySupport object not extend RetrySupport trait

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/RetrySupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/RetrySupport.scala
@@ -142,7 +142,7 @@ trait RetrySupport {
   }
 }
 
-object RetrySupport extends RetrySupport {
+object RetrySupport {
 
   private def retry[T](attempt: () => Future[T], maxAttempts: Int, attempted: Int)(
       implicit ec: ExecutionContext): Future[T] =


### PR DESCRIPTION
I don't get why the object extends the trait. Feel users should always just mixin the trait and not worry about the object?

@hepin1989 Can you help confirm this sounds correct or not? If it sounds right, I will fix the binary incompatibility issue.