### PR TITLE
Reference akka-logback extension in docs

### DIFF
--- a/akka-docs/src/main/paradox/typed/logging.md
+++ b/akka-docs/src/main/paradox/typed/logging.md
@@ -188,6 +188,7 @@ We recommend [Logback](http://logback.qos.ch/):
 
 Logback has flexible configuration options and details can be found in the
 [Logback manual](https://logback.qos.ch/manual/configuration.html) and other external resources.
+Additionally, the [akka-logback](https://github.com/armanbilge/akka-logback) extension lets you import Akka config settings into your Logback configuration.
 
 One part that is important to highlight is the importance of configuring an [AsyncAppender](http://logback.qos.ch/manual/appenders.html#AsyncAppender),
 because it offloads rendering of logging events to a background thread, increasing performance. It doesn't block


### PR DESCRIPTION
Apologies for tooting my own horn: I just released an [akka-logback](https://github.com/armanbilge/akka-logback) extension ([inspired by this thread](https://discuss.lightbend.com/t/future-of-logging-in-akka-classic-eventstream-or-slf4j/8071)) which helps integrate logback with Akka. One of its features is the ability to import configuration settings from the actor system into the `logback.xml` like so:

```xml
<configuration>
    <akkaProperty name="AKKA_LOGLEVEL" path="akka.loglevel" />
    <root level="${AKKA_LOGLEVEL}">
    </root>
</configuration>
```

If you are open to mentioning the project in your docs, I hope it can be helpful to other users.