### PR TITLE
Init Behavior

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Init.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Init.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.javadsl
+
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.SpawnProtocol
+import akka.actor.typed.TypedActorContext
+import akka.actor.typed.internal.BehaviorImpl.DeferredBehavior
+import akka.annotation.InternalApi
+import akka.util.unused
+
+/**
+ * Initialization when creating an [[akka.actor.typed.ActorSystem]] can be performed in an implementation of
+ * this [[akka.actor.typed.Behavior]]. Use it as the `guardianBehavior` when creating the `ActorSystem`.
+ * Override one of the `init` methods and place the initialization code there.
+ *
+ * It also implements the [[akka.actor.typed.SpawnProtocol]].
+ *
+ * It can be used for other child actors than the guardian.
+ */
+abstract class Init extends DeferredBehavior[SpawnProtocol.Command] {
+
+  /**
+   * Override this method to perform initialization when the `ActorSystem` is started.
+   * For example, starting Akka Management and Cluster Bootstrap, initializing Cluster Sharding,
+   * starting projections or starting a gRPC server.
+   */
+  @throws(classOf[Exception])
+  protected def init(@unused system: ActorSystem[_]): Unit = ()
+
+  /**
+   * Override this method to create initial child actors.
+   */
+  @throws(classOf[Exception])
+  protected def init(@unused context: ActorContext[SpawnProtocol.Command]): Unit = ()
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  override final def apply(ctx: TypedActorContext[SpawnProtocol.Command]): Behavior[SpawnProtocol.Command] = {
+    val context = ctx.asJava
+    init(context.getSystem)
+    init(context)
+    SpawnProtocol()
+  }
+
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Init.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Init.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.scaladsl
+
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.SpawnProtocol
+import akka.actor.typed.TypedActorContext
+import akka.actor.typed.internal.BehaviorImpl.DeferredBehavior
+import akka.annotation.InternalApi
+import akka.util.unused
+
+/**
+ * Initialization when creating an [[akka.actor.typed.ActorSystem]] can be performed in an implementation of
+ * this [[akka.actor.typed.Behavior]]. Use it as the `guardianBehavior` when creating the `ActorSystem`.
+ * Override one of the `init` methods and place the initialization code there.
+ *
+ * It also implements the [[akka.actor.typed.SpawnProtocol]].
+ *
+ * It can be used for other child actors than the guardian.
+ */
+abstract class Init extends DeferredBehavior[SpawnProtocol.Command] {
+
+  /**
+   * Override this method to perform initialization when the `ActorSystem` is started.
+   * For example, starting Akka Management and Cluster Bootstrap, initializing Cluster Sharding,
+   * starting projections or starting a gRPC server.
+   */
+  protected def init(@unused system: ActorSystem[_]): Unit = ()
+
+  /**
+   * Override this method to create initial child actors.
+   */
+  protected def init(@unused context: ActorContext[SpawnProtocol.Command]): Unit = ()
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  override final def apply(ctx: TypedActorContext[SpawnProtocol.Command]): Behavior[SpawnProtocol.Command] = {
+    val context = ctx.asScala
+    init(context.system)
+    init(context)
+    SpawnProtocol()
+  }
+
+}


### PR DESCRIPTION
@jboner liked the [Platform Guide](https://developer.lightbend.com/docs/akka-platform-guide/index.html) very much, but one improvement suggestion was to simplify the Main class. It's [introduced early](https://developer.lightbend.com/docs/akka-platform-guide/microservices-tutorial/grpc-service.html#_main_method) and requires some actor concepts that the user doesn't have to know about at that point (and not later in the tutorial either).

I think several of us (including myself) have had the same feeling, but have avoiding it with the motivation that we shouldn't add API layers or convenience that only works for the most simple cases.

* Convenience Behavior to reduce number of concepts when starting ActorSystem with plain initialization code
* No Behaviors.setup and ActorContext
* No empty receive
* Implements SpawnProtocol
* Still possible to spawn initial top level actors if needed

It would look like this:

```java
public class Main extends Init {

  public static void main(String[] args) {
    ActorSystem.create(new Main(), "ShoppingCartService");
  }

  @Override
  public void init(ActorSystem<?> system) {
    AkkaManagement.get(system).start();
    ClusterBootstrap.get(system).start();

    ShoppingCart.init(system);

    CassandraSession session =
        CassandraSessionRegistry.get(system).sessionFor("akka.persistence.cassandra"); // <1>
    // use same keyspace for the item_popularity table as the offset store
    String itemPopularityKeyspace =
        system.settings().config().getString("akka.projection.cassandra.offset-store.keyspace");
    ItemPopularityRepository itemPopularityRepository =
        new ItemPopularityRepositoryImpl(session, itemPopularityKeyspace); // <2>

    ItemPopularityProjection.init(system, itemPopularityRepository); // <3>

    String grpcInterface =
        system.settings().config().getString("shopping-cart-service.grpc.interface");
    int grpcPort = system.settings().config().getInt("shopping-cart-service.grpc.port");
    ShoppingCartService grpcService = new ShoppingCartServiceImpl(system, itemPopularityRepository);
    ShoppingCartServer.start(grpcInterface, grpcPort, system, grpcService);

    PublishEventsProjection.init(system);

    ShoppingOrderService orderService = orderServiceClient(system);
    SendOrderProjection.init(system, orderService);
  }

  // can be overridden in tests
  protected ShoppingOrderService orderServiceClient(ActorSystem<?> system) {
    GrpcClientSettings orderServiceClientSettings =
        GrpcClientSettings.connectToServiceAt(
                system.settings().config().getString("shopping-order-service.host"),
                system.settings().config().getInt("shopping-order-service.port"),
                system)
            .withTls(false);

    return ShoppingOrderServiceClient.create(orderServiceClientSettings, system);
  }
}
```

instead of 
https://github.com/akka/akka-platform-guide/blob/ae2a2849df94343e370673b12b52dc83fc68fe4f/docs-source/docs/modules/microservices-tutorial/examples/shopping-cart-service-java/src/main/java/shopping/cart/Main.java#L24-L91

TODO:
- [ ] mention in docs, maybe in the hello world example
- [ ] test
