### PR TITLE
Extend GroupedWeightedWithin to accept maxWeight and maxNumber simultaneously

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -315,7 +315,7 @@ For a pull request to be considered at all it has to meet these requirements:
 Some additional guidelines regarding source code are:
 
 - Keep the code [DRY](http://programmer.97things.oreilly.com/wiki/index.php/Don%27t_Repeat_Yourself).
-- Apply the [Boy Scout Rule](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule) whenever you have the chance to.
+- Apply the [Boy Scout Rule](https://www.oreilly.com/library/view/97-things-every/9780596809515/ch08.html) whenever you have the chance to.
 - Never delete or change existing copyright notices, just add additional info.
 - Do not use ``@author`` tags since it does not encourage [Collective Code Ownership](http://www.extremeprogramming.org/rules/collective.html).
   - Contributors , each project should make sure that the contributors gets the credit they deserve—in a text file or page on the project website and in the release notes etc.

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWeightedWithin.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/groupedWeightedWithin.md
@@ -12,8 +12,8 @@ Chunk up this stream into groups of elements received within a time window, or l
 
 ## Description
 
-Chunk up this stream into groups of elements received within a time window, or limited by the weight of the elements,
-whatever happens first. Empty groups will not be emitted if no elements are received from upstream.
+Chunk up this stream into groups of elements received within a time window, or limited by the weight and number of 
+the elements, whatever happens first. Empty groups will not be emitted if no elements are received from upstream.
 The last group before end-of-stream will contain the buffered elements since the previously emitted group.
 
 See also:

--- a/akka-stream/src/main/mima-filters/2.6.13.backwards.excludes/pr-30042-extended-group-weighted-within.excludes
+++ b/akka-stream/src/main/mima-filters/2.6.13.backwards.excludes/pr-30042-extended-group-weighted-within.excludes
@@ -1,0 +1,2 @@
+# disable compatibility check for @InternalApi private[akka] class
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.GroupedWeightedWithin.this")

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1316,6 +1316,32 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     groupedWeightedWithin(maxWeight, costFn, d.asScala)
 
   /**
+   * Chunk up this stream into groups of elements received within a time window,
+   * or limited by the weight and number of the elements, whatever happens first.
+   * Empty groups will not be emitted if no elements are received from upstream.
+   * The last group before end-of-stream will contain the buffered elements
+   * since the previously emitted group.
+   *
+   * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
+   *
+   * '''Backpressures when''' downstream backpressures, and buffered group (+ pending element) weighs more than
+   * `maxWeight` or has more than `maxNumber` elements
+   *
+   * '''Completes when''' upstream completes (emits last group)
+   *
+   * '''Cancels when''' downstream completes
+   *
+   * `maxWeight` must be positive, `maxNumber` must be positive, and `d` must be greater than 0 seconds,
+   * otherwise IllegalArgumentException is thrown.
+   */
+  def groupedWeightedWithin(
+      maxWeight: Long,
+      maxNumber: Int,
+      costFn: function.Function[Out, java.lang.Long],
+      d: java.time.Duration): javadsl.Flow[In, java.util.List[Out], Mat] =
+    new Flow(delegate.groupedWeightedWithin(maxWeight, maxNumber, d.asScala)(costFn.apply).map(_.asJava))
+
+  /**
    * Shifts elements emission in time by a specified amount. It allows to store elements
    * in internal buffer while waiting for next element to be emitted. Depending on the defined
    * [[akka.stream.DelayOverflowStrategy]] it might drop elements or backpressure the upstream if

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2756,6 +2756,32 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
     groupedWeightedWithin(maxWeight, costFn, d.asScala)
 
   /**
+   * Chunk up this stream into groups of elements received within a time window,
+   * or limited by the weight and number of the elements, whatever happens first.
+   * Empty groups will not be emitted if no elements are received from upstream.
+   * The last group before end-of-stream will contain the buffered elements
+   * since the previously emitted group.
+   *
+   * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
+   *
+   * '''Backpressures when''' downstream backpressures, and buffered group (+ pending element) weighs more than
+   * `maxWeight` or has more than `maxNumber` elements
+   *
+   * '''Completes when''' upstream completes (emits last group)
+   *
+   * '''Cancels when''' downstream completes
+   *
+   * `maxWeight` must be positive, `maxNumber` must be positive, and `d` must be greater than 0 seconds,
+   * otherwise IllegalArgumentException is thrown.
+   */
+  def groupedWeightedWithin(
+      maxWeight: Long,
+      maxNumber: Int,
+      costFn: function.Function[Out, java.lang.Long],
+      d: java.time.Duration): javadsl.Source[java.util.List[Out @uncheckedVariance], Mat] =
+    new Source(delegate.groupedWeightedWithin(maxWeight, maxNumber, d.asScala)(costFn.apply).map(_.asJava))
+
+  /**
    * Shifts elements emission in time by a specified amount. It allows to store elements
    * in internal buffer while waiting for next element to be emitted. Depending on the defined
    * [[akka.stream.DelayOverflowStrategy]] it might drop elements or backpressure the upstream if

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -753,6 +753,32 @@ class SubFlow[In, Out, Mat](
     groupedWeightedWithin(maxWeight, costFn, d.asScala)
 
   /**
+   * Chunk up this stream into groups of elements received within a time window,
+   * or limited by the weight and number of the elements, whatever happens first.
+   * Empty groups will not be emitted if no elements are received from upstream.
+   * The last group before end-of-stream will contain the buffered elements
+   * since the previously emitted group.
+   *
+   * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
+   *
+   * '''Backpressures when''' downstream backpressures, and buffered group (+ pending element) weighs more than
+   * `maxWeight` or has more than `maxNumber` elements
+   *
+   * '''Completes when''' upstream completes (emits last group)
+   *
+   * '''Cancels when''' downstream completes
+   *
+   * `maxWeight` must be positive, `maxNumber` must be positive, and `d` must be greater than 0 seconds,
+   * otherwise IllegalArgumentException is thrown.
+   */
+  def groupedWeightedWithin(
+      maxWeight: Long,
+      maxNumber: Int,
+      costFn: function.Function[Out, java.lang.Long],
+      d: java.time.Duration): javadsl.SubFlow[In, java.util.List[Out @uncheckedVariance], Mat] =
+    new SubFlow(delegate.groupedWeightedWithin(maxWeight, maxNumber, d.asScala)(costFn.apply).map(_.asJava))
+
+  /**
    * Shifts elements emission in time by a specified amount. It allows to store elements
    * in internal buffer while waiting for next element to be emitted. Depending on the defined
    * [[akka.stream.DelayOverflowStrategy]] it might drop elements or backpressure the upstream if

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -742,6 +742,32 @@ class SubSource[Out, Mat](
     groupedWeightedWithin(maxWeight, costFn, d.asScala)
 
   /**
+   * Chunk up this stream into groups of elements received within a time window,
+   * or limited by the weight and number of the elements, whatever happens first.
+   * Empty groups will not be emitted if no elements are received from upstream.
+   * The last group before end-of-stream will contain the buffered elements
+   * since the previously emitted group.
+   *
+   * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
+   *
+   * '''Backpressures when''' downstream backpressures, and buffered group (+ pending element) weighs more than
+   * `maxWeight` or has more than `maxNumber` elements
+   *
+   * '''Completes when''' upstream completes (emits last group)
+   *
+   * '''Cancels when''' downstream completes
+   *
+   * `maxWeight` must be positive, `maxNumber` must be positive, and `d` must be greater than 0 seconds,
+   * otherwise IllegalArgumentException is thrown.
+   */
+  def groupedWeightedWithin(
+      maxWeight: Long,
+      maxNumber: Int,
+      costFn: function.Function[Out, java.lang.Long],
+      d: java.time.Duration): javadsl.SubSource[java.util.List[Out @uncheckedVariance], Mat] =
+    new SubSource(delegate.groupedWeightedWithin(maxWeight, maxNumber, d.asScala)(costFn.apply).map(_.asJava))
+
+  /**
    * Discard the given number of elements at the beginning of the stream.
    * No elements will be dropped if `n` is zero or negative.
    *

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1612,7 +1612,9 @@ trait FlowOps[+Out, +Mat] {
    * '''Cancels when''' downstream completes
    */
   def groupedWithin(n: Int, d: FiniteDuration): Repr[immutable.Seq[Out]] =
-    via(new GroupedWeightedWithin[Out](n, ConstantFun.oneLong, d).withAttributes(DefaultAttributes.groupedWithin))
+    via(
+      new GroupedWeightedWithin[Out](Long.MaxValue, n, ConstantFun.zeroLong, d)
+        .withAttributes(DefaultAttributes.groupedWithin))
 
   /**
    * Chunk up this stream into groups of elements received within a time window,
@@ -1633,7 +1635,30 @@ trait FlowOps[+Out, +Mat] {
    * '''Cancels when''' downstream completes
    */
   def groupedWeightedWithin(maxWeight: Long, d: FiniteDuration)(costFn: Out => Long): Repr[immutable.Seq[Out]] =
-    via(new GroupedWeightedWithin[Out](maxWeight, costFn, d))
+    via(new GroupedWeightedWithin[Out](maxWeight, Int.MaxValue, costFn, d))
+
+  /**
+   * Chunk up this stream into groups of elements received within a time window,
+   * or limited by the weight and number of the elements, whatever happens first.
+   * Empty groups will not be emitted if no elements are received from upstream.
+   * The last group before end-of-stream will contain the buffered elements
+   * since the previously emitted group.
+   *
+   * `maxWeight` must be positive, `maxNumber` must be positive, and `d` must be greater than 0 seconds,
+   * otherwise IllegalArgumentException is thrown.
+   *
+   * '''Emits when''' the configured time elapses since the last group has been emitted or weight limit reached
+   *
+   * '''Backpressures when''' downstream backpressures, and buffered group (+ pending element) weighs more than
+   * `maxWeight` or has more than `maxNumber` elements
+   *
+   * '''Completes when''' upstream completes (emits last group)
+   *
+   * '''Cancels when''' downstream completes
+   */
+  def groupedWeightedWithin(maxWeight: Long, maxNumber: Int, d: FiniteDuration)(
+      costFn: Out => Long): Repr[immutable.Seq[Out]] =
+    via(new GroupedWeightedWithin[Out](maxWeight, maxNumber, costFn, d))
 
   /**
    * Shifts elements emission in time by a specified amount. It allows to store elements

--- a/plugins/serialversion-remover-plugin/src/main/scala/akka/Plugin.scala
+++ b/plugins/serialversion-remover-plugin/src/main/scala/akka/Plugin.scala
@@ -35,7 +35,7 @@ class SerialVersionRemoverPhase extends PluginPhase {
     if (tree.symbol.getAnnotation(defn.SerialVersionUIDAnnot).isDefined && tree.symbol.is(Trait)) {
       tree.symbol.removeAnnotation(defn.SerialVersionUIDAnnot)
     }
-    
+
     tree
   }
 


### PR DESCRIPTION
References #30020

Here is an initial attempt at extending `GroupedWeightedWithin` to handle `maxWeight` and `maxNumber` simultaneously. 

**Overall changes:**
- changed `GroupedWeightedWithin` logic
- added an overloading method to `Flow`
- added overloading methods to the corresponding _javadsl_ classes

**Questions:**
1. do I need to add an example to `SourceOrFlow`? I see no time-based operators (_*Within_) there.
2. do I need to add a sample operator to `docs.stream.operators.sourceorflow` (similarly to `GroupedWeighted`)? I see no time-based operators (_*Within_) there.


