### PR TITLE
simplify the SBR instability check

### DIFF
--- a/akka-cluster/src/main/mima-filters/2.6.9.backwards.excludes/sbr-setReachability.excludes
+++ b/akka-cluster/src/main/mima-filters/2.6.9.backwards.excludes/sbr-setReachability.excludes
@@ -1,0 +1,2 @@
+# change to internal
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.cluster.sbr.DowningStrategy.setReachability")

--- a/akka-cluster/src/main/scala/akka/cluster/sbr/DowningStrategy.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/sbr/DowningStrategy.scala
@@ -205,26 +205,12 @@ import akka.coordination.lease.scaladsl.Lease
     _allMembers.exists(m => m.uniqueAddress == node && m.dataCenter == selfDc)
   }
 
-  /**
-   * @return true if it was changed
-   */
-  private[sbr] def setReachability(r: Reachability): Boolean = {
+  private[sbr] def setReachability(r: Reachability): Unit = {
     // skip records with Reachability.Reachable, and skip records related to other DC
-    val newReachability = r.filterRecords(
+    _reachability = r.filterRecords(
       record =>
         (record.status == Reachability.Unreachable || record.status == Reachability.Terminated) &&
         isInSelfDc(record.observer) && isInSelfDc(record.subject))
-    val oldReachability = _reachability
-
-    val changed =
-      if (oldReachability.records.size != newReachability.records.size)
-        true
-      else
-        oldReachability.records.map(r => r.observer -> r.subject).toSet !=
-          newReachability.records.map(r => r.observer -> r.subject).toSet
-
-    _reachability = newReachability
-    changed
   }
 
   def seenBy: Set[Address] =

--- a/akka-cluster/src/main/scala/akka/cluster/sbr/SplitBrainResolver.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/sbr/SplitBrainResolver.scala
@@ -294,16 +294,17 @@ import akka.pattern.pipe
       val durationSinceLatestChange = (now - reachabilityChangedStats.latestChangeTimestamp).nanos
       val durationSinceFirstChange = (now - reachabilityChangedStats.firstChangeTimestamp).nanos
 
-      if (durationSinceLatestChange > (stableAfter * 2)) {
-        log.debug("SBR no reachability changes within {} ms, resetting stats", (stableAfter * 2).toMillis)
-        resetReachabilityChangedStats()
-      } else if (downAllWhenUnstable > Duration.Zero &&
-                 durationSinceFirstChange > (stableAfter + downAllWhenUnstable)) {
+      val downAllWhenUnstableEnabled = downAllWhenUnstable > Duration.Zero
+      if (downAllWhenUnstableEnabled && durationSinceFirstChange > (stableAfter + downAllWhenUnstable)) {
         log.warning(
           ClusterLogMarker.sbrInstability,
           "SBR detected instability and will down all nodes: {}",
           reachabilityChangedStats)
         actOnDecision(DownAll)
+      } else if (!downAllWhenUnstableEnabled && durationSinceLatestChange > (stableAfter * 2)) {
+        // downAllWhenUnstable is disabled but reset for meaningful logging
+        log.debug("SBR no reachability changes within {} ms, resetting stats", (stableAfter * 2).toMillis)
+        resetReachabilityChangedStats()
       }
     }
 
@@ -470,7 +471,10 @@ import akka.pattern.pipe
       log.debug("SBR unreachableMember [{}]", m)
       mutateMemberInfo(resetStable = true) { () =>
         strategy.addUnreachable(m)
+        updateReachabilityChangedStats()
         resetReachabilityChangedStatsIfAllUnreachableDowned()
+        if (!reachabilityChangedStats.isEmpty)
+          log.debug("SBR noticed {}", reachabilityChangedStats)
       }
     }
   }
@@ -480,19 +484,16 @@ import akka.pattern.pipe
       log.debug("SBR reachableMember [{}]", m)
       mutateMemberInfo(resetStable = true) { () =>
         strategy.addReachable(m)
+        updateReachabilityChangedStats()
         resetReachabilityChangedStatsIfAllUnreachableDowned()
+        if (!reachabilityChangedStats.isEmpty)
+          log.debug("SBR noticed {}", reachabilityChangedStats)
       }
     }
   }
 
   private[sbr] def reachabilityChanged(r: Reachability): Unit = {
-    if (strategy.setReachability(r)) {
-      // resetStableDeadline is done from unreachableMember/reachableMember
-      updateReachabilityChangedStats()
-      // it may also change when members are removed and therefore the reset may be needed
-      resetReachabilityChangedStatsIfAllUnreachableDowned()
-      log.debug("SBR noticed {}", reachabilityChangedStats)
-    }
+    strategy.setReachability(r)
   }
 
   private def updateReachabilityChangedStats(): Unit = {


### PR DESCRIPTION
When I debugged some test failure I thought that the SBR instability check was too aggressive because it was using the individual reachability changes for detecting instability, but it turned out that it wasn't a problem. See issue https://github.com/akka/akka/issues/29540

However, I simplified the instability tracking to be based on the aggregated information instead. UnreachableMember and UnreachableMember. The result should be the same since it was anyway measuring from the first change.
