### PR TITLE
Akka Stream. Tcp connection. Multiple delimiters.

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/FramingBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/FramingBenchmark.scala
@@ -70,7 +70,7 @@ class FramingBenchmark {
     val frame = List.range(0, messageSize, 1).map(_ => Random.nextPrintableChar()).mkString + "\n"
     val messageChunk = ByteString(List.range(0, framePerSeq, 1).map(_ => frame).mkString)
 
-    Source
+    flow = Source
       .fromGraph(new BenchTestSourceSameElement(100000, messageChunk))
       .via(Framing.delimiter(ByteString("\n"), Int.MaxValue))
   }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Framing.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Framing.scala
@@ -5,10 +5,13 @@
 package akka.stream.javadsl
 
 import java.nio.ByteOrder
+import java.util
 
 import akka.NotUsed
 import akka.stream.scaladsl
 import akka.util.ByteString
+
+import scala.collection.JavaConverters._
 
 object Framing {
 
@@ -41,6 +44,26 @@ object Framing {
    * If there are buffered bytes (an incomplete frame) when the input stream finishes and ''allowTruncation'' is set to
    * false then this Flow will fail the stream reporting a truncated frame.
    *
+   * Default truncation behavior is: when the last frame being decoded contains no valid delimiter this Flow
+   * fails the stream instead of returning a truncated frame.
+   *
+   * @param delimiters The byte sequences to be treated as the end of the frame.
+   * @param maximumFrameLength The maximum length of allowed frames while decoding. If the maximum length is
+   *                           exceeded this Flow will fail the stream.
+   */
+  def delimiters(delimiters: util.List[ByteString], maximumFrameLength: Int): Flow[ByteString, ByteString, NotUsed] = {
+    scaladsl.Framing.delimiters(delimiters.asScala.toList, maximumFrameLength).asJava
+  }
+
+  /**
+   * Creates a Flow that handles decoding a stream of unstructured byte chunks into a stream of frames where the
+   * incoming chunk stream uses a specific byte-sequence to mark frame boundaries.
+   *
+   * The decoded frames will not include the separator sequence.
+   *
+   * If there are buffered bytes (an incomplete frame) when the input stream finishes and ''allowTruncation'' is set to
+   * false then this Flow will fail the stream reporting a truncated frame.
+   *
    * @param delimiter The byte sequence to be treated as the end of the frame.
    * @param allowTruncation If set to `DISALLOW`, then when the last frame being decoded contains no valid delimiter this Flow
    *                        fails the stream instead of returning a truncated frame.
@@ -53,6 +76,29 @@ object Framing {
       allowTruncation: FramingTruncation): Flow[ByteString, ByteString, NotUsed] = {
     val truncationAllowed = allowTruncation == FramingTruncation.ALLOW
     scaladsl.Framing.delimiter(delimiter, maximumFrameLength, truncationAllowed).asJava
+  }
+
+  /**
+   * Creates a Flow that handles decoding a stream of unstructured byte chunks into a stream of frames where the
+   * incoming chunk stream uses a specific byte-sequence to mark frame boundaries.
+   *
+   * The decoded frames will not include the separator sequence.
+   *
+   * If there are buffered bytes (an incomplete frame) when the input stream finishes and ''allowTruncation'' is set to
+   * false then this Flow will fail the stream reporting a truncated frame.
+   *
+   * @param delimiters The byte sequences to be treated as the end of the frame.
+   * @param allowTruncation If set to `DISALLOW`, then when the last frame being decoded contains no valid delimiter this Flow
+   *                        fails the stream instead of returning a truncated frame.
+   * @param maximumFrameLength The maximum length of allowed frames while decoding. If the maximum length is
+   *                           exceeded this Flow will fail the stream.
+   */
+  def delimiters(
+      delimiters: util.List[ByteString],
+      maximumFrameLength: Int,
+      allowTruncation: FramingTruncation): Flow[ByteString, ByteString, NotUsed] = {
+    val truncationAllowed = allowTruncation == FramingTruncation.ALLOW
+    scaladsl.Framing.delimiters(delimiters.asScala.toList, maximumFrameLength, truncationAllowed).asJava
   }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
@@ -8,6 +8,7 @@ import java.nio.ByteOrder
 
 import scala.annotation.tailrec
 import scala.reflect.ClassTag
+import scala.collection.immutable
 
 import akka.NotUsed
 import akka.stream.{ Attributes, FlowShape, Inlet, Outlet }
@@ -34,7 +35,7 @@ object Framing {
    *                           exceeded this Flow will fail the stream.
    */
   def delimiters(
-      delimiters: Seq[ByteString],
+      delimiters: immutable.Seq[ByteString],
       maximumFrameLength: Int,
       allowTruncation: Boolean = false): Flow[ByteString, ByteString, NotUsed] =
     Flow[ByteString]
@@ -218,7 +219,7 @@ object Framing {
   }
 
   private class DelimiterFramingStage(
-      val delimiters: Seq[ByteString],
+      val delimiters: immutable.Seq[ByteString],
       val maximumLineBytes: Int,
       val allowTruncation: Boolean)
       extends GraphStage[FlowShape[ByteString, ByteString]] {


### PR DESCRIPTION
Add ability of using multiple delimiters for the frames separation.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Resolves #https://discuss.lightbend.com/t/how-to-use-multiple-frame-delimiters-in-akka-stream-tcp/6935
