### PR TITLE
EventPublishing API for Java

### DIFF
--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ActiveActiveShardingDirectReplication.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ActiveActiveShardingDirectReplication.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters._
  *
  * This actor should be started once on each node where Active Active entities will run (the same nodes that you start
  * sharding on). The entities should be set up with [[akka.persistence.typed.scaladsl.EventSourcedBehavior#withEventPublishing()]]
- * (FIXME not supported in Java yet)
+ * or [[akka.persistence.typed.javadsl.ActiveActiveEventSourcedBehavior#withEventPublishing()]]
  * If using [[ActiveActiveSharding]] the replication can be enabled through [[ActiveActiveShardingSettings#withDirectReplication()]]
  * instead of starting this actor manually.
  *

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ActiveActiveShardingSettings.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ActiveActiveShardingSettings.scala
@@ -67,9 +67,9 @@ final class ActiveActiveShardingSettings[M, E] private (
   /**
    * Start direct replication over sharding when active active sharding starts up, requires the entities
    * to also have it enabled through [[akka.persistence.typed.scaladsl.EventSourcedBehavior#withEventPublishing()]]
+   * or [[akka.persistence.typed.javadsl.ActiveActiveEventSourcedBehavior#withEventPublishing()]]
    * to work.
-   *
-   * FIXME no support for enabling that in Java because bin/source comp.
+
    */
   def withDirectReplication(): ActiveActiveShardingSettings[M, E] =
     new ActiveActiveShardingSettings(replicas, directReplication = true)

--- a/akka-docs/src/main/paradox/typed/persistence-active-active.md
+++ b/akka-docs/src/main/paradox/typed/persistence-active-active.md
@@ -277,8 +277,8 @@ As an optimization the active active events can be published across the Akka clu
 query is still needed as delivery is not guaranteed, but can be configured to poll the database less often since most
 events will arrive at the replicas through the cluster.
 
-To enable this feature you first need to enable event publishing on the `EventSourcedBehavior` with `withEventPublishing` 
-(FIXME missing Java API) and then enable direct replication through `withDirectReplication()` on @apidoc[ActiveActiveShardingSettings] (if not using
+To enable this feature you first need to enable event publishing on the @scala[`EventSourcedBehavior`]@java[`ActiveActiveEventSourcedBehavior`] with `withEventPublishing` 
+and then enable direct replication through `withDirectReplication()` on @apidoc[ActiveActiveShardingSettings] (if not using
  active active sharding the replication can be run standalone by starting the @apidoc[ActiveActiveShardingDirectReplication] actor).
 
 The "event publishing" feature publishes each event to the local system event bus as a side effect after it has been written, 


### PR DESCRIPTION
References #29409

Not really possible to add to ESB for Java because of bin/source compatibility so only available on the `ActiveActiveEventSourcedBehavior` in Java.