### PR TITLE
actor: sync allModules with current set of published modules

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -989,14 +989,18 @@ private[akka] class ActorSystemImpl(
       "akka-persistence",
       "akka-persistence-query",
       "akka-persistence-shared",
+      "akka-persistence-testkit",
       "akka-persistence-typed",
+      "akka-pki",
       "akka-protobuf",
       "akka-protobuf-v3",
       "akka-remote",
+      "akka-serialization-jackson",
       "akka-slf4j",
       "akka-stream",
       "akka-stream-testkit",
-      "akka-stream-typed")
+      "akka-stream-typed",
+      "akka-stream-testkit")
 
   @volatile private var _initialized = false
 


### PR DESCRIPTION
Refs #29351

With this fix, a version warning will be shown for the case of #29351 instead of failing with "Serializer identifier ... is not unique".