### PR TITLE
Fixes Java test on primitive state

### DIFF
--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PrimitiveStateTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/PrimitiveStateTest.java
@@ -85,6 +85,8 @@ public class PrimitiveStateTest extends JUnitSuite {
     probe.expectMessage("eventHandler:1:2");
 
     ref1.tell(-1);
+    // wait for ref1 to terminate
+    probe.expectTerminated(ref1);
     ActorRef<Integer> ref2 = testKit.spawn(b);
     // eventHandler from reply
     probe.expectMessage("eventHandler:0:1");


### PR DESCRIPTION
Try to avoid race condition by waiting for 1 persistent actor to stop before starting the next one

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/akka/akka/issues/30575
