### PR TITLE
Increase timeout to make room for leveldb disk access slow

### DIFF
--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
@@ -43,6 +43,7 @@ object EventSourcedBehaviorRetentionSpec extends Matchers {
     akka.persistence.journal.plugin = "akka.persistence.journal.leveldb"
     akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
     akka.persistence.snapshot-store.local.dir = "target/typed-persistence-${UUID.randomUUID().toString}"
+    akka.actor.testkit.typed.single-expect-default = 10s # increased for slow disk on Jenkins servers
     """)
 
   sealed trait Command extends CborSerializable

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
@@ -117,7 +117,7 @@ class PerformanceSpec extends ScalaTestWithActorTestKit(ConfigFactory.parseStrin
       akka.persistence.journal.leveldb.dir = "target/journal-PerformanceSpec"
       akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
       akka.persistence.snapshot-store.local.dir = "target/snapshots-PerformanceSpec/"
-      akka.test.single-expect-default = 10s
+      akka.actor.testkit.typed.single-expect-default = 10s
       """).withFallback(ConfigFactory.parseString(PerformanceSpec.config))) with AnyWordSpecLike with LogCapturing {
 
   import PerformanceSpec._


### PR DESCRIPTION
on Jenkins 

Refs #29787 

Logs showed recovery taking 2.8s, then two commands with a response for the second timing out at 3s. Increasing default message timeout to 10s for that and one other test failing the same way.