### PR TITLE
Fix actor ref backpressure source spec instability

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSourceSpec.scala
@@ -66,7 +66,7 @@ class ActorRefBackpressureSourceSpec extends StreamSpec {
           s.expectNextOrError() match {
             case Right(`n`) => verifyNext(n + 1)
             case Right(x)   => fail(s"expected $n, got $x")
-            case Left(t)    =>
+            case Left(t) =>
               t shouldBe an[IllegalStateException]
               t.getMessage shouldBe "Received new element before ack was signaled back"
           }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSourceSpec.scala
@@ -67,7 +67,9 @@ class ActorRefBackpressureSourceSpec extends StreamSpec {
             case Right(`n`) => verifyNext(n + 1)
             case Right(x)   => fail(s"expected $n, got $x")
             case Left(t) =>
-              t shouldBe an[IllegalStateException]
+              if (!t.isInstanceOf[IllegalStateException]) {
+                fail("Expected IllegalStateException, got", t)
+              }
               t.getMessage shouldBe "Received new element before ack was signaled back"
           }
       }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSourceSpec.scala
@@ -49,13 +49,14 @@ class ActorRefBackpressureSourceSpec extends StreamSpec {
     }
 
     "fail when consumer does not await ack" in assertAllStagesStopped {
+      val probe = TestProbe()
       val (ref, s) = Source
         .actorRefWithBackpressure[Int](AckMsg, PartialFunction.empty, PartialFunction.empty)
         .toMat(TestSink.probe[Int])(Keep.both)
         .run()
 
       val sub = s.expectSubscription()
-      for (n <- 1 to 20) ref ! n
+      for (n <- 1 to 20) probe.send(ref, n)
       sub.request(1)
 
       @scala.annotation.tailrec
@@ -67,9 +68,8 @@ class ActorRefBackpressureSourceSpec extends StreamSpec {
             case Right(`n`) => verifyNext(n + 1)
             case Right(x)   => fail(s"expected $n, got $x")
             case Left(t) =>
-              if (!t.isInstanceOf[IllegalStateException]) {
-                fail("Expected IllegalStateException, got", t)
-              }
+              if (!t.isInstanceOf[IllegalStateException])
+                fail(s"Expected IllegalStateException, got ${t.getClass}", t)
               t.getMessage shouldBe "Received new element before ack was signaled back"
           }
       }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSourceSpec.scala
@@ -66,7 +66,9 @@ class ActorRefBackpressureSourceSpec extends StreamSpec {
           s.expectNextOrError() match {
             case Right(`n`) => verifyNext(n + 1)
             case Right(x)   => fail(s"expected $n, got $x")
-            case Left(t)    => t.getMessage shouldBe "Received new element before ack was signaled back"
+            case Left(t)    =>
+              t shouldBe an[IllegalStateException]
+              t.getMessage shouldBe "Received new element before ack was signaled back"
           }
       }
       verifyNext(1)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ActorRefBackpressureSourceSpec.scala
@@ -67,10 +67,10 @@ class ActorRefBackpressureSourceSpec extends StreamSpec {
           s.expectNextOrError() match {
             case Right(`n`) => verifyNext(n + 1)
             case Right(x)   => fail(s"expected $n, got $x")
-            case Left(t) =>
-              if (!t.isInstanceOf[IllegalStateException])
-                fail(s"Expected IllegalStateException, got ${t.getClass}", t)
-              t.getMessage shouldBe "Received new element before ack was signaled back"
+            case Left(e: IllegalStateException) =>
+              e.getMessage shouldBe "Received new element before ack was signaled back"
+            case Left(e) =>
+              fail(s"Expected IllegalStateException, got ${e.getClass}", e)
           }
       }
       verifyNext(1)


### PR DESCRIPTION
The test sent messages without a 'sender', which is not allowed (since in this scenario the sender was responsible for the backpressure, which is the whole point of this source).

The test was a race between 2 problems: the error the test was intended to exercise, and the error that there was no sender.

By adding a sender, the test now reliably exercises the error it was written for.

Fixes #30515
