### PR TITLE
Log command type and entity id on ask exception on EntityRef

### DIFF
--- a/akka-cluster-sharding-typed/src/main/mima-filters/2.6.10.backwards.excludes/logging-command-type-and-entity-id-on-ask-failure.excludes
+++ b/akka-cluster-sharding-typed/src/main/mima-filters/2.6.10.backwards.excludes/logging-command-type-and-entity-id-on-ask-failure.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.typed.internal.EntityRefImpl.this")


### PR DESCRIPTION
Similar to https://github.com/lagom/lagom/pull/3121, but for Akka Typed `EntityRef`. 

Not added for classic, because there isn't an equivalent `EntityRef`. 
