### PR TITLE
Replace Charset.forName("UTF-8") on StandartCharsets.UTF_8

### DIFF
--- a/akka-docs/src/test/java/jdocs/persistence/PersistenceSchemaEvolutionDocTest.java
+++ b/akka-docs/src/test/java/jdocs/persistence/PersistenceSchemaEvolutionDocTest.java
@@ -9,6 +9,8 @@ import docs.persistence.proto.FlightAppModels;
 
 import java.io.NotSerializableException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import spray.json.JsObject;
 
 import akka.persistence.journal.EventAdapter;
@@ -186,7 +188,7 @@ public class PersistenceSchemaEvolutionDocTest {
      * to/from bytes marshalling.
      */
     static class SimplestPossiblePersonSerializer extends SerializerWithStringManifest {
-      private final Charset utf8 = Charset.forName("UTF-8");
+      private final Charset utf8 = StandardCharsets.UTF_8;
 
       private final String personManifest = Person.class.getName();
 
@@ -335,7 +337,7 @@ public class PersistenceSchemaEvolutionDocTest {
   public
   // #string-serializer-skip-deleved-event-by-manifest
   static class RemovedEventsAwareSerializer extends SerializerWithStringManifest {
-    private final Charset utf8 = Charset.forName("UTF-8");
+    private final Charset utf8 = StandardCharsets.UTF_8;
     private final String customerBlinkedManifest = "blinked";
 
     // unique identifier of the serializer
@@ -389,7 +391,7 @@ public class PersistenceSchemaEvolutionDocTest {
   public
   // #string-serializer-handle-rename
   static class RenamedEventAwareSerializer extends SerializerWithStringManifest {
-    private final Charset utf8 = Charset.forName("UTF-8");
+    private final Charset utf8 = StandardCharsets.UTF_8;
 
     // unique identifier of the serializer
     @Override

--- a/akka-protobuf/src/main/java/akka/protobuf/ByteString.java
+++ b/akka-protobuf/src/main/java/akka/protobuf/ByteString.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -255,11 +256,7 @@ public abstract class ByteString implements Iterable<Byte> {
    * @return new {@code ByteString}
    */
   public static ByteString copyFromUtf8(String text) {
-    try {
-      return new LiteralByteString(text.getBytes("UTF-8"));
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException("UTF-8 not supported?", e);
-    }
+    return new LiteralByteString(text.getBytes(StandardCharsets.UTF_8));
   }
 
   // =================================================================
@@ -323,7 +320,7 @@ public abstract class ByteString implements Iterable<Byte> {
   // Helper method that takes the chunk size range as a parameter.
   public static ByteString readFrom(InputStream streamToDrain, int minChunkSize,
       int maxChunkSize) throws IOException {
-    Collection<ByteString> results = new ArrayList<ByteString>();
+    Collection<ByteString> results = new ArrayList<>();
 
     // copy the inbound bytes into a list of chunks; the chunk size
     // grows exponentially to support both short and long streams.
@@ -408,7 +405,7 @@ public abstract class ByteString implements Iterable<Byte> {
   public static ByteString copyFrom(Iterable<ByteString> byteStrings) {
     Collection<ByteString> collection;
     if (!(byteStrings instanceof Collection)) {
-      collection = new ArrayList<ByteString>();
+      collection = new ArrayList<>();
       for (ByteString byteString : byteStrings) {
         collection.add(byteString);
       }
@@ -736,7 +733,7 @@ public abstract class ByteString implements Iterable<Byte> {
         throw new IllegalArgumentException("Buffer size < 0");
       }
       this.initialCapacity = initialCapacity;
-      this.flushedBuffers = new ArrayList<ByteString>();
+      this.flushedBuffers = new ArrayList<>();
       this.buffer = new byte[initialCapacity];
     }
 

--- a/akka-protobuf/src/main/java/akka/protobuf/CodedOutputStream.java
+++ b/akka-protobuf/src/main/java/akka/protobuf/CodedOutputStream.java
@@ -37,7 +37,7 @@ package akka.protobuf;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Encodes and writes protocol message fields.
@@ -73,8 +73,7 @@ public final class CodedOutputStream {
    *         CodedOutputStream.
    */
   static int computePreferredBufferSize(int dataLength) {
-    if (dataLength > DEFAULT_BUFFER_SIZE) return DEFAULT_BUFFER_SIZE;
-    return dataLength;
+    return Math.min(dataLength, DEFAULT_BUFFER_SIZE);
   }
 
   private CodedOutputStream(final byte[] buffer, final int offset,
@@ -356,7 +355,7 @@ public final class CodedOutputStream {
     // Unfortunately there does not appear to be any way to tell Java to encode
     // UTF-8 directly into our buffer, so we have to let it create its own byte
     // array and then copy.
-    final byte[] bytes = value.getBytes("UTF-8");
+    final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
     writeRawVarint32(bytes.length);
     writeRawBytes(bytes);
   }
@@ -715,13 +714,9 @@ public final class CodedOutputStream {
    * {@code string} field.
    */
   public static int computeStringSizeNoTag(final String value) {
-    try {
-      final byte[] bytes = value.getBytes("UTF-8");
-      return computeRawVarint32Size(bytes.length) +
-             bytes.length;
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException("UTF-8 not supported.", e);
-    }
+    final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    return computeRawVarint32Size(bytes.length) +
+           bytes.length;
   }
 
   /**


### PR DESCRIPTION
There are some lines look like that: `Charset.forName("UTF-8")` or `stringVariable.getBytes("UTF-8")` .
It can be replaced on StandartCharsets.UTF_8  (since java 7) [Documentation](https://docs.oracle.com/javase/7/docs/api/java/nio/charset/StandardCharsets.html)

Kind regards