### PR TITLE
Docs: link to object API docs

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/RestartFlow/onFailuresWithBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartFlow/onFailuresWithBackoff.md
@@ -21,7 +21,7 @@ The restart process is inherently lossy, since there is no coordination between 
 messages. A termination signal from either end of the wrapped @apidoc[Flow] will cause the other end to be terminated,
 and any in transit messages will be lost. During backoff, this @apidoc[Flow] will backpressure.
 
-This uses the same exponential backoff algorithm as @apidoc[Backoff].
+This uses the same exponential backoff algorithm as @apidoc[Backoff$].
 
 ## Reactive Streams semantics
 

--- a/akka-docs/src/main/paradox/stream/operators/RestartFlow/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartFlow/withBackoff.md
@@ -19,7 +19,7 @@ The restart process is inherently lossy, since there is no coordination between 
 messages. A termination signal from either end of the wrapped @apidoc[Flow] will cause the other end to be terminated,
 and any in transit messages will be lost. During backoff, this @apidoc[Flow] will backpressure.
 
-This uses the same exponential backoff algorithm as @apidoc[Backoff].
+This uses the same exponential backoff algorithm as @apidoc[Backoff$].
 
 ## Reactive Streams semantics
 

--- a/akka-docs/src/main/paradox/stream/operators/RestartSink/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartSink/withBackoff.md
@@ -21,4 +21,4 @@ The restart process is inherently lossy, since there is no coordination between 
 messages. When the wrapped @apidoc[Sink] does cancel, this @apidoc[Sink] will backpressure, however any elements already
 sent may have been lost.
 
-This uses the same exponential backoff algorithm as @apidoc[Backoff].
+This uses the same exponential backoff algorithm as @apidoc[Backoff$].

--- a/akka-docs/src/main/paradox/stream/operators/RestartSource/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartSource/withBackoff.md
@@ -16,7 +16,7 @@ When that happens, the wrapped @apidoc[Source], if currently running will be can
 This can be triggered simply by the downstream cancelling, or externally by introducing a @apidoc[KillSwitch] right
 after this @apidoc[Source] in the graph.
 
-This uses the same exponential backoff algorithm as @apidoc[Backoff].
+This uses the same exponential backoff algorithm as @apidoc[Backoff$].
 
 ## Reactive Streams semantics
 

--- a/akka-docs/src/main/paradox/stream/operators/Source/fromJavaStream.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/fromJavaStream.md
@@ -14,7 +14,8 @@ Stream the values from a Java 8 `Stream`, requesting the next value when there i
 Stream the values from a Java 8 `Stream`, requesting the next value when there is demand. The iterator will be created anew
 for each materialization, which is the reason the @scala[`method`] @java[`factory`] takes a @scala[`function`] @java[`Creator`] rather than an `Stream` directly.
 
- You can use [[Source.async]] to create asynchronous boundaries between synchronous java stream and the rest of flow.
+You can use `Source.async` to create asynchronous boundaries between synchronous java stream and the rest of flow.
+
 ## Example
  
 Scala

--- a/akka-docs/src/main/paradox/typed/persistence-testing.md
+++ b/akka-docs/src/main/paradox/typed/persistence-testing.md
@@ -134,7 +134,7 @@ Event storage has the following operations:
  * @apidoc[ReadEvents] Read the events from the storage.
  * @apidoc[WriteEvents] Write the events to the storage.
  * @apidoc[DeleteEvents] Delete the events from the storage.
- * @apidoc[ReadSeqNum] Read the highest sequence number for particular persistence id.
+ * @apidoc[ReadSeqNum$] Read the highest sequence number for particular persistence id.
 
 Snapshot storage has the following operations:
 


### PR DESCRIPTION
Fixes a few occurences where the API doc link should point to the object.