### PR TITLE
Akka 29891  testkit msg adaptors

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -171,7 +171,7 @@ private[akka] final class BehaviorTestKitImpl[T](_path: ActorPath, _initialBehav
 }
 
 object BehaviorTestKitImpl {
-  private [akka] object Interceptor extends BehaviorInterceptor[Any, Any]() {
+  private[akka] object Interceptor extends BehaviorInterceptor[Any, Any]() {
 
     /**
      * Intercept a message sent to the running actor. Pass the message on to the next behavior

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -134,33 +134,8 @@ private[akka] final class BehaviorTestKitImpl[T](_path: ActorPath, _initialBehav
       context.setCurrentActorThread()
       try {
         //we need this to handle message adapters related messages
-        val intercepted0 = Behaviors.intercept{ () =>
-          new BehaviorInterceptor[Any, T]() {
-            import BehaviorInterceptor._
-            /**
-             * Intercept a message sent to the running actor. Pass the message on to the next behavior
-             * in the stack by passing it to `target.apply`, return `Behaviors.same` without invoking `target`
-             * to filter out the message.
-             *
-             * @return The behavior for next message or signal
-             */
-            override def aroundReceive(ctx: TypedActorContext[Any], msg: Any, target: BehaviorInterceptor.ReceiveTarget[T]): Behavior[T] = {
-              msg match {
-                case AdaptWithRegisteredMessageAdapter(msgToAdapt) =>
-                  val fn = context
-                    .messageAdapters
-                    .find(_._1.isInstance(msgToAdapt))
-                    .getOrElse(sys error s"can't find a message adaptor for $msgToAdapt")
-                    ._2
-                  val adaptedMsg = fn(msgToAdapt)
-                  target.apply(ctx, adaptedMsg)
-                case t => target.apply(ctx, t.asInstanceOf[T @unchecked])
-              }
-            }
-          }
-        } (current)
-        val intercepted = Behavior.start(intercepted0, context.asInstanceOf[TypedActorContext[Any]])
-        currentUncanonical = Behavior.interpretMessage(intercepted, context.asInstanceOf[TypedActorContext[Any]], message).asInstanceOf[Behavior[T]]
+        val intercepted = BehaviorTestKitImpl.Interceptor.inteceptBehaviour(current, context)
+        currentUncanonical = Behavior.interpretMessage(intercepted, context, message)
         //notice we pass current and not intercepted, this way Behaviors.same will be resolved to current which will be intercepted again on the next message
         //otherwise we would have risked intercepting and already intercepted behaviour (or explicitly checking if the current behaviour is already intercepted by us)
         current = Behavior.canonicalize(currentUncanonical, current, context)
@@ -193,4 +168,39 @@ private[akka] final class BehaviorTestKitImpl[T](_path: ActorPath, _initialBehav
   override def clearLog(): Unit = context.clearLog()
 
   override def receptionistInbox(): TestInboxImpl[Receptionist.Command] = context.system.receptionistInbox
+}
+
+object BehaviorTestKitImpl {
+  object Interceptor extends BehaviorInterceptor[Any, Any]() {
+    import BehaviorInterceptor._
+    /**
+     * Intercept a message sent to the running actor. Pass the message on to the next behavior
+     * in the stack by passing it to `target.apply`, return `Behaviors.same` without invoking `target`
+     * to filter out the message.
+     *
+     * @return The behavior for next message or signal
+     */
+    override def aroundReceive(ctx: TypedActorContext[Any], msg: Any, target: BehaviorInterceptor.ReceiveTarget[Any]): Behavior[Any] = {
+      msg match {
+        case AdaptWithRegisteredMessageAdapter(msgToAdapt) =>
+          val fn = ctx
+            .asInstanceOf[StubbedActorContext[Any]]
+            .messageAdapters
+            .collectFirst {
+              case (clazz, func) if clazz.isInstance(msgToAdapt) => func
+            }.getOrElse(sys error s"can't find a message adaptor for $msgToAdapt")
+
+          val adaptedMsg = fn(msgToAdapt)
+          target.apply(ctx, adaptedMsg)
+        case t => target.apply(ctx, t)
+      }
+    }
+
+    def inteceptBehaviour[T](behavior: Behavior[T], ctx: TypedActorContext[T]) : Behavior[T] = Behavior.start(
+      Behaviors.intercept {
+        () => this.asInstanceOf[BehaviorInterceptor[Any, T]]
+      } (behavior),
+      ctx.asInstanceOf[TypedActorContext[Any]]
+    ).unsafeCast[T]
+  }
 }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -170,8 +170,8 @@ private[akka] final class BehaviorTestKitImpl[T](_path: ActorPath, _initialBehav
   override def receptionistInbox(): TestInboxImpl[Receptionist.Command] = context.system.receptionistInbox
 }
 
-object BehaviorTestKitImpl {
-  private[akka] object Interceptor extends BehaviorInterceptor[Any, Any]() {
+private[akka] object BehaviorTestKitImpl {
+  object Interceptor extends BehaviorInterceptor[Any, Any]() {
 
     /**
      * Intercept a message sent to the running actor. Pass the message on to the next behavior

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -172,8 +172,7 @@ private[akka] final class BehaviorTestKitImpl[T](_path: ActorPath, _initialBehav
 
 object BehaviorTestKitImpl {
   object Interceptor extends BehaviorInterceptor[Any, Any]() {
-    import BehaviorInterceptor._
-
+    
     /**
      * Intercept a message sent to the running actor. Pass the message on to the next behavior
      * in the stack by passing it to `target.apply`, return `Behaviors.same` without invoking `target`

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -137,7 +137,7 @@ private[akka] final class BehaviorTestKitImpl[T](_path: ActorPath, _initialBehav
         val intercepted = BehaviorTestKitImpl.Interceptor.inteceptBehaviour(current, context)
         currentUncanonical = Behavior.interpretMessage(intercepted, context, message)
         //notice we pass current and not intercepted, this way Behaviors.same will be resolved to current which will be intercepted again on the next message
-        //otherwise we would have risked intercepting and already intercepted behaviour (or explicitly checking if the current behaviour is already intercepted by us)
+        //otherwise we would have risked intercepting an already intercepted behavior (or would have had to explicitly check if the current behavior is already intercepted by us)
         current = Behavior.canonicalize(currentUncanonical, current, context)
       } finally {
         context.clearCurrentActorThread()

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -173,13 +173,7 @@ private[akka] final class BehaviorTestKitImpl[T](_path: ActorPath, _initialBehav
 private[akka] object BehaviorTestKitImpl {
   object Interceptor extends BehaviorInterceptor[Any, Any]() {
 
-    /**
-     * Intercept a message sent to the running actor. Pass the message on to the next behavior
-     * in the stack by passing it to `target.apply`, return `Behaviors.same` without invoking `target`
-     * to filter out the message.
-     *
-     * @return The behavior for next message or signal
-     */
+    // Intercept a internal message adaptors related messages, forward the rest
     override def aroundReceive(
         ctx: TypedActorContext[Any],
         msg: Any,

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -171,8 +171,8 @@ private[akka] final class BehaviorTestKitImpl[T](_path: ActorPath, _initialBehav
 }
 
 object BehaviorTestKitImpl {
-  object Interceptor extends BehaviorInterceptor[Any, Any]() {
-    
+  private [akka] object Interceptor extends BehaviorInterceptor[Any, Any]() {
+
     /**
      * Intercept a message sent to the running actor. Pass the message on to the next behavior
      * in the stack by passing it to `target.apply`, return `Behaviors.same` without invoking `target`

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
@@ -284,10 +284,10 @@ class BehaviorTestKitSpec extends AnyWordSpec with Matchers with LogCapturing {
       testkit.selfInbox().hasMessages should be (true)
       testkit.runOne()
       testkit.expectEffectPF{
-        case Spawned(_, childName, _) => childName should equal ("child1")
+        case Spawned(_, childName, _) => childName should equal ("child0")
       }
       testkit.expectEffectPF{
-        case Spawned(_, childName, _) => childName should equal ("child2")
+        case Spawned(_, childName, _) => childName should equal ("child1")
       }
     }
   }

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
@@ -35,7 +35,11 @@ object BehaviorTestKitSpec {
     case class StopChild(child: ActorRef[String]) extends Command
     case object SpawnAdapter extends Command
     case class SpawnAdapterWithName(name: String) extends Command
-    case class CreateMessageAdapter[U](messageClass: Class[U], f: U => Command, replyTo : Option[ActorRef[ActorRef[U]]] = None) extends Command
+    case class CreateMessageAdapter[U](
+        messageClass: Class[U],
+        f: U => Command,
+        replyTo: Option[ActorRef[ActorRef[U]]] = None)
+        extends Command
     case class SpawnAndWatchUnwatch(name: String) extends Command
     case class SpawnAndWatchWith(name: String) extends Command
     case class SpawnSession(replyTo: ActorRef[ActorRef[String]], sessionHandler: ActorRef[String]) extends Command
@@ -281,13 +285,13 @@ class BehaviorTestKitSpec extends AnyWordSpec with Matchers with LogCapturing {
       testkit.expectEffectType[MessageAdapter[String, Command]]
       val adaptorRef = replyTo.receiveMessage()
       adaptorRef ! 2
-      testkit.selfInbox().hasMessages should be (true)
+      testkit.selfInbox().hasMessages should be(true)
       testkit.runOne()
-      testkit.expectEffectPF{
-        case Spawned(_, childName, _) => childName should equal ("child0")
+      testkit.expectEffectPF {
+        case Spawned(_, childName, _) => childName should equal("child0")
       }
-      testkit.expectEffectPF{
-        case Spawned(_, childName, _) => childName should equal ("child1")
+      testkit.expectEffectPF {
+        case Spawned(_, childName, _) => childName should equal("child1")
       }
     }
   }

--- a/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKitSpec.scala
@@ -35,7 +35,7 @@ object BehaviorTestKitSpec {
     case class StopChild(child: ActorRef[String]) extends Command
     case object SpawnAdapter extends Command
     case class SpawnAdapterWithName(name: String) extends Command
-    case class CreateMessageAdapter[U](messageClass: Class[U], f: U => Command) extends Command
+    case class CreateMessageAdapter[U](messageClass: Class[U], f: U => Command, replyTo : Option[ActorRef[ActorRef[U]]] = None) extends Command
     case class SpawnAndWatchUnwatch(name: String) extends Command
     case class SpawnAndWatchWith(name: String) extends Command
     case class SpawnSession(replyTo: ActorRef[ActorRef[String]], sessionHandler: ActorRef[String]) extends Command
@@ -102,8 +102,9 @@ object BehaviorTestKitSpec {
             context.stop(session)
             replyTo ! Done
             Behaviors.same
-          case CreateMessageAdapter(messageClass, f) =>
-            context.messageAdapter(f)(ClassTag(messageClass))
+          case CreateMessageAdapter(messageClass, f, replyTo) =>
+            val adaptor = context.messageAdapter(f)(ClassTag(messageClass))
+            replyTo.foreach(_ ! adaptor.unsafeUpcast)
             Behaviors.same
           case Log(what) =>
             context.log.info(what)
@@ -271,6 +272,23 @@ class BehaviorTestKitSpec extends AnyWordSpec with Matchers with LogCapturing {
       val testkit = BehaviorTestKit[Parent.Command](Parent.init)
       testkit.run(CreateMessageAdapter(classOf[String], (_: String) => SpawnChildren(1)))
       testkit.expectEffectType[MessageAdapter[String, Command]]
+    }
+
+    "create message adapter and receive messages via the newly created adapter" in {
+      val testkit = BehaviorTestKit[Parent.Command](Parent.init)
+      val replyTo = TestInbox[ActorRef[Int]]("replyTo")
+      testkit.run(CreateMessageAdapter(classOf[Int], SpawnChildren.apply, Some(replyTo.ref)))
+      testkit.expectEffectType[MessageAdapter[String, Command]]
+      val adaptorRef = replyTo.receiveMessage()
+      adaptorRef ! 2
+      testkit.selfInbox().hasMessages should be (true)
+      testkit.runOne()
+      testkit.expectEffectPF{
+        case Spawned(_, childName, _) => childName should equal ("child1")
+      }
+      testkit.expectEffectPF{
+        case Spawned(_, childName, _) => childName should equal ("child2")
+      }
     }
   }
 


### PR DESCRIPTION
BehaviourTestKit support for message adapters was broken, it kept the adapting function, created a child and a FunctionRef, however when a message was sent via the returned ActorRef it resulted with a class-cast-exception when the message was handed over to the behaviour.
This PR introduces a fix by intercepting adapter related messages prior to forwarding them to the tested behaviour.

References #29891
