### PR TITLE
Fail fix in ClusterShardingPreparingForShutdownSpec

### DIFF
--- a/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/ClusterShardingPreparingForShutdownSpec.scala
+++ b/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/ClusterShardingPreparingForShutdownSpec.scala
@@ -119,10 +119,10 @@ class ClusterShardingPreparingForShutdownSpec
 
       // trigger creation of a new shard should be fine even though one node left
       runOn(first, third) {
-        
+
         awaitAssert({
-        shardRegion ! ShardingEnvelope("id3", Pinger.Ping(3, probe.ref))
-        probe.expectMessage(Pong(3))
+          shardRegion ! ShardingEnvelope("id3", Pinger.Ping(3, probe.ref))
+          probe.expectMessage(Pong(3))
         }, 10.seconds)
       }
       enterBarrier("new-shards-verified")

--- a/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/ClusterShardingPreparingForShutdownSpec.scala
+++ b/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/ClusterShardingPreparingForShutdownSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2020-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.sharding.typed
@@ -89,7 +89,6 @@ class ClusterShardingPreparingForShutdownSpec
 
       runOn(second) {
         cluster.manager ! PrepareForFullClusterShutdown
-
       }
       awaitAssert({
         withClue("members: " + cluster.state.members) {
@@ -118,9 +117,13 @@ class ClusterShardingPreparingForShutdownSpec
         }
       }, 5.seconds) // keep this lower than coordinated shutdown timeout
 
+      // trigger creation of a new shard should be fine even though one node left
       runOn(first, third) {
+        
+        awaitAssert({
         shardRegion ! ShardingEnvelope("id3", Pinger.Ping(3, probe.ref))
         probe.expectMessage(Pong(3))
+        }, 10.seconds)
       }
       enterBarrier("new-shards-verified")
 


### PR DESCRIPTION
References #30037

Not 100% sure but I think the problem is that sometimes the shard coordinator state ddata write fails when one out of three nodes is shutting down so that the allocation of the shard and the message to the shard is dropped, the test optimistically expects all messages to sharding to arrive and has failed a couple of times. Retrying that message through sharding fixes it.