### PR TITLE
[Docs] Make Rejected extend OperationResult

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
@@ -322,7 +322,7 @@ object StyleGuideDocExamples {
 
       sealed trait OperationResult
       case object Confirmed extends OperationResult
-      final case class Rejected(reason: String)
+      final case class Rejected(reason: String) extends OperationResult
     }
     //#message-protocol
   }


### PR DESCRIPTION
To keep consistency with the documentation and the style guide `Rejected` case class should extend `OperationResult`
