### PR TITLE
Make RestartSpec a little bit less flaky

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
@@ -42,8 +42,8 @@ class RestartSpec
 
   import system.dispatcher
 
-  private val shortMinBackoff = 10.millis
-  private val shortMaxBackoff = 20.millis
+  private val shortMinBackoff = 200.millis
+  private val shortMaxBackoff = 300.millis
   private val minBackoff = 1.second.dilated
   private val maxBackoff = 3.seconds.dilated
 


### PR DESCRIPTION
* not a final solution, but I think it can make it less flaky
* the whole test is written in a very timing sensitive way

See https://github.com/akka/akka/issues/30540 and https://github.com/akka/akka/issues/30320 but the issues should not be closed by this PR.