### PR TITLE
Remove unnecessary modifiers from FI.java

### DIFF
--- a/akka-actor/src/main/java/akka/japi/pf/FI.java
+++ b/akka-actor/src/main/java/akka/japi/pf/FI.java
@@ -22,14 +22,14 @@ public final class FI {
    * @param <I> the input type, that this Apply will be applied to
    * @param <R> the return type, that the results of the application will have
    */
-  public static interface Apply<I, R> {
+  public interface Apply<I, R> {
     /**
      * The application to perform.
      *
      * @param i an instance that the application is performed on
      * @return the result of the application
      */
-    public R apply(I i) throws Exception;
+    R apply(I i) throws Exception;
   }
 
   /**
@@ -42,7 +42,7 @@ public final class FI {
    * @param <I2> the second input type, that this Apply will be applied to
    * @param <R> the return type, that the results of the application will have
    */
-  public static interface Apply2<I1, I2, R> {
+  public interface Apply2<I1, I2, R> {
     /**
      * The application to perform.
      *
@@ -50,7 +50,7 @@ public final class FI {
      * @param i2 an instance that the application is performed on
      * @return the result of the application
      */
-    public R apply(I1 i1, I2 i2) throws Exception;
+    R apply(I1 i1, I2 i2) throws Exception;
   }
 
   /**
@@ -61,14 +61,14 @@ public final class FI {
    *
    * @param <T> the type that the predicate will operate on.
    */
-  public static interface TypedPredicate<T> {
+  public interface TypedPredicate<T> {
     /**
      * The predicate to evaluate.
      *
      * @param t an instance that the predicate is evaluated on.
      * @return the result of the predicate
      */
-    public boolean defined(T t);
+    boolean defined(T t);
   }
 
   /**
@@ -77,7 +77,7 @@ public final class FI {
    * @param <T> the type that the predicate will operate on.
    * @param <U> the type that the predicate will operate on.
    */
-  public static interface TypedPredicate2<T, U> {
+  public interface TypedPredicate2<T, U> {
     /**
      * The predicate to evaluate.
      *
@@ -85,7 +85,7 @@ public final class FI {
      * @param u an instance that the predicate is evaluated on.
      * @return the result of the predicate
      */
-    public boolean defined(T t, U u);
+    boolean defined(T t, U u);
   }
 
   /**
@@ -96,13 +96,13 @@ public final class FI {
    *
    * @param <I> the input type, that this Apply will be applied to
    */
-  public static interface UnitApply<I> {
+  public interface UnitApply<I> {
     /**
      * The application to perform.
      *
      * @param i an instance that the application is performed on
      */
-    public void apply(I i) throws Exception;
+    void apply(I i) throws Exception;
   }
 
   /**
@@ -111,14 +111,14 @@ public final class FI {
    * @param <I1> the first input type, that this Apply will be applied to
    * @param <I2> the second input type, that this Apply will be applied to
    */
-  public static interface UnitApply2<I1, I2> {
+  public interface UnitApply2<I1, I2> {
     /**
      * The application to perform.
      *
      * @param i1 an instance that the application is performed on
      * @param i2 an instance that the application is performed on
      */
-    public void apply(I1 i1, I2 i2) throws Exception;
+    void apply(I1 i1, I2 i2) throws Exception;
   }
 
   /**
@@ -128,7 +128,7 @@ public final class FI {
    * @param <I2> the second input type, that this Apply will be applied to
    * @param <I3> the third input type, that this Apply will be applied to
    */
-  public static interface UnitApply3<I1, I2, I3> {
+  public interface UnitApply3<I1, I2, I3> {
     /**
      * The application to perform.
      *
@@ -136,7 +136,7 @@ public final class FI {
      * @param i2 an instance that the application is performed on
      * @param i3 an instance that the application is performed on
      */
-    public void apply(I1 i1, I2 i2, I3 i3) throws Exception;
+    void apply(I1 i1, I2 i2, I3 i3) throws Exception;
   }
 
   /**
@@ -147,7 +147,7 @@ public final class FI {
    * @param <I3> the third input type, that this Apply will be applied to
    * @param <I4> the fourth input type, that this Apply will be applied to
    */
-  public static interface UnitApply4<I1, I2, I3, I4> {
+  public interface UnitApply4<I1, I2, I3, I4> {
     /**
      * The application to perform.
      *
@@ -156,7 +156,7 @@ public final class FI {
      * @param i3 an instance that the application is performed on
      * @param i4 an instance that the application is performed on
      */
-    public void apply(I1 i1, I2 i2, I3 i3, I4 i4) throws Exception;
+    void apply(I1 i1, I2 i2, I3 i3, I4 i4) throws Exception;
   }
 
   /**
@@ -165,9 +165,9 @@ public final class FI {
    * <p>This class is kept for compatibility, but for future API's please prefer {@link
    * akka.japi.function.Effect}.
    */
-  public static interface UnitApplyVoid {
+  public interface UnitApplyVoid {
     /** The application to perform. */
-    public void apply() throws Exception;
+    void apply() throws Exception;
   }
 
   /**
@@ -177,13 +177,13 @@ public final class FI {
    * <p>This class is kept for compatibility, but for future API's please prefer {@link
    * java.util.function.Predicate} or {@link akka.japi.function.Predicate}.
    */
-  static interface Predicate {
+  interface Predicate {
     /**
      * The predicate to evaluate.
      *
      * @param o an instance that the predicate is evaluated on.
      * @return the result of the predicate
      */
-    public boolean defined(Object o);
+    boolean defined(Object o);
   }
 }


### PR DESCRIPTION
There are many lines look like:
`public static interface Foo {}` , but a member interface is implicitly static [jls documentations](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.5.1) . 
So `public static interface` 
can be replaced on `public interface` .

Methods in interface are implicitly public [documentation](https://docs.oracle.com/javase/tutorial/java/IandI/interfaceDef.html) , so the code 
`interface My {
  public someMethod();
}` can be replaced on 
`interface My {
  someMethod();
}`

Kind regards
