### PR TITLE
Add draining control support to MergeHub #30057

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
@@ -184,15 +184,16 @@ class HubSpec extends StreamSpec {
       result.futureValue.sorted should ===(1 to 10)
 
     }
-    
+
     "complete after draining control is invoked and all connected producers complete" in assertAllStagesStopped {
       val downstream = TestSubscriber.probe[Int]()
-      val (sink, draining) = MergeHub.sourceWithDraining[Int](16).take(20).toMat(Sink.fromSubscriber(downstream))(Keep.left).run()
+      val (sink, draining) =
+        MergeHub.sourceWithDraining[Int](16).take(20).toMat(Sink.fromSubscriber(downstream))(Keep.left).run()
       Source(1 to 10).runWith(sink)
       Source(11 to 20).runWith(sink)
 
       val completeF = draining.drainAndComplete()
-      
+
       downstream.request(20)
       downstream.expectNextN(20).sorted should ===(1 to 20)
       downstream.expectComplete()
@@ -202,7 +203,8 @@ class HubSpec extends StreamSpec {
 
     "immediately cancel new producers while draining" in assertAllStagesStopped {
       val downstream = TestSubscriber.probe[Int]()
-      val (sink, draining) = MergeHub.sourceWithDraining[Int](16).take(20).toMat(Sink.fromSubscriber(downstream))(Keep.left).run()
+      val (sink, draining) =
+        MergeHub.sourceWithDraining[Int](16).take(20).toMat(Sink.fromSubscriber(downstream))(Keep.left).run()
       Source(1 to 10).runWith(sink)
       Source(11 to 20).runWith(sink)
       val completeF = draining.drainAndComplete()
@@ -213,17 +215,18 @@ class HubSpec extends StreamSpec {
       val upstream = TestPublisher.probe[Int]()
       Source.fromPublisher(upstream).runWith(sink)
       upstream.expectCancellation()
-      
+
       downstream.request(10)
       downstream.expectNextN(10).sorted should ===(11 to 20)
-      
+
       downstream.expectComplete()
       completeF.futureValue should ===(akka.Done)
     }
 
     "gracefully handle repeated draining requests after completion" in assertAllStagesStopped {
       val downstream = TestSubscriber.probe[Int]()
-      val (_, draining) = MergeHub.sourceWithDraining[Int](16).take(20).toMat(Sink.fromSubscriber(downstream))(Keep.left).run()
+      val (_, draining) =
+        MergeHub.sourceWithDraining[Int](16).take(20).toMat(Sink.fromSubscriber(downstream))(Keep.left).run()
 
       val completeF = draining.drainAndComplete()
       completeF.futureValue should ===(akka.Done)

--- a/akka-stream/src/main/mima-filters/2.6.13.backwards.excludes/30059-mergehub-draining-support.excludes
+++ b/akka-stream/src/main/mima-filters/2.6.13.backwards.excludes/30059-mergehub-draining-support.excludes
@@ -1,1 +1,2 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.MergeHub.this")
 ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.scaladsl.MergeHub.createLogicAndMaterializedValue")

--- a/akka-stream/src/main/mima-filters/2.6.13.backwards.excludes/30059-mergehub-draining-support.excludes
+++ b/akka-stream/src/main/mima-filters/2.6.13.backwards.excludes/30059-mergehub-draining-support.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.stream.scaladsl.MergeHub.createLogicAndMaterializedValue")

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
@@ -5,12 +5,9 @@
 package akka.stream.javadsl
 
 import java.util.function.{ BiFunction, Supplier, ToLongBiFunction }
-import akka.{ Done, NotUsed }
+import akka.NotUsed
 import akka.annotation.DoNotInherit
 import akka.util.unused
-
-import java.util.concurrent.CompletionStage
-import scala.compat.java8.FutureConverters
 
 /**
  * A MergeHub is a special streaming hub that is able to collect streamed elements from a dynamic set of
@@ -24,23 +21,21 @@ object MergeHub {
   /**
    * A DrainingControl object is created during the materialization of a MergeHub and allows to initiate the draining
    * and eventual completion of the Hub from the outside.
+   * 
+   * Not for user extension
    */
-  trait DrainingControl {
+  @DoNotInherit
+  sealed trait DrainingControl {
 
     /**
      * Set the operation mode of the linked MergeHub to draining. In this mode the Hub will cancel any new producer and
      * will complete as soon as all the currently connected producers complete.
-     *
-     * The returned [[CompletionStage]] will be completed as soon as the Hub finish processing all messages and completes.
-     * @return CompletionStage of Hub completion
      */
-    def drainAndComplete(): CompletionStage[Done]
+    def drainAndComplete(): Unit
   }
 
-  private class DrainingControlImpl(c: akka.stream.scaladsl.MergeHub.DrainingControl) extends DrainingControl {
-    override def drainAndComplete(): CompletionStage[Done] = {
-      FutureConverters.toJava(c.drainAndComplete())
-    }
+  private final class DrainingControlImpl(c: akka.stream.scaladsl.MergeHub.DrainingControl) extends DrainingControl {
+    override def drainAndComplete(): Unit = c.drainAndComplete()
   }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
@@ -103,7 +103,7 @@ object MergeHub {
   /**
    * Creates a [[Source]] that emits elements merged from a dynamic set of producers. After the [[Source]] returned
    * by this method is materialized, it returns a [[Sink]] as a materialized value. This [[Sink]] can be materialized
-   * arbitrary many times and each of the materializations will feed the elements into the original [[Source]].
+   * arbitrarily many times and each of the materializations will feed the elements into the original [[Source]].
    *
    * Every new materialization of the [[Source]] results in a new, independent hub, which materializes to its own
    * [[Sink]] for feeding that materialization.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
@@ -21,7 +21,7 @@ object MergeHub {
   /**
    * A DrainingControl object is created during the materialization of a MergeHub and allows to initiate the draining
    * and eventual completion of the Hub from the outside.
-   * 
+   *
    * Not for user extension
    */
   @DoNotInherit

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
@@ -4,11 +4,13 @@
 
 package akka.stream.javadsl
 
-import java.util.function.{ BiFunction, Supplier, ToLongBiFunction }
-
-import akka.NotUsed
+import java.util.function.{BiFunction, Supplier, ToLongBiFunction}
+import akka.{Done, NotUsed}
 import akka.annotation.DoNotInherit
 import akka.util.unused
+
+import java.util.concurrent.CompletionStage
+import scala.compat.java8.FutureConverters
 
 /**
  * A MergeHub is a special streaming hub that is able to collect streamed elements from a dynamic set of
@@ -19,6 +21,26 @@ import akka.util.unused
  */
 object MergeHub {
 
+  /**
+   * A DrainingControl object is created during the materialization of a MergeHub and allows to initiate the draining
+   * and eventual completion of the Hub from the outside.
+   */
+  trait DrainingControl {
+    /**
+     * Set the operation mode of the linked MergeHub to draining. In this mode the Hub will cancel any new producer and
+     * will complete as soon as all the currently connected producers complete.
+     *
+     * The returned [[CompletionStage]] will be completed as soon as the Hub finish processing all messages and completes.
+     * @return CompletionStage of Hub completion
+     */
+    def drainAndComplete(): CompletionStage[Done]
+  }
+
+  private class DrainingControlImpl(c: akka.stream.scaladsl.MergeHub.DrainingControl) extends DrainingControl {
+    override def drainAndComplete(): CompletionStage[Done] = {
+      FutureConverters.toJava(c.drainAndComplete())
+    }
+  }
   /**
    * Creates a [[Source]] that emits elements merged from a dynamic set of producers. After the [[Source]] returned
    * by this method is materialized, it returns a [[Sink]] as a materialized value. This [[Sink]] can be materialized
@@ -48,9 +70,50 @@ object MergeHub {
    * Completed or failed [[Sink]]s are simply removed. Once the [[Source]] is cancelled, the Hub is considered closed
    * and any new producers using the [[Sink]] will be cancelled.
    *
+   * The materialized [[DrainingControl]] can be used to drain the Hub: any new produces using the [[Sink]] will be cancelled
+   * and the Hub will be closed completing the [[Source]] as soon as all currently connected producers complete.
+   *
+   * @param clazz Type of elements this hub emits and consumes
+   * @param perProducerBufferSize Buffer space used per producer. Default value is 16.
+   */
+  def withDraining[T](@unused clazz: Class[T], perProducerBufferSize: Int): Source[T, akka.japi.Pair[Sink[T, NotUsed], DrainingControl]] = {
+    akka.stream.scaladsl.MergeHub.sourceWithDraining[T](perProducerBufferSize).mapMaterializedValue { case (sink, draining) =>
+      akka.japi.Pair(sink.asJava[T], new DrainingControlImpl(draining): DrainingControl)
+    }.asJava
+  }
+
+  /**
+   * Creates a [[Source]] that emits elements merged from a dynamic set of producers. After the [[Source]] returned
+   * by this method is materialized, it returns a [[Sink]] as a materialized value. This [[Sink]] can be materialized
+   * arbitrary many times and each of the materializations will feed the elements into the original [[Source]].
+   *
+   * Every new materialization of the [[Source]] results in a new, independent hub, which materializes to its own
+   * [[Sink]] for feeding that materialization.
+   *
+   * Completed or failed [[Sink]]s are simply removed. Once the [[Source]] is cancelled, the Hub is considered closed
+   * and any new producers using the [[Sink]] will be cancelled.
+   *
    * @param clazz Type of elements this hub emits and consumes
    */
   def of[T](clazz: Class[T]): Source[T, Sink[T, NotUsed]] = of(clazz, 16)
+
+  /**
+   * Creates a [[Source]] that emits elements merged from a dynamic set of producers. After the [[Source]] returned
+   * by this method is materialized, it returns a [[Sink]] as a materialized value. This [[Sink]] can be materialized
+   * arbitrary many times and each of the materializations will feed the elements into the original [[Source]].
+   *
+   * Every new materialization of the [[Source]] results in a new, independent hub, which materializes to its own
+   * [[Sink]] for feeding that materialization.
+   *
+   * Completed or failed [[Sink]]s are simply removed. Once the [[Source]] is cancelled, the Hub is considered closed
+   * and any new producers using the [[Sink]] will be cancelled.
+   *
+   * The materialized [[DrainingControl]] can be used to drain the Hub: any new produces using the [[Sink]] will be cancelled
+   * and the Hub will be closed completing the [[Source]] as soon as all currently connected producers complete.
+   *
+   * @param clazz Type of elements this hub emits and consumes
+   */
+  def withDraining[T](clazz: Class[T]): Source[T, akka.japi.Pair[Sink[T, NotUsed], DrainingControl]] = withDraining(clazz, 16)
 
 }
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
@@ -59,7 +59,7 @@ object MergeHub {
   /**
    * Creates a [[Source]] that emits elements merged from a dynamic set of producers. After the [[Source]] returned
    * by this method is materialized, it returns a [[Sink]] as a materialized value. This [[Sink]] can be materialized
-   * arbitrary many times and each of the materializations will feed the elements into the original [[Source]].
+   * arbitrarily many times and each of the materializations will feed the elements into the original [[Source]].
    *
    * Every new materialization of the [[Source]] results in a new, independent hub, which materializes to its own
    * [[Sink]] for feeding that materialization.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
@@ -4,8 +4,8 @@
 
 package akka.stream.javadsl
 
-import java.util.function.{BiFunction, Supplier, ToLongBiFunction}
-import akka.{Done, NotUsed}
+import java.util.function.{ BiFunction, Supplier, ToLongBiFunction }
+import akka.{ Done, NotUsed }
 import akka.annotation.DoNotInherit
 import akka.util.unused
 
@@ -26,6 +26,7 @@ object MergeHub {
    * and eventual completion of the Hub from the outside.
    */
   trait DrainingControl {
+
     /**
      * Set the operation mode of the linked MergeHub to draining. In this mode the Hub will cancel any new producer and
      * will complete as soon as all the currently connected producers complete.
@@ -41,6 +42,7 @@ object MergeHub {
       FutureConverters.toJava(c.drainAndComplete())
     }
   }
+
   /**
    * Creates a [[Source]] that emits elements merged from a dynamic set of producers. After the [[Source]] returned
    * by this method is materialized, it returns a [[Sink]] as a materialized value. This [[Sink]] can be materialized
@@ -76,10 +78,16 @@ object MergeHub {
    * @param clazz Type of elements this hub emits and consumes
    * @param perProducerBufferSize Buffer space used per producer. Default value is 16.
    */
-  def withDraining[T](@unused clazz: Class[T], perProducerBufferSize: Int): Source[T, akka.japi.Pair[Sink[T, NotUsed], DrainingControl]] = {
-    akka.stream.scaladsl.MergeHub.sourceWithDraining[T](perProducerBufferSize).mapMaterializedValue { case (sink, draining) =>
-      akka.japi.Pair(sink.asJava[T], new DrainingControlImpl(draining): DrainingControl)
-    }.asJava
+  def withDraining[T](
+      @unused clazz: Class[T],
+      perProducerBufferSize: Int): Source[T, akka.japi.Pair[Sink[T, NotUsed], DrainingControl]] = {
+    akka.stream.scaladsl.MergeHub
+      .sourceWithDraining[T](perProducerBufferSize)
+      .mapMaterializedValue {
+        case (sink, draining) =>
+          akka.japi.Pair(sink.asJava[T], new DrainingControlImpl(draining): DrainingControl)
+      }
+      .asJava
   }
 
   /**
@@ -113,7 +121,8 @@ object MergeHub {
    *
    * @param clazz Type of elements this hub emits and consumes
    */
-  def withDraining[T](clazz: Class[T]): Source[T, akka.japi.Pair[Sink[T, NotUsed], DrainingControl]] = withDraining(clazz, 16)
+  def withDraining[T](clazz: Class[T]): Source[T, akka.japi.Pair[Sink[T, NotUsed], DrainingControl]] =
+    withDraining(clazz, 16)
 
 }
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Hub.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Hub.scala
@@ -74,7 +74,7 @@ object MergeHub {
    * Completed or failed [[Sink]]s are simply removed. Once the [[Source]] is cancelled, the Hub is considered closed
    * and any new producers using the [[Sink]] will be cancelled.
    *
-   * The materialized [[DrainingControl]] can be used to drain the Hub: any new produces using the [[Sink]] will be cancelled
+   * The materialized [[DrainingControl]] can be used to drain the Hub: any new producers using the [[Sink]] will be cancelled
    * and the Hub will be closed completing the [[Source]] as soon as all currently connected producers complete.
    *
    * @param perProducerBufferSize Buffer space used per producer. Default value is 16.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Hub.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Hub.scala
@@ -106,7 +106,7 @@ object MergeHub {
    * Completed or failed [[Sink]]s are simply removed. Once the [[Source]] is cancelled, the Hub is considered closed
    * and any new producers using the [[Sink]] will be cancelled.
    *
-   * The materialized [[DrainingControl]] can be used to drain the Hub: any new produces using the [[Sink]] will be cancelled
+   * The materialized [[DrainingControl]] can be used to drain the Hub: any new producers using the [[Sink]] will be cancelled
    * and the Hub will be closed completing the [[Source]] as soon as all currently connected producers complete.
    */
   def sourceWithDraining[T](): Source[T, (Sink[T, NotUsed], DrainingControl)] =

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Hub.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Hub.scala
@@ -200,7 +200,7 @@ private[akka] class MergeHub[T](perProducerBufferSize: Int, drainingEnabled: Boo
         true
       case Deregister(id) =>
         demands.remove(id)
-        if (draining) tryCompleteOnDraining()
+        if (drainingEnabled && draining) tryCompleteOnDraining()
         true
     }
 
@@ -230,13 +230,13 @@ private[akka] class MergeHub[T](perProducerBufferSize: Int, drainingEnabled: Boo
         // and have been enqueued just after it
         if (firstAttempt)
           tryProcessNext(firstAttempt = false)
-        else if (draining)
+        else if (drainingEnabled && draining)
           tryCompleteOnDraining()
       }
     }
 
     def isShuttingDown: Boolean = shuttingDown
-    def isDraining: Boolean = draining
+    def isDraining: Boolean = drainingEnabled && draining
 
     // External API
     def enqueue(ev: Event): Unit = {


### PR DESCRIPTION
- MergeHub materialization now produces a DrainingControl object alongside the Sink
- The DrainingControl can be invoked to initiate the draining procedure
- No new producers can be connected to the Hub
- The Hub is completed as soon as all the currently connected producers complete

References #30057
