### PR TITLE
move mima filter to right version

### DIFF
--- a/akka-cluster/src/main/mima-filters/2.6.9.backwards.excludes/issue-27300-appVersion.excludes
+++ b/akka-cluster/src/main/mima-filters/2.6.9.backwards.excludes/issue-27300-appVersion.excludes
@@ -7,3 +7,4 @@ ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.cluster.InternalClust
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.Member.apply")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.Member.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterCoreDaemon.joining")
+ProblemFilters.exclude[Problem]("akka.cluster.protobuf.msg.ClusterMessages*")


### PR DESCRIPTION
PR https://github.com/akka/akka/pull/29546 was validated before 2.6.9 but merged after.
