### PR TITLE
Adds 'exists' and 'contains' method to StashBuffer

### DIFF
--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/StashBufferTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/StashBufferTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.javadsl;
+
+import akka.actor.testkit.typed.internal.StubbedActorContext;
+import akka.actor.testkit.typed.javadsl.LogCapturing;
+import akka.actor.typed.internal.StashBufferImpl;
+import org.junit.Rule;
+import org.junit.Test;
+import org.scalatestplus.junit.JUnitSuite;
+
+import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class StashBufferTest extends JUnitSuite {
+
+  @Rule public final LogCapturing logCapturing = new LogCapturing();
+
+  StubbedActorContext<String> context =
+      new StubbedActorContext<String>(
+          "StashBufferTest",
+          () -> {
+            throw new UnsupportedOperationException("Will never be invoked in this test");
+          });
+
+  @Test
+  public void testProcessElementsInTheRightOrder() {
+
+    StashBuffer<String> buffer = StashBufferImpl.apply(context, 10);
+    buffer.stash("m1");
+    buffer.stash("m2");
+    buffer.stash("m3");
+
+    StringBuilder sb1 = new StringBuilder();
+    buffer.forEach(sb1::append);
+    assertEquals("m1m2m3", sb1.toString());
+
+    buffer.unstash(Behaviors.ignore(), 1, Function.identity());
+    StringBuilder sb2 = new StringBuilder();
+    buffer.forEach(sb2::append);
+    assertEquals("m2m3", sb2.toString());
+  }
+
+  @Test
+  public void testAnyMatchAndContains() {
+    StashBuffer<String> buffer = StashBufferImpl.apply(context, 10);
+    buffer.stash("m1");
+    buffer.stash("m2");
+
+    assertTrue(buffer.anyMatch(m -> m.startsWith("m")));
+    assertTrue(buffer.anyMatch(m -> m.endsWith("2")));
+
+    assertTrue(buffer.contains("m1"));
+    assertTrue(buffer.contains("m2"));
+  }
+}

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashBufferSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/StashBufferSpec.scala
@@ -81,6 +81,18 @@ class StashBufferSpec extends AnyWordSpec with Matchers with LogCapturing {
       sb2.toString() should ===("m2m3")
     }
 
+    "answer 'exists' and 'contains' correctly" in {
+      val buffer = StashBuffer[String](context, 10)
+      buffer.stash("m1")
+      buffer.stash("m2")
+
+      buffer.contains("m1") shouldBe true
+      buffer.exists(_ == "m2") shouldBe true
+
+      buffer.contains("m3") shouldBe false
+      buffer.exists(_ == "m4") shouldBe false
+    }
+
     "unstash to returned behaviors" in {
       val buffer = StashBuffer[String](context, 10)
       buffer.stash("m1")

--- a/akka-actor-typed/src/main/mima-filters/2.6.10.backwards.excludes/stash-buffer-exists-contains.excludes
+++ b/akka-actor-typed/src/main/mima-filters/2.6.10.backwards.excludes/stash-buffer-exists-contains.excludes
@@ -1,0 +1,4 @@
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.javadsl.StashBuffer.contains")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.javadsl.StashBuffer.anyMatch")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.scaladsl.StashBuffer.contains")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.scaladsl.StashBuffer.exists")

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
@@ -4,11 +4,9 @@
 
 package akka.actor.typed.internal
 
-import java.util.function.{ Function => JFunction }
-
+import java.util.function.{Function => JFunction}
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
-
 import akka.actor.DeadLetter
 import akka.actor.typed.Behavior
 import akka.actor.typed.Signal
@@ -16,9 +14,9 @@ import akka.actor.typed.TypedActorContext
 import akka.actor.typed.javadsl
 import akka.actor.typed.scaladsl
 import akka.actor.typed.scaladsl.ActorContext
-import akka.annotation.{ InternalApi, InternalStableApi }
-import akka.japi.function.Procedure
-import akka.util.{ unused, ConstantFun }
+import akka.annotation.{InternalApi, InternalStableApi}
+import akka.japi.function.{Predicate, Procedure}
+import akka.util.{ConstantFun, unused}
 import akka.util.OptionVal
 
 /**
@@ -127,6 +125,22 @@ import akka.util.OptionVal
   }
 
   override def forEach(f: Procedure[T]): Unit = foreach(f.apply)
+
+
+  override def contains[U >: T](message: U): Boolean =
+    exists(_ == message)
+
+  override def exists(predicate: T => Boolean): Boolean = {
+    var hasElement = false
+    var node = _first
+    while (node != null && !hasElement) {
+      hasElement = predicate(node.message)
+      node = node.next
+    }
+    hasElement
+  }
+
+  override def anyMatch(predicate: Predicate[T]): Boolean = exists(predicate.test)
 
   override def unstashAll(behavior: Behavior[T]): Behavior[T] = {
     val behav = unstash(behavior, size, ConstantFun.scalaIdentityFunction[T])

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/StashBufferImpl.scala
@@ -4,7 +4,7 @@
 
 package akka.actor.typed.internal
 
-import java.util.function.{Function => JFunction}
+import java.util.function.{ Function => JFunction }
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 import akka.actor.DeadLetter
@@ -14,9 +14,9 @@ import akka.actor.typed.TypedActorContext
 import akka.actor.typed.javadsl
 import akka.actor.typed.scaladsl
 import akka.actor.typed.scaladsl.ActorContext
-import akka.annotation.{InternalApi, InternalStableApi}
-import akka.japi.function.{Predicate, Procedure}
-import akka.util.{ConstantFun, unused}
+import akka.annotation.{ InternalApi, InternalStableApi }
+import akka.japi.function.{ Predicate, Procedure }
+import akka.util.{ unused, ConstantFun }
 import akka.util.OptionVal
 
 /**
@@ -125,7 +125,6 @@ import akka.util.OptionVal
   }
 
   override def forEach(f: Procedure[T]): Unit = foreach(f.apply)
-
 
   override def contains[U >: T](message: U): Boolean =
     exists(_ == message)

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/StashBuffer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/StashBuffer.scala
@@ -85,7 +85,7 @@ import java.util.function.{Function => JFunction}
    * Tests whether this [[StashBuffer]] contains a given message.
    *
    * @param message the message to test
-   * @return true if the buffer contains the element, false otherwise.
+   * @return true if the buffer contains the message, false otherwise.
    */
   def contains[U >: T](message:U): Boolean
 
@@ -93,7 +93,7 @@ import java.util.function.{Function => JFunction}
    * Tests whether a predicate holds for at least one element of this [[StashBuffer]].
    *
    * @param predicate the predicate used to test
-   * @return true if the predicate holds for at least one element, false otherwise.
+   * @return true if the predicate holds for at least one message, false otherwise.
    */
   def anyMatch(predicate:Predicate[T]): Boolean
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/StashBuffer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/StashBuffer.scala
@@ -4,11 +4,11 @@
 
 package akka.actor.typed.javadsl
 
-import akka.actor.typed.{Behavior, scaladsl}
+import akka.actor.typed.{ scaladsl, Behavior }
 import akka.annotation.DoNotInherit
-import akka.japi.function.{Predicate, Procedure}
+import akka.japi.function.{ Predicate, Procedure }
 
-import java.util.function.{Function => JFunction}
+import java.util.function.{ Function => JFunction }
 
 /**
  * A non thread safe mutable message buffer that can be used to buffer messages inside actors
@@ -80,14 +80,13 @@ import java.util.function.{Function => JFunction}
    */
   def forEach(f: Procedure[T]): Unit
 
-
   /**
    * Tests whether this [[StashBuffer]] contains a given message.
    *
    * @param message the message to test
    * @return true if the buffer contains the message, false otherwise.
    */
-  def contains[U >: T](message:U): Boolean
+  def contains[U >: T](message: U): Boolean
 
   /**
    * Tests whether a predicate holds for at least one element of this [[StashBuffer]].
@@ -95,7 +94,7 @@ import java.util.function.{Function => JFunction}
    * @param predicate the predicate used to test
    * @return true if the predicate holds for at least one message, false otherwise.
    */
-  def anyMatch(predicate:Predicate[T]): Boolean
+  def anyMatch(predicate: Predicate[T]): Boolean
 
   /**
    * Removes all messages from the buffer.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/StashBuffer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/StashBuffer.scala
@@ -4,12 +4,11 @@
 
 package akka.actor.typed.javadsl
 
-import java.util.function.{ Function => JFunction }
-
-import akka.actor.typed.Behavior
-import akka.actor.typed.scaladsl
+import akka.actor.typed.{Behavior, scaladsl}
 import akka.annotation.DoNotInherit
-import akka.japi.function.Procedure
+import akka.japi.function.{Predicate, Procedure}
+
+import java.util.function.{Function => JFunction}
 
 /**
  * A non thread safe mutable message buffer that can be used to buffer messages inside actors
@@ -80,6 +79,23 @@ import akka.japi.function.Procedure
    * @param f the function to apply to each element
    */
   def forEach(f: Procedure[T]): Unit
+
+
+  /**
+   * Tests whether this [[StashBuffer]] contains a given message.
+   *
+   * @param message the message to test
+   * @return true if the buffer contains the element, false otherwise.
+   */
+  def contains[U >: T](message:U): Boolean
+
+  /**
+   * Tests whether a predicate holds for at least one element of this [[StashBuffer]].
+   *
+   * @param predicate the predicate used to test
+   * @return true if the predicate holds for at least one element, false otherwise.
+   */
+  def anyMatch(predicate:Predicate[T]): Boolean
 
   /**
    * Removes all messages from the buffer.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/StashBuffer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/StashBuffer.scala
@@ -93,6 +93,21 @@ import akka.annotation.{ DoNotInherit, InternalApi }
   def foreach(f: T => Unit): Unit
 
   /**
+   * Tests whether this [[StashBuffer]] contains a given message.
+   *
+   * @param message the message to test
+   * @return true if the buffer contains the element, false otherwise.
+   */
+  def contains[U >: T](message:U): Boolean
+
+  /**
+   * Tests whether a predicate holds for at least one element of this [[StashBuffer]].
+   * @param predicate the predicate used to test
+   * @return true if the predicate holds for at least one element, false otherwise.
+   */
+  def exists(predicate:T => Boolean): Boolean
+
+  /**
    * Removes all messages from the buffer.
    */
   def clear(): Unit

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/StashBuffer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/StashBuffer.scala
@@ -96,14 +96,15 @@ import akka.annotation.{ DoNotInherit, InternalApi }
    * Tests whether this [[StashBuffer]] contains a given message.
    *
    * @param message the message to test
-   * @return true if the buffer contains the element, false otherwise.
+   * @return true if the buffer contains the message, false otherwise.
    */
   def contains[U >: T](message:U): Boolean
 
   /**
    * Tests whether a predicate holds for at least one element of this [[StashBuffer]].
+   *
    * @param predicate the predicate used to test
-   * @return true if the predicate holds for at least one element, false otherwise.
+   * @return true if the predicate holds for at least one message, false otherwise.
    */
   def exists(predicate:T => Boolean): Boolean
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/StashBuffer.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/StashBuffer.scala
@@ -98,7 +98,7 @@ import akka.annotation.{ DoNotInherit, InternalApi }
    * @param message the message to test
    * @return true if the buffer contains the message, false otherwise.
    */
-  def contains[U >: T](message:U): Boolean
+  def contains[U >: T](message: U): Boolean
 
   /**
    * Tests whether a predicate holds for at least one element of this [[StashBuffer]].
@@ -106,7 +106,7 @@ import akka.annotation.{ DoNotInherit, InternalApi }
    * @param predicate the predicate used to test
    * @return true if the predicate holds for at least one message, false otherwise.
    */
-  def exists(predicate:T => Boolean): Boolean
+  def exists(predicate: T => Boolean): Boolean
 
   /**
    * Removes all messages from the buffer.


### PR DESCRIPTION
This is useful when stashing repeated messages, like ticks and keep-alive. 

In such a scenario, it doesn't make sense to stash all ticks or keep-alives. One is enough. While stashing, we can test if the buffer already have such a message and eventually skip it. 

```scala
case Tick =>  
	if (!buffer.contains(Tick)) buffer.stash(Tick)
	Behaviors.same
```

Or similar. 

