### PR TITLE
Compile akka-discovery with Scala 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     - stage: scala3
       name: scala3
       # separate job since only a few modules compile with Scala 3 yet
-      script: jabba install adopt@1.11-0 && jabba use adopt@1.11-0 && sbt -Dakka.build.scalaVersion=3.0 "akka-actor-tests/test:compile" akka-actor-testkit-typed/compile akka-actor-typed/compile akka-pki/test:compile akka-protobuf/test:compile akka-protobuf-v3/test:compile akka-slf4j/test:compile akka-stream/compile akka-stream-tests-tck/test
+      script: jabba install adopt@1.11-0 && jabba use adopt@1.11-0 && sbt -Dakka.build.scalaVersion=3.0 "akka-actor-tests/test:compile" akka-actor-testkit-typed/compile akka-actor-typed/compile akka-discovery/compile akka-pki/test:compile akka-protobuf/test:compile akka-protobuf-v3/test:compile akka-slf4j/test:compile akka-stream/compile akka-stream-tests-tck/test
 
 stages:
   - name: whitesource

--- a/akka-discovery/src/main/scala/akka/discovery/Discovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/Discovery.scala
@@ -113,7 +113,7 @@ object Discovery extends ExtensionId[Discovery] with ExtensionIdProvider {
   @InternalApi
   private[akka] def checkClassPathForOldDiscovery(system: ExtendedActorSystem): Unit = {
     try {
-      system.dynamicAccess.getClassFor("akka.discovery.SimpleServiceDiscovery").get
+      system.dynamicAccess.getClassFor[Any]("akka.discovery.SimpleServiceDiscovery").get
       throw new RuntimeException(
         "Old version of Akka Discovery from Akka Management found on the classpath. Remove `com.lightbend.akka.discovery:akka-discovery` from the classpath..")
     } catch {

--- a/akka-discovery/src/main/scala/akka/discovery/aggregate/AggregateServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/aggregate/AggregateServiceDiscovery.scala
@@ -48,7 +48,7 @@ private object AggregateServiceDiscovery {
 @InternalApi
 private[akka] final class AggregateServiceDiscovery(system: ExtendedActorSystem) extends ServiceDiscovery {
 
-  private val log = Logging(system, getClass)
+  private val log = Logging(system, classOf[AggregateServiceDiscovery])
 
   private val settings =
     new AggregateServiceDiscoverySettings(system.settings.config.getConfig("akka.discovery.aggregate"))

--- a/akka-discovery/src/main/scala/akka/discovery/config/ConfigServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/config/ConfigServiceDiscovery.scala
@@ -50,7 +50,7 @@ private object ConfigServicesParser {
 @InternalApi
 private[akka] class ConfigServiceDiscovery(system: ExtendedActorSystem) extends ServiceDiscovery {
 
-  private val log = Logging(system, getClass)
+  private val log = Logging(system, classOf[ConfigServiceDiscovery])
 
   private val resolvedServices = ConfigServicesParser.parse(
     system.settings.config.getConfig(system.settings.config.getString("akka.discovery.config.services-path")))

--- a/akka-discovery/src/main/scala/akka/discovery/dns/DnsServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/dns/DnsServiceDiscovery.scala
@@ -71,7 +71,7 @@ private[akka] class DnsServiceDiscovery(system: ExtendedActorSystem) extends Ser
   import DnsServiceDiscovery._
   import ServiceDiscovery._
 
-  private val log = Logging(system, getClass)
+  private val log = Logging(system, classOf[DnsServiceDiscovery])
   private val dns = initializeDns()
 
   // exposed for testing


### PR DESCRIPTION
The tests don't compile because of the ambiguous forwarder problem that
has been fixed upstream in dotty since.

Refs #30243