### PR TITLE
EventSourcedBehaviorTestKit serialization improvements

### DIFF
--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
@@ -84,6 +84,13 @@ import akka.stream.scaladsl.Sink
   import EventSourcedBehaviorTestKitImpl._
 
   private def system: ActorSystem[_] = actorTestKit.system
+  if (system.settings.config.getBoolean("akka.persistence.testkit.events.serialize") ||
+      system.settings.config.getBoolean("akka.persistence.testkit.snapshots.serialize")) {
+    system.log.warn(
+      "Persistence TestKit serialization enabled when using EventSourcedBehaviorTestKit, this is not intended. " +
+      "make sure you create the system used in the test with the config from EventSourcedBehaviorTestKit.config " +
+      "as described in the docs https://doc.akka.io/docs/akka/current/typed/persistence-testing.html#unit-testing")
+  }
 
   override val persistenceTestKit: PersistenceTestKit = PersistenceTestKit(system)
   persistenceTestKit.clearAll()

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKit.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKit.scala
@@ -37,6 +37,7 @@ object EventSourcedBehaviorTestKit {
    */
   val config: Config = ConfigFactory.parseString("""
     akka.persistence.testkit.events.serialize = off
+    akka.persistence.testkit.snapshots.serialize = off
     """).withFallback(PersistenceTestKitPlugin.config)
 
   object SerializationSettings {


### PR DESCRIPTION
Disable snapshot serialization by default, log warning if inmem journal serialization enabled 

References #29904