### PR TITLE
A fast dropping queue implementation

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FastDroppingQueueSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FastDroppingQueueSpec.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2020-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.scaladsl
+
+import java.util.concurrent.{ CountDownLatch, ThreadLocalRandom }
+import java.util.concurrent.atomic.AtomicLong
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.impl.FastDroppingQueue
+import FastDroppingQueue.OfferResult
+import akka.stream.testkit.TestSubscriber
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.MustMatchers
+import org.scalatest.WordSpec
+
+import scala.concurrent.duration._
+
+class FastDroppingQueueSpec extends WordSpec with BeforeAndAfterAll with MustMatchers with ScalaFutures {
+  implicit val system = ActorSystem("SimpleQueueSpec")
+  implicit val mat = ActorMaterializer()
+  implicit val ec = system.dispatcher
+
+  "SimpleQueue" should {
+    "not drop elements if buffer is not full" in {
+      val sub = TestSubscriber.probe[Int]()
+      val queue =
+        FastDroppingQueue[Int](100).toMat(Sink.fromSubscriber(sub))(Keep.left).run()
+
+      val elements = 1 to 100
+
+      elements.foreach { i =>
+        queue.offer(i) mustBe OfferResult.Enqueued
+      }
+      queue.complete()
+
+      val subIt = Iterator.continually(sub.requestNext())
+      subIt.zip(elements.iterator).foreach {
+        case (subEle, origEle) => subEle mustBe origEle
+      }
+      sub.expectComplete()
+    }
+    "drop elements if buffer is full" in {
+      val sub = TestSubscriber.probe[Int]()
+      val queue =
+        FastDroppingQueue[Int](10).toMat(Sink.fromSubscriber(sub))(Keep.left).run()
+
+      val elements = 1 to 100
+
+      val histo =
+        elements
+          .map { i =>
+            queue.offer(i)
+          }
+          .groupBy(identity)
+          .mapValues(_.size)
+
+      // it should be 100 elements - 10 buffer slots = 90, but there might be other implicit buffers involved
+      histo(OfferResult.Dropped) must be > 80
+    }
+    "without cancellation only flag elements as enqueued that will also passed to downstream" in {
+      val counter = new AtomicLong()
+      val (queue, result) =
+        FastDroppingQueue[Int](100000).toMat(Sink.fold(0L)(_ + _))(Keep.both).run()
+
+      val numThreads = 32
+      val stopProb = 1000000
+      val expected = 1d / (1d - math.pow(1d - 1d / stopProb, numThreads))
+      println(s"Expected elements per thread: $expected") // variance might be quite high depending on number of threads
+      val barrier = new CountDownLatch(numThreads)
+
+      class QueueingThread extends Thread {
+        override def run(): Unit = {
+          var numElemsEnqueued = 0
+          var numElemsDropped = 0
+          def runLoop(): Unit = {
+            val r = ThreadLocalRandom.current()
+
+            while (true) {
+              val i = r.nextInt(0, Int.MaxValue)
+              queue.offer(i) match {
+                case OfferResult.Enqueued =>
+                  counter.addAndGet(i)
+                  numElemsEnqueued += 1
+                case OfferResult.Dropped =>
+                  numElemsDropped += 1
+                case _: OfferResult.CompletionResult => return // other thread completed
+              }
+
+              if ((i % stopProb) == 0) { // probabilistic exit condition
+                queue.complete()
+                return
+              }
+
+              if (i % 100 == 0) Thread.sleep(1) // probabilistic producer throttling delay
+            }
+          }
+
+          barrier.countDown()
+          barrier.await() // wait for all threads being in this state before starting race
+          runLoop()
+          println(f"Thread $getName%-20s enqueued: $numElemsEnqueued%7d dropped: $numElemsDropped%7d before completion")
+        }
+      }
+
+      (1 to numThreads).foreach { i =>
+        val t = new QueueingThread
+        t.setName(s"QueuingThread-$i")
+        t.start()
+      }
+
+      result.futureValue mustBe counter.get()
+    }
+
+  }
+
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(5.seconds)
+
+  override protected def afterAll(): Unit = system.terminate()
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/FastDroppingQueue.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/FastDroppingQueue.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2020-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.impl
+
+import java.util.concurrent.atomic.AtomicReference
+
+import akka.dispatch.AbstractBoundedNodeQueue
+import akka.stream.scaladsl.Source
+import akka.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, OutHandler }
+import akka.stream.{ Attributes, Outlet, SourceShape }
+
+import scala.annotation.tailrec
+
+trait FastDroppingQueue[T] {
+
+  /**
+   * Returns true if element could be enqueued and false if not.
+   *
+   * Even if it returns true it does not guarantee that an element also has been or will be processed by the downstream.
+   */
+  def offer(elem: T): FastDroppingQueue.OfferResult
+
+  def complete(): Unit
+  def fail(ex: Throwable): Unit
+}
+
+object FastDroppingQueue {
+
+  /**
+   * A queue of the given size that gives immediate feedback whether an element could be enqueued or not.
+   * @param size
+   * @tparam T
+   * @return
+   */
+  def apply[T](size: Int): Source[T, FastDroppingQueue[T]] =
+    Source.fromGraph(new FastDroppingQueueStage[T](size))
+
+  sealed trait OfferResult
+  object OfferResult {
+    case object Enqueued extends OfferResult
+    case object Dropped extends OfferResult
+
+    sealed trait CompletionResult extends OfferResult
+    case object Completed extends CompletionResult
+    case object Cancelled extends CompletionResult
+    case class Failed(cause: Throwable) extends CompletionResult
+  }
+}
+class FastDroppingQueueStage[T](bufferSize: Int)
+    extends GraphStageWithMaterializedValue[SourceShape[T], FastDroppingQueue[T]] {
+  val out = Outlet[T]("FastDroppingQueueStage.out")
+  val shape = SourceShape(out)
+
+  override def createLogicAndMaterializedValue(
+      inheritedAttributes: Attributes): (GraphStageLogic, FastDroppingQueue[T]) = {
+    import FastDroppingQueue._
+
+    sealed trait State
+    case object NeedsActivation extends State
+    case object Running extends State
+    case class Done(result: OfferResult.CompletionResult) extends State
+
+    val state = new AtomicReference[State](Running)
+
+    val queue = new AbstractBoundedNodeQueue[T](bufferSize) {}
+
+    object Logic extends GraphStageLogic(shape) with OutHandler {
+      setHandler(out, this)
+      val callback = getAsyncCallback[Unit] { _ =>
+        clearNeedsActivation()
+        run()
+      }
+
+      override def onPull(): Unit = run()
+
+      override def onDownstreamFinish(): Unit = {
+        setDone(Done(OfferResult.Cancelled))
+
+        super.onDownstreamFinish()
+      }
+
+      override def postStop(): Unit =
+        // drain queue
+        while (!queue.isEmpty) queue.poll()
+
+      /**
+       * Main loop of the queue. We do two volatile reads for the fast path of pushing elements
+       * from the queue to the stream: one for the state and one to poll the queue. This leads to a somewhat simple design
+       * that will quickly pick up failures from the queue interface.
+       *
+       * An even more optimized version could use a fast path in onPull to avoid reading the state for every element.
+       */
+      @tailrec
+      def run(): Unit =
+        state.get() match {
+          case Running =>
+            if (isAvailable(out)) {
+              val next = queue.poll()
+              if (next == null) { // queue empty
+                if (!setNeedsActivation())
+                  run() // didn't manage to set because stream has been completed in the meantime
+                else if (!queue.isEmpty) /* && setNeedsActivation was true */ {
+                  // tricky case: new element might have been added in the meantime without callback being sent because
+                  // NeedsActivation had not yet been set
+
+                  clearNeedsActivation()
+                  run()
+                } // else Queue.isEmpty && setNeedsActivation was true: waiting for next offer
+              } else
+                push(out, next) // and then: wait for pull
+            } // else: wait for pull
+
+          case Done(OfferResult.Completed) =>
+            if (queue.isEmpty) completeStage()
+            else if (isAvailable(out)) {
+              push(out, queue.poll())
+              run() // another round, might be empty now
+            }
+          // else !Queue.isEmpty: wait for pull to drain remaining elements
+          case Done(OfferResult.Failed(ex)) => failStage(ex)
+          case Done(OfferResult.Cancelled)  => throw new IllegalStateException // should not happen
+          case NeedsActivation              => throw new IllegalStateException // needs to be cleared before
+        }
+    }
+
+    object Mat extends FastDroppingQueue[T] {
+      override def offer(elem: T): OfferResult = state.get() match {
+        case Done(result) => result
+        case x =>
+          if (queue.add(elem)) {
+            if (x == NeedsActivation)
+              // if this thread wins the race to toggle the flag, schedule async callback here
+              if (clearNeedsActivation())
+                Logic.callback.invoke(())
+
+            OfferResult.Enqueued
+          } else
+            OfferResult.Dropped
+      }
+
+      override def complete(): Unit = // FIXME: should we fail here in some way if it was already completed?
+        if (setDone(Done(OfferResult.Completed)))
+          Logic.callback.invoke(()) // if this thread won the completion race also schedule an async callback
+      override def fail(ex: Throwable): Unit = // FIXME: should we fail here in some way if it was already completed?
+        if (setDone(Done(OfferResult.Failed(ex))))
+          Logic.callback.invoke(()) // if this thread won the completion race also schedule an async callback
+    }
+
+    // some state transition helpers
+    @tailrec
+    def setDone(done: Done): Boolean =
+      state.get() match {
+        case _: Done => false
+        case x =>
+          if (!state.compareAndSet(x, done)) setDone(done)
+          else true
+      }
+
+    @tailrec
+    def clearNeedsActivation(): Boolean =
+      state.get() match {
+        case NeedsActivation =>
+          if (!state.compareAndSet(NeedsActivation, Running)) clearNeedsActivation()
+          else true
+
+        case _ => false
+      }
+    @tailrec
+    def setNeedsActivation(): Boolean =
+      state.get() match {
+        case Running =>
+          if (!state.compareAndSet(Running, NeedsActivation)) setNeedsActivation()
+          else true
+
+        case _ => false
+      }
+
+    (Logic, Mat)
+  }
+}


### PR DESCRIPTION
This is an attempt to solve #29558 for the special case of a queue with strategy `dropNew`.

As detailed in #29557, the current queue suffers from future management overhead and has the general risk of OOM because of the future-based interface to find out if an element was dropped. If elements cannot be dropped fast enough, just tracking those futures can lead to OOM in high overload scenarios.

This queue implementation tries to avoid overhead while dropping by piggy-backing on top of our `AbstractBoundedNodeQueue` which is a fast lock-free non-blocking queue implementation that gives immediate feedback whether an element could be appended to the bounded queue or not. In the fast path, no async callbacks are required. In the fast-path, the stage adds one volatile read (in addition to the underlying queue implementation) for appending an element, and another volatile read for polling an element (+ queue).