### PR TITLE
Longer DNS timeout to avoiding ci fail

### DIFF
--- a/akka-docs/src/test/java/jdocs/discovery/DnsDiscoveryDocTest.java
+++ b/akka-docs/src/test/java/jdocs/discovery/DnsDiscoveryDocTest.java
@@ -18,6 +18,7 @@ import org.scalatestplus.junit.JUnitSuite;
 
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("unused")
 public class DnsDiscoveryDocTest extends JUnitSuite {
@@ -42,7 +43,9 @@ public class DnsDiscoveryDocTest extends JUnitSuite {
     ServiceDiscovery discovery = Discovery.get(system).discovery();
     // ...
     CompletionStage<ServiceDiscovery.Resolved> result =
-        discovery.lookup("akka.io", Duration.ofMillis(500));
+        discovery.lookup("akka.io", Duration.ofSeconds(2));
     // #lookup-dns
+
+    result.toCompletableFuture().get(3, TimeUnit.SECONDS);
   }
 }

--- a/akka-docs/src/test/scala/docs/discovery/DnsDiscoveryDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/discovery/DnsDiscoveryDocSpec.scala
@@ -32,8 +32,9 @@ class DnsDiscoveryDocSpec extends AkkaSpec(DnsDiscoveryDocSpec.config) {
 
       val discovery: ServiceDiscovery = Discovery(system).discovery
       // ...
-      val result: Future[ServiceDiscovery.Resolved] = discovery.lookup("akka.io", resolveTimeout = 500.millis)
+      val result: Future[ServiceDiscovery.Resolved] = discovery.lookup("akka.io", resolveTimeout = 2.seconds)
       // #lookup-dns
+
       val resolved = result.futureValue
       resolved.serviceName shouldBe "akka.io"
       resolved.addresses shouldNot be(Symbol("empty"))


### PR DESCRIPTION
References #29858

Not sure why it was so low, default is 5s and setting it short does not speed up test.

Additionally made the Java test actually verify it got a result rather than just async fire off and return (would prefer making it non-test but that is more work).