### PR TITLE
Explain why Mailbox#cleanup uses recursion [ci skip]

### DIFF
--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -385,6 +385,9 @@ trait MessageQueue {
    * is expected to transfer all remaining messages into the dead letter queue
    * which is passed in. The owner of this MessageQueue is passed in if
    * available (e.g. for creating DeadLetters()), “/deadletters” otherwise.
+   *
+   * Note that we implement the method in a recursive manner mainly for
+   * atomicity (not touching the queue twice).
    */
   def cleanUp(owner: ActorRef, deadLetters: MessageQueue): Unit
 }


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Follow up to https://github.com/akka/akka/pull/29632/files#r497599069
