### PR TITLE
PoC for a universally failable ask

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/AlwaysFailingResponse.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AlwaysFailingResponse.scala
@@ -1,0 +1,16 @@
+package akka.pattern
+
+import akka.pattern.internal.FaultyResponseMarker
+
+/**
+ * A response message that will always cause ask to fail with a [[RuntimeException]] with the given
+ * error description as message.
+ *
+ * Can be used when a request response protocol has separate messages for a successful response and a faulty response.
+ *
+ * For a single response that can contain either success or failure see:
+ * [[akka.actor.typed.scaladsl.MaybeFailingResponse]] and [[akka.actor.typed.javadsl.MaybeFailingResponse]].
+ */
+trait AlwaysFailingResponse extends FaultyResponseMarker {
+  def failureDescription: String
+}

--- a/akka-actor/src/main/scala/akka/pattern/internal/FaultyResponseMarker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/internal/FaultyResponseMarker.scala
@@ -1,0 +1,9 @@
+package akka.pattern.internal
+
+import akka.annotation.InternalApi
+
+/**
+ * NOT FOR USER EXTENSION
+ */
+@InternalApi
+trait FaultyResponseMarker {}

--- a/akka-actor/src/main/scala/akka/pattern/javadsl/MaybeFailingResponse.scala
+++ b/akka-actor/src/main/scala/akka/pattern/javadsl/MaybeFailingResponse.scala
@@ -1,0 +1,21 @@
+package akka.pattern.javadsl
+
+import java.util.Optional
+
+import akka.pattern.AlwaysFailingResponse
+import akka.pattern.internal.FaultyResponseMarker
+
+/**
+ * A response message that may cause ask to fail with a [[RuntimeException]] if `failureDescription` returns a an error
+ * description. The description will then be passed as the message of the exception.
+ *
+ * See also [[AlwaysFailingResponse]]
+ */
+trait MaybeFailingResponse extends FaultyResponseMarker {
+
+  /**
+   * @return `Optional.empty` for a successful message, which will then complete the future as is, or a description that will
+   *         then cause the `ask` to fail.
+   */
+  def failureDescription: Optional[String]
+}

--- a/akka-actor/src/main/scala/akka/pattern/scaladsl/MaybeFailingResponse.scala
+++ b/akka-actor/src/main/scala/akka/pattern/scaladsl/MaybeFailingResponse.scala
@@ -1,0 +1,19 @@
+package akka.pattern.scaladsl
+
+import akka.pattern.AlwaysFailingResponse
+import akka.pattern.internal.FaultyResponseMarker
+
+/**
+ * A response message that may cause ask to fail with a [[RuntimeException]] if `failureDescription` returns a an error
+ * description. The description will then be passed as the message of the exception.
+ *
+ * See also [[AlwaysFailingResponse]]
+ */
+trait MaybeFailingResponse extends FaultyResponseMarker {
+
+  /**
+   * @return `None` for a successful message, which will then complete the future as is, or a description that will
+   *        then cause the `ask` to fail.
+   */
+  def failureDescription: Option[String]
+}


### PR DESCRIPTION
References #29133

Introduces two different ways of failing asks:

1. a marker trait style which will always fail all asks, for cases when a separate failure response message is defined, so for example:

```
sealed trait MyResponse
case class MySuccess(ok) extends MyResponse
case class MyFailure(failureDescription) extends MyResponse with AlwaysFailingResponse
```

2. one that gives the user the ability to define a single response containing whichever maybe-fail representation they want (Try, Either, custom, etc) that ask will look at to determine if the response was a failure. For example:

```
case class MyResponse(maybe: Either[String, Ok]) extends MaybeFailingResponse {
  def failureDescription = maybe.left.toOption
}
```

By implementing it in the core ask impl, it should work the same across typed and classic actors rather than be specific to typed. 

For interactions where the initiating side is not an ask, this does not change things at all (so I don't think we should implement the same for typed `context.ask` or `messageAdapter`). I think that is a nice benefit compared to introducing some top level response type encoding success and failure. 