### PR TITLE
Fix mapConcat context propagation

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/ContextPropagation.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ContextPropagation.scala
@@ -26,11 +26,6 @@ import akka.annotation.InternalApi
 }
 
 private[akka] final class ContextPropagationImpl extends ContextPropagation {
-  private val buffer = Buffer[Unit](1, 1)
-  def suspendContext(): Unit = {
-    buffer.enqueue(())
-  }
-  def resumeContext(): Unit = {
-    buffer.dequeue()
-  }
+  def suspendContext(): Unit = ()
+  def resumeContext(): Unit = ()
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -2242,7 +2242,7 @@ private[akka] final class StatefulMapConcat[In, Out](val f: () => In => Iterable
     override def onUpstreamFinish(): Unit = onFinish()
 
     override def onPull(): Unit =
-      try pushPull(pullFirstSubElement = true)
+      try pushPull(pullFirstSubElement = false)
       catch handleException
 
     private def handleException: Catcher[Unit] = {

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -2212,14 +2212,20 @@ private[akka] final class StatefulMapConcat[In, Out](val f: () => In => Iterable
     lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
     var currentIterator: Iterator[Out] = _
     var plainFun = f()
+    val contextPropagation = ContextPropagation()
 
     def hasNext = if (currentIterator != null) currentIterator.hasNext else false
 
     setHandlers(in, out, this)
 
-    def pushPull(): Unit =
+    def pushPull(pullFirstSubElement: Boolean): Unit =
       if (hasNext) {
+        if (!pullFirstSubElement) contextPropagation.resumeContext()
         push(out, currentIterator.next())
+        if (hasNext) {
+          // suspend context for the next element
+          contextPropagation.suspendContext()
+        }
         if (!hasNext && isClosed(in)) completeStage()
       } else if (!isClosed(in))
         pull(in)
@@ -2230,13 +2236,13 @@ private[akka] final class StatefulMapConcat[In, Out](val f: () => In => Iterable
     override def onPush(): Unit =
       try {
         currentIterator = plainFun(grab(in)).iterator
-        pushPull()
+        pushPull(pullFirstSubElement = true)
       } catch handleException
 
     override def onUpstreamFinish(): Unit = onFinish()
 
     override def onPull(): Unit =
-      try pushPull()
+      try pushPull(pullFirstSubElement = true)
       catch handleException
 
     private def handleException: Catcher[Unit] = {


### PR DESCRIPTION
Fix mapConcat context propagation, so consecutive child elements are connected to the original span when using Telemetry tracing