### PR TITLE
Change JsonFraming to fail stage if completing within an object #29228

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
@@ -70,6 +70,9 @@ import akka.util.ByteString
 
   def isEmpty: Boolean = buffer.isEmpty
 
+  /** `true` if the buffer is in a valid state to end framing. */
+  def canComplete: Boolean = !insideObject
+
   /**
    * Attempt to locate next complete JSON object in buffered ByteString and returns `Some(it)` if found.
    * May throw a [[akka.stream.scaladsl.Framing.FramingException]] if the contained JSON is invalid or max object size is exceeded.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/JsonFraming.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/JsonFraming.scala
@@ -4,17 +4,22 @@
 
 package akka.stream.scaladsl
 
-import scala.util.control.NonFatal
-
 import akka.NotUsed
 import akka.stream.Attributes
 import akka.stream.impl.JsonObjectParser
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
+import akka.stream.scaladsl.Framing.FramingException
 import akka.stream.stage.{ GraphStageLogic, InHandler, OutHandler }
 import akka.util.ByteString
 
+import scala.util.control.NonFatal
+
 /** Provides JSON framing operators that can separate valid JSON objects from incoming [[ByteString]] objects. */
 object JsonFraming {
+
+  /** Thrown if upstream completes with a partial object in the buffer. */
+  class PartialObjectException(msg: String = "JSON stream completed with partial content in the buffer!")
+      extends FramingException(msg)
 
   /**
    * Returns a Flow that implements a "brace counting" based framing operator for emitting valid JSON chunks.
@@ -36,6 +41,8 @@ object JsonFraming {
    * The framing works independently of formatting, i.e. it will still emit valid JSON elements even if two
    * elements are separated by multiple newlines or other whitespace characters. And of course is insensitive
    * (and does not impact the emitting frame) to the JSON object's internal formatting.
+   *
+   * If the stream completes while mid-object, the stage will fail with a [[PartialObjectException]].
    *
    * @param maximumObjectLength The maximum length of allowed frames while decoding. If the maximum length is exceeded
    *                            this Flow will fail the stream.
@@ -62,18 +69,22 @@ object JsonFraming {
           override def onUpstreamFinish(): Unit = {
             buffer.poll() match {
               case Some(json) => emit(out, json)
-              case _          => completeStage()
+              case _          => complete()
             }
           }
 
-          def tryPopBuffer() = {
+          def tryPopBuffer(): Unit = {
             try buffer.poll() match {
               case Some(json) => push(out, json)
-              case _          => if (isClosed(in)) completeStage() else pull(in)
+              case _          => if (isClosed(in)) complete() else pull(in)
             } catch {
               case NonFatal(ex) => failStage(ex)
             }
           }
+
+          def complete(): Unit =
+            if (buffer.canComplete) completeStage()
+            else failStage(new PartialObjectException)
         }
     })
 


### PR DESCRIPTION
References #29228 

I found a doc reference to JsonFraming in stream-io.md, but it doesn't go into these kinds of details, so I didn't make any documentation adjustments outside the scaladoc.

It took me a little while to figure out how to get coverage for both the `onPush()`, `onPull()` and `onUpstreamFinish()` scenarios, but I'm pretty sure I've got coverage for two of those three.