### PR TITLE
avoiding fixed persistenceId on example

### DIFF
--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
@@ -46,8 +46,8 @@ public class BasicPersistentBehaviorTest {
 
       public static class State {}
 
-      public static Behavior<Command> create() {
-        return new MyPersistentBehavior(PersistenceId.ofUniqueId("pid"));
+      public static Behavior<Command> create(PersistenceId persistenceId) {
+        return new MyPersistentBehavior(persistenceId);
       }
 
       private MyPersistentBehavior(PersistenceId persistenceId) {

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/BasicPersistentBehaviorCompileOnly.scala
@@ -108,10 +108,10 @@ object BasicPersistentBehaviorCompileOnly {
   import MyPersistentBehavior._
 
   object RecoveryBehavior {
-    def apply(): Behavior[Command] =
+    def apply(persistenceId: PersistenceId): Behavior[Command] =
       //#recovery
       EventSourcedBehavior[Command, Event, State](
-        persistenceId = PersistenceId.ofUniqueId("abc"),
+        persistenceId = persistenceId,
         emptyState = State(),
         commandHandler = (state, cmd) => throw new NotImplementedError("TODO: process the command & return an Effect"),
         eventHandler = (state, evt) => throw new NotImplementedError("TODO: process the event return the next state"))


### PR DESCRIPTION
`PersistenceId` is explained right after in the docs, as @patriknw  pointed out, so this probably suffices.