### PR TITLE
Don't add MemberExited as unreachable in SBR, #29950

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/sbr/SplitBrainResolver.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/sbr/SplitBrainResolver.scala
@@ -269,9 +269,9 @@ import akka.remote.artery.ThisActorSystemQuarantinedEvent
     case MemberWeaklyUp(m)                          => addWeaklyUp(m)
     case MemberUp(m)                                => addUp(m)
     case MemberLeft(m)                              => leaving(m)
+    case MemberExited(m)                            => exited(m)
     case UnreachableMember(m)                       => unreachableMember(m)
     case MemberDowned(m)                            => unreachableMember(m)
-    case MemberExited(m)                            => unreachableMember(m)
     case ReachableMember(m)                         => reachableMember(m)
     case ReachabilityChanged(r)                     => reachabilityChanged(r)
     case MemberRemoved(m, _)                        => remove(m)
@@ -473,7 +473,7 @@ import akka.remote.artery.ThisActorSystemQuarantinedEvent
       else ""}, " +
       s"[${strategy.unreachable.size}] unreachable of [${strategy.members.size}] members" +
       indirectlyConnectedLogMessage +
-      s", all members in DC [${strategy.allMembersInDC.mkString(", ")}], full reachability status: ${strategy.reachability}" +
+      s", all members in DC [${strategy.allMembersInDC.mkString(", ")}], full reachability status: [${strategy.reachability}]" +
       unreachableDataCentersLogMessage)
   }
 
@@ -565,6 +565,15 @@ import akka.remote.artery.ThisActorSystemQuarantinedEvent
     if (selfDc == m.dataCenter) {
       log.debug("SBR leaving [{}]", m)
       mutateMemberInfo(resetStable = false) { () =>
+        strategy.add(m)
+      }
+    }
+  }
+
+  def exited(m: Member): Unit = {
+    if (selfDc == m.dataCenter) {
+      log.debug("SBR exited [{}]", m)
+      mutateMemberInfo(resetStable = true) { () =>
         strategy.add(m)
       }
     }


### PR DESCRIPTION
I could reproduce the scenario described in the issue by delaying the CoordinatedShutdown PhaseClusterLeave longer than the sbt.stable-after. Normally the leaving doesn't take that long but could happen in larger clusters or with Sharding taking long time to stop.

It was anyway not downing the Exiting members, but the logging was confusing.

References #29950
