### PR TITLE
Build javadoc on a newer jdk

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,10 +47,10 @@ jobs:
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 16
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: adopt@1.11.0-9
+          java-version: adopt@1.16.0-1
       - name: Publish
         run: |-
           eval "$(ssh-agent -s)"

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -136,7 +136,7 @@ object UnidocRoot extends AutoPlugin {
     .ifTrue(Seq(
       JavaUnidoc / unidoc / javacOptions := {
         if (JdkOptions.isJdk8) Seq("-Xdoclint:none")
-        else Seq("-Xdoclint:none", "--ignore-source-errors", "--no-module-directories")
+        else Seq("-Xdoclint:none", "--ignore-source-errors")
       },
       publishRsyncArtifacts ++= {
         val releaseVersion = if (isSnapshot.value) "snapshot" else version.value


### PR DESCRIPTION
Refs #30367

Since 1a90f22, we are passing --no-module-directories to the javadoc
generation options. However, this flag was removed from JDK13 onwards
(https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8215580),
and now produces an error.

The problem with search and module directories is reportedly fixed
(https://stackoverflow.com/a/66891038/354132, https://bugs.openjdk.java.net/browse/JDK-8215291).
I can reproduce that with JDK16 it now works again without --no-module-directories.