### PR TITLE
SubSinkInlet/SubSourceOutlet memory leak fix

### DIFF
--- a/akka-stream/src/main/mima-filters/2.6.11.backwards.excludes/29966-sub-inlet-outlet-memleak.backward.excludes
+++ b/akka-stream/src/main/mima-filters/2.6.11.backwards.excludes/29966-sub-inlet-outlet-memleak.backward.excludes
@@ -1,0 +1,7 @@
+# small optimization of ConcurrentAsyncCallback internal state
+ProblemFilters.exclude[MissingClassProblem]("akka.stream.stage.GraphStageLogic$ConcurrentAsyncCallback$Event$")
+ProblemFilters.exclude[MissingClassProblem]("akka.stream.stage.GraphStageLogic$ConcurrentAsyncCallback$State")
+ProblemFilters.exclude[MissingClassProblem]("akka.stream.stage.GraphStageLogic$ConcurrentAsyncCallback$Pending$")
+ProblemFilters.exclude[MissingClassProblem]("akka.stream.stage.GraphStageLogic$ConcurrentAsyncCallback$Event")
+ProblemFilters.exclude[MissingClassProblem]("akka.stream.stage.GraphStageLogic$ConcurrentAsyncCallback$Initialized$")
+ProblemFilters.exclude[MissingClassProblem]("akka.stream.stage.GraphStageLogic$ConcurrentAsyncCallback$Pending")

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -1435,9 +1435,11 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
         case OnComplete =>
           closed = true
           handler.onUpstreamFinish()
+          GraphStageLogic.this.completedOrFailed(this)
         case OnError(ex) =>
           closed = true
           handler.onUpstreamFailure(ex)
+          GraphStageLogic.this.completedOrFailed(this)
       }
     }.invoke _)
 
@@ -1513,6 +1515,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
           available = false
           closed = true
           handler.onDownstreamFinish(cause)
+          GraphStageLogic.this.completedOrFailed(this)
         }
     }
 


### PR DESCRIPTION
References #29966

A memory leak was introduced by the SubSinkInlet SubSourceOutlet auto closing logic introduced in the fix for #29790
where the inlet/outlets were left in the autoclose-on-stop-set when upstream/downstream completes and therefore would stay resident (and potentially keep other things resident, worst case causing OOM) for the entire life of the parent graphstage. Problematic for example for FlattenMerge which creates one such substream per element.

Couldn't think of a good test to repeat it that wouldn't be super slow, so didn't add one, but there is a repeater in the issue.

Also contains a small memory usage optimization for the AsyncCallback state classes sharing them across instances instead of creating one for each AsyncCallback.