### PR TITLE
support async reply and noReply in EventSourcedBehaviorTestKit, #29602 #29581

### DIFF
--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
@@ -155,7 +155,7 @@ import akka.persistence.typed.internal.EventSourcedBehaviorImpl
       verifySerializationAndThrow(command, "Command")
 
     if (serializationSettings.enabled && !emptyStateVerified) {
-      val emptyState = getState
+      val emptyState = getState()
       verifySerializationAndThrow(emptyState, "Empty State")
       emptyStateVerified = true
     }

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
@@ -145,7 +145,7 @@ import akka.persistence.typed.internal.EventSourcedBehaviorImpl
     persistenceTestKit.persistedInStorage(persistenceId.id).map(_.asInstanceOf[Event]).drop(dropOldEvents)
   }
 
-  private def getState(): State = {
+  override def getState(): State = {
     internalActor ! EventSourcedBehaviorImpl.GetState(stateProbe.ref)
     val newState = stateProbe.receiveMessage()
     newState

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
@@ -147,8 +147,7 @@ import akka.persistence.typed.internal.EventSourcedBehaviorImpl
 
   override def getState(): State = {
     internalActor ! EventSourcedBehaviorImpl.GetState(stateProbe.ref)
-    val newState = stateProbe.receiveMessage()
-    newState
+    stateProbe.receiveMessage()
   }
 
   private def preCommandCheck(command: Command): Unit = {

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
@@ -102,36 +102,15 @@ import akka.persistence.typed.internal.EventSourcedBehaviorImpl
   persistenceTestKit.clearByPersistenceId(persistenceId.id)
 
   override def runCommand(command: Command): CommandResult[Command, Event, State] = {
-    if (serializationSettings.enabled && serializationSettings.verifyCommands)
-      verifySerializationAndThrow(command, "Command")
-
-    if (serializationSettings.enabled && !emptyStateVerified) {
-      internalActor ! EventSourcedBehaviorImpl.GetState(stateProbe.ref)
-      val emptyState = stateProbe.receiveMessage()
-      verifySerializationAndThrow(emptyState, "Empty State")
-      emptyStateVerified = true
-    }
-
-    // FIXME we can expand the api of persistenceTestKit to read from storage from a seqNr instead
-    val oldEvents =
-      persistenceTestKit.persistedInStorage(persistenceId.id).map(_.asInstanceOf[Event])
+    preCommandCheck(command)
+    val oldEvents = getEvents(dropOldEvents = 0)
 
     actor ! command
 
-    internalActor ! EventSourcedBehaviorImpl.GetState(stateProbe.ref)
-    val newState = stateProbe.receiveMessage()
+    val newState = getState()
+    val newEvents = getEvents(oldEvents.size)
 
-    val newEvents =
-      persistenceTestKit.persistedInStorage(persistenceId.id).map(_.asInstanceOf[Event]).drop(oldEvents.size)
-
-    if (serializationSettings.enabled) {
-      if (serializationSettings.verifyEvents) {
-        newEvents.foreach(verifySerializationAndThrow(_, "Event"))
-      }
-
-      if (serializationSettings.verifyState)
-        verifySerializationAndThrow(newState, "State")
-    }
+    postCommandCheck(newEvents, newState, reply = None)
 
     CommandResultImpl[Command, Event, State, Nothing](command, newEvents, newState, None)
   }
@@ -139,7 +118,10 @@ import akka.persistence.typed.internal.EventSourcedBehaviorImpl
   override def runCommand[R](creator: ActorRef[R] => Command): CommandResultWithReply[Command, Event, State, R] = {
     val replyProbe = actorTestKit.createTestProbe[R]()
     val command = creator(replyProbe.ref)
-    val result = runCommand(command)
+    preCommandCheck(command)
+    val oldEvents = getEvents(dropOldEvents = 0)
+
+    actor ! command
 
     val reply = try {
       replyProbe.receiveMessage()
@@ -150,10 +132,74 @@ import akka.persistence.typed.internal.EventSourcedBehaviorImpl
       replyProbe.stop()
     }
 
-    if (serializationSettings.enabled && serializationSettings.verifyCommands)
-      verifySerializationAndThrow(reply, "Reply")
+    val newState = getState()
+    val newEvents = getEvents(oldEvents.size)
 
-    CommandResultImpl[Command, Event, State, R](result.command, result.events, result.state, Some(reply))
+    postCommandCheck(newEvents, newState, Some(reply))
+
+    CommandResultImpl[Command, Event, State, R](command, newEvents, newState, Some(reply))
+  }
+
+  override def runCommandExpectNoReply[R](creator: ActorRef[R] => Command): CommandResult[Command, Event, State] = {
+    val replyProbe = actorTestKit.createTestProbe[R]()
+    val command = creator(replyProbe.ref)
+    preCommandCheck(command)
+    val oldEvents = getEvents(dropOldEvents = 0)
+
+    actor ! command
+
+    try {
+      replyProbe.expectNoMessage()
+    } catch {
+      case NonFatal(e) =>
+        throw new AssertionError(s"Received unexpected reply for command [$command]. ${e.getMessage}")
+    } finally {
+      replyProbe.stop()
+    }
+
+    val newState = getState()
+    val newEvents = getEvents(oldEvents.size)
+
+    postCommandCheck(newEvents, newState, reply = None)
+
+    CommandResultImpl[Command, Event, State, Nothing](command, newEvents, newState, None)
+  }
+
+  private def getEvents[R](dropOldEvents: Int): immutable.Seq[Event] = {
+    // FIXME we can expand the api of persistenceTestKit to read from storage from a seqNr instead
+    persistenceTestKit.persistedInStorage(persistenceId.id).map(_.asInstanceOf[Event]).drop(dropOldEvents)
+  }
+
+  private def getState(): State = {
+    internalActor ! EventSourcedBehaviorImpl.GetState(stateProbe.ref)
+    val newState = stateProbe.receiveMessage()
+    newState
+  }
+
+  private def preCommandCheck(command: Command): Unit = {
+    if (serializationSettings.enabled && serializationSettings.verifyCommands)
+      verifySerializationAndThrow(command, "Command")
+
+    if (serializationSettings.enabled && !emptyStateVerified) {
+      val emptyState = getState
+      verifySerializationAndThrow(emptyState, "Empty State")
+      emptyStateVerified = true
+    }
+  }
+
+  private def postCommandCheck(newEvents: immutable.Seq[Event], newState: State, reply: Option[Any]): Unit = {
+    if (serializationSettings.enabled) {
+      if (serializationSettings.verifyEvents) {
+        newEvents.foreach(verifySerializationAndThrow(_, "Event"))
+      }
+
+      if (serializationSettings.verifyState)
+        verifySerializationAndThrow(newState, "State")
+
+      if (serializationSettings.verifyCommands) {
+        reply.foreach(verifySerializationAndThrow(_, "Reply"))
+      }
+    }
   }
 
   override def restart(): RestartResult[State] = {

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
@@ -224,6 +224,12 @@ final class EventSourcedBehaviorTestKit[Command, Event, State](
     new CommandResultWithReply(delegate.runCommand(replyTo => creator.apply(replyTo)))
 
   /**
+   * Retrieve the current state of the Behavior.
+   */
+  def getState(): State =
+    delegate.getState()
+
+  /**
    * Restart the behavior, which will then recover from stored snapshot and events. Can be used for testing
    * that the recovery is correct.
    */

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
@@ -224,14 +224,6 @@ final class EventSourcedBehaviorTestKit[Command, Event, State](
     new CommandResultWithReply(delegate.runCommand(replyTo => creator.apply(replyTo)))
 
   /**
-   * Run one command  with a `replyTo: ActorRef[R]` through the behavior, but a reply is not expected.
-   * Useful when testing commands that return `Effect.noReply`.
-   * The returned result contains emitted events, the state after applying the events, and the reply.
-   */
-  def runCommandExpectNoReply[R](creator: JFunction[ActorRef[R], Command]): CommandResult[Command, Event, State] =
-    new CommandResult(delegate.runCommandExpectNoReply[R](replyTo => creator.apply(replyTo)))
-
-  /**
    * Restart the behavior, which will then recover from stored snapshot and events. Can be used for testing
    * that the recovery is correct.
    */

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
@@ -224,6 +224,14 @@ final class EventSourcedBehaviorTestKit[Command, Event, State](
     new CommandResultWithReply(delegate.runCommand(replyTo => creator.apply(replyTo)))
 
   /**
+   * Run one command  with a `replyTo: ActorRef[R]` through the behavior, but a reply is not expected.
+   * Useful when testing commands that return `Effect.noReply`.
+   * The returned result contains emitted events, the state after applying the events, and the reply.
+   */
+  def runCommandExpectNoReply[R](creator: JFunction[ActorRef[R], Command]): CommandResult[Command, Event, State] =
+    new CommandResult(delegate.runCommandExpectNoReply[R](replyTo => creator.apply(replyTo)))
+
+  /**
    * Restart the behavior, which will then recover from stored snapshot and events. Can be used for testing
    * that the recovery is correct.
    */

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKit.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKit.scala
@@ -205,6 +205,11 @@ object EventSourcedBehaviorTestKit {
   def runCommand[R](creator: ActorRef[R] => Command): CommandResultWithReply[Command, Event, State, R]
 
   /**
+   * Retrieve the current state of the Behavior.
+   */
+  def getState(): State
+
+  /**
    * Restart the behavior, which will then recover from stored snapshot and events. Can be used for testing
    * that the recovery is correct.
    */

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKit.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKit.scala
@@ -205,6 +205,13 @@ object EventSourcedBehaviorTestKit {
   def runCommand[R](creator: ActorRef[R] => Command): CommandResultWithReply[Command, Event, State, R]
 
   /**
+   * Run one command  with a `replyTo: ActorRef[R]` through the behavior, but a reply is not expected.
+   * Useful when testing commands that return `Effect.noReply`.
+   * The returned result contains emitted events, the state after applying the events, and the reply.
+   */
+  def runCommandExpectNoReply[R](creator: ActorRef[R] => Command): CommandResult[Command, Event, State]
+
+  /**
    * Restart the behavior, which will then recover from stored snapshot and events. Can be used for testing
    * that the recovery is correct.
    */

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKit.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKit.scala
@@ -205,13 +205,6 @@ object EventSourcedBehaviorTestKit {
   def runCommand[R](creator: ActorRef[R] => Command): CommandResultWithReply[Command, Event, State, R]
 
   /**
-   * Run one command  with a `replyTo: ActorRef[R]` through the behavior, but a reply is not expected.
-   * Useful when testing commands that return `Effect.noReply`.
-   * The returned result contains emitted events, the state after applying the events, and the reply.
-   */
-  def runCommandExpectNoReply[R](creator: ActorRef[R] => Command): CommandResult[Command, Event, State]
-
-  /**
    * Restart the behavior, which will then recover from stored snapshot and events. Can be used for testing
    * that the recovery is correct.
    */

--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKitSpec.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKitSpec.scala
@@ -24,7 +24,6 @@ import akka.persistence.typed.scaladsl.Effect
 import akka.persistence.typed.scaladsl.EventSourcedBehavior
 import akka.serialization.DisabledJavaSerializer
 import akka.serialization.jackson.CborSerializable
-import akka.util.unused
 
 object EventSourcedBehaviorTestKitSpec {
 
@@ -32,8 +31,12 @@ object EventSourcedBehaviorTestKitSpec {
     sealed trait Command
     case object Increment extends Command with CborSerializable
     final case class IncrementWithConfirmation(replyTo: ActorRef[Done]) extends Command with CborSerializable
+    final case class IncrementWithNoReply(replyTo: ActorRef[Done]) extends Command with CborSerializable
+    final case class IncrementWithAsyncReply(replyTo: ActorRef[Done]) extends Command with CborSerializable
     case class IncrementSeveral(n: Int) extends Command with CborSerializable
     final case class GetValue(replyTo: ActorRef[State]) extends Command with CborSerializable
+
+    private case class AsyncReply(replyTo: ActorRef[Done]) extends Command with CborSerializable
 
     sealed trait Event
     final case class Incremented(delta: Int) extends Event with CborSerializable
@@ -62,7 +65,7 @@ object EventSourcedBehaviorTestKitSpec {
       Behaviors.setup(ctx => counter(ctx, persistenceId, emptyState))
 
     private def counter(
-        @unused ctx: ActorContext[Command],
+        ctx: ActorContext[Command],
         persistenceId: PersistenceId,
         emptyState: State): EventSourcedBehavior[Command, Event, State] = {
       EventSourcedBehavior.withEnforcedReplies[Command, Event, State](
@@ -75,6 +78,17 @@ object EventSourcedBehaviorTestKitSpec {
 
             case IncrementWithConfirmation(replyTo) =>
               Effect.persist(Incremented(1)).thenReply(replyTo)(_ => Done)
+
+            case IncrementWithAsyncReply(replyTo) =>
+              Thread.sleep(500)
+              ctx.self ! AsyncReply(replyTo)
+              Effect.noReply
+
+            case AsyncReply(replyTo) =>
+              Effect.persist(Incremented(1)).thenReply(replyTo)(_ => Done)
+
+            case IncrementWithNoReply(_) =>
+              Effect.persist(Incremented(1)).thenNoReply()
 
             case IncrementSeveral(n: Int) =>
               val events = (1 to n).map(_ => Incremented(1))
@@ -184,6 +198,22 @@ class EventSourcedBehaviorTestKitSpec
       intercept[AssertionError] {
         result.event
       }
+      result.state should ===(TestCounter.RealState(1, Vector(0)))
+    }
+
+    "run command with async reply" in {
+      val eventSourcedTestKit = createTestKit()
+      val result = eventSourcedTestKit.runCommand[Done](replyTo => TestCounter.IncrementWithAsyncReply(replyTo))
+      result.event should ===(TestCounter.Incremented(1))
+      result.reply should ===(Done)
+      result.state should ===(TestCounter.RealState(1, Vector(0)))
+    }
+
+    "run command with no reply" in {
+      val eventSourcedTestKit = createTestKit()
+      val result =
+        eventSourcedTestKit.runCommandExpectNoReply[Done](replyTo => TestCounter.IncrementWithNoReply(replyTo))
+      result.event should ===(TestCounter.Incremented(1))
       result.state should ===(TestCounter.RealState(1, Vector(0)))
     }
 

--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKitSpec.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKitSpec.scala
@@ -80,7 +80,6 @@ object EventSourcedBehaviorTestKitSpec {
               Effect.persist(Incremented(1)).thenReply(replyTo)(_ => Done)
 
             case IncrementWithAsyncReply(replyTo) =>
-              Thread.sleep(500)
               ctx.self ! AsyncReply(replyTo)
               Effect.noReply
 

--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKitSpec.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKitSpec.scala
@@ -219,6 +219,17 @@ class EventSourcedBehaviorTestKitSpec
       replyToProbe.expectNoMessage()
     }
 
+    "give access to current state" in {
+      val eventSourcedTestKit = createTestKit()
+
+      // initial state
+      eventSourcedTestKit.getState() should ===(TestCounter.RealState(0, Vector.empty))
+
+      // state after command
+      eventSourcedTestKit.runCommand(TestCounter.Increment)
+      eventSourcedTestKit.getState() should ===(TestCounter.RealState(1, Vector(0)))
+    }
+
     "detect non-serializable events" in {
       val eventSourcedTestKit = createTestKit()
 

--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKitSpec.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKitSpec.scala
@@ -209,11 +209,14 @@ class EventSourcedBehaviorTestKitSpec
     }
 
     "run command with no reply" in {
+      // This is a fictive usage scenario. If the command has a replyTo the Behavior should (eventually) reply,
+      // but here we verify that it doesn't reply.
       val eventSourcedTestKit = createTestKit()
-      val result =
-        eventSourcedTestKit.runCommandExpectNoReply[Done](replyTo => TestCounter.IncrementWithNoReply(replyTo))
+      val replyToProbe = createTestProbe[Done]()
+      val result = eventSourcedTestKit.runCommand(TestCounter.IncrementWithNoReply(replyToProbe.ref))
       result.event should ===(TestCounter.Incremented(1))
       result.state should ===(TestCounter.RealState(1, Vector(0)))
+      replyToProbe.expectNoMessage()
     }
 
     "detect non-serializable events" in {


### PR DESCRIPTION
* retrieve events and state after the reply

References #29602 
References #29581
