### PR TITLE
Combine some tests projects in Scala3 build

### DIFF
--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -20,26 +20,17 @@ jobs:
     strategy:
       matrix:
         command:
-          - akka-actor-tests/test
-          - akka-actor-testkit-typed/test
-          - akka-actor-tests/test
-          - akka-actor-testkit-typed/test
-          - akka-actor-typed/compile
-          - akka-actor-typed-tests/test
+          - akka-testkit/test akka-actor-tests/test
+          - akka-actor-testkit-typed/test akka-actor-typed-tests/test
           - akka-cluster/Test/compile
           - akka-coordination/test
           - akka-discovery/test
           - akka-pki/test
-          - akka-protobuf/test
-          - akka-protobuf-v3/test
           - akka-serialization-jackson/test:compile
           - akka-slf4j/test
-          - akka-stream/test
-          - akka-stream-testkit/test
+          - akka-stream-testkit/test akka-stream/test
           - akka-stream-tests-tck/test
-          - akka-remote/test
-          - akka-remote-tests/test
-          - akka-testkit/test
+          - akka-remote/test akka-remote-tests/test akka-protobuf/test akka-protobuf-v3/test
       fail-fast: true
     steps:
       - name: Checkout


### PR DESCRIPTION
Some were listed twice. Should be somewhat quicker to combine some of them since it will be less total compilation. Still enough parallelism.