### PR TITLE
[2.5.x] CI: check policies with environment key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,11 @@ script:
   # make 'git branch' work again
   - git branch -f "$TRAVIS_BRANCH" && git checkout "$TRAVIS_BRANCH"
   # check policies, if on master also upload
-  - if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "push" ]]; then sbt 'set credentials += Credentials("whitesource", "whitesourcesoftware.com", "", System.getenv("WHITESOURCE_KEY"))' whitesourceCheckPolicies whitesourceUpdate; else sbt 'set credentials += Credentials("whitesource", "whitesourcesoftware.com", "", System.getenv("WHITESOURCE_KEY"))' whitesourceCheckPolicies; fi ; fi
+  - if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "push" ]]; then sbt whitesourceCheckPolicies whitesourceUpdate; else sbt whitesourceCheckPolicies; fi ; fi
 
 env:
   global:
     - TRAVIS_JDK=8
-    # encrypt with: travis encrypt WHITESOURCE_KEY=...
-    - secure: "L/wJ7TbgY+oPULgbv+giFZejnQERfv/8/9Ex/nwRni8qnpxw5Q6BqB86Sch6b79irQiOdb+hr2tq3/m3KzXjC58xppRPfnmXsu3yI9XAln9WPi/sPvqUL8WPJmRfGswAw3L8w2JdD9VBP4iv0dWpRghGD27iqgipVRdN62PU+nU="
 
 # safelist
 branches:


### PR DESCRIPTION
Since the CI moved to travis-ci.com the old encryption won't work. 
The password is now added to the Travis settings instead.

References https://github.com/akka/akka/pull/29824