### PR TITLE
fix StreamRefs IllegalStateException 

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/streamref/SinkRefImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/streamref/SinkRefImpl.scala
@@ -196,7 +196,7 @@ private[stream] final class SinkRefStageImpl[In] private[akka] (val initialPartn
       }
 
       private def tryPull(): Unit =
-        if (remoteCumulativeDemandConsumed < remoteCumulativeDemandReceived && !hasBeenPulled(in)) {
+        if (remoteCumulativeDemandConsumed < remoteCumulativeDemandReceived && !hasBeenPulled(in) && !isClosed(in)) {
           pull(in)
         }
 


### PR DESCRIPTION
I tracked #28852 to an IllegalStateException in SinkRefStageImpl caused by pulling from a closed inlet when a SourceRef's subscriber or the network is too slow.

ed436ef: Added test for the scenario.
b31dd5c: Fixed the test by always checking whether inlet is closed before pulling.

Added the test to StreamRefsSpec, but there is no other test for StreamRefs on a protocol level. Given the remote nature of the protocol between SourceRefStage and SinkRefStage it weren't terrible to codify the protocol somewhat and run it through the reactive streams TCK. I'm happy to write a follow-up PR should there be interest on the Akka team's part.

References #28852
