### PR TITLE
Remove usage of Java assert in tests (#30220)

### DIFF
--- a/akka-actor-tests/src/test/java/akka/util/JavaDuration.java
+++ b/akka-actor-tests/src/test/java/akka/util/JavaDuration.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import org.scalatestplus.junit.JUnitSuite;
 import scala.concurrent.duration.Duration;
 
+import static org.junit.Assert.assertTrue;
+
 public class JavaDuration extends JUnitSuite {
 
   @Test
@@ -15,8 +17,8 @@ public class JavaDuration extends JUnitSuite {
     final Duration fivesec = Duration.create(5, "seconds");
     final Duration threemillis = Duration.create("3 millis");
     final Duration diff = fivesec.minus(threemillis);
-    assert diff.lt(fivesec);
-    assert Duration.Zero().lteq(Duration.Inf());
-    assert Duration.Inf().gt(Duration.Zero().neg());
+    assertTrue(diff.lt(fivesec));
+    assertTrue(Duration.Zero().lteq(Duration.Inf()));
+    assertTrue(Duration.Inf().gt(Duration.Zero().neg()));
   }
 }

--- a/akka-docs/src/test/java/jdocs/actor/FaultHandlingTest.java
+++ b/akka-docs/src/test/java/jdocs/actor/FaultHandlingTest.java
@@ -22,6 +22,8 @@ import akka.testkit.EventFilter;
 import akka.testkit.TestEvent;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static akka.japi.Util.immutableSeq;
+import static org.junit.Assert.assertEquals;
+
 import scala.concurrent.Await;
 
 // #testkit
@@ -182,14 +184,14 @@ public class FaultHandlingTest extends AbstractJavaTest {
 
     // #resume
     child.tell(42, ActorRef.noSender());
-    assert Await.result(ask(child, "get", 5000), timeout).equals(42);
+    assertEquals(42, Await.result(ask(child, "get", 5000), timeout));
     child.tell(new ArithmeticException(), ActorRef.noSender());
-    assert Await.result(ask(child, "get", 5000), timeout).equals(42);
+    assertEquals(42, Await.result(ask(child, "get", 5000), timeout));
     // #resume
 
     // #restart
     child.tell(new NullPointerException(), ActorRef.noSender());
-    assert Await.result(ask(child, "get", 5000), timeout).equals(0);
+    assertEquals(0, Await.result(ask(child, "get", 5000), timeout));
     // #restart
 
     // #stop
@@ -202,7 +204,7 @@ public class FaultHandlingTest extends AbstractJavaTest {
     // #escalate-kill
     child = (ActorRef) Await.result(ask(supervisor, Props.create(Child.class), 5000), timeout);
     probe.watch(child);
-    assert Await.result(ask(child, "get", 5000), timeout).equals(0);
+    assertEquals(0, Await.result(ask(child, "get", 5000), timeout));
     child.tell(new Exception(), ActorRef.noSender());
     probe.expectMsgClass(Terminated.class);
     // #escalate-kill
@@ -212,9 +214,9 @@ public class FaultHandlingTest extends AbstractJavaTest {
     supervisor = system.actorOf(superprops);
     child = (ActorRef) Await.result(ask(supervisor, Props.create(Child.class), 5000), timeout);
     child.tell(23, ActorRef.noSender());
-    assert Await.result(ask(child, "get", 5000), timeout).equals(23);
+    assertEquals(23, Await.result(ask(child, "get", 5000), timeout));
     child.tell(new Exception(), ActorRef.noSender());
-    assert Await.result(ask(child, "get", 5000), timeout).equals(0);
+    assertEquals(0, Await.result(ask(child, "get", 5000), timeout));
     // #escalate-restart
     // #testkit
   }

--- a/akka-docs/src/test/java/jdocs/duration/Java.java
+++ b/akka-docs/src/test/java/jdocs/duration/Java.java
@@ -7,6 +7,8 @@ package jdocs.duration;
 // #import
 import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.Deadline;
+
+import static org.junit.Assert.assertTrue;
 // #import
 
 class Java {
@@ -15,8 +17,8 @@ class Java {
     final Duration fivesec = Duration.create(5, "seconds");
     final Duration threemillis = Duration.create("3 millis");
     final Duration diff = fivesec.minus(threemillis);
-    assert diff.lt(fivesec);
-    assert Duration.Zero().lt(Duration.Inf());
+    assertTrue(diff.lt(fivesec));
+    assertTrue(Duration.Zero().lt(Duration.Inf()));
     // #dsl
     // #deadline
     final Deadline deadline = Duration.create(10, "seconds").fromNow();

--- a/akka-docs/src/test/java/jdocs/io/japi/EchoHandler.java
+++ b/akka-docs/src/test/java/jdocs/io/japi/EchoHandler.java
@@ -21,6 +21,9 @@ import akka.io.Tcp.WritingResumed;
 import akka.io.TcpMessage;
 import akka.util.ByteString;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 // #echo-handler
 public class EchoHandler extends AbstractActor {
 
@@ -36,7 +39,7 @@ public class EchoHandler extends AbstractActor {
   private long transferred;
   private int storageOffset = 0;
   private long stored = 0;
-  private Queue<ByteString> storage = new LinkedList<ByteString>();
+  private Queue<ByteString> storage = new LinkedList<>();
 
   private boolean suspended = false;
 
@@ -220,8 +223,8 @@ public class EchoHandler extends AbstractActor {
   }
 
   protected void acknowledge(int ack) {
-    assert ack == storageOffset;
-    assert !storage.isEmpty();
+    assertEquals(storageOffset, ack);
+    assertFalse(storage.isEmpty());
 
     final ByteString acked = storage.remove();
     stored -= acked.size();

--- a/akka-docs/src/test/java/jdocs/io/japi/IODocTest.java
+++ b/akka-docs/src/test/java/jdocs/io/japi/IODocTest.java
@@ -28,6 +28,9 @@ import akka.util.ByteString;
 
 import akka.testkit.AkkaSpec;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class IODocTest extends AbstractJavaTest {
 
   public
@@ -186,12 +189,12 @@ public class IODocTest extends AbstractJavaTest {
 
         final Connected c1 = expectMsgClass(Connected.class);
         final Connected c2 = expectMsgClass(Connected.class);
-        assert c1.localAddress().equals(c2.remoteAddress());
-        assert c2.localAddress().equals(c1.remoteAddress());
+        assertTrue(c1.localAddress().equals(c2.remoteAddress()));
+        assertTrue(c2.localAddress().equals(c1.remoteAddress()));
 
         client.tell(ByteString.fromString("hello"), getRef());
         final ByteString reply = expectMsgClass(ByteString.class);
-        assert reply.utf8String().equals("hello");
+        assertEquals("hello", reply.utf8String());
 
         watch(client);
         client.tell("close", getRef());

--- a/akka-docs/src/test/java/jdocs/stream/StreamTestKitDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/StreamTestKitDocTest.java
@@ -20,6 +20,7 @@ import jdocs.AbstractJavaTest;
 import akka.testkit.javadsl.TestKit;
 import org.junit.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import akka.actor.*;
 import akka.japi.Pair;
@@ -54,7 +55,7 @@ public class StreamTestKitDocTest extends AbstractJavaTest {
     final CompletionStage<Integer> future =
         Source.from(Arrays.asList(1, 2, 3, 4)).runWith(sinkUnderTest, system);
     final Integer result = future.toCompletableFuture().get(3, TimeUnit.SECONDS);
-    assert (result == 20);
+    assertEquals(20, result.intValue());
     // #strict-collection
   }
 
@@ -66,7 +67,7 @@ public class StreamTestKitDocTest extends AbstractJavaTest {
     final CompletionStage<List<Integer>> future =
         sourceUnderTest.take(10).runWith(Sink.seq(), system);
     final List<Integer> result = future.toCompletableFuture().get(3, TimeUnit.SECONDS);
-    assertEquals(result, Collections.nCopies(10, 2));
+    assertEquals(Collections.nCopies(10, 2), result);
     // #grouped-infinite
   }
 
@@ -81,7 +82,7 @@ public class StreamTestKitDocTest extends AbstractJavaTest {
             .via(flowUnderTest)
             .runWith(Sink.fold(0, (agg, next) -> agg + next), system);
     final Integer result = future.toCompletableFuture().get(3, TimeUnit.SECONDS);
-    assert (result == 10);
+    assertEquals(10, result.intValue());
     // #folded-stream
   }
 
@@ -151,7 +152,7 @@ public class StreamTestKitDocTest extends AbstractJavaTest {
     ref.tell(Done.getInstance(), ActorRef.noSender());
 
     final String result = future.toCompletableFuture().get(1, TimeUnit.SECONDS);
-    assertEquals(result, "123");
+    assertEquals("123", result);
     // #source-actorref
   }
 
@@ -192,13 +193,10 @@ public class StreamTestKitDocTest extends AbstractJavaTest {
     final CompletionStage<Integer> future = probeAndCompletionStage.second();
     probe.sendError(new Exception("boom"));
 
-    try {
-      future.toCompletableFuture().get(3, TimeUnit.SECONDS);
-      assert false;
-    } catch (ExecutionException ee) {
-      final Throwable exception = ee.getCause();
-      assertEquals(exception.getMessage(), "boom");
-    }
+    ExecutionException exception =
+        Assert.assertThrows(
+            ExecutionException.class, () -> future.toCompletableFuture().get(3, TimeUnit.SECONDS));
+    assertEquals("boom", exception.getCause().getMessage());
     // #injecting-failure
   }
 
@@ -232,7 +230,7 @@ public class StreamTestKitDocTest extends AbstractJavaTest {
 
     pub.sendError(new Exception("Power surge in the linear subroutine C-47!"));
     final Throwable ex = sub.expectError();
-    assert (ex.getMessage().contains("C-47"));
+    assertTrue(ex.getMessage().contains("C-47"));
     // #test-source-and-sink
   }
 }

--- a/akka-persistence-typed-tests/src/test/java/jdocs/akka/persistence/typed/ReplicatedAuctionExampleTest.java
+++ b/akka-persistence-typed-tests/src/test/java/jdocs/akka/persistence/typed/ReplicatedAuctionExampleTest.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 
 import static jdocs.akka.persistence.typed.AuctionEntity.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ReplicatedAuctionExampleTest extends JUnitSuite {
   @ClassRule
@@ -210,15 +211,15 @@ class AuctionEntity
     }
 
     AuctionState withNewHighestBid(Bid bid) {
-      assert (stillRunning);
-      assert (isHigherBid(bid, highestBid));
+      assertTrue(stillRunning);
+      assertTrue(isHigherBid(bid, highestBid));
       return new AuctionState(
           stillRunning, bid, highestBid.offer, finishedAtDc); // keep last highest bid around
     }
 
     AuctionState withTooLowBid(Bid bid) {
-      assert (stillRunning);
-      assert (isHigherBid(highestBid, bid));
+      assertTrue(stillRunning);
+      assertTrue(isHigherBid(highestBid, bid));
       return new AuctionState(
           stillRunning, highestBid, Math.max(highestCounterOffer, bid.offer), finishedAtDc);
     }

--- a/akka-stream-tests/src/test/java/akka/stream/javadsl/SinkTest.java
+++ b/akka-stream-tests/src/test/java/akka/stream/javadsl/SinkTest.java
@@ -39,8 +39,7 @@ public class SinkTest extends StreamTest {
   public void mustBeAbleToUseFanoutPublisher() throws Exception {
     final Sink<Object, Publisher<Object>> pubSink = Sink.asPublisher(AsPublisher.WITH_FANOUT);
     @SuppressWarnings("unused")
-    final Publisher<Object> publisher =
-        Source.from(new ArrayList<Object>()).runWith(pubSink, system);
+    final Publisher<Object> publisher = Source.from(new ArrayList<>()).runWith(pubSink, system);
   }
 
   @Test
@@ -48,7 +47,7 @@ public class SinkTest extends StreamTest {
     final Sink<Integer, CompletionStage<Integer>> futSink = Sink.head();
     final List<Integer> list = Collections.singletonList(1);
     final CompletionStage<Integer> future = Source.from(list).runWith(futSink, system);
-    assert future.toCompletableFuture().get(1, TimeUnit.SECONDS).equals(1);
+    assertEquals(1, future.toCompletableFuture().get(1, TimeUnit.SECONDS).intValue());
   }
 
   @Test
@@ -127,14 +126,14 @@ public class SinkTest extends StreamTest {
         Sink.<String>head().preMaterialize(system);
 
     CompletableFuture<String> future = pair.first().toCompletableFuture();
-    assertEquals(false, future.isDone()); // not yet, only once actually source attached
+    assertFalse(future.isDone()); // not yet, only once actually source attached
 
     String element = "element";
     Source.single(element).runWith(pair.second(), system);
 
     String got = future.get(3, TimeUnit.SECONDS); // should complete nicely
     assertEquals(element, got);
-    assertEquals(true, future.isDone());
+    assertTrue(future.isDone());
   }
 
   public void mustSuitablyOverrideAttributeHandlingMethods() {


### PR DESCRIPTION
References #30220

I removed assert almost everywhere, but some tests failed:
`ActorCreationTest.testWrongAnonymousInPlaceCreator` from [here](https://github.com/akka/akka/pull/30165#issuecomment-831126790)
`RemoteDeploymentDocTest.demonstrateDeployment` I have found

I didn't change them in this PR. I'm going to investigate the tests in my next PR. It can take some time and show some different problems (maybe).

Kind regards