### PR TITLE
harden ReliableDeliverySpec, #29340

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/delivery/ReliableDeliverySpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/delivery/ReliableDeliverySpec.scala
@@ -137,6 +137,7 @@ class ReliableDeliverySpec(config: Config)
       consumerController ! ConsumerController.RegisterToProducerController(producerController)
 
       consumerEndProbe.receiveMessage(5.seconds)
+      consumerEndProbe.expectTerminated(consumerController)
 
       val consumerEndProbe2 = createTestProbe[TestConsumer.Collected]()
       val consumerController2 =
@@ -148,7 +149,7 @@ class ReliableDeliverySpec(config: Config)
 
       testKit.stop(producer)
       testKit.stop(producerController)
-      testKit.stop(consumerController)
+      testKit.stop(consumerController2)
     }
 
     "allow replacement of producer" in {
@@ -178,6 +179,7 @@ class ReliableDeliverySpec(config: Config)
 
       // replace producer
       testKit.stop(producerController1)
+      producerProbe1.expectTerminated(producerController1)
       val producerController2 =
         spawn(ProducerController[TestConsumer.Job](s"p-${idCount}", None), s"producerController2-${idCount}")
       val producerProbe2 = createTestProbe[ProducerController.RequestNext[TestConsumer.Job]]()


### PR DESCRIPTION
* "allow replacement of destination" failed because
  new ConsumerController is started before previous had been fully terminated

References #29340


From the logs it was clear what was wrong:
```
>>> processed 42 in consumer1, last message and then it will stop
2020-09-22 08:38:15,093 INFO  TestConsumer  - processed [42] from [p-1] MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumer1-1, sourceActorSystem=ReliableDeliverySpec}
2020-09-22 08:38:15,093 INFO  TestProducer  - sent msg-43 MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/producer-1, sourceActorSystem=ReliableDeliverySpec}
2020-09-22 08:38:15,093 DEBUG TestConsumer  - End at [42] MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumer1-1, sourceActorSystem=ReliableDeliverySpec}
2020-09-22 08:38:15,093 TRACE akka.actor.typed.delivery.ConsumerController  - Received Confirmed seqNr [42] from consumer, stashed size [0]. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumerController1-1, sourceActorSystem=ReliableDeliverySpec}
2020-09-22 08:38:15,093 TRACE akka.actor.typed.delivery.ProducerController  - Sending [akka.actor.typed.delivery.TestConsumer$Job] with seqNr [43]. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/producerController-1, sourceActorSystem=ReliableDeliverySpec, producerId=p-1}
2020-09-22 08:38:15,093 TRACE akka.actor.typed.delivery.ConsumerController  - Received SequencedMessage seqNr [43], delivering to consumer. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumerController1-1, sourceActorSystem=ReliableDeliverySpec, producerId=p-1}
2020-09-22 08:38:15,097 DEBUG akka.actor.typed.delivery.ConsumerController  - Cancel timer [Retry] with generation [1] MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumerController2-1, sourceActorSystem=ReliableDeliverySpec}

>>> consumerController2 starting
2020-09-22 08:38:15,097 DEBUG akka.actor.typed.delivery.ConsumerController  - Received Start, unstash [0] messages. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumerController2-1, sourceActorSystem=ReliableDeliverySpec}
2020-09-22 08:38:15,098 DEBUG akka.actor.typed.delivery.ProducerController  - Register new ConsumerController [Actor[akka://ReliableDeliverySpec/user/consumerController2-1#-451307426]], starting with seqNr [41]. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/producerController-1, sourceActorSystem=ReliableDeliverySpec, producerId=p-1}
2020-09-22 08:38:15,100 DEBUG akka.actor.typed.delivery.ProducerController  - Resending first, [41]. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/producerController-1, sourceActorSystem=ReliableDeliverySpec, producerId=p-1}
2020-09-22 08:38:15,100 TRACE akka.actor.typed.delivery.ConsumerController  - Received first SequencedMessage seqNr [41], delivering to consumer. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumerController2-1, sourceActorSystem=ReliableDeliverySpec, producerId=p-1}

>>> 
2020-09-22 08:38:15,100 DEBUG akka.actor.typed.delivery.ConsumerController  - Associated with new ProducerController [Actor[akka://ReliableDeliverySpec/user/producerController-1#-786874801]], seqNr [41]. MDC: {akkaAddress=akka://ReliableDeliverySpec, producerId=p-1, akkaSource=akka://ReliableDeliverySpec/user/consumerController2-1, sourceActorSystem=ReliableDeliverySpec}
2020-09-22 08:38:15,100 DEBUG akka.actor.typed.delivery.ConsumerController  - Sending Request with requestUpToSeqNr [60] after first SequencedMessage. MDC: {akkaAddress=akka://ReliableDeliverySpec, producerId=p-1, akkaSource=akka://ReliableDeliverySpec/user/consumerController2-1, sourceActorSystem=ReliableDeliverySpec}

>>> deliver 41 to consumer2
2020-09-22 08:38:15,100 TRACE TestConsumer  - SeqNr [41] was delivered to consumer. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumer2-1, sourceActorSystem=ReliableDeliverySpec}
2020-09-22 08:38:15,100 DEBUG akka.actor.typed.delivery.ProducerController  - Received Request, confirmed [0], requested [60], current [44] MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/producerController-1, sourceActorSystem=ReliableDeliverySpec, producerId=p-1}

>>> terminated consumer1
2020-09-22 08:38:15,101 DEBUG akka.actor.typed.delivery.ConsumerController  - Consumer [Actor[akka://ReliableDeliverySpec/user/consumer1-1/$$a-adapter#-350867895]] terminated. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumerController1-1, sourceActorSystem=ReliableDeliverySpec}
2020-09-22 08:38:15,101 DEBUG akka.actor.typed.delivery.ConsumerController  - Cancel all timers MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumerController1-1, sourceActorSystem=ReliableDeliverySpec}

>>> confirmed 42, from consumer1, because ack is sent when it's stopped
2020-09-22 08:38:15,102 TRACE akka.actor.typed.delivery.ProducerController  - Received Ack, confirmed [42], current [44]. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/producerController-1, sourceActorSystem=ReliableDeliverySpec, producerId=p-1}
2020-09-22 08:38:15,104 INFO  akka.actor.LocalActorRef akkaDeadLetter - Message [akka.actor.typed.delivery.ConsumerController$Delivery] wrapped in [akka.actor.typed.internal.AdaptMessage] to Actor[akka://ReliableDeliverySpec/user/consumer1-1#1227028356] was not delivered. [1] dead letters encountered. If this is not an expected behavior then Actor[akka://ReliableDeliverySpec/user/consumer1-1#1227028356] may have terminated unexpectedly. This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' and 'akka.log-dead-letters-during-shutdown'. MDC: {akkaAddress=akka://ReliableDeliverySpec, sourceThread=ReliableDeliverySpec-akka.actor.default-dispatcher-7, akkaSource=akka://ReliableDeliverySpec/user/consumer1-1, sourceActorSystem=ReliableDeliverySpec, akkaMessageClass=akka.actor.typed.delivery.ConsumerController$Delivery, akkaTimestamp=05:38:15.101UTC}
2020-09-22 08:38:15,124 INFO  TestProducer  - sent msg-44 MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/producer-1, sourceActorSystem=ReliableDeliverySpec}

>>> processed 41 in consumer2
2020-09-22 08:38:15,124 INFO  TestConsumer  - processed [41] from [p-1] MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumer2-1, sourceActorSystem=ReliableDeliverySpec}

>>> sending 44
2020-09-22 08:38:15,124 TRACE akka.actor.typed.delivery.ProducerController  - Sending [akka.actor.typed.delivery.TestConsumer$Job] with seqNr [44]. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/producerController-1, sourceActorSystem=ReliableDeliverySpec, producerId=p-1}
2020-09-22 08:38:15,124 TRACE akka.actor.typed.delivery.ConsumerController  - Received Confirmed seqNr [41] from consumer, stashed size [0]. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumerController2-1, sourceActorSystem=ReliableDeliverySpec}
2020-09-22 08:38:15,124 DEBUG akka.actor.typed.delivery.ConsumerController  - Sending Request after first with confirmedSeqNr [41], requestUpToSeqNr [60]. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumerController2-1, sourceActorSystem=ReliableDeliverySpec}
2020-09-22 08:38:15,124 DEBUG akka.actor.typed.delivery.ProducerController  - Received Request, confirmed [41], requested [60], current [45] MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/producerController-1, sourceActorSystem=ReliableDeliverySpec, producerId=p-1}
2020-09-22 08:38:15,124 DEBUG akka.actor.typed.delivery.ProducerController  - Cancel timer [ResendFirst] with generation [2] MDC: {akkaAddress=akka://ReliableDeliverySpec, producerId=p-1, akkaSource=akka://ReliableDeliverySpec/user/producerController-1, sourceActorSystem=ReliableDeliverySpec}
2020-09-22 08:38:15,124 DEBUG akka.actor.typed.delivery.ProducerController  - Resending [43 - 44]. MDC: {akkaAddress=akka://ReliableDeliverySpec, producerId=p-1, akkaSource=akka://ReliableDeliverySpec/user/producerController-1, sourceActorSystem=ReliableDeliverySpec}

>> missing 42 because that was confirmed by the old consumerController1 but never received in consumerController2
2020-09-22 08:38:15,127 DEBUG akka.actor.typed.delivery.ConsumerController  - Received SequencedMessage seqNr [44], but expected [42], requesting resend from expected seqNr. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumerController2-1, sourceActorSystem=ReliableDeliverySpec, producerId=p-1}
2020-09-22 08:38:15,127 DEBUG akka.actor.typed.delivery.ConsumerController  - Cancel timer [Retry] with generation [2] MDC: {akkaAddress=akka://ReliableDeliverySpec, producerId=p-1, akkaSource=akka://ReliableDeliverySpec/user/consumerController2-1, sourceActorSystem=ReliableDeliverySpec}
2020-09-22 08:38:15,129 DEBUG akka.actor.typed.delivery.ConsumerController  - Received SequencedMessage seqNr [43], discarding message because waiting for [42]. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumerController2-1, sourceActorSystem=ReliableDeliverySpec, producerId=p-1}
2020-09-22 08:38:15,129 DEBUG akka.actor.typed.delivery.ConsumerController  - Received SequencedMessage seqNr [44], discarding message because waiting for [42]. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/consumerController2-1, sourceActorSystem=ReliableDeliverySpec, producerId=p-1}
2020-09-22 08:38:15,130 DEBUG akka.actor.typed.delivery.ProducerController  - Resending [43 - 44]. MDC: {akkaAddress=akka://ReliableDeliverySpec, akkaSource=akka://ReliableDeliverySpec/user/producerController-1, sourceActorSystem=ReliableDeliverySpec, producerId=p-1}
```