### PR TITLE
ActorLeakSpec fail fix 

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/classic/ActorsLeakSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/ActorsLeakSpec.scala
@@ -177,9 +177,11 @@ class ActorsLeakSpec extends AkkaSpec(ActorsLeakSpec.config) with ImplicitSender
           remoteSystem.terminate()
         }
 
-        EventFilter.warning(start = s"Association with remote system [${remoteAddress}] has failed", occurrences = 1).intercept {
-          Await.result(remoteSystem.whenTerminated, 10.seconds)
-        }
+        EventFilter
+          .warning(start = s"Association with remote system [${remoteAddress}] has failed", occurrences = 1)
+          .intercept {
+            Await.result(remoteSystem.whenTerminated, 10.seconds)
+          }
       }
 
       // Remote idle for too long case

--- a/akka-remote/src/test/scala/akka/remote/classic/ActorsLeakSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/classic/ActorsLeakSpec.scala
@@ -23,6 +23,7 @@ import akka.testkit.TestActors.EchoActor
 object ActorsLeakSpec {
 
   val config = ConfigFactory.parseString("""
+       akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
        akka.actor.provider = remote
        akka.remote.artery.enabled = false
        akka.remote.classic.netty.tcp.applied-adapters = ["trttl"]
@@ -176,7 +177,7 @@ class ActorsLeakSpec extends AkkaSpec(ActorsLeakSpec.config) with ImplicitSender
           remoteSystem.terminate()
         }
 
-        EventFilter.warning(pattern = "Association with remote system", occurrences = 1).intercept {
+        EventFilter.warning(start = s"Association with remote system [${remoteAddress}] has failed", occurrences = 1).intercept {
           Await.result(remoteSystem.whenTerminated, 10.seconds)
         }
       }


### PR DESCRIPTION
References #30639

Wait for a specific association to be lost instead of any association. Will probably fail anyway but this more explicitly states intent to see the stopping remote association lost, hopefully that will give more information if it fails again.