### PR TITLE
Add more trace logging to TcpConnection

### DIFF
--- a/akka-actor/src/main/scala/akka/io/TcpConnection.scala
+++ b/akka-actor/src/main/scala/akka/io/TcpConnection.scala
@@ -388,11 +388,17 @@ private[io] abstract class TcpConnection(val tcp: TcpExt, val channel: SocketCha
         context.stop(self)
       case Some(reg) =>
         context.become(unregistering)
-        reg.cancelAndClose(() => self ! Unregistered)
+        if (TraceLogging) log.debug("Unregistering channel")
+        reg.cancelAndClose(() => {
+          if (TraceLogging) log.debug("Unregistered channel")
+          self ! Unregistered
+        })
     }
   }
 
   override def postStop(): Unit = {
+    if (TraceLogging) log.debug("TcpConnection post-stop")
+
     if (writePending) pendingWrite.release()
 
     val interestedInClose: Set[ActorRef] =


### PR DESCRIPTION
To make it easier to diagnose problems such as #30435/#30474/#30509

Tried running this test on repeat in https://github.com/akka/akka/pull/30510
but didn't succeed in triggering the problem again yet...