### PR TITLE
ReplicaId extends AnyVal

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/ReplicaId.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/ReplicaId.scala
@@ -5,6 +5,6 @@
 package akka.persistence.typed
 
 /**
- * Identifies a replica in Active Active eventsourcing, could be a datacenter name or a logical identifier.
+ * Identifies a replica in Active Active event sourcing, could be a data center name or a logical identifier.
  */
-final case class ReplicaId(id: String)
+final case class ReplicaId(id: String) extends AnyVal


### PR DESCRIPTION
Noticed that we changed `replicaId: String` to `replicaId: ReplicaId`. 

This is used pretty much everywhere and for each new replicated event. It might be good to make it a `AnyVal`.