### PR TITLE
Add settings to use context.log for internal ESB logging

### DIFF
--- a/akka-persistence-typed/src/main/mima-filters/2.6.14.backwards.excludes/settings-to-fallback-to-context-log.excludes
+++ b/akka-persistence-typed/src/main/mima-filters/2.6.14.backwards.excludes/settings-to-fallback-to-context-log.excludes
@@ -1,0 +1,5 @@
+# settings to fallback to actor's context.log for internal EventSourcedBehavior logging
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.typed.internal.EventSourcedSettings.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.typed.internal.EventSourcedSettings.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.typed.internal.EventSourcedSettings.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.typed.internal.EventSourcedSettings.this")

--- a/akka-persistence-typed/src/main/resources/reference.conf
+++ b/akka-persistence-typed/src/main/resources/reference.conf
@@ -39,6 +39,12 @@ akka.persistence.typed {
   # enables automatic DEBUG level logging of messages stashed automatically by an EventSourcedBehavior,
   # this may happen while it receives commands while it is recovering events or while it is persisting events
   log-stashing = off
+
+  # By default, internal event sourced behavior logging are sent to
+  # akka.persistence.typed.internal.EventSourcedBehaviorImpl
+  # this can be changed by setting this to 'true' in which case the internal logging is sent to
+  # the actor context logger.
+  use-context-logger-for-internal-logging = false
 }
 
 akka.reliable-delivery {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -108,7 +108,7 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
     throw new IllegalArgumentException("persistenceId must not be null")
 
   // Don't use it directly, but instead call internalLogger() (see below)
-  private val logger = LoggerFactory.getLogger(this.getClass)
+  private val loggerForInternal = LoggerFactory.getLogger(this.getClass)
 
   override def apply(context: typed.TypedActorContext[Command]): Behavior[Command] = {
     val ctx = context.asScala
@@ -127,7 +127,9 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
       // MDC is cleared (if used) from aroundReceive in ActorAdapter after processing each message,
       // but important to call `context.log` to mark MDC as used
       ctx.log
-      logger
+
+      if (settings.useContextLoggerForInternalLogging) ctx.log
+      else loggerForInternal
     }
 
     val actualSignalHandler: PartialFunction[(State, Signal), Unit] = signalHandler.orElse {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -124,12 +124,13 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
 
     // This method ensures that the MDC is set before we use the internal logger
     def internalLogger() = {
-      // MDC is cleared (if used) from aroundReceive in ActorAdapter after processing each message,
-      // but important to call `context.log` to mark MDC as used
-      ctx.log
-
       if (settings.useContextLoggerForInternalLogging) ctx.log
-      else loggerForInternal
+      else {
+        // MDC is cleared (if used) from aroundReceive in ActorAdapter after processing each message,
+        // but important to call `context.log` to mark MDC as used
+        ctx.log
+        loggerForInternal
+      }
     }
 
     val actualSignalHandler: PartialFunction[(State, Signal), Unit] = signalHandler.orElse {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedSettings.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedSettings.scala
@@ -80,7 +80,7 @@ private[akka] final case class EventSourcedSettings(
     recoveryEventTimeout: FiniteDuration,
     journalPluginId: String,
     snapshotPluginId: String,
-    useContextLoggerForInternalLogging: Boolean = true) {
+    useContextLoggerForInternalLogging: Boolean) {
 
   require(journalPluginId != null, "journal plugin id must not be null; use empty string for 'default' journal")
   require(

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedSettings.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedSettings.scala
@@ -41,6 +41,8 @@ import akka.persistence.Persistence
     val recoveryEventTimeout: FiniteDuration =
       journalConfig.getDuration("recovery-event-timeout", TimeUnit.MILLISECONDS).millis
 
+    val useContextLoggerForInternalLogging = typedConfig.getBoolean("use-context-logger-for-internal-logging")
+
     Persistence.verifyPluginConfigExists(config, snapshotPluginId, "Snapshot store")
 
     EventSourcedSettings(
@@ -49,7 +51,8 @@ import akka.persistence.Persistence
       logOnStashing = logOnStashing,
       recoveryEventTimeout,
       journalPluginId,
-      snapshotPluginId)
+      snapshotPluginId,
+      useContextLoggerForInternalLogging)
   }
 
   private def journalConfigFor(config: Config, journalPluginId: String): Config = {
@@ -76,7 +79,8 @@ private[akka] final case class EventSourcedSettings(
     logOnStashing: Boolean,
     recoveryEventTimeout: FiniteDuration,
     journalPluginId: String,
-    snapshotPluginId: String) {
+    snapshotPluginId: String,
+    useContextLoggerForInternalLogging: Boolean = true) {
 
   require(journalPluginId != null, "journal plugin id must not be null; use empty string for 'default' journal")
   require(

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/StashStateSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/StashStateSpec.scala
@@ -66,6 +66,7 @@ class StashStateSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with
       logOnStashing = false,
       recoveryEventTimeout = 3.seconds,
       journalPluginId = "",
-      snapshotPluginId = "")
+      snapshotPluginId = "",
+      useContextLoggerForInternalLogging = false)
 
 }


### PR DESCRIPTION
In #30007, we changed the EventSourcedBehavior to use an internal logger for internal mesages. 

This PR adds back an option to use actor's context.log