### PR TITLE
Unstash GetShardHome requests one-by-one, #29742

### DIFF
--- a/akka-cluster-sharding/src/main/mima-filters/2.6.10.backwards.excludes/issue-29742-unstash-GetShardHome.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.6.10.backwards.excludes/issue-29742-unstash-GetShardHome.excludes
@@ -1,0 +1,2 @@
+# #29742 Unstash GetShardHome requests one-by-one
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.sharding.ShardCoordinator.unstashGetShardHomeRequests")

--- a/akka-cluster-sharding/src/main/mima-filters/2.6.10.backwards.excludes/issue-29742-unstash-GetShardHome.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.6.10.backwards.excludes/issue-29742-unstash-GetShardHome.excludes
@@ -1,2 +1,2 @@
 # #29742 Unstash GetShardHome requests one-by-one
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.sharding.ShardCoordinator.unstashGetShardHomeRequests")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.cluster.sharding.ShardCoordinator.unstashOneGetShardHomeRequest")

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -1650,9 +1650,10 @@ private[akka] class DDataShardCoordinator(
   override protected def unstashOneGetShardHomeRequest(): Unit = {
     if (getShardHomeRequests.nonEmpty) {
       // unstash one, will continue unstash of next after receive GetShardHome or update completed
-      val (originalSender, request) = getShardHomeRequests.head
+      val requestTuple = getShardHomeRequests.head
+      val (originalSender, request) = requestTuple
       self.tell(request, sender = originalSender)
-      getShardHomeRequests -= (originalSender -> request)
+      getShardHomeRequests -= requestTuple
     }
   }
 


### PR DESCRIPTION
* because it's likely that the first GetShardHome request will result in
  allocation update and then all are stashed again

Inspecting the log of DDataClusterShardingGracefulShutdownSpec it previously had 2653 stash log messages and after this change it has 109.

References #29742
