### PR TITLE
Scala 3 compatible tailrec

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/LightArrayRevolverScheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/LightArrayRevolverScheduler.scala
@@ -128,16 +128,16 @@ class LightArrayRevolverScheduler(config: Config, log: LoggingAdapter, threadFac
         }
       }
 
-      @tailrec private final def tailrecCancel(): Boolean = {
-        get match {
-          case null => false
-          case c =>
-            if (c.cancel()) compareAndSet(c, null)
-            else compareAndSet(c, null) || tailrecCancel()
-        }
-      }
-
       final def cancel(): Boolean = {
+        @tailrec def tailrecCancel(): Boolean = {
+          get match {
+            case null => false
+            case c =>
+              if (c.cancel()) compareAndSet(c, null)
+              else compareAndSet(c, null) || tailrecCancel()
+          }
+        }
+
         tailrecCancel()
       }
 

--- a/akka-actor/src/main/scala/akka/actor/LightArrayRevolverScheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/LightArrayRevolverScheduler.scala
@@ -128,13 +128,17 @@ class LightArrayRevolverScheduler(config: Config, log: LoggingAdapter, threadFac
         }
       }
 
-      @tailrec final def cancel(): Boolean = {
+      @tailrec private final def tailrecCancel(): Boolean = {
         get match {
           case null => false
           case c =>
             if (c.cancel()) compareAndSet(c, null)
-            else compareAndSet(c, null) || cancel()
+            else compareAndSet(c, null) || tailrecCancel()
         }
+      }
+
+      final def cancel(): Boolean = {
+        tailrecCancel()
       }
 
       override def isCancelled: Boolean = get == null

--- a/akka-actor/src/main/scala/akka/actor/Scheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/Scheduler.scala
@@ -98,13 +98,17 @@ trait Scheduler {
         }
       }
 
-      @tailrec final def cancel(): Boolean = {
+      @tailrec private def tailrecCancel(): Boolean = {
         get match {
           case null => false
           case c =>
             if (c.cancel()) compareAndSet(c, null)
-            else compareAndSet(c, null) || cancel()
+            else compareAndSet(c, null) || tailrecCancel()
         }
+      }
+
+      final def cancel(): Boolean = {
+        tailrecCancel()
       }
 
       override def isCancelled: Boolean = get == null

--- a/akka-actor/src/main/scala/akka/actor/Scheduler.scala
+++ b/akka-actor/src/main/scala/akka/actor/Scheduler.scala
@@ -98,16 +98,16 @@ trait Scheduler {
         }
       }
 
-      @tailrec private def tailrecCancel(): Boolean = {
-        get match {
-          case null => false
-          case c =>
-            if (c.cancel()) compareAndSet(c, null)
-            else compareAndSet(c, null) || tailrecCancel()
-        }
-      }
-
       final def cancel(): Boolean = {
+        @tailrec def tailrecCancel(): Boolean = {
+          get match {
+            case null => false
+            case c =>
+              if (c.cancel()) compareAndSet(c, null)
+              else compareAndSet(c, null) || tailrecCancel()
+          }
+        }
+
         tailrecCancel()
       }
 

--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -956,8 +956,7 @@ object BoundedControlAwareMailbox {
     override def numberOfMessages: Int = size.get()
     override def hasMessages: Boolean = numberOfMessages > 0
 
-    @tailrec
-    final override def dequeue(): Envelope = {
+    @tailrec private final def tailrecDequeue(): Envelope = {
       val count = size.get()
 
       // if both queues are empty return null
@@ -971,11 +970,15 @@ object BoundedControlAwareMailbox {
 
           item
         } else {
-          dequeue()
+          tailrecDequeue()
         }
       } else {
         null
       }
+    }
+
+    final override def dequeue(): Envelope = {
+      tailrecDequeue()
     }
 
     private def signalNotFull(): Unit = {

--- a/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailbox.scala
@@ -956,28 +956,28 @@ object BoundedControlAwareMailbox {
     override def numberOfMessages: Int = size.get()
     override def hasMessages: Boolean = numberOfMessages > 0
 
-    @tailrec private final def tailrecDequeue(): Envelope = {
-      val count = size.get()
-
-      // if both queues are empty return null
-      if (count > 0) {
-        // if there are messages try to fetch the current head
-        // or retry if other consumer dequeued in the mean time
-        if (size.compareAndSet(count, count - 1)) {
-          val item = super.dequeue()
-
-          if (size.get < capacity) signalNotFull()
-
-          item
-        } else {
-          tailrecDequeue()
-        }
-      } else {
-        null
-      }
-    }
-
     final override def dequeue(): Envelope = {
+      @tailrec def tailrecDequeue(): Envelope = {
+        val count = size.get()
+
+        // if both queues are empty return null
+        if (count > 0) {
+          // if there are messages try to fetch the current head
+          // or retry if other consumer dequeued in the mean time
+          if (size.compareAndSet(count, count - 1)) {
+            val item = super.dequeue()
+
+            if (size.get < capacity) signalNotFull()
+
+            item
+          } else {
+            tailrecDequeue()
+          }
+        } else {
+          null
+        }
+      }
+
       tailrecDequeue()
     }
 

--- a/akka-actor/src/main/scala/akka/util/Collections.scala
+++ b/akka-actor/src/main/scala/akka/util/Collections.scala
@@ -28,18 +28,19 @@ private[akka] object Collections {
         private[this] var _next: To = _
         private[this] var _hasNext = false
 
-        @tailrec private final def tailrecHasNext: Boolean =
-          if (!_hasNext && superIterator.hasNext) { // If we need and are able to look for the next value
-            val potentiallyNext = superIterator.next()
-            if (isDefinedAt(potentiallyNext)) {
-              _next = apply(potentiallyNext)
-              _hasNext = true
-              true
-            } else tailrecHasNext //Attempt to find the next
-          } else _hasNext // Return if we found one
-
         override final def hasNext: Boolean = {
-          tailrecHasNext
+          @tailrec def tailrecHasNext(): Boolean = {
+            if (!_hasNext && superIterator.hasNext) { // If we need and are able to look for the next value
+              val potentiallyNext = superIterator.next()
+              if (isDefinedAt(potentiallyNext)) {
+                _next = apply(potentiallyNext)
+                _hasNext = true
+                true
+              } else tailrecHasNext //Attempt to find the next
+            } else _hasNext // Return if we found one
+          }
+
+          tailrecHasNext()
         }
 
         override final def next(): To =

--- a/akka-actor/src/main/scala/akka/util/Collections.scala
+++ b/akka-actor/src/main/scala/akka/util/Collections.scala
@@ -36,7 +36,7 @@ private[akka] object Collections {
                 _next = apply(potentiallyNext)
                 _hasNext = true
                 true
-              } else tailrecHasNext //Attempt to find the next
+              } else tailrecHasNext() //Attempt to find the next
             } else _hasNext // Return if we found one
           }
 

--- a/akka-actor/src/main/scala/akka/util/Collections.scala
+++ b/akka-actor/src/main/scala/akka/util/Collections.scala
@@ -28,15 +28,19 @@ private[akka] object Collections {
         private[this] var _next: To = _
         private[this] var _hasNext = false
 
-        @tailrec override final def hasNext: Boolean =
+        @tailrec private final def tailrecHasNext: Boolean =
           if (!_hasNext && superIterator.hasNext) { // If we need and are able to look for the next value
             val potentiallyNext = superIterator.next()
             if (isDefinedAt(potentiallyNext)) {
               _next = apply(potentiallyNext)
               _hasNext = true
               true
-            } else hasNext //Attempt to find the next
+            } else tailrecHasNext //Attempt to find the next
           } else _hasNext // Return if we found one
+
+        override final def hasNext: Boolean = {
+          tailrecHasNext
+        }
 
         override final def next(): To =
           if (hasNext) {


### PR DESCRIPTION
References #29929 

This encoding of `tailrec` methods is compatible with Scala 3 checks (thanks for the explanation @smarter !).
To the best of my knowledge, this is not going to degrade runtime perf.
