### PR TITLE
Publish releases as 'github release' as well

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -116,6 +116,7 @@ Now wait until all artifacts have been properly propagated. Then:
   * Tweet about it
   * Post about it on Discuss
   * Post about it on Gitter
+  * Create a GitHub 'release' for the tag via https://github.com/akka/akka/releases with a link to the release notes
 
 ## Update references
 


### PR DESCRIPTION
To make it show up nicely in the right-side sidebar
and in links from Scala Steward

Refs #29571