### PR TITLE
Use the correct name for Akka HTTP

### DIFF
--- a/akka-docs/src/main/paradox/typed/dispatchers.md
+++ b/akka-docs/src/main/paradox/typed/dispatchers.md
@@ -173,7 +173,7 @@ avoid blocking APIs. The following solution explains how to handle blocking
 operations properly.
 
 Note that the same hints apply to managing blocking operations anywhere in Akka,
-including Streams, Http and other reactive libraries built on top of it.
+including Streams, HTTP and other reactive libraries built on top of it.
 
 @@@
 


### PR DESCRIPTION
Correct the typo in the name of Akka HTTP, it's written in lower case but the project name is in upper case.

There is no related issue as it's just a typo
