### PR TITLE
Inner stages of lazy/future stages should inherit attributes

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LazySinkSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/LazySinkSpec.scala
@@ -161,7 +161,7 @@ class LazySinkSpec extends StreamSpec("""
 
     }
 
-    "provide attributes to inner source" in assertAllStagesStopped {
+    "provide attributes to inner sink" in assertAllStagesStopped {
       val attributes = Source
         .single(Done)
         .toMat(Sink.lazyFutureSink(() => Future(Sink.fromGraph(new AttributesSink()))))(Keep.right)

--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -29,9 +29,7 @@ import akka.stream.impl.QueueSink.Output
 import akka.stream.impl.QueueSink.Pull
 import akka.stream.impl.Stages.DefaultAttributes
 import akka.stream.impl.StreamLayout.AtomicModule
-import akka.stream.scaladsl.Sink
-import akka.stream.scaladsl.SinkQueueWithCancel
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{ Keep, Sink, SinkQueueWithCancel, Source }
 import akka.stream.stage._
 import akka.util.ccompat._
 
@@ -604,7 +602,8 @@ import akka.util.ccompat._
 
         val subOutlet = new SubSourceOutlet[T]("LazySink")
 
-        val matVal = Source.fromGraph(subOutlet.source).runWith(sink)(interpreter.subFusingMaterializer)
+        val matVal = interpreter.subFusingMaterializer
+          .materialize(Source.fromGraph(subOutlet.source).toMat(sink)(Keep.right), inheritedAttributes)
 
         def maybeCompleteStage(): Unit = {
           if (isClosed(in) && subOutlet.isClosed) {

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/FlatMapPrefix.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/FlatMapPrefix.scala
@@ -147,7 +147,7 @@ import akka.util.OptionVal
           val matVal = try {
             val flow = f(prefix)
             val runnableGraph = Source.fromGraph(theSubSource.source).viaMat(flow)(Keep.right).to(theSubSink.sink)
-            interpreter.subFusingMaterializer.materialize(runnableGraph)
+            interpreter.subFusingMaterializer.materialize(runnableGraph, inheritedAttributes)
           } catch {
             case NonFatal(ex) =>
               matPromise.failure(new NeverMaterializedException(ex))

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/FutureFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/FutureFlow.scala
@@ -111,8 +111,9 @@ import scala.util.{ Failure, Success, Try }
             }
           }
           try {
-            val matVal =
-              Source.fromGraph(subSource.source).viaMat(flow)(Keep.right).to(subSink.sink).run()(subFusingMaterializer)
+            val matVal = subFusingMaterializer.materialize(
+              Source.fromGraph(subSource.source).viaMat(flow)(Keep.right).to(subSink.sink),
+              inheritedAttributes)
             innerMatValue.success(matVal)
             upstreamFailure match {
               case OptionVal.Some(ex) => subSource.fail(ex)


### PR DESCRIPTION
This PR continues the effort to fix bugs related to attribute inheritance (see also #29973, #30142), in this case focused on lazy/future stages.

The first commit adds test coverage and the second follows up with the necessary fixes.