### PR TITLE
Don't use GraphStage toString when materializing Source.fromPublisher, #30022

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -769,10 +769,9 @@ private final case class SavedIslandData(
 
   override def takePublisher(slot: Int, publisher: Publisher[Any]): Unit = {
     val connection = conn(slot)
-    // TODO: proper input port debug string (currently prints the stage)
     val bufferSize = connection.inOwner.attributes.mandatoryAttribute[InputBuffer].max
     val boundary =
-      new BatchingActorInputBoundary(bufferSize, shell, publisher, connection.inOwner.toString)
+      new BatchingActorInputBoundary(bufferSize, shell, publisher, "publisher.in")
     logics.add(boundary)
     boundary.stageId = logics.size() - 1
     boundary.attributes = connection.inOwner.attributes.and(DefaultAttributes.inputBoundary)


### PR DESCRIPTION
* Fixes performance regression in Akka 2.6.11/2.6.12

See issue #30022 for details

References #30022
