### PR TITLE
Changed seqNr to 'revision' for all durable state APIs and implementations

### DIFF
--- a/akka-persistence-query/src/main/scala/akka/persistence/query/DurableStateChange.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/DurableStateChange.scala
@@ -16,7 +16,7 @@ package akka.persistence.query
  */
 final class DurableStateChange[A](
     val persistenceId: String,
-    val seqNr: Long,
+    val revision: Long,
     val value: A,
     val offset: Offset,
     val timestamp: Long)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateStoreInteractions.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateStoreInteractions.scala
@@ -42,12 +42,13 @@ private[akka] trait DurableStateStoreInteractions[C, S] {
       state: Running.RunningState[S],
       value: Any): Running.RunningState[S] = {
 
-    val newRunningState = state.nextSequenceNr()
+    val newRunningState = state.nextRevision()
     val persistenceId = setup.persistenceId.id
 
     onWriteInitiated(ctx, cmd)
 
-    ctx.pipeToSelf[Done](setup.durableStateStore.upsertObject(persistenceId, newRunningState.seqNr, value, setup.tag)) {
+    ctx.pipeToSelf[Done](
+      setup.durableStateStore.upsertObject(persistenceId, newRunningState.revision, value, setup.tag)) {
       case Success(_)     => InternalProtocol.UpsertSuccess
       case Failure(cause) => InternalProtocol.UpsertFailure(cause)
     }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/DurableStateBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/DurableStateBehavior.scala
@@ -94,7 +94,7 @@ object DurableStateBehavior {
       }
 
     extractConcreteBehavior(context.currentBehavior) match {
-      case w: Running.WithSeqNrAccessible => w.currentSequenceNumber
+      case w: Running.WithRevisionAccessible => w.currentRevision
       case s =>
         throw new IllegalStateException(s"Cannot extract the lastSequenceNumber in state ${s.getClass.getName}")
     }

--- a/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateStore.scala
@@ -20,4 +20,4 @@ trait DurableStateStore[A] {
 
 }
 
-final case class GetObjectResult[A](value: Optional[A], seqNr: Long)
+final case class GetObjectResult[A](value: Optional[A], revision: Long)

--- a/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateUpdateStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/javadsl/DurableStateUpdateStore.scala
@@ -18,7 +18,7 @@ trait DurableStateUpdateStore[A] extends DurableStateStore[A] {
   /**
    * @param seqNr sequence number for optimistic locking. starts at 1.
    */
-  def upsertObject(persistenceId: String, seqNr: Long, value: A, tag: String): CompletionStage[Done]
+  def upsertObject(persistenceId: String, revision: Long, value: A, tag: String): CompletionStage[Done]
 
   def deleteObject(persistenceId: String): CompletionStage[Done]
 }

--- a/akka-persistence/src/main/scala/akka/persistence/state/scaladsl/DurableStateStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/scaladsl/DurableStateStore.scala
@@ -19,4 +19,4 @@ trait DurableStateStore[A] {
 
 }
 
-final case class GetObjectResult[A](value: Option[A], seqNr: Long)
+final case class GetObjectResult[A](value: Option[A], revision: Long)

--- a/akka-persistence/src/main/scala/akka/persistence/state/scaladsl/DurableStateUpdateStore.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/state/scaladsl/DurableStateUpdateStore.scala
@@ -18,7 +18,7 @@ trait DurableStateUpdateStore[A] extends DurableStateStore[A] {
   /**
    * @param seqNr sequence number for optimistic locking. starts at 1.
    */
-  def upsertObject(persistenceId: String, seqNr: Long, value: A, tag: String): Future[Done]
+  def upsertObject(persistenceId: String, revision: Long, value: A, tag: String): Future[Done]
 
   def deleteObject(persistenceId: String): Future[Done]
 


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/akka/akka/issues/30277
as per this [discussion](https://github.com/akka/akka-persistence-jdbc/pull/544#discussion_r659359672) on jdbc implementation
