### PR TITLE
cleanup associations when handshake didn't complete, #29615

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -108,9 +108,9 @@ private[remote] object AssociationState {
       listeners: List[UniqueAddress => Unit])
 
   sealed trait UniqueRemoteAddressState
-  final case class UidKnown(uniqueAddress: UniqueAddress) extends UniqueRemoteAddressState
+  case object UidKnown extends UniqueRemoteAddressState
   case object UidUnknown extends UniqueRemoteAddressState
-  final case class UidQuarantined(uniqueAddress: UniqueAddress) extends UniqueRemoteAddressState
+  case object UidQuarantined extends UniqueRemoteAddressState
 
 }
 
@@ -134,8 +134,8 @@ private[remote] final class AssociationState(
 
   def uniqueRemoteAddressState(): UniqueRemoteAddressState = {
     uniqueRemoteAddress() match {
-      case Some(a) if isQuarantined(a.uid) => UidQuarantined(a)
-      case Some(a)                         => UidKnown(a)
+      case Some(a) if isQuarantined(a.uid) => UidQuarantined
+      case Some(_)                         => UidKnown
       case None                            => UidUnknown // handshake not completed yet
     }
   }

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -106,6 +106,12 @@ private[remote] object AssociationState {
   private final case class UniqueRemoteAddressValue(
       uniqueRemoteAddress: Option[UniqueAddress],
       listeners: List[UniqueAddress => Unit])
+
+  sealed trait UniqueRemoteAddressState
+  final case class UidKnown(uniqueAddress: UniqueAddress) extends UniqueRemoteAddressState
+  case object UidUnknown extends UniqueRemoteAddressState
+  final case class UidQuarantined(uniqueAddress: UniqueAddress) extends UniqueRemoteAddressState
+
 }
 
 /**
@@ -118,14 +124,30 @@ private[remote] final class AssociationState(
     val quarantined: ImmutableLongMap[AssociationState.QuarantinedTimestamp],
     _uniqueRemoteAddress: AtomicReference[AssociationState.UniqueRemoteAddressValue]) {
 
-  import AssociationState.QuarantinedTimestamp
-  import AssociationState.UniqueRemoteAddressValue
+  import AssociationState._
 
   /**
    * Full outbound address with UID for this association.
    * Completed by the handshake.
    */
   def uniqueRemoteAddress(): Option[UniqueAddress] = _uniqueRemoteAddress.get().uniqueRemoteAddress
+
+  def uniqueRemoteAddressState(): UniqueRemoteAddressState = {
+    uniqueRemoteAddress() match {
+      case Some(a) if isQuarantined(a.uid) => UidQuarantined(a)
+      case Some(a)                         => UidKnown(a)
+      case None                            => UidUnknown // handshake not completed yet
+    }
+  }
+
+  def isQuarantined(): Boolean = {
+    uniqueRemoteAddress() match {
+      case Some(a) => isQuarantined(a.uid)
+      case None    => false // handshake not completed yet
+    }
+  }
+
+  def isQuarantined(uid: Long): Boolean = quarantined.contains(uid)
 
   @tailrec def completeUniqueRemoteAddress(peer: UniqueAddress): Unit = {
     val current = _uniqueRemoteAddress.get()
@@ -175,18 +197,6 @@ private[remote] final class AssociationState(
           _uniqueRemoteAddress)
       case None => this
     }
-
-  def isQuarantined(): Boolean = {
-    uniqueRemoteAddress() match {
-      case Some(a) => isQuarantined(a.uid)
-      case None    => false // handshake not completed yet
-    }
-  }
-
-  def isQuarantined(uid: Long): Boolean = quarantined.contains(uid)
-
-  def isHandshakeCompleted(): Boolean =
-    uniqueRemoteAddress().isDefined
 
   def withControlIdleKillSwitch(killSwitch: OptionVal[SharedKillSwitch]): AssociationState =
     new AssociationState(

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -185,6 +185,9 @@ private[remote] final class AssociationState(
 
   def isQuarantined(uid: Long): Boolean = quarantined.contains(uid)
 
+  def isHandshakeCompleted(): Boolean =
+    uniqueRemoteAddress().isDefined
+
   def withControlIdleKillSwitch(killSwitch: OptionVal[SharedKillSwitch]): AssociationState =
     new AssociationState(
       incarnation,

--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -667,8 +667,8 @@ private[remote] class Association(
             // doesn't get through it will be quarantined to cleanup lingering associations to crashed systems.
             quarantine(s"Idle longer than quarantine-idle-outbound-after [${QuarantineIdleOutboundAfter.pretty}]")
             associationState.uniqueRemoteAddressState() match {
-              case AssociationState.UidQuarantined(_) => // quarantined as expected
-              case AssociationState.UidKnown(_)       => // must be new uid, keep as is
+              case AssociationState.UidQuarantined => // quarantined as expected
+              case AssociationState.UidKnown       => // must be new uid, keep as is
               case AssociationState.UidUnknown =>
                 val newLastUsedDurationNanos = System.nanoTime() - associationState.lastUsedTimestamp.get
                 // quarantine ignored due to unknown UID, have to stop this task anyway
@@ -1177,9 +1177,8 @@ private[remote] class AssociationRegistry(createAssociation: Address => Associat
         val state = association.associationState
         if ((now - state.lastUsedTimestamp.get) >= afterNanos) {
           state.uniqueRemoteAddressState() match {
-            case AssociationState.UidQuarantined(_) => acc.updated(address, association)
-            case AssociationState.UidUnknown        => acc.updated(address, association)
-            case AssociationState.UidKnown(_)       => acc
+            case AssociationState.UidQuarantined | AssociationState.UidUnknown => acc.updated(address, association)
+            case AssociationState.UidKnown                                     => acc
           }
         } else {
           acc
@@ -1204,9 +1203,8 @@ private[remote] class AssociationRegistry(createAssociation: Address => Associat
         val state = association.associationState
         if ((now - state.lastUsedTimestamp.get) >= afterNanos) {
           state.uniqueRemoteAddressState() match {
-            case AssociationState.UidQuarantined(_) => acc.updated(uid, association)
-            case AssociationState.UidUnknown        => acc.updated(uid, association)
-            case AssociationState.UidKnown(_)       => acc
+            case AssociationState.UidQuarantined | AssociationState.UidUnknown => acc.updated(uid, association)
+            case AssociationState.UidKnown                                     => acc
           }
         } else {
           acc


### PR DESCRIPTION
* symptom was continously logged "Quarantine of [] ignored because unknown UID,
  triggered from the Association.setupIdleTimer task
* when handshake wasn't completed for some reason the UID is unknown and then
  this task continues forever
* abort such associations and cancel the idle task in that case
* also cleanup such associations from AssociationRegistry.removeUnusedQuarantined

References #29615

I tested with an example, and had to simulate broken handshake exchange.
