### PR TITLE
Exhaustive comparison for cache policies

### DIFF
--- a/akka-actor/src/main/scala/akka/io/dns/internal/package.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/package.scala
@@ -30,7 +30,9 @@ package object internal {
         case (Never, Never)     => 0
         case (Ttl(v1), Ttl(v2)) => v1.compare(v2)
         case (Never, _)         => -1
+        case (_, Forever)       => -1
         case (Forever, _)       => 1
+        case (_, Never)         => 1
       }
   }
 


### PR DESCRIPTION
The 2 cases that were missing would probably never be encountered
because this ordering is only used with `min` with `Ttl` objects on
the right-hand side, but it still feels safer to have all the cases
here.