### PR TITLE
Change parameters order for assertEquals in tests: JavaFutureTests and LeaseProviderTest

### DIFF
--- a/akka-actor-tests/src/test/java/akka/dispatch/JavaFutureTests.java
+++ b/akka-actor-tests/src/test/java/akka/dispatch/JavaFutureTests.java
@@ -34,7 +34,7 @@ public class JavaFutureTests extends JUnitSuite {
     new AkkaJUnitActorSystemResource("JavaFutureTests", AkkaSpec.testConf());
 
   private final ActorSystem system = actorSystemResource.getSystem();
-  private final Duration fiveSecondsTimeout = Duration.create(5, TimeUnit.SECONDS);
+  private final Duration timeout = Duration.create(5, TimeUnit.SECONDS);
 
   @Test
   public void mustBeAbleToMapAFuture() throws Exception {
@@ -51,7 +51,7 @@ public class JavaFutureTests extends JUnitSuite {
       }
     }, system.dispatcher());
 
-    assertEquals("Hello World", Await.result(f2, fiveSecondsTimeout));
+    assertEquals("Hello World", Await.result(f2, timeout));
   }
 
   @Test
@@ -68,7 +68,7 @@ public class JavaFutureTests extends JUnitSuite {
 
     cf.success("foo");
     assertTrue(latch.await(5, TimeUnit.SECONDS));
-    assertEquals("foo", Await.result(f, fiveSecondsTimeout));
+    assertEquals("foo", Await.result(f, timeout));
   }
 
   @Test
@@ -103,7 +103,7 @@ public class JavaFutureTests extends JUnitSuite {
 
     cf.success("foo");
     assertTrue(latch.await(5, TimeUnit.SECONDS));
-    assertEquals("foo", Await.result(f, fiveSecondsTimeout));
+    assertEquals("foo", Await.result(f, timeout));
   }
 
   @Test
@@ -119,7 +119,7 @@ public class JavaFutureTests extends JUnitSuite {
 
     cf.success("foo");
     assertTrue(latch.await(5, TimeUnit.SECONDS));
-    assertEquals("foo", Await.result(f, fiveSecondsTimeout));
+    assertEquals("foo", Await.result(f, timeout));
   }
 
   @Test
@@ -138,8 +138,8 @@ public class JavaFutureTests extends JUnitSuite {
       }
     }, system.dispatcher());
 
-    assertEquals("1000", Await.result(f, fiveSecondsTimeout));
-    assertEquals(1000, Await.result(r, fiveSecondsTimeout).intValue());
+    assertEquals("1000", Await.result(f, timeout));
+    assertEquals(1000, Await.result(r, timeout).intValue());
     assertTrue(latch.await(5, TimeUnit.SECONDS));
   }
 
@@ -157,8 +157,8 @@ public class JavaFutureTests extends JUnitSuite {
 
     cf.success("foo");
     assertTrue(latch.await(5, TimeUnit.SECONDS));
-    assertEquals("foo", Await.result(f, fiveSecondsTimeout));
-    assertEquals("foo", Await.result(r, fiveSecondsTimeout));
+    assertEquals("foo", Await.result(f, timeout));
+    assertEquals("foo", Await.result(r, timeout));
   }
 
   // TODO: Improve this test, perhaps with an Actor
@@ -178,7 +178,7 @@ public class JavaFutureTests extends JUnitSuite {
 
     Future<Iterable<String>> futureList = Futures.sequence(listFutures, system.dispatcher());
 
-    assertEquals(listExpected, Await.result(futureList, fiveSecondsTimeout));
+    assertEquals(listExpected, Await.result(futureList, timeout));
   }
 
   // TODO: Improve this test, perhaps with an Actor
@@ -202,7 +202,7 @@ public class JavaFutureTests extends JUnitSuite {
       }
     }, system.dispatcher());
 
-    assertEquals(expected.toString(), Await.result(result, fiveSecondsTimeout));
+    assertEquals(expected.toString(), Await.result(result, timeout));
   }
 
   @Test
@@ -225,7 +225,7 @@ public class JavaFutureTests extends JUnitSuite {
       }
     }, system.dispatcher());
 
-    assertEquals(expected.toString(), Await.result(result, fiveSecondsTimeout));
+    assertEquals(expected.toString(), Await.result(result, timeout));
   }
 
   @Test
@@ -248,7 +248,7 @@ public class JavaFutureTests extends JUnitSuite {
       }
     }, system.dispatcher());
 
-    assertEquals(expectedStrings, Await.result(result, fiveSecondsTimeout));
+    assertEquals(expectedStrings, Await.result(result, timeout));
   }
 
   @Test
@@ -269,7 +269,7 @@ public class JavaFutureTests extends JUnitSuite {
       }
     }, system.dispatcher());
 
-    assertEquals(expect, Await.result(f, fiveSecondsTimeout).get());
+    assertEquals(expect, Await.result(f, timeout).get());
   }
 
   @Test

--- a/akka-actor-tests/src/test/java/akka/dispatch/JavaFutureTests.java
+++ b/akka-actor-tests/src/test/java/akka/dispatch/JavaFutureTests.java
@@ -34,7 +34,7 @@ public class JavaFutureTests extends JUnitSuite {
     new AkkaJUnitActorSystemResource("JavaFutureTests", AkkaSpec.testConf());
 
   private final ActorSystem system = actorSystemResource.getSystem();
-  private final Duration timeout = Duration.create(5, TimeUnit.SECONDS);
+  private final Duration fiveSecondsTimeout = Duration.create(5, TimeUnit.SECONDS);
 
   @Test
   public void mustBeAbleToMapAFuture() throws Exception {
@@ -51,7 +51,7 @@ public class JavaFutureTests extends JUnitSuite {
       }
     }, system.dispatcher());
 
-    assertEquals("Hello World", Await.result(f2, timeout));
+    assertEquals("Hello World", Await.result(f2, fiveSecondsTimeout));
   }
 
   @Test
@@ -68,7 +68,7 @@ public class JavaFutureTests extends JUnitSuite {
 
     cf.success("foo");
     assertTrue(latch.await(5, TimeUnit.SECONDS));
-    assertEquals(Await.result(f, timeout), "foo");
+    assertEquals("foo", Await.result(f, fiveSecondsTimeout));
   }
 
   @Test
@@ -87,7 +87,7 @@ public class JavaFutureTests extends JUnitSuite {
     Throwable exception = new NullPointerException();
     cf.failure(exception);
     assertTrue(latch.await(5, TimeUnit.SECONDS));
-    assertEquals(f.value().get().failed().get(), exception);
+    assertEquals(exception, f.value().get().failed().get());
   }
 
   @Test
@@ -103,7 +103,7 @@ public class JavaFutureTests extends JUnitSuite {
 
     cf.success("foo");
     assertTrue(latch.await(5, TimeUnit.SECONDS));
-    assertEquals(Await.result(f, timeout), "foo");
+    assertEquals("foo", Await.result(f, fiveSecondsTimeout));
   }
 
   @Test
@@ -119,7 +119,7 @@ public class JavaFutureTests extends JUnitSuite {
 
     cf.success("foo");
     assertTrue(latch.await(5, TimeUnit.SECONDS));
-    assertEquals(Await.result(f, timeout), "foo");
+    assertEquals("foo", Await.result(f, fiveSecondsTimeout));
   }
 
   @Test
@@ -138,8 +138,8 @@ public class JavaFutureTests extends JUnitSuite {
       }
     }, system.dispatcher());
 
-    assertEquals(Await.result(f, timeout), "1000");
-    assertEquals(Await.result(r, timeout).intValue(), 1000);
+    assertEquals("1000", Await.result(f, fiveSecondsTimeout));
+    assertEquals(1000, Await.result(r, fiveSecondsTimeout).intValue());
     assertTrue(latch.await(5, TimeUnit.SECONDS));
   }
 
@@ -157,15 +157,15 @@ public class JavaFutureTests extends JUnitSuite {
 
     cf.success("foo");
     assertTrue(latch.await(5, TimeUnit.SECONDS));
-    assertEquals(Await.result(f, timeout), "foo");
-    assertEquals(Await.result(r, timeout), "foo");
+    assertEquals("foo", Await.result(f, fiveSecondsTimeout));
+    assertEquals("foo", Await.result(r, fiveSecondsTimeout));
   }
 
   // TODO: Improve this test, perhaps with an Actor
   @Test
   public void mustSequenceAFutureList() throws Exception{
-    LinkedList<Future<String>> listFutures = new LinkedList<Future<String>>();
-    LinkedList<String> listExpected = new LinkedList<String>();
+    LinkedList<Future<String>> listFutures = new LinkedList<>();
+    LinkedList<String> listExpected = new LinkedList<>();
 
     for (int i = 0; i < 10; i++) {
       listExpected.add("test");
@@ -178,13 +178,13 @@ public class JavaFutureTests extends JUnitSuite {
 
     Future<Iterable<String>> futureList = Futures.sequence(listFutures, system.dispatcher());
 
-    assertEquals(Await.result(futureList, timeout), listExpected);
+    assertEquals(listExpected, Await.result(futureList, fiveSecondsTimeout));
   }
 
   // TODO: Improve this test, perhaps with an Actor
   @Test
   public void foldForJavaApiMustWork() throws Exception{
-    LinkedList<Future<String>> listFutures = new LinkedList<Future<String>>();
+    LinkedList<Future<String>> listFutures = new LinkedList<>();
     StringBuilder expected = new StringBuilder();
 
     for (int i = 0; i < 10; i++) {
@@ -202,12 +202,12 @@ public class JavaFutureTests extends JUnitSuite {
       }
     }, system.dispatcher());
 
-    assertEquals(Await.result(result, timeout), expected.toString());
+    assertEquals(expected.toString(), Await.result(result, fiveSecondsTimeout));
   }
 
   @Test
   public void reduceForJavaApiMustWork() throws Exception{
-    LinkedList<Future<String>> listFutures = new LinkedList<Future<String>>();
+    LinkedList<Future<String>> listFutures = new LinkedList<>();
     StringBuilder expected = new StringBuilder();
 
     for (int i = 0; i < 10; i++) {
@@ -225,13 +225,13 @@ public class JavaFutureTests extends JUnitSuite {
       }
     }, system.dispatcher());
 
-    assertEquals(Await.result(result, timeout), expected.toString());
+    assertEquals(expected.toString(), Await.result(result, fiveSecondsTimeout));
   }
 
   @Test
   public void traverseForJavaApiMustWork() throws Exception{
-    LinkedList<String> listStrings = new LinkedList<String>();
-    LinkedList<String> expectedStrings = new LinkedList<String>();
+    LinkedList<String> listStrings = new LinkedList<>();
+    LinkedList<String> expectedStrings = new LinkedList<>();
 
     for (int i = 0; i < 10; i++) {
       expectedStrings.add("TEST");
@@ -248,12 +248,12 @@ public class JavaFutureTests extends JUnitSuite {
       }
     }, system.dispatcher());
 
-    assertEquals(Await.result(result, timeout), expectedStrings);
+    assertEquals(expectedStrings, Await.result(result, fiveSecondsTimeout));
   }
 
   @Test
   public void findForJavaApiMustWork() throws Exception{
-    LinkedList<Future<Integer>> listFutures = new LinkedList<Future<Integer>>();
+    LinkedList<Future<Integer>> listFutures = new LinkedList<>();
     for (int i = 0; i < 10; i++) {
       final Integer fi = i;
       listFutures.add(Futures.future(new Callable<Integer>() {
@@ -269,7 +269,7 @@ public class JavaFutureTests extends JUnitSuite {
       }
     }, system.dispatcher());
 
-    assertEquals(expect, Await.result(f, timeout).get());
+    assertEquals(expect, Await.result(f, fiveSecondsTimeout).get());
   }
 
   @Test
@@ -278,7 +278,7 @@ public class JavaFutureTests extends JUnitSuite {
     Duration d = Duration.create(1, TimeUnit.SECONDS);
     p.success("foo");
     Await.ready(p.future(), d);
-    assertEquals(Await.result(p.future(), d), "foo");
+    assertEquals("foo", Await.result(p.future(), d));
   }
 
   @Test
@@ -288,7 +288,7 @@ public class JavaFutureTests extends JUnitSuite {
     Duration d = Duration.create(1, TimeUnit.SECONDS);
     p.success("foo");
     Await.ready(p.future(), d);
-    assertEquals(Await.result(p.future(), d), "foo");
+    assertEquals("foo", Await.result(p.future(), d));
   }
 
   @Test
@@ -305,7 +305,7 @@ public class JavaFutureTests extends JUnitSuite {
     }, system.dispatcher());
     Duration d = Duration.create(1, TimeUnit.SECONDS);
     p.failure(fail);
-    assertEquals(Await.result(f, d), "foo");
+    assertEquals("foo", Await.result(f, d));
   }
 
   @Test
@@ -315,13 +315,13 @@ public class JavaFutureTests extends JUnitSuite {
     Future<Object> f = p.future().recoverWith(new Recover<Future<Object>>() {
       public Future<Object> recover(Throwable t) throws Throwable {
         if (t == fail)
-          return Futures.<Object>successful("foo");
+          return Futures.successful("foo");
         else
           throw t;
       }
     }, system.dispatcher());
     Duration d = Duration.create(1, TimeUnit.SECONDS);
     p.failure(fail);
-    assertEquals(Await.result(f, d), "foo");
+    assertEquals("foo", Await.result(f, d));
   }
 }

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerPreparingForShutdownSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerPreparingForShutdownSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.singleton

--- a/akka-coordination/src/test/java/akka/coordination/lease/javadsl/LeaseProviderTest.java
+++ b/akka-coordination/src/test/java/akka/coordination/lease/javadsl/LeaseProviderTest.java
@@ -29,14 +29,14 @@ public class LeaseProviderTest {
   public void loadLeaseImpl() {
     Lease leaseA = LeaseProvider.get(system).getLease("a", "lease-a", "owner1");
 
-    assertEquals(leaseA.getSettings().leaseName(), "a");
-    assertEquals(leaseA.getSettings().ownerName(), "owner1");
-    assertEquals(leaseA.getSettings().leaseConfig().getString("key1"), "value1");
+    assertEquals("a", leaseA.getSettings().leaseName());
+    assertEquals("owner1", leaseA.getSettings().ownerName());
+    assertEquals("value1", leaseA.getSettings().leaseConfig().getString("key1"));
 
     Lease leaseB = LeaseProvider.get(system).getLease("b", "lease-b", "owner2");
 
-    assertEquals(leaseB.getSettings().leaseName(), "b");
-    assertEquals(leaseB.getSettings().ownerName(), "owner2");
-    assertEquals(leaseB.getSettings().leaseConfig().getString("key2"), "value2");
+    assertEquals("b", leaseB.getSettings().leaseName());
+    assertEquals("owner2", leaseB.getSettings().ownerName());
+    assertEquals("value2", leaseB.getSettings().leaseConfig().getString("key2"));
   }
 }


### PR DESCRIPTION
assertEquals have signature is:
`assertEquals(expectedValue,actualValue)` [documentation](https://javadoc.io/doc/junit/junit/4.13/org/junit/Assert.html) , but there are some tests: JavaFutureTests and LeaseProviderTest with wrong parameters order `assertEquals(actualValue,expectedValue)` . 
I think it can be fixed.

Kind regards