### PR TITLE
Exclude more tests from PR validation

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingSpec.scala
@@ -16,7 +16,6 @@ import akka.persistence.testkit.query.scaladsl.PersistenceTestKitReadJournal
 import akka.persistence.testkit.scaladsl.PersistenceTestKit
 import akka.persistence.typed.scaladsl.{ Effect, EventSourcedBehavior, ReplicatedEventSourcing, ReplicationContext }
 import akka.serialization.jackson.CborSerializable
-import akka.testkit.GHExcludeTest
 import org.scalatest.concurrent.Eventually
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -201,8 +200,7 @@ class ReplicatedEventSourcingSpec
       recoveryProbe.expectMessage(EventAndContext("Event", ReplicaId("R1"), recoveryRunning = true, false))
     }
 
-    // https://github.com/akka/akka/issues/30548
-    "persist all" taggedAs GHExcludeTest in {
+    "persist all" in {
       val entityId = nextEntityId
       val probe = createTestProbe[Done]()
       val eventProbeR1 = createTestProbe[EventAndContext]()

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingSpec.scala
@@ -16,6 +16,7 @@ import akka.persistence.testkit.query.scaladsl.PersistenceTestKitReadJournal
 import akka.persistence.testkit.scaladsl.PersistenceTestKit
 import akka.persistence.typed.scaladsl.{ Effect, EventSourcedBehavior, ReplicatedEventSourcing, ReplicationContext }
 import akka.serialization.jackson.CborSerializable
+import akka.testkit.GHExcludeTest
 import org.scalatest.concurrent.Eventually
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -200,7 +201,7 @@ class ReplicatedEventSourcingSpec
       recoveryProbe.expectMessage(EventAndContext("Event", ReplicaId("R1"), recoveryRunning = true, false))
     }
 
-    "persist all" in {
+    "persist all" taggedAs GHExcludeTest in {
       val entityId = nextEntityId
       val probe = createTestProbe[Done]()
       val eventProbeR1 = createTestProbe[EventAndContext]()

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingSpec.scala
@@ -201,6 +201,7 @@ class ReplicatedEventSourcingSpec
       recoveryProbe.expectMessage(EventAndContext("Event", ReplicaId("R1"), recoveryRunning = true, false))
     }
 
+    // https://github.com/akka/akka/issues/30548
     "persist all" taggedAs GHExcludeTest in {
       val entityId = nextEntityId
       val probe = createTestProbe[Done]()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
@@ -18,7 +18,7 @@ import akka.stream.ThrottleMode.{ Enforcing, Shaping }
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.{ TimingTest, GHExcludeTest }
+import akka.testkit.{ GHExcludeTest, TimingTest }
 import akka.util.ByteString
 
 class FlowThrottleSpec extends StreamSpec("""

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
@@ -18,7 +18,7 @@ import akka.stream.ThrottleMode.{ Enforcing, Shaping }
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.TimingTest
+import akka.testkit.{ TimingTest, GHExcludeTest }
 import akka.util.ByteString
 
 class FlowThrottleSpec extends StreamSpec("""
@@ -111,7 +111,8 @@ class FlowThrottleSpec extends StreamSpec("""
       downstream.cancel()
     }
 
-    "send elements downstream as soon as time comes" in assertAllStagesStopped {
+    // https://github.com/akka/akka/issues/30574
+    "send elements downstream as soon as time comes" taggedAs GHExcludeTest in assertAllStagesStopped {
       val probe = Source(1 to 10).throttle(2, 750.millis, 0, Shaping).runWith(TestSink.probe[Int]).request(5)
       probe.receiveWithin(900.millis) should be(Seq(1, 2))
       probe.expectNoMessage(150.millis).expectNext(3).expectNoMessage(150.millis).expectNext(4).cancel()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
@@ -33,6 +33,7 @@ import akka.stream.testkit.scaladsl.TestSink
 import akka.stream.testkit.scaladsl.TestSource
 import akka.testkit.DefaultTimeout
 import akka.testkit.EventFilter
+import akka.testkit.GHExcludeTest
 import akka.testkit.TestDuration
 
 class RestartSpec
@@ -318,7 +319,8 @@ class RestartSpec
       probe.cancel()
     }
 
-    "allow using withMaxRestarts instead of minBackoff to determine the maxRestarts reset time" in assertAllStagesStopped {
+    // https://github.com/akka/akka/issues/30540
+    "allow using withMaxRestarts instead of minBackoff to determine the maxRestarts reset time" taggedAs GHExcludeTest in assertAllStagesStopped {
       val created = new AtomicInteger()
       val probe = RestartSource
         .withBackoff(shortRestartSettings.withMaxRestarts(2, 1.second)) { () =>


### PR DESCRIPTION
Those are failing constantly in the multi-node PR