### PR TITLE
Replace reference to deprecated API

### DIFF
--- a/akka-docs/src/main/paradox/stream/stream-composition.md
+++ b/akka-docs/src/main/paradox/stream/stream-composition.md
@@ -54,8 +54,8 @@ parameters.
 Please note that when combining a `Flow` using that method, the termination signals are not carried 
 "through" as the `Sink` and `Source` are assumed to be fully independent. If however you want to construct
 a `Flow` like this but need the termination events to trigger "the other side" of the composite flow, you can use
-`CoupledTerminationFlow.fromSinkAndSource` which does just that. For example the cancelation of the composite flows 
-source-side will then lead to completion of its sink-side. Read `CoupledTerminationFlow`'s scaladoc for a 
+`Flow.fromSinkAndSourceCoupled` or `Flow.fromSinkAndSourceCoupledMat` which does just that. For example the cancelation of the composite flows 
+source-side will then lead to completion of its sink-side. Read `Flow`'s scaladoc for a 
 detailed explanation how this works.
 
 The example `BidiFlow` demonstrates that internally a module can be of arbitrary complexity, and the exposed

--- a/akka-docs/src/main/paradox/stream/stream-composition.md
+++ b/akka-docs/src/main/paradox/stream/stream-composition.md
@@ -55,7 +55,7 @@ Please note that when combining a `Flow` using that method, the termination sign
 "through" as the `Sink` and `Source` are assumed to be fully independent. If however you want to construct
 a `Flow` like this but need the termination events to trigger "the other side" of the composite flow, you can use
 `Flow.fromSinkAndSourceCoupled` or `Flow.fromSinkAndSourceCoupledMat` which does just that. For example the cancelation of the composite flows 
-source-side will then lead to completion of its sink-side. Read `Flow`'s scaladoc for a 
+source-side will then lead to completion of its sink-side. Read @apidoc[Flow]'s API documentation for a 
 detailed explanation how this works.
 
 The example `BidiFlow` demonstrates that internally a module can be of arbitrary complexity, and the exposed


### PR DESCRIPTION
Updated stream-composition.md to use Flow.fromSinkAndSourceCoupledMat or Flow.fromSinkAndSourceCoupled rather than the deprecated CoupledTerminationFlow.fromSinkAndSource.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
