### PR TITLE
Multiple remember entities fixes

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -800,7 +800,10 @@ abstract class ShardCoordinator(
       deferGetShardHomeRequest(shard, sender())
       true
     } else if (!hasAllRegionsRegistered()) {
-      log.debug("GetShardHome [{}] request ignored, because not all regions have registered yet.", shard)
+      log.debug(
+        "GetShardHome [{}] request from [{}] ignored, because not all regions have registered yet.",
+        shard,
+        sender())
       true
     } else {
       state.shards.get(shard) match {

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -1328,22 +1328,28 @@ private[akka] class DDataShardCoordinator(
       stash()
 
     case RememberEntitiesCoordinatorStore.UpdateDone(shard) =>
-      require(shardId.contains(shard))
-      if (!waitingForStateWrite) {
-        log.debug("The ShardCoordinator saw remember shard start successfully written {}", evt)
-        if (shardId.isDefined) timers.cancel(RememberEntitiesTimeoutKey)
-        unbecomeAfterUpdate(evt, afterUpdateCallback)
+      if (!shardId.contains(shard)) {
+        log.warning(
+          "Saw remember entities update complete for shard id [{}], while waiting for [{}]",
+          shard,
+          shardId.getOrElse(""))
       } else {
-        log.debug(
-          "The ShardCoordinator saw remember shard start successfully written {}, waiting for state update",
-          evt)
-        context.become(
-          waitingForUpdate(
-            evt,
-            shardId,
-            waitingForStateWrite = true,
-            waitingForRememberShard = false,
-            afterUpdateCallback = afterUpdateCallback))
+        if (!waitingForStateWrite) {
+          log.debug("The ShardCoordinator saw remember shard start successfully written {}", evt)
+          if (shardId.isDefined) timers.cancel(RememberEntitiesTimeoutKey)
+          unbecomeAfterUpdate(evt, afterUpdateCallback)
+        } else {
+          log.debug(
+            "The ShardCoordinator saw remember shard start successfully written {}, waiting for state update",
+            evt)
+          context.become(
+            waitingForUpdate(
+              evt,
+              shardId,
+              waitingForStateWrite = true,
+              waitingForRememberShard = false,
+              afterUpdateCallback = afterUpdateCallback))
+        }
       }
 
     case RememberEntitiesCoordinatorStore.UpdateFailed(shard) =>

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -981,7 +981,7 @@ private[akka] class ShardRegion(
   }
 
   def initializeShard(id: ShardId, shard: ActorRef): Unit = {
-    log.debug("{}: Shard was initialized {}", typeName, id)
+    log.debug("{}: Shard was initialized [{}]", typeName, id)
     startingShards -= id
     deliverBufferedMessages(id, shard)
   }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/DDataRememberEntitiesShardStore.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/DDataRememberEntitiesShardStore.scala
@@ -174,7 +174,8 @@ private[akka] final class DDataRememberEntitiesShardStore(
       allIds: Set[EntityId],
       updates: Map[Set[EntityId], (Update[ORSet[EntityId]], Int)]): Receive = {
     case UpdateSuccess(_, Some(ids: Set[EntityId] @unchecked)) =>
-      log.debug("The DDataShard state was successfully updated for [{}]", ids)
+      if (log.isDebugEnabled)
+        log.debug("The DDataShard state was successfully updated for [{}]", ids.mkString(", "))
       val remaining = updates - ids
       if (remaining.isEmpty) {
         requestor ! RememberEntitiesShardStore.UpdateDone(allIds)


### PR DESCRIPTION
Fixing some issues we introduced in the feature branch

* Cherry picked @chbatey s fix for watchWith not working (in wait for #29101 )
* I saw that mixing stash and per entity buffer lead to re-order of message delivery so changed to always buffer.
* Some logging cleanups