### PR TITLE
Fix for ReplicatedShardingSpec failing 

### DIFF
--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ShardingDirectReplication.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ShardingDirectReplication.scala
@@ -75,12 +75,17 @@ private[akka] object ShardingDirectReplication {
                 event.sequenceNumber)
               replicaShardingProxies.foreach {
                 case (replica, proxy) =>
-                  val newId = ReplicationId.fromString(event.persistenceId.id).withReplica(replica)
+                  val newId = replicationId.withReplica(replica)
                   val envelopedEvent = ShardingEnvelope(newId.persistenceId.id, event)
                   if (!selfReplica.contains(replica)) {
                     proxy.asInstanceOf[ActorRef[ShardingEnvelope[PublishedEvent]]] ! envelopedEvent
                   }
               }
+            } else {
+              context.log.traceN(
+                "Not forwarding event for persistence id [{}] to replicas (wrong type name, expected [{}]).",
+                event.persistenceId,
+                typeName)
             }
           }
           Behaviors.same

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ReplicatedShardingExtensionImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ReplicatedShardingExtensionImpl.scala
@@ -43,13 +43,14 @@ private[akka] final class ReplicatedShardingExtensionImpl(system: ActorSystem[_]
       thisReplica: Option[ReplicaId],
       settings: ReplicatedEntityProvider[M]): ReplicatedSharding[M] = {
     require(settings.replicas.nonEmpty, "Replicas must not be empty")
-    val typeName = settings.replicas.head._1.entity.typeKey.name
+    // typeName without the replica id
+    val typeName = settings.replicas.head._2
     val sharding = ClusterSharding(system)
     val initializedReplicas = settings.replicas.map {
       case (replicaSettings, typeName) =>
         // start up a sharding instance per replica id
         logger.infoN(
-          "Starting Replicated Event Sourcing sharding for replica [{}] (ShardType: [{}])",
+          "Starting Replicated Event Sourcing sharding for replica [{}] (ShardType: [{}], typeName [{}])",
           replicaSettings.replicaId.id,
           replicaSettings.entity.typeKey.name)
         val regionOrProxy = sharding.init(replicaSettings.entity)


### PR DESCRIPTION
References #29674

The issue was about including or not including the replication ID in the `typeName` - when creating the `ShardingDirectReplication` (one per node) it was picked from the wrong place and included the replica id (so something like `TypeName|R1`) while the published event would have an id not including the replication id in the type name (`TypeName|pid|R1`) leading to all events being filtered and never direct-published as intended.