### PR TITLE
docs: show Akka version as symbol

### DIFF
--- a/akka-docs/src/main/paradox/actors.md
+++ b/akka-docs/src/main/paradox/actors.md
@@ -7,9 +7,11 @@
 To use Classic Actors, add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-actor" }

--- a/akka-docs/src/main/paradox/additional/osgi.md
+++ b/akka-docs/src/main/paradox/additional/osgi.md
@@ -5,9 +5,11 @@
 To use Akka in OSGi, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-osgi_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 ## Background

--- a/akka-docs/src/main/paradox/cluster-client.md
+++ b/akka-docs/src/main/paradox/cluster-client.md
@@ -14,9 +14,11 @@ It is not advised to build new applications with Cluster Client, and existing us
 To use Cluster Client, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-tools_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-cluster-tools" }

--- a/akka-docs/src/main/paradox/cluster-metrics.md
+++ b/akka-docs/src/main/paradox/cluster-metrics.md
@@ -5,9 +5,11 @@
 To use Cluster Metrics Extension, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-metrics_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 and add the following configuration stanza to your `application.conf`

--- a/akka-docs/src/main/paradox/cluster-routing.md
+++ b/akka-docs/src/main/paradox/cluster-routing.md
@@ -32,9 +32,11 @@ on other nodes in the cluster.
 To use Cluster aware routers, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-cluster_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Router with Group of Routees

--- a/akka-docs/src/main/paradox/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/cluster-sharding.md
@@ -8,9 +8,11 @@ For the full documentation of this feature and for new projects see @ref:[Cluste
 To use Cluster Sharding, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-sharding_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-cluster-sharding" }

--- a/akka-docs/src/main/paradox/cluster-singleton.md
+++ b/akka-docs/src/main/paradox/cluster-singleton.md
@@ -8,9 +8,11 @@ For the full documentation of this feature and for new projects see @ref:[Cluste
 To use Cluster Singleton, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-tools_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-cluster-tools" }

--- a/akka-docs/src/main/paradox/cluster-usage.md
+++ b/akka-docs/src/main/paradox/cluster-usage.md
@@ -24,9 +24,11 @@ recommendation if you don't have other preferences or constraints.
 To use Akka Cluster add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-cluster_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-cluster" }

--- a/akka-docs/src/main/paradox/coordination.md
+++ b/akka-docs/src/main/paradox/coordination.md
@@ -8,9 +8,11 @@ Akka Coordination is a set of tools for distributed coordination.
 ## Module info
 
 @@dependency[sbt,Gradle,Maven] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-coordination_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-coordination" }

--- a/akka-docs/src/main/paradox/discovery/index.md
+++ b/akka-docs/src/main/paradox/discovery/index.md
@@ -34,9 +34,11 @@ See @ref:[Migration hints](#migrating-from-akka-management-discovery-before-1-0-
 ## Module info
 
 @@dependency[sbt,Gradle,Maven] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-discovery_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-discovery" }

--- a/akka-docs/src/main/paradox/dispatchers.md
+++ b/akka-docs/src/main/paradox/dispatchers.md
@@ -8,9 +8,11 @@ For the full documentation of this feature and for new projects see @ref:[Dispat
 Dispatchers are part of core Akka, which means that they are part of the akka-actor dependency:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 <a id="dispatcher-lookup"></a>

--- a/akka-docs/src/main/paradox/distributed-data.md
+++ b/akka-docs/src/main/paradox/distributed-data.md
@@ -8,9 +8,11 @@ For the full documentation of this feature and for new projects see @ref:[Distri
 To use Akka Distributed Data, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-distributed-data_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/distributed-pub-sub.md
+++ b/akka-docs/src/main/paradox/distributed-pub-sub.md
@@ -8,9 +8,11 @@ For the new API see @ref[Distributed Publish Subscribe in Cluster](./typed/distr
 To use Distributed Publish Subscribe you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-cluster-tools_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-cluster-tools" }

--- a/akka-docs/src/main/paradox/fault-tolerance.md
+++ b/akka-docs/src/main/paradox/fault-tolerance.md
@@ -8,9 +8,11 @@ For the full documentation of this feature and for new projects see @ref:[fault 
 The concept of fault tolerance relates to actors, so in order to use these make sure to depend on actors:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/fsm.md
+++ b/akka-docs/src/main/paradox/fsm.md
@@ -8,9 +8,11 @@ For the documentation of the new API of this feature and for new projects see @r
 To use Finite State Machine actors, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Overview

--- a/akka-docs/src/main/paradox/index-actors.md
+++ b/akka-docs/src/main/paradox/index-actors.md
@@ -7,9 +7,11 @@
 To use Classic Akka Actors, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 @@toc { depth=2 }

--- a/akka-docs/src/main/paradox/index-utilities-classic.md
+++ b/akka-docs/src/main/paradox/index-utilities-classic.md
@@ -5,9 +5,11 @@
 To use Utilities, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 @@toc { depth=2 }

--- a/akka-docs/src/main/paradox/io-tcp.md
+++ b/akka-docs/src/main/paradox/io-tcp.md
@@ -8,9 +8,11 @@ project.description: Low level API for using TCP with classic actors.
 To use TCP, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/io-udp.md
+++ b/akka-docs/src/main/paradox/io-udp.md
@@ -8,9 +8,11 @@ project.description: Low level API for using UDP with classic actors.
 To use UDP, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/io.md
+++ b/akka-docs/src/main/paradox/io.md
@@ -5,9 +5,11 @@
 To use I/O, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/logging.md
+++ b/akka-docs/src/main/paradox/logging.md
@@ -8,9 +8,11 @@ For the new API see @ref[Logging](typed/logging.md).
 To use Logging, you must at least use the Akka actors dependency in your project, and will most likely want to configure logging via the SLF4J module (@ref:[see below](#slf4j)).
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-slf4j" }
@@ -338,9 +340,11 @@ Akka provides a logger for [SLF4J](http://www.slf4j.org/). This module is availa
 It has a single dependency: the slf4j-api jar. In your runtime, you also need a SLF4J backend. We recommend [Logback](http://logback.qos.ch/):
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-slf4j_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
   group2="ch.qos.logback"
   artifact2="logback-classic"
   version2="$logback_version$"

--- a/akka-docs/src/main/paradox/mailboxes.md
+++ b/akka-docs/src/main/paradox/mailboxes.md
@@ -8,9 +8,11 @@ For the full documentation of this feature and for new projects see @ref:[mailbo
 To use Mailboxes, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/multi-node-testing.md
+++ b/akka-docs/src/main/paradox/multi-node-testing.md
@@ -8,9 +8,11 @@ project.description: Multi node testing of distributed systems built with Akka.
 To use Multi Node Testing, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-multi-node-testkit_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-multi-node-testkit" }

--- a/akka-docs/src/main/paradox/persistence-fsm.md
+++ b/akka-docs/src/main/paradox/persistence-fsm.md
@@ -7,9 +7,11 @@
 Persistent FSMs are part of Akka persistence, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-persistence_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 @@@ warning

--- a/akka-docs/src/main/paradox/persistence-journals.md
+++ b/akka-docs/src/main/paradox/persistence-journals.md
@@ -102,9 +102,11 @@ In order to help developers build correct and high quality storage plugins, we p
 The TCK is usable from Java as well as Scala projects. To test your implementation (independently of language) you need to include the akka-persistence-tck dependency:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-persistence-tck_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 To include the Journal TCK tests in your test suite simply extend the provided @scala[`JournalSpec`]@java[`JavaJournalSpec`]:

--- a/akka-docs/src/main/paradox/persistence-query-leveldb.md
+++ b/akka-docs/src/main/paradox/persistence-query-leveldb.md
@@ -5,9 +5,11 @@
 To use Persistence Query, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-persistence-query_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 This will also add dependency on the @ref[akka-persistence](persistence.md) module.

--- a/akka-docs/src/main/paradox/persistence-query.md
+++ b/akka-docs/src/main/paradox/persistence-query.md
@@ -8,9 +8,11 @@ project.description: Query side to Akka Persistence allowing for building CQRS a
 To use Persistence Query, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-persistence-query_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 This will also add dependency on the @ref[Akka Persistence](persistence.md) module.

--- a/akka-docs/src/main/paradox/persistence-schema-evolution.md
+++ b/akka-docs/src/main/paradox/persistence-schema-evolution.md
@@ -5,9 +5,11 @@
 This documentation page touches upon @ref[Akka Persistence](persistence.md), so to follow those examples you will want to depend on:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-persistence_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/persistence.md
+++ b/akka-docs/src/main/paradox/persistence.md
@@ -11,9 +11,11 @@ For the full documentation of this feature and for new projects see @ref:[Event 
 To use Akka Persistence, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-persistence_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 You also have to select journal plugin and optionally snapshot store plugin, see 

--- a/akka-docs/src/main/paradox/remoting-artery.md
+++ b/akka-docs/src/main/paradox/remoting-artery.md
@@ -21,9 +21,11 @@ such as [HTTP](https://doc.akka.io/docs/akka-http/current/),
 To use Artery Remoting, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-remote_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 Artery UDP depends on Aeron. This needs to be explicitly added as a dependency if using `aeron-udp` so that users

--- a/akka-docs/src/main/paradox/remoting.md
+++ b/akka-docs/src/main/paradox/remoting.md
@@ -25,9 +25,11 @@ such as [HTTP](https://doc.akka.io/docs/akka-http/current/),
 To use Akka Remoting, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-remote_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-remote" }

--- a/akka-docs/src/main/paradox/routing.md
+++ b/akka-docs/src/main/paradox/routing.md
@@ -8,9 +8,11 @@ For the documentation of the new API of this feature and for new projects see @r
 To use Routing, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/scheduler.md
+++ b/akka-docs/src/main/paradox/scheduler.md
@@ -11,9 +11,11 @@ For the new API see @ref:[typed scheduling](typed/interaction-patterns.md#typed-
 To use Scheduler, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/serialization-classic.md
+++ b/akka-docs/src/main/paradox/serialization-classic.md
@@ -10,9 +10,11 @@ aside from serialization of `ActorRef` that is described @ref:[here](#serializin
 To use Serialization, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Serializing ActorRefs

--- a/akka-docs/src/main/paradox/serialization-jackson.md
+++ b/akka-docs/src/main/paradox/serialization-jackson.md
@@ -8,9 +8,11 @@ project.description: Serialization with Jackson for Akka.
 To use Jackson Serialization, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-serialization-jackson_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/serialization.md
+++ b/akka-docs/src/main/paradox/serialization.md
@@ -8,9 +8,11 @@ project.description: Serialization APIs built into Akka.
 To use Serialization, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/split-brain-resolver.md
+++ b/akka-docs/src/main/paradox/split-brain-resolver.md
@@ -16,9 +16,11 @@ To use Akka Split Brain Resolver is part of `akka-cluster` and you probably alre
 dependency included. Otherwise, add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-cluster" }

--- a/akka-docs/src/main/paradox/stream/actor-interop.md
+++ b/akka-docs/src/main/paradox/stream/actor-interop.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Overview

--- a/akka-docs/src/main/paradox/stream/futures-interop.md
+++ b/akka-docs/src/main/paradox/stream/futures-interop.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Overview

--- a/akka-docs/src/main/paradox/stream/index.md
+++ b/akka-docs/src/main/paradox/stream/index.md
@@ -8,9 +8,11 @@ project.description: An intuitive and safe way to do asynchronous, non-blocking 
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-stream" }

--- a/akka-docs/src/main/paradox/stream/operators/ActorFlow/ask.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorFlow/ask.md
@@ -9,9 +9,11 @@ Use the "Ask Pattern" to send each stream element as an `ask` to the target acto
 This operator is included in:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream-typed_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Signature

--- a/akka-docs/src/main/paradox/stream/operators/ActorSink/actorRef.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorSink/actorRef.md
@@ -9,9 +9,11 @@ Sends the elements of the stream to the given @java[`ActorRef<T>`]@scala[`ActorR
 This operator is included in:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream-typed_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Signature

--- a/akka-docs/src/main/paradox/stream/operators/ActorSink/actorRefWithBackpressure.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorSink/actorRefWithBackpressure.md
@@ -9,9 +9,11 @@ Sends the elements of the stream to the given @java[`ActorRef<T>`]@scala[`ActorR
 This operator is included in:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream-typed_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Signature

--- a/akka-docs/src/main/paradox/stream/operators/ActorSource/actorRef.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorSource/actorRef.md
@@ -9,9 +9,11 @@ Materialize an @java[`ActorRef<T>`]@scala[`ActorRef[T]`] of the new actors API; 
 This operator is included in:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream-typed_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Signature

--- a/akka-docs/src/main/paradox/stream/operators/ActorSource/actorRefWithBackpressure.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorSource/actorRefWithBackpressure.md
@@ -9,9 +9,11 @@ Materialize an @java[`ActorRef<T>`]@scala[`ActorRef[T]`] of the new actors API; 
 This operator is included in:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream-typed_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Signature

--- a/akka-docs/src/main/paradox/stream/operators/Source/range.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source/range.md
@@ -7,9 +7,11 @@ Emit each integer in a range, with an option to take bigger steps than 1.
 ## Dependency
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 

--- a/akka-docs/src/main/paradox/stream/reactive-streams-interop.md
+++ b/akka-docs/src/main/paradox/stream/reactive-streams-interop.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 <a id="reactive-streams-integration"></a>

--- a/akka-docs/src/main/paradox/stream/stream-composition.md
+++ b/akka-docs/src/main/paradox/stream/stream-composition.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/stream/stream-cookbook.md
+++ b/akka-docs/src/main/paradox/stream/stream-cookbook.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/stream/stream-customize.md
+++ b/akka-docs/src/main/paradox/stream/stream-customize.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/stream/stream-dynamic.md
+++ b/akka-docs/src/main/paradox/stream/stream-dynamic.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/stream/stream-error.md
+++ b/akka-docs/src/main/paradox/stream/stream-error.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
+++ b/akka-docs/src/main/paradox/stream/stream-flows-and-basics.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/stream/stream-graphs.md
+++ b/akka-docs/src/main/paradox/stream/stream-graphs.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/stream/stream-io.md
+++ b/akka-docs/src/main/paradox/stream/stream-io.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/stream/stream-parallelism.md
+++ b/akka-docs/src/main/paradox/stream/stream-parallelism.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/stream/stream-quickstart.md
+++ b/akka-docs/src/main/paradox/stream/stream-quickstart.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 @@@ note

--- a/akka-docs/src/main/paradox/stream/stream-rate.md
+++ b/akka-docs/src/main/paradox/stream/stream-rate.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/stream/stream-refs.md
+++ b/akka-docs/src/main/paradox/stream/stream-refs.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/stream/stream-substream.md
+++ b/akka-docs/src/main/paradox/stream/stream-substream.md
@@ -5,9 +5,11 @@
 To use Akka Streams, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/stream/stream-testkit.md
+++ b/akka-docs/src/main/paradox/stream/stream-testkit.md
@@ -5,9 +5,11 @@
 To use Akka Stream TestKit, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-stream-testkit_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
   scope="test"
 }
 

--- a/akka-docs/src/main/paradox/testing.md
+++ b/akka-docs/src/main/paradox/testing.md
@@ -8,9 +8,11 @@ For the new API see @ref[testing](typed/testing.md).
 To use Akka Testkit, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-testkit_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
   scope="test"
 }
 

--- a/akka-docs/src/main/paradox/typed/actor-discovery.md
+++ b/akka-docs/src/main/paradox/typed/actor-discovery.md
@@ -7,9 +7,11 @@ You are viewing the documentation for the new actor APIs, to view the Akka Class
 To use Akka Actor Typed, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-actor-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 ## Obtaining Actor references

--- a/akka-docs/src/main/paradox/typed/actor-lifecycle.md
+++ b/akka-docs/src/main/paradox/typed/actor-lifecycle.md
@@ -10,9 +10,11 @@ You are viewing the documentation for the new actor APIs, to view the Akka Class
 To use Akka Actor Typed, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-actor-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/typed/actors.md
+++ b/akka-docs/src/main/paradox/typed/actors.md
@@ -10,9 +10,11 @@ You are viewing the documentation for the new actor APIs, to view the Akka Class
 To use Akka Actors, add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-actor-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 Both the Java and Scala DSLs of Akka modules are bundled in the same JAR. For a smooth development experience,

--- a/akka-docs/src/main/paradox/typed/cluster-dc.md
+++ b/akka-docs/src/main/paradox/typed/cluster-dc.md
@@ -19,9 +19,11 @@ up a large cluster into smaller groups of nodes for better scalability.
 To use Akka Cluster add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 ## Motivation

--- a/akka-docs/src/main/paradox/typed/cluster-sharded-daemon-process.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharded-daemon-process.md
@@ -14,9 +14,11 @@ warning or deprecation period. It is also not recommended to use this module in 
 To use Akka Sharded Daemon Process, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-sharding-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-cluster-sharding-typed" }

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -10,9 +10,11 @@ You are viewing the documentation for the new actor APIs, to view the Akka Class
 To use Akka Cluster Sharding, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-sharding-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-cluster-sharding-typed" }

--- a/akka-docs/src/main/paradox/typed/cluster-singleton.md
+++ b/akka-docs/src/main/paradox/typed/cluster-singleton.md
@@ -7,9 +7,11 @@ You are viewing the documentation for the new actor APIs, to view the Akka Class
 To use Cluster Singleton, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-cluster-typed" }

--- a/akka-docs/src/main/paradox/typed/cluster.md
+++ b/akka-docs/src/main/paradox/typed/cluster.md
@@ -26,9 +26,11 @@ recommendation if you don't have other preferences or constraints.
 To use Akka Cluster add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-cluster-typed" }

--- a/akka-docs/src/main/paradox/typed/coexisting.md
+++ b/akka-docs/src/main/paradox/typed/coexisting.md
@@ -5,9 +5,11 @@
 To use Akka Actor Typed, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-actor-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/typed/dispatchers.md
+++ b/akka-docs/src/main/paradox/typed/dispatchers.md
@@ -11,9 +11,11 @@ Dispatchers are part of core Akka, which means that they are part of the `akka-a
 page describes how to use dispatchers with `akka-actor-typed`, which has dependency:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor-typed_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction 

--- a/akka-docs/src/main/paradox/typed/distributed-data.md
+++ b/akka-docs/src/main/paradox/typed/distributed-data.md
@@ -10,9 +10,11 @@ You are viewing the documentation for the new actor APIs, to view the Akka Class
 To use Akka Cluster Distributed Data, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 @@project-info{ projectId="akka-cluster-typed" }

--- a/akka-docs/src/main/paradox/typed/distributed-pub-sub.md
+++ b/akka-docs/src/main/paradox/typed/distributed-pub-sub.md
@@ -8,9 +8,11 @@ The distributed publish subscribe topic API is available and usable with the cor
 when used in a clustered application:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-cluster-typed_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## The Topic Actor

--- a/akka-docs/src/main/paradox/typed/from-classic.md
+++ b/akka-docs/src/main/paradox/typed/from-classic.md
@@ -26,9 +26,11 @@ module, with a few exceptions.
 For example `akka-cluster-typed`:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 Artifact names:

--- a/akka-docs/src/main/paradox/typed/guide/modules.md
+++ b/akka-docs/src/main/paradox/typed/guide/modules.md
@@ -34,9 +34,11 @@ This page does not list all available modules, but overviews the main functional
 ### Actor library
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-actor-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 The core Akka library is `akka-actor-typed`, but actors are used across Akka libraries, providing a consistent, integrated model that relieves you from individually
@@ -59,9 +61,11 @@ Challenges that actors solve include the following:
 ### Remoting
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-remote_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 Remoting enables actors that live on different computers to seamlessly exchange messages.
@@ -82,9 +86,11 @@ Challenges Remoting solves include the following:
 ### Cluster
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 If you have a set of actor systems that cooperate to solve some business problem, then you likely want to manage these set of
@@ -105,9 +111,11 @@ Challenges the Cluster module solves include the following:
 ### Cluster Sharding
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-sharding-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 Sharding helps to solve the problem of distributing a set of actors among members of an Akka cluster.
@@ -124,9 +132,11 @@ Challenges that Sharding solves include the following:
 ### Cluster Singleton
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-singleton_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 A common (in fact, a bit too common) use case in distributed systems is to have a single entity responsible
@@ -145,9 +155,11 @@ The Singleton module can be used to solve these challenges:
 ### Persistence
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-persistence-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 Just like objects in OOP, actors keep their state in volatile memory. Once the system is shut down, gracefully or
@@ -167,9 +179,11 @@ Persistence tackles the following challenges:
 ### Distributed Data
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 In situations where eventual consistency is acceptable, it is possible to share data between nodes in
@@ -186,9 +200,11 @@ Distributed Data is intended to solve the following challenges:
 ### Streams
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-stream-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 Actors are a fundamental model for concurrency, but there are common patterns where their use requires the user

--- a/akka-docs/src/main/paradox/typed/guide/tutorial_1.md
+++ b/akka-docs/src/main/paradox/typed/guide/tutorial_1.md
@@ -5,9 +5,11 @@
 Add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor-typed_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/typed/interaction-patterns.md
+++ b/akka-docs/src/main/paradox/typed/interaction-patterns.md
@@ -7,9 +7,11 @@ You are viewing the documentation for the new actor APIs, to view the Akka Class
 To use Akka Actor Typed, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-actor-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/typed/logging.md
+++ b/akka-docs/src/main/paradox/typed/logging.md
@@ -11,9 +11,11 @@ To use Logging, you must at least use the Akka actors dependency in your project
 via the SLF4J backend, such as Logback configuration.
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor-typed_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/typed/mailboxes.md
+++ b/akka-docs/src/main/paradox/typed/mailboxes.md
@@ -8,9 +8,11 @@ Mailboxes are part of core Akka, which means that they are part of the `akka-act
 page describes how to use mailboxes with `akka-actor-typed`, which has dependency:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-actor-typed_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 ## Introduction 

--- a/akka-docs/src/main/paradox/typed/persistence-testing.md
+++ b/akka-docs/src/main/paradox/typed/persistence-testing.md
@@ -5,12 +5,14 @@
 To use Akka Persistence TestKit, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group1=com.typesafe.akka
   artifact1=akka-persistence-typed_$scala.binary.version$
-  version1=$akka.version$
+  version1=AkkaVersion
   group2=com.typesafe.akka
   artifact2=akka-persistence-testkit_$scala.binary.version$
-  version2=$akka.version$
+  version2=AkkaVersion
   scope2=test
 }
 
@@ -60,9 +62,11 @@ Persistence testkit allows to check events saved in a storage, emulate storage o
 To use the testkit you need to add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-persistence-testkit_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 There are two testkit classes which have similar api:
@@ -194,9 +198,11 @@ the plugins at the same time. To coordinate initialization you can use the `Pers
 `PersistenceInit` is part of `akka-persistence-testkit` and you need to add the dependency to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group="com.typesafe.akka"
   artifact="akka-persistence-testkit_$scala.binary.version$"
-  version="$akka.version$"
+  version=AkkaVersion
 }
 
 Scala

--- a/akka-docs/src/main/paradox/typed/persistence.md
+++ b/akka-docs/src/main/paradox/typed/persistence.md
@@ -10,9 +10,11 @@ You are viewing the documentation for the new actor APIs, to view the Akka Class
 To use Akka Persistence, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-persistence-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 You also have to select journal plugin and optionally snapshot store plugin, see 

--- a/akka-docs/src/main/paradox/typed/reliable-delivery.md
+++ b/akka-docs/src/main/paradox/typed/reliable-delivery.md
@@ -18,9 +18,11 @@ warning or deprecation period. It is also not recommended to use this module in 
 To use reliable delivery, add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-actor-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 ## Introduction
@@ -248,9 +250,11 @@ In that case some of these may already have been processed by the previous worke
 To use reliable delivery with Cluster Sharding, add the following module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-cluster-sharding-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 Reliable delivery between a producer actor sending messages to @ref:[sharded](cluster-sharding.md) consumer
@@ -354,9 +358,11 @@ Be aware of that a `DurableProducerQueue` will add a substantial performance ove
 When using the `EventSourcedProducerQueue` the following dependency is needed:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-persistence-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 } 
 
 You also have to select journal plugin and snapshot store plugin, see 

--- a/akka-docs/src/main/paradox/typed/routers.md
+++ b/akka-docs/src/main/paradox/typed/routers.md
@@ -7,9 +7,11 @@ You are viewing the documentation for the new actor APIs, to view the Akka Class
 To use Akka Actor Typed, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-actor-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/typed/stash.md
+++ b/akka-docs/src/main/paradox/typed/stash.md
@@ -7,9 +7,11 @@ You are viewing the documentation for the new actor APIs, to view the Akka Class
 To use Akka Actor Typed, you must add the following dependency in your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-actor-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
 }
 
 ## Introduction

--- a/akka-docs/src/main/paradox/typed/testing.md
+++ b/akka-docs/src/main/paradox/typed/testing.md
@@ -7,9 +7,11 @@ You are viewing the documentation for the new actor APIs, to view the Akka Class
 To use Actor TestKit add the module to your project:
 
 @@dependency[sbt,Maven,Gradle] {
+  symbol1=AkkaVersion
+  value1="$akka.version$"
   group=com.typesafe.akka
   artifact=akka-actor-testkit-typed_$scala.binary.version$
-  version=$akka.version$
+  version=AkkaVersion
   scope=test
 }
 


### PR DESCRIPTION
Updates all listings of the Akka dependency to show `AkkaVersion` as a constant/property so that users less likely end up with mixed Akka dependencies.