### PR TITLE
Reduce sharding warnings when there are no buffered messages

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -940,15 +940,14 @@ private[akka] class ShardRegion(
               actorSelections.mkString(", "),
               bufferSize,
               coordinatorMessage)
-          } else {
-            log.debug(
-              "{}: Trying to register to coordinator at [{}], but no acknowledgement. No buffered messages yet. [{}]",
-              typeName,
-              actorSelections.mkString(", "),
-              coordinatorMessage)
           }
+        } else if (log.isDebugEnabled) {
+          log.debug(
+            "{}: Trying to register to coordinator at [{}], but no acknowledgement. No buffered messages yet. [{}]",
+            typeName,
+            actorSelections.mkString(", "),
+            coordinatorMessage)
         }
-
       } else {
         // Members start off as "Removed"
         val partOfCluster = cluster.selfMember.status != MemberStatus.Removed

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -931,20 +931,20 @@ private[akka] class ShardRegion(
         val coordinatorMessage =
           if (cluster.state.unreachable(membersByAge.head)) s"Coordinator [${membersByAge.head}] is unreachable."
           else s"Coordinator [${membersByAge.head}] is reachable."
-        if (shardBuffers.totalSize > 0) {
+        val bufferSize = shardBuffers.totalSize
+        if (bufferSize > 0) {
           if (log.isWarningEnabled) {
             log.warning(
               "{}: Trying to register to coordinator at [{}], but no acknowledgement. Total [{}] buffered messages. [{}]",
               typeName,
               actorSelections.mkString(", "),
-              shardBuffers.totalSize,
+              bufferSize,
               coordinatorMessage)
           } else {
             log.debug(
               "{}: Trying to register to coordinator at [{}], but no acknowledgement. No buffered messages yet. [{}]",
               typeName,
               actorSelections.mkString(", "),
-              shardBuffers.totalSize,
               coordinatorMessage)
           }
         }
@@ -958,12 +958,13 @@ private[akka] class ShardRegion(
           else
             "Probably, no seed-nodes configured and manual cluster or bootstrap join not performed?"
 
-        if (shardBuffers.totalSize > 0) {
+        val bufferSize = shardBuffers.totalSize
+        if (bufferSize > 0) {
           log.warning(
             "{}: No coordinator found to register. {} Total [{}] buffered messages.",
             typeName,
             possibleReason,
-            shardBuffers.totalSize)
+            bufferSize)
         } else {
           log.debug("{}: No coordinator found to register. {} No buffered messages yet.", typeName, possibleReason)
         }


### PR DESCRIPTION
If shard regions are started before the cluster is formed warnings are
logged. The user can wait until SelfUp but for the cases they don't make
logging debug until the user has buffered messages.