### PR TITLE
Change parameter order in assertEquals

### DIFF
--- a/akka-actor-tests/src/test/java/akka/actor/StashJavaAPITestActors.java
+++ b/akka-actor-tests/src/test/java/akka/actor/StashJavaAPITestActors.java
@@ -25,8 +25,8 @@ public class StashJavaAPITestActors {
         return count + 1;
       }
     } else if (msg instanceof Integer) {
-      int value = ((Integer) msg).intValue();
-      assertEquals(value, 5);
+      int value = (Integer) msg;
+      assertEquals(5, value);
     }
     return count;
   }

--- a/akka-actor-tests/src/test/java/akka/actor/setup/ActorSystemSetupTest.java
+++ b/akka-actor-tests/src/test/java/akka/actor/setup/ActorSystemSetupTest.java
@@ -28,6 +28,6 @@ public class ActorSystemSetupTest extends JUnitSuite {
         ActorSystemSetup.create().withSetup(javaSetting).get(JavaSetup.class);
 
     assertTrue(result.isPresent());
-    assertEquals(result.get(), javaSetting);
+    assertEquals(javaSetting, result.get());
   }
 }

--- a/akka-persistence-typed-tests/src/test/java/akka/persistence/typed/ReplicatedEventSourcingTest.java
+++ b/akka-persistence-typed-tests/src/test/java/akka/persistence/typed/ReplicatedEventSourcingTest.java
@@ -180,8 +180,8 @@ public class ReplicatedEventSourcingTest extends JUnitSuite {
           replicaA.tell(new TestBehavior.GetState(probe.ref().narrow()));
           TestBehavior.State reply = probe.expectMessageClass(TestBehavior.State.class);
           assertEquals(
-              reply.texts,
-              new HashSet<String>(Arrays.asList("stored-to-a", "stored-to-b", "stored-to-c")));
+              new HashSet<>(Arrays.asList("stored-to-a", "stored-to-b", "stored-to-c")),
+              reply.texts);
           return null;
         });
     probe.awaitAssert(
@@ -189,8 +189,8 @@ public class ReplicatedEventSourcingTest extends JUnitSuite {
           replicaB.tell(new TestBehavior.GetState(probe.ref().narrow()));
           TestBehavior.State reply = probe.expectMessageClass(TestBehavior.State.class);
           assertEquals(
-              reply.texts,
-              new HashSet<String>(Arrays.asList("stored-to-a", "stored-to-b", "stored-to-c")));
+              new HashSet<>(Arrays.asList("stored-to-a", "stored-to-b", "stored-to-c")),
+              reply.texts);
           return null;
         });
     probe.awaitAssert(
@@ -198,8 +198,8 @@ public class ReplicatedEventSourcingTest extends JUnitSuite {
           replicaC.tell(new TestBehavior.GetState(probe.ref().narrow()));
           TestBehavior.State reply = probe.expectMessageClass(TestBehavior.State.class);
           assertEquals(
-              reply.texts,
-              new HashSet<String>(Arrays.asList("stored-to-a", "stored-to-b", "stored-to-c")));
+              new HashSet<>(Arrays.asList("stored-to-a", "stored-to-b", "stored-to-c")),
+              reply.texts);
           return null;
         });
   }

--- a/akka-persistence-typed-tests/src/test/java/jdocs/akka/persistence/typed/ReplicatedAuctionExampleTest.java
+++ b/akka-persistence-typed-tests/src/test/java/jdocs/akka/persistence/typed/ReplicatedAuctionExampleTest.java
@@ -70,7 +70,7 @@ public class ReplicatedAuctionExampleTest extends JUnitSuite {
         () -> {
           replicaA.tell(new GetHighestBid(replyProbe.ref()));
           Bid bid = replyProbe.expectMessageClass(Bid.class);
-          assertEquals(bid.offer, 202);
+          assertEquals(202, bid.offer);
           return bid;
         });
 


### PR DESCRIPTION
There are some `assertEquals` with wrong parameters order. First parameter should be expected. [Documentation](http://junit.sourceforge.net/javadoc/org/junit/Assert.html#assertEquals(java.lang.Object,%20java.lang.Object))

Kind regards