### PR TITLE
Durable pruning fail fix 

### DIFF
--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurablePruningSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/DurablePruningSpec.scala
@@ -169,6 +169,11 @@ class DurablePruningSpec extends MultiNodeSpec(DurablePruningSpec) with STMultiN
         val probe3 = TestProbe()(sys3)
         cluster3.join(node(first).address)
 
+        awaitAssert({
+          cluster.state.members.exists(m =>
+            m.uniqueAddress == cluster3.selfUniqueAddress && m.status == MemberStatus.Up) should ===(true)
+        }, 10.seconds)
+
         within(10.seconds) {
           var values = Set.empty[Int]
           awaitAssert {


### PR DESCRIPTION
Failed once when the new cluster node had not joined the cluster yet, so start with waiting for that.

References #29270
