### PR TITLE
Use latest Ubuntu and JDK latest LTS

### DIFF
--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         command:
@@ -44,7 +44,7 @@ jobs:
       - name: Set up JDK 11
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: adopt@1.11.0-9
+          java-version: adopt@1.11
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.2


### PR DESCRIPTION
Avoid using `latest` as a version, but at least move to the latest LTS family