### PR TITLE
Avoid warning for NoState to RememberingStart

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -170,10 +170,10 @@ private[akka] object Shard {
    */
   case object NoState extends EntityState {
     override def transition(newState: EntityState, entities: Entities): EntityState = newState match {
-      case RememberedButNotCreated if entities.rememberingEntities       => RememberedButNotCreated
-      case remembering: RememberingStart if entities.rememberingEntities => remembering
-      case active: Active if !entities.rememberingEntities               => active
-      case _                                                             => invalidTransition(newState, entities)
+      case RememberedButNotCreated if entities.rememberingEntities => RememberedButNotCreated
+      case remembering: RememberingStart                           => remembering // we go via this state even if not really remembering
+      case active: Active if !entities.rememberingEntities         => active
+      case _                                                       => invalidTransition(newState, entities)
     }
   }
 


### PR DESCRIPTION
When not remembering entities

This is an unexpected transition but we did it as an implementation detail and
it should not cause a logged error. (We first go to RememberingStart and then immediately active when remember entities is disabled)

References  #29400