### PR TITLE
Race condition in DeprecatedSupervisionSpec fixed 

### DIFF
--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/SupervisionSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/SupervisionSpec.scala
@@ -5,13 +5,12 @@
 package akka.cluster.sharding
 
 import scala.concurrent.duration._
-
 import com.typesafe.config.ConfigFactory
-
 import akka.actor.{ Actor, ActorLogging, ActorRef, PoisonPill, Props }
 import akka.cluster.Cluster
 import akka.cluster.sharding.ShardRegion.Passivate
 import akka.pattern.{ BackoffOpts, BackoffSupervisor }
+import akka.testkit.EventFilter
 import akka.testkit.WithLogCapturing
 import akka.testkit.{ AkkaSpec, ImplicitSender }
 
@@ -98,8 +97,12 @@ class DeprecatedSupervisionSpec extends AkkaSpec(SupervisionSpec.config) with Im
       val response = expectMsgType[Response](5.seconds)
       watch(response.self)
 
-      region ! Msg(10, "passivate")
-      expectTerminated(response.self)
+      // We need the shard to have observed the passivation for this test but
+      // we don't know that this means the passivation reached the shard yet unless we observe it
+      EventFilter.debug("passy: Passivation started for [10]", occurrences = 1).intercept {
+        region ! Msg(10, "passivate")
+        expectTerminated(response.self)
+      }
 
       // This would fail before as sharded actor would be stuck passivating
       region ! Msg(10, "hello")


### PR DESCRIPTION
References #29735

Race condition was (I think) that test expected that observing that a supervised sharded actor child terminating in the test guaranteed that the shard had seen a passivate message from it (that needs to be forwarded through the supervisor).