### PR TITLE
clearAll when creating new EventSourcedBehaviorTestKit, #29609

### DIFF
--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
@@ -81,6 +81,7 @@ import akka.persistence.typed.internal.EventSourcedBehaviorImpl
   private def system: ActorSystem[_] = actorTestKit.system
 
   override val persistenceTestKit: PersistenceTestKit = PersistenceTestKit(system)
+  persistenceTestKit.clearAll()
 
   private val probe = actorTestKit.createTestProbe[Any]()
   private val stateProbe = actorTestKit.createTestProbe[State]()
@@ -98,8 +99,6 @@ import akka.persistence.typed.internal.EventSourcedBehaviorImpl
   private val serializationTestKit = new SerializationTestKit(system)
 
   private var emptyStateVerified = false
-
-  persistenceTestKit.clearByPersistenceId(persistenceId.id)
 
   override def runCommand(command: Command): CommandResult[Command, Event, State] = {
     if (serializationSettings.enabled && serializationSettings.verifyCommands)


### PR DESCRIPTION
* issue could be reproduced with sleep(200) before the persistenceTestKit.clearByPersistenceId
  in EventSourcedBehaviorTestKitImpl
* problem is that there is a race condition betwen that clear and that the EventSourcedBehavior
  is starting concurrently, which can result in that the EventSourcedBehavior may see events from
  previous test if using same persistenceId
* solution is to clearAll before starting the EventSourcedBehavior

References #29609
