### PR TITLE
Change jdk version for javadoc generation in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -367,7 +367,7 @@ If you'd like to check if your links and formatting look good in JavaDoc (and no
 sbt -Dakka.genjavadoc.enabled=true javaunidoc:doc
 ```
 
-Which will generate JavaDoc style docs in `./target/javaunidoc/index.html`. This requires a jdk version 9 or later.
+Which will generate JavaDoc style docs in `./target/javaunidoc/index.html`. This requires a jdk version 11 or later.
 
 ## External dependencies
 


### PR DESCRIPTION
I tried to generate javadoc for #30193  and noticed deprecated jdk version in CONTRIBUTING.md . The code and error message tell different thing:
<img width="1440" alt="Снимок экрана 2021-04-20 в 00 47 07" src="https://user-images.githubusercontent.com/4740207/115308589-9e0e9980-a173-11eb-8130-64495e0c5da1.png">

Kind regards
