### PR TITLE
Add entity type name for replicated entity

### DIFF
--- a/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/ReplicatedShardingTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/ReplicatedShardingTest.java
@@ -66,7 +66,8 @@ public class ReplicatedShardingTest extends JUnitSuite {
 
     static Behavior<Command> create(
         String entityId, ReplicaId replicaId, Set<ReplicaId> allReplicas) {
-      return ReplicatedEventSourcing.withSharedJournal("StringSet",
+      return ReplicatedEventSourcing.withSharedJournal(
+          "StringSet",
           entityId,
           replicaId,
           allReplicas,

--- a/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/ReplicatedShardingTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/ReplicatedShardingTest.java
@@ -66,7 +66,7 @@ public class ReplicatedShardingTest extends JUnitSuite {
 
     static Behavior<Command> create(
         String entityId, ReplicaId replicaId, Set<ReplicaId> allReplicas) {
-      return ReplicatedEventSourcing.withSharedJournal(
+      return ReplicatedEventSourcing.withSharedJournal("StringSet",
           entityId,
           replicaId,
           allReplicas,

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ReplicatedShardingDirectReplicationSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ReplicatedShardingDirectReplicationSpec.scala
@@ -37,7 +37,7 @@ class ReplicatedShardingDirectReplicationSpec extends ScalaTestWithActorTestKit 
       upProbe.receiveMessage() // not bullet proof wrt to subscription being complete but good enough
 
       val event = PublishedEventImpl(
-        PersistenceId.replicatedUniqueId("pid", ReplicaId("ReplicaA")),
+        PersistenceId.replicatedId("pid", ReplicaId("ReplicaA")),
         1L,
         "event",
         System.currentTimeMillis(),

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ReplicatedShardingDirectReplicationSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ReplicatedShardingDirectReplicationSpec.scala
@@ -37,7 +37,7 @@ class ReplicatedShardingDirectReplicationSpec extends ScalaTestWithActorTestKit 
       upProbe.receiveMessage() // not bullet proof wrt to subscription being complete but good enough
 
       val event = PublishedEventImpl(
-        PersistenceId.replicatedId("pid", ReplicaId("ReplicaA")),
+        PersistenceId.replicatedId("ReplicatedShardingSpec", "pid", ReplicaId("ReplicaA")),
         1L,
         "event",
         System.currentTimeMillis(),

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ReplicatedShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/ReplicatedShardingSpec.scala
@@ -49,6 +49,7 @@ class ReplicatedShardingSpec
 
     def apply(entityId: String, replicaId: ReplicaId, allReplicas: Set[ReplicaId]): Behavior[Command] =
       ReplicatedEventSourcing.withSharedJournal(
+        "StringSet",
         entityId,
         replicaId,
         allReplicas,

--- a/akka-persistence-typed-tests/src/test/java/akka/persistence/typed/ReplicatedEventSourcingTest.java
+++ b/akka-persistence-typed-tests/src/test/java/akka/persistence/typed/ReplicatedEventSourcingTest.java
@@ -80,7 +80,7 @@ public class ReplicatedEventSourcingTest extends JUnitSuite {
 
     public static Behavior<Command> create(
         String entityId, ReplicaId replicaId, Set<ReplicaId> allReplicas) {
-      return ReplicatedEventSourcing.withSharedJournal(
+      return ReplicatedEventSourcing.withSharedJournal("ReplicatedEventSourcingTest",
           entityId,
           replicaId,
           allReplicas,

--- a/akka-persistence-typed-tests/src/test/java/jdocs/akka/persistence/typed/MyReplicatedBehavior.java
+++ b/akka-persistence-typed-tests/src/test/java/jdocs/akka/persistence/typed/MyReplicatedBehavior.java
@@ -33,7 +33,7 @@ public class MyReplicatedBehavior
   public static Behavior<Command> create(
       String entityId, ReplicaId replicaId, String queryPluginId) {
     return ReplicatedEventSourcing.withSharedJournal(
-        entityId, replicaId, ALL_REPLICAS, queryPluginId, MyReplicatedBehavior::new);
+        "EntityType", entityId, replicaId, ALL_REPLICAS, queryPluginId, MyReplicatedBehavior::new);
   }
   // #factory-shared
 
@@ -44,7 +44,7 @@ public class MyReplicatedBehavior
     allReplicasAndQueryPlugins.put(DCB, "journalForDCB");
 
     return ReplicatedEventSourcing.create(
-        entityId, replicaId, allReplicasAndQueryPlugins, MyReplicatedBehavior::new);
+        "EntityType", entityId, replicaId, allReplicasAndQueryPlugins, MyReplicatedBehavior::new);
   }
 
   private MyReplicatedBehavior(ReplicationContext replicationContext) {

--- a/akka-persistence-typed-tests/src/test/java/jdocs/akka/persistence/typed/MyReplicatedBehavior.java
+++ b/akka-persistence-typed-tests/src/test/java/jdocs/akka/persistence/typed/MyReplicatedBehavior.java
@@ -33,7 +33,7 @@ public class MyReplicatedBehavior
   public static Behavior<Command> create(
       String entityId, ReplicaId replicaId, String queryPluginId) {
     return ReplicatedEventSourcing.withSharedJournal(
-        "EntityType", entityId, replicaId, ALL_REPLICAS, queryPluginId, MyReplicatedBehavior::new);
+        "MyReplicatedEntity", entityId, replicaId, ALL_REPLICAS, queryPluginId, MyReplicatedBehavior::new);
   }
   // #factory-shared
 
@@ -44,7 +44,7 @@ public class MyReplicatedBehavior
     allReplicasAndQueryPlugins.put(DCB, "journalForDCB");
 
     return ReplicatedEventSourcing.create(
-        "EntityType", entityId, replicaId, allReplicasAndQueryPlugins, MyReplicatedBehavior::new);
+        "MyReplicatedEntity", entityId, replicaId, allReplicasAndQueryPlugins, MyReplicatedBehavior::new);
   }
 
   private MyReplicatedBehavior(ReplicationContext replicationContext) {

--- a/akka-persistence-typed-tests/src/test/java/jdocs/akka/persistence/typed/ReplicatedAuctionExampleTest.java
+++ b/akka-persistence-typed-tests/src/test/java/jdocs/akka/persistence/typed/ReplicatedAuctionExampleTest.java
@@ -100,7 +100,7 @@ class ReplicatedAuctionExample
   public static Behavior<Command> create(AuctionSetup setup, ReplicaId replica) {
     return Behaviors.setup(
         ctx ->
-            ReplicatedEventSourcing.withSharedJournal(
+            ReplicatedEventSourcing.withSharedJournal("Auction",
                 setup.name,
                 replica,
                 ALL_REPLICAS,

--- a/akka-persistence-typed-tests/src/test/java/jdocs/akka/persistence/typed/ReplicatedStringSet.java
+++ b/akka-persistence-typed-tests/src/test/java/jdocs/akka/persistence/typed/ReplicatedStringSet.java
@@ -26,7 +26,7 @@ public final class ReplicatedStringSet
 
   public static Behavior<Command> create(
       String entityId, ReplicaId replicaId, Set<ReplicaId> allReplicas) {
-    return ReplicatedEventSourcing.withSharedJournal(
+    return ReplicatedEventSourcing.withSharedJournal("StringSet",
         entityId,
         replicaId,
         allReplicas,

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/MultiJournalReplicationSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/MultiJournalReplicationSpec.scala
@@ -33,6 +33,7 @@ object MultiJournalReplicationSpec {
     private val writeJournalPerReplica = Map("R1" -> "journal1.journal", "R2" -> "journal2.journal")
     def apply(entityId: String, replicaId: String): Behavior[Command] = {
       ReplicatedEventSourcing(
+        "MultiJournalSpec",
         entityId,
         ReplicaId(replicaId),
         Map(ReplicaId("R1") -> "journal1.query", ReplicaId("R2") -> "journal2.query"))(

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventPublishingSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventPublishingSpec.scala
@@ -20,6 +20,8 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 object ReplicatedEventPublishingSpec {
 
+  val EntityType = "EventPublishingSpec"
+
   object MyReplicatedBehavior {
     trait Command
     case class Add(text: String, replyTo: ActorRef[Done]) extends Command
@@ -29,13 +31,14 @@ object ReplicatedEventPublishingSpec {
     def apply(entityId: String, replicaId: ReplicaId, allReplicas: Set[ReplicaId]): Behavior[Command] =
       Behaviors.setup { ctx =>
         ReplicatedEventSourcing.withSharedJournal(
+          EntityType,
           entityId,
           replicaId,
           allReplicas,
           PersistenceTestKitReadJournal.Identifier)(
-          replicationctx =>
+          replicationContext =>
             EventSourcedBehavior[Command, String, Set[String]](
-              replicationctx.persistenceId,
+              replicationContext.persistenceId,
               Set.empty,
               (state, command) =>
                 command match {
@@ -83,7 +86,7 @@ class ReplicatedEventPublishingSpec
 
       // simulate a published event from another replica
       actor.asInstanceOf[ActorRef[Any]] ! internal.PublishedEventImpl(
-        PersistenceId.replicatedUniqueId(id, DCB),
+        PersistenceId.replicatedId(EntityType, id, DCB),
         1L,
         "two",
         System.currentTimeMillis(),
@@ -104,7 +107,7 @@ class ReplicatedEventPublishingSpec
 
       // simulate a published event from another replica
       actor.asInstanceOf[ActorRef[Any]] ! internal.PublishedEventImpl(
-        PersistenceId.replicatedUniqueId(id, DCB),
+        PersistenceId.replicatedId(EntityType, id, DCB),
         2L, // missing 1L
         "two",
         System.currentTimeMillis(),
@@ -125,7 +128,7 @@ class ReplicatedEventPublishingSpec
 
       // simulate a published event from another replica
       actor.asInstanceOf[ActorRef[Any]] ! internal.PublishedEventImpl(
-        PersistenceId.replicatedUniqueId(id, DCC),
+        PersistenceId.replicatedId(EntityType, id, DCC),
         1L,
         "two",
         System.currentTimeMillis(),
@@ -146,14 +149,14 @@ class ReplicatedEventPublishingSpec
 
       // simulate a published event from another replica
       actor.asInstanceOf[ActorRef[Any]] ! internal.PublishedEventImpl(
-        PersistenceId.replicatedUniqueId("myId4", DCB),
+        PersistenceId.replicatedId(EntityType, "myId4", DCB),
         1L,
         "two",
         System.currentTimeMillis(),
         Some(new ReplicatedPublishedEventMetaData(DCB, VersionVector.empty)))
       // simulate another published event from that replica
       actor.asInstanceOf[ActorRef[Any]] ! internal.PublishedEventImpl(
-        PersistenceId.replicatedUniqueId(id, DCB),
+        PersistenceId.replicatedId(EntityType, id, DCB),
         1L,
         "two-again", // ofc this would be the same in the real world, different just so we can detect
         System.currentTimeMillis(),
@@ -185,7 +188,7 @@ class ReplicatedEventPublishingSpec
 
       // simulate a published event from another replica
       incarnation2.asInstanceOf[ActorRef[Any]] ! internal.PublishedEventImpl(
-        PersistenceId.replicatedUniqueId(id, DCB),
+        PersistenceId.replicatedId(EntityType, id, DCB),
         1L,
         "two",
         System.currentTimeMillis(),
@@ -208,7 +211,7 @@ class ReplicatedEventPublishingSpec
 
       // simulate a published event from another replica
       incarnationA1.asInstanceOf[ActorRef[Any]] ! internal.PublishedEventImpl(
-        PersistenceId.replicatedUniqueId(id, DCB),
+        PersistenceId.replicatedId(EntityType, id, DCB),
         1L,
         "two",
         System.currentTimeMillis(),
@@ -221,7 +224,7 @@ class ReplicatedEventPublishingSpec
 
       // simulate a published event from another replica
       incarnationA2.asInstanceOf[ActorRef[Any]] ! internal.PublishedEventImpl(
-        PersistenceId.replicatedUniqueId(id, DCB),
+        PersistenceId.replicatedId(EntityType, id, DCB),
         2L,
         "three",
         System.currentTimeMillis(),

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingSpec.scala
@@ -72,6 +72,7 @@ object ReplicatedEventSourcingSpec {
       replicaId: String,
       probe: Option[ActorRef[EventAndContext]] = None): Behavior[Command] =
     ReplicatedEventSourcing.withSharedJournal(
+      "ReplicatedEventSourcingSpec",
       entityId,
       ReplicaId(replicaId),
       AllReplicas,

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingTaggingSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingTaggingSpec.scala
@@ -42,7 +42,7 @@ object ReplicatedEventSourcingTaggingSpec {
         replica: ReplicaId,
         allReplicas: Set[ReplicaId]): EventSourcedBehavior[Command, String, State] = {
       // #tagging
-      ReplicatedEventSourcing.withSharedJournal(entityId, replica, allReplicas, queryPluginId)(
+      ReplicatedEventSourcing.withSharedJournal("TaggingSpec", entityId, replica, allReplicas, queryPluginId)(
         replicationContext =>
           EventSourcedBehavior[Command, String, State](
             replicationContext.persistenceId,

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicationIllegalAccessSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicationIllegalAccessSpec.scala
@@ -28,7 +28,12 @@ object ReplicationIllegalAccessSpec {
   case class State(all: List[String]) extends CborSerializable
 
   def apply(entityId: String, replica: ReplicaId): Behavior[Command] = {
-    ReplicatedEventSourcing.withSharedJournal(entityId, replica, AllReplicas, PersistenceTestKitReadJournal.Identifier)(
+    ReplicatedEventSourcing.withSharedJournal(
+      "IllegalAccessSpec",
+      entityId,
+      replica,
+      AllReplicas,
+      PersistenceTestKitReadJournal.Identifier)(
       replicationContext =>
         EventSourcedBehavior[Command, String, State](
           replicationContext.persistenceId,
@@ -85,10 +90,14 @@ class ReplicationIllegalAccessSpec
     }
     "detect illegal access in the factory" in {
       val exception = intercept[UnsupportedOperationException] {
-        ReplicatedEventSourcing.withSharedJournal("id2", R1, AllReplicas, PersistenceTestKitReadJournal.Identifier) {
-          replicationContext =>
-            replicationContext.origin
-            ???
+        ReplicatedEventSourcing.withSharedJournal(
+          "IllegalAccessSpec",
+          "id2",
+          R1,
+          AllReplicas,
+          PersistenceTestKitReadJournal.Identifier) { replicationContext =>
+          replicationContext.origin
+          ???
         }
       }
       exception.getMessage should include("from the event handler")

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicationSnapshotSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicationSnapshotSpec.scala
@@ -20,6 +20,8 @@ object ReplicationSnapshotSpec {
 
   import ReplicatedEventSourcingSpec._
 
+  val EntityType = "SpapsnotSpec"
+
   def behaviorWithSnapshotting(entityId: String, replicaId: ReplicaId): Behavior[Command] =
     behaviorWithSnapshotting(entityId, replicaId, None)
 
@@ -34,6 +36,7 @@ object ReplicationSnapshotSpec {
       replicaId: ReplicaId,
       probe: Option[ActorRef[EventAndContext]]): Behavior[Command] = {
     ReplicatedEventSourcing.withSharedJournal(
+      EntityType,
       entityId,
       replicaId,
       AllReplicas,
@@ -81,7 +84,7 @@ class ReplicationSnapshotSpec
         snapshotTestKit.expectNextPersisted(persistenceIdR2, State(List("r1 2", "r1 1")))
 
         r2.asInstanceOf[ActorRef[Any]] ! internal.PublishedEventImpl(
-          PersistenceId.replicatedUniqueId(entityId, R1),
+          PersistenceId.replicatedId(EntityType, entityId, R1),
           1L,
           "two-again",
           System.currentTimeMillis(),
@@ -95,7 +98,7 @@ class ReplicationSnapshotSpec
       {
         val r2 = spawn(behaviorWithSnapshotting(entityId, R2, r2EventProbe.ref))
         r2.asInstanceOf[ActorRef[Any]] ! internal.PublishedEventImpl(
-          PersistenceId.replicatedUniqueId(entityId, R1),
+          PersistenceId.replicatedId(EntityType, entityId, R1),
           1L,
           "two-again",
           System.currentTimeMillis(),

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/crdt/CounterSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/crdt/CounterSpec.scala
@@ -29,6 +29,7 @@ object CounterSpec {
       eventProbe: Option[ActorRef[Counter.Updated]] = None) =
     Behaviors.setup[PlainCounter.Command] { context =>
       ReplicatedEventSourcing.withSharedJournal(
+        "CounterSpec",
         entityId,
         replicaId,
         AllReplicas,

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/crdt/LwwSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/crdt/LwwSpec.scala
@@ -27,6 +27,7 @@ object LwwSpec {
 
     def apply(entityId: String, replica: ReplicaId): Behavior[Command] = {
       ReplicatedEventSourcing.withSharedJournal(
+        "LwwRegistrySpec",
         entityId,
         replica,
         AllReplicas,

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/crdt/ORSetSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/crdt/ORSetSpec.scala
@@ -28,6 +28,7 @@ object ORSetSpec {
     def apply(entityId: String, replica: ReplicaId): Behavior[ORSetEntity.Command] = {
 
       ReplicatedEventSourcing.withSharedJournal(
+        "ORSetSpec",
         entityId,
         replica,
         AllReplicas,

--- a/akka-persistence-typed-tests/src/test/scala/docs/akka/persistence/typed/ReplicatedAuctionExampleSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/docs/akka/persistence/typed/ReplicatedAuctionExampleSpec.scala
@@ -218,15 +218,18 @@ object ReplicatedAuctionExampleSpec {
 
   def behavior(replica: ReplicaId, setup: AuctionSetup): Behavior[AuctionCommand] = Behaviors.setup[AuctionCommand] {
     ctx =>
-      ReplicatedEventSourcing
-        .withSharedJournal(setup.name, replica, setup.allReplicas, PersistenceTestKitReadJournal.Identifier) {
-          replicationCtx =>
-            EventSourcedBehavior(
-              replicationCtx.persistenceId,
-              initialState(setup),
-              commandHandler(setup, ctx, replicationCtx),
-              eventHandler(ctx, replicationCtx, setup))
-        }
+      ReplicatedEventSourcing.withSharedJournal(
+        "auction",
+        setup.name,
+        replica,
+        setup.allReplicas,
+        PersistenceTestKitReadJournal.Identifier) { replicationCtx =>
+        EventSourcedBehavior(
+          replicationCtx.persistenceId,
+          initialState(setup),
+          commandHandler(setup, ctx, replicationCtx),
+          eventHandler(ctx, replicationCtx, setup))
+      }
   }
 }
 

--- a/akka-persistence-typed-tests/src/test/scala/docs/akka/persistence/typed/ReplicatedBlogExampleSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/docs/akka/persistence/typed/ReplicatedBlogExampleSpec.scala
@@ -115,6 +115,7 @@ class ReplicatedBlogExampleSpec
         spawn(
           Behaviors.setup[BlogCommand] { ctx =>
             ReplicatedEventSourcing.withSharedJournal(
+              "blog",
               "cat",
               ReplicaId("DC-A"),
               Set(ReplicaId("DC-A"), ReplicaId("DC-B")),
@@ -128,6 +129,7 @@ class ReplicatedBlogExampleSpec
         spawn(
           Behaviors.setup[BlogCommand] { ctx =>
             ReplicatedEventSourcing.withSharedJournal(
+              "blog",
               "cat",
               ReplicaId("DC-B"),
               Set(ReplicaId("DC-A"), ReplicaId("DC-B")),

--- a/akka-persistence-typed-tests/src/test/scala/docs/akka/persistence/typed/ReplicatedEventSourcingCompileOnlySpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/docs/akka/persistence/typed/ReplicatedEventSourcingCompileOnlySpec.scala
@@ -24,14 +24,15 @@ object ReplicatedEventSourcingCompileOnlySpec {
   trait Event
 
   //#factory-shared
-  ReplicatedEventSourcing.withSharedJournal("entityId", DCA, AllReplicas, queryPluginId) { context =>
+  ReplicatedEventSourcing.withSharedJournal("entityTypeHint", "entityId", DCA, AllReplicas, queryPluginId) { context =>
     EventSourcedBehavior[Command, State, Event](???, ???, ???, ???)
   }
   //#factory-shared
 
   //#factory
-  ReplicatedEventSourcing("entityId", DCA, Map(DCA -> "journalForDCA", DCB -> "journalForDCB")) { context =>
-    EventSourcedBehavior[Command, State, Event](???, ???, ???, ???)
+  ReplicatedEventSourcing("entityTypeHint", "entityId", DCA, Map(DCA -> "journalForDCA", DCB -> "journalForDCB")) {
+    context =>
+      EventSourcedBehavior[Command, State, Event](???, ???, ???, ???)
   }
   //#factory
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/PersistenceId.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/PersistenceId.scala
@@ -4,7 +4,6 @@
 
 package akka.persistence.typed
 import akka.annotation.ApiMayChange
-import akka.annotation.InternalApi
 
 object PersistenceId {
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/PersistenceId.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/PersistenceId.scala
@@ -3,6 +3,7 @@
  */
 
 package akka.persistence.typed
+import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
 
 object PersistenceId {
@@ -127,10 +128,11 @@ object PersistenceId {
     new PersistenceId(id)
 
   /**
-   * Constructs a persistence id from a unique entity id that includes the replica id.
+   * Constructs a [[PersistenceId]] from the given `entityTypeHint`, `entityId` and `replicaId` by
+   * concatenating them with the `|` separator.
    */
-  @InternalApi
-  private[akka] def replicatedId(entityTypeHint: String, entityId: String, replicaId: ReplicaId): PersistenceId = {
+  @ApiMayChange
+  def replicatedId(entityTypeHint: String, entityId: String, replicaId: ReplicaId): PersistenceId = {
     if (entityTypeHint.contains(DefaultSeparator))
       throw new IllegalArgumentException(
         s"entityTypeHint [$entityTypeHint] contains [$DefaultSeparator] which is a reserved character")

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/PersistenceId.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/PersistenceId.scala
@@ -130,7 +130,11 @@ object PersistenceId {
    * Constructs a persistence id from a unique entity id that includes the replica id.
    */
   @InternalApi
-  private[akka] def replicatedUniqueId(entityId: String, replicaId: ReplicaId): PersistenceId = {
+  private[akka] def replicatedId(entityTypeHint: String, entityId: String, replicaId: ReplicaId): PersistenceId = {
+    if (entityTypeHint.contains(DefaultSeparator))
+      throw new IllegalArgumentException(
+        s"entityTypeHint [$entityTypeHint] contains [$DefaultSeparator] which is a reserved character")
+
     if (entityId.contains(DefaultSeparator))
       throw new IllegalArgumentException(
         s"entityId [$entityId] contains [$DefaultSeparator] which is a reserved character")
@@ -139,7 +143,7 @@ object PersistenceId {
       throw new IllegalArgumentException(
         s"replicaId [${replicaId.id}] contains [$DefaultSeparator] which is a reserved character")
 
-    new PersistenceId(entityId + DefaultSeparator + replicaId.id)
+    new PersistenceId(entityTypeHint + DefaultSeparator + entityId + DefaultSeparator + replicaId.id)
   }
 }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplicationSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplicationSetup.scala
@@ -14,11 +14,9 @@ import akka.util.ccompat.JavaConverters._
 /**
  * INTERNAL API
  */
-// FIXME, parts of this can be set during initialisation
-// Other fields will be set before executing the event handler as they change per event
-// https://github.com/akka/akka/issues/29258
 @InternalApi
 private[akka] final class ReplicationContextImpl(
+    val entityTypeHint: String,
     val entityId: String,
     val replicaId: ReplicaId,
     val replicasAndQueryPlugins: Map[ReplicaId, String])
@@ -67,7 +65,7 @@ private[akka] final class ReplicationContextImpl(
     _concurrent
   }
 
-  override def persistenceId: PersistenceId = PersistenceId.replicatedUniqueId(entityId, replicaId)
+  override def persistenceId: PersistenceId = PersistenceId.replicatedId(entityTypeHint, entityId, replicaId)
 
   override def currentTimeMillis(): Long = {
     WallClock.AlwaysIncreasingClock.currentTimeMillis()

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -128,7 +128,10 @@ private[akka] object Running {
     val query = PersistenceQuery(system)
     replicationSetup.allReplicas.foldLeft(state) { (state, replicaId) =>
       if (replicaId != replicationSetup.replicaId) {
-        val pid = PersistenceId.replicatedUniqueId(replicationSetup.replicationContext.entityId, replicaId)
+        val pid = PersistenceId.replicatedId(
+          replicationSetup.replicationContext.entityTypeHint,
+          replicationSetup.replicationContext.entityId,
+          replicaId)
         val queryPluginId = replicationSetup.allReplicasAndQueryPlugins(replicaId)
         val replication = query.readJournalFor[EventsByPersistenceIdQuery](queryPluginId)
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/ReplicatedEventSourcing.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/ReplicatedEventSourcing.scala
@@ -81,18 +81,25 @@ object ReplicatedEventSourcing {
    * can be used for each replica.
    * The events from other replicas are read using PersistentQuery.
    *
+   * @param entityType The name of the entity type e.g. account, user. Made part of the persistence id so that entity ids don't need to be unique across different replicated entities
    * @param replicaId The unique identity for this entity. The underlying persistence id will include the replica.
    * @param allReplicaIds All replica ids. These need to be known to receive events from all replicas.
    * @param queryPluginId A single query plugin used to read the events from other replicas. Must be the query side of your configured journal plugin.
    */
   def withSharedJournal[Command, Event, State](
+      entityType: String,
       entityId: String,
       replicaId: ReplicaId,
       allReplicaIds: JSet[ReplicaId],
       queryPluginId: String,
       behaviorFactory: JFunction[ReplicationContext, EventSourcedBehavior[Command, Event, State]])
       : EventSourcedBehavior[Command, Event, State] =
-    create(entityId, replicaId, allReplicaIds.asScala.map(id => id -> queryPluginId).toMap.asJava, behaviorFactory)
+    create(
+      entityType,
+      entityId,
+      replicaId,
+      allReplicaIds.asScala.map(id => id -> queryPluginId).toMap.asJava,
+      behaviorFactory)
 
   /**
    * Initialize a replicated event sourced behavior.
@@ -106,17 +113,19 @@ object ReplicatedEventSourcing {
    * A query side identifier is passed per replica allowing for separate database/journal configuration per
    * replica. The events from other replicas are read using PersistentQuery.
    *
+   * @param entityType The name of the entity type e.g. account, user. Made part of the persistence id so that entity ids don't need to be unique across different replicated entities
    * @param replicaId The unique identity for this entity. The underlying persistence id will include the replica.
    * @param allReplicasAndQueryPlugins All replica ids and a query plugin per replica id. These need to be known to receive events from all replicas
    *                                   and configured with the query plugin for the journal that each replica uses.
    */
   def create[Command, Event, State](
+      entityType: String,
       entityId: String,
       replicaId: ReplicaId,
       allReplicasAndQueryPlugins: JMap[ReplicaId, String],
       eventSourcedBehaviorFactory: JFunction[ReplicationContext, EventSourcedBehavior[Command, Event, State]])
       : EventSourcedBehavior[Command, Event, State] = {
-    val context = new ReplicationContextImpl(entityId, replicaId, allReplicasAndQueryPlugins.asScala.toMap)
+    val context = new ReplicationContextImpl(entityType, entityId, replicaId, allReplicasAndQueryPlugins.asScala.toMap)
     eventSourcedBehaviorFactory(context)
   }
 


### PR DESCRIPTION
Also made it mandatory as can't see a reason for not including a name as part of the persistence id

Refs #29458