### PR TITLE
[2.5 backport] testkit: more resilient check for available loopback addresses in SocketUtil on MacOS

### DIFF
--- a/akka-testkit/src/main/scala/akka/testkit/SocketUtil.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/SocketUtil.scala
@@ -24,8 +24,7 @@ object SocketUtil {
       SocketUtil.temporaryServerAddress(address = "127.20.0.0")
       true
     } catch {
-      case _: java.net.BindException =>
-        false
+      case NonFatal(_) => false
     }
   }
 


### PR DESCRIPTION
Backport of #29607 