### PR TITLE
Upgrade jackson to 2.12.3

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,7 +2,7 @@ pullRequests.frequency = "@monthly"
 
 updates.pin  = [
   { groupId = "org.scalatest", artifactId = "scalatest", version = "3.1." }
-  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-core", version = "2.11." }
+  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-core", version = "2.12." }
 ]
 
 updates.ignore = [

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
   val protobufJavaVersion = "3.11.4"
   val logbackVersion = "1.2.3"
 
-  val jacksonVersion = "2.11.4"
+  val jacksonVersion = "2.12.3"
 
   val scala212Version = "2.12.14"
   val scala213Version = "2.13.5"


### PR DESCRIPTION
A variety of libraries have recently migrated to jackson 2.12.
Since jackson 2.11 and 2.12 are not binary compatible, Akka using 2.11 will not work with those libraries.

Previously, the version 2.11 upgraded was caused by a security vulnerability. (#30130)
To resolve the issue with the library you are using with Akka, you need to upgrade Akka to jackson 2.12.

jackson is working on version 2.13. The day will come when 2.11 will no longer be supported.
https://github.com/FasterXML/jackson/wiki/Jackson-Releases

It's worth upgrading even if it breaks binary compatibility.
