### PR TITLE
allow scala3 job to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ version: ~> 1.0
 
 language: scala
 
-sudo: false
-
 scala:
   - "2.12.11"
   - "2.13.3"
@@ -39,6 +37,8 @@ jobs:
       name: scala3
       # separate job since only a few modules compile with Scala 3 yet
       script: jabba install adopt@1.11-0 && jabba use adopt@1.11-0 && sbt -jvm-opts .jvmopts-travis -Dakka.build.scalaVersion=3.0 akka-actor-tests/test akka-actor-testkit-typed/test akka-actor-typed/compile akka-actor-typed-tests/test akka-discovery/test akka-pki/test akka-protobuf/test akka-protobuf-v3/test akka-slf4j/test akka-stream/test akka-stream-tests-tck/test akka-coordination/test akka-serialization-jackson/test:compile akka-testkit/test akka-stream-testkit/test akka-remote/compile
+  allow_failures:
+    - name: scala3
 
 stages:
   - name: whitesource
@@ -47,6 +47,7 @@ stages:
     if: type == pull_request OR NOT tag =~ ^v
   - name: scala3
     if: type == pull_request OR NOT tag =~ ^v
+
 
 env:
   global:


### PR DESCRIPTION
We don't usually run the tests in Travis, but we have been doing for Scala3 (Jenkins is not setup for it). 

However, the tests can be a little flaky in Travis so instead of blocking PRs, we should allow the Scala3 tests to fail in Travis. 

The real solution is to start to move to GH Action in the hope that the machines will be more stable for our tests.
