### PR TITLE
Add limitation about supervision in sync Testkit #29767

### DIFF
--- a/akka-docs/src/main/paradox/typed/testing-sync.md
+++ b/akka-docs/src/main/paradox/typed/testing-sync.md
@@ -15,6 +15,7 @@ limitations:
 * `EventSourcedBehavior` can't be tested.
 * Interactions with other actors must be stubbed.
 * Blackbox testing style.
+* Supervision is not supported.
 
 The `BehaviorTestKit` will be improved and some of these problems will be removed but it will always have limitations.
 


### PR DESCRIPTION
Refs: #29767
Currently, sync Testkit doesn't support supervision as it often involves async interactions.

