### PR TITLE
stream: when coalesce-writes is enabled loop through stageActor

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TcpStages.scala
@@ -214,7 +214,6 @@ private[stream] object ConnectionSourceStage {
   case object WriteAck extends Tcp.Event
 
   private case object WriteDelayAck extends Tcp.Event
-  private val WriteDelayMessage = Write(ByteString.empty, WriteDelayAck)
 
   trait TcpRole {
     def halfClose: Boolean
@@ -328,7 +327,7 @@ private[stream] object ConnectionSourceStage {
     private def sendWriteDelay(): Unit = {
       previousWriteBufferSize = writeBuffer.length
       writeInProgress = true
-      connection ! WriteDelayMessage
+      stageActor.ref ! WriteDelayAck
     }
 
     // Used for both inbound and outbound connections


### PR DESCRIPTION
Before it was cycling to the TCP connection actor. Sending messages to
idle actors can be relatively expensive if a mailbox needs to be
scheduled and a pool thread needs to be woken up.

Looping through the stageActor means effectively scheduling an
asyncCallback to the shortcutCircuit which is quite cheap.

On the other hand, it might be that we want to avoid the shortCircuitBuffer
to allow the upstream part of the stream to handle events that come
in asynchronously via the mailbox in the meantime.

I therefore added another commit that tries to add some extra logic to mark
an async callback as having to go through the mailbox. We should benchmark
both solutions (and the existing) before committing to any one.