### PR TITLE
PersistentActor stops if receiveRecover fails to process RecoveryCompleted

### DIFF
--- a/akka-persistence/src/test/scala/akka/persistence/RecoveryPermitterSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/RecoveryPermitterSpec.scala
@@ -168,11 +168,7 @@ class RecoveryPermitterSpec extends PersistenceSpec(ConfigFactory.parseString(s"
       val persistentActor = system.actorOf(testProps("p3", p3.ref, throwFromRecoveryCompleted = true))
       p3.expectMsg(RecoveryCompleted)
       p3.expectMsg("postStop")
-      // it's restarting
-      (1 to 5).foreach { _ =>
-        p3.expectMsg(RecoveryCompleted)
-        p3.expectMsg("postStop")
-      }
+
       // stop it
       val stopProbe = TestProbe()
       stopProbe.watch(persistentActor)


### PR DESCRIPTION
According to the documentation to 'receiveRecover' method "If there is a problem with recovering the state of the actor from the journal, the error will be logged and the actor will be stopped.". However, it doesn't happen if error is raised on RecoveryCompleted message.
