### PR TITLE
Fix MailboxSelectorSpec race

### DIFF
--- a/akka-actor-testkit-typed/src/main/mima-filters/2.6.15.backwards.excludes/excess-checking.excludes
+++ b/akka-actor-testkit-typed/src/main/mima-filters/2.6.15.backwards.excludes/excess-checking.excludes
@@ -1,0 +1,6 @@
+# Extra methods on interfaces not for user extension:
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.testkit.typed.javadsl.LoggingTestKit.withCheckExcess")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.actor.testkit.typed.scaladsl.LoggingTestKit.withCheckExcess")
+
+# Impl
+ProblemFilters.exclude[Problem]("akka.actor.testkit.typed.internal.LoggingTestKitImpl.*")

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/LoggingTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/LoggingTestKit.scala
@@ -77,6 +77,11 @@ import akka.annotation.DoNotInherit
   def withMdc(newMdc: java.util.Map[String, String]): LoggingTestKit
 
   /**
+   * After matching the expected number of hits, check for excess messages
+   */
+  def withCheckExcess(check: Boolean): LoggingTestKit
+
+  /**
    * Matching events for which the supplied function returns `true`.
    */
   def withCustom(newCustom: Function[LoggingEvent, Boolean]): LoggingTestKit

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/LoggingTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/LoggingTestKit.scala
@@ -77,6 +77,11 @@ import akka.annotation.DoNotInherit
   def withMdc(newMdc: Map[String, String]): LoggingTestKit
 
   /**
+   * After matching the expected number of hits, check for excess messages
+   */
+  def withCheckExcess(checkExcess: Boolean): LoggingTestKit
+
+  /**
    * Matching events for which the supplied function returns`true`.
    */
   def withCustom(newCustom: Function[LoggingEvent, Boolean]): LoggingTestKit

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/MailboxSelectorSpec.scala
@@ -74,7 +74,7 @@ class MailboxSelectorSpec extends ScalaTestWithActorTestKit("""
       }, MailboxSelector.bounded(2))
       actor ! "one" // actor will block here
       actor ! "two"
-      LoggingTestKit.deadLetters().expect {
+      LoggingTestKit.deadLetters().withCheckExcess(false).expect {
         // one or both of these doesn't fit in mailbox
         // depending on race with how fast actor consumes
         actor ! "three"


### PR DESCRIPTION
The comment already said there could be 2 dead letters, but the log
assertion failed when there was a second 'excess' one. Add a flag to
skip checking for excess log lines.

Refs #30363