### PR TITLE
Quieter logging for ShardCoordinator initialization

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -1472,7 +1472,9 @@ private[akka] class DDataShardCoordinator(
         initialStateRetries += 1
         val template =
           "{}: The ShardCoordinator was unable to get an initial state within 'waiting-for-state-timeout': {} millis (retrying). Has ClusterSharding been started on all nodes?"
-        if (initialStateRetries < 5)
+        if (initialStateRetries == 1)
+          log.info(template, typeName, stateReadConsistency.timeout.toMillis)
+        else if (initialStateRetries < 5)
           log.warning(template, typeName, stateReadConsistency.timeout.toMillis)
         else
           log.error(template, typeName, stateReadConsistency.timeout.toMillis)


### PR DESCRIPTION
Tested 'manually', maybe not worth having a unit test for:
```
[2021-08-06 16:05:53,735] [WARN] [akka.cluster.sharding.DDataShardCoordinator] [] [KillrWeather-akka.actor.default-dispatcher-31] - WeatherStation: The ShardCoordinator was unable to get an initial state within 'waiting-for-state-timeout': 1000 millis (retrying). Has ClusterSharding been started on all nodes? MDC: {akkaAddress=akka://KillrWeather@127.0.0.1:2552, sourceThread=KillrWeather-akka.actor.default-dispatcher-27, akkaSource=akka://KillrWeather@127.0.0.1:2552/system/sharding/WeatherStationCoordinator/singleton/coordinator, sourceActorSystem=KillrWeather, akkaTimestamp=14:05:53.735UTC}
[2021-08-06 16:05:54,759] [WARN] [akka.cluster.sharding.DDataShardCoordinator] [] [KillrWeather-akka.actor.default-dispatcher-27] - WeatherStation: The ShardCoordinator was unable to get an initial state within 'waiting-for-state-timeout': 1000 millis (retrying). Has ClusterSharding been started on all nodes? MDC: {akkaAddress=akka://KillrWeather@127.0.0.1:2552, sourceThread=KillrWeather-akka.actor.default-dispatcher-31, akkaSource=akka://KillrWeather@127.0.0.1:2552/system/sharding/WeatherStationCoordinator/singleton/coordinator, sourceActorSystem=KillrWeather, akkaTimestamp=14:05:54.758UTC}
[2021-08-06 16:05:55,777] [ERROR] [akka.cluster.sharding.DDataShardCoordinator] [] [KillrWeather-akka.actor.default-dispatcher-31] - WeatherStation: The ShardCoordinator was unable to get an initial state within 'waiting-for-state-timeout': 1000 millis (retrying). Has ClusterSharding been started on all nodes? MDC: {akkaAddress=akka://KillrWeather@127.0.0.1:2552, sourceThread=KillrWeather-akka.actor.default-dispatcher-31, akkaSource=akka://KillrWeather@127.0.0.1:2552/system/sharding/WeatherStationCoordinator/singleton/coordinator, sourceActorSystem=KillrWeather, akkaTimestamp=14:05:55.776UTC}
```