### PR TITLE
fix(docs): java snippet showing how to tag events

### DIFF
--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/BasicPersistentBehaviorTest.java
@@ -355,7 +355,10 @@ public class BasicPersistentBehaviorTest {
       // #tagging
       @Override
       public Set<String> tagsFor(Event event) {
-        throw new RuntimeException("TODO: inspect the event and return any tags it should have");
+        Set<String> tags = new HashSet<>();
+        tags.add("tag1");
+        tags.add("tag2");
+        return tags;
       }
       // #tagging
       // #supervision


### PR DESCRIPTION
Reported by @michael-read

Documentation for java was showing a `RuntimeException` with a TODO

see https://doc.akka.io/docs/akka/current/typed/persistence.html#tagging