### PR TITLE
Extra catch-ignore for source attributes in case not possible

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/SourceLocationAttributeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/SourceLocationAttributeSpec.scala
@@ -8,15 +8,14 @@ import akka.stream.scaladsl.Flow
 import akka.stream.testkit.StreamSpec
 
 class SourceLocationAttributeSpec extends StreamSpec {
-  
+
   "The SourceLocation attribute" must {
     "not throw NPE" in {
       // #30138
-      val f1 = Flow[Int].fold(0)(_+_)
-      val f2 = Flow[Int].fold(0)(_+_)
+      val f1 = Flow[Int].fold(0)(_ + _)
+      val f2 = Flow[Int].fold(0)(_ + _)
       f1.join(f2).toString
     }
   }
-  
 
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/SourceLocationAttributeSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/SourceLocationAttributeSpec.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream
+
+import akka.stream.scaladsl.Flow
+import akka.stream.testkit.StreamSpec
+
+class SourceLocationAttributeSpec extends StreamSpec {
+  
+  "The SourceLocation attribute" must {
+    "not throw NPE" in {
+      // #30138
+      val f1 = Flow[Int].fold(0)(_+_)
+      val f2 = Flow[Int].fold(0)(_+_)
+      f1.join(f2).toString
+    }
+  }
+  
+
+}

--- a/akka-stream/src/main/scala/akka/stream/Attributes.scala
+++ b/akka-stream/src/main/scala/akka/stream/Attributes.scala
@@ -10,14 +10,14 @@ import java.util.Optional
 import scala.annotation.tailrec
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.FiniteDuration
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.{ classTag, ClassTag }
 import akka.annotation.ApiMayChange
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
 import akka.event.Logging
 import akka.japi.function
 import akka.stream.impl.TraversalBuilder
-import akka.util.{ByteString, OptionVal}
+import akka.util.{ ByteString, OptionVal }
 import akka.util.JavaDurationConverters._
 import akka.util.LineNumbers
 

--- a/akka-stream/src/main/scala/akka/stream/Attributes.scala
+++ b/akka-stream/src/main/scala/akka/stream/Attributes.scala
@@ -10,16 +10,18 @@ import java.util.Optional
 import scala.annotation.tailrec
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.FiniteDuration
-import scala.reflect.{ classTag, ClassTag }
+import scala.reflect.{ClassTag, classTag}
 import akka.annotation.ApiMayChange
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
 import akka.event.Logging
 import akka.japi.function
 import akka.stream.impl.TraversalBuilder
-import akka.util.{ ByteString, OptionVal }
+import akka.util.{ByteString, OptionVal}
 import akka.util.JavaDurationConverters._
 import akka.util.LineNumbers
+
+import scala.util.control.NonFatal
 
 /**
  * Holds attributes which can be used to alter [[akka.stream.scaladsl.Flow]] / [[akka.stream.javadsl.Flow]]
@@ -308,7 +310,7 @@ object Attributes {
    * for debugging. Included in the default toString of GraphStageLogic if present
    */
   final class SourceLocation(lambda: AnyRef) extends Attribute {
-    lazy val locationName: String = {
+    lazy val locationName: String = try {
       val locationName = LineNumbers(lambda) match {
         case LineNumbers.NoSourceInfo           => "unknown"
         case LineNumbers.UnknownSourceFormat(_) => "unknown"
@@ -317,6 +319,8 @@ object Attributes {
           s"$filename:$from"
       }
       s"${lambda.getClass.getPackage.getName}-$locationName"
+    } catch {
+      case NonFatal(_) => "unknown" // location is not critical so give up without failing
     }
 
     override def toString: String = locationName


### PR DESCRIPTION
References #30138

Actually does work on supported JDKs as far as I understand, but good to do anyway since the source location information is not really critical.