### PR TITLE
Fix supervision sample project link

### DIFF
--- a/akka-docs/src/main/paradox/general/supervision.md
+++ b/akka-docs/src/main/paradox/general/supervision.md
@@ -7,7 +7,7 @@ refer to the corresponding chapters for Scala and Java APIs.
 ## Sample project
 
 You can look at the
-@extref[Supervision example project](samples:akka-samples-supervision-java)
+@link[Supervision example project](https://github.com/akka/akka-samples/tree/2.5/akka-sample-supervision-java) { open=new }
 to see what this looks like in practice.
 
 <a id="supervision-directives"></a>

--- a/akka-docs/src/main/paradox/general/supervision.md
+++ b/akka-docs/src/main/paradox/general/supervision.md
@@ -7,7 +7,7 @@ refer to the corresponding chapters for Scala and Java APIs.
 ## Sample project
 
 You can look at the
-@extref[Supervision example project](supervisor-sample)
+@link[Supervision example project](https://github.com/akka/akka-samples/tree/2.5/akka-sample-supervision-java) { open=new }
 to see what this looks like in practice.
 
 <a id="supervision-directives"></a>

--- a/akka-docs/src/main/paradox/general/supervision.md
+++ b/akka-docs/src/main/paradox/general/supervision.md
@@ -7,7 +7,7 @@ refer to the corresponding chapters for Scala and Java APIs.
 ## Sample project
 
 You can look at the
-@link[Supervision example project](https://github.com/akka/akka-samples/tree/2.5/akka-sample-supervision-java) { open=new }
+@extref[Supervision example project](supervisor-sample)
 to see what this looks like in practice.
 
 <a id="supervision-directives"></a>

--- a/build.sbt
+++ b/build.sbt
@@ -252,7 +252,6 @@ lazy val docs = akkaModule("akka-docs")
       "extref.github.base_url" -> (GitHub.url(version.value) + "/%s"), // for links to our sources
       "extref.samples.base_url" -> "https://developer.lightbend.com/start/?group=akka&project=%s",
       "extref.ecs.base_url" -> "https://example.lightbend.com/v1/download/%s",
-      "extref.superviser_sample" -> "https://github.com/akka/akka-samples/tree/2.5/akka-sample-supervision-java",
       "scaladoc.akka.base_url" -> "https://doc.akka.io/api/akka/2.5",
       "scaladoc.akka.http.base_url" -> "https://doc.akka.io/api/akka-http/current",
       "javadoc.akka.base_url" -> "https://doc.akka.io/japi/akka/2.5",

--- a/build.sbt
+++ b/build.sbt
@@ -252,6 +252,7 @@ lazy val docs = akkaModule("akka-docs")
       "extref.github.base_url" -> (GitHub.url(version.value) + "/%s"), // for links to our sources
       "extref.samples.base_url" -> "https://developer.lightbend.com/start/?group=akka&project=%s",
       "extref.ecs.base_url" -> "https://example.lightbend.com/v1/download/%s",
+      "extref.superviser_sample" -> "https://github.com/akka/akka-samples/tree/2.5/akka-sample-supervision-java",
       "scaladoc.akka.base_url" -> "https://doc.akka.io/api/akka/2.5",
       "scaladoc.akka.http.base_url" -> "https://doc.akka.io/api/akka-http/current",
       "javadoc.akka.base_url" -> "https://doc.akka.io/japi/akka/2.5",


### PR DESCRIPTION
Per [this linked conversation thread](https://typesafe.slack.com/archives/C1ETEPM36/p1612549367066100), this addresses a broken link to the Supervision sample project in the Supervision and Monitoring page of the Akka docs by hard-linking it specifically for the 2.5 docs. 

It would be beneficial to include a similar link in the 2.6 documentation for Classic Actors Supervision since it's still applicable, I believe.
