### PR TITLE
testkit: do not try to use 127.x.y.255 as a test localhost address

### DIFF
--- a/akka-testkit/src/main/scala/akka/testkit/SocketUtil.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/SocketUtil.scala
@@ -82,22 +82,27 @@ object SocketUtil {
 
         val address = hostname match {
           case RANDOM_LOOPBACK_ADDRESS =>
-            if (canBindOnAlternativeLoopbackAddresses) s"127.20.${Random.nextInt(256)}.${Random.nextInt(256)}"
+            // JDK limitation? You cannot bind on addresses matching the pattern 127.x.y.255,
+            // that's why the last component must be < 255
+            if (canBindOnAlternativeLoopbackAddresses) s"127.20.${Random.nextInt(256)}.${Random.nextInt(255)}"
             else "127.0.0.1"
           case other =>
             other
         }
 
-        if (udp) {
+        val addr = new InetSocketAddress(address, 0)
+        try if (udp) {
           val ds = DatagramChannel.open().socket()
-          ds.bind(new InetSocketAddress(address, 0))
+          ds.bind(addr)
           (ds, new InetSocketAddress(address, ds.getLocalPort))
         } else {
           val ss = ServerSocketChannel.open().socket()
-          ss.bind(new InetSocketAddress(address, 0))
+          ss.bind(addr)
           (ss, new InetSocketAddress(address, ss.getLocalPort))
+        } catch {
+          case NonFatal(ex) =>
+            throw new RuntimeException(s"Binding to $addr failed with ${ex.getMessage}", ex)
         }
-
       }
       .collect { case (socket, address) => socket.close(); address }
   }


### PR DESCRIPTION
For some arcane reason, the JDK seems to block binding attempts to that
address.

Backport from https://github.com/akka/akka-http/pull/3460