### PR TITLE
Support throwing exception in Java TestProbe.awaitAssert

### DIFF
--- a/akka-actor-testkit-typed/src/main/mima-filters/2.6.9.backwards.excludes/29687-java-TestProbe-awaitAssert-support-checked-exception.excludes
+++ b/akka-actor-testkit-typed/src/main/mima-filters/2.6.9.backwards.excludes/29687-java-TestProbe-awaitAssert-support-checked-exception.excludes
@@ -1,0 +1,4 @@
+# Support throwing exception in Java TestProbe.awaitAssert (#29687)
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.actor.testkit.typed.javadsl.TestProbe.awaitAssert")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.testkit.typed.javadsl.TestProbe.awaitAssert")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.actor.testkit.typed.internal.TestProbeImpl.awaitAssert")

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
@@ -340,14 +340,14 @@ private[akka] final class TestProbeImpl[M](name: String, system: ActorSystem[_])
   override def awaitAssert[A](a: => A): A =
     awaitAssert_internal(a, remainingOrDefault, 100.millis)
 
-  override def awaitAssert[A](max: JDuration, interval: JDuration, supplier: Creator[A]): A =
-    awaitAssert_internal(supplier.create(), max.asScala.dilated, interval.asScala)
+  override def awaitAssert[A](max: JDuration, interval: JDuration, creator: Creator[A]): A =
+    awaitAssert_internal(creator.create(), max.asScala.dilated, interval.asScala)
 
-  def awaitAssert[A](max: JDuration, supplier: Creator[A]): A =
-    awaitAssert(max, JDuration.ofMillis(100), supplier)
+  def awaitAssert[A](max: JDuration, creator: Creator[A]): A =
+    awaitAssert(max, JDuration.ofMillis(100), creator)
 
-  def awaitAssert[A](supplier: Creator[A]): A =
-    awaitAssert(getRemainingOrDefault, supplier)
+  def awaitAssert[A](creator: Creator[A]): A =
+    awaitAssert(getRemainingOrDefault, creator)
 
   private def awaitAssert_internal[A](a: => A, max: FiniteDuration, interval: FiniteDuration): A = {
     val stop = now + max

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
@@ -28,6 +28,7 @@ import akka.actor.typed.Signal
 import akka.actor.typed.Terminated
 import akka.actor.typed.scaladsl.Behaviors
 import akka.annotation.InternalApi
+import akka.japi.function.Creator
 import akka.util.BoxedType
 import akka.util.JavaDurationConverters._
 import akka.util.PrettyDuration._
@@ -339,13 +340,13 @@ private[akka] final class TestProbeImpl[M](name: String, system: ActorSystem[_])
   override def awaitAssert[A](a: => A): A =
     awaitAssert_internal(a, remainingOrDefault, 100.millis)
 
-  override def awaitAssert[A](max: JDuration, interval: JDuration, supplier: Supplier[A]): A =
-    awaitAssert_internal(supplier.get(), max.asScala.dilated, interval.asScala)
+  override def awaitAssert[A](max: JDuration, interval: JDuration, supplier: Creator[A]): A =
+    awaitAssert_internal(supplier.create(), max.asScala.dilated, interval.asScala)
 
-  def awaitAssert[A](max: JDuration, supplier: Supplier[A]): A =
+  def awaitAssert[A](max: JDuration, supplier: Creator[A]): A =
     awaitAssert(max, JDuration.ofMillis(100), supplier)
 
-  def awaitAssert[A](supplier: Supplier[A]): A =
+  def awaitAssert[A](supplier: Creator[A]): A =
     awaitAssert(getRemainingOrDefault, supplier)
 
   private def awaitAssert_internal[A](a: => A, max: FiniteDuration, interval: FiniteDuration): A = {

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
@@ -7,6 +7,7 @@ package akka.actor.testkit.typed.javadsl
 import java.time.Duration
 import java.util.{ List => JList }
 import java.util.function.Supplier
+import akka.japi.function.Creator
 
 import akka.actor.testkit.typed.FishingOutcome
 import akka.actor.testkit.typed.TestKitSettings
@@ -241,7 +242,7 @@ abstract class TestProbe[M] {
    *
    * Note that the timeout is scaled using the configuration entry "akka.actor.testkit.typed.timefactor".
    */
-  def awaitAssert[A](max: Duration, interval: Duration, supplier: Supplier[A]): A
+  def awaitAssert[A](max: Duration, interval: Duration, supplier: Creator[A]): A
 
   /**
    * Evaluate the given assert every 100 milliseconds until it does not throw an exception and return the
@@ -251,13 +252,13 @@ abstract class TestProbe[M] {
    *
    * Note that the timeout is scaled using the configuration entry "akka.actor.testkit.typed.timefactor".
    */
-  def awaitAssert[A](max: Duration, supplier: Supplier[A]): A
+  def awaitAssert[A](max: Duration, supplier: Creator[A]): A
 
   /**
    * Evaluate the given assert every 100 milliseconds until it does not throw an exception and return the
    * result. A max time is taken it from the innermost enclosing `within` block.
    */
-  def awaitAssert[A](supplier: Supplier[A]): A
+  def awaitAssert[A](supplier: Creator[A]): A
 
   // FIXME awaitAssert(Procedure): Unit would be nice for java people to not have to return null
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
@@ -242,7 +242,7 @@ abstract class TestProbe[M] {
    *
    * Note that the timeout is scaled using the configuration entry "akka.actor.testkit.typed.timefactor".
    */
-  def awaitAssert[A](max: Duration, interval: Duration, supplier: Creator[A]): A
+  def awaitAssert[A](max: Duration, interval: Duration, creator: Creator[A]): A
 
   /**
    * Evaluate the given assert every 100 milliseconds until it does not throw an exception and return the
@@ -252,13 +252,13 @@ abstract class TestProbe[M] {
    *
    * Note that the timeout is scaled using the configuration entry "akka.actor.testkit.typed.timefactor".
    */
-  def awaitAssert[A](max: Duration, supplier: Creator[A]): A
+  def awaitAssert[A](max: Duration, creator: Creator[A]): A
 
   /**
    * Evaluate the given assert every 100 milliseconds until it does not throw an exception and return the
    * result. A max time is taken it from the innermost enclosing `within` block.
    */
-  def awaitAssert[A](supplier: Creator[A]): A
+  def awaitAssert[A](creator: Creator[A]): A
 
   // FIXME awaitAssert(Procedure): Unit would be nice for java people to not have to return null
 

--- a/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/TestProbeTest.java
+++ b/akka-actor-testkit-typed/src/test/java/akka/actor/testkit/typed/javadsl/TestProbeTest.java
@@ -84,6 +84,15 @@ public class TestProbeTest extends JUnitSuite {
     assertEquals("some result", awaitAssertResult);
   }
 
+  @Test(expected = Exception.class)
+  public void testAwaitAssertThrowingCheckedException() {
+    TestProbe<String> probe = TestProbe.create(testKit.system());
+    probe.awaitAssert(
+        () -> {
+          throw new Exception("checked exception");
+        });
+  }
+
   @Test
   public void testExpectMessage() {
     TestProbe<String> probe = TestProbe.create(testKit.system());


### PR DESCRIPTION
#29677

How to fix bin compat ?
[error] (akka-actor-testkit-typed / mimaReportBinaryIssues) Failed binary compatibility check against com.typesafe.akka:akka-actor-testkit-typed_2.12:2.6.8! Found 9 potential problems
