### PR TITLE
Update scalatest within 3.1

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -4,7 +4,6 @@ updates.ignore = [
   { groupId = "com.google.protobuf", artifactId = "protobuf-java" },
   { groupId = "org.scalameta", artifactId = "scalafmt-core" },
   { groupId = "org.scalameta", artifactId = "sbt-scalafmt" },
-  { groupId = "org.scalatest", artifactId = "scalatest" },
   { groupId = "com.fasterxml.jackson.module", artifactId = "jackson-module-parameter-names" },
   { groupId = "com.fasterxml.jackson.module", artifactId = "jackson-module-scala" },
   { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-annotations" },
@@ -17,6 +16,10 @@ updates.ignore = [
   { groupId = "com.typesafe.sbt", artifactId = "sbt-osgi" },
   { groupId = "org.agrona", artifactId = "agrona" },
   { groupId = "org.mockito", artifactId = "mockito-core" }
+]
+
+updates.pin [
+  { groupId = "org.scalatest", artifactId = "scalatest", version = "3.1." },
 ]
 
 updatePullRequests = false

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,7 @@ object Dependencies {
 
   val sslConfigVersion = "0.4.2"
 
-  val scalaTestVersion = "3.1.3"
+  val scalaTestVersion = "3.1.4"
   val scalaCheckVersion = "1.14.3"
 
   val Versions =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,7 @@ object Dependencies {
 
   val sslConfigVersion = "0.4.2"
 
-  val scalaTestVersion = "3.1.1"
+  val scalaTestVersion = "3.1.3"
   val scalaCheckVersion = "1.14.3"
 
   val Versions =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -128,7 +128,7 @@ object Dependencies {
       val scalatestJUnit = "org.scalatestplus" %% "junit-4-12" % (scalaTestVersion + ".0") % "test" // ApacheV2
       val scalatestTestNG = "org.scalatestplus" %% "testng-6-7" % (scalaTestVersion + ".0") % "test" // ApacheV2
       val scalatestScalaCheck = "org.scalatestplus" %% "scalacheck-1-14" % (scalaTestVersion + ".0") % "test" // ApacheV2
-      val scalatestMockito = "org.scalatestplus" %% "mockito-3-2" % (scalaTestVersion + ".0") % "test" // ApacheV2
+      val scalatestMockito = "org.scalatestplus" %% "mockito-3-3" % (scalaTestVersion + ".0") % "test" // ApacheV2
 
       val pojosr = "com.googlecode.pojosr" % "de.kalpatec.pojosr.framework" % "0.2.1" % "test" // ApacheV2
       val tinybundles = "org.ops4j.pax.tinybundles" % "tinybundles" % "3.0.0" % "test" // ApacheV2


### PR DESCRIPTION
This will avoid polling in `futureValue`.

However, a failing test now results in a `java.io.NotSerializableException: org.scalatest.matchers.should.Matchers$AWord` instead of in a nice stacktrace (tested with AttributesSpec). Keeping as 'draft' until we figure that out.