### PR TITLE
Don't check for jdk9 tests when running on jdk8

### DIFF
--- a/project/TestExtras.scala
+++ b/project/TestExtras.scala
@@ -8,7 +8,7 @@ import sbt.Keys._
 import sbt._
 
 object TestExtras {
-
+  import JdkOptions.isJdk8
   object Filter {
     object Keys {
       val excludeTestNames = settingKey[Set[String]](
@@ -54,11 +54,18 @@ object TestExtras {
           def shouldExist(description: String, filename: String): Unit =
             require(file(filename).exists, s"$description should be run as part of the build")
 
-          List(
-            "The java JavaExtension.java" -> "akka-actor-tests/target/test-reports/TEST-akka.actor.JavaExtension.xml",
+          val baseList =
+            List(
+              "The java JavaExtension.java" -> "akka-actor-tests/target/test-reports/TEST-akka.actor.JavaExtension.xml")
+          val jdk9Only = List(
             "The jdk9-only FlowPublisherSinkSpec.scala" -> "akka-stream-tests/target/test-reports/TEST-akka.stream.scaladsl.FlowPublisherSinkSpec.xml",
             "The jdk9-only JavaFlowSupportCompileTest.java" -> "akka-stream-tests/target/test-reports/TEST-akka.stream.javadsl.JavaFlowSupportCompileTest.xml")
-            .foreach((shouldExist _).tupled)
+
+          val testsToCheck =
+            if (isJdk8) baseList
+            else baseList ::: jdk9Only
+
+          testsToCheck.foreach((shouldExist _).tupled)
         })
     }
 


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #30617
