### PR TITLE
Fix scaladoc warning in CircuitBreaker.scala

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
+++ b/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala
@@ -411,7 +411,7 @@ class CircuitBreaker(
       callTimeout)
 
   /**
-   * Java API for [[#withSyncCircuitBreaker]]. Throws [[java.util.concurrent.TimeoutException]] if the call timed out.
+   * Java API for [[withSyncCircuitBreaker[T](body:=>T):T* withSyncCircuitBreaker(=>T)]]. Throws [[java.util.concurrent.TimeoutException]] if the call timed out.
    *
    * @param body Call needing protected
    * @return The result of the call
@@ -420,7 +420,7 @@ class CircuitBreaker(
     callWithSyncCircuitBreaker(body, CircuitBreaker.exceptionAsFailureJava[T])
 
   /**
-   * Java API for [[#withSyncCircuitBreaker]]. Throws [[java.util.concurrent.TimeoutException]] if the call timed out.
+   * Java API for [[withSyncCircuitBreaker[T](body:=>T,defineFailureFn:* withSyncCircuitBreaker[T](=>T,Try[T]=>Boolean)]]. Throws [[java.util.concurrent.TimeoutException]] if the call timed out.
    *
    * @param body Call needing protected
    * @param defineFailureFn function that define what should be consider failure and thus increase failure count


### PR DESCRIPTION
It's first part of #19999. It's only one method.  Test it, please. The result looks like that:

![example](https://user-images.githubusercontent.com/4740207/115096985-50561f00-9f30-11eb-8164-5737994d0601.png)

The full page looks like that:

<img width="1440" alt="Снимок экрана 2021-04-17 в 03 38 27" src="https://user-images.githubusercontent.com/4740207/115097023-7ed3fa00-9f30-11eb-8007-3d5e910db60f.png">

The scaladoc generates some anchor. I hope it will be appropriate. I'm going to fix the issue class by class (different PR's. It's really hard to write the scaladoc and test it :)). 

Kind regards