### PR TITLE
Add how to compose Partial Behaviors #29832

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
@@ -559,13 +559,12 @@ object StyleGuideDocExamples {
     //#set-handler-zero-partial
 
     //#top-level-behaviors-partial
-    val zero: Behavior[Command] = Behaviors.receive { (context, command) =>
-      getHandler(0).orElse(setHandlerZero(context.log))(command)
+    val zero: Behavior[Command] = Behaviors.setup { context =>
+      Behaviors.receiveMessagePartial(getHandler(0).orElse(setHandlerZero(context.log)))
     }
 
-    def nonZero(capacity: Int): Behavior[Command] = Behaviors.receiveMessage { command =>
-      getHandler(capacity).orElse(setHandlerNotZero(capacity))(command)
-    }
+    def nonZero(capacity: Int): Behavior[Command] =
+      Behaviors.receiveMessagePartial(getHandler(capacity).orElse(setHandlerNotZero(capacity)))
 
     // Default Initial Behavior for this actor
     def apply(initialCapacity: Int): Behavior[Command] = nonZero(initialCapacity)

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
@@ -13,7 +13,6 @@ import akka.actor.typed.scaladsl.TimerScheduler
 import akka.actor.typed.SupervisorStrategy
 
 import scala.concurrent.duration.FiniteDuration
-import scala.annotation.tailrec
 import akka.Done
 import com.github.ghik.silencer.silent
 

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
@@ -25,6 +25,7 @@ import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
 //#fun-style
 import akka.actor.typed.scaladsl.AbstractBehavior
+import org.slf4j.Logger
 //#oo-style
 
 object StyleGuideDocExamples {
@@ -525,10 +526,12 @@ object StyleGuideDocExamples {
 
   object BehaviorCompositionWithPartialFunction {
 
+    //#messages-sealed-composition
     sealed trait Command
     case object Down extends Command
     final case class GetValue(replyTo: ActorRef[Value]) extends Command
     final case class Value(n: Int)
+    //#messages-sealed-composition
 
     //#get-handler-partial
     def getHandler(value: Int): PartialFunction[Command, Behavior[Command]] = {
@@ -548,86 +551,26 @@ object StyleGuideDocExamples {
     }
     //#set-handler-non-zero-partial
 
-    //#handle-partial
-    def handle(command: Command, handlers: List[PartialFunction[Command, Behavior[Command]]]): Behavior[Command] = {
-      handlers match {
-        case Nil          => Behaviors.unhandled
-        case head :: tail => head.applyOrElse(command, handle(_, tail))
-      }
-    }
-    //#handle-partial
-
-    //#top-level-behaviors-partial
-    val zero: Behavior[Command] = Behaviors.receiveMessage { command =>
-      handle(command, List(getHandler(0)))
-    }
-
-    def nonZero(initialCapacity: Int): Behavior[Command] = Behaviors.receiveMessage { command =>
-      handle(command, List(getHandler(initialCapacity), setHandlerNotZero(initialCapacity)))
-    }
-    //#top-level-behaviors-partial
-  }
-
-  object BehaviorCompositionWithReceivePartial {
-
-    //#messages-sealed-composition
-    sealed trait Command
-    case object Down extends Command
-    final case class GetValue(replyTo: ActorRef[Value]) extends Command
-    final case class Value(n: Int)
-    //#messages-sealed-composition
-
-    //#get-handler
-    def getHandler(value: Int): Behavior[Command] = Behaviors.receiveMessagePartial {
-      case GetValue(replyTo) =>
-        replyTo ! Value(value)
-        Behaviors.same
-    }
-    //#get-handler
-
-    //#set-handler-non-zero
-    def setHandlerNotZero(value: Int): Behavior[Command] = Behaviors.receiveMessagePartial {
+    //#set-handler-zero-partial
+    def setHandlerZero(log: Logger): PartialFunction[Command, Behavior[Command]] = {
       case Down =>
-        if (value == 1)
-          zero
-        else
-          nonZero(value - 1)
-    }
-    //#set-handler-non-zero
-
-    //#set-handler-zero
-    val setHandlerZero: Behavior[Command] = Behaviors.receivePartial {
-      case (context, Down) =>
-        context.log.error("Counter is already at zero!")
+        log.error("Counter is already at zero!")
         Behaviors.same
     }
-    //#set-handler-zero
+    //#set-handler-zero-partial
 
-    //#handle
-    @tailrec def handle(
-        command: Command,
-        handlers: List[Behavior[Command]],
-        ctx: ActorContext[Command]): Behavior[Command] = {
-      handlers match {
-        case Nil          => Behaviors.unhandled
-        case head :: tail =>
-          //Process the given message with the next Behavior in the list
-          val next = Behavior.interpretMessage(head, ctx, command)
-          if (Behavior.isUnhandled(next)) handle(command, tail, ctx)
-          else next
-      }
-    }
-    //#handle
-
-    //#top-level-behaviors
+    //#top-level-behaviors-partial
     val zero: Behavior[Command] = Behaviors.receive { (context, command) =>
-      handle(command, List(getHandler(0), setHandlerZero), context)
+      getHandler(0).orElse(setHandlerZero(context.log))(command)
     }
 
-    def nonZero(initialCapacity: Int): Behavior[Command] = Behaviors.receive { (context, command) =>
-      handle(command, List(getHandler(initialCapacity), setHandlerNotZero(initialCapacity)), context)
+    def nonZero(capacity: Int): Behavior[Command] = Behaviors.receiveMessage { command =>
+      getHandler(capacity).orElse(setHandlerNotZero(capacity))(command)
     }
-    //#top-level-behaviors
+
+    // Default Initial Behavior for this actor
+    def apply(initialCapacity: Int): Behavior[Command] = nonZero(initialCapacity)
+    //#top-level-behaviors-partial
   }
 
   object NestingSample1 {

--- a/akka-docs/src/main/paradox/typed/style-guide.md
+++ b/akka-docs/src/main/paradox/typed/style-guide.md
@@ -412,6 +412,62 @@ Scala
 
 @@@ div {.group-scala}
 
+## How to compose Partial Behaviors
+
+Following up from previous section, there are times when one might want to use `Behaviors.receivePartial` or `Behaviors.receiveMessagePartial` instead of their total counterparts.
+
+A good use case for composing Partial Behaviors is when there is a bit of behavior that repeats across different states of the Actor. Below, you can find a simplified example for this use case.
+
+The Command definition is still highly recommended be kept within a `sealed` Trait:
+
+Scala
+:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #messages-sealed-composition }
+
+In this particular case, the Behavior that is repeating over is the one in charge to handle
+the `GetValue` Command, as it behaves the same regardless of the Actor's internal state.
+Notice that the behavior is created using `Behaviors.receiveMessagePartial` instead of the known `Behaviors.receiveMessage`:
+
+Scala
+:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #get-handler }
+
+After this, we can continue defining the differing behaviors independently, also using `Behaviors.receiveMessagePartial` or `Behaviors.receivePartial` accordingly:
+
+Scala
+:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #set-handler-non-zero #set-handler-zero }
+
+The next step is to define a method that goes over a sequence of `Behavior` objects until the first one that can handle the given `Command` is found:
+
+Scala
+:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #handle }
+
+Now, we can go on defining the two different behaviors for this specific actor:
+
+Scala
+:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #top-level-behaviors }
+
+### Using PartialFunction
+
+Instead of defining the specific handlers as partial Behaviors, we can define them as a `PartialFunction`:
+
+Scala
+:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #get-handler-partial #set-handler-non-zero-partial }
+
+For this particular case, and to keep the example simple, we will leave `Down` messages unhandled when the actor's internal counter is already at 0.
+
+Once we have all this, the next step is to write a function that given a `Command` and a sequence of `PartialFunction`, finds and executes the first one where the function is defined for the given `Command`:
+
+Scala
+:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #handle-partial }
+
+Finally, we can define the two different behaviors for this specific actor:
+
+Scala
+:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #top-level-behaviors-partial }
+
+@@@
+
+@@@ div {.group-scala}
+
 ## ask versus ?
 
 When using the `AskPattern` it's recommended to use the `ask` method rather than the infix `?` operator, like so:

--- a/akka-docs/src/main/paradox/typed/style-guide.md
+++ b/akka-docs/src/main/paradox/typed/style-guide.md
@@ -412,11 +412,11 @@ Scala
 
 @@@ div {.group-scala}
 
-## How to compose Partial Behaviors
+## How to compose Partial Functions
 
-Following up from previous section, there are times when one might want to use `Behaviors.receivePartial` or `Behaviors.receiveMessagePartial` instead of their total counterparts.
+Following up from previous section, there are times when one might want to combine different `PartialFunction`s into one `Behavior`.
 
-A good use case for composing Partial Behaviors is when there is a bit of behavior that repeats across different states of the Actor. Below, you can find a simplified example for this use case.
+A good use case for composing two or more `PartialFunction`s is when there is a bit of behavior that repeats across different states of the Actor. Below, you can find a simplified example for this use case.
 
 The Command definition is still highly recommended be kept within a `sealed` Trait:
 
@@ -425,41 +425,12 @@ Scala
 
 In this particular case, the Behavior that is repeating over is the one in charge to handle
 the `GetValue` Command, as it behaves the same regardless of the Actor's internal state.
-Notice that the behavior is created using `Behaviors.receiveMessagePartial` instead of the known `Behaviors.receiveMessage`:
+Instead of defining the specific handlers as a `Behavior`, we can define them as a `PartialFunction`:
 
 Scala
-:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #get-handler }
+:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #get-handler-partial #set-handler-non-zero-partial #set-handler-zero-partial }
 
-After this, we can continue defining the differing behaviors independently, also using `Behaviors.receiveMessagePartial` or `Behaviors.receivePartial` accordingly:
-
-Scala
-:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #set-handler-non-zero #set-handler-zero }
-
-The next step is to define a method that goes over a sequence of `Behavior` objects until the first one that can handle the given `Command` is found:
-
-Scala
-:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #handle }
-
-Now, we can go on defining the two different behaviors for this specific actor:
-
-Scala
-:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #top-level-behaviors }
-
-### Using PartialFunction
-
-Instead of defining the specific handlers as partial Behaviors, we can define them as a `PartialFunction`:
-
-Scala
-:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #get-handler-partial #set-handler-non-zero-partial }
-
-For this particular case, and to keep the example simple, we will leave `Down` messages unhandled when the actor's internal counter is already at 0.
-
-Once we have all this, the next step is to write a function that given a `Command` and a sequence of `PartialFunction`, finds and executes the first one where the function is defined for the given `Command`:
-
-Scala
-:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #handle-partial }
-
-Finally, we can define the two different behaviors for this specific actor:
+Finally, we can go on defining the two different behaviors for this specific actor. For each `Behavior` we would go and concatenate all needed `PartialFunction` instances with `orElse` to finally apply the command to the resulting one:
 
 Scala
 :  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #top-level-behaviors-partial }

--- a/akka-docs/src/main/paradox/typed/style-guide.md
+++ b/akka-docs/src/main/paradox/typed/style-guide.md
@@ -435,6 +435,8 @@ Finally, we can go on defining the two different behaviors for this specific act
 Scala
 :  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #top-level-behaviors-partial }
 
+Even though in this particular example we could use `receiveMessage` as we cover all cases, we use `receiveMessagePartial` instead to cover potential future unhandled message cases.
+
 @@@
 
 @@@ div {.group-scala}


### PR DESCRIPTION
References: #29832

Adds 2 examples on how to compose partial behaviors:
- Using `receivePartial`
- Using `PartialFunction`

Examples are rewritten to follow the main one in the page.
Instead of composing through Functions of `Command => Behavior[Command]` I decided to use `Behaviors.receivePartial` as it seems more idiomatic.

Adds docs for both examples under the style guide page.
