### PR TITLE
Configure visibility

### DIFF
--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -129,11 +129,13 @@ akka.serialization.jackson {
   # Configuration of the JsonFactory Visibility.
   # See com.fasterxml.jackson.annotation.PropertyAccessor
   # and com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
-  # Enum values, for example:
+  # Enum values. For example, to serialize only public fields
+  # overwrite the default values with:
   #
-  # json-write-features {
+  # visibility {
   #   FIELD = PUBLIC_ONLY
   # }
+  # Default: all fields (including private and protected) are serialized.
   visibility {
     FIELD = ANY
   }

--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -126,6 +126,18 @@ akka.serialization.jackson {
   # }
   json-write-features {}
 
+  # Configuration of the JsonFactory Visibility.
+  # See com.fasterxml.jackson.annotation.PropertyAccessor
+  # and com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
+  # Enum values, for example:
+  #
+  # json-write-features {
+  #   FIELD = PUBLIC_ONLY
+  # }
+  visibility {
+    FIELD = ANY
+  }
+
   # Deprecated, use `allowed-class-prefix` instead
   whitelist-class-prefix = []
 

--- a/akka-serialization-jackson/src/test/java/akka/serialization/jackson/JavaTestMessages.java
+++ b/akka-serialization-jackson/src/test/java/akka/serialization/jackson/JavaTestMessages.java
@@ -528,4 +528,15 @@ public interface JavaTestMessages {
       return name != null ? name.hashCode() : 0;
     }
   }
+
+  // A class with non-public fields
+  final class ClassWithVisibility {
+    public final String publicField = "1234";
+    final String defaultField = "abcd";
+    protected final String protectedField = "vwxyz";
+    private final String privateField = "ABCD";
+
+    @JsonCreator
+    public ClassWithVisibility() {}
+  }
 }

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -451,7 +451,6 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
       }
     }
 
-
   }
 
   "JacksonJsonSerializer with Scala message classes" must {

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -411,6 +411,47 @@ class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
     "be possible to create custom ObjectMapper" in {
       pending
     }
+
+    "be possible to tune the visibility at ObjectMapper level (FIELD, PUBLIC_ONLY)" in {
+      withSystem("""
+        akka.actor {
+          serialization-bindings {
+            "akka.serialization.jackson.JavaTestMessages$ClassWithVisibility" = jackson-json
+          }
+        }
+        akka.serialization.jackson.visibility {
+          FIELD = PUBLIC_ONLY
+        }
+        """) { sys =>
+        val msg = new ClassWithVisibility();
+        val json = serializeToJsonString(msg, sys)
+        val expected = """{"publicField":"1234"}"""
+        json should ===(expected)
+      }
+    }
+
+    // This test ensures the default behavior in Akka 2.6 series
+    // (that is "FIELD = ANY") stays consistent
+    "be possible to tune the visibility at ObjectMapper level (Akka default)" in {
+      withSystem("""
+        akka.actor {
+          serialization-bindings {
+            "akka.serialization.jackson.JavaTestMessages$ClassWithVisibility" = jackson-json
+          }
+        }
+        akka.serialization.jackson.visibility {
+          ## No overrides
+        }
+        """) { sys =>
+        val msg = new ClassWithVisibility();
+        val json = serializeToJsonString(msg, sys)
+        val expected =
+          """{"publicField":"1234","defaultField":"abcd","protectedField":"vwxyz","privateField":"ABCD"}""".stripMargin
+        json should ===(expected)
+      }
+    }
+
+
   }
 
   "JacksonJsonSerializer with Scala message classes" must {


### PR DESCRIPTION
References https://github.com/playframework/playframework/issues/10523

The default visibility for `FIELD` properties in Jackson is `PUBLIC_ONLY` but Akka 2.6.0 configured `ObjectMapper`'s to `FIELD=ANY`. 

With this change visibility can be configured using the same mechanisms than features. 