### PR TITLE
Fixes Java test on null empty state

### DIFF
--- a/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/NullEmptyStateTest.java
+++ b/akka-persistence-typed/src/test/java/akka/persistence/typed/javadsl/NullEmptyStateTest.java
@@ -90,6 +90,8 @@ public class NullEmptyStateTest extends JUnitSuite {
     ActorRef<String> ref1 = testKit.spawn(b);
     probe.expectMessage("onRecoveryCompleted:null");
     ref1.tell("stop");
+    // wait till ref1 stops
+    probe.expectTerminated(ref1);
 
     ActorRef<String> ref2 = testKit.spawn(b);
     probe.expectMessage("onRecoveryCompleted:null");
@@ -99,6 +101,8 @@ public class NullEmptyStateTest extends JUnitSuite {
     probe.expectMessage("eventHandler:one:two");
 
     ref2.tell("stop");
+    // wait till ref2 stops
+    probe.expectTerminated(ref2);
     ActorRef<String> ref3 = testKit.spawn(b);
     // eventHandler from reply
     probe.expectMessage("eventHandler:null:one");


### PR DESCRIPTION
Try to avoid race condition by waiting for 1 persistent actor to stop before starting the next one

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/akka/akka/issues/30527
