### PR TITLE
Fix logging: expectTerminated instead

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
@@ -327,7 +327,7 @@ private[akka] final class TestProbeImpl[M](name: String, system: ActorSystem[_])
       } else {
         terminations.takeFirst
       }
-    assert(message != null, s"timeout ($max) during expectStop waiting for actor [${actorRef.path}] to stop")
+    assert(message != null, s"timeout ($max) during expectTerminated waiting for actor [${actorRef.path}] to stop")
     assert(message.ref == actorRef, s"expected [${actorRef.path}] to stop, but saw [${message.ref.path}] stop")
   }
 


### PR DESCRIPTION
Minor logging fix. 

I notice that when calling `TestProbe.expectTerminated` and it fails, we log `expectStop` (probably previous method name).