### PR TITLE
Refactor GeneratedMessageLite

### DIFF
--- a/akka-protobuf/src/main/java/akka/protobuf/FieldSet.java
+++ b/akka-protobuf/src/main/java/akka/protobuf/FieldSet.java
@@ -461,7 +461,7 @@ final class FieldSet<FieldDescriptorType extends
   /**
    * Given a field type, return the wire type.
    *
-   * @returns One of the {@code WIRETYPE_} constants defined in
+   * @return One of the {@code WIRETYPE_} constants defined in
    *          {@link WireFormat}.
    */
   static int getWireFormatForFieldType(final WireFormat.FieldType type,
@@ -471,6 +471,25 @@ final class FieldSet<FieldDescriptorType extends
     } else {
       return type.getWireType();
     }
+  }
+
+  /**
+   *
+   * @return Constant WIRETYPE_LENGTH_DELIMITED defined in
+   *          {@link WireFormat} for packed field type.
+   */
+  static int getPackedWireFormatForFieldType() {
+    return WireFormat.WIRETYPE_LENGTH_DELIMITED;
+  }
+
+  /**
+   * Given an unpacked field type, return the wire type.
+   *
+   * @return One of the {@code WIRETYPE_} constants defined in
+   *          {@link WireFormat}.
+   */
+  static int getUnPackedWireFormatForFieldType(final WireFormat.FieldType type) {
+    return type.getWireType();
   }
 
   /**


### PR DESCRIPTION
It's only draft PR. I have noticed some code in GeneratedMessageLite - determine field type (unknow, packed, unpacked). 
I think the code can be extracted in different method 

 [AbstractMessage](https://github.com/akka/akka/blob/146944f99934557eac72e6dc7fa25fc6b2f0f11c/akka-protobuf/src/main/java/akka/protobuf/AbstractMessage.java#L494) constains the similar code. 

Will it be useful to creare some separated class with oveloaded methods with tests? 
Also I think the method [FieldSet.getWireFormatForFieldType](https://github.com/akka/akka/blob/146944f99934557eac72e6dc7fa25fc6b2f0f11c/akka-protobuf/src/main/java/akka/protobuf/FieldSet.java#L467) can be replaced on two methods. Because unanamed boolean parameters maybe little "not readable".

Should I do these changes? I'm not sure, indeed.  What do you think? I need your opinion

Kind regards
