### PR TITLE
actor: remove stack trace from AskTimeoutException

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
@@ -20,12 +20,14 @@ import akka.util.ByteString
 import akka.util.{ Timeout, Unsafe }
 import akka.util.unused
 
+import scala.util.control.NoStackTrace
+
 /**
  * This is what is used to complete a Future that is returned from an ask/? call,
  * when it times out. A typical reason for `AskTimeoutException` is that the recipient
  * actor didn't send a reply.
  */
-class AskTimeoutException(message: String, cause: Throwable) extends TimeoutException(message) {
+class AskTimeoutException(message: String, cause: Throwable) extends TimeoutException(message) with NoStackTrace {
   def this(message: String) = this(message, null: Throwable)
   override def getCause(): Throwable = cause
 }


### PR DESCRIPTION
The exception will be instantiated from the scheduler thread so it does not contain any more helpful information. 

In https://discuss.lightbend.com/t/resolve-1000-dns-with-async-dns-without-oom-error/6845/3, it has been observed that collecting the stack trace can be a scalability issue. Both the CPU and memory allocation overhead for collecting the stack trace can become a problem if timeouts are frequent (and may even amplify an ongoing situation if the timeouts are caused by CPU or memory pressure).

The question is if the change is good to do in light of other usages of that exception that might benefit from the stack trace. The ones I checked were mostly run through the scheduler. Others seems to be mostly for "is already terminated" kind of messages for which it is not quite clear why they use an `AskTimeoutException` in the first place or whether the stack trace would be useful.