### PR TITLE
ActorSinkWithAckExample Ack message

### DIFF
--- a/akka-stream-typed/src/test/java/docs/akka/stream/typed/ActorSinkWithAckExample.java
+++ b/akka-stream-typed/src/test/java/docs/akka/stream/typed/ActorSinkWithAckExample.java
@@ -17,7 +17,9 @@ public class ActorSinkWithAckExample {
 
   // #actor-sink-ref-with-backpressure
 
-  enum Ack { INSTANCE; }
+  enum Ack {
+    INSTANCE;
+  }
 
   interface Protocol {}
 

--- a/akka-stream-typed/src/test/java/docs/akka/stream/typed/ActorSinkWithAckExample.java
+++ b/akka-stream-typed/src/test/java/docs/akka/stream/typed/ActorSinkWithAckExample.java
@@ -17,7 +17,7 @@ public class ActorSinkWithAckExample {
 
   // #actor-sink-ref-with-backpressure
 
-  class Ack {}
+  enum Ack { INSTANCE; }
 
   interface Protocol {}
 
@@ -58,7 +58,6 @@ public class ActorSinkWithAckExample {
     final ActorRef<Protocol> actorRef = // spawned actor
         null; // #hidden
 
-    final Ack ackMessage = new Ack();
     final Complete completeMessage = new Complete();
 
     final Sink<String, NotUsed> sink =
@@ -66,7 +65,7 @@ public class ActorSinkWithAckExample {
             actorRef,
             (responseActorRef, element) -> new Message(responseActorRef, element),
             (responseActorRef) -> new Init(responseActorRef),
-            ackMessage,
+            Ack.INSTANCE,
             completeMessage,
             (exception) -> new Fail(exception));
 


### PR DESCRIPTION
Using the example does not work in Java, because it seems that `Sink` compares by equality, no by class.