### PR TITLE
remove default-dispatcher from heartbeat delay message

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterHeartbeat.scala
@@ -232,8 +232,7 @@ private[cluster] class ClusterHeartbeatSender extends Actor {
         ClusterLogMarker.heartbeatStarvation,
         "Scheduled sending of heartbeat was delayed. " +
         "Previous heartbeat was sent [{}] ms ago, expected interval is [{}] ms. This may cause failure detection " +
-        "to mark members as unreachable. The reason can be thread starvation, e.g. by running blocking tasks on the " +
-        "default dispatcher, CPU overload, or GC.",
+        "to mark members as unreachable. The reason can be thread starvation, CPU overload, or GC.",
         TimeUnit.NANOSECONDS.toMillis(now - tickTimestamp),
         HeartbeatInterval.toMillis)
     tickTimestamp = now


### PR DESCRIPTION
* Cluster actors are running on internal dispatcher

(I double-checked that the tick is also scheduled with that dispatcher)