### PR TITLE
stream: actually read coalesce-writes setting from config

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/ActorMaterializer.scala
@@ -778,7 +778,9 @@ object IOSettings {
     "Use setting 'akka.stream.materializer.io.tcp.write-buffer-size' or attribute TcpAttributes.writeBufferSize instead",
     "2.6.0")
   def apply(config: Config): IOSettings =
-    new IOSettings(tcpWriteBufferSize = math.min(Int.MaxValue, config.getBytes("tcp.write-buffer-size")).toInt)
+    new IOSettings(
+      tcpWriteBufferSize = math.min(Int.MaxValue, config.getBytes("tcp.write-buffer-size")).toInt,
+      coalesceWrites = config.getInt("tcp.coalesce-writes"))
 
   @deprecated(
     "Use setting 'akka.stream.materializer.io.tcp.write-buffer-size' or attribute TcpAttributes.writeBufferSize instead",


### PR DESCRIPTION
Follow up to #30334.

Due to the setup of nested deprecated constructors, it wasn't obvious that it was missing. Actually testing the feature is hard to do since it is not necessarily observable from the outside (would have to trace `write` syscalls).