### PR TITLE
Fix time in AtLeastOnce.setDeliverySnapshot, #27786

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/AtLeastOnceDelivery.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/AtLeastOnceDelivery.scala
@@ -361,7 +361,8 @@ trait AtLeastOnceDeliveryLike extends Eventsourced {
    */
   def setDeliverySnapshot(snapshot: AtLeastOnceDeliverySnapshot): Unit = {
     deliverySequenceNr = snapshot.currentDeliveryId
-    val now = System.nanoTime()
+    // deliver on next tick
+    val now = System.nanoTime() - redeliverInterval.toNanos
     unconfirmed = scala.collection.immutable.SortedMap.from(snapshot.unconfirmedDeliveries.iterator.map(d =>
       d.deliveryId -> Delivery(d.destination, d.message, now, 0)))
   }


### PR DESCRIPTION
* to be consistent with internalDeliver when recoveryRunning

References #27786
