### PR TITLE
Fixed race condition in MergeHub draining test: 30207

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
@@ -208,14 +208,16 @@ class HubSpec extends StreamSpec {
       draining.drainAndComplete()
 
       downstream.request(10)
-      downstream.expectNextN(10).sorted should ===(1 to 10)
+      val firstBatch = downstream.expectNextN(10)
 
       val upstream = TestPublisher.probe[Int]()
       Source.fromPublisher(upstream).runWith(sink)
       upstream.expectCancellation()
 
       downstream.request(10)
-      downstream.expectNextN(10).sorted should ===(11 to 20)
+      val secondBatch = downstream.expectNextN(10)
+
+      (firstBatch ++ secondBatch).sorted should ===(1 to 20)
 
       downstream.expectComplete()
     }


### PR DESCRIPTION
This pull request fixes a race condition that might occasionally happen when testing the draining support feature of MergeHub.

The issue happens because 2 distinct sources are merged, however the consumption of the streams is done in 2 different batches with the expectations that the partial elements are ordered according to the order in which the sources have been added. This is NOT guaranteed!

A simple fix is to defer the assertion on the correctness of the output to the end of the test where we know what the union of the 2 batches is supposed to be like.

References #30207
