### PR TITLE
Preserve attributes of inner stages when using {Source,Flow,Sink}.fromMaterializer

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FromMaterializationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FromMaterializationSpec.scala
@@ -10,9 +10,7 @@ import akka.stream.Attributes.Attribute
 import akka.stream.testkit.StreamSpec
 
 class FromMaterializerSpec extends StreamSpec {
-
-  import system.dispatcher
-
+  
   case class MyAttribute() extends Attribute
   val myAttributes = Attributes(MyAttribute())
 
@@ -199,7 +197,7 @@ class FromMaterializerSpec extends StreamSpec {
         Sink.fold(mat.isShutdown)(Keep.left)
       }
 
-      Source.empty.runWith(sink).flatMap(identity).futureValue shouldBe false
+      Source.empty.runWith(sink).flatten.futureValue shouldBe false
     }
 
     "expose attributes" in {
@@ -207,7 +205,7 @@ class FromMaterializerSpec extends StreamSpec {
         Sink.fold(attr.attributeList)(Keep.left)
       }
 
-      Source.empty.runWith(sink).flatMap(identity).futureValue should not be empty
+      Source.empty.runWith(sink).flatten.futureValue should not be empty
     }
 
     "propagate materialized value" in {
@@ -215,7 +213,7 @@ class FromMaterializerSpec extends StreamSpec {
         Sink.fold(NotUsed)(Keep.left)
       }
 
-      Source.empty.runWith(sink).flatMap(identity).futureValue shouldBe NotUsed
+      Source.empty.runWith(sink).flatten.futureValue shouldBe NotUsed
     }
 
     "propagate attributes" in {
@@ -225,7 +223,7 @@ class FromMaterializerSpec extends StreamSpec {
         }
         .named("my-name")
 
-      Source.empty.runWith(sink).flatMap(identity).futureValue shouldBe Some("setup-my-name")
+      Source.empty.runWith(sink).flatten.futureValue shouldBe Some("setup-my-name")
     }
 
     "propagate attributes when nested" in {
@@ -237,7 +235,7 @@ class FromMaterializerSpec extends StreamSpec {
         }
         .named("my-name")
 
-      Source.empty.runWith(sink).flatMap(identity).flatMap(identity).futureValue shouldBe Some("setup-setup-my-name")
+      Source.empty.runWith(sink).flatten.flatten.futureValue shouldBe Some("setup-setup-my-name")
     }
 
     "preserve attributes of inner sink" in {
@@ -251,7 +249,7 @@ class FromMaterializerSpec extends StreamSpec {
         }
         .named("my-name")
 
-      Source.empty.runWith(sink).flatMap(identity).flatMap(identity).futureValue shouldBe Some(MyAttribute())
+      Source.empty.runWith(sink).flatten.flatten.futureValue shouldBe Some(MyAttribute())
     }
 
     "handle factory failure" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FromMaterializationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FromMaterializationSpec.scala
@@ -73,7 +73,6 @@ class FromMaterializerSpec extends StreamSpec {
             }
             .addAttributes(myAttributes)
         }
-        .named("my-name")
 
       source.runWith(Sink.head).futureValue shouldBe Some(MyAttribute())
     }
@@ -161,7 +160,6 @@ class FromMaterializerSpec extends StreamSpec {
             }
             .addAttributes(myAttributes)
         }
-        .named("my-name")
 
       Source.empty.via(flow).runWith(Sink.head).futureValue shouldBe Some(MyAttribute())
     }
@@ -247,7 +245,6 @@ class FromMaterializerSpec extends StreamSpec {
             }
             .addAttributes(myAttributes)
         }
-        .named("my-name")
 
       Source.empty.runWith(sink).flatten.flatten.futureValue shouldBe Some(MyAttribute())
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FromMaterializationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FromMaterializationSpec.scala
@@ -10,7 +10,7 @@ import akka.stream.Attributes.Attribute
 import akka.stream.testkit.StreamSpec
 
 class FromMaterializerSpec extends StreamSpec {
-  
+
   case class MyAttribute() extends Attribute
   val myAttributes = Attributes(MyAttribute())
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FromMaterializationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FromMaterializationSpec.scala
@@ -63,7 +63,7 @@ class FromMaterializerSpec extends StreamSpec {
         }
         .named("my-name")
 
-      source.runWith(Sink.head).futureValue shouldBe Some("setup-my-name")
+      source.runWith(Sink.head).futureValue shouldBe Some("setup-setup-my-name")
     }
 
     "preserve attributes of inner source" in {
@@ -149,7 +149,7 @@ class FromMaterializerSpec extends StreamSpec {
         }
         .named("my-name")
 
-      Source.empty.via(flow).runWith(Sink.head).futureValue shouldBe Some("setup-my-name")
+      Source.empty.via(flow).runWith(Sink.head).futureValue shouldBe Some("setup-setup-my-name")
     }
 
     "preserve attributes of inner flow" in {
@@ -233,7 +233,7 @@ class FromMaterializerSpec extends StreamSpec {
         }
         .named("my-name")
 
-      Source.empty.runWith(sink).flatMap(identity).flatMap(identity).futureValue shouldBe Some("setup-my-name")
+      Source.empty.runWith(sink).flatMap(identity).flatMap(identity).futureValue shouldBe Some("setup-setup-my-name")
     }
 
     "preserve attributes of inner sink" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FromMaterializationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FromMaterializationSpec.scala
@@ -15,7 +15,7 @@ class FromMaterializerSpec extends StreamSpec {
 
   case class MyAttribute() extends Attribute
   val myAttributes = Attributes(MyAttribute())
-  
+
   "Source.fromMaterializer" should {
 
     "expose materializer" in {
@@ -69,9 +69,11 @@ class FromMaterializerSpec extends StreamSpec {
     "preserve attributes of inner source" in {
       val source = Source
         .fromMaterializer { (_, _) =>
-          Source.fromMaterializer { (_, attr) =>
-            Source.single(attr.get[MyAttribute])
-          }.addAttributes(myAttributes)
+          Source
+            .fromMaterializer { (_, attr) =>
+              Source.single(attr.get[MyAttribute])
+            }
+            .addAttributes(myAttributes)
         }
         .named("my-name")
 
@@ -155,9 +157,11 @@ class FromMaterializerSpec extends StreamSpec {
     "preserve attributes of inner flow" in {
       val flow = Flow
         .fromMaterializer { (_, _) =>
-          Flow.fromMaterializer { (_, attr) =>
-            Flow.fromSinkAndSource(Sink.ignore, Source.single(attr.get[MyAttribute]))
-          }.addAttributes(myAttributes)
+          Flow
+            .fromMaterializer { (_, attr) =>
+              Flow.fromSinkAndSource(Sink.ignore, Source.single(attr.get[MyAttribute]))
+            }
+            .addAttributes(myAttributes)
         }
         .named("my-name")
 
@@ -239,9 +243,11 @@ class FromMaterializerSpec extends StreamSpec {
     "preserve attributes of inner sink" in {
       val sink = Sink
         .fromMaterializer { (_, _) =>
-          Sink.fromMaterializer { (_, attr) =>
-            Sink.fold(attr.get[MyAttribute])(Keep.left)
-          }.addAttributes(myAttributes)
+          Sink
+            .fromMaterializer { (_, attr) =>
+              Sink.fold(attr.get[MyAttribute])(Keep.left)
+            }
+            .addAttributes(myAttributes)
         }
         .named("my-name")
 

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FromMaterializationSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FromMaterializationSpec.scala
@@ -65,14 +65,13 @@ class FromMaterializerSpec extends StreamSpec {
     }
 
     "preserve attributes of inner source" in {
-      val source = Source
-        .fromMaterializer { (_, _) =>
-          Source
-            .fromMaterializer { (_, attr) =>
-              Source.single(attr.get[MyAttribute])
-            }
-            .addAttributes(myAttributes)
-        }
+      val source = Source.fromMaterializer { (_, _) =>
+        Source
+          .fromMaterializer { (_, attr) =>
+            Source.single(attr.get[MyAttribute])
+          }
+          .addAttributes(myAttributes)
+      }
 
       source.runWith(Sink.head).futureValue shouldBe Some(MyAttribute())
     }
@@ -152,14 +151,13 @@ class FromMaterializerSpec extends StreamSpec {
     }
 
     "preserve attributes of inner flow" in {
-      val flow = Flow
-        .fromMaterializer { (_, _) =>
-          Flow
-            .fromMaterializer { (_, attr) =>
-              Flow.fromSinkAndSource(Sink.ignore, Source.single(attr.get[MyAttribute]))
-            }
-            .addAttributes(myAttributes)
-        }
+      val flow = Flow.fromMaterializer { (_, _) =>
+        Flow
+          .fromMaterializer { (_, attr) =>
+            Flow.fromSinkAndSource(Sink.ignore, Source.single(attr.get[MyAttribute]))
+          }
+          .addAttributes(myAttributes)
+      }
 
       Source.empty.via(flow).runWith(Sink.head).futureValue shouldBe Some(MyAttribute())
     }
@@ -237,14 +235,13 @@ class FromMaterializerSpec extends StreamSpec {
     }
 
     "preserve attributes of inner sink" in {
-      val sink = Sink
-        .fromMaterializer { (_, _) =>
-          Sink
-            .fromMaterializer { (_, attr) =>
-              Sink.fold(attr.get[MyAttribute])(Keep.left)
-            }
-            .addAttributes(myAttributes)
-        }
+      val sink = Sink.fromMaterializer { (_, _) =>
+        Sink
+          .fromMaterializer { (_, attr) =>
+            Sink.fold(attr.get[MyAttribute])(Keep.left)
+          }
+          .addAttributes(myAttributes)
+      }
 
       Source.empty.runWith(sink).flatten.flatten.futureValue shouldBe Some(MyAttribute())
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
@@ -11,9 +11,7 @@ import akka.stream.testkit.StreamSpec
 
 @nowarn("msg=deprecated")
 class SetupSpec extends StreamSpec {
-
-  import system.dispatcher
-
+  
   "Source.setup" should {
 
     "expose materializer" in {
@@ -169,7 +167,7 @@ class SetupSpec extends StreamSpec {
         Sink.fold(mat.isShutdown)(Keep.left)
       }
 
-      Source.empty.runWith(sink).flatMap(identity).futureValue shouldBe false
+      Source.empty.runWith(sink).flatten.futureValue shouldBe false
     }
 
     "expose attributes" in {
@@ -177,7 +175,7 @@ class SetupSpec extends StreamSpec {
         Sink.fold(attr.attributeList)(Keep.left)
       }
 
-      Source.empty.runWith(sink).flatMap(identity).futureValue should not be empty
+      Source.empty.runWith(sink).flatten.futureValue should not be empty
     }
 
     "propagate materialized value" in {
@@ -185,7 +183,7 @@ class SetupSpec extends StreamSpec {
         Sink.fold(NotUsed)(Keep.left)
       }
 
-      Source.empty.runWith(sink).flatMap(identity).futureValue shouldBe NotUsed
+      Source.empty.runWith(sink).flatten.futureValue shouldBe NotUsed
     }
 
     "propagate attributes" in {
@@ -195,7 +193,7 @@ class SetupSpec extends StreamSpec {
         }
         .named("my-name")
 
-      Source.empty.runWith(sink).flatMap(identity).futureValue shouldBe Some("setup-my-name")
+      Source.empty.runWith(sink).flatten.futureValue shouldBe Some("setup-my-name")
     }
 
     "propagate attributes when nested" in {
@@ -207,7 +205,7 @@ class SetupSpec extends StreamSpec {
         }
         .named("my-name")
 
-      Source.empty.runWith(sink).flatMap(identity).flatMap(identity).futureValue shouldBe Some("setup-setup-my-name")
+      Source.empty.runWith(sink).flatten.flatten.futureValue shouldBe Some("setup-setup-my-name")
     }
 
     "handle factory failure" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
@@ -61,7 +61,7 @@ class SetupSpec extends StreamSpec {
         }
         .named("my-name")
 
-      source.runWith(Sink.head).futureValue shouldBe Some("setup-my-name")
+      source.runWith(Sink.head).futureValue shouldBe Some("setup-setup-my-name")
     }
 
     "handle factory failure" in {
@@ -135,7 +135,7 @@ class SetupSpec extends StreamSpec {
         }
         .named("my-name")
 
-      Source.empty.via(flow).runWith(Sink.head).futureValue shouldBe Some("setup-my-name")
+      Source.empty.via(flow).runWith(Sink.head).futureValue shouldBe Some("setup-setup-my-name")
     }
 
     "handle factory failure" in {
@@ -207,7 +207,7 @@ class SetupSpec extends StreamSpec {
         }
         .named("my-name")
 
-      Source.empty.runWith(sink).flatMap(identity).flatMap(identity).futureValue shouldBe Some("setup-my-name")
+      Source.empty.runWith(sink).flatMap(identity).flatMap(identity).futureValue shouldBe Some("setup-setup-my-name")
     }
 
     "handle factory failure" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SetupSpec.scala
@@ -11,7 +11,7 @@ import akka.stream.testkit.StreamSpec
 
 @nowarn("msg=deprecated")
 class SetupSpec extends StreamSpec {
-  
+
   "Source.setup" should {
 
     "expose materializer" in {

--- a/akka-stream/src/main/scala/akka/stream/impl/SetupStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SetupStage.scala
@@ -44,7 +44,7 @@ import akka.stream.stage.OutHandler
       try {
         val sink = factory(materializer, attributes)
 
-        val mat = Source.fromGraph(subOutlet.source).runWith(sink.withAttributes(attributes))(subFusingMaterializer)
+        val mat = Source.fromGraph(subOutlet.source).runWith(sink.addAttributes(attributes))(subFusingMaterializer)
         matPromise.success(mat)
       } catch {
         case NonFatal(ex) =>
@@ -89,7 +89,7 @@ import akka.stream.stage.OutHandler
 
         val mat = Source
           .fromGraph(subOutlet.source)
-          .viaMat(flow.withAttributes(attributes))(Keep.right)
+          .viaMat(flow.addAttributes(attributes))(Keep.right)
           .to(Sink.fromGraph(subInlet.sink))
           .run()(subFusingMaterializer)
         matPromise.success(mat)
@@ -127,7 +127,7 @@ import akka.stream.stage.OutHandler
       try {
         val source = factory(materializer, attributes)
 
-        val mat = source.withAttributes(attributes).to(Sink.fromGraph(subInlet.sink)).run()(subFusingMaterializer)
+        val mat = source.addAttributes(attributes).to(Sink.fromGraph(subInlet.sink)).run()(subFusingMaterializer)
         matPromise.success(mat)
       } catch {
         case NonFatal(ex) =>


### PR DESCRIPTION
References #29134, #30141

This fix ensures that the attributes of inner stages are preserved when they are created inside a `{Source,Flow,Sink}.fromMaterializer`.

I had to modify some existing tests so that they pass: they depended on the previous behavior, although I believe this was unintentional. The actual behavior being tested `"propagate attributes when nested"` still holds true.
