### PR TITLE
Bytestring bits

### DIFF
--- a/akka-actor/src/main/scala-2.12/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala-2.12/akka/util/ByteString.scala
@@ -714,6 +714,8 @@ sealed abstract class ByteString extends IndexedSeq[Byte] with IndexedSeqOptimiz
 
   override protected[this] def newBuilder: ByteStringBuilder = ByteString.newBuilder
 
+  override def isEmpty: Boolean = length == 0
+
   // *must* be overridden by derived classes. This construction is necessary
   // to specialize the return type, as the method is already implemented in
   // a parent trait.

--- a/akka-actor/src/main/scala-2.13/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala-2.13/akka/util/ByteString.scala
@@ -755,6 +755,8 @@ sealed abstract class ByteString
   // of ByteString which changed for Scala 2.12, see https://github.com/akka/akka/issues/21774
   override final def className: String = "ByteString"
 
+  override def isEmpty: Boolean = length == 0
+
   // override protected[this] def newBuilder: ByteStringBuilder = ByteString.newBuilder
 
   // *must* be overridden by derived classes. This construction is necessary


### PR DESCRIPTION
Two performance improvements for ByteString and ByteStringBuilder mostly for 2.13.

    actor: improve ByteStringBuilder.++= / addAll
    
    Especially in the Scala 2.13 version, the previous `if xs.iterator.isEmpty`
    for the common case was a big problem, since it expensively created an
    iterator even for the most common ++=(ByteString) case.

    actor: implement ByteString.isEmpty in as simple terms as possible
    
    It turned up in profiles, the usual implementation in 2.13 is through
    SeqOps.isEmpty -> lengthCompare which checks if knownSize != -1 for
    the fast path. All of that doesn't sound too bad but introduces enough
    indirection that the inliner might not be able to inline all of that
    which then leads to a multimorphic callsite e.g. to call lengthCompare.