### PR TITLE
oldest means differnt to Akka than to Kubernetes

### DIFF
--- a/akka-docs/src/main/paradox/additional/rolling-updates.md
+++ b/akka-docs/src/main/paradox/additional/rolling-updates.md
@@ -78,9 +78,6 @@ it is recommended to upgrade the oldest node last. This way cluster singletons a
 Otherwise, in the worst case cluster singletons may be migrated from node to node which requires coordination and initialization 
 overhead several times.
 
-[Kubernetes Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) with `RollingUpdate`
-strategy will roll out updates in this preferred order, from newest to oldest. 
-
 ## Cluster Shutdown
  
 ### Graceful shutdown 


### PR DESCRIPTION
After two tests in Kubernetes with a Rollling Update, I found that the text "Kubernetes Deployments with RollingUpdate strategy will roll out updates in this preferred order, from newest to oldest.", more specifically "in this preferred order" is misleading. The oldest for Akka is the lowest IP while in Kubernetes is time-wise. 

I don't think the user can assume the lowest IP will be deleted last. 

Please let me know your thoughts.


ps. Am I right about  the lowest IP? can't find that now in the docs. Not so sure now.