### PR TITLE
Fixed typo: statefulMapConcat example corrected typo

### DIFF
--- a/akka-docs/src/test/java/jdocs/stream/operators/flow/StatefulMapConcat.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/flow/StatefulMapConcat.java
@@ -57,7 +57,7 @@ public class StatefulMapConcat {
 
                   return (element) -> {
                     if (element.startsWith("deny:")) {
-                      denyList.add(element.substring(10));
+                      denyList.add(element.substring("deny:".length()));
                       return Collections
                           .emptyList(); // no element downstream when adding a deny listed keyword
                     } else if (denyList.contains(element)) {

--- a/akka-docs/src/test/scala/docs/stream/operators/flow/StatefulMapConcat.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/flow/StatefulMapConcat.scala
@@ -44,7 +44,7 @@ class StatefulMapConcat {
 
       { element =>
         if (element.startsWith("deny:")) {
-          denyList += element.drop(10)
+          denyList += element.drop("deny:".size)
           Nil // no element downstream when adding a deny listed keyword
         } else if (denyList(element)) {
           Nil // no element downstream if element is deny listed


### PR DESCRIPTION
When I was referring to the documentation of [statefulMapConcat](https://doc.akka.io/docs/akka/current/stream/operators/Source-or-Flow/statefulMapConcat.html), I think, I found very small typo, so created in both `java` and `scala`. 
