### PR TITLE
Fix doc typo

### DIFF
--- a/akka-docs/src/test/java/jdocs/stream/operators/PartitionDocExample.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/PartitionDocExample.java
@@ -36,7 +36,7 @@ public class PartitionDocExample {
             .to(Sink.ignore());
     Sink<Integer, NotUsed> odd =
         Flow.of(Integer.class)
-            .log("even")
+            .log("odd")
             .withAttributes(Attributes.createLogLevels(Attributes.logLevelInfo()))
             .to(Sink.ignore());
 


### PR DESCRIPTION
Fix a typo in the java example. 