### PR TITLE
ClusterShardingLeaseSpec: extractShardId should include StartEntity

### DIFF
--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingLeaseSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingLeaseSpec.scala
@@ -9,6 +9,7 @@ import scala.util.Success
 import scala.util.control.NoStackTrace
 import com.typesafe.config.{ Config, ConfigFactory }
 import akka.actor.Props
+import akka.cluster.sharding.ShardRegion.StartEntity
 import akka.cluster.{ Cluster, MemberStatus }
 import akka.coordination.lease.TestLease
 import akka.coordination.lease.TestLeaseExt
@@ -50,9 +51,12 @@ object ClusterShardingLeaseSpec {
     case msg: Int => (msg.toString, msg)
   }
 
+  val numOfShards = 10
+
   val extractShardId: ShardRegion.ExtractShardId = {
-    case msg: Int => (msg % 10).toString
-    case _        => throw new IllegalArgumentException()
+    case msg: Int         => (msg % numOfShards).toString
+    case msg: StartEntity => (msg.entityId.toInt % numOfShards).toString
+    case _                => throw new IllegalArgumentException()
   }
   case class LeaseFailed(msg: String) extends RuntimeException(msg) with NoStackTrace
 }


### PR DESCRIPTION
References #30622

The shard was never coming back to life because of the following exception. 

```scala
java.lang.IllegalArgumentException
 at akka.cluster.sharding.ClusterShardingLeaseSpec$.$anonfun$extractShardId$1(ClusterShardingLeaseSpec.scala:55)
 at akka.cluster.sharding.ShardRegion.deliverMessage(ShardRegion.scala:1245)
 at akka.cluster.sharding.ShardRegion.deliverStartEntity(ShardRegion.scala:1213)
 at akka.cluster.sharding.ShardRegion$$anonfun$receive$2.applyOrElse(ShardRegion.scala:732) 
 at akka.actor.Actor.aroundReceive(Actor.scala:537) 
 at akka.actor.Actor.aroundReceive$(Actor.scala:535)
 at akka.cluster.sharding.ShardRegion.akka$actor$Timers$$super$aroundReceive(ShardRegion.scala:588) 
 at akka.actor.Timers.aroundReceive(Timers.scala:56)
 at akka.actor.Timers.aroundReceive$(Timers.scala:41)
```

`StartEntity` was getting in before the `Int` sent by the test. Surprising that we never hit that before (or didn't notice).
