### PR TITLE
Fix grammar error in streams cookbook

### DIFF
--- a/akka-docs/src/main/paradox/stream/stream-cookbook.md
+++ b/akka-docs/src/main/paradox/stream/stream-cookbook.md
@@ -237,7 +237,7 @@ Java
 ### Adhoc source
 
 **Situation:** The idea is that you have a source which you don't want to start until you have a demand.
-Also, you want to shutdown it down when there is no more demand, and start it up again there is new demand again.
+Also, you want to shut it down when there is no more demand, and start it up again there is new demand again.
 
 You can achieve this behavior by combining `lazily`, `backpressureTimeout` and `recoverWithRetries` as follows:
 


### PR DESCRIPTION
"shutdown it down" -> "shut it down"