### PR TITLE
Stream Testkit: new-API-friendly 

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StreamRefSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StreamRefSpec.scala
@@ -167,7 +167,7 @@ abstract class StreamRefSpec extends MultiNodeSpec(StreamRefSpec) with MultiNode
         val ref = expectMsgType[ActorIdentity].ref.get
         ref ! RequestLogs(1337)
         val dataSourceRef = expectMsgType[LogsOffer].sourceRef
-        destinationForSource = dataSourceRef.runWith(TestSink.probe)
+        destinationForSource = dataSourceRef.runWith(TestSink())
         destinationForSource.request(3).expectNext("elem-1").expectNext("elem-2").expectNext("elem-3")
       }
       runOn(second) {

--- a/akka-docs/src/test/scala/docs/stream/GraphStageDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/GraphStageDocSpec.scala
@@ -328,8 +328,8 @@ class GraphStageDocSpec extends AkkaSpec {
     val switch = Promise[Unit]()
     val duplicator = Flow.fromGraph(new KillSwitch[Int](switch.future))
 
-    val in = TestPublisher.probe[Int]()
-    val out = TestSubscriber.probe[Int]()
+    val in = TestPublisher.Probe[Int]()
+    val out = TestSubscriber.Probe[Int]()
 
     Source
       .fromPublisher(in)
@@ -524,8 +524,8 @@ class GraphStageDocSpec extends AkkaSpec {
 
     Await.result(result1, 3.seconds) should ===(Vector(1, 2, 3))
 
-    val subscriber = TestSubscriber.manualProbe[Int]()
-    val publisher = TestPublisher.probe[Int]()
+    val subscriber = TestSubscriber.ManualProbe[Int]()
+    val publisher = TestPublisher.Probe[Int]()
     val flow2 =
       Source.fromPublisher(publisher).via(new TwoBuffer).to(Sink.fromSubscriber(subscriber))
 

--- a/akka-docs/src/test/scala/docs/stream/RateTransformationDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/RateTransformationDocSpec.scala
@@ -88,7 +88,7 @@ class RateTransformationDocSpec extends AkkaSpec {
       case (d, _) => latch.countDown(); Iterator.from(1).map(d -> _)
     }
 
-    val (pub, sub) = TestSource.probe[Double].via(realDriftFlow).toMat(TestSink.probe[(Double, Int)])(Keep.both).run()
+    val (pub, sub) = TestSource.probe[Double].via(realDriftFlow).toMat(TestSink[(Double, Int)]())(Keep.both).run()
 
     sub.request(1)
     pub.sendNext(1.0)
@@ -109,7 +109,7 @@ class RateTransformationDocSpec extends AkkaSpec {
     val latch = TestLatch(2)
     val realDriftFlow = Flow[Double].expand(d => { latch.countDown(); Iterator.from(0).map(d -> _) })
 
-    val (pub, sub) = TestSource.probe[Double].via(realDriftFlow).toMat(TestSink.probe[(Double, Int)])(Keep.both).run()
+    val (pub, sub) = TestSource.probe[Double].via(realDriftFlow).toMat(TestSink[(Double, Int)]())(Keep.both).run()
 
     sub.request(1)
     pub.sendNext(1.0)

--- a/akka-docs/src/test/scala/docs/stream/StreamTestKitDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/StreamTestKitDocSpec.scala
@@ -112,7 +112,7 @@ class StreamTestKitDocSpec extends AkkaSpec {
     //#test-sink-probe
     val sourceUnderTest = Source(1 to 4).filter(_ % 2 == 0).map(_ * 2)
 
-    sourceUnderTest.runWith(TestSink.probe[Int]).request(2).expectNext(4, 8).expectComplete()
+    sourceUnderTest.runWith(TestSink[Int]()).request(2).expectNext(4, 8).expectComplete()
     //#test-sink-probe
   }
 
@@ -142,7 +142,7 @@ class StreamTestKitDocSpec extends AkkaSpec {
       pattern.after(10.millis * sleep, using = system.scheduler)(Future.successful(sleep))
     }
 
-    val (pub, sub) = TestSource.probe[Int].via(flowUnderTest).toMat(TestSink.probe[Int])(Keep.both).run()
+    val (pub, sub) = TestSource.probe[Int].via(flowUnderTest).toMat(TestSink[Int]())(Keep.both).run()
 
     sub.request(n = 3)
     pub.sendNext(3)

--- a/akka-docs/src/test/scala/docs/stream/cookbook/RecipeAdhocSource.scala
+++ b/akka-docs/src/test/scala/docs/stream/cookbook/RecipeAdhocSource.scala
@@ -32,13 +32,13 @@ class RecipeAdhocSource extends RecipeSpec {
     "not start the source if there is no demand" taggedAs TimingTest in {
       val isStarted = new AtomicBoolean()
       adhocSource(Source.empty.mapMaterializedValue(_ => isStarted.set(true)), 200.milliseconds, 3)
-        .runWith(TestSink.probe[Int])
+        .runWith(TestSink[Int]())
       Thread.sleep(300)
       isStarted.get() should be(false)
     }
 
     "start the source when there is a demand" taggedAs TimingTest in {
-      val sink = adhocSource(Source.repeat("a"), 200.milliseconds, 3).runWith(TestSink.probe[String])
+      val sink = adhocSource(Source.repeat("a"), 200.milliseconds, 3).runWith(TestSink[String]())
       sink.requestNext("a")
     }
 
@@ -46,7 +46,7 @@ class RecipeAdhocSource extends RecipeSpec {
       val shutdown = Promise[Done]()
       val sink = adhocSource(Source.repeat("a").watchTermination() { (_, term) =>
         shutdown.completeWith(term)
-      }, 200.milliseconds, 3).runWith(TestSink.probe[String])
+      }, 200.milliseconds, 3).runWith(TestSink[String]())
 
       sink.requestNext("a")
       Thread.sleep(200)
@@ -57,7 +57,7 @@ class RecipeAdhocSource extends RecipeSpec {
       val shutdown = Promise[Done]()
       val sink = adhocSource(Source.repeat("a").watchTermination() { (_, term) =>
         shutdown.completeWith(term)
-      }, 200.milliseconds, 3).runWith(TestSink.probe[String])
+      }, 200.milliseconds, 3).runWith(TestSink[String]())
 
       sink.requestNext("a")
       Thread.sleep(100)
@@ -81,7 +81,7 @@ class RecipeAdhocSource extends RecipeSpec {
 
       val sink = adhocSource(source.watchTermination() { (_, term) =>
         shutdown.completeWith(term)
-      }, 200.milliseconds, 3).runWith(TestSink.probe[String])
+      }, 200.milliseconds, 3).runWith(TestSink[String]())
 
       sink.requestNext("a")
       startedCount.get() should be(1)
@@ -97,7 +97,7 @@ class RecipeAdhocSource extends RecipeSpec {
 
       val sink = adhocSource(source.watchTermination() { (_, term) =>
         shutdown.completeWith(term)
-      }, 200.milliseconds, 3).runWith(TestSink.probe[String])
+      }, 200.milliseconds, 3).runWith(TestSink[String]())
 
       sink.requestNext("a")
       startedCount.get() should be(1)

--- a/akka-docs/src/test/scala/docs/stream/cookbook/RecipeDroppyBroadcast.scala
+++ b/akka-docs/src/test/scala/docs/stream/cookbook/RecipeDroppyBroadcast.scala
@@ -12,12 +12,12 @@ class RecipeDroppyBroadcast extends RecipeSpec {
 
   "Recipe for a droppy broadcast" must {
     "work" in {
-      val pub = TestPublisher.probe[Int]()
+      val pub = TestPublisher.Probe[Int]()
       val myElements = Source.fromPublisher(pub)
 
-      val sub1 = TestSubscriber.manualProbe[Int]()
-      val sub2 = TestSubscriber.manualProbe[Int]()
-      val sub3 = TestSubscriber.probe[Int]()
+      val sub1 = TestSubscriber.ManualProbe[Int]()
+      val sub2 = TestSubscriber.ManualProbe[Int]()
+      val sub3 = TestSubscriber.Probe[Int]()
       val futureSink = Sink.head[Seq[Int]]
       val mySink1 = Sink.fromSubscriber(sub1)
       val mySink2 = Sink.fromSubscriber(sub2)

--- a/akka-stream-testkit/src/main/mima-filters/2.5.x.backwards.excludes/2.6.0.excludes
+++ b/akka-stream-testkit/src/main/mima-filters/2.5.x.backwards.excludes/2.6.0.excludes
@@ -1,0 +1,10 @@
+# Akka 2.6.0 changes to cancellation
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.testkit.StreamTestKit#PublisherProbeSubscription.expectCancellation")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.testkit.TestPublisher#CancelSubscription.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.testkit.TestPublisher#CancelSubscription.this")
+ProblemFilters.exclude[MissingTypesProblem]("akka.stream.testkit.TestPublisher$CancelSubscription$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.testkit.TestPublisher#CancelSubscription.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.testkit.TestPublisher#CancelSubscription.unapply")
+# Throwable in errors
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.testkit.StreamTestKit#PublisherProbeSubscription.sendError")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.stream.testkit.TestPublisher#Probe.sendError")

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/javadsl/TestSink.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/javadsl/TestSink.scala
@@ -5,6 +5,7 @@
 package akka.stream.testkit.javadsl
 
 import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.stream.javadsl.Sink
 import akka.stream.testkit._
 
@@ -16,5 +17,11 @@ object TestSink {
    */
   def probe[T](system: ActorSystem): Sink[T, TestSubscriber.Probe[T]] =
     new Sink(scaladsl.TestSink.probe[T](system))
+
+  /**
+   * A Sink that materialized to a [[akka.stream.testkit.TestSubscriber.Probe]].
+   */
+  def create[T](system: ClassicActorSystemProvider): Sink[T, TestSubscriber.Probe[T]] =
+    probe(system.classicSystem)
 
 }

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/javadsl/TestSource.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/javadsl/TestSource.scala
@@ -5,6 +5,7 @@
 package akka.stream.testkit.javadsl
 
 import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.stream.javadsl.Source
 import akka.stream.testkit._
 
@@ -16,5 +17,11 @@ object TestSource {
    */
   def probe[T](system: ActorSystem): Source[T, TestPublisher.Probe[T]] =
     new Source(scaladsl.TestSource.probe[T](system))
+
+  /**
+   * A Source that materializes to a [[akka.stream.testkit.TestPublisher.Probe]].
+   */
+  def create[T](system: ClassicActorSystemProvider): Source[T, TestPublisher.Probe[T]] =
+    probe(system.classicSystem)
 
 }

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/scaladsl/TestSink.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/scaladsl/TestSink.scala
@@ -5,6 +5,7 @@
 package akka.stream.testkit.scaladsl
 
 import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.stream._
 import akka.stream.Attributes.none
 import akka.stream.scaladsl._
@@ -22,5 +23,11 @@ object TestSink {
    */
   def probe[T](implicit system: ActorSystem): Sink[T, Probe[T]] =
     Sink.fromGraph[T, TestSubscriber.Probe[T]](new ProbeSink(none, SinkShape(Inlet("ProbeSink.in"))))
+
+  /**
+   * A Sink that materialized to a [[akka.stream.testkit.TestSubscriber.Probe]].
+   */
+  def apply[T]()(implicit system: ClassicActorSystemProvider): Sink[T, Probe[T]] =
+    probe(system.classicSystem)
 
 }

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/scaladsl/TestSource.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/scaladsl/TestSource.scala
@@ -5,6 +5,7 @@
 package akka.stream.testkit.scaladsl
 
 import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.stream._
 import akka.stream.Attributes.none
 import akka.stream.scaladsl._
@@ -19,7 +20,13 @@ object TestSource {
   /**
    * A Source that materializes to a [[akka.stream.testkit.TestPublisher.Probe]].
    */
-  def probe[T](implicit system: ActorSystem) =
+  def probe[T](implicit system: ActorSystem): Source[T, TestPublisher.Probe[T]] =
     Source.fromGraph[T, TestPublisher.Probe[T]](new ProbeSource(none, SourceShape(Outlet("ProbeSource.out"))))
+
+  /**
+   * A Source that materializes to a [[akka.stream.testkit.TestPublisher.Probe]].
+   */
+  def apply[T]()(implicit system: ClassicActorSystemProvider): Source[T, TestPublisher.Probe[T]] =
+    probe(system.classicSystem)
 
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphDSLCompileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphDSLCompileSpec.scala
@@ -317,10 +317,10 @@ class GraphDSLCompileSpec extends StreamSpec {
 
     "build with implicits and variance" in {
       RunnableGraph.fromGraph(GraphDSL.create() { implicit b =>
-        def appleSource = b.add(Source.fromPublisher(TestPublisher.manualProbe[Apple]()))
-        def fruitSource = b.add(Source.fromPublisher(TestPublisher.manualProbe[Fruit]()))
-        val outA = b.add(Sink.fromSubscriber(TestSubscriber.manualProbe[Fruit]()))
-        val outB = b.add(Sink.fromSubscriber(TestSubscriber.manualProbe[Fruit]()))
+        def appleSource = b.add(Source.fromPublisher(TestPublisher.ManualProbe[Apple]()))
+        def fruitSource = b.add(Source.fromPublisher(TestPublisher.ManualProbe[Fruit]()))
+        val outA = b.add(Sink.fromSubscriber(TestSubscriber.ManualProbe[Fruit]()))
+        val outB = b.add(Sink.fromSubscriber(TestSubscriber.ManualProbe[Fruit]()))
         val merge = b.add(Merge[Fruit](11))
         val unzip = b.add(Unzip[Int, String]())
         val whatever = b.add(Sink.asPublisher[Any](false))

--- a/build.sbt
+++ b/build.sbt
@@ -350,8 +350,7 @@ lazy val protobufV3 = akkaModule("akka-protobuf-v3")
         .withConfigurations(Vector(Compile)), // prevent original dependency to be added to pom as runtime dep
     packagedArtifact in (Compile, packageBin) := Scoped.mkTuple2(
         (artifact in (Compile, packageBin)).value,
-        ReproducibleBuildsPlugin.postProcessJar(OsgiKeys.bundle.value)
-    ),
+        ReproducibleBuildsPlugin.postProcessJar(OsgiKeys.bundle.value)),
     packageBin in Compile := ReproducibleBuildsPlugin
         .postProcessJar((assembly in Compile).value), // package by running assembly
     // Prevent cyclic task dependencies, see https://github.com/sbt/sbt-assembly/issues/365
@@ -418,7 +417,6 @@ lazy val streamTestkit = akkaModule("akka-stream-testkit")
   .settings(Dependencies.streamTestkit)
   .settings(AutomaticModuleName.settings("akka.stream.testkit"))
   .settings(OSGi.streamTestkit)
-  .disablePlugins(MimaPlugin)
 
 lazy val streamTests = akkaModule("akka-stream-tests")
   .configs(akka.Jdk9.TestJdk9)


### PR DESCRIPTION
Add alternatives that use `ClassicActorSystemProvider` to allow for the use of the new actors API when testing streams.

- enable Mima on akka-stream-testkit
- add `apply`/`create` methods to complement 
	- `TestSink.probe`
	- `TestSource.probe`
	- `TestPublisher.probe`
	- `TestPublisher.manualProbe`
	- `TestSubscriber.probe`
	- `TestSubscriber.manualProbe`

The third commit uses the new variants at some random places.
- [ ] should all use in Akka be switched?
- [ ] should the old variants become deprecated (I'm not in favour)

This is a new variant of the non-binary compatible #29815 
