### PR TITLE
Include Scala 3 in cross-build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -413,8 +413,8 @@ lazy val remote =
     .settings(Test / parallelExecution := false)
     .settings(serialversionRemoverPluginSettings)
     .enablePlugins(Jdk9)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
+    // TODO https://github.com/akka/akka/issues/30243
+    .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val remoteTests = akkaModule("akka-remote-tests")
   .dependsOn(
@@ -619,12 +619,10 @@ lazy val serialversionRemoverPlugin =
 
 lazy val serialversionRemoverPluginSettings = Seq(
   Compile / scalacOptions ++= (
-    if (scalaVersion.value.startsWith("3.")) Seq(
-      "-Xplugin:" + (serialversionRemoverPlugin / Compile / Keys.`package`).value.getAbsolutePath.toString
-    )
-    else Nil
-  )
-)
+      if (scalaVersion.value.startsWith("3."))
+        Seq("-Xplugin:" + (serialversionRemoverPlugin / Compile / Keys.`package`).value.getAbsolutePath.toString)
+      else Nil
+    ))
 
 def akkaModule(name: String): Project =
   Project(id = name, base = file(name))

--- a/build.sbt
+++ b/build.sbt
@@ -53,8 +53,6 @@ shellPrompt := { s =>
 }
 resolverSettings
 
-def isScala213: Boolean = System.getProperty("akka.build.scalaVersion", "").startsWith("2.13")
-
 // When this is updated the set of modules in ActorSystem.allModules should also be updated
 lazy val userProjects: Seq[ProjectReference] = List[ProjectReference](
   actor,
@@ -114,6 +112,8 @@ lazy val root = Project(id = "akka", base = file("."))
         serialversionRemoverPlugin))
   .settings(Compile / headerCreate / unmanagedSources := (baseDirectory.value / "project").**("*.scala").get)
   .enablePlugins(CopyrightHeaderForBuild)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions := Nil)
 
 lazy val actor = akkaModule("akka-actor")
   .settings(Dependencies.actor)
@@ -126,6 +126,8 @@ lazy val actor = akkaModule("akka-actor")
   .settings(VersionGenerator.settings)
   .settings(serialversionRemoverPluginSettings)
   .enablePlugins(BoilerplatePlugin)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions += akka.Dependencies.scala3Version)
 
 lazy val actorTests = akkaModule("akka-actor-tests")
   .dependsOn(testkit % "compile->compile;test->test")
@@ -161,6 +163,8 @@ lazy val cluster = akkaModule("akka-cluster")
   .settings(Test / parallelExecution := false)
   .configs(MultiJvm)
   .enablePlugins(MultiNodeScalaTest)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val clusterMetrics = akkaModule("akka-cluster-metrics")
   .dependsOn(
@@ -257,6 +261,8 @@ lazy val docs = akkaModule("akka-docs")
     Jdk9)
   .disablePlugins(MimaPlugin)
   .disablePlugins((if (ScalafixSupport.fixTestScope) Nil else Seq(ScalafixPlugin)): _*)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val jackson = akkaModule("akka-serialization-jackson")
   .dependsOn(
@@ -270,6 +276,8 @@ lazy val jackson = akkaModule("akka-serialization-jackson")
   .settings(OSGi.jackson)
   .settings(javacOptions += "-parameters")
   .enablePlugins(ScaladocNoVerificationOfDiagrams)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val multiNodeTestkit = akkaModule("akka-multi-node-testkit")
   .dependsOn(remote, testkit)
@@ -292,6 +300,8 @@ lazy val persistence = akkaModule("akka-persistence")
   .settings(OSGi.persistence)
   .settings(Protobuf.settings)
   .settings(Test / fork := true)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val persistenceQuery = akkaModule("akka-persistence-query")
   .dependsOn(stream, persistence % "compile->compile;test->test", streamTestkit % "test")
@@ -339,6 +349,8 @@ lazy val persistenceTypedTests = akkaModule("akka-persistence-typed-tests")
   .settings(javacOptions += "-parameters") // for Jackson
   .disablePlugins(MimaPlugin)
   .enablePlugins(NoPublish)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val protobuf = akkaModule("akka-protobuf")
   .settings(OSGi.protobuf)
@@ -401,6 +413,8 @@ lazy val remote =
     .settings(Test / parallelExecution := false)
     .settings(serialversionRemoverPluginSettings)
     .enablePlugins(Jdk9)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val remoteTests = akkaModule("akka-remote-tests")
   .dependsOn(
@@ -415,6 +429,8 @@ lazy val remoteTests = akkaModule("akka-remote-tests")
   .configs(MultiJvm)
   .enablePlugins(MultiNodeScalaTest, NoPublish)
   .disablePlugins(MimaPlugin)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val slf4j = akkaModule("akka-slf4j")
   .dependsOn(actor, testkit % "test->test")
@@ -435,6 +451,8 @@ lazy val streamTestkit = akkaModule("akka-stream-testkit")
   .settings(Dependencies.streamTestkit)
   .settings(AutomaticModuleName.settings("akka.stream.testkit"))
   .settings(OSGi.streamTestkit)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val streamTests = akkaModule("akka-stream-tests")
   .configs(akka.Jdk9.TestJdk9)
@@ -496,6 +514,8 @@ lazy val persistenceTyped = akkaModule("akka-persistence-typed")
   // To be able to import ContainerFormats.proto
   .settings(Protobuf.importPath := Some(baseDirectory.value / ".." / "akka-remote" / "src" / "main" / "protobuf"))
   .settings(OSGi.persistenceTyped)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val clusterTyped = akkaModule("akka-cluster-typed")
   .dependsOn(
@@ -537,6 +557,8 @@ lazy val clusterShardingTyped = akkaModule("akka-cluster-sharding-typed")
   .settings(Protobuf.importPath := Some(baseDirectory.value / ".." / "akka-remote" / "src" / "main" / "protobuf"))
   .configs(MultiJvm)
   .enablePlugins(MultiNodeScalaTest)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val streamTyped = akkaModule("akka-stream-typed")
   .dependsOn(
@@ -552,6 +574,8 @@ lazy val actorTestkitTyped = akkaModule("akka-actor-testkit-typed")
   .dependsOn(actorTyped, slf4j, testkit % "compile->compile;test->test")
   .settings(AutomaticModuleName.settings("akka.actor.testkit.typed"))
   .settings(Dependencies.actorTestkitTyped)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val actorTypedTests = akkaModule("akka-actor-typed-tests")
   .dependsOn(actorTyped % "compile->CompileJdk9", actorTestkitTyped % "compile->compile;test->test")
@@ -564,12 +588,16 @@ lazy val discovery = akkaModule("akka-discovery")
   .settings(Dependencies.discovery)
   .settings(AutomaticModuleName.settings("akka.discovery"))
   .settings(OSGi.discovery)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val coordination = akkaModule("akka-coordination")
   .dependsOn(actor, testkit % "test->test", actorTests % "test->test")
   .settings(Dependencies.coordination)
   .settings(AutomaticModuleName.settings("akka.coordination"))
   .settings(OSGi.coordination)
+  // TODO https://github.com/akka/akka/issues/30243
+  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val billOfMaterials = Project("akka-bill-of-materials", file("akka-bill-of-materials"))
   .enablePlugins(BillOfMaterialsPlugin)
@@ -589,17 +617,14 @@ lazy val serialversionRemoverPlugin =
     Compile / doc / sources := Nil,
     Compile / publishArtifact := false)
 
-lazy val serialversionRemoverPluginSettings = {
-  if (akka.Dependencies.getScalaVersion() == akka.Dependencies.scala3Version) {
-    Seq(
-      autoCompilerPlugins := true,
-      Compile / scalacOptions += (
-          "-Xplugin:" + (serialversionRemoverPlugin / Compile / Keys.`package`).value.getAbsolutePath.toString
-        ))
-  } else {
-    Seq()
-  }
-}
+lazy val serialversionRemoverPluginSettings = Seq(
+  Compile / scalacOptions ++= (
+    if (scalaVersion.value.startsWith("3.")) Seq(
+      "-Xplugin:" + (serialversionRemoverPlugin / Compile / Keys.`package`).value.getAbsolutePath.toString
+    )
+    else Nil
+  )
+)
 
 def akkaModule(name: String): Project =
   Project(id = name, base = file(name))

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -90,8 +90,8 @@ object AkkaBuild {
 
   private def allWarnings: Boolean = System.getProperty("akka.allwarnings", "false").toBoolean
 
-  final val DefaultScalacOptions = {
-    if (Dependencies.getScalaVersion().startsWith("3.")) {
+  final val DefaultScalacOptions = Def.setting {
+    if (scalaVersion.value.startsWith("3.")) {
       Seq(
         "-encoding",
         "UTF-8",
@@ -127,9 +127,9 @@ object AkkaBuild {
     resolverSettings,
     TestExtras.Filter.settings,
     // compile options
-    Compile / scalacOptions ++= DefaultScalacOptions,
+    Compile / scalacOptions ++= DefaultScalacOptions.value,
     Compile / scalacOptions ++=
-      JdkOptions.targetJdkScalacOptions(targetSystemJdk.value, optionalDir(jdk8home.value), fullJavaHomes.value),
+      JdkOptions.targetJdkScalacOptions(targetSystemJdk.value, optionalDir(jdk8home.value), fullJavaHomes.value, scalaVersion.value),
     Compile / scalacOptions ++= (if (allWarnings) Seq("-deprecation") else Nil),
     Test / scalacOptions := (Test / scalacOptions).value.filterNot(opt =>
         opt == "-Xlog-reflective-calls" || opt.contains("genjavadoc")),

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -129,7 +129,11 @@ object AkkaBuild {
     // compile options
     Compile / scalacOptions ++= DefaultScalacOptions.value,
     Compile / scalacOptions ++=
-      JdkOptions.targetJdkScalacOptions(targetSystemJdk.value, optionalDir(jdk8home.value), fullJavaHomes.value, scalaVersion.value),
+      JdkOptions.targetJdkScalacOptions(
+        targetSystemJdk.value,
+        optionalDir(jdk8home.value),
+        fullJavaHomes.value,
+        scalaVersion.value),
     Compile / scalacOptions ++= (if (allWarnings) Seq("-deprecation") else Nil),
     Test / scalacOptions := (Test / scalacOptions).value.filterNot(opt =>
         opt == "-Xlog-reflective-calls" || opt.contains("genjavadoc")),

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -65,33 +65,29 @@ object AkkaDisciplinePlugin extends AutoPlugin {
 
   val defaultScalaOptions = "-Wconf:cat=unused-nowarn:s,any:e"
 
-  lazy val nowarnSettings = {
-    Dependencies.getScalaVersion() match {
-      case three if three.startsWith("3.") =>
-        Seq(Compile / scalacOptions := Seq(), Compile / doc / scalacOptions := Seq())
-      case _ =>
-        Seq(
-          Compile / scalacOptions += defaultScalaOptions,
-          Test / scalacOptions += defaultScalaOptions,
-          Compile / doc / scalacOptions := Seq())
-    }
-  }
+  lazy val nowarnSettings = Seq(
+    Compile / scalacOptions ++= (
+      if (scalaVersion.value.startsWith("3.")) Nil
+      else Seq(defaultScalaOptions)
+    ),
+    Test / scalacOptions ++= (
+      if (scalaVersion.value.startsWith("3.")) Nil
+      else Seq(defaultScalaOptions)
+    ),
+    Compile / doc / scalacOptions := Seq()
+  )
 
   /**
    * We are a little less strict in docs
    */
-  val docs = {
-    Dependencies.getScalaVersion() match {
-      case _ =>
-        Seq(
-          Compile / scalacOptions -= defaultScalaOptions,
-          Compile / scalacOptions += "-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e",
-          Test / scalacOptions --= Seq("-Xlint", "-unchecked", "-deprecation"),
-          Test / scalacOptions -= defaultScalaOptions,
-          Test / scalacOptions += "-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e",
-          Compile / doc / scalacOptions := Seq())
-    }
-  }
+  val docs =
+    Seq(
+      Compile / scalacOptions -= defaultScalaOptions,
+      Compile / scalacOptions += "-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e",
+      Test / scalacOptions --= Seq("-Xlint", "-unchecked", "-deprecation"),
+      Test / scalacOptions -= defaultScalaOptions,
+      Test / scalacOptions += "-Wconf:cat=unused:s,cat=deprecation:s,cat=unchecked:s,any:e",
+      Compile / doc / scalacOptions := Seq())
 
   lazy val disciplineSettings =
     if (enabled) {
@@ -99,7 +95,7 @@ object AkkaDisciplinePlugin extends AutoPlugin {
         Compile / scalacOptions ++= Seq("-Xfatal-warnings"),
         Test / scalacOptions --= testUndicipline,
         Compile / javacOptions ++= (
-            if (Dependencies.getScalaVersion().startsWith("3.")) {
+            if (scalaVersion.value.startsWith("3.")) {
               Seq()
             } else {
               if (!nonFatalJavaWarningsFor(name.value)) Seq("-Werror", "-Xlint:deprecation", "-Xlint:unchecked")

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -67,15 +67,14 @@ object AkkaDisciplinePlugin extends AutoPlugin {
 
   lazy val nowarnSettings = Seq(
     Compile / scalacOptions ++= (
-      if (scalaVersion.value.startsWith("3.")) Nil
-      else Seq(defaultScalaOptions)
-    ),
+        if (scalaVersion.value.startsWith("3.")) Nil
+        else Seq(defaultScalaOptions)
+      ),
     Test / scalacOptions ++= (
-      if (scalaVersion.value.startsWith("3.")) Nil
-      else Seq(defaultScalaOptions)
-    ),
-    Compile / doc / scalacOptions := Seq()
-  )
+        if (scalaVersion.value.startsWith("3.")) Nil
+        else Seq(defaultScalaOptions)
+      ),
+    Compile / doc / scalacOptions := Seq())
 
   /**
    * We are a little less strict in docs

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -142,10 +142,18 @@ object Dependencies {
       // The 'scalaTestPlus' projects are independently versioned,
       // but the version of each module starts with the scalatest
       // version it was intended to work with
-      val scalatestJUnit = Def.setting { "org.scalatestplus" %% "junit-4-13" % (scalaTestVersion.value + ".0") % "test" } // ApacheV2
-      val scalatestTestNG = Def.setting { "org.scalatestplus" %% "testng-6-7" % (scalaTestVersion.value + ".0") % "test" } // ApacheV2
-      val scalatestScalaCheck = Def.setting { "org.scalatestplus" %% s"scalacheck-${scalaTestScalaCheckVersion.value}" % (scalaTestVersion.value + ".0") % "test" } // ApacheV2
-      val scalatestMockito = Def.setting { "org.scalatestplus" %% "mockito-3-4" % (scalaTestVersion.value + ".0") % "test" } // ApacheV2
+      val scalatestJUnit = Def.setting {
+        "org.scalatestplus" %% "junit-4-13" % (scalaTestVersion.value + ".0") % "test"
+      } // ApacheV2
+      val scalatestTestNG = Def.setting {
+        "org.scalatestplus" %% "testng-6-7" % (scalaTestVersion.value + ".0") % "test"
+      } // ApacheV2
+      val scalatestScalaCheck = Def.setting {
+        "org.scalatestplus" %% s"scalacheck-${scalaTestScalaCheckVersion.value}" % (scalaTestVersion.value + ".0") % "test"
+      } // ApacheV2
+      val scalatestMockito = Def.setting {
+        "org.scalatestplus" %% "mockito-3-4" % (scalaTestVersion.value + ".0") % "test"
+      } // ApacheV2
 
       val pojosr = "com.googlecode.pojosr" % "de.kalpatec.pojosr.framework" % "0.2.1" % "test" // ApacheV2
       val tinybundles = "org.ops4j.pax.tinybundles" % "tinybundles" % "3.0.0" % "test" // ApacheV2
@@ -222,7 +230,11 @@ object Dependencies {
         Provided.activation // dockerClient needs javax.activation.DataSource in JDK 11+
       )
 
-  val actorTestkitTyped = l ++= Seq(Provided.logback, Provided.junit, Provided.scalatest.value, Test.scalatestJUnit.value)
+  val actorTestkitTyped = l ++= Seq(
+        Provided.logback,
+        Provided.junit,
+        Provided.scalatest.value,
+        Test.scalatestJUnit.value)
 
   val pki = l ++=
       Seq(
@@ -271,7 +283,12 @@ object Dependencies {
         Test.commonsIo,
         Test.commonsCodec)
 
-  val persistenceQuery = l ++= Seq(Test.scalatest.value, Test.junit, Test.commonsIo, Provided.levelDB, Provided.levelDBNative)
+  val persistenceQuery = l ++= Seq(
+        Test.scalatest.value,
+        Test.junit,
+        Test.commonsIo,
+        Provided.levelDB,
+        Provided.levelDBNative)
 
   val persistenceTck = l ++= Seq(
         Test.scalatest.value.withConfigurations(Some("compile")),
@@ -296,15 +313,15 @@ object Dependencies {
         lz4Java,
         Test.junit,
         Test.scalatest.value) ++
-        (
-          // jackson-module-scala is only available for Scala 3 from 2.13.0 onwards.
-          // since we don't depend on it ourselves, but provide it as a transitive
-          // dependency for convenience, we can leave it out for Scala 3 for now,
-          // and depend on 2.13.0-rc1 for our tests. Eventually we should consider
-          // whether to update all jackson artifacts for Scala 3.
-          if (scalaVersion.value.startsWith("3.")) Nil
-          else Seq("com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.0-rc1" % "test")
-        )
+      (
+        // jackson-module-scala is only available for Scala 3 from 2.13.0 onwards.
+        // since we don't depend on it ourselves, but provide it as a transitive
+        // dependency for convenience, we can leave it out for Scala 3 for now,
+        // and depend on 2.13.0-rc1 for our tests. Eventually we should consider
+        // whether to update all jackson artifacts for Scala 3.
+        if (scalaVersion.value.startsWith("3.")) Nil
+        else Seq("com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.0-rc1" % "test")
+      )
 
   val osgi = l ++= Seq(
         osgiCore,
@@ -326,7 +343,12 @@ object Dependencies {
 
   lazy val streamTestkit = l ++= Seq(Test.scalatest.value, Test.scalatestScalaCheck.value, Test.junit)
 
-  lazy val streamTests = l ++= Seq(Test.scalatest.value, Test.scalatestScalaCheck.value, Test.junit, Test.commonsIo, Test.jimfs)
+  lazy val streamTests = l ++= Seq(
+        Test.scalatest.value,
+        Test.scalatestScalaCheck.value,
+        Test.junit,
+        Test.commonsIo,
+        Test.jimfs)
 
   lazy val streamTestsTck = l ++= Seq(
         Test.scalatest.value,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -319,8 +319,10 @@ object Dependencies {
         // dependency for convenience, we can leave it out for Scala 3 for now,
         // and depend on 2.13.0-rc1 for our tests. Eventually we should consider
         // whether to update all jackson artifacts for Scala 3.
-        if (scalaVersion.value.startsWith("3.")) Nil
-        else Seq("com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.0-rc1" % "test")
+        if (scalaVersion.value.startsWith("3."))
+          Seq("com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.0-rc1" % "test")
+        else
+          Seq(jacksonScala)
       )
 
   val osgi = l ++= Seq(

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -39,9 +39,9 @@ object Scaladoc extends AutoPlugin {
       // Publishing scala3 docs is broken (https://github.com/akka/akka/issues/30788),
       // for now we just skip it:
       Compile / doc / sources := (
-        if (scalaVersion.value.startsWith("3.")) Seq()
-        else (Compile / doc / sources).value
-      ),
+          if (scalaVersion.value.startsWith("3.")) Seq()
+          else (Compile / doc / sources).value
+        ),
       Compile / validateDiagrams := true) ++
     CliOptions.scaladocDiagramsEnabled.ifTrue(Compile / doc := {
       val docs = (Compile / doc).value

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -38,7 +38,10 @@ object Scaladoc extends AutoPlugin {
     Seq(
       // Publishing scala3 docs is broken (https://github.com/akka/akka/issues/30788),
       // for now we just skip it:
-      Compile / packageDoc / publishArtifact := !scalaVersion.value.startsWith("3."),
+      Compile / doc / sources := (
+        if (scalaVersion.value.startsWith("3.")) Seq()
+        else (Compile / doc / sources).value
+      ),
       Compile / validateDiagrams := true) ++
     CliOptions.scaladocDiagramsEnabled.ifTrue(Compile / doc := {
       val docs = (Compile / doc).value

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -35,7 +35,12 @@ object Scaladoc extends AutoPlugin {
         // -release caused build failures when generating javadoc:
         Compile / scalacOptions --= Seq("-release", "8"),
         autoAPIMappings := CliOptions.scaladocAutoAPI.get)) ++
-    Seq(Compile / validateDiagrams := true) ++
+    Seq(
+      // Publishing scala3 docs is broken (https://github.com/akka/akka/issues/30788),
+      // for now we just skip it:
+      Compile / packageDoc / publishArtifact := !scalaVersion.value.startsWith("3."),
+      Compile / validateDiagrams := true
+    ) ++
     CliOptions.scaladocDiagramsEnabled.ifTrue(Compile / doc := {
       val docs = (Compile / doc).value
       if ((Compile / validateDiagrams).value)

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -39,8 +39,7 @@ object Scaladoc extends AutoPlugin {
       // Publishing scala3 docs is broken (https://github.com/akka/akka/issues/30788),
       // for now we just skip it:
       Compile / packageDoc / publishArtifact := !scalaVersion.value.startsWith("3."),
-      Compile / validateDiagrams := true
-    ) ++
+      Compile / validateDiagrams := true) ++
     CliOptions.scaladocDiagramsEnabled.ifTrue(Compile / doc := {
       val docs = (Compile / doc).value
       if ((Compile / validateDiagrams).value)

--- a/project/Jdk9.scala
+++ b/project/Jdk9.scala
@@ -25,7 +25,7 @@ object Jdk9 extends AutoPlugin {
         Seq(
           (Compile / sourceDirectory).value / SCALA_SOURCE_DIRECTORY,
           (Compile / sourceDirectory).value / JAVA_SOURCE_DIRECTORY)),
-    scalacOptions := AkkaBuild.DefaultScalacOptions ++ notOnJdk8(Seq("-release", "11")),
+    scalacOptions := AkkaBuild.DefaultScalacOptions.value ++ notOnJdk8(Seq("-release", "11")),
     javacOptions := AkkaBuild.DefaultJavacOptions ++ notOnJdk8(Seq("--release", "11")))
 
   val testJdk9Settings = Seq(
@@ -34,7 +34,7 @@ object Jdk9 extends AutoPlugin {
         Seq(
           (Test / sourceDirectory).value / SCALA_TEST_SOURCE_DIRECTORY,
           (Test / sourceDirectory).value / JAVA_TEST_SOURCE_DIRECTORY)),
-    scalacOptions := AkkaBuild.DefaultScalacOptions ++ notOnJdk8(Seq("-release", "11")),
+    scalacOptions := AkkaBuild.DefaultScalacOptions.value ++ notOnJdk8(Seq("-release", "11")),
     javacOptions := AkkaBuild.DefaultJavacOptions ++ notOnJdk8(Seq("--release", "11")),
     compile := compile.dependsOn(CompileJdk9 / compile).value,
     classpathConfiguration := TestJdk9,

--- a/project/JdkOptions.scala
+++ b/project/JdkOptions.scala
@@ -32,12 +32,13 @@ object JdkOptions extends AutoPlugin {
   def targetJdkScalacOptions(
       targetSystemJdk: Boolean,
       jdk8home: Option[File],
-      fullJavaHomes: Map[String, File]): Seq[String] =
+      fullJavaHomes: Map[String, File],
+      scalaVersion: String): Seq[String] =
     selectOptions(
       targetSystemJdk,
       jdk8home,
       fullJavaHomes,
-      Seq(if (Dependencies.getScalaVersion().startsWith("3.0")) "-Xtarget:8" else "-target:jvm-1.8"),
+      Seq(if (scalaVersion.startsWith("3.0")) "-Xtarget:8" else "-target:jvm-1.8"),
       // '-release 8' is not enough, for some reason we need the 8 rt.jar
       // explicitly. To test whether this has the desired effect, compile
       // akka-remote and check the invocation of 'ByteBuffer.clear()' in

--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -38,7 +38,7 @@ object Paradox {
         "scala.version" -> scalaVersion.value,
         "scala.binary.version" -> scalaBinaryVersion.value,
         "akka.version" -> version.value,
-        "scalatest.version" -> Dependencies.scalaTestVersion,
+        "scalatest.version" -> Dependencies.scalaTestVersion.value,
         "sigar_loader.version" -> "1.6.6-rev002",
         "algolia.docsearch.api_key" -> "543bad5ad786495d9ccd445ed34ed082",
         "algolia.docsearch.index_name" -> "akka_io",


### PR DESCRIPTION
~sbt cross-building sometimes behaves surprisingly, so this does not work
yet: when switching to 3.0.1-RC1 it still tries to build the modules
that do not support that version yet, even though they are 'excluded'.~ (all projects can be compiled with scala3 now)

~This also currently breaks cross-publishing, so we cannot merge in this form.~ (should work now)

Once this works we should add a note to the documentation clarifying
that the Scala 3 artifacts are experimental.

Related to #30243 