### PR TITLE
Fix documentation about the way to enable the akka async dns resolver

### DIFF
--- a/akka-actor/src/main/scala/akka/io/dns/DnsProtocol.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/DnsProtocol.scala
@@ -20,7 +20,7 @@ import akka.util.ccompat.JavaConverters._
 /**
  * Supersedes [[akka.io.Dns]] protocol.
  *
- * Note that one MUST configure `akka.io.dns.resolver = async` to make use of this protocol and resolver.
+ * Note that one MUST configure `akka.io.dns.resolver = async-dns` to make use of this protocol and resolver.
  *
  * Allows for more detailed lookups, by specifying which records should be checked,
  * and responses can more information than plain IP addresses (e.g. ports for SRV records).


### PR DESCRIPTION
I noticed that the documentation incorrectly specifies the way to enable the async dns resolver.  This updates the documentation to be inline with the implementation, and the primary documentation that exists here: https://doc.akka.io/docs/akka/current/io-dns.html