### PR TITLE
compile akka-coordination with scala3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     - stage: scala3
       name: scala3
       # separate job since only a few modules compile with Scala 3 yet
-      script: jabba install adopt@1.11-0 && jabba use adopt@1.11-0 && sbt -Dakka.build.scalaVersion=3.0 "akka-actor-tests/test:compile" akka-actor-testkit-typed/compile akka-actor-typed/compile akka-pki/test:compile akka-protobuf/test:compile akka-protobuf-v3/test:compile akka-slf4j/test:compile akka-stream/compile akka-stream-tests-tck/test
+      script: jabba install adopt@1.11-0 && jabba use adopt@1.11-0 && sbt -Dakka.build.scalaVersion=3.0 "akka-actor-tests/test:compile" akka-actor-testkit-typed/compile akka-actor-typed/compile akka-coordination/compile akka-pki/test:compile akka-protobuf/test:compile akka-protobuf-v3/test:compile akka-slf4j/test:compile akka-stream/compile akka-stream-tests-tck/test
 
 stages:
   - name: whitesource

--- a/akka-coordination/src/main/scala/akka/coordination/lease/scaladsl/LeaseProvider.scala
+++ b/akka-coordination/src/main/scala/akka/coordination/lease/scaladsl/LeaseProvider.scala
@@ -35,7 +35,7 @@ object LeaseProvider extends ExtensionId[LeaseProvider] with ExtensionIdProvider
 final class LeaseProvider(system: ExtendedActorSystem) extends Extension {
   import LeaseProvider.LeaseKey
 
-  private val log = Logging(system, getClass)
+  private val log = Logging(system, classOf[LeaseProvider])
   private val leases = new ConcurrentHashMap[LeaseKey, Lease]()
 
   /**

--- a/akka-coordination/src/test/scala/akka/coordination/lease/TestLease.scala
+++ b/akka-coordination/src/test/scala/akka/coordination/lease/TestLease.scala
@@ -61,7 +61,7 @@ object TestLease {
 class TestLease(settings: LeaseSettings, system: ExtendedActorSystem) extends Lease(settings) {
   import TestLease._
 
-  val log = Logging(system, getClass)
+  val log = Logging(system, classOf[TestLease])
   val probe = TestProbe()(system)
 
   log.info("Creating lease {}", settings)

--- a/akka-coordination/src/test/scala/akka/coordination/lease/TestLeaseActor.scala
+++ b/akka-coordination/src/test/scala/akka/coordination/lease/TestLeaseActor.scala
@@ -98,7 +98,7 @@ class TestLeaseActorClient(settings: LeaseSettings, system: ExtendedActorSystem)
   import TestLeaseActor.Create
   import TestLeaseActor.Release
 
-  private val log = Logging(system, getClass)
+  private val log = Logging(system, classOf[TestLeaseActorClient])
   val leaseActor = TestLeaseActorClientExt(system).getLeaseActor()
 
   log.info("lease created {}", settings)


### PR DESCRIPTION
Unfortunately the tests reveal a problem: a duplicate 'get' static
forwarder method is generated on the `LeaseProvider` class, which
produces a problem getting the extension from Java. To be
investigated, but let's at least start checking compilation.

Refs #30243