### PR TITLE
remove top object name because it doesn't work if you write it as documented

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala
@@ -219,7 +219,7 @@ object IntroSpec {
         val chatRoom = context.spawn(ChatRoom(), "chatroom")
         val gabblerRef = context.spawn(Gabbler(), "gabbler")
         context.watch(gabblerRef)
-        chatRoom ! ChatRoom.GetSession("ol’ Gabbler", gabblerRef)
+        chatRoom ! GetSession("ol’ Gabbler", gabblerRef)
 
         Behaviors.receiveSignal {
           case (_, Terminated(_)) =>


### PR DESCRIPTION
This PR about Akka Documentation [Introduction to Actors](https://doc.akka.io/docs/akka/current/typed/actors.html)

 In the documentation, it looks like GetSession (The protocol definition) is defined outside of the ChatRoom object.

However, in the Main object, GetSession is called as a member of ChatRoom, and if you write the code according to the document, you will make a mistake.

When I looked at  [the code](https://github.com/akka/akka/blob/v2.6.12/akka-actor-typed-tests/src/test/scala/docs/akka/typed/IntroSpec.scala#L132-L237) that the documentation refers to, I found that it is defined inside the ChatRoom object.

So, how about refer to GetSession  as it is?

-------

this is the capture from  Akka Documentation version 2.6.XX
[Introduction to Actors version current](https://doc.akka.io/docs/akka/current/typed/actors.html)

<img width="600" alt="2021-02-14 0 07 36" src="https://user-images.githubusercontent.com/72712082/107853345-a6d3ae00-6e58-11eb-99f0-38a1c8511c4a.png">



In the previous Documentation version (2.5.XX), GetSession was referenced directly.

[Introduction to Actors version 2.5.32][https://doc.akka.io/docs/akka/2.5.32/typed/actors.html#]

<img width="600" alt="2021-02-14 0 08 30" src="https://user-images.githubusercontent.com/72712082/107853358-c7036d00-6e58-11eb-9892-c06d33092e69.png">





