### PR TITLE
DeathWatchNotification: more prominent logging on timeout

### DIFF
--- a/akka-cluster/src/test/scala/akka/cluster/ClusterDeathWatchNotificationSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterDeathWatchNotificationSpec.scala
@@ -82,7 +82,7 @@ class ClusterDeathWatchNotificationSpec
   }
 
   // https://github.com/akka/akka/issues/30135
-  "receive Terminated after ordinary messages" taggedAs GHExcludeTest in {
+  "receive Terminated after ordinary messages" in {
     val receiverProbe = TestProbe()
     setupSender(system2, receiverProbe, "sender")
     val sender = identifySender(system2, "sender")

--- a/akka-remote/src/main/scala/akka/remote/artery/FlushBeforeDeathWatchNotification.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/FlushBeforeDeathWatchNotification.scala
@@ -77,7 +77,7 @@ private[remote] class FlushBeforeDeathWatchNotification(
       if (remaining == 0)
         context.stop(self)
     case Timeout =>
-      log.debug("Flush timeout, [{}] remaining", remaining)
+      log.warning("Flush timeout, [{}] remaining", remaining)
       context.stop(self)
   }
 }


### PR DESCRIPTION
To diagnose whether this is what makes the ClusterDeathWatchNotificationSpec
flakey.