### PR TITLE
Smart batching of writes in TcpStages

### DIFF
--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -15,6 +15,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.util.control.{ NoStackTrace, NonFatal }
+
 import scala.annotation.nowarn
 
 import akka.actor._
@@ -385,11 +386,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
     }
   }
 
-  println(s"# [${self.path.uid}] start connection") // FIXME
-
   override def postStop(): Unit = {
-    println(s"# [${self.path.uid}] stop connection") // FIXME
-
     if (writePending) pendingWrite.release()
 
     val interestedInClose: Set[ActorRef] =

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -5,20 +5,20 @@
 package akka.io
 
 import java.io.IOException
-import java.net.{InetSocketAddress, SocketException}
+import java.net.{ InetSocketAddress, SocketException }
 import java.nio.ByteBuffer
-import java.nio.channels.{FileChannel, SocketChannel}
+import java.nio.channels.{ FileChannel, SocketChannel }
 import java.nio.channels.SelectionKey._
-import java.nio.file.{Path, Paths}
+import java.nio.file.{ Path, Paths }
 
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.duration._
-import scala.util.control.{NoStackTrace, NonFatal}
+import scala.util.control.{ NoStackTrace, NonFatal }
 import scala.annotation.nowarn
 
 import akka.actor._
-import akka.dispatch.{RequiresMessageQueue, UnboundedMessageQueueSemantics}
+import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
 import akka.io.Inet.SocketOption
 import akka.io.SelectionHandler._
 import akka.io.Tcp._
@@ -389,7 +389,7 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
 
   override def postStop(): Unit = {
     println(s"# [${self.path.uid}] stop connection") // FIXME
-    
+
     if (writePending) pendingWrite.release()
 
     val interestedInClose: Set[ActorRef] =

--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -5,21 +5,20 @@
 package akka.io
 
 import java.io.IOException
-import java.net.{ InetSocketAddress, SocketException }
+import java.net.{InetSocketAddress, SocketException}
 import java.nio.ByteBuffer
-import java.nio.channels.{ FileChannel, SocketChannel }
+import java.nio.channels.{FileChannel, SocketChannel}
 import java.nio.channels.SelectionKey._
-import java.nio.file.{ Path, Paths }
+import java.nio.file.{Path, Paths}
 
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.duration._
-import scala.util.control.{ NoStackTrace, NonFatal }
-
+import scala.util.control.{NoStackTrace, NonFatal}
 import scala.annotation.nowarn
 
 import akka.actor._
-import akka.dispatch.{ RequiresMessageQueue, UnboundedMessageQueueSemantics }
+import akka.dispatch.{RequiresMessageQueue, UnboundedMessageQueueSemantics}
 import akka.io.Inet.SocketOption
 import akka.io.SelectionHandler._
 import akka.io.Tcp._
@@ -386,7 +385,11 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
     }
   }
 
+  println(s"# [${self.path.uid}] start connection") // FIXME
+
   override def postStop(): Unit = {
+    println(s"# [${self.path.uid}] stop connection") // FIXME
+    
     if (writePending) pendingWrite.release()
 
     val interestedInClose: Set[ActorRef] =

--- a/akka-stream/src/main/resources/reference.conf
+++ b/akka-stream/src/main/resources/reference.conf
@@ -87,6 +87,21 @@ akka {
         # slightly more bytes than this limit (at most one element more). It can be set to 0
         # to disable the usage of the buffer.
         write-buffer-size = 16 KiB
+
+        # In addition to the buffering described for property write-buffer-size, more messages (frames)
+        # are collected if they arrive immediately before they are written as one buffer to the TCP output.
+        # This improves throughput for small messages. For example gRPC (HTTP/2) unary requests and responses
+        # consists of several frames (headers, body, trailers).
+        # By writing larger buffers the number of system calls can be reduced and thereby the write efficiency
+        # is improved.
+        # The frames are collected by inducing a short delay via a message round trip to the connection actor
+        # before flushing the write buffer. At most the number of round trips defined by this property,
+        # but as soon as no more frames arrive within such round trip the buffer is flushed.
+        # In other words, this adds a short latency. At low throughput rates the additional latency is
+        # very small, and it will increase at higher throughput but it is still small and bounded by
+        # the number of actor message round trips defined here.
+        # It can be set to 0 to disable this feature.
+        coalesce-writes = 10
       }
 
       # Time to wait for async materializer creation before throwing an exception

--- a/akka-stream/src/main/resources/reference.conf
+++ b/akka-stream/src/main/resources/reference.conf
@@ -88,19 +88,37 @@ akka {
         # to disable the usage of the buffer.
         write-buffer-size = 16 KiB
 
-        # In addition to the buffering described for property write-buffer-size, more messages (frames)
-        # are collected if they arrive immediately before they are written as one buffer to the TCP output.
-        # This improves throughput for small messages. For example gRPC (HTTP/2) unary requests and responses
-        # consists of several frames (headers, body, trailers).
-        # By writing larger buffers the number of system calls can be reduced and thereby the write efficiency
-        # is improved.
-        # The frames are collected by inducing a short delay via a message round trip to the connection actor
-        # before flushing the write buffer. At most the number of round trips defined by this property,
-        # but as soon as no more frames arrive within such round trip the buffer is flushed.
-        # In other words, this adds a short latency. At low throughput rates the additional latency is
-        # very small, and it will increase at higher throughput but it is still small and bounded by
-        # the number of actor message round trips defined here.
-        # It can be set to 0 to disable this feature.
+        # In addition to the buffering described for property write-buffer-size, try to collect
+        # more consecutive writes from the upstream stream producers.
+        #
+        # The rationale is to increase write efficiency by avoiding separate small 
+        # writes to the network which is expensive to do. Merging those writes together
+        # (up to `write-buffer-size`) improves throughput for small writes.
+        #
+        # The idea is that a running stream may produce multiple small writes consecutively
+        # in one go without waiting for any external input. To probe the stream for
+        # data, this features delays sending a write immediately by probing the stream
+        # for more writes. This works by rescheduling the TCP connection stage via the
+        # actor mailbox of the underlying actor. Thus, before the stage is reactivated
+        # the upstream gets another opportunity to emit writes.
+        #
+        # When the stage is reactivated and if new writes are detected another round-trip
+        # is scheduled. The loop repeats until either the number of round trips given in this
+        # setting is reached, the buffer reaches `write-buffer-size`, or no new writes
+        # were detected during the last round-trip.
+        #
+        # This mechanism ensures that a write is guaranteed to be sent when the remaining stream
+        # becomes idle waiting for external signals.
+        #
+        # In most cases, the extra latency this mechanism introduces should be negligible,
+        # but depending on the stream setup it may introduce a noticeable delay,
+        # if the upstream continuously produces small amounts of writes in a
+        # blocking (CPU-bound) way.
+        #
+        # In that case, the feature can either be disabled, or the producing CPU-bound
+        # work can be taken off-stream to avoid excessive delays (e.g. using `mapAsync` instead of `map`).
+        #
+        # A value of 0 disables this feature.
         coalesce-writes = 10
       }
 

--- a/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
@@ -809,19 +809,30 @@ object IOSettings {
 @nowarn("msg=deprecated")
 final class IOSettings private (
     @deprecated("Use attribute 'TcpAttributes.TcpWriteBufferSize' to read the concrete setting value", "2.6.0")
-    val tcpWriteBufferSize: Int) {
+    val tcpWriteBufferSize: Int,
+    val coalesceWrites: Int) {
+
+  // constructor for binary compatibility with version 2.6.15 and earlier
+  @deprecated("Use attribute 'TcpAttributes.TcpWriteBufferSize' to read the concrete setting value", "2.6.0")
+  def this(tcpWriteBufferSize: Int) = this(tcpWriteBufferSize, coalesceWrites = 10)
 
   def withTcpWriteBufferSize(value: Int): IOSettings = copy(tcpWriteBufferSize = value)
 
-  private def copy(tcpWriteBufferSize: Int): IOSettings = new IOSettings(tcpWriteBufferSize = tcpWriteBufferSize)
+  def withCoalesceWrites(value: Int): IOSettings = copy(coalesceWrites = value)
+
+  private def copy(tcpWriteBufferSize: Int = tcpWriteBufferSize, coalesceWrites: Int = coalesceWrites): IOSettings =
+    new IOSettings(tcpWriteBufferSize, coalesceWrites)
 
   override def equals(other: Any): Boolean = other match {
-    case s: IOSettings => s.tcpWriteBufferSize == tcpWriteBufferSize
+    case s: IOSettings => s.tcpWriteBufferSize == tcpWriteBufferSize && s.coalesceWrites == coalesceWrites
     case _             => false
   }
 
+  override def hashCode(): Int =
+    31 * tcpWriteBufferSize + coalesceWrites
+
   override def toString =
-    s"""IoSettings(${tcpWriteBufferSize})"""
+    s"""IoSettings($tcpWriteBufferSize,$coalesceWrites)"""
 }
 
 object StreamSubscriptionTimeoutSettings {

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
@@ -267,7 +267,7 @@ private[stream] object ConnectionSourceStage {
 
     @nowarn("msg=deprecated")
     private val coalesceWrites = eagerMaterializer.settings.ioSettings.coalesceWrites
-    private val coalesceWritesDisabled = coalesceWrites == 0
+    private def coalesceWritesDisabled = coalesceWrites == 0
     private var writeDelayCountDown = 0
     private var previousWriteBufferSize = 0
 


### PR DESCRIPTION
* collect more ByteString elements before writing to tcp connection
* without sacrificing latency for lower throughput scenarios
* just using additional actor message roundtrip to the connection
  actor to collect more elements, those messages would previously
  have been performed anyway, but with real writes

