### PR TITLE
GCounter merge without var

### DIFF
--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/GCounter.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/GCounter.scala
@@ -114,13 +114,12 @@ final class GCounter private[akka] (
     if ((this eq that) || that.isAncestorOf(this)) this.clearAncestor()
     else if (this.isAncestorOf(that)) that.clearAncestor()
     else {
-      var merged = that.state
-      for ((key, thisValue) <- state) {
-        val thatValue = merged.getOrElse(key, Zero)
-        if (thisValue > thatValue)
-          merged = merged.updated(key, thisValue)
-      }
       clearAncestor()
+      val merged = (state.keys ++ that.state.keys).map { key =>
+        val thisValue = state.getOrElse(key, Zero)
+        val thatValue = that.state.getOrElse(key, Zero)
+        (key, thisValue.max(thatValue))
+      }.toMap
       new GCounter(merged)
     }
 


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
I find having var in scala code makes it a bit difficult to understand, so I change it to val

If it looks good, I will change several other `merge` implementation