### PR TITLE
Remove unused class SerializedTypedActorInvocationHandler

### DIFF
--- a/akka-actor/src/main/mima-filters/2.6.14.backwards.excludes/pr-30228-remove-unused-internal-SerializedTypedActorInvocationHandler.excludes
+++ b/akka-actor/src/main/mima-filters/2.6.14.backwards.excludes/pr-30228-remove-unused-internal-SerializedTypedActorInvocationHandler.excludes
@@ -1,0 +1,3 @@
+# internals only
+ProblemFilters.exclude[MissingClassProblem]("akka.actor.TypedActor$SerializedTypedActorInvocationHandler")
+ProblemFilters.exclude[MissingClassProblem]("akka.actor.TypedActor$SerializedTypedActorInvocationHandler$")


### PR DESCRIPTION
The private final case class SerializedTypedActorInvocationHandler looks like unused. I removed it and akka compiles  successful. Is it worth to remove it?

Kind regards