### PR TITLE
Access to config through behavior testkit

### DIFF
--- a/akka-actor-testkit-typed/src/main/mima-filters/2.6.16.backwards.excludes/typed-behaviour-testkit.excludes
+++ b/akka-actor-testkit-typed/src/main/mima-filters/2.6.16.backwards.excludes/typed-behaviour-testkit.excludes
@@ -1,0 +1,4 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.testkit.typed.internal.BehaviorTestKitImpl.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.testkit.typed.internal.StubbedActorContext.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.testkit.typed.internal.ActorSystemStub.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.testkit.typed.internal.EffectfulActorContext.this")

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -4,19 +4,16 @@
 
 package akka.actor.testkit.typed.internal
 
-import java.util.concurrent.{ CompletionStage, ThreadFactory }
-
+import java.util.concurrent.{CompletionStage, ThreadFactory}
 import scala.compat.java8.FutureConverters
 import scala.concurrent._
-
 import scala.annotation.nowarn
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-
-import akka.{ actor => classic }
+import akka.{actor => classic}
 import akka.Done
-import akka.actor.{ ActorPath, ActorRefProvider, Address, ReflectiveDynamicAccess }
+import akka.actor.{ActorPath, ActorRefProvider, Address, ReflectiveDynamicAccess}
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -36,7 +33,8 @@ import akka.annotation.InternalApi
  * INTERNAL API
  */
 @nowarn
-@InternalApi private[akka] final class ActorSystemStub(val name: String)
+@InternalApi private[akka] final class ActorSystemStub(val name: String,
+    config : Config = ActorSystemStub.config.defaultReference)
     extends ActorSystem[Nothing]
     with ActorRef[Nothing]
     with ActorRefImpl[Nothing]
@@ -49,9 +47,9 @@ import akka.annotation.InternalApi
   override val settings: Settings = {
     val classLoader = getClass.getClassLoader
     val dynamicAccess = new ReflectiveDynamicAccess(classLoader)
-    val config =
-      classic.ActorSystem.Settings.amendSlf4jConfig(ConfigFactory.defaultReference(classLoader), dynamicAccess)
-    val untypedSettings = new classic.ActorSystem.Settings(classLoader, config, name)
+    val config_ =
+      classic.ActorSystem.Settings.amendSlf4jConfig(config, dynamicAccess)
+    val untypedSettings = new classic.ActorSystem.Settings(classLoader, config_, name)
     new Settings(untypedSettings)
   }
 
@@ -124,4 +122,15 @@ import akka.annotation.InternalApi
   override def log: Logger = LoggerFactory.getLogger(getClass)
 
   def address: Address = rootPath.address
+}
+
+@InternalApi private[akka] object ActorSystemStub {
+  object config {
+    // this is backward compatible with the old behaviour, hence it uses the loader used to load the test-kit
+    // which is not necessarily the one used to load the tests...
+    // hence this might not include reference config related to the actually executing test
+    //todo: might be better NOT to pass any class loader and let typesafeConfig rely on the contextClassLoader
+    // (which is usually the system class loader)
+    def defaultReference: Config = ConfigFactory.defaultReference(getClass.getClassLoader)
+  }
 }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/ActorSystemStub.scala
@@ -4,16 +4,16 @@
 
 package akka.actor.testkit.typed.internal
 
-import java.util.concurrent.{CompletionStage, ThreadFactory}
+import java.util.concurrent.{ CompletionStage, ThreadFactory }
 import scala.compat.java8.FutureConverters
 import scala.concurrent._
 import scala.annotation.nowarn
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{ Config, ConfigFactory }
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import akka.{actor => classic}
+import akka.{ actor => classic }
 import akka.Done
-import akka.actor.{ActorPath, ActorRefProvider, Address, ReflectiveDynamicAccess}
+import akka.actor.{ ActorPath, ActorRefProvider, Address, ReflectiveDynamicAccess }
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -33,8 +33,9 @@ import akka.annotation.InternalApi
  * INTERNAL API
  */
 @nowarn
-@InternalApi private[akka] final class ActorSystemStub(val name: String,
-    config : Config = ActorSystemStub.config.defaultReference)
+@InternalApi private[akka] final class ActorSystemStub(
+    val name: String,
+    config: Config = ActorSystemStub.config.defaultReference)
     extends ActorSystem[Nothing]
     with ActorRef[Nothing]
     with ActorRefImpl[Nothing]

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/BehaviorTestKitImpl.scala
@@ -25,12 +25,16 @@ import akka.util.ccompat.JavaConverters._
  * INTERNAL API
  */
 @InternalApi
-private[akka] final class BehaviorTestKitImpl[T](_path: ActorPath, _initialBehavior: Behavior[T])
+private[akka] final class BehaviorTestKitImpl[T](
+    system: ActorSystemStub,
+    _path: ActorPath,
+    _initialBehavior: Behavior[T])
     extends akka.actor.testkit.typed.javadsl.BehaviorTestKit[T]
     with akka.actor.testkit.typed.scaladsl.BehaviorTestKit[T] {
 
   // really this should be private, make so when we port out tests that need it
-  private[akka] val context: EffectfulActorContext[T] = new EffectfulActorContext[T](_path, () => currentBehavior)
+  private[akka] val context: EffectfulActorContext[T] =
+    new EffectfulActorContext[T](system, _path, () => currentBehavior)
 
   private[akka] def as[U]: BehaviorTestKitImpl[U] = this.asInstanceOf[BehaviorTestKitImpl[U]]
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/EffectfulActorContext.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/EffectfulActorContext.scala
@@ -20,9 +20,10 @@ import scala.reflect.ClassTag
  * INTERNAL API
  */
 @InternalApi private[akka] final class EffectfulActorContext[T](
+    system: ActorSystemStub,
     path: ActorPath,
     currentBehaviorProvider: () => Behavior[T])
-    extends StubbedActorContext[T](path, currentBehaviorProvider) {
+    extends StubbedActorContext[T](system, path, currentBehaviorProvider) {
 
   private[akka] val effectQueue = new ConcurrentLinkedQueue[Effect]
 

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/StubbedActorContext.scala
@@ -4,25 +4,20 @@
 
 package akka.actor.testkit.typed.internal
 
-import java.util.concurrent.ThreadLocalRandom.{ current => rnd }
+import akka.actor.testkit.typed.CapturedLogEvent
+import akka.actor.typed._
+import akka.actor.typed.internal._
+import akka.actor.{ ActorPath, ActorRefProvider, InvalidMessageException }
+import akka.annotation.InternalApi
+import akka.util.Helpers
+import akka.{ actor => classic }
+import org.slf4j.Logger
+import org.slf4j.helpers.{ MessageFormatter, SubstituteLoggerFactory }
 
+import java.util.concurrent.ThreadLocalRandom.{ current => rnd }
 import scala.collection.immutable.TreeMap
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.FiniteDuration
-
-import org.slf4j.Logger
-import org.slf4j.helpers.MessageFormatter
-import org.slf4j.helpers.SubstituteLoggerFactory
-
-import akka.{ actor => classic }
-import akka.actor.{ ActorPath, InvalidMessageException }
-import akka.actor.ActorRefProvider
-import akka.actor.testkit.typed.CapturedLogEvent
-import akka.actor.testkit.typed.scaladsl.TestInbox
-import akka.actor.typed._
-import akka.actor.typed.internal._
-import akka.annotation.InternalApi
-import akka.util.Helpers
 
 /**
  * INTERNAL API

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
@@ -19,7 +19,7 @@ object BehaviorTestKit {
    * JAVA API
    */
   @ApiMayChange
-  def ApplicationTestConfig: Config = akka.actor.testkit.typed.scaladsl.BehaviorTestKit.ApplicationTestConfig
+  def applicationTestConfig: Config = akka.actor.testkit.typed.scaladsl.BehaviorTestKit.ApplicationTestConfig
 
   /**
    * JAVA API

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
@@ -5,9 +5,8 @@
 package akka.actor.testkit.typed.javadsl
 
 import java.util.concurrent.ThreadLocalRandom
-
 import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
-import akka.actor.testkit.typed.internal.BehaviorTestKitImpl
+import akka.actor.testkit.typed.internal.{ ActorSystemStub, BehaviorTestKitImpl }
 import akka.actor.typed.{ ActorRef, Behavior, Signal }
 import akka.actor.typed.receptionist.Receptionist
 import akka.annotation.{ ApiMayChange, DoNotInherit }
@@ -20,8 +19,9 @@ object BehaviorTestKit {
    */
   @ApiMayChange
   def create[T](initialBehavior: Behavior[T], name: String): BehaviorTestKit[T] = {
+    val system = new ActorSystemStub("StubbedActorContext")
     val uid = ThreadLocalRandom.current().nextInt()
-    new BehaviorTestKitImpl((address / name).withUid(uid), initialBehavior)
+    new BehaviorTestKitImpl(system, (system.path / name).withUid(uid), initialBehavior)
   }
 
   /**

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
@@ -5,7 +5,6 @@
 package akka.actor.testkit.typed.javadsl
 
 import akka.actor.testkit.typed.internal.{ ActorSystemStub, BehaviorTestKitImpl }
-import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
 import akka.actor.typed.receptionist.Receptionist
 import akka.actor.typed.{ ActorRef, Behavior, Signal }
@@ -20,7 +19,7 @@ object BehaviorTestKit {
    * JAVA API
    */
   @ApiMayChange
-  def ApplicationTestConfig: Config = ActorTestKit.ApplicationTestConfig
+  def ApplicationTestConfig: Config = akka.actor.testkit.typed.scaladsl.BehaviorTestKit.ApplicationTestConfig
 
   /**
    * JAVA API

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
@@ -5,11 +5,11 @@
 package akka.actor.testkit.typed.javadsl
 
 import java.util.concurrent.ThreadLocalRandom
-import akka.actor.testkit.typed.{CapturedLogEvent, Effect, scaladsl}
-import akka.actor.testkit.typed.internal.{ActorSystemStub, BehaviorTestKitImpl}
-import akka.actor.typed.{ActorRef, Behavior, Signal}
+import akka.actor.testkit.typed.{ scaladsl, CapturedLogEvent, Effect }
+import akka.actor.testkit.typed.internal.{ ActorSystemStub, BehaviorTestKitImpl }
+import akka.actor.typed.{ ActorRef, Behavior, Signal }
 import akka.actor.typed.receptionist.Receptionist
-import akka.annotation.{ApiMayChange, DoNotInherit}
+import akka.annotation.{ ApiMayChange, DoNotInherit }
 import com.typesafe.config.Config
 
 object BehaviorTestKit {
@@ -25,7 +25,7 @@ object BehaviorTestKit {
    * JAVA API
    */
   @ApiMayChange
-  def create[T](initialBehavior: Behavior[T], name: String, config : Config): BehaviorTestKit[T] = {
+  def create[T](initialBehavior: Behavior[T], name: String, config: Config): BehaviorTestKit[T] = {
     val system = new ActorSystemStub("StubbedActorContext", config)
     val uid = ThreadLocalRandom.current().nextInt()
     new BehaviorTestKitImpl(system, (system.path / name).withUid(uid), initialBehavior)

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
@@ -5,7 +5,8 @@
 package akka.actor.testkit.typed.javadsl
 
 import akka.actor.testkit.typed.internal.{ ActorSystemStub, BehaviorTestKitImpl }
-import akka.actor.testkit.typed.{ scaladsl, CapturedLogEvent, Effect }
+import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
 import akka.actor.typed.receptionist.Receptionist
 import akka.actor.typed.{ ActorRef, Behavior, Signal }
 import akka.annotation.{ ApiMayChange, DoNotInherit }
@@ -19,7 +20,7 @@ object BehaviorTestKit {
    * JAVA API
    */
   @ApiMayChange
-  def config(): akka.actor.testkit.typed.scaladsl.BehaviorTestKit.config = scaladsl.BehaviorTestKit.config
+  def ApplicationTestConfig: Config = ActorTestKit.ApplicationTestConfig
 
   /**
    * JAVA API

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
@@ -4,16 +4,16 @@
 
 package akka.actor.testkit.typed.javadsl
 
-import java.util.concurrent.ThreadLocalRandom
-import akka.actor.testkit.typed.{ scaladsl, CapturedLogEvent, Effect }
 import akka.actor.testkit.typed.internal.{ ActorSystemStub, BehaviorTestKitImpl }
-import akka.actor.typed.{ ActorRef, Behavior, Signal }
+import akka.actor.testkit.typed.{ scaladsl, CapturedLogEvent, Effect }
 import akka.actor.typed.receptionist.Receptionist
+import akka.actor.typed.{ ActorRef, Behavior, Signal }
 import akka.annotation.{ ApiMayChange, DoNotInherit }
 import com.typesafe.config.Config
 
+import java.util.concurrent.ThreadLocalRandom
+
 object BehaviorTestKit {
-  import akka.actor.testkit.typed.scaladsl.TestInbox.address
 
   /**
    * JAVA API

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/BehaviorTestKit.scala
@@ -5,11 +5,12 @@
 package akka.actor.testkit.typed.javadsl
 
 import java.util.concurrent.ThreadLocalRandom
-import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
-import akka.actor.testkit.typed.internal.{ ActorSystemStub, BehaviorTestKitImpl }
-import akka.actor.typed.{ ActorRef, Behavior, Signal }
+import akka.actor.testkit.typed.{CapturedLogEvent, Effect, scaladsl}
+import akka.actor.testkit.typed.internal.{ActorSystemStub, BehaviorTestKitImpl}
+import akka.actor.typed.{ActorRef, Behavior, Signal}
 import akka.actor.typed.receptionist.Receptionist
-import akka.annotation.{ ApiMayChange, DoNotInherit }
+import akka.annotation.{ApiMayChange, DoNotInherit}
+import com.typesafe.config.Config
 
 object BehaviorTestKit {
   import akka.actor.testkit.typed.scaladsl.TestInbox.address
@@ -18,10 +19,24 @@ object BehaviorTestKit {
    * JAVA API
    */
   @ApiMayChange
-  def create[T](initialBehavior: Behavior[T], name: String): BehaviorTestKit[T] = {
-    val system = new ActorSystemStub("StubbedActorContext")
+  def config(): akka.actor.testkit.typed.scaladsl.BehaviorTestKit.config = scaladsl.BehaviorTestKit.config
+
+  /**
+   * JAVA API
+   */
+  @ApiMayChange
+  def create[T](initialBehavior: Behavior[T], name: String, config : Config): BehaviorTestKit[T] = {
+    val system = new ActorSystemStub("StubbedActorContext", config)
     val uid = ThreadLocalRandom.current().nextInt()
     new BehaviorTestKitImpl(system, (system.path / name).withUid(uid), initialBehavior)
+  }
+
+  /**
+   * JAVA API
+   */
+  @ApiMayChange
+  def create[T](initialBehavior: Behavior[T], name: String): BehaviorTestKit[T] = {
+    create(initialBehavior, name, ActorSystemStub.config.defaultReference)
   }
 
   /**

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
@@ -4,19 +4,19 @@
 
 package akka.actor.testkit.typed.scaladsl
 
+import akka.actor.testkit.typed.internal.{ ActorSystemStub, BehaviorTestKitImpl }
+import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
+import akka.actor.typed.receptionist.Receptionist
+import akka.actor.typed.{ ActorRef, Behavior, Signal, TypedActorContext }
+import akka.annotation.{ ApiMayChange, DoNotInherit }
+import com.typesafe.config.Config
+
 import java.util.concurrent.ThreadLocalRandom
 import scala.collection.immutable
 import scala.reflect.ClassTag
-import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
-import akka.actor.testkit.typed.internal.{ ActorSystemStub, BehaviorTestKitImpl }
-import akka.actor.typed.{ ActorRef, Behavior, Signal, TypedActorContext }
-import akka.actor.typed.receptionist.Receptionist
-import akka.annotation.{ ApiMayChange, DoNotInherit }
-import com.typesafe.config.{ Config, ConfigFactory }
 
 @ApiMayChange
 object BehaviorTestKit {
-  import akka.actor.testkit.typed.scaladsl.TestInbox.address
 
   trait config {
     def appTestConfig: Config = ActorTestKit.ApplicationTestConfig

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
@@ -18,10 +18,7 @@ import scala.reflect.ClassTag
 @ApiMayChange
 object BehaviorTestKit {
 
-  trait config {
-    def appTestConfig: Config = ActorTestKit.ApplicationTestConfig
-  }
-  object config extends config
+  val ApplicationTestConfig: Config = ActorTestKit.ApplicationTestConfig
 
   def apply[T](initialBehavior: Behavior[T], name: String, config: Config): BehaviorTestKit[T] = {
     val system = new ActorSystemStub("StubbedActorContext", config)

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
@@ -5,12 +5,10 @@
 package akka.actor.testkit.typed.scaladsl
 
 import java.util.concurrent.ThreadLocalRandom
-
 import scala.collection.immutable
 import scala.reflect.ClassTag
-
 import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
-import akka.actor.testkit.typed.internal.BehaviorTestKitImpl
+import akka.actor.testkit.typed.internal.{ ActorSystemStub, BehaviorTestKitImpl }
 import akka.actor.typed.{ ActorRef, Behavior, Signal, TypedActorContext }
 import akka.actor.typed.receptionist.Receptionist
 import akka.annotation.{ ApiMayChange, DoNotInherit }
@@ -20,8 +18,9 @@ object BehaviorTestKit {
   import akka.actor.testkit.typed.scaladsl.TestInbox.address
 
   def apply[T](initialBehavior: Behavior[T], name: String): BehaviorTestKit[T] = {
+    val system = new ActorSystemStub("StubbedActorContext")
     val uid = ThreadLocalRandom.current().nextInt()
-    new BehaviorTestKitImpl((address / name).withUid(uid), initialBehavior)
+    new BehaviorTestKitImpl(system, (system.path / name).withUid(uid), initialBehavior)
   }
   def apply[T](initialBehavior: Behavior[T]): BehaviorTestKit[T] =
     apply(initialBehavior, "testkit")

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
@@ -7,20 +7,29 @@ package akka.actor.testkit.typed.scaladsl
 import java.util.concurrent.ThreadLocalRandom
 import scala.collection.immutable
 import scala.reflect.ClassTag
-import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
-import akka.actor.testkit.typed.internal.{ ActorSystemStub, BehaviorTestKitImpl }
-import akka.actor.typed.{ ActorRef, Behavior, Signal, TypedActorContext }
+import akka.actor.testkit.typed.{CapturedLogEvent, Effect}
+import akka.actor.testkit.typed.internal.{ActorSystemStub, BehaviorTestKitImpl}
+import akka.actor.typed.{ActorRef, Behavior, Signal, TypedActorContext}
 import akka.actor.typed.receptionist.Receptionist
-import akka.annotation.{ ApiMayChange, DoNotInherit }
+import akka.annotation.{ApiMayChange, DoNotInherit}
+import com.typesafe.config.{Config, ConfigFactory}
 
 @ApiMayChange
 object BehaviorTestKit {
   import akka.actor.testkit.typed.scaladsl.TestInbox.address
 
-  def apply[T](initialBehavior: Behavior[T], name: String): BehaviorTestKit[T] = {
-    val system = new ActorSystemStub("StubbedActorContext")
+  trait config {
+    def appTestConfig: Config = ActorTestKit.ApplicationTestConfig
+  }
+  object config extends config
+
+  def apply[T](initialBehavior: Behavior[T], name: String, config : Config): BehaviorTestKit[T] = {
+    val system = new ActorSystemStub("StubbedActorContext", config)
     val uid = ThreadLocalRandom.current().nextInt()
     new BehaviorTestKitImpl(system, (system.path / name).withUid(uid), initialBehavior)
+  }
+  def apply[T](initialBehavior: Behavior[T], name: String): BehaviorTestKit[T] = {
+    apply(initialBehavior, name, ActorSystemStub.config.defaultReference)
   }
   def apply[T](initialBehavior: Behavior[T]): BehaviorTestKit[T] =
     apply(initialBehavior, "testkit")

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/BehaviorTestKit.scala
@@ -7,12 +7,12 @@ package akka.actor.testkit.typed.scaladsl
 import java.util.concurrent.ThreadLocalRandom
 import scala.collection.immutable
 import scala.reflect.ClassTag
-import akka.actor.testkit.typed.{CapturedLogEvent, Effect}
-import akka.actor.testkit.typed.internal.{ActorSystemStub, BehaviorTestKitImpl}
-import akka.actor.typed.{ActorRef, Behavior, Signal, TypedActorContext}
+import akka.actor.testkit.typed.{ CapturedLogEvent, Effect }
+import akka.actor.testkit.typed.internal.{ ActorSystemStub, BehaviorTestKitImpl }
+import akka.actor.typed.{ ActorRef, Behavior, Signal, TypedActorContext }
 import akka.actor.typed.receptionist.Receptionist
-import akka.annotation.{ApiMayChange, DoNotInherit}
-import com.typesafe.config.{Config, ConfigFactory}
+import akka.annotation.{ ApiMayChange, DoNotInherit }
+import com.typesafe.config.{ Config, ConfigFactory }
 
 @ApiMayChange
 object BehaviorTestKit {
@@ -23,7 +23,7 @@ object BehaviorTestKit {
   }
   object config extends config
 
-  def apply[T](initialBehavior: Behavior[T], name: String, config : Config): BehaviorTestKit[T] = {
+  def apply[T](initialBehavior: Behavior[T], name: String, config: Config): BehaviorTestKit[T] = {
     val system = new ActorSystemStub("StubbedActorContext", config)
     val uid = ThreadLocalRandom.current().nextInt()
     new BehaviorTestKitImpl(system, (system.path / name).withUid(uid), initialBehavior)

--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/SyncTestingExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/SyncTestingExampleTest.java
@@ -205,7 +205,7 @@ public class SyncTestingExampleTest extends JUnitSuite {
   public void testWithAppTestCfg() {
 
     // #test-app-test-config
-    Config cfg = BehaviorTestKit.config().appTestConfig();
+    Config cfg = BehaviorTestKit.ApplicationTestConfig();
     BehaviorTestKit<Hello.Command> test = BehaviorTestKit.create(Hello.create(), "hello", cfg);
   }
 }

--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/SyncTestingExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/SyncTestingExampleTest.java
@@ -205,7 +205,7 @@ public class SyncTestingExampleTest extends JUnitSuite {
   public void testWithAppTestCfg() {
 
     // #test-app-test-config
-    Config cfg = BehaviorTestKit.ApplicationTestConfig();
+    Config cfg = BehaviorTestKit.applicationTestConfig();
     BehaviorTestKit<Hello.Command> test = BehaviorTestKit.create(Hello.create(), "hello", cfg);
   }
 }

--- a/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/SyncTestingExampleTest.java
+++ b/akka-actor-testkit-typed/src/test/java/jdocs/akka/actor/testkit/typed/javadsl/SyncTestingExampleTest.java
@@ -14,6 +14,8 @@ import akka.actor.typed.javadsl.*;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+
+import com.typesafe.config.Config;
 import org.slf4j.event.Level;
 // #imports
 import org.junit.Test;
@@ -197,5 +199,13 @@ public class SyncTestingExampleTest extends JUnitSuite {
             new HashMap<>());
     assertEquals(expectedLogEvent, allLogEntries.get(0));
     // #test-check-logging
+  }
+
+  @Test
+  public void testWithAppTestCfg() {
+
+    // #test-app-test-config
+    Config cfg = BehaviorTestKit.config().appTestConfig();
+    BehaviorTestKit<Hello.Command> test = BehaviorTestKit.create(Hello.create(), "hello", cfg);
   }
 }

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/SyncTestingExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/SyncTestingExampleSpec.scala
@@ -63,7 +63,7 @@ object SyncTestingExampleSpec {
   }
 
   object ConfigAware {
-    trait Command
+    sealed trait Command
     case class GetCfgString(key: String, replyTo: ActorRef[String]) extends Command
     case class SpawnChild(replyTo: ActorRef[ActorRef[Command]]) extends Command
 
@@ -155,6 +155,9 @@ class SyncTestingExampleSpec extends AnyWordSpec with Matchers {
       val childTestKit = inbox.receiveMessage() match {
         case ar: ActorRef[_] =>
           testKit.childTestKit(ar.unsafeUpcast[Any].narrow[ConfigAware.Command])
+        case unexpected =>
+          unexpected should be (a[ActorRef[_]])
+          ???
       }
 
       childTestKit.run(ConfigAware.GetCfgString("test.secret", inbox.ref.narrow))

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/SyncTestingExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/SyncTestingExampleSpec.scala
@@ -156,7 +156,7 @@ class SyncTestingExampleSpec extends AnyWordSpec with Matchers {
         case ar: ActorRef[_] =>
           testKit.childTestKit(ar.unsafeUpcast[Any].narrow[ConfigAware.Command])
         case unexpected =>
-          unexpected should be (a[ActorRef[_]])
+          unexpected should be(a[ActorRef[_]])
           ???
       }
 

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/SyncTestingExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/SyncTestingExampleSpec.scala
@@ -11,7 +11,10 @@ import akka.actor.testkit.typed.scaladsl.BehaviorTestKit
 import akka.actor.testkit.typed.scaladsl.TestInbox
 import akka.actor.typed._
 import akka.actor.typed.scaladsl._
+import com.typesafe.config.ConfigFactory
 import org.slf4j.event.Level
+
+import scala.jdk.CollectionConverters.MapHasAsJava
 //#imports
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -57,6 +60,25 @@ object SyncTestingExampleSpec {
         Behaviors.same
     }
     //#under-test
+  }
+
+  object ConfigAware {
+    trait Command
+    case class GetCfgString(key: String, replyTo: ActorRef[String]) extends Command
+    case class SpawnChild(replyTo: ActorRef[ActorRef[Command]]) extends Command
+
+    def apply(): Behavior[Command] = Behaviors.setup[Command] { ctx =>
+      Behaviors.receiveMessage {
+        case GetCfgString(key, replyTo) =>
+          val str = ctx.system.settings.config.getString(key)
+          replyTo ! str
+          Behaviors.same
+        case SpawnChild(replyTo) =>
+          val child = ctx.spawnAnonymous(ConfigAware())
+          replyTo ! child
+          Behaviors.same
+      }
+    }
   }
 
 }
@@ -119,6 +141,24 @@ class SyncTestingExampleSpec extends AnyWordSpec with Matchers {
       testKit.run(Hello.LogAndSayHello(inbox.ref))
       testKit.logEntries() shouldBe Seq(CapturedLogEvent(Level.INFO, "Saying hello to Inboxer"))
       //#test-check-logging
+    }
+
+    "has access to the provided config" in {
+      val conf =
+        BehaviorTestKit.config.appTestConfig.withFallback(ConfigFactory.parseMap(Map("test.secret" -> "shhhhh").asJava))
+      val testKit = BehaviorTestKit(ConfigAware(), "root", conf)
+      val inbox = TestInbox[AnyRef]("Inboxer")
+      testKit.run(ConfigAware.GetCfgString("test.secret", inbox.ref.narrow))
+      inbox.expectMessage("shhhhh")
+
+      testKit.run(ConfigAware.SpawnChild(inbox.ref.narrow))
+      val childTestKit = inbox.receiveMessage() match {
+        case ar: ActorRef[_] =>
+          testKit.childTestKit(ar.unsafeUpcast[Any].narrow[ConfigAware.Command])
+      }
+
+      childTestKit.run(ConfigAware.GetCfgString("test.secret", inbox.ref.narrow))
+      inbox.expectMessage("shhhhh")
     }
   }
 }

--- a/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/SyncTestingExampleSpec.scala
+++ b/akka-actor-testkit-typed/src/test/scala/docs/akka/actor/testkit/typed/scaladsl/SyncTestingExampleSpec.scala
@@ -145,7 +145,8 @@ class SyncTestingExampleSpec extends AnyWordSpec with Matchers {
 
     "has access to the provided config" in {
       val conf =
-        BehaviorTestKit.config.appTestConfig.withFallback(ConfigFactory.parseMap(Map("test.secret" -> "shhhhh").asJava))
+        BehaviorTestKit.ApplicationTestConfig.withFallback(
+          ConfigFactory.parseMap(Map("test.secret" -> "shhhhh").asJava))
       val testKit = BehaviorTestKit(ConfigAware(), "root", conf)
       val inbox = TestInbox[AnyRef]("Inboxer")
       testKit.run(ConfigAware.GetCfgString("test.secret", inbox.ref.narrow))


### PR DESCRIPTION
References #29994

* share a single stubbed actor system across a behaviours test kit hierarchy
* parameterize the stubbed actor system and behaviour test kit with a config object
* expose reasonable default for config: backward compatible reference.conf and an application-test.conf