### PR TITLE
Improvements to documentation on Stream-Actor interop

### DIFF
--- a/akka-docs/src/main/paradox/stream/actor-interop.md
+++ b/akka-docs/src/main/paradox/stream/actor-interop.md
@@ -176,7 +176,7 @@ The stream can be completed successfully by sending any message to the actor tha
 by the completion matching function that was provided when the actor reference was created.
 If the returned completion strategy is `akka.stream.CompletionStrategy.immediately` the completion will be signaled immediately.
 If the completion strategy is `akka.stream.CompletionStrategy.draining`, already buffered elements will be processed before signaling completion.
-Any additional content will be ignored and fall back to the draining behaviour.
+Any subsequent elements that are delivered to the actor's mailbox will not be processed.
 
 The stream can be completed with failure by sending any message to the
 actor that is handled by the failure matching function that was specified

--- a/akka-docs/src/main/paradox/stream/actor-interop.md
+++ b/akka-docs/src/main/paradox/stream/actor-interop.md
@@ -176,7 +176,7 @@ The stream can be completed successfully by sending any message to the actor tha
 by the completion matching function that was provided when the actor reference was created.
 If the returned completion strategy is `akka.stream.CompletionStrategy.immediately` the completion will be signaled immediately.
 If the completion strategy is `akka.stream.CompletionStrategy.draining`, already buffered elements will be processed before signaling completion.
-Any subsequent elements that are delivered to the actor's mailbox will not be processed.
+Any elements that are in the actor's mailbox and subsequent elements sent to the actor will not be processed.
 
 The stream can be completed with failure by sending any message to the
 actor that is handled by the failure matching function that was specified

--- a/akka-docs/src/main/paradox/stream/actor-interop.md
+++ b/akka-docs/src/main/paradox/stream/actor-interop.md
@@ -172,18 +172,18 @@ for this Source type, i.e. elements will be dropped if the buffer is filled by s
 at a rate that is faster than the stream can consume. You should consider using `Source.queue`
 if you want a backpressured actor interface.
 
-The stream can be completed successfully by sending `akka.actor.Status.Success` to the actor reference.
-If the content is `akka.stream.CompletionStrategy.immediately` the completion will be signaled immediately.
-If the content is `akka.stream.CompletionStrategy.draining` already buffered elements will be signaled before signaling completion.
-Any other content will be ignored and fall back to the draining behaviour. 
+The stream can be completed successfully by sending any message to the actor that is handled
+by the completion matching function that was provided when the actor reference was created.
+If the returned completion strategy is `akka.stream.CompletionStrategy.immediately` the completion will be signaled immediately.
+If the completion strategy is `akka.stream.CompletionStrategy.draining`, already buffered elements will be processed before signaling completion.
+Any additional content will be ignored and fall back to the draining behaviour.
 
-The stream can be completed with failure by sending `akka.actor.Status.Failure` to the
-actor reference.
+The stream can be completed with failure by sending any message to the
+actor that is handled by the failure matching function that was specified
+when the actor reference was created.
 
-Note: Sending a `PoisonPill` is deprecated and will be ignored in the future.
-
-The actor will be stopped when the stream is completed, failed or cancelled from downstream,
-i.e. you can watch it to get notified when that happens.
+The actor will be stopped when the stream is completed, failed or cancelled from downstream.
+You can watch it to get notified when that happens.
 
 
 Scala

--- a/akka-docs/src/test/scala/docs/stream/IntegrationDocSpec.scala
+++ b/akka-docs/src/test/scala/docs/stream/IntegrationDocSpec.scala
@@ -203,7 +203,7 @@ class IntegrationDocSpec extends AkkaSpec(IntegrationDocSpec.config) {
     val onErrorMessage = (ex: Throwable) => AckingReceiver.StreamFailure(ex)
 
     val probe = TestProbe()
-    val receiver = system.actorOf(Props(new AckingReceiver(probe.ref, ackWith = AckMessage)))
+    val receiver = system.actorOf(Props(new AckingReceiver(probe.ref)))
     val sink = Sink.actorRefWithBackpressure(
       receiver,
       onInitMessage = InitMessage,
@@ -229,7 +229,7 @@ class IntegrationDocSpec extends AkkaSpec(IntegrationDocSpec.config) {
     final case class StreamFailure(ex: Throwable)
   }
 
-  class AckingReceiver(probe: ActorRef, ackWith: Any) extends Actor with ActorLogging {
+  class AckingReceiver(probe: ActorRef) extends Actor with ActorLogging {
     import AckingReceiver._
 
     def receive: Receive = {


### PR DESCRIPTION
There are 2 changes in this branch.

1. I have updated the text describing `Source.actorRef` to match the current, supported method with that name. The existing text describes the behavior of the deprecated two-argument method with the same name.
2. I have made a change to the Scala code example that relates to `Source.actorRefWithBackpressure`. The existing code has  an `Actor` that expects a parameter (`ackWith`) that is never used in the implementation. I don't think it is needed and its presence confused me when I studied this example.
