### PR TITLE
-Xmx512M for multi-node

### DIFF
--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -54,7 +54,7 @@ jobs:
             -Dakka.test.multi-node.java=${JAVA_HOME}/bin/java \
             -Dmultinode.XX:MetaspaceSize=128M \
             -Dmultinode.Xms512M \
-            -Dmultinode.Xmx1536G \
+            -Dmultinode.Xmx512M \
             -Dmultinode.Xlog:gc \
             multiNodeTest
       - name: Email on failure


### PR DESCRIPTION
* I noticed "command terminated with exit code 137" in some test failure,
  and that is Kubernetes OOM kill.
* Container memory limit is 2Gi
* We didn't used more than 512M previously
