### PR TITLE
Use scalafix to update scala 2.13.3, silencer 1.7.0

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -3,14 +3,17 @@ rules = [
   RemoveUnused
   SortImports
   ExplicitResultTypes
-  "github:ohze/scalafix-rules/ExplicitNonNullaryApply"
-  "github:ohze/scalafix-rules/ConstructorProcedureSyntax"
   "github:ohze/scalafix-rules/FinalObject"
-  "github:ohze/scalafix-rules/Any2StringAdd"
+  fix.scala213.DottyMigrate
+//  fix.scala213.NullaryOverride
 ]
+//NullaryOverride.mode = Rewrite
 ExplicitResultTypes {
   memberVisibility = [] # only rewrite implicit members
   skipSimpleDefinitions = []
+}
+ExplicitImplicitTypes.symbolReplacements {
+  "scala/concurrent/ExecutionContextExecutor#" = "scala/concurrent/ExecutionContext#"
 }
 RemoveUnused.imports = true
 RemoveUnused.privates = false

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
@@ -118,7 +118,7 @@ class ActorLifeCycleSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitS
     "log failures in postStop" in {
       val a = system.actorOf(Props(new Actor {
         def receive = Actor.emptyBehavior
-        override def postStop: Unit = { throw new Exception("hurrah") }
+        override def postStop(): Unit = { throw new Exception("hurrah") }
       }))
       EventFilter[Exception]("hurrah", occurrences = 1).intercept {
         a ! PoisonPill

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
@@ -101,7 +101,7 @@ object ActorWithStashSpec {
 class ActorWithStashSpec extends AkkaSpec with DefaultTimeout with BeforeAndAfterEach {
   import ActorWithStashSpec._
 
-  override def atStartup: Unit = {
+  override def atStartup(): Unit = {
     system.eventStream.publish(Mute(EventFilter[Exception]("Crashing...")))
   }
 

--- a/akka-actor-tests/src/test/scala/akka/actor/FSMActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/FSMActorSpec.scala
@@ -183,7 +183,7 @@ class FSMActorSpec extends AkkaSpec(Map("akka.actor.debug.fsm" -> true)) with Im
        * It is necessary here because of the path-dependent type fsm.StopEvent.
        */
       lazy val fsm = new Actor with FSM[Int, Null] {
-        override def preStart = { started.countDown() }
+        override def preStart() = { started.countDown() }
         startWith(1, null)
         when(1) { FSM.NullFunction }
         onTermination {

--- a/akka-actor-tests/src/test/scala/akka/actor/RestartStrategySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/RestartStrategySpec.scala
@@ -22,7 +22,7 @@ import akka.testkit.TestLatch
 @silent
 class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
 
-  override def atStartup: Unit = {
+  override def atStartup(): Unit = {
     system.eventStream.publish(Mute(EventFilter[Exception]("Crashing...")))
   }
 

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/DnsClientSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/DnsClientSpec.scala
@@ -31,7 +31,7 @@ class DnsClientSpec extends AkkaSpec with ImplicitSender {
       val client = system.actorOf(Props(new DnsClient(dnsServerAddress) {
         override val udp = udpExtensionProbe.ref
 
-        override def createTcpClient = {
+        override def createTcpClient() = {
           tcpClientCreated.set(true)
           TestProbe().ref
         }
@@ -57,7 +57,7 @@ class DnsClientSpec extends AkkaSpec with ImplicitSender {
       val client = system.actorOf(Props(new DnsClient(dnsServerAddress) {
         override val udp = udpExtensionProbe.ref
 
-        override def createTcpClient = tcpClientProbe.ref
+        override def createTcpClient() = tcpClientProbe.ref
       }))
 
       client ! exampleRequest

--- a/akka-actor-tests/src/test/scala/akka/routing/ScatterGatherFirstCompletedSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ScatterGatherFirstCompletedSpec.scala
@@ -37,7 +37,7 @@ object ScatterGatherFirstCompletedSpec {
           }
         }
 
-        override def postStop = {
+        override def postStop() = {
           shudownLatch.foreach(_.countDown())
         }
       }),

--- a/akka-bench-jmh/src/main/scala/akka/BenchRunner.scala
+++ b/akka-bench-jmh/src/main/scala/akka/BenchRunner.scala
@@ -22,7 +22,7 @@ object BenchRunner {
     val opts = new CommandLineOptions(args2: _*)
     val results = new Runner(opts).run()
 
-    val report = results.asScala.map { result: RunResult =>
+    val report = results.asScala.map { (result: RunResult) =>
       val bench = result.getParams.getBenchmark
       val params =
         result.getParams.getParamsKeys.asScala.map(key => s"$key=${result.getParams.getParam(key)}").mkString("_")

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/SbrTestLeaseActor.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/SbrTestLeaseActor.scala
@@ -97,7 +97,7 @@ class SbrTestLeaseActorClient(settings: LeaseSettings, system: ExtendedActorSyst
 
   SbrTestLeaseActorClientExt(system).setActorLeaseClient(this)
 
-  private implicit val timeout = Timeout(3.seconds)
+  private implicit val timeout: Timeout = Timeout(3.seconds)
 
   private val _leaseRef = new AtomicReference[ActorRef]
 

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesFailureSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesFailureSpec.scala
@@ -20,6 +20,7 @@ import com.github.ghik.silencer.silent
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
 
 import akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
 
@@ -98,7 +99,7 @@ object RememberEntitiesFailureSpec {
   class FakeShardStoreActor(shardId: ShardId) extends Actor with ActorLogging with Timers {
     import FakeShardStoreActor._
 
-    implicit val ec = context.system.dispatcher
+    implicit val ec: ExecutionContext = context.system.dispatcher
     private var failUpdate: Option[Fail] = None
 
     context.system.eventStream.publish(ShardStoreCreated(self, shardId))
@@ -201,7 +202,7 @@ class RememberEntitiesFailureSpec
 
   "Remember entities handling in sharding" must {
 
-    List(NoResponse, CrashStore, StopStore, Delay(500.millis), Delay(1.second)).foreach { wayToFail: Fail =>
+    List(NoResponse, CrashStore, StopStore, Delay(500.millis), Delay(1.second)).foreach { (wayToFail: Fail) =>
       s"recover when initial remember entities load fails $wayToFail" in {
         log.debug("Getting entities for shard 1 will fail")
         failShardGetEntities = Map("1" -> wayToFail)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ActorSystemSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ActorSystemSpec.scala
@@ -129,7 +129,7 @@ class ActorSystemSpec
         Behaviors.receiveMessage[Done] { _ =>
           Behaviors.stopped
         }
-      withSystem("shutdown", stoppable, doTerminate = false) { sys: ActorSystem[Done] =>
+      withSystem("shutdown", stoppable, doTerminate = false) { (sys: ActorSystem[Done]) =>
         sys ! Done
         sys.whenTerminated.futureValue
       }

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/ddata/typed/scaladsl/ReplicatorDocSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/ddata/typed/scaladsl/ReplicatorDocSpec.scala
@@ -117,7 +117,7 @@ class ReplicatorDocSpec
 
   import ReplicatorDocSpec._
 
-  implicit val selfNodeAddress = DistributedData(system).selfUniqueAddress
+  implicit val selfNodeAddress: SelfUniqueAddress = DistributedData(system).selfUniqueAddress
 
   "Replicator" must {
 

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
@@ -109,7 +109,7 @@ akka {
 class BasicClusterConfigSpec extends AnyWordSpec with ScalaFutures with Eventually with Matchers with LogCapturing {
   import BasicClusterExampleSpec._
 
-  implicit override val patienceConfig =
+  implicit override val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(100, Millis)))
 
   "Cluster API" must {
@@ -166,7 +166,7 @@ class BasicClusterManualSpec extends AnyWordSpec with ScalaFutures with Eventual
 
   import BasicClusterManualSpec._
 
-  implicit override val patienceConfig =
+  implicit override val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(100, Millis)))
 
   "Cluster API" must {

--- a/akka-docs/src/test/scala/docs/actor/ActorDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/actor/ActorDocSpec.scala
@@ -453,7 +453,7 @@ class ActorDocSpec extends AkkaSpec("""
       class DependencyInjector(applicationContext: AnyRef, beanName: String) extends IndirectActorProducer {
 
         override def actorClass = classOf[Actor]
-        override def produce =
+        override def produce() =
           //#obtain-fresh-Actor-instance-from-DI-framework
           new Echo(beanName)
 
@@ -585,7 +585,7 @@ class ActorDocSpec extends AkkaSpec("""
       //#watch
 
       val victim = system.actorOf(Props(classOf[WatchActor], this))
-      implicit val sender = testActor
+      implicit val sender: ActorRef = testActor
       victim ! "kill"
       expectMsg("finished")
     }

--- a/akka-docs/src/test/scala/docs/actor/ActorDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/actor/ActorDocSpec.scala
@@ -578,15 +578,16 @@ class ActorDocSpec extends AkkaSpec("""
 
         def receive = {
           case "kill" =>
-            context.stop(child); lastSender = sender()
-          case Terminated(`child`) => lastSender ! "finished"
+            context.stop(child)
+            lastSender = sender()
+          case Terminated(`child`) =>
+            lastSender ! "finished"
         }
       }
       //#watch
 
       val victim = system.actorOf(Props(classOf[WatchActor], this))
-      implicit val sender: ActorRef = testActor
-      victim ! "kill"
+      victim.tell("kill", testActor)
       expectMsg("finished")
     }
   }

--- a/akka-docs/src/test/scala/docs/actor/FaultHandlingDocSample.scala
+++ b/akka-docs/src/test/scala/docs/actor/FaultHandlingDocSample.scala
@@ -80,7 +80,7 @@ object Worker {
 class Worker extends Actor with ActorLogging {
   import Worker._
   import CounterService._
-  implicit val askTimeout = Timeout(5 seconds)
+  implicit val askTimeout: Timeout = Timeout(5 seconds)
 
   // Stop the CounterService child if it throws ServiceUnavailable
   override val supervisorStrategy = OneForOneStrategy() {

--- a/akka-docs/src/test/scala/docs/actor/io/dns/DnsCompileOnlyDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/actor/io/dns/DnsCompileOnlyDocSpec.scala
@@ -16,8 +16,8 @@ import scala.concurrent.duration._
 
 object DnsCompileOnlyDocSpec {
 
-  implicit val system = ActorSystem()
-  implicit val timeout = Timeout(1.second)
+  implicit val system: ActorSystem = ActorSystem()
+  implicit val timeout: Timeout = Timeout(1.second)
 
   val actorRef: ActorRef = ???
   //#resolve

--- a/akka-docs/src/test/scala/docs/ddata/DistributedDataDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/ddata/DistributedDataDocSpec.scala
@@ -63,7 +63,7 @@ object DistributedDataDocSpec {
     import DataBot._
 
     val replicator = DistributedData(context.system).replicator
-    implicit val node = DistributedData(context.system).selfUniqueAddress
+    implicit val node: SelfUniqueAddress = DistributedData(context.system).selfUniqueAddress
 
     import context.dispatcher
     val tickTask = context.system.scheduler.scheduleWithFixedDelay(5.seconds, 5.seconds, self, Tick)

--- a/akka-docs/src/test/scala/docs/ddata/ShoppingCart.scala
+++ b/akka-docs/src/test/scala/docs/ddata/ShoppingCart.scala
@@ -12,6 +12,7 @@ import akka.actor.Props
 import akka.cluster.ddata.DistributedData
 import akka.cluster.ddata.LWWMap
 import akka.cluster.ddata.LWWMapKey
+import akka.cluster.ddata.SelfUniqueAddress
 
 object ShoppingCart {
   import akka.cluster.ddata.Replicator._
@@ -38,7 +39,7 @@ class ShoppingCart(userId: String) extends Actor {
   import akka.cluster.ddata.Replicator._
 
   val replicator = DistributedData(context.system).replicator
-  implicit val node = DistributedData(context.system).selfUniqueAddress
+  implicit val node: SelfUniqueAddress = DistributedData(context.system).selfUniqueAddress
 
   val DataKey = LWWMapKey[String, LineItem]("cart-" + userId)
 

--- a/akka-docs/src/test/scala/docs/future/FutureDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/future/FutureDocSpec.scala
@@ -106,7 +106,7 @@ object FutureDocSpec {
     import akka.pattern.{ ask, pipe }
     implicit val ec: ExecutionContext = context.dispatcher
 
-    implicit val timeout = Timeout(5 seconds)
+    implicit val timeout: Timeout = Timeout(5 seconds)
 
     def receive = {
       case GetUserData =>

--- a/akka-docs/src/test/scala/docs/io/EchoServer.scala
+++ b/akka-docs/src/test/scala/docs/io/EchoServer.scala
@@ -16,7 +16,7 @@ import scala.io.StdIn
 object EchoServer extends App {
 
   val config = ConfigFactory.parseString("akka.loglevel = DEBUG")
-  implicit val system = ActorSystem("EchoServer", config)
+  implicit val system: ActorSystem = ActorSystem("EchoServer", config)
 
   system.actorOf(Props(classOf[EchoManager], classOf[EchoHandler]), "echo")
   system.actorOf(Props(classOf[EchoManager], classOf[SimpleEchoHandler]), "simple")

--- a/akka-docs/src/test/scala/docs/persistence/PersistenceEventAdapterDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/persistence/PersistenceEventAdapterDocSpec.scala
@@ -14,7 +14,7 @@ import scala.collection.immutable
 
 class PersistenceEventAdapterDocSpec(config: String) extends AkkaSpec(config) {
 
-  def this() = {
+  def this() =
     this("""
       akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
 
@@ -65,7 +65,6 @@ class PersistenceEventAdapterDocSpec(config: String) extends AkkaSpec(config) {
         }
       }
     """)
-  }
 
   "MyAutomaticJsonEventAdapter" must {
     "demonstrate how to implement a JSON adapter" in {

--- a/akka-docs/src/test/scala/docs/persistence/query/PersistenceQueryDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/persistence/query/PersistenceQueryDocSpec.scala
@@ -24,7 +24,7 @@ import com.typesafe.config.Config
 
 object PersistenceQueryDocSpec {
 
-  implicit val timeout = Timeout(3.seconds)
+  implicit val timeout: Timeout = Timeout(3.seconds)
 
   //#advanced-journal-query-types
   final case class RichEvent(tags: Set[String], payload: Any)
@@ -150,7 +150,7 @@ object PersistenceQueryDocSpec {
     }
 
     //#projection-into-different-store-rs
-    implicit val system = ActorSystem()
+    implicit val system: ActorSystem = ActorSystem()
 
     val readJournal =
       PersistenceQuery(system).readJournalFor[MyScaladslReadJournal](JournalId)
@@ -199,14 +199,13 @@ object PersistenceQueryDocSpec {
 class PersistenceQueryDocSpec(s: String) extends AkkaSpec(s) {
   import PersistenceQueryDocSpec._
 
-  def this() = {
+  def this() =
     this("""
         akka.persistence.query.my-read-journal {
           class = "docs.persistence.query.PersistenceQueryDocSpec$MyReadJournalProvider"
           refresh-interval = 3s
         }
       """)
-  }
 
   class BasicUsage {
     //#basic-usage

--- a/akka-docs/src/test/scala/docs/stream/CompositionDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/CompositionDocSpec.scala
@@ -12,10 +12,11 @@ import akka.testkit.AkkaSpec
 import akka.util.ByteString
 
 import scala.concurrent.{ Future, Promise }
+import scala.concurrent.ExecutionContext
 
 class CompositionDocSpec extends AkkaSpec {
 
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContext = system.dispatcher
 
   "nonnested flow" in {
     //#non-nested-flow

--- a/akka-docs/src/test/scala/docs/stream/FlowDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/FlowDocSpec.scala
@@ -16,10 +16,11 @@ import docs.CompileOnlySpec
 
 import scala.concurrent.{ Future, Promise }
 import scala.util.{ Failure, Success }
+import scala.concurrent.ExecutionContext
 
 class FlowDocSpec extends AkkaSpec with CompileOnlySpec {
 
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContext = system.dispatcher
 
   "source is immutable" in {
     //#source-immutable
@@ -251,7 +252,7 @@ object FlowDocSpec {
 
   //#materializer-from-actor-context
   final class RunWithMyself extends Actor {
-    implicit val mat = Materializer(context)
+    implicit val mat: Materializer = Materializer(context)
 
     Source.maybe.runWith(Sink.onComplete {
       case Success(done) => println(s"Completed: $done")

--- a/akka-docs/src/test/scala/docs/stream/GraphDSLDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/GraphDSLDocSpec.scala
@@ -12,10 +12,11 @@ import akka.testkit.AkkaSpec
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
+import scala.concurrent.ExecutionContext
 
 class GraphDSLDocSpec extends AkkaSpec {
 
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContext = system.dispatcher
 
   "build simple graph" in {
     //format: OFF

--- a/akka-docs/src/test/scala/docs/stream/GraphStageLoggingDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/GraphStageLoggingDocSpec.scala
@@ -9,10 +9,11 @@ import java.util.concurrent.ThreadLocalRandom
 import akka.stream._
 import akka.stream.scaladsl._
 import akka.testkit.{ AkkaSpec, EventFilter }
+import scala.concurrent.ExecutionContext
 
 class GraphStageLoggingDocSpec extends AkkaSpec("akka.loglevel = DEBUG") {
 
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContext = system.dispatcher
 
   //#operator-with-logging
   import akka.stream.stage.{ GraphStage, GraphStageLogic, OutHandler, StageLogging }

--- a/akka-docs/src/test/scala/docs/stream/QuickStartDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/QuickStartDocSpec.scala
@@ -24,13 +24,13 @@ import org.scalatest.concurrent._
 
 //#main-app
 object Main extends App {
-  implicit val system = ActorSystem("QuickStart")
+  implicit val system: ActorSystem = ActorSystem("QuickStart")
   // Code here
 }
 //#main-app
 
 class QuickStartDocSpec extends AnyWordSpec with BeforeAndAfterAll with ScalaFutures {
-  implicit val patience = PatienceConfig(5.seconds)
+  implicit val patience: PatienceConfig = PatienceConfig(5.seconds)
 
   def println(any: Any) = () // silence printing stuff
 

--- a/akka-docs/src/test/scala/docs/stream/StreamPartialGraphDSLDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/StreamPartialGraphDSLDocSpec.scala
@@ -11,10 +11,11 @@ import akka.testkit.AkkaSpec
 
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
 
 class StreamPartialGraphDSLDocSpec extends AkkaSpec {
 
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContext = system.dispatcher
 
   "build with open ports" in {
     //#simple-partial-graph-dsl

--- a/akka-docs/src/test/scala/docs/stream/TwitterStreamQuickstartDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/TwitterStreamQuickstartDocSpec.scala
@@ -17,6 +17,7 @@ import scala.io.StdIn.readLine
 //#imports
 
 import akka.testkit.AkkaSpec
+import scala.concurrent.ExecutionContext
 
 object TwitterStreamQuickstartDocSpec {
   //#fiddle_code
@@ -70,7 +71,7 @@ object TwitterStreamQuickstartDocSpec {
 class TwitterStreamQuickstartDocSpec extends AkkaSpec {
   import TwitterStreamQuickstartDocSpec._
 
-  implicit val executionContext = system.dispatcher
+  implicit val executionContext: ExecutionContext = system.dispatcher
 
   // Disable println
   def println(s: Any): Unit = ()
@@ -79,7 +80,7 @@ class TwitterStreamQuickstartDocSpec extends AkkaSpec {
     //#fiddle_code
     //#first-sample
     //#system-setup
-    implicit val system = ActorSystem("reactive-tweets")
+    implicit val system: ActorSystem = ActorSystem("reactive-tweets")
     //#system-setup
     //#first-sample
 

--- a/akka-docs/src/test/scala/docs/stream/cookbook/RecipeMultiGroupBy.scala
+++ b/akka-docs/src/test/scala/docs/stream/cookbook/RecipeMultiGroupBy.scala
@@ -20,7 +20,7 @@ class RecipeMultiGroupBy extends RecipeSpec {
       case class Topic(name: String)
 
       val elems = Source(List("1: a", "1: b", "all: c", "all: d", "1: e"))
-      val extractTopics = { msg: Message =>
+      val extractTopics = { (msg: Message) =>
         if (msg.startsWith("1")) List(Topic("1"))
         else List(Topic("1"), Topic("2"))
       }
@@ -28,7 +28,7 @@ class RecipeMultiGroupBy extends RecipeSpec {
       //#multi-groupby
       val topicMapper: (Message) => immutable.Seq[Topic] = extractTopics
 
-      val messageAndTopic: Source[(Message, Topic), NotUsed] = elems.mapConcat { msg: Message =>
+      val messageAndTopic: Source[(Message, Topic), NotUsed] = elems.mapConcat { (msg: Message) =>
         val topicsForMessage = topicMapper(msg)
         // Create a (Msg, Topic) pair for each of the topics
         // the message belongs to

--- a/akka-docs/src/test/scala/docs/stream/io/StreamFileDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/io/StreamFileDocSpec.scala
@@ -13,10 +13,11 @@ import akka.util.ByteString
 import akka.testkit.AkkaSpec
 
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
 
 class StreamFileDocSpec extends AkkaSpec(UnboundedMailboxConfig) {
 
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContext = system.dispatcher
 
   // silence sysout
   def println(s: String) = ()

--- a/akka-docs/src/test/scala/docs/stream/io/StreamTcpDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/io/StreamTcpDocSpec.scala
@@ -14,10 +14,11 @@ import akka.util.ByteString
 
 import scala.concurrent.Future
 import akka.testkit.SocketUtil
+import scala.concurrent.ExecutionContext
 
 class StreamTcpDocSpec extends AkkaSpec {
 
-  implicit val ec = system.dispatcher
+  implicit val ec: ExecutionContext = system.dispatcher
 
   // silence sysout
   def println(s: String) = ()

--- a/akka-docs/src/test/scala/docs/stream/operators/source/Restart.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/source/Restart.scala
@@ -52,7 +52,7 @@ object Restart extends App {
 
   }
 
-  def onRestartWithBackoffInnerComplete() = {
+  def onRestartWithBackoffInnerComplete(): Unit = {
 
     //#restart-failure-inner-complete
     val finiteSource = Source.tick(1.second, 1.second, "tick").take(3)

--- a/akka-docs/src/test/scala/docs/stream/operators/source/Tick.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/source/Tick.scala
@@ -27,7 +27,7 @@ object Tick {
     case class Response(text: String)
   }
 
-  def simple() = {
+  def simple(): Unit = {
     // #simple
     Source
       .tick(
@@ -39,7 +39,7 @@ object Tick {
     // #simple
   }
 
-  def pollSomething() = {
+  def pollSomething(): Unit = {
     // #poll-actor
     val periodicActorResponse: Source[String, Cancellable] = Source
       .tick(1.second, 1.second, "tick")

--- a/akka-docs/src/test/scala/docs/stream/operators/source/Zip.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/source/Zip.scala
@@ -47,7 +47,7 @@ object Zip {
     // #zipWithN-simple
   }
 
-  def zipAll() = {
+  def zipAll(): Unit = {
     // #zipAll-simple
     val numbers = Source(1 :: 2 :: 3 :: 4 :: Nil)
     val letters = Source("a" :: "b" :: "c" :: Nil)

--- a/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/ExtrapolateAndExpand.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/ExtrapolateAndExpand.scala
@@ -25,7 +25,7 @@ import scala.util.Random
  *
  */
 object ExtrapolateAndExpandMain extends App {
-  implicit val sys = ActorSystem("25fps-stream")
+  implicit val sys: ActorSystem = ActorSystem("25fps-stream")
   videoAt25Fps.map(_.pixels.utf8String).map(frame => s"$nowInSeconds - $frame").to(Sink.foreach(println)).run()
 
 }

--- a/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/Fold.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/Fold.scala
@@ -17,7 +17,7 @@ object Fold extends App {
   }
   //#histogram
 
-  implicit val sys = ActorSystem()
+  implicit val sys: ActorSystem = ActorSystem()
 
   //#fold
   Source(1 to 150).fold(Histogram())((acc, n) => acc.add(n)).runForeach(println)

--- a/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MergeLatest.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MergeLatest.scala
@@ -7,7 +7,7 @@ import akka.actor.ActorSystem
 import akka.stream.scaladsl.Source
 
 object MergeLatest extends App {
-  implicit val system = ActorSystem()
+  implicit val system: ActorSystem = ActorSystem()
 
   //#mergeLatest
   val prices = Source(List(100, 101, 99, 103))

--- a/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/Throttle.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/Throttle.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration._
  */
 object Throttle extends App {
 
-  implicit val sys = ActorSystem("25fps-stream")
+  implicit val sys: ActorSystem = ActorSystem("25fps-stream")
 
   val frameSource: Source[Int, NotUsed] =
     Source.fromIterator(() => Iterator.from(0))

--- a/akka-docs/src/test/scala/docs/testkit/ParentChildSpec.scala
+++ b/akka-docs/src/test/scala/docs/testkit/ParentChildSpec.scala
@@ -76,7 +76,7 @@ class MockedChild extends Actor {
 }
 
 class ParentChildSpec extends AnyWordSpec with Matchers with TestKitBase with BeforeAndAfterAll {
-  implicit lazy val system = ActorSystem("ParentChildSpec")
+  implicit lazy val system: ActorSystem = ActorSystem("ParentChildSpec")
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)

--- a/akka-docs/src/test/scala/docs/testkit/TestkitDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/testkit/TestkitDocSpec.scala
@@ -342,7 +342,7 @@ class TestKitDocSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
     import akka.testkit.TestKitBase
 
     class MyTest extends TestKitBase {
-      implicit lazy val system = ActorSystem()
+      implicit lazy val system: ActorSystem = ActorSystem()
 
       //#put-your-test-code-here
       val probe = TestProbe()

--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
@@ -49,8 +49,8 @@ private[akka] class SnapshotAfter(config: Config) extends Extension {
    * sequence number should trigger auto snapshot or not
    */
   val isSnapshotAfterSeqNo: Long => Boolean = snapshotAfterValue match {
-    case Some(snapShotAfterValue) => seqNo: Long => seqNo % snapShotAfterValue == 0
-    case None                     => _: Long => false //always false, if snapshotAfter is not specified in config
+    case Some(snapShotAfterValue) => (seqNo: Long) => seqNo % snapShotAfterValue == 0
+    case None                     => (_: Long) => false //always false, if snapshotAfter is not specified in config
   }
 }
 
@@ -380,7 +380,7 @@ object PersistentFSM {
       stopReason: Option[Reason] = None,
       replies: List[Any] = Nil,
       domainEvents: Seq[E] = Nil,
-      afterTransitionDo: D => Unit = { _: D =>
+      afterTransitionDo: D => Unit = { (_: D) =>
       })(private[akka] val notifies: Boolean = true) {
 
     /**

--- a/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSourceSpec.scala
@@ -42,7 +42,7 @@ class InputStreamSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
       StreamConverters
         .fromInputStream(() => inputStreamFor(Array(1, 2, 3)))
         .toMat(Sink.ignore)(Keep.left)
-        .run
+        .run()
         .futureValue shouldEqual IOResult(3, Success(Done))
     }
 
@@ -90,7 +90,7 @@ class InputStreamSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
         .fromInputStream(() => inputStreamFor(Array.fill(100)(1)), 1)
         .take(1) // stream is not completely read
         .toMat(Sink.ignore)(Keep.left)
-        .run
+        .run()
         .futureValue
 
       f.status shouldEqual Success(Done)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipWithIndexSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipWithIndexSpec.scala
@@ -5,7 +5,7 @@
 package akka.stream.scaladsl
 
 import akka.stream.testkit.scaladsl.StreamTestKit._
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings, Materializer }
 import akka.stream.testkit.{ StreamSpec, TestSubscriber }
 import com.github.ghik.silencer.silent
 
@@ -19,7 +19,7 @@ class FlowZipWithIndexSpec extends StreamSpec {
 //#zip-with-index
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 2, maxSize = 16)
 
-  implicit val materializer = ActorMaterializer(settings)
+  implicit val materializer: Materializer = ActorMaterializer(settings)
 
   "A ZipWithIndex for Flow " must {
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkForeachAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkForeachAsyncSpec.scala
@@ -40,7 +40,7 @@ class SinkForeachAsyncSpec extends StreamSpec {
       val latch = (1 to 4).map(_ -> TestLatch(1)).toMap
 
       val sink: Sink[Int, Future[Done]] = {
-        Sink.foreachAsync(4) { n: Int =>
+        Sink.foreachAsync(4) { (n: Int) =>
           Future {
             Await.result(latch(n), remainingOrDefault)
             probe.ref ! n

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StageActorRefSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StageActorRefSpec.scala
@@ -194,7 +194,7 @@ object StageActorRefSpec {
       val p: Promise[Int] = Promise()
 
       val logic = new GraphStageLogic(shape) {
-        implicit def self = stageActor.ref // must be a `def`; we want self to be the sender for our replies
+        implicit def self: ActorRef = stageActor.ref // must be a `def`; we want self to be the sender for our replies
         var sum: Int = 0
 
         override def preStart(): Unit = {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamConvertersSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamConvertersSpec.scala
@@ -37,7 +37,7 @@ class StreamConvertersSpec extends StreamSpec with DefaultTimeout {
     import scala.compat.java8.FunctionConverters._
 
     def javaStreamInts =
-      IntStream.iterate(1, { i: Int =>
+      IntStream.iterate(1, { (i: Int) =>
         i + 1
       }.asJava)
 
@@ -70,7 +70,7 @@ class StreamConvertersSpec extends StreamSpec with DefaultTimeout {
     "work with a filtered stream" in {
       StreamConverters
         .fromJavaStream(() =>
-          javaStreamInts.filter({ i: Int =>
+          javaStreamInts.filter({ (i: Int) =>
             i % 2 == 0
           }.asJava))
         .take(1000)

--- a/akka-stream/src/main/scala/akka/stream/impl/UnfoldResourceSourceAsync.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/UnfoldResourceSourceAsync.scala
@@ -15,6 +15,7 @@ import akka.stream._
 import akka.stream.ActorAttributes.SupervisionStrategy
 import akka.stream.impl.Stages.DefaultAttributes
 import akka.stream.stage._
+import scala.concurrent.ExecutionContext
 
 /**
  * INTERNAL API
@@ -30,7 +31,7 @@ import akka.stream.stage._
 
   def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) with OutHandler {
     lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
-    private implicit def ec = materializer.executionContext
+    private implicit def ec: ExecutionContext = materializer.executionContext
     private var state: Option[S] = None
 
     private val createdCallback = getAsyncCallback[Try[S]] {

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -58,7 +58,7 @@ object Source {
    * with an empty Optional.
    */
   def maybe[T]: Source[T, CompletableFuture[Optional[T]]] = {
-    new Source(scaladsl.Source.maybe[T].mapMaterializedValue { scalaOptionPromise: Promise[Option[T]] =>
+    new Source(scaladsl.Source.maybe[T].mapMaterializedValue { (scalaOptionPromise: Promise[Option[T]]) =>
       val javaOptionPromise = new CompletableFuture[Optional[T]]()
       scalaOptionPromise.completeWith(
         javaOptionPromise.toScala.map(_.asScala)(akka.dispatch.ExecutionContexts.parasitic))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/TLS.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/TLS.scala
@@ -84,7 +84,7 @@ object TLS {
     def theSslConfig(system: ActorSystem): AkkaSSLConfig =
       sslConfig.getOrElse(AkkaSSLConfig(system))
 
-    val createSSLEngine = { system: ActorSystem =>
+    val createSSLEngine = { (system: ActorSystem) =>
       val config = theSslConfig(system)
 
       val engine = hostInfo match {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
@@ -180,7 +180,7 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       halfClose: Boolean = false,
       idleTimeout: Duration = Duration.Inf)(implicit m: Materializer): Future[ServerBinding] = {
     bind(interface, port, backlog, options, halfClose, idleTimeout)
-      .to(Sink.foreach { conn: IncomingConnection =>
+      .to(Sink.foreach { (conn: IncomingConnection) =>
         conn.flow.join(handler).run()
       })
       .run()
@@ -469,7 +469,7 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       verifySession: SSLSession => Try[Unit],
       closing: TLSClosing)(implicit m: Materializer): Future[ServerBinding] = {
     bindWithTls(interface, port, createSSLEngine, backlog, options, idleTimeout, verifySession, closing)
-      .to(Sink.foreach { conn: IncomingConnection =>
+      .to(Sink.foreach { (conn: IncomingConnection) =>
         conn.handleWith(handler)
       })
       .run()
@@ -500,7 +500,7 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       options: immutable.Traversable[SocketOption] = Nil,
       idleTimeout: Duration = Duration.Inf)(implicit m: Materializer): Future[ServerBinding] = {
     bindTls(interface, port, sslContext, negotiateNewSession, backlog, options, idleTimeout)
-      .to(Sink.foreach { conn: IncomingConnection =>
+      .to(Sink.foreach { (conn: IncomingConnection) =>
         conn.handleWith(handler)
       })
       .run()

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import akka.{ AutomaticModuleName, CopyrightHeaderForBuild, Paradox, ScalafixIgnoreFilePlugin }
 
+ThisBuild / scalafixScalaBinaryVersion := scalaBinaryVersion.value
+
 enablePlugins(
   UnidocRoot,
   UnidocWithPrValidation,
@@ -29,11 +31,11 @@ addCommandAlias("applyCodeStyle", "headerCreateAll; javafmtAll; scalafmtAll")
 addCommandAlias(
   name = "fixall",
   value =
-    ";scalafixEnable; compile:scalafix; test:scalafix; multi-jvm:scalafix; scalafmtAll; test:compile; multi-jvm:compile; reload")
+    ";scalafixEnable; scalafixAll; scalafmtAll; test:compile; multi-jvm:compile; reload")
 
 addCommandAlias(
   name = "sortImports",
-  value = ";scalafixEnable; compile:scalafix SortImports; test:scalafix SortImports; scalafmtAll")
+  value = ";scalafixEnable; scalafixAll SortImports; scalafmtAll")
 
 import akka.AkkaBuild._
 import akka.{ AkkaBuild, Dependencies, OSGi, Protobuf, SigarLoader, VersionGenerator }
@@ -245,7 +247,7 @@ lazy val docs = akkaModule("akka-docs")
     StreamOperatorsIndexGenerator,
     Jdk9)
   .disablePlugins(MimaPlugin, WhiteSourcePlugin)
-  .disablePlugins(ScalafixPlugin)
+  .disablePlugins((if (ScalafixSupport.noIgnore) Nil else Seq(ScalafixPlugin)): _*)
 
 lazy val jackson = akkaModule("akka-serialization-jackson")
   .dependsOn(
@@ -329,6 +331,7 @@ lazy val protobuf = akkaModule("akka-protobuf")
   .settings(AutomaticModuleName.settings("akka.protobuf"))
   .enablePlugins(ScaladocNoVerificationOfDiagrams)
   .disablePlugins(MimaPlugin)
+  .settings(autoScalaLibrary := false) // Pure java project
 
 lazy val protobufV3 = akkaModule("akka-protobuf-v3")
   .settings(OSGi.protobufV3)

--- a/build.sbt
+++ b/build.sbt
@@ -247,7 +247,7 @@ lazy val docs = akkaModule("akka-docs")
     StreamOperatorsIndexGenerator,
     Jdk9)
   .disablePlugins(MimaPlugin, WhiteSourcePlugin)
-  .disablePlugins((if (ScalafixSupport.noIgnore) Nil else Seq(ScalafixPlugin)): _*)
+  .disablePlugins((if (ScalafixSupport.fixTestScope) Nil else Seq(ScalafixPlugin)): _*)
 
 lazy val jackson = akkaModule("akka-serialization-jackson")
   .dependsOn(

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -65,10 +65,10 @@ object AkkaDisciplinePlugin extends AutoPlugin {
 
   lazy val silencerSettings = {
     val silencerVersion = "1.7.1"
-    Seq(
-      libraryDependencies ++= Seq(
-          compilerPlugin(("com.github.ghik" %% "silencer-plugin" % silencerVersion).cross(CrossVersion.patch)),
-          ("com.github.ghik" %% "silencer-lib" % silencerVersion % Provided).cross(CrossVersion.patch)))
+    val libs = Seq(
+      compilerPlugin(("com.github.ghik" %% "silencer-plugin" % silencerVersion).cross(CrossVersion.patch)),
+      ("com.github.ghik" %% "silencer-lib" % silencerVersion % Provided).cross(CrossVersion.patch))
+    Seq(libraryDependencies ++= (if (autoScalaLibrary.value) libs else Nil))
   }
 
   lazy val disciplineSettings =

--- a/project/ScalaFixExtraRulesPlugin.scala
+++ b/project/ScalaFixExtraRulesPlugin.scala
@@ -17,6 +17,8 @@ object ScalaFixExtraRulesPlugin extends AutoPlugin with ScalafixSupport {
   override def projectSettings: Seq[Def.Setting[_]] = super.projectSettings ++ {
     scalafixDependencies in ThisBuild ++= Seq(
       "com.nequissimus" %% "sort-imports" % "0.5.5",
-      "com.sandinh" %% "scala-rewrites" % "0.1.7-sd")
+      // https://github.com/ohze/scala-rewrites
+      // an extended version of https://github.com/scala/scala-rewrites
+      "com.sandinh" %% "scala-rewrites" % "0.1.10-sd")
   }
 }

--- a/project/ScalaFixExtraRulesPlugin.scala
+++ b/project/ScalaFixExtraRulesPlugin.scala
@@ -4,10 +4,10 @@
 
 package akka
 
-import sbt.{AutoPlugin, PluginTrigger, Plugins, ScalafixSupport}
+import sbt.{ AutoPlugin, PluginTrigger, Plugins, ScalafixSupport }
 import scalafix.sbt.ScalafixPlugin
 
-object ScalaFixExtraRulesPlugin extends AutoPlugin with ScalafixSupport{
+object ScalaFixExtraRulesPlugin extends AutoPlugin with ScalafixSupport {
   override def trigger: PluginTrigger = allRequirements
 
   override def requires: Plugins = ScalafixPlugin
@@ -17,7 +17,6 @@ object ScalaFixExtraRulesPlugin extends AutoPlugin with ScalafixSupport{
   override def projectSettings: Seq[Def.Setting[_]] = super.projectSettings ++ {
     scalafixDependencies in ThisBuild ++= Seq(
       "com.nequissimus" %% "sort-imports" % "0.5.5",
-      "com.sandinh" %% "scala-rewrites" % "0.1.7-sd"
-    )
+      "com.sandinh" %% "scala-rewrites" % "0.1.7-sd")
   }
 }

--- a/project/ScalaFixExtraRulesPlugin.scala
+++ b/project/ScalaFixExtraRulesPlugin.scala
@@ -15,6 +15,9 @@ object ScalaFixExtraRulesPlugin extends AutoPlugin with ScalafixSupport{
   import sbt._
   import scalafix.sbt.ScalafixPlugin.autoImport.scalafixDependencies
   override def projectSettings: Seq[Def.Setting[_]] = super.projectSettings ++ {
-    scalafixDependencies in ThisBuild += "com.nequissimus" %% "sort-imports" % "0.5.5"
+    scalafixDependencies in ThisBuild ++= Seq(
+      "com.nequissimus" %% "sort-imports" % "0.5.5",
+      "com.sandinh" %% "scala-rewrites" % "0.1.7-sd"
+    )
   }
 }

--- a/project/ScalaFixForJdk9Plugin.scala
+++ b/project/ScalaFixForJdk9Plugin.scala
@@ -9,7 +9,7 @@ import scalafix.sbt.ScalafixPlugin
 object ScalaFixForJdk9Plugin extends AutoPlugin with ScalafixSupport {
   override def trigger: PluginTrigger = allRequirements
   import Jdk9._
-  override def requires: Plugins = Jdk9
+  override def requires: Plugins = Jdk9 && ScalafixPlugin
 
   import ScalafixPlugin.autoImport.scalafixConfigSettings
   import sbt._
@@ -23,9 +23,9 @@ object ScalaFixForJdk9Plugin extends AutoPlugin with ScalafixSupport {
       scalafixIgnoredSetting ++ Seq(
       updateProjectCommands(
         alias = "fixall",
-        value = ";scalafixEnable;compile:scalafix;test:scalafix;multi-jvm:scalafix;scalafmtAll;test:compile;multi-jvm:compile;reload"),
+        value = ";scalafixEnable;scalafixAll;scalafmtAll;test:compile;multi-jvm:compile;reload"),
       updateProjectCommands(
         alias = "sortImports",
-        value = ";scalafixEnable;compile:scalafix SortImports;test:scalafix SortImports;CompileJdk9:scalafix SortImports;TestJdk9:scalafix SortImports;scalafmtAll")
+        value = ";scalafixEnable;scalafixAll SortImports;scalafmtAll")
     )
 }

--- a/project/ScalafixForMultiNodePlugin.scala
+++ b/project/ScalafixForMultiNodePlugin.scala
@@ -6,12 +6,13 @@ package akka
 
 import com.typesafe.sbt.MultiJvmPlugin
 import sbt.{AutoPlugin, Def, PluginTrigger, Plugins, ScalafixSupport, Setting, inConfig}
+import scalafix.sbt.ScalafixPlugin
 import scalafix.sbt.ScalafixPlugin.autoImport.scalafixConfigSettings
 
 object ScalafixForMultiNodePlugin extends AutoPlugin with ScalafixSupport {
   override def trigger: PluginTrigger = allRequirements
 
-  override def requires: Plugins = MultiNode
+  override def requires: Plugins = MultiNode && ScalafixPlugin
 
   import MultiJvmPlugin.autoImport._
 
@@ -24,9 +25,9 @@ object ScalafixForMultiNodePlugin extends AutoPlugin with ScalafixSupport {
       scalafixIgnoredSetting ++ Seq(
       updateProjectCommands(
         alias = "fixall",
-        value = ";scalafixEnable;compile:scalafix;test:scalafix;multi-jvm:scalafix;scalafmtAll"),
+        value = ";scalafixEnable;scalafixAll;scalafmtAll"),
       updateProjectCommands(
         alias = "sortImports",
-        value = ";scalafixEnable;compile:scalafix SortImports;test:scalafix SortImports;multi-jvm:scalafix SortImports;scalafmtAll")
+        value = ";scalafixEnable;scalafixAll SortImports;scalafmtAll")
     )
 }

--- a/project/ScalafixIgnoreFilePlugin.scala
+++ b/project/ScalafixIgnoreFilePlugin.scala
@@ -6,18 +6,17 @@ package akka
 
 import sbt.plugins.JvmPlugin
 import sbt.{AutoPlugin, PluginTrigger, Plugins, ScalafixSupport}
+import scalafix.sbt.ScalafixPlugin
 
 object ScalafixIgnoreFilePlugin extends AutoPlugin with ScalafixSupport {
   override def trigger: PluginTrigger = allRequirements
 
-  override def requires: Plugins = JvmPlugin
+  override def requires: Plugins = JvmPlugin && ScalafixPlugin
   import sbt._
-  lazy val scalafixIgnoredSetting: Seq[Setting[_]] = Seq(
-    ignore(Test)
-  )
+  lazy val scalafixIgnoredSetting: Seq[Setting[_]] = if (ScalafixSupport.noIgnore) Nil else Seq(ignore(Test))
 
   override def projectSettings: Seq[Def.Setting[_]] = scalafixIgnoredSetting ++ Seq(
     addProjectCommandsIfAbsent(
       alias = "fix",
-      value = ";scalafixEnable;compile:scalafix;test:scalafix;test:compile;reload"))
+      value = ";scalafixEnable;scalafixAll;test:compile;reload"))
 }

--- a/project/ScalafixIgnoreFilePlugin.scala
+++ b/project/ScalafixIgnoreFilePlugin.scala
@@ -5,7 +5,7 @@
 package akka
 
 import sbt.plugins.JvmPlugin
-import sbt.{AutoPlugin, PluginTrigger, Plugins, ScalafixSupport}
+import sbt.{ AutoPlugin, PluginTrigger, Plugins, ScalafixSupport }
 import scalafix.sbt.ScalafixPlugin
 
 object ScalafixIgnoreFilePlugin extends AutoPlugin with ScalafixSupport {
@@ -13,10 +13,9 @@ object ScalafixIgnoreFilePlugin extends AutoPlugin with ScalafixSupport {
 
   override def requires: Plugins = JvmPlugin && ScalafixPlugin
   import sbt._
-  lazy val scalafixIgnoredSetting: Seq[Setting[_]] = if (ScalafixSupport.noIgnore) Nil else Seq(ignore(Test))
+  lazy val scalafixIgnoredSetting: Seq[Setting[_]] = if (ScalafixSupport.fixTestScope) Nil else Seq(ignore(Test))
 
-  override def projectSettings: Seq[Def.Setting[_]] = scalafixIgnoredSetting ++ Seq(
-    addProjectCommandsIfAbsent(
-      alias = "fix",
-      value = ";scalafixEnable;scalafixAll;test:compile;reload"))
+  override def projectSettings: Seq[Def.Setting[_]] =
+    scalafixIgnoredSetting ++ Seq(
+      addProjectCommandsIfAbsent(alias = "fixall", value = ";scalafixEnable;scalafixAll;test:compile;reload"))
 }

--- a/project/ScalafixSupport.scala
+++ b/project/ScalafixSupport.scala
@@ -54,3 +54,7 @@ trait ScalafixSupport {
     }
   }
 }
+
+object ScalafixSupport {
+  def noIgnore: Boolean = System.getProperty("akka.scalafixNoIgnore", "false").toBoolean
+}

--- a/project/ScalafixSupport.scala
+++ b/project/ScalafixSupport.scala
@@ -16,13 +16,12 @@ trait ScalafixSupport {
     import scalafix.sbt.ScalafixPlugin.autoImport._
 
     unmanagedSources.in(configKey, scalafix) := {
-      val ignoreSupport = new ProjectFileIgnoreSupport((baseDirectory in ThisBuild).value / ignoreConfigFileName, descriptor)
+      val ignoreSupport =
+        new ProjectFileIgnoreSupport((baseDirectory in ThisBuild).value / ignoreConfigFileName, descriptor)
 
-      unmanagedSources.in(configKey, scalafix).value
-        .filterNot(file => ignoreSupport.isIgnoredByFileOrPackages(file))
+      unmanagedSources.in(configKey, scalafix).value.filterNot(file => ignoreSupport.isIgnoredByFileOrPackages(file))
     }
   }
-
 
   import sbt.Keys._
 
@@ -35,10 +34,7 @@ trait ScalafixSupport {
       if (isPresent)
         commands.value
       else
-        commands.value :+ BasicCommands.newAlias(
-          name = alias,
-          value = value
-        )
+        commands.value :+ BasicCommands.newAlias(name = alias, value = value)
     }
   }
 
@@ -46,15 +42,12 @@ trait ScalafixSupport {
     commands := {
       commands.value.filterNot({
         case command: SimpleCommand => command.name == alias
-        case _ => false
-      }) :+ BasicCommands.newAlias(
-        name = alias,
-        value = value
-      )
+        case _                      => false
+      }) :+ BasicCommands.newAlias(name = alias, value = value)
     }
   }
 }
 
 object ScalafixSupport {
-  def noIgnore: Boolean = System.getProperty("akka.scalafixNoIgnore", "false").toBoolean
+  def fixTestScope: Boolean = System.getProperty("akka.scalafix.fixTestScope", "false").toBoolean
 }


### PR DESCRIPTION
This PR is similar to #28991 but:
+ Use scalafix `fix.scala213.DottyMigrate` rule to auto fix the errors.
+ Some other errors need manually fix: Use the fixed code from #28991
+ Update sbt-scalafix 0.9.18-1
Edit: The following changes are moved to another PRs
~~+ Update scalatest 3.2.0 and mockito-3-3~~
~~+ Update ssl-config 0.4.2~~ #29365
~~+ Update sbt 1.3.13~~ #29366