### PR TITLE
Detect duplicate serializer identifiers, #29100

### DIFF
--- a/akka-actor/src/main/scala/akka/serialization/Serialization.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serialization.scala
@@ -503,8 +503,18 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
   /**
    * Maps from a Serializer Identity (Int) to a Serializer instance (optimization)
    */
-  val serializerByIdentity: Map[Int, Serializer] =
-    Map(NullSerializer.identifier -> NullSerializer) ++ serializers.map { case (_, v) => (v.identifier, v) }
+  val serializerByIdentity: Map[Int, Serializer] = {
+    val zero: Map[Int, Serializer] = Map(NullSerializer.identifier -> NullSerializer)
+    serializers.foldLeft(zero) {
+      case (acc, (_, ser)) =>
+        val id = ser.identifier
+        if (acc.contains(id))
+          throw new IllegalArgumentException(
+            s"Serializer identifier [$id] of [${ser.getClass.getName}] " +
+            s"is not unique. It is also used by ${acc(id).getClass.getName}.")
+        acc.updated(id, ser)
+    }
+  }
 
   /**
    * Serializers with id 0 - 1023 are stored in an array for quick allocation free access

--- a/akka-actor/src/main/scala/akka/serialization/Serialization.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serialization.scala
@@ -508,11 +508,14 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
     serializers.foldLeft(zero) {
       case (acc, (_, ser)) =>
         val id = ser.identifier
-        if (acc.contains(id))
-          throw new IllegalArgumentException(
-            s"Serializer identifier [$id] of [${ser.getClass.getName}] " +
-            s"is not unique. It is also used by ${acc(id).getClass.getName}.")
-        acc.updated(id, ser)
+        acc.get(id) match {
+          case Some(existing) if existing != ser =>
+            throw new IllegalArgumentException(
+              s"Serializer identifier [$id] of [${ser.getClass.getName}] " +
+              s"is not unique. It is also used by [${acc(id).getClass.getName}].")
+          case _ =>
+            acc.updated(id, ser)
+        }
     }
   }
 

--- a/akka-docs/src/main/paradox/serialization.md
+++ b/akka-docs/src/main/paradox/serialization.md
@@ -82,6 +82,7 @@ Scala
 Java
 :  @@snip [SerializationDocTest.java](/akka-docs/src/test/java/jdocs/serialization/SerializationDocTest.java) { #programmatic }
 
+
 The manifest is a type hint so that the same serializer can be used for different classes.
 
 Note that when deserializing from bytes the manifest and the identifier of the serializer are needed.
@@ -118,6 +119,21 @@ Scala
 
 Java
 :  @@snip [SerializationDocTest.java](/akka-docs/src/test/java/jdocs/serialization/SerializationDocTest.java) { #my-own-serializer }
+
+The `identifier` must be unique. The identifier is used when selecting which serializer to use for deserialization.
+If you have accidentally configured several serializers with the same identifier that will be detected and prevent
+the `ActorSystem` from being started. It can be a hardcoded value because it must remain the same value to support
+rolling updates. 
+
+@@@ div { .group-scala }
+
+If you prefer to define the identifier in cofiguration that is supported by the `BaseSerializer` trait, which
+implements the `def identifier` by reading it from configuration based on the serializer's class name:
+
+Scala
+:  @@snip [SerializationDocSpec.scala](/akka-docs/src/test/scala/docs/serialization/SerializationDocSpec.scala) { #serialization-identifiers-config }
+
+@@@
 
 The manifest is a type hint so that the same serializer can be used for different
 classes. The manifest parameter in @scala[`fromBinary`]@java[`fromBinaryJava`] is the class of the object that

--- a/akka-docs/src/test/scala/docs/serialization/SerializationDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/serialization/SerializationDocSpec.scala
@@ -109,6 +109,21 @@ package docs.serialization {
    */
   trait JsonSerializable
 
+  object SerializerIdConfig {
+    val config =
+      """
+        #//#serialization-identifiers-config
+        akka {
+          actor {
+            serialization-identifiers {
+              "docs.serialization.MyOwnSerializer" = 1234567
+            }
+          }
+        }
+        #//#serialization-identifiers-config
+        """
+  }
+
   class SerializationDocSpec extends AkkaSpec {
     "demonstrate configuration of serialize messages" in {
       val config = ConfigFactory.parseString("""


### PR DESCRIPTION
* and expand the documentation for the serializer identifier
* and mention BaseSerializer to read the identifier from config

References #29100
