### PR TITLE
Allow 2.5 snapshot requirement in version check

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/AkkaVersionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/AkkaVersionSpec.scala
@@ -60,23 +60,25 @@ class AkkaVersionSpec extends AnyWordSpec with Matchers {
       }
     }
 
-    "succeed if Akka version is SNAPSHOT" in {
+    "succeed if current Akka version is SNAPSHOT" in {
       AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5-SNAPSHOT")
     }
 
-    "succeed if Akka version is timestamped SNAPSHOT" in {
+    "succeed if current Akka version is timestamped SNAPSHOT" in {
       AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5-20180109-133700")
+    }
+
+    "succeed if required Akka version is SNAPSHOT" in {
+      AkkaVersion.require("AkkaVersionSpec", "2.5-SNAPSHOT", "2.5-SNAPSHOT")
+    }
+
+    "succeed if required Akka version is timestamped SNAPSHOT" in {
+      AkkaVersion.require("AkkaVersionSpec", "2.5-20180109-133700", "2.5-20180109-133700")
     }
 
     "silently comply if current version is incomprehensible" in {
       // because we may want to release with weird numbers for some reason
       AkkaVersion.require("nonsense", "2.5.6", "nonsense")
-    }
-
-    "fail if fed incomprehensible requirement" in {
-      intercept[IllegalArgumentException] {
-        AkkaVersion.require("AkkaVersionSpec", "nonsense", "2.5.6")
-      }
     }
 
   }

--- a/akka-actor/src/main/scala/akka/AkkaVersion.scala
+++ b/akka-actor/src/main/scala/akka/AkkaVersion.scala
@@ -44,7 +44,7 @@ object AkkaVersion {
                   (requiredMinorStr == currentMinorStr && requiredPatchStr.toInt > currentPatch))
                 throw new UnsupportedAkkaVersion(
                   s"Current version of Akka is [$currentVersion], but $libraryName requires version [$requiredVersion]")
-            case _ => throw new IllegalArgumentException(s"Required version string is invalid: [$requiredVersion]")
+            case _ => // SNAPSHOT or unknown - you're on your own
           }
 
         case _ => // SNAPSHOT or unknown - you're on your own


### PR DESCRIPTION
This happens for example when running the Akka HTTP documentation
tests, which use Akka 2.6, on a branch where Akka HTTP itself requires
a snapshot version of Akka 2.5

For example https://github.com/akka/akka-http/pull/2983