### PR TITLE
Handle early terminated when passivating 

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -866,17 +866,13 @@ private[akka] class Shard(
             } else {
               if (messageBuffers.getOrEmpty(entityId).nonEmpty) {
                 if (verboseDebug)
-                  log.debug(
-                    "[{}] terminated after passivating, buffered messages found, restarting",
-                    entityId)
+                  log.debug("[{}] terminated after passivating, buffered messages found, restarting", entityId)
                 entities.removeEntity(entityId)
                 getOrCreateEntity(entityId)
                 sendMsgBuffer(entityId)
               } else {
                 if (verboseDebug)
-                  log.debug(
-                    "[{}] terminated after passivating",
-                    entityId)
+                  log.debug("[{}] terminated after passivating", entityId)
                 entities.removeEntity(entityId)
               }
             }

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/SupervisionSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/SupervisionSpec.scala
@@ -59,6 +59,7 @@ object SupervisionSpec {
       case "hello" =>
         sender() ! Response(self)
       case StopMessage =>
+        // note that we never see this because we stop early
         log.info("Received stop from region")
         context.parent ! PoisonPill
     }
@@ -71,7 +72,7 @@ class DeprecatedSupervisionSpec extends AkkaSpec(SupervisionSpec.config) with Im
 
   "Supervision for a sharded actor (deprecated)" must {
 
-    "allow passivation" in {
+    "allow passivation and early stop" in {
 
       val supervisedProps =
         BackoffOpts
@@ -112,7 +113,7 @@ class SupervisionSpec extends AkkaSpec(SupervisionSpec.config) with ImplicitSend
 
   "Supervision for a sharded actor" must {
 
-    "allow passivation" in {
+    "allow passivation and early stop" in {
 
       val supervisedProps = BackoffSupervisor.props(
         BackoffOpts


### PR DESCRIPTION
References #29359

Either something we missed in the rewrite or always was flakey, not sure:

When remember entities is **not** enabled and an entity passivates but then stops before receiving the stop message we need to handle that there may be messages in its buffer and restart it in that case.