### PR TITLE
Increase stable-after in StressSpec, #29512

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -100,7 +100,7 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
       failure-detector.acceptable-heartbeat-pause =  3s
       downing-provider-class = akka.cluster.sbr.SplitBrainResolverProvider
       split-brain-resolver {
-          stable-after = 5s
+          stable-after = 10s
       }
       publish-stats-interval = 1s
     }


### PR DESCRIPTION
This should fix the test failures. I could reproduce rather frequently in local repeat run. Here is a log excerpt of what happens:
```
[info] [JVM-9] [WARN] [akkaUnreachable][09/15/2020 08:10:22.885] [Stress-akka.actor.internal-dispatcher-16] [Cluster(akka://Stress)] Cluster Node [akka://Stress@localhost:51824] - Marking node as UNREACHABLE [Member(akka://Stress@localhost:52160, Up)].
... more of these
[info] [JVM-5] [WARN] [akkaUnreachable][09/15/2020 08:10:24.013] [Stress-akka.actor.internal-dispatcher-2] [Cluster(akka://Stress)] Cluster Node [akka://Stress@localhost:51827] - Marking node as UNREACHABLE [Member(akka://Stress@localhost:52159, Up)].

[info] [JVM-1] [WARN] [akkaSbrDowning][09/15/2020 08:10:29.754] [Stress-akka.actor.default-dispatcher-22] [akka://Stress/system/cluster/core/daemon/downingProvider] SBR took decision DownUnreachable and is downing [akka://Stress@localhost:52159, akka://Stress@localhost:52160], [2] unreachable of [15] members, ...

[info] [JVM-7] [DEBUG] [09/15/2020 08:10:30.694] [Stress-akka.actor.default-dispatcher-32] [akka://Stress/system/cluster/core/daemon/downingProvider] SBR resetting reachability stats, after all unreachable healed, downed or removed
[info] [JVM-5] [DEBUG] [09/15/2020 08:10:31.054] [Stress-akka.actor.default-dispatcher-36] [akka://Stress/system/cluster/core/daemon/downingProvider] SBR resetting reachability stats, after all unreachable healed, downed or removed
[info] [JVM-9] [DEBUG] [09/15/2020 08:10:31.141] [Stress-akka.actor.default-dispatcher-21] [akka://Stress/system/cluster/core/daemon/downingProvider] SBR resetting reachability stats, after all unreachable healed, downed or removed
... more of these but not on JVM-3


[info] [JVM-3] [WARN] [akkaSbrInstability][09/15/2020 08:10:32.091] [Stress-akka.actor.default-dispatcher-4] [akka://Stress/system/cluster/core/daemon/downingProvider] SBR detected instability and will down all nodes: reachability changed 6 times since 8931 ms ago, latest change was 7467 ms ago
[info] [JVM-3] [WARN] [akkaSbrDowning][09/15/2020 08:10:32.097] [Stress-akka.actor.default-dispatcher-4] [akka://Stress/system/cluster/core/daemon/downingProvider] SBR took decision DownAll ...
```

The first downing decision is as expected, but then "SBR detected instability... DownAll" from another node. That is tracking changes to the reachability table and if it hasn't seen a downing decision within (stable-after + (stable-after * 3/4) = 8 sec) it will down all. The first downing hadn't fully propagated with the gossip within this time.

I'm running this in a repeat job, and I also have some other ideas of improvements, but let's merge this first.

References #29512
