### PR TITLE
Start entity ack not needed in shard

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -853,14 +853,15 @@ private[akka] class Shard(
         timers.startSingleTimer(msg, msg, entityRestartBackoff)
 
       case Passivating(_) =>
-        entities.rememberingStop(entityId)
         if (entities.pendingRememberedEntitiesExist()) {
           // will go in next batch update
           if (verboseDebug)
             log.debug(
               "Stop of [{}] after passivating, arrived while updating, adding it to batch of pending stops",
               entityId)
+          entities.rememberingStop(entityId)
         } else {
+          entities.rememberingStop(entityId)
           rememberUpdate(remove = Set(entityId))
         }
       case unexpected =>

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/RememberEntitiesStarter.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/RememberEntitiesStarter.scala
@@ -70,7 +70,7 @@ private[akka] final class RememberEntityStarter(
       waitingForAck -= entityId
       if (shardId != ackFromShardId) entitiesMoved += entityId
       if (waitingForAck.isEmpty) {
-        if (entitiesMoved.nonEmpty) shard ! Shard.ShardIdsMoved(ids)
+        if (entitiesMoved.nonEmpty) shard ! Shard.EntitiesMovedToOtherShard(ids)
         context.stop(self)
       }
 

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/EntitiesSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/EntitiesSpec.scala
@@ -8,7 +8,6 @@ import akka.cluster.sharding
 import akka.cluster.sharding.Shard.Active
 import akka.cluster.sharding.Shard.NoState
 import akka.cluster.sharding.Shard.Passivating
-import akka.cluster.sharding.Shard.PassivationComplete
 import akka.cluster.sharding.Shard.RememberedButNotCreated
 import akka.cluster.sharding.Shard.RememberingStart
 import akka.cluster.sharding.Shard.RememberingStop
@@ -57,8 +56,8 @@ class EntitiesSpec extends AnyWordSpec with Matchers {
       val entities = newEntities(rememberingEntities = true)
       entities.addEntity("a", ActorRef.noSender) // need to go through active to passivate
       entities.entityPassivating("a") // need to go through passivate to remember stop
-      entities.rememberingStop("a", PassivationComplete)
-      entities.entityState("a") shouldEqual RememberingStop(PassivationComplete)
+      entities.rememberingStop("a")
+      entities.entityState("a") shouldEqual RememberingStop
       entities.pendingRememberedEntitiesExist() should ===(true)
       val (starts, stops) = entities.pendingRememberEntities()
       stops should contain("a")

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesShardIdExtractorChangeSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesShardIdExtractorChangeSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import java.util.UUID
+
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.Props
+import akka.cluster.Cluster
+import akka.persistence.PersistentActor
+import akka.testkit.AkkaSpec
+import akka.testkit.ImplicitSender
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object RememberEntitiesShardIdExtractorChangeSpec {
+  val config = ConfigFactory.parseString(s"""
+       akka.loglevel = INFO
+       akka.actor.provider = "cluster"
+       akka.remote.artery.canonical.port = 0 
+       akka.cluster.sharding {
+        remember-entities = on
+        remember-entities-store = "eventsourced"
+        state-store-mode = "ddata"
+       }
+       
+       akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
+       akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
+       akka.persistence.snapshot-store.local.dir = "target/RememberEntitiesShardIdExtractorChangeSpec-${UUID
+    .randomUUID()
+    .toString}"
+       akka.persistence.journal.leveldb {
+         native = off
+          dir = "target/journal-PersistentShardingMigrationSpec-${UUID.randomUUID()}"
+      }
+      """)
+
+  case class Message(id: Long)
+
+  class PA extends PersistentActor {
+    override def persistenceId: String = "pa-" + self.path.name
+    override def receiveRecover: Receive = {
+      case _ =>
+    }
+    override def receiveCommand: Receive = {
+      case _ =>
+        sender() ! "ack"
+    }
+  }
+
+  val extractEntityId: ShardRegion.ExtractEntityId = {
+    case msg @ Message(id) => (id.toString, msg)
+  }
+
+  val firstExtractShardId: ShardRegion.ExtractShardId = {
+    case Message(id)                 => (id % 10).toString
+    case ShardRegion.StartEntity(id) => (id.toInt % 10).toString
+  }
+
+  val secondExtractShardId: ShardRegion.ExtractShardId = {
+    case Message(id)                 => (id % 10 + 1L).toString
+    case ShardRegion.StartEntity(id) => (id.toInt % 10 + 1L).toString
+  }
+
+  val TypeName = "ShardIdExtractorChange"
+}
+class RememberEntitiesShardIdExtractorChangeSpec
+    extends AkkaSpec(PersistentShardingMigrationSpec.config)
+    with ImplicitSender {
+
+  import RememberEntitiesShardIdExtractorChangeSpec._
+
+  "Sharding with remember entities enabled" should {
+    "allow a change to the shard id extractor" in {
+
+      withSystem("FirstShardIdExtractor", firstExtractShardId) { (_, region) =>
+        region ! Message(1)
+        expectMsg("ack")
+        region ! Message(11)
+        expectMsg("ack")
+        region ! Message(21)
+        expectMsg("ack")
+      }
+
+      withSystem("SecondShardIdExtractor", secondExtractShardId) { (system, region) =>
+        val probe = TestProbe()(system)
+
+        awaitAssert {
+          region.tell(ShardRegion.GetShardRegionState, probe.ref)
+          val state = probe.expectMsgType[ShardRegion.CurrentShardRegionState]
+          // shards should have been remembered but migrated over to shard 2
+          state.shards.collect { case ShardRegion.ShardState("1", entities) => entities } shouldEqual Set(Set.empty)
+          state.shards.collect { case ShardRegion.ShardState("2", entities) => entities } shouldEqual Set(
+            Set("1", "11", "21"))
+        }
+      }
+
+      withSystem("ThirdIncarnation", secondExtractShardId) { (system, region) =>
+        val probe = TestProbe()(system)
+        // Only way to verify that they were "normal"-remember-started here is to look at debug logs, will show
+        // [akka://ThirdIncarnation@127.0.0.1:51533/system/sharding/ShardIdExtractorChange/1/RememberEntitiesStore] Recovery completed for shard [1] with [0] entities
+        // [akka://ThirdIncarnation@127.0.0.1:51533/system/sharding/ShardIdExtractorChange/2/RememberEntitiesStore] Recovery completed for shard [2] with [3] entities
+        awaitAssert {
+          region.tell(ShardRegion.GetShardRegionState, probe.ref)
+          val state = probe.expectMsgType[ShardRegion.CurrentShardRegionState]
+          state.shards.collect { case ShardRegion.ShardState("1", entities) => entities } shouldEqual Set(Set.empty)
+          state.shards.collect { case ShardRegion.ShardState("2", entities) => entities } shouldEqual Set(
+            Set("1", "11", "21"))
+        }
+      }
+    }
+
+    def withSystem(systemName: String, extractShardId: ShardRegion.ExtractShardId)(
+        f: (ActorSystem, ActorRef) => Unit): Unit = {
+      val system = ActorSystem(systemName, config)
+      Cluster(system).join(Cluster(system).selfAddress)
+      try {
+        val region = ClusterSharding(system).start(TypeName, Props(new PA()), extractEntityId, extractShardId)
+        f(system, region)
+      } finally {
+        Await.ready(system.terminate(), 20.seconds)
+      }
+    }
+  }
+}

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesShardIdExtractorChangeSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesShardIdExtractorChangeSpec.scala
@@ -19,6 +19,10 @@ import com.typesafe.config.ConfigFactory
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
+/**
+ * Covers that remembered entities is correctly migrated when used and the shard id extractor
+ * is changed so that entities should live on other shards after a full restart of the cluster.
+ */
 object RememberEntitiesShardIdExtractorChangeSpec {
   val config = ConfigFactory.parseString(s"""
        akka.loglevel = INFO


### PR DESCRIPTION
The only place it is sent to the shard is from the `RememberEntitiesStarter` when it has been sent the ack for starting a remembered entity, I don't think we need that and can drop that logic and eliminate some extra messaging during shard startup.