### PR TITLE
Fix issue in MarkerLoggingAdapter when logging with argument as an Array - #29272

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/event/MarkerLoggingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/MarkerLoggingSpec.scala
@@ -25,6 +25,29 @@ class MarkerLoggingSpec extends AkkaSpec with ImplicitSender {
       info.marker.name should be("SECURITY")
     }
 
+    "add markers to logging using Array as value" in {
+      system.eventStream.subscribe(self, classOf[Info])
+      system.eventStream.publish(TestEvent.Mute(EventFilter.info()))
+      markerLogging.info(LogMarker.Security, "This is a security problem because of {} and {}",
+        Array("this", "that")
+      )
+
+      val info = expectMsgType[Info3]
+      info.message should be("This is a security problem because of this and that")
+      info.marker.name should be("SECURITY")
+    }
+
+    "add markers to logging using 2 arguments as values" in {
+      system.eventStream.subscribe(self, classOf[Info])
+      system.eventStream.publish(TestEvent.Mute(EventFilter.info()))
+      markerLogging.info(LogMarker.Security, "This is a security problem because of {} and {}", "this",
+        "that")
+
+      val info = expectMsgType[Info3]
+      info.message should be("This is a security problem because of this and that")
+      info.marker.name should be("SECURITY")
+    }
+
     "allow cause exceptions in error messages" in {
       class MyException(message: String) extends Exception(message)
       system.eventStream.subscribe(self, classOf[Error])

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -1472,7 +1472,7 @@ trait LoggingAdapter {
     formatImpl(t, arg)
   }
 
-  private def formatImpl(t: String, arg: Seq[Any]): String = {
+  def formatImpl(t: String, arg: Seq[Any]): String = {
     val sb = new java.lang.StringBuilder(64)
     var p = 0
     var startIndex = 0
@@ -1943,8 +1943,8 @@ class MarkerLoggingAdapter(
 
   // Copy of LoggingAdapter.format1 due to binary compatibility restrictions
   private def format1(t: String, arg: Any): String = arg match {
-    case a: Array[_] if !a.getClass.getComponentType.isPrimitive => format(t, a.toIndexedSeq)
-    case a: Array[_]                                             => format(t, a.map(_.asInstanceOf[AnyRef]).toIndexedSeq)
+    case a: Array[_] if !a.getClass.getComponentType.isPrimitive => formatImpl(t, a.toSeq)
+    case a: Array[_]                                             => formatImpl(t, a.map(_.asInstanceOf[AnyRef]).toSeq)
     case x                                                       => format(t, x)
   }
 }


### PR DESCRIPTION
    Logging using an Array as argument such as below:

          markerLogging.info(LogMarker.Security, "This is a security problem because of {} and {}",
            Array("this", "that")
          )

    Now the ouput is the expected one with:

	"This is a security problem because of this and that"

    Instead of the unexpected:

	"This is a security problem because of [Vector(this, that) and {}]"

References #29272
