### PR TITLE
Cluster aware shard allocation and rolling updates

### DIFF
--- a/akka-actor/src/main/scala/akka/util/ConstantFun.scala
+++ b/akka-actor/src/main/scala/akka/util/ConstantFun.scala
@@ -35,6 +35,7 @@ import akka.japi.function.{ Function => JFun, Function2 => JFun2 }
   def scalaAnyTwoToTrue[A, B]: (A, B) => Boolean = two2true
   def scalaAnyThreeToFalse[A, B, C]: (A, B, C) => Boolean = three2false
   def scalaAnyThreeToThird[A, B, C]: (A, B, C) => C = three2third.asInstanceOf[(A, B, C) => C]
+
   def javaAnyToNone[A, B]: A => Option[B] = none
   def nullFun[T] = _nullFun.asInstanceOf[Any => T]
 
@@ -45,6 +46,8 @@ import akka.japi.function.{ Function => JFun, Function2 => JFun2 }
   val oneInt = (_: Any) => 1
 
   val unitToUnit = () => ()
+
+  val anyToTrue: Any => Boolean = (_: Any) => true
 
   private val _nullFun = (_: Any) => null
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -284,15 +284,6 @@ object ShardCoordinator {
 
     import AbstractLeastShardAllocationStrategy.ShardSuitabilityOrdering
 
-    override def allocateShard(
-        requester: ActorRef,
-        shardId: ShardId,
-        currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardId]]): Future[ActorRef] = {
-      val regionEntries = regionEntriesFor(currentShardAllocations)
-      val (region, _) = mostSuitableRegion(regionEntries)
-      Future.successful(region)
-    }
-
     override def rebalance(
         currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardId]],
         rebalanceInProgress: Set[ShardId]): Future[Set[ShardId]] = {

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -301,7 +301,7 @@ object ShardCoordinator {
           // even if it is to another new node.
           val mostShards = regionEntries
             .collect {
-              case RegionEntry(_, _, v) => v.filterNot(s => rebalanceInProgress(s))
+              case RegionEntry(_, _, shardIds) => shardIds.filterNot(id => rebalanceInProgress(id))
             }
             .maxBy(_.size)
           val difference = mostShards.size - leastShards.size

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/AbstractLeastShardAllocationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/AbstractLeastShardAllocationStrategy.scala
@@ -91,7 +91,7 @@ private[akka] abstract class AbstractLeastShardAllocationStrategy extends ActorS
       regionEntries: Iterable[RegionEntry]): (ActorRef, immutable.IndexedSeq[ShardId]) = {
     regionEntries.toVector
       .sorted(ShardSuitabilityOrdering)
-      .map { case RegionEntry(region, _, shards) => region -> shards }
+      .map { case RegionEntry(region, _, shardIds) => region -> shardIds }
       .head
   }
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/AbstractLeastShardAllocationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/AbstractLeastShardAllocationStrategy.scala
@@ -7,16 +7,19 @@ package akka.cluster.sharding.internal
 import java.lang.{ Boolean => JBoolean, Integer => JInteger }
 
 import akka.actor.ActorRef
+import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.actor.Address
 import akka.annotation.InternalApi
 import akka.cluster.Cluster
 import akka.cluster.ClusterEvent.CurrentClusterState
 import akka.cluster.Member
+import akka.cluster.Member
 import akka.cluster.MemberStatus
 import akka.cluster.sharding.ShardCoordinator.ActorSystemDependentAllocationStrategy
 import akka.cluster.sharding.ShardRegion.ShardId
 
+import scala.collection.immutable
 import scala.collection.immutable
 
 /**
@@ -28,17 +31,15 @@ import scala.collection.immutable
 private[akka] object AbstractLeastShardAllocationStrategy {
   import MemberStatus._
   private val LeavingClusterStatuses: Set[MemberStatus] = Set(Leaving, Exiting, Down)
-  // defer rebalance when nodes are soon becoming up
-  private val AvoidRebalanceWhen: Set[MemberStatus] = Set(Joining, WeaklyUp)
 
   type AllocationMap = Map[ActorRef, immutable.IndexedSeq[ShardId]]
 
-  implicit object ShardSuitabilityOrdering extends Ordering[(ActorRef, Member, immutable.IndexedSeq[ShardId])] {
-    override def compare(
-        x: (ActorRef, Member, immutable.IndexedSeq[ShardId]),
-        y: (ActorRef, Member, immutable.IndexedSeq[ShardId])): Int = {
-      val (_, memberX, allocatedShardsX) = x
-      val (_, memberY, allocatedShardsY) = y
+  final case class RegionEntry(region: ActorRef, member: Member, shardIds: immutable.IndexedSeq[ShardId])
+
+  implicit object ShardSuitabilityOrdering extends Ordering[RegionEntry] {
+    override def compare(x: RegionEntry, y: RegionEntry): Int = {
+      val RegionEntry(_, memberX, allocatedShardsX) = x
+      val RegionEntry(_, memberY, allocatedShardsY) = y
       if (memberX.status != memberY.status) {
         // prefer allocating to nodes that are not on their way out of the cluster
         val xIsLeaving = LeavingClusterStatuses(memberX.status)
@@ -74,21 +75,26 @@ private[akka] abstract class AbstractLeastShardAllocationStrategy extends ActorS
   protected def selfAddress: Address = cluster.selfAddress
   protected def clusterState: CurrentClusterState = cluster.state
 
-  protected def isAGoodTimeToRebalance: Boolean = {
-    // rolling upgrade in progress
-    !clusterState.hasMoreThanOneAppVersion &&
-    !clusterState.members.exists(m => AvoidRebalanceWhen(m.status))
-    clusterState.unreachable.isEmpty // because rebalance requires ack from all anyway
+  final protected def isAGoodTimeToRebalance(regionEntries: Iterable[RegionEntry]): Boolean = {
+    // this will filter out member with no shard regions (bc role or not yet completed joining)
+    val shardRegionMembers = regionEntries.map { case RegionEntry(_, member, _) => member }
+    // avoid rebalance when rolling update is in progress
+    def allNodesSameVersion = shardRegionMembers.map(_.appVersion).toSet.size == 1
+    // rebalance requires ack from all anyway
+    def allRegionsReachable = clusterState.unreachable.diff(shardRegionMembers.toSet).isEmpty
+
+    allNodesSameVersion && allRegionsReachable
   }
 
-  protected def mostSuitableRegion(
-      currentShardAllocations: AllocationMap): (ActorRef, immutable.IndexedSeq[ShardId]) = {
-    val decorated = decorate(currentShardAllocations)
-    decorated.toVector.sorted(ShardSuitabilityOrdering).map { case (region, _, shards) => region -> shards }.head
+  final protected def mostSuitableRegion(
+      regionEntries: Iterable[RegionEntry]): (ActorRef, immutable.IndexedSeq[ShardId]) = {
+    regionEntries.toVector
+      .sorted(ShardSuitabilityOrdering)
+      .map { case RegionEntry(region, _, shards) => region -> shards }
+      .head
   }
 
-  private def decorate(
-      currentShardAllocations: AllocationMap): Iterable[(ActorRef, Member, immutable.IndexedSeq[ShardId])] = {
+  final protected def regionEntriesFor(currentShardAllocations: AllocationMap): Iterable[RegionEntry] = {
     val addressToMember: Map[Address, Member] = clusterState.members.iterator.map(m => m.address -> m).toMap
     currentShardAllocations.flatMap {
       case (region, shardIds) =>
@@ -100,7 +106,7 @@ private[akka] abstract class AbstractLeastShardAllocationStrategy extends ActorS
         val memberForRegion = addressToMember.get(regionAddress)
         // if the member is unknown (very unlikely but not impossible) because of view not updated yet
         // that node is ignored for this invocation
-        memberForRegion.map(member => (region, member, shardIds))
+        memberForRegion.map(member => RegionEntry(region, member, shardIds))
     }
   }
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/AbstractLeastShardAllocationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/AbstractLeastShardAllocationStrategy.scala
@@ -99,21 +99,18 @@ private[akka] abstract class AbstractLeastShardAllocationStrategy extends ActorS
 
   final protected def regionEntriesFor(currentShardAllocations: AllocationMap): Iterable[RegionEntry] = {
     val addressToMember: Map[Address, Member] = clusterState.members.iterator.map(m => m.address -> m).toMap
-    currentShardAllocations
-      .flatMap {
-        case (region, shardIds) =>
-          val regionAddress = {
-            if (region.path.address.hasLocalScope) selfMember.address
-            else region.path.address
-          }
+    currentShardAllocations.flatMap {
+      case (region, shardIds) =>
+        val regionAddress = {
+          if (region.path.address.hasLocalScope) selfMember.address
+          else region.path.address
+        }
 
-          val memberForRegion = addressToMember.get(regionAddress)
-          // if the member is unknown (very unlikely but not impossible) because of view not updated yet
-          // that node is ignored for this invocation
-          memberForRegion.map(member => RegionEntry(region, member, shardIds))
-      }
-      .toSeq
-      .sorted(ShardSuitabilityOrdering)
+        val memberForRegion = addressToMember.get(regionAddress)
+        // if the member is unknown (very unlikely but not impossible) because of view not updated yet
+        // that node is ignored for this invocation
+        memberForRegion.map(member => RegionEntry(region, member, shardIds))
+    }
   }
 
 }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/AbstractLeastShardAllocationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/AbstractLeastShardAllocationStrategy.scala
@@ -7,19 +7,16 @@ package akka.cluster.sharding.internal
 import java.lang.{ Boolean => JBoolean, Integer => JInteger }
 
 import akka.actor.ActorRef
-import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.actor.Address
 import akka.annotation.InternalApi
 import akka.cluster.Cluster
 import akka.cluster.ClusterEvent.CurrentClusterState
 import akka.cluster.Member
-import akka.cluster.Member
 import akka.cluster.MemberStatus
 import akka.cluster.sharding.ShardCoordinator.ActorSystemDependentAllocationStrategy
 import akka.cluster.sharding.ShardRegion.ShardId
 
-import scala.collection.immutable
 import scala.collection.immutable
 
 /**

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/AbstractLeastShardAllocationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/AbstractLeastShardAllocationStrategy.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding.internal
+
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.Address
+import akka.annotation.InternalApi
+import akka.cluster.Cluster
+import akka.cluster.Member
+import akka.cluster.MemberStatus
+import akka.cluster.sharding.ShardCoordinator.ActorSystemDependentAllocationStrategy
+import akka.cluster.sharding.ShardRegion.ShardId
+
+import scala.collection.immutable
+import scala.collection.immutable.SortedSet
+
+/**
+ * Common logic for the least shard allocation strategy implementations
+ *
+ * INTERNAL API
+ */
+private[akka] object AbstractLeastShardAllocationStrategy {
+  import MemberStatus._
+  private val DoNotRebalanceTo: Set[MemberStatus] = Set(Leaving, Exiting, Down)
+  // defer rebalance when nodes are soon becoming up
+  private val AvoidRebalanceWhen: Set[MemberStatus] = Set(Joining, WeaklyUp)
+
+  type AllocationMap = Map[ActorRef, immutable.IndexedSeq[ShardId]]
+
+  implicit object ShardSuitabilityOrdering extends Ordering[(ActorRef, Member, immutable.IndexedSeq[ShardId])] {
+    override def compare(
+        x: (ActorRef, Member, immutable.IndexedSeq[ShardId]),
+        y: (ActorRef, Member, immutable.IndexedSeq[ShardId])): Int = {
+      val (_, memberX, allocatedShardsX) = x
+      val (_, memberY, allocatedShardsY) = y
+      if (memberX.status != memberY.status) {
+        // allocating to nodes that are on their way out of the cluster should always be
+        // the least option
+        // FIXME: more clever logic around states here (prefer up over joining)?
+        DoNotRebalanceTo(memberX.status).compareTo(DoNotRebalanceTo(memberY.status))
+      } else if (memberX.appVersion != memberY.appVersion) {
+        // prefer nodes with the highest rolling update app version
+        memberY.appVersion.compareTo(memberX.appVersion)
+      } else {
+        // prefer the node with the least allocated shards
+        allocatedShardsX.size.compareTo(allocatedShardsY.size)
+      }
+    }
+  }
+}
+
+/**
+
+ *
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] abstract class AbstractLeastShardAllocationStrategy extends ActorSystemDependentAllocationStrategy {
+  import AbstractLeastShardAllocationStrategy._
+
+  @volatile private var cluster: Cluster = _
+
+  override def start(system: ActorSystem): Unit = {
+    cluster = Cluster(system)
+  }
+
+  // protected for testability
+  protected def selfAddress: Address = cluster.selfAddress
+  private[akka] def members: SortedSet[Member] = cluster.state.members
+  protected def rollingUpdateInProgress: Boolean =
+    cluster.state.hasMoreThanOneAppVersion
+  protected def isAGoodTimeToRebalance: Boolean =
+    !rollingUpdateInProgress &&
+    !cluster.state.members.exists(m => AvoidRebalanceWhen(m.status))
+
+  protected def mostSuitableRegion(
+      currentShardAllocations: AllocationMap): (ActorRef, immutable.IndexedSeq[ShardId]) = {
+    val decorated = decorate(currentShardAllocations)
+    decorated.toVector.sorted(ShardSuitabilityOrdering).map { case (region, _, shards) => region -> shards }.head
+  }
+
+  private def decorate(
+      currentShardAllocations: AllocationMap): Iterable[(ActorRef, Member, immutable.IndexedSeq[ShardId])] = {
+    val addressToMember: Map[Address, Member] = members.toIterator.map(m => m.address -> m).toMap
+    currentShardAllocations.flatMap {
+      case (region, shardIds) =>
+        val regionAddress = {
+          if (region.path.address.hasLocalScope) selfAddress
+          else region.path.address
+        }
+
+        val memberForRegion = addressToMember.get(regionAddress)
+        // if the member is unknown (very unlikely but not impossible) because of view not updated yet
+        // that node is ignored for this invocation
+        memberForRegion.map(member => (region, member, shardIds))
+    }
+  }
+
+}

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/LeastShardAllocationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/LeastShardAllocationStrategy.scala
@@ -66,9 +66,9 @@ import akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy.Regio
         sortedAllocations: Iterable[RegionEntry]): Set[ShardId] = {
       val selected = Vector.newBuilder[ShardId]
       sortedAllocations.foreach {
-        case RegionEntry(_, _, shards) =>
-          if (shards.size > optimalPerRegion) {
-            selected ++= shards.take(shards.size - optimalPerRegion)
+        case RegionEntry(_, _, shardIds) =>
+          if (shardIds.size > optimalPerRegion) {
+            selected ++= shardIds.take(shardIds.size - optimalPerRegion)
           }
       }
       val result = selected.result()
@@ -89,9 +89,9 @@ import akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy.Regio
       } else {
         val selected = Vector.newBuilder[ShardId]
         sortedAllocations.foreach {
-          case RegionEntry(_, _, shards) =>
-            if (shards.size >= optimalPerRegion) {
-              selected += shards.head
+          case RegionEntry(_, _, shardIds) =>
+            if (shardIds.size >= optimalPerRegion) {
+              selected += shardIds.head
             }
         }
         val result = selected.result().take(min(countBelowOptimal, limit(numberOfShards))).toSet

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/LeastShardAllocationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/LeastShardAllocationStrategy.scala
@@ -43,15 +43,6 @@ import akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy.Shard
     extends AbstractLeastShardAllocationStrategy {
   import LeastShardAllocationStrategy.emptyRebalanceResult
 
-  override def allocateShard(
-      requester: ActorRef,
-      shardId: ShardId,
-      currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardId]]): Future[ActorRef] = {
-    val regionEntries = regionEntriesFor(currentShardAllocations)
-    val (region, _) = mostSuitableRegion(regionEntries)
-    Future.successful(region)
-  }
-
   override def rebalance(
       currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardId]],
       rebalanceInProgress: Set[ShardId]): Future[Set[ShardId]] = {

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/RollingUpdateShardAllocationSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/RollingUpdateShardAllocationSpec.scala
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import akka.actor.Actor
+import akka.actor.ActorLogging
+import akka.actor.Address
+import akka.actor.Props
+import akka.cluster.Cluster
+import akka.cluster.MemberStatus.Up
+import akka.serialization.jackson.CborSerializable
+import akka.testkit.ImplicitSender
+import com.typesafe.config.ConfigFactory
+import scala.concurrent.duration._
+
+object RollingUpdateShardAllocationSpecConfig
+    extends MultiNodeClusterShardingConfig(
+      additionalConfig = """
+      akka.cluster.sharding {
+        # speed up forming and handovers a bit
+        retry-interval = 500ms
+        waiting-for-state-timeout = 500ms
+        rebalance-interval = 1s
+        # we are leaving cluster nodes but they need to stay in test
+        akka.coordinated-shutdown.terminate-actor-system = off
+      }
+     """) {
+
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+  val fourth = role("fourth")
+
+  nodeConfig(first, second)(ConfigFactory.parseString("""
+      akka.cluster.app-version = 1.0.0
+      """))
+
+  nodeConfig(third, fourth)(ConfigFactory.parseString("""
+      akka.cluster.app-version = 1.0.1
+      """))
+
+}
+
+object RollingUpdateShardAllocationSpec {
+  object GiveMeYourHome {
+    case class Get(id: String) extends CborSerializable
+    case class Home(address: Address) extends CborSerializable
+
+    val extractEntityId: ShardRegion.ExtractEntityId = {
+      case g @ Get(id) => (id, g)
+    }
+
+    // shard == id to make testing easier
+    val extractShardId: ShardRegion.ExtractShardId = {
+      case Get(id) => id
+    }
+  }
+
+  class GiveMeYourHome extends Actor with ActorLogging {
+    import GiveMeYourHome._
+
+    val selfAddress = Cluster(context.system).selfAddress
+
+    log.info("Started on {}", selfAddress)
+
+    override def receive: Receive = {
+      case Get(_) =>
+        sender() ! Home(selfAddress)
+    }
+  }
+}
+
+class RollingUpdateShardAllocationSpecMultiJvmNode1 extends RollingUpdateShardAllocationSpec
+class RollingUpdateShardAllocationSpecMultiJvmNode2 extends RollingUpdateShardAllocationSpec
+class RollingUpdateShardAllocationSpecMultiJvmNode3 extends RollingUpdateShardAllocationSpec
+class RollingUpdateShardAllocationSpecMultiJvmNode4 extends RollingUpdateShardAllocationSpec
+
+abstract class RollingUpdateShardAllocationSpec
+    extends MultiNodeClusterShardingSpec(RollingUpdateShardAllocationSpecConfig)
+    with ImplicitSender {
+
+  import RollingUpdateShardAllocationSpecConfig._
+  import RollingUpdateShardAllocationSpec._
+
+  val typeName = "home"
+
+  def upMembers = cluster.state.members.filter(_.status == Up)
+
+  "Cluster sharding" must {
+
+    "form cluster" in {
+      awaitClusterUp(first, second)
+      enterBarrier("cluster-started")
+    }
+    lazy val shardRegion = startSharding(
+      system,
+      typeName = typeName,
+      entityProps = Props[GiveMeYourHome](),
+      extractEntityId = GiveMeYourHome.extractEntityId,
+      extractShardId = GiveMeYourHome.extractShardId)
+
+    "start cluster sharding on first" in {
+      runOn(first, second) {
+        shardRegion
+        shardRegion ! GiveMeYourHome.Get("id1")
+        // started on either of the nodes
+        val address1 = expectMsgType[GiveMeYourHome.Home].address
+
+        shardRegion ! GiveMeYourHome.Get("id2")
+        // started on the other of the nodes (because least
+        val address2 = expectMsgType[GiveMeYourHome.Home].address
+
+        // one on each node
+        Set(address1, address2) should have size (2)
+      }
+      enterBarrier("first-version-started")
+    }
+    "start a rolling upgrade" in {
+      join(third, first)
+
+      runOn(first, second, third) {
+        shardRegion
+
+        // new shards should now go on third since that is the highest version,
+        // however there is a race where the shard has not yet completed registration
+        // with the coordinator and shards will be allocated on the old nodes, so we need
+        // to make sure the third region has completed registration before trying
+        // if we didn't the strategy will default it back to the old nodes
+        awaitAssert {
+          shardRegion ! ShardRegion.GetCurrentRegions
+          expectMsgType[ShardRegion.CurrentRegions].regions should have size (3)
+        }
+      }
+      enterBarrier("third-region-registered")
+      runOn(first, second) {
+        shardRegion ! GiveMeYourHome.Get("id3")
+        expectMsgType[GiveMeYourHome.Home]
+      }
+      runOn(third) {
+        // now third region should be only option as the other two are old versions
+        // but first new allocated shard would anyway go there because of balance, so we
+        // need to do more than one
+        (3 to 5).foreach { n =>
+          shardRegion ! GiveMeYourHome.Get(s"id$n")
+          expectMsgType[GiveMeYourHome.Home].address should ===(Cluster(system).selfAddress)
+        }
+      }
+      enterBarrier("rolling-upgrade-in-progress")
+    }
+    "complete a rolling upgrade" in {
+      join(fourth, first)
+
+      runOn(first) {
+        val cluster = Cluster(system)
+        cluster.leave(cluster.selfAddress)
+      }
+      runOn(second, third, fourth) {
+        awaitAssert(upMembers.size should ===(3))
+      }
+      enterBarrier("first-left")
+
+      runOn(second, third, fourth) {
+        awaitAssert({
+          shardRegion ! ShardRegion.GetCurrentRegions
+          expectMsgType[ShardRegion.CurrentRegions].regions should have size (3)
+        }, 30.seconds)
+      }
+      enterBarrier("sharding-handed-off")
+
+      // trigger allocation (we don't know which id was on node 1)
+      runOn(second, third, fourth) {
+        awaitAssert {
+          shardRegion ! GiveMeYourHome.Get("id1")
+          expectMsgType[GiveMeYourHome.Home]
+
+          shardRegion ! GiveMeYourHome.Get("id2")
+          expectMsgType[GiveMeYourHome.Home]
+        }
+      }
+      enterBarrier("first-allocated")
+
+      runOn(second) {
+        val cluster = Cluster(system)
+        cluster.leave(cluster.selfAddress)
+      }
+      runOn(third, fourth) {
+        awaitAssert(upMembers.size should ===(2))
+      }
+      enterBarrier("second-left")
+
+      // trigger allocation (we don't know which id was on node 1)
+      runOn(third, fourth) {
+        awaitAssert {
+          shardRegion ! GiveMeYourHome.Get("id1")
+          val address1 = expectMsgType[GiveMeYourHome.Home].address
+          upMembers.map(_.address) should contain(address1)
+
+          shardRegion ! GiveMeYourHome.Get("id2")
+          val address2 = expectMsgType[GiveMeYourHome.Home].address
+          upMembers.map(_.address) should contain(address2)
+        }
+      }
+      enterBarrier("completo")
+    }
+
+  }
+
+}

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/DeprecatedLeastShardAllocationStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/DeprecatedLeastShardAllocationStrategySpec.scala
@@ -46,7 +46,7 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
     }
 
   "DeprecatedLeastShardAllocationStrategy" must {
-    "allocate to region with least number of shards" in {
+    "allocate to region with least number of shards [1, 1, 0]" in {
       val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 3, maxSimultaneousRebalance = 10)
       val allocations = createAllocations(aCount = 1, bCount = 1)
       allocationStrategy.allocateShard(regionA, "003", allocations).futureValue should ===(regionC)
@@ -151,14 +151,14 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
         Set("003", "004"))
     }
 
-    "limit number of simultaneous rebalance" in {
+    "limit number of simultaneous rebalance [1, 10, 0]" in {
       val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 3, maxSimultaneousRebalance = 2)
       val allocations = createAllocations(aCount = 1, bCount = 10)
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("002", "003"))
       allocationStrategy.rebalance(allocations, Set("002", "003")).futureValue should ===(Set.empty[String])
     }
 
-    "not pick shards that are in progress" in {
+    "not pick shards that are in progress [10, 0, 0]" in {
       val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 3, maxSimultaneousRebalance = 4)
       val allocations = createAllocations(aCount = 10)
       allocationStrategy.rebalance(allocations, Set("002", "003")).futureValue should ===(Set("001", "004"))

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/DeprecatedLeastShardAllocationStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/DeprecatedLeastShardAllocationStrategySpec.scala
@@ -5,15 +5,25 @@
 package akka.cluster.sharding
 
 import akka.actor.ActorRef
-import akka.actor.Props
+import akka.cluster.ClusterEvent.CurrentClusterState
+import akka.cluster.MemberStatus
+import akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy
+import akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy.RegionEntry
 import akka.testkit.AkkaSpec
+import akka.util.Version
+
+import scala.collection.immutable.SortedSet
 
 class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
-  import ShardCoordinator._
+  import LeastShardAllocationStrategySpec._
 
-  val regionA = system.actorOf(Props.empty, "regionA")
-  val regionB = system.actorOf(Props.empty, "regionB")
-  val regionC = system.actorOf(Props.empty, "regionC")
+  val memberA = newUpMember("127.0.0.1")
+  val memberB = newUpMember("127.0.0.2")
+  val memberC = newUpMember("127.0.0.3")
+
+  val regionA = newFakeRegion("regionA", memberA)
+  val regionB = newFakeRegion("regionB", memberB)
+  val regionC = newFakeRegion("regionC", memberC)
 
   def createAllocations(aCount: Int, bCount: Int = 0, cCount: Int = 0): Map[ActorRef, Vector[String]] = {
     val shards = (1 to (aCount + bCount + cCount)).map(n => ("00" + n.toString).takeRight(3))
@@ -23,15 +33,22 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
       regionC -> shards.takeRight(cCount).toVector)
   }
 
+  private def allocationStrategyWithFakeCluster(rebalanceThreshold: Int, maxSimultaneousRebalance: Int) =
+    // we don't really "start" it as we fake the cluster access
+    new ShardCoordinator.LeastShardAllocationStrategy(rebalanceThreshold, maxSimultaneousRebalance) {
+      override protected def clusterState: CurrentClusterState =
+        CurrentClusterState(SortedSet(memberA, memberB, memberC))
+    }
+
   "DeprecatedLeastShardAllocationStrategy" must {
     "allocate to region with least number of shards" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 3, maxSimultaneousRebalance = 10)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 3, maxSimultaneousRebalance = 10)
       val allocations = createAllocations(aCount = 1, bCount = 1)
       allocationStrategy.allocateShard(regionA, "003", allocations).futureValue should ===(regionC)
     }
 
     "rebalance from region with most number of shards [2, 0, 0], rebalanceThreshold=1" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 1, maxSimultaneousRebalance = 10)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 1, maxSimultaneousRebalance = 10)
       val allocations = createAllocations(aCount = 2)
 
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001"))
@@ -39,13 +56,13 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
     }
 
     "not rebalance when diff equal to threshold, [1, 1, 0], rebalanceThreshold=1" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 1, maxSimultaneousRebalance = 10)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 1, maxSimultaneousRebalance = 10)
       val allocations = createAllocations(aCount = 1, bCount = 1)
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set.empty[String])
     }
 
     "rebalance from region with most number of shards [1, 2, 0], rebalanceThreshold=1" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 1, maxSimultaneousRebalance = 10)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 1, maxSimultaneousRebalance = 10)
       val allocations = createAllocations(aCount = 1, bCount = 2)
 
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("002"))
@@ -53,7 +70,7 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
     }
 
     "rebalance from region with most number of shards [3, 0, 0], rebalanceThreshold=1" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 1, maxSimultaneousRebalance = 10)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 1, maxSimultaneousRebalance = 10)
       val allocations = createAllocations(aCount = 3)
 
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001"))
@@ -61,7 +78,7 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
     }
 
     "rebalance from region with most number of shards [4, 4, 0], rebalanceThreshold=1" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 1, maxSimultaneousRebalance = 10)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 1, maxSimultaneousRebalance = 10)
       val allocations = createAllocations(aCount = 4, bCount = 4)
 
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001"))
@@ -69,7 +86,7 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
     }
 
     "rebalance from region with most number of shards [4, 4, 2], rebalanceThreshold=1" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 1, maxSimultaneousRebalance = 10)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 1, maxSimultaneousRebalance = 10)
       val allocations = createAllocations(aCount = 4, bCount = 4, cCount = 2)
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001"))
       // not optimal, 005 stopped and started again, but ok
@@ -77,7 +94,7 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
     }
 
     "rebalance from region with most number of shards [1, 3, 0], rebalanceThreshold=2" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 2, maxSimultaneousRebalance = 10)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 2, maxSimultaneousRebalance = 10)
       val allocations = createAllocations(aCount = 1, bCount = 2)
 
       // so far regionB has 2 shards and regionC has 0 shards, but the diff is <= rebalanceThreshold
@@ -89,13 +106,13 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
     }
 
     "not rebalance when diff equal to threshold, [2, 2, 0], rebalanceThreshold=2" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 2, maxSimultaneousRebalance = 10)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 2, maxSimultaneousRebalance = 10)
       val allocations = createAllocations(aCount = 2, bCount = 2)
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set.empty[String])
     }
 
     "rebalance from region with most number of shards [3, 3, 0], rebalanceThreshold=2" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 2, maxSimultaneousRebalance = 10)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 2, maxSimultaneousRebalance = 10)
       val allocations = createAllocations(aCount = 3, bCount = 3)
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001"))
       allocationStrategy.rebalance(allocations, Set("001")).futureValue should ===(Set("004"))
@@ -103,7 +120,7 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
     }
 
     "rebalance from region with most number of shards [4, 4, 0], rebalanceThreshold=2" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 2, maxSimultaneousRebalance = 10)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 2, maxSimultaneousRebalance = 10)
       val allocations = createAllocations(aCount = 4, bCount = 4)
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001", "002"))
       allocationStrategy.rebalance(allocations, Set("001", "002")).futureValue should ===(Set("005", "006"))
@@ -111,7 +128,7 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
     }
 
     "rebalance from region with most number of shards [5, 5, 0], rebalanceThreshold=2" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 2, maxSimultaneousRebalance = 10)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 2, maxSimultaneousRebalance = 10)
       val allocations = createAllocations(aCount = 5, bCount = 5)
       // optimal would => [4, 4, 2] or even => [3, 4, 3]
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001", "002"))
@@ -121,7 +138,7 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
     }
 
     "rebalance from region with most number of shards [50, 50, 0], rebalanceThreshold=2" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 2, maxSimultaneousRebalance = 100)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 2, maxSimultaneousRebalance = 100)
       val allocations = createAllocations(aCount = 50, cCount = 50)
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("001", "002"))
       allocationStrategy.rebalance(allocations, Set("001", "002")).futureValue should ===(Set("051", "052"))
@@ -130,16 +147,89 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
     }
 
     "limit number of simultaneous rebalance" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 3, maxSimultaneousRebalance = 2)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 3, maxSimultaneousRebalance = 2)
       val allocations = createAllocations(aCount = 1, bCount = 10)
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("002", "003"))
       allocationStrategy.rebalance(allocations, Set("002", "003")).futureValue should ===(Set.empty[String])
     }
 
     "not pick shards that are in progress" in {
-      val allocationStrategy = new LeastShardAllocationStrategy(rebalanceThreshold = 3, maxSimultaneousRebalance = 4)
+      val allocationStrategy = allocationStrategyWithFakeCluster(rebalanceThreshold = 3, maxSimultaneousRebalance = 4)
       val allocations = createAllocations(aCount = 10)
       allocationStrategy.rebalance(allocations, Set("002", "003")).futureValue should ===(Set("001", "004"))
+    }
+
+    "prefer least shards, latest version, non downed, leaving or exiting nodes" in {
+      // old version, up
+      val oldMember = newUpMember("127.0.0.1", version = Version("1.0.0"))
+      // leaving, new version
+      val leavingMember = newUpMember("127.0.0.2", version = Version("1.0.0")).copy(MemberStatus.Leaving)
+      // new version, up
+      val newVersionMember1 = newUpMember("127.0.0.3", version = Version("1.0.1"))
+      // new version, up
+      val newVersionMember2 = newUpMember("127.0.0.4", version = Version("1.0.1"))
+      // new version, up
+      val newVersionMember3 = newUpMember("127.0.0.5", version = Version("1.0.1"))
+
+      val fakeLocalRegion = newFakeRegion("oldapp", oldMember)
+      val fakeRegionA = newFakeRegion("leaving", leavingMember)
+      val fakeRegionB = newFakeRegion("fewest", newVersionMember1)
+      val fakeRegionC = newFakeRegion("oneshard", newVersionMember2)
+      val fakeRegionD = newFakeRegion("most", newVersionMember3)
+
+      val shardsAndMembers =
+        Seq(
+          RegionEntry(fakeRegionB, newVersionMember1, Vector.empty),
+          RegionEntry(fakeRegionA, leavingMember, Vector.empty),
+          RegionEntry(fakeRegionD, newVersionMember3, Vector("ShardId2", "ShardId3")),
+          RegionEntry(fakeLocalRegion, oldMember, Vector.empty),
+          RegionEntry(fakeRegionC, newVersionMember2, Vector("ShardId1")))
+
+      val sortedRegions =
+        shardsAndMembers.sorted(AbstractLeastShardAllocationStrategy.ShardSuitabilityOrdering).map(_.region)
+
+      // only node b has the new version
+      sortedRegions should ===(
+        Seq(
+          fakeRegionB, // fewest shards, newest version, up
+          fakeRegionC, // newest version, up
+          fakeRegionD, // most shards, up
+          fakeLocalRegion, // old app version
+          fakeRegionA)) // leaving
+    }
+
+    "not rebalance when rolling update in progress" in {
+      val allocationStrategy =
+        new ShardCoordinator.LeastShardAllocationStrategy(rebalanceThreshold = 2, maxSimultaneousRebalance = 100) {
+
+          // multiple versions to simulate rolling update in progress
+          override protected def clusterState: CurrentClusterState =
+            CurrentClusterState(
+              SortedSet(
+                newUpMember("127.0.0.1", version = Version("1.0.0")),
+                newUpMember("127.0.0.1", version = Version("1.0.1"))))
+        }
+      val allocations = createAllocations(aCount = 5, bCount = 5)
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set.empty)
+      allocationStrategy.rebalance(allocations, Set("001", "002")).futureValue should ===(Set.empty)
+      allocationStrategy.rebalance(allocations, Set("001", "002", "051", "052")).futureValue should ===(Set.empty)
+    }
+
+    "not rebalance when regions are unreachable" in {
+      val allocationStrategy =
+        new ShardCoordinator.LeastShardAllocationStrategy(rebalanceThreshold = 2, maxSimultaneousRebalance = 100) {
+
+          val memberA = newUpMember("127.0.0.1")
+          val memberB = newUpMember("127.0.0.2")
+
+          // multiple versions to simulate rolling update in progress
+          override protected def clusterState: CurrentClusterState =
+            CurrentClusterState(SortedSet(memberA, memberB), unreachable = Set(memberB))
+        }
+      val allocations = createAllocations(aCount = 5, bCount = 5)
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set.empty)
+      allocationStrategy.rebalance(allocations, Set("001", "002")).futureValue should ===(Set.empty)
+      allocationStrategy.rebalance(allocations, Set("001", "002", "051", "052")).futureValue should ===(Set.empty)
     }
 
   }

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/LeastShardAllocationStrategyRandomizedSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/LeastShardAllocationStrategyRandomizedSpec.scala
@@ -43,6 +43,8 @@ class LeastShardAllocationStrategyRandomizedSpec extends AkkaSpec("akka.loglevel
       // we don't really "start" it as we fake the cluster access
       override protected def clusterState: ClusterEvent.CurrentClusterState =
         CurrentClusterState(clusterMembers)
+
+      override protected def selfMember: Member = clusterMembers.head
     }
 
   private val rndSeed = System.currentTimeMillis()

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/LeastShardAllocationStrategyRandomizedSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/LeastShardAllocationStrategyRandomizedSpec.scala
@@ -61,7 +61,7 @@ class LeastShardAllocationStrategyRandomizedSpec extends AkkaSpec("akka.loglevel
       iteration += 1
       val numberOfRegions = rnd.nextInt(maxRegions) + 1
       val memberArray = (1 to numberOfRegions).map(n => newUpMember("127.0.0.1", port = n)).toArray
-      clusterMembers = SortedSet(memberArray: _*)
+      clusterMembers = SortedSet(memberArray.toIndexedSeq: _*)
       val regions = (1 to numberOfRegions).map(n => newFakeRegion(s"$iteration-R$n", memberArray(n - 1)))
       val countPerRegion = regions.map { region =>
         region -> rnd.nextInt(maxShardsPerRegion)

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/LeastShardAllocationStrategyRandomizedSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/LeastShardAllocationStrategyRandomizedSpec.scala
@@ -7,15 +7,27 @@ package akka.cluster.sharding
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.util.Random
-
 import akka.actor.ActorRef
-import akka.actor.Props
+import akka.cluster.ClusterEvent
+import akka.cluster.ClusterEvent.CurrentClusterState
+import akka.cluster.Member
 import akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
 import akka.cluster.sharding.ShardRegion.ShardId
+import akka.cluster.sharding.internal.LeastShardAllocationStrategy
 import akka.testkit.AkkaSpec
 
+import scala.collection.immutable.SortedSet
+
 class LeastShardAllocationStrategyRandomizedSpec extends AkkaSpec("akka.loglevel = INFO") {
-  import LeastShardAllocationStrategySpec.{ afterRebalance, countShards, countShardsPerRegion }
+  import LeastShardAllocationStrategySpec.{
+    afterRebalance,
+    countShards,
+    countShardsPerRegion,
+    newFakeRegion,
+    newUpMember
+  }
+
+  @volatile var clusterMembers: SortedSet[Member] = SortedSet.empty
 
   def createAllocations(countPerRegion: Map[ActorRef, Int]): Map[ActorRef, immutable.IndexedSeq[ShardId]] = {
     countPerRegion.map {
@@ -24,8 +36,14 @@ class LeastShardAllocationStrategyRandomizedSpec extends AkkaSpec("akka.loglevel
     }
   }
 
-  private val strategyWithoutLimits =
-    ShardAllocationStrategy.leastShardAllocationStrategy(absoluteLimit = 100000, relativeLimit = 1.0)
+  private val strategyWithoutLimits = strategyWithFakeCluster()
+
+  private def strategyWithFakeCluster(absoluteLimit: Int = 100000, relativeLimit: Double = 1.0) =
+    new LeastShardAllocationStrategy(absoluteLimit, relativeLimit) {
+      // we don't really "start" it as we fake the cluster access
+      override protected def clusterState: ClusterEvent.CurrentClusterState =
+        CurrentClusterState(clusterMembers)
+    }
 
   private val rndSeed = System.currentTimeMillis()
   private val rnd = new Random(rndSeed)
@@ -42,7 +60,9 @@ class LeastShardAllocationStrategyRandomizedSpec extends AkkaSpec("akka.loglevel
     (1 to iterationsPerTest).foreach { _ =>
       iteration += 1
       val numberOfRegions = rnd.nextInt(maxRegions) + 1
-      val regions = (1 to numberOfRegions).map(n => system.actorOf(Props.empty, s"$iteration-R$n"))
+      val memberArray = (1 to numberOfRegions).map(n => newUpMember("127.0.0.1", port = n)).toArray
+      clusterMembers = SortedSet(memberArray: _*)
+      val regions = (1 to numberOfRegions).map(n => newFakeRegion(s"$iteration-R$n", memberArray(n - 1)))
       val countPerRegion = regions.map { region =>
         region -> rnd.nextInt(maxShardsPerRegion)
       }.toMap
@@ -117,7 +137,7 @@ class LeastShardAllocationStrategyRandomizedSpec extends AkkaSpec("akka.loglevel
       val absoluteLimit = 3 + rnd.nextInt(7) + 3
       val relativeLimit = 0.05 + (rnd.nextDouble() * 0.95)
 
-      val strategy = ShardAllocationStrategy.leastShardAllocationStrategy(absoluteLimit, relativeLimit)
+      val strategy = strategyWithFakeCluster(absoluteLimit, relativeLimit)
       testRebalance(strategy, maxRegions = 20, maxShardsPerRegion = 20, expectedMaxSteps = 20)
     }
 

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/LeastShardAllocationStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/LeastShardAllocationStrategySpec.scala
@@ -13,6 +13,7 @@ import akka.actor.MinimalActorRef
 import akka.actor.RootActorPath
 import akka.cluster.ClusterEvent
 import akka.cluster.ClusterEvent.CurrentClusterState
+import akka.cluster.ClusterSettings
 import akka.cluster.Member
 import akka.cluster.MemberStatus
 import akka.cluster.UniqueAddress
@@ -69,7 +70,10 @@ object LeastShardAllocationStrategySpec {
   }
 
   def newUpMember(host: String, port: Int = 252525, version: Version = Version("1.0.0")) =
-    Member(UniqueAddress(Address("akka", "myapp", host, port), 1L), Set.empty, version).copy(MemberStatus.Up)
+    Member(
+      UniqueAddress(Address("akka", "myapp", host, port), 1L),
+      Set(ClusterSettings.DcRolePrefix + ClusterSettings.DefaultDataCenter),
+      version).copy(MemberStatus.Up)
 
   def newFakeRegion(idForDebug: String, member: Member): ActorRef =
     new DummyActorRef(RootActorPath(member.address) / "system" / "fake" / idForDebug)
@@ -103,6 +107,7 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
     new LeastShardAllocationStrategy(absoluteLimit, relativeLimit) {
       override protected def clusterState: ClusterEvent.CurrentClusterState =
         CurrentClusterState(SortedSet(memberA, memberB, memberC))
+      override protected def selfMember: Member = memberA
     }
 
   "LeastShardAllocationStrategy" must {
@@ -258,12 +263,14 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
       val allocationStrategy =
         new LeastShardAllocationStrategy(absoluteLimit = 1000, relativeLimit = 1.0) {
 
+          val member1 = newUpMember("127.0.0.1", version = Version("1.0.0"))
+          val member2 = newUpMember("127.0.0.1", version = Version("1.0.1"))
+
           // multiple versions to simulate rolling update in progress
           override protected def clusterState: CurrentClusterState =
-            CurrentClusterState(
-              SortedSet(
-                newUpMember("127.0.0.1", version = Version("1.0.0")),
-                newUpMember("127.0.0.1", version = Version("1.0.1"))))
+            CurrentClusterState(SortedSet(member1, member2))
+
+          override protected def selfMember: Member = member1
         }
       val allocations = createAllocations(aCount = 5, bCount = 5)
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set.empty)
@@ -275,12 +282,34 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
       val allocationStrategy =
         new LeastShardAllocationStrategy(absoluteLimit = 1000, relativeLimit = 1.0) {
 
-          val memberA = newUpMember("127.0.0.1")
-          val memberB = newUpMember("127.0.0.2")
+          val member1 = newUpMember("127.0.0.1")
+          val member2 = newUpMember("127.0.0.2")
 
           // multiple versions to simulate rolling update in progress
           override protected def clusterState: CurrentClusterState =
-            CurrentClusterState(SortedSet(memberA, memberB), unreachable = Set(memberB))
+            CurrentClusterState(SortedSet(member1, member2), unreachable = Set(member2))
+          override protected def selfMember: Member = member2
+        }
+      val allocations = createAllocations(aCount = 5, bCount = 5)
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set.empty)
+      allocationStrategy.rebalance(allocations, Set("001", "002")).futureValue should ===(Set.empty)
+      allocationStrategy.rebalance(allocations, Set("001", "002", "051", "052")).futureValue should ===(Set.empty)
+    }
+    "not rebalance when members are joining dc" in {
+      val allocationStrategy =
+        new LeastShardAllocationStrategy(absoluteLimit = 1000, relativeLimit = 1.0) {
+
+          val member1 = newUpMember("127.0.0.1")
+          val member2 =
+            Member(
+              UniqueAddress(Address("akka", "myapp", "127.0.0.2", 252525), 1L),
+              Set(ClusterSettings.DcRolePrefix + ClusterSettings.DefaultDataCenter),
+              member1.appVersion)
+
+          // multiple versions to simulate rolling update in progress
+          override protected def clusterState: CurrentClusterState =
+            CurrentClusterState(SortedSet(member1, member2), unreachable = Set(member2))
+          override protected def selfMember: Member = member2
         }
       val allocations = createAllocations(aCount = 5, bCount = 5)
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set.empty)

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/LeastShardAllocationStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/LeastShardAllocationStrategySpec.scala
@@ -5,17 +5,26 @@
 package akka.cluster.sharding
 
 import scala.collection.immutable
-
 import akka.actor.ActorPath
 import akka.actor.ActorRef
 import akka.actor.ActorRefProvider
 import akka.actor.Address
 import akka.actor.MinimalActorRef
-import akka.actor.Props
 import akka.actor.RootActorPath
+import akka.cluster.ClusterEvent
+import akka.cluster.ClusterEvent.CurrentClusterState
+import akka.cluster.Member
+import akka.cluster.MemberStatus
+import akka.cluster.UniqueAddress
 import akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
 import akka.cluster.sharding.ShardRegion.ShardId
+import akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy
+import akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy.RegionEntry
+import akka.cluster.sharding.internal.LeastShardAllocationStrategy
 import akka.testkit.AkkaSpec
+import akka.util.Version
+
+import scala.collection.immutable.SortedSet
 
 object LeastShardAllocationStrategySpec {
 
@@ -54,14 +63,28 @@ object LeastShardAllocationStrategySpec {
       rebalance: Set[ShardId]): Vector[Int] = {
     countShardsPerRegion(afterRebalance(allocationStrategy, allocations, rebalance))
   }
+
+  final class DummyActorRef(val path: ActorPath) extends MinimalActorRef {
+    override def provider: ActorRefProvider = ???
+  }
+
+  def newUpMember(host: String, port: Int = 252525, version: Version = Version("1.0.0")) =
+    Member(UniqueAddress(Address("akka", "myapp", host, port), 1L), Set.empty, version).copy(MemberStatus.Up)
+
+  def newFakeRegion(idForDebug: String, member: Member): ActorRef =
+    new DummyActorRef(RootActorPath(member.address) / "system" / "fake" / idForDebug)
 }
 
 class LeastShardAllocationStrategySpec extends AkkaSpec {
-  import LeastShardAllocationStrategySpec.{ afterRebalance, allocationCountsAfterRebalance }
+  import LeastShardAllocationStrategySpec._
 
-  private val regionA = system.actorOf(Props.empty, "regionA")
-  private val regionB = system.actorOf(Props.empty, "regionB")
-  private val regionC = system.actorOf(Props.empty, "regionC")
+  val memberA = newUpMember("127.0.0.1")
+  val memberB = newUpMember("127.0.0.2")
+  val memberC = newUpMember("127.0.0.3")
+
+  val regionA = newFakeRegion("regionA", memberA)
+  val regionB = newFakeRegion("regionB", memberB)
+  val regionC = newFakeRegion("regionC", memberC)
 
   private val shards = (1 to 999).map(n => ("00" + n.toString).takeRight(3))
 
@@ -73,7 +96,14 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
   }
 
   private val strategyWithoutLimits =
-    ShardAllocationStrategy.leastShardAllocationStrategy(absoluteLimit = 1000, relativeLimit = 1.0)
+    strategyWithFakeCluster(absoluteLimit = 1000, relativeLimit = 1.0)
+
+  private def strategyWithFakeCluster(absoluteLimit: Int, relativeLimit: Double) =
+    // we don't really "start" it as we fake the cluster access
+    new LeastShardAllocationStrategy(absoluteLimit, relativeLimit) {
+      override protected def clusterState: ClusterEvent.CurrentClusterState =
+        CurrentClusterState(SortedSet(memberA, memberB, memberC))
+    }
 
   "LeastShardAllocationStrategy" must {
     "allocate to region with least number of shards" in {
@@ -163,7 +193,7 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
 
     "respect absolute limit of number shards" in {
       val allocationStrategy =
-        ShardAllocationStrategy.leastShardAllocationStrategy(absoluteLimit = 3, relativeLimit = 1.0)
+        strategyWithFakeCluster(absoluteLimit = 3, relativeLimit = 1.0)
       val allocations = createAllocations(aCount = 1, bCount = 9)
       val result = allocationStrategy.rebalance(allocations, Set.empty).futureValue
       result should ===(Set("002", "003", "004"))
@@ -172,7 +202,7 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
 
     "respect relative limit of number shards" in {
       val allocationStrategy =
-        ShardAllocationStrategy.leastShardAllocationStrategy(absoluteLimit = 5, relativeLimit = 0.3)
+        strategyWithFakeCluster(absoluteLimit = 5, relativeLimit = 0.3)
       val allocations = createAllocations(aCount = 1, bCount = 9)
       val result = allocationStrategy.rebalance(allocations, Set.empty).futureValue
       result should ===(Set("002", "003", "004"))
@@ -183,6 +213,79 @@ class LeastShardAllocationStrategySpec extends AkkaSpec {
       val allocationStrategy = strategyWithoutLimits
       val allocations = createAllocations(aCount = 10)
       allocationStrategy.rebalance(allocations, Set("002", "003")).futureValue should ===(Set.empty[String])
+    }
+
+    "prefer least shards, latest version, non downed, leaving or exiting nodes" in {
+      // old version, up
+      val oldMember = newUpMember("127.0.0.1", version = Version("1.0.0"))
+      // leaving, new version
+      val leavingMember = newUpMember("127.0.0.2", version = Version("1.0.0")).copy(MemberStatus.Leaving)
+      // new version, up
+      val newVersionMember1 = newUpMember("127.0.0.3", version = Version("1.0.1"))
+      // new version, up
+      val newVersionMember2 = newUpMember("127.0.0.4", version = Version("1.0.1"))
+      // new version, up
+      val newVersionMember3 = newUpMember("127.0.0.5", version = Version("1.0.1"))
+
+      val fakeLocalRegion = newFakeRegion("oldapp", oldMember)
+      val fakeRegionA = newFakeRegion("leaving", leavingMember)
+      val fakeRegionB = newFakeRegion("fewest", newVersionMember1)
+      val fakeRegionC = newFakeRegion("oneshard", newVersionMember2)
+      val fakeRegionD = newFakeRegion("most", newVersionMember3)
+
+      val shardsAndMembers =
+        Seq(
+          RegionEntry(fakeRegionB, newVersionMember1, Vector.empty),
+          RegionEntry(fakeRegionA, leavingMember, Vector.empty),
+          RegionEntry(fakeRegionD, newVersionMember3, Vector("ShardId2", "ShardId3")),
+          RegionEntry(fakeLocalRegion, oldMember, Vector.empty),
+          RegionEntry(fakeRegionC, newVersionMember2, Vector("ShardId1")))
+
+      val sortedRegions =
+        shardsAndMembers.sorted(AbstractLeastShardAllocationStrategy.ShardSuitabilityOrdering).map(_.region)
+
+      // only node b has the new version
+      sortedRegions should ===(
+        Seq(
+          fakeRegionB, // fewest shards, newest version, up
+          fakeRegionC, // newest version, up
+          fakeRegionD, // most shards, up
+          fakeLocalRegion, // old app version
+          fakeRegionA)) // leaving
+    }
+
+    "not rebalance when rolling update in progress" in {
+      val allocationStrategy =
+        new LeastShardAllocationStrategy(absoluteLimit = 1000, relativeLimit = 1.0) {
+
+          // multiple versions to simulate rolling update in progress
+          override protected def clusterState: CurrentClusterState =
+            CurrentClusterState(
+              SortedSet(
+                newUpMember("127.0.0.1", version = Version("1.0.0")),
+                newUpMember("127.0.0.1", version = Version("1.0.1"))))
+        }
+      val allocations = createAllocations(aCount = 5, bCount = 5)
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set.empty)
+      allocationStrategy.rebalance(allocations, Set("001", "002")).futureValue should ===(Set.empty)
+      allocationStrategy.rebalance(allocations, Set("001", "002", "051", "052")).futureValue should ===(Set.empty)
+    }
+
+    "not rebalance when regions are unreachable" in {
+      val allocationStrategy =
+        new LeastShardAllocationStrategy(absoluteLimit = 1000, relativeLimit = 1.0) {
+
+          val memberA = newUpMember("127.0.0.1")
+          val memberB = newUpMember("127.0.0.2")
+
+          // multiple versions to simulate rolling update in progress
+          override protected def clusterState: CurrentClusterState =
+            CurrentClusterState(SortedSet(memberA, memberB), unreachable = Set(memberB))
+        }
+      val allocations = createAllocations(aCount = 5, bCount = 5)
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set.empty)
+      allocationStrategy.rebalance(allocations, Set("001", "002")).futureValue should ===(Set.empty)
+      allocationStrategy.rebalance(allocations, Set("001", "002", "051", "052")).futureValue should ===(Set.empty)
     }
 
   }


### PR DESCRIPTION
Don't allocate to older nodes during rolling update and don't rebalance at all until rolling update has completed.

Refs #27368 prefer shard allocations on new nodes during rolling updates
Refs #27367 don't rebalance during rolling update
Refs #29554 don't rebalance when there are joining nodes
Refs #29553 don't allocate to leaving, downed, exiting and unreachable nodes (unreachable part not done)