### PR TITLE
Revert "Hide private members in documentation (#20185)"

### DIFF
--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -186,6 +186,6 @@ object BootstrapGenjavadoc extends AutoPlugin {
   override lazy val projectSettings = UnidocRoot.CliOptions.genjavadocEnabled
     .ifTrue(Seq(
       unidocGenjavadocVersion := "0.17",
-      Compile / scalacOptions ++= Seq("-P:genjavadoc:fabricateParams=false", "-P:genjavadoc:suppressSynthetic=false", "-P:genjavadoc:strictVisibility=true")))
+      Compile / scalacOptions ++= Seq("-P:genjavadoc:fabricateParams=false", "-P:genjavadoc:suppressSynthetic=false")))
     .getOrElse(Nil)
 }


### PR DESCRIPTION
Reverts akka/akka#30356

As it caused a NPE in javadoc: https://jenkins.akka.io:8498/job/akka-docs/4010/consoleFull