### PR TITLE
Fixed a formatting issue

### DIFF
--- a/akka-docs/src/main/paradox/typed/fsm.md
+++ b/akka-docs/src/main/paradox/typed/fsm.md
@@ -43,7 +43,7 @@ Scala
 Java
 :  @@snip [FSMSocTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/FSMDocTest.java) { #simple-state}
 
-@scala[
+@@@ div { .group-scala }
 The method `idle` above makes use of `Behaviors.unhandled` which advises the system to reuse the previous behavior, 
 including the hint that the message has not been handled.
 There are two related behaviors:
@@ -53,7 +53,7 @@ There are two related behaviors:
   Unhandled messages are still logged with this behavior.
 - return `Behaviors.ignore` as next behavior in case you don't care about unhandled messages. 
   All messages sent to an actor with such a behavior are simply dropped and ignored (without logging)
-]
+@@@
 
 To set state timeouts use `Behaviors.withTimers` along with a `startSingleTimer`.
 


### PR DESCRIPTION
The `@scala[]` block marker, does not seem to handle blocks of texts with CRLF in it. Used the `@@@ div { .group-scala }` marker instead which seem to solve the issue.

Orginal page with the issue (bottom part):

https://doc.akka.io/docs/akka/current/typed/fsm.html