### PR TITLE
stream: make keepAlive/IdleInject more reliable against flukes

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/Timers.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Timers.scala
@@ -255,20 +255,27 @@ import akka.stream.stage._
             if (isClosed(in)) completeStage()
             else pull(in)
           } else {
-            val time = System.nanoTime
-            if (nextDeadline - time < 0) {
-              nextDeadline = time + timeout.toNanos
+            val now = System.nanoTime()
+            // Idle timeout triggered a while ago and we were just waiting for pull.
+            // In the case of now == deadline, the deadline has not passed strictly, but scheduling another thunk
+            // for that seems wasteful.
+            if (now - nextDeadline >= 0) {
+              nextDeadline = now + timeout.toNanos
               push(out, inject())
-            } else scheduleOnce(GraphStageLogicTimer, FiniteDuration(nextDeadline - time, TimeUnit.NANOSECONDS))
+            } else
+              scheduleOnce(GraphStageLogicTimer, FiniteDuration(nextDeadline - now, TimeUnit.NANOSECONDS))
           }
         }
 
         override protected def onTimer(timerKey: Any): Unit = {
-          val time = System.nanoTime
-          if ((nextDeadline - time < 0) && isAvailable(out)) {
-            push(out, inject())
-            nextDeadline = time + timeout.toNanos
-          }
+          val now = System.nanoTime()
+          // Timer is reliably cancelled if a regular element arrives first. Scheduler rather schedules too late
+          // than too early so the deadline must have passed at this time.
+          assert(
+            now - nextDeadline >= 0,
+            s"Timer should have triggered only after deadline but now is $now and deadline was $nextDeadline diff ${now - nextDeadline}.")
+          push(out, inject())
+          nextDeadline = now + timeout.toNanos
         }
       }
 


### PR DESCRIPTION
Refs #28993

The previous `nextDeadline - time < 0` required that nanoTime resolution is
actually high enough to see that the deadline had already passed. If it
had not, the current keep alive was missed and also all future ones (until
another a regular element would trigger another push/pull cycle).

Now, with `>=` it also works in that case and just fails noisily if our
assumptions are not true.

It's not clear how it could have happened. On my machine, timers
trigger 1-2 tick-durations too late (but at least ~2ms). How that could be
the same in terms of the nanoTime resolution is hard to see.