### PR TITLE
stream: more useful default names for common operators

### DIFF
--- a/akka-stream/src/main/mima-filters/2.6.10.backwards.excludes/29874-better-stream-operator-names.excludes
+++ b/akka-stream/src/main/mima-filters/2.6.10.backwards.excludes/29874-better-stream-operator-names.excludes
@@ -1,0 +1,2 @@
+# Internal classes
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.Stages*")

--- a/akka-stream/src/main/resources/reference.conf
+++ b/akka-stream/src/main/resources/reference.conf
@@ -6,7 +6,6 @@
 akka.library-extensions += "akka.stream.SystemMaterializer$"
 akka {
   stream {
-
     # Default materializer settings
     materializer {
 
@@ -135,6 +134,12 @@ akka {
     # Deprecated, will not be used unless user code refer to it, use 'akka.stream.materializer.blocking-io-dispatcher'
     # instead, or if from code, prefer the 'ActorAttributes.IODispatcher' attribute
     default-blocking-io-dispatcher = "akka.actor.default-blocking-io-dispatcher"
+
+    # Enable to give operators more descriptive default names that contain package, sourcefile, and line number where
+    # it can be figured out.
+    #
+    # Disable to retain simple default names as were used before Akka 2.6.11.
+    verbose-operator-names = on
   }
 
   # configure overrides to ssl-configuration here (to be used by akka-streams, and akka-http – i.e. when serving https connections)

--- a/akka-stream/src/main/resources/reference.conf
+++ b/akka-stream/src/main/resources/reference.conf
@@ -139,6 +139,9 @@ akka {
     # it can be figured out.
     #
     # Disable to retain simple default names as were used before Akka 2.6.11.
+    #
+    # This setting is always loaded from the classpath and not from the ActorSystem configuration. To override, you need
+    # to place this setting in an application.conf in the classpath or use `-Dakka.stream.verbose-operator-names=off`.
     verbose-operator-names = on
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -5,7 +5,6 @@
 package akka.stream.impl.fusing
 
 import java.util.concurrent.TimeUnit.NANOSECONDS
-
 import akka.actor.{ ActorRef, Terminated }
 import akka.annotation.{ DoNotInherit, InternalApi }
 import akka.event.Logging.LogLevel
@@ -40,7 +39,7 @@ import akka.util.ccompat._
   val out = Outlet[Out]("Map.out")
   override val shape = FlowShape(in, out)
 
-  override def initialAttributes: Attributes = DefaultAttributes.map
+  override def initialAttributes: Attributes = DefaultAttributes.map(f)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with InHandler with OutHandler {
@@ -69,7 +68,7 @@ import akka.util.ccompat._
  * INTERNAL API
  */
 @InternalApi private[akka] final case class Filter[T](p: T => Boolean) extends SimpleLinearGraphStage[T] {
-  override def initialAttributes: Attributes = DefaultAttributes.filter
+  override def initialAttributes: Attributes = DefaultAttributes.filter(p)
 
   override def toString: String = "Filter"
 
@@ -231,7 +230,7 @@ private[stream] object Collect {
   val out = Outlet[Out]("Collect.out")
   override val shape = FlowShape(in, out)
 
-  override def initialAttributes: Attributes = DefaultAttributes.collect
+  override def initialAttributes: Attributes = DefaultAttributes.collect(pf)
 
   def createLogic(inheritedAttributes: Attributes) =
     new SupervisedGraphStageLogic(inheritedAttributes, shape) with InHandler with OutHandler {
@@ -1253,7 +1252,7 @@ private[stream] object Collect {
   private val in = Inlet[In]("MapAsync.in")
   private val out = Outlet[Out]("MapAsync.out")
 
-  override def initialAttributes = DefaultAttributes.mapAsync
+  override def initialAttributes = DefaultAttributes.mapAsync(f)
 
   override val shape = FlowShape(in, out)
 
@@ -1353,7 +1352,7 @@ private[stream] object Collect {
   private val in = Inlet[In]("MapAsyncUnordered.in")
   private val out = Outlet[Out]("MapAsyncUnordered.out")
 
-  override def initialAttributes = DefaultAttributes.mapAsyncUnordered
+  override def initialAttributes = DefaultAttributes.mapAsyncUnordered(f)
 
   override val shape = FlowShape(in, out)
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1204,7 +1204,7 @@ trait FlowOps[+Out, +Mat] {
    * '''Cancels when''' downstream cancels
    */
   def filterNot(p: Out => Boolean): Repr[Out] =
-    via(Flow[Out].filter(!p(_)).withAttributes(DefaultAttributes.filterNot))
+    via(Flow[Out].filter(!p(_)).withAttributes(DefaultAttributes.filterNot(p)))
 
   /**
    * Terminate processing (and cancel the upstream publisher) after predicate


### PR DESCRIPTION
Names will then for example look like this

```
map-akka.stream.scaladsl-FlowMapSpec.scala-line-22
```

I.e

```
<operator name>-<package name of lambda>-<file name of lambda>-line-<line number of lambda>
```

 * Still needs some tests but names are not easily observable, let's see if there are tests that examine the default naming behavior.
 * There's some risk that users already depend on the default naming. I find that somewhat unlikely given that the current names are too generic and provide too little to pinpoint which operator is which. Also, if you need better and fixed names, you shouldn't rely on default names.
 * The naming will be based on the definition site of the lambda, not at the application site in the flow dsl. That can be confusing but seems like the right trade-off: the number of lambda classes is finite so caching will work well, while figuring out stack traces where operators are instantiated will be a higher cost.