### PR TITLE
Re-add parenthesis to ExtensionIdProvider.lookup method

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ExtensionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ExtensionSpec.scala
@@ -16,7 +16,7 @@ import akka.testkit.EventFilter
 import akka.testkit.TestKit._
 
 object TestExtension extends ExtensionId[TestExtension] with ExtensionIdProvider {
-  def lookup = this
+  override def lookup() = this
   def createExtension(s: ExtendedActorSystem) = new TestExtension(s)
 }
 
@@ -24,7 +24,7 @@ object TestExtension extends ExtensionId[TestExtension] with ExtensionIdProvider
 class TestExtension(val system: ExtendedActorSystem) extends Extension
 
 object FailingTestExtension extends ExtensionId[FailingTestExtension] with ExtensionIdProvider {
-  def lookup = this
+  override def lookup() = this
   def createExtension(s: ExtendedActorSystem) = new FailingTestExtension(s)
 
   class TestException extends IllegalArgumentException("ERR") with NoStackTrace
@@ -35,7 +35,7 @@ object InstanceCountingExtension extends ExtensionId[InstanceCountingExtension] 
   override def createExtension(system: ExtendedActorSystem): InstanceCountingExtension = {
     new InstanceCountingExtension
   }
-  override def lookup: ExtensionId[_ <: Extension] = this
+  override def lookup(): ExtensionId[_ <: Extension] = this
 }
 
 class InstanceCountingExtension extends Extension {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorSystemAdapter.scala
@@ -137,7 +137,7 @@ private[akka] object ActorSystemAdapter {
 
   object AdapterExtension extends classic.ExtensionId[AdapterExtension] with classic.ExtensionIdProvider {
     override def get(system: classic.ActorSystem): AdapterExtension = super.get(system)
-    override def lookup = AdapterExtension
+    override def lookup() = AdapterExtension
     override def createExtension(system: classic.ExtendedActorSystem): AdapterExtension =
       new AdapterExtension(system)
   }
@@ -154,7 +154,7 @@ private[akka] object ActorSystemAdapter {
   }
 
   object LoadTypedExtensions extends classic.ExtensionId[LoadTypedExtensions] with classic.ExtensionIdProvider {
-    override def lookup: actor.ExtensionId[_ <: actor.Extension] = this
+    override def lookup(): actor.ExtensionId[_ <: actor.Extension] = this
     override def createExtension(system: ExtendedActorSystem): LoadTypedExtensions =
       new LoadTypedExtensions(system)
   }

--- a/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorSystem.scala
@@ -1198,7 +1198,7 @@ private[akka] class ActorSystemImpl(
             dynamicAccess.createInstanceFor[AnyRef](fqcn, Nil).recoverWith { case _ => Failure(firstProblem) }
         } match {
           case Success(p: ExtensionIdProvider) =>
-            registerExtension(p.lookup)
+            registerExtension(p.lookup())
           case Success(p: ExtensionId[_]) =>
             registerExtension(p)
           case Success(_) =>

--- a/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
+++ b/akka-actor/src/main/scala/akka/actor/CoordinatedShutdown.scala
@@ -182,7 +182,7 @@ object CoordinatedShutdown extends ExtensionId[CoordinatedShutdown] with Extensi
 
   override def get(system: ClassicActorSystemProvider): CoordinatedShutdown = super.get(system)
 
-  override def lookup = CoordinatedShutdown
+  override def lookup() = CoordinatedShutdown
 
   override def createExtension(system: ExtendedActorSystem): CoordinatedShutdown = {
     val conf = system.settings.config.getConfig("akka.coordinated-shutdown")

--- a/akka-actor/src/main/scala/akka/actor/Extension.scala
+++ b/akka-actor/src/main/scala/akka/actor/Extension.scala
@@ -25,7 +25,7 @@ package akka.actor
  * {{{
  * object MyExt extends ExtensionId[Ext] with ExtensionIdProvider {
  *
- *   override def lookup = MyExt
+ *   override def lookup() = MyExt
  *
  *   override def createExtension(system: ExtendedActorSystem): Ext = new Ext(system)
  *
@@ -132,5 +132,5 @@ trait ExtensionIdProvider {
   /**
    * Returns the canonical ExtensionId for this Extension
    */
-  def lookup: ExtensionId[_ <: Extension]
+  def lookup(): ExtensionId[_ <: Extension]
 }

--- a/akka-actor/src/main/scala/akka/actor/TypedActor.scala
+++ b/akka-actor/src/main/scala/akka/actor/TypedActor.scala
@@ -110,7 +110,7 @@ object TypedActor extends ExtensionId[TypedActorExtension] with ExtensionIdProvi
   override def get(system: ActorSystem): TypedActorExtension = super.get(system)
   override def get(system: ClassicActorSystemProvider): TypedActorExtension = super.get(system)
 
-  def lookup = this
+  override def lookup() = this
   def createExtension(system: ExtendedActorSystem): TypedActorExtension = new TypedActorExtension(system)
 
   /**

--- a/akka-actor/src/main/scala/akka/event/AddressTerminatedTopic.scala
+++ b/akka-actor/src/main/scala/akka/event/AddressTerminatedTopic.scala
@@ -29,7 +29,7 @@ private[akka] object AddressTerminatedTopic extends ExtensionId[AddressTerminate
   override def get(system: ActorSystem): AddressTerminatedTopic = super.get(system)
   override def get(system: ClassicActorSystemProvider): AddressTerminatedTopic = super.get(system)
 
-  override def lookup = AddressTerminatedTopic
+  override def lookup() = AddressTerminatedTopic
 
   override def createExtension(system: ExtendedActorSystem): AddressTerminatedTopic =
     new AddressTerminatedTopic

--- a/akka-actor/src/main/scala/akka/io/Dns.scala
+++ b/akka-actor/src/main/scala/akka/io/Dns.scala
@@ -137,7 +137,7 @@ object Dns extends ExtensionId[DnsExt] with ExtensionIdProvider {
     Dns(system).cache.resolve(name, system, sender)
   }
 
-  override def lookup = Dns
+  override def lookup() = Dns
 
   override def createExtension(system: ExtendedActorSystem): DnsExt = new DnsExt(system)
 

--- a/akka-actor/src/main/scala/akka/io/Tcp.scala
+++ b/akka-actor/src/main/scala/akka/io/Tcp.scala
@@ -39,7 +39,7 @@ import akka.util.ccompat.JavaConverters._
  */
 object Tcp extends ExtensionId[TcpExt] with ExtensionIdProvider {
 
-  override def lookup = Tcp
+  override def lookup() = Tcp
 
   override def createExtension(system: ExtendedActorSystem): TcpExt = new TcpExt(system)
 

--- a/akka-actor/src/main/scala/akka/io/Udp.scala
+++ b/akka-actor/src/main/scala/akka/io/Udp.scala
@@ -33,7 +33,7 @@ import akka.util.ccompat._
 @ccompatUsedUntil213
 object Udp extends ExtensionId[UdpExt] with ExtensionIdProvider {
 
-  override def lookup = Udp
+  override def lookup() = Udp
 
   override def createExtension(system: ExtendedActorSystem): UdpExt = new UdpExt(system)
 

--- a/akka-actor/src/main/scala/akka/io/UdpConnected.scala
+++ b/akka-actor/src/main/scala/akka/io/UdpConnected.scala
@@ -32,7 +32,7 @@ import akka.util.ccompat._
 @ccompatUsedUntil213
 object UdpConnected extends ExtensionId[UdpConnectedExt] with ExtensionIdProvider {
 
-  override def lookup = UdpConnected
+  override def lookup() = UdpConnected
 
   override def createExtension(system: ExtendedActorSystem): UdpConnectedExt = new UdpConnectedExt(system)
 

--- a/akka-actor/src/main/scala/akka/serialization/SerializationExtension.scala
+++ b/akka-actor/src/main/scala/akka/serialization/SerializationExtension.scala
@@ -14,6 +14,6 @@ import akka.actor.ClassicActorSystemProvider
 object SerializationExtension extends ExtensionId[Serialization] with ExtensionIdProvider {
   override def get(system: ActorSystem): Serialization = super.get(system)
   override def get(system: ClassicActorSystemProvider): Serialization = super.get(system)
-  override def lookup = SerializationExtension
+  override def lookup() = SerializationExtension
   override def createExtension(system: ExtendedActorSystem): Serialization = new Serialization(system)
 }

--- a/akka-actor/src/main/scala/akka/util/ManifestInfo.scala
+++ b/akka-actor/src/main/scala/akka/util/ManifestInfo.scala
@@ -44,7 +44,7 @@ object ManifestInfo extends ExtensionId[ManifestInfo] with ExtensionIdProvider {
   override def get(system: ActorSystem): ManifestInfo = super.get(system)
   override def get(system: ClassicActorSystemProvider): ManifestInfo = super.get(system)
 
-  override def lookup: ManifestInfo.type = ManifestInfo
+  override def lookup(): ManifestInfo.type = ManifestInfo
 
   override def createExtension(system: ExtendedActorSystem): ManifestInfo = new ManifestInfo(system)
 

--- a/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsExtension.scala
+++ b/akka-cluster-metrics/src/main/scala/akka/cluster/metrics/ClusterMetricsExtension.scala
@@ -88,7 +88,7 @@ class ClusterMetricsExtension(system: ExtendedActorSystem) extends Extension {
  * Cluster metrics extension provider.
  */
 object ClusterMetricsExtension extends ExtensionId[ClusterMetricsExtension] with ExtensionIdProvider {
-  override def lookup = ClusterMetricsExtension
+  override def lookup() = ClusterMetricsExtension
   override def get(system: ActorSystem): ClusterMetricsExtension = super.get(system)
   override def get(system: ClassicActorSystemProvider): ClusterMetricsExtension = super.get(system)
   override def createExtension(system: ExtendedActorSystem): ClusterMetricsExtension =

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -159,7 +159,7 @@ object ClusterSharding extends ExtensionId[ClusterSharding] with ExtensionIdProv
   override def get(system: ActorSystem): ClusterSharding = super.get(system)
   override def get(system: ClassicActorSystemProvider): ClusterSharding = super.get(system)
 
-  override def lookup = ClusterSharding
+  override def lookup() = ClusterSharding
 
   override def createExtension(system: ExtendedActorSystem): ClusterSharding =
     new ClusterSharding(system)

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardingFlightRecorder.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardingFlightRecorder.scala
@@ -13,7 +13,7 @@ import akka.util.FlightRecorderLoader
 @InternalApi
 object ShardingFlightRecorder extends ExtensionId[ShardingFlightRecorder] with ExtensionIdProvider {
 
-  override def lookup: ExtensionId[_ <: Extension] = this
+  override def lookup(): ExtensionId[_ <: Extension] = this
 
   override def createExtension(system: ExtendedActorSystem): ShardingFlightRecorder =
     FlightRecorderLoader.load[ShardingFlightRecorder](

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/external/ExternalShardAllocation.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/external/ExternalShardAllocation.scala
@@ -48,7 +48,7 @@ object ExternalShardAllocation extends ExtensionId[ExternalShardAllocation] with
   override def createExtension(system: ExtendedActorSystem): ExternalShardAllocation =
     new ExternalShardAllocation(system)
 
-  override def lookup: ExternalShardAllocation.type = ExternalShardAllocation
+  override def lookup(): ExternalShardAllocation.type = ExternalShardAllocation
 
   override def get(system: ClassicActorSystemProvider): ExternalShardAllocation = super.get(system)
 }

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/SbrTestLeaseActor.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/SbrTestLeaseActor.scala
@@ -71,7 +71,7 @@ class SbrTestLeaseActor extends Actor with ActorLogging {
 
 object SbrTestLeaseActorClientExt extends ExtensionId[SbrTestLeaseActorClientExt] with ExtensionIdProvider {
   override def get(system: ActorSystem): SbrTestLeaseActorClientExt = super.get(system)
-  override def lookup = SbrTestLeaseActorClientExt
+  override def lookup() = SbrTestLeaseActorClientExt
   override def createExtension(system: ExtendedActorSystem): SbrTestLeaseActorClientExt =
     new SbrTestLeaseActorClientExt(system)
 }

--- a/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/client/ClusterClient.scala
@@ -561,7 +561,7 @@ object ClusterClientReceptionist extends ExtensionId[ClusterClientReceptionist] 
   override def get(system: ActorSystem): ClusterClientReceptionist = super.get(system)
   override def get(system: ClassicActorSystemProvider): ClusterClientReceptionist = super.get(system)
 
-  override def lookup = ClusterClientReceptionist
+  override def lookup() = ClusterClientReceptionist
 
   override def createExtension(system: ExtendedActorSystem): ClusterClientReceptionist =
     new ClusterClientReceptionist(system)

--- a/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
+++ b/akka-cluster-tools/src/main/scala/akka/cluster/pubsub/DistributedPubSubMediator.scala
@@ -922,7 +922,7 @@ object DistributedPubSub extends ExtensionId[DistributedPubSub] with ExtensionId
 
   override def get(system: ClassicActorSystemProvider): DistributedPubSub = super.get(system)
 
-  override def lookup = DistributedPubSub
+  override def lookup() = DistributedPubSub
 
   override def createExtension(system: ExtendedActorSystem): DistributedPubSub =
     new DistributedPubSub(system)

--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -38,7 +38,7 @@ object Cluster extends ExtensionId[Cluster] with ExtensionIdProvider {
 
   override def get(system: ClassicActorSystemProvider): Cluster = super.get(system)
 
-  override def lookup = Cluster
+  override def lookup() = Cluster
 
   override def createExtension(system: ExtendedActorSystem): Cluster = new Cluster(system)
 

--- a/akka-coordination/src/main/scala/akka/coordination/lease/javadsl/LeaseProvider.scala
+++ b/akka-coordination/src/main/scala/akka/coordination/lease/javadsl/LeaseProvider.scala
@@ -14,7 +14,7 @@ object LeaseProvider extends ExtensionId[LeaseProvider] with ExtensionIdProvider
   override def get(system: ActorSystem): LeaseProvider = super.get(system)
   override def get(system: ClassicActorSystemProvider): LeaseProvider = super.get(system)
 
-  override def lookup = LeaseProvider
+  override def lookup() = LeaseProvider
 
   override def createExtension(system: ExtendedActorSystem): LeaseProvider = new LeaseProvider(system)
 

--- a/akka-coordination/src/main/scala/akka/coordination/lease/scaladsl/LeaseProvider.scala
+++ b/akka-coordination/src/main/scala/akka/coordination/lease/scaladsl/LeaseProvider.scala
@@ -25,7 +25,7 @@ object LeaseProvider extends ExtensionId[LeaseProvider] with ExtensionIdProvider
   override def get(system: ActorSystem): LeaseProvider = super.get(system)
   override def get(system: ClassicActorSystemProvider): LeaseProvider = super.get(system)
 
-  override def lookup = LeaseProvider
+  override def lookup() = LeaseProvider
 
   override def createExtension(system: ExtendedActorSystem): LeaseProvider = new LeaseProvider(system)
 

--- a/akka-coordination/src/test/scala/akka/coordination/lease/TestLease.scala
+++ b/akka-coordination/src/test/scala/akka/coordination/lease/TestLease.scala
@@ -26,7 +26,7 @@ import akka.util.ccompat.JavaConverters._
 object TestLeaseExt extends ExtensionId[TestLeaseExt] with ExtensionIdProvider {
   override def get(system: ActorSystem): TestLeaseExt = super.get(system)
   override def get(system: ClassicActorSystemProvider): TestLeaseExt = super.get(system)
-  override def lookup = TestLeaseExt
+  override def lookup() = TestLeaseExt
   override def createExtension(system: ExtendedActorSystem): TestLeaseExt = new TestLeaseExt(system)
 }
 

--- a/akka-coordination/src/test/scala/akka/coordination/lease/TestLeaseActor.scala
+++ b/akka-coordination/src/test/scala/akka/coordination/lease/TestLeaseActor.scala
@@ -73,7 +73,7 @@ class TestLeaseActor extends Actor with ActorLogging {
 object TestLeaseActorClientExt extends ExtensionId[TestLeaseActorClientExt] with ExtensionIdProvider {
   override def get(system: ActorSystem): TestLeaseActorClientExt = super.get(system)
   override def get(system: ClassicActorSystemProvider): TestLeaseActorClientExt = super.get(system)
-  override def lookup = TestLeaseActorClientExt
+  override def lookup() = TestLeaseActorClientExt
   override def createExtension(system: ExtendedActorSystem): TestLeaseActorClientExt =
     new TestLeaseActorClientExt(system)
 }

--- a/akka-discovery/src/main/scala/akka/discovery/Discovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/Discovery.scala
@@ -99,7 +99,7 @@ final class Discovery(implicit system: ExtendedActorSystem) extends Extension {
 object Discovery extends ExtensionId[Discovery] with ExtensionIdProvider {
   override def apply(system: ActorSystem): Discovery = super.apply(system)
 
-  override def lookup: Discovery.type = Discovery
+  override def lookup(): Discovery.type = Discovery
 
   override def get(system: ActorSystem): Discovery = super.get(system)
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/DistributedData.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/DistributedData.scala
@@ -18,7 +18,7 @@ object DistributedData extends ExtensionId[DistributedData] with ExtensionIdProv
   override def get(system: ActorSystem): DistributedData = super.get(system)
   override def get(system: ClassicActorSystemProvider): DistributedData = super.get(system)
 
-  override def lookup = DistributedData
+  override def lookup() = DistributedData
 
   override def createExtension(system: ExtendedActorSystem): DistributedData =
     new DistributedData(system)

--- a/akka-docs/src/test/scala/docs/extension/ExtensionDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/extension/ExtensionDocSpec.scala
@@ -34,7 +34,7 @@ object CountExtension extends ExtensionId[CountExtensionImpl] with ExtensionIdPr
   // so we return ourselves here, this allows us
   // to configure our extension to be loaded when
   // the ActorSystem starts up
-  override def lookup = CountExtension
+  override def lookup() = CountExtension
 
   //This method will be called by Akka
   // to instantiate our Extension

--- a/akka-docs/src/test/scala/docs/extension/SettingsExtensionDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/extension/SettingsExtensionDocSpec.scala
@@ -33,7 +33,7 @@ class SettingsImpl(config: Config) extends Extension {
 //#extensionid
 object Settings extends ExtensionId[SettingsImpl] with ExtensionIdProvider {
 
-  override def lookup = Settings
+  override def lookup() = Settings
 
   override def createExtension(system: ExtendedActorSystem) =
     new SettingsImpl(system.settings.config)

--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Extension.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Extension.scala
@@ -24,7 +24,7 @@ import akka.util.Timeout
  */
 object TestConductor extends ExtensionId[TestConductorExt] with ExtensionIdProvider {
 
-  override def lookup = TestConductor
+  override def lookup() = TestConductor
 
   override def createExtension(system: ExtendedActorSystem): TestConductorExt = new TestConductorExt(system)
 

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/PersistenceQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/PersistenceQuery.scala
@@ -24,7 +24,7 @@ object PersistenceQuery extends ExtensionId[PersistenceQuery] with ExtensionIdPr
 
   def createExtension(system: ExtendedActorSystem): PersistenceQuery = new PersistenceQuery(system)
 
-  def lookup: PersistenceQuery.type = PersistenceQuery
+  override def lookup(): PersistenceQuery.type = PersistenceQuery
 
   @InternalApi
   private[akka] val pluginProvider: PluginProvider[ReadJournalProvider, ReadJournal, javadsl.ReadJournal] =

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/InMemStorageExtension.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/InMemStorageExtension.scala
@@ -26,7 +26,7 @@ private[testkit] object InMemStorageExtension extends ExtensionId[InMemStorageEx
   override def createExtension(system: ExtendedActorSystem): InMemStorageExtension =
     new InMemStorageExtension(system)
 
-  override def lookup = InMemStorageExtension
+  override def lookup() = InMemStorageExtension
 
 }
 

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/SnapshotStorageEmulatorExtension.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/SnapshotStorageEmulatorExtension.scala
@@ -25,6 +25,6 @@ private[testkit] object SnapshotStorageEmulatorExtension extends ExtensionId[Sna
       new SimpleSnapshotStorageImpl
     }
 
-  override def lookup: ExtensionId[_ <: Extension] =
+  override def lookup(): ExtensionId[_ <: Extension] =
     SnapshotStorageEmulatorExtension
 }

--- a/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
@@ -149,7 +149,7 @@ object Persistence extends ExtensionId[Persistence] with ExtensionIdProvider {
 
   def createExtension(system: ExtendedActorSystem): Persistence = new Persistence(system)
 
-  def lookup = Persistence
+  override def lookup() = Persistence
 
   /** INTERNAL API. */
   private[persistence] case class PluginHolder(actorFactory: () => ActorRef, adapters: EventAdapters, config: Config)

--- a/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/fsm/PersistentFSM.scala
@@ -28,7 +28,7 @@ private[akka] object SnapshotAfter extends ExtensionId[SnapshotAfter] with Exten
 
   override def get(system: ClassicActorSystemProvider): SnapshotAfter = super.get(system)
 
-  override def lookup = SnapshotAfter
+  override def lookup() = SnapshotAfter
 
   override def createExtension(system: ExtendedActorSystem): SnapshotAfter = new SnapshotAfter(system.settings.config)
 }

--- a/akka-persistence/src/main/scala/akka/persistence/journal/PersistencePluginProxy.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/PersistencePluginProxy.scala
@@ -67,7 +67,7 @@ object PersistencePluginProxyExtension
     with ExtensionIdProvider {
   override def createExtension(system: ExtendedActorSystem): PersistencePluginProxyExtensionImpl =
     new PersistencePluginProxyExtensionImpl(system)
-  override def lookup: ExtensionId[_ <: Extension] = PersistencePluginProxyExtension
+  override def lookup(): ExtensionId[_ <: Extension] = PersistencePluginProxyExtension
   override def get(system: ActorSystem): PersistencePluginProxyExtensionImpl = super.get(system)
   override def get(system: ClassicActorSystemProvider): PersistencePluginProxyExtensionImpl = super.get(system)
 }

--- a/akka-persistence/src/test/scala/akka/persistence/PersistentActorJournalProtocolSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistentActorJournalProtocolSpec.scala
@@ -78,7 +78,7 @@ akka.persistence.snapshot-store.plugin = "akka.persistence.no-snapshot-store"
 }
 
 object JournalPuppet extends ExtensionId[JournalProbe] with ExtensionIdProvider {
-  override def lookup = JournalPuppet
+  override def lookup() = JournalPuppet
 
   override def createExtension(system: ExtendedActorSystem): JournalProbe =
     new JournalProbe()(system)

--- a/akka-remote/src/main/scala/akka/remote/AddressUidExtension.scala
+++ b/akka-remote/src/main/scala/akka/remote/AddressUidExtension.scala
@@ -25,7 +25,7 @@ object AddressUidExtension extends ExtensionId[AddressUidExtension] with Extensi
   override def get(system: ActorSystem): AddressUidExtension = super.get(system)
   override def get(system: ClassicActorSystemProvider): AddressUidExtension = super.get(system)
 
-  override def lookup = AddressUidExtension
+  override def lookup() = AddressUidExtension
 
   override def createExtension(system: ExtendedActorSystem): AddressUidExtension = new AddressUidExtension(system)
 

--- a/akka-remote/src/main/scala/akka/remote/BoundAddressesExtension.scala
+++ b/akka-remote/src/main/scala/akka/remote/BoundAddressesExtension.scala
@@ -20,7 +20,7 @@ object BoundAddressesExtension extends ExtensionId[BoundAddressesExtension] with
   override def get(system: ActorSystem): BoundAddressesExtension = super.get(system)
   override def get(system: ClassicActorSystemProvider): BoundAddressesExtension = super.get(system)
 
-  override def lookup = BoundAddressesExtension
+  override def lookup() = BoundAddressesExtension
 
   override def createExtension(system: ExtendedActorSystem): BoundAddressesExtension =
     new BoundAddressesExtension(system)

--- a/akka-remote/src/main/scala/akka/remote/RemoteMetricsExtension.scala
+++ b/akka-remote/src/main/scala/akka/remote/RemoteMetricsExtension.scala
@@ -30,7 +30,7 @@ private[akka] object RemoteMetricsExtension extends ExtensionId[RemoteMetrics] w
   override def get(system: ActorSystem): RemoteMetrics = super.get(system)
   override def get(system: ClassicActorSystemProvider): RemoteMetrics = super.get(system)
 
-  override def lookup = RemoteMetricsExtension
+  override def lookup() = RemoteMetricsExtension
 
   override def createExtension(system: ExtendedActorSystem): RemoteMetrics =
     if (RARP(system).provider.remoteSettings.LogFrameSizeExceeding.isEmpty)

--- a/akka-remote/src/main/scala/akka/remote/Remoting.scala
+++ b/akka-remote/src/main/scala/akka/remote/Remoting.scala
@@ -55,7 +55,7 @@ private[akka] final case class RARP(provider: RemoteActorRefProvider) extends Ex
  */
 private[akka] object RARP extends ExtensionId[RARP] with ExtensionIdProvider {
 
-  override def lookup = RARP
+  override def lookup() = RARP
 
   override def createExtension(system: ExtendedActorSystem) = RARP(system.provider.asInstanceOf[RemoteActorRefProvider])
 }

--- a/akka-remote/src/main/scala/akka/remote/artery/RemotingFlightRecorder.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/RemotingFlightRecorder.scala
@@ -27,7 +27,7 @@ object RemotingFlightRecorder extends ExtensionId[RemotingFlightRecorder] with E
       "akka.remote.artery.jfr.JFRRemotingFlightRecorder",
       NoOpRemotingFlightRecorder)
 
-  override def lookup: ExtensionId[_ <: Extension] = this
+  override def lookup(): ExtensionId[_ <: Extension] = this
 }
 
 /**

--- a/akka-remote/src/main/scala/akka/remote/serialization/ActorRefResolveCache.scala
+++ b/akka-remote/src/main/scala/akka/remote/serialization/ActorRefResolveCache.scala
@@ -31,7 +31,7 @@ private[akka] object ActorRefResolveThreadLocalCache
   override def get(system: ActorSystem): ActorRefResolveThreadLocalCache = super.get(system)
   override def get(system: ClassicActorSystemProvider): ActorRefResolveThreadLocalCache = super.get(system)
 
-  override def lookup = ActorRefResolveThreadLocalCache
+  override def lookup() = ActorRefResolveThreadLocalCache
 
   override def createExtension(system: ExtendedActorSystem): ActorRefResolveThreadLocalCache =
     new ActorRefResolveThreadLocalCache(system)

--- a/akka-remote/src/main/scala/akka/remote/transport/AbstractTransportAdapter.scala
+++ b/akka-remote/src/main/scala/akka/remote/transport/AbstractTransportAdapter.scala
@@ -51,7 +51,7 @@ class TransportAdapters(system: ExtendedActorSystem) extends Extension {
 object TransportAdaptersExtension extends ExtensionId[TransportAdapters] with ExtensionIdProvider {
   override def get(system: ActorSystem): TransportAdapters = super.get(system)
   override def get(system: ClassicActorSystemProvider): TransportAdapters = super.get(system)
-  override def lookup = TransportAdaptersExtension
+  override def lookup() = TransportAdaptersExtension
   override def createExtension(system: ExtendedActorSystem): TransportAdapters =
     new TransportAdapters(system)
 }

--- a/akka-remote/src/test/scala/akka/remote/artery/MetadataCarryingSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/MetadataCarryingSpec.scala
@@ -18,7 +18,7 @@ import akka.util.ByteString
 object MetadataCarryingSpy extends ExtensionId[MetadataCarryingSpy] with ExtensionIdProvider {
   override def get(system: ActorSystem): MetadataCarryingSpy = super.get(system)
   override def get(system: ClassicActorSystemProvider): MetadataCarryingSpy = super.get(system)
-  override def lookup = MetadataCarryingSpy
+  override def lookup() = MetadataCarryingSpy
   override def createExtension(system: ExtendedActorSystem): MetadataCarryingSpy = new MetadataCarryingSpy
 
   final case class RemoteMessageSent(recipient: ActorRef, message: Object, sender: ActorRef, size: Int, time: Long)

--- a/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonObjectMapperProvider.scala
+++ b/akka-serialization-jackson/src/main/scala/akka/serialization/jackson/JacksonObjectMapperProvider.scala
@@ -49,7 +49,7 @@ object JacksonObjectMapperProvider extends ExtensionId[JacksonObjectMapperProvid
   override def get(system: ActorSystem): JacksonObjectMapperProvider = super.get(system)
   override def get(system: ClassicActorSystemProvider): JacksonObjectMapperProvider = super.get(system)
 
-  override def lookup = JacksonObjectMapperProvider
+  override def lookup() = JacksonObjectMapperProvider
 
   override def createExtension(system: ExtendedActorSystem): JacksonObjectMapperProvider =
     new JacksonObjectMapperProvider(system)

--- a/akka-stream-tests/src/test/scala/akka/stream/ActorMaterializerSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/ActorMaterializerSpec.scala
@@ -29,7 +29,7 @@ object IndirectMaterializerCreation extends ExtensionId[IndirectMaterializerCrea
   def createExtension(system: ExtendedActorSystem): IndirectMaterializerCreation =
     new IndirectMaterializerCreation(system)
 
-  def lookup: ExtensionId[IndirectMaterializerCreation] = this
+  override def lookup(): ExtensionId[IndirectMaterializerCreation] = this
 }
 
 @nowarn

--- a/akka-stream-tests/src/test/scala/akka/stream/SystemMaterializerSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/SystemMaterializerSpec.scala
@@ -39,7 +39,7 @@ class SystemMaterializerEagerStartupSpec extends StreamSpec {
   "The SystemMaterializer" must {
 
     "be eagerly started on system startup" in {
-      system.hasExtension(SystemMaterializer.lookup) should ===(true)
+      system.hasExtension(SystemMaterializer.lookup()) should ===(true)
     }
   }
 

--- a/akka-stream/src/main/scala/akka/stream/SystemMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/SystemMaterializer.scala
@@ -33,7 +33,7 @@ object SystemMaterializer extends ExtensionId[SystemMaterializer] with Extension
   override def get(system: ActorSystem): SystemMaterializer = super.get(system)
   override def get(system: ClassicActorSystemProvider): SystemMaterializer = super.get(system)
 
-  override def lookup = SystemMaterializer
+  override def lookup() = SystemMaterializer
 
   override def createExtension(system: ExtendedActorSystem): SystemMaterializer =
     new SystemMaterializer(system)

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
@@ -170,7 +170,7 @@ private[akka] class SubFusingActorMaterializerImpl(
 @InternalApi private[akka] object FlowNames extends ExtensionId[FlowNames] with ExtensionIdProvider {
   override def get(system: ActorSystem): FlowNames = super.get(system)
   override def get(system: ClassicActorSystemProvider): FlowNames = super.get(system)
-  override def lookup = FlowNames
+  override def lookup() = FlowNames
   override def createExtension(system: ExtendedActorSystem): FlowNames = new FlowNames
 }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/streamref/StreamRefsMaster.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/streamref/StreamRefsMaster.scala
@@ -16,7 +16,7 @@ private[stream] object StreamRefsMaster extends ExtensionId[StreamRefsMaster] wi
   override def createExtension(system: ExtendedActorSystem): StreamRefsMaster =
     new StreamRefsMaster
 
-  override def lookup: StreamRefsMaster.type = this
+  override def lookup(): StreamRefsMaster.type = this
 
   override def get(system: ActorSystem): StreamRefsMaster = super.get(system)
   override def get(system: ClassicActorSystemProvider): StreamRefsMaster = super.get(system)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Tcp.scala
@@ -131,7 +131,7 @@ object Tcp extends ExtensionId[Tcp] with ExtensionIdProvider {
 
   override def get(system: ClassicActorSystemProvider): Tcp = super.get(system)
 
-  def lookup = Tcp
+  override def lookup() = Tcp
 
   def createExtension(system: ExtendedActorSystem): Tcp = new Tcp(system)
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
@@ -84,7 +84,7 @@ object Tcp extends ExtensionId[Tcp] with ExtensionIdProvider {
   override def get(system: ActorSystem): Tcp = super.get(system)
   override def get(system: ClassicActorSystemProvider): Tcp = super.get(system)
 
-  def lookup = Tcp
+  override def lookup() = Tcp
 
   def createExtension(system: ExtendedActorSystem): Tcp = new Tcp(system)
 

--- a/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/AkkaSSLConfig.scala
+++ b/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/AkkaSSLConfig.scala
@@ -26,7 +26,7 @@ object AkkaSSLConfig extends ExtensionId[AkkaSSLConfig] with ExtensionIdProvider
   override def get(system: ClassicActorSystemProvider): AkkaSSLConfig = super.get(system)
   def apply()(implicit system: ActorSystem): AkkaSSLConfig = super.apply(system)
 
-  override def lookup = AkkaSSLConfig
+  override def lookup() = AkkaSSLConfig
 
   override def createExtension(system: ExtendedActorSystem): AkkaSSLConfig =
     new AkkaSSLConfig(system, defaultSSLConfigSettings(system))

--- a/akka-testkit/src/main/scala/akka/testkit/CallingThreadDispatcher.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/CallingThreadDispatcher.scala
@@ -59,7 +59,7 @@ import akka.util.Switch
 private[testkit] object CallingThreadDispatcherQueues
     extends ExtensionId[CallingThreadDispatcherQueues]
     with ExtensionIdProvider {
-  override def lookup = CallingThreadDispatcherQueues
+  override def lookup() = CallingThreadDispatcherQueues
   override def createExtension(system: ExtendedActorSystem): CallingThreadDispatcherQueues =
     new CallingThreadDispatcherQueues
 }


### PR DESCRIPTION
Removing it causes problems for projects using Scala 2.13.3+ and -Xfatal-warnings, which seems like a fairly common setup. I did some validation locally using `sbt -Dakka.allwarnings=true test:compile`.