### PR TITLE
Update scalatest 3.2.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,7 @@ object Dependencies {
 
   val sslConfigVersion = "0.4.1"
 
-  val scalaTestVersion = "3.1.1"
+  val scalaTestVersion = "3.2.0"
   val scalaCheckVersion = "1.14.3"
 
   val Versions = Seq(
@@ -118,7 +118,7 @@ object Dependencies {
       val scalatestJUnit = "org.scalatestplus" %% "junit-4-12" % (scalaTestVersion + ".0") % "test" // ApacheV2
       val scalatestTestNG = "org.scalatestplus" %% "testng-6-7" % (scalaTestVersion + ".0") % "test" // ApacheV2
       val scalatestScalaCheck = "org.scalatestplus" %% "scalacheck-1-14" % (scalaTestVersion + ".0") % "test" // ApacheV2
-      val scalatestMockito = "org.scalatestplus" %% "mockito-3-2" % (scalaTestVersion + ".0") % "test" // ApacheV2
+      val scalatestMockito = "org.scalatestplus" %% "mockito-3-3" % (scalaTestVersion + ".0") % "test" // ApacheV2
 
       val pojosr = "com.googlecode.pojosr" % "de.kalpatec.pojosr.framework" % "0.2.1" % "test" // ApacheV2
       val tinybundles = "org.ops4j.pax.tinybundles" % "tinybundles" % "3.0.0" % "test" // ApacheV2


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #29368 

I just move the commits that update scalatest 3.2.0 from #29367 to this separated PR.

I don't have much time to follow this PR.
If someone want scalatest 3.2 in akka => he/she can take this PR as a start.