### PR TITLE
Fix context propagation

### DIFF
--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipLatestWithApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipLatestWithApply.scala.template
@@ -36,7 +36,7 @@ class ZipLatestWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[F
       private var willShutDown = false
 
       private val contextPropagation = ContextPropagation()
-      [#val inlet0 = new ZipLatestInlet(in0, 0)#
+      [#val inlet0 = new ZipLatestInlet(in0)#
       ]
       private var waitingForTuple = false
       private var staleTupleValues = true
@@ -83,15 +83,15 @@ class ZipLatestWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[F
         ]
       }
 
-      private class ZipLatestInlet[T](in: Inlet[T], index: Int) extends InHandler {
+      private class ZipLatestInlet[T](in: Inlet[T]) extends InHandler {
          var value: T = _
          var hasValue = false
 
          override def onPush() = {
-              // Only one context can be propagated. Picked the first element as an arbitrary but deterministic choice.
-              if (index == ##0) contextPropagation.suspendContext()
-              value = outer.grab(in)
               hasValue = true
+              value = outer.grab(in)
+              // Only one context can be propagated.
+              if (outer.hasAllValues) contextPropagation.suspendContext()
               outer.staleTupleValues = false
               if (outer.waitingForTuple && outer.hasAllValues) {
                   outer.pushOutput()

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipLatestWithApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipLatestWithApply.scala.template
@@ -5,6 +5,7 @@
 package akka.stream.scaladsl
 
 import akka.stream._
+import akka.stream.impl.ContextPropagation
 import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 
 trait ZipLatestWithApply {
@@ -34,9 +35,8 @@ class ZipLatestWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[F
       // Without this field the completion signalling would take one extra pull
       private var willShutDown = false
 
-      // Use buffer for the first input to preserve upstream context
-      val inlet##0 = new ZipLatestInletBuffered(in##0)
-      [2..#val inlet0 = new ZipLatestInlet(in0)#
+      private val contextPropagation = ContextPropagation()
+      [#val inlet0 = new ZipLatestInlet(in0, 0)#
       ]
       private var waitingForTuple = false
       private var staleTupleValues = true
@@ -70,6 +70,7 @@ class ZipLatestWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[F
       private def hasAllValues = [#inlet0.hasValue#&&]
 
       private def pushOutput(): Unit = {
+        contextPropagation.resumeContext()
         push(out, zipper([#inlet0.value#]))
         if (willShutDown) completeStage()
         staleTupleValues = true
@@ -82,14 +83,13 @@ class ZipLatestWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[F
         ]
       }
 
-      private abstract class AbstractZipLatestInlet[T](in: Inlet[T]) extends InHandler {
+      private class ZipLatestInlet[T](in: Inlet[T], index: Int) extends InHandler {
+         var value: T = _
          var hasValue = false
 
-         def setValue(v: T): Unit
-         def value: T
-
          override def onPush() = {
-              setValue(outer.grab(in))
+              if (index == ##0) contextPropagation.suspendContext()
+              value = outer.grab(in)
               hasValue = true
               outer.staleTupleValues = false
               if (outer.waitingForTuple && outer.hasAllValues) {
@@ -103,28 +103,6 @@ class ZipLatestWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[F
            if (!hasValue || outer.staleTupleValues) completeStage()
            else outer.willShutDown = true
          }
-      }
-
-      private class ZipLatestInlet[T](in: Inlet[T]) extends AbstractZipLatestInlet[T](in) {
-         var value: T = _
-
-         def setValue(v: T): Unit = {
-            value = v
-         }
-      }
-
-      private class ZipLatestInletBuffered[T](in: Inlet[T]) extends AbstractZipLatestInlet[T](in) {
-         // A buffer to preserve context
-         val buffer = impl.Buffer[T](##1, ##1)
-
-         def setValue(v: T): Unit = {
-           if (buffer.isFull) {
-             buffer.clear()
-           }
-           buffer.enqueue(v)
-         }
-
-         def value: T = buffer.peek()
        }
     }
 

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipLatestWithApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipLatestWithApply.scala.template
@@ -34,7 +34,9 @@ class ZipLatestWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[F
       // Without this field the completion signalling would take one extra pull
       private var willShutDown = false
 
-      [#val inlet0 = new ZipLatestInlet(in0)#
+      // Use buffer for the first input to preserve upstream context
+      val inlet##0 = new ZipLatestInletBuffered(in##0)
+      [2..#val inlet0 = new ZipLatestInlet(in0)#
       ]
       private var waitingForTuple = false
       private var staleTupleValues = true
@@ -68,7 +70,7 @@ class ZipLatestWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[F
       private def hasAllValues = [#inlet0.hasValue#&&]
 
       private def pushOutput(): Unit = {
-        push(out, zipper([#inlet0.value#,]))
+        push(out, zipper([#inlet0.value#]))
         if (willShutDown) completeStage()
         staleTupleValues = true
       }
@@ -80,12 +82,14 @@ class ZipLatestWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[F
         ]
       }
 
-      private class ZipLatestInlet[T](in: Inlet[T]) extends InHandler {
-         var value: T = _
+      private abstract class AbstractZipLatestInlet[T](in: Inlet[T]) extends InHandler {
          var hasValue = false
 
+         def setValue(v: T): Unit
+         def value: T
+
          override def onPush() = {
-              value = outer.grab(in)
+              setValue(outer.grab(in))
               hasValue = true
               outer.staleTupleValues = false
               if (outer.waitingForTuple && outer.hasAllValues) {
@@ -99,6 +103,28 @@ class ZipLatestWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[F
            if (!hasValue || outer.staleTupleValues) completeStage()
            else outer.willShutDown = true
          }
+      }
+
+      private class ZipLatestInlet[T](in: Inlet[T]) extends AbstractZipLatestInlet[T](in) {
+         var value: T = _
+
+         def setValue(v: T): Unit = {
+            value = v
+         }
+      }
+
+      private class ZipLatestInletBuffered[T](in: Inlet[T]) extends AbstractZipLatestInlet[T](in) {
+         // A buffer to preserve context
+         val buffer = impl.Buffer[T](##1, ##1)
+
+         def setValue(v: T): Unit = {
+           if (buffer.isFull) {
+             buffer.clear()
+           }
+           buffer.enqueue(v)
+         }
+
+         def value: T = buffer.peek()
        }
     }
 

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipLatestWithApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipLatestWithApply.scala.template
@@ -88,6 +88,7 @@ class ZipLatestWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[F
          var hasValue = false
 
          override def onPush() = {
+              // Only one context can be propagated. Picked the first element as an arbitrary but deterministic choice.
               if (index == ##0) contextPropagation.suspendContext()
               value = outer.grab(in)
               hasValue = true

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipWithApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipWithApply.scala.template
@@ -34,9 +34,11 @@ class ZipWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[FanInSh
     var pending = ##0
     // Without this field the completion signalling would take one extra pull
     var willShutDown = false
+    // A buffer for the first input to preserve context
+    private val buffer##0 = impl.Buffer[A##1](##1, ##1)
 
     private def pushAll(): Unit = {
-      push(out, zipper([#grab(in0)#]))
+      push(out, zipper(buffer##0.dequeue(), [2..#grab(in0)#]))
       if (willShutDown) completeStage()
       else {
         [#pull(in0)#
@@ -49,7 +51,21 @@ class ZipWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[FanInSh
       ]
     }
 
-    [#setHandler(in0, new InHandler {
+    setHandler(in##0, new InHandler {
+      override def onPush(): Unit = {
+        pending -= ##1
+        buffer##0.enqueue(grab(in##0))
+        if (pending == ##0) pushAll()
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        if (!isAvailable(in##0) && buffer##0.isEmpty) completeStage()
+        willShutDown = true
+      }
+
+    })
+
+    [2..#setHandler(in0, new InHandler {
       override def onPush(): Unit = {
         pending -= ##1
         if (pending == ##0) pushAll()

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipWithApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipWithApply.scala.template
@@ -5,6 +5,7 @@
 package akka.stream.scaladsl
 
 import akka.stream._
+import akka.stream.impl.ContextPropagation
 import akka.stream.stage._
 
 trait ZipWithApply {
@@ -34,11 +35,11 @@ class ZipWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[FanInSh
     var pending = ##0
     // Without this field the completion signalling would take one extra pull
     var willShutDown = false
-    // A buffer for the first input to preserve context
-    private val buffer##0 = impl.Buffer[A##1](##1, ##1)
+    private val contextPropagation = ContextPropagation()
 
     private def pushAll(): Unit = {
-      push(out, zipper(buffer##0.dequeue(), [2..#grab(in0)#]))
+      contextPropagation.resumeContext()
+      push(out, zipper([#grab(in0)#]))
       if (willShutDown) completeStage()
       else {
         [#pull(in0)#
@@ -51,22 +52,9 @@ class ZipWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[FanInSh
       ]
     }
 
-    setHandler(in##0, new InHandler {
+    [#setHandler(in0, new InHandler {
       override def onPush(): Unit = {
-        pending -= ##1
-        buffer##0.enqueue(grab(in##0))
-        if (pending == ##0) pushAll()
-      }
-
-      override def onUpstreamFinish(): Unit = {
-        if (!isAvailable(in##0) && buffer##0.isEmpty) completeStage()
-        willShutDown = true
-      }
-
-    })
-
-    [2..#setHandler(in0, new InHandler {
-      override def onPush(): Unit = {
+        if (0 == ##0) contextPropagation.suspendContext()
         pending -= ##1
         if (pending == ##0) pushAll()
       }

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipWithApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipWithApply.scala.template
@@ -54,6 +54,7 @@ class ZipWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[FanInSh
 
     [#setHandler(in0, new InHandler {
       override def onPush(): Unit = {
+        // Only one context can be propagated. Picked the first element as an arbitrary but deterministic choice.
         if (0 == ##0) contextPropagation.suspendContext()
         pending -= ##1
         if (pending == ##0) pushAll()

--- a/akka-stream/src/main/scala/akka/stream/impl/Buffers.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Buffers.scala
@@ -5,8 +5,7 @@
 package akka.stream.impl
 
 import java.{ util => ju }
-
-import akka.annotation.InternalApi
+import akka.annotation.{ InternalApi, InternalStableApi }
 import akka.stream._
 
 /**
@@ -35,7 +34,7 @@ private[akka] object Buffer {
   def apply[T](size: Int, effectiveAttributes: Attributes): Buffer[T] =
     apply(size, effectiveAttributes.mandatoryAttribute[ActorAttributes.MaxFixedBufferSize].size)
 
-  def apply[T](size: Int, max: Int): Buffer[T] =
+  @InternalStableApi def apply[T](size: Int, max: Int): Buffer[T] =
     if (size < FixedQueueSize || size < max) FixedSizeBuffer(size)
     else new BoundedBuffer(size)
 }
@@ -54,7 +53,7 @@ private[akka] object Buffer {
    *
    * Returns a specialized instance for power-of-two sized buffers.
    */
-  @InternalApi private[akka] def apply[T](size: Int): FixedSizeBuffer[T] =
+  @InternalStableApi private[akka] def apply[T](size: Int): FixedSizeBuffer[T] =
     if (size < 1) throw new IllegalArgumentException("size must be positive")
     else if (((size - 1) & size) == 0) new PowerOfTwoFixedSizeBuffer(size)
     else new ModuloFixedSizeBuffer(size)

--- a/akka-stream/src/main/scala/akka/stream/impl/ContextPropagation.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ContextPropagation.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.impl
+
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] trait ContextPropagation {
+  def suspendContext(): Unit
+  def resumeContext(): Unit
+}
+
+private[akka] object ContextPropagation {
+  def apply(): ContextPropagation = new ContextPropagationImpl
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] final class ContextPropagationImpl extends ContextPropagation {
+  private val buffer = Buffer[Unit](1, 1)
+  def suspendContext(): Unit = {
+    buffer.enqueue(())
+  }
+  def resumeContext(): Unit = {
+    buffer.dequeue()
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/ContextPropagation.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ContextPropagation.scala
@@ -14,14 +14,18 @@ import akka.annotation.InternalApi
   def resumeContext(): Unit
 }
 
-private[akka] object ContextPropagation {
-  def apply(): ContextPropagation = new ContextPropagationImpl
-}
-
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] final class ContextPropagationImpl extends ContextPropagation {
+@InternalApi private[akka] object ContextPropagation {
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi def apply(): ContextPropagation = new ContextPropagationImpl
+}
+
+private[akka] final class ContextPropagationImpl extends ContextPropagation {
   private val buffer = Buffer[Unit](1, 1)
   def suspendContext(): Unit = {
     buffer.enqueue(())

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -1775,6 +1775,7 @@ private[stream] object Collect {
       private var totalWeight = 0L
       private var totalNumber = 0
       private var hasElements = false
+      private val contextPropagation = ContextPropagation()
 
       override def preStart() = {
         scheduleWithFixedDelay(GroupedWeightedWithin.groupedWeightedWithinTimer, interval, interval)
@@ -1833,6 +1834,7 @@ private[stream] object Collect {
 
       private def emitGroup(): Unit = {
         groupEmitted = true
+        contextPropagation.resumeContext()
         push(out, buf.result())
         buf.clear()
         if (!finished) startNewGroup()
@@ -1859,6 +1861,7 @@ private[stream] object Collect {
       }
 
       override def onPush(): Unit = {
+        contextPropagation.suspendContext()
         if (pending == null) nextElement(grab(in)) // otherwise keep the element for next round
       }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -91,8 +91,7 @@ import akka.util.ccompat._
             } else {
               buffer = OptionVal.Some(elem)
               contextPropagation.suspendContext()
-            }
-          else pull(in)
+            } else pull(in)
         } catch {
           case NonFatal(ex) =>
             decider(ex) match {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -1223,6 +1223,7 @@ class ZipWithN[A, O](zipper: immutable.Seq[A] => O)(n: Int) extends GraphStage[U
         case (in, i) =>
           setHandler(in, new InHandler {
             override def onPush(): Unit = {
+              // Only one context can be propagated. Picked the first element as an arbitrary but deterministic choice.
               if (i == 0) contextPropagation.suspendContext()
               pending -= 1
               if (pending == 0) pushAll()

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -1203,14 +1203,14 @@ class ZipWithN[A, O](zipper: immutable.Seq[A] => O)(n: Int) extends GraphStage[U
       // Without this field the completion signalling would take one extra pull
       var willShutDown = false
 
-      // A buffer for the first input to preserve context
-      private val buffer0 = impl.Buffer[A](1, 1)
+      private val contextPropagation = ContextPropagation()
 
       val grabInlet = grab[A] _
       val pullInlet = pull[A] _
 
       private def pushAll(): Unit = {
-        push(out, zipper(buffer0.dequeue() +: shape.inlets.tail.map(grabInlet)))
+        contextPropagation.resumeContext()
+        push(out, zipper(shape.inlets.map(grabInlet)))
         if (willShutDown) completeStage()
         else shape.inlets.foreach(pullInlet)
       }
@@ -1219,34 +1219,21 @@ class ZipWithN[A, O](zipper: immutable.Seq[A] => O)(n: Int) extends GraphStage[U
         shape.inlets.foreach(pullInlet)
       }
 
-      shape.inlets.headOption.foreach(in => {
-        setHandler(in, new InHandler {
-          override def onPush(): Unit = {
-            pending -= 1
-            buffer0.enqueue(grab(in))
-            if (pending == 0) pushAll()
-          }
+      shape.inlets.zipWithIndex.foreach {
+        case (in, i) =>
+          setHandler(in, new InHandler {
+            override def onPush(): Unit = {
+              if (i == 0) contextPropagation.suspendContext()
+              pending -= 1
+              if (pending == 0) pushAll()
+            }
 
-          override def onUpstreamFinish(): Unit = {
-            if (!isAvailable(in) && buffer0.isEmpty) completeStage()
-            willShutDown = true
-          }
-        })
-      })
-
-      shape.inlets.tail.foreach(in => {
-        setHandler(in, new InHandler {
-          override def onPush(): Unit = {
-            pending -= 1
-            if (pending == 0) pushAll()
-          }
-
-          override def onUpstreamFinish(): Unit = {
-            if (!isAvailable(in)) completeStage()
-            willShutDown = true
-          }
-        })
-      })
+            override def onUpstreamFinish(): Unit = {
+              if (!isAvailable(in)) completeStage()
+              willShutDown = true
+            }
+          })
+      }
 
       def onPull(): Unit = {
         pending += n

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -1233,7 +1233,7 @@ class ZipWithN[A, O](zipper: immutable.Seq[A] => O)(n: Int) extends GraphStage[U
           }
         })
       })
-      
+
       shape.inlets.tail.foreach(in => {
         setHandler(in, new InHandler {
           override def onPush(): Unit = {

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -1087,9 +1087,9 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
   private class EmittingSingle[T](_out: Outlet[T], _elem: T, _previous: OutHandler, _andThen: () => Unit)
       extends Emitting(_out, _previous, _andThen) {
 
-    // A buffer to preserve context 
+    // A buffer to preserve context
     private val buffer = impl.Buffer[T](1, 1)
-    
+
     buffer.enqueue(_elem)
 
     override def onPull(): Unit = {
@@ -1113,7 +1113,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
         followUp()
       }
     }
-    
+
     override def onPull(): Unit = {
       if (buffer.nonEmpty) {
         push(out, buffer.dequeue())

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -18,7 +18,8 @@ import akka.annotation.InternalApi
 import akka.japi.function.{ Effect, Procedure }
 import akka.stream.Attributes.SourceLocation
 import akka.stream._
-import akka.stream.impl.{ ActorSubscriberMessage, ContextPropagation, ReactiveStreamsCompliance, TraversalBuilder }
+import akka.stream.impl.{ ReactiveStreamsCompliance, TraversalBuilder }
+import akka.stream.impl.ActorSubscriberMessage
 import akka.stream.impl.fusing.{ GraphInterpreter, GraphStageModule, SubSink, SubSource }
 import akka.stream.scaladsl.GenericGraphWithChangedAttributes
 import akka.util.OptionVal
@@ -1086,11 +1087,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
   private class EmittingSingle[T](_out: Outlet[T], elem: T, _previous: OutHandler, _andThen: () => Unit)
       extends Emitting(_out, _previous, _andThen) {
 
-    private val contextPropagation = ContextPropagation()
-    contextPropagation.suspendContext()
-
     override def onPull(): Unit = {
-      contextPropagation.resumeContext()
       push(out, elem)
       followUp()
     }
@@ -1099,13 +1096,8 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
   private class EmittingIterator[T](_out: Outlet[T], elems: Iterator[T], _previous: OutHandler, _andThen: () => Unit)
       extends Emitting(_out, _previous, _andThen) {
 
-    private val contextPropagation = ContextPropagation()
-    contextPropagation.suspendContext()
-
     override def onPull(): Unit = {
-      contextPropagation.resumeContext()
       push(out, elems.next())
-      contextPropagation.suspendContext()
       if (!elems.hasNext) {
         followUp()
       }


### PR DESCRIPTION
Fix for the case when the stage pulls upstream eagerly leading to the state when an element already available onPull. As opposed to the case when element is propagated on push. The problem is that in the former case the original context is not available and needs to be preserved. The simplest solution is to use `impl.Buffer` that the Telementry is aware of and instruments to preserve original context on `buffer.enqeue` and restore it on `buffer.deque`.

- [x] ZipWith
- [x] ZipLatest
- [x] ZipWithN

Recently changed:
- [x] [akka.stream.impl.fusing.Filter](https://github.com/akka/akka/commit/c39dd6506edfaa858c7de5f5c561c95e426c8b5c#diff-bd2245f426341c705c174f7469f72[…]43c6792d6b55587ea892c9412515151R84)

Next stage implementations have always pulled in preStart:
- [x] IdleInject
- [x] Detacher
- [x] Batch
- [x] Expand
- [x] GroupedWeightedWithin

Test:
- [x] MergeSequence, mergePreferred, MergePrioritized, MergeSorted. Should propagate context properly because they use emit.
  
These are stage implementation that may lose context but out of scope for this PR because they require queue abstraction that can be instrumented to preserve context (similar to `impl.Buffer`):
- MergeHub. Uses AbstractNodeQueue that doesn't preserve context.
- BroadcastHub. Uses a queue that's an Array with random access and can't be replaced by FixedSizedBuffer.
- PartitionHub. Uses PartitionSinkLogic that uses PartitionQueueImpl.
- RestartWithBackoffLogic. 
