### PR TITLE
Add more explicit annotations of top level coexistence

### DIFF
--- a/akka-docs/src/main/paradox/typed/coexisting.md
+++ b/akka-docs/src/main/paradox/typed/coexisting.md
@@ -84,6 +84,7 @@ Scala
 Java
 :  @@snip [ClassicWatchingTypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/ClassicWatchingTypedTest.java) { #adapter-import }
 
+
 @scala[That adds some implicit extension methods that are added to classic and typed `ActorSystem`, `ActorContext` and `ActorRef` in both directions.]
 @java[To convert between typed and classic `ActorSystem`, `ActorContext` and `ActorRef` in both directions there are adapter methods in `akka.actor.typed.javadsl.Adapter`.]
 Note the inline comments in the example above. Additionally, note that the above method of using a top level classic actor is the suggested path for this type of co-existence. However, if you prefer to start with a typed top level actor then you can use the implicits and then call `spawn` directly from the typed system:

--- a/akka-docs/src/main/paradox/typed/coexisting.md
+++ b/akka-docs/src/main/paradox/typed/coexisting.md
@@ -84,10 +84,17 @@ Scala
 Java
 :  @@snip [ClassicWatchingTypedTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/ClassicWatchingTypedTest.java) { #adapter-import }
 
-
 @scala[That adds some implicit extension methods that are added to classic and typed `ActorSystem`, `ActorContext` and `ActorRef` in both directions.]
 @java[To convert between typed and classic `ActorSystem`, `ActorContext` and `ActorRef` in both directions there are adapter methods in `akka.actor.typed.javadsl.Adapter`.]
-Note the inline comments in the example above.
+Note the inline comments in the example above. Additionally, note that the above method of using a top level classic actor is the suggested path for this type of co-existence. However, if you prefer to start with a typed top level actor then you can use the implicits and then call `spawn` directly from the typed system:
+
+Scala
+:  @@snip [TypedWatchingClassicSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingClassicSpec.scala) { #create }
+
+Java
+:  @@snip [TypedWatchingClassicTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingClassicTest.java) { #create }
+
+Once migrated to a fully typed system the concept is to provide the root actor in the `ActorSystem` constructor, and then spawn actors from the `ActorContext` of the actor itself. The rationale for this is partly about consistency. In a typed system you can’t create children to an arbitrary actor from anywhere in your app without messaging it, so this will also hold true for the User guardian actor. Whereas in a classic system it was mostly not noticed that the guardian was an actor. That noted, in cases where you do need to spawn outside of this guardian then you can use the @ref:[`SpawnProtocol`](../actor-lifecycle.md#spawnprotocol) to spawn as needed.
 
 ## Typed to classic
 

--- a/akka-docs/src/main/paradox/typed/coexisting.md
+++ b/akka-docs/src/main/paradox/typed/coexisting.md
@@ -97,7 +97,7 @@ Scala
 Java
 :  @@snip [TypedWatchingClassicTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingClassicTest.java) { #create }
 
-Once migrated to a fully typed system the concept is to provide the root actor in the `ActorSystem` constructor, and then spawn actors from the `ActorContext` of the actor itself. The rationale for this is partly about consistency. In a typed system you can’t create children to an arbitrary actor from anywhere in your app without messaging it, so this will also hold true for the User guardian actor. Whereas in a classic system it was mostly not noticed that the guardian was an actor. That noted, in cases where you do need to spawn outside of this guardian then you can use the @ref:[`SpawnProtocol`](./actor-lifecycle.md#spawnprotocol) to spawn as needed.
+This classic-typed difference is discussed further in @ref:[the `ActorSystem` section](./from-classic.md#actorsystem) of "Learning Akka Typed from Classic". 
 
 ## Typed to classic
 

--- a/akka-docs/src/main/paradox/typed/coexisting.md
+++ b/akka-docs/src/main/paradox/typed/coexisting.md
@@ -87,7 +87,9 @@ Java
 
 @scala[That adds some implicit extension methods that are added to classic and typed `ActorSystem`, `ActorContext` and `ActorRef` in both directions.]
 @java[To convert between typed and classic `ActorSystem`, `ActorContext` and `ActorRef` in both directions there are adapter methods in `akka.actor.typed.javadsl.Adapter`.]
-Note the inline comments in the example above. Additionally, note that the above method of using a top level classic actor is the suggested path for this type of co-existence. However, if you prefer to start with a typed top level actor then you can use the implicits and then call `spawn` directly from the typed system:
+Note the inline comments in the example above. 
+
+This method of using a top level classic actor is the suggested path for this type of co-existence. However, if you prefer to start with a typed top level actor then you can use the @scala[implicit `spawn` -method]@java[`Adapter.spawn`] directly from the typed system:
 
 Scala
 :  @@snip [TypedWatchingClassicSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/coexistence/TypedWatchingClassicSpec.scala) { #create }
@@ -148,6 +150,5 @@ The default supervision for classic actors is to restart whereas for typed it is
 When combining classic and typed actors the default supervision is based on the default behavior of
 the child, for example if a classic actor creates a typed child, its default supervision will be to stop. If a typed
 actor creates a classic child, its default supervision will be to restart.
-
 
 

--- a/akka-docs/src/main/paradox/typed/coexisting.md
+++ b/akka-docs/src/main/paradox/typed/coexisting.md
@@ -97,7 +97,7 @@ Scala
 Java
 :  @@snip [TypedWatchingClassicTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingClassicTest.java) { #create }
 
-This classic-typed difference is discussed further in @ref:[the `ActorSystem` section](./from-classic.md#actorsystem) of "Learning Akka Typed from Classic". 
+The above classic-typed difference is further elaborated in @ref:[the `ActorSystem` section](./from-classic.md#actorsystem) of "Learning Akka Typed from Classic". 
 
 ## Typed to classic
 

--- a/akka-docs/src/main/paradox/typed/coexisting.md
+++ b/akka-docs/src/main/paradox/typed/coexisting.md
@@ -95,7 +95,7 @@ Scala
 Java
 :  @@snip [TypedWatchingClassicTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/coexistence/TypedWatchingClassicTest.java) { #create }
 
-Once migrated to a fully typed system the concept is to provide the root actor in the `ActorSystem` constructor, and then spawn actors from the `ActorContext` of the actor itself. The rationale for this is partly about consistency. In a typed system you can’t create children to an arbitrary actor from anywhere in your app without messaging it, so this will also hold true for the User guardian actor. Whereas in a classic system it was mostly not noticed that the guardian was an actor. That noted, in cases where you do need to spawn outside of this guardian then you can use the @ref:[`SpawnProtocol`](../actor-lifecycle.md#spawnprotocol) to spawn as needed.
+Once migrated to a fully typed system the concept is to provide the root actor in the `ActorSystem` constructor, and then spawn actors from the `ActorContext` of the actor itself. The rationale for this is partly about consistency. In a typed system you can’t create children to an arbitrary actor from anywhere in your app without messaging it, so this will also hold true for the User guardian actor. Whereas in a classic system it was mostly not noticed that the guardian was an actor. That noted, in cases where you do need to spawn outside of this guardian then you can use the @ref:[`SpawnProtocol`](./actor-lifecycle.md#spawnprotocol) to spawn as needed.
 
 ## Typed to classic
 

--- a/akka-docs/src/main/paradox/typed/from-classic.md
+++ b/akka-docs/src/main/paradox/typed/from-classic.md
@@ -155,7 +155,10 @@ typically performed from the "outside".
 
 The `actorOf` method of the classic `ActorSystem` is typically used to create a few (or many) top level actors. The
 `ActorSystem` in Typed doesn't have that capability. Instead, such actors are started as children of
-the user guardian actor or children of other actors in the actor hierarchy.
+the user guardian actor or children of other actors in the actor hierarchy. The rationale for this is partly about consistency. 
+In a typed system you can’t create children to an arbitrary actor from anywhere in your app without messaging it, 
+so this will also hold true for the user guardian actor. That noted, in cases where you do need to spawn outside of this guardian 
+then you can use the @ref:[`SpawnProtocol`](./actor-lifecycle.md#spawnprotocol) to spawn as needed.
 
 ## become
 


### PR DESCRIPTION
A user recently ran into some difficulties when trying to convert a provided classic system and then create a top level typed actor. The idioms changed between classic and typed, so it should be called out and documented explicitly for transitions such as this.
