### PR TITLE
Ensure little endian ordering when copying envelope buffer

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/EnvelopeBufferPool.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/EnvelopeBufferPool.scala
@@ -557,7 +557,7 @@ private[remote] final class EnvelopeBuffer(val byteBuffer: ByteBuffer) {
     byteBuffer.rewind()
     val bytes = new Array[Byte](byteBuffer.remaining)
     byteBuffer.get(bytes)
-    val newByteBuffer = ByteBuffer.wrap(bytes)
+    val newByteBuffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
     newByteBuffer.position(p)
     byteBuffer.position(p)
     new EnvelopeBuffer(newByteBuffer)

--- a/akka-remote/src/test/scala/akka/remote/artery/EnvelopeBufferSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/EnvelopeBufferSpec.scala
@@ -5,7 +5,6 @@
 package akka.remote.artery
 
 import java.nio.{ ByteBuffer, ByteOrder }
-
 import akka.actor._
 import akka.remote.artery.compress.{ CompressionTable, CompressionTestUtils, InboundCompressions }
 import akka.serialization.Serialization
@@ -213,6 +212,26 @@ class EnvelopeBufferSpec extends AkkaSpec {
       ByteString.fromByteBuffer(envelope.byteBuffer) should ===(payload)
     }
 
+    "produce an identical copy" in {
+      val senderRef = minimalRef("uncompressable0")
+      val recipientRef = minimalRef("uncompressable11")
+
+      headerIn.setVersion(version)
+      headerIn.setUid(42)
+      headerIn.setSerializer(4)
+      headerIn.setSenderActorRef(senderRef)
+      headerIn.setRecipientActorRef(recipientRef)
+      headerIn.setManifest("uncompressable3333")
+
+      envelope.writeHeader(headerIn)
+
+      val copy = envelope.copy()
+      val position = copy.byteBuffer.position()
+      position should ===(envelope.byteBuffer.position())
+      copy.byteBuffer.order() should ===(envelope.byteBuffer.order())
+      copy.byteBuffer should ===(envelope.byteBuffer)
+      (copy.byteBuffer shouldNot be).theSameInstanceAs(envelope.byteBuffer)
+    }
   }
 
   def lengthOfSerializedActorRefPath(ref: ActorRef): Int =

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteInstrumentsSerializationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteInstrumentsSerializationSpec.scala
@@ -6,14 +6,14 @@ package akka.remote.artery
 
 import java.nio.{ ByteBuffer, CharBuffer }
 import java.nio.charset.Charset
-
 import scala.concurrent.duration._
-
 import akka.actor.{ ActorRef, ActorSystem, ExtendedActorSystem, InternalActorRef }
 import akka.event._
 import akka.testkit.{ AkkaSpec, EventFilter, TestProbe }
 import akka.testkit.TestEvent.Mute
 import akka.util.{ unused, OptionVal }
+
+import java.nio.ByteOrder
 
 class RemoteInstrumentsSerializationSpec extends AkkaSpec("akka.loglevel = DEBUG") {
   import RemoteInstrumentsSerializationSpec._
@@ -34,7 +34,7 @@ class RemoteInstrumentsSerializationSpec extends AkkaSpec("akka.loglevel = DEBUG
 
   "RemoteInstruments" should {
     "not write anything in the buffer if not deserializing" in {
-      val buffer = ByteBuffer.allocate(1024)
+      val buffer = ByteBuffer.allocate(1024).order(ByteOrder.LITTLE_ENDIAN)
       serialize(remoteInstruments(), buffer)
       buffer.position() should be(0)
     }
@@ -209,7 +209,7 @@ object RemoteInstrumentsSerializationSpec {
       riD: RemoteInstruments,
       recipient: ActorRef,
       message: AnyRef): Unit = {
-    val buffer = ByteBuffer.allocate(1024)
+    val buffer = ByteBuffer.allocate(1024).order(ByteOrder.LITTLE_ENDIAN)
     serialize(riS, buffer)
     buffer.flip()
     deserialize(riD, buffer, recipient, message)


### PR DESCRIPTION
References #29911


Couldn't figure out how to reproduce, or why `RemoteInstrumentsSerializationSpec` doesn't catch this one, but added another test verifying `EnvelopeBuffer.copy` at least.