### PR TITLE
Fix test to avoid race condition from multiple persistent actors

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingSpec.scala
@@ -18,6 +18,7 @@ import akka.persistence.typed.scaladsl.{ Effect, EventSourcedBehavior, Replicate
 import akka.serialization.jackson.CborSerializable
 import org.scalatest.concurrent.Eventually
 import org.scalatest.wordspec.AnyWordSpecLike
+import akka.testkit.GHExcludeTest
 
 object ReplicatedEventSourcingSpec {
 
@@ -329,7 +330,7 @@ class ReplicatedEventSourcingSpec
       eventProbeR3.expectNoMessage()
     }
 
-    "set concurrent on replay of events" in {
+    "set concurrent on replay of events" taggedAs GHExcludeTest in {
       val entityId = nextEntityId
       val probe = createTestProbe[Done]()
       val eventProbeR1 = createTestProbe[EventAndContext]()

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -360,9 +360,14 @@ class EventSourcedBehaviorSpec
 
       val counterDefaultRecoveryStrategy = spawn(counterWithRecoveryStrategy(Recovery.default))
       counterSetup ! Increment
+
       counterSetup ! StopIt
       probe.expectTerminated(counterSetup)
+
       counterDefaultRecoveryStrategy ! GetValue(probe.ref)
+      counterDefaultRecoveryStrategy ! StopIt
+      probe.expectTerminated(counterDefaultRecoveryStrategy)
+
       probe.expectMessage(State(4, Vector(0, 1, 2, 3)))
 
       val counterDisabledRecoveryStrategy = spawn(counterWithRecoveryStrategy(Recovery.disabled))

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -360,6 +360,8 @@ class EventSourcedBehaviorSpec
 
       val counterDefaultRecoveryStrategy = spawn(counterWithRecoveryStrategy(Recovery.default))
       counterSetup ! Increment
+      counterSetup ! StopIt
+      probe.expectTerminated(counterSetup)
       counterDefaultRecoveryStrategy ! GetValue(probe.ref)
       probe.expectMessage(State(4, Vector(0, 1, 2, 3)))
 
@@ -389,6 +391,8 @@ class EventSourcedBehaviorSpec
       eventProbe.receiveMessages(3)
       snapshotProbe.receiveMessages(3)
       counterSetup ! GetValue(commandProbe.ref)
+      counterSetup ! StopIt
+      commandProbe.expectTerminated(counterSetup)
       commandProbe.expectMessage(State(3, Vector(0, 1, 2)))
 
       val counterWithSnapshotSelectionCriteriaNone = spawn(
@@ -401,6 +405,9 @@ class EventSourcedBehaviorSpec
       eventProbe.expectMessage(State(3, Vector(0, 1, 2)) -> Incremented(1))
       counterWithSnapshotSelectionCriteriaNone ! GetValue(commandProbe.ref)
       commandProbe.expectMessage(State(4, Vector(0, 1, 2, 3)))
+
+      counterWithSnapshotSelectionCriteriaNone ! StopIt
+      commandProbe.expectTerminated(counterWithSnapshotSelectionCriteriaNone)
 
       val counterWithSnapshotSelectionCriteriaLatest = spawn(
         counterWithSnapshotSelectionCriteria(Recovery.withSnapshotSelectionCriteria(SnapshotSelectionCriteria.latest)))

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -365,9 +365,6 @@ class EventSourcedBehaviorSpec
       probe.expectTerminated(counterSetup)
 
       counterDefaultRecoveryStrategy ! GetValue(probe.ref)
-      counterDefaultRecoveryStrategy ! StopIt
-      probe.expectTerminated(counterDefaultRecoveryStrategy)
-
       probe.expectMessage(State(4, Vector(0, 1, 2, 3)))
 
       val counterDisabledRecoveryStrategy = spawn(counterWithRecoveryStrategy(Recovery.disabled))

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
@@ -226,7 +226,7 @@ class FlowThrottleSpec extends StreamSpec("""
       downstream.cancel()
     }
 
-    "send elements downstream as soon as time comes" in assertAllStagesStopped {
+    "send elements downstream as soon as time comes" taggedAs GHExcludeTest in assertAllStagesStopped {
       val probe = Source(1 to 10).throttle(4, 500.millis, 0, _ => 2, Shaping).runWith(TestSink.probe[Int]).request(5)
       probe.receiveWithin(600.millis) should be(Seq(1, 2))
       probe.expectNoMessage(100.millis).expectNext(3).expectNoMessage(100.millis).expectNext(4).cancel()

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
@@ -562,7 +562,7 @@ class RestartSpec
       probe.sendComplete()
     }
 
-    "allow using withMaxRestarts instead of minBackoff to determine the maxRestarts reset time" in assertAllStagesStopped {
+    "allow using withMaxRestarts instead of minBackoff to determine the maxRestarts reset time" taggedAs GHExcludeTest in assertAllStagesStopped {
       val created = new AtomicInteger()
       val (queue, sinkProbe) = TestSource.probe[String].toMat(TestSink.probe)(Keep.both).run()
       val probe = TestSource


### PR DESCRIPTION
Fixed `EventSourcedBehaviorSpec` avoiding race conditions with multiple persistent actors. Also tagged a few tests in `ReplicatedEventSourcingSpec`, `RestartSpec` and `FlowThrottleSpec` with `GHExcludeTest`.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/akka/akka/issues/30532
