### PR TITLE
Refactor exception handling in StatusReplyTest

### DIFF
--- a/akka-actor-tests/src/test/java/akka/pattern/StatusReplyTest.java
+++ b/akka-actor-tests/src/test/java/akka/pattern/StatusReplyTest.java
@@ -36,7 +36,7 @@ public class StatusReplyTest extends JUnitSuite {
     assertFalse(reply.isError());
     assertEquals("woho", reply.getValue());
     Assert.assertThrows(
-        "Calling get error on success did not throw",
+        "Calling .getError() on success should throw",
         IllegalArgumentException.class,
         reply::getError);
   }
@@ -48,7 +48,7 @@ public class StatusReplyTest extends JUnitSuite {
     assertFalse(reply.isSuccess());
     assertEquals("boho", reply.getError().getMessage());
     Assert.assertThrows(
-        "Calling get value on error did not throw",
+        "Calling .getValue() on error should throw",
         StatusReply.ErrorMessage.class,
         reply::getValue);
   }
@@ -60,7 +60,7 @@ public class StatusReplyTest extends JUnitSuite {
     assertFalse(reply.isSuccess());
     assertEquals("boho", reply.getError().getMessage());
     Assert.assertThrows(
-        "Calling get value on error did not throw", TestException.class, reply::getValue);
+        "Calling .getValue() on error should throw", TestException.class, reply::getValue);
   }
 
   @Test

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerPreparingForShutdownSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerPreparingForShutdownSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.singleton


### PR DESCRIPTION
It's my first and simple PR to akka. 
I have noticed some lines `try .. catch` in tests StatusReplyTest. 
I think these lines can be replaced on [assertThrows from junit 4.13](https://junit.org/junit4/javadoc/latest/org/junit/Assert.html#assertThrows(java.lang.String,%20java.lang.Class,%20org.junit.function.ThrowingRunnable))

I'm not sure about separated issue for the PR. I can create the issue if it's necessary.  Any advice will be appreciated.

Kind regards