### PR TITLE
enable all tests that are passing with scala 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     - stage: scala3
       name: scala3
       # separate job since only a few modules compile with Scala 3 yet
-      script: jabba install adopt@1.11-0 && jabba use adopt@1.11-0 && sbt -jvm-opts .jvmopts-travis -Dakka.build.scalaVersion=3.0 "akka-actor-tests/test:compile" akka-actor-testkit-typed/compile akka-actor-typed/compile akka-actor-typed-tests/test akka-discovery/test akka-pki/test:compile akka-protobuf/test:compile akka-protobuf-v3/test:compile akka-slf4j/test:compile akka-stream/compile akka-stream-tests-tck/test akka-coordination/test akka-serialization-jackson/test:compile akka-testkit/test akka-stream-testkit/test akka-remote/compile
+      script: jabba install adopt@1.11-0 && jabba use adopt@1.11-0 && sbt -jvm-opts .jvmopts-travis -Dakka.build.scalaVersion=3.0 akka-actor-tests/test akka-actor-testkit-typed/test akka-actor-typed/compile akka-actor-typed-tests/test akka-discovery/test akka-pki/test akka-protobuf/test akka-protobuf-v3/test akka-slf4j/test akka-stream/test akka-stream-tests-tck/test akka-coordination/test akka-serialization-jackson/test:compile akka-testkit/test akka-stream-testkit/test akka-remote/compile
 
 stages:
   - name: whitesource


### PR DESCRIPTION
References #30243 

### Tests enabled for: 

akka-actor-tests/test 
akka-actor-testkit-typed/test
akka-pki/test 
akka-slf4j/test

### No tests at all, only compile
akka-protobuf/compile 
akka-protobuf-v3/compile  

### Tests not passing with Scala 3 
akka-serialization-jackson/test:compile (one test failure)