### PR TITLE
Hide private members in documentation (#20185)

### DIFF
--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -186,6 +186,6 @@ object BootstrapGenjavadoc extends AutoPlugin {
   override lazy val projectSettings = UnidocRoot.CliOptions.genjavadocEnabled
     .ifTrue(Seq(
       unidocGenjavadocVersion := "0.17",
-      Compile / scalacOptions ++= Seq("-P:genjavadoc:fabricateParams=false", "-P:genjavadoc:suppressSynthetic=false")))
+      Compile / scalacOptions ++= Seq("-P:genjavadoc:fabricateParams=false", "-P:genjavadoc:suppressSynthetic=false", "-P:genjavadoc:strictVisibility=true")))
     .getOrElse(Nil)
 }


### PR DESCRIPTION
References #20185

It looks good. Only one public method is visible. One private method disappeared.

<img width="1440" alt="Снимок экрана 2021-07-01 в 21 17 23" src="https://user-images.githubusercontent.com/4740207/124173921-62b61280-dab4-11eb-870f-f914d710897c.png">

Kind regards