### PR TITLE
Fix acceptable-heartbeat-pause in cluster.StressSpec, #29512

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -97,7 +97,7 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
 
     akka.actor.provider = cluster
     akka.cluster {
-      failure-detector.acceptable-heartbeat-pause =  10s
+      failure-detector.acceptable-heartbeat-pause =  3s
       downing-provider-class = akka.cluster.sbr.SplitBrainResolverProvider
       split-brain-resolver {
           stable-after = 5s


### PR DESCRIPTION
References #29512

Might not solve the test failures we have seen, but this is better (and more default) config. I have created issue #29540 for what I think is the real cause of the test failures (but it could also be timing related).
