### PR TITLE
Call BoundaryEvent cancellation hook for telemetry when ActorGraphInterpreter stops

### DIFF
--- a/akka-actor/src/main/scala/akka/actor/ActorCell.scala
+++ b/akka-actor/src/main/scala/akka/actor/ActorCell.scala
@@ -322,6 +322,7 @@ private[akka] trait Cell {
    * schedule the actor to run, depending on which type of cell it is.
    * Is only allowed to throw Fatal Throwables.
    */
+  @InternalStableApi
   final def sendMessage(message: Any, sender: ActorRef): Unit =
     sendMessage(Envelope(message, sender, system))
 

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/ActorGraphInterpreter.scala
@@ -836,6 +836,7 @@ import akka.util.OptionVal
           case b: BoundaryEvent =>
             // signal to telemetry that this event won't be processed
             b.cancel()
+          case _ => // ignore
         }
       }
     }


### PR DESCRIPTION
This is a missing part of #30246