### PR TITLE
io: probe TCP socket when reading before registering interest

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/TcpConnectionSpec.scala
@@ -390,28 +390,19 @@ class TcpConnectionSpec extends AkkaSpec("""
         connectionHandler.expectNoMessage(100.millis)
 
         connectionActor ! ResumeReading
-        interestCallReceiver.expectMsg(OP_READ)
-        selector.send(connectionActor, ChannelReadable)
         connectionHandler.expectMsgType[Received].data.decodeString("ASCII") should ===(ts)
 
-        interestCallReceiver.expectNoMessage(100.millis)
         connectionHandler.expectNoMessage(100.millis)
 
         connectionActor ! ResumeReading
-        interestCallReceiver.expectMsg(OP_READ)
-        selector.send(connectionActor, ChannelReadable)
         connectionHandler.expectMsgType[Received].data.decodeString("ASCII") should ===(us)
 
-        // make sure that after reading all pending data we don't yet register for reading more data
-        interestCallReceiver.expectNoMessage(100.millis)
         connectionHandler.expectNoMessage(100.millis)
 
         val vs = "v" * (maxBufferSize / 2)
         serverSideChannel.write(ByteBuffer.wrap(vs.getBytes("ASCII")))
 
         connectionActor ! ResumeReading
-        interestCallReceiver.expectMsg(OP_READ)
-        selector.send(connectionActor, ChannelReadable)
 
         connectionHandler.expectMsgType[Received].data.decodeString("ASCII") should ===(vs)
       } finally shutdown(system)

--- a/akka-actor/src/main/mima-filters/2.6.15.backwards.excludes/30354-improve-TcpConnection.excludes
+++ b/akka-actor/src/main/mima-filters/2.6.15.backwards.excludes/30354-improve-TcpConnection.excludes
@@ -1,0 +1,2 @@
+# internal actor class
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.io.TcpConnection.resumeReading")


### PR DESCRIPTION
Just asking once for more data is cheaper than instantly updating epoll.