### PR TITLE
Use the target actor name in the temporary ask actor name

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
@@ -246,10 +246,14 @@ class AskSpec extends AkkaSpec("""
         }
       }), "myName")
 
-      val f = (act ? "ask").mapTo[String]
+      (act ? "ask").mapTo[String]
       val (promiseActorRef, "ask") = p.expectMsgType[(ActorRef, String)]
 
       promiseActorRef.path.name should startWith("myName")
+
+      (system.actorSelection("/user/myName") ? "ask").mapTo[String]
+      val (promiseActorRefForSelection, "ask") = p.expectMsgType[(ActorRef, String)]
+      promiseActorRefForSelection.path.name should startWith("_user_myName")
     }
   }
 

--- a/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
@@ -7,16 +7,19 @@ package akka.pattern
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Failure
-
 import com.github.ghik.silencer.silent
-import language.postfixOps
 
+import language.postfixOps
 import akka.actor._
+import akka.testkit.WithLogCapturing
 import akka.testkit.{ AkkaSpec, TestProbe }
 import akka.util.Timeout
 
 @silent
-class AskSpec extends AkkaSpec {
+class AskSpec extends AkkaSpec("""
+     akka.loglevel = DEBUG
+     akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
+    """) with WithLogCapturing {
 
   "The “ask” pattern" must {
     "send request to actor and wrap the answer in Future" in {
@@ -231,6 +234,22 @@ class AskSpec extends AkkaSpec {
       val completed = f.futureValue
       completed should ===("complete")
       expectTerminated(promiseActorRef, 1.second)
+    }
+
+    "encode target name in temporary actor name" in {
+      implicit val timeout: Timeout = Timeout(300 millis)
+      val p = TestProbe()
+
+      val act = system.actorOf(Props(new Actor {
+        def receive = {
+          case msg => p.ref ! sender() -> msg
+        }
+      }), "myName")
+
+      val f = (act ? "ask").mapTo[String]
+      val (promiseActorRef, "ask") = p.expectMsgType[(ActorRef, String)]
+
+      promiseActorRef.path.name should startWith("myName")
     }
   }
 

--- a/akka-actor-typed/src/main/mima-filters/2.6.6.backwards.excludes/actor-path-in-ask-temp-name.excludes
+++ b/akka-actor-typed/src/main/mima-filters/2.6.6.backwards.excludes/actor-path-in-ask-temp-name.excludes
@@ -1,0 +1,2 @@
+# target actor name in the temporary ask actor name #29205, changes to ask internals
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.typed.scaladsl.AskPattern.AskPath")

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/InternalRecipientRef.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/InternalRecipientRef.scala
@@ -23,4 +23,6 @@ import akka.annotation.InternalApi
    */
   def isTerminated: Boolean
 
+  def refPrefix: String = toString
+
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorRefAdapter.scala
@@ -38,6 +38,8 @@ import akka.dispatch.sysmsg
   // impl InternalRecipientRef
   def isTerminated: Boolean = classicRef.isTerminated
 
+  override def refPrefix: String = path.name
+
   @throws(classOf[java.io.ObjectStreamException])
   private def writeReplace(): AnyRef = SerializedActorRef[T](this)
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -121,6 +121,8 @@ import akka.annotation.InternalApi
     ActorRefAdapter(ref)
   }
 
+  override def refPrefix: String = "user"
+
   override def address: Address = system.provider.getDefaultAddress
 
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
@@ -7,9 +7,7 @@ package akka.actor.typed.scaladsl
 import java.util.concurrent.TimeoutException
 
 import scala.concurrent.Future
-
 import com.github.ghik.silencer.silent
-
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.RecipientRef
@@ -137,7 +135,7 @@ object AskPattern {
           null)
       else {
         // messageClassName "unknown' is set later, after applying the message factory
-        val a = PromiseActorRef(target.provider, timeout, target, "unknown", onTimeout = onTimeout)
+        val a = PromiseActorRef(target.provider, timeout, target, "unknown", target.refPrefix, onTimeout = onTimeout)
         val b = adapt.ActorRefAdapter[U](a)
         (b, a.result.future.asInstanceOf[Future[U]], a)
       }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
@@ -10,14 +10,13 @@ import scala.concurrent.Future
 
 import com.github.ghik.silencer.silent
 
-import akka.actor.{ Address, RootActorPath }
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.RecipientRef
 import akka.actor.typed.Scheduler
 import akka.actor.typed.internal.{ adapter => adapt }
 import akka.actor.typed.internal.InternalRecipientRef
-import akka.annotation.{ InternalApi, InternalStableApi }
+import akka.annotation.InternalStableApi
 import akka.pattern.PromiseActorRef
 import akka.util.{ unused, Timeout }
 
@@ -161,9 +160,4 @@ object AskPattern {
     p.ask(target, m, timeout)
   }
 
-  /**
-   * INTERNAL API
-   */
-  @InternalApi
-  private[typed] val AskPath = RootActorPath(Address("akka.actor.typed.internal", "ask"))
 }

--- a/akka-actor/src/main/mima-filters/2.6.6.backwards.excludes/actor-path-in-ask-temp-name.excludes
+++ b/akka-actor/src/main/mima-filters/2.6.6.backwards.excludes/actor-path-in-ask-temp-name.excludes
@@ -1,0 +1,6 @@
+# target actor name in the temporary ask actor name #29205, changes to ask internals
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.ActorRefProvider.tempPath")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.pattern.PromiseActorRef.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.pattern.PromiseActorRef.apply$default$5")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.pattern.PromiseActorRef.apply$default$6")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.pattern.PromiseActorRef.this")

--- a/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
@@ -4,19 +4,19 @@
 
 package akka.pattern
 
+import java.net.URLEncoder
 import java.util.concurrent.TimeoutException
 
 import scala.annotation.tailrec
 import scala.concurrent.{ Future, Promise }
 import scala.language.implicitConversions
 import scala.util.{ Failure, Success }
-
 import com.github.ghik.silencer.silent
-
 import akka.actor._
 import akka.annotation.{ InternalApi, InternalStableApi }
 import akka.dispatch.ExecutionContexts
 import akka.dispatch.sysmsg._
+import akka.util.ByteString
 import akka.util.{ Timeout, Unsafe }
 import akka.util.unused
 
@@ -340,7 +340,7 @@ final class AskableActorRef(val actorRef: ActorRef) extends AnyVal {
       if (timeout.duration.length <= 0)
         Future.failed[Any](AskableActorRef.negativeTimeoutException(actorRef, message, sender))
       else {
-        PromiseActorRef(ref.provider, timeout, targetName = actorRef, message.getClass.getName, sender)
+        PromiseActorRef(ref.provider, timeout, targetName = actorRef, message.getClass.getName, ref.path.name, sender)
           .ask(actorRef, message, timeout)
       }
     case _ => Future.failed[Any](AskableActorRef.unsupportedRecipientType(actorRef, message, sender))
@@ -373,7 +373,7 @@ final class ExplicitlyAskableActorRef(val actorRef: ActorRef) extends AnyVal {
           val message = messageFactory(ref.provider.deadLetters)
           Future.failed[Any](AskableActorRef.negativeTimeoutException(actorRef, message, sender))
         } else {
-          val a = PromiseActorRef(ref.provider, timeout, targetName = actorRef, "unknown", sender)
+          val a = PromiseActorRef(ref.provider, timeout, targetName = actorRef, "unknown", ref.path.name, sender)
           val message = messageFactory(a)
           a.messageClassName = message.getClass.getName
           a.ask(actorRef, message, timeout)
@@ -422,7 +422,8 @@ final class AskableActorSelection(val actorSel: ActorSelection) extends AnyVal {
         if (timeout.duration.length <= 0)
           Future.failed[Any](AskableActorRef.negativeTimeoutException(actorSel, message, sender))
         else {
-          PromiseActorRef(ref.provider, timeout, targetName = actorSel, message.getClass.getName, sender)
+          val refPrefix = URLEncoder.encode(actorSel.pathString.replace("/", "_"), ByteString.UTF_8)
+          PromiseActorRef(ref.provider, timeout, targetName = actorSel, message.getClass.getName, refPrefix, sender)
             .ask(actorSel, message, timeout)
         }
       case _ => Future.failed[Any](AskableActorRef.unsupportedRecipientType(actorSel, message, sender))
@@ -450,7 +451,8 @@ final class ExplicitlyAskableActorSelection(val actorSel: ActorSelection) extend
           val message = messageFactory(ref.provider.deadLetters)
           Future.failed[Any](AskableActorRef.negativeTimeoutException(actorSel, message, sender))
         } else {
-          val a = PromiseActorRef(ref.provider, timeout, targetName = actorSel, "unknown", sender)
+          val refPrefix = URLEncoder.encode(actorSel.pathString.replace("/", "_"), ByteString.UTF_8)
+          val a = PromiseActorRef(ref.provider, timeout, targetName = actorSel, "unknown", refPrefix, sender)
           val message = messageFactory(a)
           a.messageClassName = message.getClass.getName
           a.ask(actorSel, message, timeout)
@@ -477,7 +479,7 @@ private[akka] final class PromiseActorRef private (
     val provider: ActorRefProvider,
     val result: Promise[Any],
     _mcn: String,
-    targetName: Any)
+    refPathPrefix: String)
     extends MinimalActorRef {
   import AbstractPromiseActorRef.{ stateOffset, watchedByOffset }
   import PromiseActorRef._
@@ -554,11 +556,7 @@ private[akka] final class PromiseActorRef private (
       if (updateState(null, Registering)) {
         var p: ActorPath = null
         try {
-          val prefix = targetName match {
-            case ref: ActorRef => ref.path.name
-            case other         => other.toString.replaceAll("[./*]", "_")
-          }
-          p = provider.tempPath(prefix)
+          p = provider.tempPath(refPathPrefix)
           provider.registerTempActor(this, p)
           p
         } finally {
@@ -675,11 +673,14 @@ private[akka] object PromiseActorRef {
       timeout: Timeout,
       targetName: Any,
       messageClassName: String,
+      refPathPrefix: String,
       sender: ActorRef = Actor.noSender,
       onTimeout: String => Throwable = defaultOnTimeout): PromiseActorRef = {
+    if (refPathPrefix.indexOf('/') > -1)
+      throw new IllegalArgumentException(s"refPathPrefix must not contain slash, was: $refPathPrefix")
     val result = Promise[Any]()
     val scheduler = provider.guardian.underlying.system.scheduler
-    val a = new PromiseActorRef(provider, result, messageClassName, targetName)
+    val a = new PromiseActorRef(provider, result, messageClassName, refPathPrefix)
     implicit val ec = ExecutionContexts.parasitic
     val f = scheduler.scheduleOnce(timeout.duration) {
       val timedOut = result.tryComplete {

--- a/akka-actor/src/main/scala/akka/pattern/GracefulStopSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/GracefulStopSupport.scala
@@ -48,7 +48,8 @@ trait GracefulStopSupport {
    */
   def gracefulStop(target: ActorRef, timeout: FiniteDuration, stopMessage: Any = PoisonPill): Future[Boolean] = {
     val internalTarget = target.asInstanceOf[InternalActorRef]
-    val ref = PromiseActorRef(internalTarget.provider, Timeout(timeout), target, stopMessage.getClass.getName)
+    val ref =
+      PromiseActorRef(internalTarget.provider, Timeout(timeout), target, stopMessage.getClass.getName, target.path.name)
     internalTarget.sendSystemMessage(Watch(internalTarget, ref))
     target.tell(stopMessage, Actor.noSender)
     ref.result.future.transform({

--- a/akka-actor/src/main/scala/akka/pattern/PromiseRef.scala
+++ b/akka-actor/src/main/scala/akka/pattern/PromiseRef.scala
@@ -154,7 +154,8 @@ private[akka] final class AskPromiseRef private (promiseActorRef: PromiseActorRe
 private[akka] object AskPromiseRef {
   def apply(provider: ActorRefProvider, timeout: Timeout): AskPromiseRef = {
     if (timeout.duration.length > 0) {
-      val promiseActorRef = PromiseActorRef(provider, timeout, "unknown", "unknown", provider.deadLetters)
+      val promiseActorRef =
+        PromiseActorRef(provider, timeout, "unknown", "unknown", "deadLetters", provider.deadLetters)
       new AskPromiseRef(promiseActorRef)
     } else {
       throw new IllegalArgumentException(s"Timeout length must not be negative, was: $timeout")

--- a/akka-cluster-sharding-typed/src/main/mima-filters/2.6.6.backwards.excludes/actor-path-in-ask-temp-name.excludes
+++ b/akka-cluster-sharding-typed/src/main/mima-filters/2.6.6.backwards.excludes/actor-path-in-ask-temp-name.excludes
@@ -1,0 +1,2 @@
+# target actor name in the temporary ask actor name #29205, changes to ask internals
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.typed.internal.EntityRefImpl#EntityPromiseRef.this")

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -199,6 +199,7 @@ private[akka] class RemoteActorRefProvider(
     local.registerTempActor(actorRef, path)
   override def unregisterTempActor(path: ActorPath): Unit = local.unregisterTempActor(path)
   override def tempPath(): ActorPath = local.tempPath()
+  override def tempPath(prefix: String): ActorPath = local.tempPath(prefix)
   override def tempContainer: VirtualPathContainer = local.tempContainer
 
   @volatile private var _internals: Internals = _

--- a/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
@@ -358,7 +358,8 @@ private[transport] class ThrottlerManager(wrappedTransport: Transport)
     if (target.isTerminated) Future.successful(SetThrottleAck)
     else {
       val internalTarget = target.asInstanceOf[InternalActorRef]
-      val ref = PromiseActorRef(internalTarget.provider, timeout, target, mode.getClass.getName)
+      val ref =
+        PromiseActorRef(internalTarget.provider, timeout, target, mode.getClass.getName, internalTarget.path.name)
       internalTarget.sendSystemMessage(Watch(internalTarget, ref))
       target.tell(mode, ref)
       ref.result.future.transform({


### PR DESCRIPTION
Used as a prefix to the unique tmp identifier

 * Allows specifying the large message channel for the response using wildcard patterns in config
 * Makes debugging asks somewhat easier

References #29205
