### PR TITLE
Fix Akka Persistence Docs Java Example

### DIFF
--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/StashingExample.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/StashingExample.java
@@ -134,7 +134,9 @@ public interface StashingExample {
     private Effect<Event, State> onEndTask(State state, EndTask command) {
       if (state.taskIdInProgress.isPresent()) {
         if (state.taskIdInProgress.get().equals(command.taskId))
-          return Effect().persist(new TaskCompleted(command.taskId));
+          return Effect()
+              .persist(new TaskCompleted(command.taskId))
+              .thenUnstashAll(); // continue with next task
         else return Effect().stash(); // other task in progress, wait with new task until later
       } else {
         return Effect().unhandled();


### PR DESCRIPTION
Add the missing `.thenUnstashAll()` call so that the next task would continue after a task successfully completed.

This is present in the Scala example (https://github.com/akka/akka/blob/master/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/StashingExample.scala#L68) but missing in the Java version.