### PR TITLE
avoiding the superposing of the buttons and the code

### DIFF
--- a/akka-docs/src/test/scala/docs/stream/StreamTestKitDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/StreamTestKitDocSpec.scala
@@ -19,7 +19,8 @@ class StreamTestKitDocSpec extends AkkaSpec {
 
   "strict collection" in {
     //#strict-collection
-    val sinkUnderTest = Flow[Int].map(_ * 2).toMat(Sink.fold(0)(_ + _))(Keep.right)
+    val sinkUnderTest = 
+      Flow[Int].map(_ * 2).toMat(Sink.fold(0)(_ + _))(Keep.right)
 
     val future = Source(1 to 4).runWith(sinkUnderTest)
     val result = Await.result(future, 3.seconds)

--- a/akka-docs/src/test/scala/docs/stream/StreamTestKitDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/StreamTestKitDocSpec.scala
@@ -19,7 +19,7 @@ class StreamTestKitDocSpec extends AkkaSpec {
 
   "strict collection" in {
     //#strict-collection
-    val sinkUnderTest = 
+    val sinkUnderTest =
       Flow[Int].map(_ * 2).toMat(Sink.fold(0)(_ + _))(Keep.right)
 
     val future = Source(1 to 4).runWith(sinkUnderTest)


### PR DESCRIPTION
avoiding the superposing of the buttons and the code in the examples. Not only for readability also otherwise the buttons don't work

tested with  `akka-docs/paradoxBrowse`
