### PR TITLE
SnapshotTestKit: Reset index if it gets out of sync with the snapshot storage

### DIFF
--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
@@ -51,10 +51,9 @@ sealed trait InMemStorage[K, R] extends InternalReprSupport[R] {
 
   def removeFirstInExpectNextQueue(key: K): Unit = synchronized(expectNextQueue.get(key).foreach(_.poll()))
 
-  def firstInExpectNextQueue(key: K): Option[R] =
-    synchronized(expectNextQueue.get(key).flatMap { item =>
-      Try(item.element()).toOption.map(toRepr)
-    })
+  def firstInExpectNextQueue(key: K): Option[R] = expectNextQueue.get(key).flatMap { item =>
+    Try(item.element()).toOption.map(toRepr)
+  }
 
   def findOneByIndex(key: K, index: Int): Option[R] =
     eventsMap

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
@@ -107,14 +107,9 @@ sealed trait InMemStorage[K, R] extends InternalReprSupport[R] {
       }
 
     val oldValue = eventsMap.getOrElse(key, (0L, Vector.empty))
-    (Option(remappingFunction(key, oldValue)) match {
-      case Some(newValue) =>
-        eventsMap = eventsMap.updated(key, newValue)
-        newValue
-      case None =>
-        eventsMap = eventsMap - key
-        oldValue
-    })._2.map(toRepr)
+    val newValue = remappingFunction(key, oldValue)
+    eventsMap = eventsMap.updated(key, newValue)
+    newValue._2.map(toRepr)
   }
 
   def read(key: K): Option[Vector[R]] = lock.synchronized {

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
@@ -5,14 +5,13 @@
 package akka.persistence.testkit.internal
 
 import java.util
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 
 import akka.annotation.InternalApi
 import akka.persistence.testkit.ProcessingPolicy
 import akka.util.ccompat.JavaConverters._
 
-import scala.collection.{ immutable, mutable }
+import scala.collection.{immutable, mutable}
 import scala.util.Try
 
 /**

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
@@ -65,9 +65,7 @@ sealed trait InMemStorage[K, R] extends InternalReprSupport[R] {
       .map(toRepr)
 
   def add(key: K, p: R): Unit = {
-    if (!Try(eventsLog.containsKey(key)).getOrElse(false)) {
-      eventsLog.put(key, new util.LinkedList[InternalRepr]())
-    }
+    eventsLog.putIfAbsent(key, new util.LinkedList[InternalRepr]())
     eventsLog.get(key).add(toInternal(p))
     add(key, List(p))
   }

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
@@ -11,7 +11,7 @@ import akka.annotation.InternalApi
 import akka.persistence.testkit.ProcessingPolicy
 import akka.util.ccompat.JavaConverters._
 
-import scala.collection.{immutable, mutable}
+import scala.collection.{ immutable, mutable }
 import scala.util.Try
 
 /**

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
@@ -51,9 +51,9 @@ sealed trait InMemStorage[K, R] extends InternalReprSupport[R] {
           Some(value.drop(fromInclusive).take(maxNum))
         else None)
 
-  def removeFirst(key: K): Unit = Try(eventsLog.get(key)).foreach(_.poll())
+  def removeFirst(key: K): Unit = Option(eventsLog.get(key)).foreach(_.poll())
 
-  def first(key: K): Option[R] = Try(eventsLog.get(key)).toOption.flatMap { item =>
+  def first(key: K): Option[R] = Option(eventsLog.get(key)).flatMap { item =>
     Try(item.element()).toOption.map(toRepr)
   }
 

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/PersistenceTestKit.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/PersistenceTestKit.scala
@@ -328,6 +328,16 @@ class SnapshotTestKit(system: ActorSystem)
 
   override protected val storage: SnapshotStorage = SnapshotStorageEmulatorExtension(system)
 
+  override def getItem(persistenceId: String, nextInd: Int): Option[Any] = {
+    storage.first(persistenceId).map(reprToAny)
+  }
+
+  override def expectNextPersisted[A](persistenceId: String, event: A): A = {
+    val item = super.expectNextPersisted(persistenceId, event)
+    storage.removeFirst(persistenceId)
+    item
+  }
+
   private val settings = Settings(system)
 
   override private[testkit] val probe = TestProbe()(system)

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/PersistenceTestKit.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/PersistenceTestKit.scala
@@ -329,12 +329,12 @@ class SnapshotTestKit(system: ActorSystem)
   override protected val storage: SnapshotStorage = SnapshotStorageEmulatorExtension(system)
 
   override def getItem(persistenceId: String, nextInd: Int): Option[Any] = {
-    storage.first(persistenceId).map(reprToAny)
+    storage.firstInExpectNextQueue(persistenceId).map(reprToAny)
   }
 
   override def expectNextPersisted[A](persistenceId: String, event: A): A = {
     val item = super.expectNextPersisted(persistenceId, event)
-    storage.removeFirst(persistenceId)
+    storage.removeFirstInExpectNextQueue(persistenceId)
     item
   }
 

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/TestOps.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/TestOps.scala
@@ -142,7 +142,6 @@ private[testkit] trait ExpectOps[U] {
    */
   def expectNextPersisted[A](persistenceId: String, event: A, max: FiniteDuration): A = {
     val nextInd = nextIndex(persistenceId)
-
     val expected = Some(event)
     val res = awaitAssert({
       val actual = getItem(persistenceId, nextInd)

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/TestOps.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/TestOps.scala
@@ -134,14 +134,18 @@ private[testkit] trait ExpectOps[U] {
   def expectNextPersisted[A](persistenceId: String, event: A): A =
     expectNextPersisted(persistenceId, event, maxTimeout)
 
+  def getItem(persistenceId: String, nextInd: Int): Option[Any] =
+    storage.findOneByIndex(persistenceId, nextInd).map(reprToAny)
+
   /**
    * Check for `max` time that next persisted in storage for particular persistence id event/snapshot was `event`.
    */
   def expectNextPersisted[A](persistenceId: String, event: A, max: FiniteDuration): A = {
     val nextInd = nextIndex(persistenceId)
+
     val expected = Some(event)
     val res = awaitAssert({
-      val actual = storage.findOneByIndex(persistenceId, nextInd).map(reprToAny)
+      val actual = getItem(persistenceId, nextInd)
       assert(actual == expected, s"Failed to persist $event, got $actual instead")
       actual
     }, max = max.dilated, interval = pollInterval)

--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/CommonUtils.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/CommonUtils.scala
@@ -102,5 +102,6 @@ case class Cmd(data: String) extends TestCommand
 case object Passivate extends TestCommand
 case class Evt(data: String)
 case class EmptyState()
+case class NonEmptyState(data: String)
 case object Recovered
 case object Stopped

--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/CommonSnapshotTests.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/CommonSnapshotTests.scala
@@ -10,6 +10,7 @@ import akka.actor.Props
 import akka.actor.typed.scaladsl.adapter._
 import akka.persistence._
 import akka.persistence.testkit._
+import akka.persistence.typed.scaladsl.RetentionCriteria
 import akka.testkit.EventFilter
 
 trait CommonSnapshotTests extends ScalaDslUtils {
@@ -489,6 +490,70 @@ trait CommonSnapshotTests extends ScalaDslUtils {
       system.actorOf(Props(classOf[A], pid, Some(testActor)))
 
       expectMsg((List.empty, 3))
+
+    }
+
+    "work with typed actors on after deleting snapshots" in {
+
+      lazy val tk = new SnapshotTestKit(system)
+
+      val pid = randomPid()
+      val act = system.spawn(
+        eventSourcedBehaviorWithState(pid).withRetention(
+          RetentionCriteria.snapshotEvery(numberOfEvents = 2, keepNSnapshots = 2)),
+        pid)
+
+      act ! Cmd("a")
+      act ! Cmd("b")
+      tk.expectNextPersisted(pid, NonEmptyState("ab"))
+
+      act ! Cmd("c")
+      act ! Cmd("d")
+      tk.expectNextPersisted(pid, NonEmptyState("abcd"))
+
+      act ! Cmd("e")
+      act ! Cmd("f")
+      tk.expectNextPersisted(pid, NonEmptyState("abcdef"))
+
+      act ! Cmd("g")
+      act ! Cmd("h")
+      tk.expectNextPersisted(pid, NonEmptyState("abcdefgh"))
+
+      act ! Cmd("i")
+      act ! Cmd("j")
+      act ! Cmd("k")
+
+      tk.expectNextPersisted(pid, NonEmptyState("abcdefghij"))
+
+    }
+
+    "testing snapshots at the end" in {
+
+      lazy val tk = new SnapshotTestKit(system)
+
+      val pid = randomPid()
+      val act = system.spawn(
+        eventSourcedBehaviorWithState(pid).withRetention(
+          RetentionCriteria.snapshotEvery(numberOfEvents = 2, keepNSnapshots = 2)),
+        pid)
+
+      act ! Cmd("a")
+      act ! Cmd("b")
+      act ! Cmd("c")
+      act ! Cmd("d")
+      act ! Cmd("e")
+      act ! Cmd("f")
+      act ! Cmd("g")
+      act ! Cmd("h")
+      act ! Cmd("i")
+      act ! Cmd("j")
+      act ! Cmd("k")
+
+      tk.expectNextPersisted(pid, NonEmptyState("ab"))
+      tk.expectNextPersisted(pid, NonEmptyState("abcd"))
+      tk.expectNextPersisted(pid, NonEmptyState("abcdef"))
+      tk.expectNextPersisted(pid, NonEmptyState("abcdefgh"))
+      tk.expectNextPersisted(pid, NonEmptyState("abcdefghij"))
 
     }
 

--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/CommonSnapshotTests.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/CommonSnapshotTests.scala
@@ -493,7 +493,7 @@ trait CommonSnapshotTests extends ScalaDslUtils {
 
     }
 
-    "work with typed actors on after deleting snapshots" in {
+    "test snapshot events with RetentionCriteria" in {
 
       lazy val tk = new SnapshotTestKit(system)
 
@@ -527,7 +527,7 @@ trait CommonSnapshotTests extends ScalaDslUtils {
 
     }
 
-    "testing snapshots at the end" in {
+    "test snapshot events with RetentionCriteria after sending commands" in {
 
       lazy val tk = new SnapshotTestKit(system)
 


### PR DESCRIPTION
## Before this PR

The [SnapshotTestKit](https://github.com/akka/akka/blob/master/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/PersistenceTestKit.scala#L318) is used to test the behaviour of snapshots created by persistent actors. Here all snapshots are stored in a [buffer](https://github.com/akka/akka/blob/master/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala#L38). If you limit the amount of snapshots stored (e.g. `RetentionCriteria.snapshotEvery(numberOfEvents = 2, keepNSnapshots = 2))`) this buffer only keep that amount of snapshots. 

Following up on the example from above. If we send 4 events we end up with two snapshots (let call them `0 -> Snapshot-A` and `1 -> Snapshot-B`) in the buffer where `0` and `1` is the index to access the buffer. Sending another two events will change the buffer as follows: `0 -> Snapshot-B` and `1 -> Snapshot-C`. They move along the buffer. 

To test snapshots the `SnapshotTestKit.expectNextPersisted` api is used. It maintains a growing [index](https://github.com/akka/akka/blob/master/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/TestOps.scala#L318) that gets [incremented](https://github.com/akka/akka/blob/master/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/TestOps.scala#L141) each time the assertion (`expectNextPersisted`) is called. This index is used to access the respective snapshot. 

## The problem
That index quickly gets out of sync with the stored snapshots by e.g. writing the asserting after the events have been send.

Furthermore, the main problem is, that it is not possible to test any snapshot after a `RetentionCriteria` deleted a snapshot because the ever growing index is not aware of the replacement of the snapshots in the buffer.

---

## Proposed fix

Maintain a queue that gets all snapshots appended. This queue is only used for testing. Testing snapshots using the `SnapshotTestKit` now does not rely on the index anymore to lookup "the next snapshot to test" but rater the state of the queue. Once an assertion succeeds the current (first) item is popped from the queue.