### PR TITLE
Tests for EventSourced remember entities shard store

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/OldCoordinatorStateMigrationEventAdapter.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/OldCoordinatorStateMigrationEventAdapter.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import akka.annotation.InternalApi
+import akka.cluster.sharding.ShardCoordinator.Internal.ShardHomeAllocated
+import akka.persistence.journal.EventAdapter
+import akka.persistence.journal.EventSeq
+
+/**
+ * Used for migrating from persistent state store mode to the new event sourced remember entities. No user API,
+ * used through configuration. See reference docs for details.
+ *
+ * INTERNAL API
+ */
+@InternalApi
+final class OldCoordinatorStateMigrationEventAdapter extends EventAdapter {
+  override def manifest(event: Any): String =
+    ""
+
+  override def toJournal(event: Any): Any =
+    event
+
+  override def fromJournal(event: Any, manifest: String): EventSeq = {
+    event match {
+      case ShardHomeAllocated(shardId, _) =>
+        EventSeq.single(shardId)
+      case _ => EventSeq.empty
+    }
+
+  }
+}

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -20,9 +20,9 @@ import akka.cluster.ddata.LWWRegisterKey
 import akka.cluster.ddata.Replicator._
 import akka.cluster.ddata.SelfUniqueAddress
 import akka.cluster.sharding.ShardRegion.ShardId
-import akka.cluster.sharding.internal.EventSourcedRememberShards.MigrationMarker
+import akka.cluster.sharding.internal.EventSourcedRememberEntitiesCoordinatorStore.MigrationMarker
 import akka.cluster.sharding.internal.{
-  EventSourcedRememberShards,
+  EventSourcedRememberEntitiesCoordinatorStore,
   RememberEntitiesCoordinatorStore,
   RememberEntitiesProvider
 }
@@ -1012,7 +1012,7 @@ class PersistentShardCoordinator(
   override def snapshotPluginId: String = settings.snapshotPluginId
 
   override def receiveRecover: Receive = {
-    case MigrationMarker | SnapshotOffer(_, _: EventSourcedRememberShards.State) =>
+    case MigrationMarker | SnapshotOffer(_, _: EventSourcedRememberEntitiesCoordinatorStore.State) =>
       throw new IllegalStateException(
         "state-store is set to persistence but a migration has taken place to remember-entities-store=eventsourced. You can not downgrade.")
     case evt: DomainEvent =>

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/EventSourcedRememberEntitiesCoordinatorStore.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/EventSourcedRememberEntitiesCoordinatorStore.scala
@@ -19,9 +19,9 @@ import scala.collection.mutable
  * INTERNAL API
  */
 @InternalApi
-private[akka] object EventSourcedRememberShards {
+private[akka] object EventSourcedRememberEntitiesCoordinatorStore {
   def props(typeName: String, settings: ClusterShardingSettings): Props =
-    Props(new EventSourcedRememberShards(typeName, settings))
+    Props(new EventSourcedRememberEntitiesCoordinatorStore(typeName, settings))
 
   class FromOldCoordinatorState() extends EventAdapter {
     override def manifest(event: Any): String =
@@ -49,11 +49,13 @@ private[akka] object EventSourcedRememberShards {
  * INTERNAL API
  */
 @InternalApi
-private[akka] final class EventSourcedRememberShards(typeName: String, settings: ClusterShardingSettings)
+private[akka] final class EventSourcedRememberEntitiesCoordinatorStore(
+    typeName: String,
+    settings: ClusterShardingSettings)
     extends PersistentActor
     with ActorLogging {
 
-  import EventSourcedRememberShards._
+  import EventSourcedRememberEntitiesCoordinatorStore._
 
   // Uses the same persistence id as the old persistent coordinator so that the old data can be migrated
   // without any user action

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/EventSourcedRememberEntitiesCoordinatorStore.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/EventSourcedRememberEntitiesCoordinatorStore.scala
@@ -4,14 +4,14 @@
 
 package akka.cluster.sharding.internal
 
-import akka.actor.{ ActorLogging, Props }
+import akka.actor.ActorLogging
+import akka.actor.Props
 import akka.annotation.InternalApi
-import akka.cluster.sharding.{ ClusterShardingSerializable, ClusterShardingSettings }
 import akka.cluster.sharding.ShardCoordinator.Internal
-import akka.cluster.sharding.ShardCoordinator.Internal.ShardHomeAllocated
 import akka.cluster.sharding.ShardRegion.ShardId
+import akka.cluster.sharding.ClusterShardingSerializable
+import akka.cluster.sharding.ClusterShardingSettings
 import akka.persistence._
-import akka.persistence.journal.{ EventAdapter, EventSeq }
 
 import scala.collection.mutable
 
@@ -22,23 +22,6 @@ import scala.collection.mutable
 private[akka] object EventSourcedRememberEntitiesCoordinatorStore {
   def props(typeName: String, settings: ClusterShardingSettings): Props =
     Props(new EventSourcedRememberEntitiesCoordinatorStore(typeName, settings))
-
-  class FromOldCoordinatorState() extends EventAdapter {
-    override def manifest(event: Any): String =
-      ""
-
-    override def toJournal(event: Any): Any =
-      event
-
-    override def fromJournal(event: Any, manifest: String): EventSeq = {
-      event match {
-        case ShardHomeAllocated(shardId, _) =>
-          EventSeq.single(shardId)
-        case _ => EventSeq.empty
-      }
-
-    }
-  }
 
   case class State(shards: Set[ShardId], writtenMigrationMarker: Boolean = false) extends ClusterShardingSerializable
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/EventSourcedRememberEntitiesProvider.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/EventSourcedRememberEntitiesProvider.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding.internal
+
+import akka.actor.Props
+import akka.annotation.InternalApi
+import akka.cluster.sharding.ClusterShardingSettings
+import akka.cluster.sharding.ShardRegion.ShardId
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] final class EventSourcedRememberEntitiesProvider(typeName: String, settings: ClusterShardingSettings)
+    extends RememberEntitiesProvider {
+
+  // this is backed by an actor using the same events, at the serialization level, as the now removed PersistentShard when state-store-mode=persistence
+  // new events can be added but the old events should continue to be handled
+  override def shardStoreProps(shardId: ShardId): Props =
+    EventSourcedRememberEntitiesShardStore.props(typeName, shardId, settings)
+
+  // Note that this one is never used for the deprecated persistent state store mode, only when state store is ddata
+  // combined with eventsourced remember entities storage
+  override def coordinatorStoreProps(): Props =
+    EventSourcedRememberEntitiesCoordinatorStore.props(typeName, settings)
+}

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/protobuf/ClusterShardingMessageSerializer.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/protobuf/ClusterShardingMessageSerializer.scala
@@ -23,9 +23,12 @@ import akka.cluster.sharding.ShardCoordinator
 import akka.cluster.sharding.ShardRegion._
 import akka.cluster.sharding.protobuf.msg.{ ClusterShardingMessages => sm }
 import akka.cluster.sharding.protobuf.msg.ClusterShardingMessages
-import akka.cluster.sharding.internal.EventSourcedRememberShards.{ MigrationMarker, State => RememberShardsState }
-import akka.cluster.sharding.internal.EventSourcedRememberEntitiesStore.{ State => EntityState }
-import akka.cluster.sharding.internal.EventSourcedRememberEntitiesStore.{ EntitiesStarted, EntitiesStopped }
+import akka.cluster.sharding.internal.EventSourcedRememberEntitiesCoordinatorStore.{
+  MigrationMarker,
+  State => RememberShardsState
+}
+import akka.cluster.sharding.internal.EventSourcedRememberEntitiesShardStore.{ State => EntityState }
+import akka.cluster.sharding.internal.EventSourcedRememberEntitiesShardStore.{ EntitiesStarted, EntitiesStopped }
 import akka.protobufv3.internal.MessageLite
 import akka.serialization.BaseSerializer
 import akka.serialization.Serialization

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/PersistentShardingMigrationSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/PersistentShardingMigrationSpec.scala
@@ -50,8 +50,7 @@ object PersistentShardingMigrationSpec {
       """)
 
   val configForNewMode = ConfigFactory
-    .parseString(
-      """
+    .parseString("""
        akka.cluster.sharding {
         remember-entities = on
         remember-entities-store = "eventsourced"
@@ -60,7 +59,7 @@ object PersistentShardingMigrationSpec {
        
        akka.persistence.journal.leveldb {
         event-adapters {
-          coordinator-migration = "akka.cluster.sharding.internal.EventSourcedRememberShards$FromOldCoordinatorState"
+          coordinator-migration = "akka.cluster.sharding.OldCoordinatorStateMigrationEventAdapter"
         }
 
         event-adapter-bindings {

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/protobuf/ClusterShardingMessageSerializerSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/protobuf/ClusterShardingMessageSerializerSpec.scala
@@ -12,8 +12,8 @@ import akka.cluster.sharding.Shard
 import akka.cluster.sharding.ShardCoordinator
 import akka.cluster.sharding.ShardRegion
 import akka.cluster.sharding.ShardRegion.ShardId
-import akka.cluster.sharding.internal.EventSourcedRememberEntitiesStore
-import akka.cluster.sharding.internal.EventSourcedRememberEntitiesStore.EntitiesStarted
+import akka.cluster.sharding.internal.EventSourcedRememberEntitiesShardStore
+import akka.cluster.sharding.internal.EventSourcedRememberEntitiesShardStore.EntitiesStarted
 import akka.serialization.SerializationExtension
 import akka.testkit.AkkaSpec
 
@@ -71,12 +71,12 @@ class ClusterShardingMessageSerializerSpec extends AkkaSpec {
     }
 
     "be able to serialize PersistentShard snapshot state" in {
-      checkSerialization(EventSourcedRememberEntitiesStore.State(Set("e1", "e2", "e3")))
+      checkSerialization(EventSourcedRememberEntitiesShardStore.State(Set("e1", "e2", "e3")))
     }
 
     "be able to serialize PersistentShard domain events" in {
-      checkSerialization(EventSourcedRememberEntitiesStore.EntitiesStarted(Set("e1", "e2")))
-      checkSerialization(EventSourcedRememberEntitiesStore.EntitiesStopped(Set("e1", "e2")))
+      checkSerialization(EventSourcedRememberEntitiesShardStore.EntitiesStarted(Set("e1", "e2")))
+      checkSerialization(EventSourcedRememberEntitiesShardStore.EntitiesStopped(Set("e1", "e2")))
     }
 
     "be able to deserialize old entity started event into entities started" in {

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -323,9 +323,24 @@ If using remembered entities there are two migration options:
 
 * `ddata` for the state store and `ddata` for remembering entities. All remembered entities will be lost after a full cluster restart.
 * `ddata` for the state store and `eventsourced` for remembering entities. The new `eventsourced` remembering entities store 
-   reads the data written by the old `persistence` mode. Your remembered entities will be remembered.
+   reads the data written by the old `persistence` mode. Your remembered entities will be remembered after a full cluster restart. 
 
-Once you have migrated you cannot go back to the old persistence store.
+For migrating existing remembered entities an event adapter needs to be configured in the config for the journal you use in your `application.conf`.
+In this example `leveldb` is the used journal:
+
+```
+akka.persistence.journal.leveldb {
+  event-adapters {
+    coordinator-migration = "akka.cluster.sharding.OldCoordinatorStateMigrationEventAdapter"
+  }
+
+  event-adapter-bindings {
+    "akka.cluster.sharding.ShardCoordinator$Internal$DomainEvent" = coordinator-migration
+  }
+}
+```
+
+Once you have migrated you cannot go back to the old persistence store, a rolling upgrade is therefore not possible.
 
 ## Passivation
 


### PR DESCRIPTION
The existing DDataRememberEntitiesShardStoreSpec generalized and now covers EventSourcedRememberEntitiesShardStore as well.

Aligned the EventSourced class/filenames with the DData one as well.