### PR TITLE
Make HubSpec draining support tests more robust w.r.t. CI environments #30581

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
@@ -202,7 +202,7 @@ class HubSpec extends StreamSpec {
       downstream.request(2)
       probe1.sendNext(-1)
       probe2.sendNext(-2)
-      downstream.expectNextN(2) should contain theSameElementsAs(List(-1, -2))
+      downstream.expectNextN(2) should contain theSameElementsAs (List(-1, -2))
 
       draining.drainAndComplete()
 
@@ -239,7 +239,7 @@ class HubSpec extends StreamSpec {
       downstream.request(2)
       probe1.sendNext(-1)
       probe2.sendNext(-2)
-      downstream.expectNextN(2) should contain theSameElementsAs(List(-1, -2))
+      downstream.expectNextN(2) should contain theSameElementsAs (List(-1, -2))
 
       draining.drainAndComplete()
 
@@ -269,7 +269,6 @@ class HubSpec extends StreamSpec {
       val downstream = TestSubscriber.probe[Int]()
       val (_, draining) =
         MergeHub.sourceWithDraining[Int](16).toMat(Sink.fromSubscriber(downstream))(Keep.left).run()
-
 
       draining.drainAndComplete()
       downstream.request(1)


### PR DESCRIPTION
References #30581

This pull request makes the `MergeHub` draining support tests more robust w.r.t. CI environments.

Specifically, this is achieved by using the following 2 strategies:
1. `TestPublisher`s are employed to verify the successful registration of publishers to the `MergeHub` before initiating the draining process. This should protect against unfortunate scheduling where the draining is initiated before the producers had a chance to register.
2. After starting the draining a delay is added to allow the `MergeHub` to actually receive the command (this is unfortunate but inevitable without a feedback mechanism in the `drainAndComplete` method). This should protect against failures and undesired changes in test semantics caused by all registered producers completing before the draining is registered or conversely producers registering before then.

As a bonus, a small test has been added to cover the previously untested case where the draining process is started with no producer registered in the `MergeHub`.