### PR TITLE
Harden EventSourcedBehaviorStashSpec, #30543

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
@@ -622,8 +622,6 @@ class EventSourcedBehaviorStashSpec
     "stop from PoisonPill after unstashing completed" in {
       val c = spawn(counter(nextPid()))
       val ackProbe = TestProbe[Ack]()
-      val unhandledProbe = createTestProbe[UnhandledMessage]()
-      system.eventStream ! EventStream.Subscribe(unhandledProbe.ref)
 
       c ! Increment("1", ackProbe.ref)
       ackProbe.expectMessage(Ack("1"))
@@ -647,8 +645,6 @@ class EventSourcedBehaviorStashSpec
       ackProbe.expectMessage(Ack("4"))
 
       ackProbe.expectTerminated(c)
-
-      unhandledProbe.receiveMessage()
 
       // 6 shouldn't make it, already stopped
       ackProbe.expectNoMessage(100.millis)


### PR DESCRIPTION
* remove assert on unhandled message, not important to
  what the test is verifying
* I think message 6 might not have arrived yet, and
  therefore not directed to unhandled

References #30543
