### PR TITLE
Avoid 'dead code after this construct' warnings in jackson-databind example

### DIFF
--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -125,9 +125,9 @@ class ScalaTestEventMigration extends JacksonMigration {
 
   override def transform(fromVersion: Int, json: JsonNode): JsonNode = {
     val root = json.asInstanceOf[ObjectNode]
-    root.set("field1V2", root.get("field1"))
+    root.set[JsonNode]("field1V2", root.get("field1"))
     root.remove("field1")
-    root.set("field2", IntNode.valueOf(17))
+    root.set[JsonNode]("field2", IntNode.valueOf(17))
     root
   }
 }

--- a/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/v2a/CustomerMigration.scala
+++ b/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/v2a/CustomerMigration.scala
@@ -17,10 +17,10 @@ class CustomerMigration extends JacksonMigration {
     val root = json.asInstanceOf[ObjectNode]
     if (fromVersion <= 1) {
       val shippingAddress = root.`with`("shippingAddress")
-      shippingAddress.set("street", root.get("street"))
-      shippingAddress.set("city", root.get("city"))
-      shippingAddress.set("zipCode", root.get("zipCode"))
-      shippingAddress.set("country", root.get("country"))
+      shippingAddress.set[JsonNode]("street", root.get("street"))
+      shippingAddress.set[JsonNode]("city", root.get("city"))
+      shippingAddress.set[JsonNode]("zipCode", root.get("zipCode"))
+      shippingAddress.set[JsonNode]("country", root.get("country"))
       root.remove("street")
       root.remove("city")
       root.remove("zipCode")

--- a/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/v2c/ItemAddedMigration.scala
+++ b/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/v2c/ItemAddedMigration.scala
@@ -16,7 +16,7 @@ class ItemAddedMigration extends JacksonMigration {
   override def transform(fromVersion: Int, json: JsonNode): JsonNode = {
     val root = json.asInstanceOf[ObjectNode]
     if (fromVersion <= 1) {
-      root.set("itemId", root.get("productId"))
+      root.set[JsonNode]("itemId", root.get("productId"))
       root.remove("productId")
     }
     root


### PR DESCRIPTION
This signature of jackson-databind's `set` is:

    public <T extends JsonNode> T set(String fieldName, JsonNode value)

When running the Scala compiler with dead code warnings enabled, this
will cause warnings due to https://github.com/scala/bug/issues/8109 .
Making the generic type explicit avoids that.

IntelliJ for some reason shows dead code warnings as errors for me in
this subproject, though we have this disabled in sbt for the test scope.