### PR TITLE
First implementation of DurableStateBehavior, #30277

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,4 +59,5 @@ branches:
   only:
   - master
   - release-2.5
+  - dev-durable-state
   - /^v\d+\.\d+(\.\d+)?(-\S*)?$/

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/DurableStateChange.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/DurableStateChange.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query
+
+/**
+ * @param persistenceId The persistence id of the origin entity.
+ * @param seqNr The sequence number from the origin entity.
+ * @param value The object value.
+ * @param offset The offset that can be used in next `changes` or `currentChanges` query.
+ * @param timestamp The time the state was stored, in milliseconds since midnight, January 1, 1970 UTC
+ *   (same as `System.currentTimeMillis`).
+ *
+ * @tparam A the type of the value
+ */
+final class DurableStateChange[A](
+    val persistenceId: String,
+    val seqNr: Long,
+    val value: A,
+    val offset: Offset,
+    val timestamp: Long)

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/DurableStateStoreQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/DurableStateStoreQuery.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.javadsl
+
+import akka.NotUsed
+import akka.persistence.state.scaladsl.DurableStateStore
+import akka.persistence.query.DurableStateChange
+import akka.persistence.query.Offset
+import akka.stream.javadsl.Source
+
+/**
+ * Query API for reading durable state objects.
+ *
+ * For Scala API see [[akka.persistence.query.scaladsl.DurableStateStoreQuery]].
+ */
+trait DurableStateStoreQuery[A] extends DurableStateStore[A] {
+
+  /**
+   * Get a source of the most recent changes made to objects with the given tag since the passed in offset.
+   *
+   * Note that this only returns the most recent change to each object, if an object has been updated multiple times
+   * since the offset, only the most recent of those changes will be part of the stream.
+   *
+   * This will return changes that occurred up to when the `Source` returned by this call is materialized. Changes to
+   * objects made since materialization are not guaranteed to be included in the results.
+   *
+   * @param tag The type of entity to get changes for.
+   * @param offset The offset to get changes since. Must either be [[akka.persistence.query.NoOffset]] to get
+   *               changes since the beginning of time, or an offset that has been previously returned by this query.
+   *               Any other offsets are invalid.
+   * @return A source of change events.
+   */
+  def currentChanges(tag: String, offset: Offset): Source[DurableStateChange[A], NotUsed]
+
+  /**
+   * Get a source of the most recent changes made to objects of the given entity type since the passed in offset.
+   *
+   * The returned source will never terminate, it effectively watches for changes to the objects and emits changes as
+   * they happen.
+   *
+   * Not all changes that occur are guaranteed to be emitted, this call only guarantees that eventually, the most
+   * recent change for each object since the offset will be emitted. In particular, multiple updates to a given object
+   * in quick succession are likely to be skipped, with only the last update resulting in a change event from this
+   * source.
+   *
+   * @param tag The type of entity to get changes for.
+   * @param offset The offset to get changes since. Must either be [[akka.persistence.query.NoOffset]] to get
+   *               changes since the beginning of time, or an offset that has been previously returned by this query.
+   *               Any other offsets are invalid.
+   * @return A source of change events.
+   */
+  def changes(tag: String, offset: Offset): Source[DurableStateChange[A], NotUsed]
+}

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/DurableStateStoreQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/DurableStateStoreQuery.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.scaladsl
+
+import akka.NotUsed
+import akka.persistence.state.scaladsl.DurableStateStore
+import akka.persistence.query.DurableStateChange
+import akka.persistence.query.Offset
+import akka.stream.scaladsl.Source
+
+/**
+ * Query API for reading durable state objects.
+ *
+ * For Java API see [[akka.persistence.query.javadsl.DurableStateStoreQuery]].
+ */
+trait DurableStateStoreQuery[A] extends DurableStateStore[A] {
+
+  /**
+   * Get a source of the most recent changes made to objects with the given tag since the passed in offset.
+   *
+   * Note that this only returns the most recent change to each object, if an object has been updated multiple times
+   * since the offset, only the most recent of those changes will be part of the stream.
+   *
+   * This will return changes that occurred up to when the `Source` returned by this call is materialized. Changes to
+   * objects made since materialization are not guaranteed to be included in the results.
+   *
+   * @param tag The type of entity to get changes for.
+   * @param offset The offset to get changes since. Must either be [[akka.persistence.query.NoOffset]] to get
+   *               changes since the beginning of time, or an offset that has been previously returned by this query.
+   *               Any other offsets are invalid.
+   * @return A source of change events.
+   */
+  def currentChanges(tag: String, offset: Offset): Source[DurableStateChange[A], NotUsed]
+
+  /**
+   * Get a source of the most recent changes made to objects of the given entity type since the passed in offset.
+   *
+   * The returned source will never terminate, it effectively watches for changes to the objects and emits changes as
+   * they happen.
+   *
+   * Not all changes that occur are guaranteed to be emitted, this call only guarantees that eventually, the most
+   * recent change for each object since the offset will be emitted. In particular, multiple updates to a given object
+   * in quick succession are likely to be skipped, with only the last update resulting in a change event from this
+   * source.
+   *
+   * @param tag The type of entity to get changes for.
+   * @param offset The offset to get changes since. Must either be [[akka.persistence.query.NoOffset]] to get
+   *               changes since the beginning of time, or an offset that has been previously returned by this query.
+   *               Any other offsets are invalid.
+   * @return A source of change events.
+   */
+  def changes(tag: String, offset: Offset): Source[DurableStateChange[A], NotUsed]
+}

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorReplySpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorReplySpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.scaladsl
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import akka.Done
+import akka.actor.testkit.typed.scaladsl._
+import akka.actor.typed.ActorRef
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.Behaviors
+import akka.persistence.typed.PersistenceId
+import akka.serialization.jackson.CborSerializable
+
+object DurableStateBehaviorReplySpec {
+  def conf: Config = ConfigFactory.parseString(s"""
+    akka.loglevel = INFO
+    akka.persistence.state.plugin = "akka.persistence.state.inmem"
+    akka.persistence.state.inmem {
+      class = "akka.persistence.state.inmem.InmemDurableStateStoreProvider"
+      # FIXME we should change this to use a fallback in reference.conf
+      recovery-timeout = 30s
+    }
+    """)
+
+  sealed trait Command[ReplyMessage] extends CborSerializable
+  final case class IncrementWithConfirmation(replyTo: ActorRef[Done]) extends Command[Done]
+  final case class IncrementReplyLater(replyTo: ActorRef[Done]) extends Command[Done]
+  final case class ReplyNow(replyTo: ActorRef[Done]) extends Command[Done]
+  final case class GetValue(replyTo: ActorRef[State]) extends Command[State]
+
+  final case class State(value: Int) extends CborSerializable
+
+  def counter(persistenceId: PersistenceId): Behavior[Command[_]] =
+    Behaviors.setup(ctx => counter(ctx, persistenceId))
+
+  def counter(ctx: ActorContext[Command[_]], persistenceId: PersistenceId): DurableStateBehavior[Command[_], State] = {
+    DurableStateBehavior
+      .withEnforcedReplies[Command[_], State](
+        persistenceId,
+        emptyState = State(0),
+        commandHandler = (state, command) =>
+          command match {
+
+            case IncrementWithConfirmation(replyTo) =>
+              Effect.persist(state.copy(value = state.value + 1)).thenReply(replyTo)(_ => Done)
+
+            case IncrementReplyLater(replyTo) =>
+              Effect
+                .persist(state.copy(value = state.value + 1))
+                .thenRun((_: State) => ctx.self ! ReplyNow(replyTo))
+                .thenNoReply()
+
+            case ReplyNow(replyTo) =>
+              Effect.reply(replyTo)(Done)
+
+            case GetValue(replyTo) =>
+              Effect.reply(replyTo)(state)
+
+          })
+      .withDurableStateStorePluginId("akka.persistence.state.inmem")
+  }
+}
+
+class DurableStateBehaviorReplySpec
+    extends ScalaTestWithActorTestKit(DurableStateBehaviorReplySpec.conf)
+    with AnyWordSpecLike
+    with LogCapturing {
+
+  import DurableStateBehaviorReplySpec._
+
+  val pidCounter = new AtomicInteger(0)
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()})")
+
+  "A typed persistent actor with commands that are expecting replies" must {
+
+    "persist an event thenReply" in {
+      val c = spawn(counter(nextPid()))
+      val probe = TestProbe[Done]()
+      c ! IncrementWithConfirmation(probe.ref)
+      probe.expectMessage(Done)
+
+      c ! IncrementWithConfirmation(probe.ref)
+      c ! IncrementWithConfirmation(probe.ref)
+      probe.expectMessage(Done)
+      probe.expectMessage(Done)
+    }
+
+    "persist an event thenReply later" in {
+      val c = spawn(counter(nextPid()))
+      val probe = TestProbe[Done]()
+      c ! IncrementReplyLater(probe.ref)
+      probe.expectMessage(Done)
+    }
+
+    "reply to query command" in {
+      val c = spawn(counter(nextPid()))
+      val updateProbe = TestProbe[Done]()
+      c ! IncrementWithConfirmation(updateProbe.ref)
+
+      val queryProbe = TestProbe[State]()
+      c ! GetValue(queryProbe.ref)
+      queryProbe.expectMessage(State(1))
+    }
+  }
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/DurableStateSignal.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/DurableStateSignal.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state
+
+import akka.actor.typed.Signal
+import akka.annotation.DoNotInherit
+
+/**
+ * Supertype for all `DurableStateBehavior` specific signals
+ *
+ * Not for user extension
+ */
+@DoNotInherit
+sealed trait DurableStateSignal extends Signal
+
+@DoNotInherit sealed abstract class RecoveryCompleted extends DurableStateSignal
+case object RecoveryCompleted extends RecoveryCompleted {
+  def instance: RecoveryCompleted = this
+}
+
+final case class RecoveryFailed(failure: Throwable) extends DurableStateSignal {
+
+  /**
+   * Java API
+   */
+  def getFailure(): Throwable = failure
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/BehaviorSetup.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.internal
+
+import scala.util.control.NonFatal
+
+import org.slf4j.Logger
+import org.slf4j.MDC
+
+import akka.actor.Cancellable
+import akka.actor.typed.Signal
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.{ ActorRef => ClassicActorRef }
+import akka.annotation.InternalApi
+import akka.persistence._
+import akka.persistence.typed.state.internal.InternalProtocol.RecoveryTimeout
+import akka.persistence.typed.state.scaladsl.DurableStateBehavior
+import akka.persistence.state.DurableStateStoreRegistry
+import akka.persistence.state.scaladsl.DurableStateUpdateStore
+import akka.persistence.typed.PersistenceId
+import akka.persistence.typed.SnapshotAdapter
+import akka.util.OptionVal
+
+/**
+ * INTERNAL API: Carry state for the `DurableStateBehavior` implementation behaviors.
+ */
+@InternalApi
+private[akka] final class BehaviorSetup[C, S](
+    val context: ActorContext[InternalProtocol],
+    val persistenceId: PersistenceId,
+    val emptyState: S,
+    val commandHandler: DurableStateBehavior.CommandHandler[C, S],
+    private val signalHandler: PartialFunction[(S, Signal), Unit],
+    val tag: String,
+    val snapshotAdapter: SnapshotAdapter[S],
+    var holdingRecoveryPermit: Boolean,
+    val settings: DurableStateSettings,
+    val stashState: StashState,
+    private val internalLoggerFactory: () => Logger) {
+
+  import akka.actor.typed.scaladsl.adapter._
+
+  val persistence: Persistence = Persistence(context.system.toClassic)
+
+  // Any instead S because adapter may change the type
+  val durableStateStore: DurableStateUpdateStore[Any] =
+    DurableStateStoreRegistry(context.system.toClassic)
+      .durableStateStoreFor[DurableStateUpdateStore[Any]](settings.durableStateStorePluginId)
+
+  def selfClassic: ClassicActorRef = context.self.toClassic
+
+  private var mdcPhase = PersistenceMdc.Initializing
+
+  def internalLogger: Logger = {
+    PersistenceMdc.setMdc(persistenceId, mdcPhase)
+    internalLoggerFactory()
+  }
+
+  def setMdcPhase(phaseName: String): BehaviorSetup[C, S] = {
+    mdcPhase = phaseName
+    this
+  }
+
+  private var recoveryTimer: OptionVal[Cancellable] = OptionVal.None
+
+  def startRecoveryTimer(): Unit = {
+    cancelRecoveryTimer()
+    val timer = context.scheduleOnce(settings.recoveryTimeout, context.self, RecoveryTimeout)
+    recoveryTimer = OptionVal.Some(timer)
+  }
+
+  def cancelRecoveryTimer(): Unit = {
+    recoveryTimer match {
+      case OptionVal.Some(t) => t.cancel()
+      case _                 =>
+    }
+    recoveryTimer = OptionVal.None
+  }
+
+  /**
+   * Applies the `signalHandler` if defined and returns true, otherwise returns false.
+   * If an exception is thrown and `catchAndLog=true` it is logged and returns true, otherwise it is thrown.
+   *
+   * `catchAndLog=true` should be used for "unknown" signals in the phases before Running
+   * to avoid restart loops if restart supervision is used.
+   */
+  def onSignal[T](state: S, signal: Signal, catchAndLog: Boolean): Boolean = {
+    try {
+      var handled = true
+      signalHandler.applyOrElse((state, signal), (_: (S, Signal)) => handled = false)
+      handled
+    } catch {
+      case NonFatal(ex) =>
+        if (catchAndLog) {
+          internalLogger.error(s"Error while processing signal [$signal]: $ex", ex)
+          true
+        } else {
+          if (internalLogger.isDebugEnabled)
+            internalLogger.debug(s"Error while processing signal [$signal]: $ex", ex)
+          throw ex
+        }
+    }
+  }
+
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] object PersistenceMdc {
+  // format: OFF
+  val Initializing      = "initializing"
+  val AwaitingPermit    = "get-permit"
+  val RecoveringState = "recovering"
+  val RunningCmds       = "running-cmd"
+  val PersistingState  = "persist-state"
+  // format: ON
+
+  val PersistencePhaseKey = "persistencePhase"
+  val PersistenceIdKey = "persistenceId"
+
+  // MDC is cleared (if used) from aroundReceive in ActorAdapter after processing each message,
+  // but important to call `context.log` to mark MDC as used
+  def setMdc(persistenceId: PersistenceId, phase: String): Unit = {
+    MDC.put(PersistenceIdKey, persistenceId.id)
+    MDC.put(PersistencePhaseKey, phase)
+  }
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateBehaviorImpl.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2017-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.internal
+
+import org.slf4j.LoggerFactory
+
+import akka.actor.typed
+import akka.actor.typed.ActorRef
+import akka.actor.typed.BackoffSupervisorStrategy
+import akka.actor.typed.Behavior
+import akka.actor.typed.BehaviorInterceptor
+import akka.actor.typed.PostStop
+import akka.actor.typed.Signal
+import akka.actor.typed.SupervisorStrategy
+import akka.actor.typed.internal.ActorContextImpl
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.Behaviors
+import akka.annotation._
+import akka.persistence.RecoveryPermitter
+import akka.persistence.typed.state.scaladsl._
+import akka.persistence.state.scaladsl.GetObjectResult
+import akka.persistence.typed.PersistenceId
+import akka.persistence.typed.SnapshotAdapter
+import akka.util.unused
+
+@InternalApi
+private[akka] object DurableStateBehaviorImpl {
+
+  /**
+   * Used by DurableStateBehaviorTestKit to retrieve the `persistenceId`.
+   */
+  final case class GetPersistenceId(replyTo: ActorRef[PersistenceId]) extends Signal
+
+  /**
+   * Used by DurableStateBehaviorTestKit to retrieve the state.
+   * Can't be a Signal because those are not stashed.
+   */
+  final case class GetState[State](replyTo: ActorRef[State]) extends InternalProtocol
+
+}
+
+@InternalApi
+private[akka] final case class DurableStateBehaviorImpl[Command, State](
+    persistenceId: PersistenceId,
+    emptyState: State,
+    commandHandler: DurableStateBehavior.CommandHandler[Command, State],
+    loggerClass: Class[_],
+    durableStateStorePluginId: Option[String] = None,
+    tag: String = "",
+    snapshotAdapter: SnapshotAdapter[State] = NoOpSnapshotAdapter.instance[State],
+    supervisionStrategy: SupervisorStrategy = SupervisorStrategy.stop,
+    override val signalHandler: PartialFunction[(State, Signal), Unit] = PartialFunction.empty)
+    extends DurableStateBehavior[Command, State] {
+
+  if (persistenceId eq null)
+    throw new IllegalArgumentException("persistenceId must not be null")
+
+  // Don't use it directly, but instead call internalLogger() (see below)
+  private val loggerForInternal = LoggerFactory.getLogger(this.getClass)
+
+  override def apply(context: typed.TypedActorContext[Command]): Behavior[Command] = {
+    val ctx = context.asScala
+    val hasCustomLoggerName = ctx match {
+      case internalCtx: ActorContextImpl[_] => internalCtx.hasCustomLoggerName
+      case _                                => false
+    }
+    if (!hasCustomLoggerName) ctx.setLoggerName(loggerClass)
+    val settings = DurableStateSettings(ctx.system, durableStateStorePluginId.getOrElse(""))
+
+    // stashState outside supervise because StashState should survive restarts due to persist failures
+    val stashState = new StashState(ctx.asInstanceOf[ActorContext[InternalProtocol]], settings)
+
+    // This method ensures that the MDC is set before we use the internal logger
+    def internalLogger() = {
+      if (settings.useContextLoggerForInternalLogging) ctx.log
+      else {
+        // MDC is cleared (if used) from aroundReceive in ActorAdapter after processing each message,
+        // but important to call `context.log` to mark MDC as used
+        ctx.log
+        loggerForInternal
+      }
+    }
+
+    val actualSignalHandler: PartialFunction[(State, Signal), Unit] = signalHandler.orElse {
+      // default signal handler is always the fallback
+      case (_, DurableStateBehaviorImpl.GetPersistenceId(replyTo)) => replyTo ! persistenceId
+    }
+
+    // do this once, even if the actor is restarted
+    initialize(context.asScala)
+
+    Behaviors
+      .supervise {
+        Behaviors.setup[Command] { _ =>
+          val durableStateSetup = new BehaviorSetup(
+            ctx.asInstanceOf[ActorContext[InternalProtocol]],
+            persistenceId,
+            emptyState,
+            commandHandler,
+            actualSignalHandler,
+            tag,
+            snapshotAdapter,
+            holdingRecoveryPermit = false,
+            settings = settings,
+            stashState = stashState,
+            internalLoggerFactory = () => internalLogger())
+
+          // needs to accept Any since we also can get messages from outside
+          // not part of the user facing Command protocol
+          def interceptor: BehaviorInterceptor[Any, InternalProtocol] = new BehaviorInterceptor[Any, InternalProtocol] {
+
+            import BehaviorInterceptor._
+            override def aroundReceive(
+                ctx: typed.TypedActorContext[Any],
+                msg: Any,
+                target: ReceiveTarget[InternalProtocol]): Behavior[InternalProtocol] = {
+              val innerMsg = msg match {
+                case RecoveryPermitter.RecoveryPermitGranted => InternalProtocol.RecoveryPermitGranted
+                case internal: InternalProtocol              => internal // such as RecoveryTimeout
+                case cmd                                     => InternalProtocol.IncomingCommand(cmd.asInstanceOf[Command])
+              }
+              target(ctx, innerMsg)
+            }
+
+            override def aroundSignal(
+                ctx: typed.TypedActorContext[Any],
+                signal: Signal,
+                target: SignalTarget[InternalProtocol]): Behavior[InternalProtocol] = {
+              if (signal == PostStop) {
+                durableStateSetup.cancelRecoveryTimer()
+                // clear stash to be GC friendly
+                stashState.clearStashBuffers()
+              }
+              target(ctx, signal)
+            }
+
+            override def toString: String = "DurableStateBehaviorInterceptor"
+          }
+
+          Behaviors.intercept(() => interceptor)(RequestingRecoveryPermit(durableStateSetup)).narrow
+        }
+
+      }
+      .onFailure[DurableStateStoreException](supervisionStrategy)
+  }
+
+  @InternalStableApi
+  private[akka] def initialize(@unused context: ActorContext[_]): Unit = ()
+
+  override def receiveSignal(handler: PartialFunction[(State, Signal), Unit]): DurableStateBehavior[Command, State] =
+    copy(signalHandler = handler)
+
+  override def withDurableStateStorePluginId(id: String): DurableStateBehavior[Command, State] = {
+    require(id != null, "DurableStateBehavior plugin id must not be null; use empty string for 'default' state store")
+    copy(durableStateStorePluginId = if (id != "") Some(id) else None)
+  }
+
+  override def withTag(tag: String): DurableStateBehavior[Command, State] =
+    copy(tag = tag)
+
+  override def snapshotAdapter(adapter: SnapshotAdapter[State]): DurableStateBehavior[Command, State] =
+    copy(snapshotAdapter = adapter)
+
+  override def onPersistFailure(backoffStrategy: BackoffSupervisorStrategy): DurableStateBehavior[Command, State] =
+    copy(supervisionStrategy = backoffStrategy)
+
+}
+
+/** Protocol used internally by the DurableStateBehavior. */
+@InternalApi private[akka] sealed trait InternalProtocol
+@InternalApi private[akka] object InternalProtocol {
+  case object RecoveryPermitGranted extends InternalProtocol
+  final case class GetSuccess[S](result: GetObjectResult[S]) extends InternalProtocol
+  final case class GetFailure(cause: Throwable) extends InternalProtocol
+  case object UpsertSuccess extends InternalProtocol
+  final case class UpsertFailure(cause: Throwable) extends InternalProtocol
+  case object RecoveryTimeout extends InternalProtocol
+  final case class IncomingCommand[C](c: C) extends InternalProtocol
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateSettings.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateSettings.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.internal
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
+
+import com.typesafe.config.Config
+
+import akka.actor.typed.ActorSystem
+import akka.annotation.InternalApi
+import akka.persistence.Persistence
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object DurableStateSettings {
+
+  def apply(system: ActorSystem[_], durableStateStorePluginId: String): DurableStateSettings =
+    apply(system.settings.config, durableStateStorePluginId)
+
+  def apply(config: Config, durableStateStorePluginId: String): DurableStateSettings = {
+    val typedConfig = config.getConfig("akka.persistence.typed")
+
+    val stashOverflowStrategy = typedConfig.getString("stash-overflow-strategy").toLowerCase match {
+      case "drop" => StashOverflowStrategy.Drop
+      case "fail" => StashOverflowStrategy.Fail
+      case unknown =>
+        throw new IllegalArgumentException(s"Unknown value for stash-overflow-strategy: [$unknown]")
+    }
+
+    val stashCapacity = typedConfig.getInt("stash-capacity")
+    require(stashCapacity > 0, "stash-capacity MUST be > 0, unbounded buffering is not supported.")
+
+    val logOnStashing = typedConfig.getBoolean("log-stashing")
+
+    val durableStateStoreConfig = durableStateStoreConfigFor(config, durableStateStorePluginId)
+    val recoveryTimeout: FiniteDuration =
+      durableStateStoreConfig.getDuration("recovery-timeout", TimeUnit.MILLISECONDS).millis
+
+    val useContextLoggerForInternalLogging = typedConfig.getBoolean("use-context-logger-for-internal-logging")
+
+    DurableStateSettings(
+      stashCapacity = stashCapacity,
+      stashOverflowStrategy,
+      logOnStashing = logOnStashing,
+      recoveryTimeout,
+      durableStateStorePluginId,
+      useContextLoggerForInternalLogging)
+  }
+
+  private def durableStateStoreConfigFor(config: Config, pluginId: String): Config = {
+    def defaultPluginId = {
+      val configPath = config.getString("akka.persistence.state.plugin")
+      Persistence.verifyPluginConfigIsDefined(configPath, "Default DurableStateStore")
+      configPath
+    }
+
+    val configPath = if (pluginId == "") defaultPluginId else pluginId
+    Persistence.verifyPluginConfigExists(config, configPath, "DurableStateStore")
+    config.getConfig(configPath)
+  }
+
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] final case class DurableStateSettings(
+    stashCapacity: Int,
+    stashOverflowStrategy: StashOverflowStrategy,
+    logOnStashing: Boolean,
+    recoveryTimeout: FiniteDuration,
+    durableStateStorePluginId: String,
+    useContextLoggerForInternalLogging: Boolean) {
+
+  require(
+    durableStateStorePluginId != null,
+    "DurableStateBehavior plugin id must not be null; use empty string for 'default' state store")
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] sealed trait StashOverflowStrategy
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] object StashOverflowStrategy {
+  case object Drop extends StashOverflowStrategy
+  case object Fail extends StashOverflowStrategy
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateStoreException.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateStoreException.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2018-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.internal
+
+import akka.annotation.InternalApi
+import akka.persistence.typed.PersistenceId
+
+/**
+ * INTERNAL API
+ *
+ * Used for store failures. Private to akka as only internal supervision strategies should use it.
+ */
+@InternalApi
+final private[akka] class DurableStateStoreException(msg: String, cause: Throwable)
+    extends RuntimeException(msg, cause) {
+  def this(persistenceId: PersistenceId, sequenceNr: Long, cause: Throwable) =
+    this(s"Failed to persist state with sequence number [$sequenceNr] for persistenceId [${persistenceId.id}]", cause)
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateStoreInteractions.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateStoreInteractions.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2016-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.internal
+
+import scala.util.Failure
+import scala.util.Success
+
+import akka.Done
+import akka.actor.typed.Behavior
+import akka.actor.typed.PostStop
+import akka.actor.typed.PreRestart
+import akka.actor.typed.Signal
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.Behaviors
+import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
+import akka.persistence._
+import akka.persistence.state.scaladsl.GetObjectResult
+import akka.util.unused
+
+/** INTERNAL API */
+@InternalApi
+private[akka] trait DurableStateStoreInteractions[C, S] {
+
+  def setup: BehaviorSetup[C, S]
+
+  // FIXME use CircuitBreaker here, that can also replace the RecoveryTimeout
+
+  protected def internalGet(ctx: ActorContext[InternalProtocol]): Unit = {
+    val persistenceId = setup.persistenceId.id
+    ctx.pipeToSelf[GetObjectResult[Any]](setup.durableStateStore.getObject(persistenceId)) {
+      case Success(state) => InternalProtocol.GetSuccess(state)
+      case Failure(cause) => InternalProtocol.GetFailure(cause)
+    }
+  }
+
+  protected def internalUpsert(
+      ctx: ActorContext[InternalProtocol],
+      cmd: Any,
+      state: Running.RunningState[S],
+      value: Any): Running.RunningState[S] = {
+
+    val newRunningState = state.nextSequenceNr()
+    val persistenceId = setup.persistenceId.id
+
+    onWriteInitiated(ctx, cmd)
+
+    ctx.pipeToSelf[Done](setup.durableStateStore.upsertObject(persistenceId, newRunningState.seqNr, value, setup.tag)) {
+      case Success(_)     => InternalProtocol.UpsertSuccess
+      case Failure(cause) => InternalProtocol.UpsertFailure(cause)
+    }
+
+    newRunningState
+  }
+
+  // FIXME These hook methods are for Telemetry. What more parameters are needed? persistenceId?
+  @InternalStableApi
+  private[akka] def onWriteInitiated(@unused ctx: ActorContext[_], @unused cmd: Any): Unit = ()
+
+  protected def requestRecoveryPermit(): Unit = {
+    setup.persistence.recoveryPermitter.tell(RecoveryPermitter.RequestRecoveryPermit, setup.selfClassic)
+  }
+
+  /** Intended to be used in .onSignal(returnPermitOnStop) by behaviors */
+  protected def returnPermitOnStop
+      : PartialFunction[(ActorContext[InternalProtocol], Signal), Behavior[InternalProtocol]] = {
+    case (_, PostStop) =>
+      tryReturnRecoveryPermit("PostStop")
+      Behaviors.stopped
+    case (_, PreRestart) =>
+      tryReturnRecoveryPermit("PreRestart")
+      Behaviors.stopped
+  }
+
+  /** Mutates setup, by setting the `holdingRecoveryPermit` to false */
+  protected def tryReturnRecoveryPermit(reason: String): Unit = {
+    if (setup.holdingRecoveryPermit) {
+      setup.internalLogger.debug("Returning recovery permit, reason: {}", reason)
+      setup.persistence.recoveryPermitter.tell(RecoveryPermitter.ReturnRecoveryPermit, setup.selfClassic)
+      setup.holdingRecoveryPermit = false
+    } // else, no need to return the permit
+  }
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/EffectImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/EffectImpl.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2018-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.internal
+
+import scala.collection.immutable
+
+import akka.actor.typed.ActorRef
+import akka.annotation.InternalApi
+import akka.persistence.typed.state.javadsl
+import akka.persistence.typed.state.scaladsl
+
+/** INTERNAL API */
+@InternalApi
+private[akka] abstract class EffectImpl[State]
+    extends javadsl.EffectBuilder[State]
+    with javadsl.ReplyEffect[State]
+    with scaladsl.ReplyEffect[State]
+    with scaladsl.EffectBuilder[State] {
+  /* The state that will be persisted in this effect */
+  override def state: Option[State] = None
+
+  override def thenRun(chainedEffect: State => Unit): EffectImpl[State] =
+    CompositeEffect(this, new Callback[State](chainedEffect))
+
+  override def thenReply[ReplyMessage](replyTo: ActorRef[ReplyMessage])(
+      replyWithMessage: State => ReplyMessage): EffectImpl[State] =
+    CompositeEffect(this, new ReplyEffectImpl[ReplyMessage, State](replyTo, replyWithMessage))
+
+  override def thenUnstashAll(): EffectImpl[State] =
+    CompositeEffect(this, UnstashAll.asInstanceOf[SideEffect[State]])
+
+  override def thenNoReply(): EffectImpl[State] =
+    CompositeEffect(this, new NoReplyEffectImpl[State])
+
+  override def thenStop(): EffectImpl[State] =
+    CompositeEffect(this, Stop.asInstanceOf[SideEffect[State]])
+
+}
+
+/** INTERNAL API */
+@InternalApi
+private[akka] object CompositeEffect {
+  def apply[State](effect: scaladsl.EffectBuilder[State], sideEffects: SideEffect[State]): CompositeEffect[State] =
+    CompositeEffect[State](effect, sideEffects :: Nil)
+}
+
+/** INTERNAL API */
+@InternalApi
+private[akka] final case class CompositeEffect[State](
+    persistingEffect: scaladsl.EffectBuilder[State],
+    _sideEffects: immutable.Seq[SideEffect[State]])
+    extends EffectImpl[State] {
+
+  override val state: Option[State] = persistingEffect.state
+
+  override def toString: String =
+    s"CompositeEffect($persistingEffect, sideEffects: ${_sideEffects.size})"
+}
+
+/** INTERNAL API */
+@InternalApi
+private[akka] case object PersistNothing extends EffectImpl[Nothing]
+
+/** INTERNAL API */
+@InternalApi
+private[akka] final case class Persist[State](newState: State) extends EffectImpl[State] {
+  override val state: Option[State] = Option(newState)
+
+  override def toString: String = s"Persist(${newState.getClass.getName})"
+}
+
+/** INTERNAL API */
+@InternalApi
+private[akka] case object Unhandled extends EffectImpl[Nothing]
+
+/** INTERNAL API */
+@InternalApi
+private[akka] case object Stash extends EffectImpl[Nothing]

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/NoOpSnapshotAdapter.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/NoOpSnapshotAdapter.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2019-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.internal
+
+import akka.annotation.InternalApi
+import akka.persistence.typed.SnapshotAdapter
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] class NoOpSnapshotAdapter extends SnapshotAdapter[Any] {
+  override def toJournal(state: Any): Any = state
+  override def fromJournal(from: Any): Any = from
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] object NoOpSnapshotAdapter {
+  val i = new NoOpSnapshotAdapter
+  def instance[S]: SnapshotAdapter[S] = i.asInstanceOf[SnapshotAdapter[S]]
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Recovering.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Recovering.scala
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2016-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.internal
+
+import scala.concurrent.duration._
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.internal.PoisonPill
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
+import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
+import akka.persistence._
+import akka.persistence.typed.state.internal.DurableStateBehaviorImpl.GetState
+import akka.persistence.typed.state.internal.Running.WithSeqNrAccessible
+import akka.persistence.state.scaladsl.GetObjectResult
+import akka.persistence.typed.state.RecoveryCompleted
+import akka.persistence.typed.state.RecoveryFailed
+import akka.util.PrettyDuration._
+import akka.util.unused
+
+/**
+ * INTERNAL API
+ *
+ * Second (of three) behavior of a `DurableStateBehavior`.
+ *
+ * In this behavior the recovery process is initiated.
+ * We try to obtain the state from the configured `DurableStateStore`,
+ * and if it exists, we use it instead of the initial `emptyState`.
+ *
+ * See next behavior [[Running]].
+ * See previous behavior [[RequestingRecoveryPermit]].
+ */
+@InternalApi
+private[akka] object Recovering {
+
+  def apply[C, S](setup: BehaviorSetup[C, S], receivedPoisonPill: Boolean): Behavior[InternalProtocol] =
+    new Recovering(setup.setMdcPhase(PersistenceMdc.RecoveringState)).createBehavior(receivedPoisonPill)
+
+  @InternalApi
+  private[akka] final case class RecoveryState[State](
+      seqNr: Long,
+      state: State,
+      receivedPoisonPill: Boolean,
+      recoveryStartTime: Long)
+
+}
+
+@InternalApi
+private[akka] class Recovering[C, S](override val setup: BehaviorSetup[C, S])
+    extends DurableStateStoreInteractions[C, S]
+    with StashManagement[C, S]
+    with WithSeqNrAccessible {
+
+  import InternalProtocol._
+  import Recovering.RecoveryState
+
+  // Needed for WithSeqNrAccessible
+  private var _currentSequenceNumber = 0L
+
+  onRecoveryStart(setup.context)
+
+  def createBehavior(receivedPoisonPillInPreviousPhase: Boolean): Behavior[InternalProtocol] = {
+    // protect against store stalling forever because of store overloaded and such
+    setup.startRecoveryTimer()
+
+    internalGet(setup.context)
+
+    def stay(receivedPoisonPill: Boolean): Behavior[InternalProtocol] = {
+      Behaviors
+        .receiveMessage[InternalProtocol] {
+          case success: GetSuccess[S] => onGetSuccess(success.result, receivedPoisonPill)
+          case GetFailure(exc)        => onGetFailure(exc)
+          case RecoveryTimeout        => onRecoveryTimeout()
+          case cmd: IncomingCommand[C] =>
+            if (receivedPoisonPill) {
+              if (setup.settings.logOnStashing)
+                setup.internalLogger.debug("Discarding message [{}], because actor is to be stopped.", cmd)
+              Behaviors.unhandled
+            } else
+              onCommand(cmd)
+          case get: GetState[S @unchecked] => stashInternal(get)
+          case RecoveryPermitGranted       => Behaviors.unhandled // should not happen, we already have the permit
+          case UpsertSuccess               => Behaviors.unhandled
+          case _: UpsertFailure            => Behaviors.unhandled
+        }
+        .receiveSignal(returnPermitOnStop.orElse {
+          case (_, PoisonPill) =>
+            stay(receivedPoisonPill = true)
+          case (_, signal) =>
+            if (setup.onSignal(setup.emptyState, signal, catchAndLog = true)) Behaviors.same
+            else Behaviors.unhandled
+        })
+    }
+    stay(receivedPoisonPillInPreviousPhase)
+  }
+
+  /**
+   * Called whenever recovery fails.
+   *
+   * This method throws `DurableStateStoreException` which will be caught by the internal
+   * supervision strategy to stop or restart the actor with backoff.
+   *
+   * @param cause failure cause.
+   */
+  private def onRecoveryFailure(cause: Throwable): Behavior[InternalProtocol] = {
+    onRecoveryFailed(setup.context, cause)
+    setup.onSignal(setup.emptyState, RecoveryFailed(cause), catchAndLog = true)
+    setup.cancelRecoveryTimer()
+
+    tryReturnRecoveryPermit("on recovery failure: " + cause.getMessage)
+
+    if (setup.internalLogger.isDebugEnabled)
+      setup.internalLogger.debug("Recovery failure for persistenceId [{}]", setup.persistenceId)
+
+    val msg = s"Exception during recovery. " +
+      s"PersistenceId [${setup.persistenceId.id}]. ${cause.getMessage}"
+    throw new DurableStateStoreException(msg, cause)
+  }
+
+  @InternalStableApi
+  def onRecoveryStart(@unused context: ActorContext[_]): Unit = ()
+  @InternalStableApi
+  def onRecoveryComplete(@unused context: ActorContext[_]): Unit = ()
+  @InternalStableApi
+  def onRecoveryFailed(@unused context: ActorContext[_], @unused reason: Throwable): Unit = ()
+
+  private def onRecoveryTimeout(): Behavior[InternalProtocol] = {
+    val ex = new RecoveryTimedOut(s"Recovery timed out, didn't get state within ${setup.settings.recoveryTimeout}")
+    onRecoveryFailure(ex)
+  }
+
+  def onCommand(cmd: IncomingCommand[C]): Behavior[InternalProtocol] = {
+    // during recovery, stash all incoming commands
+    stashInternal(cmd)
+  }
+
+  def onGetSuccess(result: GetObjectResult[S], receivedPoisonPill: Boolean): Behavior[InternalProtocol] = {
+    val state = result.value match {
+      case Some(s) => setup.snapshotAdapter.fromJournal(s)
+      case None    => setup.emptyState
+    }
+
+    setup.context.log.debug("Recovered from seqNr [{}]", result.seqNr)
+
+    setup.cancelRecoveryTimer()
+
+    onRecoveryCompleted(RecoveryState(result.seqNr, state, receivedPoisonPill, System.nanoTime()))
+
+  }
+
+  private def onRecoveryCompleted(state: RecoveryState[S]): Behavior[InternalProtocol] =
+    try {
+      _currentSequenceNumber = state.seqNr
+      onRecoveryComplete(setup.context)
+      tryReturnRecoveryPermit("recovery completed successfully")
+      if (setup.internalLogger.isDebugEnabled) {
+        setup.internalLogger.debug2(
+          "Recovery for persistenceId [{}] took {}",
+          setup.persistenceId,
+          (System.nanoTime() - state.recoveryStartTime).nanos.pretty)
+      }
+
+      setup.onSignal(state.state, RecoveryCompleted, catchAndLog = false)
+
+      if (state.receivedPoisonPill && isInternalStashEmpty && !isUnstashAllInProgress)
+        Behaviors.stopped
+      else {
+        val runningState = Running
+          .RunningState[S](seqNr = state.seqNr, state = state.state, receivedPoisonPill = state.receivedPoisonPill)
+        val running = new Running(setup.setMdcPhase(PersistenceMdc.RunningCmds))
+        tryUnstashOne(new running.HandlingCommands(runningState))
+      }
+    } finally {
+      setup.cancelRecoveryTimer()
+    }
+
+  def onGetFailure(cause: Throwable): Behavior[InternalProtocol] = {
+    onRecoveryFailure(cause)
+  }
+
+  override def currentSequenceNumber: Long =
+    _currentSequenceNumber
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/RequestingRecoveryPermit.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/RequestingRecoveryPermit.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2016-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.internal
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.internal.PoisonPill
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.annotation.{ InternalApi, InternalStableApi }
+import akka.util.unused
+
+/**
+ * INTERNAL API
+ *
+ * First (of three) behavior of a `DurableStateBehavior`.
+ *
+ * Requests a permit to start recovery of this actor; this is tone to avoid
+ * hammering the store with too many concurrently recovering actors.
+ *
+ * See next behavior [[Recovering]].
+ */
+@InternalApi
+private[akka] object RequestingRecoveryPermit {
+
+  def apply[C, S](setup: BehaviorSetup[C, S]): Behavior[InternalProtocol] =
+    new RequestingRecoveryPermit(setup.setMdcPhase(PersistenceMdc.AwaitingPermit)).createBehavior()
+
+}
+
+@InternalApi
+private[akka] class RequestingRecoveryPermit[C, S](override val setup: BehaviorSetup[C, S])
+    extends StashManagement[C, S]
+    with DurableStateStoreInteractions[C, S] {
+
+  onRequestingRecoveryPermit(setup.context)
+
+  def createBehavior(): Behavior[InternalProtocol] = {
+    // request a permit, as only once we obtain one we can start recovery
+    requestRecoveryPermit()
+
+    def stay(receivedPoisonPill: Boolean): Behavior[InternalProtocol] = {
+      Behaviors
+        .receiveMessage[InternalProtocol] {
+          case InternalProtocol.RecoveryPermitGranted =>
+            becomeRecovering(receivedPoisonPill)
+
+          case other =>
+            if (receivedPoisonPill) {
+              if (setup.settings.logOnStashing)
+                setup.internalLogger.debug("Discarding message [{}], because actor is to be stopped.", other)
+              Behaviors.unhandled
+            } else {
+              stashInternal(other)
+            }
+
+        }
+        .receiveSignal {
+          case (_, PoisonPill) =>
+            stay(receivedPoisonPill = true)
+          case (_, signal) =>
+            if (setup.onSignal(setup.emptyState, signal, catchAndLog = true)) Behaviors.same
+            else Behaviors.unhandled
+        }
+    }
+    stay(receivedPoisonPill = false)
+  }
+
+  @InternalStableApi
+  def onRequestingRecoveryPermit(@unused context: ActorContext[_]): Unit = ()
+
+  private def becomeRecovering(receivedPoisonPill: Boolean): Behavior[InternalProtocol] = {
+    setup.internalLogger.debug(s"Initializing recovery")
+
+    setup.holdingRecoveryPermit = true
+    Recovering(setup, receivedPoisonPill)
+  }
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Running.scala
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2016-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.internal
+
+import scala.annotation.tailrec
+import scala.collection.immutable
+
+import akka.actor.UnhandledMessage
+import akka.actor.typed.Behavior
+import akka.actor.typed.Signal
+import akka.actor.typed.internal.PoisonPill
+import akka.actor.typed.scaladsl.AbstractBehavior
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
+import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
+import akka.persistence.typed.state.internal.DurableStateBehaviorImpl.GetState
+import akka.persistence.typed.state.scaladsl.Effect
+import akka.util.unused
+
+/**
+ * INTERNAL API
+ *
+ * Conceptually third (of three) -- also known as 'final' or 'ultimate' -- form of `DurableStateBehavior`.
+ *
+ * In this phase recovery has completed successfully and we continue handling incoming commands,
+ * as well as persisting new state as dictated by the user handlers.
+ *
+ * This behavior operates in two phases (also behaviors):
+ * - HandlingCommands - where the command handler is invoked for incoming commands
+ * - PersistingState - where incoming commands are stashed until persistence completes
+ *
+ * This is implemented as such to avoid creating many Running instances,
+ * which perform the Persistence extension lookup on creation and similar things (config lookup)
+ *
+ * See previous [[Recovering]].
+ */
+@InternalApi
+private[akka] object Running {
+
+  trait WithSeqNrAccessible {
+    def currentSequenceNumber: Long
+  }
+
+  final case class RunningState[State](seqNr: Long, state: State, receivedPoisonPill: Boolean) {
+
+    def nextSequenceNr(): RunningState[State] =
+      copy(seqNr = seqNr + 1)
+
+    def applyState[C, E](@unused setup: BehaviorSetup[C, State], updated: State): RunningState[State] = {
+      copy(state = updated)
+    }
+  }
+}
+
+// ===============================================
+
+/** INTERNAL API */
+@InternalApi private[akka] final class Running[C, S](override val setup: BehaviorSetup[C, S])
+    extends DurableStateStoreInteractions[C, S]
+    with StashManagement[C, S] {
+  import InternalProtocol._
+  import Running.RunningState
+  import Running.WithSeqNrAccessible
+
+  // Needed for WithSeqNrAccessible, when unstashing
+  private var _currentSequenceNumber = 0L
+
+  final class HandlingCommands(state: RunningState[S])
+      extends AbstractBehavior[InternalProtocol](setup.context)
+      with WithSeqNrAccessible {
+
+    _currentSequenceNumber = state.seqNr
+
+    def onMessage(msg: InternalProtocol): Behavior[InternalProtocol] = msg match {
+      case IncomingCommand(c: C @unchecked) => onCommand(state, c)
+      case get: GetState[S @unchecked]      => onGetState(get)
+      case _                                => Behaviors.unhandled
+    }
+
+    override def onSignal: PartialFunction[Signal, Behavior[InternalProtocol]] = {
+      case PoisonPill =>
+        if (isInternalStashEmpty && !isUnstashAllInProgress) Behaviors.stopped
+        else new HandlingCommands(state.copy(receivedPoisonPill = true))
+      case signal =>
+        if (setup.onSignal(state.state, signal, catchAndLog = false)) this
+        else Behaviors.unhandled
+    }
+
+    def onCommand(state: RunningState[S], cmd: C): Behavior[InternalProtocol] = {
+      val effect = setup.commandHandler(state.state, cmd)
+      val (next, doUnstash) = applyEffects(cmd, state, effect.asInstanceOf[EffectImpl[S]]) // TODO can we avoid the cast?
+      if (doUnstash) tryUnstashOne(next)
+      else next
+    }
+
+    // Used by DurableStateBehaviorTestKit to retrieve the state.
+    def onGetState(get: GetState[S]): Behavior[InternalProtocol] = {
+      get.replyTo ! state.state
+      this
+    }
+
+    private def handlePersist(
+        newState: S,
+        cmd: Any,
+        sideEffects: immutable.Seq[SideEffect[S]]): (Behavior[InternalProtocol], Boolean) = {
+      _currentSequenceNumber = state.seqNr + 1
+
+      val stateAfterApply = state.applyState(setup, newState)
+      val stateToPersist = adaptState(newState)
+
+      val newState2 =
+        internalUpsert(setup.context, cmd, stateAfterApply, stateToPersist)
+
+      (persistingState(newState2, state, sideEffects), false)
+    }
+
+    @tailrec def applyEffects(
+        msg: Any,
+        state: RunningState[S],
+        effect: Effect[S],
+        sideEffects: immutable.Seq[SideEffect[S]] = Nil): (Behavior[InternalProtocol], Boolean) = {
+      if (setup.internalLogger.isDebugEnabled && !effect.isInstanceOf[CompositeEffect[_]])
+        setup.internalLogger.debugN(
+          s"Handled command [{}], resulting effect: [{}], side effects: [{}]",
+          msg.getClass.getName,
+          effect,
+          sideEffects.size)
+
+      effect match {
+        case CompositeEffect(eff, currentSideEffects) =>
+          // unwrap and accumulate effects
+          applyEffects(msg, state, eff, currentSideEffects ++ sideEffects)
+
+        case Persist(newState) =>
+          handlePersist(newState, msg, sideEffects)
+
+        case _: PersistNothing.type =>
+          (applySideEffects(sideEffects, state), true)
+
+        case _: Unhandled.type =>
+          import akka.actor.typed.scaladsl.adapter._
+          setup.context.system.toClassic.eventStream
+            .publish(UnhandledMessage(msg, setup.context.system.toClassic.deadLetters, setup.context.self.toClassic))
+          (applySideEffects(sideEffects, state), true)
+
+        case _: Stash.type =>
+          stashUser(IncomingCommand(msg))
+          (applySideEffects(sideEffects, state), true)
+
+        case unexpected => throw new IllegalStateException(s"Unexpected effect: $unexpected")
+      }
+    }
+
+    def adaptState(newState: S): Any = {
+      setup.snapshotAdapter.toJournal(newState)
+    }
+
+    setup.setMdcPhase(PersistenceMdc.RunningCmds)
+
+    override def currentSequenceNumber: Long =
+      _currentSequenceNumber
+  }
+
+  // ===============================================
+
+  def persistingState(
+      state: RunningState[S],
+      visibleState: RunningState[S], // previous state until write success
+      sideEffects: immutable.Seq[SideEffect[S]]): Behavior[InternalProtocol] = {
+    setup.setMdcPhase(PersistenceMdc.PersistingState)
+    new PersistingState(state, visibleState, sideEffects)
+  }
+
+  /** INTERNAL API */
+  @InternalApi private[akka] class PersistingState(
+      var state: RunningState[S],
+      var visibleState: RunningState[S], // previous state until write success
+      var sideEffects: immutable.Seq[SideEffect[S]],
+      persistStartTime: Long = System.nanoTime())
+      extends AbstractBehavior[InternalProtocol](setup.context)
+      with WithSeqNrAccessible {
+
+    override def onMessage(msg: InternalProtocol): Behavior[InternalProtocol] = {
+      msg match {
+        case UpsertSuccess                     => onUpsertSuccess()
+        case UpsertFailure(exc)                => onUpsertFailed(exc)
+        case in: IncomingCommand[C @unchecked] => onCommand(in)
+        case get: GetState[S @unchecked]       => stashInternal(get)
+        case RecoveryTimeout                   => Behaviors.unhandled
+        case RecoveryPermitGranted             => Behaviors.unhandled
+        case _: GetSuccess[_]                  => Behaviors.unhandled
+        case _: GetFailure                     => Behaviors.unhandled
+      }
+    }
+
+    def onCommand(cmd: IncomingCommand[C]): Behavior[InternalProtocol] = {
+      if (state.receivedPoisonPill) {
+        if (setup.settings.logOnStashing)
+          setup.internalLogger.debug("Discarding message [{}], because actor is to be stopped.", cmd)
+        Behaviors.unhandled
+      } else {
+        stashInternal(cmd)
+      }
+    }
+
+    final def onUpsertSuccess(): Behavior[InternalProtocol] = {
+      if (setup.internalLogger.isDebugEnabled) {
+        setup.internalLogger
+          .debug("Received UpsertSuccess response after: {} nanos", System.nanoTime() - persistStartTime)
+      }
+
+      onWriteSuccess(setup.context)
+
+      visibleState = state
+      val newState = applySideEffects(sideEffects, state)
+      tryUnstashOne(newState)
+    }
+
+    final def onUpsertFailed(cause: Throwable): Behavior[InternalProtocol] = {
+      onWriteFailed(setup.context, cause)
+      throw new DurableStateStoreException(setup.persistenceId, currentSequenceNumber, cause)
+    }
+
+    override def onSignal: PartialFunction[Signal, Behavior[InternalProtocol]] = {
+      case PoisonPill =>
+        // wait for store responses before stopping
+        state = state.copy(receivedPoisonPill = true)
+        this
+      case signal =>
+        if (setup.onSignal(visibleState.state, signal, catchAndLog = false)) this
+        else Behaviors.unhandled
+    }
+
+    override def currentSequenceNumber: Long = {
+      _currentSequenceNumber
+    }
+  }
+
+  // ===============================================
+
+  def applySideEffects(effects: immutable.Seq[SideEffect[S]], state: RunningState[S]): Behavior[InternalProtocol] = {
+    var behavior: Behavior[InternalProtocol] = new HandlingCommands(state)
+    val it = effects.iterator
+
+    // if at least one effect results in a `stop`, we need to stop
+    // manual loop implementation to avoid allocations and multiple scans
+    while (it.hasNext) {
+      val effect = it.next()
+      behavior = applySideEffect(effect, state, behavior)
+    }
+
+    if (state.receivedPoisonPill && isInternalStashEmpty && !isUnstashAllInProgress)
+      Behaviors.stopped
+    else
+      behavior
+  }
+
+  def applySideEffect(
+      effect: SideEffect[S],
+      state: RunningState[S],
+      behavior: Behavior[InternalProtocol]): Behavior[InternalProtocol] = {
+    effect match {
+      case _: Stop.type @unchecked =>
+        Behaviors.stopped
+
+      case _: UnstashAll.type @unchecked =>
+        unstashAll()
+        behavior
+
+      case callback: Callback[_] =>
+        callback.sideEffect(state.state)
+        behavior
+
+      case _ =>
+        throw new IllegalArgumentException(s"Unsupported side effect detected [${effect.getClass.getName}]")
+    }
+  }
+
+  @InternalStableApi
+  private[akka] def onWriteFailed(@unused ctx: ActorContext[_], @unused reason: Throwable): Unit = ()
+  @InternalStableApi
+  private[akka] def onWriteSuccess(@unused ctx: ActorContext[_]): Unit = ()
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/SideEffect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/SideEffect.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2018-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.internal
+
+import akka.actor.typed.ActorRef
+import akka.annotation.InternalApi
+
+/**
+ * A [[SideEffect]] is an side effect that can be chained after a main effect.
+ *
+ * Persist, none and unhandled are main effects. Then any number of
+ * call backs can be added to these effects.
+ *
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] sealed abstract class SideEffect[State]
+
+/** INTERNAL API */
+@InternalApi
+private[akka] class Callback[State](val sideEffect: State => Unit) extends SideEffect[State] {
+  override def toString: String = "Callback"
+}
+
+/** INTERNAL API */
+@InternalApi
+final private[akka] class ReplyEffectImpl[ReplyMessage, State](
+    replyTo: ActorRef[ReplyMessage],
+    replyWithMessage: State => ReplyMessage)
+    extends Callback[State](state => replyTo ! replyWithMessage(state)) {
+  override def toString: String = "Reply"
+}
+
+/** INTERNAL API */
+@InternalApi
+final private[akka] class NoReplyEffectImpl[State] extends Callback[State](_ => ()) {
+  override def toString: String = "NoReply"
+}
+
+/** INTERNAL API */
+@InternalApi
+private[akka] case object Stop extends SideEffect[Nothing]
+
+/** INTERNAL API */
+@InternalApi
+private[akka] case object UnstashAll extends SideEffect[Nothing]
+
+/** INTERNAL API */
+@InternalApi
+private[akka] object SideEffect {
+
+  def apply[State](callback: State => Unit): SideEffect[State] =
+    new Callback(callback)
+
+  def unstashAll[State](): SideEffect[State] = UnstashAll.asInstanceOf[SideEffect[State]]
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/StashManagement.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/StashManagement.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2016-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.internal
+
+import akka.actor.Dropped
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
+import akka.actor.typed.scaladsl.StashBuffer
+import akka.actor.typed.scaladsl.StashOverflowException
+import akka.actor.typed.scaladsl.adapter._
+import akka.annotation.InternalApi
+import akka.util.ConstantFun
+
+/** INTERNAL API: Stash management for persistent behaviors */
+@InternalApi
+private[akka] trait StashManagement[C, S] {
+
+  def setup: BehaviorSetup[C, S]
+
+  private def context: ActorContext[InternalProtocol] = setup.context
+
+  private def stashState: StashState = setup.stashState
+
+  protected def isInternalStashEmpty: Boolean = stashState.internalStashBuffer.isEmpty
+
+  /**
+   * Stash a command to the internal stash buffer, which is used while waiting for persist to be completed.
+   */
+  protected def stashInternal(msg: InternalProtocol): Behavior[InternalProtocol] = {
+    stash(msg, stashState.internalStashBuffer)
+    Behaviors.same
+  }
+
+  /**
+   * Stash a command to the user stash buffer, which is used when `Stash` effect is used.
+   */
+  protected def stashUser(msg: InternalProtocol): Unit =
+    stash(msg, stashState.userStashBuffer)
+
+  private def stash(msg: InternalProtocol, buffer: StashBuffer[InternalProtocol]): Unit = {
+    logStashMessage(msg, buffer)
+
+    try buffer.stash(msg)
+    catch {
+      case e: StashOverflowException =>
+        setup.settings.stashOverflowStrategy match {
+          case StashOverflowStrategy.Drop =>
+            val dropName = msg match {
+              case InternalProtocol.IncomingCommand(actual) => actual.getClass.getName
+              case other                                    => other.getClass.getName
+            }
+            context.log.warn("Stash buffer is full, dropping message [{}]", dropName)
+            context.system.toClassic.eventStream.publish(Dropped(msg, "Stash buffer is full", context.self.toClassic))
+          case StashOverflowStrategy.Fail =>
+            throw e
+        }
+    }
+  }
+
+  /**
+   * `tryUnstashOne` is called at the end of processing each command, or when persist is completed
+   */
+  protected def tryUnstashOne(behavior: Behavior[InternalProtocol]): Behavior[InternalProtocol] = {
+    val buffer =
+      if (stashState.isUnstashAllInProgress) stashState.userStashBuffer
+      else stashState.internalStashBuffer
+
+    if (buffer.nonEmpty) {
+      logUnstashMessage(buffer)
+
+      stashState.decrementUnstashAllProgress()
+
+      buffer.unstash(behavior, 1, ConstantFun.scalaIdentityFunction)
+    } else behavior
+
+  }
+
+  /**
+   * Subsequent `tryUnstashOne` will drain the user stash buffer before using the
+   * internal stash buffer. It will unstash as many commands as are in the buffer when
+   * `unstashAll` was called, i.e. if subsequent commands stash more, those will
+   * not be unstashed until `unstashAll` is called again.
+   */
+  protected def unstashAll(): Unit = {
+    if (stashState.userStashBuffer.nonEmpty) {
+      logUnstashAll()
+      stashState.startUnstashAll()
+      // tryUnstashOne is called from Running at the end of processing each command
+      // or when persist is completed
+    }
+  }
+
+  protected def isUnstashAllInProgress: Boolean =
+    stashState.isUnstashAllInProgress
+
+  private def logStashMessage(msg: InternalProtocol, buffer: StashBuffer[InternalProtocol]): Unit = {
+    if (setup.settings.logOnStashing)
+      setup.internalLogger.debugN(
+        "Stashing message to {} stash: [{}] ",
+        if (buffer eq stashState.internalStashBuffer) "internal" else "user",
+        msg)
+  }
+
+  private def logUnstashMessage(buffer: StashBuffer[InternalProtocol]): Unit = {
+    if (setup.settings.logOnStashing)
+      setup.internalLogger.debugN(
+        "Unstashing message from {} stash: [{}]",
+        if (buffer eq stashState.internalStashBuffer) "internal" else "user",
+        buffer.head)
+  }
+
+  private def logUnstashAll(): Unit = {
+    if (setup.settings.logOnStashing)
+      setup.internalLogger.debug2(
+        "Unstashing all [{}] messages from user stash, first is: [{}]",
+        stashState.userStashBuffer.size,
+        stashState.userStashBuffer.head)
+  }
+
+}
+
+/** INTERNAL API: stash buffer state in order to survive restart of internal behavior */
+@InternalApi
+private[akka] class StashState(ctx: ActorContext[InternalProtocol], settings: DurableStateSettings) {
+
+  private var _internalStashBuffer: StashBuffer[InternalProtocol] = StashBuffer(ctx, settings.stashCapacity)
+  private var _userStashBuffer: StashBuffer[InternalProtocol] = StashBuffer(ctx, settings.stashCapacity)
+  private var unstashAllInProgress = 0
+
+  def internalStashBuffer: StashBuffer[InternalProtocol] = _internalStashBuffer
+
+  def userStashBuffer: StashBuffer[InternalProtocol] = _userStashBuffer
+
+  def clearStashBuffers(): Unit = {
+    _internalStashBuffer = StashBuffer(ctx, settings.stashCapacity)
+    _userStashBuffer = StashBuffer(ctx, settings.stashCapacity)
+    unstashAllInProgress = 0
+  }
+
+  def isUnstashAllInProgress: Boolean =
+    unstashAllInProgress > 0
+
+  def decrementUnstashAllProgress(): Unit = {
+    if (isUnstashAllInProgress)
+      unstashAllInProgress -= 1
+  }
+
+  def startUnstashAll(): Unit =
+    unstashAllInProgress = _userStashBuffer.size
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/CommandHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/CommandHandler.scala
@@ -1,0 +1,404 @@
+/*
+ * Copyright (C) 2018-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.javadsl
+
+import java.util.Objects
+import java.util.function.BiFunction
+import java.util.function.Predicate
+import java.util.function.Supplier
+import java.util.function.{ Function => JFunction }
+
+import scala.compat.java8.FunctionConverters._
+
+import akka.annotation.InternalApi
+import akka.persistence.typed.state.internal._
+import akka.util.OptionVal
+
+/**
+ * FunctionalInterface for reacting on commands
+ *
+ * Used with [[CommandHandlerBuilder]] to setup the behavior of a [[DurableStateBehavior]]
+ */
+@FunctionalInterface
+trait CommandHandler[Command, State] {
+  def apply(state: State, command: Command): Effect[State]
+}
+
+object CommandHandlerBuilder {
+  def builder[Command, State](): CommandHandlerBuilder[Command, State] =
+    new CommandHandlerBuilder[Command, State]
+}
+
+final class CommandHandlerBuilder[Command, State]() {
+
+  private var builders: List[CommandHandlerBuilderByState[Command, State, State]] = Nil
+
+  /**
+   * Use this method to define command handlers that are selected when the passed predicate holds true.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * @param statePredicate The handlers defined by this builder are used when the `statePredicate` is `true`
+   *
+   * @return A new, mutable, CommandHandlerBuilderByState
+   */
+  def forState(statePredicate: Predicate[State]): CommandHandlerBuilderByState[Command, State, State] = {
+    val builder = CommandHandlerBuilderByState.builder[Command, State](statePredicate)
+    builders = builder :: builders
+    builder
+  }
+
+  /**
+   * Use this method to define command handlers that are selected when the passed predicate holds true
+   * for a given subtype of your model. Useful when the model is defined as class hierarchy.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * @param stateClass The handlers defined by this builder are used when the state is an instance of the `stateClass`
+   * @param statePredicate The handlers defined by this builder are used when the `statePredicate` is `true`
+   *
+   * @return A new, mutable, CommandHandlerBuilderByState
+   */
+  def forState[S <: State](
+      stateClass: Class[S],
+      statePredicate: Predicate[S]): CommandHandlerBuilderByState[Command, S, State] = {
+    val builder = new CommandHandlerBuilderByState[Command, S, State](stateClass, statePredicate)
+    builders = builder.asInstanceOf[CommandHandlerBuilderByState[Command, State, State]] :: builders
+    builder
+  }
+
+  /**
+   * Use this method to define command handlers for a given subtype of your model. Useful when the model is defined as class hierarchy.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * @param stateClass The handlers defined by this builder are used when the state is an instance of the `stateClass`.
+   * @return A new, mutable, CommandHandlerBuilderByState
+   */
+  def forStateType[S <: State](stateClass: Class[S]): CommandHandlerBuilderByState[Command, S, State] = {
+    val builder = CommandHandlerBuilderByState.builder[Command, S, State](stateClass)
+    builders = builder.asInstanceOf[CommandHandlerBuilderByState[Command, State, State]] :: builders
+    builder
+  }
+
+  /**
+   * The handlers defined by this builder are used when the state is `null`.
+   * This variant is particular useful when the empty state of your model is defined as `null`.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * @return A new, mutable, CommandHandlerBuilderByState
+   */
+  def forNullState(): CommandHandlerBuilderByState[Command, State, State] = {
+    val predicate: Predicate[State] = asJavaPredicate(s => Objects.isNull(s))
+    val builder = CommandHandlerBuilderByState.builder[Command, State](predicate)
+    builders = builder :: builders
+    builder
+  }
+
+  /**
+   * The handlers defined by this builder are used for any not `null` state.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * @return A new, mutable, CommandHandlerBuilderByState
+   */
+  def forNonNullState(): CommandHandlerBuilderByState[Command, State, State] = {
+    val predicate: Predicate[State] = asJavaPredicate(s => Objects.nonNull(s))
+    val builder = CommandHandlerBuilderByState.builder[Command, State](predicate)
+    builders = builder :: builders
+    builder
+  }
+
+  /**
+   * The handlers defined by this builder are used for any state.
+   * This variant is particular useful for models that have a single type (ie: no class hierarchy).
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   * Extra care should be taken when using [[forAnyState]] as it will match any state. Any command handler define after it will never be reached.
+   *
+   * @return A new, mutable, CommandHandlerBuilderByState
+   */
+  def forAnyState(): CommandHandlerBuilderByState[Command, State, State] = {
+    val predicate: Predicate[State] = asJavaPredicate(_ => true)
+    val builder = CommandHandlerBuilderByState.builder[Command, State](predicate)
+    builders = builder :: builders
+    builder
+  }
+
+  def build(): CommandHandler[Command, State] = {
+
+    val combined =
+      builders.reverse match {
+        case head :: Nil => head
+        case head :: tail =>
+          tail.foldLeft(head) { (acc, builder) =>
+            acc.orElse(builder)
+          }
+        case Nil => throw new IllegalStateException("No matchers defined")
+      }
+
+    combined.build()
+  }
+
+}
+
+object CommandHandlerBuilderByState {
+
+  private val _trueStatePredicate: Predicate[Any] = new Predicate[Any] {
+    override def test(t: Any): Boolean = true
+  }
+
+  private def trueStatePredicate[S]: Predicate[S] = _trueStatePredicate.asInstanceOf[Predicate[S]]
+
+  /**
+   * @param stateClass The handlers defined by this builder are used when the state is an instance of the `stateClass`
+   * @return A new, mutable, CommandHandlerBuilderByState
+   */
+  def builder[Command, S <: State, State](stateClass: Class[S]): CommandHandlerBuilderByState[Command, S, State] =
+    new CommandHandlerBuilderByState(stateClass, statePredicate = trueStatePredicate)
+
+  /**
+   * @param statePredicate The handlers defined by this builder are used when the `statePredicate` is `true`,
+   *                       useful for example when state type is an Optional
+   * @return A new, mutable, CommandHandlerBuilderByState
+   */
+  def builder[Command, State](statePredicate: Predicate[State]): CommandHandlerBuilderByState[Command, State, State] =
+    new CommandHandlerBuilderByState(classOf[Any].asInstanceOf[Class[State]], statePredicate)
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private final case class CommandHandlerCase[Command, State](
+      commandPredicate: Command => Boolean,
+      statePredicate: State => Boolean,
+      handler: BiFunction[State, Command, Effect[State]])
+}
+
+final class CommandHandlerBuilderByState[Command, S <: State, State] @InternalApi private[akka] (
+    private val stateClass: Class[S],
+    private val statePredicate: Predicate[S]) {
+
+  import CommandHandlerBuilderByState.CommandHandlerCase
+
+  private var cases: List[CommandHandlerCase[Command, State]] = Nil
+
+  private def addCase(predicate: Command => Boolean, handler: BiFunction[S, Command, Effect[State]]): Unit = {
+    cases = CommandHandlerCase[Command, State](
+        commandPredicate = predicate,
+        statePredicate = state =>
+          if (state == null) statePredicate.test(state.asInstanceOf[S])
+          else
+            statePredicate.test(state.asInstanceOf[S]) && stateClass.isAssignableFrom(state.getClass),
+        handler.asInstanceOf[BiFunction[State, Command, Effect[State]]]) :: cases
+  }
+
+  /**
+   * Matches any command which the given `predicate` returns true for.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   */
+  def onCommand(
+      predicate: Predicate[Command],
+      handler: BiFunction[S, Command, Effect[State]]): CommandHandlerBuilderByState[Command, S, State] = {
+    addCase(cmd => predicate.test(cmd), handler)
+    this
+  }
+
+  /**
+   * Matches any command which the given `predicate` returns true for.
+   *
+   * Use this when the `State` is not needed in the `handler`, otherwise there is an overloaded method that pass
+   * the state in a `BiFunction`.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   */
+  def onCommand(
+      predicate: Predicate[Command],
+      handler: JFunction[Command, Effect[State]]): CommandHandlerBuilderByState[Command, S, State] = {
+    addCase(cmd => predicate.test(cmd), new BiFunction[S, Command, Effect[State]] {
+      override def apply(state: S, cmd: Command): Effect[State] = handler(cmd)
+    })
+    this
+  }
+
+  /**
+   * Matches commands that are of the given `commandClass` or subclass thereof
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   */
+  def onCommand[C <: Command](
+      commandClass: Class[C],
+      handler: BiFunction[S, C, Effect[State]]): CommandHandlerBuilderByState[Command, S, State] = {
+    addCase(
+      cmd => commandClass.isAssignableFrom(cmd.getClass),
+      handler.asInstanceOf[BiFunction[S, Command, Effect[State]]])
+    this
+  }
+
+  /**
+   * Matches commands that are of the given `commandClass` or subclass thereof.
+   *
+   * Use this when the `State` is not needed in the `handler`, otherwise there is an overloaded method that pass
+   * the state in a `BiFunction`.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   */
+  def onCommand[C <: Command](
+      commandClass: Class[C],
+      handler: JFunction[C, Effect[State]]): CommandHandlerBuilderByState[Command, S, State] = {
+    onCommand[C](commandClass, new BiFunction[S, C, Effect[State]] {
+      override def apply(state: S, cmd: C): Effect[State] = handler(cmd)
+    })
+  }
+
+  /**
+   * Matches commands that are of the given `commandClass` or subclass thereof.
+   *
+   * Use this when you just need to initialize the `State` without using any data from the command.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   */
+  def onCommand[C <: Command](
+      commandClass: Class[C],
+      handler: Supplier[Effect[State]]): CommandHandlerBuilderByState[Command, S, State] = {
+    onCommand[C](commandClass, new BiFunction[S, C, Effect[State]] {
+      override def apply(state: S, cmd: C): Effect[State] = handler.get()
+    })
+  }
+
+  /**
+   * Matches any command.
+   *
+   * Use this to declare a command handler that will match any command. This is particular useful when encoding
+   * a finite state machine in which the final state is not supposed to handle any new command.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
+   *
+   * @return A CommandHandler from the appended states.
+   */
+  def onAnyCommand(handler: BiFunction[S, Command, Effect[State]]): CommandHandler[Command, State] = {
+    addCase(_ => true, handler)
+    build()
+  }
+
+  /**
+   * Matches any command.
+   *
+   * Use this to declare a command handler that will match any command. This is particular useful when encoding
+   * a finite state machine in which the final state is not supposed to handle any new command.
+   *
+   * Use this when you just need to return an [[Effect]] without using any data from the state.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
+   *
+   * @return A CommandHandler from the appended states.
+   */
+  def onAnyCommand(handler: JFunction[Command, Effect[State]]): CommandHandler[Command, State] = {
+    addCase(_ => true, new BiFunction[S, Command, Effect[State]] {
+      override def apply(state: S, cmd: Command): Effect[State] = handler(cmd)
+    })
+    build()
+  }
+
+  /**
+   * Matches any command.
+   *
+   * Use this to declare a command handler that will match any command. This is particular useful when encoding
+   * a finite state machine in which the final state is not supposed to handle any new command.
+   *
+   * Use this when you just need to return an [[Effect]] without using any data from the command or from the state.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
+   *
+   * @return A CommandHandler from the appended states.
+   */
+  def onAnyCommand(handler: Supplier[Effect[State]]): CommandHandler[Command, State] = {
+    addCase(_ => true, new BiFunction[S, Command, Effect[State]] {
+      override def apply(state: S, cmd: Command): Effect[State] = handler.get()
+    })
+    build()
+  }
+
+  /**
+   * Compose this builder with another builder. The handlers in this builder will be tried first followed
+   * by the handlers in `other`.
+   */
+  def orElse[S2 <: State](
+      other: CommandHandlerBuilderByState[Command, S2, State]): CommandHandlerBuilderByState[Command, S2, State] = {
+    val newBuilder = new CommandHandlerBuilderByState[Command, S2, State](other.stateClass, other.statePredicate)
+    // problem with overloaded constructor with `cases` as parameter
+    newBuilder.cases = other.cases ::: cases
+    newBuilder
+  }
+
+  /**
+   * Builds and returns a handler from the appended states. The returned [[CommandHandler]] will throw a [[scala.MatchError]]
+   * if applied to a command that has no defined case.
+   */
+  def build(): CommandHandler[Command, State] = {
+    val builtCases = cases.reverse.toArray
+
+    new CommandHandler[Command, State] {
+      override def apply(state: State, command: Command): Effect[State] = {
+        var idx = 0
+        var effect: OptionVal[Effect[State]] = OptionVal.None
+
+        while (idx < builtCases.length && effect.isEmpty) {
+          val curr = builtCases(idx)
+          if (curr.statePredicate(state) && curr.commandPredicate(command)) {
+            val x: Effect[State] = curr.handler.apply(state, command)
+            effect = OptionVal.Some(x)
+          }
+          idx += 1
+        }
+
+        effect match {
+          case OptionVal.Some(e) => e.asInstanceOf[EffectImpl[State]]
+          case _ =>
+            throw new MatchError(s"No match found for command of type [${command.getClass.getName}]")
+        }
+      }
+    }
+  }
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/CommandHandlerWithReply.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/CommandHandlerWithReply.scala
@@ -1,0 +1,415 @@
+/*
+ * Copyright (C) 2018-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.javadsl
+
+import java.util.Objects
+import java.util.function.BiFunction
+import java.util.function.Predicate
+import java.util.function.Supplier
+import java.util.function.{ Function => JFunction }
+
+import scala.compat.java8.FunctionConverters._
+
+import akka.annotation.InternalApi
+import akka.persistence.typed.state.internal._
+import akka.util.OptionVal
+
+/* Note that this is a copy of CommandHandler.scala to support ReplyEffect
+ * s/Effect/ReplyEffect/
+ * s/CommandHandler/CommandHandlerWithReply/
+ * s/CommandHandlerBuilder/CommandHandlerWithReplyBuilder/
+ * s/CommandHandlerBuilderByState/CommandHandlerWithReplyBuilderByState/
+ * s/DurableStateBehavior/DurableStateBehaviorWithEnforcedReplies/
+ */
+
+/**
+ * FunctionalInterface for reacting on commands
+ *
+ * Used with [[CommandHandlerWithReplyBuilder]] to setup the behavior of a [[DurableStateBehaviorWithEnforcedReplies]]
+ */
+@FunctionalInterface
+trait CommandHandlerWithReply[Command, State] extends CommandHandler[Command, State] {
+  def apply(state: State, command: Command): ReplyEffect[State]
+}
+
+object CommandHandlerWithReplyBuilder {
+  def builder[Command, State](): CommandHandlerWithReplyBuilder[Command, State] =
+    new CommandHandlerWithReplyBuilder[Command, State]
+}
+
+final class CommandHandlerWithReplyBuilder[Command, State]() {
+
+  private var builders: List[CommandHandlerWithReplyBuilderByState[Command, State, State]] = Nil
+
+  /**
+   * Use this method to define command handlers that are selected when the passed predicate holds true.
+   *
+   * Note: command handlers are matched in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * @param statePredicate The handlers defined by this builder are used when the `statePredicate` is `true`
+   *
+   * @return A new, mutable, CommandHandlerWithReplyBuilderByState
+   */
+  def forState(statePredicate: Predicate[State]): CommandHandlerWithReplyBuilderByState[Command, State, State] = {
+    val builder = CommandHandlerWithReplyBuilderByState.builder[Command, State](statePredicate)
+    builders = builder :: builders
+    builder
+  }
+
+  /**
+   * Use this method to define command handlers that are selected when the passed predicate holds true
+   * for a given subtype of your model. Useful when the model is defined as class hierarchy.
+   *
+   * Note: command handlers are matched in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * @param stateClass The handlers defined by this builder are used when the state is an instance of the `stateClass`
+   * @param statePredicate The handlers defined by this builder are used when the `statePredicate` is `true`
+   *
+   * @return A new, mutable, CommandHandlerWithReplyBuilderByState
+   */
+  def forState[S <: State](
+      stateClass: Class[S],
+      statePredicate: Predicate[S]): CommandHandlerWithReplyBuilderByState[Command, S, State] = {
+    val builder = new CommandHandlerWithReplyBuilderByState[Command, S, State](stateClass, statePredicate)
+    builders = builder.asInstanceOf[CommandHandlerWithReplyBuilderByState[Command, State, State]] :: builders
+    builder
+  }
+
+  /**
+   * Use this method to define command handlers for a given subtype of your model. Useful when the model is defined as class hierarchy.
+   *
+   * Note: command handlers are matched in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * @param stateClass The handlers defined by this builder are used when the state is an instance of the `stateClass`.
+   * @return A new, mutable, CommandHandlerWithReplyBuilderByState
+   */
+  def forStateType[S <: State](stateClass: Class[S]): CommandHandlerWithReplyBuilderByState[Command, S, State] = {
+    val builder = CommandHandlerWithReplyBuilderByState.builder[Command, S, State](stateClass)
+    builders = builder.asInstanceOf[CommandHandlerWithReplyBuilderByState[Command, State, State]] :: builders
+    builder
+  }
+
+  /**
+   * The handlers defined by this builder are used when the state is `null`.
+   * This variant is particular useful when the empty state of your model is defined as `null`.
+   *
+   * Note: command handlers are matched in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * @return A new, mutable, CommandHandlerWithReplyBuilderByState
+   */
+  def forNullState(): CommandHandlerWithReplyBuilderByState[Command, State, State] = {
+    val predicate: Predicate[State] = asJavaPredicate(s => Objects.isNull(s))
+    val builder = CommandHandlerWithReplyBuilderByState.builder[Command, State](predicate)
+    builders = builder :: builders
+    builder
+  }
+
+  /**
+   * The handlers defined by this builder are used for any not `null` state.
+   *
+   * Note: command handlers are matched in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * @return A new, mutable, CommandHandlerWithReplyBuilderByState
+   */
+  def forNonNullState(): CommandHandlerWithReplyBuilderByState[Command, State, State] = {
+    val predicate: Predicate[State] = asJavaPredicate(s => Objects.nonNull(s))
+    val builder = CommandHandlerWithReplyBuilderByState.builder[Command, State](predicate)
+    builders = builder :: builders
+    builder
+  }
+
+  /**
+   * The handlers defined by this builder are used for any state.
+   * This variant is particular useful for models that have a single type (ie: no class hierarchy).
+   *
+   * Note: command handlers are matched in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   * Extra care should be taken when using [[forAnyState]] as it will match any state. Any command handler define after it will never be reached.
+   *
+   * @return A new, mutable, CommandHandlerWithReplyBuilderByState
+   */
+  def forAnyState(): CommandHandlerWithReplyBuilderByState[Command, State, State] = {
+    val predicate: Predicate[State] = asJavaPredicate(_ => true)
+    val builder = CommandHandlerWithReplyBuilderByState.builder[Command, State](predicate)
+    builders = builder :: builders
+    builder
+  }
+
+  def build(): CommandHandlerWithReply[Command, State] = {
+
+    val combined =
+      builders.reverse match {
+        case head :: Nil => head
+        case head :: tail =>
+          tail.foldLeft(head) { (acc, builder) =>
+            acc.orElse(builder)
+          }
+        case Nil => throw new IllegalStateException("No matchers defined")
+      }
+
+    combined.build()
+  }
+
+}
+
+object CommandHandlerWithReplyBuilderByState {
+
+  private val _trueStatePredicate: Predicate[Any] = new Predicate[Any] {
+    override def test(t: Any): Boolean = true
+  }
+
+  private def trueStatePredicate[S]: Predicate[S] = _trueStatePredicate.asInstanceOf[Predicate[S]]
+
+  /**
+   * @param stateClass The handlers defined by this builder are used when the state is an instance of the `stateClass`
+   * @return A new, mutable, CommandHandlerWithReplyBuilderByState
+   */
+  def builder[Command, S <: State, State](
+      stateClass: Class[S]): CommandHandlerWithReplyBuilderByState[Command, S, State] =
+    new CommandHandlerWithReplyBuilderByState(stateClass, statePredicate = trueStatePredicate)
+
+  /**
+   * @param statePredicate The handlers defined by this builder are used when the `statePredicate` is `true`,
+   *                       useful for example when state type is an Optional
+   * @return A new, mutable, CommandHandlerWithReplyBuilderByState
+   */
+  def builder[Command, State](
+      statePredicate: Predicate[State]): CommandHandlerWithReplyBuilderByState[Command, State, State] =
+    new CommandHandlerWithReplyBuilderByState(classOf[Any].asInstanceOf[Class[State]], statePredicate)
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private final case class CommandHandlerCase[Command, State](
+      commandPredicate: Command => Boolean,
+      statePredicate: State => Boolean,
+      handler: BiFunction[State, Command, ReplyEffect[State]])
+}
+
+final class CommandHandlerWithReplyBuilderByState[Command, S <: State, State] @InternalApi private[persistence] (
+    private val stateClass: Class[S],
+    private val statePredicate: Predicate[S]) {
+
+  import CommandHandlerWithReplyBuilderByState.CommandHandlerCase
+
+  private var cases: List[CommandHandlerCase[Command, State]] = Nil
+
+  private def addCase(predicate: Command => Boolean, handler: BiFunction[S, Command, ReplyEffect[State]]): Unit = {
+    cases = CommandHandlerCase[Command, State](
+        commandPredicate = predicate,
+        statePredicate = state =>
+          if (state == null) statePredicate.test(state.asInstanceOf[S])
+          else
+            statePredicate.test(state.asInstanceOf[S]) && stateClass.isAssignableFrom(state.getClass),
+        handler.asInstanceOf[BiFunction[State, Command, ReplyEffect[State]]]) :: cases
+  }
+
+  /**
+   * Matches any command which the given `predicate` returns true for.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   */
+  def onCommand(
+      predicate: Predicate[Command],
+      handler: BiFunction[S, Command, ReplyEffect[State]]): CommandHandlerWithReplyBuilderByState[Command, S, State] = {
+    addCase(cmd => predicate.test(cmd), handler)
+    this
+  }
+
+  /**
+   * Matches any command which the given `predicate` returns true for.
+   *
+   * Use this when the `State` is not needed in the `handler`, otherwise there is an overloaded method that pass
+   * the state in a `BiFunction`.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   */
+  def onCommand(
+      predicate: Predicate[Command],
+      handler: JFunction[Command, ReplyEffect[State]]): CommandHandlerWithReplyBuilderByState[Command, S, State] = {
+    addCase(cmd => predicate.test(cmd), new BiFunction[S, Command, ReplyEffect[State]] {
+      override def apply(state: S, cmd: Command): ReplyEffect[State] = handler(cmd)
+    })
+    this
+  }
+
+  /**
+   * Matches commands that are of the given `commandClass` or subclass thereof
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   */
+  def onCommand[C <: Command](
+      commandClass: Class[C],
+      handler: BiFunction[S, C, ReplyEffect[State]]): CommandHandlerWithReplyBuilderByState[Command, S, State] = {
+    addCase(
+      cmd => commandClass.isAssignableFrom(cmd.getClass),
+      handler.asInstanceOf[BiFunction[S, Command, ReplyEffect[State]]])
+    this
+  }
+
+  /**
+   * Matches commands that are of the given `commandClass` or subclass thereof.
+   *
+   * Use this when the `State` is not needed in the `handler`, otherwise there is an overloaded method that pass
+   * the state in a `BiFunction`.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   */
+  def onCommand[C <: Command](
+      commandClass: Class[C],
+      handler: JFunction[C, ReplyEffect[State]]): CommandHandlerWithReplyBuilderByState[Command, S, State] = {
+    onCommand[C](commandClass, new BiFunction[S, C, ReplyEffect[State]] {
+      override def apply(state: S, cmd: C): ReplyEffect[State] = handler(cmd)
+    })
+  }
+
+  /**
+   * Matches commands that are of the given `commandClass` or subclass thereof.
+   *
+   * Use this when you just need to initialize the `State` without using any data from the command.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   */
+  def onCommand[C <: Command](
+      commandClass: Class[C],
+      handler: Supplier[ReplyEffect[State]]): CommandHandlerWithReplyBuilderByState[Command, S, State] = {
+    onCommand[C](commandClass, new BiFunction[S, C, ReplyEffect[State]] {
+      override def apply(state: S, cmd: C): ReplyEffect[State] = handler.get()
+    })
+  }
+
+  /**
+   * Matches any command.
+   *
+   * Use this to declare a command handler that will match any command. This is particular useful when encoding
+   * a finite state machine in which the final state is not supposed to handle any new command.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
+   *
+   * @return A CommandHandlerWithReply from the appended states.
+   */
+  def onAnyCommand(handler: BiFunction[S, Command, ReplyEffect[State]]): CommandHandlerWithReply[Command, State] = {
+    addCase(_ => true, handler)
+    build()
+  }
+
+  /**
+   * Matches any command.
+   *
+   * Use this to declare a command handler that will match any command. This is particular useful when encoding
+   * a finite state machine in which the final state is not supposed to handle any new command.
+   *
+   * Use this when you just need to return an [[ReplyEffect]] without using any data from the state.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
+   *
+   * @return A CommandHandlerWithReply from the appended states.
+   */
+  def onAnyCommand(handler: JFunction[Command, ReplyEffect[State]]): CommandHandlerWithReply[Command, State] = {
+    addCase(_ => true, new BiFunction[S, Command, ReplyEffect[State]] {
+      override def apply(state: S, cmd: Command): ReplyEffect[State] = handler(cmd)
+    })
+    build()
+  }
+
+  /**
+   * Matches any command.
+   *
+   * Use this to declare a command handler that will match any command. This is particular useful when encoding
+   * a finite state machine in which the final state is not supposed to handle any new command.
+   *
+   * Use this when you just need to return an [[ReplyEffect]] without using any data from the command or from the state.
+   *
+   * Note: command handlers are selected in the order they are added. Once a matching is found, it's selected for handling the command
+   * and no further lookup is done. Therefore you must make sure that their matching conditions don't overlap,
+   * otherwise you risk to 'shadow' part of your command handlers.
+   *
+   * Extra care should be taken when using [[onAnyCommand]] as it will match any command.
+   * This method builds and returns the command handler since this will not let through any states to subsequent match statements.
+   *
+   * @return A CommandHandlerWithReply from the appended states.
+   */
+  def onAnyCommand(handler: Supplier[ReplyEffect[State]]): CommandHandlerWithReply[Command, State] = {
+    addCase(_ => true, new BiFunction[S, Command, ReplyEffect[State]] {
+      override def apply(state: S, cmd: Command): ReplyEffect[State] = handler.get()
+    })
+    build()
+  }
+
+  /**
+   * Compose this builder with another builder. The handlers in this builder will be tried first followed
+   * by the handlers in `other`.
+   */
+  def orElse[S2 <: State](other: CommandHandlerWithReplyBuilderByState[Command, S2, State])
+      : CommandHandlerWithReplyBuilderByState[Command, S2, State] = {
+    val newBuilder =
+      new CommandHandlerWithReplyBuilderByState[Command, S2, State](other.stateClass, other.statePredicate)
+    // problem with overloaded constructor with `cases` as parameter
+    newBuilder.cases = other.cases ::: cases
+    newBuilder
+  }
+
+  /**
+   * Builds and returns a handler from the appended states. The returned [[CommandHandlerWithReply]] will throw a [[scala.MatchError]]
+   * if applied to a command that has no defined case.
+   */
+  def build(): CommandHandlerWithReply[Command, State] = {
+    val builtCases = cases.reverse.toArray
+
+    new CommandHandlerWithReply[Command, State] {
+      override def apply(state: State, command: Command): ReplyEffect[State] = {
+        var idx = 0
+        var effect: OptionVal[ReplyEffect[State]] = OptionVal.None
+
+        while (idx < builtCases.length && effect.isEmpty) {
+          val curr = builtCases(idx)
+          if (curr.statePredicate(state) && curr.commandPredicate(command)) {
+            val x: ReplyEffect[State] = curr.handler.apply(state, command)
+            effect = OptionVal.Some(x)
+          }
+          idx += 1
+        }
+
+        effect match {
+          case OptionVal.Some(e) => e.asInstanceOf[EffectImpl[State]]
+          case _ =>
+            throw new MatchError(s"No match found for command of type [${command.getClass.getName}]")
+        }
+      }
+    }
+  }
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/DurableStateBehavior.scala
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2018-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.javadsl
+
+import java.util.Optional
+
+import akka.actor.typed
+import akka.actor.typed.BackoffSupervisorStrategy
+import akka.actor.typed.Behavior
+import akka.actor.typed.internal.BehaviorImpl.DeferredBehavior
+import akka.actor.typed.javadsl.ActorContext
+import akka.annotation.InternalApi
+import akka.persistence.typed.state.internal
+import akka.persistence.typed.state.internal._
+import akka.persistence.typed.state.scaladsl
+import akka.persistence.typed.PersistenceId
+import akka.persistence.typed.SnapshotAdapter
+
+/**
+ * A `Behavior` for a persistent actor with durable storage of its state.
+ */
+abstract class DurableStateBehavior[Command, State] private[akka] (
+    val persistenceId: PersistenceId,
+    onPersistFailure: Optional[BackoffSupervisorStrategy])
+    extends DeferredBehavior[Command] {
+
+  /**
+   * @param persistenceId stable unique identifier for the `DurableStateBehavior`
+   */
+  def this(persistenceId: PersistenceId) = {
+    this(persistenceId, Optional.empty[BackoffSupervisorStrategy])
+  }
+
+  /**
+   * If using onPersistFailure the supervision is only around the `DurableStateBehavior` not any outer setup/withTimers
+   * block. If using restart any actions e.g. scheduling timers, can be done on the PreRestart signal or on the
+   * RecoveryCompleted signal.
+   *
+   * @param persistenceId stable unique identifier for the `DurableStateBehavior`
+   * @param onPersistFailure BackoffSupervisionStrategy for persist failures
+   */
+  def this(persistenceId: PersistenceId, onPersistFailure: BackoffSupervisorStrategy) = {
+    this(persistenceId, Optional.ofNullable(onPersistFailure))
+  }
+
+  /**
+   * Factory of effects.
+   *
+   * Return effects from your handlers in order to instruct persistence on how to act on the incoming message (i.e. persist state).
+   */
+  protected final def Effect: EffectFactories[State] =
+    EffectFactories.asInstanceOf[EffectFactories[State]]
+
+  /**
+   * Implement by returning the initial empty state object.
+   * This object will be passed into this behaviors handlers, until a new state replaces it.
+   *
+   * Also known as "zero state" or "neutral state".
+   */
+  protected def emptyState: State
+
+  /**
+   * Implement by handling incoming commands and return an `Effect()` to persist or signal other effects
+   * of the command handling such as stopping the behavior or others.
+   *
+   * Use [[DurableStateBehavior#newCommandHandlerBuilder]] to define the command handlers.
+   *
+   * The command handlers are only invoked when the actor is running (i.e. not recovering).
+   * While the actor is persisting state, the incoming messages are stashed and only
+   * delivered to the handler once persisting them has completed.
+   */
+  protected def commandHandler(): CommandHandler[Command, State]
+
+  /**
+   * Override to react on general lifecycle signals and `DurableStateBehavior` specific signals
+   * (recovery related). Those are all subtypes of [[akka.persistence.typed.state.DurableStateSignal]].
+   *
+   * Use [[DurableStateBehavior#newSignalHandlerBuilder]] to define the signal handler.
+   */
+  protected def signalHandler(): SignalHandler[State] = SignalHandler.empty[State]
+
+  /**
+   * @return A new, mutable signal handler builder
+   */
+  protected final def newSignalHandlerBuilder(): SignalHandlerBuilder[State] =
+    SignalHandlerBuilder.builder[State]
+
+  /**
+   * @return A new, mutable, command handler builder
+   */
+  protected def newCommandHandlerBuilder(): CommandHandlerBuilder[Command, State] = {
+    CommandHandlerBuilder.builder[Command, State]()
+  }
+
+  /**
+   * Override and define the `DurableStateStore` plugin id that this actor should use instead of the default.
+   */
+  def durableStateStorePluginId: String = ""
+
+  /**
+   * The tag that can be used in persistence query.
+   */
+  def tag: String = ""
+
+  /**
+   * Transform the state into another type before giving it to and from the store. Can be used
+   * to migrate from different state types e.g. when migration from PersistentFSM to Typed DurableStateBehavior.
+   */
+  def snapshotAdapter(): SnapshotAdapter[State] = NoOpSnapshotAdapter.instance[State]
+
+  /**
+   * INTERNAL API: DeferredBehavior init, not for user extension
+   */
+  @InternalApi override def apply(context: typed.TypedActorContext[Command]): Behavior[Command] =
+    createDurableStateBehavior()
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] final def createDurableStateBehavior(): scaladsl.DurableStateBehavior[Command, State] = {
+
+    val behavior = new internal.DurableStateBehaviorImpl[Command, State](
+      persistenceId,
+      emptyState,
+      (state, cmd) => commandHandler()(state, cmd).asInstanceOf[EffectImpl[State]],
+      getClass).withTag(tag).snapshotAdapter(snapshotAdapter()).withDurableStateStorePluginId(durableStateStorePluginId)
+
+    val handler = signalHandler()
+    val behaviorWithSignalHandler =
+      if (handler.isEmpty) behavior
+      else behavior.receiveSignal(handler.handler)
+
+    if (onPersistFailure.isPresent)
+      behaviorWithSignalHandler.onPersistFailure(onPersistFailure.get)
+    else
+      behaviorWithSignalHandler
+  }
+
+  /**
+   * The last sequence number that was persisted, can only be called from inside the handlers of a `DurableStateBehavior`
+   */
+  final def lastSequenceNumber(ctx: ActorContext[_]): Long = {
+    scaladsl.DurableStateBehavior.lastSequenceNumber(ctx.asScala)
+  }
+
+}
+
+/**
+ * A [[DurableStateBehavior]] that is enforcing that replies to commands are not forgotten.
+ * There will be compilation errors if the returned effect isn't a [[ReplyEffect]], which can be
+ * created with `Effects().reply`, `Effects().noReply`, [[EffectBuilder.thenReply]], or [[EffectBuilder.thenNoReply]].
+ */
+abstract class DurableStateBehaviorWithEnforcedReplies[Command, State](
+    persistenceId: PersistenceId,
+    backoffSupervisorStrategy: Optional[BackoffSupervisorStrategy])
+    extends DurableStateBehavior[Command, State](persistenceId, backoffSupervisorStrategy) {
+
+  def this(persistenceId: PersistenceId) = {
+    this(persistenceId, Optional.empty[BackoffSupervisorStrategy])
+  }
+
+  def this(persistenceId: PersistenceId, backoffSupervisorStrategy: BackoffSupervisorStrategy) = {
+    this(persistenceId, Optional.ofNullable(backoffSupervisorStrategy))
+  }
+
+  /**
+   * Implement by handling incoming commands and return an `Effect()` to persist or signal other effects
+   * of the command handling such as stopping the behavior or others.
+   *
+   * Use [[DurableStateBehaviorWithEnforcedReplies#newCommandHandlerWithReplyBuilder]] to define the command handlers.
+   *
+   * The command handlers are only invoked when the actor is running (i.e. not recovering).
+   * While the actor is persisting state, the incoming messages are stashed and only
+   * delivered to the handler once persisting them has completed.
+   */
+  override protected def commandHandler(): CommandHandlerWithReply[Command, State]
+
+  /**
+   * @return A new, mutable, command handler builder
+   */
+  protected def newCommandHandlerWithReplyBuilder(): CommandHandlerWithReplyBuilder[Command, State] = {
+    CommandHandlerWithReplyBuilder.builder[Command, State]()
+  }
+
+  /**
+   * Use [[DurableStateBehaviorWithEnforcedReplies#newCommandHandlerWithReplyBuilder]] instead, or
+   * extend [[DurableStateBehavior]] instead of [[DurableStateBehaviorWithEnforcedReplies]].
+   *
+   * @throws UnsupportedOperationException use newCommandHandlerWithReplyBuilder instead
+   */
+  override protected def newCommandHandlerBuilder(): CommandHandlerBuilder[Command, State] =
+    throw new UnsupportedOperationException("Use newCommandHandlerWithReplyBuilder instead")
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/Effect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/Effect.scala
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2018-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.javadsl
+
+import akka.actor.typed.ActorRef
+import akka.annotation.DoNotInherit
+import akka.annotation.InternalApi
+import akka.japi.function
+import akka.persistence.typed.state.internal.SideEffect
+import akka.persistence.typed.state.internal._
+
+/**
+ * INTERNAL API: see `class EffectFactories`
+ */
+@InternalApi private[akka] object EffectFactories extends EffectFactories[Nothing]
+
+/**
+ * Factory methods for creating [[Effect]] directives - how a `DurableStateBehavior` reacts on a command.
+ * Created via [[DurableStateBehavior.Effect]].
+ *
+ * Not for user extension
+ */
+@DoNotInherit sealed class EffectFactories[State] {
+
+  /**
+   * Persist new state.
+   *
+   * Side effects can be chained with `thenRun`.
+   */
+  final def persist(state: State): EffectBuilder[State] = Persist(state)
+
+  // FIXME add delete effect
+
+  /**
+   * Do not persist anything
+   *
+   * Side effects can be chained with `thenRun`
+   */
+  def none(): EffectBuilder[State] = PersistNothing.asInstanceOf[EffectBuilder[State]]
+
+  /**
+   * Stop this persistent actor
+   *
+   * Side effects can be chained with `thenRun`
+   */
+  def stop(): EffectBuilder[State] = none().thenStop()
+
+  /**
+   * This command is not handled, but it is not an error that it isn't.
+   *
+   * Side effects can be chained with `thenRun`
+   */
+  def unhandled(): EffectBuilder[State] = Unhandled.asInstanceOf[EffectBuilder[State]]
+
+  /**
+   * Stash the current command. Can be unstashed later with `Effect.thenUnstashAll`
+   * or `EffectFactories.unstashAll`.
+   *
+   * Note that the stashed commands are kept in an in-memory buffer, so in case of a crash they will not be
+   * processed. They will also be discarded if the actor is restarted (or stopped) due to that an exception was
+   * thrown from processing a command or side effect after persisting. The stash buffer is preserved for persist
+   * failures if an `onPersistFailure` backoff supervisor strategy is defined.
+   *
+   * Side effects can be chained with `thenRun`.
+   */
+  def stash(): ReplyEffect[State] =
+    Stash.asInstanceOf[EffectBuilder[State]].thenNoReply()
+
+  /**
+   * Unstash the commands that were stashed with `EffectFactories.stash`.
+   *
+   * It's allowed to stash messages while unstashing. Those newly added
+   * commands will not be processed by this `unstashAll` effect and have to be unstashed
+   * by another `unstashAll`.
+   *
+   * @see [[EffectBuilder.thenUnstashAll]]
+   */
+  def unstashAll(): Effect[State] =
+    none().thenUnstashAll()
+
+  /**
+   * Send a reply message to the command. The type of the
+   * reply message must conform to the type specified by the passed replyTo `ActorRef`.
+   *
+   * This has the same semantics as `replyTo.tell`.
+   *
+   * It is provided as a convenience (reducing boilerplate) and a way to enforce that replies are not forgotten
+   * when the `DurableStateBehavior` is created with [[DurableStateBehaviorWithEnforcedReplies]]. When
+   * `withEnforcedReplies` is used there will be compilation errors if the returned effect isn't a [[ReplyEffect]].
+   * The reply message will be sent also if `withEnforcedReplies` isn't used, but then the compiler will not help
+   * finding mistakes.
+   */
+  def reply[ReplyMessage](replyTo: ActorRef[ReplyMessage], replyWithMessage: ReplyMessage): ReplyEffect[State] =
+    none().thenReply[ReplyMessage](replyTo, new function.Function[State, ReplyMessage] {
+      override def apply(param: State): ReplyMessage = replyWithMessage
+    })
+
+  /**
+   * When [[DurableStateBehaviorWithEnforcedReplies]] is used there will be compilation errors if the returned effect
+   * isn't a [[ReplyEffect]]. This `noReply` can be used as a conscious decision that a reply shouldn't be
+   * sent for a specific command or the reply will be sent later.
+   */
+  def noReply(): ReplyEffect[State] =
+    none().thenNoReply()
+}
+
+/**
+ * A command handler returns an `Effect` directive that defines what state to persist.
+ *
+ * Instances of `Effect` are available through factories [[DurableStateBehavior.Effect]].
+ *
+ * Not intended for user extension.
+ */
+@DoNotInherit trait Effect[State] {
+  self: EffectImpl[State] =>
+}
+
+/**
+ * A command handler returns an `Effect` directive that defines what state to persist.
+ *
+ * Additional side effects can be performed in the callback `thenRun`
+ *
+ * Instances of `Effect` are available through factories [[DurableStateBehavior.Effect]].
+ *
+ * Not intended for user extension.
+ */
+@DoNotInherit abstract class EffectBuilder[State] extends Effect[State] {
+  self: EffectImpl[State] =>
+
+  /**
+   * Run the given callback. Callbacks are run sequentially.
+   *
+   * @tparam NewState The type of the state after the state is persisted, when not specified will be the same as `State`
+   *                  but if a known subtype of `State` is expected that can be specified instead (preferably by
+   *                  explicitly typing the lambda parameter like so: `thenRun((SubState state) -> { ... })`).
+   *                  If the state is not of the expected type an [[java.lang.ClassCastException]] is thrown.
+   *
+   */
+  final def thenRun[NewState <: State](callback: function.Procedure[NewState]): EffectBuilder[State] =
+    CompositeEffect(this, SideEffect[State](s => callback.apply(s.asInstanceOf[NewState])))
+
+  /**
+   * Run the given callback. Callbacks are run sequentially.
+   */
+  final def thenRun(callback: function.Effect): EffectBuilder[State] =
+    CompositeEffect(this, SideEffect[State]((_: State) => callback.apply()))
+
+  /** The side effect is to stop the actor */
+  def thenStop(): EffectBuilder[State]
+
+  /**
+   * Unstash the commands that were stashed with `EffectFactories.stash`.
+   *
+   * It's allowed to stash messages while unstashing. Those newly added
+   * commands will not be processed by this `unstashAll` effect and have to be unstashed
+   * by another `unstashAll`.
+   */
+  def thenUnstashAll(): Effect[State]
+
+  /**
+   * Send a reply message to the command. The type of the
+   * reply message must conform to the type specified by the passed replyTo `ActorRef`.
+   *
+   * This has the same semantics as `replyTo.tell`.
+   *
+   * It is provided as a convenience (reducing boilerplate) and a way to enforce that replies are not forgotten
+   * when the `DurableStateBehavior` is created with [[DurableStateBehaviorWithEnforcedReplies]]. When
+   * `withEnforcedReplies` is used there will be compilation errors if the returned effect isn't a [[ReplyEffect]].
+   * The reply message will be sent also if `withEnforcedReplies` isn't used, but then the compiler will not help
+   * finding mistakes.
+   */
+  def thenReply[ReplyMessage](
+      replyTo: ActorRef[ReplyMessage],
+      replyWithMessage: function.Function[State, ReplyMessage]): ReplyEffect[State] =
+    CompositeEffect(this, SideEffect[State](newState => replyTo ! replyWithMessage(newState)))
+
+  /**
+   * When [[DurableStateBehaviorWithEnforcedReplies]] is used there will be compilation errors if the returned effect
+   * isn't a [[ReplyEffect]]. This `thenNoReply` can be used as a conscious decision that a reply shouldn't be
+   * sent for a specific command or the reply will be sent later.
+   */
+  def thenNoReply(): ReplyEffect[State]
+
+}
+
+/**
+ * [[DurableStateBehaviorWithEnforcedReplies]] can be used to enforce that replies are not forgotten.
+ * Then there will be compilation errors if the returned effect isn't a [[ReplyEffect]], which can be
+ * created with `Effects().reply`, `Effects().noReply`, [[EffectBuilder.thenReply]], or [[EffectBuilder.thenNoReply]].
+ */
+@DoNotInherit trait ReplyEffect[State] extends Effect[State] {
+  self: EffectImpl[State] =>
+
+  /**
+   * Unstash the commands that were stashed with `EffectFactories.stash`.
+   *
+   * It's allowed to stash messages while unstashing. Those newly added
+   * commands will not be processed by this `unstashAll` effect and have to be unstashed
+   * by another `unstashAll`.
+   */
+  def thenUnstashAll(): ReplyEffect[State]
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/SignalHandler.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/SignalHandler.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.javadsl
+
+import java.util.function.BiConsumer
+import java.util.function.Consumer
+
+import akka.actor.typed.Signal
+import akka.annotation.InternalApi
+
+object SignalHandler {
+  private val Empty: SignalHandler[Any] = new SignalHandler[Any](PartialFunction.empty)
+
+  def empty[State]: SignalHandler[State] = Empty.asInstanceOf[SignalHandler[State]]
+}
+
+final class SignalHandler[State](_handler: PartialFunction[(State, Signal), Unit]) {
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private[akka] def isEmpty: Boolean = _handler eq PartialFunction.empty
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private[akka] def handler: PartialFunction[(State, Signal), Unit] = _handler
+}
+
+object SignalHandlerBuilder {
+  def builder[State]: SignalHandlerBuilder[State] = new SignalHandlerBuilder
+}
+
+/**
+ * Mutable builder for handling signals in [[DurableStateBehavior]]
+ *
+ * Not for user instantiation, use [[DurableStateBehavior.newSignalHandlerBuilder]] to get an instance.
+ */
+final class SignalHandlerBuilder[State] {
+
+  private var handler: PartialFunction[(State, Signal), Unit] = PartialFunction.empty
+
+  /**
+   * If the behavior receives a signal of type `T`, `callback` is invoked with the signal instance as input.
+   */
+  def onSignal[T <: Signal](signalType: Class[T], callback: BiConsumer[State, T]): SignalHandlerBuilder[State] = {
+    val newPF: PartialFunction[(State, Signal), Unit] = {
+      case (state, t) if signalType.isInstance(t) =>
+        callback.accept(state, t.asInstanceOf[T])
+    }
+    handler = newPF.orElse(handler)
+    this
+  }
+
+  /**
+   * If the behavior receives exactly the signal `signal`, `callback` is invoked.
+   */
+  def onSignal[T <: Signal](signal: T, callback: Consumer[State]): SignalHandlerBuilder[State] = {
+    val newPF: PartialFunction[(State, Signal), Unit] = {
+      case (state, `signal`) =>
+        callback.accept(state)
+    }
+    handler = newPF.orElse(handler)
+    this
+  }
+
+  def build: SignalHandler[State] = new SignalHandler(handler)
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/DurableStateBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/DurableStateBehavior.scala
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2017-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.scaladsl
+
+import scala.annotation.tailrec
+
+import akka.actor.typed.BackoffSupervisorStrategy
+import akka.actor.typed.Behavior
+import akka.actor.typed.Signal
+import akka.actor.typed.internal.BehaviorImpl.DeferredBehavior
+import akka.actor.typed.internal.InterceptorImpl
+import akka.actor.typed.internal.LoggerClass
+import akka.actor.typed.scaladsl.ActorContext
+import akka.annotation.DoNotInherit
+import akka.persistence.typed.state.internal._
+import akka.persistence.typed.PersistenceId
+import akka.persistence.typed.SnapshotAdapter
+
+object DurableStateBehavior {
+
+  /**
+   * Type alias for the command handler function that defines how to act on commands.
+   *
+   * The type alias is not used in API signatures because it's easier to see (in IDE) what is needed
+   * when full function type is used. When defining the handler as a separate function value it can
+   * be useful to use the alias for shorter type signature.
+   */
+  type CommandHandler[Command, State] = (State, Command) => Effect[State]
+
+  private val logPrefixSkipList = classOf[DurableStateBehavior[_, _]].getName :: Nil
+
+  /**
+   * Create a `Behavior` for a persistent actor with durable storage of its state.
+   *
+   * @param persistenceId stable unique identifier for the `DurableStateBehavior`
+   * @param emptyState the intial state for the entity before any state has been stored
+   * @param commandHandler map commands to effects e.g. persisting state, replying to commands
+   */
+  def apply[Command, State](
+      persistenceId: PersistenceId,
+      emptyState: State,
+      commandHandler: (State, Command) => Effect[State]): DurableStateBehavior[Command, State] = {
+    val loggerClass = LoggerClass.detectLoggerClassFromStack(classOf[DurableStateBehavior[_, _]], logPrefixSkipList)
+    DurableStateBehaviorImpl(persistenceId, emptyState, commandHandler, loggerClass)
+  }
+
+  /**
+   * Create a `Behavior` for a persistent actor that is enforcing that replies to commands are not forgotten.
+   * Then there will be compilation errors if the returned effect isn't a [[ReplyEffect]], which can be
+   * created with [[Effect.reply]], [[Effect.noReply]], [[EffectBuilder.thenReply]], or [[EffectBuilder.thenNoReply]].
+   */
+  def withEnforcedReplies[Command, State](
+      persistenceId: PersistenceId,
+      emptyState: State,
+      commandHandler: (State, Command) => ReplyEffect[State]): DurableStateBehavior[Command, State] = {
+    val loggerClass = LoggerClass.detectLoggerClassFromStack(classOf[DurableStateBehavior[_, _]], logPrefixSkipList)
+    DurableStateBehaviorImpl(persistenceId, emptyState, commandHandler, loggerClass)
+  }
+
+  /**
+   * The `CommandHandler` defines how to act on commands. A `CommandHandler` is
+   * a function:
+   *
+   * {{{
+   *   (State, Command) => Effect[State]
+   * }}}
+   *
+   * The [[CommandHandler#command]] is useful for simple commands that don't need the state
+   * and context.
+   */
+  object CommandHandler {
+
+    /**
+     * Convenience for simple commands that don't need the state and context.
+     *
+     * @see [[Effect]] for possible effects of a command.
+     */
+    def command[Command, State](commandHandler: Command => Effect[State]): (State, Command) => Effect[State] =
+      (_, cmd) => commandHandler(cmd)
+
+  }
+
+  /**
+   * The last sequence number that was persisted, can only be called from inside the handlers of a `DurableStateBehavior`
+   */
+  def lastSequenceNumber(context: ActorContext[_]): Long = {
+    @tailrec
+    def extractConcreteBehavior(beh: Behavior[_]): Behavior[_] =
+      beh match {
+        case interceptor: InterceptorImpl[_, _] => extractConcreteBehavior(interceptor.nestedBehavior)
+        case concrete                           => concrete
+      }
+
+    extractConcreteBehavior(context.currentBehavior) match {
+      case w: Running.WithSeqNrAccessible => w.currentSequenceNumber
+      case s =>
+        throw new IllegalStateException(s"Cannot extract the lastSequenceNumber in state ${s.getClass.getName}")
+    }
+  }
+
+}
+
+/**
+ * Further customization of the `DurableStateBehavior` can be done with the methods defined here.
+ *
+ * Not for user extension
+ */
+@DoNotInherit trait DurableStateBehavior[Command, State] extends DeferredBehavior[Command] {
+
+  def persistenceId: PersistenceId
+
+  /**
+   * Allows the `DurableStateBehavior` to react on signals.
+   *
+   * The regular lifecycle signals can be handled as well as `DurableStateBehavior` specific signals
+   * (recovery related). Those are all subtypes of [[akka.persistence.typed.state.DurableStateSignal]]
+   */
+  def receiveSignal(signalHandler: PartialFunction[(State, Signal), Unit]): DurableStateBehavior[Command, State]
+
+  /**
+   * @return The currently defined signal handler or an empty handler if no custom handler previously defined
+   */
+  def signalHandler: PartialFunction[(State, Signal), Unit]
+
+  /**
+   * Change the `DurableStateStore` plugin id that this actor should use.
+   */
+  def withDurableStateStorePluginId(id: String): DurableStateBehavior[Command, State]
+
+  /**
+   * The tag that can used in persistence query
+   */
+  def withTag(tag: String): DurableStateBehavior[Command, State]
+
+  /**
+   * Transform the state to another type before giving to the store. Can be used to transform older
+   * state types into the current state type e.g. when migrating from Persistent FSM to Typed DurableStateBehavior.
+   */
+  def snapshotAdapter(adapter: SnapshotAdapter[State]): DurableStateBehavior[Command, State]
+
+  /**
+   * Back off strategy for persist failures.
+   *
+   * Specifically BackOff to prevent resume being used. Resume is not allowed as
+   * it will be unknown if the state has been persisted.
+   *
+   * This supervision is only around the `DurableStateBehavior` not any outer setup/withTimers
+   * block. If using restart, any actions e.g. scheduling timers, can be done on the PreRestart
+   *
+   * If not specified the actor will be stopped on failure.
+   */
+  def onPersistFailure(backoffStrategy: BackoffSupervisorStrategy): DurableStateBehavior[Command, State]
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/Effect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/Effect.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2017-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.scaladsl
+
+import akka.actor.typed.ActorRef
+import akka.annotation.DoNotInherit
+import akka.persistence.typed.state.internal.SideEffect
+import akka.persistence.typed.state.internal._
+
+/**
+ * Factory methods for creating [[Effect]] directives - how a `DurableStateBehavior` reacts on a command.
+ */
+object Effect {
+
+  /**
+   * Persist new state.
+   *
+   * Side effects can be chained with `thenRun`
+   */
+  def persist[State](state: State): EffectBuilder[State] = Persist(state)
+
+  // FIXME add delete effect
+
+  /**
+   * Do not persist anything
+   *
+   * Side effects can be chained with `thenRun`
+   */
+  def none[State]: EffectBuilder[State] = PersistNothing.asInstanceOf[EffectBuilder[State]]
+
+  /**
+   * This command is not handled, but it is not an error that it isn't.
+   *
+   * Side effects can be chained with `thenRun`
+   */
+  def unhandled[State]: EffectBuilder[State] = Unhandled.asInstanceOf[EffectBuilder[State]]
+
+  /**
+   * Stop this persistent actor
+   * Side effects can be chained with `thenRun`
+   */
+  def stop[State](): EffectBuilder[State] =
+    none.thenStop()
+
+  /**
+   * Stash the current command. Can be unstashed later with [[Effect.unstashAll]].
+   *
+   * Note that the stashed commands are kept in an in-memory buffer, so in case of a crash they will not be
+   * processed. They will also be discarded if the actor is restarted (or stopped) due to that an exception was
+   * thrown from processing a command or side effect after persisting. The stash buffer is preserved for persist
+   * failures if a backoff supervisor strategy is defined with [[DurableStateBehavior.onPersistFailure]].
+   *
+   * Side effects can be chained with `thenRun`
+   */
+  def stash[State](): ReplyEffect[State] =
+    Stash.asInstanceOf[EffectBuilder[State]].thenNoReply()
+
+  /**
+   * Unstash the commands that were stashed with [[Effect.stash]].
+   *
+   * It's allowed to stash messages while unstashing. Those newly added
+   * commands will not be processed by this `unstashAll` effect and have to be unstashed
+   * by another `unstashAll`.
+   *
+   * @see [[EffectBuilder.thenUnstashAll]]
+   */
+  def unstashAll[State](): Effect[State] =
+    CompositeEffect(none.asInstanceOf[EffectBuilder[State]], SideEffect.unstashAll[State]())
+
+  /**
+   * Send a reply message to the command. The type of the
+   * reply message must conform to the type specified by the passed replyTo `ActorRef`.
+   *
+   * This has the same semantics as `cmd.replyTo.tell`.
+   *
+   * It is provided as a convenience (reducing boilerplate) and a way to enforce that replies are not forgotten
+   * when the `DurableStateBehavior` is created with [[DurableStateBehavior.withEnforcedReplies]]. When
+   * `withEnforcedReplies` is used there will be compilation errors if the returned effect isn't a [[ReplyEffect]].
+   * The reply message will be sent also if `withEnforcedReplies` isn't used, but then the compiler will not help
+   * finding mistakes.
+   */
+  def reply[ReplyMessage, State](replyTo: ActorRef[ReplyMessage])(replyWithMessage: ReplyMessage): ReplyEffect[State] =
+    none[State].thenReply[ReplyMessage](replyTo)(_ => replyWithMessage)
+
+  /**
+   * When [[DurableStateBehavior.withEnforcedReplies]] is used there will be compilation errors if the returned effect
+   * isn't a [[ReplyEffect]]. This `noReply` can be used as a conscious decision that a reply shouldn't be
+   * sent for a specific command or the reply will be sent later.
+   */
+  def noReply[State]: ReplyEffect[State] =
+    none.thenNoReply()
+
+}
+
+/**
+ * A command handler returns an `Effect` directive that defines what state to persist.
+ *
+ * Instances are created through the factories in the [[Effect]] companion object.
+ *
+ * Not for user extension.
+ */
+@DoNotInherit
+trait Effect[State]
+
+/**
+ *  A command handler returns an `Effect` directive that defines what state to persist.
+ *
+ * Instances are created through the factories in the [[Effect]] companion object.
+ *
+ * Additional side effects can be performed in the callback `thenRun`
+ *
+ * Not for user extension.
+ */
+@DoNotInherit
+trait EffectBuilder[State] extends Effect[State] {
+  /* The state that will be persisted in this effect */
+  def state: Option[State]
+
+  /**
+   * Run the given callback. Callbacks are run sequentially.
+   */
+  def thenRun(callback: State => Unit): EffectBuilder[State]
+
+  /** The side effect is to stop the actor */
+  def thenStop(): EffectBuilder[State]
+
+  /**
+   * Unstash the commands that were stashed with [[Effect.stash]].
+   *
+   * It's allowed to stash messages while unstashing. Those newly added
+   * commands will not be processed by this `unstashAll` effect and have to be unstashed
+   * by another `unstashAll`.
+   */
+  def thenUnstashAll(): Effect[State]
+
+  /**
+   * Send a reply message to the command. The type of the
+   * reply message must conform to the type specified by the passed replyTo `ActorRef`.
+   *
+   * This has the same semantics as `replyTo.tell`.
+   *
+   * It is provided as a convenience (reducing boilerplate) and a way to enforce that replies are not forgotten
+   * when the `DurableStateBehavior` is created with [[DurableStateBehavior.withEnforcedReplies]]. When
+   * `withEnforcedReplies` is used there will be compilation errors if the returned effect isn't a [[ReplyEffect]].
+   * The reply message will be sent also if `withEnforcedReplies` isn't used, but then the compiler will not help
+   * finding mistakes.
+   */
+  def thenReply[ReplyMessage](replyTo: ActorRef[ReplyMessage])(
+      replyWithMessage: State => ReplyMessage): ReplyEffect[State]
+
+  /**
+   * When [[DurableStateBehavior.withEnforcedReplies]] is used there will be compilation errors if the returned effect
+   * isn't a [[ReplyEffect]]. This `thenNoReply` can be used as a conscious decision that a reply shouldn't be
+   * sent for a specific command or the reply will be sent later.
+   */
+  def thenNoReply(): ReplyEffect[State]
+
+}
+
+/**
+ * [[DurableStateBehavior.withEnforcedReplies]] can be used to enforce that replies are not forgotten.
+ * Then there will be compilation errors if the returned effect isn't a [[ReplyEffect]], which can be
+ * created with [[Effect.reply]], [[Effect.noReply]], [[EffectBuilder.thenReply]], or [[EffectBuilder.thenNoReply]].
+ *
+ * Not intended for user extension.
+ */
+@DoNotInherit trait ReplyEffect[State] extends Effect[State] {
+
+  /**
+   * Unstash the commands that were stashed with [[Effect.stash]].
+   *
+   * It's allowed to stash messages while unstashing. Those newly added
+   * commands will not be processed by this `unstashAll` effect and have to be unstashed
+   * by another `unstashAll`.
+   */
+  def thenUnstashAll(): ReplyEffect[State]
+}

--- a/akka-persistence/src/main/resources/reference.conf
+++ b/akka-persistence/src/main/resources/reference.conf
@@ -187,6 +187,16 @@ akka.persistence {
     # which means a snapshot is taken after persisting every 1000 events.
     snapshot-after = off
   }
+
+  state {
+    # Absolute path to the KeyValueStore plugin configuration entry used by
+    # KeyValueBehavior actors by default.
+    # KeyValueBehavior can override `keyValueStorePluginId` method (`withKeyValueStorePluginId`)
+    # in order to rely on a different plugin.
+    plugin = ""
+
+    recovery-timeout = 30s
+  }
 }
 
 # Protobuf serialization for the persistent extension messages.

--- a/akka-persistence/src/main/scala/akka/persistence/state/DurableStateStoreProvider.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/DurableStateStoreProvider.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.state
+
+/**
+ * A durable state store plugin must implement a class that implements this trait.
+ * It provides the concrete implementations for the Java and Scala APIs.
+ *
+ * A durable state store plugin plugin must provide implementations for both
+ * `akka.persistence.state.scaladsl.DurableStateStore` and `akka.persistence.state.javadsl.DurableStateStore`.
+ * One of the implementations can delegate to the other.
+ */
+trait DurableStateStoreProvider {
+
+  /**
+   * The `ReadJournal` implementation for the Scala API.
+   * This corresponds to the instance that is returned by [[DurableStateStoreRegistry#durableStateStoreFor]].
+   */
+  def scaladslDurableStateStore(): scaladsl.DurableStateStore[Any]
+
+  /**
+   * The `DurableStateStore` implementation for the Java API.
+   * This corresponds to the instance that is returned by [[DurableStateStoreRegistry#getDurableStateStoreFor]].
+   */
+  def javadslDurableStateStore(): javadsl.DurableStateStore[AnyRef]
+}

--- a/akka-persistence/src/main/scala/akka/persistence/state/DurableStateStoreRegistry.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/DurableStateStoreRegistry.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.state
+
+import scala.reflect.ClassTag
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+
+import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
+import akka.actor.ExtendedActorSystem
+import akka.actor.Extension
+import akka.actor.ExtensionId
+import akka.actor.ExtensionIdProvider
+import akka.annotation.InternalApi
+import akka.persistence.PersistencePlugin
+import akka.persistence.PluginProvider
+import akka.persistence.state.scaladsl.DurableStateStore
+import akka.util.unused
+
+/**
+ * Persistence extension for queries.
+ */
+object DurableStateStoreRegistry extends ExtensionId[DurableStateStoreRegistry] with ExtensionIdProvider {
+
+  override def get(system: ActorSystem): DurableStateStoreRegistry = super.get(system)
+  override def get(system: ClassicActorSystemProvider): DurableStateStoreRegistry = super.get(system)
+
+  def createExtension(system: ExtendedActorSystem): DurableStateStoreRegistry = new DurableStateStoreRegistry(system)
+
+  def lookup: DurableStateStoreRegistry.type = DurableStateStoreRegistry
+
+  @InternalApi
+  private[akka] val pluginProvider
+      : PluginProvider[DurableStateStoreProvider, DurableStateStore[_], javadsl.DurableStateStore[_]] =
+    new PluginProvider[DurableStateStoreProvider, scaladsl.DurableStateStore[_], javadsl.DurableStateStore[_]] {
+      override def scalaDsl(t: DurableStateStoreProvider): DurableStateStore[_] = t.scaladslDurableStateStore()
+      override def javaDsl(t: DurableStateStoreProvider): javadsl.DurableStateStore[_] = t.javadslDurableStateStore()
+    }
+
+}
+
+class DurableStateStoreRegistry(system: ExtendedActorSystem)
+    extends PersistencePlugin[scaladsl.DurableStateStore[_], javadsl.DurableStateStore[_], DurableStateStoreProvider](
+      system)(ClassTag(classOf[DurableStateStoreProvider]), DurableStateStoreRegistry.pluginProvider)
+    with Extension {
+
+  /**
+   * Scala API: Returns the [[akka.persistence.state.scaladsl.DurableStateStore]] specified by the given
+   * read journal configuration entry.
+   *
+   * The provided durableStateStorePluginConfig will be used to configure the journal plugin instead of the actor system
+   * config.
+   */
+  final def durableStateStoreFor[T <: scaladsl.DurableStateStore[_]](
+      durableStateStorePluginId: String,
+      durableStateStorePluginConfig: Config): T =
+    pluginFor(durableStateStorePluginId, durableStateStorePluginConfig).scaladslPlugin.asInstanceOf[T]
+
+  /**
+   * Scala API: Returns the [[akka.persistence.state.scaladsl.DurableStateStore]] specified by the given
+   * read journal configuration entry.
+   */
+  final def durableStateStoreFor[T <: scaladsl.DurableStateStore[_]](durableStateStorePluginId: String): T =
+    durableStateStoreFor(durableStateStorePluginId, ConfigFactory.empty)
+
+  /**
+   * Java API: Returns the [[akka.persistence.state.javadsl.DurableStateStore]] specified by the given
+   * read journal configuration entry.
+   */
+  final def getDurableStateStoreFor[T <: javadsl.DurableStateStore[_]](
+      @unused clazz: Class[T], // FIXME generic Class could be problematic in Java
+      durableStateStorePluginId: String,
+      durableStateStorePluginConfig: Config): T =
+    pluginFor(durableStateStorePluginId, durableStateStorePluginConfig).javadslPlugin.asInstanceOf[T]
+
+  final def getDurableStateStoreFor[T <: javadsl.DurableStateStore[_]](
+      clazz: Class[T],
+      durableStateStorePluginId: String): T =
+    getDurableStateStoreFor[T](clazz, durableStateStorePluginId, ConfigFactory.empty())
+
+}

--- a/akka-persistence/src/main/scala/akka/persistence/state/inmem/InmemDurableStateStoreProvider.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/inmem/InmemDurableStateStoreProvider.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.state.inmem
+
+import akka.persistence.state.DurableStateStoreProvider
+import akka.persistence.state.scaladsl.DurableStateStore
+import akka.persistence.state.inmem.scaladsl.InmemDurableStateStore
+import akka.persistence.state.javadsl.{ DurableStateStore => JDurableStateStore }
+import akka.persistence.state.inmem.javadsl.{ InmemDurableStateStore => JInmemDurableStateStore }
+
+class InmemDurableStateStoreProvider extends DurableStateStoreProvider {
+  override def scaladslDurableStateStore(): DurableStateStore[Any] =
+    new InmemDurableStateStore[Any]
+
+  override def javadslDurableStateStore(): JDurableStateStore[AnyRef] =
+    new JInmemDurableStateStore[AnyRef]
+}

--- a/akka-persistence/src/main/scala/akka/persistence/state/inmem/javadsl/InmemDurableStateStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/inmem/javadsl/InmemDurableStateStore.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.state.inmem.javadsl
+
+import java.util.Optional
+import java.util.concurrent.{ CompletionStage, ConcurrentHashMap }
+
+import scala.concurrent.Future
+import scala.compat.java8.FutureConverters._
+
+import akka.Done
+
+import akka.persistence.state.javadsl.{ DurableStateUpdateStore, GetObjectResult }
+
+class InmemDurableStateStore[A] extends DurableStateUpdateStore[A] {
+  val store = new ConcurrentHashMap[String, A]()
+
+  def getObject(persistenceId: String): CompletionStage[GetObjectResult[A]] =
+    toJava(Future.successful(GetObjectResult(Optional.ofNullable(store.get(persistenceId)), 0)))
+
+  def upsertObject(persistenceId: String, seqNr: Long, value: A, tag: String): CompletionStage[Done] =
+    toJava(Future.successful(store.put(persistenceId, value) match {
+      case _ => Done
+    }))
+
+  def deleteObject(persistenceId: String): CompletionStage[Done] =
+    toJava(Future.successful(store.remove(persistenceId) match {
+      case _ => Done
+    }))
+}

--- a/akka-persistence/src/main/scala/akka/persistence/state/inmem/scaladsl/InmemDurableStateStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/inmem/scaladsl/InmemDurableStateStore.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.state.inmem.scaladsl
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.Future
+
+import akka.Done
+import akka.persistence.state.scaladsl.{ DurableStateUpdateStore, GetObjectResult }
+
+class InmemDurableStateStore[A] extends DurableStateUpdateStore[A] {
+  val store = new TrieMap[String, A]()
+
+  def getObject(persistenceId: String): Future[GetObjectResult[A]] =
+    Future.successful(GetObjectResult(store.get(persistenceId), 0))
+
+  def upsertObject(persistenceId: String, seqNr: Long, value: A, tag: String): Future[Done] =
+    Future.successful(store.put(persistenceId, value) match {
+      case _ => Done
+    })
+
+  def deleteObject(persistenceId: String): Future[Done] =
+    Future.successful(store.remove(persistenceId) match {
+      case _ => Done
+    })
+}

--- a/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateStore.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.state.javadsl
+
+import java.util.Optional
+import java.util.concurrent.CompletionStage
+
+/**
+ * API for reading durable state objects.
+ *
+ * For Scala API see [[akka.persistence.state.scaladsl.DurableStateStore]].
+ *
+ * See also [[DurableStateUpdateStore]]
+ */
+trait DurableStateStore[A] {
+
+  def getObject(persistenceId: String): CompletionStage[GetObjectResult[A]]
+
+}
+
+final case class GetObjectResult[A](value: Optional[A], seqNr: Long)

--- a/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateUpdateStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateUpdateStore.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.state.javadsl
+
+import java.util.concurrent.CompletionStage
+
+import akka.Done
+
+/**
+ * API for updating durable state objects.
+ *
+ * For Scala API see [[akka.persistence.state.scaladsl.DurableStateUpdateStore]].
+ */
+trait DurableStateUpdateStore[A] extends DurableStateStore[A] {
+
+  /**
+   * @param seqNr sequence number for optimistic locking. starts at 1.
+   */
+  def upsertObject(persistenceId: String, seqNr: Long, value: A, tag: String): CompletionStage[Done]
+
+  def deleteObject(persistenceId: String): CompletionStage[Done]
+}

--- a/akka-persistence/src/main/scala/akka/persistence/state/scaladsl/DurableStateStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/scaladsl/DurableStateStore.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.state.scaladsl
+
+import scala.concurrent.Future
+
+/**
+ * API for reading durable state objects.
+ *
+ * For Java API see [[akka.persistence.state.javadsl.DurableStateStore]].
+ *
+ * See also [[DurableStateUpdateStore]]
+ */
+trait DurableStateStore[A] {
+
+  def getObject(persistenceId: String): Future[GetObjectResult[A]]
+
+}
+
+final case class GetObjectResult[A](value: Option[A], seqNr: Long)

--- a/akka-persistence/src/main/scala/akka/persistence/state/scaladsl/DurableStateUpdateStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/scaladsl/DurableStateUpdateStore.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.state.scaladsl
+
+import scala.concurrent.Future
+
+import akka.Done
+
+/**
+ * API for updating durable state objects.
+ *
+ * For Java API see [[akka.persistence.state.javadsl.DurableStateUpdateStore]].
+ */
+trait DurableStateUpdateStore[A] extends DurableStateStore[A] {
+
+  /**
+   * @param seqNr sequence number for optimistic locking. starts at 1.
+   */
+  def upsertObject(persistenceId: String, seqNr: Long, value: A, tag: String): Future[Done]
+
+  def deleteObject(persistenceId: String): Future[Done]
+
+}


### PR DESCRIPTION
* implementation is based on a copy of the EventSourcedBehavior and then
  refactoring all things that are not needed or different such as:
  * remove replicated event sourcing
  * remove ReplayingEvents recovery phase
  * remove retention and snapshotting
  * remove SnapshotSelectionCriteria and snapshots
  * remove PersistAll
  * remove event handler, event types
  * rename EventSourced
  * single static tag
  * DurableStateAdapter
  * DurableStateSignal

* DurableStateStore plugin api with similar extension mechanism as query plugins
  * DurableStateStore, DurableStateUpdateStore
  * DurableStateStoreQuery

* note that the DurableStateStore can be pretty useful for other things also

References #30277

Targeting `dev-durable-state` branch so that we can implement this feature incrementally without including partial work in release.
