### PR TITLE
genjavadoc: update 0.16 -> 0.17

### DIFF
--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -185,7 +185,7 @@ object BootstrapGenjavadoc extends AutoPlugin {
 
   override lazy val projectSettings = UnidocRoot.CliOptions.genjavadocEnabled
     .ifTrue(Seq(
-      unidocGenjavadocVersion := "0.16",
+      unidocGenjavadocVersion := "0.17",
       scalacOptions in Compile ++= Seq("-P:genjavadoc:fabricateParams=false", "-P:genjavadoc:suppressSynthetic=false")))
     .getOrElse(Nil)
 }


### PR DESCRIPTION
To get the fix for 'rangepos', which is becoming the default with 2.13.5