### PR TITLE
Parallelize GH Action for Scala 3

### DIFF
--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -54,5 +54,5 @@ jobs:
           sbt -jvm-opts .jvmopts-ci \
             -Dakka.build.scalaVersion=3.0 \
             -Dakka.test.multi-in-test=false \
-            -Dakka.test.tags.exclude=performance,timing,long-running \
+            -Dakka.test.tags.exclude=performance,timing,long-running,gh-exclude \
             ${{ matrix.command }}

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -35,6 +35,7 @@ jobs:
           - akka-remote/test
           - akka-remote-tests/test
           - akka-testkit/test
+      fail-fast: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -21,7 +21,7 @@ jobs:
           - akka-actor-testkit-typed/test
           - akka-actor-typed/compile
           - akka-actor-typed-tests/test
-          - akka-cluster/test/compile
+          - akka-cluster/Test/compile
           - akka-coordination/test
           - akka-discovery/test
           - akka-pki/test
@@ -48,6 +48,7 @@ jobs:
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.2
+
       - name: Compile and run tests on Scala 3
         run: |
           sbt -jvm-opts .jvmopts-ci \

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -1,14 +1,15 @@
 name: Build Akka with Scala 3
 
 on:
-  pull_request:
   push:
-    branches:
-      - master
-    tags-ignore: [ v.* ]
+  # pull_request:
+  # push:
+  #   branches:
+  #     - master
+  #   tags-ignore: [ v.* ]
 
 jobs:
-  compile-and-test-with-scala3:
+  setup-runner:
     name: Compile and test with Scala 3
     runs-on: ubuntu-18.04
     steps:
@@ -25,27 +26,37 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.2
 
+  test:
+    needs: setup-runner
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        command:
+          - akka-actor-tests/test
+          - akka-actor-testkit-typed/test
+          - akka-actor-tests/test
+          - akka-actor-testkit-typed/test
+          - akka-actor-typed/compile
+          - akka-actor-typed-tests/test
+          - akka-cluster/test/compile
+          - akka-coordination/test
+          - akka-discovery/test
+          - akka-pki/test
+          - akka-protobuf/test
+          - akka-protobuf-v3/test
+          - akka-serialization-jackson/test:compile
+          - akka-slf4j/test
+          - akka-stream/test
+          - akka-stream-testkit/test
+          - akka-stream-tests-tck/test
+          - akka-remote/test
+          - akka-remote-tests/test
+          - akka-testkit/test
+    steps:
       - name: Compile and test selected modules on Scala 3
         run: |
           sbt -jvm-opts .jvmopts-ci \
             -Dakka.build.scalaVersion=3.0 \
             -Dakka.test.multi-in-test=false \
-            -Dakka.test.tags.exclude=performance,timing,long-running,gh-exclude \
-            akka-actor-tests/test \
-            akka-actor-testkit-typed/test \
-            akka-actor-typed/compile \
-            akka-actor-typed-tests/test \
-            akka-cluster/Test/compile \
-            akka-coordination/test \
-            akka-discovery/test \
-            akka-pki/test \
-            akka-protobuf/test \
-            akka-protobuf-v3/test \
-            akka-serialization-jackson/test:compile \
-            akka-slf4j/test \
-            akka-stream/test \
-            akka-stream-testkit/test \
-            akka-stream-tests-tck/test \
-            akka-remote/test \
-            akka-remote-tests/test \
-            akka-testkit/test
+            -Dakka.test.tags.exclude=performance,timing,long-running \
+            ${{ matrix.command }}

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -1,12 +1,11 @@
 name: Build Akka with Scala 3
 
 on:
+  pull_request:
   push:
-  # pull_request:
-  # push:
-  #   branches:
-  #     - master
-  #   tags-ignore: [ v.* ]
+    branches:
+      - master
+    tags-ignore: [ v.* ]
 
 jobs:
   test:

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: Compile and run tests on Scala 3
+    name: Test
     runs-on: ubuntu-18.04
     strategy:
       matrix:
@@ -48,7 +48,7 @@ jobs:
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.2
-      - name: Test
+      - name: Compile and run tests on Scala 3
         run: |
           sbt -jvm-opts .jvmopts-ci \
             -Dakka.build.scalaVersion=3.0 \

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   setup-runner:
-    name: Compile and test with Scala 3
+    name: Setup runner
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -27,7 +27,7 @@ jobs:
         uses: coursier/cache-action@v6.2
 
   test:
-    needs: setup-runner
+    name: Compile and run tests on Scala 3
     runs-on: ubuntu-18.04
     strategy:
       matrix:
@@ -53,6 +53,18 @@ jobs:
           - akka-remote-tests/test
           - akka-testkit/test
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11.0-9
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6.2
       - name: Compile and test selected modules on Scala 3
         run: |
           sbt -jvm-opts .jvmopts-ci \

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -9,23 +9,6 @@ on:
   #   tags-ignore: [ v.* ]
 
 jobs:
-  setup-runner:
-    name: Setup runner
-    runs-on: ubuntu-18.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
-      - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
-
   test:
     name: Compile and run tests on Scala 3
     runs-on: ubuntu-18.04
@@ -65,7 +48,7 @@ jobs:
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.2
-      - name: Compile and test selected modules on Scala 3
+      - name: Test
         run: |
           sbt -jvm-opts .jvmopts-ci \
             -Dakka.build.scalaVersion=3.0 \


### PR DESCRIPTION
This is a first step to save time and have more precise and clean output logs.
I will use the same mechanism for other builds.

Example output:
https://github.com/andreaTP/akka/actions/runs/1097493871
(we would have noticed the `multiNodeTest` earlier probably)