### PR TITLE
Restart(Source|Flow|Sink): Configurable stream restart deadline

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/RestartFlow/onFailuresWithBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartFlow/onFailuresWithBackoff.md
@@ -11,7 +11,7 @@ Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it f
 
 ## Description
 
-Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it fails using an exponential backoff.
+Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it fails using exponential backoff.
 The backoff resets back to `minBackoff` if there hasn't been a restart within `maxRestartsWithin` (which defaults to `minBackoff` if max restarts).
 
 This @apidoc[Flow] will not emit any failure as long as maxRestarts is not reached.
@@ -40,6 +40,6 @@ See also:
 
 **backpressures** during backoff and when the wrapped flow backpressures
 
-**completes** when the wrapped flow completes or maxRestarts are reached
+**completes** when the wrapped flow completes or `maxRestarts` are reached within the given time limit
 
 @@@

--- a/akka-docs/src/main/paradox/stream/operators/RestartFlow/onFailuresWithBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartFlow/onFailuresWithBackoff.md
@@ -6,22 +6,31 @@ Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it f
 
 ## Signature
 
-@apidoc[RestartFlow.onFailuresWithBackoff](RestartFlow$) { scala="#onFailuresWithBackoff[In,Out](minBackoff:scala.concurrent.duration.FiniteDuration,maxBackoff:scala.concurrent.duration.FiniteDuration,randomFactor:Double,maxRestarts:Int)(flowFactory:()=&gt;akka.stream.scaladsl.Flow[In,Out,_]):akka.stream.scaladsl.Flow[In,Out,akka.NotUsed]" java="#onFailuresWithBackoff(java.time.Duration,java.time.Duration,double,int,akka.japi.function.Creator)" }
+@apidoc[RestartFlow.onFailuresWithBackoff](RestartFlow$) { scala="#onFailuresWithBackoff[In,Out](settings:akka.stream.RestartSettings)(flowFactory:()=&gt;akka.stream.scaladsl.Flow[In,Out,_]):akka.stream.scaladsl.Flow[In,Out,akka.NotUsed]" java="#onFailuresWithBackoff(akka.stream.RestartSettings,akka.japi.function.Creator)" }
 
 
 ## Description
 
-This @apidoc[Flow] will not emit any failure
-The failures by the wrapped @apidoc[Flow] will be handled by
-restarting the wrapping @apidoc[Flow] as long as maxRestarts is not reached.
-Any termination signals sent to this @apidoc[Flow] however will terminate the wrapped @apidoc[Flow], if it's
+Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it fails using an exponential backoff.
+The backoff resets back to `minBackoff` if there hasn't been a restart within `maxRestartsWithin` (which defaults to `minBackoff` if max restarts).
+
+This @apidoc[Flow] will not emit any failure as long as maxRestarts is not reached.
+The failure of the wrapped @apidoc[Flow] will be handled by restarting it.
+However, any termination signals sent to this @apidoc[Flow] will terminate the wrapped @apidoc[Flow], if it's
 running, and then the @apidoc[Flow] will be allowed to terminate without being restarted.
 
 The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
 messages. A termination signal from either end of the wrapped @apidoc[Flow] will cause the other end to be terminated,
 and any in transit messages will be lost. During backoff, this @apidoc[Flow] will backpressure.
 
-This uses the same exponential backoff algorithm as @apidoc[Backoff$].
+This uses the same exponential backoff algorithm as @apidoc[BackoffOpts$].
+
+See also: 
+ 
+* @ref:[RestartSource.withBackoff](../RestartSource/withBackoff.md)
+* @ref:[RestartSource.onFailuresWithBackoff](../RestartSource/onFailuresWithBackoff.md)
+* @ref:[RestartFlow.withBackoff](../RestartFlow/withBackoff.md)
+* @ref:[RestartSink.withBackoff](../RestartSink/withBackoff.md)
 
 ## Reactive Streams semantics
 
@@ -30,5 +39,7 @@ This uses the same exponential backoff algorithm as @apidoc[Backoff$].
 **emits** when the wrapped flow emits
 
 **backpressures** during backoff and when the wrapped flow backpressures
+
+**completes** when the wrapped flow completes or maxRestarts are reached
 
 @@@

--- a/akka-docs/src/main/paradox/stream/operators/RestartFlow/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartFlow/withBackoff.md
@@ -10,7 +10,7 @@ Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it f
 
 ## Description
 
-Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it fails or complete using an exponential backoff.
+Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it completes or fails using exponential backoff.
 The backoff resets back to `minBackoff` if there hasn't been a restart within `maxRestartsWithin`  (which defaults to `minBackoff`).
 
 This @apidoc[Flow] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
@@ -39,6 +39,6 @@ See also:
 
 **backpressures** during backoff and when the wrapped flow backpressures
 
-**completes** when maxRestarts are reached
+**completes** when `maxRestarts` are reached within the given time limit
 
 @@@

--- a/akka-docs/src/main/paradox/stream/operators/RestartFlow/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartFlow/withBackoff.md
@@ -6,20 +6,30 @@ Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it f
 
 ## Signature
 
-@apidoc[RestartFlow.withBackoff](RestartFlow$) { scala="#withBackoff[In,Out](minBackoff:scala.concurrent.duration.FiniteDuration,maxBackoff:scala.concurrent.duration.FiniteDuration,randomFactor:Double)(flowFactory:()=&gt;akka.stream.scaladsl.Flow[In,Out,_]):akka.stream.scaladsl.Flow[In,Out,akka.NotUsed]" java="#withBackoff(java.time.Duration,java.time.Duration,double,int,akka.japi.function.Creator)" }
+@apidoc[RestartFlow.withBackoff](RestartFlow$) { scala="#withBackoff[In,Out](settings:akka.stream.RestartSettings)(flowFactory:()=&gt;akka.stream.scaladsl.Flow[In,Out,_]):akka.stream.scaladsl.Flow[In,Out,akka.NotUsed]" java="#withBackoff(akka.stream.RestartSettings,akka.japi.function.Creator)" }
 
 ## Description
 
-The resulting @apidoc[Flow] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
-completed. Any termination by the @apidoc[Flow] before that time will be handled by restarting it. Any termination
-signals sent to this @apidoc[Flow] however will terminate the wrapped @apidoc[Flow], if it's running, and then the @apidoc[Flow]
-will be allowed to terminate without being restarted.
+Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it fails or complete using an exponential backoff.
+The backoff resets back to `minBackoff` if there hasn't been a restart within `maxRestartsWithin`  (which defaults to `minBackoff`).
+
+This @apidoc[Flow] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
+completed. Any termination by the @apidoc[Flow] before that time will be handled by restarting it as long as maxRestarts
+is not reached. Any termination signals sent to this @apidoc[Flow] however will terminate the wrapped @apidoc[Flow], if it's
+running, and then the @apidoc[Flow] will be allowed to terminate without being restarted.
 
 The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
 messages. A termination signal from either end of the wrapped @apidoc[Flow] will cause the other end to be terminated,
 and any in transit messages will be lost. During backoff, this @apidoc[Flow] will backpressure.
 
-This uses the same exponential backoff algorithm as @apidoc[Backoff$].
+This uses the same exponential backoff algorithm as @apidoc[BackoffOpts$].
+
+See also: 
+ 
+* @ref:[RestartSource.withBackoff](../RestartSource/withBackoff.md)
+* @ref:[RestartSource.onFailuresWithBackoff](../RestartSource/onFailuresWithBackoff.md)
+* @ref:[RestartFlow.onFailuresWithBackoff](../RestartFlow/onFailuresWithBackoff.md)
+* @ref:[RestartSink.withBackoff](../RestartSink/withBackoff.md)
 
 ## Reactive Streams semantics
 
@@ -29,6 +39,6 @@ This uses the same exponential backoff algorithm as @apidoc[Backoff$].
 
 **backpressures** during backoff and when the wrapped flow backpressures
 
-**completes** when the wrapped flow completes
+**completes** when maxRestarts are reached
 
 @@@

--- a/akka-docs/src/main/paradox/stream/operators/RestartSink/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartSink/withBackoff.md
@@ -10,7 +10,7 @@ Wrap the given @apidoc[Sink] with a @apidoc[Sink] that will restart it when it f
 
 ## Description
 
-Wrap the given @apidoc[Sink] with a @apidoc[Sink] that will restart it when it fails or complete using an exponential backoff.
+Wrap the given @apidoc[Sink] with a @apidoc[Sink] that will restart it when it completes or fails using exponential backoff.
 The backoff resets back to `minBackoff` if there hasn't been a restart within `maxRestartsWithin`  (which defaults to `minBackoff`).
 
 This @apidoc[Sink] will not cancel as long as maxRestarts is not reached, since cancellation by the wrapped @apidoc[Sink]
@@ -31,3 +31,13 @@ See also:
 * @ref:[RestartSource.onFailuresWithBackoff](../RestartSource/onFailuresWithBackoff.md)
 * @ref:[RestartFlow.onFailuresWithBackoff](../RestartFlow/onFailuresWithBackoff.md)
 * @ref:[RestartFlow.withBackoff](../RestartFlow/withBackoff.md)
+
+## Reactive Streams semantics
+
+@@@div { .callout }
+
+**backpressures** during backoff and when the wrapped sink backpressures
+
+**completes** when upstream completes or when `maxRestarts` are reached within the given time limit
+
+@@@

--- a/akka-docs/src/main/paradox/stream/operators/RestartSink/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartSink/withBackoff.md
@@ -6,19 +6,28 @@ Wrap the given @apidoc[Sink] with a @apidoc[Sink] that will restart it when it f
 
 ## Signature
 
-@apidoc[RestartSink.withBackoff](RestartSink$) { scala="#withBackoff[T](minBackoff:scala.concurrent.duration.FiniteDuration,maxBackoff:scala.concurrent.duration.FiniteDuration,randomFactor:Double,maxRestarts:Int)(sinkFactory:()=&gt;akka.stream.scaladsl.Sink[T,_]):akka.stream.scaladsl.Sink[T,akka.NotUsed]"  java="#withBackoff(java.time.Duration,java.time.Duration,double,int,akka.japi.function.Creator)" }
-
+@apidoc[RestartSink.withBackoff](RestartSink$) { scala="#withBackoff[T](settings:akka.stream.RestartSettings)(sinkFactory:()=&gt;akka.stream.scaladsl.Sink[T,_]):akka.stream.scaladsl.Sink[T,akka.NotUsed]"  java="#withBackoff(akka.stream.RestartSettings,akka.japi.function.Creator)" }
 
 ## Description
 
-This @apidoc[Sink] will never cancel, since cancellation by the wrapped @apidoc[Sink] is always handled by restarting it.
-The wrapped @apidoc[Sink] can however be completed by feeding a completion or error into this @apidoc[Sink]. When that
-happens, the @apidoc[Sink], if currently running, will terminate and will not be restarted. This can be triggered
-simply by the upstream completing, or externally by introducing a @apidoc[KillSwitch] right before this @apidoc[Sink] in the
-graph.
+Wrap the given @apidoc[Sink] with a @apidoc[Sink] that will restart it when it fails or complete using an exponential backoff.
+The backoff resets back to `minBackoff` if there hasn't been a restart within `maxRestartsWithin`  (which defaults to `minBackoff`).
+
+This @apidoc[Sink] will not cancel as long as maxRestarts is not reached, since cancellation by the wrapped @apidoc[Sink]
+is handled by restarting it. The wrapped @apidoc[Sink] can however be completed by feeding a completion or error into
+this @apidoc[Sink]. When that happens, the @apidoc[Sink], if currently running, will terminate and will not be restarted.
+This can be triggered simply by the upstream completing, or externally by introducing a @ref[KillSwitch](../../stream-dynamic.md#controlling-stream-completion-with-killswitch) right
+before this @apidoc[Sink] in the graph.
 
 The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
 messages. When the wrapped @apidoc[Sink] does cancel, this @apidoc[Sink] will backpressure, however any elements already
 sent may have been lost.
 
-This uses the same exponential backoff algorithm as @apidoc[Backoff$].
+This uses the same exponential backoff algorithm as @apidoc[BackoffOpts$].
+
+See also: 
+ 
+* @ref:[RestartSource.withBackoff](../RestartSource/withBackoff.md)
+* @ref:[RestartSource.onFailuresWithBackoff](../RestartSource/onFailuresWithBackoff.md)
+* @ref:[RestartFlow.onFailuresWithBackoff](../RestartFlow/onFailuresWithBackoff.md)
+* @ref:[RestartFlow.withBackoff](../RestartFlow/withBackoff.md)

--- a/akka-docs/src/main/paradox/stream/operators/RestartSource/onFailuresWithBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartSource/onFailuresWithBackoff.md
@@ -10,7 +10,7 @@ Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when 
 
 ## Description
 
-Wraps the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails using an exponential backoff.
+Wraps the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails using exponential backoff.
 The backoff resets back to `minBackoff` if there hasn't been a restart within `maxRestartsWithin`  (which defaults to `minBackoff`).
  
 This @apidoc[Source] will not emit a failure as long as maxRestarts is not reached.
@@ -66,7 +66,7 @@ Java
 
 **backpressures** during backoff and when downstream backpressures
 
-**completes** when the wrapped source completes or maxRestarts is reached
+**completes** when the wrapped source completes or `maxRestarts` are reached within the given time limit
 
 **cancels** when downstream cancels
 

--- a/akka-docs/src/main/paradox/stream/operators/RestartSource/onFailuresWithBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartSource/onFailuresWithBackoff.md
@@ -1,26 +1,29 @@
 # RestartSource.onFailuresWithBackoff
 
-Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails using an exponential backoff.
+Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails using an exponential backoff. Notice that this @apidoc[Source] will not restart on completion of the wrapped flow.
 
 @ref[Error handling](../index.md#error-handling)
 
 ## Signature
 
-@apidoc[RestartSource.onFailuresWithBackoff](RestartSource$) { scala="#onFailuresWithBackoff[T](minBackoff:scala.concurrent.duration.FiniteDuration,maxBackoff:scala.concurrent.duration.FiniteDuration,randomFactor:Double)(sourceFactory:()=&gt;akka.stream.scaladsl.Source[T,_]):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#onFailuresWithBackoff(java.time.Duration,java.time.Duration,double,int,akka.japi.function.Creator)" }
+@apidoc[RestartSource.onFailuresWithBackoff](RestartSource$) { scala="#onFailuresWithBackoff[T](settings:akka.stream.RestartSettings)(sourceFactory:()=&gt;akka.stream.scaladsl.Source[T,_]):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#onFailuresWithBackoff(akka.stream.RestartSettings,akka.japi.function.Creator)" }
 
 ## Description
 
 Wraps the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails using an exponential backoff.
-The backoff resets back to `minBackoff` if there hasn't been a failure within `minBackoff`.
+The backoff resets back to `minBackoff` if there hasn't been a restart within `maxRestartsWithin`  (which defaults to `minBackoff`).
  
-This @apidoc[Source] will never emit a failure, since the failure of the wrapped @apidoc[Source] is always handled by
-restarting. The wrapped @apidoc[Source] can be completed by completing this @apidoc[Source].
-When that happens, the wrapped @apidoc[Source], if currently running will be cancelled, and it will not be restarted.
-This can be triggered by the downstream cancelling, or externally by introducing a @ref[KillSwitch](../../stream-dynamic.md#controlling-stream-completion-with-killswitch) right
-after this @apidoc[Source] in the graph.
+This @apidoc[Source] will not emit a failure as long as maxRestarts is not reached.
+The failure of the wrapped @apidoc[Source] is handled by restarting it.
+However, the wrapped @apidoc[Source] can be cancelled by cancelling this @apidoc[Source].
+When that happens, the wrapped @apidoc[Source], if currently running will, be cancelled and not restarted.
+This can be triggered by the downstream cancelling, or externally by introducing a @ref[KillSwitch](../../stream-dynamic.md#controlling-stream-completion-with-killswitch) right after this @apidoc[Source] in the graph.
+
+This uses the same exponential backoff algorithm as @apidoc[BackoffOpts$].
 
 See also: 
  
+* @ref:[RestartSource.withBackoff](../RestartSource/withBackoff.md)
 * @ref:[RestartFlow.onFailuresWithBackoff](../RestartFlow/onFailuresWithBackoff.md)
 * @ref:[RestartFlow.withBackoff](../RestartFlow/withBackoff.md)
 * @ref:[RestartSink.withBackoff](../RestartSink/withBackoff.md)
@@ -60,5 +63,11 @@ Java
 @@@div { .callout }
 
 **emits** when the wrapped source emits
+
+**backpressures** during backoff and when downstream backpressures
+
+**completes** when the wrapped source completes or maxRestarts is reached
+
+**cancels** when downstream cancels
 
 @@@

--- a/akka-docs/src/main/paradox/stream/operators/RestartSource/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartSource/withBackoff.md
@@ -10,10 +10,10 @@ Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when 
 
 ## Description
 
-Wraps the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails or completes using an exponential backoff.
+Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when it completes or fails using exponential backoff.
 The backoff resets back to `minBackoff` if there hasn't been a restart within `maxRestartsWithin`  (which defaults to `minBackoff`).
 
-This @apidoc[Source] will not emit a complete or failure as long as maxRestarts is not reached, since the completion
+This @apidoc[Source] will not emit a complete or fail as long as maxRestarts is not reached, since the completion
 or failure of the wrapped @apidoc[Source] is handled by restarting it. The wrapped @apidoc[Source] can however be cancelled
 by cancelling this @apidoc[Source]. When that happens, the wrapped @apidoc[Source], if currently running, will be cancelled,
 and it will not be restarted.
@@ -37,7 +37,7 @@ See also:
 
 **backpressures** during backoff and when downstream backpressures
 
-**completes** when maxRestarts is reached
+**completes** when `maxRestarts` are reached within the given time limit
 
 **cancels** when downstream cancels
 

--- a/akka-docs/src/main/paradox/stream/operators/RestartSource/withBackoff.md
+++ b/akka-docs/src/main/paradox/stream/operators/RestartSource/withBackoff.md
@@ -1,22 +1,33 @@
 # RestartSource.withBackoff
 
-Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails or complete using an exponential backoff.
+Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails or completes using an exponential backoff.
 
 @ref[Error handling](../index.md#error-handling)
 
 ## Signature
 
-@apidoc[RestartSource.withBackoff](RestartSource$) { scala="#withBackoff[T](minBackoff:scala.concurrent.duration.FiniteDuration,maxBackoff:scala.concurrent.duration.FiniteDuration,randomFactor:Double,maxRestarts:Int)(sourceFactory:()=&gt;akka.stream.scaladsl.Source[T,_]):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#withBackoff(java.time.Duration,java.time.Duration,double,int,akka.japi.function.Creator)" }
+@apidoc[RestartSource.withBackoff](RestartSource$) { scala="#withBackoff[T](settings:akka.stream.RestartSettings)(sourceFactory:()=&gt;akka.stream.scaladsl.Source[T,_]):akka.stream.scaladsl.Source[T,akka.NotUsed]" java="#withBackoff(akka.stream.RestartSettings,akka.japi.function.Creator)" }
 
 ## Description
 
-This @apidoc[Flow] will never emit a complete or failure, since the completion or failure of the wrapped @apidoc[Source]
-is always handled by restarting it. The wrapped @apidoc[Source] can however be cancelled by cancelling this @apidoc[Source].
-When that happens, the wrapped @apidoc[Source], if currently running will be cancelled, and it will not be restarted.
-This can be triggered simply by the downstream cancelling, or externally by introducing a @apidoc[KillSwitch] right
+Wraps the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails or completes using an exponential backoff.
+The backoff resets back to `minBackoff` if there hasn't been a restart within `maxRestartsWithin`  (which defaults to `minBackoff`).
+
+This @apidoc[Source] will not emit a complete or failure as long as maxRestarts is not reached, since the completion
+or failure of the wrapped @apidoc[Source] is handled by restarting it. The wrapped @apidoc[Source] can however be cancelled
+by cancelling this @apidoc[Source]. When that happens, the wrapped @apidoc[Source], if currently running, will be cancelled,
+and it will not be restarted.
+This can be triggered simply by the downstream cancelling, or externally by introducing a @ref[KillSwitch](../../stream-dynamic.md#controlling-stream-completion-with-killswitch) right
 after this @apidoc[Source] in the graph.
 
-This uses the same exponential backoff algorithm as @apidoc[Backoff$].
+This uses the same exponential backoff algorithm as @apidoc[BackoffOpts$].
+
+See also: 
+ 
+* @ref:[RestartSource.onFailuresWithBackoff](../RestartSource/onFailuresWithBackoff.md)
+* @ref:[RestartFlow.onFailuresWithBackoff](../RestartFlow/onFailuresWithBackoff.md)
+* @ref:[RestartFlow.withBackoff](../RestartFlow/withBackoff.md)
+* @ref:[RestartSink.withBackoff](../RestartSink/withBackoff.md)
 
 ## Reactive Streams semantics
 
@@ -24,6 +35,10 @@ This uses the same exponential backoff algorithm as @apidoc[Backoff$].
 
 **emits** when the wrapped source emits
 
-**completes** when the wrapped source completes
+**backpressures** during backoff and when downstream backpressures
+
+**completes** when maxRestarts is reached
+
+**cancels** when downstream cancels
 
 @@@

--- a/akka-docs/src/main/paradox/stream/operators/index.md
+++ b/akka-docs/src/main/paradox/stream/operators/index.md
@@ -344,9 +344,9 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 
 | |Operator|Description|
 |--|--|--|
-|RestartSource|<a name="onfailureswithbackoff"></a>@ref[onFailuresWithBackoff](RestartSource/onFailuresWithBackoff.md)|Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails using an exponential backoff.|
+|RestartSource|<a name="onfailureswithbackoff"></a>@ref[onFailuresWithBackoff](RestartSource/onFailuresWithBackoff.md)|Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails using an exponential backoff. Notice that this @apidoc[Source] will not restart on completion of the wrapped flow.|
 |RestartFlow|<a name="onfailureswithbackoff"></a>@ref[onFailuresWithBackoff](RestartFlow/onFailuresWithBackoff.md)|Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it fails using an exponential backoff. Notice that this @apidoc[Flow] will not restart on completion of the wrapped flow.|
-|RestartSource|<a name="withbackoff"></a>@ref[withBackoff](RestartSource/withBackoff.md)|Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails or complete using an exponential backoff.|
+|RestartSource|<a name="withbackoff"></a>@ref[withBackoff](RestartSource/withBackoff.md)|Wrap the given @apidoc[Source] with a @apidoc[Source] that will restart it when it fails or completes using an exponential backoff.|
 |RestartFlow|<a name="withbackoff"></a>@ref[withBackoff](RestartFlow/withBackoff.md)|Wrap the given @apidoc[Flow] with a @apidoc[Flow] that will restart it when it fails or complete using an exponential backoff.|
 |RestartSink|<a name="withbackoff"></a>@ref[withBackoff](RestartSink/withBackoff.md)|Wrap the given @apidoc[Sink] with a @apidoc[Sink] that will restart it when it fails or complete using an exponential backoff.|
 |RetryFlow|<a name="withbackoff"></a>@ref[withBackoff](RetryFlow/withBackoff.md)|Wrap the given @apidoc[Flow] and retry individual elements in that stream with an exponential backoff. A decider function tests every emitted element and can return a new element to be sent to the wrapped flow for another try.|

--- a/akka-docs/src/main/paradox/stream/stream-error.md
+++ b/akka-docs/src/main/paradox/stream/stream-error.md
@@ -114,6 +114,15 @@ when a WebSocket connection fails due to the HTTP server it's running on going d
 By using an exponential backoff, we avoid going into a tight reconnect loop, which both gives the HTTP server some time
 to recover, and it avoids using needless resources on the client side.
 
+The various restart shapes mentioned all expect an `akka.stream.RestartSettings` which configures the restart behaviour.
+Configurable parameters are:
+
+* `minBackoff` is the initial duration until the underlying stream is restarted
+* `maxBackoff` caps the exponential backoff
+* `randomFactor` allows addition of a random delay following backoff calculation
+* `maxRestarts` caps the total number of restarts
+* `maxRestartsWithin` sets a timeframe during which restarts are counted towards the same total for `maxRestarts`
+
 The following snippet shows how to create a backoff supervisor using @scala[`akka.stream.scaladsl.RestartSource`] 
 @java[`akka.stream.javadsl.RestartSource`] which will supervise the given `Source`. The `Source` in this case is a 
 stream of Server Sent Events, produced by akka-http. If the stream fails or completes at any point, the request will

--- a/akka-docs/src/test/java/jdocs/stream/RestartDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/RestartDocTest.java
@@ -62,24 +62,29 @@ public class RestartDocTest {
 
   public void recoverWithBackoffSource() {
     // #restart-with-backoff-source
-    RestartSettings settings = RestartSettings.create(
-        Duration.ofSeconds(3), // min backoff
-        Duration.ofSeconds(30), // max backoff
-        0.2 // adds 20% "noise" to vary the intervals slightly
-    ).withMaxRestarts(20, Duration.ofMinutes(5)); // limits the amount of restarts to 20 within 5 minutes
+    RestartSettings settings =
+        RestartSettings.create(
+                Duration.ofSeconds(3), // min backoff
+                Duration.ofSeconds(30), // max backoff
+                0.2 // adds 20% "noise" to vary the intervals slightly
+                )
+            .withMaxRestarts(
+                20, Duration.ofMinutes(5)); // limits the amount of restarts to 20 within 5 minutes
 
     Source<ServerSentEvent, NotUsed> eventStream =
-        RestartSource.withBackoff(settings, () ->
-            // Create a source from a future of a source
-            Source.completionStageSource(
-                // Issue a GET request on the event stream
-                Http.get(system)
-                    .singleRequest(HttpRequest.create("http://example.com/eventstream"))
-                    .thenCompose(
-                        response ->
-                            // Unmarshall it to a stream of ServerSentEvents
-                            EventStreamUnmarshalling.fromEventStream()
-                                .unmarshall(response, materializer))));
+        RestartSource.withBackoff(
+            settings,
+            () ->
+                // Create a source from a future of a source
+                Source.completionStageSource(
+                    // Issue a GET request on the event stream
+                    Http.get(system)
+                        .singleRequest(HttpRequest.create("http://example.com/eventstream"))
+                        .thenCompose(
+                            response ->
+                                // Unmarshall it to a stream of ServerSentEvents
+                                EventStreamUnmarshalling.fromEventStream()
+                                    .unmarshall(response, materializer))));
     // #restart-with-backoff-source
 
     // #with-kill-switch

--- a/akka-docs/src/test/java/jdocs/stream/RestartDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/RestartDocTest.java
@@ -9,6 +9,7 @@ import akka.actor.ActorSystem;
 import akka.stream.KillSwitch;
 import akka.stream.KillSwitches;
 import akka.stream.Materializer;
+import akka.stream.RestartSettings;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.RestartSource;
 import akka.stream.javadsl.Sink;
@@ -61,23 +62,24 @@ public class RestartDocTest {
 
   public void recoverWithBackoffSource() {
     // #restart-with-backoff-source
+    RestartSettings settings = RestartSettings.create(
+        Duration.ofSeconds(3), // min backoff
+        Duration.ofSeconds(30), // max backoff
+        0.2 // adds 20% "noise" to vary the intervals slightly
+    ).withMaxRestarts(20, Duration.ofMinutes(5)); // limits the amount of restarts to 20 within 5 minutes
+
     Source<ServerSentEvent, NotUsed> eventStream =
-        RestartSource.withBackoff(
-            Duration.ofSeconds(3), // min backoff
-            Duration.ofSeconds(30), // max backoff
-            0.2, // adds 20% "noise" to vary the intervals slightly
-            20, // limits the amount of restarts to 20
-            () ->
-                // Create a source from a future of a source
-                Source.completionStageSource(
-                    // Issue a GET request on the event stream
-                    Http.get(system)
-                        .singleRequest(HttpRequest.create("http://example.com/eventstream"))
-                        .thenCompose(
-                            response ->
-                                // Unmarshall it to a stream of ServerSentEvents
-                                EventStreamUnmarshalling.fromEventStream()
-                                    .unmarshall(response, materializer))));
+        RestartSource.withBackoff(settings, () ->
+            // Create a source from a future of a source
+            Source.completionStageSource(
+                // Issue a GET request on the event stream
+                Http.get(system)
+                    .singleRequest(HttpRequest.create("http://example.com/eventstream"))
+                    .thenCompose(
+                        response ->
+                            // Unmarshall it to a stream of ServerSentEvents
+                            EventStreamUnmarshalling.fromEventStream()
+                                .unmarshall(response, materializer))));
     // #restart-with-backoff-source
 
     // #with-kill-switch

--- a/akka-docs/src/test/java/jdocs/stream/operators/source/Restart.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/source/Restart.java
@@ -35,7 +35,8 @@ public class Restart {
                 }));
     Source<Creator<Integer>, NotUsed> forever =
         RestartSource.onFailuresWithBackoff(
-                RestartSettings.create(Duration.ofSeconds(1), Duration.ofSeconds(10), 0.1), () -> flakySource);
+            RestartSettings.create(Duration.ofSeconds(1), Duration.ofSeconds(10), 0.1),
+            () -> flakySource);
     forever.runWith(
         Sink.foreach((Creator<Integer> nr) -> system.log().info("{}", nr.create())), system);
     // logs
@@ -100,7 +101,8 @@ public class Restart {
                 }));
     UniqueKillSwitch stopRestarting =
         RestartSource.onFailuresWithBackoff(
-                RestartSettings.create(Duration.ofSeconds(1), Duration.ofSeconds(10), 0.1), () -> flakySource)
+                RestartSettings.create(Duration.ofSeconds(1), Duration.ofSeconds(10), 0.1),
+                () -> flakySource)
             .viaMat(KillSwitches.single(), Keep.right())
             .toMat(Sink.foreach(nr -> System.out.println("nr " + nr.create())), Keep.left())
             .run(system);

--- a/akka-docs/src/test/java/jdocs/stream/operators/source/Restart.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/source/Restart.java
@@ -8,6 +8,7 @@ import akka.NotUsed;
 import akka.actor.Cancellable;
 import akka.japi.Creator;
 import akka.stream.KillSwitches;
+import akka.stream.RestartSettings;
 import akka.stream.UniqueKillSwitch;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.RestartSource;
@@ -34,7 +35,7 @@ public class Restart {
                 }));
     Source<Creator<Integer>, NotUsed> forever =
         RestartSource.onFailuresWithBackoff(
-            Duration.ofSeconds(1), Duration.ofSeconds(10), 0.1, () -> flakySource);
+                RestartSettings.create(Duration.ofSeconds(1), Duration.ofSeconds(10), 0.1), () -> flakySource);
     forever.runWith(
         Sink.foreach((Creator<Integer> nr) -> system.log().info("{}", nr.create())), system);
     // logs
@@ -99,7 +100,7 @@ public class Restart {
                 }));
     UniqueKillSwitch stopRestarting =
         RestartSource.onFailuresWithBackoff(
-                Duration.ofSeconds(1), Duration.ofSeconds(10), 0.1, () -> flakySource)
+                RestartSettings.create(Duration.ofSeconds(1), Duration.ofSeconds(10), 0.1), () -> flakySource)
             .viaMat(KillSwitches.single(), Keep.right())
             .toMat(Sink.foreach(nr -> System.out.println("nr " + nr.create())), Keep.left())
             .run(system);

--- a/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
@@ -38,7 +38,7 @@ class RestartDocSpec extends AkkaSpec with CompileOnlySpec {
         minBackoff = 3.seconds,
         maxBackoff = 30.seconds,
         randomFactor = 0.2) // adds 20% "noise" to vary the intervals slightly
-        .withMaxRestarts(20) // limits the amount of restarts to 20
+        .withMaxRestarts(20, 5.minutes) // limits the amount of restarts to 20 within 5 minutes
       ) { () =>
         // Create a source from a future of a source
         Source.futureSource {

--- a/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
@@ -34,12 +34,13 @@ class RestartDocSpec extends AkkaSpec with CompileOnlySpec {
     "demonstrate a restart with backoff source" in compileOnlySpec {
 
       //#restart-with-backoff-source
-      val restartSource = RestartSource.withBackoff(RestartSettings(
+      val settings = RestartSettings(
         minBackoff = 3.seconds,
         maxBackoff = 30.seconds,
-        randomFactor = 0.2) // adds 20% "noise" to vary the intervals slightly
-        .withMaxRestarts(20, 5.minutes) // limits the amount of restarts to 20 within 5 minutes
-      ) { () =>
+        randomFactor = 0.2 // adds 20% "noise" to vary the intervals slightly
+      ).withMaxRestarts(20, 5.minutes) // limits the amount of restarts to 20 within 5 minutes
+
+      val restartSource = RestartSource.withBackoff(settings) { () =>
         // Create a source from a future of a source
         Source.futureSource {
           // Make a single request with akka-http

--- a/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/RestartDocSpec.scala
@@ -5,7 +5,7 @@
 package docs.stream
 
 import akka.NotUsed
-import akka.stream.KillSwitches
+import akka.stream.{ KillSwitches, RestartSettings }
 import akka.stream.scaladsl._
 import akka.testkit.AkkaSpec
 import docs.CompileOnlySpec
@@ -34,11 +34,11 @@ class RestartDocSpec extends AkkaSpec with CompileOnlySpec {
     "demonstrate a restart with backoff source" in compileOnlySpec {
 
       //#restart-with-backoff-source
-      val restartSource = RestartSource.withBackoff(
+      val restartSource = RestartSource.withBackoff(RestartSettings(
         minBackoff = 3.seconds,
         maxBackoff = 30.seconds,
-        randomFactor = 0.2, // adds 20% "noise" to vary the intervals slightly
-        maxRestarts = 20 // limits the amount of restarts to 20
+        randomFactor = 0.2) // adds 20% "noise" to vary the intervals slightly
+        .withMaxRestarts(20) // limits the amount of restarts to 20
       ) { () =>
         // Create a source from a future of a source
         Source.futureSource {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -55,8 +55,7 @@ import akka.persistence.typed.internal.JournalInteractions.EventToPersist
 import akka.persistence.typed.internal.Running.WithSeqNrAccessible
 import akka.persistence.typed.scaladsl.Effect
 import akka.stream.scaladsl.Keep
-import akka.stream.SystemMaterializer
-import akka.stream.WatchedActorTerminatedException
+import akka.stream.{ RestartSettings, SystemMaterializer, WatchedActorTerminatedException }
 import akka.stream.scaladsl.Source
 import akka.stream.scaladsl.{ RestartSource, Sink }
 import akka.stream.typed.scaladsl.ActorFlow
@@ -144,7 +143,7 @@ private[akka] object Running {
 
         import akka.actor.typed.scaladsl.AskPattern._
         val source = RestartSource
-          .withBackoff(2.seconds, 10.seconds, randomFactor = 0.2) { () =>
+          .withBackoff(RestartSettings(2.seconds, 10.seconds, randomFactor = 0.2)) { () =>
             Source.futureSource {
               setup.context.self.ask[Long](replyTo => GetSeenSequenceNr(replicaId, replyTo)).map { seqNr =>
                 replication

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -35,6 +35,7 @@ import akka.stream.Attributes.LogLevels
 import akka.stream.IgnoreComplete
 import akka.stream.KillSwitches
 import akka.stream.Materializer
+import akka.stream.RestartSettings
 import akka.stream.SharedKillSwitch
 import akka.stream.SinkShape
 import akka.stream.scaladsl.Flow
@@ -208,10 +209,8 @@ private[remote] class ArteryTcpTransport(
       // stream. For message stream it's best effort retry a few times.
       RestartFlow
         .withBackoff[ByteString, ByteString](
-          settings.Advanced.OutboundRestartBackoff,
-          settings.Advanced.OutboundRestartBackoff * 5,
-          0.1,
-          maxRestarts)(flowFactory)
+          RestartSettings(settings.Advanced.OutboundRestartBackoff, settings.Advanced.OutboundRestartBackoff * 5, 0.1)
+            .withMaxRestarts(maxRestarts))(flowFactory)
         // silence "Restarting graph due to failure" logging by RestartFlow
         .addAttributes(Attributes.logLevels(onFailure = LogLevels.Off))
 

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/ArteryTcpTransport.scala
@@ -210,7 +210,7 @@ private[remote] class ArteryTcpTransport(
       RestartFlow
         .withBackoff[ByteString, ByteString](
           RestartSettings(settings.Advanced.OutboundRestartBackoff, settings.Advanced.OutboundRestartBackoff * 5, 0.1)
-            .withMaxRestarts(maxRestarts))(flowFactory)
+            .withMaxRestarts(maxRestarts, settings.Advanced.OutboundRestartBackoff))(flowFactory)
         // silence "Restarting graph due to failure" logging by RestartFlow
         .addAttributes(Attributes.logLevels(onFailure = LogLevels.Off))
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
@@ -292,7 +292,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
       probe.cancel()
     }
 
-    "allow using maxRestartsWithin instead of minBackoff to determine maxRestarts reset time" in assertAllStagesStopped {
+    "allow using withMaxRestarts instead of minBackoff to determine the maxRestarts reset time" in assertAllStagesStopped {
       val created = new AtomicInteger()
       val probe = RestartSource
         .withBackoff(shortRestartSettings.withMaxRestarts(2, 1.second)) { () =>
@@ -517,7 +517,7 @@ class RestartSpec extends StreamSpec(Map("akka.test.single-expect-default" -> "1
       probe.sendComplete()
     }
 
-    "allow using maxRestartsWithin instead of minBackoff to determine maxRestarts reset time" in assertAllStagesStopped {
+    "allow using withMaxRestarts instead of minBackoff to determine the maxRestarts reset time" in assertAllStagesStopped {
       val created = new AtomicInteger()
       val (queue, sinkProbe) = TestSource.probe[String].toMat(TestSink.probe)(Keep.both).run()
       val probe = TestSource

--- a/akka-stream/src/main/mima-filters/2.6.9.backwards.excludes/29591-restart-deadline.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.6.9.backwards.excludes/29591-restart-deadline.backwards.excludes
@@ -1,4 +1,5 @@
 # Changes to private internals
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.scaladsl.RestartWithBackoffLogic.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartWithBackoffLogic.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartWithBackoffSource.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartWithBackoffFlow.this")

--- a/akka-stream/src/main/mima-filters/2.6.9.backwards.excludes/29591-restart-deadline.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.6.9.backwards.excludes/29591-restart-deadline.backwards.excludes
@@ -1,0 +1,5 @@
+# Changes to private internals
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartWithBackoffLogic.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartWithBackoffSource.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartWithBackoffFlow.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.RestartWithBackoffSink.this")

--- a/akka-stream/src/main/scala/akka/stream/RestartSettings.scala
+++ b/akka-stream/src/main/scala/akka/stream/RestartSettings.scala
@@ -41,6 +41,14 @@ final class RestartSettings private (
   def withMaxRestarts(count: Int, within: java.time.Duration): RestartSettings =
     copy(maxRestarts = count, maxRestartsWithin = within.asScala)
 
+  override def toString: String =
+    "RestartSettings(" +
+    s"minBackoff=$minBackoff," +
+    s"maxBackoff=$maxBackoff," +
+    s"randomFactor=$randomFactor," +
+    s"maxRestarts=$maxRestarts," +
+    s"maxRestartsWithin=$maxRestartsWithin)"
+
   private def copy(
       minBackoff: FiniteDuration = minBackoff,
       maxBackoff: FiniteDuration = maxBackoff,

--- a/akka-stream/src/main/scala/akka/stream/RestartSettings.scala
+++ b/akka-stream/src/main/scala/akka/stream/RestartSettings.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream
+
+import scala.concurrent.duration.FiniteDuration
+
+import akka.util.JavaDurationConverters._
+
+final class RestartSettings private (
+    val minBackoff: FiniteDuration,
+    val maxBackoff: FiniteDuration,
+    val randomFactor: Double,
+    val maxRestarts: Int,
+    val maxRestartsWithin: FiniteDuration) {
+
+  /** Scala API: minimum (initial) duration until the child actor will started again, if it is terminated */
+  def withMinBackoff(value: FiniteDuration): RestartSettings = copy(minBackoff = value)
+
+  /** Java API: minimum (initial) duration until the child actor will started again, if it is terminated */
+  def withMinBackoff(value: java.time.Duration): RestartSettings = copy(minBackoff = value.asScala)
+
+  /** Scala API: the exponential back-off is capped to this duration */
+  def withMaxBackoff(value: FiniteDuration): RestartSettings = copy(maxBackoff = value)
+
+  /** Java API: the exponential back-off is capped to this duration */
+  def withMaxBackoff(value: java.time.Duration): RestartSettings = copy(maxBackoff = value.asScala)
+
+  /**
+   * After calculation of the exponential back-off an additional random delay based on this factor is added
+   * e.g. `0.2` adds up to `20%` delay.  In order to skip this additional delay pass in `0`
+   */
+  def withRandomFactor(value: Double): RestartSettings = copy(randomFactor = value)
+
+  /** The amount of restarts is capped to this amount within a timeframe of [[maxRestartsWithin]] */
+  def withMaxRestarts(value: Int): RestartSettings = copy(maxRestarts = value)
+
+  /** Scala API: the duration after which to reset the restart count and current exponential backoff */
+  def withMaxRestartsWithin(value: FiniteDuration): RestartSettings = copy(maxRestartsWithin = value)
+
+  /** Java API: the duration after which to reset the restart count and current exponential backoff */
+  def withMaxRestartsWithin(value: java.time.Duration): RestartSettings = copy(maxRestartsWithin = value.asScala)
+
+  private def copy(
+      minBackoff: FiniteDuration = minBackoff,
+      maxBackoff: FiniteDuration = maxBackoff,
+      randomFactor: Double = randomFactor,
+      maxRestarts: Int = maxRestarts,
+      maxRestartsWithin: FiniteDuration = maxRestartsWithin): RestartSettings =
+    new RestartSettings(minBackoff, maxBackoff, randomFactor, maxRestarts, maxRestartsWithin)
+
+}
+
+object RestartSettings {
+
+  /** Scala API */
+  def apply(minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double): RestartSettings =
+    new RestartSettings(
+      minBackoff = minBackoff,
+      maxBackoff = maxBackoff,
+      randomFactor = randomFactor,
+      maxRestarts = Int.MaxValue,
+      maxRestartsWithin = minBackoff)
+
+  /** Java API */
+  def create(minBackoff: java.time.Duration, maxBackoff: java.time.Duration, randomFactor: Double): RestartSettings =
+    new RestartSettings(
+      minBackoff = minBackoff.asScala,
+      maxBackoff = maxBackoff.asScala,
+      randomFactor = randomFactor,
+      maxRestarts = Int.MaxValue,
+      maxRestartsWithin = minBackoff.asScala)
+}

--- a/akka-stream/src/main/scala/akka/stream/RestartSettings.scala
+++ b/akka-stream/src/main/scala/akka/stream/RestartSettings.scala
@@ -33,14 +33,13 @@ final class RestartSettings private (
    */
   def withRandomFactor(value: Double): RestartSettings = copy(randomFactor = value)
 
-  /** The amount of restarts is capped to this amount within a timeframe of [[maxRestartsWithin]] */
-  def withMaxRestarts(value: Int): RestartSettings = copy(maxRestarts = value)
+  /** Scala API: The amount of restarts is capped to `count` within a timeframe of `within` */
+  def withMaxRestarts(count: Int, within: FiniteDuration): RestartSettings =
+    copy(maxRestarts = count, maxRestartsWithin = within)
 
-  /** Scala API: the duration after which to reset the restart count and current exponential backoff */
-  def withMaxRestartsWithin(value: FiniteDuration): RestartSettings = copy(maxRestartsWithin = value)
-
-  /** Java API: the duration after which to reset the restart count and current exponential backoff */
-  def withMaxRestartsWithin(value: java.time.Duration): RestartSettings = copy(maxRestartsWithin = value.asScala)
+  /** Java API: The amount of restarts is capped to `count` within a timeframe of `within` */
+  def withMaxRestarts(count: Int, within: java.time.Duration): RestartSettings =
+    copy(maxRestarts = count, maxRestartsWithin = within.asScala)
 
   private def copy(
       minBackoff: FiniteDuration = minBackoff,

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartFlow.scala
@@ -184,9 +184,10 @@ object RestartFlow {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of resetDeadline.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of maxRestartsWithin.
    *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
-   * @param resetDeadline the duration after which to reset the restart count and current exponential
+   * @param maxRestartsWithin the duration after which to reset the restart count and current exponential backoff
+   *   back to `0` and minBackoff respectively
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
   def withBackoff[In, Out](
@@ -194,11 +195,11 @@ object RestartFlow {
       maxBackoff: java.time.Duration,
       randomFactor: Double,
       maxRestarts: Int,
-      resetDeadline: java.time.Duration,
+      maxRestartsWithin: java.time.Duration,
       flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
     import akka.util.JavaDurationConverters._
     akka.stream.scaladsl.RestartFlow
-      .withBackoff(minBackoff.asScala, maxBackoff.asScala, randomFactor, maxRestarts, resetDeadline.asScala) { () =>
+      .withBackoff(minBackoff.asScala, maxBackoff.asScala, randomFactor, maxRestarts, maxRestartsWithin.asScala) { () =>
         flowFactory.create().asScala
       }
       .asJava
@@ -298,9 +299,10 @@ object RestartFlow {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of resetDeadline.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of maxRestartsWithin.
    *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
-   * @param resetDeadline the duration after which to reset the restart count and current exponential
+   * @param maxRestartsWithin the duration after which to reset the restart count and current exponential backoff
+   *   back to `0` and minBackoff respectively
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
   def onFailuresWithBackoff[In, Out](
@@ -308,13 +310,17 @@ object RestartFlow {
       maxBackoff: java.time.Duration,
       randomFactor: Double,
       maxRestarts: Int,
-      resetDeadline: java.time.Duration,
+      maxRestartsWithin: java.time.Duration,
       flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
     import akka.util.JavaDurationConverters._
     akka.stream.scaladsl.RestartFlow
-      .onFailuresWithBackoff(minBackoff.asScala, maxBackoff.asScala, randomFactor, maxRestarts, resetDeadline.asScala) {
-        () =>
-          flowFactory.create().asScala
+      .onFailuresWithBackoff(
+        minBackoff.asScala,
+        maxBackoff.asScala,
+        randomFactor,
+        maxRestarts,
+        maxRestartsWithin.asScala) { () =>
+        flowFactory.create().asScala
       }
       .asJava
   }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartFlow.scala
@@ -32,7 +32,7 @@ object RestartFlow {
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -66,7 +66,7 @@ object RestartFlow {
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -100,7 +100,7 @@ object RestartFlow {
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -137,7 +137,7 @@ object RestartFlow {
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -174,7 +174,7 @@ object RestartFlow {
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param settings [[RestartSettings]] defining restart configuration
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
@@ -199,7 +199,7 @@ object RestartFlow {
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -236,7 +236,7 @@ object RestartFlow {
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -273,7 +273,7 @@ object RestartFlow {
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param settings [[RestartSettings]] defining restart configuration
    * @param flowFactory A factory for producing the [[Flow]] to wrap.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartFlow.scala
@@ -35,8 +35,7 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -72,8 +71,7 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -105,8 +103,7 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -145,8 +142,7 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -155,25 +151,22 @@ object RestartFlow {
    *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
-  @silent("deprecated")
   def withBackoff[In, Out](
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
       randomFactor: Double,
       maxRestarts: Int,
-      flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
-    import akka.util.JavaDurationConverters._
-    withBackoff(minBackoff.asScala, maxBackoff.asScala, randomFactor, maxRestarts, flowFactory)
-  }
+      flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] =
+    withBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts, minBackoff, flowFactory)
 
   /**
-   * Wrap the given [[Flow]] with a [[Flow]] that will restart only when it fails that restarts
-   * using an exponential backoff.
+   * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails or complete using an exponential
+   * backoff.
    *
-   * This new [[Flow]] will not emit failures. Any failure by the original [[Flow]] (the wrapped one) before that
-   * time will be handled by restarting it as long as maxRestarts  is not reached.
-   * However, any termination signals, completion or cancellation sent to this [[Flow]] will terminate
-   * the wrapped [[Flow]], if it's running, and then the [[Flow]] will be allowed to terminate without being restarted.
+   * This [[Flow]] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
+   * completed. Any termination by the [[Flow]] before that time will be handled by restarting it as long as maxRestarts
+   * is not reached. Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
+   * running, and then the [[Flow]] will be allowed to terminate without being restarted.
    *
    * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
@@ -181,26 +174,26 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of resetDeadline.
    *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
+   * @param resetDeadline the duration after which to reset the restart count and current exponential
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
-  @Deprecated
-  @deprecated("Use the overloaded one which accepts java.time.Duration instead.", since = "2.5.12")
-  def onFailuresWithBackoff[In, Out](
-      minBackoff: FiniteDuration,
-      maxBackoff: FiniteDuration,
+  def withBackoff[In, Out](
+      minBackoff: java.time.Duration,
+      maxBackoff: java.time.Duration,
       randomFactor: Double,
       maxRestarts: Int,
+      resetDeadline: java.time.Duration,
       flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
+    import akka.util.JavaDurationConverters._
     akka.stream.scaladsl.RestartFlow
-      .onFailuresWithBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts) { () =>
+      .withBackoff(minBackoff.asScala, maxBackoff.asScala, randomFactor, maxRestarts, resetDeadline.asScala) { () =>
         flowFactory.create().asScala
       }
       .asJava
@@ -221,8 +214,7 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -231,14 +223,91 @@ object RestartFlow {
    *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
-  @silent("deprecated")
+  @Deprecated
+  @deprecated("Use the overloaded one which accepts java.time.Duration instead.", since = "2.5.12")
+  def onFailuresWithBackoff[In, Out](
+      minBackoff: FiniteDuration,
+      maxBackoff: FiniteDuration,
+      randomFactor: Double,
+      maxRestarts: Int,
+      flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
+    akka.stream.scaladsl.RestartFlow
+      .onFailuresWithBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts, minBackoff) { () =>
+        flowFactory.create().asScala
+      }
+      .asJava
+  }
+
+  /**
+   * Wrap the given [[Flow]] with a [[Flow]] that will restart only when it fails that restarts
+   * using an exponential backoff.
+   *
+   * This new [[Flow]] will not emit failures. Any failure by the original [[Flow]] (the wrapped one) before that
+   * time will be handled by restarting it as long as maxRestarts  is not reached.
+   * However, any termination signals, completion or cancellation sent to this [[Flow]] will terminate
+   * the wrapped [[Flow]], if it's running, and then the [[Flow]] will be allowed to terminate without being restarted.
+   *
+   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+   * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
+   * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
+   * @param flowFactory A factory for producing the [[Flow]] to wrap.
+   */
   def onFailuresWithBackoff[In, Out](
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
       randomFactor: Double,
       maxRestarts: Int,
+      flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] =
+    onFailuresWithBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts, minBackoff, flowFactory)
+
+  /**
+   * Wrap the given [[Flow]] with a [[Flow]] that will restart only when it fails that restarts
+   * using an exponential backoff.
+   *
+   * This new [[Flow]] will not emit failures. Any failure by the original [[Flow]] (the wrapped one) before that
+   * time will be handled by restarting it as long as maxRestarts  is not reached.
+   * However, any termination signals, completion or cancellation sent to this [[Flow]] will terminate
+   * the wrapped [[Flow]], if it's running, and then the [[Flow]] will be allowed to terminate without being restarted.
+   *
+   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+   * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
+   * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of resetDeadline.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
+   * @param resetDeadline the duration after which to reset the restart count and current exponential
+   * @param flowFactory A factory for producing the [[Flow]] to wrap.
+   */
+  def onFailuresWithBackoff[In, Out](
+      minBackoff: java.time.Duration,
+      maxBackoff: java.time.Duration,
+      randomFactor: Double,
+      maxRestarts: Int,
+      resetDeadline: java.time.Duration,
       flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
     import akka.util.JavaDurationConverters._
-    onFailuresWithBackoff(minBackoff.asScala, maxBackoff.asScala, randomFactor, maxRestarts, flowFactory)
+    akka.stream.scaladsl.RestartFlow
+      .onFailuresWithBackoff(minBackoff.asScala, maxBackoff.asScala, randomFactor, maxRestarts, resetDeadline.asScala) {
+        () =>
+          flowFactory.create().asScala
+      }
+      .asJava
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartFlow.scala
@@ -35,7 +35,8 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -71,7 +72,8 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -103,7 +105,8 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -142,7 +145,8 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -174,7 +178,8 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -214,7 +219,8 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -253,7 +259,8 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -285,7 +292,8 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartFlow.scala
@@ -120,7 +120,7 @@ object RestartFlow {
       randomFactor: Double,
       maxRestarts: Int,
       flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
-    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings, flowFactory)
   }
 
@@ -157,7 +157,7 @@ object RestartFlow {
       randomFactor: Double,
       maxRestarts: Int,
       flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
-    val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings, flowFactory)
   }
 
@@ -219,7 +219,7 @@ object RestartFlow {
       randomFactor: Double,
       maxRestarts: Int,
       flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
-    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     onFailuresWithBackoff(settings, flowFactory)
   }
 
@@ -256,7 +256,7 @@ object RestartFlow {
       randomFactor: Double,
       maxRestarts: Int,
       flowFactory: Creator[Flow[In, Out, _]]): Flow[In, Out, NotUsed] = {
-    val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     onFailuresWithBackoff(settings, flowFactory)
   }
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartSink.scala
@@ -189,9 +189,10 @@ object RestartSink {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of resetDeadline.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of maxRestartsWithin.
    *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
-   * @param resetDeadline the duration after which to reset the restart count and current exponential
+   * @param maxRestartsWithin the duration after which to reset the restart count and current exponential backoff
+   *   back to `0` and minBackoff respectively
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
   def withBackoff[T](
@@ -199,11 +200,11 @@ object RestartSink {
       maxBackoff: java.time.Duration,
       randomFactor: Double,
       maxRestarts: Int,
-      resetDeadline: java.time.Duration,
+      maxRestartsWithin: java.time.Duration,
       sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] = {
     import akka.util.JavaDurationConverters._
     akka.stream.scaladsl.RestartSink
-      .withBackoff(minBackoff.asScala, maxBackoff.asScala, randomFactor, maxRestarts, resetDeadline.asScala) { () =>
+      .withBackoff(minBackoff.asScala, maxBackoff.asScala, randomFactor, maxRestarts, maxRestartsWithin.asScala) { () =>
         sinkFactory.create().asScala
       }
       .asJava

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartSink.scala
@@ -33,7 +33,7 @@ object RestartSink {
    * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
    * sent may have been lost.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -68,7 +68,7 @@ object RestartSink {
    * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
    * sent may have been lost.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -103,7 +103,7 @@ object RestartSink {
    * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
    * sent may have been lost.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -141,7 +141,7 @@ object RestartSink {
    * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
    * sent may have been lost.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -179,7 +179,7 @@ object RestartSink {
    * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
    * sent may have been lost.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param settings [[RestartSettings]] defining restart configuration
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartSink.scala
@@ -36,8 +36,7 @@ object RestartSink {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -74,8 +73,7 @@ object RestartSink {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -108,8 +106,7 @@ object RestartSink {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -149,8 +146,7 @@ object RestartSink {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -159,14 +155,52 @@ object RestartSink {
    *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
-  @silent("deprecated")
   def withBackoff[T](
       minBackoff: java.time.Duration,
       maxBackoff: java.time.Duration,
       randomFactor: Double,
       maxRestarts: Int,
+      sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] =
+    withBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts, minBackoff, sinkFactory)
+
+  /**
+   * Wrap the given [[Sink]] with a [[Sink]] that will restart it when it fails or complete using an exponential
+   * backoff.
+   *
+   * This [[Sink]] will not cancel as long as maxRestarts is not reached, since cancellation by the wrapped [[Sink]]
+   * is handled by restarting it. The wrapped [[Sink]] can however be completed by feeding a completion or error into
+   * this [[Sink]]. When that happens, the [[Sink]], if currently running, will terminate and will not be restarted.
+   * This can be triggered simply by the upstream completing, or externally by introducing a [[KillSwitch]] right
+   * before this [[Sink]] in the graph.
+   *
+   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+   * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
+   * sent may have been lost.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of resetDeadline.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
+   * @param resetDeadline the duration after which to reset the restart count and current exponential
+   * @param sinkFactory A factory for producing the [[Sink]] to wrap.
+   */
+  def withBackoff[T](
+      minBackoff: java.time.Duration,
+      maxBackoff: java.time.Duration,
+      randomFactor: Double,
+      maxRestarts: Int,
+      resetDeadline: java.time.Duration,
       sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] = {
     import akka.util.JavaDurationConverters._
-    withBackoff(minBackoff.asScala, maxBackoff.asScala, randomFactor, maxRestarts, sinkFactory)
+    akka.stream.scaladsl.RestartSink
+      .withBackoff(minBackoff.asScala, maxBackoff.asScala, randomFactor, maxRestarts, resetDeadline.asScala) { () =>
+        sinkFactory.create().asScala
+      }
+      .asJava
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartSink.scala
@@ -123,7 +123,7 @@ object RestartSink {
       randomFactor: Double,
       maxRestarts: Int,
       sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] = {
-    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings, sinkFactory)
   }
 
@@ -161,7 +161,7 @@ object RestartSink {
       randomFactor: Double,
       maxRestarts: Int,
       sinkFactory: Creator[Sink[T, _]]): Sink[T, NotUsed] = {
-    val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings, sinkFactory)
   }
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartSink.scala
@@ -36,7 +36,8 @@ object RestartSink {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -73,7 +74,8 @@ object RestartSink {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -106,7 +108,8 @@ object RestartSink {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -146,7 +149,8 @@ object RestartSink {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -179,7 +183,8 @@ object RestartSink {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartSource.scala
@@ -30,7 +30,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -58,7 +59,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -85,7 +87,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -122,7 +125,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -152,7 +156,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor
+   *   will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -188,7 +193,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -216,7 +222,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -242,7 +249,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -278,7 +286,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -307,7 +316,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor
+   *   will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -327,8 +337,9 @@ object RestartSource {
       sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
     import akka.util.JavaDurationConverters._
     akka.stream.scaladsl.RestartSource
-      .onFailuresWithBackoff(minBackoff.asScala, maxBackoff.asScala, randomFactor, maxRestarts, resetDeadline.asScala) { () =>
-        sourceFactory.create().asScala
+      .onFailuresWithBackoff(minBackoff.asScala, maxBackoff.asScala, randomFactor, maxRestarts, resetDeadline.asScala) {
+        () =>
+          sourceFactory.create().asScala
       }
       .asJava
   }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartSource.scala
@@ -112,7 +112,7 @@ object RestartSource {
       randomFactor: Double,
       maxRestarts: Int,
       sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
-    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings, sourceFactory)
   }
 
@@ -147,7 +147,7 @@ object RestartSource {
       randomFactor: Double,
       maxRestarts: Int,
       sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
-    val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings, sourceFactory)
   }
 
@@ -266,7 +266,7 @@ object RestartSource {
       randomFactor: Double,
       maxRestarts: Int,
       sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
-    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     onFailuresWithBackoff(settings, sourceFactory)
   }
 
@@ -300,7 +300,7 @@ object RestartSource {
       randomFactor: Double,
       maxRestarts: Int,
       sourceFactory: Creator[Source[T, _]]): Source[T, NotUsed] = {
-    val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings.create(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     onFailuresWithBackoff(settings, sourceFactory)
   }
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/RestartSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/RestartSource.scala
@@ -29,7 +29,7 @@ object RestartSource {
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -60,7 +60,7 @@ object RestartSource {
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -92,7 +92,7 @@ object RestartSource {
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -127,7 +127,7 @@ object RestartSource {
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -162,7 +162,7 @@ object RestartSource {
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param settings [[RestartSettings]] defining restart configuration
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
@@ -183,7 +183,7 @@ object RestartSource {
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -214,7 +214,7 @@ object RestartSource {
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -245,7 +245,7 @@ object RestartSource {
    * and it will not be restarted. This can be triggered simply by the downstream cancelling, or externally by
    * introducing a [[KillSwitch]] right after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -279,7 +279,7 @@ object RestartSource {
    * and it will not be restarted. This can be triggered simply by the downstream cancelling, or externally by
    * introducing a [[KillSwitch]] right after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -313,7 +313,7 @@ object RestartSource {
    * and it will not be restarted. This can be triggered simply by the downstream cancelling, or externally by
    * introducing a [[KillSwitch]] right after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param settings [[RestartSettings]] defining restart configuration
    * @param sourceFactory A factory for producing the [[Source]] to wrap.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala
@@ -41,7 +41,8 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -67,7 +68,8 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -98,7 +100,8 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor
+   *   will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -142,7 +145,8 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -174,7 +178,8 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *    started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala
@@ -89,7 +89,7 @@ object RestartFlow {
       maxBackoff: FiniteDuration,
       randomFactor: Double,
       maxRestarts: Int)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
-    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings)(flowFactory)
   }
 
@@ -147,7 +147,7 @@ object RestartFlow {
       maxBackoff: FiniteDuration,
       randomFactor: Double,
       maxRestarts: Int)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
-    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     onFailuresWithBackoff(settings)(flowFactory)
   }
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala
@@ -39,7 +39,7 @@ object RestartFlow {
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -70,7 +70,7 @@ object RestartFlow {
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -106,7 +106,7 @@ object RestartFlow {
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param settings [[RestartSettings]] defining restart configuration
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
@@ -128,7 +128,7 @@ object RestartFlow {
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -165,7 +165,7 @@ object RestartFlow {
    * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
    * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param settings [[RestartSettings]] defining restart configuration
    * @param flowFactory A factory for producing the [[Flow]] to wrap.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala
@@ -41,8 +41,7 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -50,16 +49,8 @@ object RestartFlow {
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
   def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double)(
-      flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
-    Flow.fromGraph(
-      new RestartWithBackoffFlow(
-        flowFactory,
-        minBackoff,
-        maxBackoff,
-        randomFactor,
-        onlyOnFailures = false,
-        Int.MaxValue))
-  }
+      flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] =
+    withBackoff(minBackoff, maxBackoff, randomFactor, Int.MaxValue)(flowFactory)
 
   /**
    * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails or complete using an exponential
@@ -76,8 +67,7 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -90,7 +80,41 @@ object RestartFlow {
       minBackoff: FiniteDuration,
       maxBackoff: FiniteDuration,
       randomFactor: Double,
-      maxRestarts: Int)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
+      maxRestarts: Int)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] =
+    withBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts, minBackoff)(flowFactory)
+
+  /**
+   * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails or complete using an exponential
+   * backoff.
+   *
+   * This [[Flow]] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
+   * completed. Any termination by the [[Flow]] before that time will be handled by restarting it as long as maxRestarts
+   * is not reached. Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
+   * running, and then the [[Flow]] will be allowed to terminate without being restarted.
+   *
+   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+   * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
+   * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of resetDeadline.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
+   * @param resetDeadline the duration after which to reset the restart count and current exponential backoff
+   *   back to `0` and minBackoff respectively
+   * @param flowFactory A factory for producing the [[Flow]] to wrap.
+   */
+  def withBackoff[In, Out](
+      minBackoff: FiniteDuration,
+      maxBackoff: FiniteDuration,
+      randomFactor: Double,
+      maxRestarts: Int,
+      resetDeadline: FiniteDuration)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
     Flow.fromGraph(
       new RestartWithBackoffFlow(
         flowFactory,
@@ -98,7 +122,8 @@ object RestartFlow {
         maxBackoff,
         randomFactor,
         onlyOnFailures = false,
-        maxRestarts))
+        maxRestarts,
+        resetDeadline))
   }
 
   /**
@@ -117,8 +142,7 @@ object RestartFlow {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -131,9 +155,51 @@ object RestartFlow {
       minBackoff: FiniteDuration,
       maxBackoff: FiniteDuration,
       randomFactor: Double,
-      maxRestarts: Int)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
+      maxRestarts: Int)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] =
+    onFailuresWithBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts, minBackoff)(flowFactory)
+
+  /**
+   * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails using an exponential
+   * backoff. Notice that this [[Flow]] will not restart on completion of the wrapped flow.
+   *
+   * This [[Flow]] will not emit any failure
+   * The failures by the wrapped [[Flow]] will be handled by
+   * restarting the wrapping [[Flow]] as long as maxRestarts is not reached.
+   * Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
+   * running, and then the [[Flow]] will be allowed to terminate without being restarted.
+   *
+   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+   * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
+   * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of resetDeadline.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
+   * @param resetDeadline the duration after which to reset the restart count and current exponential backoff
+   *   back to `0` and minBackoff respectively
+   * @param flowFactory A factory for producing the [[Flow]] to wrap.
+   */
+  def onFailuresWithBackoff[In, Out](
+      minBackoff: FiniteDuration,
+      maxBackoff: FiniteDuration,
+      randomFactor: Double,
+      maxRestarts: Int,
+      resetDeadline: FiniteDuration)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
     Flow.fromGraph(
-      new RestartWithBackoffFlow(flowFactory, minBackoff, maxBackoff, randomFactor, onlyOnFailures = true, maxRestarts))
+      new RestartWithBackoffFlow(
+        flowFactory,
+        minBackoff,
+        maxBackoff,
+        randomFactor,
+        onlyOnFailures = true,
+        maxRestarts,
+        resetDeadline))
   }
 
 }
@@ -144,7 +210,8 @@ private final class RestartWithBackoffFlow[In, Out](
     maxBackoff: FiniteDuration,
     randomFactor: Double,
     onlyOnFailures: Boolean,
-    maxRestarts: Int)
+    maxRestarts: Int,
+    resetDeadline: FiniteDuration)
     extends GraphStage[FlowShape[In, Out]] { self =>
 
   val in = Inlet[In]("RestartWithBackoffFlow.in")
@@ -161,7 +228,8 @@ private final class RestartWithBackoffFlow[In, Out](
       maxBackoff,
       randomFactor,
       onlyOnFailures,
-      maxRestarts) {
+      maxRestarts,
+      resetDeadline) {
       val delay = inheritedAttributes.get[Delay](Delay(50.millis)).duration
 
       var activeOutIn: Option[(SubSourceOutlet[In], SubSinkInlet[Out])] = None
@@ -222,10 +290,11 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
     maxBackoff: FiniteDuration,
     randomFactor: Double,
     onlyOnFailures: Boolean,
-    maxRestarts: Int)
+    maxRestarts: Int,
+    resetDeadline: FiniteDuration)
     extends TimerGraphStageLogicWithLogging(shape) {
   var restartCount = 0
-  var resetDeadline = minBackoff.fromNow
+  var resetAfter = resetDeadline.fromNow
 
   // This is effectively only used for flows, if either the main inlet or outlet of this stage finishes, then we
   // don't want to restart the sub inlet when it finishes, we just finish normally.
@@ -335,9 +404,9 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
   }
 
   protected final def maxRestartsReached(): Boolean = {
-    // Check if the last start attempt was more than the minimum backoff
-    if (resetDeadline.isOverdue()) {
-      log.debug("Last restart attempt was more than {} ago, resetting restart count", minBackoff)
+    // Check if the last start attempt was more than the reset deadline
+    if (resetAfter.isOverdue()) {
+      log.debug("Last restart attempt was more than {} ago, resetting restart count", resetDeadline)
       restartCount = 0
     }
     restartCount == maxRestarts
@@ -356,7 +425,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
   // Invoked when the backoff timer ticks
   override protected def onTimer(timerKey: Any) = {
     startGraph()
-    resetDeadline = minBackoff.fromNow
+    resetAfter = resetDeadline.fromNow
   }
 
   // When the stage starts, start the source

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala
@@ -49,174 +49,137 @@ object RestartFlow {
    *   In order to skip this additional delay pass in `0`.
    * @param flowFactory A factory for producing the [[Flow]] to wrap.
    */
+  @Deprecated
+  @deprecated("Use the overloaded method which accepts akka.stream.RestartSettings instead.", since = "2.6.10")
   def withBackoff[In, Out](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double)(
+      flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
+    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor)
+    withBackoff(settings)(flowFactory)
+  }
+
+  /**
+   * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails or complete using an exponential
+   * backoff.
+   *
+   * This [[Flow]] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
+   * completed. Any termination by the [[Flow]] before that time will be handled by restarting it as long as maxRestarts
+   * is not reached. Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
+   * running, and then the [[Flow]] will be allowed to terminate without being restarted.
+   *
+   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+   * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
+   * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
+   * @param flowFactory A factory for producing the [[Flow]] to wrap.
+   */
+  @Deprecated
+  @deprecated("Use the overloaded method which accepts akka.stream.RestartSettings instead.", since = "2.6.10")
+  def withBackoff[In, Out](
+      minBackoff: FiniteDuration,
+      maxBackoff: FiniteDuration,
+      randomFactor: Double,
+      maxRestarts: Int)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
+    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    withBackoff(settings)(flowFactory)
+  }
+
+  /**
+   * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails or complete using an exponential
+   * backoff.
+   *
+   * This [[Flow]] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
+   * completed. Any termination by the [[Flow]] before that time will be handled by restarting it as long as maxRestarts
+   * is not reached. Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
+   * running, and then the [[Flow]] will be allowed to terminate without being restarted.
+   *
+   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+   * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
+   * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param settings [[RestartSettings]] defining restart configuration
+   * @param flowFactory A factory for producing the [[Flow]] to wrap.
+   */
+  def withBackoff[In, Out](settings: RestartSettings)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] =
+    Flow.fromGraph(new RestartWithBackoffFlow(flowFactory, settings, onlyOnFailures = false))
+
+  /**
+   * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails using an exponential
+   * backoff. Notice that this [[Flow]] will not restart on completion of the wrapped flow.
+   *
+   * This [[Flow]] will not emit any failure
+   * The failures by the wrapped [[Flow]] will be handled by
+   * restarting the wrapping [[Flow]] as long as maxRestarts is not reached.
+   * Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
+   * running, and then the [[Flow]] will be allowed to terminate without being restarted.
+   *
+   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+   * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
+   * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
+   * @param flowFactory A factory for producing the [[Flow]] to wrap.
+   */
+  @Deprecated
+  @deprecated("Use the overloaded method which accepts akka.stream.RestartSettings instead.", since = "2.6.10")
+  def onFailuresWithBackoff[In, Out](
+      minBackoff: FiniteDuration,
+      maxBackoff: FiniteDuration,
+      randomFactor: Double,
+      maxRestarts: Int)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
+    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    onFailuresWithBackoff(settings)(flowFactory)
+  }
+
+  /**
+   * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails using an exponential
+   * backoff. Notice that this [[Flow]] will not restart on completion of the wrapped flow.
+   *
+   * This [[Flow]] will not emit any failure
+   * The failures by the wrapped [[Flow]] will be handled by
+   * restarting the wrapping [[Flow]] as long as maxRestarts is not reached.
+   * Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
+   * running, and then the [[Flow]] will be allowed to terminate without being restarted.
+   *
+   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+   * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
+   * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param settings [[RestartSettings]] defining restart configuration
+   * @param flowFactory A factory for producing the [[Flow]] to wrap.
+   */
+  def onFailuresWithBackoff[In, Out](settings: RestartSettings)(
       flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] =
-    withBackoff(minBackoff, maxBackoff, randomFactor, Int.MaxValue)(flowFactory)
-
-  /**
-   * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails or complete using an exponential
-   * backoff.
-   *
-   * This [[Flow]] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
-   * completed. Any termination by the [[Flow]] before that time will be handled by restarting it as long as maxRestarts
-   * is not reached. Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
-   * running, and then the [[Flow]] will be allowed to terminate without being restarted.
-   *
-   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
-   * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
-   * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
-   *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
-   *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
-   * @param maxBackoff the exponential back-off is capped to this duration
-   * @param randomFactor after calculation of the exponential back-off an additional
-   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
-   *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
-   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
-   * @param flowFactory A factory for producing the [[Flow]] to wrap.
-   */
-  def withBackoff[In, Out](
-      minBackoff: FiniteDuration,
-      maxBackoff: FiniteDuration,
-      randomFactor: Double,
-      maxRestarts: Int)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] =
-    withBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts, minBackoff)(flowFactory)
-
-  /**
-   * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails or complete using an exponential
-   * backoff.
-   *
-   * This [[Flow]] will not cancel, complete or emit a failure, until the opposite end of it has been cancelled or
-   * completed. Any termination by the [[Flow]] before that time will be handled by restarting it as long as maxRestarts
-   * is not reached. Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
-   * running, and then the [[Flow]] will be allowed to terminate without being restarted.
-   *
-   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
-   * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
-   * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
-   *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
-   *
-   * @param minBackoff minimum (initial) duration until the child actor
-   *   will started again, if it is terminated
-   * @param maxBackoff the exponential back-off is capped to this duration
-   * @param randomFactor after calculation of the exponential back-off an additional
-   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
-   *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of maxRestartsWithin.
-   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
-   * @param maxRestartsWithin the duration after which to reset the restart count and current exponential backoff
-   *   back to `0` and minBackoff respectively
-   * @param flowFactory A factory for producing the [[Flow]] to wrap.
-   */
-  def withBackoff[In, Out](
-      minBackoff: FiniteDuration,
-      maxBackoff: FiniteDuration,
-      randomFactor: Double,
-      maxRestarts: Int,
-      maxRestartsWithin: FiniteDuration)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
-    Flow.fromGraph(
-      new RestartWithBackoffFlow(
-        flowFactory,
-        minBackoff,
-        maxBackoff,
-        randomFactor,
-        onlyOnFailures = false,
-        maxRestarts,
-        maxRestartsWithin))
-  }
-
-  /**
-   * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails using an exponential
-   * backoff. Notice that this [[Flow]] will not restart on completion of the wrapped flow.
-   *
-   * This [[Flow]] will not emit any failure
-   * The failures by the wrapped [[Flow]] will be handled by
-   * restarting the wrapping [[Flow]] as long as maxRestarts is not reached.
-   * Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
-   * running, and then the [[Flow]] will be allowed to terminate without being restarted.
-   *
-   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
-   * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
-   * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
-   *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
-   *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
-   * @param maxBackoff the exponential back-off is capped to this duration
-   * @param randomFactor after calculation of the exponential back-off an additional
-   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
-   *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of minBackoff.
-   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
-   * @param flowFactory A factory for producing the [[Flow]] to wrap.
-   */
-  def onFailuresWithBackoff[In, Out](
-      minBackoff: FiniteDuration,
-      maxBackoff: FiniteDuration,
-      randomFactor: Double,
-      maxRestarts: Int)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] =
-    onFailuresWithBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts, minBackoff)(flowFactory)
-
-  /**
-   * Wrap the given [[Flow]] with a [[Flow]] that will restart it when it fails using an exponential
-   * backoff. Notice that this [[Flow]] will not restart on completion of the wrapped flow.
-   *
-   * This [[Flow]] will not emit any failure
-   * The failures by the wrapped [[Flow]] will be handled by
-   * restarting the wrapping [[Flow]] as long as maxRestarts is not reached.
-   * Any termination signals sent to this [[Flow]] however will terminate the wrapped [[Flow]], if it's
-   * running, and then the [[Flow]] will be allowed to terminate without being restarted.
-   *
-   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
-   * messages. A termination signal from either end of the wrapped [[Flow]] will cause the other end to be terminated,
-   * and any in transit messages will be lost. During backoff, this [[Flow]] will backpressure.
-   *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
-   *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *    started again, if it is terminated
-   * @param maxBackoff the exponential back-off is capped to this duration
-   * @param randomFactor after calculation of the exponential back-off an additional
-   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
-   *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of maxRestartsWithin.
-   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
-   * @param maxRestartsWithin the duration after which to reset the restart count and current exponential backoff
-   *   back to `0` and minBackoff respectively
-   * @param flowFactory A factory for producing the [[Flow]] to wrap.
-   */
-  def onFailuresWithBackoff[In, Out](
-      minBackoff: FiniteDuration,
-      maxBackoff: FiniteDuration,
-      randomFactor: Double,
-      maxRestarts: Int,
-      maxRestartsWithin: FiniteDuration)(flowFactory: () => Flow[In, Out, _]): Flow[In, Out, NotUsed] = {
-    Flow.fromGraph(
-      new RestartWithBackoffFlow(
-        flowFactory,
-        minBackoff,
-        maxBackoff,
-        randomFactor,
-        onlyOnFailures = true,
-        maxRestarts,
-        maxRestartsWithin))
-  }
+    Flow.fromGraph(new RestartWithBackoffFlow(flowFactory, settings, onlyOnFailures = true))
 
 }
 
 private final class RestartWithBackoffFlow[In, Out](
     flowFactory: () => Flow[In, Out, _],
-    minBackoff: FiniteDuration,
-    maxBackoff: FiniteDuration,
-    randomFactor: Double,
-    onlyOnFailures: Boolean,
-    maxRestarts: Int,
-    maxRestartsWithin: FiniteDuration)
+    settings: RestartSettings,
+    onlyOnFailures: Boolean)
     extends GraphStage[FlowShape[In, Out]] { self =>
 
   val in = Inlet[In]("RestartWithBackoffFlow.in")
@@ -225,16 +188,7 @@ private final class RestartWithBackoffFlow[In, Out](
   override def shape = FlowShape(in, out)
 
   override def createLogic(inheritedAttributes: Attributes) =
-    new RestartWithBackoffLogic(
-      "Flow",
-      shape,
-      inheritedAttributes,
-      minBackoff,
-      maxBackoff,
-      randomFactor,
-      onlyOnFailures,
-      maxRestarts,
-      maxRestartsWithin) {
+    new RestartWithBackoffLogic("Flow", shape, inheritedAttributes, settings, onlyOnFailures) {
       val delay = inheritedAttributes.get[Delay](Delay(50.millis)).duration
 
       var activeOutIn: Option[(SubSourceOutlet[In], SubSinkInlet[Out])] = None
@@ -291,13 +245,10 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
     name: String,
     shape: S,
     inheritedAttributes: Attributes,
-    minBackoff: FiniteDuration,
-    maxBackoff: FiniteDuration,
-    randomFactor: Double,
-    onlyOnFailures: Boolean,
-    maxRestarts: Int,
-    maxRestartsWithin: FiniteDuration)
+    settings: RestartSettings,
+    onlyOnFailures: Boolean)
     extends TimerGraphStageLogicWithLogging(shape) {
+  import settings._
   var restartCount = 0
   var resetDeadline = maxRestartsWithin.fromNow
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSink.scala
@@ -35,7 +35,8 @@ object RestartSink {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -62,7 +63,8 @@ object RestartSink {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -91,7 +93,8 @@ object RestartSink {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSink.scala
@@ -35,8 +35,7 @@ object RestartSink {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -44,9 +43,8 @@ object RestartSink {
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double)(
-      sinkFactory: () => Sink[T, _]): Sink[T, NotUsed] = {
-    Sink.fromGraph(new RestartWithBackoffSink(sinkFactory, minBackoff, maxBackoff, randomFactor, Int.MaxValue))
-  }
+      sinkFactory: () => Sink[T, _]): Sink[T, NotUsed] =
+    withBackoff(minBackoff, maxBackoff, randomFactor, Int.MaxValue)(sinkFactory)
 
   /**
    * Wrap the given [[Sink]] with a [[Sink]] that will restart it when it fails or complete using an exponential
@@ -64,8 +62,7 @@ object RestartSink {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will
-   *   started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -75,9 +72,44 @@ object RestartSink {
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.
    */
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int)(
-      sinkFactory: () => Sink[T, _]): Sink[T, NotUsed] = {
-    Sink.fromGraph(new RestartWithBackoffSink(sinkFactory, minBackoff, maxBackoff, randomFactor, maxRestarts))
-  }
+      sinkFactory: () => Sink[T, _]): Sink[T, NotUsed] =
+    withBackoff(minBackoff, maxBackoff, randomFactor, maxRestarts, minBackoff)(sinkFactory)
+
+  /**
+   * Wrap the given [[Sink]] with a [[Sink]] that will restart it when it fails or complete using an exponential
+   * backoff.
+   *
+   * This [[Sink]] will not cancel as long as maxRestarts is not reached, since cancellation by the wrapped [[Sink]]
+   * is handled by restarting it. The wrapped [[Sink]] can however be completed by feeding a completion or error into
+   * this [[Sink]]. When that happens, the [[Sink]], if currently running, will terminate and will not be restarted.
+   * This can be triggered simply by the upstream completing, or externally by introducing a [[KillSwitch]] right
+   * before this [[Sink]] in the graph.
+   *
+   * The restart process is inherently lossy, since there is no coordination between cancelling and the sending of
+   * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
+   * sent may have been lost.
+   *
+   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   *
+   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param maxBackoff the exponential back-off is capped to this duration
+   * @param randomFactor after calculation of the exponential back-off an additional
+   *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
+   *   In order to skip this additional delay pass in `0`.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of resetDeadline.
+   *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
+   * @param resetDeadline the duration after which to reset the restart count and current exponential backoff
+   *   back to `0` and minBackoff respectively
+   * @param sinkFactory A factory for producing the [[Sink]] to wrap.
+   */
+  def withBackoff[T](
+      minBackoff: FiniteDuration,
+      maxBackoff: FiniteDuration,
+      randomFactor: Double,
+      maxRestarts: Int,
+      resetDeadline: FiniteDuration)(sinkFactory: () => Sink[T, _]): Sink[T, NotUsed] =
+    Sink.fromGraph(
+      new RestartWithBackoffSink(sinkFactory, minBackoff, maxBackoff, randomFactor, maxRestarts, resetDeadline))
 }
 
 private final class RestartWithBackoffSink[T](
@@ -85,7 +117,8 @@ private final class RestartWithBackoffSink[T](
     minBackoff: FiniteDuration,
     maxBackoff: FiniteDuration,
     randomFactor: Double,
-    maxRestarts: Int)
+    maxRestarts: Int,
+    resetDeadline: FiniteDuration)
     extends GraphStage[SinkShape[T]] { self =>
 
   val in = Inlet[T]("RestartWithBackoffSink.in")
@@ -100,7 +133,8 @@ private final class RestartWithBackoffSink[T](
       maxBackoff,
       randomFactor,
       onlyOnFailures = false,
-      maxRestarts) {
+      maxRestarts,
+      resetDeadline) {
       override protected def logSource = self.getClass
 
       override protected def startGraph() = {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSink.scala
@@ -81,7 +81,7 @@ object RestartSink {
   @deprecated("Use the overloaded method which accepts akka.stream.RestartSettings instead.", since = "2.6.10")
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int)(
       sinkFactory: () => Sink[T, _]): Sink[T, NotUsed] = {
-    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings)(sinkFactory)
   }
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSink.scala
@@ -33,7 +33,7 @@ object RestartSink {
    * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
    * sent may have been lost.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -65,7 +65,7 @@ object RestartSink {
    * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
    * sent may have been lost.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -99,7 +99,7 @@ object RestartSink {
    * messages. When the wrapped [[Sink]] does cancel, this [[Sink]] will backpressure, however any elements already
    * sent may have been lost.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param settings [[RestartSettings]] defining restart configuration
    * @param sinkFactory A factory for producing the [[Sink]] to wrap.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSource.scala
@@ -89,9 +89,9 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of resetDeadline.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of maxRestartsWithin.
    *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
-   * @param resetDeadline the duration after which to reset the restart count and current exponential backoff
+   * @param maxRestartsWithin the duration after which to reset the restart count and current exponential backoff
    *   back to `0` and minBackoff respectively
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    */
@@ -100,7 +100,7 @@ object RestartSource {
       maxBackoff: FiniteDuration,
       randomFactor: Double,
       maxRestarts: Int,
-      resetDeadline: FiniteDuration)(sourceFactory: () => Source[T, _]): Source[T, NotUsed] = {
+      maxRestartsWithin: FiniteDuration)(sourceFactory: () => Source[T, _]): Source[T, NotUsed] = {
     Source.fromGraph(
       new RestartWithBackoffSource(
         sourceFactory,
@@ -109,7 +109,7 @@ object RestartSource {
         randomFactor,
         onlyOnFailures = false,
         maxRestarts,
-        resetDeadline))
+        maxRestartsWithin))
   }
 
   /**
@@ -184,9 +184,9 @@ object RestartSource {
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
    *   In order to skip this additional delay pass in `0`.
-   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of the resetDeadline.
+   * @param maxRestarts the amount of restarts is capped to this amount within a time frame of the maxRestartsWithin.
    *   Passing `0` will cause no restarts and a negative number will not cap the amount of restarts.
-   * @param resetDeadline the duration after which to reset the restart count and current exponential backoff
+   * @param maxRestartsWithin the duration after which to reset the restart count and current exponential backoff
    *   back to `0` and minBackoff respectively
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
    *
@@ -196,7 +196,7 @@ object RestartSource {
       maxBackoff: FiniteDuration,
       randomFactor: Double,
       maxRestarts: Int,
-      resetDeadline: FiniteDuration)(sourceFactory: () => Source[T, _]): Source[T, NotUsed] = {
+      maxRestartsWithin: FiniteDuration)(sourceFactory: () => Source[T, _]): Source[T, NotUsed] = {
     Source.fromGraph(
       new RestartWithBackoffSource(
         sourceFactory,
@@ -205,7 +205,7 @@ object RestartSource {
         randomFactor,
         onlyOnFailures = true,
         maxRestarts,
-        resetDeadline))
+        maxRestartsWithin))
   }
 }
 
@@ -216,7 +216,7 @@ private final class RestartWithBackoffSource[T](
     randomFactor: Double,
     onlyOnFailures: Boolean,
     maxRestarts: Int,
-    resetDeadline: FiniteDuration)
+    maxRestartsWithin: FiniteDuration)
     extends GraphStage[SourceShape[T]] { self =>
 
   val out = Outlet[T]("RestartWithBackoffSource.out")
@@ -232,7 +232,7 @@ private final class RestartWithBackoffSource[T](
       randomFactor,
       onlyOnFailures,
       maxRestarts,
-      resetDeadline) {
+      maxRestartsWithin) {
 
       override protected def logSource = self.getClass
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSource.scala
@@ -29,7 +29,7 @@ object RestartSource {
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -58,7 +58,7 @@ object RestartSource {
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -89,7 +89,7 @@ object RestartSource {
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param settings [[RestartSettings]] defining restart configuration
    * @param sourceFactory A factory for producing the [[Source]] to wrap.
@@ -106,7 +106,7 @@ object RestartSource {
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -135,7 +135,7 @@ object RestartSource {
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param minBackoff minimum (initial) duration until the child actor will
    *   started again, if it is terminated
@@ -169,7 +169,7 @@ object RestartSource {
    * This can be triggered simply by the downstream cancelling, or externally by introducing a [[KillSwitch]] right
    * after this [[Source]] in the graph.
    *
-   * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
+   * This uses the same exponential backoff algorithm as [[akka.pattern.BackoffOpts]].
    *
    * @param settings [[RestartSettings]] defining restart configuration
    * @param sourceFactory A factory for producing the [[Source]] to wrap.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSource.scala
@@ -74,7 +74,7 @@ object RestartSource {
   @deprecated("Use the overloaded method which accepts akka.stream.RestartSettings instead.", since = "2.6.10")
   def withBackoff[T](minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double, maxRestarts: Int)(
       sourceFactory: () => Source[T, _]): Source[T, NotUsed] = {
-    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     withBackoff(settings)(sourceFactory)
   }
 
@@ -155,7 +155,7 @@ object RestartSource {
       maxBackoff: FiniteDuration,
       randomFactor: Double,
       maxRestarts: Int)(sourceFactory: () => Source[T, _]): Source[T, NotUsed] = {
-    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts)
+    val settings = RestartSettings(minBackoff, maxBackoff, randomFactor).withMaxRestarts(maxRestarts, minBackoff)
     onFailuresWithBackoff(settings)(sourceFactory)
   }
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartSource.scala
@@ -31,7 +31,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -55,7 +56,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -81,7 +83,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -120,7 +123,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -144,7 +148,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -173,7 +178,8 @@ object RestartSource {
    *
    * This uses the same exponential backoff algorithm as [[akka.pattern.Backoff]].
    *
-   * @param minBackoff minimum (initial) duration until the child actor will started again, if it is terminated
+   * @param minBackoff minimum (initial) duration until the child actor will
+   *   started again, if it is terminated
    * @param maxBackoff the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *   random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.


### PR DESCRIPTION
References #29291 (and sort of #29550)

Docs could probably also do with a bit of an update after this but was waiting to see general thoughts first.

Currently introducing additional overloaded methods (except for the deprecated javadsl) to try to keep binary compatibility but there are now quite a lot of these methods hanging around which might make this harder to follow. Another option could be to introduce a settings class for these sort of options. Probably wouldn't make much difference in this PR as we would still need keep existing methods and introduce new ones to receive the settings class but it might make future changes easier? Let me know what's preferred and happy to update.

---
Edit - dc3c1e7 includes creating `RestartSettings` to hold configuration which can then be passed as a whole to the actual restart methods. I think this ends up looking a bit tidier and expect it should be easier to add additional configuration options in the future if needed. I'm not sure what anyone thinks about exactly what config options should be part of this class but for now I've just put everything except `onlyOnFailures` (I quite like having the separate `withBackoff` and `onFailuresWithBackoff` functions).

Let me know if the original API is preferred and I can just remove that commit.
