### PR TITLE
Drop the java supervision sample link

### DIFF
--- a/akka-docs/src/main/paradox/general/supervision.md
+++ b/akka-docs/src/main/paradox/general/supervision.md
@@ -4,12 +4,6 @@ This chapter outlines the concept behind supervision, the primitives offered
 and their semantics. For details on how that translates into real code, please
 refer to the corresponding chapters for Scala and Java APIs.
 
-## Sample project
-
-You can look at the
-@extref[Supervision example project](samples:akka-samples-supervision-java)
-to see what this looks like in practice.
-
 <a id="supervision-directives"></a>
 ## What Supervision Means
 


### PR DESCRIPTION
In 2.5 (even thought the sample is still there in the 2.5 branch of the samples repo) since it was bad enough a sample that we decided to remove it. This is instead of fixing the broken link.

Superseedes #30006 
