### PR TITLE
Stream Testkit: use assertAllStagesStopped with system in the Java DSL

### DIFF
--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/javadsl/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/javadsl/StreamTestKit.scala
@@ -4,7 +4,8 @@
 
 package akka.stream.testkit.javadsl
 
-import akka.stream.Materializer
+import akka.actor.ClassicActorSystemProvider
+import akka.stream.{ Materializer, SystemMaterializer }
 import akka.stream.impl.PhasedFusingActorMaterializer
 import akka.stream.testkit.scaladsl
 
@@ -21,4 +22,13 @@ object StreamTestKit {
         scaladsl.StreamTestKit.assertNoChildren(impl.system, impl.supervisor)
       case _ =>
     }
+
+  /**
+   * Assert that there are no stages running under a given system's materializer.
+   * Usually this assertion is run after a test-case to check that all of the
+   * stages have terminated successfully.
+   */
+  def assertAllStagesStopped(system: ClassicActorSystemProvider): Unit = {
+    assertAllStagesStopped(SystemMaterializer(system).materializer)
+  }
 }


### PR DESCRIPTION
Allow the use of `assertAllStagesStopped` with an `akka.actor.ActorSystem` or `akka.actor.typed.ActorSystem` in the Java DSL.

For the Scala DSL this is implemented by the implicit conversion of the system to a materializer.