### PR TITLE
Unwatch before watch in typed Supervision

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/Supervision.scala
@@ -386,6 +386,8 @@ private class RestartSupervisor[T, Thr <: Throwable: ClassTag](initial: Behavior
 
   private def stopChildren(ctx: TypedActorContext[_], children: Set[ActorRef[Nothing]]): Unit = {
     children.foreach { child =>
+      // Unwatch in case the actor being restarted used watchWith to watch the child.
+      ctx.asScala.unwatch(child)
       ctx.asScala.watch(child)
       ctx.asScala.stop(child)
     }


### PR DESCRIPTION
If an actor supervised with a restart strategy uses `context.watchWith` to watch for failures in its child actors, `Supervision`'s implementation will watch the children before stopping them, which will trigger an `IllegalStateException` in the supervision.

This change unwatches before watching the children, which will allow the restart strategy to proceed.