### PR TITLE
Akka29924 router pool  bcast

### DIFF
--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/RoutersTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/RoutersTest.java
@@ -19,10 +19,8 @@ public class RoutersTest {
   }
 
   public void poolBroadcastCompileOnlyApiTest() {
-    Behavior<String> b = Behaviors
-            .receiveMessage( (String str) -> Behaviors.same() );
-    Behavior<String> poolBehavior = Routers
-            .pool(5, b)
-            .withBroadcastPredicate( str -> str.startsWith("bc-"));
+    Behavior<String> b = Behaviors.receiveMessage((String str) -> Behaviors.same());
+    Behavior<String> poolBehavior =
+        Routers.pool(5, b).withBroadcastPredicate(str -> str.startsWith("bc-"));
   }
 }

--- a/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/RoutersTest.java
+++ b/akka-actor-typed-tests/src/test/java/akka/actor/typed/javadsl/RoutersTest.java
@@ -17,4 +17,12 @@ public class RoutersTest {
     Behavior<String> pool =
         Routers.pool(5, Behaviors.<String>empty()).withRandomRouting().withRoundRobinRouting();
   }
+
+  public void poolBroadcastCompileOnlyApiTest() {
+    Behavior<String> b = Behaviors
+            .receiveMessage( (String str) -> Behaviors.same() );
+    Behavior<String> poolBehavior = Routers
+            .pool(5, b)
+            .withBroadcastPredicate( str -> str.startsWith("bc-"));
+  }
 }

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java
@@ -37,6 +37,14 @@ public class RouterTest {
       }
     }
 
+    static class DoBroadcastLog implements Command {
+        public final String text;
+
+        public DoBroadcastLog(String text) {
+            this.text = text;
+        }
+    }
+
     static final Behavior<Command> create() {
       return Behaviors.setup(
           context -> {
@@ -44,6 +52,7 @@ public class RouterTest {
 
             return Behaviors.receive(Command.class)
                 .onMessage(DoLog.class, doLog -> onDoLog(context, doLog))
+                .onMessage(DoBroadcastLog.class, doBCast -> onDoBroadcast(context, doBCast))
                 .build();
           });
     }
@@ -52,6 +61,11 @@ public class RouterTest {
       context.getLog().info("Got message {}", doLog.text);
       return Behaviors.same();
     }
+
+      private static Behavior<Command> onDoBroadcast(ActorContext<Command> context, DoBroadcastLog doBCast) {
+          context.getLog().info("Got broadcast message {}", doBCast.text);
+          return Behaviors.same();
+      }
   }
 
   // #routee
@@ -87,6 +101,10 @@ public class RouterTest {
           // #strategy
           PoolRouter<Worker.Command> alternativePool = pool.withPoolSize(2).withRoundRobinRouting();
           // #strategy
+
+          // #broadcast
+            PoolRouter<Worker.Command> broadcastingPool = pool.withBroadcastPredicate(msg -> msg instanceof Worker.DoBroadcastLog);
+          // #broadcast
 
           return Behaviors.empty();
           // #pool

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java
@@ -37,14 +37,6 @@ public class RouterTest {
       }
     }
 
-    static class DoBroadcastLog implements Command {
-      public final String text;
-
-      public DoBroadcastLog(String text) {
-        this.text = text;
-      }
-    }
-
     static final Behavior<Command> create() {
       return Behaviors.setup(
           context -> {
@@ -52,7 +44,6 @@ public class RouterTest {
 
             return Behaviors.receive(Command.class)
                 .onMessage(DoLog.class, doLog -> onDoLog(context, doLog))
-                .onMessage(DoBroadcastLog.class, doBCast -> onDoBroadcast(context, doBCast))
                 .build();
           });
     }
@@ -61,15 +52,17 @@ public class RouterTest {
       context.getLog().info("Got message {}", doLog.text);
       return Behaviors.same();
     }
-
-    private static Behavior<Command> onDoBroadcast(
-        ActorContext<Command> context, DoBroadcastLog doBCast) {
-      context.getLog().info("Got broadcast message {}", doBCast.text);
-      return Behaviors.same();
-    }
   }
 
   // #routee
+
+  // intentionally outside the routee scope
+  static class DoBroadcastLog extends Worker.DoLog {
+
+    public DoBroadcastLog(String text) {
+      super(text);
+    }
+  }
 
   static Behavior<Void> showPoolRouting() {
     return
@@ -105,7 +98,7 @@ public class RouterTest {
 
           // #broadcast
           PoolRouter<Worker.Command> broadcastingPool =
-              pool.withBroadcastPredicate(msg -> msg instanceof Worker.DoBroadcastLog);
+              pool.withBroadcastPredicate(msg -> msg instanceof DoBroadcastLog);
           // #broadcast
 
           return Behaviors.empty();

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java
@@ -38,11 +38,11 @@ public class RouterTest {
     }
 
     static class DoBroadcastLog implements Command {
-        public final String text;
+      public final String text;
 
-        public DoBroadcastLog(String text) {
-            this.text = text;
-        }
+      public DoBroadcastLog(String text) {
+        this.text = text;
+      }
     }
 
     static final Behavior<Command> create() {
@@ -62,10 +62,11 @@ public class RouterTest {
       return Behaviors.same();
     }
 
-      private static Behavior<Command> onDoBroadcast(ActorContext<Command> context, DoBroadcastLog doBCast) {
-          context.getLog().info("Got broadcast message {}", doBCast.text);
-          return Behaviors.same();
-      }
+    private static Behavior<Command> onDoBroadcast(
+        ActorContext<Command> context, DoBroadcastLog doBCast) {
+      context.getLog().info("Got broadcast message {}", doBCast.text);
+      return Behaviors.same();
+    }
   }
 
   // #routee
@@ -103,7 +104,8 @@ public class RouterTest {
           // #strategy
 
           // #broadcast
-            PoolRouter<Worker.Command> broadcastingPool = pool.withBroadcastPredicate(msg -> msg instanceof Worker.DoBroadcastLog);
+          PoolRouter<Worker.Command> broadcastingPool =
+              pool.withBroadcastPredicate(msg -> msg instanceof Worker.DoBroadcastLog);
           // #broadcast
 
           return Behaviors.empty();

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/RoutersSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/RoutersSpec.scala
@@ -6,7 +6,7 @@ package akka.actor.typed.scaladsl
 import java.util.concurrent.atomic.AtomicInteger
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import akka.actor.{ActorPath, ActorSystem}
+import akka.actor.{ ActorPath, ActorSystem }
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.LoggingTestKit
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
@@ -113,14 +113,12 @@ class RoutersSpec extends ScalaTestWithActorTestKit("""
       }
     }
 
-
-
     "support broadcast" must {
       trait Cmd
       case object ReplyWithAck extends Cmd
       case class BCast(cmd: Cmd) extends Cmd
 
-      def behavior(replyTo : ActorRef[AnyRef]) = Behaviors.setup[Cmd] { ctx =>
+      def behavior(replyTo: ActorRef[AnyRef]) = Behaviors.setup[Cmd] { ctx =>
         Behaviors.receiveMessage[Cmd] {
           case ReplyWithAck =>
             val reply = ctx.self.path
@@ -145,17 +143,13 @@ class RoutersSpec extends ScalaTestWithActorTestKit("""
 
       "when enabled" in {
         val probe = testKit.createTestProbe[AnyRef]()
-        val pool = testKit.spawn(Routers
-          .pool(4)(behavior(probe.ref))
-          .withBroadcastPredicate(_.isInstanceOf[BCast]))
+        val pool = testKit.spawn(Routers.pool(4)(behavior(probe.ref)).withBroadcastPredicate(_.isInstanceOf[BCast]))
         pool ! BCast(ReplyWithAck)
-        val msgs = probe
-          .receiveMessages(4)
-          .map{m =>
-            m should be (an[ActorPath])
-            m.asInstanceOf[ActorPath]
-          }
-        msgs should equal (msgs.distinct)
+        val msgs = probe.receiveMessages(4).map { m =>
+          m should be(an[ActorPath])
+          m.asInstanceOf[ActorPath]
+        }
+        msgs should equal(msgs.distinct)
         probe.expectNoMessage()
       }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/RoutersSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/RoutersSpec.scala
@@ -151,6 +151,10 @@ class RoutersSpec extends ScalaTestWithActorTestKit("""
         }
         msgs should equal(msgs.distinct)
         probe.expectNoMessage()
+
+        pool ! ReplyWithAck
+        probe.expectMessageType[ActorPath]
+        probe.expectNoMessage()
       }
 
     }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/RoutersSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/RoutersSpec.scala
@@ -118,32 +118,34 @@ class RoutersSpec extends ScalaTestWithActorTestKit("""
     "supports broadcast" in {
       trait Cmd
       case object ReplyWithAck extends Cmd
-      case class BCast(cmd : Cmd) extends Cmd
+      case class BCast(cmd: Cmd) extends Cmd
 
       val atomicInt = new AtomicInteger(0)
       val probe = testKit.createTestProbe[AnyRef]()
 
-      val behavior = Behaviors
-        .receiveMessage[Cmd]{
-          case ReplyWithAck =>
-            val reply = Integer.valueOf(atomicInt.incrementAndGet())
-            probe.ref ! reply
-            Behaviors.same
-          case BCast(cmd) =>
-            fail("totally unacceptable")
-        }
-      val router = testKit
-        .spawn(Routers.pool(4)(behavior))
-      router ! ReplyWithAck
+      val behavior = Behaviors.receiveMessage[Cmd] {
+        case ReplyWithAck =>
+          val reply = Integer.valueOf(atomicInt.incrementAndGet())
+          probe.ref ! reply
+          Behaviors.same
+        case BCast(BCast(_)) =>
+          fail("totally unacceptable")
+        case BCast(ReplyWithAck) =>
+          val reply = Integer.valueOf(atomicInt.incrementAndGet())
+          probe.ref ! reply
+          Behaviors.same
+      }
+      val router = testKit.spawn(Routers.pool(4)(behavior).withBroadcastPredicate(_.isInstanceOf[BCast]))
+      router ! BCast(ReplyWithAck)
 
       val expected = (1 to 4).map(Integer.valueOf).toSet
       val actual = probe
         .receiveMessages(4)
-        .map{
-          case i : Integer => i
+        .map {
+          case i: Integer => i
         }
         .toSet
-      actual should equal (expected)
+      actual should equal(expected)
 
       probe.expectNoMessage()
     }

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala
@@ -5,7 +5,6 @@
 package docs.akka.typed
 
 import akka.actor.typed.DispatcherSelector
-import docs.akka.typed.RouterSpec.Worker.DoBroadcastLog
 // #pool
 import akka.actor.testkit.typed.scaladsl.{ LogCapturing, ScalaTestWithActorTestKit }
 import akka.actor.typed.{ Behavior, SupervisorStrategy }
@@ -20,7 +19,6 @@ object RouterSpec {
   object Worker {
     sealed trait Command
     case class DoLog(text: String) extends Command
-    case class DoBroadcastLog(text: String) extends Command
 
     def apply(): Behavior[Command] = Behaviors.setup { context =>
       context.log.info("Starting worker")
@@ -29,14 +27,18 @@ object RouterSpec {
         case DoLog(text) =>
           context.log.info("Got message {}", text)
           Behaviors.same
-        case DoBroadcastLog(text) =>
-          context.log.info("Got broadcast message {}", text)
-          Behaviors.same
       }
     }
   }
 
   // #routee
+
+  //intentionally out of the routee section
+  class DoBroadcastLog(text: String) extends Worker.DoLog(text)
+  object DoBroadcastLog {
+    def apply(text: String) = new DoBroadcastLog(text)
+  }
+
   // This code is extra indented for visualization purposes
   // format: OFF
   // #group

--- a/akka-actor-typed/src/main/mima-filters/2.6.10.backwards.excludes/routers-pool-bcast.backwards.excludes
+++ b/akka-actor-typed/src/main/mima-filters/2.6.10.backwards.excludes/routers-pool-bcast.backwards.excludes
@@ -1,0 +1,14 @@
+# akka29924 aktor.typed Router.Pool support for broadcast messages
+
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.javadsl.PoolRouter.withBroadcastPredicate")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.typed.scaladsl.PoolRouter.withBroadcastPredicate")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.actor.typed.internal.routing.PoolRouterBuilder.unapply")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.actor.typed.internal.routing.PoolRouterBuilder.<init>$default$4")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.actor.typed.internal.routing.PoolRouterBuilder.unapply")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.actor.typed.internal.routing.PoolRouterBuilder.apply$default$4")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.actor.typed.internal.routing.PoolRouterBuilder.apply$default$4")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.typed.internal.routing.PoolRouterBuilder.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.typed.internal.routing.PoolRouterBuilder.copy")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.actor.typed.internal.routing.PoolRouterBuilder.copy$default$4")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.typed.internal.routing.PoolRouterImpl.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.typed.internal.routing.PoolRouterBuilder.this")

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/PoolRouterImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/PoolRouterImpl.scala
@@ -7,9 +7,11 @@ package akka.actor.typed.internal.routing
 import java.util.function
 import akka.actor.typed._
 import akka.actor.typed.javadsl.PoolRouter
-import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, Behaviors }
+import akka.actor.typed.scaladsl.{AbstractBehavior, ActorContext, Behaviors}
 import akka.annotation.InternalApi
-import akka.japi.Predicate
+import akka.util.ConstantFun
+
+import java.util.function.Predicate
 
 /**
  * INTERNAL API
@@ -19,7 +21,7 @@ private[akka] final case class PoolRouterBuilder[T](
     poolSize: Int,
     behavior: Behavior[T],
     logicFactory: ActorSystem[_] => RoutingLogic[T] = (_: ActorSystem[_]) => new RoutingLogics.RoundRobinLogic[T],
-    broadcastPredicate: T => Boolean = (_: T) => false,
+    broadcastPredicate: T => Boolean = ConstantFun.anyToFalse,
     routeeProps: Props = Props.empty)
     extends javadsl.PoolRouter[T]
     with scaladsl.PoolRouter[T] {
@@ -82,7 +84,7 @@ private final class PoolRouterImpl[T](
   }
 
   def onMessage(msg: T): Behavior[T] = {
-    if (broadcastPredicate(msg)) {
+    if ((broadcastPredicate ne ConstantFun.anyToFalse) && broadcastPredicate(msg)) {
       ctx.children.foreach(_.unsafeUpcast ! msg)
     } else {
       logic.selectRoutee(msg) ! msg

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/PoolRouterImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/PoolRouterImpl.scala
@@ -7,7 +7,7 @@ package akka.actor.typed.internal.routing
 import java.util.function
 import akka.actor.typed._
 import akka.actor.typed.javadsl.PoolRouter
-import akka.actor.typed.scaladsl.{AbstractBehavior, ActorContext, Behaviors}
+import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, Behaviors }
 import akka.annotation.InternalApi
 import akka.util.ConstantFun
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/PoolRouterImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/routing/PoolRouterImpl.scala
@@ -5,11 +5,11 @@
 package akka.actor.typed.internal.routing
 
 import java.util.function
-
 import akka.actor.typed._
 import akka.actor.typed.javadsl.PoolRouter
 import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, Behaviors }
 import akka.annotation.InternalApi
+import akka.japi.Predicate
 
 /**
  * INTERNAL API
@@ -19,6 +19,7 @@ private[akka] final case class PoolRouterBuilder[T](
     poolSize: Int,
     behavior: Behavior[T],
     logicFactory: ActorSystem[_] => RoutingLogic[T] = (_: ActorSystem[_]) => new RoutingLogics.RoundRobinLogic[T],
+    broadcastPredicate: T => Boolean = (_: T) => false,
     routeeProps: Props = Props.empty)
     extends javadsl.PoolRouter[T]
     with scaladsl.PoolRouter[T] {
@@ -26,7 +27,13 @@ private[akka] final case class PoolRouterBuilder[T](
 
   // deferred creation of the actual router
   def apply(ctx: TypedActorContext[T]): Behavior[T] =
-    new PoolRouterImpl[T](ctx.asScala, poolSize, behavior, logicFactory(ctx.asScala.system), routeeProps)
+    new PoolRouterImpl[T](
+      ctx.asScala,
+      poolSize,
+      behavior,
+      logicFactory(ctx.asScala.system),
+      broadcastPredicate,
+      routeeProps)
 
   def withRandomRouting(): PoolRouterBuilder[T] = copy(logicFactory = _ => new RoutingLogics.RandomLogic[T]())
 
@@ -43,6 +50,10 @@ private[akka] final case class PoolRouterBuilder[T](
   def withPoolSize(poolSize: Int): PoolRouterBuilder[T] = copy(poolSize = poolSize)
 
   def withRouteeProps(routeeProps: Props): PoolRouterBuilder[T] = copy(routeeProps = routeeProps)
+
+  override def withBroadcastPredicate(pred: Predicate[T]): PoolRouter[T] = withBroadcastPredicate(pred.test _)
+
+  override def withBroadcastPredicate(pred: T => Boolean): scaladsl.PoolRouter[T] = copy(broadcastPredicate = pred)
 }
 
 /**
@@ -54,6 +65,7 @@ private final class PoolRouterImpl[T](
     poolSize: Int,
     behavior: Behavior[T],
     logic: RoutingLogic[T],
+    broadcastPredicate: T => Boolean,
     routeeProps: Props)
     extends AbstractBehavior[T](ctx) {
 
@@ -70,7 +82,11 @@ private final class PoolRouterImpl[T](
   }
 
   def onMessage(msg: T): Behavior[T] = {
-    logic.selectRoutee(msg) ! msg
+    if (broadcastPredicate(msg)) {
+      ctx.children.foreach(_.unsafeUpcast ! msg)
+    } else {
+      logic.selectRoutee(msg) ! msg
+    }
     this
   }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Routers.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Routers.scala
@@ -181,4 +181,6 @@ abstract class PoolRouter[T] extends DeferredBehavior[T] {
    * Set the props used to spawn the pool's routees
    */
   def withRouteeProps(routeeProps: Props): PoolRouter[T]
+
+  def withBroadcastPredicate(pred: akka.japi.Predicate[T]): PoolRouter[T]
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Routers.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Routers.scala
@@ -185,8 +185,7 @@ abstract class PoolRouter[T] extends DeferredBehavior[T] {
   def withRouteeProps(routeeProps: Props): PoolRouter[T]
 
   /**
-   * install a predicate that identifies messages intended to be broadcasted to all routees.
-   * @param pred paredicate used to determine if a message is to be broadcasted or not.
+   * Any message that the predicate returns true for will be broadcast to all routees.
    */
   def withBroadcastPredicate(pred: Predicate[T]): PoolRouter[T]
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Routers.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Routers.scala
@@ -10,6 +10,8 @@ import akka.actor.typed.internal.routing.{ GroupRouterBuilder, PoolRouterBuilder
 import akka.actor.typed.receptionist.ServiceKey
 import akka.annotation.DoNotInherit
 
+import java.util.function.Predicate
+
 object Routers {
 
   /**
@@ -186,5 +188,5 @@ abstract class PoolRouter[T] extends DeferredBehavior[T] {
    * install a predicate that identifies messages intended to be broadcasted to all routees.
    * @param pred paredicate used to determine if a message is to be broadcasted or not.
    */
-  def withBroadcastPredicate(pred: akka.japi.Predicate[T]): PoolRouter[T]
+  def withBroadcastPredicate(pred: Predicate[T]): PoolRouter[T]
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Routers.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Routers.scala
@@ -182,5 +182,9 @@ abstract class PoolRouter[T] extends DeferredBehavior[T] {
    */
   def withRouteeProps(routeeProps: Props): PoolRouter[T]
 
+  /**
+   * install a predicate that identifies messages intended to be broadcasted to all routees.
+   * @param pred paredicate used to determine if a message is to be broadcasted or not.
+   */
   def withBroadcastPredicate(pred: akka.japi.Predicate[T]): PoolRouter[T]
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Routers.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Routers.scala
@@ -173,8 +173,7 @@ trait PoolRouter[T] extends Behavior[T] {
   def withRouteeProps(routeeProps: Props): PoolRouter[T]
 
   /**
-   * install a predicate that identifies messages intended to be broadcasted to all routees.
-   * @param pred paredicate used to determine if a message is to be broadcasted or not.
+   * Any message that the predicate returns true for will be broadcast to all routees.
    */
   def withBroadcastPredicate(pred: T => Boolean): PoolRouter[T]
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Routers.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Routers.scala
@@ -171,4 +171,6 @@ trait PoolRouter[T] extends Behavior[T] {
    * Set the props used to spawn the pool's routees
    */
   def withRouteeProps(routeeProps: Props): PoolRouter[T]
+
+  def withBroadcastPredicate(pred: T => Boolean): PoolRouter[T]
 }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Routers.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/Routers.scala
@@ -172,5 +172,9 @@ trait PoolRouter[T] extends Behavior[T] {
    */
   def withRouteeProps(routeeProps: Props): PoolRouter[T]
 
+  /**
+   * install a predicate that identifies messages intended to be broadcasted to all routees.
+   * @param pred paredicate used to determine if a message is to be broadcasted or not.
+   */
   def withBroadcastPredicate(pred: T => Boolean): PoolRouter[T]
 }

--- a/akka-actor/src/main/scala/akka/util/ConstantFun.scala
+++ b/akka-actor/src/main/scala/akka/util/ConstantFun.scala
@@ -48,6 +48,7 @@ import akka.japi.function.{ Function => JFun, Function2 => JFun2 }
   val unitToUnit = () => ()
 
   val anyToTrue: Any => Boolean = (_: Any) => true
+  val anyToFalse: Any => Boolean = (_: Any) => false
 
   private val _nullFun = (_: Any) => null
 

--- a/akka-docs/src/main/paradox/typed/routers.md
+++ b/akka-docs/src/main/paradox/typed/routers.md
@@ -57,15 +57,21 @@ The routees, however, are spawned by the router.
 Therefore, the `PoolRouter` has a property to configure the `Props` of its routees:
 
 Scala
-:  @@snip [RouterSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala) { #broadcast }
+:  @@snip [RouterSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala) { #pool-dispatcher }
 
 Java
-:  @@snip [RouterTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java) { #broadcast }
+:  @@snip [RouterTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java) { #pool-dispatcher }
 
 ### Broadcasting a message to all routees
 
 Pool routers can be configured to identify messages intended to be broad-casted to all routees.
-Therefore, the `PoolRouter` has a property to configure its `broadcastPredicate`: 
+Therefore, the `PoolRouter` has a property to configure its `broadcastPredicate`:
+
+Scala
+:  @@snip [RouterSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala) { #broadcast }
+
+Java
+:  @@snip [RouterTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java) { #broadcast }
 
 ## Group Router
 

--- a/akka-docs/src/main/paradox/typed/routers.md
+++ b/akka-docs/src/main/paradox/typed/routers.md
@@ -57,10 +57,15 @@ The routees, however, are spawned by the router.
 Therefore, the `PoolRouter` has a property to configure the `Props` of its routees:
 
 Scala
-:  @@snip [RouterSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala) { #pool-dispatcher }
+:  @@snip [RouterSpec.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/RouterSpec.scala) { #broadcast }
 
 Java
-:  @@snip [RouterTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java) { #pool-dispatcher }
+:  @@snip [RouterTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/RouterTest.java) { #broadcast }
+
+### Broadcasting a message to all routees
+
+Pool routers can be configured to identify messages intended to be broad-casted to all routees.
+Therefore, the `PoolRouter` has a property to configure its `broadcastPredicate`: 
 
 ## Group Router
 


### PR DESCRIPTION
#29924 enhance `Routers.pool` with the ability to broadcast messages to all routees.

this PR introduces a new method to trait `PoolRouter` (and its javadsl equivalent):

```
/**
   * install a predicate that identifies messages intended to be broadcasted to all routees.
   * @param pred paredicate used to determine if a message is to be broadcasted or not.
   */
  def withBroadcastPredicate(pred: T => Boolean): PoolRouter[T]
```

the resulting `PoolRouter`'s behavior will use this predicate to identify messages which are intended to be broadcasted to all routies, such message will be forwarded to all child actors (bypassing the pool policy).