### PR TITLE
fix: enable akka-actor-testkit-typed test compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     - stage: scala3
       name: scala3
       # separate job since only a few modules compile with Scala 3 yet
-      script: jabba install adopt@1.11-0 && jabba use adopt@1.11-0 && sbt -Dakka.build.scalaVersion=3.0 "akka-actor-tests/test:compile" akka-actor-testkit-typed/test:compile akka-actor-typed/compile akka-discovery/test akka-pki/test:compile akka-protobuf/test:compile akka-protobuf-v3/test:compile akka-slf4j/test:compile akka-stream/compile akka-stream-tests-tck/test akka-coordination/test akka-serialization-jackson/test:compile akka-testkit/test akka-stream-testkit/test akka-remote/compile
+      script: jabba install adopt@1.11-0 && jabba use adopt@1.11-0 && sbt -Dakka.build.scalaVersion=3.0 "akka-actor-tests/test:compile" akka-actor-testkit-typed/test akka-actor-typed/compile akka-discovery/test akka-pki/test:compile akka-protobuf/test:compile akka-protobuf-v3/test:compile akka-slf4j/test:compile akka-stream/compile akka-stream-tests-tck/test akka-coordination/test akka-serialization-jackson/test:compile akka-testkit/test akka-stream-testkit/test akka-remote/compile
 
 stages:
   - name: whitesource

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     - stage: scala3
       name: scala3
       # separate job since only a few modules compile with Scala 3 yet
-      script: jabba install adopt@1.11-0 && jabba use adopt@1.11-0 && sbt -Dakka.build.scalaVersion=3.0 "akka-actor-tests/test:compile" akka-actor-testkit-typed/compile akka-actor-typed/compile akka-discovery/test akka-pki/test:compile akka-protobuf/test:compile akka-protobuf-v3/test:compile akka-slf4j/test:compile akka-stream/compile akka-stream-tests-tck/test akka-coordination/test akka-serialization-jackson/test:compile akka-testkit/test akka-stream-testkit/test akka-remote/compile
+      script: jabba install adopt@1.11-0 && jabba use adopt@1.11-0 && sbt -Dakka.build.scalaVersion=3.0 "akka-actor-tests/test:compile" akka-actor-testkit-typed/test:compile akka-actor-typed/compile akka-discovery/test akka-pki/test:compile akka-protobuf/test:compile akka-protobuf-v3/test:compile akka-slf4j/test:compile akka-stream/compile akka-stream-tests-tck/test akka-coordination/test akka-serialization-jackson/test:compile akka-testkit/test akka-stream-testkit/test akka-remote/compile
 
 stages:
   - name: whitesource


### PR DESCRIPTION
References #30243

Tests just compile, so this PR enables it. That's all.