### PR TITLE
Forward terminated from ShardCoordinator to RebalanceWorker

### DIFF
--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingLeavingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingLeavingSpec.scala
@@ -48,7 +48,7 @@ abstract class ClusterShardingLeavingSpecConfig(mode: String)
       loglevel = "DEBUG",
       additionalConfig = """
         akka.cluster.sharding.verbose-debug-logging = on
-        akka.cluster.sharding.rebalance-interval = 120 s
+        akka.cluster.sharding.rebalance-interval = 1s # make it more likely to happen 
         akka.cluster.sharding.distributed-data.majority-min-cap = 1
         akka.cluster.sharding.coordinator-state.write-majority-plus = 1
         akka.cluster.sharding.coordinator-state.read-majority-plus = 1

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingLeavingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingLeavingSpec.scala
@@ -46,9 +46,10 @@ abstract class ClusterShardingLeavingSpecConfig(mode: String)
     extends MultiNodeClusterShardingConfig(
       mode,
       loglevel = "DEBUG",
-      additionalConfig = """
+      additionalConfig =
+        """
         akka.cluster.sharding.verbose-debug-logging = on
-        akka.cluster.sharding.rebalance-interval = 1s # make it more likely to happen 
+        akka.cluster.sharding.rebalance-interval = 1s # make rebalancing more likely to happen to test for https://github.com/akka/akka/issues/29093
         akka.cluster.sharding.distributed-data.majority-min-cap = 1
         akka.cluster.sharding.coordinator-state.write-majority-plus = 1
         akka.cluster.sharding.coordinator-state.read-majority-plus = 1


### PR DESCRIPTION
Avoiding the need for rebalance workers to watch shard regions which is
expensive as there is one rebalance worker per shard

Refs https://github.com/akka/akka/issues/29093

This is running on repeat for the cluster tests in: https://jenkins.akka.io:8498/job/legacy-akka-multi-node-repeat4/