### PR TITLE
Fix test ActorCreationTest.testWrongAnonymousInPlaceCreator

### DIFF
--- a/akka-actor-tests/src/test/java/akka/actor/ActorCreationTest.java
+++ b/akka-actor-tests/src/test/java/akka/actor/ActorCreationTest.java
@@ -176,21 +176,21 @@ public class ActorCreationTest extends JUnitSuite {
 
   @Test
   public void testWrongAnonymousInPlaceCreator() {
-    try {
-      Props.create(
-          Actor.class,
-          new Creator<Actor>() {
-            @Override
-            public Actor create() throws Exception {
-              return null;
-            }
-          });
-      assert false;
-    } catch (IllegalArgumentException e) {
-      assertEquals(
-          "cannot use non-static local Creator to create actors; make it static (e.g. local to a static method) or top-level",
-          e.getMessage());
-    }
+    IllegalArgumentException exception =
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                Props.create(
+                    Actor.class,
+                    new Creator<Actor>() {
+                      @Override
+                      public Actor create() throws Exception {
+                        return null;
+                      }
+                    }));
+    assertEquals(
+        "cannot use non-static local Creator to create actors; make it static (e.g. local to a static method) or top-level",
+        exception.getMessage());
   }
 
   @Test

--- a/akka-actor-tests/src/test/scala/akka/actor/PropsCreationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/PropsCreationSpec.scala
@@ -64,8 +64,8 @@ class PropsCreationSpec extends AkkaSpec("""
       val p = Props.create(OneParamActorCreator)
       system.actorOf(p)
     }
-    "work with create(class, param)" in {
-      val p = Props.create(classOf[OneParamActor], null)
+    "work with create(class, creator)" in {
+      val p = Props.create(classOf[Actor], OneParamActorCreator)
       system.actorOf(p)
     }
   }

--- a/akka-actor/src/main/scala/akka/actor/AbstractProps.scala
+++ b/akka-actor/src/main/scala/akka/actor/AbstractProps.scala
@@ -75,6 +75,7 @@ private[akka] trait AbstractProps {
    * Create new Props from the given [[akka.japi.Creator]] with the type set to the given actorClass.
    */
   def create[T <: Actor](actorClass: Class[T], creator: Creator[T]): Props = {
+    checkCreatorClosingOver(creator.getClass)
     create(classOf[CreatorConsumer], actorClass, creator)
   }
 


### PR DESCRIPTION
References #30220 

Looks like the method ` checkCreatorClosingOver` was used in deprecated `Props.create(Creator)`, but was forgotten in new `Props.create(ActorClass,Creator)`. 

Kind regards