### PR TITLE
Update `scala-java8-compat` to `1.0.0`

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,8 +71,8 @@ object Dependencies {
         CrossVersion.partialVersion(scalaVersion.value) match {
           // java8-compat is only used in a couple of places for 2.13,
           // it is probably possible to remove the dependency if needed.
-          case Some((3, _))            => "0.9.0"
-          case Some((2, n)) if n >= 13 => "0.9.0"
+          case Some((3, _))            => "1.0.0"
+          case Some((2, n)) if n >= 13 => "1.0.0"
           case _                       => "0.8.0"
         }
       })


### PR DESCRIPTION
The compat library [added](https://github.com/scala/scala-java8-compat/commit/82be2fa7960c2e4eaad720cbb8e4503ef1a3f80d#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91R21) an `early-semver` versionScheme which means
that 1.0.0 is marked as binary incompatible with any version lower
than 0.9.1 - even though it's not.

For example:

```
[error] (update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error]
[error] 	* org.scala-lang.modules:scala-java8-compat_2.13:1.0.0 (early-semver) is selected over 0.9.0
[error] 	    +- com.github.blemale:scaffeine_2.13:4.1.0            (depends on 1.0.0)
[error] 	    +- com.typesafe.akka:akka-actor_2.13:2.6.14           (depends on 0.9.0)
```

The `scalaModuleMimaPreviousVersion` has been set to `0.9.1` in the project, so upgrading
Akka to this should allow it to work with a lot of other libraries who have already done
the major update (supports Scala 3) to 1.0.0.

