### PR TITLE
Fix documentation version warning for 'series' page

### DIFF
--- a/akka-docs/src/main/paradox/assets/js/warnOldDocs.js
+++ b/akka-docs/src/main/paradox/assets/js/warnOldDocs.js
@@ -99,6 +99,8 @@ jQuery(document).ready(function ($) {
           $('#samePageLink').html('<a href="' + insteadPage + '">Click here to go to the same page on the ' + instead.latest + ' version of the docs.</a>');
         }
       });
+    } else if (version == series) {
+      // The series already points to the latest version in that series
     } else if (version != seriesInfo.latest) {
       showWarning(
         site,


### PR DESCRIPTION
Tested by manually replacing the script at
https://doc.akka.io/docs/akka/2.6/

After review/merge I can replace other old scripts as well