### PR TITLE
FlowThrottleSpec: Track time in stream, verify intervals after 

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
@@ -12,7 +12,7 @@ import scala.util.Random
 import scala.util.control.NoStackTrace
 import akka.Done
 import akka.stream._
-import akka.stream.ThrottleMode.{Enforcing, Shaping}
+import akka.stream.ThrottleMode.{ Enforcing, Shaping }
 import akka.stream.testkit._
 import akka.stream.testkit.scaladsl.StreamTestKit._
 import akka.stream.testkit.scaladsl.TestSink
@@ -115,12 +115,15 @@ class FlowThrottleSpec extends StreamSpec("""
         .throttle(2, throttleInterval)
         .runFold(Nil: List[(Long, Int)]) { (acc, n) =>
           (System.nanoTime() / 1000000, n) :: acc
-        }.futureValue(timeout(5.seconds))
+        }
+        .futureValue(timeout(5.seconds))
         .reverse
 
       val startMs = elementsAndTimestampsMs.head._1
-      val elemsAndTimeFromStart = elementsAndTimestampsMs.map { case (ts, n) => (ts - startMs, n)}
-      val perThrottleInterval = elemsAndTimeFromStart.groupBy { case (fromStart, _) => fromStart / throttleInterval.toMillis}
+      val elemsAndTimeFromStart = elementsAndTimestampsMs.map { case (ts, n) => (ts - startMs, n) }
+      val perThrottleInterval = elemsAndTimeFromStart.groupBy {
+        case (fromStart, _) => fromStart / throttleInterval.toMillis
+      }
       withClue(perThrottleInterval) {
         perThrottleInterval.forall { case (_, entries) => entries.size == 2 } should ===(true)
       }
@@ -240,12 +243,15 @@ class FlowThrottleSpec extends StreamSpec("""
         .throttle(4, throttleInterval, _ => 2)
         .runFold(Nil: List[(Long, Int)]) { (acc, n) =>
           (System.nanoTime() / 1000000, n) :: acc
-        }.futureValue(timeout(5.seconds))
+        }
+        .futureValue(timeout(5.seconds))
         .reverse
 
       val startMs = elementsAndTimestampsMs.head._1
-      val elemsAndTimeFromStart = elementsAndTimestampsMs.map { case (ts, n) => (ts - startMs, n)}
-      val perThrottleInterval = elemsAndTimeFromStart.groupBy { case (fromStart, _) => fromStart / throttleInterval.toMillis}
+      val elemsAndTimeFromStart = elementsAndTimestampsMs.map { case (ts, n) => (ts - startMs, n) }
+      val perThrottleInterval = elemsAndTimeFromStart.groupBy {
+        case (fromStart, _) => fromStart / throttleInterval.toMillis
+      }
       withClue(perThrottleInterval) {
         perThrottleInterval.forall { case (_, entries) => entries.size == 2 } should ===(true)
       }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowThrottleSpec.scala
@@ -110,9 +110,9 @@ class FlowThrottleSpec extends StreamSpec("""
     }
 
     "send elements downstream as soon as time comes" in assertAllStagesStopped {
-      val throttleInterval = 300.millis
-      val elementsAndTimestampsMs = Source(1 to 10)
-        .throttle(2, throttleInterval)
+      val throttleInterval = 500.millis
+      val elementsAndTimestampsMs = Source(1 to 5)
+        .throttle(1, throttleInterval)
         .runFold(Nil: List[(Long, Int)]) { (acc, n) =>
           (System.nanoTime() / 1000000, n) :: acc
         }
@@ -125,7 +125,7 @@ class FlowThrottleSpec extends StreamSpec("""
         case (fromStart, _) => fromStart / throttleInterval.toMillis
       }
       withClue(perThrottleInterval) {
-        perThrottleInterval.forall { case (_, entries) => entries.size == 2 } should ===(true)
+        perThrottleInterval.forall { case (_, entries) => entries.size == 1 } should ===(true)
       }
     }
 
@@ -238,9 +238,9 @@ class FlowThrottleSpec extends StreamSpec("""
     }
 
     "send elements downstream as soon as time comes" in assertAllStagesStopped {
-      val throttleInterval = 300.millis
-      val elementsAndTimestampsMs = Source(1 to 10)
-        .throttle(4, throttleInterval, _ => 2)
+      val throttleInterval = 500.millis
+      val elementsAndTimestampsMs = Source(1 to 5)
+        .throttle(2, throttleInterval, _ => 2)
         .runFold(Nil: List[(Long, Int)]) { (acc, n) =>
           (System.nanoTime() / 1000000, n) :: acc
         }
@@ -253,7 +253,7 @@ class FlowThrottleSpec extends StreamSpec("""
         case (fromStart, _) => fromStart / throttleInterval.toMillis
       }
       withClue(perThrottleInterval) {
-        perThrottleInterval.forall { case (_, entries) => entries.size == 2 } should ===(true)
+        perThrottleInterval.forall { case (_, entries) => entries.size == 1 } should ===(true)
       }
     }
 


### PR DESCRIPTION
References #30574

Instead of verifying timing from test thread, track time elements arrive in stream (same actor) and verify that the right number of throttled elements arrived within each timeslot afterwards instead. Should be less racy wrt to things happening in different threads.

Also uses the overloads that correctly calculates burst rate depending on throttle interval for good measure.
