### PR TITLE
Test customizing the Jackson object mapper

### DIFF
--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -26,7 +26,7 @@ jobs:
           - akka-discovery/test
           - akka-persistence/compile
           - akka-pki/test
-          - akka-serialization-jackson/Test/compile
+          - akka-serialization-jackson/test
           - akka-slf4j/test
           - akka-stream/test akka-stream-testkit/test akka-stream-tests/test
           - akka-stream-tests-tck/test


### PR DESCRIPTION
Starting with https://github.com/FasterXML/jackson-databind/issues/2683
Jackson will no longer use the generic bean serialization when serializing a
`java.time.Instant`, but throw an error (since the bean serialization
doesn't make sense for those types anyway).

Our test relied on the bean serialization to test using custom object
mappers. This PR improves the test to use a 'real' custom mapper instead
of just relying on the bean fallback.