### PR TITLE
Akka 29194  errors via async boundary

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
@@ -86,7 +86,8 @@ class FusingSpec extends StreamSpec {
 
     "propagate downstream errors through async boundary" in {
       val slowInitSrc = Source
-        .unfoldResource( () => {Thread.sleep(5000)},
+        //todo: can this be replaced with some promise+future composition?
+        .unfoldResource( () => {Thread.sleep(800)},
           (_ : Unit) => Some(1),
           (_ : Unit) => ()
         )
@@ -105,13 +106,14 @@ class FusingSpec extends StreamSpec {
 
       val (f1, f2) = g.run()
       f2.failed.futureValue should have message("I hate mondays")
-      Thread.sleep(5000)
+      Thread.sleep(1000)
       f1.failed.futureValue should have message("I hate mondays")
     }
 
     "propagate 'parallel' errors through async boundary via a common downstream" in {
       val slowInitSrc = Source
-        .unfoldResource( () => {Thread.sleep(5000)},
+        //todo: can this be replaced with some promise+future composition?
+        .unfoldResource( () => {Thread.sleep(800)},
           (_ : Unit) => Some(1),
           (_ : Unit) => ()
         )
@@ -128,7 +130,7 @@ class FusingSpec extends StreamSpec {
 
       val (f1, f2) = g.run()
       f2.failed.futureValue should have message("I hate mondays")
-      Thread.sleep(5000)
+      Thread.sleep(1000)
       f1.failed.futureValue should have message("I hate mondays")
     }
 

--- a/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
@@ -13,6 +13,7 @@ import akka.stream.testkit.StreamSpec
 import akka.stream.testkit.Utils.TE
 
 import scala.concurrent.{ duration, Await, Promise }
+import duration._
 
 class FusingSpec extends StreamSpec {
 
@@ -103,7 +104,7 @@ class FusingSpec extends StreamSpec {
     "propagate downstream errors through async boundary" in {
       val promise = Promise[Done]
       val slowInitSrc = UnfoldResourceNoAsyncBoundry(
-        () => { Await.result(promise.future, duration.Duration.Inf); () },
+        () => { Await.result(promise.future, 1.minute); () },
         (_: Unit) => Some(1),
         (_: Unit) => ()).asSource.watchTermination()(Keep.right).async //commenting this out, makes the test pass
       val downstream = Flow[Int]
@@ -123,7 +124,7 @@ class FusingSpec extends StreamSpec {
       //hence we know for sure that all graph stage locics in the downstream interpreter were initialized(=preStart)
       //hence upstream subscription was initiated.
       //since we're still blocking upstream's preStart we know for sure it didn't respond to the subscription request
-      //since a blocked actor can process additional messages from its inbox.
+      //since a blocked actor can not process additional messages from its inbox.
       //so long story short: downstream was able to initialize, subscribe and fail before upstream responded to the subscription request.
       //prior to akka#29194, this scenario resulted with cancellation signal rather than the expected error signal.
       promise.success(Done)
@@ -133,7 +134,7 @@ class FusingSpec extends StreamSpec {
     "propagate 'parallel' errors through async boundary via a common downstream" in {
       val promise = Promise[Done]
       val slowInitSrc = UnfoldResourceNoAsyncBoundry(
-        () => { Await.result(promise.future, duration.Duration.Inf); () },
+        () => { Await.result(promise.future, 1.minute); () },
         (_: Unit) => Some(1),
         (_: Unit) => ()).asSource.watchTermination()(Keep.right).async //commenting this out, makes the test pass
 
@@ -148,7 +149,7 @@ class FusingSpec extends StreamSpec {
       //hence we know for sure that all graph stage locics in the downstream interpreter were initialized(=preStart)
       //hence upstream subscription was initiated.
       //since we're still blocking upstream's preStart we know for sure it didn't respond to the subscription request
-      //since a blocked actor can process additional messages from its inbox.
+      //since a blocked actor can not process additional messages from its inbox.
       //so long story short: downstream was able to initialize, subscribe and fail before upstream responded to the subscription request.
       //prior to akka#29194, this scenario resulted with cancellation signal rather than the expected error signal.
       promise.success(Done)

--- a/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
@@ -123,6 +123,13 @@ class FusingSpec extends StreamSpec {
       val (f1, f2) = g.run()
       f2.failed.futureValue shouldEqual TE("I hate mondays")
       f1.value should be (empty)
+      //by now downstream managed to fail, hence it already processed the message from Flow.single,
+      //hence we know for sure that all graph stage locics in the downstream interpreter were initialized(=preStart)
+      //hence upstream subscription was initiated.
+      //since we're still blocking upstream's preStart we know for sure it didn't respond to the subscription request
+      //since a blocked actor can process additional messages from its inbox.
+      //so long story short: downstream was able to initialize, subscribe and fail before upstream responded to the subscription request.
+      //prior to akka#29194, this scenario resulted with cancellation signal rather than the expected error signal.
       promise.success(Done)
       f1.failed.futureValue shouldEqual TE("I hate mondays")
     }
@@ -144,6 +151,13 @@ class FusingSpec extends StreamSpec {
       val (f1, f2) = g.run()
       f2.failed.futureValue shouldEqual TE("I hate mondays")
       f1.value should be (empty)
+      //by now downstream managed to fail, hence it already processed the message from Flow.single,
+      //hence we know for sure that all graph stage locics in the downstream interpreter were initialized(=preStart)
+      //hence upstream subscription was initiated.
+      //since we're still blocking upstream's preStart we know for sure it didn't respond to the subscription request
+      //since a blocked actor can process additional messages from its inbox.
+      //so long story short: downstream was able to initialize, subscribe and fail before upstream responded to the subscription request.
+      //prior to akka#29194, this scenario resulted with cancellation signal rather than the expected error signal.
       promise.success(Done)
       f1.failed.futureValue shouldEqual TE("I hate mondays")
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/FusingSpec.scala
@@ -84,6 +84,54 @@ class FusingSpec extends StreamSpec {
       refs.toSet should have size (in.size + 1) // outer/main actor + 1 actor per subflow
     }
 
+    "propagate downstream errors through async boundary" in {
+      val slowInitSrc = Source
+        .unfoldResource( () => {Thread.sleep(5000)},
+          (_ : Unit) => Some(1),
+          (_ : Unit) => ()
+        )
+        .watchTermination()(Keep.right)
+        .async  //commenting this out, makes the test pass
+      val downstream = Flow[Int]
+        .prepend(Source single 1)
+        .flatMapPrefix(0){
+          case Nil => sys error "I hate mondays"
+        }
+        .watchTermination()(Keep.right)
+        .to(Sink.ignore)
+
+      val g = slowInitSrc
+        .toMat(downstream)(Keep.both)
+
+      val (f1, f2) = g.run()
+      f2.failed.futureValue should have message("I hate mondays")
+      Thread.sleep(5000)
+      f1.failed.futureValue should have message("I hate mondays")
+    }
+
+    "propagate 'parallel' errors through async boundary via a common downstream" in {
+      val slowInitSrc = Source
+        .unfoldResource( () => {Thread.sleep(5000)},
+          (_ : Unit) => Some(1),
+          (_ : Unit) => ()
+        )
+        .watchTermination()(Keep.right)
+        .async  //commenting this out, makes the test pass
+
+      val failingSrc = Source
+        .failed(new RuntimeException("I hate mondays"))
+        .watchTermination()(Keep.right)
+
+      val g = slowInitSrc
+        .zipMat(failingSrc)(Keep.both)
+        .to(Sink.ignore)
+
+      val (f1, f2) = g.run()
+      f2.failed.futureValue should have message("I hate mondays")
+      Thread.sleep(5000)
+      f1.failed.futureValue should have message("I hate mondays")
+    }
+
   }
 
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -220,12 +220,12 @@ import akka.util.OptionVal
 
     def onSubscribe(subscription: Subscription): Unit = {
       ReactiveStreamsCompliance.requireNonNullSubscription(subscription)
-      if (upstreamCompleted) {
-        // onComplete or onError has been called before OnSubscribe
-        tryCancel(subscription, SubscriptionWithCancelException.NoMoreElementsNeeded)
-      } else if (downstreamCanceled.isDefined) {
+      if (downstreamCanceled.isDefined) {
         upstreamCompleted = true
         tryCancel(subscription, downstreamCanceled.get)
+      } else if (upstreamCompleted) {
+        // onComplete or onError has been called before OnSubscribe
+        tryCancel(subscription, SubscriptionWithCancelException.NoMoreElementsNeeded)
       } else if (upstream != null) { // reactive streams spec 2.5
         tryCancel(subscription, new IllegalStateException("Publisher can only be subscribed once."))
       } else {


### PR DESCRIPTION
#29194 

introduce two test cases demonstrating a bug in the way akka-stream's async boundaries propagate downstream errors, then fix the issue.