### PR TITLE
Clarify pool router routees are always local

### DIFF
--- a/akka-docs/src/main/paradox/typed/routers.md
+++ b/akka-docs/src/main/paradox/typed/routers.md
@@ -27,7 +27,7 @@ There are two kinds of routers included in Akka Typed - the pool router and the 
 ## Pool Router
 
 The pool router is created with a routee `Behavior` and spawns a number of children with that behavior which it will 
-then forward messages to. 
+then forward messages to.
 
 If a child is stopped the pool router removes it from its set of routees. When the last child stops the router itself stops.
 To make a resilient router that deals with failures the routee `Behavior` must be supervised.

--- a/akka-docs/src/main/paradox/typed/routers.md
+++ b/akka-docs/src/main/paradox/typed/routers.md
@@ -27,10 +27,12 @@ There are two kinds of routers included in Akka Typed - the pool router and the 
 ## Pool Router
 
 The pool router is created with a routee `Behavior` and spawns a number of children with that behavior which it will 
-then forward messages to.
+then forward messages to. 
 
 If a child is stopped the pool router removes it from its set of routees. When the last child stops the router itself stops.
 To make a resilient router that deals with failures the routee `Behavior` must be supervised.
+
+As actor children are always local the routees are never spread across a cluster with a pool router.
 
 Scala
 :  @@snip [RouterSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala) { #pool }


### PR DESCRIPTION
From discuss question: https://discuss.lightbend.com/t/akka-typed-router-cluster-aware/6917/3
