### PR TITLE
Move to nowarn instead of silencer

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.{ CompletionStage, ThreadFactory }
 import scala.compat.java8.FutureConverters
 import scala.concurrent._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -35,7 +35,7 @@ import akka.annotation.InternalApi
 /**
  * INTERNAL API
  */
-@silent
+@nowarn
 @InternalApi private[akka] final class ActorSystemStub(val name: String)
     extends ActorSystem[Nothing]
     with ActorRef[Nothing]

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ScalaTestIntegrationExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/ScalaTestIntegrationExampleSpec.scala
@@ -4,7 +4,7 @@
 
 package docs.akka.actor.testkit.typed.scaladsl
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import docs.akka.actor.testkit.typed.scaladsl.AsyncTestingExampleSpec.Echo
 
 //#log-capturing
@@ -16,7 +16,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 //#scalatest-integration
 //#log-capturing
 
-@silent
+@nowarn
 //#scalatest-integration
 class ScalaTestIntegrationExampleSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
 

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorSystemSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.{ Config, ConfigFactory }
 
 import akka.actor.setup.ActorSystemSetup
@@ -64,7 +64,7 @@ object ActorSystemSpec {
     }
   }
 
-  @silent
+  @nowarn
   final case class FastActor(latch: TestLatch, testActor: ActorRef) extends Actor {
     val ref1 = context.actorOf(Props.empty)
     context.actorSelection(ref1.path.toString).tell(Identify(ref1), testActor)
@@ -113,7 +113,7 @@ object ActorSystemSpec {
 
 }
 
-@silent
+@nowarn
 class ActorSystemSpec extends AkkaSpec(ActorSystemSpec.config) with ImplicitSender {
 
   import ActorSystemSpec.FastActor

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorWithStashSpec.scala
@@ -7,7 +7,7 @@ package akka.actor
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import language.postfixOps
 import org.scalatest.BeforeAndAfterEach
 
@@ -97,7 +97,7 @@ object ActorWithStashSpec {
 
 }
 
-@silent
+@nowarn
 class ActorWithStashSpec extends AkkaSpec with DefaultTimeout with BeforeAndAfterEach {
   import ActorWithStashSpec._
 

--- a/akka-actor-tests/src/test/scala/akka/actor/DeathWatchSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/DeathWatchSpec.scala
@@ -7,7 +7,7 @@ package akka.actor
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import language.postfixOps
 
 import akka.actor.Props.EmptyActor
@@ -107,7 +107,7 @@ object DeathWatchSpec {
   }
 }
 
-@silent
+@nowarn
 trait DeathWatchSpec { this: AkkaSpec with ImplicitSender with DefaultTimeout =>
 
   import DeathWatchSpec._

--- a/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/LocalActorRefProviderSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import language.postfixOps
 
 import akka.testkit._
@@ -33,7 +33,7 @@ object LocalActorRefProviderSpec {
   """
 }
 
-@silent
+@nowarn
 class LocalActorRefProviderSpec extends AkkaSpec(LocalActorRefProviderSpec.config) {
   "An LocalActorRefProvider" must {
 

--- a/akka-actor-tests/src/test/scala/akka/actor/PropsCreationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/PropsCreationSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.actor
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.testkit.AkkaSpec
 import akka.util.unused
@@ -60,7 +60,7 @@ class PropsCreationSpec extends AkkaSpec("""
 
   "Props Java API" must {
     "work with create(creator)" in {
-      @silent
+      @nowarn
       val p = Props.create(OneParamActorCreator)
       system.actorOf(p)
     }

--- a/akka-actor-tests/src/test/scala/akka/actor/RestartStrategySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/RestartStrategySpec.scala
@@ -9,7 +9,7 @@ import java.lang.Thread.sleep
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import language.postfixOps
 
 import akka.pattern.ask
@@ -19,7 +19,7 @@ import akka.testkit.EventFilter
 import akka.testkit.TestEvent._
 import akka.testkit.TestLatch
 
-@silent
+@nowarn
 class RestartStrategySpec extends AkkaSpec with DefaultTimeout {
 
   override def atStartup(): Unit = {

--- a/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SchedulerSpec.scala
@@ -15,7 +15,7 @@ import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
 
 import atomic.{ AtomicInteger, AtomicReference }
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.{ Config, ConfigFactory }
 import language.postfixOps
 import org.scalatest.BeforeAndAfterEach
@@ -684,7 +684,7 @@ class LightArrayRevolverSchedulerSpec extends AkkaSpec(SchedulerSpec.testConfRev
     def reportFailure(t: Throwable): Unit = { t.printStackTrace() }
   }
 
-  @silent
+  @nowarn
   def withScheduler(start: Long = 0L, _startTick: Int = 0, config: Config = ConfigFactory.empty)(
       thunk: (Scheduler with Closeable, Driver) => Unit): Unit = {
     import akka.actor.{ LightArrayRevolverScheduler => LARS }

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorHierarchySpec.scala
@@ -16,7 +16,7 @@ import scala.util.Random
 import scala.util.control.NoStackTrace
 
 import SupervisorStrategy.{ Directive, Restart, Resume, Stop }
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.{ Config, ConfigFactory }
 import language.postfixOps
 
@@ -598,7 +598,7 @@ object SupervisorHierarchySpec {
     when(Stopping, stateTimeout = 5.seconds.dilated) {
       case Event(PongOfDeath, _) => stay()
       case Event(Terminated(r), _) if r == hierarchy =>
-        @silent
+        @nowarn
         val undead = children.filterNot(_.isTerminated)
         if (undead.nonEmpty) {
           log.info("undead:\n" + undead.mkString("\n"))

--- a/akka-actor-tests/src/test/scala/akka/actor/SupervisorMiscSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/SupervisorMiscSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import language.postfixOps
 
 import akka.pattern.ask
@@ -29,7 +29,7 @@ object SupervisorMiscSpec {
     """
 }
 
-@silent
+@nowarn
 class SupervisorMiscSpec extends AkkaSpec(SupervisorMiscSpec.config) with DefaultTimeout {
 
   "A Supervisor" must {

--- a/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/TypedActorSpec.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
 
 import akka.actor.TypedActor._
@@ -26,7 +26,7 @@ import akka.util.Timeout
 
 object TypedActorSpec {
 
-  @silent
+  @nowarn
   val config = """
     pooled-dispatcher {
       type = "akka.dispatch.BalancingDispatcherConfigurator"
@@ -70,7 +70,7 @@ object TypedActorSpec {
   trait Foo {
     def pigdog(): String
 
-    @silent
+    @nowarn
     @throws(classOf[TimeoutException])
     def self = TypedActor.self[Foo]
 
@@ -136,7 +136,7 @@ object TypedActorSpec {
       Future.successful(pigdog() + numbered)
     }
 
-    @silent
+    @nowarn
     def futureComposePigdogFrom(foo: Foo): Future[String] = {
       foo.futurePigdog(500 millis).map(_.toUpperCase)
     }
@@ -192,7 +192,7 @@ object TypedActorSpec {
       with LifeCycles
       with Receiver {
 
-    @silent
+    @nowarn
     private def ensureContextAvailable[T](f: => T): T = TypedActor.context match {
       case null => throw new IllegalStateException("TypedActor.context is null!")
       case _    => f
@@ -247,7 +247,7 @@ object TypedActorSpec {
 
 }
 
-@silent
+@nowarn
 class TypedActorSpec
     extends AkkaSpec(TypedActorSpec.config)
     with BeforeAndAfterEach
@@ -571,7 +571,7 @@ class TypedActorSpec
   }
 }
 
-@silent
+@nowarn
 class TypedActorRouterSpec
     extends AkkaSpec(TypedActorSpec.config)
     with BeforeAndAfterEach

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/ActorModelSpec.scala
@@ -12,7 +12,7 @@ import scala.annotation.tailrec
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 import language.postfixOps
 import org.scalatest.Assertions._
@@ -602,7 +602,7 @@ class DispatcherModelSpec extends ActorModelSpec(DispatcherModelSpec.config) {
   }
 }
 
-@silent
+@nowarn
 object BalancingDispatcherModelSpec {
   import ActorModelSpec._
 
@@ -641,7 +641,7 @@ object BalancingDispatcherModelSpec {
   }
 }
 
-@silent
+@nowarn
 class BalancingDispatcherModelSpec extends ActorModelSpec(BalancingDispatcherModelSpec.config) {
   import ActorModelSpec._
 

--- a/akka-actor-tests/src/test/scala/akka/io/InetAddressDnsResolverSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/InetAddressDnsResolverSpec.scala
@@ -7,12 +7,12 @@ package akka.io
 import java.security.Security
 import java.util.concurrent.TimeUnit
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.Props
 import akka.testkit.{ AkkaSpec, TestActorRef }
 
-@silent
+@nowarn
 class InetAddressDnsResolverSpec extends AkkaSpec("""
     akka.io.dns.inet-address.positive-ttl = default
     akka.io.dns.inet-address.negative-ttl = default
@@ -120,7 +120,7 @@ class InetAddressDnsResolverSpec extends AkkaSpec("""
 
 }
 
-@silent
+@nowarn
 class InetAddressDnsResolverConfigSpec extends AkkaSpec("""
     akka.io.dns.inet-address.positive-ttl = forever
     akka.io.dns.inet-address.negative-ttl = never

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsManagerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsManagerSpec.scala
@@ -8,7 +8,7 @@ import java.net.InetAddress
 
 import scala.collection.immutable.Seq
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.io.Dns
 import akka.io.dns.AAAARecord
@@ -18,7 +18,7 @@ import akka.testkit.{ AkkaSpec, ImplicitSender }
 import akka.testkit.WithLogCapturing
 
 // tests deprecated DNS API
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class AsyncDnsManagerSpec extends AkkaSpec("""
     akka.loglevel = DEBUG
     akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]

--- a/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
@@ -7,7 +7,7 @@ package akka.pattern
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Failure
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import language.postfixOps
 import akka.actor._
@@ -15,7 +15,7 @@ import akka.testkit.WithLogCapturing
 import akka.testkit.{ AkkaSpec, TestProbe }
 import akka.util.Timeout
 
-@silent
+@nowarn
 class AskSpec extends AkkaSpec("""
      akka.loglevel = DEBUG
      akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]

--- a/akka-actor-tests/src/test/scala/akka/pattern/BackoffOnRestartSupervisorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/BackoffOnRestartSupervisorSpec.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.{ CountDownLatch, TimeUnit }
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor._
 import akka.pattern.TestActor.NormalException
@@ -154,7 +154,7 @@ class BackoffOnRestartSupervisorSpec extends AkkaSpec("""
 
     "accept commands while child is terminating" in {
       val postStopLatch = new CountDownLatch(1)
-      @silent
+      @nowarn
       val options = BackoffOpts
         .onFailure(Props(new SlowlyFailingActor(postStopLatch)), "someChildName", 1 nanos, 1 nanos, 0.0)
         .withMaxNrOfRetries(-1)

--- a/akka-actor-tests/src/test/scala/akka/routing/ConfiguredLocalRoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ConfiguredLocalRoutingSpec.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 import language.postfixOps
 
@@ -170,7 +170,7 @@ class ConfiguredLocalRoutingSpec
     "not get confused when trying to wildcard-configure children" in {
       system.actorOf(FromConfig.props(routeeProps = Props(classOf[SendRefAtStartup], testActor)), "weird")
       val recv = (for (_ <- 1 to 3) yield expectMsgType[ActorRef].path.elements.mkString("/", "/", "")).toSet
-      @silent
+      @nowarn
       val expc = Set('a', 'b', 'c').map(i => "/user/weird/$" + i)
       recv should ===(expc)
       expectNoMessage(1 second)

--- a/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import SerializationTests._
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config._
 import language.postfixOps
 import test.akka.serialization.NoVerification
@@ -58,10 +58,10 @@ object SerializationTests {
 
   protected[akka] trait Marker
   protected[akka] trait Marker2
-  @silent // can't use unused otherwise case class below gets a deprecated
+  @nowarn // can't use unused otherwise case class below gets a deprecated
   class SimpleMessage(s: String) extends Marker
 
-  @silent
+  @nowarn
   class ExtendedSimpleMessage(s: String, i: Int) extends SimpleMessage(s)
 
   trait AnotherInterface extends Marker

--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringSpec.scala
@@ -12,7 +12,7 @@ import java.nio.ByteOrder.{ BIG_ENDIAN, LITTLE_ENDIAN }
 
 import scala.collection.mutable.Builder
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.apache.commons.codec.binary.Hex.encodeHex
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalacheck.Arbitrary.arbitrary
@@ -167,7 +167,7 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
     body(bsA, bsB) == body(vecA, vecB)
   }
 
-  @silent
+  @nowarn
   def likeVecIt(bs: ByteString)(body: BufferedIterator[Byte] => Any, strict: Boolean = true): Boolean = {
     val bsIterator = bs.iterator
     val vecIterator = Vector(bs: _*).iterator.buffered
@@ -175,7 +175,7 @@ class ByteStringSpec extends AnyWordSpec with Matchers with Checkers {
     (!strict || (bsIterator.toSeq == vecIterator.toSeq))
   }
 
-  @silent
+  @nowarn
   def likeVecIts(a: ByteString, b: ByteString)(
       body: (BufferedIterator[Byte], BufferedIterator[Byte]) => Any,
       strict: Boolean = true): Boolean = {

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/BehaviorSpec.scala
@@ -6,7 +6,7 @@ package akka.actor.typed
 
 import java.util.function.{ Function => F1 }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -22,7 +22,7 @@ import akka.japi.pf.{ FI, PFBuilder }
 
 object BehaviorSpec {
   sealed trait Command {
-    @silent
+    @nowarn
     def expectedResponse(context: TypedActorContext[Command]): Seq[Event] = Nil
   }
   case object GetSelf extends Command {
@@ -73,9 +73,9 @@ object BehaviorSpec {
   trait Common extends AnyWordSpecLike with Matchers with TypeCheckedTripleEquals with LogCapturing {
     type Aux >: Null <: AnyRef
     def behavior(monitor: ActorRef[Event]): (Behavior[Command], Aux)
-    @silent("never used")
+    @nowarn("msg=never used")
     def checkAux(signal: Signal, aux: Aux): Unit = ()
-    @silent("never used")
+    @nowarn("msg=never used")
     def checkAux(command: Command, aux: Aux): Unit = ()
 
     case class Init(behv: Behavior[Command], inbox: TestInbox[Event], aux: Aux) {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/FaultToleranceDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/FaultToleranceDocSpec.scala
@@ -6,7 +6,7 @@ package docs.akka.typed
 
 import scala.concurrent.duration._
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.scalatest.wordspec.AnyWordSpecLike
 
 object FaultToleranceDocSpec {
@@ -77,7 +77,7 @@ object FaultToleranceDocSpec {
   // #bubbling-example
 }
 
-@silent("never used")
+@nowarn("msg=never used")
 class FaultToleranceDocSpec extends ScalaTestWithActorTestKit("""
       # silenced to not put noise in test logs
       akka.loglevel = off

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/SpawnProtocolDocSpec.scala
@@ -12,7 +12,7 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import docs.akka.typed.IntroSpec.HelloWorld
 import org.scalatest.wordspec.AnyWordSpecLike
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 //#imports1
 import akka.actor.typed.Behavior
@@ -33,7 +33,7 @@ import akka.util.Timeout
 object SpawnProtocolDocSpec {
 
   // Silent because we want to name the unused 'context' parameter
-  @silent("never used")
+  @nowarn("msg=never used")
   //#main
   object HelloWorldMain {
     def apply(): Behavior[SpawnProtocol.Command] =

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
@@ -14,7 +14,7 @@ import akka.actor.typed.SupervisorStrategy
 
 import scala.concurrent.duration.FiniteDuration
 import akka.Done
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 //#oo-style
 //#fun-style
@@ -481,7 +481,7 @@ object StyleGuideDocExamples {
         //#pattern-match-guard
       }
 
-      @silent
+      @nowarn
       private def counter(remaining: Int): Behavior[Command] = {
         //#pattern-match-without-guard
         Behaviors.receiveMessage {
@@ -507,7 +507,7 @@ object StyleGuideDocExamples {
       }
       //#pattern-match-unhandled
 
-      @silent
+      @nowarn
       object partial {
         //#pattern-match-partial
         private val zero: Behavior[Command] = {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/extensions/ExtensionDocSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/extensions/ExtensionDocSpec.scala
@@ -9,7 +9,7 @@ import akka.actor.typed.Behavior
 import akka.actor.typed.Extension
 import akka.actor.typed.ExtensionId
 import akka.actor.typed.scaladsl.Behaviors
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.Future
@@ -30,7 +30,7 @@ object DatabasePool extends ExtensionId[DatabasePool] {
 }
 //#extension-id
 
-@silent
+@nowarn
 //#extension
 class DatabasePool(system: ActorSystem[_]) extends Extension {
   // database configuration can be loaded from config
@@ -41,7 +41,7 @@ class DatabasePool(system: ActorSystem[_]) extends Extension {
 }
 //#extension
 
-@silent
+@nowarn
 object ExtensionDocSpec {
   val config = ConfigFactory.parseString("""
       #config      

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/supervision/SupervisionCompileOnly.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/supervision/SupervisionCompileOnly.scala
@@ -9,7 +9,7 @@ import akka.actor.typed.PostStop
 import akka.actor.typed.PreRestart
 import akka.actor.typed.{ Behavior, SupervisorStrategy }
 import akka.actor.typed.scaladsl.Behaviors
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import scala.concurrent.duration._
 
@@ -112,7 +112,7 @@ object SupervisionCompileOnly {
   }
   def claimResource(): Resource = ???
 
-  @silent("never used")
+  @nowarn("msg=never used")
   //#restart-PreRestart-signal
   def withPreRestart: Behavior[String] = {
     Behaviors

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
@@ -13,7 +13,7 @@ import java.util.concurrent.CompletionStage
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 import scala.reflect.ClassTag
 import scala.util.Try
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import akka.actor.Address
@@ -219,7 +219,7 @@ import scala.util.Success
     }
 
   // Java API impl
-  @silent("never used") // resClass is just a pretend param
+  @nowarn("msg=never used") // resClass is just a pretend param
   override def ask[Req, Res](
       resClass: Class[Res],
       target: RecipientRef[Req],

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/scaladsl/AskPattern.scala
@@ -7,7 +7,7 @@ package akka.actor.typed.scaladsl
 import java.util.concurrent.TimeoutException
 
 import scala.concurrent.Future
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.RecipientRef
@@ -103,7 +103,7 @@ object AskPattern {
      *
      * @tparam Res The response protocol, what the other actor sends back
      */
-    @silent("never used")
+    @nowarn("msg=never used")
     def ask[Res](replyTo: ActorRef[Res] => Req)(implicit timeout: Timeout, scheduler: Scheduler): Future[Res] = {
       // We do not currently use the implicit sched, but want to require it
       // because it might be needed when we move to a 'native' typed runtime, see #24219

--- a/akka-actor/src/main/boilerplate/akka/japi/function/Functions.scala.template
+++ b/akka-actor/src/main/boilerplate/akka/japi/function/Functions.scala.template
@@ -4,13 +4,13 @@
 
 package akka.japi.function
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 [3..22#/**
  * A Function interface. Used to create 1-arg first-class-functions is Java.
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  */
-@silent
+@nowarn
 @SerialVersionUID(##1L)
 trait Function1[[#-T1#], +R] extends java.io.Serializable {
   @throws(classOf[Exception])
@@ -24,7 +24,7 @@ trait Function1[[#-T1#], +R] extends java.io.Serializable {
  * A Procedure is like a Function, but it doesn't produce a return value.
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(##1L)
 trait Procedure1[[#-T1#]] extends java.io.Serializable {
   @throws(classOf[Exception])

--- a/akka-actor/src/main/scala-2.12/akka/compat/Future.scala
+++ b/akka-actor/src/main/scala-2.12/akka/compat/Future.scala
@@ -7,7 +7,7 @@ package akka.compat
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future => SFuture }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.annotation.InternalApi
 import akka.util.ccompat._
@@ -20,7 +20,7 @@ import akka.util.ccompat._
  *
  * Remove these classes as soon as support for Scala 2.12 is dropped!
  */
-@silent @InternalApi private[akka] object Future {
+@nowarn @InternalApi private[akka] object Future {
   def fold[T, R](futures: IterableOnce[SFuture[T]])(zero: R)(op: (R, T) => R)(
       implicit executor: ExecutionContext): SFuture[R] =
     SFuture.fold[T, R](futures)(zero)(op)(executor)

--- a/akka-actor/src/main/scala-2.12/scala/annotation/nowarn.scala
+++ b/akka-actor/src/main/scala-2.12/scala/annotation/nowarn.scala
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+// TODO: remove this when upgrading to Scala 2.12.13
+// https://github.com/scala/scala/pull/9248
+package scala.annotation
+
+class nowarn(str: String = "") extends com.github.ghik.silencer.silent(str.replaceFirst("msg=", ""))

--- a/akka-actor/src/main/scala-2.12/scala/annotation/nowarn.scala
+++ b/akka-actor/src/main/scala-2.12/scala/annotation/nowarn.scala
@@ -1,9 +1,0 @@
-/*
- * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
- */
-
-// TODO: remove this when upgrading to Scala 2.12.13
-// https://github.com/scala/scala/pull/9248
-package scala.annotation
-
-class nowarn(str: String = "") extends com.github.ghik.silencer.silent(str.replaceFirst("msg=", ""))

--- a/akka-actor/src/main/scala-2.13/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala-2.13/akka/util/ByteString.scala
@@ -16,7 +16,7 @@ import scala.collection.immutable.{ IndexedSeq, IndexedSeqOps, StrictOptimizedSe
 import scala.collection.mutable.{ Builder, WrappedArray }
 import scala.reflect.ClassTag
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 object ByteString {
 
@@ -897,7 +897,7 @@ sealed abstract class ByteString
    * Java API: Returns an Iterable of read-only ByteBuffers that directly wraps this ByteStrings
    * all fragments. Will always have at least one entry.
    */
-  @silent
+  @nowarn
   def getByteBuffers(): JIterable[ByteBuffer] = {
     import scala.collection.JavaConverters.asJavaIterableConverter
     asByteBuffers.asJava

--- a/akka-actor/src/main/scala/akka/actor/AbstractActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/AbstractActor.scala
@@ -10,7 +10,7 @@ import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.Duration
 import scala.runtime.BoxedUnit
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.annotation.DoNotInherit
 import akka.japi.pf.ReceiveBuilder
@@ -273,7 +273,7 @@ abstract class AbstractActor extends Actor {
   // TODO In 2.6.0 we can remove deprecation and make the method final
   @deprecated("Override preRestart with message parameter with Optional type instead", "2.5.0")
   @throws(classOf[Exception])
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   override def preRestart(reason: Throwable, message: Option[Any]): Unit = {
     import scala.compat.java8.OptionConverters._
     preRestart(reason, message.asJava)

--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.dungeon.ChildrenContainer
 import akka.annotation.{ InternalApi, InternalStableApi }
@@ -406,7 +406,7 @@ private[akka] object ActorCell {
  * supported APIs in this place. This is not the API you were looking
  * for! (waves hand)
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[akka] class ActorCell(
     val system: ActorSystemImpl,
     val self: InternalActorRef,
@@ -687,7 +687,7 @@ private[akka] class ActorCell(
   }
 
   @InternalStableApi
-  @silent("never used")
+  @nowarn("msg=never used")
   final protected def clearActorFields(actorInstance: Actor, recreate: Boolean): Unit = {
     currentMessage = null
     behaviorStack = emptyBehaviorStack

--- a/akka-actor/src/main/scala/akka/actor/ActorPath.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorPath.scala
@@ -9,7 +9,7 @@ import java.net.MalformedURLException
 import scala.annotation.{ switch, tailrec }
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.japi.Util.immutableSeq
 
@@ -153,8 +153,8 @@ object ActorPath {
  * references are compared the unique id of the actor is not taken into account
  * when comparing actor paths.
  */
-@silent("@SerialVersionUID has no effect on traits")
-@silent("deprecated")
+@nowarn("msg=@SerialVersionUID has no effect on traits")
+@nowarn("msg=deprecated")
 @SerialVersionUID(1L)
 sealed trait ActorPath extends Comparable[ActorPath] with Serializable {
 

--- a/akka-actor/src/main/scala/akka/actor/ActorPath.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorPath.scala
@@ -153,7 +153,7 @@ object ActorPath {
  * references are compared the unique id of the actor is not taken into account
  * when comparing actor paths.
  */
-@nowarn("msg=@SerialVersionUID has no effect on traits,msg=deprecated")
+@nowarn("msg=@SerialVersionUID has no effect on traits")
 @SerialVersionUID(1L)
 sealed trait ActorPath extends Comparable[ActorPath] with Serializable {
 
@@ -202,6 +202,7 @@ sealed trait ActorPath extends Comparable[ActorPath] with Serializable {
   /**
    * Java API: Sequence of names for this path from root to this. Performance implication: has to allocate a list.
    */
+  @nowarn("msg=deprecated")
   def getElements: java.lang.Iterable[String] =
     scala.collection.JavaConverters.asJavaIterableConverter(elements).asJava
 

--- a/akka-actor/src/main/scala/akka/actor/ActorPath.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorPath.scala
@@ -153,8 +153,7 @@ object ActorPath {
  * references are compared the unique id of the actor is not taken into account
  * when comparing actor paths.
  */
-@nowarn("msg=@SerialVersionUID has no effect on traits")
-@nowarn("msg=deprecated")
+@nowarn("msg=@SerialVersionUID has no effect on traits,msg=deprecated")
 @SerialVersionUID(1L)
 sealed trait ActorPath extends Comparable[ActorPath] with Serializable {
 

--- a/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSelection.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration._
 import scala.language.implicitConversions
 import scala.util.Success
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.dispatch.ExecutionContexts
 import akka.pattern.ask
@@ -328,7 +328,7 @@ private[akka] final case class ActorSelectionMessage(
 /**
  * INTERNAL API
  */
-@silent("@SerialVersionUID has no effect on traits")
+@nowarn("msg=@SerialVersionUID has no effect on traits")
 @SerialVersionUID(1L)
 private[akka] sealed trait SelectionPathElement
 

--- a/akka-actor/src/main/scala/akka/actor/Deployer.scala
+++ b/akka-actor/src/main/scala/akka/actor/Deployer.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import scala.annotation.tailrec
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config._
 
 import akka.annotation.InternalApi
@@ -172,7 +172,7 @@ trait Scope {
   def withFallback(other: Scope): Scope
 }
 
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 abstract class LocalScope extends Scope
 
@@ -181,7 +181,7 @@ abstract class LocalScope extends Scope
  * which do not set a different scope. It is also the only scope handled by
  * the LocalActorRefProvider.
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 case object LocalScope extends LocalScope {
 
@@ -196,7 +196,7 @@ case object LocalScope extends LocalScope {
 /**
  * This is the default value and as such allows overrides.
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 abstract class NoScopeGiven extends Scope
 @SerialVersionUID(1L)

--- a/akka-actor/src/main/scala/akka/actor/FSM.scala
+++ b/akka-actor/src/main/scala/akka/actor/FSM.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import language.implicitConversions
 
 import akka.annotation.InternalApi
@@ -254,7 +254,7 @@ object FSM {
      * Modify state transition descriptor with new state data. The data will be
      * set when transitioning to the new state.
      */
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     def using(@deprecatedName(Symbol("nextStateDate")) nextStateData: D): State[S, D] = {
       copy(stateData = nextStateData)
     }

--- a/akka-actor/src/main/scala/akka/actor/IndirectActorProducer.scala
+++ b/akka-actor/src/main/scala/akka/actor/IndirectActorProducer.scala
@@ -6,7 +6,7 @@ package akka.actor
 
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.japi.Creator
 import akka.util.Reflect
@@ -42,7 +42,7 @@ private[akka] object IndirectActorProducer {
   val CreatorFunctionConsumerClass = classOf[CreatorFunctionConsumer]
   val CreatorConsumerClass = classOf[CreatorConsumer]
   val TypedCreatorFunctionConsumerClass = classOf[TypedCreatorFunctionConsumer]
-  @silent
+  @nowarn
   def apply(clazz: Class[_], args: immutable.Seq[Any]): IndirectActorProducer = {
     if (classOf[IndirectActorProducer].isAssignableFrom(clazz)) {
       def get1stArg[T]: T = args.head.asInstanceOf[T]

--- a/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
+++ b/akka-actor/src/main/scala/akka/actor/RepointableActorRef.scala
@@ -11,7 +11,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.dungeon.ChildrenContainer
 import akka.dispatch._
@@ -49,8 +49,8 @@ private[akka] class RepointableActorRef(
    * processing the very first message (i.e. before Cell.start()). Hence there
    * are two refs here, one for each function, and they are switched just so.
    */
-  @silent @volatile private var _cellDoNotCallMeDirectly: Cell = _
-  @silent @volatile private var _lookupDoNotCallMeDirectly: Cell = _
+  @nowarn @volatile private var _cellDoNotCallMeDirectly: Cell = _
+  @nowarn @volatile private var _lookupDoNotCallMeDirectly: Cell = _
 
   def underlying: Cell = Unsafe.instance.getObjectVolatile(this, cellOffset).asInstanceOf[Cell]
   def lookup = Unsafe.instance.getObjectVolatile(this, lookupOffset).asInstanceOf[Cell]

--- a/akka-actor/src/main/scala/akka/actor/Scheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/Scheduler.scala
@@ -11,7 +11,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.annotation.InternalApi
 import akka.util.JavaDurationConverters
@@ -158,7 +158,7 @@ trait Scheduler {
    *
    * Note: For scheduling within actors `with Timers` should be preferred.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   final def scheduleWithFixedDelay(
       initialDelay: FiniteDuration,
       delay: FiniteDuration,
@@ -233,7 +233,7 @@ trait Scheduler {
    *
    * Note: For scheduling within actors `with Timers` should be preferred.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   final def scheduleAtFixedRate(initialDelay: FiniteDuration, interval: FiniteDuration)(runnable: Runnable)(
       implicit executor: ExecutionContext): Cancellable =
     schedule(initialDelay, interval, runnable)(executor)
@@ -302,7 +302,7 @@ trait Scheduler {
    *
    * Note: For scheduling within actors `with Timers` should be preferred.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   final def scheduleAtFixedRate(
       initialDelay: FiniteDuration,
       interval: FiniteDuration,
@@ -355,7 +355,7 @@ trait Scheduler {
     "Use scheduleWithFixedDelay or scheduleAtFixedRate instead. This has the same semantics as " +
     "scheduleAtFixedRate, but scheduleWithFixedDelay is often preferred.",
     since = "2.6.0")
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   final def schedule(initialDelay: FiniteDuration, interval: FiniteDuration, receiver: ActorRef, message: Any)(
       implicit
       executor: ExecutionContext,

--- a/akka-actor/src/main/scala/akka/actor/TypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/TypedActor.scala
@@ -17,7 +17,7 @@ import scala.reflect.ClassTag
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.dispatch._
 import akka.japi.{ Creator, Option => JOption }
@@ -128,7 +128,7 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
    *
    * Java API
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def get(context: ActorContext): TypedActorFactory = apply(context)
 
   /**
@@ -284,7 +284,7 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
       }
     }
 
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     override def postStop(): Unit =
       try {
         withContext {
@@ -499,7 +499,7 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
         case some => toTypedActorInvocationHandler(some)
       }
 
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     def toTypedActorInvocationHandler(system: ActorSystem): TypedActorInvocationHandler =
       new TypedActorInvocationHandler(TypedActor(system), new AtomVar[ActorRef](actor), new Timeout(timeout))
   }
@@ -675,14 +675,14 @@ final case class TypedProps[T <: AnyRef] protected[TypedProps] (
  * ContextualTypedActorFactory allows TypedActors to create children, effectively forming the same Actor Supervision Hierarchies
  * as normal Actors can.
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 final case class ContextualTypedActorFactory(typedActor: TypedActorExtension, actorFactory: ActorContext)
     extends TypedActorFactory {
   override def getActorRefFor(proxy: AnyRef): ActorRef = typedActor.getActorRefFor(proxy)
   override def isTypedActor(proxyOrNot: AnyRef): Boolean = typedActor.isTypedActor(proxyOrNot)
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class TypedActorExtension(val system: ExtendedActorSystem) extends TypedActorFactory with Extension {
   import TypedActor._ //Import the goodies from the companion object
   protected def actorFactory: ActorRefFactory = system

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
@@ -9,7 +9,7 @@ import java.util.Optional
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.util.control.NonFatal
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import akka.actor._
 import akka.annotation.InternalStableApi
 import akka.serialization.{ Serialization, SerializationExtension, Serializers }
@@ -23,7 +23,7 @@ private[akka] trait Children { this: ActorCell =>
 
   import ChildrenContainer._
 
-  @silent("never used")
+  @nowarn("msg=never used")
   @volatile
   private var _childrenRefsDoNotCallMeDirectly: ChildrenContainer = EmptyChildrenContainer
 
@@ -31,7 +31,7 @@ private[akka] trait Children { this: ActorCell =>
     Unsafe.instance.getObjectVolatile(this, AbstractActorCell.childrenOffset).asInstanceOf[ChildrenContainer]
 
   final def children: immutable.Iterable[ActorRef] = childrenRefs.children
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   final def getChildren(): java.lang.Iterable[ActorRef] =
     scala.collection.JavaConverters.asJavaIterableConverter(children).asJava
 
@@ -51,7 +51,7 @@ private[akka] trait Children { this: ActorCell =>
   private[akka] def attachChild(props: Props, name: String, systemService: Boolean): ActorRef =
     makeChild(this, props, checkName(name), async = true, systemService = systemService)
 
-  @silent @volatile private var _functionRefsDoNotCallMeDirectly = Map.empty[String, FunctionRef]
+  @nowarn @volatile private var _functionRefsDoNotCallMeDirectly = Map.empty[String, FunctionRef]
   private def functionRefs: Map[String, FunctionRef] =
     Unsafe.instance.getObjectVolatile(this, AbstractActorCell.functionRefsOffset).asInstanceOf[Map[String, FunctionRef]]
 
@@ -104,7 +104,7 @@ private[akka] trait Children { this: ActorCell =>
     refs.valuesIterator.foreach(_.stop())
   }
 
-  @silent @volatile private var _nextNameDoNotCallMeDirectly = 0L
+  @nowarn @volatile private var _nextNameDoNotCallMeDirectly = 0L
   final protected def randomName(sb: java.lang.StringBuilder): String = {
     val num = Unsafe.instance.getAndAddLong(this, AbstractActorCell.nextNameOffset, 1)
     Helpers.base64(num, sb)

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Dispatch.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Dispatch.scala
@@ -8,7 +8,7 @@ import scala.annotation.tailrec
 import scala.util.control.{ NoStackTrace, NonFatal }
 import scala.util.control.Exception.Catcher
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.AkkaException
 import akka.actor._
@@ -36,7 +36,7 @@ final case class SerializationCheckFailedException private (msg: Object, cause: 
 @InternalApi
 private[akka] trait Dispatch { this: ActorCell =>
 
-  @silent @volatile private var _mailboxDoNotCallMeDirectly
+  @nowarn @volatile private var _mailboxDoNotCallMeDirectly
       : Mailbox = _ //This must be volatile since it isn't protected by the mailbox status
 
   @inline final def mailbox: Mailbox =

--- a/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/AbstractDispatcher.scala
@@ -12,7 +12,7 @@ import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.actor._
@@ -104,8 +104,8 @@ abstract class MessageDispatcher(val configurator: MessageDispatcherConfigurator
   val mailboxes = prerequisites.mailboxes
   val eventStream = prerequisites.eventStream
 
-  @silent @volatile private[this] var _inhabitantsDoNotCallMeDirectly: Long = _ // DO NOT TOUCH!
-  @silent @volatile private[this] var _shutdownScheduleDoNotCallMeDirectly: Int = _ // DO NOT TOUCH!
+  @nowarn @volatile private[this] var _inhabitantsDoNotCallMeDirectly: Long = _ // DO NOT TOUCH!
+  @nowarn @volatile private[this] var _shutdownScheduleDoNotCallMeDirectly: Int = _ // DO NOT TOUCH!
 
   private final def addInhabitants(add: Long): Long = {
     val old = Unsafe.instance.getAndAddLong(this, inhabitantsOffset, add)

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatcher.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.ActorCell
 import akka.dispatch.sysmsg.SystemMessage
@@ -49,7 +49,7 @@ class Dispatcher(
    * At first glance this var does not seem to be updated anywhere, but in
    * fact it is, via the esUpdater [[AtomicReferenceFieldUpdater]] below.
    */
-  @silent("never updated")
+  @nowarn("msg=never updated")
   @volatile private var executorServiceDelegate: LazyExecutorServiceDelegate =
     new LazyExecutorServiceDelegate(executorServiceFactoryProvider.createExecutorServiceFactory(id, threadFactory))
 

--- a/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Dispatchers.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.{ ConcurrentHashMap, ThreadFactory }
 
 import scala.concurrent.ExecutionContext
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueType }
 
 import akka.ConfigurationException
@@ -317,7 +317,7 @@ private[akka] object BalancingDispatcherConfigurator {
  * Returns the same dispatcher instance for each invocation
  * of the `dispatcher()` method.
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class BalancingDispatcherConfigurator(_config: Config, _prerequisites: DispatcherPrerequisites)
     extends MessageDispatcherConfigurator(BalancingDispatcherConfigurator.amendConfig(_config), _prerequisites) {
 

--- a/akka-actor/src/main/scala/akka/dispatch/Future.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Future.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, ExecutionC
 import scala.runtime.{ AbstractPartialFunction, BoxedUnit }
 import scala.util.{ Failure, Success, Try }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.annotation.InternalApi
 import akka.annotation.InternalStableApi
@@ -257,7 +257,7 @@ object japi {
  *
  * Java API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 abstract class OnSuccess[-T] extends japi.CallbackBridge[T] {
   protected final override def internal(result: T) = onSuccess(result)
 
@@ -275,7 +275,7 @@ abstract class OnSuccess[-T] extends japi.CallbackBridge[T] {
  *
  * Java API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 abstract class OnFailure extends japi.CallbackBridge[Throwable] {
   protected final override def internal(failure: Throwable) = onFailure(failure)
 
@@ -293,7 +293,7 @@ abstract class OnFailure extends japi.CallbackBridge[Throwable] {
  *
  * Java API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 abstract class OnComplete[-T] extends japi.CallbackBridge[Try[T]] {
   protected final override def internal(value: Try[T]): Unit = value match {
     case Failure(t) => onComplete(t, null.asInstanceOf[T])
@@ -316,7 +316,7 @@ abstract class OnComplete[-T] extends japi.CallbackBridge[Try[T]] {
  *
  * Java API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 abstract class Recover[+T] extends japi.RecoverBridge[T] {
   protected final override def internal(result: Throwable): T = recover(result)
 
@@ -370,7 +370,7 @@ object Filter {
  * SAM (Single Abstract Method) class
  * Java API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 abstract class Foreach[-T] extends japi.UnitFunctionBridge[T] {
   override final def internal(t: T): Unit = each(t)
 

--- a/akka-actor/src/main/scala/akka/event/EventStream.scala
+++ b/akka-actor/src/main/scala/akka/event/EventStream.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import scala.annotation.tailrec
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.event.Logging.simpleName
@@ -41,7 +41,7 @@ class EventStream(sys: ActorSystem, private val debug: Boolean) extends LoggingB
   protected def classify(event: Any): Class[_] = event.getClass
 
   // TODO consider avoiding the deprecated `isTerminated`?
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   protected def publish(event: Any, subscriber: ActorRef) = {
     if (sys == null && subscriber.isTerminated) unsubscribe(subscriber)
     else subscriber ! event

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Await
 import scala.language.existentials
 import scala.util.control.{ NoStackTrace, NonFatal }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.{ AkkaException, ConfigurationException }
 import akka.actor._
@@ -170,7 +170,7 @@ trait LoggingBus extends ActorEventBus {
    * Internal Akka use only
    */
   private[akka] def stopDefaultLoggers(system: ActorSystem): Unit = {
-    @silent("never used")
+    @nowarn("msg=never used")
     val level = _logLevel // volatile access before reading loggers
     if (!(loggers contains StandardOutLogger)) {
       setUpStdoutLogger(system.settings)
@@ -1514,7 +1514,7 @@ trait LoggingFilter {
  * In retrospect should have been abstract, but we cannot change that
  * without breaking binary compatibility
  */
-@silent("never us")
+@nowarn("msg=never us")
 trait LoggingFilterWithMarker extends LoggingFilter {
   def isErrorEnabled(logClass: Class[_], logSource: String, marker: LogMarker): Boolean =
     isErrorEnabled(logClass, logSource)

--- a/akka-actor/src/main/scala/akka/io/Dns.scala
+++ b/akka-actor/src/main/scala/akka/io/Dns.scala
@@ -10,7 +10,7 @@ import java.util.function.{ Function => JFunction }
 
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.actor._
@@ -116,7 +116,7 @@ object Dns extends ExtensionId[DnsExt] with ExtensionIdProvider {
    * trigger a resolve and return None.
    */
   @deprecated("use resolve(DnsProtocol.Resolve)", "2.6.0")
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def resolve(name: String)(system: ActorSystem, sender: ActorRef): Option[Resolved] = {
     Dns(system).cache.resolve(name)(system, sender)
   }
@@ -163,7 +163,7 @@ class DnsExt private[akka] (val system: ExtendedActorSystem, resolverName: Strin
    * be used in this case
    */
   @InternalApi
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   private[akka] def loadAsyncDns(managerName: String): ActorRef = {
     // This can't pass in `this` as then AsyncDns would pick up the system settings
     asyncDns.computeIfAbsent(
@@ -220,7 +220,7 @@ class DnsExt private[akka] (val system: ExtendedActorSystem, resolverName: Strin
   val Settings: Settings = new Settings(system.settings.config.getConfig("akka.io.dns"), resolverName)
 
   // System DNS resolver
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   val provider: DnsProvider =
     system.dynamicAccess.createInstanceFor[DnsProvider](Settings.ProviderObjectName, Nil).get
 

--- a/akka-actor/src/main/scala/akka/io/InetAddressDnsProvider.scala
+++ b/akka-actor/src/main/scala/akka/io/InetAddressDnsProvider.scala
@@ -4,14 +4,14 @@
 
 package akka.io
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.annotation.InternalApi
 
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 @InternalApi
 class InetAddressDnsProvider extends DnsProvider {
   override def cache: Dns = new SimpleDnsCache()

--- a/akka-actor/src/main/scala/akka/io/InetAddressDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/InetAddressDnsResolver.scala
@@ -14,7 +14,7 @@ import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.actor.{ Actor, ActorLogging }
@@ -34,7 +34,7 @@ import akka.util.Helpers.Requiring
  *
  * Respects the settings that can be set on the Java runtime via parameters.
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 @InternalApi
 class InetAddressDnsResolver(cache: SimpleDnsCache, config: Config) extends Actor with ActorLogging {
 

--- a/akka-actor/src/main/scala/akka/io/SimpleDnsCache.scala
+++ b/akka-actor/src/main/scala/akka/io/SimpleDnsCache.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.tailrec
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.NoSerializationVerificationNeeded
 import akka.annotation.InternalApi
@@ -42,7 +42,7 @@ class SimpleDnsCache extends Dns with PeriodicCacheCleanup with NoSerializationV
    * This method is deprecated and involves a copy from the new protocol to
    * remain compatible
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   override def cached(name: String): Option[Dns.Resolved] = {
     // adapt response to the old protocol
     val ipv4 = cacheRef.get().get((name, Ip(ipv6 = false))).toList.flatMap(_.records)

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -12,7 +12,7 @@ import java.nio.file.{ Path, Paths }
 import scala.collection.immutable
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.actor._
@@ -119,7 +119,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    * @param localAddress optionally specifies a specific address to bind to
    * @param options Please refer to the `Tcp.SO` object for a list of all supported options.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   final case class Connect(
       remoteAddress: InetSocketAddress,
       localAddress: Option[InetSocketAddress] = None,
@@ -147,7 +147,7 @@ object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
    *
    * @param options Please refer to the `Tcp.SO` object for a list of all supported options.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   final case class Bind(
       handler: ActorRef,
       localAddress: InetSocketAddress,

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -16,7 +16,7 @@ import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.util.control.{ NoStackTrace, NonFatal }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor._
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
@@ -207,7 +207,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
   // AUXILIARIES and IMPLEMENTATION
 
   /** used in subclasses to start the common machinery above once a channel is connected */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def completeConnect(
       registration: ChannelRegistration,
       commander: ActorRef,

--- a/akka-actor/src/main/scala/akka/io/TcpIncomingConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpIncomingConnection.scala
@@ -8,7 +8,7 @@ import java.nio.channels.SocketChannel
 
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.ActorRef
 import akka.io.Inet.SocketOption
@@ -19,7 +19,7 @@ import akka.io.Inet.SocketOption
  *
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[io] class TcpIncomingConnection(
     _tcp: TcpExt,
     _channel: SocketChannel,

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -9,7 +9,7 @@ import java.net.InetSocketAddress
 
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.actor._
@@ -100,7 +100,7 @@ object Udp extends ExtensionId[UdpExt] with ExtensionIdProvider {
    * The listener actor for the newly bound port will reply with a [[Bound]]
    * message, or the manager will reply with a [[CommandFailed]] message.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   final case class Bind(
       handler: ActorRef,
       localAddress: InetSocketAddress,
@@ -124,7 +124,7 @@ object Udp extends ExtensionId[UdpExt] with ExtensionIdProvider {
    * The “simple sender” will not stop itself, you will have to send it a [[akka.actor.PoisonPill]]
    * when you want to close the socket.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   case class SimpleSender(options: immutable.Traversable[SocketOption] = Nil) extends Command
   object SimpleSender extends SimpleSender(Nil)
 

--- a/akka-actor/src/main/scala/akka/io/UdpConnected.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnected.scala
@@ -9,7 +9,7 @@ import java.net.InetSocketAddress
 
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor._
 import akka.io.Inet.SocketOption
@@ -94,7 +94,7 @@ object UdpConnected extends ExtensionId[UdpConnectedExt] with ExtensionIdProvide
    * which is restricted to sending to and receiving from the given `remoteAddress`.
    * All received datagrams will be sent to the designated `handler` actor.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   final case class Connect(
       handler: ActorRef,
       remoteAddress: InetSocketAddress,

--- a/akka-actor/src/main/scala/akka/io/UdpSender.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpSender.scala
@@ -8,7 +8,7 @@ import akka.actor._
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.io.Inet.{ DatagramChannelCreator, SocketOption }
 import akka.io.Udp._
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import scala.collection.immutable
 import scala.util.control.NonFatal
@@ -16,7 +16,7 @@ import scala.util.control.NonFatal
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[io] class UdpSender(
     val udp: UdpExt,
     channelRegistry: ChannelRegistry,

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.Duration
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.actor.{ Actor, ActorLogging, ActorRefFactory, Deploy, ExtendedActorSystem, Props, Timers }
@@ -37,7 +37,7 @@ private[akka] object AsyncDnsManager {
  * INTERNAL API
  */
 @InternalApi
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[io] final class AsyncDnsManager(
     name: String,
     system: ExtendedActorSystem,
@@ -91,7 +91,7 @@ private[io] final class AsyncDnsManager(
   }
 
   // still support deprecated DNS API
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   override def receive: Receive = {
     case r: DnsProtocol.Resolve =>
       log.debug("Resolution request for {} {} from {}", r.name, r.requestType, sender())

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsProvider.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsProvider.scala
@@ -4,7 +4,7 @@
 
 package akka.io.dns.internal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.annotation.InternalApi
 import akka.io._
@@ -13,7 +13,7 @@ import akka.io._
  * INTERNAL API
  */
 @InternalApi
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[akka] class AsyncDnsProvider extends DnsProvider {
   override def cache: Dns = new SimpleDnsCache()
   override def actorClass = classOf[AsyncDnsResolver]

--- a/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
@@ -10,7 +10,7 @@ import scala.collection.{ immutable => im }
 import scala.concurrent.duration._
 import scala.util.Try
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.{ Actor, ActorLogging, ActorRef, NoSerializationVerificationNeeded, Props, Stash }
 import akka.actor.Status.Failure
@@ -73,7 +73,7 @@ import akka.pattern.{ BackoffOpts, BackoffSupervisor }
   /**
    * Silent to allow map update syntax
    */
-  @silent()
+  @nowarn()
   def ready(socket: ActorRef): Receive = {
     case DropRequest(id) =>
       log.debug("Dropping request [{}]", id)

--- a/akka-actor/src/main/scala/akka/io/dns/internal/DnsMessage.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/DnsMessage.scala
@@ -8,7 +8,7 @@ import scala.collection.GenTraversableOnce
 import scala.collection.immutable.Seq
 import scala.util.{ Failure, Success, Try }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.annotation.InternalApi
 import akka.io.dns.ResourceRecord
@@ -157,7 +157,7 @@ private[internal] object Message {
     }
 
     import scala.language.implicitConversions
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     implicit def flattener[T](tried: Try[T]): GenTraversableOnce[T] =
       if (flags.isTruncated) tried.toOption
       else

--- a/akka-actor/src/main/scala/akka/japi/JavaAPI.scala
+++ b/akka-actor/src/main/scala/akka/japi/JavaAPI.scala
@@ -12,7 +12,7 @@ import scala.reflect.ClassTag
 import scala.runtime.AbstractPartialFunction
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.util.Collections.EmptyImmutableSeq
 
@@ -84,7 +84,7 @@ object Pair {
  *
  * This class is kept for compatibility, but for future API's please prefer [[akka.japi.function.Creator]].
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait Creator[T] extends Serializable {
 

--- a/akka-actor/src/main/scala/akka/japi/function/Function.scala
+++ b/akka-actor/src/main/scala/akka/japi/function/Function.scala
@@ -4,14 +4,14 @@
 
 package akka.japi.function
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 /**
  * A Function interface. Used to create first-class-functions is Java.
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Function` counterpart does not.
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait Function[-T, +R] extends java.io.Serializable {
   @throws(classOf[Exception])
@@ -23,7 +23,7 @@ trait Function[-T, +R] extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.BiFunction` counterpart does not.
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait Function2[-T1, -T2, +R] extends java.io.Serializable {
   @throws(classOf[Exception])
@@ -35,7 +35,7 @@ trait Function2[-T1, -T2, +R] extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Consumer` counterpart does not.
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait Procedure[-T] extends java.io.Serializable {
   @throws(classOf[Exception])
@@ -47,7 +47,7 @@ trait Procedure[-T] extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Effect` counterpart does not.
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait Effect extends java.io.Serializable {
 
@@ -60,7 +60,7 @@ trait Effect extends java.io.Serializable {
  * `Serializable` is needed to be able to grab line number for Java 8 lambdas.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Predicate` counterpart does not.
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait Predicate[-T] extends java.io.Serializable {
   def test(param: T): Boolean
@@ -70,7 +70,7 @@ trait Predicate[-T] extends java.io.Serializable {
  * A constructor/factory, takes no parameters but creates a new value of type T every call.
  * Supports throwing `Exception` in the apply, which the `java.util.function.Creator` counterpart does not.
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait Creator[+T] extends Serializable {
 

--- a/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
@@ -11,7 +11,7 @@ import scala.annotation.tailrec
 import scala.concurrent.{ Future, Promise }
 import scala.language.implicitConversions
 import scala.util.{ Failure, Success }
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import akka.actor._
 import akka.annotation.{ InternalApi, InternalStableApi }
 import akka.dispatch.ExecutionContexts
@@ -529,11 +529,11 @@ private[akka] final class PromiseActorRef private (
    * Stopped               => stopped, path not yet created
    */
   @volatile
-  @silent("never used")
+  @nowarn("msg=never used")
   private[this] var _stateDoNotCallMeDirectly: AnyRef = _
 
   @volatile
-  @silent("never used")
+  @nowarn("msg=never used")
   private[this] var _watchedByDoNotCallMeDirectly: Set[ActorRef] = ActorCell.emptyActorRefSet
 
   @inline

--- a/akka-actor/src/main/scala/akka/pattern/Backoff.scala
+++ b/akka-actor/src/main/scala/akka/pattern/Backoff.scala
@@ -6,7 +6,7 @@ package akka.pattern
 
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.{ OneForOneStrategy, Props, SupervisorStrategy }
 import akka.annotation.DoNotInherit
@@ -567,7 +567,7 @@ trait BackoffOptions {
   private[akka] def props: Props
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private final case class BackoffOptionsImpl(
     backoffType: BackoffType = RestartImpliesFailure,
     childProps: Props,

--- a/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
@@ -18,7 +18,7 @@ import scala.util.{ Failure, Success, Try }
 import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import akka.AkkaException
 import akka.actor.Scheduler
 import akka.dispatch.ExecutionContexts.parasitic
@@ -250,14 +250,14 @@ class CircuitBreaker(
    * Holds reference to current state of CircuitBreaker - *access only via helper methods*
    */
   @volatile
-  @silent("never used")
+  @nowarn("msg=never used")
   private[this] var _currentStateDoNotCallMeDirectly: State = Closed
 
   /**
    * Holds reference to current resetTimeout of CircuitBreaker - *access only via helper methods*
    */
   @volatile
-  @silent("never used")
+  @nowarn("msg=never used")
   private[this] var _currentResetTimeoutDoNotCallMeDirectly: FiniteDuration = resetTimeout
 
   /**

--- a/akka-actor/src/main/scala/akka/routing/Balancing.scala
+++ b/akka-actor/src/main/scala/akka/routing/Balancing.scala
@@ -6,7 +6,7 @@ package akka.routing
 
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
@@ -28,7 +28,7 @@ private[akka] object BalancingRoutingLogic {
  * INTERNAL API
  * Selects the first routee, balancing will be done by the dispatcher.
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 private[akka] final class BalancingRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =

--- a/akka-actor/src/main/scala/akka/routing/Broadcast.scala
+++ b/akka-actor/src/main/scala/akka/routing/Broadcast.scala
@@ -6,7 +6,7 @@ package akka.routing
 
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.actor.ActorSystem
@@ -21,7 +21,7 @@ object BroadcastRoutingLogic {
 /**
  * Broadcasts a message to all its routees.
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 final class BroadcastRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =

--- a/akka-actor/src/main/scala/akka/routing/MurmurHash.scala
+++ b/akka-actor/src/main/scala/akka/routing/MurmurHash.scala
@@ -21,7 +21,7 @@ package akka.routing
 
 import java.lang.Integer.{ rotateLeft => rotl }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.util.ccompat._
 
@@ -133,7 +133,7 @@ object MurmurHash {
    *  where the order of appearance of elements does not matter.
    *  This is useful for hashing sets, for example.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def symmetricHash[T](xs: IterableOnce[T], seed: Int): Int = {
     var a, b, n = 0
     var c = 1

--- a/akka-actor/src/main/scala/akka/routing/Random.scala
+++ b/akka-actor/src/main/scala/akka/routing/Random.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.ThreadLocalRandom
 
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.actor.ActorSystem
@@ -23,7 +23,7 @@ object RandomRoutingLogic {
 /**
  * Randomly selects one of the target routees to send a message to
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 final class RandomRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =

--- a/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoundRobin.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.actor.ActorSystem
@@ -24,7 +24,7 @@ object RoundRobinRoutingLogic {
  * Uses round-robin to select a routee. For concurrent calls,
  * round robin is just a best effort.
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 final class RoundRobinRoutingLogic extends RoutingLogic {
   val next = new AtomicLong

--- a/akka-actor/src/main/scala/akka/routing/RoutedActorRef.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoutedActorRef.scala
@@ -4,7 +4,7 @@
 
 package akka.routing
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.ConfigurationException
 import akka.actor.ActorPath
@@ -24,7 +24,7 @@ import akka.dispatch.MessageDispatcher
  * A RoutedActorRef is an ActorRef that has a set of connected ActorRef and it uses a Router to
  * send a message to one (or more) of these actors.
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[akka] class RoutedActorRef(
     _system: ActorSystemImpl,
     _routerProps: Props,

--- a/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
+++ b/akka-actor/src/main/scala/akka/routing/RouterConfig.scala
@@ -6,7 +6,7 @@ package akka.routing
 
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.ConfigurationException
 import akka.actor.ActorContext
@@ -39,7 +39,7 @@ import akka.util.unused
  * someone tries sending a message to that reference before the constructor of
  * RoutedActorRef has returned, there will be a `NullPointerException`!
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait RouterConfig extends Serializable {
 
@@ -376,7 +376,7 @@ case object NoRouter extends NoRouter {
 /**
  * INTERNAL API
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 private[akka] trait RouterManagementMesssage
 
@@ -385,7 +385,7 @@ private[akka] trait RouterManagementMesssage
  * A [[Routees]] message is sent asynchronously to the "requester" containing information
  * about what routees the router is routing over.
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 abstract class GetRoutees extends RouterManagementMesssage
 

--- a/akka-actor/src/main/scala/akka/routing/SmallestMailbox.scala
+++ b/akka-actor/src/main/scala/akka/routing/SmallestMailbox.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.ThreadLocalRandom
 import scala.annotation.tailrec
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.actor.ActorCell
@@ -33,7 +33,7 @@ object SmallestMailboxRoutingLogic {
  *     since their mailbox size is unknown</li>
  * </ul>
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 class SmallestMailboxRoutingLogic extends RoutingLogic {
   override def select(message: Any, routees: immutable.IndexedSeq[Routee]): Routee =
@@ -83,7 +83,7 @@ class SmallestMailboxRoutingLogic extends RoutingLogic {
   }
 
   // TODO should we rewrite this not to use isTerminated?
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   protected def isTerminated(a: Routee): Boolean = a match {
     case ActorRefRoutee(ref) => ref.isTerminated
     case _                   => false
@@ -181,7 +181,7 @@ class SmallestMailboxRoutingLogic extends RoutingLogic {
  * @param routerDispatcher dispatcher to use for the router head actor, which handles
  *   supervision, death watch and router management messages
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 final case class SmallestMailboxPool(
     nrOfInstances: Int,

--- a/akka-actor/src/main/scala/akka/util/Index.scala
+++ b/akka-actor/src/main/scala/akka/util/Index.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.{ ConcurrentHashMap, ConcurrentSkipListSet }
 import scala.collection.JavaConverters.collectionAsScalaIterableConverter
 
 import annotation.tailrec
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.util.ccompat.JavaConverters._
 
@@ -145,7 +145,7 @@ class Index[K, V](val mapSize: Int, val valueComparator: Comparator[V]) {
     if (set ne null) {
       set.synchronized {
         container.remove(key, set)
-        @silent("deprecated")
+        @nowarn("msg=deprecated")
         val ret = collectionAsScalaIterableConverter(set.clone()).asScala // Make copy since we need to clear the original
         set.clear() // Clear the original set to signal to any pending writers that there was a conflict
         Some(ret)

--- a/akka-actor/src/main/scala/akka/util/ManifestInfo.scala
+++ b/akka-actor/src/main/scala/akka/util/ManifestInfo.scala
@@ -10,7 +10,7 @@ import java.util.jar.Manifest
 
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.ActorSystem
 import akka.actor.ClassicActorSystemProvider
@@ -74,7 +74,7 @@ object ManifestInfo extends ExtensionId[ManifestInfo] with ExtensionIdProvider {
       productName: String,
       dependencies: immutable.Seq[String],
       versions: Map[String, Version]): Option[String] = {
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     val filteredVersions = versions.filterKeys(dependencies.toSet)
     val values = filteredVersions.values.toSet
     if (values.size > 1) {

--- a/akka-actor/src/main/scala/akka/util/Unused.scala
+++ b/akka-actor/src/main/scala/akka/util/Unused.scala
@@ -4,7 +4,7 @@
 
 package akka.util
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.annotation.InternalApi
 
@@ -24,5 +24,5 @@ import akka.annotation.InternalApi
  *
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 @InternalApi private[akka] class unused extends deprecated("unused", "")

--- a/akka-bench-jmh/src/main/scala/akka/remote/artery/CodecBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/remote/artery/CodecBenchmark.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations._
 
@@ -41,7 +41,7 @@ import akka.util.OptionVal
 class CodecBenchmark {
   import CodecBenchmark._
 
-  @silent("immutable val") // JMH updates this via reflection
+  @nowarn("msg=immutable val") // JMH updates this via reflection
   @Param(Array(Standard, RemoteInstrument))
   private var configType: String = _
 
@@ -70,10 +70,10 @@ class CodecBenchmark {
     override def publishDropped(inbound: InboundEnvelope, reason: String): Unit = ()
   }
 
-  @silent("never used") private var remoteRefB: RemoteActorRef = _
-  @silent("never used") private var resolvedRef: InternalActorRef = _
-  @silent("never used") private var senderStringA: String = _
-  @silent("never used") private var recipientStringB: String = _
+  @nowarn("msg=never used") private var remoteRefB: RemoteActorRef = _
+  @nowarn("msg=never used") private var resolvedRef: InternalActorRef = _
+  @nowarn("msg=never used") private var senderStringA: String = _
+  @nowarn("msg=never used") private var recipientStringB: String = _
 
   private var encodeGraph: Flow[String, Unit, NotUsed] = _
   private var decodeGraph: Flow[String, Unit, NotUsed] = _

--- a/akka-bench-jmh/src/main/scala/akka/serialization/jackson/JacksonSerializationBench.scala
+++ b/akka-bench-jmh/src/main/scala/akka/serialization/jackson/JacksonSerializationBench.scala
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations._
 
@@ -186,11 +186,11 @@ class JacksonSerializationBench {
   var system: ActorSystem = _
   var serialization: Serialization = _
 
-  @silent("immutable val") // JMH updates this via reflection
+  @nowarn("msg=immutable val") // JMH updates this via reflection
   @Param(Array("jackson-json", "jackson-cbor")) // "java"
   private var serializerName: String = _
 
-  @silent("immutable val")
+  @nowarn("msg=immutable val")
   @Param(Array("off", "gzip", "lz4"))
   private var compression: String = _
 

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsCollector.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsCollector.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.ThreadLocalRandom
 
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.Actor
 import akka.actor.ActorLogging
@@ -96,7 +96,7 @@ trait ClusterMetricsEvent
 final case class ClusterMetricsChanged(nodeMetrics: Set[NodeMetrics]) extends ClusterMetricsEvent {
 
   /** Java API */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def getNodeMetrics: java.lang.Iterable[NodeMetrics] =
     scala.collection.JavaConverters.asJavaIterableConverter(nodeMetrics).asJava
 }

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsRouting.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsRouting.scala
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.tailrec
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.actor.Actor
@@ -420,7 +420,7 @@ object MetricsSelector {
 /**
  * A MetricsSelector is responsible for producing weights from the node metrics.
  */
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 trait MetricsSelector extends Serializable {
 
@@ -434,7 +434,7 @@ trait MetricsSelector extends Serializable {
  * A MetricsSelector producing weights from remaining capacity.
  * The weights are typically proportional to the remaining capacity.
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 @SerialVersionUID(1L)
 abstract class CapacityMetricsSelector extends MetricsSelector {
 

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/Metric.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/Metric.scala
@@ -8,7 +8,7 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.Address
 
@@ -324,7 +324,7 @@ final case class NodeMetrics(address: Address, timestamp: Long, metrics: Set[Met
   /**
    * Java API
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def getMetrics: java.lang.Iterable[Metric] =
     scala.collection.JavaConverters.asJavaIterableConverter(metrics).asJava
 

--- a/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/EWMASpec.scala
+++ b/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/EWMASpec.scala
@@ -8,11 +8,11 @@ import java.util.concurrent.ThreadLocalRandom
 
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.testkit.{ AkkaSpec, LongRunningTest }
 
-@silent
+@nowarn
 class EWMASpec extends AkkaSpec(MetricsConfig.defaultEnabled) with MetricsCollectorFactory {
 
   val collector = createMetricsCollector

--- a/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/MetricSpec.scala
+++ b/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/MetricSpec.scala
@@ -8,7 +8,7 @@ import java.lang.System.{ currentTimeMillis => newTimestamp }
 
 import scala.util.Failure
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -17,7 +17,7 @@ import akka.cluster.metrics.StandardMetrics._
 import akka.testkit.AkkaSpec
 import akka.testkit.ImplicitSender
 
-@silent
+@nowarn
 class MetricNumericConverterSpec extends AnyWordSpec with Matchers with MetricNumericConverter {
 
   "MetricNumericConverter" must {
@@ -56,7 +56,7 @@ class MetricNumericConverterSpec extends AnyWordSpec with Matchers with MetricNu
   }
 }
 
-@silent
+@nowarn
 class NodeMetricsSpec extends AnyWordSpec with Matchers {
 
   val node1 = Address("akka", "sys", "a", 2554)
@@ -238,7 +238,7 @@ class MetricsGossipSpec
   }
 }
 
-@silent
+@nowarn
 class MetricValuesSpec extends AkkaSpec(MetricsConfig.defaultEnabled) with MetricsCollectorFactory {
   import akka.cluster.metrics.StandardMetrics._
 

--- a/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/MetricsCollectorSpec.scala
+++ b/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/MetricsCollectorSpec.scala
@@ -8,12 +8,12 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.Try
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.cluster.metrics.StandardMetrics._
 import akka.testkit._
 
-@silent
+@nowarn
 class MetricsCollectorSpec
     extends AkkaSpec(MetricsConfig.defaultEnabled)
     with ImplicitSender

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ClusterSharding.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/javadsl/ClusterSharding.scala
@@ -9,7 +9,7 @@ import java.time.Duration
 import java.util.Optional
 import java.util.concurrent.CompletionStage
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -385,7 +385,7 @@ final class EntityContext[M](
 
 }
 
-@silent // for unused msgClass to make class type explicit in the Java API. Not using @unused as the user is likely to see it
+@nowarn // for unused msgClass to make class type explicit in the Java API. Not using @unused as the user is likely to see it
 /** Allows starting a specific Sharded Entity by its entity identifier */
 object StartEntity {
 

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ReplicatedShardingCompileOnlySpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ReplicatedShardingCompileOnlySpec.scala
@@ -14,9 +14,9 @@ import akka.cluster.sharding.typed.scaladsl.Entity
 import akka.cluster.sharding.typed.scaladsl.EntityRef
 import akka.persistence.typed.ReplicaId
 import akka.persistence.typed.ReplicationId
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
-@silent("never used")
+@nowarn("msg=never used")
 object ReplicatedShardingCompileOnlySpec {
 
   sealed trait Command

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ShardingCompileOnlySpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ShardingCompileOnlySpec.scala
@@ -10,14 +10,14 @@ import akka.actor.typed.{ ActorRef, ActorSystem, Behavior }
 import akka.actor.typed.scaladsl.Behaviors
 import akka.cluster.sharding.typed.scaladsl.Entity
 import akka.persistence.typed.PersistenceId
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import docs.akka.persistence.typed.BlogPostEntity
 import docs.akka.persistence.typed.BlogPostEntity.Command
 
 import akka.cluster.sharding.typed.scaladsl.ClusterSharding
 import akka.cluster.sharding.typed.scaladsl.EntityTypeKey
 
-@silent
+@nowarn
 object ShardingCompileOnlySpec {
 
   val system = ActorSystem(Behaviors.empty, "Sharding")

--- a/akka-cluster-sharding-typed/src/test/scala/docs/delivery/PointToPointDocExample.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/delivery/PointToPointDocExample.scala
@@ -6,7 +6,7 @@ package docs.delivery
 
 import java.util.UUID
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.typed.ActorSystem
 
@@ -18,7 +18,7 @@ import akka.actor.typed.scaladsl.Behaviors
 
 //#imports
 
-@silent("never used")
+@nowarn("msg=never used")
 object PointToPointDocExample {
 
   //#producer

--- a/akka-cluster-sharding-typed/src/test/scala/docs/delivery/WorkPullingDocExample.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/delivery/WorkPullingDocExample.scala
@@ -12,9 +12,9 @@ import scala.util.Success
 
 import akka.Done
 import akka.actor.typed.ActorRef
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
-@silent("never used")
+@nowarn("msg=never used")
 object WorkPullingDocExample {
 
   //#imports

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Success
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import akka.actor._
 import akka.actor.DeadLetterSuppression
 import akka.annotation.DoNotInherit
@@ -47,7 +47,7 @@ object ShardCoordinator {
    * INTERNAL API
    * Factory method for the [[akka.actor.Props]] of the [[ShardCoordinator]] actor.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   private[akka] def props(
       typeName: String,
       settings: ClusterShardingSettings,

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesFailureSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesFailureSpec.scala
@@ -16,7 +16,7 @@ import akka.testkit.AkkaSpec
 import akka.testkit.TestException
 import akka.testkit.TestProbe
 import akka.testkit.WithLogCapturing
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 import scala.concurrent.duration._
@@ -82,7 +82,7 @@ object RememberEntitiesFailureSpec {
   case class ShardStoreCreated(store: ActorRef, shardId: ShardId)
   case class CoordinatorStoreCreated(store: ActorRef)
 
-  @silent("never used")
+  @nowarn("msg=never used")
   class FakeStore(settings: ClusterShardingSettings, typeName: String) extends RememberEntitiesProvider {
     override def shardStoreProps(shardId: ShardId): Props = FakeShardStoreActor.props(shardId)
     override def coordinatorStoreProps(): Props = FakeCoordinatorStoreActor.props()

--- a/akka-cluster-tools/src/main/scala/akka/cluster/client/protobuf/ClusterClientMessageSerializer.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/client/protobuf/ClusterClientMessageSerializer.scala
@@ -6,7 +6,7 @@ package akka.cluster.client.protobuf
 
 import java.io.NotSerializableException
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.ExtendedActorSystem
 import akka.cluster.client.ClusterReceptionist
@@ -18,7 +18,7 @@ import akka.util.ccompat.JavaConverters._
 /**
  * INTERNAL API: Serializer of ClusterClient messages.
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[akka] class ClusterClientMessageSerializer(val system: ExtendedActorSystem)
     extends SerializerWithStringManifest
     with BaseSerializer {

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientHandoverSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientHandoverSpec.scala
@@ -6,7 +6,7 @@ package akka.cluster.client
 
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.actor.{ ActorPath, ActorRef }
@@ -38,7 +38,7 @@ class ClusterClientHandoverSpecMultiJvmNode1 extends ClusterClientHandoverSpec
 class ClusterClientHandoverSpecMultiJvmNode2 extends ClusterClientHandoverSpec
 class ClusterClientHandoverSpecMultiJvmNode3 extends ClusterClientHandoverSpec
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class ClusterClientHandoverSpec
     extends MultiNodeSpec(ClusterClientHandoverSpec)
     with STMultiNodeSpec

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientSpec.scala
@@ -7,7 +7,7 @@ package akka.cluster.client
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 import language.postfixOps
 
@@ -163,7 +163,7 @@ class ClusterClientMultiJvmNode3 extends ClusterClientSpec
 class ClusterClientMultiJvmNode4 extends ClusterClientSpec
 class ClusterClientMultiJvmNode5 extends ClusterClientSpec
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class ClusterClientSpec extends MultiNodeSpec(ClusterClientSpec) with STMultiNodeSpec with ImplicitSender {
   import ClusterClientSpec._
 

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientStopSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientStopSpec.scala
@@ -7,7 +7,7 @@ package akka.cluster.client
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.actor.{ Actor, Props }
@@ -46,7 +46,7 @@ class ClusterClientStopMultiJvmNode1 extends ClusterClientStopSpec
 class ClusterClientStopMultiJvmNode2 extends ClusterClientStopSpec
 class ClusterClientStopMultiJvmNode3 extends ClusterClientStopSpec
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class ClusterClientStopSpec extends MultiNodeSpec(ClusterClientStopSpec) with STMultiNodeSpec with ImplicitSender {
 
   import ClusterClientStopSpec._

--- a/akka-cluster-tools/src/test/scala/akka/cluster/client/protobuf/ClusterClientMessageSerializerSpec.scala
+++ b/akka-cluster-tools/src/test/scala/akka/cluster/client/protobuf/ClusterClientMessageSerializerSpec.scala
@@ -4,13 +4,13 @@
 
 package akka.cluster.client.protobuf
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.ExtendedActorSystem
 import akka.cluster.client.ClusterReceptionist.Internal._
 import akka.testkit.AkkaSpec
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class ClusterClientMessageSerializerSpec extends AkkaSpec {
 
   val serializer = new ClusterClientMessageSerializer(system.asInstanceOf[ExtendedActorSystem])

--- a/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/ReplicatorMessageAdapter.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/ddata/typed/javadsl/ReplicatorMessageAdapter.scala
@@ -10,7 +10,7 @@ import java.util.function.{ Function => JFunction }
 import scala.util.Failure
 import scala.util.Success
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.typed.ActorRef
 import akka.actor.typed.javadsl.ActorContext
@@ -115,7 +115,7 @@ class ReplicatorMessageAdapter[A, B <: ReplicatedData](
    * `ActorRef[GetResponse]` that the the replicator will send the response message back through.
    * Use that `ActorRef[GetResponse]` as the `replyTo` parameter in the `Get` message.
    */
-  @silent
+  @nowarn
   def askGet(
       createRequest: JFunction[ActorRef[Replicator.GetResponse[B]], Replicator.Get[B]],
       responseAdapter: JFunction[Replicator.GetResponse[B], A]): Unit = {

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
@@ -7,7 +7,7 @@ package docs.akka.cluster.typed
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.testkit.SocketUtil
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
@@ -90,7 +90,7 @@ akka {
     //#hasRole
   }
 
-  @silent("never used")
+  @nowarn("msg=never used")
   def illustrateDcAccess(): Unit = {
     val system: ActorSystem[_] = ???
 

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{ Await, ExecutionContext }
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.{ Config, ConfigFactory }
 
 import akka.ConfigurationException
@@ -100,7 +100,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
   /**
    * Java API: roles that this member has
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def getSelfRoles: java.util.Set[String] =
     scala.collection.JavaConverters.setAsJavaSetConverter(selfRoles).asJava
 
@@ -179,7 +179,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
 
         override def maxFrequency: Double = systemScheduler.maxFrequency
 
-        @silent("deprecated")
+        @nowarn("msg=deprecated")
         override def schedule(initialDelay: FiniteDuration, interval: FiniteDuration, runnable: Runnable)(
             implicit executor: ExecutionContext): Cancellable =
           systemScheduler.schedule(initialDelay, interval, runnable)

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterActorRefProvider.scala
@@ -4,7 +4,7 @@
 
 package akka.cluster
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
@@ -127,7 +127,7 @@ private[akka] class ClusterDeployer(_settings: ActorSystem.Settings, _pm: Dynami
 
 }
 
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 abstract class ClusterScope extends Scope
 

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterDaemon.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.Done
@@ -439,7 +439,7 @@ private[cluster] class ClusterCoreDaemon(publisher: ActorRef, joinConfigCompatCh
     }
   }
 
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   private def subscribeQuarantinedEvent(): Unit = {
     context.system.eventStream.subscribe(self, classOf[QuarantinedEvent])
     context.system.eventStream.subscribe(self, classOf[ClassicQuarantinedEvent])

--- a/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterEvent.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable
 import scala.collection.immutable.{ SortedSet, VectorBuilder }
 import scala.runtime.AbstractFunction5
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import language.postfixOps
 
 import akka.actor.{ Actor, ActorRef, Address }
@@ -74,7 +74,7 @@ object ClusterEvent {
         Map[String, Option[Address]],
         CurrentClusterState] {
 
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     def apply(
         members: immutable.SortedSet[Member] = immutable.SortedSet.empty,
         unreachable: Set[Member] = Set.empty,
@@ -144,21 +144,21 @@ object ClusterEvent {
     /**
      * Java API: get current unreachable set.
      */
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     def getUnreachable: java.util.Set[Member] =
       scala.collection.JavaConverters.setAsJavaSetConverter(unreachable).asJava
 
     /**
      * Java API: All data centers in the cluster
      */
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     def getUnreachableDataCenters: java.util.Set[String] =
       scala.collection.JavaConverters.setAsJavaSetConverter(unreachableDataCenters).asJava
 
     /**
      * Java API: get current “seen-by” set.
      */
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     def getSeenBy: java.util.Set[Address] =
       scala.collection.JavaConverters.setAsJavaSetConverter(seenBy).asJava
 
@@ -186,7 +186,7 @@ object ClusterEvent {
     /**
      * Java API: All node roles in the cluster
      */
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     def getAllRoles: java.util.Set[String] =
       scala.collection.JavaConverters.setAsJavaSetConverter(allRoles).asJava
 
@@ -198,7 +198,7 @@ object ClusterEvent {
     /**
      * Java API: All data centers in the cluster
      */
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     def getAllDataCenters: java.util.Set[String] =
       scala.collection.JavaConverters.setAsJavaSetConverter(allDataCenters).asJava
 

--- a/akka-cluster/src/main/scala/akka/cluster/Member.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Member.scala
@@ -6,7 +6,7 @@ package akka.cluster
 
 import scala.runtime.AbstractFunction2
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.Address
 import akka.annotation.InternalApi
@@ -51,7 +51,7 @@ class Member private[cluster] (
   /**
    * Java API
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def getRoles: java.util.Set[String] =
     scala.collection.JavaConverters.setAsJavaSetConverter(roles).asJava
 
@@ -325,7 +325,7 @@ final case class UniqueAddress(address: Address, longUid: Long) extends Ordered[
    * Stops `copy(Address, Long)` copy from being generated, use `apply` instead.
    */
   @deprecated("Use Long UID constructor instead", since = "2.4.11")
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def copy(address: Address = address, uid: Int = uid) = new UniqueAddress(address, uid.toLong)
 
 }

--- a/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/protobuf/ClusterMessageSerializer.scala
@@ -11,7 +11,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.duration.Deadline
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.{ Config, ConfigFactory, ConfigRenderOptions }
 
 import akka.actor.{ Address, ExtendedActorSystem }
@@ -232,7 +232,7 @@ final class ClusterMessageSerializer(val system: ExtendedActorSystem)
     builder.build()
   }
 
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   private def clusterRouterPoolSettingsToProto(settings: ClusterRouterPoolSettings): cm.ClusterRouterPoolSettings = {
     val builder = cm.ClusterRouterPoolSettings.newBuilder()
     builder

--- a/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/routing/ClusterRouterConfig.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.annotation.{ tailrec, varargs }
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
@@ -102,7 +102,7 @@ final case class ClusterRouterGroupSettings(
 
   // For binary compatibility
   @deprecated("Use constructor with useRoles instead", since = "2.5.4")
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def copy(
       totalInstances: Int = totalInstances,
       routeesPaths: immutable.Seq[String] = routeesPaths,
@@ -197,7 +197,7 @@ final case class ClusterRouterPoolSettings(
 
   // For binary compatibility
   @deprecated("Use copy with useRoles instead", since = "2.5.4")
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def copy(
       totalInstances: Int = totalInstances,
       maxInstancesPerNode: Int = maxInstancesPerNode,

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SurviveNetworkInstabilitySpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SurviveNetworkInstabilitySpec.scala
@@ -7,7 +7,7 @@ package akka.cluster
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.actor.Actor
@@ -94,14 +94,14 @@ abstract class SurviveNetworkInstabilitySpec
 
   private val remoteSettings = RARP(system).provider.remoteSettings
 
-  @silent
+  @nowarn
   def quarantinedEventClass: Class[_] =
     if (remoteSettings.Artery.Enabled)
       classOf[QuarantinedEvent]
     else
       classOf[akka.remote.QuarantinedEvent]
 
-  @silent
+  @nowarn
   def quarantinedEventFrom(event: Any): Address = {
     event match {
       case QuarantinedEvent(uniqueAddress)          => uniqueAddress.address
@@ -110,7 +110,7 @@ abstract class SurviveNetworkInstabilitySpec
 
   }
 
-  @silent
+  @nowarn
   def sysMsgBufferSize: Int =
     if (RARP(system).provider.remoteSettings.Artery.Enabled)
       remoteSettings.Artery.Advanced.SysMsgBufferSize

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterConfigSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterConfigSpec.scala
@@ -6,7 +6,7 @@ package akka.cluster
 
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 import language.postfixOps
 
@@ -17,7 +17,7 @@ import akka.testkit.AkkaSpec
 import akka.util.Helpers.ConfigOps
 import akka.util.Version
 
-@silent
+@nowarn
 class ClusterConfigSpec extends AkkaSpec {
 
   "Clustering" must {

--- a/akka-cluster/src/test/scala/akka/cluster/ReachabilityPerfSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ReachabilityPerfSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.cluster
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -28,7 +28,7 @@ class ReachabilityPerfSpec extends AnyWordSpec with Matchers {
         r.unreachable(observer, subject).reachable(observer, subject)
     }
 
-  @silent
+  @nowarn
   private def addUnreachable(base: Reachability, count: Int): Reachability = {
     val observers = base.versions.keySet.take(count)
     val subjects = Stream.continually(base.versions.keySet).flatten.iterator

--- a/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/protobuf/ClusterMessageSerializerSpec.scala
@@ -6,7 +6,7 @@ package akka.cluster.protobuf
 
 import collection.immutable.SortedSet
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.actor.{ Address, ExtendedActorSystem }
@@ -17,7 +17,7 @@ import akka.routing.RoundRobinPool
 import akka.testkit.AkkaSpec
 import akka.util.Version
 
-@silent
+@nowarn
 class ClusterMessageSerializerSpec extends AkkaSpec("akka.actor.provider = cluster") {
 
   val serializer = new ClusterMessageSerializer(system.asInstanceOf[ExtendedActorSystem])

--- a/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/ServiceDiscovery.scala
@@ -67,8 +67,8 @@ object ServiceDiscovery {
   object ResolvedTarget {
     // Simply compare the bytes of the address.
     // This may not work in exotic cases such as IPv4 addresses encoded as IPv6 addresses.
-    import com.github.ghik.silencer.silent
-    @silent("deprecated")
+    import scala.annotation.nowarn
+    @nowarn("msg=deprecated")
     private implicit val inetAddressOrdering: Ordering[InetAddress] =
       Ordering.by[InetAddress, Iterable[Byte]](_.getAddress)
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
@@ -22,7 +22,7 @@ import scala.util.Try
 import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.actor.Actor
@@ -1488,9 +1488,9 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
   // possibility to disable Gossip for testing purpose
   var fullStateGossipEnabled = true
 
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   val subscribers = new mutable.HashMap[KeyId, mutable.Set[ActorRef]] with mutable.MultiMap[KeyId, ActorRef]
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   val newSubscribers = new mutable.HashMap[KeyId, mutable.Set[ActorRef]] with mutable.MultiMap[KeyId, ActorRef]
   var subscriptionKeys = Map.empty[KeyId, KeyR]
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
@@ -14,7 +14,7 @@ import java.util.Comparator
 import scala.annotation.tailrec
 import scala.collection.immutable
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.ActorRef
 import akka.actor.ExtendedActorSystem
@@ -47,7 +47,7 @@ private object ReplicatedDataSerializer {
     def getKey(entry: A): Any
     final def compare(x: A, y: A): Int = compareKeys(getKey(x), getKey(y))
 
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     private final def compareKeys(t1: Any, t2: Any): Int = (t1, t2) match {
       case (k1: String, k2: String)             => k1.compareTo(k2)
       case (_: String, _)                       => -1

--- a/akka-docs/src/test/java/jdocs/stream/operators/sourceorflow/MapError.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/sourceorflow/MapError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2019-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package jdocs.stream.operators.sourceorflow;

--- a/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/FoldAsync.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/FoldAsync.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2019-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.stream.operators.sourceorflow

--- a/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapError.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2019-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.stream.operators.sourceorflow

--- a/akka-persistence-typed-tests/src/test/scala/docs/akka/persistence/typed/ReplicatedEventSourcingCompileOnlySpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/docs/akka/persistence/typed/ReplicatedEventSourcingCompileOnlySpec.scala
@@ -7,9 +7,9 @@ package docs.akka.persistence.typed
 import akka.persistence.typed.ReplicaId
 import akka.persistence.typed.ReplicationId
 import akka.persistence.typed.scaladsl.{ EventSourcedBehavior, ReplicatedEventSourcing }
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
-@silent("never used")
+@nowarn("msg=never used")
 object ReplicatedEventSourcingCompileOnlySpec {
 
   //#replicas

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/scaladsl/PersistentActorCompileOnlyTest.scala
@@ -8,7 +8,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.typed.{ ActorRef, Behavior }
 import akka.actor.typed.ActorSystem
@@ -18,7 +18,7 @@ import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.RecoveryCompleted
 
 // unused names in pattern match can be useful in the docs
-@silent
+@nowarn
 object PersistentActorCompileOnlyTest {
 
   import akka.persistence.typed.scaladsl.EventSourcedBehavior._

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
@@ -25,10 +25,10 @@ import akka.persistence.typed.PersistenceId
 //#structure
 import akka.persistence.typed.RecoveryCompleted
 import akka.persistence.typed.SnapshotFailed
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 // unused variables in pattern match are useful in the docs
-@silent
+@nowarn
 object BasicPersistentBehaviorCompileOnly {
 
   import akka.persistence.typed.scaladsl.RetentionCriteria

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -11,7 +11,7 @@ import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.actor.{ Actor, ActorCell, DeadLetter, StashOverflowException }
@@ -89,7 +89,7 @@ private[persistence] trait Eventsourced
 
   private var journalBatch = Vector.empty[PersistentEnvelope]
   // no longer used, but kept for binary compatibility
-  @silent("never used")
+  @nowarn("msg=never used")
   private val maxMessageBatchSize = {
     val journalPluginConfig = this match {
       case c: RuntimePluginConfig => c.journalPluginConfig

--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
@@ -10,7 +10,7 @@ import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.actor._
@@ -124,7 +124,7 @@ trait PersistentFSM[S <: FSMState, D, E] extends PersistentActor with Persistent
   /**
    * Discover the latest recorded state
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   override def receiveRecover: Receive = {
     case domainEventTag(event)                      => startWith(stateName, applyEvent(event, stateData))
     case StateChangeEvent(stateIdentifier, timeout) => startWith(statesMap(stateIdentifier), stateData, timeout)
@@ -527,7 +527,7 @@ abstract class AbstractPersistentFSM[S <: FSMState, D, E]
  * Persistent Finite State Machine actor abstract base class with FSM Logging
  *
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 @deprecated("Use EventSourcedBehavior", "2.6.0")
 abstract class AbstractPersistentLoggingFSM[S <: FSMState, D, E]
     extends AbstractPersistentFSM[S, D, E]

--- a/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/leveldb/LeveldbStore.scala
@@ -53,11 +53,11 @@ private[persistence] trait LeveldbStore
   override val compactionIntervals: Map[String, Long] =
     LeveldbStore.toCompactionIntervalMap(config.getObject("compaction-intervals"))
 
-  import com.github.ghik.silencer.silent
-  @silent("deprecated")
+  import scala.annotation.nowarn
+  @nowarn("msg=deprecated")
   private val persistenceIdSubscribers = new mutable.HashMap[String, mutable.Set[ActorRef]]
     with mutable.MultiMap[String, ActorRef]
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   private val tagSubscribers = new mutable.HashMap[String, mutable.Set[ActorRef]]
     with mutable.MultiMap[String, ActorRef]
   private var allPersistenceIdsSubscribers = Set.empty[ActorRef]

--- a/akka-persistence/src/main/scala/akka/persistence/serialization/MessageSerializer.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/serialization/MessageSerializer.scala
@@ -11,7 +11,7 @@ import scala.collection.immutable.VectorBuilder
 import scala.concurrent.duration
 import scala.concurrent.duration.Duration
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.{ ActorPath, ExtendedActorSystem }
 import akka.actor.Actor
@@ -129,7 +129,7 @@ class MessageSerializer(val system: ExtendedActorSystem) extends BaseSerializer 
     AtLeastOnceDeliverySnapshot(atLeastOnceDeliverySnapshot.getCurrentDeliveryId, unconfirmedDeliveries.result())
   }
 
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def stateChange(persistentStateChange: mf.PersistentStateChangeEvent): StateChangeEvent = {
     StateChangeEvent(
       persistentStateChange.getStateIdentifier,

--- a/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 import scala.util.Random
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.{ Config, ConfigFactory }
 
 import akka.actor._
@@ -401,7 +401,7 @@ object PersistentActorSpec {
       extends AsyncPersistSameEventTwicePersistentActor(name)
       with InmemRuntimePluginConfig
 
-  @silent // compiler knows persistAll(Nil)(lambda) will never invoke lambda
+  @nowarn // compiler knows persistAll(Nil)(lambda) will never invoke lambda
   class PersistAllNilPersistentActor(name: String) extends ExamplePersistentActor(name) {
 
     val receiveCommand: Receive = commonBehavior.orElse {

--- a/akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/fsm/PersistentFSMSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.reflect.ClassTag
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.apache.commons.io.FileUtils
 
@@ -19,7 +19,7 @@ import akka.persistence._
 import akka.persistence.fsm.PersistentFSM._
 import akka.testkit._
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 abstract class PersistentFSMSpec(config: Config) extends PersistenceSpec(config) with ImplicitSender {
   import PersistentFSMSpec._
 
@@ -401,7 +401,7 @@ abstract class PersistentFSMSpec(config: Config) extends PersistenceSpec(config)
   }
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 object PersistentFSMSpec {
   //#customer-states
   sealed trait UserState extends FSMState

--- a/akka-remote-tests/src/multi-jvm/scala/akka/io/DnsSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/io/DnsSpec.scala
@@ -8,7 +8,7 @@ import java.net.Inet4Address
 import java.net.Inet6Address
 import java.net.InetAddress
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.remote.RemotingMultiNodeSpec
 import akka.remote.testkit.MultiNodeConfig
@@ -20,7 +20,7 @@ object DnsSpec extends MultiNodeConfig {
 class DnsSpecMultiJvmNode1 extends DnsSpec
 
 // This is a multi-jvm tests because it is modifying global System.properties
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class DnsSpec extends RemotingMultiNodeSpec(DnsSpec) {
 
   def initialParticipants = roles.size

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/TransportFailSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/TransportFailSpec.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
@@ -98,7 +98,7 @@ object TransportFailSpec {
  * This was fixed by not stopping the ReliableDeliverySupervisor so that the
  * receive buffer was preserved.
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 abstract class TransportFailSpec extends RemotingMultiNodeSpec(TransportFailConfig) {
   import TransportFailConfig._
   import TransportFailSpec._

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/SurviveNetworkPartitionSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/SurviveNetworkPartitionSpec.scala
@@ -6,7 +6,7 @@ package akka.remote.artery
 
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.actor._
@@ -37,7 +37,7 @@ object SurviveNetworkPartitionSpec extends MultiNodeConfig {
 class SurviveNetworkPartitionSpecMultiJvmNode1 extends SurviveNetworkPartitionSpec
 class SurviveNetworkPartitionSpecMultiJvmNode2 extends SurviveNetworkPartitionSpec
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 abstract class SurviveNetworkPartitionSpec extends RemotingMultiNodeSpec(SurviveNetworkPartitionSpec) {
 
   import SurviveNetworkPartitionSpec._

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/RemoteGatePiercingSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/RemoteGatePiercingSpec.scala
@@ -7,7 +7,7 @@ package akka.remote.classic
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.actor.{ ActorIdentity, Identify, _ }
@@ -48,7 +48,7 @@ object RemoteGatePiercingSpec extends MultiNodeConfig {
 class RemoteGatePiercingSpecMultiJvmNode1 extends RemoteGatePiercingSpec
 class RemoteGatePiercingSpecMultiJvmNode2 extends RemoteGatePiercingSpec
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 abstract class RemoteGatePiercingSpec extends RemotingMultiNodeSpec(RemoteGatePiercingSpec) {
 
   import RemoteGatePiercingSpec._

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/RemoteNodeRestartGateSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/RemoteNodeRestartGateSpec.scala
@@ -7,7 +7,7 @@ package akka.remote.classic
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.actor.{ ActorIdentity, Identify, _ }
@@ -45,7 +45,7 @@ object RemoteNodeRestartGateSpec extends MultiNodeConfig {
 class RemoteNodeRestartGateSpecMultiJvmNode1 extends RemoteNodeRestartGateSpec
 class RemoteNodeRestartGateSpecMultiJvmNode2 extends RemoteNodeRestartGateSpec
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 abstract class RemoteNodeRestartGateSpec extends RemotingMultiNodeSpec(RemoteNodeRestartGateSpec) {
 
   import RemoteNodeRestartGateSpec._

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/Ticket15109Spec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/Ticket15109Spec.scala
@@ -7,7 +7,7 @@ package akka.remote.classic
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.actor.{ ActorIdentity, Identify, _ }
@@ -47,7 +47,7 @@ object Ticket15109Spec extends MultiNodeConfig {
 class Ticket15109SpecMultiJvmNode1 extends Ticket15109Spec
 class Ticket15109SpecMultiJvmNode2 extends Ticket15109Spec
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 abstract class Ticket15109Spec extends RemotingMultiNodeSpec(Ticket15109Spec) {
 
   import Ticket15109Spec._

--- a/akka-remote/src/main/scala/akka/remote/Endpoint.scala
+++ b/akka-remote/src/main/scala/akka/remote/Endpoint.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration.Deadline
 import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.{ AkkaException, OnlyCauseStackTrace }
 import akka.actor._
@@ -54,7 +54,7 @@ private[remote] trait InboundMessageDispatcher {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] class DefaultMessageDispatcher(
     private val system: ExtendedActorSystem,
     private val provider: RemoteActorRefProvider,
@@ -245,7 +245,7 @@ private[remote] object ReliableDeliverySupervisor {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] class ReliableDeliverySupervisor(
     handleOrActive: Option[AkkaProtocolHandle],
     val localAddress: Address,
@@ -536,7 +536,7 @@ private[remote] class ReliableDeliverySupervisor(
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] abstract class EndpointActor(
     val localAddress: Address,
     val remoteAddress: Address,
@@ -563,7 +563,7 @@ private[remote] abstract class EndpointActor(
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] object EndpointWriter {
 
   def props(
@@ -620,7 +620,7 @@ private[remote] object EndpointWriter {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] class EndpointWriter(
     handleOrActive: Option[AkkaProtocolHandle],
     localAddress: Address,
@@ -1041,7 +1041,7 @@ private[remote] class EndpointWriter(
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] object EndpointReader {
 
   def props(
@@ -1073,7 +1073,7 @@ private[remote] object EndpointReader {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] class EndpointReader(
     localAddress: Address,
     remoteAddress: Address,

--- a/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteActorRefProvider.scala
@@ -9,7 +9,7 @@ import scala.util.Failure
 import scala.util.control.Exception.Catcher
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.ConfigurationException
 import akka.Done
@@ -676,7 +676,7 @@ private[akka] class RemoteActorRef private[akka] (
   // used by artery to direct messages to separate specialized streams
   @volatile private[remote] var cachedSendQueueIndex: Int = -1
 
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def getChild(name: Iterator[String]): InternalActorRef = {
     val s = name.toStream
     s.headOption match {

--- a/akka-remote/src/main/scala/akka/remote/RemoteMetricsExtension.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteMetricsExtension.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.annotation.tailrec
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.ActorSelectionMessage
 import akka.actor.ActorSystem
@@ -25,7 +25,7 @@ import akka.routing.RouterEnvelope
  * Extension that keeps track of remote metrics, such
  * as max size of different message types.
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[akka] object RemoteMetricsExtension extends ExtensionId[RemoteMetrics] with ExtensionIdProvider {
   override def get(system: ActorSystem): RemoteMetrics = super.get(system)
   override def get(system: ClassicActorSystemProvider): RemoteMetrics = super.get(system)
@@ -62,7 +62,7 @@ private[akka] class RemoteMetricsOff extends RemoteMetrics {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[akka] class RemoteMetricsOn(system: ExtendedActorSystem) extends RemoteMetrics {
 
   private val logFrameSizeExceeding: Int =

--- a/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteSettings.scala
@@ -7,7 +7,7 @@ package akka.remote
 import scala.collection.immutable
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.ConfigurationException
@@ -47,7 +47,7 @@ final class RemoteSettings(val config: Config) {
   /**
    * INTERNAL API
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   @InternalApi private[akka] def untrustedMode: Boolean =
     if (Artery.Enabled) Artery.UntrustedMode else UntrustedMode
   @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
@@ -69,7 +69,7 @@ final class RemoteSettings(val config: Config) {
   @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
   val Dispatcher: String = getString("akka.remote.classic.use-dispatcher")
 
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def configureDispatcher(props: Props): Props =
     if (Artery.Enabled) {
       if (Artery.Advanced.Dispatcher.isEmpty) props else props.withDispatcher(Artery.Advanced.Dispatcher)

--- a/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteWatcher.scala
@@ -7,7 +7,7 @@ package akka.remote
 import scala.collection.mutable
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor._
 import akka.annotation.InternalApi
@@ -113,18 +113,18 @@ private[akka] class RemoteWatcher(
     if (artery) (ArteryHeartbeat, ArteryHeartbeatRsp(AddressUidExtension(context.system).longAddressUid))
     else {
       // For classic remoting the 'int' part is sufficient
-      @silent("deprecated")
+      @nowarn("msg=deprecated")
       val addressUid = AddressUidExtension(context.system).addressUid
       (Heartbeat, HeartbeatRsp(addressUid))
     }
 
   // actors that this node is watching, map of watchee -> Set(watchers)
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   val watching = new mutable.HashMap[InternalActorRef, mutable.Set[InternalActorRef]]()
     with mutable.MultiMap[InternalActorRef, InternalActorRef]
 
   // nodes that this node is watching, i.e. expecting heartbeats from these nodes. Map of address -> Set(watchee) on this address
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   val watcheeByNodes = new mutable.HashMap[Address, mutable.Set[InternalActorRef]]()
     with mutable.MultiMap[Address, InternalActorRef]
   def watchingNodes = watcheeByNodes.keySet

--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.Done
@@ -78,7 +78,7 @@ private[akka] trait HeartbeatMessage extends PriorityMessage
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] object Remoting {
 
   final val EndpointManagerName = "endpointManager"
@@ -134,7 +134,7 @@ private[remote] object Remoting {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 @ccompatUsedUntil213
 private[remote] class Remoting(_system: ExtendedActorSystem, _provider: RemoteActorRefProvider)
     extends RemoteTransport(_system, _provider) {
@@ -288,7 +288,7 @@ private[remote] class Remoting(_system: ExtendedActorSystem, _provider: RemoteAc
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] object EndpointManager {
 
   // Messages between Remoting and EndpointManager
@@ -481,7 +481,7 @@ private[remote] object EndpointManager {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] class EndpointManager(conf: Config, log: LoggingAdapter)
     extends Actor
     with RequiresMessageQueue[UnboundedMessageQueueSemantics] {
@@ -780,7 +780,7 @@ private[remote] class EndpointManager(conf: Config, log: LoggingAdapter)
     case ShutdownAndFlush =>
       // Shutdown all endpoints and signal to sender() when ready (and whether all endpoints were shut down gracefully)
 
-      @silent("deprecated")
+      @nowarn("msg=deprecated")
       def shutdownAll[T](resources: IterableOnce[T])(shutdown: T => Future[Boolean]): Future[Boolean] = {
         Future.sequence(resources.toList.map(shutdown)).map(_.forall(identity)).recover {
           case NonFatal(_) => false

--- a/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemotingLifecycleEvent.scala
@@ -6,20 +6,20 @@ package akka.remote
 
 import scala.runtime.AbstractFunction2
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.{ ActorSystem, Address }
 import akka.event.{ Logging, LoggingAdapter }
 import akka.event.Logging.LogLevel
 
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
 sealed trait RemotingLifecycleEvent extends Serializable {
   def logLevel: Logging.LogLevel
 }
 
-@silent("@SerialVersionUID has no effect")
+@nowarn("msg=@SerialVersionUID has no effect")
 @SerialVersionUID(1L)
 @deprecated("Classic remoting is deprecated, use Artery", "2.6.0")
 sealed trait AssociationEvent extends RemotingLifecycleEvent {
@@ -66,7 +66,7 @@ final case class AssociationErrorEvent(
 }
 
 @SerialVersionUID(1L)
-@silent("deprecated")
+@nowarn("msg=deprecated")
 final case class RemotingListenEvent(listenAddresses: Set[Address]) extends RemotingLifecycleEvent {
   def getListenAddresses: java.util.Set[Address] =
     scala.collection.JavaConverters.setAsJavaSetConverter(listenAddresses).asJava
@@ -115,7 +115,7 @@ final case class QuarantinedEvent(address: Address, longUid: Long) extends Remot
   @deprecated("Use long uid", "2.4.x")
   def uid: Int = longUid.toInt
 
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   @deprecated("Use long uid copy method", "2.4.x")
   def copy(address: Address = address, uid: Int = uid) = new QuarantinedEvent(address, uid.toLong)
 }
@@ -144,7 +144,7 @@ final case class ThisActorSystemQuarantinedEvent(localAddress: Address, remoteAd
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] class EventPublisher(system: ActorSystem, log: LoggingAdapter, logLevel: Logging.LogLevel) {
   def notifyListeners(message: RemotingLifecycleEvent): Unit = {
     system.eventStream.publish(message)

--- a/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArterySettings.scala
@@ -8,7 +8,7 @@ import java.net.InetAddress
 
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
@@ -102,10 +102,10 @@ private[akka] final class ArterySettings private (config: Config) {
     val TestMode: Boolean = getBoolean("test-mode")
     val Dispatcher: String = getString("use-dispatcher")
     val ControlStreamDispatcher: String = getString("use-control-stream-dispatcher")
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     val MaterializerSettings: ActorMaterializerSettings =
       ActorMaterializerSettings(config.getConfig("materializer")).withDispatcher(Dispatcher)
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     val ControlStreamMaterializerSettings: ActorMaterializerSettings =
       ActorMaterializerSettings(config.getConfig("materializer")).withDispatcher(ControlStreamDispatcher)
 

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration._
 import scala.util.Try
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.Done
 import akka.NotUsed
@@ -558,7 +558,7 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
               // and can result in forming two separate clusters (cluster split).
               // Instead, the downing strategy should act on ThisActorSystemQuarantinedEvent, e.g.
               // use it as a STONITH signal.
-              @silent("deprecated")
+              @nowarn("msg=deprecated")
               val lifecycleEvent = ThisActorSystemQuarantinedEvent(localAddress, from)
               system.eventStream.publish(lifecycleEvent)
 
@@ -671,7 +671,7 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
 
   private[remote] def isShutdown: Boolean = hasBeenShutdown.get()
 
-  @silent // ThrottleMode from classic is deprecated, we can replace when removing classic
+  @nowarn // ThrottleMode from classic is deprecated, we can replace when removing classic
   override def managementCommand(cmd: Any): Future[Boolean] = {
     cmd match {
       case SetThrottle(address, direction, Blackhole) =>

--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -18,7 +18,7 @@ import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.agrona.concurrent.ManyToOneConcurrentArrayQueue
 
 import akka.Done
@@ -249,7 +249,7 @@ private[remote] class Association(
    * Holds reference to shared state of Association - *access only via helper methods*
    */
   @volatile
-  @silent("never used")
+  @nowarn("msg=never used")
   private[this] var _sharedStateDoNotCallMeDirectly: AssociationState = AssociationState()
 
   /**
@@ -338,7 +338,7 @@ private[remote] class Association(
       outboundEnvelopePool.acquire().init(recipient, message.asInstanceOf[AnyRef], sender)
 
     // volatile read to see latest queue array
-    @silent("never used")
+    @nowarn("msg=never used")
     val unused = queuesVisibility
 
     def dropped(queueIndex: Int, qSize: Int, env: OutboundEnvelope): Unit = {
@@ -791,7 +791,7 @@ private[remote] class Association(
   }
 
   private def getOrCreateQueueWrapper(queueIndex: Int, capacity: Int): QueueWrapper = {
-    @silent("never used")
+    @nowarn("msg=never used")
     val unused = queuesVisibility // volatile read to see latest queues array
     queues(queueIndex) match {
       case existing: QueueWrapper => existing

--- a/akka-remote/src/main/scala/akka/remote/routing/RemoteRouterConfig.scala
+++ b/akka-remote/src/main/scala/akka/remote/routing/RemoteRouterConfig.scala
@@ -6,7 +6,7 @@ package akka.remote.routing
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.actor.ActorCell
@@ -41,7 +41,7 @@ final case class RemoteRouterConfig(local: Pool, nodes: Iterable[Address]) exten
   def this(local: Pool, nodes: Array[Address]) = this(local, nodes: Iterable[Address])
 
   // need this iterator as instance variable since Resizer may call createRoutees several times
-  @silent @transient private val nodeAddressIter: Iterator[Address] = Stream.continually(nodes).flatten.iterator
+  @nowarn @transient private val nodeAddressIter: Iterator[Address] = Stream.continually(nodes).flatten.iterator
   // need this counter as instance variable since Resizer may call createRoutees several times
   @transient private val childNameCounter = new AtomicInteger
 

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaPduCodec.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaPduCodec.scala
@@ -4,7 +4,7 @@
 
 package akka.remote.transport
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.AkkaException
 import akka.actor.{ ActorRef, Address, AddressFromURIString, InternalActorRef }
@@ -27,7 +27,7 @@ private[remote] class PduCodecException(msg: String, cause: Throwable) extends A
  * Companion object of the [[akka.remote.transport.AkkaPduCodec]] trait. Contains the representation case classes
  * of decoded Akka Protocol Data Units (PDUs).
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] object AkkaPduCodec {
 
   /**
@@ -58,7 +58,7 @@ private[remote] object AkkaPduCodec {
  *
  * A Codec that is able to convert Akka PDUs (Protocol Data Units) from and to [[akka.util.ByteString]]s.
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] trait AkkaPduCodec {
   import AkkaPduCodec._
 
@@ -118,7 +118,7 @@ private[remote] trait AkkaPduCodec {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] object AkkaPduProtobufCodec extends AkkaPduCodec {
   import AkkaPduCodec._
 

--- a/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AkkaProtocolTransport.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.{ AkkaException, OnlyCauseStackTrace }
@@ -60,7 +60,7 @@ private[remote] class AkkaProtocolSettings(config: Config) {
   }
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] object AkkaProtocolTransport { //Couldn't these go into the Remoting Extension/ RemoteSettings instead?
   val AkkaScheme: String = "akka"
   val AkkaOverhead: Int = 0 //Don't know yet
@@ -103,7 +103,7 @@ final case class HandshakeInfo(origin: Address, uid: Int, cookie: Option[String]
  * @param codec
  *   the codec that will be used to encode/decode Akka PDUs
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] class AkkaProtocolTransport(
     wrappedTransport: Transport,
     private val system: ActorSystem,
@@ -133,7 +133,7 @@ private[remote] class AkkaProtocolTransport(
   }
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[transport] class AkkaProtocolManager(
     private val wrappedTransport: Transport,
     private val settings: AkkaProtocolSettings)
@@ -156,7 +156,7 @@ private[transport] class AkkaProtocolManager(
       val failureDetector = createTransportFailureDetector()
 
       // Using the 'int' addressUid rather than the 'long' is sufficient for Classic Remoting
-      @silent("deprecated")
+      @nowarn("msg=deprecated")
       val addressUid = AddressUidExtension(context.system).addressUid
 
       context.actorOf(
@@ -188,7 +188,7 @@ private[transport] class AkkaProtocolManager(
     val failureDetector = createTransportFailureDetector()
 
     // Using the 'int' addressUid rather than the 'long' is sufficient for Classic Remoting
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     val addressUid = AddressUidExtension(context.system).addressUid
 
     context.actorOf(
@@ -210,7 +210,7 @@ private[transport] class AkkaProtocolManager(
 
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] class AkkaProtocolHandle(
     _localAddress: Address,
     _remoteAddress: Address,
@@ -228,7 +228,7 @@ private[remote] class AkkaProtocolHandle(
   def disassociate(info: DisassociateInfo): Unit = stateActor ! DisassociateUnderlying(info)
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] object ProtocolStateActor {
   sealed trait AssociationState
 
@@ -331,7 +331,7 @@ private[remote] object ProtocolStateActor {
       failureDetector).withDeploy(Deploy.local)
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] class ProtocolStateActor(
     initialData: InitialProtocolStateData,
     private val localHandshakeInfo: HandshakeInfo,

--- a/akka-remote/src/main/scala/akka/remote/transport/FailureInjectorTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/FailureInjectorTransportAdapter.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ Future, Promise }
 import scala.util.control.NoStackTrace
 
 import FailureInjectorTransportAdapter._
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.AkkaException
 import akka.actor.{ Address, ExtendedActorSystem }
@@ -61,7 +61,7 @@ private[remote] object FailureInjectorTransportAdapter {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] class FailureInjectorTransportAdapter(
     wrappedTransport: Transport,
     val extendedSystem: ExtendedActorSystem)
@@ -162,7 +162,7 @@ private[remote] class FailureInjectorTransportAdapter(
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] final case class FailureInjectorHandle(
     _wrappedHandle: AssociationHandle,
     private val gremlinAdapter: FailureInjectorTransportAdapter)
@@ -189,7 +189,7 @@ private[remote] final case class FailureInjectorHandle(
   @deprecated(
     message = "Use method that states reasons to make sure disassociation reasons are logged.",
     since = "2.5.3")
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   override def disassociate(): Unit =
     wrappedHandle.disassociate()
 

--- a/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/ThrottlerTransportAdapter.scala
@@ -15,7 +15,7 @@ import scala.math.min
 import scala.util.{ Failure, Success }
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor._
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
@@ -235,7 +235,7 @@ class ThrottlerTransportAdapter(_wrappedTransport: Transport, _system: ExtendedA
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[transport] object ThrottlerManager {
   final case class Checkin(origin: Address, handle: ThrottlerHandle) extends NoSerializationVerificationNeeded
 
@@ -253,7 +253,7 @@ private[transport] object ThrottlerManager {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[transport] class ThrottlerManager(wrappedTransport: Transport)
     extends ActorTransportAdapterManager
     with ActorLogging {
@@ -352,7 +352,7 @@ private[transport] class ThrottlerManager(wrappedTransport: Transport)
   }
 
   // silent because of use of isTerminated
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   private def askModeWithDeathCompletion(target: ActorRef, mode: ThrottleMode)(
       implicit timeout: Timeout): Future[SetThrottleAck.type] = {
     if (target.isTerminated) Future.successful(SetThrottleAck)
@@ -424,7 +424,7 @@ private[transport] object ThrottledAssociation {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[transport] class ThrottledAssociation(
     val manager: ActorRef,
     val associationHandler: AssociationEventListener,
@@ -588,7 +588,7 @@ private[transport] class ThrottledAssociation(
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[transport] final case class ThrottlerHandle(_wrappedHandle: AssociationHandle, throttlerActor: ActorRef)
     extends AbstractTransportAdapterHandle(_wrappedHandle, SchemeIdentifier) {
 

--- a/akka-remote/src/main/scala/akka/remote/transport/Transport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/Transport.scala
@@ -7,7 +7,7 @@ package akka.remote.transport
 import scala.concurrent.{ Future, Promise }
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.AkkaException
 import akka.actor.{ ActorRef, Address, NoSerializationVerificationNeeded }
@@ -284,7 +284,7 @@ trait AssociationHandle {
    * be notified, but this is not guaranteed. The Transport that provides the handle MUST guarantee that disassociate()
    * could be called arbitrarily many times.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def disassociate(reason: String, log: LoggingAdapter): Unit = {
     if (log.isDebugEnabled)
       log.debug(

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettySSLSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettySSLSupport.scala
@@ -4,7 +4,7 @@
 
 package akka.remote.transport.netty
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 import org.jboss.netty.handler.ssl.SslHandler
 
@@ -44,7 +44,7 @@ private[akka] class SSLSettings(config: Config) {
  * The `SSLEngine` is created via the configured [[SSLEngineProvider]].
  */
 @ccompatUsedUntil213
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[akka] object NettySSLSupport {
 
   /**

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/NettyTransport.scala
@@ -21,7 +21,7 @@ import scala.util.Try
 import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 import org.jboss.netty.bootstrap.Bootstrap
 import org.jboss.netty.bootstrap.ClientBootstrap
@@ -170,7 +170,7 @@ class NettyTransportSettings(config: Config) {
   val PortSelector: Int = getInt("port")
 
   @deprecated("WARNING: This should only be used by professionals.", "2.4")
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   val BindPortSelector: Int = getString("bind-port") match {
     case ""    => PortSelector
     case value => value.toInt
@@ -213,7 +213,7 @@ class NettyTransportSettings(config: Config) {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[netty] trait CommonHandlers extends NettyHelpers {
   protected val transport: NettyTransport
 
@@ -256,7 +256,7 @@ private[netty] trait CommonHandlers extends NettyHelpers {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[netty] abstract class ServerHandler(
     protected final val transport: NettyTransport,
     private final val associationListenerFuture: Future[AssociationEventListener])
@@ -288,7 +288,7 @@ private[netty] abstract class ServerHandler(
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[netty] abstract class ClientHandler(protected final val transport: NettyTransport, remoteAddress: Address)
     extends NettyClientHelpers
     with CommonHandlers {
@@ -498,7 +498,7 @@ class NettyTransport(val settings: NettyTransportSettings, val system: ExtendedA
   }
 
   override def listen: Future[(Address, Promise[AssociationEventListener])] = {
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     val bindPort = settings.BindPortSelector
 
     for {
@@ -516,7 +516,7 @@ class NettyTransport(val settings: NettyTransportSettings, val system: ExtendedA
 
         serverChannel = newServerChannel
 
-        @silent("deprecated")
+        @nowarn("msg=deprecated")
         val port = if (settings.PortSelector == 0) None else Some(settings.PortSelector)
 
         addressFromSocketAddress(

--- a/akka-remote/src/main/scala/akka/remote/transport/netty/TcpSupport.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/netty/TcpSupport.scala
@@ -8,7 +8,7 @@ import java.net.InetSocketAddress
 
 import scala.concurrent.{ Future, Promise }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.jboss.netty.buffer.{ ChannelBuffer, ChannelBuffers }
 import org.jboss.netty.channel._
 
@@ -30,7 +30,7 @@ private[remote] object ChannelLocalActor extends ChannelLocal[Option[HandleEvent
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] trait TcpHandlers extends CommonHandlers {
   protected def log: LoggingAdapter
 
@@ -66,7 +66,7 @@ private[remote] trait TcpHandlers extends CommonHandlers {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] class TcpServerHandler(
     _transport: NettyTransport,
     _associationListenerFuture: Future[AssociationEventListener],
@@ -82,7 +82,7 @@ private[remote] class TcpServerHandler(
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] class TcpClientHandler(_transport: NettyTransport, remoteAddress: Address, val log: LoggingAdapter)
     extends ClientHandler(_transport, remoteAddress)
     with TcpHandlers {
@@ -95,7 +95,7 @@ private[remote] class TcpClientHandler(_transport: NettyTransport, remoteAddress
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 private[remote] class TcpAssociationHandle(
     val localAddress: Address,
     val remoteAddress: Address,

--- a/akka-remote/src/test/scala/akka/remote/AccrualFailureDetectorSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/AccrualFailureDetectorSpec.scala
@@ -7,12 +7,12 @@ package akka.remote
 import scala.collection.immutable.TreeMap
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.remote.FailureDetector.Clock
 import akka.testkit.AkkaSpec
 
-@silent
+@nowarn
 class AccrualFailureDetectorSpec extends AkkaSpec("akka.loglevel = INFO") {
 
   "An AccrualFailureDetector" must {

--- a/akka-remote/src/test/scala/akka/remote/AckedDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/AckedDeliverySpec.scala
@@ -8,11 +8,11 @@ import java.util.concurrent.ThreadLocalRandom
 
 import scala.annotation.tailrec
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.testkit.AkkaSpec
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 object AckedDeliverySpec {
 
   final case class Sequenced(seq: SeqNo, body: String) extends HasSequenceNumber {
@@ -21,7 +21,7 @@ object AckedDeliverySpec {
 
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class AckedDeliverySpec extends AkkaSpec {
   import AckedDeliverySpec._
 

--- a/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteConfigSpec.scala
@@ -6,7 +6,7 @@ package akka.remote
 
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import language.postfixOps
 
 import akka.remote.transport.AkkaProtocolSettings
@@ -15,7 +15,7 @@ import akka.testkit.AkkaSpec
 import akka.util.Helpers
 import akka.util.Helpers.ConfigOps
 
-@silent // classic deprecated
+@nowarn // classic deprecated
 class RemoteConfigSpec extends AkkaSpec("""
     akka.actor.provider = remote
     akka.remote.classic.netty.tcp.port = 0

--- a/akka-remote/src/test/scala/akka/remote/RemoteFeaturesSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteFeaturesSpec.scala
@@ -6,7 +6,7 @@ package akka.remote
 
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
@@ -57,7 +57,7 @@ abstract class RemoteFeaturesSpec(c: Config) extends ArteryMultiNodeSpec(c) with
 
   protected val remoteSystem1 = newRemoteSystem(name = Some("RS1"), extraConfig = Some(common(useUnsafe)))
 
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   private def mute(): Unit = {
     Seq(system, remoteSystem1).foreach(
       muteDeadLetters(

--- a/akka-remote/src/test/scala/akka/remote/Ticket1978CommunicationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/Ticket1978CommunicationSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import scala.reflect.classTag
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config._
 
 import akka.actor._
@@ -24,7 +24,7 @@ import akka.remote.transport.netty.SSLSettings
 import akka.testkit._
 import akka.util.Timeout
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 object Configuration {
   // set this in your JAVA_OPTS to see all ssl debug info: "-Djavax.net.debug=ssl,keymanager"
   // The certificate will expire in 2109
@@ -124,7 +124,7 @@ class Ticket1978CrappyRSAWithMD5OnlyHereToMakeSureThingsWorkSpec
 class Ticket1978NonExistingRNGSecureSpec
     extends Ticket1978CommunicationSpec(CipherConfig(false, AkkaSpec.testConf, "NonExistingRNG", 12345, 12346, None))
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 abstract class Ticket1978CommunicationSpec(val cipherConfig: CipherConfig)
     extends AkkaSpec(cipherConfig.config)
     with ImplicitSender {

--- a/akka-remote/src/test/scala/akka/remote/TypedActorRemoteDeploySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/TypedActorRemoteDeploySpec.scala
@@ -8,7 +8,7 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
 import TypedActorRemoteDeploySpec._
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config._
 
 import akka.actor.{ ActorSystem, Deploy, TypedActor, TypedProps }
@@ -29,10 +29,10 @@ object TypedActorRemoteDeploySpec {
   }
 
   class RemoteNameServiceImpl extends RemoteNameService {
-    @silent
+    @nowarn
     def getName: Future[String] = Future.successful(TypedActor.context.system.name)
 
-    @silent
+    @nowarn
     def getNameSelfDeref: Future[String] = TypedActor.self[RemoteNameService].getName
   }
 
@@ -43,7 +43,7 @@ class TypedActorRemoteDeploySpec extends AkkaSpec(conf) {
   val remoteSystem = ActorSystem(remoteName, conf)
   val remoteAddress = RARP(remoteSystem).provider.getDefaultAddress
 
-  @silent
+  @nowarn
   def verify[T](f: RemoteNameService => Future[T], expected: T) = {
     val ts = TypedActor(system)
     val echoService: RemoteNameService =

--- a/akka-remote/src/test/scala/akka/remote/artery/LruBoundedCacheSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/LruBoundedCacheSpec.scala
@@ -6,12 +6,12 @@ package akka.remote.artery
 
 import scala.util.Random
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.testkit.AkkaSpec
 import akka.util.Unsafe
 
-@silent
+@nowarn
 class LruBoundedCacheSpec extends AkkaSpec {
 
   class TestCache(_capacity: Int, threshold: Int, hashSeed: String = "")

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteDeathWatchSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteDeathWatchSpec.scala
@@ -6,7 +6,7 @@ package akka.remote.artery
 
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.actor._
@@ -86,7 +86,7 @@ class RemoteDeathWatchSpec
     val path = RootActorPath(Address("akka", system.name, "unknownhost", 2552)) / "user" / "subject"
 
     system.actorOf(Props(new Actor {
-      @silent
+      @nowarn
       val watchee = RARP(context.system).provider.resolveActorRef(path)
       context.watch(watchee)
 

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteMessageSerializationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteMessageSerializationSpec.scala
@@ -8,7 +8,7 @@ import java.io.NotSerializableException
 import java.util.concurrent.ThreadLocalRandom
 
 import scala.concurrent.duration._
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import akka.actor.{ Actor, ActorRef, Dropped, PoisonPill, Props }
 import akka.remote.{ AssociationErrorEvent, DisassociatedEvent, OversizedPayloadException, RARP }
 import akka.testkit.{ EventFilter, ImplicitSender, TestActors, TestProbe }
@@ -93,7 +93,7 @@ class RemoteMessageSerializationSpec extends ArteryMultiNodeSpec with ImplicitSe
         case x      => sender() ! x
       }
     }), bigBounceId)
-    @silent
+    @nowarn
     val bigBounceHere =
       RARP(system).provider.resolveActorRef(s"akka://${remoteSystem.name}@localhost:$remotePort/user/$bigBounceId")
 

--- a/akka-remote/src/test/scala/akka/remote/classic/ActorsLeakSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/ActorsLeakSpec.scala
@@ -10,7 +10,7 @@ import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.actor._
@@ -131,7 +131,7 @@ class ActorsLeakSpec extends AkkaSpec(ActorsLeakSpec.config) with ImplicitSender
           val beforeQuarantineActors = targets.flatMap(collectLiveActors).toSet
 
           // it must not quarantine the current connection
-          @silent
+          @nowarn
           val addressUid = AddressUidExtension(remoteSystem).addressUid + 1
           RARP(system).provider.transport.quarantine(remoteAddress, Some(addressUid), "test")
 

--- a/akka-remote/src/test/scala/akka/remote/classic/RemoteDeathWatchSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/RemoteDeathWatchSpec.scala
@@ -6,7 +6,7 @@ package akka.remote.classic
 
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.actor.{ RootActorPath, _ }
@@ -14,7 +14,7 @@ import akka.event.Logging.Warning
 import akka.remote.{ QuarantinedEvent, RARP, RemoteActorRef }
 import akka.testkit.{ SocketUtil, _ }
 
-@silent // classic deprecated
+@nowarn // classic deprecated
 class RemoteDeathWatchSpec
     extends AkkaSpec(ConfigFactory.parseString("""
 akka {
@@ -94,7 +94,7 @@ akka.actor.warn-about-java-serializer-usage = off
     val path = RootActorPath(Address(protocol, system.name, "unknownhost", 2552)) / "user" / "subject"
 
     system.actorOf(Props(new Actor {
-      @silent
+      @nowarn
       val watchee = RARP(context.system).provider.resolveActorRef(path)
       context.watch(watchee)
 

--- a/akka-remote/src/test/scala/akka/remote/classic/RemoteDeploymentAllowListSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/RemoteDeploymentAllowListSpec.scala
@@ -5,7 +5,7 @@
 package akka.remote.classic
 
 import scala.concurrent.duration._
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config._
 import akka.actor._
 import akka.remote.EndpointException
@@ -104,7 +104,7 @@ object RemoteDeploymentAllowListSpec {
   }
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class RemoteDeploymentAllowListSpec
     extends AkkaSpec(RemoteDeploymentAllowListSpec.cfg)
     with ImplicitSender

--- a/akka-remote/src/test/scala/akka/remote/classic/RemoteSettingsSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/RemoteSettingsSpec.scala
@@ -4,14 +4,14 @@
 
 package akka.remote.classic
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import akka.remote.RemoteSettings
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class RemoteSettingsSpec extends AnyWordSpec with Matchers {
 
   "Remote settings" must {

--- a/akka-remote/src/test/scala/akka/remote/classic/RemoteWatcherSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/RemoteWatcherSpec.scala
@@ -7,7 +7,7 @@ package akka.remote.classic
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor._
 import akka.remote._
@@ -68,7 +68,7 @@ object RemoteWatcherSpec {
 
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class RemoteWatcherSpec extends AkkaSpec("""
      akka {
        loglevel = INFO
@@ -93,7 +93,7 @@ class RemoteWatcherSpec extends AkkaSpec("""
 
   val remoteSystem = ActorSystem("RemoteSystem", system.settings.config)
   val remoteAddress = remoteSystem.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
-  @silent
+  @nowarn
   def remoteAddressUid = AddressUidExtension(remoteSystem).addressUid
 
   Seq(system, remoteSystem).foreach(

--- a/akka-remote/src/test/scala/akka/remote/classic/RemotingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/RemotingSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config._
 
 import akka.actor._
@@ -134,7 +134,7 @@ object RemotingSpec {
   }
 }
 
-@silent
+@nowarn
 class RemotingSpec extends AkkaSpec(RemotingSpec.cfg) with ImplicitSender with DefaultTimeout {
 
   import RemotingSpec._

--- a/akka-remote/src/test/scala/akka/remote/classic/transport/AkkaProtocolSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/transport/AkkaProtocolSpec.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeoutException
 import scala.concurrent.{ Await, Promise }
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.actor.Address
@@ -44,7 +44,7 @@ object AkkaProtocolSpec {
 
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class AkkaProtocolSpec extends AkkaSpec("""akka.actor.provider = remote """) with ImplicitSender {
 
   val conf = ConfigFactory.parseString("""

--- a/akka-remote/src/test/scala/akka/remote/classic/transport/GenericTransportSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/transport/GenericTransportSpec.scala
@@ -6,7 +6,7 @@ package akka.remote.classic.transport
 
 import scala.concurrent.{ Await, Future }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.{ Address, ExtendedActorSystem }
 import akka.remote.RemoteActorRefProvider
@@ -17,7 +17,7 @@ import akka.remote.transport.Transport._
 import akka.testkit.{ AkkaSpec, DefaultTimeout, ImplicitSender }
 import akka.util.ByteString
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 abstract class GenericTransportSpec(withAkkaProtocol: Boolean = false)
     extends AkkaSpec("""
          akka.remote.artery.enabled = false

--- a/akka-remote/src/test/scala/akka/remote/classic/transport/SystemMessageDeliveryStressTest.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/transport/SystemMessageDeliveryStressTest.scala
@@ -7,7 +7,7 @@ package akka.remote.classic.transport
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.{ Config, ConfigFactory }
 
 import akka.actor.{ Actor, ActorRef, ActorSystem, ExtendedActorSystem, Props, RootActorPath, _ }
@@ -102,7 +102,7 @@ object SystemMessageDeliveryStressTest {
 
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 abstract class SystemMessageDeliveryStressTest(msg: String, cfg: String)
     extends AkkaSpec(ConfigFactory.parseString(cfg).withFallback(SystemMessageDeliveryStressTest.baseConfig))
     with ImplicitSender

--- a/akka-remote/src/test/scala/akka/remote/classic/transport/TestTransportSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/transport/TestTransportSpec.scala
@@ -6,7 +6,7 @@ package akka.remote.classic.transport
 
 import scala.concurrent._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.Address
 import akka.remote.transport.{ AssociationHandle, TestTransport }
@@ -16,7 +16,7 @@ import akka.remote.transport.Transport._
 import akka.testkit._
 import akka.util.ByteString
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class TestTransportSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
 
   val addressA: Address = Address("test", "testsytemA", "testhostA", 4321)

--- a/akka-remote/src/test/scala/akka/remote/classic/transport/ThrottlerTransportAdapterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/transport/ThrottlerTransportAdapterSpec.scala
@@ -7,7 +7,7 @@ package akka.remote.classic.transport
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.{ Config, ConfigFactory }
 
 import akka.actor._
@@ -74,7 +74,7 @@ object ThrottlerTransportAdapterSpec {
   final case class Lost(msg: String)
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class ThrottlerTransportAdapterSpec extends AkkaSpec(configA) with ImplicitSender with DefaultTimeout {
 
   val systemB = ActorSystem("systemB", system.settings.config)
@@ -161,7 +161,7 @@ class ThrottlerTransportAdapterSpec extends AkkaSpec(configA) with ImplicitSende
   override def afterTermination(): Unit = shutdown(systemB)
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class ThrottlerTransportAdapterGenericSpec extends GenericTransportSpec(withAkkaProtocol = true) {
 
   def transportName = "ThrottlerTransportAdapter"

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.databind.exc.InvalidTypeIdException
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.scala.JsonScalaEnumeration
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
@@ -164,7 +164,7 @@ class JacksonCborSerializerSpec extends JacksonSerializerSpec("jackson-cbor") {
   }
 }
 
-@silent // this test uses Jackson deprecated APIs
+@nowarn // this test uses Jackson deprecated APIs
 class JacksonJsonSerializerSpec extends JacksonSerializerSpec("jackson-json") {
 
   def serializeToJsonString(obj: AnyRef, sys: ActorSystem = system): String = {

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/scaladsl/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/scaladsl/StreamTestKit.scala
@@ -102,7 +102,7 @@ object StreamTestKit {
         .append(logic.attributes.attributeList.mkString(", "))
         .append("],\n")
     }
-    builder.setLength(builder.length() - 2)
+    builder.setLength(builder.length - 2)
     shell match {
       case running: RunningInterpreter =>
         builder.append("\n  ],\n  connections: [\n")
@@ -119,7 +119,7 @@ object StreamTestKit {
             .append(connection.state)
             .append(")\n")
         }
-        builder.setLength(builder.length() - 2)
+        builder.setLength(builder.length - 2)
 
       case _ =>
     }

--- a/akka-stream-testkit/src/test/scala/akka/stream/impl/fusing/GraphInterpreterSpecKit.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/impl/fusing/GraphInterpreterSpecKit.scala
@@ -8,7 +8,7 @@ import scala.collection.{ Map => SMap }
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.FiniteDuration
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.ActorSystem
 import akka.actor.Cancellable
@@ -79,7 +79,7 @@ private[akka] object NoMaterializer extends Materializer {
     throw new UnsupportedOperationException("NoMaterializer does not have settings")
 }
 
-@silent
+@nowarn
 object GraphInterpreterSpecKit {
 
   /**
@@ -101,7 +101,7 @@ object GraphInterpreterSpecKit {
     if (attributes.nonEmpty && attributes.length != stages.length)
       throw new IllegalArgumentException("Attributes must be either empty or one per stage")
 
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     val defaultAttributes = ActorMaterializerSettings(system).toAttributes
 
     var inOwners = SMap.empty[Inlet[_], GraphStageLogic]
@@ -251,7 +251,7 @@ trait GraphInterpreterSpecKit extends StreamSpec {
 
   import GraphInterpreterSpecKit._
   val logger = Logging(system, "InterpreterSpecKit")
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   val defaultAttributes = ActorMaterializerSettings(system).toAttributes
 
   abstract class Builder {

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/ChainSetup.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/ChainSetup.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.testkit
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.reactivestreams.Publisher
 
 import akka.NotUsed
@@ -21,14 +21,14 @@ class ChainSetup[In, Out, M](
     materializer: Materializer,
     toPublisher: (Source[Out, _], Materializer) => Publisher[Out])(implicit val system: ActorSystem) {
 
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def this(
       stream: Flow[In, In, NotUsed] => Flow[In, Out, M],
       settings: ActorMaterializerSettings,
       toPublisher: (Source[Out, _], Materializer) => Publisher[Out])(implicit system: ActorSystem) =
     this(stream, settings, ActorMaterializer(settings)(system), toPublisher)(system)
 
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def this(
       stream: Flow[In, In, NotUsed] => Flow[In, Out, M],
       settings: ActorMaterializerSettings,

--- a/akka-stream-testkit/src/test/scala/akka/stream/testkit/ScriptedTest.scala
+++ b/akka-stream-testkit/src/test/scala/akka/stream/testkit/ScriptedTest.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.ThreadLocalRandom
 import scala.annotation.tailrec
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.reactivestreams.Publisher
 import org.scalatest.matchers.should.Matchers
 
@@ -235,7 +235,7 @@ trait ScriptedTest extends Matchers {
 
   }
 
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def runScript[In, Out, M](script: Script[In, Out])(op: Flow[In, In, NotUsed] => Flow[In, Out, M])(
       implicit system: ActorSystem): Unit =
     runScript(script, SystemMaterializer(system).materializer.settings)(op)(system)

--- a/akka-stream-tests/src/test/scala/akka/stream/ActorMaterializerSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/ActorMaterializerSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{ Failure, Try }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.Done
@@ -32,7 +32,7 @@ object IndirectMaterializerCreation extends ExtensionId[IndirectMaterializerCrea
   def lookup: ExtensionId[IndirectMaterializerCreation] = this
 }
 
-@silent
+@nowarn
 class IndirectMaterializerCreation(ex: ExtendedActorSystem) extends Extension {
   // extension instantiation blocked on materializer (which has Await.result inside)
   implicit val mat: ActorMaterializer = ActorMaterializer()(ex)
@@ -43,7 +43,7 @@ class IndirectMaterializerCreation(ex: ExtendedActorSystem) extends Extension {
 
 }
 
-@silent
+@nowarn
 class ActorMaterializerSpec extends StreamSpec with ImplicitSender {
 
   "ActorMaterializer" must {
@@ -157,7 +157,7 @@ class ActorMaterializerSpec extends StreamSpec with ImplicitSender {
 
 object ActorMaterializerSpec {
 
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   class ActorWithMaterializer(p: TestProbe) extends Actor {
     private val settings: ActorMaterializerSettings =
       ActorMaterializerSettings(context.system).withDispatcher("akka.test.stream-dispatcher")

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/FixedBufferSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/FixedBufferSpec.scala
@@ -4,14 +4,14 @@
 
 package akka.stream.impl
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.stream.ActorAttributes
 import akka.stream.ActorAttributes.MaxFixedBufferSize
 import akka.stream.ActorMaterializerSettings
 import akka.stream.testkit.StreamSpec
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class FixedBufferSpec extends StreamSpec {
 
   for (size <- List(1, 3, 4)) {

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/fusing/InterpreterSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.impl.fusing
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.stream._
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
@@ -536,7 +536,7 @@ class InterpreterSpec extends StreamSpec with GraphInterpreterSpecKit {
 
   }
 
-  @silent
+  @nowarn
   private[akka] final case class Doubler[T]() extends SimpleLinearGraphStage[T] {
 
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
@@ -568,7 +568,7 @@ class InterpreterSpec extends StreamSpec with GraphInterpreterSpecKit {
 
   }
 
-  @silent
+  @nowarn
   private[akka] final case class KeepGoing[T]() extends SimpleLinearGraphStage[T] {
 
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =

--- a/akka-stream-tests/src/test/scala/akka/stream/io/DeprecatedTlsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/DeprecatedTlsSpec.scala
@@ -16,7 +16,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Random
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 
 import akka.NotUsed
@@ -97,7 +97,7 @@ object DeprecatedTlsSpec {
     """
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class DeprecatedTlsSpec extends StreamSpec(DeprecatedTlsSpec.configOverrides) with WithLogCapturing {
   import DeprecatedTlsSpec._
   import GraphDSL.Implicits._

--- a/akka-stream-tests/src/test/scala/akka/stream/io/FileSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/FileSinkSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import scala.util.Success
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.google.common.jimfs.{ Configuration, Jimfs }
 import org.scalatest.concurrent.ScalaFutures
 
@@ -26,7 +26,7 @@ import akka.stream.testkit.Utils._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.util.ByteString
 
-@silent
+@nowarn
 class FileSinkSpec extends StreamSpec(UnboundedMailboxConfig) with ScalaFutures {
 
   val settings = ActorMaterializerSettings(system).withDispatcher("akka.actor.default-dispatcher")

--- a/akka-stream-tests/src/test/scala/akka/stream/io/FileSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/FileSourceSpec.scala
@@ -11,7 +11,7 @@ import java.util.Random
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.google.common.jimfs.{ Configuration, Jimfs }
 
 import akka.actor.ActorSystem
@@ -31,7 +31,7 @@ object FileSourceSpec {
   final case class Settings(chunkSize: Int, readAhead: Int)
 }
 
-@silent
+@nowarn
 class FileSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
 
   val settings = ActorMaterializerSettings(system).withDispatcher("akka.actor.default-dispatcher")

--- a/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/InputStreamSourceSpec.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.CountDownLatch
 
 import scala.util.Success
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.Done
 import akka.stream.{ AbruptStageTerminationException, ActorMaterializer, ActorMaterializerSettings, IOResult }
@@ -20,7 +20,7 @@ import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.scaladsl.TestSink
 import akka.util.ByteString
 
-@silent
+@nowarn
 class InputStreamSourceSpec extends StreamSpec(UnboundedMailboxConfig) {
 
   val settings = ActorMaterializerSettings(system).withDispatcher("akka.actor.default-dispatcher")

--- a/akka-stream-tests/src/test/scala/akka/stream/io/OutputStreamSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/OutputStreamSinkSpec.scala
@@ -8,7 +8,7 @@ import java.io.OutputStream
 
 import scala.util.Success
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.scalatest.concurrent.ScalaFutures
 
 import akka.Done
@@ -20,7 +20,7 @@ import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.testkit.TestProbe
 import akka.util.ByteString
 
-@silent
+@nowarn
 class OutputStreamSinkSpec extends StreamSpec(UnboundedMailboxConfig) with ScalaFutures {
 
   val settings = ActorMaterializerSettings(system).withDispatcher("akka.actor.default-dispatcher")

--- a/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/io/TcpSpec.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.PatienceConfiguration
@@ -50,7 +50,7 @@ import akka.testkit.TestProbe
 import akka.testkit.WithLogCapturing
 import akka.util.ByteString
 
-@silent("never used")
+@nowarn("msg=never used")
 class NonResolvingDnsActor(cache: SimpleDnsCache, config: Config) extends Actor {
   def receive = {
     case msg =>
@@ -58,7 +58,7 @@ class NonResolvingDnsActor(cache: SimpleDnsCache, config: Config) extends Actor 
   }
 }
 
-@silent("never used")
+@nowarn("msg=never used")
 class NonResolvingDnsManager(ext: akka.io.DnsExt) extends Actor {
 
   def receive = {
@@ -67,7 +67,7 @@ class NonResolvingDnsManager(ext: akka.io.DnsExt) extends Actor {
   }
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class FailingDnsResolver extends DnsProvider {
   override val cache: Dns = new Dns {
     override def cached(name: String): Option[Dns.Resolved] = None
@@ -968,7 +968,7 @@ class TcpSpec extends StreamSpec("""
       test()
     }
 
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     def test(): Unit = {
       // cert is valid until 2025, so if this tests starts failing after that you need to create a new one
       val (sslContext, firstSession) = initSslMess()
@@ -1004,7 +1004,7 @@ class TcpSpec extends StreamSpec("""
       result.futureValue(PatienceConfiguration.Timeout(10.seconds)) should ===("hello")
     }
 
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     def initSslMess() = {
       // #setting-up-ssl-context
       import java.security.KeyStore

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/AttributesSpec.scala
@@ -6,7 +6,7 @@ package akka.stream.scaladsl
 
 import java.util.concurrent.{ CompletionStage, TimeUnit }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 
 import akka.{ Done, NotUsed }
@@ -104,7 +104,7 @@ object AttributesSpec {
   case class WhateverAttribute(label: String) extends Attribute
 }
 
-@silent // tests deprecated APIs
+@nowarn // tests deprecated APIs
 class AttributesSpec
     extends StreamSpec(
       ConfigFactory

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/BidiFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/BidiFlowSpec.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.NotUsed
 import akka.stream._
@@ -16,7 +16,7 @@ import akka.stream.testkit.StreamSpec
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.util.ByteString
 
-@silent // tests deprecated APIs
+@nowarn // tests deprecated APIs
 class BidiFlowSpec extends StreamSpec {
   import Attributes._
   import GraphDSL.Implicits._

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowCompileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowCompileSpec.scala
@@ -7,13 +7,13 @@ package akka.stream.scaladsl
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.reactivestreams.Publisher
 
 import akka.NotUsed
 import akka.stream.testkit.StreamSpec
 
-@silent // unused vars are used in shouldNot compile tests
+@nowarn // unused vars are used in shouldNot compile tests
 class FlowCompileSpec extends StreamSpec {
 
   val intSeq = Source(Seq(1, 2, 3))

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDispatcherSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowDispatcherSpec.scala
@@ -4,14 +4,14 @@
 
 package akka.stream.scaladsl
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.stream.ActorMaterializer
 import akka.stream.ActorMaterializerSettings
 import akka.stream.testkit.StreamSpec
 import akka.testkit.TestProbe
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class FlowDispatcherSpec extends StreamSpec(s"my-dispatcher = $${akka.test.stream-dispatcher}") {
 
   val defaultSettings = ActorMaterializerSettings(system)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFromFutureSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFromFutureSpec.scala
@@ -9,12 +9,12 @@ import scala.concurrent.Promise
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 
-@silent("deprecated") // testing deprecated API
+@nowarn("msg=deprecated") // testing deprecated API
 class FlowFromFutureSpec extends StreamSpec {
 
   "A Flow based on a Future" must {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrefixAndTailSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrefixAndTailSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.stream._
 import akka.stream.testkit._
@@ -112,7 +112,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
     "signal error if substream has been not subscribed in time" in assertAllStagesStopped {
       val ms = 300
 
-      @silent("deprecated")
+      @nowarn("msg=deprecated")
       val tightTimeoutMaterializer =
         ActorMaterializer(
           ActorMaterializerSettings(system).withSubscriptionTimeoutSettings(
@@ -131,7 +131,7 @@ class FlowPrefixAndTailSpec extends StreamSpec("""
         s"Substream Source(TailSource) has not been materialized in ${ms} milliseconds")
     }
     "not fail the stream if substream has not been subscribed in time and configured subscription timeout is noop" in assertAllStagesStopped {
-      @silent("deprecated")
+      @nowarn("msg=deprecated")
       val tightTimeoutMaterializer =
         ActorMaterializer(
           ActorMaterializerSettings(system).withSubscriptionTimeoutSettings(

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrependSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrependSpec.scala
@@ -5,9 +5,9 @@
 package akka.stream.scaladsl
 
 import akka.testkit.AkkaSpec
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
-@silent // for keeping imports
+@nowarn // for keeping imports
 class FlowPrependSpec extends AkkaSpec {
 
 //#prepend

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowRecoverWithSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowRecoverWithSpec.scala
@@ -6,7 +6,7 @@ package akka.stream.scaladsl
 
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.stream._
 import akka.stream.stage.{ GraphStage, GraphStageLogic }
@@ -15,7 +15,7 @@ import akka.stream.testkit.Utils._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.scaladsl.TestSink
 
-@silent // tests deprecated APIs
+@nowarn // tests deprecated APIs
 class FlowRecoverWithSpec extends StreamSpec {
 
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 1, maxSize = 1)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSlidingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSlidingSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.scaladsl
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
@@ -13,7 +13,7 @@ import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 
-@silent
+@nowarn
 class FlowSlidingSpec extends StreamSpec with ScalaCheckPropertyChecks {
   import system.dispatcher
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 2, maxSize = 16)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 import org.reactivestreams.{ Publisher, Subscriber }
 
@@ -35,7 +35,7 @@ object FlowSpec {
 
 }
 
-@silent // tests type assignments compile
+@nowarn // tests type assignments compile
 class FlowSpec extends StreamSpec(ConfigFactory.parseString("akka.actor.debug.receive=off\nakka.loglevel=INFO")) {
   import FlowSpec._
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipSpec.scala
@@ -6,10 +6,10 @@ package akka.stream.scaladsl
 
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.{ BaseTwoStreamsSetup, TestSubscriber }
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.reactivestreams.Publisher
 
-@silent // keep unused imports
+@nowarn // keep unused imports
 class FlowZipSpec extends BaseTwoStreamsSetup {
 
 //#zip

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipWithIndexSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipWithIndexSpec.scala
@@ -7,9 +7,9 @@ package akka.stream.scaladsl
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.{ ActorMaterializer, ActorMaterializerSettings, Materializer }
 import akka.stream.testkit.{ StreamSpec, TestSubscriber }
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
-@silent // keep unused imports
+@nowarn // keep unused imports
 class FlowZipWithIndexSpec extends StreamSpec {
 
 //#zip-with-index

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipWithSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowZipWithSpec.scala
@@ -9,9 +9,9 @@ import org.reactivestreams.Publisher
 
 import scala.concurrent.duration._
 import akka.testkit.EventFilter
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
-@silent // keep unused imports
+@nowarn // keep unused imports
 class FlowZipWithSpec extends BaseTwoStreamsSetup {
 
 //#zip-with

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBackedFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphBackedFlowSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.scaladsl
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.reactivestreams.Subscriber
 
 import akka.stream._
@@ -38,7 +38,7 @@ object GraphFlowSpec {
   val stdResult = Set(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 }
 
-@silent
+@nowarn
 class GraphFlowSpec extends StreamSpec {
 
   import GraphFlowSpec._

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphDSLCompileSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphDSLCompileSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.scaladsl
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.NotUsed
 import akka.stream._
@@ -17,7 +17,7 @@ object GraphDSLCompileSpec {
   class Apple extends Fruit
 }
 
-@silent // tests deprecated APIs
+@nowarn // tests deprecated APIs
 class GraphDSLCompileSpec extends StreamSpec {
   import GraphDSLCompileSpec._
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergePreferredSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergePreferredSpec.scala
@@ -7,12 +7,12 @@ package akka.stream.scaladsl
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.stream._
 import akka.stream.testkit.TwoStreamsSetup
 
-@silent // stream usage
+@nowarn // stream usage
 class GraphMergePreferredSpec extends TwoStreamsSetup {
   import GraphDSL.Implicits._
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphMergeSortedSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.scaladsl
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.scalacheck.Gen
 import org.scalacheck.Shrink
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -12,7 +12,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import akka.stream._
 import akka.stream.testkit.TwoStreamsSetup
 
-@silent // tests deprecated apis
+@nowarn // tests deprecated apis
 class GraphMergeSortedSpec extends TwoStreamsSetup with ScalaCheckPropertyChecks {
 
   override type Outputs = Int

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LazilyAsyncSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LazilyAsyncSpec.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.concurrent.Future
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.scalatest.concurrent.ScalaFutures
 
 import akka.Done
@@ -17,7 +17,7 @@ import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.testkit.DefaultTimeout
 
-@silent("deprecated") // tests deprecated methods
+@nowarn("msg=deprecated") // tests deprecated methods
 class LazilyAsyncSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
 
   import system.dispatcher

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LazyFlowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LazyFlowSpec.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import akka.{ Done, NotUsed }
 import akka.stream.AbruptStageTerminationException
 import akka.stream.Materializer
@@ -21,7 +21,7 @@ import akka.stream.testkit.scaladsl.TestSink
 import akka.stream.testkit.scaladsl.TestSource
 import akka.testkit.TestProbe
 
-@silent("deprecated") // tests deprecated API as well
+@nowarn("msg=deprecated") // tests deprecated API as well
 class LazyFlowSpec extends StreamSpec("""
     akka.stream.materializer.initial-input-buffer-size = 1
     akka.stream.materializer.max-input-buffer-size = 1

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LazySinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LazySinkSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.NotUsed
 import akka.stream._
@@ -25,7 +25,7 @@ import akka.stream.testkit.Utils._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.scaladsl.TestSink
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class LazySinkSpec extends StreamSpec("""
     akka.stream.materializer.initial-input-buffer-size = 1
     akka.stream.materializer.max-input-buffer-size = 1

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
@@ -4,12 +4,12 @@
 
 package akka.stream.scaladsl
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.NotUsed
 import akka.stream.testkit.StreamSpec
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 class SetupSpec extends StreamSpec {
 
   import system.dispatcher

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkForeachParallelSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkForeachParallelSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.stream.ActorAttributes._
 import akka.stream.Supervision._
@@ -20,7 +20,7 @@ import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.testkit.TestLatch
 import akka.testkit.TestProbe
 
-@silent // tests deprecated APIs
+@nowarn // tests deprecated APIs
 class SinkForeachParallelSpec extends StreamSpec {
 
   "A ForeachParallel" must {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkSpec.scala
@@ -7,7 +7,7 @@ package akka.stream.scaladsl
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.reactivestreams.Publisher
 import org.scalatest.concurrent.ScalaFutures
 
@@ -154,7 +154,7 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
       val s: Sink[Int, Future[Int]] = Sink.head[Int].async.addAttributes(none).named("name")
 
       s.traversalBuilder.attributes.filtered[Name] shouldEqual List(Name("name"), Name("headSink"))
-      @silent("deprecated")
+      @nowarn("msg=deprecated")
       val res = s.traversalBuilder.attributes.getFirst[Attributes.AsyncBoundary.type]
       res shouldEqual (Some(AsyncBoundary))
     }
@@ -177,7 +177,7 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
       import Attributes._
       val s: Sink[Int, Future[Int]] = Sink.head[Int].withAttributes(none).async
 
-      @silent("deprecated")
+      @nowarn("msg=deprecated")
       val res = s.traversalBuilder.attributes.getFirst[Name](Name("default"))
       res shouldEqual Name("default")
     }
@@ -192,7 +192,7 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
     "given multiple attributes of a class when getting first attribute with default value should get first attribute" in {
       import Attributes._
       val s: Sink[Int, Future[Int]] = Sink.head[Int].withAttributes(none).async.named("name").named("another_name")
-      @silent("deprecated")
+      @nowarn("msg=deprecated")
       val res = s.traversalBuilder.attributes.getFirst[Name](Name("default"))
       res shouldEqual Name("name")
     }
@@ -212,7 +212,7 @@ class SinkSpec extends StreamSpec with DefaultTimeout with ScalaFutures {
   "The ignore sink" should {
 
     "fail its materialized value on abrupt materializer termination" in {
-      @silent("deprecated")
+      @nowarn("msg=deprecated")
       val mat = ActorMaterializer()
 
       val matVal = Source.maybe[Int].runWith(Sink.ignore)(mat)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
@@ -7,7 +7,7 @@ package akka.stream.scaladsl
 import akka.Done
 import akka.stream.testkit.Utils.TE
 import akka.testkit.DefaultTimeout
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.scalatest.time.Millis
 import org.scalatest.time.Span
 
@@ -23,7 +23,7 @@ import akka.testkit.EventFilter
 
 import scala.collection.immutable
 
-@silent // tests assigning to typed val
+@nowarn // tests assigning to typed val
 class SourceSpec extends StreamSpec with DefaultTimeout {
 
   implicit val config: PatienceConfig = PatienceConfig(timeout = Span(timeout.duration.toMillis, Millis))

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/TakeLastSinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/TakeLastSinkSpec.scala
@@ -7,12 +7,12 @@ package akka.stream.scaladsl
 import scala.collection.immutable
 import scala.concurrent.{ Await, Future }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.stream.{ AbruptTerminationException, ActorMaterializer, ActorMaterializerSettings }
 import akka.stream.testkit.{ StreamSpec, TestPublisher }
 
-@silent
+@nowarn
 class TakeLastSinkSpec extends StreamSpec {
 
   val settings = ActorMaterializerSettings(system).withInputBuffer(initialSize = 2, maxSize = 16)

--- a/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
@@ -420,7 +420,7 @@ object ActorMaterializerSettings {
  *
  * The constructor is not public API, use create or apply on the [[ActorMaterializerSettings]] companion instead.
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 final class ActorMaterializerSettings @InternalApi private (
     /*
      * Important note: `initialInputBufferSize`, `maxInputBufferSize`, `dispatcher` and
@@ -803,7 +803,7 @@ object IOSettings {
     apply(tcpWriteBufferSize)
 }
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 final class IOSettings private (
     @deprecated("Use attribute 'TcpAttributes.TcpWriteBufferSize' to read the concrete setting value", "2.6.0")
     val tcpWriteBufferSize: Int) {
@@ -863,7 +863,7 @@ object StreamSubscriptionTimeoutSettings {
  * Leaked publishers and subscribers are cleaned up when they are not used within a given
  * deadline, configured by [[StreamSubscriptionTimeoutSettings]].
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 final class StreamSubscriptionTimeoutSettings(
     @deprecated(
       "Use attribute 'ActorAttributes.StreamSubscriptionTimeoutMode' to read the concrete setting value",

--- a/akka-stream/src/main/scala/akka/stream/IOResult.scala
+++ b/akka-stream/src/main/scala/akka/stream/IOResult.scala
@@ -7,7 +7,7 @@ package akka.stream
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.Done
 
@@ -17,7 +17,7 @@ import akka.Done
  * @param count Numeric value depending on context, for example IO operations performed or bytes processed.
  * @param status Status of the result. Can be either [[akka.Done]] or an exception.
  */
-@silent("deprecated") // Status
+@nowarn("msg=deprecated") // Status
 final case class IOResult(
     count: Long,
     @deprecated("status is always set to Success(Done)", "2.6.0") status: Try[Done]) {

--- a/akka-stream/src/main/scala/akka/stream/Materializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/Materializer.scala
@@ -7,7 +7,7 @@ package akka.stream
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.FiniteDuration
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
@@ -25,7 +25,7 @@ import akka.event.LoggingAdapter
  *
  * Not for user extension
  */
-@silent("deprecated") // Name(symbol) is deprecated but older Scala versions don't have a string signature, since "2.5.8"
+@nowarn("msg=deprecated") // Name(symbol) is deprecated but older Scala versions don't have a string signature, since "2.5.8"
 @DoNotInherit
 abstract class Materializer {
 
@@ -203,7 +203,7 @@ object Materializer {
    *
    * You can pass either a classic actor context or a typed actor context.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def apply(contextProvider: ClassicActorContextProvider): Materializer =
     ActorMaterializer(None, None)(contextProvider.classicActorContext)
 

--- a/akka-stream/src/main/scala/akka/stream/StreamRefSettings.scala
+++ b/akka-stream/src/main/scala/akka/stream/StreamRefSettings.scala
@@ -8,14 +8,14 @@ import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import akka.actor.ActorSystem
 import akka.annotation.DoNotInherit
 import akka.stream.impl.streamref.StreamRefSettingsImpl
 
-@silent("deprecated")
+@nowarn("msg=deprecated")
 object StreamRefSettings {
 
   /** Java API */
@@ -56,7 +56,7 @@ object StreamRefSettings {
  * More detailed documentation about each of the settings is available in `reference.conf`.
  */
 @DoNotInherit
-@silent("deprecated")
+@nowarn("msg=deprecated")
 trait StreamRefSettings {
   @deprecated("Use attribute 'StreamRefAttributes.BufferCapacity' to read the concrete setting value", "2.6.0")
   def bufferCapacity: Int

--- a/akka-stream/src/main/scala/akka/stream/SystemMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/SystemMaterializer.scala
@@ -7,7 +7,7 @@ package akka.stream
 import scala.concurrent.Await
 import scala.concurrent.Promise
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.ActorSystem
 import akka.actor.ClassicActorSystemProvider
@@ -46,13 +46,13 @@ final class SystemMaterializer(system: ExtendedActorSystem) extends Extension {
   /**
    * INTERNAL API
    */
-  @InternalApi @silent("deprecated")
+  @InternalApi @nowarn("msg=deprecated")
   private[akka] val materializerSettings = ActorMaterializerSettings(system)
 
   private implicit val materializerTimeout: Timeout =
     system.settings.config.getDuration("akka.stream.materializer.creation-timeout").asScala
 
-  @InternalApi @silent("deprecated")
+  @InternalApi @nowarn("msg=deprecated")
   private val materializerGuardian = system.systemActorOf(
     MaterializerGuardian
       .props(systemMaterializerPromise, materializerSettings)
@@ -75,7 +75,7 @@ final class SystemMaterializer(system: ExtendedActorSystem) extends Extension {
    * INTERNAL API
    */
   @InternalApi
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   private[akka] def createAdditionalLegacySystemMaterializer(
       namePrefix: String,
       settings: ActorMaterializerSettings): Materializer = {

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.immutable
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import akka.actor._
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
@@ -27,7 +27,7 @@ import akka.util.OptionVal
  *
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 @DoNotInherit private[akka] abstract class ExtendedActorMaterializer extends ActorMaterializer {
 
   override def withNamePrefix(name: String): ExtendedActorMaterializer
@@ -160,7 +160,7 @@ private[akka] class SubFusingActorMaterializerImpl(
   override private[akka] def actorOf(context: MaterializationContext, props: Props): ActorRef =
     delegate.actorOf(context, props)
 
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   override def settings: ActorMaterializerSettings = delegate.settings
 }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/MaterializerGuardian.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/MaterializerGuardian.scala
@@ -6,7 +6,7 @@ package akka.stream.impl
 
 import scala.concurrent.Promise
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor.Actor
 import akka.actor.Props
@@ -37,7 +37,7 @@ private[akka] object MaterializerGuardian {
 /**
  * INTERNAL API
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 @InternalApi
 private[akka] final class MaterializerGuardian(
     systemMaterializerPromise: Promise[Materializer],

--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -11,7 +11,7 @@ import scala.collection.immutable.Map
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.FiniteDuration
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.reactivestreams.Processor
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
@@ -610,7 +610,7 @@ private final case class SavedIslandData(
   /**
    * INTERNAL API
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   @InternalApi private[akka] override def actorOf(context: MaterializationContext, props: Props): ActorRef = {
     val effectiveProps = props.dispatcher match {
       case Dispatchers.DefaultDispatcherId =>

--- a/akka-stream/src/main/scala/akka/stream/impl/StreamSubscriptionTimeout.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/StreamSubscriptionTimeout.scala
@@ -7,7 +7,7 @@ package akka.stream.impl
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.reactivestreams._
 
 import akka.actor._
@@ -58,7 +58,7 @@ import akka.stream.StreamSubscriptionTimeoutTerminationMode.{ CancelTermination,
  *
  * See `akka.stream.materializer.subscription-timeout` for configuration options.
  */
-@silent("deprecated")
+@nowarn("msg=deprecated")
 @InternalApi private[akka] trait StreamSubscriptionTimeoutSupport {
   this: Actor with ActorLogging =>
 
@@ -114,7 +114,7 @@ import akka.stream.StreamSubscriptionTimeoutTerminationMode.{ CancelTermination,
   /**
    * Called by the actor when a subscription has timed out. Expects the actual `Publisher` or `Processor` target.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   protected def subscriptionTimedOut(target: Publisher[_]): Unit = subscriptionTimeoutSettings.mode match {
     case NoopTermination   => // ignore...
     case WarnTermination   => warn(target, subscriptionTimeoutSettings.timeout)

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -20,7 +20,7 @@ import akka.stream.scaladsl.{ DelayStrategy, Source }
 import akka.stream.stage._
 import akka.stream.{ Supervision, _ }
 import akka.util.{ unused, OptionVal }
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import scala.annotation.tailrec
 import scala.collection.immutable
@@ -2066,7 +2066,7 @@ private[stream] object Collect {
         })
       }
 
-      @silent // compiler complaining about aggregator = _: T
+      @nowarn // compiler complaining about aggregator = _: T
       override def onPush(): Unit = {
         val elem = grab(in)
         try {

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
@@ -12,7 +12,7 @@ import scala.collection.immutable
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.{ Done, NotUsed }
 import akka.actor.{ ActorRef, Terminated }
@@ -246,7 +246,7 @@ private[stream] object ConnectionSourceStage {
     // After that remains immutable
     private var connection: ActorRef = _
 
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     private val writeBufferSize = inheritedAttributes
       .get[TcpAttributes.TcpWriteBufferSize](
         TcpAttributes.TcpWriteBufferSize(

--- a/akka-stream/src/main/scala/akka/stream/impl/streamref/SinkRefImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/streamref/SinkRefImpl.scala
@@ -6,7 +6,7 @@ package akka.stream.impl.streamref
 
 import scala.util.{ Failure, Success, Try }
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.Done
 import akka.NotUsed
@@ -65,7 +65,7 @@ private[stream] final class SinkRefStageImpl[In] private[akka] (val initialPartn
       private[this] val streamRefsMaster = StreamRefsMaster(eagerMaterializer.system)
 
       // settings ---
-      @silent("deprecated") // can't remove this settings access without breaking compat
+      @nowarn("msg=deprecated") // can't remove this settings access without breaking compat
       private[this] val subscriptionTimeout = {
         import StreamRefAttributes._
         val settings = eagerMaterializer.settings.streamRefSettings

--- a/akka-stream/src/main/scala/akka/stream/impl/streamref/SourceRefImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/streamref/SourceRefImpl.scala
@@ -4,7 +4,7 @@
 
 package akka.stream.impl.streamref
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.NotUsed
 import akka.actor.{ ActorRef, Terminated }
@@ -124,24 +124,24 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
 
       // settings ---
       import StreamRefAttributes._
-      @silent("deprecated") // can't remove this settings access without breaking compat
+      @nowarn("msg=deprecated") // can't remove this settings access without breaking compat
       private[this] val settings = eagerMaterializer.settings.streamRefSettings
 
-      @silent("deprecated") // can't remove this settings access without breaking compat
+      @nowarn("msg=deprecated") // can't remove this settings access without breaking compat
       private[this] val subscriptionTimeout = inheritedAttributes.get[StreamRefAttributes.SubscriptionTimeout](
         SubscriptionTimeout(settings.subscriptionTimeout))
 
-      @silent("deprecated") // can't remove this settings access without breaking compat
+      @nowarn("msg=deprecated") // can't remove this settings access without breaking compat
       private[this] val bufferCapacity = inheritedAttributes
         .get[StreamRefAttributes.BufferCapacity](StreamRefAttributes.BufferCapacity(settings.bufferCapacity))
         .capacity
 
-      @silent("deprecated") // can't remove this settings access without breaking compat
+      @nowarn("msg=deprecated") // can't remove this settings access without breaking compat
       private[this] val demandRedeliveryInterval = inheritedAttributes
         .get[StreamRefAttributes.DemandRedeliveryInterval](DemandRedeliveryInterval(settings.demandRedeliveryInterval))
         .timeout
 
-      @silent("deprecated") // can't remove this settings access without breaking compat
+      @nowarn("msg=deprecated") // can't remove this settings access without breaking compat
       private[this] val finalTerminationSignalDeadline =
         inheritedAttributes
           .get[StreamRefAttributes.FinalTerminationSignalDeadline](

--- a/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
@@ -6,7 +6,7 @@ package akka.stream.javadsl
 
 import scala.concurrent.duration.FiniteDuration
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.NotUsed
 import akka.japi.function
@@ -110,7 +110,7 @@ object BidiFlow {
    * every second in one direction, but no elements are flowing in the other direction. I.e. this operator considers
    * the *joint* frequencies of the elements in both directions.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def bidirectionalIdleTimeout[I, O](timeout: java.time.Duration): BidiFlow[I, I, O, O, NotUsed] = {
     import akka.util.JavaDurationConverters._
     bidirectionalIdleTimeout(timeout.asScala)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -15,7 +15,7 @@ import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.reactivestreams.Processor
 
 import akka.Done
@@ -1240,7 +1240,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * `n` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def groupedWithin(n: Int, d: java.time.Duration): javadsl.Flow[In, java.util.List[Out], Mat] =
     groupedWithin(n, d.asScala)
 
@@ -1288,7 +1288,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * `maxWeight` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def groupedWeightedWithin(
       maxWeight: Long,
       costFn: function.Function[Out, java.lang.Long],
@@ -1350,7 +1350,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * @param of time to shift all messages
    * @param strategy Strategy that is used when incoming elements cannot fit inside the buffer
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def delay(of: java.time.Duration, strategy: DelayOverflowStrategy): Flow[In, Out, Mat] =
     delay(of.asScala, strategy)
 
@@ -1432,7 +1432,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def dropWithin(d: java.time.Duration): javadsl.Flow[In, Out, Mat] =
     dropWithin(d.asScala)
 
@@ -1603,7 +1603,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * '''Cancels when''' downstream cancels
    *
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def recoverWith(pf: PartialFunction[Throwable, _ <: Graph[SourceShape[Out], NotUsed]]): javadsl.Flow[In, Out, Mat] =
     new Flow(delegate.recoverWith(pf))
 
@@ -1766,7 +1766,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * See also [[Flow.limit]], [[Flow.limitWeighted]]
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def takeWithin(d: java.time.Duration): javadsl.Flow[In, Out, Mat] =
     takeWithin(d.asScala)
 
@@ -3023,7 +3023,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def initialTimeout(timeout: java.time.Duration): javadsl.Flow[In, Out, Mat] =
     initialTimeout(timeout.asScala)
 
@@ -3056,7 +3056,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def completionTimeout(timeout: java.time.Duration): javadsl.Flow[In, Out, Mat] =
     completionTimeout(timeout.asScala)
 
@@ -3091,7 +3091,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def idleTimeout(timeout: java.time.Duration): javadsl.Flow[In, Out, Mat] =
     idleTimeout(timeout.asScala)
 
@@ -3126,7 +3126,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def backpressureTimeout(timeout: java.time.Duration): javadsl.Flow[In, Out, Mat] =
     backpressureTimeout(timeout.asScala)
 
@@ -3169,7 +3169,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def keepAlive(maxIdle: java.time.Duration, injectedElem: function.Creator[Out]): javadsl.Flow[In, Out, Mat] =
     keepAlive(maxIdle.asScala, injectedElem)
 
@@ -3577,7 +3577,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def initialDelay(delay: java.time.Duration): javadsl.Flow[In, Out, Mat] =
     initialDelay(delay.asScala)
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -17,7 +17,7 @@ import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import org.reactivestreams.{ Publisher, Subscriber }
 import akka.{ Done, NotUsed }
 import akka.actor.{ ActorRef, Cancellable, ClassicActorSystemProvider }
@@ -237,7 +237,7 @@ object Source {
    * element is produced it will not receive that tick element later. It will
    * receive new tick elements as soon as it has requested more elements.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def tick[O](initialDelay: java.time.Duration, interval: java.time.Duration, tick: O): javadsl.Source[O, Cancellable] =
     Source.tick(initialDelay.asScala, interval.asScala, tick)
 
@@ -2001,7 +2001,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    */
   @Deprecated
   @deprecated("Use recoverWithRetries instead.", "2.6.6")
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def recoverWith(pf: PartialFunction[Throwable, _ <: Graph[SourceShape[Out], NotUsed]]): Source[Out, Mat] =
     new Source(delegate.recoverWith(pf))
 
@@ -2028,7 +2028,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    */
   @Deprecated
   @deprecated("Use recoverWithRetries instead.", "2.6.6")
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def recoverWith(
       clazz: Class[_ <: Throwable],
       supplier: Supplier[Graph[SourceShape[Out], NotUsed]]): Source[Out, Mat] =
@@ -2680,7 +2680,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * `n` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def groupedWithin(n: Int, d: java.time.Duration): javadsl.Source[java.util.List[Out @uncheckedVariance], Mat] =
     groupedWithin(n, d.asScala)
 
@@ -2728,7 +2728,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * `maxWeight` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def groupedWeightedWithin(
       maxWeight: Long,
       costFn: function.Function[Out, java.lang.Long],
@@ -2790,7 +2790,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * @param of time to shift all messages
    * @param strategy Strategy that is used when incoming elements cannot fit inside the buffer
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def delay(of: java.time.Duration, strategy: DelayOverflowStrategy): Source[Out, Mat] =
     delay(of.asScala, strategy)
 
@@ -2872,7 +2872,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def dropWithin(d: java.time.Duration): javadsl.Source[Out, Mat] =
     dropWithin(d.asScala)
 
@@ -2998,7 +2998,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels or timer fires
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def takeWithin(d: java.time.Duration): javadsl.Source[Out, Mat] =
     takeWithin(d.asScala)
 
@@ -3588,7 +3588,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def initialTimeout(timeout: java.time.Duration): javadsl.Source[Out, Mat] =
     initialTimeout(timeout.asScala)
 
@@ -3621,7 +3621,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def completionTimeout(timeout: java.time.Duration): javadsl.Source[Out, Mat] =
     completionTimeout(timeout.asScala)
 
@@ -3656,7 +3656,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def idleTimeout(timeout: java.time.Duration): javadsl.Source[Out, Mat] =
     idleTimeout(timeout.asScala)
 
@@ -3691,7 +3691,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def backpressureTimeout(timeout: java.time.Duration): javadsl.Source[Out, Mat] =
     backpressureTimeout(timeout.asScala)
 
@@ -3734,7 +3734,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def keepAlive(maxIdle: java.time.Duration, injectedElem: function.Creator[Out]): javadsl.Source[Out, Mat] =
     keepAlive(maxIdle.asScala, injectedElem)
 
@@ -4140,7 +4140,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def initialDelay(delay: java.time.Duration): javadsl.Source[Out, Mat] =
     initialDelay(delay.asScala)
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/StreamConverters.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/StreamConverters.scala
@@ -10,7 +10,7 @@ import java.util.stream.Collector
 
 import scala.concurrent.duration.FiniteDuration
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.NotUsed
 import akka.japi.function
@@ -112,7 +112,7 @@ object StreamConverters {
    *
    * @param readTimeout the max time the read operation on the materialized InputStream should block
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def asInputStream(readTimeout: java.time.Duration): Sink[ByteString, InputStream] = {
     import akka.util.JavaDurationConverters._
     asInputStream(readTimeout.asScala)
@@ -190,7 +190,7 @@ object StreamConverters {
    *
    * @param writeTimeout the max time the write operation on the materialized OutputStream should block
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def asOutputStream(writeTimeout: java.time.Duration): javadsl.Source[ByteString, OutputStream] = {
     import akka.util.JavaDurationConverters._
     asOutputStream(writeTimeout.asScala)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -13,7 +13,7 @@ import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.NotUsed
 import akka.event.{ LogMarker, LoggingAdapter, MarkerLoggingAdapter }
@@ -677,7 +677,7 @@ class SubFlow[In, Out, Mat](
    * `n` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def groupedWithin(n: Int, d: java.time.Duration): SubFlow[In, java.util.List[Out @uncheckedVariance], Mat] =
     groupedWithin(n, d.asScala)
 
@@ -725,7 +725,7 @@ class SubFlow[In, Out, Mat](
    * `maxWeight` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def groupedWeightedWithin(
       maxWeight: Long,
       costFn: function.Function[Out, java.lang.Long],
@@ -787,7 +787,7 @@ class SubFlow[In, Out, Mat](
    * @param of time to shift all messages
    * @param strategy Strategy that is used when incoming elements cannot fit inside the buffer
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def delay(of: java.time.Duration, strategy: DelayOverflowStrategy): SubFlow[In, Out, Mat] =
     delay(of.asScala, strategy)
 
@@ -869,7 +869,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def dropWithin(d: java.time.Duration): SubFlow[In, Out, Mat] =
     dropWithin(d.asScala)
 
@@ -1110,7 +1110,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels or timer fires
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def takeWithin(d: java.time.Duration): SubFlow[In, Out, Mat] =
     takeWithin(d.asScala)
 
@@ -1787,7 +1787,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def initialTimeout(timeout: java.time.Duration): SubFlow[In, Out, Mat] =
     initialTimeout(timeout.asScala)
 
@@ -1820,7 +1820,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def completionTimeout(timeout: java.time.Duration): SubFlow[In, Out, Mat] =
     completionTimeout(timeout.asScala)
 
@@ -1855,7 +1855,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def idleTimeout(timeout: java.time.Duration): SubFlow[In, Out, Mat] =
     idleTimeout(timeout.asScala)
 
@@ -1890,7 +1890,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def backpressureTimeout(timeout: java.time.Duration): SubFlow[In, Out, Mat] =
     backpressureTimeout(timeout.asScala)
 
@@ -1933,7 +1933,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def keepAlive(maxIdle: java.time.Duration, injectedElem: function.Creator[Out]): SubFlow[In, Out, Mat] =
     keepAlive(maxIdle.asScala, injectedElem)
 
@@ -2301,7 +2301,7 @@ class SubFlow[In, Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def initialDelay(delay: java.time.Duration): SubFlow[In, Out, Mat] =
     initialDelay(delay.asScala)
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -13,7 +13,7 @@ import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.NotUsed
 import akka.event.{ LogMarker, LoggingAdapter, MarkerLoggingAdapter }
@@ -666,7 +666,7 @@ class SubSource[Out, Mat](
    * `n` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def groupedWithin(n: Int, d: java.time.Duration): SubSource[java.util.List[Out @uncheckedVariance], Mat] =
     groupedWithin(n, d.asScala)
 
@@ -714,7 +714,7 @@ class SubSource[Out, Mat](
    * `maxWeight` must be positive, and `d` must be greater than 0 seconds, otherwise
    * IllegalArgumentException is thrown.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def groupedWeightedWithin(
       maxWeight: Long,
       costFn: function.Function[Out, java.lang.Long],
@@ -763,7 +763,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def dropWithin(d: java.time.Duration): SubSource[Out, Mat] =
     dropWithin(d.asScala)
 
@@ -880,7 +880,7 @@ class SubSource[Out, Mat](
    * @param of time to shift all messages
    * @param strategy Strategy that is used when incoming elements cannot fit inside the buffer
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def delay(of: java.time.Duration, strategy: DelayOverflowStrategy): SubSource[Out, Mat] =
     delay(of.asScala, strategy)
 
@@ -1090,7 +1090,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels or timer fires
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def takeWithin(d: java.time.Duration): SubSource[Out, Mat] =
     takeWithin(d.asScala)
 
@@ -1766,7 +1766,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def initialTimeout(timeout: java.time.Duration): SubSource[Out, Mat] =
     initialTimeout(timeout.asScala)
 
@@ -1799,7 +1799,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def completionTimeout(timeout: java.time.Duration): SubSource[Out, Mat] =
     completionTimeout(timeout.asScala)
 
@@ -1834,7 +1834,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def idleTimeout(timeout: java.time.Duration): SubSource[Out, Mat] =
     idleTimeout(timeout.asScala)
 
@@ -1869,7 +1869,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def backpressureTimeout(timeout: java.time.Duration): SubSource[Out, Mat] =
     backpressureTimeout(timeout.asScala)
 
@@ -1912,7 +1912,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def keepAlive(maxIdle: java.time.Duration, injectedElem: function.Creator[Out]): SubSource[Out, Mat] =
     keepAlive(maxIdle.asScala, injectedElem)
 
@@ -2276,7 +2276,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def initialDelay(delay: java.time.Duration): SubSource[Out, Mat] =
     initialDelay(delay.asScala)
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.{ Done, NotUsed }
 import akka.actor.ActorSystem
@@ -440,7 +440,7 @@ class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       negotiateNewSession: NegotiateNewSession,
       backlog: Int,
       options: JIterable[SocketOption],
-      @silent // unused #26689
+      @nowarn // unused #26689
       halfClose: Boolean,
       idleTimeout: Duration): Source[IncomingConnection, CompletionStage[ServerBinding]] =
     Source.fromGraph(

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
@@ -18,7 +18,7 @@ import scala.util.Success
 import scala.util.Try
 import scala.util.control.NoStackTrace
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.Done
 import akka.NotUsed
@@ -133,7 +133,7 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       interface: String,
       port: Int,
       backlog: Int = defaultBacklog,
-      @silent // Traversable deprecated in 2.13
+      @nowarn // Traversable deprecated in 2.13
       options: immutable.Traversable[SocketOption] = Nil,
       halfClose: Boolean = false,
       idleTimeout: Duration = Duration.Inf): Source[IncomingConnection, Future[ServerBinding]] =
@@ -175,7 +175,7 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       interface: String,
       port: Int,
       backlog: Int = defaultBacklog,
-      @silent // Traversable deprecated in 2.13
+      @nowarn // Traversable deprecated in 2.13
       options: immutable.Traversable[SocketOption] = Nil,
       halfClose: Boolean = false,
       idleTimeout: Duration = Duration.Inf)(implicit m: Materializer): Future[ServerBinding] = {
@@ -209,7 +209,7 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
   def outgoingConnection(
       remoteAddress: InetSocketAddress,
       localAddress: Option[InetSocketAddress] = None,
-      @silent // Traversable deprecated in 2.13
+      @nowarn // Traversable deprecated in 2.13
       options: immutable.Traversable[SocketOption] = Nil,
       halfClose: Boolean = true,
       connectTimeout: Duration = Duration.Inf,
@@ -285,13 +285,13 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       sslContext: SSLContext,
       negotiateNewSession: NegotiateNewSession,
       localAddress: Option[InetSocketAddress] = None,
-      @silent // Traversable deprecated in 2.13
+      @nowarn // Traversable deprecated in 2.13
       options: immutable.Traversable[SocketOption] = Nil,
       connectTimeout: Duration = Duration.Inf,
       idleTimeout: Duration = Duration.Inf): Flow[ByteString, ByteString, Future[OutgoingConnection]] = {
 
     val connection = outgoingConnection(remoteAddress, localAddress, options, true, connectTimeout, idleTimeout)
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     val tls = TLS(sslContext, negotiateNewSession, TLSRole.client)
     connection.join(tlsWrapping.atop(tls).reversed)
   }
@@ -362,10 +362,10 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       sslContext: SSLContext,
       negotiateNewSession: NegotiateNewSession,
       backlog: Int = defaultBacklog,
-      @silent // Traversable deprecated in 2.13
+      @nowarn // Traversable deprecated in 2.13
       options: immutable.Traversable[SocketOption] = Nil,
       idleTimeout: Duration = Duration.Inf): Source[IncomingConnection, Future[ServerBinding]] = {
-    @silent("deprecated")
+    @nowarn("msg=deprecated")
     val tls = tlsWrapping.atop(TLS(sslContext, negotiateNewSession, TLSRole.server)).reversed
 
     bind(interface, port, backlog, options, halfClose = false, idleTimeout).map { incomingConnection =>
@@ -496,7 +496,7 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
       sslContext: SSLContext,
       negotiateNewSession: NegotiateNewSession,
       backlog: Int = defaultBacklog,
-      @silent // Traversable deprecated in 2.13
+      @nowarn // Traversable deprecated in 2.13
       options: immutable.Traversable[SocketOption] = Nil,
       idleTimeout: Duration = Duration.Inf)(implicit m: Materializer): Future[ServerBinding] = {
     bindTls(interface, port, sslContext, negotiateNewSession, backlog, options, idleTimeout)

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -9,7 +9,9 @@ import scala.annotation.tailrec
 import scala.collection.{ immutable, mutable }
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration.FiniteDuration
-import com.github.ghik.silencer.silent
+
+import scala.annotation.nowarn
+
 import akka.{ Done, NotUsed }
 import akka.actor._
 import akka.annotation.InternalApi
@@ -1920,7 +1922,7 @@ trait OutHandler {
       require(cause ne null, "Cancellation cause must not be null")
       require(thisStage.lastCancellationCause eq null, "onDownstreamFinish(cause) must not be called recursively")
       thisStage.lastCancellationCause = cause
-      (onDownstreamFinish(): @silent("deprecated")) // if not overridden, call old deprecated variant
+      (onDownstreamFinish(): @nowarn("msg=deprecated")) // if not overridden, call old deprecated variant
     } finally thisStage.lastCancellationCause = null
   }
 }

--- a/akka-testkit/src/main/scala/akka/testkit/TestActorRef.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestActorRef.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.Await
 import scala.reflect.ClassTag
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor._
 import akka.dispatch._
@@ -22,7 +22,7 @@ import akka.pattern.ask
  *
  * @since 1.1
  */
-@silent // 'early initializers' are deprecated on 2.13 and will be replaced with trait parameters on 2.14. https://github.com/akka/akka/issues/26753
+@nowarn // 'early initializers' are deprecated on 2.13 and will be replaced with trait parameters on 2.14. https://github.com/akka/akka/issues/26753
 class TestActorRef[T <: Actor](_system: ActorSystem, _props: Props, _supervisor: ActorRef, name: String) extends {
   val props =
     _props.withDispatcher(

--- a/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKit.scala
@@ -16,7 +16,7 @@ import scala.language.postfixOps
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor._
 import akka.actor.DeadLetter
@@ -965,7 +965,7 @@ trait TestKitBase {
  *
  * @since 1.1
  */
-@silent // 'early initializers' are deprecated on 2.13 and will be replaced with trait parameters on 2.14. https://github.com/akka/akka/issues/26753
+@nowarn // 'early initializers' are deprecated on 2.13 and will be replaced with trait parameters on 2.14. https://github.com/akka/akka/issues/26753
 class TestKit(_system: ActorSystem) extends { implicit val system: ActorSystem = _system } with TestKitBase
 
 object TestKit {

--- a/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/javadsl/TestKit.scala
@@ -10,7 +10,7 @@ import java.util.function.{ Supplier, Function => JFunction }
 import scala.annotation.varargs
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import akka.actor._
 import akka.annotation.InternalApi
@@ -535,7 +535,7 @@ class TestKit(system: ActorSystem) {
    * Use this variant to implement more complicated or conditional
    * processing.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def expectMsgPF[T](max: java.time.Duration, hint: String, f: JFunction[Any, T]): T = expectMsgPF(max.asScala, hint, f)
 
   /**
@@ -729,7 +729,7 @@ class TestKit(system: ActorSystem) {
    * @return the last received message, i.e. the first one for which the
    *         partial function returned true
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def fishForMessage(max: java.time.Duration, hint: String, f: JFunction[Any, Boolean]): Any =
     fishForMessage(max.asScala, hint, f)
 
@@ -747,7 +747,7 @@ class TestKit(system: ActorSystem) {
   /**
    * Same as `fishForMessage`, but gets a different partial function and returns properly typed message.
    */
-  @silent("deprecated")
+  @nowarn("msg=deprecated")
   def fishForSpecificMessage[T](max: java.time.Duration, hint: String, f: JFunction[Any, T]): T =
     fishForSpecificMessage(max.asScala, hint, f)
 

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpecSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpecSpec.scala
@@ -7,7 +7,7 @@ package akka.testkit
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
 import language.postfixOps
 import org.scalatest.matchers.should.Matchers
@@ -17,7 +17,7 @@ import akka.actor._
 import akka.actor.DeadLetter
 import akka.pattern.ask
 
-@silent
+@nowarn
 class AkkaSpecSpec extends AnyWordSpec with Matchers {
 
   "An AkkaSpec" must {

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ enablePlugins(
   JavaFormatterPlugin)
 disablePlugins(MimaPlugin)
 
-
 // check format and headers
 TaskKey[Unit]("verifyCodeFmt") := {
   javafmtCheckAll.all(ScopeFilter(inAnyProject)).result.value.toEither.left.foreach { _ =>
@@ -31,12 +30,9 @@ addCommandAlias("applyCodeStyle", "headerCreateAll; javafmtAll; scalafmtAll")
 
 addCommandAlias(
   name = "fixall",
-  value =
-    ";scalafixEnable; scalafixAll; scalafmtAll; test:compile; multi-jvm:compile; reload")
+  value = ";scalafixEnable; scalafixAll; scalafmtAll; test:compile; multi-jvm:compile; reload")
 
-addCommandAlias(
-  name = "sortImports",
-  value = ";scalafixEnable; scalafixAll SortImports; scalafmtAll")
+addCommandAlias(name = "sortImports", value = ";scalafixEnable; scalafixAll SortImports; scalafmtAll")
 
 import akka.AkkaBuild._
 import akka.{ AkkaBuild, Dependencies, OSGi, Protobuf, SigarLoader, VersionGenerator }

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -5,7 +5,7 @@
 package akka
 
 import java.io.FileReader
-import java.io.{FileInputStream, InputStreamReader}
+import java.io.{ FileInputStream, InputStreamReader }
 import java.util.Properties
 import java.time.format.DateTimeFormatter
 import java.time.ZonedDateTime
@@ -25,20 +25,18 @@ object AkkaBuild {
 
   val parallelExecutionByDefault = false // TODO: enable this once we're sure it does not break things
 
-  lazy val buildSettings = Def.settings(
-    organization := "com.typesafe.akka",
-    Dependencies.Versions)
+  lazy val buildSettings = Def.settings(organization := "com.typesafe.akka", Dependencies.Versions)
 
   lazy val rootSettings = Def.settings(
     UnidocRoot.akkaSettings,
     Protobuf.settings,
-    parallelExecution in GlobalScope := System.getProperty("akka.parallelExecution", parallelExecutionByDefault.toString).toBoolean,
+    parallelExecution in GlobalScope := System
+        .getProperty("akka.parallelExecution", parallelExecutionByDefault.toString)
+        .toBoolean,
     // used for linking to API docs (overwrites `project-info.version`)
-    ThisBuild / projectInfoVersion := { if (isSnapshot.value) "snapshot" else version.value }
-  )
+    ThisBuild / projectInfoVersion := { if (isSnapshot.value) "snapshot" else version.value })
 
-  lazy val mayChangeSettings = Seq(
-    description := """|This module of Akka is marked as
+  lazy val mayChangeSettings = Seq(description := """|This module of Akka is marked as
                       |'may change', which means that it is in early
                       |access mode, which also means that it is not covered
                       |by commercial support. An module marked 'may change' doesn't
@@ -59,18 +57,20 @@ object AkkaBuild {
           (outputPath / "[artifact]-[revision](-[classifier]).[ext]").absolutePath
 
         val resolver = Resolver.file("user-publish-m2-local", new File(path))
-        (resolver, Seq(
-          otherResolvers := resolver :: publishTo.value.toList,
-          publishM2Configuration := Classpaths.publishConfig(
-            publishMavenStyle.value,
-            deliverPattern(crossTarget.value),
-            if (isSnapshot.value) "integration" else "release",
-            ivyConfigurations.value.map(c => ConfigRef(c.name)).toVector,
-            artifacts = packagedArtifacts.value.toVector,
-            resolverName = resolver.name,
-            checksums = checksums.in(publishM2).value.toVector,
-            logging = ivyLoggingLevel.value,
-            overwrite = true)))
+        (
+          resolver,
+          Seq(
+            otherResolvers := resolver :: publishTo.value.toList,
+            publishM2Configuration := Classpaths.publishConfig(
+                publishMavenStyle.value,
+                deliverPattern(crossTarget.value),
+                if (isSnapshot.value) "integration" else "release",
+                ivyConfigurations.value.map(c => ConfigRef(c.name)).toVector,
+                artifacts = packagedArtifacts.value.toVector,
+                resolverName = resolver.name,
+                checksums = checksums.in(publishM2).value.toVector,
+                logging = ivyLoggingLevel.value,
+                overwrite = true)))
     }
 
   lazy val resolverSettings = Def.settings(
@@ -82,13 +82,14 @@ object AkkaBuild {
     if (System.getProperty("akka.build.useSnapshotSonatypeResolver", "false").toBoolean)
       resolvers += Resolver.sonatypeRepo("snapshots")
     else Seq.empty,
-    pomIncludeRepository := (_ => false), // do not leak internal repositories during staging
+    pomIncludeRepository := (_ => false) // do not leak internal repositories during staging
   )
 
   private def allWarnings: Boolean = System.getProperty("akka.allwarnings", "false").toBoolean
 
   final val DefaultScalacOptions = Seq(
-    "-encoding", "UTF-8",
+    "-encoding",
+    "UTF-8",
     "-feature",
     "-unchecked",
     "-Xlog-reflective-calls",
@@ -107,30 +108,27 @@ object AkkaBuild {
       JdkOptions.targetJdkScalacOptions(targetSystemJdk.value, optionalDir(jdk8home.value), fullJavaHomes.value),
     scalacOptions in Compile ++= (if (allWarnings) Seq("-deprecation") else Nil),
     scalacOptions in Test := (scalacOptions in Test).value.filterNot(opt =>
-      opt == "-Xlog-reflective-calls" || opt.contains("genjavadoc")),
+        opt == "-Xlog-reflective-calls" || opt.contains("genjavadoc")),
     javacOptions in Compile ++= {
       DefaultJavacOptions ++
-        JdkOptions.targetJdkJavacOptions(targetSystemJdk.value, optionalDir(jdk8home.value), fullJavaHomes.value)
+      JdkOptions.targetJdkJavacOptions(targetSystemJdk.value, optionalDir(jdk8home.value), fullJavaHomes.value)
     },
     javacOptions in Test ++= DefaultJavacOptions ++
       JdkOptions.targetJdkJavacOptions(targetSystemJdk.value, optionalDir(jdk8home.value), fullJavaHomes.value),
     javacOptions in Compile ++= (if (allWarnings) Seq("-Xlint:deprecation") else Nil),
     javacOptions in doc := Seq(),
-
     crossVersion := CrossVersion.binary,
-
     ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet,
-
     licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))),
     homepage := Some(url("https://akka.io/")),
     description := "Akka is a toolkit for building highly concurrent, distributed, and resilient message-driven applications for Java and Scala.",
-    scmInfo := Some(ScmInfo(
-      url("https://github.com/akka/akka"),
-      "scm:git:https://github.com/akka/akka.git",
-      "scm:git:git@github.com:akka/akka.git",
-    )),
+    scmInfo := Some(
+        ScmInfo(
+          url("https://github.com/akka/akka"),
+          "scm:git:https://github.com/akka/akka.git",
+          "scm:git:git@github.com:akka/akka.git"
+        )),
     apiURL := Some(url(s"https://doc.akka.io/api/akka/${version.value}")),
-
     initialCommands :=
       """|import language.postfixOps
          |import akka.actor._
@@ -146,12 +144,10 @@ object AkkaBuild {
          |implicit def ec = system.dispatcher
          |implicit val timeout: Timeout = Timeout(5 seconds)
          |""".stripMargin,
-
     /**
      * Test settings
      */
     fork in Test := true,
-
     // default JVM config for tests
     javaOptions in Test ++= {
       val defaults = Seq(
@@ -159,10 +155,10 @@ object AkkaBuild {
         "-XX:+UseG1GC",
         // most tests actually don't really use _that_ much memory (>1g usually)
         // twice used (and then some) keeps G1GC happy - very few or to no full gcs
-        "-Xms3g", "-Xmx3g",
+        "-Xms3g",
+        "-Xmx3g",
         // increase stack size (todo why?)
         "-Xss2m",
-
         // ## extra memory/gc tuning
         // this breaks jstat, but could avoid costly syncs to disc see http://www.evanjones.ca/jvm-mmap-pause.html
         "-XX:+PerfDisableSharedMem",
@@ -171,7 +167,6 @@ object AkkaBuild {
         "-XX:MaxGCPauseMillis=300",
         // nio direct memory limit for artery/aeron (probably)
         "-XX:MaxDirectMemorySize=256m",
-
         // faster random source
         "-Djava.security.egd=file:/dev/./urandom")
 
@@ -180,17 +175,14 @@ object AkkaBuild {
       else
         defaults
     },
-
     // all system properties passed to sbt prefixed with "akka." will be passed on to the forked jvms as is
     javaOptions in Test := {
       val base = (javaOptions in Test).value
       val akkaSysProps: Seq[String] =
-        sys.props.filter(_._1.startsWith("akka"))
-          .map { case (key, value) => s"-D$key=$value" }(breakOut)
+        sys.props.filter(_._1.startsWith("akka")).map { case (key, value) => s"-D$key=$value" }(breakOut)
 
       base ++ akkaSysProps
     },
-
     // with forked tests the working directory is set to each module's home directory
     // rather than the Akka root, some tests depend on Akka root being working dir, so reset
     testGrouping in Test := {
@@ -199,30 +191,32 @@ object AkkaBuild {
       original.map { group =>
         group.runPolicy match {
           case Tests.SubProcess(forkOptions) =>
-            group.copy(runPolicy = Tests.SubProcess(forkOptions.withWorkingDirectory(
-              workingDirectory = Some(new File(System.getProperty("user.dir"))))))
+            // format: off
+            group.copy(runPolicy = Tests.SubProcess(
+              forkOptions.withWorkingDirectory(workingDirectory = Some(new File(System.getProperty("user.dir"))))))
+            // format: on
           case _ => group
         }
       }
     },
-
-    parallelExecution in Test := System.getProperty("akka.parallelExecution", parallelExecutionByDefault.toString).toBoolean,
+    parallelExecution in Test := System
+        .getProperty("akka.parallelExecution", parallelExecutionByDefault.toString)
+        .toBoolean,
     logBuffered in Test := System.getProperty("akka.logBufferedTests", "false").toBoolean,
-
     // show full stack traces and test case durations
     testOptions in Test += Tests.Argument("-oDF"),
-
     mavenLocalResolverSettings,
     docLintingSettings,
     JdkOptions.targetJdkSettings,
-
     // a workaround for https://github.com/akka/akka/issues/27661
     // see also project/Protobuf.scala that introduces /../ to make "intellij happy"
     MultiJvm / assembly / fullClasspath := {
       val old = (MultiJvm / assembly / fullClasspath).value.toVector
       val files = old.map(_.data.getCanonicalFile).distinct
-      files map { x => Attributed.blank(x) }
-    },
+      files.map { x =>
+        Attributed.blank(x)
+      }
+    }
   )
 
   private def optionalDir(path: String): Option[File] =
@@ -239,9 +233,7 @@ object AkkaBuild {
     javacOptions in doc ++= {
       if (JdkOptions.isJdk8) Seq("-Xdoclint:none")
       else Seq("-Xdoclint:none", "--ignore-source-errors")
-    }
-  )
-
+    })
 
   def loadSystemProperties(fileName: String): Unit = {
     import scala.collection.JavaConverters._

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -65,14 +65,6 @@ object AkkaDisciplinePlugin extends AutoPlugin {
 
   lazy val nowarnSettings = {
     Dependencies.getScalaVersion() match {
-      // TODO: remove this when upgrading to Scala 2.12.13
-      // https://github.com/scala/scala/pull/9248
-      case twoTwelve if twoTwelve.startsWith("2.12") =>
-        val silencerVersion = "1.7.1"
-        val libs = Seq(
-          compilerPlugin(("com.github.ghik" %% "silencer-plugin" % silencerVersion).cross(CrossVersion.patch)),
-          ("com.github.ghik" %% "silencer-lib" % silencerVersion % Provided).cross(CrossVersion.patch))
-        Seq(libraryDependencies ++= (if (autoScalaLibrary.value) libs else Nil))
       case _ =>
         Seq(scalacOptions += "-Wconf:cat=unused-nowarn:s,any:e")
     }
@@ -83,23 +75,6 @@ object AkkaDisciplinePlugin extends AutoPlugin {
    */
   val docs = {
     Dependencies.getScalaVersion() match {
-      // TODO: remove this when upgrading to Scala 2.12.13
-      // https://github.com/scala/scala/pull/9248
-      case twoTwelve if twoTwelve.startsWith("2.12") =>
-        val patterns = Seq(
-          // In docs, 'unused' variables can be useful for naming and showing the type
-          "is never used",
-          // Import statements are often duplicated across multiple snippets in one file
-          "Unused import",
-          // We keep documentation for this old API around for a while:
-          "in object Dns is deprecated",
-          "in class Dns is deprecated",
-          // Because we sometimes wrap things in a class:
-          "The outer reference in this type test cannot be checked at run time",
-          // Because we show some things that are deprecated in
-          // 2.13 but don't have a replacement that was in 2.12:
-          "deprecated \\(since 2.13.0\\)")
-        Seq(scalacOptions ++= patterns.map(msg => s"-P:silencer:globalFilters=$msg"))
       case _ =>
         Seq(
           Test / scalacOptions --= Seq("-Xlint", "-unchecked", "-deprecation"),

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -66,7 +66,11 @@ object AkkaDisciplinePlugin extends AutoPlugin {
   lazy val nowarnSettings = {
     Dependencies.getScalaVersion() match {
       case _ =>
-        Seq(scalacOptions += "-Wconf:cat=unused-nowarn:s,any:e")
+        Seq(
+          Compile / scalacOptions += "-Wconf:cat=unused-nowarn:s,any:e",
+          Test / scalacOptions += "-Wconf:cat=unused-nowarn:s,any:e",
+          Compile / doc / scalacOptions := Seq()
+        )
     }
   }
 
@@ -77,9 +81,13 @@ object AkkaDisciplinePlugin extends AutoPlugin {
     Dependencies.getScalaVersion() match {
       case _ =>
         Seq(
+          Compile / scalacOptions -= "-Wconf:cat=unused-nowarn:s,any:e",
+          Compile / scalacOptions += "-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e",
           Test / scalacOptions --= Seq("-Xlint", "-unchecked", "-deprecation"),
-          scalacOptions -= "-Wconf:cat=unused-nowarn:s,any:e",
-          scalacOptions += "-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e")
+          Test / scalacOptions -= "-Wconf:cat=unused-nowarn:s,any:e",
+          Test / scalacOptions += "-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e",
+          Compile / doc / scalacOptions := Seq()
+        )
     }
   }
 

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -74,7 +74,7 @@ object AkkaDisciplinePlugin extends AutoPlugin {
           ("com.github.ghik" %% "silencer-lib" % silencerVersion % Provided).cross(CrossVersion.patch))
         Seq(libraryDependencies ++= (if (autoScalaLibrary.value) libs else Nil))
       case _ =>
-        Seq(scalacOptions += "-Wconf:any:e")
+        Seq(scalacOptions ++= Seq("-nowarn", "-Wconf:any:e"))
     }
   }
 
@@ -101,10 +101,7 @@ object AkkaDisciplinePlugin extends AutoPlugin {
           "deprecated \\(since 2.13.0\\)"
         )
         Seq(scalacOptions ++= patterns.map(msg => s"-P:silencer:globalFilters=$msg"))
-      case _ =>
-        Seq(
-          scalacOptions --= Seq("-Wconf:any:e"),
-          scalacOptions += "-Wconf:cat=unused:s,any:e")
+      case _ => Seq()
     }
   }
 

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -63,12 +63,14 @@ object AkkaDisciplinePlugin extends AutoPlugin {
     "akka-stream-tests-tck",
     "akka-testkit")
 
+  val defaultScalaOptions = "-Wconf:cat=unused-nowarn:s,any:e"
+
   lazy val nowarnSettings = {
     Dependencies.getScalaVersion() match {
       case _ =>
         Seq(
-          Compile / scalacOptions += "-Wconf:cat=unused-nowarn:s,any:e",
-          Test / scalacOptions += "-Wconf:cat=unused-nowarn:s,any:e",
+          Compile / scalacOptions += defaultScalaOptions,
+          Test / scalacOptions += defaultScalaOptions,
           Compile / doc / scalacOptions := Seq()
         )
     }
@@ -81,10 +83,10 @@ object AkkaDisciplinePlugin extends AutoPlugin {
     Dependencies.getScalaVersion() match {
       case _ =>
         Seq(
-          Compile / scalacOptions -= "-Wconf:cat=unused-nowarn:s,any:e",
+          Compile / scalacOptions -= defaultScalaOptions,
           Compile / scalacOptions += "-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e",
           Test / scalacOptions --= Seq("-Xlint", "-unchecked", "-deprecation"),
-          Test / scalacOptions -= "-Wconf:cat=unused-nowarn:s,any:e",
+          Test / scalacOptions -= defaultScalaOptions,
           Test / scalacOptions += "-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e",
           Compile / doc / scalacOptions := Seq()
         )

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -71,8 +71,7 @@ object AkkaDisciplinePlugin extends AutoPlugin {
         Seq(
           Compile / scalacOptions += defaultScalaOptions,
           Test / scalacOptions += defaultScalaOptions,
-          Compile / doc / scalacOptions := Seq()
-        )
+          Compile / doc / scalacOptions := Seq())
     }
   }
 
@@ -88,8 +87,7 @@ object AkkaDisciplinePlugin extends AutoPlugin {
           Test / scalacOptions --= Seq("-Xlint", "-unchecked", "-deprecation"),
           Test / scalacOptions -= defaultScalaOptions,
           Test / scalacOptions += "-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e",
-          Compile / doc / scalacOptions := Seq()
-        )
+          Compile / doc / scalacOptions := Seq())
     }
   }
 

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -74,7 +74,7 @@ object AkkaDisciplinePlugin extends AutoPlugin {
           ("com.github.ghik" %% "silencer-lib" % silencerVersion % Provided).cross(CrossVersion.patch))
         Seq(libraryDependencies ++= (if (autoScalaLibrary.value) libs else Nil))
       case _ =>
-        Seq(scalacOptions ++= Seq("-nowarn", "-Wconf:any:e"))
+        Seq(scalacOptions += "-Wconf:cat=unused-nowarn:s,any:e")
     }
   }
 
@@ -98,10 +98,13 @@ object AkkaDisciplinePlugin extends AutoPlugin {
           "The outer reference in this type test cannot be checked at run time",
           // Because we show some things that are deprecated in
           // 2.13 but don't have a replacement that was in 2.12:
-          "deprecated \\(since 2.13.0\\)"
-        )
+          "deprecated \\(since 2.13.0\\)")
         Seq(scalacOptions ++= patterns.map(msg => s"-P:silencer:globalFilters=$msg"))
-      case _ => Seq()
+      case _ =>
+        Seq(
+          Test / scalacOptions --= Seq("-Xlint", "-unchecked", "-deprecation"),
+          scalacOptions -= "-Wconf:cat=unused-nowarn:s,any:e",
+          scalacOptions += "-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e")
     }
   }
 

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -74,7 +74,37 @@ object AkkaDisciplinePlugin extends AutoPlugin {
           ("com.github.ghik" %% "silencer-lib" % silencerVersion % Provided).cross(CrossVersion.patch))
         Seq(libraryDependencies ++= (if (autoScalaLibrary.value) libs else Nil))
       case _ =>
-        Seq(scalacOptions += "-Wconf:any:s")
+        Seq(scalacOptions += "-Wconf:any:e")
+    }
+  }
+
+  /**
+   * We are a little less strict in docs
+   */
+  val docs = {
+    Dependencies.getScalaVersion() match {
+      // TODO: remove this when upgrading to Scala 2.12.13
+      // https://github.com/scala/scala/pull/9248
+      case twoTwelve if twoTwelve.startsWith("2.12") =>
+        val patterns = Seq(
+          // In docs, 'unused' variables can be useful for naming and showing the type
+          "is never used",
+          // Import statements are often duplicated across multiple snippets in one file
+          "Unused import",
+          // We keep documentation for this old API around for a while:
+          "in object Dns is deprecated",
+          "in class Dns is deprecated",
+          // Because we sometimes wrap things in a class:
+          "The outer reference in this type test cannot be checked at run time",
+          // Because we show some things that are deprecated in
+          // 2.13 but don't have a replacement that was in 2.12:
+          "deprecated \\(since 2.13.0\\)"
+        )
+        Seq(scalacOptions ++= patterns.map(msg => s"-P:silencer:globalFilters=$msg"))
+      case _ =>
+        Seq(
+          scalacOptions --= Seq("-Wconf:any:e"),
+          scalacOptions += "-Wconf:cat=unused:s,any:e")
     }
   }
 
@@ -140,21 +170,4 @@ object AkkaDisciplinePlugin extends AutoPlugin {
     "-Ypartial-unification",
     "-Ywarn-extra-implicit")
 
-  /**
-   * We are a little less strict in docs
-   */
-  val docs = Seq(
-    scalacOptions ++= Seq(
-        // In docs, 'unused' variables can be useful for naming and showing the type
-        "-P:silencer:globalFilters=is never used",
-        // Import statements are often duplicated across multiple snippets in one file
-        "-P:silencer:globalFilters=Unused import",
-        // We keep documentation for this old API around for a while:
-        "-P:silencer:globalFilters=in object Dns is deprecated",
-        "-P:silencer:globalFilters=in class Dns is deprecated",
-        // Because we sometimes wrap things in a class:
-        "-P:silencer:globalFilters=The outer reference in this type test cannot be checked at run time",
-        // Because we show some things that are deprecated in
-        // 2.13 but don't have a replacement that was in 2.12:
-        "-P:silencer:globalFilters=deprecated \\(since 2.13.0\\)"))
 }

--- a/project/AutomaticModuleName.scala
+++ b/project/AutomaticModuleName.scala
@@ -4,7 +4,7 @@
 
 package akka
 
-import sbt.{Def, _}
+import sbt.{ Def, _ }
 import sbt.Keys._
 
 /**
@@ -15,10 +15,9 @@ import sbt.Keys._
  * The names carry a lot of implications and DO NOT have to always align 1:1 with the group ids or package names,
  * though there should be of course a strong relationship between them.
  */
-object AutomaticModuleName  {
+object AutomaticModuleName {
   private val AutomaticModuleName = "Automatic-Module-Name"
 
   def settings(name: String): Seq[Def.Setting[Task[Seq[PackageOption]]]] = Seq(
-    packageOptions in (Compile, packageBin) += Package.ManifestAttributes(AutomaticModuleName -> name)
-  )
+    packageOptions in (Compile, packageBin) += Package.ManifestAttributes(AutomaticModuleName -> name))
 }

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -30,13 +30,14 @@ trait CopyrightHeader extends AutoPlugin {
 
   override def projectSettings: Seq[Def.Setting[_]] = Def.settings(headerMappingSettings, additional)
 
-  def additional: Seq[Def.Setting[_]] = Def.settings((compile in Compile) := {
-    (headerCreate in Compile).value
-    (compile in Compile).value
-  }, (compile in Test) := {
-    (headerCreate in Test).value
-    (compile in Test).value
-  })
+  def additional: Seq[Def.Setting[_]] =
+    Def.settings((compile in Compile) := {
+      (headerCreate in Compile).value
+      (compile in Compile).value
+    }, (compile in Test) := {
+      (headerCreate in Test).value
+      (compile in Test).value
+    })
 
   // We hard-code this so PR's created in year X will not suddenly fail in X+1.
   // Of course we should remember to update it early in the year.

--- a/project/CopyrightHeaderForBoilerplate.scala
+++ b/project/CopyrightHeaderForBoilerplate.scala
@@ -7,12 +7,12 @@ package akka
 import de.heikoseeberger.sbtheader.HeaderPlugin
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import sbt.Keys.sourceDirectory
-import sbt.{Compile, Def, Plugins, Test, inConfig, _}
+import sbt.{ Compile, Def, Plugins, Test, inConfig, _ }
 import spray.boilerplate.BoilerplatePlugin
 
 object CopyrightHeaderForBoilerplate extends CopyrightHeader {
   override def requires: Plugins = BoilerplatePlugin && HeaderPlugin
-  
+
   override protected def headerMappingSettings: Seq[Def.Setting[_]] = {
     super.headerMappingSettings
     Seq(Compile, Test).flatMap { config =>
@@ -20,10 +20,7 @@ object CopyrightHeaderForBoilerplate extends CopyrightHeader {
         Seq(
           headerSources in config ++=
             (((sourceDirectory in config).value / "boilerplate") ** "*.template").get,
-          headerMappings := headerMappings.value ++ Map(
-            HeaderFileType("template") -> cStyleComment
-          )
-        )
+          headerMappings := headerMappings.value ++ Map(HeaderFileType("template") -> cStyleComment))
       }
     }
   }

--- a/project/CopyrightHeaderForBuild.scala
+++ b/project/CopyrightHeaderForBuild.scala
@@ -4,9 +4,9 @@
 
 package akka
 
-import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{HeaderFileType, headerMappings, headerSources}
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{ headerMappings, headerSources, HeaderFileType }
 import sbt.Keys.baseDirectory
-import sbt.{Compile, Def, PluginTrigger, Test, inConfig, _}
+import sbt.{ Compile, Def, PluginTrigger, Test, inConfig, _ }
 
 object CopyrightHeaderForBuild extends CopyrightHeader {
   override def trigger: PluginTrigger = noTrigger
@@ -16,10 +16,7 @@ object CopyrightHeaderForBuild extends CopyrightHeader {
       inConfig(config) {
         Seq(
           headerSources in config ++= (((baseDirectory in config).value / "project") ** "*.scala").get,
-          headerMappings := headerMappings.value ++ Map(
-            HeaderFileType.scala -> cStyleComment
-          )
-        )
+          headerMappings := headerMappings.value ++ Map(HeaderFileType.scala -> cStyleComment))
       }
     }
   }

--- a/project/CopyrightHeaderForJdk9.scala
+++ b/project/CopyrightHeaderForJdk9.scala
@@ -6,8 +6,7 @@ package akka
 
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.headerSources
 import sbt.Keys.sourceDirectory
-import sbt.{Compile, Def, Test, _}
-
+import sbt.{ Compile, Def, Test, _ }
 
 object CopyrightHeaderForJdk9 extends CopyrightHeader {
 
@@ -22,7 +21,6 @@ object CopyrightHeaderForJdk9 extends CopyrightHeader {
       headerSources in Compile ++=
         (((sourceDirectory in Compile).value / JAVA_SOURCE_DIRECTORY) ** "*.java").get,
       headerSources in Test ++=
-        (((sourceDirectory in Test).value / JAVA_TEST_SOURCE_DIRECTORY) ** "*.java").get,
-    )
+        (((sourceDirectory in Test).value / JAVA_TEST_SOURCE_DIRECTORY) ** "*.java").get)
   }
 }

--- a/project/CopyrightHeaderForProtobuf.scala
+++ b/project/CopyrightHeaderForProtobuf.scala
@@ -4,9 +4,9 @@
 
 package akka
 
-import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{HeaderFileType, headerMappings, headerSources}
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{ headerMappings, headerSources, HeaderFileType }
 import sbt.Keys.sourceDirectory
-import sbt.{Compile, Def, Test, inConfig, _}
+import sbt.{ Compile, Def, Test, inConfig, _ }
 
 object CopyrightHeaderForProtobuf extends CopyrightHeader {
   override protected def headerMappingSettings: Seq[Def.Setting[_]] = {
@@ -16,10 +16,7 @@ object CopyrightHeaderForProtobuf extends CopyrightHeader {
         Seq(
           headerSources in config ++=
             (((sourceDirectory in config).value / "protobuf") ** "*.proto").get,
-          headerMappings := headerMappings.value ++ Map(
-            HeaderFileType("proto") -> cStyleComment
-          )
-        )
+          headerMappings := headerMappings.value ++ Map(HeaderFileType("proto") -> cStyleComment))
       }
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,19 +37,21 @@ object Dependencies {
   val scalaTestVersion = "3.1.4"
   val scalaCheckVersion = "1.15.1"
 
+    def getScalaVersion() = {
+    // don't allow full override to keep compatible with the version of silencer
+    // don't mandate patch not specified to allow builds to migrate
+    System.getProperty("akka.build.scalaVersion", "default") match {
+      case twoThirteen if twoThirteen.startsWith("2.13") => scala213Version
+      case twoTwelve if twoTwelve.startsWith("2.12")     => scala212Version
+      case "default"                                     => scala212Version
+      case other                                         => throw new IllegalArgumentException(s"Unsupported scala version [$other]. Must be 2.12, 2.13 or 3.0.")
+    }    
+  }
+
   val Versions =
     Seq(
       crossScalaVersions := Seq(scala212Version, scala213Version),
-      scalaVersion := {
-        // don't allow full override to keep compatible with the version of silencer
-        // don't mandate patch not specified to allow builds to migrate
-        System.getProperty("akka.build.scalaVersion", "default") match {
-          case twoThirteen if twoThirteen.startsWith("2.13") => scala213Version
-          case twoTwelve if twoTwelve.startsWith("2.12")     => scala212Version
-          case "default"                                     => crossScalaVersions.value.head
-          case other                                         => throw new IllegalArgumentException(s"Unsupported scala version [$other]. Must be 2.12 or 2.13.")
-        }
-      },
+      scalaVersion := getScalaVersion(),
       java8CompatVersion := {
         CrossVersion.partialVersion(scalaVersion.value) match {
           // java8-compat is only used in a couple of places for 2.13,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,15 +37,15 @@ object Dependencies {
   val scalaTestVersion = "3.1.4"
   val scalaCheckVersion = "1.15.1"
 
-    def getScalaVersion() = {
-    // don't allow full override to keep compatible with the version of silencer
+  def getScalaVersion() = {
     // don't mandate patch not specified to allow builds to migrate
     System.getProperty("akka.build.scalaVersion", "default") match {
       case twoThirteen if twoThirteen.startsWith("2.13") => scala213Version
       case twoTwelve if twoTwelve.startsWith("2.12")     => scala212Version
       case "default"                                     => scala212Version
-      case other                                         => throw new IllegalArgumentException(s"Unsupported scala version [$other]. Must be 2.12, 2.13 or 3.0.")
-    }    
+      case other =>
+        throw new IllegalArgumentException(s"Unsupported scala version [$other]. Must be 2.12, 2.13 or 3.0.")
+    }
   }
 
   val Versions =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
   val jacksonVersion = "2.10.5"
   val jacksonDatabindVersion = "2.10.5.1"
 
-  val scala212Version = "2.12.11"
+  val scala212Version = "2.12.13"
   val scala213Version = "2.13.3"
 
   val reactiveStreamsVersion = "1.0.3"

--- a/project/GitHub.scala
+++ b/project/GitHub.scala
@@ -7,9 +7,10 @@ package akka
 object GitHub {
 
   def envTokenOrThrow: Option[String] =
-    sys.env.get("PR_VALIDATOR_GH_TOKEN") orElse {
+    sys.env.get("PR_VALIDATOR_GH_TOKEN").orElse {
       if (sys.env.contains("ghprbPullId")) {
-        throw new Exception("No PR_VALIDATOR_GH_TOKEN env var provided during GitHub Pull Request Builder build, unable to reach GitHub!")
+        throw new Exception(
+          "No PR_VALIDATOR_GH_TOKEN env var provided during GitHub Pull Request Builder build, unable to reach GitHub!")
       } else {
         None
       }

--- a/project/JavaFormatter.scala
+++ b/project/JavaFormatter.scala
@@ -22,13 +22,14 @@ object JavaFormatter extends AutoPlugin {
   import sbt._
   import sbt.io._
 
-  override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    //below is for sbt java formatter
-    (excludeFilter in javafmt) := {
-      val ignoreSupport =
-        new ProjectFileIgnoreSupport((baseDirectory in ThisBuild).value / ignoreConfigFileName, descriptor)
-      val simpleFileFilter = new SimpleFileFilter(file => ignoreSupport.isIgnoredByFileOrPackages(file))
-      simpleFileFilter || (excludeFilter in javafmt).value
-    },
-    javafmtOnCompile := formatOnCompile)
+  override def projectSettings: Seq[Def.Setting[_]] =
+    Seq(
+      //below is for sbt java formatter
+      (excludeFilter in javafmt) := {
+        val ignoreSupport =
+          new ProjectFileIgnoreSupport((baseDirectory in ThisBuild).value / ignoreConfigFileName, descriptor)
+        val simpleFileFilter = new SimpleFileFilter(file => ignoreSupport.isIgnoredByFileOrPackages(file))
+        simpleFileFilter || (excludeFilter in javafmt).value
+      },
+      javafmtOnCompile := formatOnCompile)
 }

--- a/project/MultiNode.scala
+++ b/project/MultiNode.scala
@@ -75,9 +75,9 @@ object MultiNode extends AutoPlugin {
       scalacOptions in MultiJvm := (scalacOptions in Test).value,
       logLevel in multiJvmCreateLogger := Level.Debug, //  to see ssh establishment
       assemblyMergeStrategy in assembly in MultiJvm := {
-        case n if n.endsWith("logback-test.xml") ⇒ MergeStrategy.first
+        case n if n.endsWith("logback-test.xml") => MergeStrategy.first
         case n if n.toLowerCase.matches("meta-inf.*\\.default") => MergeStrategy.first
-        case n => (assemblyMergeStrategy in assembly in MultiJvm).value.apply(n)
+        case n                                                  => (assemblyMergeStrategy in assembly in MultiJvm).value.apply(n)
       },
       multiJvmCreateLogger in MultiJvm := { // to use normal sbt logging infra instead of custom sbt-multijvm-one
         val previous = (multiJvmCreateLogger in MultiJvm).value

--- a/project/MultiNode.scala
+++ b/project/MultiNode.scala
@@ -75,7 +75,7 @@ object MultiNode extends AutoPlugin {
       scalacOptions in MultiJvm := (scalacOptions in Test).value,
       logLevel in multiJvmCreateLogger := Level.Debug, //  to see ssh establishment
       assemblyMergeStrategy in assembly in MultiJvm := {
-        case n if n.endsWith("logback-test.xml") => MergeStrategy.first
+        case n if n.endsWith("logback-test.xml")                => MergeStrategy.first
         case n if n.toLowerCase.matches("meta-inf.*\\.default") => MergeStrategy.first
         case n                                                  => (assemblyMergeStrategy in assembly in MultiJvm).value.apply(n)
       },

--- a/project/ParadoxBrowse.scala
+++ b/project/ParadoxBrowse.scala
@@ -19,13 +19,11 @@ object ParadoxBrowse extends AutoPlugin {
   override def trigger = allRequirements
   override def requires = ParadoxPlugin
 
-  override lazy val projectSettings = Seq(
-    paradoxBrowse := {
-      import java.awt.Desktop
-      val rootDocFile = (paradox in Compile).value / "index.html"
-      val log = streams.value.log
-      if (Desktop.isDesktopSupported) Desktop.getDesktop.open(rootDocFile)
-      else log.info(s"Couldn't open default browser, but docs are at $rootDocFile")
-    }
-  )
+  override lazy val projectSettings = Seq(paradoxBrowse := {
+    import java.awt.Desktop
+    val rootDocFile = (paradox in Compile).value / "index.html"
+    val log = streams.value.log
+    if (Desktop.isDesktopSupported) Desktop.getDesktop.open(rootDocFile)
+    else log.info(s"Couldn't open default browser, but docs are at $rootDocFile")
+  })
 }

--- a/project/ProjectFileIgnoreSupport.scala
+++ b/project/ProjectFileIgnoreSupport.scala
@@ -12,39 +12,28 @@ import sbt.internal.sbtscalafix.Compat
 class ProjectFileIgnoreSupport(ignoreConfigFile: File, descriptor: String) {
   private val stdoutLogger = Compat.ConsoleLogger(System.out)
 
-  private val javaSourceDirectories = Set(
-    "java",
-    Jdk9.JAVA_SOURCE_DIRECTORY,
-    Jdk9.JAVA_TEST_SOURCE_DIRECTORY
-  )
+  private val javaSourceDirectories = Set("java", Jdk9.JAVA_SOURCE_DIRECTORY, Jdk9.JAVA_TEST_SOURCE_DIRECTORY)
 
-  private val scalaSourceDirectories = Set(
-    "scala",
-    Jdk9.SCALA_SOURCE_DIRECTORY,
-    Jdk9.SCALA_TEST_SOURCE_DIRECTORY
-  )
+  private val scalaSourceDirectories = Set("scala", Jdk9.SCALA_SOURCE_DIRECTORY, Jdk9.SCALA_TEST_SOURCE_DIRECTORY)
 
   private lazy val ignoreConfig = {
-    require(ignoreConfigFile.exists(), s"Expected ignore configuration for $descriptor at ${ignoreConfigFile.getAbsolutePath} but was missing")
+    require(
+      ignoreConfigFile.exists(),
+      s"Expected ignore configuration for $descriptor at ${ignoreConfigFile.getAbsolutePath} but was missing")
     ConfigFactory.parseFile(ignoreConfigFile)
   }
 
   private lazy val ignoredFiles: Set[String] = {
     import scala.collection.JavaConverters._
     stdoutLogger.debug(s"Loading ignored-files from $ignoreConfigFile:[${ignoreConfig.origin().url().toURI.getPath}]")
-    ignoreConfig
-      .getStringList("ignored-files")
-      .asScala
-      .toSet
+    ignoreConfig.getStringList("ignored-files").asScala.toSet
   }
 
   private lazy val ignoredPackages: Set[String] = {
     import scala.collection.JavaConverters._
-    stdoutLogger.debug(s"Loading ignored-packages from $ignoreConfigFile:[${ignoreConfig.origin().url().toURI.getPath}]")
-    ignoreConfig
-      .getStringList("ignored-packages")
-      .asScala
-      .toSet
+    stdoutLogger.debug(
+      s"Loading ignored-packages from $ignoreConfigFile:[${ignoreConfig.origin().url().toURI.getPath}]")
+    ignoreConfig.getStringList("ignored-packages").asScala.toSet
   }
 
   def isIgnoredByFileOrPackages(file: File): Boolean =
@@ -64,7 +53,8 @@ class ProjectFileIgnoreSupport(ignoreConfigFile: File, descriptor: String) {
         case Some(packageName) =>
           val ignored = packageName.startsWith(pkg)
           if (ignored) {
-            stdoutLogger.debug(s"$descriptor ignored file with pkg:$pkg for package:$packageName file:[${file.toPath}] ")
+            stdoutLogger.debug(
+              s"$descriptor ignored file with pkg:$pkg for package:$packageName file:[${file.toPath}] ")
           }
           ignored
         case None => false
@@ -74,9 +64,10 @@ class ProjectFileIgnoreSupport(ignoreConfigFile: File, descriptor: String) {
   }
 
   private def getPackageName(fileName: String): Option[String] = {
-    def getPackageName0(sourceDirectories:Set[String]): String = {
-      import java.io.{File => JFile}
-      val packageName = fileName.split(JFile.separatorChar)
+    def getPackageName0(sourceDirectories: Set[String]): String = {
+      import java.io.{ File => JFile }
+      val packageName = fileName
+        .split(JFile.separatorChar)
         .dropWhile(part => !sourceDirectories(part))
         .drop(1)
         .dropRight(1)

--- a/project/ScalaFixForJdk9Plugin.scala
+++ b/project/ScalaFixForJdk9Plugin.scala
@@ -4,7 +4,7 @@
 
 package akka
 
-import sbt.{AutoPlugin, PluginTrigger, Plugins, ScalafixSupport}
+import sbt.{ AutoPlugin, PluginTrigger, Plugins, ScalafixSupport }
 import scalafix.sbt.ScalafixPlugin
 object ScalaFixForJdk9Plugin extends AutoPlugin with ScalafixSupport {
   override def trigger: PluginTrigger = allRequirements
@@ -14,18 +14,13 @@ object ScalaFixForJdk9Plugin extends AutoPlugin with ScalafixSupport {
   import ScalafixPlugin.autoImport.scalafixConfigSettings
   import sbt._
 
-  lazy val scalafixIgnoredSetting: Seq[Setting[_]] = Seq(
-    ignore(TestJdk9)
-  )
+  lazy val scalafixIgnoredSetting: Seq[Setting[_]] = Seq(ignore(TestJdk9))
 
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(CompileJdk9, TestJdk9).flatMap(c => inConfig(c)(scalafixConfigSettings(c))) ++
-      scalafixIgnoredSetting ++ Seq(
+    scalafixIgnoredSetting ++ Seq(
       updateProjectCommands(
         alias = "fixall",
         value = ";scalafixEnable;scalafixAll;scalafmtAll;test:compile;multi-jvm:compile;reload"),
-      updateProjectCommands(
-        alias = "sortImports",
-        value = ";scalafixEnable;scalafixAll SortImports;scalafmtAll")
-    )
+      updateProjectCommands(alias = "sortImports", value = ";scalafixEnable;scalafixAll SortImports;scalafmtAll"))
 }

--- a/project/ScalafixForMultiNodePlugin.scala
+++ b/project/ScalafixForMultiNodePlugin.scala
@@ -5,7 +5,7 @@
 package akka
 
 import com.typesafe.sbt.MultiJvmPlugin
-import sbt.{AutoPlugin, Def, PluginTrigger, Plugins, ScalafixSupport, Setting, inConfig}
+import sbt.{ inConfig, AutoPlugin, Def, PluginTrigger, Plugins, ScalafixSupport, Setting }
 import scalafix.sbt.ScalafixPlugin
 import scalafix.sbt.ScalafixPlugin.autoImport.scalafixConfigSettings
 
@@ -16,18 +16,11 @@ object ScalafixForMultiNodePlugin extends AutoPlugin with ScalafixSupport {
 
   import MultiJvmPlugin.autoImport._
 
-  lazy val scalafixIgnoredSetting: Seq[Setting[_]] = Seq(
-    ignore(MultiJvm)
-  )
+  lazy val scalafixIgnoredSetting: Seq[Setting[_]] = Seq(ignore(MultiJvm))
 
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(MultiJvm).flatMap(c => inConfig(c)(scalafixConfigSettings(c))) ++
-      scalafixIgnoredSetting ++ Seq(
-      updateProjectCommands(
-        alias = "fixall",
-        value = ";scalafixEnable;scalafixAll;scalafmtAll"),
-      updateProjectCommands(
-        alias = "sortImports",
-        value = ";scalafixEnable;scalafixAll SortImports;scalafmtAll")
-    )
+    scalafixIgnoredSetting ++ Seq(
+      updateProjectCommands(alias = "fixall", value = ";scalafixEnable;scalafixAll;scalafmtAll"),
+      updateProjectCommands(alias = "sortImports", value = ";scalafixEnable;scalafixAll SortImports;scalafmtAll"))
 }

--- a/project/SigarLoader.scala
+++ b/project/SigarLoader.scala
@@ -33,19 +33,17 @@ object SigarLoader {
       // Prepare Sigar agent options.
       sigarArtifact := {
         val report = update.value
-        val artifactList = report.matching(
-          moduleFilter(organization = sigarLoader.organization, name = sigarLoader.name))
+        val artifactList =
+          report.matching(moduleFilter(organization = sigarLoader.organization, name = sigarLoader.name))
         require(artifactList.size == 1, "Expecting single artifact, while found: " + artifactList)
         artifactList.head
       },
       sigarFolder := target.value / "native",
       sigarOptions := "-javaagent:" + sigarArtifact.value + "=" + sigarFolderProperty + "=" + sigarFolder.value,
       //
-      fork in Test := true) ++ (
-        // Invoke Sigar agent at JVM init time, to extract and load native Sigar library.
-        if (sigarTestEnabled) Seq(
-          javaOptions in Test += sigarOptions.value)
-        else Seq())
+      fork in Test := true) ++ (// Invoke Sigar agent at JVM init time, to extract and load native Sigar library.
+    if (sigarTestEnabled) Seq(javaOptions in Test += sigarOptions.value)
+    else Seq())
   }
 
 }

--- a/project/TestExtras.scala
+++ b/project/TestExtras.scala
@@ -11,9 +11,12 @@ object TestExtras {
 
   object Filter {
     object Keys {
-      val excludeTestNames = settingKey[Set[String]]("Names of tests to be excluded. Not supported by MultiJVM tests. Example usage: -Dakka.test.names.exclude=TimingSpec")
-      val excludeTestTags = settingKey[Set[String]]("Tags of tests to be excluded. It will not be used if you specify -Dakka.test.tags.only. Example usage: -Dakka.test.tags.exclude=long-running")
-      val onlyTestTags = settingKey[Set[String]]("Tags of tests to be ran. Example usage: -Dakka.test.tags.only=long-running")
+      val excludeTestNames = settingKey[Set[String]](
+        "Names of tests to be excluded. Not supported by MultiJVM tests. Example usage: -Dakka.test.names.exclude=TimingSpec")
+      val excludeTestTags = settingKey[Set[String]](
+        "Tags of tests to be excluded. It will not be used if you specify -Dakka.test.tags.only. Example usage: -Dakka.test.tags.exclude=long-running")
+      val onlyTestTags =
+        settingKey[Set[String]]("Tags of tests to be ran. Example usage: -Dakka.test.tags.only=long-running")
 
       val checkTestsHaveRun = taskKey[Unit]("Verify a number of notable tests have actually run");
     }
@@ -34,22 +37,19 @@ object TestExtras {
           else Set.empty
         },
         onlyTestTags := Params.testTagsOnly,
-
         // add filters for tests excluded by name
-        testOptions in Test ++= excludeTestNames.value.toSeq.map(exclude => Tests.Filter(test => !test.contains(exclude))),
-
+        testOptions in Test ++= excludeTestNames.value.toSeq.map(exclude =>
+            Tests.Filter(test => !test.contains(exclude))),
         // add arguments for tests excluded by tag
         testOptions in Test ++= {
           val tags = excludeTestTags.value
           if (tags.isEmpty) Seq.empty else Seq(Tests.Argument("-l", tags.mkString(" ")))
         },
-
         // add arguments for running only tests by tag
         testOptions in Test ++= {
           val tags = onlyTestTags.value
           if (tags.isEmpty) Seq.empty else Seq(Tests.Argument("-n", tags.mkString(" ")))
         },
-
         checkTestsHaveRun := {
           def shouldExist(description: String, filename: String): Unit =
             require(file(filename).exists, s"$description should be run as part of the build")
@@ -57,10 +57,9 @@ object TestExtras {
           List(
             "The java JavaExtension.java" -> "akka-actor-tests/target/test-reports/TEST-akka.actor.JavaExtension.xml",
             "The jdk9-only FlowPublisherSinkSpec.scala" -> "akka-stream-tests/target/test-reports/TEST-akka.stream.scaladsl.FlowPublisherSinkSpec.xml",
-            "The jdk9-only JavaFlowSupportCompileTest.java" -> "akka-stream-tests/target/test-reports/TEST-akka.stream.javadsl.JavaFlowSupportCompileTest.xml",
+            "The jdk9-only JavaFlowSupportCompileTest.java" -> "akka-stream-tests/target/test-reports/TEST-akka.stream.javadsl.JavaFlowSupportCompileTest.xml"
           ).foreach((shouldExist _).tupled)
-        }
-      )
+        })
     }
 
     def containsOrNotExcludesTag(tag: String) = {

--- a/project/TestExtras.scala
+++ b/project/TestExtras.scala
@@ -57,8 +57,8 @@ object TestExtras {
           List(
             "The java JavaExtension.java" -> "akka-actor-tests/target/test-reports/TEST-akka.actor.JavaExtension.xml",
             "The jdk9-only FlowPublisherSinkSpec.scala" -> "akka-stream-tests/target/test-reports/TEST-akka.stream.scaladsl.FlowPublisherSinkSpec.xml",
-            "The jdk9-only JavaFlowSupportCompileTest.java" -> "akka-stream-tests/target/test-reports/TEST-akka.stream.javadsl.JavaFlowSupportCompileTest.xml"
-          ).foreach((shouldExist _).tupled)
+            "The jdk9-only JavaFlowSupportCompileTest.java" -> "akka-stream-tests/target/test-reports/TEST-akka.stream.javadsl.JavaFlowSupportCompileTest.xml")
+            .foreach((shouldExist _).tupled)
         })
     }
 

--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -25,52 +25,45 @@ object AkkaValidatePullRequest extends AutoPlugin {
   override def trigger = allRequirements
   override def requires = ValidatePullRequest
 
-  val ValidatePR = config("pr-validation") extend Test
+  val ValidatePR = config("pr-validation").extend(Test)
 
   override lazy val projectConfigurations = Seq(ValidatePR)
 
   val additionalTasks = settingKey[Seq[TaskKey[_]]]("Additional tasks for pull request validation")
 
-  override lazy val globalSettings = Seq(
-    credentials ++= {
-      // todo this should probably be supplied properly
-      GitHub.envTokenOrThrow.map { token =>
-        Credentials("GitHub API", "api.github.com", "", token)
-      }
-    },
-    additionalTasks := Seq.empty
-  )
+  override lazy val globalSettings = Seq(credentials ++= {
+    // todo this should probably be supplied properly
+    GitHub.envTokenOrThrow.map { token =>
+      Credentials("GitHub API", "api.github.com", "", token)
+    }
+  }, additionalTasks := Seq.empty)
 
   override lazy val buildSettings = Seq(
     validatePullRequest / includeFilter := PathGlobFilter("akka-*/**"),
     validatePullRequestBuildAll / excludeFilter := PathGlobFilter("project/MiMa.scala"),
-    prValidatorGithubRepository := Some("akka/akka")
-  )
+    prValidatorGithubRepository := Some("akka/akka"))
 
   override lazy val projectSettings = inConfig(ValidatePR)(Defaults.testTasks) ++ Seq(
-    testOptions in ValidatePR += Tests.Argument(TestFrameworks.ScalaTest, "-l", "performance"),
-    testOptions in ValidatePR += Tests.Argument(TestFrameworks.ScalaTest, "-l", "long-running"),
-    testOptions in ValidatePR += Tests.Argument(TestFrameworks.ScalaTest, "-l", "timing"),
-
-    // make it fork just like regular test running
-    fork in ValidatePR := (fork in Test).value,
-    testGrouping in ValidatePR := (testGrouping in Test).value,
-    javaOptions in ValidatePR := (javaOptions in Test).value,
-
-    prValidatorTasks := Seq(test in ValidatePR) ++ additionalTasks.value,
-    prValidatorEnforcedBuildAllTasks := Seq(test in Test) ++ additionalTasks.value
-  )
+      testOptions in ValidatePR += Tests.Argument(TestFrameworks.ScalaTest, "-l", "performance"),
+      testOptions in ValidatePR += Tests.Argument(TestFrameworks.ScalaTest, "-l", "long-running"),
+      testOptions in ValidatePR += Tests.Argument(TestFrameworks.ScalaTest, "-l", "timing"),
+      // make it fork just like regular test running
+      fork in ValidatePR := (fork in Test).value,
+      testGrouping in ValidatePR := (testGrouping in Test).value,
+      javaOptions in ValidatePR := (javaOptions in Test).value,
+      prValidatorTasks := Seq(test in ValidatePR) ++ additionalTasks.value,
+      prValidatorEnforcedBuildAllTasks := Seq(test in Test) ++ additionalTasks.value)
 }
 
 /**
-* This autoplugin adds Multi Jvm tests to validatePullRequest task.
-* It is needed, because ValidatePullRequest autoplugin does not depend on MultiNode and
-* therefore test:executeTests is not yet modified to include multi-jvm tests when ValidatePullRequest
-* build strategy is being determined.
-*
-* Making ValidatePullRequest depend on MultiNode is impossible, as then ValidatePullRequest
-* autoplugin would trigger only on projects which have both of these plugins enabled.
-*/
+ * This autoplugin adds Multi Jvm tests to validatePullRequest task.
+ * It is needed, because ValidatePullRequest autoplugin does not depend on MultiNode and
+ * therefore test:executeTests is not yet modified to include multi-jvm tests when ValidatePullRequest
+ * build strategy is being determined.
+ *
+ * Making ValidatePullRequest depend on MultiNode is impossible, as then ValidatePullRequest
+ * autoplugin would trigger only on projects which have both of these plugins enabled.
+ */
 object MultiNodeWithPrValidation extends AutoPlugin {
   import AkkaValidatePullRequest._
   import com.typesafe.sbt.MultiJvmPlugin.MultiJvmKeys.MultiJvm
@@ -83,9 +76,9 @@ object MultiNodeWithPrValidation extends AutoPlugin {
 }
 
 /**
-* This autoplugin adds MiMa binary issue reporting to validatePullRequest task,
-* when a project has MimaPlugin autoplugin enabled.
-*/
+ * This autoplugin adds MiMa binary issue reporting to validatePullRequest task,
+ * when a project has MimaPlugin autoplugin enabled.
+ */
 object MimaWithPrValidation extends AutoPlugin {
   import AkkaValidatePullRequest._
 
@@ -96,24 +89,20 @@ object MimaWithPrValidation extends AutoPlugin {
 }
 
 /**
-  * This autoplugin adds Paradox doc generation to validatePullRequest task,
-  * when a project has ParadoxPlugin autoplugin enabled.
-  */
+ * This autoplugin adds Paradox doc generation to validatePullRequest task,
+ * when a project has ParadoxPlugin autoplugin enabled.
+ */
 object ParadoxWithPrValidation extends AutoPlugin {
   import AkkaValidatePullRequest._
 
   override def trigger = allRequirements
   override def requires = AkkaValidatePullRequest && ParadoxPlugin
-  override lazy val projectSettings = Seq(
-    additionalTasks += paradox in Compile
-  )
+  override lazy val projectSettings = Seq(additionalTasks += paradox in Compile)
 }
 
 object UnidocWithPrValidation extends AutoPlugin {
   import AkkaValidatePullRequest._
 
   override def trigger = noTrigger
-  override lazy val projectSettings = Seq(
-    additionalTasks += unidoc in Compile
-  )
+  override lazy val projectSettings = Seq(additionalTasks += unidoc in Compile)
 }

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -12,12 +12,11 @@ import sbt.Keys._
  */
 object VersionGenerator {
 
-  val settings: Seq[Setting[_]] = inConfig(Compile)(Seq(
-    resourceGenerators += generateVersion(resourceManaged, _ / "version.conf",
-      """|akka.version = "%s"
+  val settings: Seq[Setting[_]] = inConfig(Compile)(
+    Seq(
+      resourceGenerators += generateVersion(resourceManaged, _ / "version.conf", """|akka.version = "%s"
          |"""),
-    sourceGenerators += generateVersion(sourceManaged, _ / "akka" / "Version.scala",
-      """|package akka
+      sourceGenerators += generateVersion(sourceManaged, _ / "akka" / "Version.scala", """|package akka
          |
          |object Version {
          |  val current: String = "%s"


### PR DESCRIPTION
Follow up from:
https://github.com/akka/akka/pull/29929#discussion_r551826433 (#29929)

Apart from the temporary workaround for Scala 2.12 I just validate that we can use the same approach for Scala 3.
Thanks, @ghik and @raboof 