### PR TITLE
Ignore termination logging when already acked

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -548,8 +548,11 @@ object ShardCoordinator {
         log.debug("BeginHandOffAck for shard [{}] received from [{}].", shard, sender())
         acked(sender())
       case ShardRegionTerminated(shardRegion) =>
-        log.debug("ShardRegion [{}] terminated while waiting for BeginHandOffAck for shard [{}].", shardRegion, shard)
-        acked(shardRegion)
+        // ignore if already received the ack
+        if (remaining.contains(shardRegion)) {
+          log.debug("ShardRegion [{}] terminated while waiting for BeginHandOffAck for shard [{}].", shardRegion, shard)
+          acked(shardRegion)
+        }
       case ReceiveTimeout =>
         if (isRebalance)
           log.debug("Rebalance of [{}]  from [{}] timed out", shard, from)


### PR DESCRIPTION
Draft because on top of #29579.

If #29597 doesn't make the cut, we can at least avoid unnecessary logging. See condition added here.

Ready for review otherwise.
