### PR TITLE
Missing boundary for expectation to always hold 

### DIFF
--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/pubsub/DistributedPubSubMediatorSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/pubsub/DistributedPubSubMediatorSpec.scala
@@ -195,6 +195,7 @@ class DistributedPubSubMediatorSpec
         expectMsg("hello")
         lastSender should ===(u2)
       }
+      enterBarrier("2-registered")
 
       runOn(second) {
         val u3 = createChatUser("u3")


### PR DESCRIPTION
References #29777

Expected "user" creation on `second` to never happen before the assert of two users on `first` bid didn't express that with a boundary, so it failed (once).