### PR TITLE
Cleanup list of used systems

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/artery/tcp/ssl/RotatingKeysSSLEngineProviderSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/tcp/ssl/RotatingKeysSSLEngineProviderSpec.scala
@@ -266,6 +266,8 @@ abstract class RotatingKeysSSLEngineProviderSpec(extraConfig: String)
       system.log.info(s"Terminating $systemToTerminate...")
       Await.result(systemToTerminate.terminate(), 10.seconds)
     }
+    // Removed terminated items from the list to avoid: https://github.com/akka/akka/issues/29221
+    systemsToTerminate = Nil
     // Don't cleanup folder until all systems have terminated
     cleanupTemporaryDirectory()
     super.afterTermination()


### PR DESCRIPTION
References #29221

the failure is not a test but a `It is not a test it is a sbt.testing.SuiteSelector`. I suspect the suite selector there is not running any code but still tries to invoke `afterTermination` and sees the collection of actor systems. 
