### PR TITLE
Remove the extra bracket from testing documentation

### DIFF
--- a/akka-docs/src/main/paradox/testing.md
+++ b/akka-docs/src/main/paradox/testing.md
@@ -112,7 +112,7 @@ does a conformance check; if you need the class to be equal, @scala[have a look 
    An object which is an instance of the given type (after erasure) must be
 received within the allotted time frame; the object will be returned. This
 method is approximately equivalent to
-`expectMsgClass(implicitly[ClassTag[T]].runtimeClass)`.]
+`expectMsgClass(implicitly[ClassTag[T]].runtimeClass)`.
 
 @@@
 


### PR DESCRIPTION
Remove the extra bracket from testing documentation. 

<img width="853" alt="Screen Shot 2564-07-14 at 15 49 31" src="https://user-images.githubusercontent.com/21222656/125593171-71239d18-7105-4544-a827-8e2948c0d3ab.png">

Page: https://doc.akka.io/docs/akka/current/testing.html#asynchronous-testing-testkit 