### PR TITLE
stream: register newshells with no active interpreters

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringInitializationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringInitializationSpec.scala
@@ -39,7 +39,12 @@ class ByteStringInitializationSpec extends AnyWordSpec with Matchers {
 
       import scala.language.reflectiveCalls
       type WithRun = { def run(): Unit }
-      cleanCl.loadClass("akka.util.ByteStringInitTest").getDeclaredConstructor().newInstance().asInstanceOf[WithRun].run()
+      cleanCl
+        .loadClass("akka.util.ByteStringInitTest")
+        .getDeclaredConstructor()
+        .newInstance()
+        .asInstanceOf[WithRun]
+        .run()
     }
   }
 }

--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringInitializationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringInitializationSpec.scala
@@ -39,7 +39,7 @@ class ByteStringInitializationSpec extends AnyWordSpec with Matchers {
 
       import scala.language.reflectiveCalls
       type WithRun = { def run(): Unit }
-      cleanCl.loadClass("akka.util.ByteStringInitTest").newInstance().asInstanceOf[WithRun].run()
+      cleanCl.loadClass("akka.util.ByteStringInitTest").getDeclaredConstructor().newInstance().asInstanceOf[WithRun].run()
     }
   }
 }

--- a/akka-remote/src/test/scala/akka/remote/artery/tcp/ssl/PeerSubjectVerifierSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/tcp/ssl/PeerSubjectVerifierSpec.scala
@@ -52,7 +52,7 @@ class PeerSubjectVerifierSpec extends AnyWordSpec with Matchers {
       override def removeValue(name: String): Unit = throw new UnsupportedOperationException()
       override def getValueNames: Array[String] = throw new UnsupportedOperationException()
       override def getLocalCertificates: Array[Certificate] = throw new UnsupportedOperationException()
-      override def getPeerCertificateChain: Array[javax.security.cert.X509Certificate] =
+      override def getPeerCertificateChain/*: Array[javax.security.cert.X509Certificate]*/ =
         throw new UnsupportedOperationException()
       override def getPeerPrincipal: Principal = throw new UnsupportedOperationException()
       override def getLocalPrincipal: Principal = throw new UnsupportedOperationException()

--- a/akka-remote/src/test/scala/akka/remote/artery/tcp/ssl/PeerSubjectVerifierSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/tcp/ssl/PeerSubjectVerifierSpec.scala
@@ -52,7 +52,7 @@ class PeerSubjectVerifierSpec extends AnyWordSpec with Matchers {
       override def removeValue(name: String): Unit = throw new UnsupportedOperationException()
       override def getValueNames: Array[String] = throw new UnsupportedOperationException()
       override def getLocalCertificates: Array[Certificate] = throw new UnsupportedOperationException()
-      override def getPeerCertificateChain/*: Array[javax.security.cert.X509Certificate]*/ =
+      override def getPeerCertificateChain /*: Array[javax.security.cert.X509Certificate]*/ =
         throw new UnsupportedOperationException()
       override def getPeerPrincipal: Principal = throw new UnsupportedOperationException()
       override def getLocalPrincipal: Principal = throw new UnsupportedOperationException()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlatMapPrefixSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlatMapPrefixSpec.scala
@@ -584,6 +584,35 @@ class FlowFlatMapPrefixSpec extends StreamSpec {
         subscriber.expectNext("a", "b", "c")
         subscriber.expectComplete()
       }
+
+      "complete newShells registration when all active interpreters are done" in assertAllStagesStopped {
+        @volatile var closeSink : () => Unit = null
+
+        val (fNotUsed, qOut) = Source.empty[Int]
+          .flatMapPrefixMat(1){ seq =>
+            println("waiting for closer to be set")
+            while (null == closeSink) Thread.sleep(50)
+            println("closing sink")
+            closeSink()
+            println("sink closed")
+            //closing the sink before returning means that it's higly probably
+            //for the flatMapPrefix stage to receive the downstream cancellation before the actor graph interpreter
+            //gets a chance to complete the new interpreter shell's registration.
+            //this in turn exposes a bug in the actor graph interpreter when all active flows complete
+            //but there are pending new interpreter shells to be registered.
+            Flow[Int]
+              .prepend(Source(seq))
+          } (Keep.right)
+          .toMat(Sink.queue(10))(Keep.both)
+          .run
+
+        println("assigning closer")
+        closeSink = () => qOut.cancel()
+
+        println("closer assigned, waiting for completion")
+        //Thread.sleep(10000000)
+        fNotUsed.futureValue should be (NotUsed)
+      }
     }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlatMapPrefixSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlatMapPrefixSpec.scala
@@ -591,7 +591,7 @@ class FlowFlatMapPrefixSpec extends StreamSpec {
         val (fNotUsed, qOut) = Source
           .empty[Int]
           .flatMapPrefixMat(1) { seq =>
-            println("waiting for closer to be set")
+            log.debug("waiting for closer to be set")
             while (null == closeSink) Thread.sleep(50)
             log.debug("closing sink")
             closeSink()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlatMapPrefixSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlatMapPrefixSpec.scala
@@ -610,7 +610,6 @@ class FlowFlatMapPrefixSpec extends StreamSpec {
         closeSink = () => qOut.cancel()
 
         println("closer assigned, waiting for completion")
-        //Thread.sleep(10000000)
         fNotUsed.futureValue should be(NotUsed)
       }
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlatMapPrefixSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlatMapPrefixSpec.scala
@@ -586,10 +586,11 @@ class FlowFlatMapPrefixSpec extends StreamSpec {
       }
 
       "complete newShells registration when all active interpreters are done" in assertAllStagesStopped {
-        @volatile var closeSink : () => Unit = null
+        @volatile var closeSink: () => Unit = null
 
-        val (fNotUsed, qOut) = Source.empty[Int]
-          .flatMapPrefixMat(1){ seq =>
+        val (fNotUsed, qOut) = Source
+          .empty[Int]
+          .flatMapPrefixMat(1) { seq =>
             println("waiting for closer to be set")
             while (null == closeSink) Thread.sleep(50)
             println("closing sink")
@@ -600,9 +601,8 @@ class FlowFlatMapPrefixSpec extends StreamSpec {
             //gets a chance to complete the new interpreter shell's registration.
             //this in turn exposes a bug in the actor graph interpreter when all active flows complete
             //but there are pending new interpreter shells to be registered.
-            Flow[Int]
-              .prepend(Source(seq))
-          } (Keep.right)
+            Flow[Int].prepend(Source(seq))
+          }(Keep.right)
           .toMat(Sink.queue(10))(Keep.both)
           .run
 
@@ -611,7 +611,7 @@ class FlowFlatMapPrefixSpec extends StreamSpec {
 
         println("closer assigned, waiting for completion")
         //Thread.sleep(10000000)
-        fNotUsed.futureValue should be (NotUsed)
+        fNotUsed.futureValue should be(NotUsed)
       }
     }
   }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlatMapPrefixSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlatMapPrefixSpec.scala
@@ -604,7 +604,7 @@ class FlowFlatMapPrefixSpec extends StreamSpec {
             Flow[Int].prepend(Source(seq))
           }(Keep.right)
           .toMat(Sink.queue(10))(Keep.both)
-          .run
+          .run()
 
         println("assigning closer")
         closeSink = () => qOut.cancel()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlatMapPrefixSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlatMapPrefixSpec.scala
@@ -593,9 +593,9 @@ class FlowFlatMapPrefixSpec extends StreamSpec {
           .flatMapPrefixMat(1) { seq =>
             println("waiting for closer to be set")
             while (null == closeSink) Thread.sleep(50)
-            println("closing sink")
+            log.debug("closing sink")
             closeSink()
-            println("sink closed")
+            log.debug("sink closed")
             //closing the sink before returning means that it's higly probably
             //for the flatMapPrefix stage to receive the downstream cancellation before the actor graph interpreter
             //gets a chance to complete the new interpreter shell's registration.
@@ -606,10 +606,10 @@ class FlowFlatMapPrefixSpec extends StreamSpec {
           .toMat(Sink.queue(10))(Keep.both)
           .run()
 
-        println("assigning closer")
+        log.debug("assigning closer")
         closeSink = () => qOut.cancel()
 
-        println("closer assigned, waiting for completion")
+        log.debug("closer assigned, waiting for completion")
         fNotUsed.futureValue should be(NotUsed)
       }
     }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -754,8 +754,7 @@ import akka.util.OptionVal
   }
 
   private def shortCircuitBatch(): Unit = {
-    while (!shortCircuitBuffer.isEmpty && currentLimit > 0) shortCircuitBuffer
-      .poll() match {
+    while (!shortCircuitBuffer.isEmpty && currentLimit > 0) shortCircuitBuffer.poll() match {
       case b: BoundaryEvent => processEvent(b)
       case Resume           => finishShellRegistration()
     }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -754,7 +754,19 @@ import akka.util.OptionVal
   }
 
   private def shortCircuitBatch(): Unit = {
-    while (!shortCircuitBuffer.isEmpty && currentLimit > 0) shortCircuitBuffer.poll() match {
+    @tailrec private def shortCircuitBatch(): Unit = {
+    if(shortCircuitBuffer.isEmpty) ()
+    else if (currentLimit == 0) {
+      self ! Resume
+    }
+    else {
+      shortCircuitBuffer.poll() match {
+        case b: BoundaryEvent => processEvent(b)
+        case Resume           => finishShellRegistration()
+      }
+      shortCircuitBatch()
+    }
+  }
       case b: BoundaryEvent => processEvent(b)
       case Resume           => finishShellRegistration()
     }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -754,7 +754,7 @@ import akka.util.OptionVal
   }
 
   private def shortCircuitBatch(): Unit = {
-    while (!shortCircuitBuffer.isEmpty && currentLimit > 0 && activeInterpreters.nonEmpty) shortCircuitBuffer
+    while (!shortCircuitBuffer.isEmpty && currentLimit > 0 && (activeInterpreters.nonEmpty || newShells.nonEmpty)) shortCircuitBuffer
       .poll() match {
       case b: BoundaryEvent => processEvent(b)
       case Resume           => finishShellRegistration()

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -754,7 +754,7 @@ import akka.util.OptionVal
   }
 
   private def shortCircuitBatch(): Unit = {
-    while (!shortCircuitBuffer.isEmpty && currentLimit > 0 && (activeInterpreters.nonEmpty || newShells.nonEmpty)) shortCircuitBuffer
+    while (!shortCircuitBuffer.isEmpty && currentLimit > 0) shortCircuitBuffer
       .poll() match {
       case b: BoundaryEvent => processEvent(b)
       case Resume           => finishShellRegistration()


### PR DESCRIPTION
fixes #29730 .
akka-stream's actor graph interpreter failed to register new shells when current active interpreters where all completed.
The issue was first seen via `Flow.lazyFutureFlow` but is actually a specific issue of the actor graph interpreter exposed via `Flow.flatMapPrefix' and other operators built on top of it (i.e. `Flow.lazyFutureFlow`).
