### PR TITLE
typo fix in doc pointed to akka-cluster instead of akka-distributed-d…

### DIFF
--- a/akka-docs/src/main/paradox/typed/guide/modules.md
+++ b/akka-docs/src/main/paradox/typed/guide/modules.md
@@ -180,7 +180,7 @@ Persistence tackles the following challenges:
   symbol1=AkkaVersion
   value1="$akka.version$"
   group=com.typesafe.akka
-  artifact=akka-cluster-typed_$scala.binary.version$
+  artifact=akka-distributed-data_$scala.binary.version$
   version=AkkaVersion
 }
 


### PR DESCRIPTION
Fixed typo in documentation pointed to akka-cluster instead of akka-distributed-data.
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
