### PR TITLE
Explicit bang import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .*.swp
 .DS_Store
 .bloop/
+.bsp/
 .cache
 .classpath
 .codefellow

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,8 +1,7 @@
 // .scalafix.conf
 rules = [
 //  RemoveUnused
-  "github:andreaTP/akka-rewrites/ExplicitBangImport"
-//  SortImports
+  SortImports
 //  ExplicitResultTypes
 //  "github:ohze/scalafix-rules/FinalObject"
 //  fix.scala213.DottyMigrate
@@ -22,16 +21,15 @@ RemoveUnused.locals = false
 
 //ignored files
 ignored-files = [
-  "BalancingDispatcherSpec.scala"
-  # "TypedBenchmarkActors.scala",
-  # "FlowPrependSpec.scala",
-  # "FlowZipSpec.scala",
-  # "FlowZipWithSpec.scala",
-  # "FlowZipWithIndexSpec.scala",
-  # "SourceSpec.scala",
-  # "StatsSampleSpec.scala",
-  # "ActorFlowSpec.scala",
-  # "FSMTimingSpec.scala"
+  "TypedBenchmarkActors.scala",
+  "FlowPrependSpec.scala",
+  "FlowZipSpec.scala",
+  "FlowZipWithSpec.scala",
+  "FlowZipWithIndexSpec.scala",
+  "SourceSpec.scala",
+  "StatsSampleSpec.scala",
+  "ActorFlowSpec.scala",
+  "FSMTimingSpec.scala"
 ]
 
 //ignored packages

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,10 +1,11 @@
 // .scalafix.conf
 rules = [
-  RemoveUnused
-  SortImports
-  ExplicitResultTypes
-  "github:ohze/scalafix-rules/FinalObject"
-  fix.scala213.DottyMigrate
+//  RemoveUnused
+  "github:andreaTP/akka-rewrites/ExplicitBangImport"
+//  SortImports
+//  ExplicitResultTypes
+//  "github:ohze/scalafix-rules/FinalObject"
+//  fix.scala213.DottyMigrate
 //  fix.scala213.NullaryOverride
 ]
 //NullaryOverride.mode = Rewrite
@@ -21,15 +22,16 @@ RemoveUnused.locals = false
 
 //ignored files
 ignored-files = [
-  "TypedBenchmarkActors.scala",
-  "FlowPrependSpec.scala",
-  "FlowZipSpec.scala",
-  "FlowZipWithSpec.scala",
-  "FlowZipWithIndexSpec.scala",
-  "SourceSpec.scala",
-  "StatsSampleSpec.scala",
-  "ActorFlowSpec.scala",
-  "FSMTimingSpec.scala"
+  "BalancingDispatcherSpec.scala"
+  # "TypedBenchmarkActors.scala",
+  # "FlowPrependSpec.scala",
+  # "FlowZipSpec.scala",
+  # "FlowZipWithSpec.scala",
+  # "FlowZipWithIndexSpec.scala",
+  # "SourceSpec.scala",
+  # "StatsSampleSpec.scala",
+  # "ActorFlowSpec.scala",
+  # "FSMTimingSpec.scala"
 ]
 
 //ignored packages

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,10 +1,10 @@
 // .scalafix.conf
 rules = [
-//  RemoveUnused
+  RemoveUnused
   SortImports
-//  ExplicitResultTypes
-//  "github:ohze/scalafix-rules/FinalObject"
-//  fix.scala213.DottyMigrate
+  ExplicitResultTypes
+  "github:ohze/scalafix-rules/FinalObject"
+  fix.scala213.DottyMigrate
 //  fix.scala213.NullaryOverride
 ]
 //NullaryOverride.mode = Rewrite

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorLifeCycleSpec.scala
@@ -9,7 +9,9 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic._
 
 import scala.concurrent.{ Await, Future }
+
 import org.scalatest.BeforeAndAfterEach
+
 import akka.actor.Actor._
 import akka.pattern.ask
 import akka.testkit._
@@ -153,6 +155,7 @@ class ActorLifeCycleSpec extends AkkaSpec with BeforeAndAfterEach with ImplicitS
   "have a non null context after termination" in {
     class StopBeforeFutureFinishes(val latch: CountDownLatch) extends Actor {
       import context.dispatcher
+
       import akka.pattern._
 
       override def receive: Receive = {

--- a/akka-actor-tests/src/test/scala/akka/actor/ExtensionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ExtensionSpec.scala
@@ -8,11 +8,12 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.util.control.NoStackTrace
 
-import akka.testkit.EventFilter
-import akka.testkit.TestKit._
 import com.typesafe.config.ConfigFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import akka.testkit.EventFilter
+import akka.testkit.TestKit._
 
 object TestExtension extends ExtensionId[TestExtension] with ExtensionIdProvider {
   def lookup = this

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatcherActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatcherActorSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 
 import language.postfixOps
 
-import akka.actor.{ Actor, Props }
+import akka.actor.{ Actor, Props, actorRef2Scala }
 import akka.pattern.ask
 import akka.testkit.AkkaSpec
 import akka.testkit.DefaultTimeout

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatcherActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/DispatcherActorSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 
 import language.postfixOps
 
-import akka.actor.{ Actor, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, Props }
 import akka.pattern.ask
 import akka.testkit.AkkaSpec
 import akka.testkit.DefaultTimeout

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/PinnedActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/PinnedActorSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Await
 
 import org.scalatest.BeforeAndAfterEach
 
-import akka.actor.{ Actor, Props }
+import akka.actor.{ Actor, Props, actorRef2Scala }
 import akka.pattern.ask
 import akka.testkit._
 import akka.testkit.AkkaSpec

--- a/akka-actor-tests/src/test/scala/akka/actor/dispatch/PinnedActorSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dispatch/PinnedActorSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Await
 
 import org.scalatest.BeforeAndAfterEach
 
-import akka.actor.{ Actor, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, Props }
 import akka.pattern.ask
 import akka.testkit._
 import akka.testkit.AkkaSpec

--- a/akka-actor-tests/src/test/scala/akka/actor/dungeon/DispatchSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dungeon/DispatchSpec.scala
@@ -6,8 +6,8 @@ package akka.actor.dungeon
 
 import akka.actor.Actor
 import akka.actor.Props
-import akka.testkit._
 import akka.actor.actorRef2Scala
+import akka.testkit._
 
 object DispatchSpec {
   class UnserializableMessageClass

--- a/akka-actor-tests/src/test/scala/akka/actor/dungeon/DispatchSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/dungeon/DispatchSpec.scala
@@ -7,6 +7,7 @@ package akka.actor.dungeon
 import akka.actor.Actor
 import akka.actor.Props
 import akka.testkit._
+import akka.actor.actorRef2Scala
 
 object DispatchSpec {
   class UnserializableMessageClass

--- a/akka-actor-tests/src/test/scala/akka/dispatch/ControlAwareDispatcherSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/ControlAwareDispatcherSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.dispatch
 
-import akka.actor.{ Actor, Props }
+import akka.actor.{ Actor, Props, actorRef2Scala }
 import akka.testkit.{ AkkaSpec, DefaultTimeout }
 
 object ControlAwareDispatcherSpec {

--- a/akka-actor-tests/src/test/scala/akka/dispatch/ControlAwareDispatcherSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/ControlAwareDispatcherSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.dispatch
 
-import akka.actor.{ Actor, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, Props }
 import akka.testkit.{ AkkaSpec, DefaultTimeout }
 
 object ControlAwareDispatcherSpec {

--- a/akka-actor-tests/src/test/scala/akka/dispatch/ExecutionContextSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/ExecutionContextSpec.scala
@@ -13,12 +13,12 @@ import scala.concurrent.duration._
 
 import akka.actor.Actor
 import akka.actor.Props
+import akka.actor.actorRef2Scala
 import akka.testkit.{ AkkaSpec, DefaultTimeout, TestLatch }
 import akka.testkit.CallingThreadDispatcher
 import akka.testkit.TestActorRef
 import akka.testkit.TestProbe
 import akka.util.SerializedSuspendableExecutionContext
-import akka.actor.actorRef2Scala
 
 class ExecutionContextSpec extends AkkaSpec with DefaultTimeout {
 

--- a/akka-actor-tests/src/test/scala/akka/dispatch/ExecutionContextSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/ExecutionContextSpec.scala
@@ -18,6 +18,7 @@ import akka.testkit.CallingThreadDispatcher
 import akka.testkit.TestActorRef
 import akka.testkit.TestProbe
 import akka.util.SerializedSuspendableExecutionContext
+import akka.actor.actorRef2Scala
 
 class ExecutionContextSpec extends AkkaSpec with DefaultTimeout {
 

--- a/akka-actor-tests/src/test/scala/akka/dispatch/ForkJoinPoolStarvationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/ForkJoinPoolStarvationSpec.scala
@@ -6,7 +6,7 @@ package akka.dispatch
 
 import com.typesafe.config.ConfigFactory
 
-import akka.actor.{ Actor, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, Props }
 import akka.testkit.{ AkkaSpec, ImplicitSender }
 
 object ForkJoinPoolStarvationSpec {

--- a/akka-actor-tests/src/test/scala/akka/dispatch/ForkJoinPoolStarvationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/ForkJoinPoolStarvationSpec.scala
@@ -6,7 +6,7 @@ package akka.dispatch
 
 import com.typesafe.config.ConfigFactory
 
-import akka.actor.{ Actor, Props }
+import akka.actor.{ Actor, Props, actorRef2Scala }
 import akka.testkit.{ AkkaSpec, ImplicitSender }
 
 object ForkJoinPoolStarvationSpec {

--- a/akka-actor-tests/src/test/scala/akka/dispatch/PriorityDispatcherSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/PriorityDispatcherSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 import com.typesafe.config.Config
 import language.postfixOps
 
-import akka.actor.{ Actor, ActorSystem, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorSystem, Props }
 import akka.testkit.{ AkkaSpec, DefaultTimeout }
 import akka.util.unused
 

--- a/akka-actor-tests/src/test/scala/akka/dispatch/PriorityDispatcherSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/PriorityDispatcherSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 import com.typesafe.config.Config
 import language.postfixOps
 
-import akka.actor.{ Actor, ActorSystem, Props }
+import akka.actor.{ Actor, ActorSystem, Props, actorRef2Scala }
 import akka.testkit.{ AkkaSpec, DefaultTimeout }
 import akka.util.unused
 

--- a/akka-actor-tests/src/test/scala/akka/dispatch/StablePriorityDispatcherSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/StablePriorityDispatcherSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 import com.typesafe.config.Config
 import language.postfixOps
 
-import akka.actor.{ Actor, ActorSystem, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorSystem, Props }
 import akka.testkit.{ AkkaSpec, DefaultTimeout }
 import akka.util.unused
 

--- a/akka-actor-tests/src/test/scala/akka/dispatch/StablePriorityDispatcherSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/StablePriorityDispatcherSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 import com.typesafe.config.Config
 import language.postfixOps
 
-import akka.actor.{ Actor, ActorSystem, Props }
+import akka.actor.{ Actor, ActorSystem, Props, actorRef2Scala }
 import akka.testkit.{ AkkaSpec, DefaultTimeout }
 import akka.util.unused
 

--- a/akka-actor-tests/src/test/scala/akka/event/AddressTerminatedTopicBenchSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/AddressTerminatedTopicBenchSpec.scala
@@ -10,8 +10,8 @@ import akka.actor.Actor
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.actor.Props
-import akka.testkit._
 import akka.actor.actorRef2Scala
+import akka.testkit._
 
 object AddressTerminatedTopicBenchSpec {
 

--- a/akka-actor-tests/src/test/scala/akka/event/AddressTerminatedTopicBenchSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/AddressTerminatedTopicBenchSpec.scala
@@ -11,6 +11,7 @@ import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.actor.Props
 import akka.testkit._
+import akka.actor.actorRef2Scala
 
 object AddressTerminatedTopicBenchSpec {
 

--- a/akka-actor-tests/src/test/scala/akka/event/EventBusSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/EventBusSpec.scala
@@ -10,7 +10,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import language.postfixOps
 import org.scalatest.BeforeAndAfterEach
 
-import akka.actor.{ Actor, ActorRef, ActorSystem, PoisonPill, Props }
+import akka.actor.{ Actor, ActorRef, ActorSystem, PoisonPill, Props, actorRef2Scala }
 import akka.japi.Procedure
 import akka.testkit._
 

--- a/akka-actor-tests/src/test/scala/akka/event/EventBusSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/EventBusSpec.scala
@@ -10,7 +10,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import language.postfixOps
 import org.scalatest.BeforeAndAfterEach
 
-import akka.actor.{ Actor, ActorRef, ActorSystem, PoisonPill, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorRef, ActorSystem, PoisonPill, Props }
 import akka.japi.Procedure
 import akka.testkit._
 

--- a/akka-actor-tests/src/test/scala/akka/event/jul/JavaLoggerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/jul/JavaLoggerSpec.scala
@@ -10,7 +10,7 @@ import scala.util.control.NoStackTrace
 
 import com.typesafe.config.ConfigFactory
 
-import akka.actor.{ Actor, ActorLogging, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorLogging, Props }
 import akka.testkit.AkkaSpec
 
 @deprecated("Use SLF4J instead.", "2.6.0")

--- a/akka-actor-tests/src/test/scala/akka/event/jul/JavaLoggerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/jul/JavaLoggerSpec.scala
@@ -10,7 +10,7 @@ import scala.util.control.NoStackTrace
 
 import com.typesafe.config.ConfigFactory
 
-import akka.actor.{ Actor, ActorLogging, Props }
+import akka.actor.{ Actor, ActorLogging, Props, actorRef2Scala }
 import akka.testkit.AkkaSpec
 
 @deprecated("Use SLF4J instead.", "2.6.0")

--- a/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpecSupport.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpecSupport.scala
@@ -15,6 +15,7 @@ import akka.dispatch.ExecutionContexts
 import akka.io.Inet.SocketOption
 import akka.testkit.{ AkkaSpec, TestProbe }
 import akka.testkit.SocketUtil.temporaryServerAddress
+import akka.actor.actorRef2Scala
 
 trait TcpIntegrationSpecSupport { this: AkkaSpec =>
 

--- a/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpecSupport.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpIntegrationSpecSupport.scala
@@ -11,11 +11,11 @@ import Tcp._
 
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
+import akka.actor.actorRef2Scala
 import akka.dispatch.ExecutionContexts
 import akka.io.Inet.SocketOption
 import akka.testkit.{ AkkaSpec, TestProbe }
 import akka.testkit.SocketUtil.temporaryServerAddress
-import akka.actor.actorRef2Scala
 
 trait TcpIntegrationSpecSupport { this: AkkaSpec =>
 

--- a/akka-actor-tests/src/test/scala/akka/io/UdpConnectedIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpConnectedIntegrationSpec.scala
@@ -15,6 +15,7 @@ import akka.testkit.SocketUtil.temporaryServerAddresses
 import akka.testkit.TestProbe
 import akka.testkit.WithLogCapturing
 import akka.util.ByteString
+import akka.actor.actorRef2Scala
 
 class UdpConnectedIntegrationSpec extends AkkaSpec("""
     akka.loglevel = DEBUG

--- a/akka-actor-tests/src/test/scala/akka/io/UdpConnectedIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpConnectedIntegrationSpec.scala
@@ -9,13 +9,13 @@ import java.net.InetSocketAddress
 import scala.concurrent.duration._
 
 import akka.actor.ActorRef
+import akka.actor.actorRef2Scala
 import akka.testkit.AkkaSpec
 import akka.testkit.ImplicitSender
 import akka.testkit.SocketUtil.temporaryServerAddresses
 import akka.testkit.TestProbe
 import akka.testkit.WithLogCapturing
 import akka.util.ByteString
-import akka.actor.actorRef2Scala
 
 class UdpConnectedIntegrationSpec extends AkkaSpec("""
     akka.loglevel = DEBUG

--- a/akka-actor-tests/src/test/scala/akka/io/UdpIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpIntegrationSpec.scala
@@ -8,12 +8,12 @@ import java.net.DatagramSocket
 import java.net.InetSocketAddress
 
 import akka.actor.ActorRef
+import akka.actor.actorRef2Scala
 import akka.io.Inet._
 import akka.io.Udp._
 import akka.testkit.{ AkkaSpec, ImplicitSender, TestProbe }
 import akka.testkit.SocketUtil.temporaryServerAddresses
 import akka.util.ByteString
-import akka.actor.actorRef2Scala
 
 class UdpIntegrationSpec extends AkkaSpec("""
     akka.loglevel = INFO

--- a/akka-actor-tests/src/test/scala/akka/io/UdpIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/UdpIntegrationSpec.scala
@@ -13,6 +13,7 @@ import akka.io.Udp._
 import akka.testkit.{ AkkaSpec, ImplicitSender, TestProbe }
 import akka.testkit.SocketUtil.temporaryServerAddresses
 import akka.util.ByteString
+import akka.actor.actorRef2Scala
 
 class UdpIntegrationSpec extends AkkaSpec("""
     akka.loglevel = INFO

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsManagerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsManagerSpec.scala
@@ -16,6 +16,7 @@ import akka.io.dns.CachePolicy.Ttl
 import akka.io.dns.DnsProtocol.{ Resolve, Resolved }
 import akka.testkit.{ AkkaSpec, ImplicitSender }
 import akka.testkit.WithLogCapturing
+import akka.actor.actorRef2Scala
 
 // tests deprecated DNS API
 @silent("deprecated")

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsManagerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsManagerSpec.scala
@@ -10,13 +10,13 @@ import scala.collection.immutable.Seq
 
 import com.github.ghik.silencer.silent
 
+import akka.actor.actorRef2Scala
 import akka.io.Dns
 import akka.io.dns.AAAARecord
 import akka.io.dns.CachePolicy.Ttl
 import akka.io.dns.DnsProtocol.{ Resolve, Resolved }
 import akka.testkit.{ AkkaSpec, ImplicitSender }
 import akka.testkit.WithLogCapturing
-import akka.actor.actorRef2Scala
 
 // tests deprecated DNS API
 @silent("deprecated")

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsResolverSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsResolverSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 
-import akka.actor.{ ActorRef, ExtendedActorSystem, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, ActorRef, ExtendedActorSystem, Props }
 import akka.actor.Status.Failure
 import akka.io.SimpleDnsCache
 import akka.io.dns.{ AAAARecord, ARecord, DnsSettings, SRVRecord }

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsResolverSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/AsyncDnsResolverSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 
-import akka.actor.{ ActorRef, ExtendedActorSystem, Props }
+import akka.actor.{ ActorRef, ExtendedActorSystem, Props, actorRef2Scala }
 import akka.actor.Status.Failure
 import akka.io.SimpleDnsCache
 import akka.io.dns.{ AAAARecord, ARecord, DnsSettings, SRVRecord }

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/DnsClientSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/DnsClientSpec.scala
@@ -10,11 +10,11 @@ import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.immutable.Seq
 
 import akka.actor.Props
+import akka.actor.actorRef2Scala
 import akka.io.Udp
 import akka.io.dns.{ RecordClass, RecordType }
 import akka.io.dns.internal.DnsClient.{ Answer, Question4 }
 import akka.testkit.{ AkkaSpec, ImplicitSender, TestProbe }
-import akka.actor.actorRef2Scala
 
 class DnsClientSpec extends AkkaSpec with ImplicitSender {
   "The async DNS client" should {

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/DnsClientSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/DnsClientSpec.scala
@@ -14,6 +14,7 @@ import akka.io.Udp
 import akka.io.dns.{ RecordClass, RecordType }
 import akka.io.dns.internal.DnsClient.{ Answer, Question4 }
 import akka.testkit.{ AkkaSpec, ImplicitSender, TestProbe }
+import akka.actor.actorRef2Scala
 
 class DnsClientSpec extends AkkaSpec with ImplicitSender {
   "The async DNS client" should {

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/TcpDnsClientSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/TcpDnsClientSpec.scala
@@ -9,12 +9,12 @@ import java.net.InetSocketAddress
 import scala.collection.immutable.Seq
 
 import akka.actor.Props
+import akka.actor.actorRef2Scala
 import akka.io.Tcp
 import akka.io.Tcp.{ Connected, PeerClosed, Register }
 import akka.io.dns.{ RecordClass, RecordType }
 import akka.io.dns.internal.DnsClient.Answer
 import akka.testkit.{ AkkaSpec, ImplicitSender, TestProbe }
-import akka.actor.actorRef2Scala
 
 class TcpDnsClientSpec extends AkkaSpec with ImplicitSender {
   import TcpDnsClient._

--- a/akka-actor-tests/src/test/scala/akka/io/dns/internal/TcpDnsClientSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/internal/TcpDnsClientSpec.scala
@@ -14,6 +14,7 @@ import akka.io.Tcp.{ Connected, PeerClosed, Register }
 import akka.io.dns.{ RecordClass, RecordType }
 import akka.io.dns.internal.DnsClient.Answer
 import akka.testkit.{ AkkaSpec, ImplicitSender, TestProbe }
+import akka.actor.actorRef2Scala
 
 class TcpDnsClientSpec extends AkkaSpec with ImplicitSender {
   import TcpDnsClient._

--- a/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/AskSpec.scala
@@ -7,12 +7,13 @@ package akka.pattern
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Failure
-import com.github.ghik.silencer.silent
 
+import com.github.ghik.silencer.silent
 import language.postfixOps
+
 import akka.actor._
-import akka.testkit.WithLogCapturing
 import akka.testkit.{ AkkaSpec, TestProbe }
+import akka.testkit.WithLogCapturing
 import akka.util.Timeout
 
 @silent

--- a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
@@ -17,6 +17,7 @@ import scala.util.Try
 
 import akka.actor.ActorSystem
 import akka.testkit._
+import akka.actor.actorRef2Scala
 
 object CircuitBreakerSpec {
 

--- a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
@@ -16,8 +16,8 @@ import scala.util.Success
 import scala.util.Try
 
 import akka.actor.ActorSystem
-import akka.testkit._
 import akka.actor.actorRef2Scala
+import akka.testkit._
 
 object CircuitBreakerSpec {
 

--- a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerStressSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerStressSpec.scala
@@ -16,6 +16,7 @@ import akka.actor.Props
 import akka.actor.Status.Failure
 import akka.testkit.AkkaSpec
 import akka.testkit.ImplicitSender
+import akka.actor.actorRef2Scala
 
 object CircuitBreakerStressSpec {
   case object JobDone

--- a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerStressSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerStressSpec.scala
@@ -14,9 +14,9 @@ import akka.actor.Actor
 import akka.actor.ActorLogging
 import akka.actor.Props
 import akka.actor.Status.Failure
+import akka.actor.actorRef2Scala
 import akka.testkit.AkkaSpec
 import akka.testkit.ImplicitSender
-import akka.actor.actorRef2Scala
 
 object CircuitBreakerStressSpec {
   case object JobDone

--- a/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 
 import language.postfixOps
 
-import akka.actor.{ Actor, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, Props }
 import akka.testkit.{ AkkaSpec, TestLatch }
 
 object PatternSpec {

--- a/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 
 import language.postfixOps
 
-import akka.actor.{ Actor, Props }
+import akka.actor.{ Actor, Props, actorRef2Scala }
 import akka.testkit.{ AkkaSpec, TestLatch }
 
 object PatternSpec {

--- a/akka-actor-tests/src/test/scala/akka/pattern/StatusReplySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/StatusReplySpec.scala
@@ -4,16 +4,17 @@
 
 package akka.pattern
 
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import org.scalatest.concurrent.ScalaFutures
+
 import akka.Done
+import akka.actor.actorRef2Scala
 import akka.testkit.AkkaSpec
 import akka.testkit.TestException
 import akka.testkit.TestProbe
 import akka.util.Timeout
-import org.scalatest.concurrent.ScalaFutures
-
-import scala.concurrent.Future
-import scala.concurrent.duration._
-import akka.actor.actorRef2Scala
 
 class StatusReplySpec extends AkkaSpec with ScalaFutures {
 

--- a/akka-actor-tests/src/test/scala/akka/pattern/StatusReplySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/StatusReplySpec.scala
@@ -13,6 +13,7 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import akka.actor.actorRef2Scala
 
 class StatusReplySpec extends AkkaSpec with ScalaFutures {
 

--- a/akka-actor-tests/src/test/scala/akka/routing/BalancingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/BalancingSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 
 import org.scalatest.BeforeAndAfterEach
 
-import akka.actor.{ Actor, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, Props }
 import akka.actor.ActorRef
 import akka.testkit.{ AkkaSpec, ImplicitSender, TestLatch }
 

--- a/akka-actor-tests/src/test/scala/akka/routing/BalancingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/BalancingSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 
 import org.scalatest.BeforeAndAfterEach
 
-import akka.actor.{ Actor, Props }
+import akka.actor.{ Actor, Props, actorRef2Scala }
 import akka.actor.ActorRef
 import akka.testkit.{ AkkaSpec, ImplicitSender, TestLatch }
 

--- a/akka-actor-tests/src/test/scala/akka/routing/BroadcastSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/BroadcastSpec.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.Await
 
-import akka.actor.{ Actor, Props }
+import akka.actor.{ Actor, Props, actorRef2Scala }
 import akka.pattern.ask
 import akka.testkit.{ AkkaSpec, DefaultTimeout, ImplicitSender, TestLatch }
 

--- a/akka-actor-tests/src/test/scala/akka/routing/BroadcastSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/BroadcastSpec.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.concurrent.Await
 
-import akka.actor.{ Actor, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, Props }
 import akka.pattern.ask
 import akka.testkit.{ AkkaSpec, DefaultTimeout, ImplicitSender, TestLatch }
 

--- a/akka-actor-tests/src/test/scala/akka/routing/ConfiguredLocalRoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ConfiguredLocalRoutingSpec.scala
@@ -13,7 +13,7 @@ import com.typesafe.config.Config
 import language.postfixOps
 
 import akka.ConfigurationException
-import akka.actor.{ Actor, ActorRef, Deploy, Props }
+import akka.actor.{ Actor, ActorRef, Deploy, Props, actorRef2Scala }
 import akka.actor.ActorPath
 import akka.actor.ActorSystem
 import akka.actor.ExtendedActorSystem

--- a/akka-actor-tests/src/test/scala/akka/routing/ConfiguredLocalRoutingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ConfiguredLocalRoutingSpec.scala
@@ -13,7 +13,7 @@ import com.typesafe.config.Config
 import language.postfixOps
 
 import akka.ConfigurationException
-import akka.actor.{ Actor, ActorRef, Deploy, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorRef, Deploy, Props }
 import akka.actor.ActorPath
 import akka.actor.ActorSystem
 import akka.actor.ExtendedActorSystem

--- a/akka-actor-tests/src/test/scala/akka/routing/ConsistentHashingRouterSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ConsistentHashingRouterSpec.scala
@@ -10,13 +10,13 @@ import scala.concurrent.ExecutionContextExecutor
 import akka.actor.Actor
 import akka.actor.ActorRef
 import akka.actor.Props
+import akka.actor.actorRef2Scala
 import akka.pattern.ask
 import akka.routing.ConsistentHashingRouter.ConsistentHashMapping
 import akka.routing.ConsistentHashingRouter.ConsistentHashable
 import akka.routing.ConsistentHashingRouter.ConsistentHashableEnvelope
 import akka.testkit._
 import akka.testkit.AkkaSpec
-import akka.actor.actorRef2Scala
 
 object ConsistentHashingRouterSpec {
 

--- a/akka-actor-tests/src/test/scala/akka/routing/ConsistentHashingRouterSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ConsistentHashingRouterSpec.scala
@@ -16,6 +16,7 @@ import akka.routing.ConsistentHashingRouter.ConsistentHashable
 import akka.routing.ConsistentHashingRouter.ConsistentHashableEnvelope
 import akka.testkit._
 import akka.testkit.AkkaSpec
+import akka.actor.actorRef2Scala
 
 object ConsistentHashingRouterSpec {
 

--- a/akka-actor-tests/src/test/scala/akka/routing/RandomSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RandomSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 
 import language.postfixOps
 
-import akka.actor.{ Actor, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, Props }
 import akka.pattern.ask
 import akka.testkit.{ AkkaSpec, DefaultTimeout, ImplicitSender, TestLatch }
 

--- a/akka-actor-tests/src/test/scala/akka/routing/RandomSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RandomSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 
 import language.postfixOps
 
-import akka.actor.{ Actor, Props }
+import akka.actor.{ Actor, Props, actorRef2Scala }
 import akka.pattern.ask
 import akka.testkit.{ AkkaSpec, DefaultTimeout, ImplicitSender, TestLatch }
 

--- a/akka-actor-tests/src/test/scala/akka/routing/ResizerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ResizerSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 import com.typesafe.config.{ Config, ConfigFactory }
 import language.postfixOps
 
-import akka.actor.{ Actor, ActorRef, ActorSystem, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorRef, ActorSystem, Props }
 import akka.pattern.ask
 import akka.testkit._
 import akka.testkit.TestEvent._

--- a/akka-actor-tests/src/test/scala/akka/routing/ResizerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ResizerSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 import com.typesafe.config.{ Config, ConfigFactory }
 import language.postfixOps
 
-import akka.actor.{ Actor, ActorRef, ActorSystem, Props }
+import akka.actor.{ Actor, ActorRef, ActorSystem, Props, actorRef2Scala }
 import akka.pattern.ask
 import akka.testkit._
 import akka.testkit.TestEvent._

--- a/akka-actor-tests/src/test/scala/akka/routing/RoundRobinSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RoundRobinSpec.scala
@@ -17,6 +17,7 @@ import akka.actor.Props
 import akka.actor.Terminated
 import akka.pattern.ask
 import akka.testkit._
+import akka.actor.actorRef2Scala
 
 class RoundRobinSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
 

--- a/akka-actor-tests/src/test/scala/akka/routing/RoundRobinSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RoundRobinSpec.scala
@@ -15,9 +15,9 @@ import akka.actor.Actor
 import akka.actor.ActorRef
 import akka.actor.Props
 import akka.actor.Terminated
+import akka.actor.actorRef2Scala
 import akka.pattern.ask
 import akka.testkit._
-import akka.actor.actorRef2Scala
 
 class RoundRobinSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {
 

--- a/akka-actor-tests/src/test/scala/akka/routing/RouteeCreationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RouteeCreationSpec.scala
@@ -10,8 +10,8 @@ import akka.actor.Actor
 import akka.actor.ActorIdentity
 import akka.actor.Identify
 import akka.actor.Props
-import akka.testkit.AkkaSpec
 import akka.actor.actorRef2Scala
+import akka.testkit.AkkaSpec
 
 class RouteeCreationSpec extends AkkaSpec {
 

--- a/akka-actor-tests/src/test/scala/akka/routing/RouteeCreationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/RouteeCreationSpec.scala
@@ -11,6 +11,7 @@ import akka.actor.ActorIdentity
 import akka.actor.Identify
 import akka.actor.Props
 import akka.testkit.AkkaSpec
+import akka.actor.actorRef2Scala
 
 class RouteeCreationSpec extends AkkaSpec {
 

--- a/akka-actor-tests/src/test/scala/akka/routing/ScatterGatherFirstCompletedSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ScatterGatherFirstCompletedSpec.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import akka.actor.{ Actor, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, Props }
 import akka.actor.ActorSystem
 import akka.actor.Status
 import akka.pattern.ask

--- a/akka-actor-tests/src/test/scala/akka/routing/ScatterGatherFirstCompletedSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/ScatterGatherFirstCompletedSpec.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import akka.actor.{ Actor, Props }
+import akka.actor.{ Actor, Props, actorRef2Scala }
 import akka.actor.ActorSystem
 import akka.actor.Status
 import akka.pattern.ask

--- a/akka-actor-tests/src/test/scala/akka/routing/SmallestMailboxSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/SmallestMailboxSpec.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.concurrent.Await
 
-import akka.actor.{ Actor, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, Props }
 import akka.testkit.{ AkkaSpec, DefaultTimeout, ImplicitSender, TestLatch }
 
 class SmallestMailboxSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {

--- a/akka-actor-tests/src/test/scala/akka/routing/SmallestMailboxSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/SmallestMailboxSpec.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.concurrent.Await
 
-import akka.actor.{ Actor, Props }
+import akka.actor.{ Actor, Props, actorRef2Scala }
 import akka.testkit.{ AkkaSpec, DefaultTimeout, ImplicitSender, TestLatch }
 
 class SmallestMailboxSpec extends AkkaSpec with DefaultTimeout with ImplicitSender {

--- a/akka-actor-tests/src/test/scala/akka/routing/TailChoppingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/TailChoppingSpec.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import akka.actor.{ Actor, ActorRef, ActorSystem, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorRef, ActorSystem, Props }
 import akka.actor.Status.Failure
 import akka.pattern.{ ask, AskTimeoutException }
 import akka.testkit._

--- a/akka-actor-tests/src/test/scala/akka/routing/TailChoppingSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/routing/TailChoppingSpec.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-import akka.actor.{ Actor, ActorRef, ActorSystem, Props }
+import akka.actor.{ Actor, ActorRef, ActorSystem, Props, actorRef2Scala }
 import akka.actor.Status.Failure
 import akka.pattern.{ ask, AskTimeoutException }
 import akka.testkit._

--- a/akka-actor-tests/src/test/scala/akka/serialization/DisabledJavaSerializerWarningSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/DisabledJavaSerializerWarningSpec.scala
@@ -10,6 +10,7 @@ import scala.concurrent.duration._
 
 import akka.actor.ExtendedActorSystem
 import akka.testkit._
+import akka.actor.actorRef2Scala
 
 object DisabledJavaSerializerWarningSpec {
   final case class Msg(s: String)

--- a/akka-actor-tests/src/test/scala/akka/serialization/DisabledJavaSerializerWarningSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/DisabledJavaSerializerWarningSpec.scala
@@ -9,8 +9,8 @@ import java.nio.{ ByteBuffer, ByteOrder }
 import scala.concurrent.duration._
 
 import akka.actor.ExtendedActorSystem
-import akka.testkit._
 import akka.actor.actorRef2Scala
+import akka.testkit._
 
 object DisabledJavaSerializerWarningSpec {
   final case class Msg(s: String)

--- a/akka-actor-tests/src/test/scala/akka/util/ByteStringInitializationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ByteStringInitializationSpec.scala
@@ -6,11 +6,11 @@ package akka.util
 
 import java.io.InputStream
 
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuilder
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class ByteStringInitializationSpec extends AnyWordSpec with Matchers {
   "ByteString intialization" should {

--- a/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorRefProvider.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicLong
 import scala.annotation.implicitNotFound
 import scala.concurrent.{ ExecutionContextExecutor, Future, Promise }
 import scala.util.control.NonFatal
+
 import akka.ConfigurationException
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi

--- a/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
+++ b/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
@@ -18,8 +18,10 @@ import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 import scala.util.control.NonFatal
+
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
+
 import akka.Done
 import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts

--- a/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/Children.scala
@@ -9,7 +9,9 @@ import java.util.Optional
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.util.control.NonFatal
+
 import com.github.ghik.silencer.silent
+
 import akka.actor._
 import akka.annotation.InternalStableApi
 import akka.serialization.{ Serialization, SerializationExtension, Serializers }

--- a/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
+++ b/akka-actor/src/main/scala/akka/actor/dungeon/FaultHandling.scala
@@ -4,6 +4,11 @@
 
 package akka.actor.dungeon
 
+import scala.collection.immutable
+import scala.concurrent.duration.Duration
+import scala.util.control.Exception._
+import scala.util.control.NonFatal
+
 import akka.actor.{ ActorCell, ActorInterruptedException, ActorRef, InternalActorRef }
 import akka.actor.ActorRefScope
 import akka.actor.PostRestartException
@@ -15,11 +20,6 @@ import akka.dispatch.sysmsg._
 import akka.event.Logging
 import akka.event.Logging.Debug
 import akka.event.Logging.Error
-
-import scala.collection.immutable
-import scala.concurrent.duration.Duration
-import scala.util.control.Exception._
-import scala.util.control.NonFatal
 
 /**
  * INTERNAL API

--- a/akka-actor/src/main/scala/akka/dispatch/CachingConfig.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/CachingConfig.scala
@@ -4,11 +4,11 @@
 
 package akka.dispatch
 
+import java.lang.Enum
 import java.util
 import java.util.concurrent.{ ConcurrentHashMap, TimeUnit }
 
 import scala.util.{ Failure, Success, Try }
-import java.lang.Enum
 
 import com.typesafe.config._
 

--- a/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
@@ -15,7 +15,7 @@ import scala.util.control.NonFatal
 import com.typesafe.config.{ Config, ConfigFactory }
 
 import akka.ConfigurationException
-import akka.actor.{ Actor, ActorRef, ActorSystem, DeadLetter, Deploy, DynamicAccess, Props }
+import akka.actor.{ Actor, ActorRef, ActorSystem, DeadLetter, Deploy, DynamicAccess, Props, actorRef2Scala }
 import akka.dispatch.sysmsg.{
   EarliestFirstSystemMessageList,
   LatestFirstSystemMessageList,

--- a/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
@@ -15,7 +15,7 @@ import scala.util.control.NonFatal
 import com.typesafe.config.{ Config, ConfigFactory }
 
 import akka.ConfigurationException
-import akka.actor.{ Actor, ActorRef, ActorSystem, DeadLetter, Deploy, DynamicAccess, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorRef, ActorSystem, DeadLetter, Deploy, DynamicAccess, Props }
 import akka.dispatch.sysmsg.{
   EarliestFirstSystemMessageList,
   LatestFirstSystemMessageList,

--- a/akka-actor/src/main/scala/akka/event/EventBus.scala
+++ b/akka-actor/src/main/scala/akka/event/EventBus.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.immutable
 
-import akka.actor.{ ActorRef, ActorSystem }
+import akka.actor.{ ActorRef, ActorSystem, actorRef2Scala }
 import akka.util.{ Subclassification, SubclassifiedIndex }
 import akka.util.Index
 

--- a/akka-actor/src/main/scala/akka/event/EventBus.scala
+++ b/akka-actor/src/main/scala/akka/event/EventBus.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.immutable
 
-import akka.actor.{ ActorRef, ActorSystem, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, ActorRef, ActorSystem }
 import akka.util.{ Subclassification, SubclassifiedIndex }
 import akka.util.Index
 

--- a/akka-actor/src/main/scala/akka/event/EventStream.scala
+++ b/akka-actor/src/main/scala/akka/event/EventStream.scala
@@ -10,7 +10,7 @@ import scala.annotation.tailrec
 
 import com.github.ghik.silencer.silent
 
-import akka.actor.{ ActorRef, ActorSystem, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, ActorRef, ActorSystem }
 import akka.event.Logging.simpleName
 import akka.util.Subclassification
 

--- a/akka-actor/src/main/scala/akka/event/EventStream.scala
+++ b/akka-actor/src/main/scala/akka/event/EventStream.scala
@@ -10,7 +10,7 @@ import scala.annotation.tailrec
 
 import com.github.ghik.silencer.silent
 
-import akka.actor.{ ActorRef, ActorSystem }
+import akka.actor.{ ActorRef, ActorSystem, actorRef2Scala }
 import akka.event.Logging.simpleName
 import akka.util.Subclassification
 

--- a/akka-actor/src/main/scala/akka/event/jul/JavaLogger.scala
+++ b/akka-actor/src/main/scala/akka/event/jul/JavaLogger.scala
@@ -8,6 +8,7 @@ import java.util.logging
 
 import akka.actor.Actor
 import akka.actor.ActorSystem
+import akka.actor.actorRef2Scala
 import akka.dispatch.RequiresMessageQueue
 import akka.event.DummyClassForStringSources
 import akka.event.EventStream
@@ -15,7 +16,6 @@ import akka.event.LoggerMessageQueueSemantics
 import akka.event.Logging._
 import akka.event.LoggingFilter
 import akka.util.unused
-import akka.actor.actorRef2Scala
 
 /**
  * `java.util.logging` logger.

--- a/akka-actor/src/main/scala/akka/event/jul/JavaLogger.scala
+++ b/akka-actor/src/main/scala/akka/event/jul/JavaLogger.scala
@@ -15,6 +15,7 @@ import akka.event.LoggerMessageQueueSemantics
 import akka.event.Logging._
 import akka.event.LoggingFilter
 import akka.util.unused
+import akka.actor.actorRef2Scala
 
 /**
  * `java.util.logging` logger.

--- a/akka-actor/src/main/scala/akka/io/InetAddressDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/InetAddressDnsResolver.scala
@@ -17,7 +17,7 @@ import scala.util.{ Failure, Success, Try }
 import com.github.ghik.silencer.silent
 import com.typesafe.config.Config
 
-import akka.actor.{ Actor, ActorLogging }
+import akka.actor.{ Actor, ActorLogging, actorRef2Scala }
 import akka.actor.Status
 import akka.annotation.InternalApi
 import akka.io.dns.AAAARecord

--- a/akka-actor/src/main/scala/akka/io/InetAddressDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/InetAddressDnsResolver.scala
@@ -17,7 +17,7 @@ import scala.util.{ Failure, Success, Try }
 import com.github.ghik.silencer.silent
 import com.typesafe.config.Config
 
-import akka.actor.{ Actor, ActorLogging, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorLogging }
 import akka.actor.Status
 import akka.annotation.InternalApi
 import akka.io.dns.AAAARecord

--- a/akka-actor/src/main/scala/akka/io/UdpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnection.scala
@@ -12,7 +12,7 @@ import java.nio.channels.SelectionKey._
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
-import akka.actor.{ Actor, ActorLogging, ActorRef, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorLogging, ActorRef }
 import akka.actor.Status.Failure
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.io.SelectionHandler._

--- a/akka-actor/src/main/scala/akka/io/UdpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnection.scala
@@ -12,7 +12,7 @@ import java.nio.channels.SelectionKey._
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
-import akka.actor.{ Actor, ActorLogging, ActorRef }
+import akka.actor.{ Actor, ActorLogging, ActorRef, actorRef2Scala }
 import akka.actor.Status.Failure
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.io.SelectionHandler._

--- a/akka-actor/src/main/scala/akka/io/UdpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpListener.scala
@@ -11,7 +11,7 @@ import java.nio.channels.SelectionKey._
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
-import akka.actor.{ Actor, ActorLogging, ActorRef, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorLogging, ActorRef }
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.io.Inet.DatagramChannelCreator
 import akka.io.SelectionHandler._

--- a/akka-actor/src/main/scala/akka/io/UdpListener.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpListener.scala
@@ -11,7 +11,7 @@ import java.nio.channels.SelectionKey._
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
-import akka.actor.{ Actor, ActorLogging, ActorRef }
+import akka.actor.{ Actor, ActorLogging, ActorRef, actorRef2Scala }
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.io.Inet.DatagramChannelCreator
 import akka.io.SelectionHandler._

--- a/akka-actor/src/main/scala/akka/io/UdpSender.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpSender.scala
@@ -4,14 +4,15 @@
 
 package akka.io
 
+import scala.collection.immutable
+import scala.util.control.NonFatal
+
+import com.github.ghik.silencer.silent
+
 import akka.actor._
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.io.Inet.{ DatagramChannelCreator, SocketOption }
 import akka.io.Udp._
-import com.github.ghik.silencer.silent
-
-import scala.collection.immutable
-import scala.util.control.NonFatal
 
 /**
  * INTERNAL API

--- a/akka-actor/src/main/scala/akka/io/WithUdpSend.scala
+++ b/akka-actor/src/main/scala/akka/io/WithUdpSend.scala
@@ -9,7 +9,7 @@ import java.nio.channels.{ DatagramChannel, SelectionKey }
 
 import scala.util.control.NonFatal
 
-import akka.actor.{ Actor, ActorLogging, ActorRef }
+import akka.actor.{ Actor, ActorLogging, ActorRef, actorRef2Scala }
 import akka.io.SelectionHandler._
 import akka.io.Udp.{ CommandFailed, Send }
 import akka.io.dns.DnsProtocol

--- a/akka-actor/src/main/scala/akka/io/WithUdpSend.scala
+++ b/akka-actor/src/main/scala/akka/io/WithUdpSend.scala
@@ -9,7 +9,7 @@ import java.nio.channels.{ DatagramChannel, SelectionKey }
 
 import scala.util.control.NonFatal
 
-import akka.actor.{ Actor, ActorLogging, ActorRef, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorLogging, ActorRef }
 import akka.io.SelectionHandler._
 import akka.io.Udp.{ CommandFailed, Send }
 import akka.io.dns.DnsProtocol

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration.Duration
 import com.github.ghik.silencer.silent
 import com.typesafe.config.Config
 
-import akka.actor.{ Actor, ActorLogging, ActorRefFactory, Deploy, ExtendedActorSystem, Props, Timers, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorLogging, ActorRefFactory, Deploy, ExtendedActorSystem, Props, Timers }
 import akka.annotation.InternalApi
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.io.{ Dns, DnsExt, DnsProvider }

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsManager.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration.Duration
 import com.github.ghik.silencer.silent
 import com.typesafe.config.Config
 
-import akka.actor.{ Actor, ActorLogging, ActorRefFactory, Deploy, ExtendedActorSystem, Props, Timers }
+import akka.actor.{ Actor, ActorLogging, ActorRefFactory, Deploy, ExtendedActorSystem, Props, Timers, actorRef2Scala }
 import akka.annotation.InternalApi
 import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.io.{ Dns, DnsExt, DnsProvider }

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 import scala.util.Try
 import scala.util.control.NonFatal
 
-import akka.actor.{ Actor, ActorLogging, ActorRef, ActorRefFactory }
+import akka.actor.{ Actor, ActorLogging, ActorRef, ActorRefFactory, actorRef2Scala }
 import akka.annotation.InternalApi
 import akka.io.SimpleDnsCache
 import akka.io.dns._

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 import scala.util.Try
 import scala.util.control.NonFatal
 
-import akka.actor.{ Actor, ActorLogging, ActorRef, ActorRefFactory, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorLogging, ActorRef, ActorRefFactory }
 import akka.annotation.InternalApi
 import akka.io.SimpleDnsCache
 import akka.io.dns._

--- a/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
@@ -12,7 +12,7 @@ import scala.util.Try
 
 import com.github.ghik.silencer.silent
 
-import akka.actor.{ Actor, ActorLogging, ActorRef, NoSerializationVerificationNeeded, Props, Stash }
+import akka.actor.{ Actor, ActorLogging, ActorRef, NoSerializationVerificationNeeded, Props, Stash, actorRef2Scala }
 import akka.actor.Status.Failure
 import akka.annotation.InternalApi
 import akka.io.{ IO, Tcp, Udp }

--- a/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/DnsClient.scala
@@ -12,7 +12,7 @@ import scala.util.Try
 
 import com.github.ghik.silencer.silent
 
-import akka.actor.{ Actor, ActorLogging, ActorRef, NoSerializationVerificationNeeded, Props, Stash, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorLogging, ActorRef, NoSerializationVerificationNeeded, Props, Stash }
 import akka.actor.Status.Failure
 import akka.annotation.InternalApi
 import akka.io.{ IO, Tcp, Udp }

--- a/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
@@ -7,7 +7,7 @@ package akka.io.dns.internal
 import java.net.InetSocketAddress
 
 import akka.AkkaException
-import akka.actor.{ Actor, ActorLogging, ActorRef, Stash }
+import akka.actor.{ Actor, ActorLogging, ActorRef, Stash, actorRef2Scala }
 import akka.annotation.InternalApi
 import akka.io.Tcp
 import akka.io.dns.internal.DnsClient.Answer

--- a/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/TcpDnsClient.scala
@@ -7,7 +7,7 @@ package akka.io.dns.internal
 import java.net.InetSocketAddress
 
 import akka.AkkaException
-import akka.actor.{ Actor, ActorLogging, ActorRef, Stash, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorLogging, ActorRef, Stash }
 import akka.annotation.InternalApi
 import akka.io.Tcp
 import akka.io.dns.internal.DnsClient.Answer

--- a/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
@@ -11,16 +11,17 @@ import scala.annotation.tailrec
 import scala.concurrent.{ Future, Promise }
 import scala.language.implicitConversions
 import scala.util.{ Failure, Success }
+import scala.util.control.NoStackTrace
+
 import com.github.ghik.silencer.silent
+
 import akka.actor._
 import akka.annotation.{ InternalApi, InternalStableApi }
 import akka.dispatch.ExecutionContexts
 import akka.dispatch.sysmsg._
-import akka.util.ByteString
 import akka.util.{ Timeout, Unsafe }
+import akka.util.ByteString
 import akka.util.unused
-
-import scala.util.control.NoStackTrace
 
 /**
  * This is what is used to complete a Future that is returned from an ask/? call,

--- a/akka-actor/src/main/scala/akka/pattern/BackoffOptions.scala
+++ b/akka-actor/src/main/scala/akka/pattern/BackoffOptions.scala
@@ -5,6 +5,7 @@
 package akka.pattern
 
 import scala.concurrent.duration.{ Duration, FiniteDuration }
+
 import akka.actor.{ ActorRef, OneForOneStrategy, Props, SupervisorStrategy }
 import akka.annotation.{ DoNotInherit, InternalApi }
 import akka.pattern.internal.{ BackoffOnRestartSupervisor, BackoffOnStopSupervisor }

--- a/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
@@ -19,6 +19,7 @@ import scala.util.control.NoStackTrace
 import scala.util.control.NonFatal
 
 import com.github.ghik.silencer.silent
+
 import akka.AkkaException
 import akka.actor.Scheduler
 import akka.dispatch.ExecutionContexts.parasitic

--- a/akka-actor/src/main/scala/akka/pattern/HandleBackoff.scala
+++ b/akka-actor/src/main/scala/akka/pattern/HandleBackoff.scala
@@ -4,7 +4,7 @@
 
 package akka.pattern
 
-import akka.actor.{ Actor, ActorRef, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorRef, Props }
 import akka.annotation.InternalApi
 
 /**

--- a/akka-actor/src/main/scala/akka/pattern/HandleBackoff.scala
+++ b/akka-actor/src/main/scala/akka/pattern/HandleBackoff.scala
@@ -4,7 +4,7 @@
 
 package akka.pattern
 
-import akka.actor.{ Actor, ActorRef, Props }
+import akka.actor.{ Actor, ActorRef, Props, actorRef2Scala }
 import akka.annotation.InternalApi
 
 /**

--- a/akka-actor/src/main/scala/akka/pattern/Patterns.scala
+++ b/akka-actor/src/main/scala/akka/pattern/Patterns.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.{ Callable, CompletionStage, TimeUnit }
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext
+
 import akka.actor.{ ActorSelection, ClassicActorSystemProvider, Scheduler }
 import akka.util.JavaDurationConverters._
 

--- a/akka-actor/src/main/scala/akka/pattern/PipeToSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/PipeToSupport.scala
@@ -12,7 +12,7 @@ import scala.util.{ Failure, Success }
 
 import language.implicitConversions
 
-import akka.actor.{ Actor, ActorRef, Status }
+import akka.actor.{ Actor, ActorRef, Status, actorRef2Scala }
 import akka.actor.ActorSelection
 import akka.util.unused
 

--- a/akka-actor/src/main/scala/akka/pattern/PipeToSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/PipeToSupport.scala
@@ -12,7 +12,7 @@ import scala.util.{ Failure, Success }
 
 import language.implicitConversions
 
-import akka.actor.{ Actor, ActorRef, Status, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorRef, Status }
 import akka.actor.ActorSelection
 import akka.util.unused
 

--- a/akka-actor/src/main/scala/akka/pattern/StatusReply.scala
+++ b/akka-actor/src/main/scala/akka/pattern/StatusReply.scala
@@ -4,15 +4,15 @@
 
 package akka.pattern
 
+import scala.concurrent.Future
+import scala.util.{ Failure => ScalaFailure }
+import scala.util.{ Success => ScalaSuccess }
+import scala.util.Try
+import scala.util.control.NoStackTrace
+
 import akka.Done
 import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts
-
-import scala.concurrent.Future
-import scala.util.Try
-import scala.util.control.NoStackTrace
-import scala.util.{ Failure => ScalaFailure }
-import scala.util.{ Success => ScalaSuccess }
 
 /**
  * Generic top-level message type for replies that signal failure or success. Convenient to use together with the

--- a/akka-actor/src/main/scala/akka/pattern/internal/BackoffOnStopSupervisor.scala
+++ b/akka-actor/src/main/scala/akka/pattern/internal/BackoffOnStopSupervisor.scala
@@ -6,7 +6,7 @@ package akka.pattern.internal
 
 import scala.concurrent.duration.FiniteDuration
 
-import akka.actor.{ Actor, ActorLogging, OneForOneStrategy, Props, SupervisorStrategy, Terminated }
+import akka.actor.{ Actor, ActorLogging, OneForOneStrategy, Props, SupervisorStrategy, Terminated, actorRef2Scala }
 import akka.actor.SupervisorStrategy.{ Directive, Escalate }
 import akka.annotation.InternalApi
 import akka.pattern.{

--- a/akka-actor/src/main/scala/akka/pattern/internal/BackoffOnStopSupervisor.scala
+++ b/akka-actor/src/main/scala/akka/pattern/internal/BackoffOnStopSupervisor.scala
@@ -6,7 +6,7 @@ package akka.pattern.internal
 
 import scala.concurrent.duration.FiniteDuration
 
-import akka.actor.{ Actor, ActorLogging, OneForOneStrategy, Props, SupervisorStrategy, Terminated, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorLogging, OneForOneStrategy, Props, SupervisorStrategy, Terminated }
 import akka.actor.SupervisorStrategy.{ Directive, Escalate }
 import akka.annotation.InternalApi
 import akka.pattern.{

--- a/akka-actor/src/main/scala/akka/routing/Listeners.scala
+++ b/akka-actor/src/main/scala/akka/routing/Listeners.scala
@@ -6,7 +6,7 @@ package akka.routing
 
 import java.util.{ Set, TreeSet }
 
-import akka.actor.{ Actor, ActorRef }
+import akka.actor.{ Actor, ActorRef, actorRef2Scala }
 
 sealed trait ListenerMessage
 final case class Listen(listener: ActorRef) extends ListenerMessage

--- a/akka-actor/src/main/scala/akka/routing/Listeners.scala
+++ b/akka-actor/src/main/scala/akka/routing/Listeners.scala
@@ -6,7 +6,7 @@ package akka.routing
 
 import java.util.{ Set, TreeSet }
 
-import akka.actor.{ Actor, ActorRef, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorRef }
 
 sealed trait ListenerMessage
 final case class Listen(listener: ActorRef) extends ListenerMessage

--- a/akka-actor/src/main/scala/akka/routing/RoutedActorCell.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoutedActorCell.scala
@@ -21,6 +21,7 @@ import akka.actor.Terminated
 import akka.dispatch.Envelope
 import akka.dispatch.MessageDispatcher
 import akka.util.ccompat._
+import akka.actor.actorRef2Scala
 
 /**
  * INTERNAL API

--- a/akka-actor/src/main/scala/akka/routing/RoutedActorCell.scala
+++ b/akka-actor/src/main/scala/akka/routing/RoutedActorCell.scala
@@ -18,10 +18,10 @@ import akka.actor.PoisonPill
 import akka.actor.Props
 import akka.actor.SupervisorStrategy
 import akka.actor.Terminated
+import akka.actor.actorRef2Scala
 import akka.dispatch.Envelope
 import akka.dispatch.MessageDispatcher
 import akka.util.ccompat._
-import akka.actor.actorRef2Scala
 
 /**
  * INTERNAL API

--- a/akka-actor/src/main/scala/akka/util/FlightRecorderLoader.scala
+++ b/akka-actor/src/main/scala/akka/util/FlightRecorderLoader.scala
@@ -3,11 +3,11 @@
  */
 
 package akka.util
-import akka.actor.{ ClassicActorSystemProvider, ExtendedActorSystem }
-import akka.annotation.InternalApi
-
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success }
+
+import akka.actor.{ ClassicActorSystemProvider, ExtendedActorSystem }
+import akka.annotation.InternalApi
 
 /**
  * INTERNAL API

--- a/akka-actor/src/main/scala/akka/util/MessageBuffer.scala
+++ b/akka-actor/src/main/scala/akka/util/MessageBuffer.scala
@@ -4,7 +4,7 @@
 
 package akka.util
 
-import akka.actor.{ ActorRef, Dropped }
+import akka.actor.{ ActorRef, Dropped, actorRef2Scala }
 import akka.annotation.InternalApi
 import akka.japi.function.Procedure2
 

--- a/akka-actor/src/main/scala/akka/util/MessageBuffer.scala
+++ b/akka-actor/src/main/scala/akka/util/MessageBuffer.scala
@@ -4,7 +4,7 @@
 
 package akka.util
 
-import akka.actor.{ ActorRef, Dropped, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, ActorRef, Dropped }
 import akka.annotation.InternalApi
 import akka.japi.function.Procedure2
 

--- a/akka-actor/src/main/scala/akka/util/Reflect.scala
+++ b/akka-actor/src/main/scala/akka/util/Reflect.scala
@@ -7,12 +7,12 @@ import java.lang.reflect.Constructor
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 
-import akka.annotation.InternalApi
-
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.util.Try
 import scala.util.control.NonFatal
+
+import akka.annotation.InternalApi
 
 /**
  * Collection of internal reflection utilities which may or may not be

--- a/akka-actor/src/main/scala/akka/util/WallClock.scala
+++ b/akka-actor/src/main/scala/akka/util/WallClock.scala
@@ -4,10 +4,10 @@
 
 package akka.util
 
-import akka.annotation.ApiMayChange
 import java.util.concurrent.atomic.AtomicLong
 import java.util.function.LongUnaryOperator
 
+import akka.annotation.ApiMayChange
 import akka.annotation.InternalApi
 
 /**

--- a/akka-testkit/src/main/scala/akka/testkit/TestActors.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestActors.scala
@@ -4,7 +4,7 @@
 
 package akka.testkit
 
-import akka.actor.{ Actor, ActorRef, Props, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, Actor, ActorRef, Props }
 
 /**
  * A collection of common actor patterns used in tests.

--- a/akka-testkit/src/main/scala/akka/testkit/TestActors.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestActors.scala
@@ -4,7 +4,7 @@
 
 package akka.testkit
 
-import akka.actor.{ Actor, ActorRef, Props }
+import akka.actor.{ Actor, ActorRef, Props, actorRef2Scala }
 
 /**
  * A collection of common actor patterns used in tests.

--- a/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
 import scala.util.matching.Regex
 
-import akka.actor.{ ActorSystem, DeadLetter, UnhandledMessage }
+import akka.actor.{ ActorSystem, DeadLetter, UnhandledMessage, actorRef2Scala }
 import akka.actor.Dropped
 import akka.actor.NoSerializationVerificationNeeded
 import akka.dispatch.sysmsg.{ SystemMessage, Terminate }

--- a/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestEventListener.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
 import scala.util.matching.Regex
 
-import akka.actor.{ ActorSystem, DeadLetter, UnhandledMessage, actorRef2Scala }
+import akka.actor.{ actorRef2Scala, ActorSystem, DeadLetter, UnhandledMessage }
 import akka.actor.Dropped
 import akka.actor.NoSerializationVerificationNeeded
 import akka.dispatch.sysmsg.{ SystemMessage, Terminate }

--- a/akka-testkit/src/test/scala/akka/testkit/TestActorsSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/TestActorsSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.testkit
 
+import akka.actor.actorRef2Scala
 class TestActorsSpec extends AkkaSpec with ImplicitSender {
 
   import TestActors.{ echoActorProps, forwardActorProps }


### PR DESCRIPTION
References #29929 

This is a little partial step to validate the approach.
The commit history shows the steps I went through:
At each step I run:
```bash
akka > akka-actor/scalafix
akka > akka-actor/test:scalafix
akka > akka-testkit/scalafix
akka > akka-testkit/test:scalafix
akka > akka-actor-tests/scalafix
akka > akka-actor-tests/test:scalafix
```

Findings:
 - the current `.scalafix.conf` setup breaks the build if applied (need more love to understand the reason, I haven't investigated further)
 - Having multiple `scalafix` rules acting on the imports break the code ( `akka-actor-tests` )
 - Started a little project to help with those Akka specific rewrites: https://github.com/andreaTP/akka-rewrites

