### PR TITLE
Fix MessageAdapterSpec instability

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
@@ -257,6 +257,8 @@ class MessageAdapterSpec
         behv(count = 1)
       }
 
+      val deadLetterProbe = testKit.createDeadLetterProbe()
+
       // Not expecting "Exception thrown out of adapter. Stopping myself"
       LoggingTestKit.error[TestException].withMessageContains("boom").expect {
         spawn(snitch)
@@ -267,6 +269,9 @@ class MessageAdapterSpec
       probe.expectMessage(3)
       // exception was thrown for 3
       probe.expectMessage("stopped")
+
+      deadLetterProbe.receiveMessage().message.asInstanceOf[AdaptMessage[_, _]].message shouldBe (Pong("hello"))
+      deadLetterProbe.receiveMessage().message.asInstanceOf[AdaptMessage[_, _]].message shouldBe (Pong("hello"))
     }
 
   }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
@@ -270,8 +270,16 @@ class MessageAdapterSpec
       // exception was thrown for 3
       probe.expectMessage("stopped")
 
-      deadLetterProbe.receiveMessage().message.asInstanceOf[AdaptMessage[Pong, _]].message.greeting shouldBe "hello"
-      deadLetterProbe.receiveMessage().message.asInstanceOf[AdaptMessage[Pong, _]].message.greeting shouldBe "hello"
+      deadLetterProbe.receiveMessage().message match {
+        case AdaptMessage(Pong(greeting), _) => greeting shouldBe "hello"
+        case  Pong(greeting) => greeting shouldBe "hello"
+        case other => fail(s"Unexpected dead letter: [$other]")
+      }
+      deadLetterProbe.receiveMessage().message match {
+        case AdaptMessage(Pong(greeting), _) => greeting shouldBe "hello"
+        case Pong(greeting) => greeting shouldBe "hello"
+        case other => fail(s"Unexpected dead letter: [$other]")
+      }
     }
 
   }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
@@ -272,13 +272,13 @@ class MessageAdapterSpec
 
       deadLetterProbe.receiveMessage().message match {
         case AdaptMessage(Pong(greeting), _) => greeting shouldBe "hello"
-        case  Pong(greeting) => greeting shouldBe "hello"
-        case other => fail(s"Unexpected dead letter: [$other]")
+        case Pong(greeting)                  => greeting shouldBe "hello"
+        case other                           => fail(s"Unexpected dead letter: [$other]")
       }
       deadLetterProbe.receiveMessage().message match {
         case AdaptMessage(Pong(greeting), _) => greeting shouldBe "hello"
-        case Pong(greeting) => greeting shouldBe "hello"
-        case other => fail(s"Unexpected dead letter: [$other]")
+        case Pong(greeting)                  => greeting shouldBe "hello"
+        case other                           => fail(s"Unexpected dead letter: [$other]")
       }
     }
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
@@ -270,8 +270,8 @@ class MessageAdapterSpec
       // exception was thrown for 3
       probe.expectMessage("stopped")
 
-      deadLetterProbe.receiveMessage().message.asInstanceOf[AdaptMessage[_, _]].message shouldBe (Pong("hello"))
-      deadLetterProbe.receiveMessage().message.asInstanceOf[AdaptMessage[_, _]].message shouldBe (Pong("hello"))
+      deadLetterProbe.receiveMessage().message.asInstanceOf[AdaptMessage[Pong, _]].message.greeting shouldBe "hello"
+      deadLetterProbe.receiveMessage().message.asInstanceOf[AdaptMessage[Pong, _]].message.greeting shouldBe "hello"
     }
 
   }


### PR DESCRIPTION
Consume dead letters in one test so they don't
pollute the next test

Fixes #30552