### PR TITLE
Stream Testkit: new-API-friendly

### DIFF
--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/javadsl/TestSink.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/javadsl/TestSink.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.testkit.javadsl
 
-import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.stream.javadsl.Sink
 import akka.stream.testkit._
 
@@ -14,7 +14,7 @@ object TestSink {
   /**
    * A Sink that materialized to a [[akka.stream.testkit.TestSubscriber.Probe]].
    */
-  def probe[T](system: ActorSystem): Sink[T, TestSubscriber.Probe[T]] =
+  def probe[T](system: ClassicActorSystemProvider): Sink[T, TestSubscriber.Probe[T]] =
     new Sink(scaladsl.TestSink.probe[T](system))
 
 }

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/javadsl/TestSource.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/javadsl/TestSource.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.testkit.javadsl
 
-import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.stream.javadsl.Source
 import akka.stream.testkit._
 
@@ -14,7 +14,7 @@ object TestSource {
   /**
    * A Source that materializes to a [[akka.stream.testkit.TestPublisher.Probe]].
    */
-  def probe[T](system: ActorSystem): Source[T, TestPublisher.Probe[T]] =
+  def probe[T](system: ClassicActorSystemProvider): Source[T, TestPublisher.Probe[T]] =
     new Source(scaladsl.TestSource.probe[T](system))
 
 }

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/scaladsl/TestSink.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/scaladsl/TestSink.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.testkit.scaladsl
 
-import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.stream._
 import akka.stream.Attributes.none
 import akka.stream.scaladsl._
@@ -20,7 +20,7 @@ object TestSink {
   /**
    * A Sink that materialized to a [[akka.stream.testkit.TestSubscriber.Probe]].
    */
-  def probe[T](implicit system: ActorSystem): Sink[T, Probe[T]] =
+  def probe[T](implicit system: ClassicActorSystemProvider): Sink[T, Probe[T]] =
     Sink.fromGraph[T, TestSubscriber.Probe[T]](new ProbeSink(none, SinkShape(Inlet("ProbeSink.in"))))
 
 }

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/scaladsl/TestSource.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/scaladsl/TestSource.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.testkit.scaladsl
 
-import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.stream._
 import akka.stream.Attributes.none
 import akka.stream.scaladsl._
@@ -19,7 +19,7 @@ object TestSource {
   /**
    * A Source that materializes to a [[akka.stream.testkit.TestPublisher.Probe]].
    */
-  def probe[T](implicit system: ActorSystem) =
+  def probe[T](implicit system: ClassicActorSystemProvider) =
     Source.fromGraph[T, TestPublisher.Probe[T]](new ProbeSource(none, SourceShape(Outlet("ProbeSource.out"))))
 
 }


### PR DESCRIPTION
Use `ClassicActorSystemProvider` to allow for the use of the new actors API when testing streams.

This is not binary-compatible (which is not promised for Akka TestKits) but source-compatible as `akka.actor.ActorSystem` extends `akka.actor.ClassicActorSystemProvider`.

A follow-up to #29814 
