### PR TITLE
Fix FlowFlatMapPrefixSpec instability

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlatMapPrefixSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowFlatMapPrefixSpec.scala
@@ -423,7 +423,6 @@ class FlowFlatMapPrefixSpec extends StreamSpec("akka.loglevel = debug") {
           .withAttributes(attributes)
           .run()
 
-        notUsedF.value should be(empty)
         suffixF.value should be(empty)
         srcWatchTermF.value should be(empty)
 


### PR DESCRIPTION
`notUsedF` is resolved immediately when the substream is materialized,
unlike `suffixF` which is resolved when the stream completes. For this
reason it is entirely possible that `notUsedF` resolves before getting the
subscriptions.

Fixes #30469