### PR TITLE
Run scheduled jobs only on main repo

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -9,6 +9,7 @@ jobs:
   nightly-cluster-metrics-sigar:
     name: Akka Cluster Metrics Test with Sigar
     runs-on: ubuntu-20.04
+    if: github.repository == ‘akka/akka’
     steps:
 
       - name: Checkout
@@ -62,6 +63,7 @@ jobs:
   jdk-nightly-tests:
     name: JDK ${{ matrix.jdkVersion }} / Scala ${{ matrix.scalaVersion }}
     runs-on: ubuntu-20.04
+    if: github.repository == ‘akka/akka’
     strategy:
       matrix:
         # No need to specify the full Scala version. Only the Scala binary version


### PR DESCRIPTION
Disable scheduled jobs on forks.

Ref:
https://github.com/quarkusio/quarkus/blob/4cecb53f98cabf2fc7953a8ef685503a3fb601ee/.github/workflows/jdk-early-access-build.yml#L27

cc. @marcoderama
