### PR TITLE
Watching an actor ref on a member that left should give terminated

### DIFF
--- a/akka-cluster/src/main/mima-filters/2.6.9.backwards.excludes/issue-29628-watch-and-tombstones.excludes
+++ b/akka-cluster/src/main/mima-filters/2.6.9.backwards.excludes/issue-29628-watch-and-tombstones.excludes
@@ -1,0 +1,3 @@
+# internal apis
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterEvent#CurrentClusterState.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterDomainEventPublisher.publishDiff")

--- a/akka-cluster/src/main/mima-filters/2.6.9.backwards.excludes/issue-29628-watch-and-tombstones.excludes
+++ b/akka-cluster/src/main/mima-filters/2.6.9.backwards.excludes/issue-29628-watch-and-tombstones.excludes
@@ -1,3 +1,2 @@
 # internal apis
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterEvent#CurrentClusterState.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.ClusterDomainEventPublisher.publishDiff")

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
@@ -113,7 +113,7 @@ object ClusterEvent {
       with Serializable {
 
     // for binary compatibility
-    @deprecated("use main constructor", since = "2.5.10")
+    @deprecated("use main constructor", since = "2.6.10")
     def this(
         members: immutable.SortedSet[Member],
         unreachable: Set[Member],
@@ -124,7 +124,7 @@ object ClusterEvent {
       this(members, unreachable, seenBy, leader, roleLeaderMap, unreachableDataCenters, Set.empty)
 
     // for binary compatibility
-    @deprecated("use main constructor", since = "2.5.10")
+    @deprecated("use main constructor", since = "2.6.10")
     def this(
         members: immutable.SortedSet[Member] = immutable.SortedSet.empty,
         unreachable: Set[Member] = Set.empty,

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala
@@ -88,7 +88,8 @@ private[akka] class ClusterReadView(cluster: Cluster) extends Closeable {
                 _state = _state.withUnreachableDataCenters(_state.unreachableDataCenters - r.dataCenter)
               case r: UnreachableDataCenter =>
                 _state = _state.withUnreachableDataCenters(_state.unreachableDataCenters + r.dataCenter)
-
+              case MemberTombstonesChanged(tombstones) =>
+                _state = _state.withMemberTombstones(tombstones)
             }
 
             e match {

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
@@ -10,6 +10,7 @@ import akka.cluster.ClusterEvent.CurrentClusterState
 import akka.cluster.ClusterEvent.MemberEvent
 import akka.cluster.ClusterEvent.MemberJoined
 import akka.cluster.ClusterEvent.MemberRemoved
+import akka.cluster.ClusterEvent.MemberTombstonesChanged
 import akka.cluster.ClusterEvent.MemberUp
 import akka.cluster.ClusterEvent.MemberWeaklyUp
 import akka.dispatch.Dispatchers
@@ -44,7 +45,6 @@ private[cluster] object ClusterRemoteWatcher {
   private final case class DelayedQuarantine(m: Member, previousStatus: MemberStatus)
       extends NoSerializationVerificationNeeded
 
-  private case object TombstoneCleanUpTick
 }
 
 /**
@@ -66,7 +66,7 @@ private[cluster] class ClusterRemoteWatcher(
     extends RemoteWatcher(failureDetector, heartbeatInterval, unreachableReaperInterval, heartbeatExpectedResponseAfter)
     with Timers {
 
-  import ClusterRemoteWatcher.{ DelayedQuarantine, TombstoneCleanUpTick }
+  import ClusterRemoteWatcher.DelayedQuarantine
 
   private val arteryEnabled = RARP(context.system).provider.remoteSettings.Artery.Enabled
   val cluster = Cluster(context.system)
@@ -80,12 +80,11 @@ private[cluster] class ClusterRemoteWatcher(
   private var pendingDelayedQuarantine: Set[UniqueAddress] = Set.empty
 
   var clusterNodes: Set[Address] = Set.empty
-  var tombstones: Map[Address, Long] = Map.empty
+  var memberTombstones: Set[UniqueAddress] = Set.empty
 
   override def preStart(): Unit = {
     super.preStart()
-    cluster.subscribe(self, classOf[MemberEvent])
-    timers.startTimerWithFixedDelay(TombstoneCleanUpTick, TombstoneCleanUpTick, 1.minute)
+    cluster.subscribe(self, classOf[MemberEvent], classOf[MemberTombstonesChanged])
   }
 
   override def postStop(): Unit = {
@@ -100,13 +99,14 @@ private[cluster] class ClusterRemoteWatcher(
       clusterNodes = state.members.collect { case m if m.address != selfAddress => m.address }
       clusterNodes.foreach(takeOverResponsibility)
       unreachable = unreachable.diff(clusterNodes)
+      memberTombstones = state.memberTombstones
     case MemberJoined(m)                      => memberJoined(m)
     case MemberUp(m)                          => memberUp(m)
     case MemberWeaklyUp(m)                    => memberUp(m)
     case MemberRemoved(m, previousStatus)     => memberRemoved(m, previousStatus)
+    case MemberTombstonesChanged(tombstones)  => memberTombstones = tombstones
     case _: MemberEvent                       => // not interesting
     case DelayedQuarantine(m, previousStatus) => delayedQuarantine(m, previousStatus)
-    case TombstoneCleanUpTick                 => cleanUpTombstones()
   }
 
   private def memberJoined(m: Member): Unit = {
@@ -118,8 +118,6 @@ private[cluster] class ClusterRemoteWatcher(
     if (m.address != selfAddress) {
       quarantineOldIncarnation(m)
       clusterNodes += m.address
-      if (tombstones.contains(m.address)) // new node with same address joined
-        tombstones -= m.address
       takeOverResponsibility(m.address)
       unreachable -= m.address
     }
@@ -127,7 +125,6 @@ private[cluster] class ClusterRemoteWatcher(
   def memberRemoved(m: Member, previousStatus: MemberStatus): Unit =
     if (m.address != selfAddress) {
       clusterNodes -= m.address
-      tombstones += (m.address -> System.currentTimeMillis())
 
       if (previousStatus == MemberStatus.Down) {
         quarantine(
@@ -173,14 +170,17 @@ private[cluster] class ClusterRemoteWatcher(
     }
   }
 
-  override def addWatch(watchee: InternalActorRef, watcher: InternalActorRef): Unit =
-    if (tombstones.contains(watchee.path.address)) {
-      log.info("Watchee terminated because address [{}] has tombstone", watchee.path.address)
+  override def addWatch(watchee: InternalActorRef, watcher: InternalActorRef): Unit = {
+    val watcheeNode = watchee.path.address
+    if (!clusterNodes.contains(watcheeNode) && memberTombstones.exists(_.address == watcheeNode)) {
+      // node is not currently, but was previously part of cluster, trigger death watch notification immediately
+      log.debug("Death watch for [{}] triggered immediately because address has tombstone", watchee)
       watcher ! watcher.sendSystemMessage(
         DeathWatchNotification(watchee, existenceConfirmed = false, addressTerminated = true))
     } else {
       super.addWatch(watchee, watcher)
     }
+  }
 
   override def watchNode(watchee: InternalActorRef): Unit =
     if (!clusterNodes(watchee.path.address)) super.watchNode(watchee)
@@ -210,10 +210,5 @@ private[cluster] class ClusterRemoteWatcher(
       log.debug("Cluster is taking over responsibility of node: [{}]", address)
       unwatchNode(address)
     }
-
-  private def cleanUpTombstones(): Unit = {
-    val pruneOlderThanMs = System.currentTimeMillis() - 1.hour.toMillis // FIXME does it need to be configurable?
-    tombstones = tombstones.filter { case (_, timestamp) => timestamp > pruneOlderThanMs }
-  }
 
 }

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
@@ -22,8 +22,6 @@ import akka.remote.RARP
 import akka.remote.RemoteSettings
 import akka.remote.RemoteWatcher
 
-import scala.concurrent.duration._
-
 /**
  * INTERNAL API
  */

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
@@ -172,7 +172,7 @@ private[cluster] class ClusterRemoteWatcher(
     val watcheeNode = watchee.path.address
     if (!clusterNodes.contains(watcheeNode) && memberTombstones.exists(_.address == watcheeNode)) {
       // node is not currently, but was previously part of cluster, trigger death watch notification immediately
-      log.debug("Death watch for [{}] triggered immediately because address has tombstone", watchee)
+      log.debug("Death watch for [{}] triggered immediately because member was removed from cluster", watchee)
       watcher.sendSystemMessage(DeathWatchNotification(watchee, existenceConfirmed = false, addressTerminated = true))
     } else {
       super.addWatch(watchee, watcher)

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterRemoteWatcher.scala
@@ -173,8 +173,7 @@ private[cluster] class ClusterRemoteWatcher(
     if (!clusterNodes.contains(watcheeNode) && memberTombstones.exists(_.address == watcheeNode)) {
       // node is not currently, but was previously part of cluster, trigger death watch notification immediately
       log.debug("Death watch for [{}] triggered immediately because address has tombstone", watchee)
-      watcher ! watcher.sendSystemMessage(
-        DeathWatchNotification(watchee, existenceConfirmed = false, addressTerminated = true))
+      watcher.sendSystemMessage(DeathWatchNotification(watchee, existenceConfirmed = false, addressTerminated = true))
     } else {
       super.addWatch(watchee, watcher)
     }

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
@@ -304,7 +304,7 @@ abstract class ClusterDeathWatchSpec
         runOn(first) {
           // fourth system will be shutdown, remove to not participate in barriers any more
           testConductor.shutdown(fourth).await
-          awaitAssert(expectMsg(EndActor.End)) // get a Unit back here for some reason
+          expectMsg(EndActor.End)
         }
 
         enterBarrier("after-5")

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
@@ -30,7 +30,7 @@ object ClusterDeathWatchMultiJvmSpec extends MultiNodeConfig {
   val fifth = role("fifth")
 
   commonConfig(
-    debugConfig(false)
+    debugConfig(on = false)
       .withFallback(ConfigFactory.parseString("""
       # test is using Java serialization and not priority to rewrite
       akka.actor.allow-java-serialization = on
@@ -236,11 +236,11 @@ abstract class ClusterDeathWatchSpec
       enterBarrier("after-3")
     }
 
-    "get a terminated when trying to watch actor after node was downed" in within(max = 120.seconds) {
+    "get a terminated when trying to watch actor after node was downed" in within(max = 20.seconds) {
       runOn(first) {
         // node 5 is long gone (downed)
         watch(subject6)
-        expectTerminated(subject6, 60.seconds)
+        expectTerminated(subject6, 10.seconds)
       }
       enterBarrier("after-4")
     }

--- a/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
@@ -22,6 +22,7 @@ import akka.util.unused
 /**
  * INTERNAL API
  */
+@InternalApi
 private[akka] object RemoteWatcher {
 
   /**
@@ -91,6 +92,7 @@ private[akka] object RemoteWatcher {
  * both directions, but independent of each other.
  *
  */
+@InternalApi
 private[akka] class RemoteWatcher(
     failureDetector: FailureDetectorRegistry[Address],
     heartbeatInterval: FiniteDuration,
@@ -206,7 +208,7 @@ private[akka] class RemoteWatcher(
   /** Returns true if either has cluster or `akka.remote.use-unsafe-remote-features-outside-cluster`
    * is enabled. Can be overridden when using RemoteWatcher as a superclass.
    */
-  @InternalApi protected def shouldWatch(@unused watchee: InternalActorRef): Boolean = {
+  protected def shouldWatch(@unused watchee: InternalActorRef): Boolean = {
     // In this it is unnecessary if only created by RARP, but cluster needs it.
     // Cleaner than overriding Cluster watcher addWatch/removeWatch just for one boolean test
     remoteProvider.remoteSettings.UseUnsafeRemoteFeaturesWithoutCluster


### PR DESCRIPTION
Refs #29628 

New internal event for keeping track of tombstones nodes and looking at that in ClusterRemoteWatcher. If a node address is not in the available nodes but in the tombstones we immediately send a death watch notification.

