### PR TITLE
Lazy and fast concat and prepend

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/concat.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/concat.md
@@ -14,6 +14,17 @@ After completion of the original upstream the elements of the given source will 
 
 After completion of the original upstream the elements of the given source will be emitted.
 
+Both streams will be materialized together.
+
+@@@ note
+
+   The `concat` operator is for backwards compatibility reasons "detached" and will eagerly 
+   demand an element from both upstreams when the stream is materialized and will then have a 
+   one element buffer for each of the upstreams, this is most often not what you want, instead
+   use @ref(concatLazy)[concatLazy.md]
+
+@@@
+
 ## Example
 Scala
 :   @@snip [FlowConcatSpec.scala](/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowConcatSpec.scala) { #concat }

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/concatLazy.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/concatLazy.md
@@ -14,7 +14,9 @@ After completion of the original upstream the elements of the given source will 
 
 After completion of the original upstream the elements of the given source will be emitted.
 
-Both streams will be materialized together, but the concatenated source materialization can be deferred (and completely avoided if the stream fails or cancels before the first source has completed) by combining with @ref(Source.lazySource)[../Source/lazySource.md].
+Both streams will be materialized together, however, the given stream will be pulled for the first time only after the original upstream was completed. (In contrast, @ref(concat)[concat.md], introduces single-element buffers after both, original and given sources so that the given source is also pulled once immediately.)
+
+To defer the materialization of the given source (or to completely avoid its materialization if the original upstream fails or cancels), wrap it into @ref(Source.lazySource)[../Source/lazySource.md].
 
 ## Example
 Scala

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/concatLazy.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/concatLazy.md
@@ -18,6 +18,8 @@ Both streams will be materialized together, however, the given stream will be pu
 
 To defer the materialization of the given source (or to completely avoid its materialization if the original upstream fails or cancels), wrap it into @ref(Source.lazySource)[../Source/lazySource.md].
 
+If materialized values needs to be collected `concatLazyMat` is available.
+
 ## Example
 Scala
 :   @@snip [FlowConcatSpec.scala](/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowConcatSpec.scala) { #concatLazy }

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/concatLazy.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/concatLazy.md
@@ -1,0 +1,36 @@
+# concatLazy
+
+After completion of the original upstream the elements of the given source will be emitted.
+
+@ref[Fan-in operators](../index.md#fan-in-operators)
+
+## Signature
+
+@apidoc[Source.concat](Source) { scala="#concatLazy[U&gt;:Out,Mat2](that:akka.stream.Graph[akka.stream.SourceShape[U],Mat2]):FlowOps.this.Repr[U]" java="#concatLazy(akka.stream.Graph)" }
+@apidoc[Flow.concat](Flow) { scala="#concatLazy[U&gt;:Out,Mat2](that:akka.stream.Graph[akka.stream.SourceShape[U],Mat2]):FlowOps.this.Repr[U]" java="#concatLazy(akka.stream.Graph)" }
+
+
+## Description
+
+After completion of the original upstream the elements of the given source will be emitted.
+
+Both streams will be materialized together, but the concatenated source materialization can be deferred (and completely avoided if the stream fails or cancels before the first source has completed) by combining with @ref(Source.lazySource)[../Source/lazySource.md].
+
+## Example
+Scala
+:   @@snip [FlowConcatSpec.scala](/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowConcatSpec.scala) { #concatLazy }
+
+Java
+:   @@snip [SourceOrFlow.java](/akka-docs/src/test/java/jdocs/stream/operators/SourceOrFlow.java) { #concatLazy }
+
+## Reactive Streams semantics
+
+@@@div { .callout }
+
+**emits** when the current stream has an element available; if the current input completes, it tries the next one
+
+**backpressures** when downstream backpressures
+
+**completes** when all upstreams complete
+
+@@@

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/prepend.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/prepend.md
@@ -16,10 +16,10 @@ Prepends the given source to the flow, consuming it until completion before the 
 
 @@@ note
 
-The `prepend` operator is for backwards compatibility reasons "detached" and will eagerly
-demand an element from both upstreams when the stream is materialized and will then have a
-one element buffer for each of the upstreams, this is most often not what you want, instead
-use @ref(prependLazy)[prependLazy.md]
+    The `prepend` operator is for backwards compatibility reasons "detached" and will eagerly
+    demand an element from both upstreams when the stream is materialized and will then have a
+    one element buffer for each of the upstreams, this is most often not what you want, instead
+    use @ref(prependLazy)[prependLazy.md]
 
 @@@
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/prepend.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/prepend.md
@@ -14,7 +14,14 @@ Prepends the given source to the flow, consuming it until completion before the 
 
 Prepends the given source to the flow, consuming it until completion before the original source is consumed.
 
-Both streams will be materialized together.
+@@@ note
+
+The `prepend` operator is for backwards compatibility reasons "detached" and will eagerly
+demand an element from both upstreams when the stream is materialized and will then have a
+one element buffer for each of the upstreams, this is most often not what you want, instead
+use @ref(prependLazy)[prependLazy.md]
+
+@@@
 
 If materialized values needs to be collected `prependMat` is available.
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/prependLazy.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/prependLazy.md
@@ -1,4 +1,4 @@
-# prepend
+# prependLazy
 
 Prepends the given source to the flow, consuming it until completion before the original source is consumed.
 
@@ -14,25 +14,16 @@ Prepends the given source to the flow, consuming it until completion before the 
 
 Prepends the given source to the flow, consuming it until completion before the original source is consumed.
 
-Both streams will be materialized together.
-
 If materialized values needs to be collected `prependMat` is available.
 
-@@@ note
-
-The `prepend` operator is for backwards compatibility reasons "detached" and will eagerly
-demand an element from both upstreams when the stream is materialized and will then have a
-one element buffer for each of the upstreams, this is not always what you want, if not,
-use @ref(prependLazy)[prependLazy.md]
-
-@@@
+See also @ref[prepend](prepend.md) which is detached.
 
 ## Example
 Scala
-:   @@snip [FlowOrElseSpec.scala](/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrependSpec.scala) { #prepend }
+:   @@snip [FlowPrependSpec.scala](/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrependSpec.scala) { #prependLazy }
 
 Java
-:   @@snip [SourceOrFlow.java](/akka-docs/src/test/java/jdocs/stream/operators/SourceOrFlow.java) { #prepend }
+:   @@snip [SourceOrFlow.java](/akka-docs/src/test/java/jdocs/stream/operators/SourceOrFlow.java) { #prependLazy }
 
 ## Reactive Streams semantics
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/prependLazy.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/prependLazy.md
@@ -14,7 +14,9 @@ Prepends the given source to the flow, consuming it until completion before the 
 
 Prepends the given source to the flow, consuming it until completion before the original source is consumed.
 
-If materialized values needs to be collected `prependMat` is available.
+Both streams will be materialized together, however, the original stream will be pulled for the first time only after the prepended upstream was completed. (In contrast, @ref(prepend)[prepend.md], introduces single-element buffers after both, original and given sources so that the original source is also pulled once immediately.)
+
+If materialized values needs to be collected `prependLazyMat` is available.
 
 See also @ref[prepend](prepend.md) which is detached.
 

--- a/akka-docs/src/main/paradox/stream/operators/index.md
+++ b/akka-docs/src/main/paradox/stream/operators/index.md
@@ -262,6 +262,7 @@ the inputs in different ways.
 |--|--|--|
 | |<a name="mergesequence"></a>@ref[MergeSequence](MergeSequence.md)|Merge a linear sequence partitioned across multiple sources.|
 |Source/Flow|<a name="concat"></a>@ref[concat](Source-or-Flow/concat.md)|After completion of the original upstream the elements of the given source will be emitted.|
+|Source/Flow|<a name="concatlazy"></a>@ref[concatLazy](Source-or-Flow/concatLazy.md)|After completion of the original upstream the elements of the given source will be emitted.|
 |Source/Flow|<a name="interleave"></a>@ref[interleave](Source-or-Flow/interleave.md)|Emits a specifiable number of elements from the original source, then from the provided source and repeats.|
 |Source/Flow|<a name="merge"></a>@ref[merge](Source-or-Flow/merge.md)|Merge multiple sources.|
 |Source/Flow|<a name="mergelatest"></a>@ref[mergeLatest](Source-or-Flow/mergeLatest.md)|Merge multiple sources.|
@@ -270,6 +271,7 @@ the inputs in different ways.
 |Source/Flow|<a name="mergesorted"></a>@ref[mergeSorted](Source-or-Flow/mergeSorted.md)|Merge multiple sources.|
 |Source/Flow|<a name="orelse"></a>@ref[orElse](Source-or-Flow/orElse.md)|If the primary source completes without emitting any elements, the elements from the secondary source are emitted.|
 |Source/Flow|<a name="prepend"></a>@ref[prepend](Source-or-Flow/prepend.md)|Prepends the given source to the flow, consuming it until completion before the original source is consumed.|
+|Source/Flow|<a name="prependlazy"></a>@ref[prependLazy](Source-or-Flow/prependLazy.md)|Prepends the given source to the flow, consuming it until completion before the original source is consumed.|
 |Source/Flow|<a name="zip"></a>@ref[zip](Source-or-Flow/zip.md)|Combines elements from each of multiple sources into @scala[tuples] @java[*Pair*] and passes the @scala[tuples] @java[pairs] downstream.|
 |Source/Flow|<a name="zipall"></a>@ref[zipAll](Source-or-Flow/zipAll.md)|Combines elements from two sources into @scala[tuples] @java[*Pair*] handling early completion of either source.|
 |Source/Flow|<a name="ziplatest"></a>@ref[zipLatest](Source-or-Flow/zipLatest.md)|Combines elements from each of multiple sources into @scala[tuples] @java[*Pair*] and passes the @scala[tuples] @java[pairs] downstream, picking always the latest element of each.|
@@ -393,6 +395,7 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 * [completionStageSource](Source/completionStageSource.md)
 * [completionTimeout](Source-or-Flow/completionTimeout.md)
 * [concat](Source-or-Flow/concat.md)
+* [concatLazy](Source-or-Flow/concatLazy.md)
 * [conflate](Source-or-Flow/conflate.md)
 * [conflateWithSeed](Source-or-Flow/conflateWithSeed.md)
 * [cycle](Source/cycle.md)
@@ -504,6 +507,7 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 * [prefixAndTail](Source-or-Flow/prefixAndTail.md)
 * [preMaterialize](Sink/preMaterialize.md)
 * [prepend](Source-or-Flow/prepend.md)
+* [prependLazy](Source-or-Flow/prependLazy.md)
 * [queue](Source/queue.md)
 * [queue](Sink/queue.md)
 * [range](Source/range.md)

--- a/akka-docs/src/test/java/jdocs/stream/operators/SourceOrFlow.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/SourceOrFlow.java
@@ -19,7 +19,9 @@ import akka.japi.function.Function2;
 // #zip-with-index
 // #or-else
 // #prepend
+// #prependLazy
 // #concat
+// #concatLazy
 // #interleave
 // #merge
 // #merge-sorted
@@ -33,7 +35,9 @@ import java.util.*;
 // #merge
 // #interleave
 // #concat
+// #concatLazy
 // #prepend
+// #prependLazy
 // #or-else
 // #zip-with-index
 // #zip-with
@@ -124,11 +128,31 @@ class SourceOrFlow {
     // #prepend
   }
 
+  void prependLazyExample() {
+    // #prepend
+    Source<String, NotUsed> ladies = Source.from(Arrays.asList("Emma", "Emily"));
+    Source<String, NotUsed> gentlemen = Source.from(Arrays.asList("Liam", "William"));
+    gentlemen.prependLazy(ladies).runWith(Sink.foreach(System.out::print), system);
+    // this will print "Emma", "Emily", "Liam", "William"
+
+    // #prepend
+  }
+
   void concatExample() {
     // #concat
     Source<Integer, NotUsed> sourceA = Source.from(Arrays.asList(1, 2, 3, 4));
     Source<Integer, NotUsed> sourceB = Source.from(Arrays.asList(10, 20, 30, 40));
     sourceA.concat(sourceB).runWith(Sink.foreach(System.out::print), system);
+    // prints 1, 2, 3, 4, 10, 20, 30, 40
+
+    // #concat
+  }
+
+  void concatLazyExample() {
+    // #concat
+    Source<Integer, NotUsed> sourceA = Source.from(Arrays.asList(1, 2, 3, 4));
+    Source<Integer, NotUsed> sourceB = Source.from(Arrays.asList(10, 20, 30, 40));
+    sourceA.concatLazy(sourceB).runWith(Sink.foreach(System.out::print), system);
     // prints 1, 2, 3, 4, 10, 20, 30, 40
 
     // #concat

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowConcatSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowConcatSpec.scala
@@ -4,27 +4,36 @@
 
 package akka.stream.scaladsl
 
-import scala.concurrent.{ Await, Promise }
-import scala.concurrent.duration._
-
-import org.reactivestreams.Publisher
-
 import akka.NotUsed
-import akka.stream.testkit.{ BaseTwoStreamsSetup, TestPublisher, TestSubscriber }
+import akka.stream.testkit.BaseTwoStreamsSetup
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.scaladsl.TestSink
+import org.reactivestreams.Publisher
+import org.scalatest.concurrent.ScalaFutures
 
-class FlowConcatSpec extends BaseTwoStreamsSetup {
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.Await
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+
+abstract class AbstractFlowConcatSpec extends BaseTwoStreamsSetup {
 
   override type Outputs = Int
 
-  override def setup(p1: Publisher[Int], p2: Publisher[Int]) = {
+  def eager: Boolean
+
+  // not used but we want the rest of the BaseTwoStreamsSetup infra
+  override def setup(p1: Publisher[Int], p2: Publisher[Int]): TestSubscriber.Probe[Int] = {
     val subscriber = TestSubscriber.probe[Outputs]()
-    Source.fromPublisher(p1).concat(Source.fromPublisher(p2)).runWith(Sink.fromSubscriber(subscriber))
+    val s1 = Source.fromPublisher(p1)
+    val s2 = Source.fromPublisher(p2)
+    (if (eager) s1.concat(s2) else s1.concatLazy(s2)).runWith(Sink.fromSubscriber(subscriber))
     subscriber
   }
 
-  "A Concat for Flow " must {
+  s"${if (eager) "An eager" else "A lazy"} Concat for Flow " must {
 
     "be able to concat Flow with a Source" in {
       val f1: Flow[Int, String, _] = Flow[Int].map(_.toString + "-s")
@@ -34,7 +43,8 @@ class FlowConcatSpec extends BaseTwoStreamsSetup {
       val subs = TestSubscriber.manualProbe[Any]()
       val subSink = Sink.asPublisher[Any](false)
 
-      val (_, res) = f1.concat(s2).runWith(s1, subSink)
+      val (_, res) =
+        (if (eager) f1.concatLazy(s2) else f1.concat(s2)).runWith(s1, subSink)
 
       res.subscribe(subs)
       val sub = subs.expectSubscription()
@@ -51,7 +61,9 @@ class FlowConcatSpec extends BaseTwoStreamsSetup {
       val subs = TestSubscriber.manualProbe[Any]()
       val subSink = Sink.asPublisher[Any](false)
 
-      val (_, res) = f2.prepend(s1).runWith(s2, subSink)
+      val (_, res) =
+        (if (eager) f2.prepend(s1) else f2.prependLazy(s1)).runWith(s2, subSink)
+
 
       res.subscribe(subs)
       val sub = subs.expectSubscription()
@@ -121,7 +133,10 @@ class FlowConcatSpec extends BaseTwoStreamsSetup {
     "correctly handle async errors in secondary upstream" in assertAllStagesStopped {
       val promise = Promise[Int]()
       val subscriber = TestSubscriber.manualProbe[Int]()
-      Source(List(1, 2, 3)).concat(Source.future(promise.future)).runWith(Sink.fromSubscriber(subscriber))
+      val s1 = Source(List(1, 2, 3))
+      val s2 = Source.future(promise.future)
+
+      (if (eager) s1.concat(s2) else s1.concatLazy(s2)).runWith(Sink.fromSubscriber(subscriber))
 
       val subscription = subscriber.expectSubscription()
       subscription.request(4)
@@ -131,7 +146,9 @@ class FlowConcatSpec extends BaseTwoStreamsSetup {
     }
 
     "work with Source DSL" in {
-      val testSource = Source(1 to 5).concatMat(Source(6 to 10))(Keep.both).grouped(1000)
+      val s1 = Source(1 to 5)
+      val s2 = Source(6 to 10)
+      val testSource = (if (eager) s1.concatMat(s2)(Keep.both) else s1.concatLazyMat(s2)(Keep.both)).grouped(1000)
       Await.result(testSource.runWith(Sink.head), 3.seconds) should ===(1 to 10)
 
       val runnable = testSource.toMat(Sink.ignore)(Keep.left)
@@ -143,9 +160,11 @@ class FlowConcatSpec extends BaseTwoStreamsSetup {
     }
 
     "work with Flow DSL" in {
+      val s1 = Source(1 to 5)
+      val s2 = Source(6 to 10)
       val testFlow: Flow[Int, Seq[Int], (NotUsed, NotUsed)] =
-        Flow[Int].concatMat(Source(6 to 10))(Keep.both).grouped(1000)
-      Await.result(Source(1 to 5).viaMat(testFlow)(Keep.both).runWith(Sink.head), 3.seconds) should ===(1 to 10)
+        (if (eager) Flow[Int].concatMat(s2)(Keep.both) else Flow[Int].concatLazyMat(s2)(Keep.both)).grouped(1000)
+      Await.result(s1.viaMat(testFlow)(Keep.both).runWith(Sink.head), 3.seconds) should ===(1 to 10)
 
       val runnable = Source(1 to 5).viaMat(testFlow)(Keep.both).to(Sink.ignore)
       val x = runnable.run()
@@ -158,8 +177,13 @@ class FlowConcatSpec extends BaseTwoStreamsSetup {
     }
 
     "work with Flow DSL2" in {
-      val testFlow = Flow[Int].concatMat(Source(6 to 10))(Keep.both).grouped(1000)
-      Await.result(Source(1 to 5).viaMat(testFlow)(Keep.both).runWith(Sink.head), 3.seconds) should ===(1 to 10)
+      val s1 = Source(1 to 5)
+      val s2 = Source(6 to 10)
+      val testFlow =
+        (if (eager) Flow[Int].concatMat(s2)(Keep.both)
+        else Flow[Int].concatLazyMat(s2)(Keep.both))
+          .grouped(1000)
+      Await.result(s1.viaMat(testFlow)(Keep.both).runWith(Sink.head), 3.seconds) should ===(1 to 10)
 
       val sink = testFlow.concatMat(Source(1 to 5))(Keep.both).to(Sink.ignore).mapMaterializedValue[String] {
         case ((m1, m2), m3) =>
@@ -174,8 +198,10 @@ class FlowConcatSpec extends BaseTwoStreamsSetup {
     "subscribe at once to initial source and to one that it's concat to" in {
       val publisher1 = TestPublisher.probe[Int]()
       val publisher2 = TestPublisher.probe[Int]()
+      val s1 = Source.fromPublisher(publisher1)
+      val s2 = Source.fromPublisher(publisher2)
       val probeSink =
-        Source.fromPublisher(publisher1).concat(Source.fromPublisher(publisher2)).runWith(TestSink.probe[Int])
+        (if (eager) s1.concat(s2) else s1.concatLazy(s2)).runWith(TestSink.probe[Int])
 
       val sub1 = publisher1.expectSubscription()
       val sub2 = publisher2.expectSubscription()
@@ -196,8 +222,6 @@ class FlowConcatSpec extends BaseTwoStreamsSetup {
 
     "work in example" in {
       //#concat
-      import akka.stream.scaladsl.Sink
-      import akka.stream.scaladsl.Source
 
       val sourceA = Source(List(1, 2, 3, 4))
       val sourceB = Source(List(10, 20, 30, 40))
@@ -205,6 +229,35 @@ class FlowConcatSpec extends BaseTwoStreamsSetup {
       sourceA.concat(sourceB).runWith(Sink.foreach(println))
       //prints 1, 2, 3, 4, 10, 20, 30, 40
       //#concat
+    }
+  }
+
+}
+
+class FlowConcatSpec extends AbstractFlowConcatSpec with ScalaFutures {
+  override def eager: Boolean = true
+}
+
+class FlowConcatLazySpec extends AbstractFlowConcatSpec {
+  override def eager: Boolean = false
+
+  "concatLazy" must {
+    "Make it possible to entirely avoid materialization of the second flow" in {
+      val publisher = TestPublisher.probe[Int]()
+      val subscriber = TestSubscriber.probe[Int]()
+      val secondStreamWasMaterialized = new AtomicBoolean(false)
+      Source.fromPublisher(publisher).concatLazy(Source.lazySource { () =>
+        secondStreamWasMaterialized.set(true)
+        Source.single(3)
+      }).runWith(Sink.fromSubscriber(subscriber))
+      subscriber.request(1)
+      publisher.sendNext(1)
+      subscriber.expectNext(1)
+      subscriber.cancel()
+      publisher.expectCancellation()
+      // cancellation went all the way upstream across one async boundary so if second source materialization
+      // would happen it would have happened already
+      secondStreamWasMaterialized.get should === (false)
     }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowConcatSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowConcatSpec.scala
@@ -219,7 +219,14 @@ abstract class AbstractFlowConcatSpec extends BaseTwoStreamsSetup {
 
       probeSink.expectComplete()
     }
+  }
 
+}
+
+class FlowConcatSpec extends AbstractFlowConcatSpec with ScalaFutures {
+  override def eager: Boolean = true
+
+  "concat" must {
     "work in example" in {
       //#concat
 
@@ -231,11 +238,6 @@ abstract class AbstractFlowConcatSpec extends BaseTwoStreamsSetup {
       //#concat
     }
   }
-
-}
-
-class FlowConcatSpec extends AbstractFlowConcatSpec with ScalaFutures {
-  override def eager: Boolean = true
 }
 
 class FlowConcatLazySpec extends AbstractFlowConcatSpec {
@@ -259,5 +261,15 @@ class FlowConcatLazySpec extends AbstractFlowConcatSpec {
       // would happen it would have happened already
       secondStreamWasMaterialized.get should === (false)
     }
+
+    "work in example" in {
+      //#concatLazy
+      val sourceA = Source(List(1, 2, 3, 4))
+      val sourceB = Source(List(10, 20, 30, 40))
+
+      sourceA.concatLazy(sourceB).runWith(Sink.foreach(println))
+      //#concatLazy
+    }
   }
+
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrependSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrependSpec.scala
@@ -25,5 +25,15 @@ class FlowPrependSpec extends AkkaSpec {
       // this will print "Emma", "Emily", "Liam", "William"
       //#prepend
     }
+
+    "work in entrance example" in {
+      //#prependLazy
+      val ladies = Source(List("Emma", "Emily"))
+      val gentlemen = Source(List("Liam", "William"))
+
+      gentlemen.prependLazy(ladies).runWith(Sink.foreach(println))
+      // this will print "Emma", "Emily", "Liam", "William"
+      //#prependLazy
+    }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrependSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowPrependSpec.scala
@@ -26,7 +26,7 @@ class FlowPrependSpec extends AkkaSpec {
       //#prepend
     }
 
-    "work in entrance example" in {
+    "work in lazy entrance example" in {
       //#prependLazy
       val ladies = Source(List("Emma", "Emily"))
       val gentlemen = Source(List("Liam", "William"))

--- a/akka-stream/src/main/mima-filters/2.6.14.backwards.excludes/23044-concat-prepend-improvements.excludes
+++ b/akka-stream/src/main/mima-filters/2.6.14.backwards.excludes/23044-concat-prepend-improvements.excludes
@@ -1,0 +1,11 @@
+# internal API changes and stream operator additions
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.GraphDSL#Implicits#PortOpsImpl.concatGraph")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.GraphDSL#Implicits#PortOpsImpl.prependGraph")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Flow.concatGraph")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Flow.prependGraph")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Source.concatGraph")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.Source.prependGraph")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.FlowOps.concatGraph")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.scaladsl.FlowOps.prependGraph")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.SubFlowImpl.concatGraph")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.SubFlowImpl.prependGraph")

--- a/akka-stream/src/main/scala/akka/stream/impl/SingleConcat.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SingleConcat.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.impl
+
+import akka.annotation.InternalApi
+import akka.stream.Attributes
+import akka.stream.FlowShape
+import akka.stream.Inlet
+import akka.stream.Outlet
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+
+/**
+ * Concatenating a single element to a stream is common enough that it warrants this optimization
+ * which avoids the actual fan-out for such cases.
+ *
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] final class SingleConcat[E](singleElem: E) extends GraphStage[FlowShape[E, E]] {
+
+  val in = Inlet[E]("SingleConcat.in")
+  val out = Outlet[E]("SingleConcat.out")
+
+  override val shape: FlowShape[E, E] = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with InHandler with OutHandler {
+    override def onPush(): Unit = {
+      push(out, grab(in))
+    }
+
+    override def onPull(): Unit = pull(in)
+
+    override def onUpstreamFinish(): Unit = {
+      emit(out, singleElem, () => completeStage())
+    }
+    setHandlers(in, out, this)
+  }
+
+  override def toString: String = s"SingleConcat($singleElem)"
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/SingleConcat.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/SingleConcat.scala
@@ -28,18 +28,19 @@ private[akka] final class SingleConcat[E](singleElem: E) extends GraphStage[Flow
 
   override val shape: FlowShape[E, E] = FlowShape(in, out)
 
-  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with InHandler with OutHandler {
-    override def onPush(): Unit = {
-      push(out, grab(in))
-    }
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+      override def onPush(): Unit = {
+        push(out, grab(in))
+      }
 
-    override def onPull(): Unit = pull(in)
+      override def onPull(): Unit = pull(in)
 
-    override def onUpstreamFinish(): Unit = {
-      emit(out, singleElem, () => completeStage())
+      override def onUpstreamFinish(): Unit = {
+        emit(out, singleElem, () => completeStage())
+      }
+      setHandlers(in, out, this)
     }
-    setHandlers(in, out, this)
-  }
 
   override def toString: String = s"SingleConcat($singleElem)"
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -2355,10 +2355,13 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * Flow’s input is exhausted and all result elements have been generated,
    * the Source’s elements will be produced.
    *
-   * Note that the [[Source]] is materialized together with this Flow and just kept
-   * from producing elements by asserting back-pressure until its time comes.
+   * Note that the [[Source]] is materialized together with this Flow and is "detached" meaning it will
+   * in effect behave as a one element buffer in front of both the sources, that eagerly demands an element on start
+   * (so it can not be combined with `Source.lazy` to defer materialization of `that`).
    *
-   * If this [[Flow]] gets upstream error - no elements from the given [[Source]] will be pulled.
+   * The second source is then kept from producing elements by asserting back-pressure until its time comes.
+   *
+   * When needing a concat operator that is not detached use [[#concatLazy]]
    *
    * '''Emits when''' element is available from current stream or from the given [[Source]] when current is completed
    *
@@ -2376,10 +2379,39 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * Flow’s input is exhausted and all result elements have been generated,
    * the Source’s elements will be produced.
    *
-   * Note that the [[Source]] is materialized together with this Flow and just kept
-   * from producing elements by asserting back-pressure until its time comes.
+   * Note that the [[Source]] is materialized together with this Flow. If `lazy` materialization is what is needed
+   * the operator can be combined with for example `Source.lazySource` to defer materialization of `that` until the
+   * time when this source completes.
+   *
+   * The second source is then kept from producing elements by asserting back-pressure until its time comes.
+   *
+   * For a concat operator that is detached, use [[#concat]]
    *
    * If this [[Flow]] gets upstream error - no elements from the given [[Source]] will be pulled.
+   *
+   * '''Emits when''' element is available from current stream or from the given [[Source]] when current is completed
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' given [[Source]] completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def concatLazy[M](that: Graph[SourceShape[Out], M]): javadsl.Flow[In, Out, Mat] =
+    new Flow(delegate.concatLazy(that))
+
+  /**
+   * Concatenate the given [[Source]] to this [[Flow]], meaning that once this
+   * Flow’s input is exhausted and all result elements have been generated,
+   * the Source’s elements will be produced.
+   *
+   * Note that the [[Source]] is materialized together with this Flow and is "detached" meaning it will
+   * in effect behave as a one element buffer in front of both the sources, that eagerly demands an element on start
+   * (so it can not be combined with `Source.lazy` to defer materialization of `that`).
+   *
+   * The second source is then kept from producing elements by asserting back-pressure until its time comes.
+   *
+   * When needing a concat operator that is not detached use [[#concatLazyMat]]
    *
    * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
    * where appropriate instead of manually writing functions that pass through one of the values.
@@ -2392,14 +2424,39 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
     new Flow(delegate.concatMat(that)(combinerToScala(matF)))
 
   /**
+   * Concatenate the given [[Source]] to this [[Flow]], meaning that once this
+   * Flow’s input is exhausted and all result elements have been generated,
+   * the Source’s elements will be produced.
+   *
+   * Note that the [[Source]] is materialized together with this Flow, if `lazy` materialization is what is needed
+   * the operator can be combined with `Source.lazy` to defer materialization of `that`.
+   *
+   * The second source is then kept from producing elements by asserting back-pressure until its time comes.
+   *
+   * For a concat operator that is detached, use [[#concatMat]]
+   *
+   * @see [[#concatLazy]].
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   */
+  def concatLazyMat[M, M2](
+                        that: Graph[SourceShape[Out], M],
+                        matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, Out, M2] =
+    new Flow(delegate.concatMat(that)(combinerToScala(matF)))
+
+  /**
    * Prepend the given [[Source]] to this [[Flow]], meaning that before elements
    * are generated from this Flow, the Source's elements will be produced until it
    * is exhausted, at which point Flow elements will start being produced.
    *
-   * Note that this Flow will be materialized together with the [[Source]] and just kept
-   * from producing elements by asserting back-pressure until its time comes.
+   * Note that the [[Source]] is materialized together with this Flow and is "detached" meaning
+   * in effect behave as a one element buffer in front of both the sources, that eagerly demands an element on start
+   * (so it can not be combined with `Source.lazy` to defer materialization of `that`).
    *
-   * If the given [[Source]] gets upstream error - no elements from this [[Flow]] will be pulled.
+   * This flow will then be kept from producing elements by asserting back-pressure until its time comes.
+   *
+   * When needing a prepend operator that is not detached use [[#prependLazy]]
    *
    * '''Emits when''' element is available from the given [[Source]] or from current stream when the [[Source]] is completed
    *
@@ -2417,10 +2474,33 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * are generated from this Flow, the Source's elements will be produced until it
    * is exhausted, at which point Flow elements will start being produced.
    *
+   * Note that the [[Source]] is materialized together with this Flow and will then be kept from producing elements
+   * by asserting back-pressure until its time comes.
+   *
+   * When needing a prepend operator that is also detached use [[#prepend]]
+   *
+   * If the given [[Source]] gets upstream error - no elements from this [[Flow]] will be pulled.
+   *
+   * '''Emits when''' element is available from the given [[Source]] or from current stream when the [[Source]] is completed
+   *
+   * '''Backpressures when''' downstream backpressures
+   *
+   * '''Completes when''' this [[Flow]] completes
+   *
+   * '''Cancels when''' downstream cancels
+   */
+  def prependLazy[M](that: Graph[SourceShape[Out], M]): javadsl.Flow[In, Out, Mat] =
+    new Flow(delegate.prepend(that))
+
+  /**
+   * Prepend the given [[Source]] to this [[Flow]], meaning that before elements
+   * are generated from this Flow, the Source's elements will be produced until it
+   * is exhausted, at which point Flow elements will start being produced.
+   *
    * Note that this Flow will be materialized together with the [[Source]] and just kept
    * from producing elements by asserting back-pressure until its time comes.
    *
-   * If the given [[Source]] gets upstream error - no elements from this [[Flow]] will be pulled.
+   * When needing a prepend operator that is not detached use [[#prependLazyMat]]
    *
    * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
    * where appropriate instead of manually writing functions that pass through one of the values.
@@ -2431,6 +2511,28 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
       that: Graph[SourceShape[Out], M],
       matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, Out, M2] =
     new Flow(delegate.prependMat(that)(combinerToScala(matF)))
+
+
+  /**
+   * Prepend the given [[Source]] to this [[Flow]], meaning that before elements
+   * are generated from this Flow, the Source's elements will be produced until it
+   * is exhausted, at which point Flow elements will start being produced.
+   *
+   * Note that the [[Source]] is materialized together with this Flow.
+   *
+   * This flow will then be kept from producing elements by asserting back-pressure until its time comes.
+   *
+   * When needing a prepend operator that is detached use [[#prependMat]]
+   *
+   * @see [[#prependLazy]].
+   *
+   * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
+   * where appropriate instead of manually writing functions that pass through one of the values.
+   */
+  def prependLazyMat[M, M2](
+                         that: Graph[SourceShape[Out], M],
+                         matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, Out, M2] =
+    new Flow(delegate.prependLazyMat(that)(combinerToScala(matF)))
 
   /**
    * Provides a secondary source that will be consumed if this source completes without any

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -2441,8 +2441,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def concatLazyMat[M, M2](
-                        that: Graph[SourceShape[Out], M],
-                        matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, Out, M2] =
+      that: Graph[SourceShape[Out], M],
+      matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, Out, M2] =
     new Flow(delegate.concatMat(that)(combinerToScala(matF)))
 
   /**
@@ -2512,7 +2512,6 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
       matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, Out, M2] =
     new Flow(delegate.prependMat(that)(combinerToScala(matF)))
 
-
   /**
    * Prepend the given [[Source]] to this [[Flow]], meaning that before elements
    * are generated from this Flow, the Source's elements will be produced until it
@@ -2530,8 +2529,8 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def prependLazyMat[M, M2](
-                         that: Graph[SourceShape[Out], M],
-                         matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, Out, M2] =
+      that: Graph[SourceShape[Out], M],
+      matF: function.Function2[Mat, M, M2]): javadsl.Flow[In, Out, M2] =
     new Flow(delegate.prependLazyMat(that)(combinerToScala(matF)))
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -519,6 +519,12 @@ object Concat {
   /**
    * Create a new anonymous `Concat` operator with the specified input types.
    */
+  def create[T](inputCount: Int, detachedInputs: Boolean): Graph[UniformFanInShape[T, T], NotUsed] =
+    scaladsl.Concat[T](inputCount, detachedInputs)
+
+  /**
+   * Create a new anonymous `Concat` operator with the specified input types.
+   */
   def create[T](@unused clazz: Class[T]): Graph[UniformFanInShape[T, T], NotUsed] = create()
 
 }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -1242,8 +1242,8 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def concatLazyMat[M, M2](
-                        that: Graph[SourceShape[Out], M],
-                        matF: function.Function2[Mat, M, M2]): javadsl.Source[Out, M2] =
+      that: Graph[SourceShape[Out], M],
+      matF: function.Function2[Mat, M, M2]): javadsl.Source[Out, M2] =
     new Source(delegate.concatLazyMat(that)(combinerToScala(matF)))
 
   /**
@@ -1293,7 +1293,6 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
   def prependLazy[M](that: Graph[SourceShape[Out], M]): javadsl.Source[Out, Mat] =
     new Source(delegate.prependLazy(that))
 
-
   /**
    * Prepend the given [[Source]] to this one, meaning that once the given source
    * is exhausted and all result elements have been generated, the current source's
@@ -1331,10 +1330,9 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * where appropriate instead of manually writing functions that pass through one of the values.
    */
   def prependLazyMat[M, M2](
-                         that: Graph[SourceShape[Out], M],
-                         matF: function.Function2[Mat, M, M2]): javadsl.Source[Out, M2] =
+      that: Graph[SourceShape[Out], M],
+      matF: function.Function2[Mat, M, M2]): javadsl.Source[Out, M2] =
     new Source(delegate.prependLazyMat(that)(combinerToScala(matF)))
-
 
   /**
    * Provides a secondary source that will be consumed if this source completes without any

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -10,21 +10,30 @@ import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
-import org.reactivestreams.{Processor, Publisher, Subscriber, Subscription}
+import org.reactivestreams.{ Processor, Publisher, Subscriber, Subscription }
 import akka.Done
 import akka.NotUsed
 import akka.actor.ActorRef
 import akka.annotation.DoNotInherit
-import akka.event.{LogMarker, LoggingAdapter, MarkerLoggingAdapter}
+import akka.event.{ LogMarker, LoggingAdapter, MarkerLoggingAdapter }
 import akka.stream.Attributes.SourceLocation
 import akka.stream._
 import akka.stream.impl.SingleConcat
-import akka.stream.impl.{LinearTraversalBuilder, ProcessorModule, SetupFlowStage, SubFlowImpl, Throttle, Timers, TraversalBuilder, fusing}
+import akka.stream.impl.{
+  fusing,
+  LinearTraversalBuilder,
+  ProcessorModule,
+  SetupFlowStage,
+  SubFlowImpl,
+  Throttle,
+  Timers,
+  TraversalBuilder
+}
 import akka.stream.impl.fusing._
 import akka.stream.impl.fusing.FlattenMerge
 import akka.stream.stage._
 import akka.util.OptionVal
-import akka.util.{ConstantFun, Timeout}
+import akka.util.{ ConstantFun, Timeout }
 import akka.util.ccompat._
 
 /**
@@ -3006,7 +3015,8 @@ trait FlowOps[+Out, +Mat] {
     internalConcat(that, detached = true)
 
   protected def concatGraph[U >: Out, Mat2](
-                                             that: Graph[SourceShape[U], Mat2], detached: Boolean): Graph[FlowShape[Out @uncheckedVariance, U], Mat2] =
+      that: Graph[SourceShape[U], Mat2],
+      detached: Boolean): Graph[FlowShape[Out @uncheckedVariance, U], Mat2] =
     GraphDSL.create(that) { implicit b => r =>
       val merge = b.add(Concat[U](2, detached))
       r ~> merge.in(1)
@@ -3049,6 +3059,7 @@ trait FlowOps[+Out, +Mat] {
           case _ => via(concatGraph(other, detached))
         }
     }
+
   /**
    * Prepend the given [[Source]] to this [[Flow]], meaning that before elements
    * are generated from this Flow, the Source's elements will be produced until it
@@ -3074,7 +3085,9 @@ trait FlowOps[+Out, +Mat] {
   def prepend[U >: Out, Mat2](that: Graph[SourceShape[U], Mat2]): Repr[U] =
     via(prependGraph(that, detached = true))
 
-  protected def prependGraph[U >: Out, Mat2](that: Graph[SourceShape[U], Mat2], detached: Boolean): Graph[FlowShape[Out @uncheckedVariance, U], Mat2] =
+  protected def prependGraph[U >: Out, Mat2](
+      that: Graph[SourceShape[U], Mat2],
+      detached: Boolean): Graph[FlowShape[Out @uncheckedVariance, U], Mat2] =
     GraphDSL.create(that) { implicit b => r =>
       val merge = b.add(Concat[U](2, detached))
       r ~> merge.in(0)
@@ -3549,7 +3562,8 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
    * where appropriate instead of manually writing functions that pass through one of the values.
    */
-  def concatLazyMat[U >: Out, Mat2, Mat3](that: Graph[SourceShape[U], Mat2])(matF: (Mat, Mat2) => Mat3): ReprMat[U, Mat3] =
+  def concatLazyMat[U >: Out, Mat2, Mat3](that: Graph[SourceShape[U], Mat2])(
+      matF: (Mat, Mat2) => Mat3): ReprMat[U, Mat3] =
     viaMat(concatGraph(that, detached = false))(matF)
 
   /**
@@ -3590,7 +3604,8 @@ trait FlowOpsMat[+Out, +Mat] extends FlowOps[Out, Mat] {
    * It is recommended to use the internally optimized `Keep.left` and `Keep.right` combiners
    * where appropriate instead of manually writing functions that pass through one of the values.
    */
-  def prependLazyMat[U >: Out, Mat2, Mat3](that: Graph[SourceShape[U], Mat2])(matF: (Mat, Mat2) => Mat3): ReprMat[U, Mat3] =
+  def prependLazyMat[U >: Out, Mat2, Mat3](that: Graph[SourceShape[U], Mat2])(
+      matF: (Mat, Mat2) => Mat3): ReprMat[U, Mat3] =
     viaMat(prependGraph(that, detached = true))(matF)
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -1245,10 +1245,22 @@ class ZipWithN[A, O](zipper: immutable.Seq[A] => O)(n: Int) extends GraphStage[U
 object Concat {
 
   /**
-   * Create a new `Concat`.
+   * Create a new `Concat`. Note that this for historical reasons creates a "detached" Concat which
+   * will eagerly pull each input on materialization and act as a one element buffer for each input.
    */
   def apply[T](inputPorts: Int = 2): Graph[UniformFanInShape[T, T], NotUsed] =
-    GraphStages.withDetachedInputs(new Concat[T](inputPorts))
+    apply(inputPorts, detachedInputs = true)
+
+  /**
+   * Create a new `Concat` operator that will concatenate two or more streams.
+   * @param inputPorts The number of fan-in input ports
+   * @param detachedInputs If the ports should be detached (eagerly pull both inputs) useful to avoid deadlocks in graphs with loops
+   * @return
+   */
+  def apply[T](inputPorts: Int, detachedInputs: Boolean): Graph[UniformFanInShape[T, T], NotUsed] =
+    if (detachedInputs) GraphStages.withDetachedInputs(new Concat(inputPorts))
+    else new Concat(inputPorts)
+
 }
 
 /**

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -1244,6 +1244,11 @@ class ZipWithN[A, O](zipper: immutable.Seq[A] => O)(n: Int) extends GraphStage[U
 
 object Concat {
 
+  // two streams is so common that we can re-use a single instance to avoid some allocations
+  private val _concatTwo = new Concat[Any](2)
+  private def concatTwo[T]: GraphStage[UniformFanInShape[T, T]] =
+    _concatTwo.asInstanceOf[GraphStage[UniformFanInShape[T, T]]]
+
   /**
    * Create a new `Concat`. Note that this for historical reasons creates a "detached" Concat which
    * will eagerly pull each input on materialization and act as a one element buffer for each input.
@@ -1257,9 +1262,15 @@ object Concat {
    * @param detachedInputs If the ports should be detached (eagerly pull both inputs) useful to avoid deadlocks in graphs with loops
    * @return
    */
-  def apply[T](inputPorts: Int, detachedInputs: Boolean): Graph[UniformFanInShape[T, T], NotUsed] =
-    if (detachedInputs) GraphStages.withDetachedInputs(new Concat(inputPorts))
-    else new Concat(inputPorts)
+  def apply[T](inputPorts: Int, detachedInputs: Boolean): Graph[UniformFanInShape[T, T], NotUsed] = {
+    val concat = {
+      if (inputPorts == 2) concatTwo[T]
+      else new Concat[T](inputPorts)
+    }
+
+    if (detachedInputs) GraphStages.withDetachedInputs(concat)
+    else concat
+  }
 
 }
 


### PR DESCRIPTION
References #23044 

More generally applies the fix from https://github.com/akka/akka-grpc/pull/1350 which both avoids some extra work during materialization and during stream processing since it avoids the extra detach stages.

Additional optimizations for concatenating two streams, when concatenating `Source.empty` and `Source.single` which is quite common and re-using the operator instance for the general case.
