### PR TITLE
Extensions for spawning and watching actors from the outside

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/SpawnExtension.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/SpawnExtension.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.scaladsl
+
+import scala.concurrent.Future
+
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.Extension
+import akka.actor.typed.ExtensionId
+import akka.actor.typed.Props
+import akka.actor.typed.SpawnProtocol
+import akka.util.Timeout
+
+object SpawnExtension extends ExtensionId[SpawnExtension] {
+  override def createExtension(system: ActorSystem[_]): SpawnExtension =
+    new SpawnExtension(system)
+
+  def get(system: ActorSystem[_]): SpawnExtension = apply(system)
+}
+
+/**
+ * Convenience for spawning actors from code that is not an actor itself.
+ */
+class SpawnExtension(system: ActorSystem[_]) extends Extension {
+  private val parent: ActorRef[SpawnProtocol.Command] =
+    system.systemActorOf(SpawnProtocol(), "spawnExtension")
+  private implicit val spawnTimeout: Timeout = system.settings.classicSettings.CreationTimeout
+
+  /**
+   * If `name` is an empty string an anonymous actor (with automatically generated name) will be created.
+   *
+   * If the `name` is already taken of an existing actor a unique name will be used by appending a suffix
+   * to the the `name`. The exact format or value of the suffix is an implementation detail that is
+   * undefined. This means that reusing the same name for several actors will not result in
+   * `InvalidActorNameException`, but it's better to use unique names to begin with.
+   */
+  def spawn[T](behavior: Behavior[T], name: String, props: Props): Future[ActorRef[T]] = {
+    implicit val sys: ActorSystem[_] = system
+    import akka.actor.typed.scaladsl.AskPattern._
+    parent.ask[ActorRef[T]](replyTo => SpawnProtocol.Spawn(behavior, name, props, replyTo))
+  }
+
+  def spawn[T](behavior: Behavior[T], name: String): Future[ActorRef[T]] =
+    spawn(behavior, name, Props.empty)
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/WatchExtension.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/WatchExtension.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.scaladsl
+
+import scala.concurrent.Future
+import scala.concurrent.Promise
+
+import akka.Done
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.Extension
+import akka.actor.typed.ExtensionId
+import akka.annotation.InternalApi
+
+object WatchExtension extends ExtensionId[WatchExtension] {
+  override def createExtension(system: ActorSystem[_]): WatchExtension =
+    new WatchExtension(system)
+
+  def get(system: ActorSystem[_]): WatchExtension = apply(system)
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] object Watcher {
+    sealed trait Command
+    final case class Watch(ref: ActorRef[_], promise: Promise[Done]) extends Command
+    private final case class Stopped(promise: Promise[Done]) extends Command
+
+    def apply(): Behavior[Command] = {
+      Behaviors.receive { (context, command) =>
+        command match {
+          case Watch(ref, promise) =>
+            context.watchWith(ref, Stopped(promise))
+            Behaviors.same
+          case Stopped(promise) =>
+            promise.trySuccess(Done)
+            Behaviors.same
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Convenience for watching actors from code that is not an actor itself.
+ */
+class WatchExtension(system: ActorSystem[_]) extends Extension {
+  import WatchExtension.Watcher
+
+  private val watcher: ActorRef[Watcher.Command] =
+    system.systemActorOf(Watcher(), "watchExtension")
+
+  def watch[T](ref: ActorRef[_]): Future[Done] = {
+    val terminated = Promise[Done]()
+    watcher ! Watcher.Watch(ref, terminated)
+    terminated.future
+  }
+
+}


### PR DESCRIPTION
* maybe interesting for gRPC or HTTP where it was previously convenient to use system.actorOf

@raboof @jrudolph have you seen the need for this in gRPC or HTTP?

This is something I thought I needed in Projections, but came up with a different solution. Before throwing it away I wanted to ask if we see a need for adding it?