### PR TITLE
use internalLogger instead of context.log for recovery logging

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -151,7 +151,7 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
       val (seqNr: Long, seenPerReplica, version) = snapshot match {
         case Some(SelectedSnapshot(metadata, snapshot)) =>
           state = setup.snapshotAdapter.fromJournal(snapshot)
-          setup.context.log.debug("Loaded snapshot with metadata [{}]", metadata)
+          setup.internalLogger.debug("Loaded snapshot with metadata [{}]", metadata)
           metadata.metadata match {
             case Some(rm: ReplicatedSnapshotMetadata) => (metadata.sequenceNr, rm.seenPerReplica, rm.version)
             case _                                    => (metadata.sequenceNr, Map.empty[ReplicaId, Long].withDefaultValue(0L), VersionVector.empty)
@@ -159,7 +159,7 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
         case None => (0L, Map.empty[ReplicaId, Long].withDefaultValue(0L), VersionVector.empty)
       }
 
-      setup.context.log.debugN("Snapshot recovered from {} {} {}", seqNr, seenPerReplica, version)
+      setup.internalLogger.debugN("Snapshot recovered from {} {} {}", seqNr, seenPerReplica, version)
 
       setup.cancelRecoveryTimer()
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Recovering.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Recovering.scala
@@ -144,7 +144,7 @@ private[akka] class Recovering[C, S](override val setup: BehaviorSetup[C, S])
       case None    => setup.emptyState
     }
 
-    setup.context.log.debug("Recovered from revision [{}]", result.revision)
+    setup.internalLogger.debug("Recovered from revision [{}]", result.revision)
 
     setup.cancelRecoveryTimer()
 


### PR DESCRIPTION
Logging inside ESB has been moved to an internal logger by

References #30005 
References #30007

There are three places left where the context logger is used where I believe the internalLogger should be used too. This way esp. application code debug logs can be configured separately from akka debug logs.