### PR TITLE
Fix for PersistentShardingMigrationSpec failing 

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -1268,7 +1268,12 @@ class PersistentShardCoordinator(
 
       case StateInitialized =>
         stateInitialized()
+        log.debug("{}: Coordinator initialization completed", typeName)
         context.become(active.orElse[Any, Unit](receiveSnapshotResult))
+
+      case Register(region) =>
+        // region will retry so ok to ignore
+        log.debug("{}: Ignoring registration from region [{}] while initializing", typeName, region)
 
     }: Receive).orElse[Any, Unit](receiveTerminated).orElse[Any, Unit](receiveSnapshotResult)
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -231,9 +231,13 @@ object ShardRegion {
   @SerialVersionUID(1L) case object GetCurrentRegions extends ShardRegionQuery with ClusterShardingSerializable
 
   /**
-   * Java API:
+   * Java API: Send this message to the `ShardRegion` actor to request for [[CurrentRegions]],
+   * which contains the addresses of all registered regions.
+   *
+   * Intended for testing purpose to see when cluster sharding is "ready" or to monitor
+   * the state of the shard regions.
    */
-  def getCurrentRegionsInstance = GetCurrentRegions
+  def getCurrentRegionsInstance: GetCurrentRegions.type = GetCurrentRegions
 
   /**
    * Reply to `GetCurrentRegions`

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/PersistentShardingMigrationSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/PersistentShardingMigrationSpec.scala
@@ -107,7 +107,7 @@ class PersistentShardingMigrationSpec extends AkkaSpec(PersistentShardingMigrati
   import PersistentShardingMigrationSpec._
 
   "Migration" should {
-    "allow migration of remembered shards and now allow going back" in {
+    "allow migration of remembered shards and not allow going back" in {
       val typeName = "Migration"
 
       withSystem(config, typeName, "OldMode") { (_, region, _) =>

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesShardIdExtractorChangeSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesShardIdExtractorChangeSpec.scala
@@ -10,6 +10,7 @@ import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.actor.Props
 import akka.cluster.Cluster
+import akka.cluster.sharding.ShardRegion.CurrentRegions
 import akka.persistence.PersistentActor
 import akka.testkit.AkkaSpec
 import akka.testkit.ImplicitSender
@@ -85,6 +86,7 @@ class RememberEntitiesShardIdExtractorChangeSpec
     "allow a change to the shard id extractor" in {
 
       withSystem("FirstShardIdExtractor", firstExtractShardId) { (_, region) =>
+        assertRegionRegistrationComplete(region)
         region ! Message(1)
         expectMsg("ack")
         region ! Message(11)
@@ -132,5 +134,13 @@ class RememberEntitiesShardIdExtractorChangeSpec
         Await.ready(system.terminate(), 20.seconds)
       }
     }
+
+    def assertRegionRegistrationComplete(region: ActorRef): Unit = {
+      awaitAssert {
+        region ! ShardRegion.GetCurrentRegions
+        expectMsgType[CurrentRegions].regions should have size (1)
+      }
+    }
   }
+
 }


### PR DESCRIPTION
References #29234
References #29690

I think what happened was that LevelDB used for journal was very slow, since starting up the persistent coordinator needs wait for the recovery to complete before it can register regions (we can see the retries and the region dropping the buffered message), and the message + expect ack 3s timeout was to short for that to complete.

Added a wait for region to have registered with the coordinator to fix that.

Additional changes:

* don't let Register end up logged as unhandled when that is expected to be ignored by coordinator while starting up
* Javadoc and public API return type on `getCurrentRegionsInstance`
