### PR TITLE
Fix LineNumberSpec failing in Scala 3

### DIFF
--- a/akka-actor-tests/src/test/scala-3/akka/util/LineNumberSpec.scala
+++ b/akka-actor-tests/src/test/scala-3/akka/util/LineNumberSpec.scala
@@ -24,7 +24,7 @@ class LineNumberSpec extends AkkaSpec {
       }
 
       "work for partial functions" in {
-        LineNumbers(partial) should ===(SourceFileLines("LineNumberSpecCodeForScala.scala", 21, 22))
+        LineNumbers(partial) should ===(SourceFileLines("LineNumberSpecCodeForScala.scala", 20, 22))
       }
 
       "work for `def`" in {


### PR DESCRIPTION
Probably introduced by #30248
