### PR TITLE
ShardedDaemonProcess: Use Interger in javadsl function

### DIFF
--- a/akka-cluster-sharding-typed/src/main/mima-filters/2.6.6.backwards.excludes/daemon-process-init-overloads.excludes
+++ b/akka-cluster-sharding-typed/src/main/mima-filters/2.6.6.backwards.excludes/daemon-process-init-overloads.excludes
@@ -1,3 +1,5 @@
 # ShardedDaemonProcess: Use Interger in javadsl function #29235
-ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.cluster.sharding.typed.javadsl.ShardedDaemonProcess.init")
-ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.cluster.sharding.typed.internal.ShardedDaemonProcessImpl.init")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.sharding.typed.javadsl.ShardedDaemonProcess.init")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.sharding.typed.javadsl.ShardedDaemonProcess.init")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.cluster.sharding.typed.internal.ShardedDaemonProcessImpl.init")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.sharding.typed.javadsl.ShardedDaemonProcess.init")

--- a/akka-cluster-sharding-typed/src/main/mima-filters/2.6.6.backwards.excludes/daemon-process-init-overloads.excludes
+++ b/akka-cluster-sharding-typed/src/main/mima-filters/2.6.6.backwards.excludes/daemon-process-init-overloads.excludes
@@ -1,0 +1,3 @@
+# ShardedDaemonProcess: Use Interger in javadsl function #29235
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.cluster.sharding.typed.javadsl.ShardedDaemonProcess.init")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.cluster.sharding.typed.internal.ShardedDaemonProcessImpl.init")

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
@@ -4,6 +4,7 @@
 
 package akka.cluster.sharding.typed.internal
 
+import java.util.function.IntFunction 
 import java.util.Optional
 
 import scala.compat.java8.OptionConverters._
@@ -29,7 +30,6 @@ import akka.cluster.sharding.typed.scaladsl.Entity
 import akka.cluster.sharding.typed.scaladsl.EntityTypeKey
 import akka.cluster.sharding.typed.scaladsl.StartEntity
 import akka.cluster.typed.Cluster
-import akka.japi.function
 import akka.util.PrettyDuration
 
 /**
@@ -161,14 +161,14 @@ private[akka] final class ShardedDaemonProcessImpl(system: ActorSystem[_])
       messageClass: Class[T],
       name: String,
       numberOfInstances: Int,
-      behaviorFactory: function.Function[Integer, Behavior[T]]): Unit =
+      behaviorFactory: IntFunction[Behavior[T]]): Unit =
     init(name, numberOfInstances, n => behaviorFactory(n))(ClassTag(messageClass))
 
   override def init[T](
       messageClass: Class[T],
       name: String,
       numberOfInstances: Int,
-      behaviorFactory: function.Function[Integer, Behavior[T]],
+      behaviorFactory: IntFunction[Behavior[T]],
       stopMessage: T): Unit =
     init(name, numberOfInstances, n => behaviorFactory(n), ShardedDaemonProcessSettings(system), Some(stopMessage))(
       ClassTag(messageClass))
@@ -177,7 +177,7 @@ private[akka] final class ShardedDaemonProcessImpl(system: ActorSystem[_])
       messageClass: Class[T],
       name: String,
       numberOfInstances: Int,
-      behaviorFactory: function.Function[Integer, Behavior[T]],
+      behaviorFactory: IntFunction[Behavior[T]],
       settings: ShardedDaemonProcessSettings,
       stopMessage: Optional[T]): Unit =
     init(name, numberOfInstances, n => behaviorFactory(n), settings, stopMessage.asScala)(ClassTag(messageClass))

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
@@ -4,7 +4,7 @@
 
 package akka.cluster.sharding.typed.internal
 
-import java.util.function.IntFunction 
+import java.util.function.IntFunction
 import java.util.Optional
 
 import scala.compat.java8.OptionConverters._

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
@@ -168,7 +168,7 @@ private[akka] final class ShardedDaemonProcessImpl(system: ActorSystem[_])
       messageClass: Class[T],
       name: String,
       numberOfInstances: Int,
-      behaviorFactory: function.Function[Int, Behavior[T]],
+      behaviorFactory: function.Function[Integer, Behavior[T]],
       stopMessage: T): Unit =
     init(name, numberOfInstances, n => behaviorFactory(n), ShardedDaemonProcessSettings(system), Some(stopMessage))(
       ClassTag(messageClass))

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ShardedDaemonProcess.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ShardedDaemonProcess.scala
@@ -56,7 +56,7 @@ abstract class ShardedDaemonProcess {
       messageClass: Class[T],
       name: String,
       numberOfInstances: Int,
-      behaviorFactory: function.Function[Int, Behavior[T]],
+      behaviorFactory: function.Function[Integer, Behavior[T]],
       stopMessage: T): Unit
 
   /**

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ShardedDaemonProcess.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ShardedDaemonProcess.scala
@@ -4,6 +4,7 @@
 
 package akka.cluster.sharding.typed.javadsl
 
+import java.util.function.IntFunction 
 import java.util.Optional
 
 import akka.actor.typed.ActorSystem
@@ -11,7 +12,6 @@ import akka.actor.typed.Behavior
 import akka.annotation.ApiMayChange
 import akka.annotation.DoNotInherit
 import akka.cluster.sharding.typed.ShardedDaemonProcessSettings
-import akka.japi.function
 
 object ShardedDaemonProcess {
   def get(system: ActorSystem[_]): ShardedDaemonProcess =
@@ -43,7 +43,7 @@ abstract class ShardedDaemonProcess {
       messageClass: Class[T],
       name: String,
       numberOfInstances: Int,
-      behaviorFactory: function.Function[Integer, Behavior[T]]): Unit
+      behaviorFactory: IntFunction[Behavior[T]]): Unit
 
   /**
    * Start a specific number of actors that is then kept alive in the cluster.
@@ -56,7 +56,7 @@ abstract class ShardedDaemonProcess {
       messageClass: Class[T],
       name: String,
       numberOfInstances: Int,
-      behaviorFactory: function.Function[Integer, Behavior[T]],
+      behaviorFactory: IntFunction[Behavior[T]],
       stopMessage: T): Unit
 
   /**
@@ -69,7 +69,7 @@ abstract class ShardedDaemonProcess {
       messageClass: Class[T],
       name: String,
       numberOfInstances: Int,
-      behaviorFactory: function.Function[Integer, Behavior[T]],
+      behaviorFactory: IntFunction[Behavior[T]],
       settings: ShardedDaemonProcessSettings,
       stopMessage: Optional[T]): Unit
 

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ShardedDaemonProcess.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ShardedDaemonProcess.scala
@@ -4,7 +4,7 @@
 
 package akka.cluster.sharding.typed.javadsl
 
-import java.util.function.IntFunction 
+import java.util.function.IntFunction
 import java.util.Optional
 
 import akka.actor.typed.ActorSystem


### PR DESCRIPTION
The new `init` method is using `Int` instead of `Interger` and it doesn't play well when using from Java code.