### PR TITLE
Make Akka Stream compile with Scala 3 moar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     - stage: scala3
       name: scala3
       # separate job since only a few modules compile with Scala 3 yet
-      script: jabba install adopt@1.11-0 && jabba use adopt@1.11-0 && sbt -Dakka.build.scalaVersion=3.0 "akka-actor-tests/test:compile"
+      script: jabba install adopt@1.11-0 && jabba use adopt@1.11-0 && sbt -Dakka.build.scalaVersion=3.0 "akka-actor-tests/test:compile; akka-stream/compile"
 
 stages:
   - name: whitesource

--- a/akka-actor/src/main/scala/akka/japi/JavaAPI.scala
+++ b/akka-actor/src/main/scala/akka/japi/JavaAPI.scala
@@ -72,7 +72,7 @@ trait Predicate[T] {
  * Additional tuple types for 3 to 22 values are defined in the `akka.japi.tuple` package, e.g. [[akka.japi.tuple.Tuple3]].
  */
 @SerialVersionUID(1L)
-case class Pair[A, B](first: A, second: B) {
+case class Pair[+A, +B](first: A, second: B) {
   def toScala: (A, B) = (first, second)
 }
 object Pair {

--- a/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
+++ b/akka-stream-testkit/src/main/scala/akka/stream/testkit/StreamTestKit.scala
@@ -918,8 +918,6 @@ private[testkit] object StreamTestKit {
       val probe = TestPublisher.probe[T]()
       (probe, probe)
     }
-    override protected def newInstance(shape: SourceShape[T]): SourceModule[T, TestPublisher.Probe[T]] =
-      new ProbeSource[T](attributes, shape)
     override def withAttributes(attr: Attributes): SourceModule[T, TestPublisher.Probe[T]] =
       new ProbeSource[T](attr, amendShape(attr))
   }
@@ -930,8 +928,6 @@ private[testkit] object StreamTestKit {
       val probe = TestSubscriber.probe[T]()
       (probe, probe)
     }
-    override protected def newInstance(shape: SinkShape[T]): SinkModule[T, TestSubscriber.Probe[T]] =
-      new ProbeSink[T](attributes, shape)
     override def withAttributes(attr: Attributes): SinkModule[T, TestSubscriber.Probe[T]] =
       new ProbeSink[T](attr, amendShape(attr))
   }

--- a/akka-stream/src/main/boilerplate/akka/stream/FanInShapeN.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/FanInShapeN.scala.template
@@ -4,15 +4,13 @@
 
 package akka.stream
 
-import scala.annotation.unchecked.uncheckedVariance
-
 [2..#class FanInShape1[[#-T0#], +O](_init: FanInShape.Init[O]) extends FanInShape[O](_init) {
   def this(name: String) = this(FanInShape.Name[O](name))
   def this([#in0: Inlet[T0]#], out: Outlet[O]) = this(FanInShape.Ports(out, [#in0# :: ] :: Nil))
-  override protected def construct(init: FanInShape.Init[O @uncheckedVariance]): FanInShape[O] = new FanInShape1(init)
+  override protected def construct[N >: O](init: FanInShape.Init[N]): FanInShape[N] = new FanInShape1(init)
   override def deepCopy(): FanInShape1[[#T0#], O] = super.deepCopy().asInstanceOf[FanInShape1[[#T0#], O]]
 
-  [#val in0: Inlet[T0 @uncheckedVariance] = newInlet[T0]("in0")#
+  [#val in0: Inlet[T0] = newInlet[T0]("in0")#
   ]
 }#
 

--- a/akka-stream/src/main/boilerplate/akka/stream/FanOutShapeN.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/FanOutShapeN.scala.template
@@ -4,15 +4,13 @@
 
 package akka.stream
 
-import scala.annotation.unchecked.uncheckedVariance
-
-[2..#class FanOutShape1[-I, [#+O0#]](_init: FanOutShape.Init[I @uncheckedVariance]) extends FanOutShape[I](_init) {
+[2..#class FanOutShape1[-I, [#+O0#]](_init: FanOutShape.Init[I]) extends FanOutShape[I](_init) {
   def this(name: String) = this(FanOutShape.Name[I](name))
   def this(in: Inlet[I], [#out0: Outlet[O0]#]) = this(FanOutShape.Ports(in, [#out0# :: ] :: Nil))
-  override protected def construct(init: FanOutShape.Init[I @uncheckedVariance]): FanOutShape[I] = new FanOutShape1(init)
+  override protected def construct[J <: I](init: FanOutShape.Init[J]): FanOutShape[J] = new FanOutShape1(init)
   override def deepCopy(): FanOutShape1[I, [#O0#]] = super.deepCopy().asInstanceOf[FanOutShape1[I, [#O0#]]]
   
-  [#val out0: Outlet[O0 @uncheckedVariance] = newOutlet[O0]("out0")#
+  [#val out0: Outlet[O0] = newOutlet[O0]("out0")#
   ]
 }#
 

--- a/akka-stream/src/main/boilerplate/akka/stream/javadsl/GraphCreate.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/javadsl/GraphCreate.scala.template
@@ -22,7 +22,7 @@ private[stream] abstract class GraphCreate {
    */
   def create[S1 <: Shape, S <: Shape, M](g1: Graph[S1, M],
       block: function.Function2[GraphDSL.Builder[M], S1, S]): Graph[S, M] =
-    scaladsl.GraphDSL.create(g1) { b => s => block.apply(b.asJava, s.asInstanceOf[S1]) }
+    scaladsl.GraphDSL.create(g1) { b => s => block.apply(b.asJava, s) }
 
   /**
    * Creates a new [[Graph]] by importing the given graphs and passing their [[Shape]]s
@@ -30,7 +30,7 @@ private[stream] abstract class GraphCreate {
    */
   def create[S1 <: Shape, S2 <: Shape, S <: Shape, M1, M2, M](g1: Graph[S1, M1], g2: Graph[S2, M2], combineMat: function.Function2[M1, M2, M],
       block: function.Function3[GraphDSL.Builder[M], S1, S2, S]): Graph[S, M] =
-    scaladsl.GraphDSL.create(g1, g2)(combineMat.apply) { b => (s1, s2) => block.apply(b.asJava, s1.asInstanceOf[S1], s2.asInstanceOf[S2]) }
+    scaladsl.GraphDSL.create(g1, g2)(combineMat.apply) { b => (s1, s2) => block.apply(b.asJava, s1, s2) }
 
   [3..21#/**
    * Creates a new [[Graph]] by importing the given graphs and passing their [[Shape]]s
@@ -38,7 +38,7 @@ private[stream] abstract class GraphCreate {
    */
   def create1[[#S1 <: Shape#], S <: Shape, [#M1#], M]([#g1: Graph[S1, M1]#], combineMat: function.Function1[[#M1#], M],
       block: function.Function2[GraphDSL.Builder[M], [#S1#], S]): Graph[S, M] =
-    scaladsl.GraphDSL.create([#g1#])(combineMat.apply) { b => ([#s1#]) => block.apply(b.asJava, [#s1.asInstanceOf[S1]#]) }#
+    scaladsl.GraphDSL.create([#g1#])(combineMat.apply) { b => ([#s1#]) => block.apply(b.asJava, [#s1#]) }#
 
   ]
 }

--- a/akka-stream/src/main/boilerplate/akka/stream/javadsl/GraphCreate.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/javadsl/GraphCreate.scala.template
@@ -22,7 +22,7 @@ private[stream] abstract class GraphCreate {
    */
   def create[S1 <: Shape, S <: Shape, M](g1: Graph[S1, M],
       block: function.Function2[GraphDSL.Builder[M], S1, S]): Graph[S, M] =
-    scaladsl.GraphDSL.create(g1) { b => s => block.apply(b.asJava, s) }
+    scaladsl.GraphDSL.create(g1) { b => s => block.apply(b.asJava, s.asInstanceOf[S1]) }
 
   /**
    * Creates a new [[Graph]] by importing the given graphs and passing their [[Shape]]s
@@ -30,7 +30,7 @@ private[stream] abstract class GraphCreate {
    */
   def create[S1 <: Shape, S2 <: Shape, S <: Shape, M1, M2, M](g1: Graph[S1, M1], g2: Graph[S2, M2], combineMat: function.Function2[M1, M2, M],
       block: function.Function3[GraphDSL.Builder[M], S1, S2, S]): Graph[S, M] =
-    scaladsl.GraphDSL.create(g1, g2)(combineMat.apply) { b => (s1, s2) => block.apply(b.asJava, s1, s2) }
+    scaladsl.GraphDSL.create(g1, g2)(combineMat.apply) { b => (s1, s2) => block.apply(b.asJava, s1.asInstanceOf[S1], s2.asInstanceOf[S2]) }
 
   [3..21#/**
    * Creates a new [[Graph]] by importing the given graphs and passing their [[Shape]]s
@@ -38,7 +38,7 @@ private[stream] abstract class GraphCreate {
    */
   def create1[[#S1 <: Shape#], S <: Shape, [#M1#], M]([#g1: Graph[S1, M1]#], combineMat: function.Function1[[#M1#], M],
       block: function.Function2[GraphDSL.Builder[M], [#S1#], S]): Graph[S, M] =
-    scaladsl.GraphDSL.create([#g1#])(combineMat.apply) { b => ([#s1#]) => block.apply(b.asJava, [#s1#]) }#
+    scaladsl.GraphDSL.create([#g1#])(combineMat.apply) { b => ([#s1#]) => block.apply(b.asJava, [#s1.asInstanceOf[S1]#]) }#
 
   ]
 }

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
@@ -22,10 +22,7 @@ trait GraphApply {
    * Creates a new [[Graph]] by importing the given graph `g1` and passing its [[Shape]]
    * along with the [[GraphDSL.Builder]] to the given create function.
    */
-   /* FIXME stuck on Scala 3 not inferring Graph.Shape for g1.Shape to the concrete type here, while 2.13 does, so the graph builder
-    * implicits for the concrete type is not found and all GraphDSL usage fails to compile.
-    */
-  def create[S <: Shape, Mat](g1: Graph[Shape, Mat])(buildBlock: GraphDSL.Builder[Mat] => (g1.Shape) => S): Graph[S, Mat] = {
+  def create[S <: Shape, S1 <: Shape, Mat](g1: Graph[S1, Mat])(buildBlock: GraphDSL.Builder[Mat] => S1 => S): Graph[S, Mat] = {
     val builder = new GraphDSL.Builder
     val s1 = builder.add(g1, Keep.right)
     val s = buildBlock(builder)(s1)
@@ -40,7 +37,7 @@ trait GraphApply {
    * Creates a new [[Graph]] by importing the given graphs and passing their [[Shape]]s
    * along with the [[GraphDSL.Builder]] to the given create function.
    */
-  def create[S <: Shape, Mat, [#M1#]]([#g1: Graph[Shape, M1]#])(combineMat: ([#M1#]) => Mat)(buildBlock: GraphDSL.Builder[Mat] => ([#g1.Shape#]) => S): Graph[S, Mat] = {
+  def create[S <: Shape, Mat, [#M1#], [#S1 <: Shape#]]([#g1: Graph[S1, M1]#])(combineMat: ([#M1#]) => Mat)(buildBlock: GraphDSL.Builder[Mat] => ([#S1#]) => S): Graph[S, Mat] = {
     val builder = new GraphDSL.Builder
     val curried = combineMat.curried
     val s##1 = builder.add(g##1, (m##1: M##1) => curried(m##1))

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/GraphApply.scala.template
@@ -22,6 +22,9 @@ trait GraphApply {
    * Creates a new [[Graph]] by importing the given graph `g1` and passing its [[Shape]]
    * along with the [[GraphDSL.Builder]] to the given create function.
    */
+   /* FIXME stuck on Scala 3 not inferring Graph.Shape for g1.Shape to the concrete type here, while 2.13 does, so the graph builder
+    * implicits for the concrete type is not found and all GraphDSL usage fails to compile.
+    */
   def create[S <: Shape, Mat](g1: Graph[Shape, Mat])(buildBlock: GraphDSL.Builder[Mat] => (g1.Shape) => S): Graph[S, Mat] = {
     val builder = new GraphDSL.Builder
     val s1 = builder.add(g1, Keep.right)

--- a/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipLatestWithApply.scala.template
+++ b/akka-stream/src/main/boilerplate/akka/stream/scaladsl/ZipLatestWithApply.scala.template
@@ -34,7 +34,7 @@ class ZipLatestWith1[[#A1#], O] (val zipper: ([#A1#]) => O) extends GraphStage[F
       // Without this field the completion signalling would take one extra pull
       private var willShutDown = false
 
-      [#val inlet0 = new ZipLatestInlet(in0)#
+      [#private val inlet0 = new ZipLatestInlet(in0)#
       ]
       private var waitingForTuple = false
       private var staleTupleValues = true

--- a/akka-stream/src/main/scala-jdk-9/akka/stream/scaladsl/JavaFlowSupport.scala
+++ b/akka-stream/src/main/scala-jdk-9/akka/stream/scaladsl/JavaFlowSupport.scala
@@ -6,8 +6,6 @@ package akka.stream.scaladsl
 
 import java.util.{concurrent => juc}
 
-import scala.annotation.unchecked.uncheckedVariance
-
 import akka.NotUsed
 import akka.stream.impl.JavaFlowAndRsConverters
 import akka.stream.scaladsl
@@ -84,11 +82,11 @@ object JavaFlowSupport {
      *
      * @return A [[RunnableGraph]] that materializes to a Processor when run() is called on it.
      */
-    def toProcessor[In, Out, Mat](self: Flow[In, Out, Mat]): RunnableGraph[juc.Flow.Processor[In @uncheckedVariance, Out @uncheckedVariance]] =
+    def toProcessor[In, Out, Mat](self: Flow[In, Out, Mat]): RunnableGraph[juc.Flow.Processor[_ >: In, _ <: Out]] =
       Source.asSubscriber[In].via(self)
         .toMat(Sink.asPublisher[Out](fanout = false))(Keep.both)
         .mapMaterializedValue {
-          case (sub, pub) => new juc.Flow.Processor[In, Out] {
+          case (sub, pub) => new juc.Flow.Processor[_ >: In, _ <: Out] {
             override def onError(t: Throwable): Unit = sub.onError(t)
             override def onSubscribe(s: juc.Flow.Subscription): Unit = sub.onSubscribe(s)
             override def onComplete(): Unit = sub.onComplete()

--- a/akka-stream/src/main/scala/akka/stream/FanInShape1N.scala
+++ b/akka-stream/src/main/scala/akka/stream/FanInShape1N.scala
@@ -4,7 +4,6 @@
 
 package akka.stream
 
-import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 
 @Deprecated
@@ -14,29 +13,29 @@ import scala.collection.immutable
 class FanInShape1N[-T0, -T1, +O](val n: Int, _init: FanInShape.Init[O]) extends FanInShape[O](_init) {
 
   //ports get added to `FanInShape.inlets` as a side-effect of calling `newInlet`
-  val in0: Inlet[T0 @uncheckedVariance] = newInlet[T0]("in0")
+  val in0: Inlet[T0] = newInlet[T0]("in0")
   for (i <- 1 until n) newInlet[T1](s"in$i")
 
   def this(n: Int) = this(n, FanInShape.Name[O]("FanInShape1N"))
   def this(n: Int, name: String) = this(n, FanInShape.Name[O](name))
   def this(
-      outlet: Outlet[O @uncheckedVariance],
-      in0: Inlet[T0 @uncheckedVariance],
-      inlets1: Array[Inlet[T1 @uncheckedVariance]]) =
+      outlet: Outlet[O],
+      in0: Inlet[T0],
+      inlets1: Array[Inlet[T1]]) =
     this(inlets1.length, FanInShape.Ports(outlet, in0 :: inlets1.toList))
-  override protected def construct(init: FanInShape.Init[O @uncheckedVariance]): FanInShape[O] =
+  override protected def construct[N >: O](init: FanInShape.Init[N]): FanInShape[N] =
     new FanInShape1N(n, init)
   override def deepCopy(): FanInShape1N[T0, T1, O] = super.deepCopy().asInstanceOf[FanInShape1N[T0, T1, O]]
 
   @deprecated("Use 'inlets' or 'in(id)' instead.", "2.5.5")
-  def in1Seq: immutable.IndexedSeq[Inlet[T1 @uncheckedVariance]] = _in1Seq
+  def in1Seq: immutable.IndexedSeq[Inlet[T1]] = _in1Seq
 
   // cannot deprecate a lazy val because of genjavadoc problem https://github.com/typesafehub/genjavadoc/issues/85
-  private lazy val _in1Seq: immutable.IndexedSeq[Inlet[T1 @uncheckedVariance]] =
+  private lazy val _in1Seq: immutable.IndexedSeq[Inlet[T1]] =
     inlets.tail //head is in0
     .toIndexedSeq.asInstanceOf[immutable.IndexedSeq[Inlet[T1]]]
 
-  def in(n: Int): Inlet[T1 @uncheckedVariance] = {
+  def in(n: Int): Inlet[T1] = {
     require(n > 0, "n must be > 0")
     inlets(n).asInstanceOf[Inlet[T1]]
   }

--- a/akka-stream/src/main/scala/akka/stream/FanOutShape.scala
+++ b/akka-stream/src/main/scala/akka/stream/FanOutShape.scala
@@ -4,7 +4,6 @@
 
 package akka.stream
 
-import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 
 object FanOutShape {
@@ -24,7 +23,7 @@ object FanOutShape {
 }
 
 abstract class FanOutShape[-I] private (
-    _in: Inlet[I @uncheckedVariance],
+    _in: Inlet[I],
     _registered: Iterator[Outlet[_]],
     _name: String)
     extends Shape {
@@ -32,13 +31,13 @@ abstract class FanOutShape[-I] private (
 
   def this(init: FanOutShape.Init[I]) = this(init.inlet, init.outlets.iterator, init.name)
 
-  final def in: Inlet[I @uncheckedVariance] = _in
+  final def in: Inlet[I] = _in
 
   /**
    * Not meant for overriding outside of Akka.
    */
   override def outlets: immutable.Seq[Outlet[_]] = _outlets
-  final override def inlets: immutable.Seq[Inlet[I @uncheckedVariance]] = in :: Nil
+  final override def inlets: immutable.Seq[Inlet[I]] = in :: Nil
 
   /**
    * Performance of subclass `UniformFanOutShape` relies on `_outlets` being a `Vector`, not a `List`.
@@ -50,7 +49,7 @@ abstract class FanOutShape[-I] private (
     p
   }
 
-  protected def construct(init: Init[I @uncheckedVariance]): FanOutShape[I]
+  protected def construct[J <: I](init: Init[J]): FanOutShape[J]
 
   def deepCopy(): FanOutShape[I] = construct(Ports[I](_in.carbonCopy(), outlets.map(_.carbonCopy())))
 }

--- a/akka-stream/src/main/scala/akka/stream/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/Graph.scala
@@ -20,6 +20,7 @@ trait Graph[+S <: Shape, +M] {
   /**
    * Type-level accessor for the shape parameter of this graph.
    */
+  // FIXME deprecate, not used for Scala 3
   type Shape = S @uncheckedVariance
   /**
    * The shape of a graph is all that is externally visible: its inlets and outlets.

--- a/akka-stream/src/main/scala/akka/stream/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/Graph.scala
@@ -4,8 +4,6 @@
 
 package akka.stream
 
-import scala.annotation.unchecked.uncheckedVariance
-
 import akka.annotation.InternalApi
 import akka.stream.impl.TraversalBuilder
 import akka.stream.scaladsl.GenericGraph
@@ -17,11 +15,6 @@ import akka.stream.scaladsl.GenericGraph
  */
 trait Graph[+S <: Shape, +M] {
 
-  /**
-   * Type-level accessor for the shape parameter of this graph.
-   */
-  // FIXME deprecate, not used for Scala 3
-  type Shape = S @uncheckedVariance
   /**
    * The shape of a graph is all that is externally visible: its inlets and outlets.
    */

--- a/akka-stream/src/main/scala/akka/stream/MaterializerLoggingProvider.scala
+++ b/akka-stream/src/main/scala/akka/stream/MaterializerLoggingProvider.scala
@@ -12,6 +12,6 @@ import akka.event.LoggingAdapter
  */
 trait MaterializerLoggingProvider { this: Materializer =>
 
-  def makeLogger(logSource: Class[_]): LoggingAdapter
+  def makeLogger(logSource: Class[Any]): LoggingAdapter
 
 }

--- a/akka-stream/src/main/scala/akka/stream/Shape.scala
+++ b/akka-stream/src/main/scala/akka/stream/Shape.scala
@@ -280,13 +280,39 @@ case class AmorphousShape(inlets: immutable.Seq[Inlet[_]], outlets: immutable.Se
  * A Source [[Shape]] has exactly one output and no inputs, it models a source
  * of data.
  */
-final case class SourceShape[T](out: Outlet[T @uncheckedVariance]) extends Shape {
+final class SourceShape[+T](val out: Outlet[T @uncheckedVariance]) extends Shape with Product with Serializable {
   override val inlets: immutable.Seq[Inlet[_]] = EmptyImmutableSeq
   override val outlets: immutable.Seq[Outlet[_]] = out :: Nil
 
   override def deepCopy(): SourceShape[T] = SourceShape(out.carbonCopy())
+
+  def copy(
+      out: Outlet[T @uncheckedVariance],
+  ): SourceShape[T] = new SourceShape[T](out)
+  override def equals(other: Any): Boolean = (this eq other.asInstanceOf[AnyRef]) || (other match {
+    case that: SourceShape[_] => out == that.out
+    case _                    => false
+  })
+  override def productElement(n: Int): Any = n match {
+    case 0 => out
+    case _ => scala.runtime.Statics.ioobe(n)
+  }
+  override def productElementName(n: Int) = n match {
+    case 0 => "out"
+    case _ => scala.runtime.Statics.ioobe(n)
+  }
+  override def productPrefix       = "SourceShape"
+  override def productArity        = 1
+  override def canEqual(that: Any) = that.isInstanceOf[SourceShape[_]]
+  override def hashCode            = scala.runtime.ScalaRunTime._hashCode(this)
+  override def toString            = scala.runtime.ScalaRunTime._toString(this)
 }
 object SourceShape {
+  def apply[T](out: Outlet[T @uncheckedVariance]): SourceShape[T] =
+    new SourceShape[T](out)
+
+  def unapply[T](x: SourceShape[T @uncheckedVariance]): Some[Outlet[T @uncheckedVariance]] =
+    Some(x.out)
 
   /** Java API */
   def of[T](outlet: Outlet[T @uncheckedVariance]): SourceShape[T] =
@@ -298,13 +324,42 @@ object SourceShape {
  * outside like a pipe (but it can be a complex topology of streams within of
  * course).
  */
-final case class FlowShape[-I, +O](in: Inlet[I @uncheckedVariance], out: Outlet[O @uncheckedVariance]) extends Shape {
+final class FlowShape[-I, +O](val in: Inlet[I @uncheckedVariance], val out: Outlet[O @uncheckedVariance]) extends Shape with Product with Serializable {
   override val inlets: immutable.Seq[Inlet[_]] = in :: Nil
   override val outlets: immutable.Seq[Outlet[_]] = out :: Nil
 
   override def deepCopy(): FlowShape[I, O] = FlowShape(in.carbonCopy(), out.carbonCopy())
+
+  def copy(
+      in: Inlet[I @uncheckedVariance],
+      out: Outlet[O @uncheckedVariance],
+  ): FlowShape[I, O] = new FlowShape(in, out)
+  override def equals(other: Any): Boolean = (this eq other.asInstanceOf[AnyRef]) || (other match {
+    case that: FlowShape[_, _] => in == that.in && out == that.out
+    case _                     => false
+  })
+  override def productElement(n: Int): Any = n match {
+    case 0 => in
+    case 1 => out
+    case _ => scala.runtime.Statics.ioobe(n)
+  }
+  override def productElementName(n: Int) = n match {
+    case 0 => "in"
+    case 1 => "out"
+    case _ => scala.runtime.Statics.ioobe(n)
+  }
+  override def productPrefix       = "FlowShape"
+  override def productArity        = 2
+  override def canEqual(that: Any) = that.isInstanceOf[FlowShape[_, _]]
+  override def hashCode            = scala.runtime.ScalaRunTime._hashCode(this)
+  override def toString            = scala.runtime.ScalaRunTime._toString(this)
 }
 object FlowShape {
+  def apply[I, O](in: Inlet[I @uncheckedVariance], out: Outlet[O @uncheckedVariance]): FlowShape[I, O] =
+    new FlowShape[I, O](in, out)
+
+  def unapply[I, O](x: FlowShape[I @uncheckedVariance, O @uncheckedVariance]): Some[(Inlet[I @uncheckedVariance], Outlet[O @uncheckedVariance])] =
+    Some((x.in, x.out))
 
   /** Java API */
   def of[I, O](inlet: Inlet[I @uncheckedVariance], outlet: Outlet[O @uncheckedVariance]): FlowShape[I, O] =
@@ -314,13 +369,39 @@ object FlowShape {
 /**
  * A Sink [[Shape]] has exactly one input and no outputs, it models a data sink.
  */
-final case class SinkShape[-T](in: Inlet[T @uncheckedVariance]) extends Shape {
+final class SinkShape[-T](val in: Inlet[T @uncheckedVariance]) extends Shape with Product with Serializable {
   override val inlets: immutable.Seq[Inlet[_]] = in :: Nil
   override val outlets: immutable.Seq[Outlet[_]] = EmptyImmutableSeq
 
   override def deepCopy(): SinkShape[T] = SinkShape(in.carbonCopy())
+
+  def copy(
+      in: Inlet[T @uncheckedVariance],
+  ): SinkShape[T] = new SinkShape[T](in)
+  override def equals(other: Any): Boolean = (this eq other.asInstanceOf[AnyRef]) || (other match {
+    case that: SinkShape[_] => in == that.in
+    case _                  => false
+  })
+  override def productElement(n: Int): Any = n match {
+    case 0 => in
+    case _ => scala.runtime.Statics.ioobe(n)
+  }
+  override def productElementName(n: Int) = n match {
+    case 0 => "out"
+    case _ => scala.runtime.Statics.ioobe(n)
+  }
+  override def productPrefix       = "SinkShape"
+  override def productArity        = 1
+  override def canEqual(that: Any) = that.isInstanceOf[SinkShape[_]]
+  override def hashCode            = scala.runtime.ScalaRunTime._hashCode(this)
+  override def toString            = scala.runtime.ScalaRunTime._toString(this)
 }
 object SinkShape {
+  def apply[T](in: Inlet[T @uncheckedVariance]): SinkShape[T] =
+    new SinkShape[T](in)
+
+  def unapply[T](x: SinkShape[T @uncheckedVariance]): Some[Inlet[T @uncheckedVariance]] =
+    Some(x.in)
 
   /** Java API */
   def of[T](inlet: Inlet[T @uncheckedVariance]): SinkShape[T] =
@@ -340,12 +421,12 @@ object SinkShape {
  *        +------+
  * }}}
  */
-final case class BidiShape[-In1, +Out1, -In2, +Out2](
-    in1: Inlet[In1 @uncheckedVariance],
-    out1: Outlet[Out1 @uncheckedVariance],
-    in2: Inlet[In2 @uncheckedVariance],
-    out2: Outlet[Out2 @uncheckedVariance])
-    extends Shape {
+final class BidiShape[-In1, +Out1, -In2, +Out2](
+    val in1: Inlet[In1 @uncheckedVariance],
+    val out1: Outlet[Out1 @uncheckedVariance],
+    val in2: Inlet[In2 @uncheckedVariance],
+    val out2: Outlet[Out2 @uncheckedVariance])
+    extends Shape with Product with Serializable {
   //#implementation-details-elided
   override val inlets: immutable.Seq[Inlet[_]] = in1 :: in2 :: Nil
   override val outlets: immutable.Seq[Outlet[_]] = out1 :: out2 :: Nil
@@ -358,10 +439,54 @@ final case class BidiShape[-In1, +Out1, -In2, +Out2](
   override def deepCopy(): BidiShape[In1, Out1, In2, Out2] =
     BidiShape(in1.carbonCopy(), out1.carbonCopy(), in2.carbonCopy(), out2.carbonCopy())
 
+  def copy(
+      in1: Inlet[In1 @uncheckedVariance],
+      out1: Outlet[Out1 @uncheckedVariance],
+      in2: Inlet[In2 @uncheckedVariance],
+      out2: Outlet[Out2 @uncheckedVariance],
+  ): BidiShape[In1, Out1, In2, Out2] = new BidiShape(in1, out1, in2, out2)
+  override def equals(other: Any): Boolean = (this eq other.asInstanceOf[AnyRef]) || (other match {
+    case that: BidiShape[_, _, _, _] => in1 == that.in1 && out1 == that.out1 && in2 == that.in2 && out2 == that.out2
+    case _                           => false
+  })
+  override def productElement(n: Int): Any = n match {
+    case 0 => in1
+    case 1 => out1
+    case 2 => in2
+    case 3 => out2
+    case _ => scala.runtime.Statics.ioobe(n)
+  }
+  override def productElementName(n: Int) = n match {
+    case 0 => "in1"
+    case 1 => "out1"
+    case 2 => "in2"
+    case 3 => "out2"
+    case _ => scala.runtime.Statics.ioobe(n)
+  }
+  override def productPrefix       = "BidiShape"
+  override def productArity        = 4
+  override def canEqual(that: Any) = that.isInstanceOf[BidiShape[_, _, _, _]]
+  override def hashCode            = scala.runtime.ScalaRunTime._hashCode(this)
+  override def toString            = scala.runtime.ScalaRunTime._toString(this)
   //#implementation-details-elided
 }
 //#bidi-shape
 object BidiShape {
+  def apply[In1, Out1, In2, Out2](
+      in1: Inlet[In1 @uncheckedVariance],
+      out1: Outlet[Out1 @uncheckedVariance],
+      in2: Inlet[In2 @uncheckedVariance],
+      out2: Outlet[Out2 @uncheckedVariance],
+  ): BidiShape[In1, Out1, In2, Out2] =
+    new BidiShape[In1, Out1, In2, Out2](in1, out1, in2, out2)
+
+  def unapply[In1, Out1, In2, Out2](x: BidiShape[In1, Out1, In2, Out2]): Some[(
+      Inlet[In1 @uncheckedVariance],
+      Outlet[Out1 @uncheckedVariance],
+      Inlet[In2 @uncheckedVariance],
+      Outlet[Out2 @uncheckedVariance],
+  )] = Some((x.in1, x.out1, x.in2, x.out2))
+
   def fromFlows[I1, O1, I2, O2](top: FlowShape[I1, O1], bottom: FlowShape[I2, O2]): BidiShape[I1, O1, I2, O2] =
     BidiShape(top.in, top.out, bottom.in, bottom.out)
 

--- a/akka-stream/src/main/scala/akka/stream/Shape.scala
+++ b/akka-stream/src/main/scala/akka/stream/Shape.scala
@@ -280,7 +280,7 @@ case class AmorphousShape(inlets: immutable.Seq[Inlet[_]], outlets: immutable.Se
  * A Source [[Shape]] has exactly one output and no inputs, it models a source
  * of data.
  */
-final case class SourceShape[+T](out: Outlet[T @uncheckedVariance]) extends Shape {
+final case class SourceShape[T](out: Outlet[T @uncheckedVariance]) extends Shape {
   override val inlets: immutable.Seq[Inlet[_]] = EmptyImmutableSeq
   override val outlets: immutable.Seq[Outlet[_]] = out :: Nil
 

--- a/akka-stream/src/main/scala/akka/stream/Shape.scala
+++ b/akka-stream/src/main/scala/akka/stream/Shape.scala
@@ -4,7 +4,6 @@
 
 package akka.stream
 
-import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 
 import akka.annotation.InternalApi
@@ -87,7 +86,7 @@ object Inlet {
   def create[T](name: String): Inlet[T] = Inlet(name)
 }
 
-final class Inlet[T] private (val s: String) extends InPort {
+final class Inlet[-T] private (val s: String) extends InPort {
   def carbonCopy(): Inlet[T] = {
     val in = Inlet[T](s)
     in.mappedTo = this
@@ -129,7 +128,7 @@ object Outlet {
   def create[T](name: String): Outlet[T] = Outlet(name)
 }
 
-final class Outlet[T] private (val s: String) extends OutPort {
+final class Outlet[+T] private (val s: String) extends OutPort {
   def carbonCopy(): Outlet[T] = {
     val out = Outlet[T](s)
     out.mappedTo = this
@@ -280,42 +279,16 @@ case class AmorphousShape(inlets: immutable.Seq[Inlet[_]], outlets: immutable.Se
  * A Source [[Shape]] has exactly one output and no inputs, it models a source
  * of data.
  */
-final class SourceShape[+T](val out: Outlet[T @uncheckedVariance]) extends Shape with Product with Serializable {
+final case class SourceShape[+T](out: Outlet[T]) extends Shape {
   override val inlets: immutable.Seq[Inlet[_]] = EmptyImmutableSeq
   override val outlets: immutable.Seq[Outlet[_]] = out :: Nil
 
   override def deepCopy(): SourceShape[T] = SourceShape(out.carbonCopy())
-
-  def copy(
-      out: Outlet[T @uncheckedVariance],
-  ): SourceShape[T] = new SourceShape[T](out)
-  override def equals(other: Any): Boolean = (this eq other.asInstanceOf[AnyRef]) || (other match {
-    case that: SourceShape[_] => out == that.out
-    case _                    => false
-  })
-  override def productElement(n: Int): Any = n match {
-    case 0 => out
-    case _ => scala.runtime.Statics.ioobe(n)
-  }
-  override def productElementName(n: Int) = n match {
-    case 0 => "out"
-    case _ => scala.runtime.Statics.ioobe(n)
-  }
-  override def productPrefix       = "SourceShape"
-  override def productArity        = 1
-  override def canEqual(that: Any) = that.isInstanceOf[SourceShape[_]]
-  override def hashCode            = scala.runtime.ScalaRunTime._hashCode(this)
-  override def toString            = scala.runtime.ScalaRunTime._toString(this)
 }
 object SourceShape {
-  def apply[T](out: Outlet[T @uncheckedVariance]): SourceShape[T] =
-    new SourceShape[T](out)
-
-  def unapply[T](x: SourceShape[T @uncheckedVariance]): Some[Outlet[T @uncheckedVariance]] =
-    Some(x.out)
 
   /** Java API */
-  def of[T](outlet: Outlet[T @uncheckedVariance]): SourceShape[T] =
+  def of[T](outlet: Outlet[T]): SourceShape[T] =
     SourceShape(outlet)
 }
 
@@ -324,87 +297,32 @@ object SourceShape {
  * outside like a pipe (but it can be a complex topology of streams within of
  * course).
  */
-final class FlowShape[-I, +O](val in: Inlet[I @uncheckedVariance], val out: Outlet[O @uncheckedVariance]) extends Shape with Product with Serializable {
+final case class FlowShape[-I, +O](in: Inlet[I], out: Outlet[O]) extends Shape {
   override val inlets: immutable.Seq[Inlet[_]] = in :: Nil
   override val outlets: immutable.Seq[Outlet[_]] = out :: Nil
 
   override def deepCopy(): FlowShape[I, O] = FlowShape(in.carbonCopy(), out.carbonCopy())
-
-  def copy(
-      in: Inlet[I @uncheckedVariance],
-      out: Outlet[O @uncheckedVariance],
-  ): FlowShape[I, O] = new FlowShape(in, out)
-  override def equals(other: Any): Boolean = (this eq other.asInstanceOf[AnyRef]) || (other match {
-    case that: FlowShape[_, _] => in == that.in && out == that.out
-    case _                     => false
-  })
-  override def productElement(n: Int): Any = n match {
-    case 0 => in
-    case 1 => out
-    case _ => scala.runtime.Statics.ioobe(n)
-  }
-  override def productElementName(n: Int) = n match {
-    case 0 => "in"
-    case 1 => "out"
-    case _ => scala.runtime.Statics.ioobe(n)
-  }
-  override def productPrefix       = "FlowShape"
-  override def productArity        = 2
-  override def canEqual(that: Any) = that.isInstanceOf[FlowShape[_, _]]
-  override def hashCode            = scala.runtime.ScalaRunTime._hashCode(this)
-  override def toString            = scala.runtime.ScalaRunTime._toString(this)
 }
 object FlowShape {
-  def apply[I, O](in: Inlet[I @uncheckedVariance], out: Outlet[O @uncheckedVariance]): FlowShape[I, O] =
-    new FlowShape[I, O](in, out)
-
-  def unapply[I, O](x: FlowShape[I @uncheckedVariance, O @uncheckedVariance]): Some[(Inlet[I @uncheckedVariance], Outlet[O @uncheckedVariance])] =
-    Some((x.in, x.out))
 
   /** Java API */
-  def of[I, O](inlet: Inlet[I @uncheckedVariance], outlet: Outlet[O @uncheckedVariance]): FlowShape[I, O] =
+  def of[I, O](inlet: Inlet[I], outlet: Outlet[O]): FlowShape[I, O] =
     FlowShape(inlet, outlet)
 }
 
 /**
  * A Sink [[Shape]] has exactly one input and no outputs, it models a data sink.
  */
-final class SinkShape[-T](val in: Inlet[T @uncheckedVariance]) extends Shape with Product with Serializable {
+final case class SinkShape[-T](in: Inlet[T]) extends Shape {
   override val inlets: immutable.Seq[Inlet[_]] = in :: Nil
   override val outlets: immutable.Seq[Outlet[_]] = EmptyImmutableSeq
 
   override def deepCopy(): SinkShape[T] = SinkShape(in.carbonCopy())
-
-  def copy(
-      in: Inlet[T @uncheckedVariance],
-  ): SinkShape[T] = new SinkShape[T](in)
-  override def equals(other: Any): Boolean = (this eq other.asInstanceOf[AnyRef]) || (other match {
-    case that: SinkShape[_] => in == that.in
-    case _                  => false
-  })
-  override def productElement(n: Int): Any = n match {
-    case 0 => in
-    case _ => scala.runtime.Statics.ioobe(n)
-  }
-  override def productElementName(n: Int) = n match {
-    case 0 => "out"
-    case _ => scala.runtime.Statics.ioobe(n)
-  }
-  override def productPrefix       = "SinkShape"
-  override def productArity        = 1
-  override def canEqual(that: Any) = that.isInstanceOf[SinkShape[_]]
-  override def hashCode            = scala.runtime.ScalaRunTime._hashCode(this)
-  override def toString            = scala.runtime.ScalaRunTime._toString(this)
 }
 object SinkShape {
-  def apply[T](in: Inlet[T @uncheckedVariance]): SinkShape[T] =
-    new SinkShape[T](in)
-
-  def unapply[T](x: SinkShape[T @uncheckedVariance]): Some[Inlet[T @uncheckedVariance]] =
-    Some(x.in)
 
   /** Java API */
-  def of[T](inlet: Inlet[T @uncheckedVariance]): SinkShape[T] =
+  def of[T](inlet: Inlet[T]): SinkShape[T] =
     SinkShape(inlet)
 }
 
@@ -421,12 +339,12 @@ object SinkShape {
  *        +------+
  * }}}
  */
-final class BidiShape[-In1, +Out1, -In2, +Out2](
-    val in1: Inlet[In1 @uncheckedVariance],
-    val out1: Outlet[Out1 @uncheckedVariance],
-    val in2: Inlet[In2 @uncheckedVariance],
-    val out2: Outlet[Out2 @uncheckedVariance])
-    extends Shape with Product with Serializable {
+final case class BidiShape[-In1, +Out1, -In2, +Out2](
+    in1: Inlet[In1],
+    out1: Outlet[Out1],
+    in2: Inlet[In2],
+    out2: Outlet[Out2])
+    extends Shape {
   //#implementation-details-elided
   override val inlets: immutable.Seq[Inlet[_]] = in1 :: in2 :: Nil
   override val outlets: immutable.Seq[Outlet[_]] = out1 :: out2 :: Nil
@@ -439,63 +357,19 @@ final class BidiShape[-In1, +Out1, -In2, +Out2](
   override def deepCopy(): BidiShape[In1, Out1, In2, Out2] =
     BidiShape(in1.carbonCopy(), out1.carbonCopy(), in2.carbonCopy(), out2.carbonCopy())
 
-  def copy(
-      in1: Inlet[In1 @uncheckedVariance],
-      out1: Outlet[Out1 @uncheckedVariance],
-      in2: Inlet[In2 @uncheckedVariance],
-      out2: Outlet[Out2 @uncheckedVariance],
-  ): BidiShape[In1, Out1, In2, Out2] = new BidiShape(in1, out1, in2, out2)
-  override def equals(other: Any): Boolean = (this eq other.asInstanceOf[AnyRef]) || (other match {
-    case that: BidiShape[_, _, _, _] => in1 == that.in1 && out1 == that.out1 && in2 == that.in2 && out2 == that.out2
-    case _                           => false
-  })
-  override def productElement(n: Int): Any = n match {
-    case 0 => in1
-    case 1 => out1
-    case 2 => in2
-    case 3 => out2
-    case _ => scala.runtime.Statics.ioobe(n)
-  }
-  override def productElementName(n: Int) = n match {
-    case 0 => "in1"
-    case 1 => "out1"
-    case 2 => "in2"
-    case 3 => "out2"
-    case _ => scala.runtime.Statics.ioobe(n)
-  }
-  override def productPrefix       = "BidiShape"
-  override def productArity        = 4
-  override def canEqual(that: Any) = that.isInstanceOf[BidiShape[_, _, _, _]]
-  override def hashCode            = scala.runtime.ScalaRunTime._hashCode(this)
-  override def toString            = scala.runtime.ScalaRunTime._toString(this)
   //#implementation-details-elided
 }
 //#bidi-shape
 object BidiShape {
-  def apply[In1, Out1, In2, Out2](
-      in1: Inlet[In1 @uncheckedVariance],
-      out1: Outlet[Out1 @uncheckedVariance],
-      in2: Inlet[In2 @uncheckedVariance],
-      out2: Outlet[Out2 @uncheckedVariance],
-  ): BidiShape[In1, Out1, In2, Out2] =
-    new BidiShape[In1, Out1, In2, Out2](in1, out1, in2, out2)
-
-  def unapply[In1, Out1, In2, Out2](x: BidiShape[In1, Out1, In2, Out2]): Some[(
-      Inlet[In1 @uncheckedVariance],
-      Outlet[Out1 @uncheckedVariance],
-      Inlet[In2 @uncheckedVariance],
-      Outlet[Out2 @uncheckedVariance],
-  )] = Some((x.in1, x.out1, x.in2, x.out2))
-
   def fromFlows[I1, O1, I2, O2](top: FlowShape[I1, O1], bottom: FlowShape[I2, O2]): BidiShape[I1, O1, I2, O2] =
     BidiShape(top.in, top.out, bottom.in, bottom.out)
 
   /** Java API */
   def of[In1, Out1, In2, Out2](
-      in1: Inlet[In1 @uncheckedVariance],
-      out1: Outlet[Out1 @uncheckedVariance],
-      in2: Inlet[In2 @uncheckedVariance],
-      out2: Outlet[Out2 @uncheckedVariance]): BidiShape[In1, Out1, In2, Out2] =
+      in1: Inlet[In1],
+      out1: Outlet[Out1],
+      in2: Inlet[In2],
+      out2: Outlet[Out2]): BidiShape[In1, Out1, In2, Out2] =
     BidiShape(in1, out1, in2, out2)
 
 }

--- a/akka-stream/src/main/scala/akka/stream/UniformFanInShape.scala
+++ b/akka-stream/src/main/scala/akka/stream/UniformFanInShape.scala
@@ -4,7 +4,6 @@
 
 package akka.stream
 
-import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 
 object UniformFanInShape {
@@ -26,17 +25,17 @@ class UniformFanInShape[-T, +O](val n: Int, _init: FanInShape.Init[O]) extends F
   def this(n: Int) = this(n, FanInShape.Name[O]("UniformFanIn"))
   def this(n: Int, name: String) = this(n, FanInShape.Name[O](name))
   def this(outlet: Outlet[O], inlets: Array[Inlet[T]]) = this(inlets.length, FanInShape.Ports(outlet, inlets.toList))
-  override protected def construct(init: FanInShape.Init[O @uncheckedVariance]): FanInShape[O] =
+  override protected def construct[N >: O](init: FanInShape.Init[N]): FanInShape[N] =
     new UniformFanInShape(n, init)
   override def deepCopy(): UniformFanInShape[T, O] = super.deepCopy().asInstanceOf[UniformFanInShape[T, O]]
 
-  final override def inlets: immutable.Seq[Inlet[T @uncheckedVariance]] =
+  final override def inlets: immutable.Seq[Inlet[T]] =
     super.inlets.asInstanceOf[immutable.Seq[Inlet[T]]]
 
   @deprecated("Use 'inlets' or 'in(id)' instead.", "2.5.5")
-  def inSeq: immutable.IndexedSeq[Inlet[T @uncheckedVariance]] = _inSeq
+  def inSeq: immutable.IndexedSeq[Inlet[T]] = _inSeq
 
   // cannot deprecate a lazy val because of genjavadoc problem https://github.com/typesafehub/genjavadoc/issues/85
-  private lazy val _inSeq: immutable.IndexedSeq[Inlet[T @uncheckedVariance]] = inlets.toIndexedSeq
-  def in(n: Int): Inlet[T @uncheckedVariance] = inlets(n)
+  private lazy val _inSeq: immutable.IndexedSeq[Inlet[T]] = inlets.toIndexedSeq
+  def in(n: Int): Inlet[T] = inlets(n)
 }

--- a/akka-stream/src/main/scala/akka/stream/UniformFanOutShape.scala
+++ b/akka-stream/src/main/scala/akka/stream/UniformFanOutShape.scala
@@ -4,7 +4,6 @@
 
 package akka.stream
 
-import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 
 object UniformFanOutShape {
@@ -12,7 +11,7 @@ object UniformFanOutShape {
     new UniformFanOutShape(outlets.size, FanOutShape.Ports(inlet, outlets.toList))
 }
 
-class UniformFanOutShape[-I, +O](n: Int, _init: FanOutShape.Init[I @uncheckedVariance]) extends FanOutShape[I](_init) {
+class UniformFanOutShape[-I, +O](n: Int, _init: FanOutShape.Init[I]) extends FanOutShape[I](_init) {
 
   //initialize by side-effect
   for (i <- 0 until n) newOutlet[O](s"out$i")
@@ -20,18 +19,18 @@ class UniformFanOutShape[-I, +O](n: Int, _init: FanOutShape.Init[I @uncheckedVar
   def this(n: Int) = this(n, FanOutShape.Name[I]("UniformFanOut"))
   def this(n: Int, name: String) = this(n, FanOutShape.Name[I](name))
   def this(inlet: Inlet[I], outlets: Array[Outlet[O]]) = this(outlets.length, FanOutShape.Ports(inlet, outlets.toList))
-  override protected def construct(init: FanOutShape.Init[I @uncheckedVariance]): FanOutShape[I] =
+  override protected def construct[J <: I](init: FanOutShape.Init[J]): FanOutShape[J] =
     new UniformFanOutShape(n, init)
   override def deepCopy(): UniformFanOutShape[I, O] = super.deepCopy().asInstanceOf[UniformFanOutShape[I, O]]
 
-  final override def outlets: immutable.Seq[Outlet[O @uncheckedVariance]] =
+  final override def outlets: immutable.Seq[Outlet[O]] =
     super.outlets.asInstanceOf[immutable.Seq[Outlet[O]]]
 
   @Deprecated
   @deprecated("use 'outlets' or 'out(id)' instead", "2.5.5")
-  def outArray: Array[Outlet[O @uncheckedVariance]] = _outArray
+  def outArray: Array[_ <: Outlet[O]] = _outArray
 
   // cannot deprecate a lazy val because of genjavadoc problem https://github.com/typesafehub/genjavadoc/issues/85
-  private lazy val _outArray: Array[Outlet[O @uncheckedVariance]] = outlets.toArray
-  def out(n: Int): Outlet[O @uncheckedVariance] = outlets(n)
+  private lazy val _outArray: Array[_ <: Outlet[O]] = outlets.toArray
+  def out(n: Int): Outlet[O] = outlets(n)
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorProcessor.scala
@@ -233,7 +233,7 @@ import akka.util.unused
 
   protected def downstreamRunning: Actor.Receive = {
     case SubscribePending =>
-      subscribePending(exposedPublisher.takePendingSubscribers())
+      subscribePending(exposedPublisher.takePendingSubscribers().asInstanceOf[Seq[Subscriber[Any]]])
     case RequestMore(_, elements) =>
       if (elements < 1) {
         error(ReactiveStreamsCompliance.numberOfElementsInRequestMustBePositiveException)

--- a/akka-stream/src/main/scala/akka/stream/impl/Buffers.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Buffers.scala
@@ -143,7 +143,8 @@ private[akka] object Buffer {
  * INTERNAL API
  */
 @InternalApi private[akka] final class BoundedBuffer[T](val capacity: Int) extends Buffer[T] {
-
+  import BoundedBuffer._
+  
   def used: Int = q.used
   def isFull: Boolean = q.isFull
   def isEmpty: Boolean = q.isEmpty
@@ -156,15 +157,21 @@ private[akka] object Buffer {
   def clear(): Unit = q.clear()
   def dropHead(): Unit = q.dropHead()
   def dropTail(): Unit = q.dropTail()
+  
+  private var q: Buffer[T] = new FixedQueue[T](capacity, newBuffer => q = newBuffer)
+}
 
-  private final class FixedQueue extends Buffer[T] {
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object BoundedBuffer {
+  private final class FixedQueue[T](override val capacity: Int, switchBuffer: Buffer[T] => Unit) extends Buffer[T] {
     import Buffer._
 
     private val queue = new Array[AnyRef](FixedQueueSize)
     private var head = 0
     private var tail = 0
-
-    override def capacity = BoundedBuffer.this.capacity
+    
     override def used = tail - head
     override def isFull = used == capacity
     override def isEmpty = tail == head
@@ -172,11 +179,11 @@ private[akka] object Buffer {
 
     override def enqueue(elem: T): Unit =
       if (tail - head == FixedQueueSize) {
-        val queue = new DynamicQueue()
+        val queue = new DynamicQueue[T](capacity)
         while (nonEmpty) {
           queue.enqueue(dequeue())
         }
-        q = queue
+        switchBuffer(queue)
         queue.enqueue(elem)
       } else {
         queue(tail & FixedQueueMask) = elem.asInstanceOf[AnyRef]
@@ -204,8 +211,7 @@ private[akka] object Buffer {
     }
   }
 
-  private final class DynamicQueue() extends ju.LinkedList[T] with Buffer[T] {
-    override def capacity = BoundedBuffer.this.capacity
+  private final class DynamicQueue[T](override val capacity: Int) extends ju.LinkedList[T] with Buffer[T] {
     override def used = size
     override def isFull = size == capacity
     override def nonEmpty = !isEmpty()
@@ -216,6 +222,4 @@ private[akka] object Buffer {
     override def dropHead(): Unit = remove()
     override def dropTail(): Unit = removeLast()
   }
-
-  private var q: Buffer[T] = new FixedQueue
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/EmptySource.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/EmptySource.scala
@@ -14,7 +14,7 @@ import akka.stream.stage._
  */
 @InternalApi private[akka] object EmptySource extends GraphStage[SourceShape[Nothing]] {
   val out = Outlet[Nothing]("EmptySource.out")
-  override val shape = SourceShape(out)
+  override val shape = SourceShape[Nothing](out)
 
   override protected def initialAttributes = DefaultAttributes.lazySource
 

--- a/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/JsonObjectParser.scala
@@ -81,7 +81,7 @@ import akka.util.ByteString
     val foundObject = seekObject()
     if (!foundObject) None
     else
-      (pos: @switch) match {
+      pos match {
         case -1 | 0 => None
         case _ =>
           val (emit, buf) = buffer.splitAt(pos)

--- a/akka-stream/src/main/scala/akka/stream/impl/Modules.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Modules.scala
@@ -4,8 +4,6 @@
 
 package akka.stream.impl
 
-import scala.annotation.unchecked.uncheckedVariance
-
 import org.reactivestreams._
 
 import akka.NotUsed
@@ -23,10 +21,7 @@ import akka.stream.impl.StreamLayout.AtomicModule
   protected def label: String = Logging.simpleName(this)
   final override def toString: String = f"$label [${System.identityHashCode(this)}%08x]"
 
-  def create(context: MaterializationContext): (Publisher[Out] @uncheckedVariance, Mat)
-
-  // TODO: Remove this, no longer needed?
-  protected def newInstance(shape: SourceShape[Out] @uncheckedVariance): SourceModule[Out, Mat]
+  def create(context: MaterializationContext): (Publisher[_ <: Out], Mat)
 
   // TODO: Amendshape changed the name of ports. Is it needed anymore?
 
@@ -58,8 +53,6 @@ import akka.stream.impl.StreamLayout.AtomicModule
     (processor, processor)
   }
 
-  override protected def newInstance(shape: SourceShape[Out]): SourceModule[Out, Subscriber[Out]] =
-    new SubscriberSource[Out](attributes, shape)
   override def withAttributes(attr: Attributes): SourceModule[Out, Subscriber[Out]] =
     new SubscriberSource[Out](attr, amendShape(attr))
 }
@@ -81,8 +74,6 @@ import akka.stream.impl.StreamLayout.AtomicModule
 
   override def create(context: MaterializationContext) = (p, NotUsed)
 
-  override protected def newInstance(shape: SourceShape[Out]): SourceModule[Out, NotUsed] =
-    new PublisherSource[Out](p, attributes, shape)
   override def withAttributes(attr: Attributes): SourceModule[Out, NotUsed] =
     new PublisherSource[Out](p, attr, amendShape(attr))
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -851,20 +851,20 @@ private final case class SavedIslandData(
 @InternalApi private[akka] final class SourceModulePhase(
     materializer: PhasedFusingActorMaterializer,
     islandName: String)
-    extends PhaseIsland[Publisher[Any]] {
+    extends PhaseIsland[Publisher[_]] {
   override def name: String = s"SourceModule phase"
 
-  override def materializeAtomic(mod: AtomicModule[Shape, Any], attributes: Attributes): (Publisher[Any], Any) = {
+  override def materializeAtomic(mod: AtomicModule[Shape, Any], attributes: Attributes): (Publisher[_], Any) = {
     mod
       .asInstanceOf[SourceModule[Any, Any]]
       .create(MaterializationContext(materializer, attributes, islandName + "-" + attributes.nameOrDefault()))
   }
 
-  override def assignPort(in: InPort, slot: Int, logic: Publisher[Any]): Unit = ()
+  override def assignPort(in: InPort, slot: Int, logic: Publisher[_]): Unit = ()
 
-  override def assignPort(out: OutPort, slot: Int, logic: Publisher[Any]): Unit = ()
+  override def assignPort(out: OutPort, slot: Int, logic: Publisher[_]): Unit = ()
 
-  override def createPublisher(out: OutPort, logic: Publisher[Any]): Publisher[Any] = logic
+  override def createPublisher(out: OutPort, logic: Publisher[_]): Publisher[Any] = logic.asInstanceOf[Publisher[Any]]
 
   override def takePublisher(slot: Int, publisher: Publisher[Any]): Unit =
     throw new UnsupportedOperationException("A Source cannot take a Publisher")

--- a/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/PhasedFusingActorMaterializer.scala
@@ -604,7 +604,7 @@ private final case class SavedIslandData(
     }
   }
 
-  override def makeLogger(logSource: Class[_]): LoggingAdapter =
+  override def makeLogger(logSource: Class[Any]): LoggingAdapter =
     Logging(system, logSource)
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/impl/ResizableMultiReaderRingBuffer.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ResizableMultiReaderRingBuffer.scala
@@ -7,7 +7,7 @@ package akka.stream.impl
 import scala.annotation.tailrec
 import scala.util.control.NoStackTrace
 
-import ResizableMultiReaderRingBuffer._
+import ResizableMultiReaderRingBuffer.{Cursor, Cursors, NothingToReadException}
 
 import akka.annotation.InternalApi
 
@@ -87,7 +87,7 @@ import akka.annotation.InternalApi
       // the growing logic is quite simple: we assemble all current buffer entries in the new array
       // in their natural order (removing potential wrap around) and rebase all indices to zero
       val r = readIx & mask
-      val newArray = new Array[Any](array.length << 1)
+      val newArray = new Array[Any]((array.length << 1))
       System.arraycopy(array, r, newArray, 0, array.length - r)
       System.arraycopy(array, 0, newArray, array.length - r, r)
       @tailrec def rebaseCursors(remaining: List[Cursor]): Unit = remaining match {

--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -5,7 +5,6 @@
 package akka.stream.impl
 
 import java.util.function.BinaryOperator
-import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 import scala.collection.mutable
 import scala.concurrent.Future
@@ -55,10 +54,6 @@ import akka.util.ccompat._
   override def traversalBuilder: TraversalBuilder =
     LinearTraversalBuilder.fromModule(this, attributes).makeIsland(SinkModuleIslandTag)
 
-  // This is okay since we the only caller of this method is right below.
-  // TODO: Remove this, no longer needed
-  protected def newInstance(s: SinkShape[In] @uncheckedVariance): SinkModule[In, Mat]
-
   protected def amendShape(attr: Attributes): SinkShape[In] = {
     val thisN = traversalBuilder.attributes.nameOrDefault(null)
     val thatN = attr.nameOrDefault(null)
@@ -104,8 +99,6 @@ import akka.util.ccompat._
     (proc, proc)
   }
 
-  override protected def newInstance(shape: SinkShape[In]): SinkModule[In, Publisher[In]] =
-    new PublisherSink[In](attributes, shape)
   override def withAttributes(attr: Attributes): SinkModule[In, Publisher[In]] =
     new PublisherSink[In](attr, amendShape(attr))
 }
@@ -124,9 +117,6 @@ import akka.util.ccompat._
     (fanoutProcessor, fanoutProcessor)
   }
 
-  override protected def newInstance(shape: SinkShape[In]): SinkModule[In, Publisher[In]] =
-    new FanoutPublisherSink[In](attributes, shape)
-
   override def withAttributes(attr: Attributes): SinkModule[In, Publisher[In]] =
     new FanoutPublisherSink[In](attr, amendShape(attr))
 }
@@ -143,8 +133,6 @@ import akka.util.ccompat._
 
   override def create(context: MaterializationContext) = (subscriber, NotUsed)
 
-  override protected def newInstance(shape: SinkShape[In]): SinkModule[In, NotUsed] =
-    new SubscriberSink[In](subscriber, attributes, shape)
   override def withAttributes(attr: Attributes): SinkModule[In, NotUsed] =
     new SubscriberSink[In](subscriber, attr, amendShape(attr))
 }
@@ -157,8 +145,6 @@ import akka.util.ccompat._
     extends SinkModule[Any, NotUsed](shape) {
   override def create(context: MaterializationContext): (Subscriber[Any], NotUsed) =
     (new CancellingSubscriber[Any], NotUsed)
-  override protected def newInstance(shape: SinkShape[Any]): SinkModule[Any, NotUsed] =
-    new CancelSink(attributes, shape)
   override def withAttributes(attr: Attributes): SinkModule[Any, NotUsed] = new CancelSink(attr, amendShape(attr))
 }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -340,7 +340,7 @@ import akka.util.ccompat._
       }
 
       private val callback = getAsyncCallback[Output[T]] {
-        case QueueSink.Pull(pullPromise) =>
+        case QueueSink.Pull(pullPromise: Requested[T]) =>
           if (currentRequests.isFull)
             pullPromise.failure(
               new IllegalStateException(s"Too many concurrent pulls. Specified maximum is $maxConcurrentPulls. " +

--- a/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Sinks.scala
@@ -416,7 +416,7 @@ import akka.util.ccompat._
  * accidentally sharing state between materializations
  */
 @InternalApi private[akka] trait CollectorState[T, R] {
-  def accumulated(): Any
+  def accumulated: Any
   def update(elem: T): CollectorState[T, R]
   def finish(): R
 }
@@ -440,7 +440,7 @@ import akka.util.ccompat._
     new MutableCollectorState(collector, accumulator, accumulated)
   }
 
-  override def accumulated(): Any = {
+  override def accumulated: Any = {
     // only called if it is asked about accumulated before accepting a first element
     val collector = collectorFactory()
     collector.supplier().get()
@@ -461,19 +461,17 @@ import akka.util.ccompat._
 @InternalApi private[akka] final class MutableCollectorState[T, R](
     collector: java.util.stream.Collector[T, Any, R],
     accumulator: java.util.function.BiConsumer[Any, T],
-    _accumulated: Any)
+    val accumulated: Any)
     extends CollectorState[T, R] {
 
-  def accumulated(): Any = _accumulated
-
   override def update(elem: T): CollectorState[T, R] = {
-    accumulator.accept(accumulated(), elem)
+    accumulator.accept(accumulated, elem)
     this
   }
 
   override def finish(): R = {
     // only called if completed without elements
-    collector.finisher().apply(accumulated())
+    collector.finisher().apply(accumulated)
   }
 }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/Throttle.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Throttle.scala
@@ -40,7 +40,7 @@ import akka.util.NanoTimeTokenBucket
   private val nanosBetweenTokens = per.toNanos / cost
   // 100 ms is a realistic minimum between tokens, otherwise the maximumBurst is adjusted
   // to be able to support higher rates
-  val effectiveMaximumBurst =
+  val effectiveMaximumBurst: Long =
     if (maximumBurst == Throttle.AutomaticMaximumBurst) math.max(1, ((100 * 1000 * 1000) / nanosBetweenTokens))
     else maximumBurst
   require(!(mode == ThrottleMode.Enforcing && effectiveMaximumBurst < 0), "maximumBurst must be > 0 in Enforcing mode")

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -109,7 +109,7 @@ import akka.stream.stage._
      * when this accidentally leaks onto threads that are not stopped when this
      * class should be unloaded.
      */
-    override def initialValue = new Array(1)
+    override def initialValue(): Array[AnyRef] = new Array(1)
   }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -6,7 +6,6 @@ package akka.stream.impl.fusing
 
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicReference }
 
-import scala.annotation.unchecked.uncheckedVariance
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
@@ -28,7 +27,7 @@ import akka.stream.stage._
  * INTERNAL API
  */
 // TODO: Fix variance issues
-@InternalApi private[akka] final case class GraphStageModule[+S <: Shape @uncheckedVariance, +M](
+@InternalApi private[akka] final case class GraphStageModule[+S <: Shape, +M](
     shape: S,
     attributes: Attributes,
     stage: GraphStageWithMaterializedValue[S, M])

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -2070,8 +2070,9 @@ private[stream] object Collect {
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with InHandler with OutHandler { self =>
       override def toString = s"Reduce.Logic(aggregator=$aggregator)"
-
+      
       private var aggregator: T = _
+      private var empty: T = aggregator
 
       private def decider =
         inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
@@ -2100,7 +2101,7 @@ private[stream] object Collect {
             decider(ex) match {
               case Supervision.Stop => failStage(ex)
               case Supervision.Restart =>
-                aggregator = _: T
+                aggregator = empty
                 setInitialInHandler()
               case _ => ()
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -2072,7 +2072,7 @@ private[stream] object Collect {
       override def toString = s"Reduce.Logic(aggregator=$aggregator)"
       
       private var aggregator: T = _
-      private var empty: T = aggregator
+      private val empty: T = aggregator
 
       private def decider =
         inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider

--- a/akka-stream/src/main/scala/akka/stream/impl/io/FileOutputStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/FileOutputStage.scala
@@ -58,7 +58,7 @@ private[akka] final class FileOutputStage(path: Path, startPosition: Long, openO
       }
 
       override def onPush(): Unit = {
-        val next = grab(in)
+        val next: ByteString = grab(in)
         try {
           bytesWritten += chan.write(next.asByteBuffer)
           pull(in)

--- a/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/InputStreamSinkStage.scala
@@ -77,7 +77,7 @@ private[stream] object InputStreamSinkStage {
       def onPush(): Unit = {
         //1 is buffer for Finished or Failed callback
         require(dataQueue.remainingCapacity() > 1)
-        val bs = grab(in)
+        val bs: ByteString = grab(in)
         if (bs.nonEmpty) {
           dataQueue.add(Data(bs))
         }

--- a/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamGraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamGraphStage.scala
@@ -48,7 +48,7 @@ private[akka] final class OutputStreamGraphStage(factory: () => OutputStream, au
       }
 
       override def onPush(): Unit = {
-        val next = grab(in)
+        val next: ByteString = grab(in)
         try {
           outputStream.write(next.toArray)
           if (autoFlush) outputStream.flush()

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
@@ -425,7 +425,7 @@ import akka.util.ByteString
       case BUFFER_OVERFLOW =>
         flushToUser()
         transportInChoppingBlock.putBack(transportInBuffer)
-      case s => fail(new IllegalStateException(s"unexpected status $s in doUnwrap()"))
+      case null => fail(new IllegalStateException(s"unexpected status null in doUnwrap()"))
     }
   }
 

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
@@ -178,7 +178,7 @@ import akka.util.ByteString
 
       private def unbindCompleted(): Unit = {
         stageActor.unwatch(listener)
-        unbindPromise.trySuccess(Done)
+        unbindPromise.trySuccess(())
         if (connectionFlowsAwaitingInitialization.get() == 0) completeStage()
         else scheduleOnce(BindShutdownTimer, bindShutdownTimeout)
       }
@@ -193,7 +193,7 @@ import akka.util.ByteString
       override def postStop(): Unit = {
         // a bit unexpected to succeed here rather than fail with abrupt stage termination
         // but there was an existing test case covering this behavior
-        unbindPromise.trySuccess(Done)
+        unbindPromise.trySuccess(())
         bindingPromise.tryFailure(new NoSuchElementException("Binding was unbound before it was completely finished"))
       }
     }

--- a/akka-stream/src/main/scala/akka/stream/impl/streamref/SinkRefImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/streamref/SinkRefImpl.scala
@@ -214,7 +214,7 @@ private[stream] final class SinkRefStageImpl[In] private[akka] (val initialPartn
       }
 
       private def grabSequenced[T](in: Inlet[T]): StreamRefsProtocol.SequencedOnNext[T] = {
-        val onNext = StreamRefsProtocol.SequencedOnNext(remoteCumulativeDemandConsumed, grab(in))
+        val onNext = StreamRefsProtocol.SequencedOnNext(remoteCumulativeDemandConsumed, grab[T](in))
         remoteCumulativeDemandConsumed += 1
         onNext
       }

--- a/akka-stream/src/main/scala/akka/stream/impl/streamref/StreamRefSettingsImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/streamref/StreamRefSettingsImpl.scala
@@ -12,7 +12,7 @@ import akka.stream.StreamRefSettings
 
 /** INTERNAL API */
 @InternalApi
-private[akka] final case class StreamRefSettingsImpl private (
+private[akka] final case class StreamRefSettingsImpl (
     override val bufferCapacity: Int,
     override val demandRedeliveryInterval: FiniteDuration,
     override val subscriptionTimeout: FiniteDuration,

--- a/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/BidiFlow.scala
@@ -25,8 +25,8 @@ object BidiFlow {
    */
   def fromGraph[I1, O1, I2, O2, M](g: Graph[BidiShape[I1, O1, I2, O2], M]): BidiFlow[I1, O1, I2, O2, M] =
     g match {
-      case bidi: BidiFlow[I1, O1, I2, O2, M] => bidi
-      case other                             => new BidiFlow(scaladsl.BidiFlow.fromGraph(other))
+      case bidi: BidiFlow[I1, O1, I2, O2, M] @unchecked => bidi
+      case other                                        => new BidiFlow(scaladsl.BidiFlow.fromGraph(other))
     }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/DelayStrategy.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/DelayStrategy.scala
@@ -14,7 +14,7 @@ import akka.util.JavaDurationConverters.JavaDurationOps
  * Allows to manage delay and can be stateful to compute delay for any sequence of elements,
  * all elements go through nextDelay() updating state and returning delay for each element
  */
-trait DelayStrategy[T] {
+trait DelayStrategy[-T] {
 
   /**
    * Returns delay for ongoing element, `Duration.Zero` means passing without delay

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FileIO.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FileIO.scala
@@ -10,6 +10,8 @@ import java.util
 import java.util.concurrent.CompletionStage
 
 import akka.stream.{ javadsl, scaladsl, IOResult }
+import akka.stream.scaladsl.SourceToCompletionStage
+import akka.stream.scaladsl.SinkToCompletionStage
 import akka.util.ByteString
 import akka.util.ccompat.JavaConverters._
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -1679,9 +1679,9 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
   def recoverWith(
       clazz: Class[_ <: Throwable],
       supplier: Supplier[Graph[SourceShape[Out], NotUsed]]): javadsl.Flow[In, Out, Mat] =
-    recoverWith {
+    recoverWith({
       case elem if clazz.isInstance(elem) => supplier.get()
-    }
+    }: PartialFunction[Throwable, Graph[SourceShape[Out], NotUsed]])
 
   /**
    * RecoverWithRetries allows to switch to alternative Source on flow failure. It will stay in effect after

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -64,8 +64,8 @@ object Flow {
    */
   def fromGraph[I, O, M](g: Graph[FlowShape[I, O], M]): Flow[I, O, M] =
     g match {
-      case f: Flow[I, O, M] => f
-      case other            => new Flow(scaladsl.Flow.fromGraph(other))
+      case f: Flow[I, O, M] @unchecked => f
+      case other                       => new Flow(scaladsl.Flow.fromGraph(other))
     }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FlowWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FlowWithContext.scala
@@ -6,7 +6,6 @@ package akka.stream.javadsl
 
 import java.util.concurrent.CompletionStage
 
-import scala.annotation.unchecked.uncheckedVariance
 import scala.compat.java8.FutureConverters._
 
 import akka.event.{ LogMarker, LoggingAdapter, MarkerLoggingAdapter }
@@ -39,7 +38,7 @@ object FlowWithContext {
  * An "empty" flow can be created by calling `FlowWithContext[Ctx, T]`.
  *
  */
-final class FlowWithContext[In, CtxIn, Out, CtxOut, +Mat](
+final class FlowWithContext[-In, -CtxIn, +Out, +CtxOut, +Mat](
     delegate: javadsl.Flow[Pair[In, CtxIn], Pair[Out, CtxOut], Mat])
     extends GraphDelegate(delegate) {
 
@@ -57,7 +56,7 @@ final class FlowWithContext[In, CtxIn, Out, CtxOut, +Mat](
    * @see [[akka.stream.javadsl.Flow.via]]
    */
   def via[Out2, CtxOut2, Mat2](
-      viaFlow: Graph[FlowShape[Pair[Out @uncheckedVariance, CtxOut @uncheckedVariance], Pair[Out2, CtxOut2]], Mat2])
+      viaFlow: Graph[FlowShape[Pair[Out, CtxOut], Pair[Out2, CtxOut2]], Mat2])
       : FlowWithContext[In, CtxIn, Out2, CtxOut2, Mat] = {
     val under = asFlow().via(viaFlow)
     FlowWithContext.fromPairs(under)
@@ -90,7 +89,7 @@ final class FlowWithContext[In, CtxIn, Out, CtxOut, +Mat](
   /**
    * Creates a regular flow of pairs (data, context).
    */
-  def asFlow(): Flow[Pair[In, CtxIn], Pair[Out, CtxOut], Mat] @uncheckedVariance =
+  def asFlow(): Flow[Pair[In, CtxIn], Pair[Out, CtxOut], Mat] =
     delegate
 
   // remaining operations in alphabetic order
@@ -135,8 +134,8 @@ final class FlowWithContext[In, CtxIn, Out, CtxOut, +Mat](
   def grouped(n: Int): FlowWithContext[
     In,
     CtxIn,
-    java.util.List[Out @uncheckedVariance],
-    java.util.List[CtxOut @uncheckedVariance],
+    java.util.List[_ <: Out],
+    java.util.List[_ <: CtxOut],
     Mat] =
     viaScala(_.grouped(n).map(_.asJava).mapContext(_.asJava))
 
@@ -203,8 +202,8 @@ final class FlowWithContext[In, CtxIn, Out, CtxOut, +Mat](
   def sliding(n: Int, step: Int = 1): FlowWithContext[
     In,
     CtxIn,
-    java.util.List[Out @uncheckedVariance],
-    java.util.List[CtxOut @uncheckedVariance],
+    java.util.List[_ <: Out],
+    java.util.List[_ <: CtxOut],
     Mat] =
     viaScala(_.sliding(n, step).map(_.asJava).mapContext(_.asJava))
 

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -662,15 +662,15 @@ object GraphDSL extends GraphCreate {
     def to[I, O](j: UniformFanInShape[I, O]): ReverseOps[I] = new ReverseOps(findIn(delegate, j, 0))
     def to[I, O](j: UniformFanOutShape[I, O]): ReverseOps[I] = new ReverseOps(j.in)
 
-    final class ForwardOps[T](out: Outlet[T]) {
-      def toInlet(in: Inlet[_ >: T]): Builder[Mat] = { out ~> in; self }
-      def to(dst: SinkShape[_ >: T]): Builder[Mat] = { out ~> dst; self }
-      def toFanIn[U](j: UniformFanInShape[_ >: T, U]): Builder[Mat] = { out ~> j; self }
-      def toFanOut[U](j: UniformFanOutShape[_ >: T, U]): Builder[Mat] = { out ~> j; self }
-      def via[U](f: FlowShape[_ >: T, U]): ForwardOps[U] = from((out ~> f).outlet)
-      def viaFanIn[U](j: UniformFanInShape[_ >: T, U]): ForwardOps[U] = from((out ~> j).outlet)
-      def viaFanOut[U](j: UniformFanOutShape[_ >: T, U]): ForwardOps[U] = from((out ~> j).outlet)
-      def out(): Outlet[T] = out
+    final class ForwardOps[T](_out: Outlet[T]) {
+      def toInlet(in: Inlet[_ >: T]): Builder[Mat] = { _out ~> in; self }
+      def to(dst: SinkShape[_ >: T]): Builder[Mat] = { _out ~> dst; self }
+      def toFanIn[U](j: UniformFanInShape[_ >: T, U]): Builder[Mat] = { _out ~> j; self }
+      def toFanOut[U](j: UniformFanOutShape[_ >: T, U]): Builder[Mat] = { _out ~> j; self }
+      def via[U](f: FlowShape[_ >: T, U]): ForwardOps[U] = from((_out ~> f).outlet)
+      def viaFanIn[U](j: UniformFanInShape[_ >: T, U]): ForwardOps[U] = from((_out ~> j).outlet)
+      def viaFanOut[U](j: UniformFanOutShape[_ >: T, U]): ForwardOps[U] = from((_out ~> j).outlet)
+      def out(): Outlet[T] = _out
     }
 
     final class ReverseOps[T](out: Inlet[T]) {

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -675,7 +675,7 @@ object GraphDSL extends GraphCreate {
 
     final class ReverseOps[T](out: Inlet[T]) {
       def fromOutlet(dst: Outlet[_ <: T]): Builder[Mat] = { out <~ dst; self }
-      def from(dst: SourceShape[_ <: T]): Builder[Mat] = { out <~ dst; self }
+      def from(dst: SourceShape[_ <: T]): Builder[Mat] = { out <~ dst.asInstanceOf[SourceShape[T]]; self }
       def fromFanIn[U](j: UniformFanInShape[U, _ <: T]): Builder[Mat] = { out <~ j; self }
       def fromFanOut[U](j: UniformFanOutShape[U, _ <: T]): Builder[Mat] = { out <~ j; self }
       def via[U](f: FlowShape[U, _ <: T]): ReverseOps[U] = to((out <~ f).inlet)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -6,8 +6,6 @@ package akka.stream.javadsl
 
 import java.util
 
-import scala.annotation.unchecked.uncheckedVariance
-
 import akka.NotUsed
 import akka.japi.{ function, Pair }
 import akka.stream._
@@ -648,7 +646,7 @@ object GraphDSL extends GraphCreate {
      *
      * @return The outlet that will emit the materialized value.
      */
-    def materializedValue: Outlet[Mat @uncheckedVariance] = delegate.materializedValue
+    def materializedValue: Outlet[Mat] = delegate.materializedValue
 
     def from[T](out: Outlet[T]): ForwardOps[T] = new ForwardOps(out)
     def from[T](src: SourceShape[T]): ForwardOps[T] = new ForwardOps(src.out)

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Hub.scala
@@ -34,7 +34,7 @@ object MergeHub {
    * @param perProducerBufferSize Buffer space used per producer.
    */
   def of[T](@unused clazz: Class[T], perProducerBufferSize: Int): Source[T, Sink[T, NotUsed]] = {
-    akka.stream.scaladsl.MergeHub.source[T](perProducerBufferSize).mapMaterializedValue(_.asJava[T]).asJava
+    akka.stream.scaladsl.MergeHub.source[T](perProducerBufferSize).mapMaterializedValue(_.asJava).asJava
   }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -25,6 +25,7 @@ import akka.japi.function
 import akka.japi.function.Creator
 import akka.stream.{ javadsl, scaladsl, _ }
 import akka.stream.impl.LinearTraversalBuilder
+import akka.stream.scaladsl.SinkToCompletionStage
 
 /** Java API */
 object Sink {

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -9,7 +9,6 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import java.util.function.BiFunction
 
-import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
@@ -470,7 +469,7 @@ object Sink {
  * A `Sink` is a set of stream processing steps that has one open input.
  * Can be used as a `Subscriber`
  */
-final class Sink[In, Mat](delegate: scaladsl.Sink[In, Mat]) extends Graph[SinkShape[In], Mat] {
+final class Sink[-In, +Mat](delegate: scaladsl.Sink[In, Mat]) extends Graph[SinkShape[In], Mat] {
 
   override def shape: SinkShape[In] = delegate.shape
   override def traversalBuilder: LinearTraversalBuilder = delegate.traversalBuilder
@@ -522,7 +521,7 @@ final class Sink[In, Mat](delegate: scaladsl.Sink[In, Mat]) extends Graph[SinkSh
    * Note that the `ActorSystem` can be used as the `systemProvider` parameter.
    */
   def preMaterialize(systemProvider: ClassicActorSystemProvider)
-      : japi.Pair[Mat @uncheckedVariance, Sink[In @uncheckedVariance, NotUsed]] = {
+      : japi.Pair[Mat, Sink[In, NotUsed]] = {
     val (mat, sink) = delegate.preMaterialize()(SystemMaterializer(systemProvider.classicSystem).materializer)
     akka.japi.Pair(mat, sink.asJava)
   }
@@ -536,7 +535,7 @@ final class Sink[In, Mat](delegate: scaladsl.Sink[In, Mat]) extends Graph[SinkSh
    * Prefer the method taking an ActorSystem unless you have special requirements.
    */
   def preMaterialize(
-      materializer: Materializer): japi.Pair[Mat @uncheckedVariance, Sink[In @uncheckedVariance, NotUsed]] = {
+      materializer: Materializer): japi.Pair[Mat, Sink[In, NotUsed]] = {
     val (mat, sink) = delegate.preMaterialize()(materializer)
     akka.japi.Pair(mat, sink.asJava)
   }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Sink.scala
@@ -314,8 +314,8 @@ object Sink {
    */
   def fromGraph[T, M](g: Graph[SinkShape[T], M]): Sink[T, M] =
     g match {
-      case s: Sink[T, M] => s
-      case other         => new Sink(scaladsl.Sink.fromGraph(other))
+      case s: Sink[T, M] @unchecked => s
+      case other                    => new Sink(scaladsl.Sink.fromGraph(other))
     }
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2030,9 +2030,9 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
   def recoverWith(
       clazz: Class[_ <: Throwable],
       supplier: Supplier[Graph[SourceShape[Out], NotUsed]]): Source[Out, Mat] =
-    recoverWith {
+    recoverWith({
       case elem if clazz.isInstance(elem) => supplier.get()
-    }
+    }: PartialFunction[Throwable, Graph[SourceShape[Out], NotUsed]])
 
   /**
    * RecoverWithRetries allows to switch to alternative Source on flow failure. It will stay in effect after
@@ -2094,7 +2094,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
       supplier: Supplier[Graph[SourceShape[Out], NotUsed]]): Source[Out, Mat] =
     recoverWithRetries(attempts, {
       case elem if clazz.isInstance(elem) => supplier.get()
-    })
+    }: PartialFunction[Throwable, Graph[SourceShape[Out], NotUsed]])
 
   /**
    * Transform each input element into an `Iterable` of output elements that is

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -622,7 +622,7 @@ object Source {
    */
   def fromGraph[T, M](g: Graph[SourceShape[T], M]): Source[T, M] =
     g match {
-      case s: Source[T, M]                 => s
+      case s: Source[T, M] @unchecked      => s
       case s if s eq scaladsl.Source.empty => empty().asInstanceOf[Source[T, M]]
       case other                           => new Source(scaladsl.Source.fromGraph(other))
     }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/StreamConverters.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/StreamConverters.scala
@@ -16,6 +16,8 @@ import akka.NotUsed
 import akka.japi.function
 import akka.stream.{ javadsl, scaladsl }
 import akka.stream.IOResult
+import akka.stream.scaladsl.SinkToCompletionStage
+import akka.stream.scaladsl.SourceToCompletionStage
 import akka.util.ByteString
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -8,7 +8,6 @@ import java.util.Comparator
 import java.util.concurrent.CompletionStage
 import java.util.function.Supplier
 
-import scala.annotation.unchecked.uncheckedVariance
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
@@ -37,11 +36,11 @@ object SubSource {
  * are materialized later, during the runtime of the flow graph processing.
  */
 class SubSource[Out, Mat](
-    delegate: scaladsl.SubFlow[Out, Mat, scaladsl.Source[Out, Mat]#Repr, scaladsl.RunnableGraph[Mat]]) {
+    delegate: scaladsl.SubFlow[Out, Mat, ({ type Repr[+O] = scaladsl.Source[O, Mat] })#Repr, scaladsl.RunnableGraph[Mat]]) {
 
   /** Converts this Flow to its Scala DSL counterpart */
   def asScala
-      : scaladsl.SubFlow[Out, Mat, scaladsl.Source[Out, Mat]#Repr, scaladsl.RunnableGraph[Mat]] @uncheckedVariance =
+      : scaladsl.SubFlow[Out, Mat, ({ type Repr[+O] = scaladsl.Source[O, Mat] })#Repr, scaladsl.RunnableGraph[Mat]] =
     delegate
 
   /**
@@ -368,7 +367,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def grouped(n: Int): SubSource[java.util.List[Out @uncheckedVariance], Mat] =
+  def grouped(n: Int): SubSource[java.util.List[Out], Mat] =
     new SubSource(delegate.grouped(n).map(_.asJava)) // TODO optimize to one step
 
   /**
@@ -388,7 +387,7 @@ class SubSource[Out, Mat](
    * '''Cancels when''' downstream cancels
    */
   def groupedWeighted(minWeight: Long)(
-      costFn: function.Function[Out, java.lang.Long]): SubSource[java.util.List[Out @uncheckedVariance], Mat] =
+      costFn: function.Function[Out, java.lang.Long]): SubSource[java.util.List[Out], Mat] =
     new SubSource(delegate.groupedWeighted(minWeight)(costFn.apply).map(_.asJava)) // TODO optimize to one step
 
   /**
@@ -459,7 +458,7 @@ class SubSource[Out, Mat](
     new SubSource(delegate.limitWeighted(n)(costFn.apply))
   }
 
-  def sliding(n: Int, step: Int = 1): SubSource[java.util.List[Out @uncheckedVariance], Mat] =
+  def sliding(n: Int, step: Int = 1): SubSource[java.util.List[Out], Mat] =
     new SubSource(delegate.sliding(n, step).map(_.asJava)) // TODO optimize to one step
 
   /**
@@ -583,7 +582,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def reduce(f: function.Function2[Out, Out, Out @uncheckedVariance]): SubSource[Out, Mat] =
+  def reduce(f: function.Function2[Out, Out, Out]): SubSource[Out, Mat] =
     new SubSource(delegate.reduce(f.apply))
 
   /**
@@ -665,7 +664,7 @@ class SubSource[Out, Mat](
    */
   @Deprecated
   @deprecated("Use the overloaded one which accepts java.time.Duration instead.", since = "2.5.12")
-  def groupedWithin(maxNumber: Int, duration: FiniteDuration): SubSource[java.util.List[Out @uncheckedVariance], Mat] =
+  def groupedWithin(maxNumber: Int, duration: FiniteDuration): SubSource[java.util.List[Out], Mat] =
     new SubSource(delegate.groupedWithin(maxNumber, duration).map(_.asJava)) // TODO optimize to one step
 
   /**
@@ -689,7 +688,7 @@ class SubSource[Out, Mat](
   @nowarn("msg=deprecated")
   def groupedWithin(
       maxNumber: Int,
-      duration: java.time.Duration): SubSource[java.util.List[Out @uncheckedVariance], Mat] =
+      duration: java.time.Duration): SubSource[java.util.List[Out], Mat] =
     groupedWithin(maxNumber, duration.asScala)
 
   /**
@@ -715,7 +714,7 @@ class SubSource[Out, Mat](
   def groupedWeightedWithin(
       maxWeight: Long,
       costFn: function.Function[Out, java.lang.Long],
-      duration: FiniteDuration): javadsl.SubSource[java.util.List[Out @uncheckedVariance], Mat] =
+      duration: FiniteDuration): javadsl.SubSource[java.util.List[Out], Mat] =
     new SubSource(delegate.groupedWeightedWithin(maxWeight, duration)(costFn.apply).map(_.asJava))
 
   /**
@@ -740,7 +739,7 @@ class SubSource[Out, Mat](
   def groupedWeightedWithin(
       maxWeight: Long,
       costFn: function.Function[Out, java.lang.Long],
-      duration: java.time.Duration): javadsl.SubSource[java.util.List[Out @uncheckedVariance], Mat] =
+      duration: java.time.Duration): javadsl.SubSource[java.util.List[Out], Mat] =
     groupedWeightedWithin(maxWeight, costFn, duration.asScala)
 
   /**
@@ -766,7 +765,7 @@ class SubSource[Out, Mat](
       maxWeight: Long,
       maxNumber: Int,
       costFn: function.Function[Out, java.lang.Long],
-      duration: java.time.Duration): javadsl.SubSource[java.util.List[Out @uncheckedVariance], Mat] =
+      duration: java.time.Duration): javadsl.SubSource[java.util.List[Out], Mat] =
     new SubSource(delegate.groupedWeightedWithin(maxWeight, maxNumber, duration.asScala)(costFn.apply).map(_.asJava))
 
   /**
@@ -1321,7 +1320,7 @@ class SubSource[Out, Mat](
    *                    on the original, to be emitted in case downstream signals demand.
    * @see [[#expand]]
    */
-  def extrapolate(extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]])
+  def extrapolate(extrapolator: function.Function[Out, java.util.Iterator[Out]])
       : SubSource[Out, Mat] =
     new SubSource(delegate.extrapolate(in => extrapolator(in).asScala))
 
@@ -1351,8 +1350,8 @@ class SubSource[Out, Mat](
    * @see [[#expand]]
    */
   def extrapolate(
-      extrapolator: function.Function[Out @uncheckedVariance, java.util.Iterator[Out @uncheckedVariance]],
-      initial: Out @uncheckedVariance): SubSource[Out, Mat] =
+      extrapolator: function.Function[Out, java.util.Iterator[Out]],
+      initial: Out): SubSource[Out, Mat] =
     new SubSource(delegate.extrapolate(in => extrapolator(in).asScala, Some(initial)))
 
   /**
@@ -1401,7 +1400,7 @@ class SubSource[Out, Mat](
    * '''Cancels when''' downstream cancels or substream cancels
    */
   def prefixAndTail(n: Int): SubSource[
-    akka.japi.Pair[java.util.List[Out @uncheckedVariance], javadsl.Source[Out @uncheckedVariance, NotUsed]],
+    akka.japi.Pair[java.util.List[Out], javadsl.Source[Out, NotUsed]],
     Mat] =
     new SubSource(delegate.prefixAndTail(n).map { case (taken, tail) => akka.japi.Pair(taken.asJava, tail.asJava) })
 
@@ -1700,7 +1699,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def zip[T](source: Graph[SourceShape[T], _]): SubSource[akka.japi.Pair[Out @uncheckedVariance, T], Mat] =
+  def zip[T](source: Graph[SourceShape[T], _]): SubSource[akka.japi.Pair[Out, T], Mat] =
     new SubSource(delegate.zip(source).map { case (o, t) => akka.japi.Pair.create(o, t) })
 
   /**
@@ -1732,7 +1731,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipLatest[T](source: Graph[SourceShape[T], _]): SubSource[akka.japi.Pair[Out @uncheckedVariance, T], Mat] =
+  def zipLatest[T](source: Graph[SourceShape[T], _]): SubSource[akka.japi.Pair[Out, T], Mat] =
     new SubSource(delegate.zipLatest(source).map { case (o, t) => akka.japi.Pair.create(o, t) })
 
   /**
@@ -1782,7 +1781,7 @@ class SubSource[Out, Mat](
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipWithIndex: javadsl.SubSource[akka.japi.Pair[Out @uncheckedVariance, Long], Mat] =
+  def zipWithIndex: javadsl.SubSource[akka.japi.Pair[Out, Long], Mat] =
     new SubSource(delegate.zipWithIndex.map { case (elem, index) => akka.japi.Pair(elem, index) })
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/BidiFlow.scala
@@ -232,8 +232,8 @@ object BidiFlow {
    */
   def fromGraph[I1, O1, I2, O2, Mat](graph: Graph[BidiShape[I1, O1, I2, O2], Mat]): BidiFlow[I1, O1, I2, O2, Mat] =
     graph match {
-      case bidi: BidiFlow[I1, O1, I2, O2, Mat]         => bidi
-      case bidi: javadsl.BidiFlow[I1, O1, I2, O2, Mat] => bidi.asScala
+      case bidi: BidiFlow[I1, O1, I2, O2, Mat]                    => bidi
+      case bidi: javadsl.BidiFlow[I1, O1, I2, O2, Mat] @unchecked => bidi.asScala
       case other =>
         new BidiFlow(other.traversalBuilder, other.shape)
     }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -5,6 +5,7 @@
 package akka.stream.scaladsl
 
 import scala.annotation.implicitNotFound
+import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -45,11 +46,11 @@ final class Flow[-In, +Out, +Mat](
   // TODO: debug string
   override def toString: String = s"Flow($shape)"
 
-  override protected[this] type Repr[+O] = Flow[In, O, Mat]
-  override protected[this] type ReprMat[+O, +M] = Flow[In, O, M]
+  override /*protected[this]*/ type Repr[+O] = Flow[In @uncheckedVariance, O, Mat @uncheckedVariance]
+  override /*protected[this]*/ type ReprMat[+O, +M] = Flow[In @uncheckedVariance, O, M]
 
-  override protected[this] type Closed = Sink[In, Mat]
-  override protected[this] type ClosedMat[+M] = Sink[In, M]
+  override /*protected[this]*/ type Closed = Sink[In @uncheckedVariance, Mat @uncheckedVariance]
+  override /*protected[this]*/ type ClosedMat[+M] = Sink[In @uncheckedVariance, M]
 
   private[stream] def isIdentity: Boolean = this.traversalBuilder eq Flow.identityTraversalBuilder
 
@@ -334,7 +335,8 @@ final class Flow[-In, +Out, +Mat](
         .map(e => (e, extractContext(e))))
 
   /** Converts this Scala DSL element to it's Java DSL counterpart. */
-  def asJava: javadsl.Flow[In, Out, Mat] = new javadsl.Flow(this)
+  def asJava: javadsl.Flow[In, Out, Mat] =
+    new javadsl.Flow(this)
 }
 
 object Flow {
@@ -796,13 +798,13 @@ trait FlowOps[+Out, +Mat] {
   import GraphDSL.Implicits._
   import akka.stream.impl.Stages._
 
-  protected[this] type Repr[+O] <: FlowOps[O, Mat] {
+  /*protected[this]*/ type Repr[+O] <: FlowOps[O, Mat] {
     type Repr[+OO] = FlowOps.this.Repr[OO]
     type Closed = FlowOps.this.Closed
   }
 
   // result of closing a Source is RunnableGraph, closing a Flow is Sink
-  protected[this] type Closed
+  /*protected[this]*/ type Closed
 
   /**
    * Transform this [[Flow]] by appending the given processing steps.
@@ -3224,20 +3226,20 @@ trait FlowOps[+Out, +Mat] {
  */
 trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
 
-  protected[this] type Repr[+O] <: ReprMat[O, Mat] {
+  /*protected[this]*/ type Repr[+O] <: ReprMat[O, Mat] {
     type Repr[+OO] = FlowOpsMat.this.Repr[OO]
     type ReprMat[+OO, +MM] = FlowOpsMat.this.ReprMat[OO, MM]
     type Closed = FlowOpsMat.this.Closed
     type ClosedMat[+M] = FlowOpsMat.this.ClosedMat[M]
   }
-  protected[this] type ReprMat[+O, +M] <: FlowOpsMat[O, M] {
-    type Repr[+OO] <: FlowOpsMat.this.ReprMat[OO, M]
+  /*protected[this]*/ type ReprMat[+O, +M] <: FlowOpsMat[O, M] {
+    type Repr[+OO] = FlowOpsMat.this.ReprMat[OO, M @uncheckedVariance]
 
     type ReprMat[+OO, +MM] = FlowOpsMat.this.ReprMat[OO, MM]
-    type Closed <: FlowOpsMat.this.ClosedMat[M]
+    type Closed = FlowOpsMat.this.ClosedMat[M @uncheckedVariance]
     type ClosedMat[+MM] = FlowOpsMat.this.ClosedMat[MM]
   }
-  protected[this] type ClosedMat[+M] <: Graph[_, M]
+  /*protected[this]*/ type ClosedMat[+M] <: Graph[_, M]
 
   /**
    * Transform this [[Flow]] by appending the given processing steps.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -2679,8 +2679,8 @@ trait FlowOps[+Out, +Mat] {
       thisElem: A,
       thatElem: U): Flow[Out @uncheckedVariance, (A, U), Mat2] = {
     case object passedEnd
-    val passedEndSrc = Source.repeat(passedEnd)
-    val left: Flow[Out, Any, NotUsed] = Flow[A].concat(passedEndSrc)
+    val passedEndSrc = Source.repeat[Any](passedEnd)
+    val left: Flow[Out, Any, NotUsed] = Flow[Any].concat(passedEndSrc)
     val right: Source[Any, Mat2] = Source.fromGraph(that).concat(passedEndSrc)
     val zipFlow: Flow[Out, (A, U), Mat2] = left
       .zipMat(right)(Keep.right)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContext.scala
@@ -4,8 +4,6 @@
 
 package akka.stream.scaladsl
 
-import scala.annotation.unchecked.uncheckedVariance
-
 import akka.NotUsed
 import akka.japi.Pair
 import akka.stream._
@@ -40,8 +38,7 @@ object FlowWithContext {
 final class FlowWithContext[-In, -CtxIn, +Out, +CtxOut, +Mat](delegate: Flow[(In, CtxIn), (Out, CtxOut), Mat])
     extends GraphDelegate(delegate)
     with FlowWithContextOps[Out, CtxOut, Mat] {
-  override type ReprMat[+O, +C, +M] =
-    FlowWithContext[In @uncheckedVariance, CtxIn @uncheckedVariance, O, C, M @uncheckedVariance]
+  override protected[this] type ReprMat[+O, +C, +M] = FlowWithContext[In, CtxIn, O, C, M]
 
   override def via[Out2, Ctx2, Mat2](viaFlow: Graph[FlowShape[(Out, CtxOut), (Out2, Ctx2)], Mat2]): Repr[Out2, Ctx2] =
     new FlowWithContext(delegate.via(viaFlow))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContext.scala
@@ -4,6 +4,8 @@
 
 package akka.stream.scaladsl
 
+import scala.annotation.unchecked.uncheckedVariance
+
 import akka.NotUsed
 import akka.japi.Pair
 import akka.stream._
@@ -38,7 +40,7 @@ object FlowWithContext {
 final class FlowWithContext[-In, -CtxIn, +Out, +CtxOut, +Mat](delegate: Flow[(In, CtxIn), (Out, CtxOut), Mat])
     extends GraphDelegate(delegate)
     with FlowWithContextOps[Out, CtxOut, Mat] {
-  override protected[this] type ReprMat[+O, +C, +M] = FlowWithContext[In, CtxIn, O, C, M]
+  override /*protected[this]*/ type ReprMat[+O, +C, +M] = FlowWithContext[In @uncheckedVariance, CtxIn @uncheckedVariance, O, C, M]
 
   override def via[Out2, Ctx2, Mat2](viaFlow: Graph[FlowShape[(Out, CtxOut), (Out2, Ctx2)], Mat2]): Repr[Out2, Ctx2] =
     new FlowWithContext(delegate.via(viaFlow))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
@@ -4,6 +4,7 @@
 
 package akka.stream.scaladsl
 
+import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -22,10 +23,10 @@ import ccompat._
  */
 @ccompatUsedUntil213
 trait FlowWithContextOps[+Out, +Ctx, +Mat] {
-  protected[this] type ReprMat[+O, +C, +M] <: FlowWithContextOps[O, C, M] {
+  /*protected[this]*/ type ReprMat[+O, +C, +M] <: FlowWithContextOps[O, C, M] {
     type ReprMat[+OO, +CC, +MatMat] = FlowWithContextOps.this.ReprMat[OO, CC, MatMat]
   }
-  protected[this] type Repr[+O, +C] = ReprMat[O, C, Mat]
+  /*protected[this]*/ type Repr[+O, +C] = ReprMat[O, C, Mat @uncheckedVariance]
 
   /**
    * Transform this flow by the regular flow. The given flow must support manual context propagation by

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
@@ -190,7 +190,7 @@ trait FlowWithContextOps[+Out, +Ctx, +Mat] {
    *
    * @see [[akka.stream.scaladsl.FlowOps.log]]
    */
-  def log(name: String, extract: Out => Any = ConstantFun.scalaIdentityFunction)(
+  def log(name: String, extract: Out @uncheckedVariance => Any = ConstantFun.scalaIdentityFunction)(
       implicit log: LoggingAdapter = null): Repr[Out, Ctx] = {
     val extractWithContext: ((Out, Ctx)) => Any = { case (e, _) => extract(e) }
     via(flow.log(name, extractWithContext)(log))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
@@ -4,7 +4,6 @@
 
 package akka.stream.scaladsl
 
-import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -23,10 +22,10 @@ import ccompat._
  */
 @ccompatUsedUntil213
 trait FlowWithContextOps[+Out, +Ctx, +Mat] {
-  type ReprMat[+O, +C, +M] <: FlowWithContextOps[O, C, M] {
+  protected[this] type ReprMat[+O, +C, +M] <: FlowWithContextOps[O, C, M] {
     type ReprMat[+OO, +CC, +MatMat] = FlowWithContextOps.this.ReprMat[OO, CC, MatMat]
   }
-  type Repr[+O, +C] = ReprMat[O, C, Mat @uncheckedVariance]
+  protected[this] type Repr[+O, +C] = ReprMat[O, C, Mat]
 
   /**
    * Transform this flow by the regular flow. The given flow must support manual context propagation by

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Framing.scala
@@ -178,7 +178,7 @@ object Framing {
         setHandlers(in, out, this)
 
         override def onPush(): Unit = {
-          val message = grab(in)
+          val message: ByteString = grab(in)
           val msgSize = message.size
 
           if (msgSize > maximumMessageLength)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -1574,7 +1574,7 @@ object GraphDSL extends GraphApply {
      * connected.
      */
     // FIXME source incompatible change for Scala 3 adding the M type parameter
-    def add[S <: Shape, M](graph: Graph[S, M]): S = {
+    def add[S <: Shape, M2](graph: Graph[S, M2]): S = {
       val newShape = graph.shape.deepCopy()
       traversalBuilderInProgress = traversalBuilderInProgress.add(graph.traversalBuilder, newShape, Keep.left)
 
@@ -1590,7 +1590,7 @@ object GraphDSL extends GraphApply {
      * This is only used by the materialization-importing apply methods of Source,
      * Flow, Sink and Graph.
      */
-    private[stream] def add[S <: Shape, A, M](graph: Graph[S, M], transform: (A) => Any): S = {
+    private[stream] def add[S <: Shape, A, M2](graph: Graph[S, M2], transform: (A) => Any): S = {
       val newShape = graph.shape.deepCopy()
       traversalBuilderInProgress =
         traversalBuilderInProgress.add(graph.traversalBuilder.transformMat(transform), newShape, Keep.right)
@@ -1607,7 +1607,7 @@ object GraphDSL extends GraphApply {
      * This is only used by the materialization-importing apply methods of Source,
      * Flow, Sink and Graph.
      */
-    private[stream] def add[S <: Shape, A, B, M](graph: Graph[S, M], combine: (A, B) => Any): S = {
+    private[stream] def add[S <: Shape, A, B, M2](graph: Graph[S, M2], combine: (A, B) => Any): S = {
       val newShape = graph.shape.deepCopy()
       traversalBuilderInProgress = traversalBuilderInProgress.add(graph.traversalBuilder, newShape, combine)
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -1573,7 +1573,8 @@ object GraphDSL extends GraphApply {
      * materialized value and returning the copied Ports that are now to be
      * connected.
      */
-    def add[S <: Shape](graph: Graph[S, _]): S = {
+    // FIXME source incompatible change for Scala 3 adding the M type parameter
+    def add[S <: Shape, M](graph: Graph[S, M]): S = {
       val newShape = graph.shape.deepCopy()
       traversalBuilderInProgress = traversalBuilderInProgress.add(graph.traversalBuilder, newShape, Keep.left)
 
@@ -1589,7 +1590,7 @@ object GraphDSL extends GraphApply {
      * This is only used by the materialization-importing apply methods of Source,
      * Flow, Sink and Graph.
      */
-    private[stream] def add[S <: Shape, A](graph: Graph[S, _], transform: (A) => Any): S = {
+    private[stream] def add[S <: Shape, A, M](graph: Graph[S, M], transform: (A) => Any): S = {
       val newShape = graph.shape.deepCopy()
       traversalBuilderInProgress =
         traversalBuilderInProgress.add(graph.traversalBuilder.transformMat(transform), newShape, Keep.right)
@@ -1606,7 +1607,7 @@ object GraphDSL extends GraphApply {
      * This is only used by the materialization-importing apply methods of Source,
      * Flow, Sink and Graph.
      */
-    private[stream] def add[S <: Shape, A, B](graph: Graph[S, _], combine: (A, B) => Any): S = {
+    private[stream] def add[S <: Shape, A, B, M](graph: Graph[S, M], combine: (A, B) => Any): S = {
       val newShape = graph.shape.deepCopy()
       traversalBuilderInProgress = traversalBuilderInProgress.add(graph.traversalBuilder, newShape, combine)
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Hub.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Hub.scala
@@ -163,7 +163,7 @@ private[akka] class MergeHub[T](perProducerBufferSize: Int)
     def isShuttingDown: Boolean = shuttingDown
 
     // External API
-    def enqueue(ev: Event): Unit = {
+    private[MergeHub] def enqueue(ev: Event): Unit = {
       queue.add(ev)
       /*
        * Simple volatile var is enough, there is no need for a CAS here. The first important thing to note

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Hub.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Hub.scala
@@ -206,8 +206,8 @@ private[akka] class MergeHub[T](perProducerBufferSize: Int)
       var event = queue.poll()
       while (event ne null) {
         event match {
-          case Register(_, demandCallback) => demandCallback.invoke(MergeHub.Cancel)
-          case _                           =>
+          case Register(_, demandCallback)   => demandCallback.invoke(MergeHub.Cancel)
+          case Element(_, _) | Deregister(_) =>
         }
         event = queue.poll()
       }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -5,7 +5,6 @@
 package akka.stream.scaladsl
 
 import scala.annotation.tailrec
-import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -124,7 +123,7 @@ final class Sink[-In, +Mat](override val traversalBuilder: LinearTraversalBuilde
   /**
    * Converts this Scala DSL element to it's Java DSL counterpart.
    */
-  def asJava[JIn <: In]: javadsl.Sink[JIn, Mat @uncheckedVariance] = new javadsl.Sink(this)
+  def asJava: javadsl.Sink[In, Mat] = new javadsl.Sink(this)
 }
 
 object Sink {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -139,7 +139,7 @@ object Sink {
   def fromGraph[T, M](g: Graph[SinkShape[T], M]): Sink[T, M] =
     g match {
       case s: Sink[T, M]                                       => s
-      case s: javadsl.Sink[T, M]                               => s.asScala
+      case s: javadsl.Sink[T, M] @unchecked                    => s.asScala
       case g: GraphStageWithMaterializedValue[SinkShape[T], M] =>
         // move these from the stage itself to make the returned source
         // behave as it is the stage with regards to attributes

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Sink.scala
@@ -572,7 +572,7 @@ object Sink {
       onInitMessage: Any,
       ackMessage: Any,
       onCompleteMessage: Any,
-      onFailureMessage: (Throwable) => Any = Status.Failure): Sink[T, NotUsed] =
+      onFailureMessage: (Throwable) => Any = Status.Failure.apply): Sink[T, NotUsed] =
     actorRefWithAck(ref, _ => identity, _ => onInitMessage, Some(ackMessage), onCompleteMessage, onFailureMessage)
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -7,7 +7,6 @@ package akka.stream.scaladsl
 import java.util.concurrent.CompletionStage
 
 import scala.annotation.tailrec
-import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.{ Future, Promise }
@@ -34,15 +33,12 @@ import akka.util.ConstantFun
  */
 final class Source[+Out, +Mat](
     override val traversalBuilder: LinearTraversalBuilder,
-    override val shape: SourceShape[Out])
-    extends FlowOpsMat[Out, Mat]
-    with Graph[SourceShape[Out], Mat] {
-
-  override type Repr[+O] = Source[O, Mat @uncheckedVariance]
-  override type ReprMat[+O, +M] = Source[O, M]
-
-  override type Closed = RunnableGraph[Mat @uncheckedVariance]
-  override type ClosedMat[+M] = RunnableGraph[M]
+    override val shape: SourceShape[Out]
+) extends FlowOpsMat[Out, Mat] with Graph[SourceShape[Out], Mat] {
+  override protected[this] type Repr[+O]        = Source[O, Mat]
+  override protected[this] type ReprMat[+O, +M] = Source[O, M]
+  override protected[this] type Closed          = RunnableGraph[Mat]
+  override protected[this] type ClosedMat[+M]   = RunnableGraph[M]
 
   override def toString: String = s"Source($shape)"
 
@@ -223,7 +219,7 @@ final class Source[+Out, +Mat](
   /**
    * Converts this Scala DSL element to it's Java DSL counterpart.
    */
-  def asJava: javadsl.Source[Out @uncheckedVariance, Mat @uncheckedVariance] = new javadsl.Source(this)
+  def asJava: javadsl.Source[Out, Mat] = new javadsl.Source(this)
 
   /**
    * Combines several sources with fan-in strategy like `Merge` or `Concat` and returns `Source`.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -315,7 +315,7 @@ object Source {
    */
   def fromGraph[T, M](g: Graph[SourceShape[T], M]): Source[T, M] = g match {
     case s: Source[T, M]                                       => s
-    case s: javadsl.Source[T, M]                               => s.asScala
+    case s: javadsl.Source[T, M] @unchecked                    => s.asScala
     case g: GraphStageWithMaterializedValue[SourceShape[T], M] =>
       // move these from the stage itself to make the returned source
       // behave as it is the stage with regards to attributes

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -7,6 +7,7 @@ package akka.stream.scaladsl
 import java.util.concurrent.CompletionStage
 
 import scala.annotation.tailrec
+import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.{ Future, Promise }
@@ -35,10 +36,10 @@ final class Source[+Out, +Mat](
     override val traversalBuilder: LinearTraversalBuilder,
     override val shape: SourceShape[Out]
 ) extends FlowOpsMat[Out, Mat] with Graph[SourceShape[Out], Mat] {
-  override protected[this] type Repr[+O]        = Source[O, Mat]
-  override protected[this] type ReprMat[+O, +M] = Source[O, M]
-  override protected[this] type Closed          = RunnableGraph[Mat]
-  override protected[this] type ClosedMat[+M]   = RunnableGraph[M]
+  override /*protected[this]*/ type Repr[+O]        = Source[O, Mat @uncheckedVariance]
+  override /*protected[this]*/ type ReprMat[+O, +M] = Source[O, M]
+  override /*protected[this]*/ type Closed          = RunnableGraph[Mat @uncheckedVariance]
+  override /*protected[this]*/ type ClosedMat[+M]   = RunnableGraph[M]
 
   override def toString: String = s"Source($shape)"
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/SourceWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/SourceWithContext.scala
@@ -4,8 +4,6 @@
 
 package akka.stream.scaladsl
 
-import scala.annotation.unchecked.uncheckedVariance
-
 import akka.stream._
 
 object SourceWithContext {
@@ -28,7 +26,7 @@ object SourceWithContext {
 final class SourceWithContext[+Out, +Ctx, +Mat] private[stream] (delegate: Source[(Out, Ctx), Mat])
     extends GraphDelegate(delegate)
     with FlowWithContextOps[Out, Ctx, Mat] {
-  override type ReprMat[+O, +C, +M] = SourceWithContext[O, C, M @uncheckedVariance]
+  override protected[this] type ReprMat[+O, +C, +M] = SourceWithContext[O, C, M]
 
   override def via[Out2, Ctx2, Mat2](viaFlow: Graph[FlowShape[(Out, Ctx), (Out2, Ctx2)], Mat2]): Repr[Out2, Ctx2] =
     new SourceWithContext(delegate.via(viaFlow))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/SourceWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/SourceWithContext.scala
@@ -26,7 +26,7 @@ object SourceWithContext {
 final class SourceWithContext[+Out, +Ctx, +Mat] private[stream] (delegate: Source[(Out, Ctx), Mat])
     extends GraphDelegate(delegate)
     with FlowWithContextOps[Out, Ctx, Mat] {
-  override protected[this] type ReprMat[+O, +C, +M] = SourceWithContext[O, C, M]
+  override /*protected[this]*/ type ReprMat[+O, +C, +M] = SourceWithContext[O, C, M]
 
   override def via[Out2, Ctx2, Mat2](viaFlow: Graph[FlowShape[(Out, Ctx), (Out2, Ctx2)], Mat2]): Repr[Out2, Ctx2] =
     new SourceWithContext(delegate.via(viaFlow))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/StreamConverters.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/StreamConverters.scala
@@ -153,7 +153,7 @@ object StreamConverters {
 
           merge.out
             .fold(new FirstReducerState(factory): ReducerState[T, R]) { (state, elem) =>
-              state.update(elem.accumulated())
+              state.update(elem.accumulated)
             }
             .map(state => state.finish()) ~> sink.in
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/SubFlow.scala
@@ -4,6 +4,8 @@
 
 package akka.stream.scaladsl
 
+import scala.annotation.unchecked.uncheckedVariance
+
 import akka.stream._
 
 /**
@@ -13,8 +15,8 @@ import akka.stream._
  */
 trait SubFlow[+Out, +Mat, +F[+_], +C] extends FlowOps[Out, Mat] {
 
-  override protected[this] type Repr[+T] = SubFlow[T, Mat, F, C]
-  override protected[this] type Closed = C
+  override /*protected[this]*/ type Repr[+T] = SubFlow[T, Mat @uncheckedVariance, F @uncheckedVariance, C @uncheckedVariance]
+  override /*protected[this]*/ type Closed = C @uncheckedVariance
 
   /**
    * Attach a [[Sink]] to each sub-flow, closing the overall Graph that is being

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/SubFlow.scala
@@ -4,8 +4,6 @@
 
 package akka.stream.scaladsl
 
-import scala.annotation.unchecked.uncheckedVariance
-
 import akka.stream._
 
 /**
@@ -13,10 +11,10 @@ import akka.stream._
  * SubFlows cannot contribute to the super-flow’s materialized value since they
  * are materialized later, during the runtime of the flow graph processing.
  */
-trait SubFlow[+Out, +Mat, +F[+_], C] extends FlowOps[Out, Mat] {
+trait SubFlow[+Out, +Mat, +F[+_], +C] extends FlowOps[Out, Mat] {
 
-  override type Repr[+T] = SubFlow[T, Mat @uncheckedVariance, F @uncheckedVariance, C @uncheckedVariance]
-  override type Closed = C
+  override protected[this] type Repr[+T] = SubFlow[T, Mat, F, C]
+  override protected[this] type Closed = C
 
   /**
    * Attach a [[Sink]] to each sub-flow, closing the overall Graph that is being

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
@@ -79,8 +79,6 @@ object Tcp extends ExtensionId[Tcp] with ExtensionIdProvider {
    */
   final case class OutgoingConnection(remoteAddress: InetSocketAddress, localAddress: InetSocketAddress)
 
-  def apply()(implicit system: ActorSystem): Tcp = super.apply(system)
-
   override def get(system: ActorSystem): Tcp = super.get(system)
   override def get(system: ClassicActorSystemProvider): Tcp = super.get(system)
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
@@ -79,6 +79,8 @@ object Tcp extends ExtensionId[Tcp] with ExtensionIdProvider {
    */
   final case class OutgoingConnection(remoteAddress: InetSocketAddress, localAddress: InetSocketAddress)
 
+  def apply()(implicit system: ActorSystem): Tcp = super.apply(system)
+
   override def get(system: ActorSystem): Tcp = super.get(system)
   override def get(system: ClassicActorSystemProvider): Tcp = super.get(system)
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
@@ -90,7 +90,7 @@ object Tcp extends ExtensionId[Tcp] with ExtensionIdProvider {
 
   // just wraps/unwraps the TLS byte events to provide ByteString, ByteString flows
   private val tlsWrapping: BidiFlow[ByteString, TLSProtocol.SendBytes, TLSProtocol.SslTlsInbound, ByteString, NotUsed] =
-    BidiFlow.fromFlows(Flow[ByteString].map(TLSProtocol.SendBytes), Flow[TLSProtocol.SslTlsInbound].collect {
+    BidiFlow.fromFlows(Flow[ByteString].map(TLSProtocol.SendBytes.apply), Flow[TLSProtocol.SslTlsInbound].collect {
       case sb: TLSProtocol.SessionBytes => sb.bytes
       // ignore other kinds of inbounds (currently only Truncated)
     })

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -282,7 +282,7 @@ private[akka] object ConcurrentAsyncCallbackState {
   // stream is initialized and so no threads can just send events without any synchronization overhead
   case object Initialized extends State[Nothing]
   // Event with feedback promise
-  final case class Event[E](e: E, handlingPromise: Promise[Done])
+  final case class Event[+E](e: E, handlingPromise: Promise[Done])
 
   val NoPendingEvents = Pending[Nothing](Nil)
 }

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -1243,7 +1243,7 @@ abstract class GraphStageLogic private[stream] (val inCount: Int, val outCount: 
           // started - can just dispatch async message to interpreter
           onAsyncInput(event, promise)
 
-        case list @ Pending(l) =>
+        case list @ Pending(l: List[Event[T]]) =>
           // not started yet
           if (!currentState.compareAndSet(list, Pending[T](Event[T](event, promise) :: l)))
             invokeWithPromise(event, promise)

--- a/akka-stream/src/main/scala/akka/stream/stage/StageLogging.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/StageLogging.scala
@@ -30,7 +30,7 @@ trait StageLogging { self: GraphStageLogic =>
     if (_log eq null) {
       materializer match {
         case p: MaterializerLoggingProvider =>
-          _log = p.makeLogger(logSource)
+          _log = p.makeLogger(logSource.asInstanceOf[Class[Any]])
         case _ =>
           _log = NoLogging
       }

--- a/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/AkkaSSLConfig.scala
+++ b/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/AkkaSSLConfig.scala
@@ -44,7 +44,7 @@ final class AkkaSSLConfig(system: ExtendedActorSystem, val config: SSLConfigSett
 
   private val mkLogger = new AkkaLoggerFactory(system)
 
-  private val log = Logging(system, getClass)
+  private val log = Logging(system, classOf[AkkaSSLConfig])
   log.debug("Initializing AkkaSSLConfig extension...")
 
   /** Can be used to modify the underlying config, most typically used to change a few values in the default config */

--- a/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/AkkaSSLConfig.scala
+++ b/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/AkkaSSLConfig.scala
@@ -24,7 +24,6 @@ object AkkaSSLConfig extends ExtensionId[AkkaSSLConfig] with ExtensionIdProvider
 
   override def get(system: ActorSystem): AkkaSSLConfig = super.get(system)
   override def get(system: ClassicActorSystemProvider): AkkaSSLConfig = super.get(system)
-  def apply()(implicit system: ActorSystem): AkkaSSLConfig = super.apply(system)
 
   override def lookup = AkkaSSLConfig
 


### PR DESCRIPTION
This is a continuation of #30174, where I added 2 commits:
the first of which goes all the way to remove all the uncheckedVariance usages
by fixing all the variance issues around that (every single method..).

The second commit goes back to make sure it compiles on Scala 3
where I found out that `protected[this]` doesn't work in Scala 3 like it does in Scala 2,
where it suppresses the variance problems.  So I added the annotations again,
and made the types public again (needlessly, probably).
I also had to undo a `<:` usage fix...

Fixing all the variance issues means changing the method signatures,
which means source-compatibility.  Understanding which ones are acceptable or not
is something that only an Akka maintainer can do, so I leave this PR in your hands,
take/amend/squash/cherry-pick any parts of it as you please.

Refs #30243