### PR TITLE
Parse service names with special characters in them

### DIFF
--- a/akka-discovery/src/main/scala/akka/discovery/config/ConfigServiceDiscovery.scala
+++ b/akka-discovery/src/main/scala/akka/discovery/config/ConfigServiceDiscovery.scala
@@ -7,7 +7,7 @@ package akka.discovery.config
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
-import com.typesafe.config.Config
+import com.typesafe.config.{ Config, ConfigUtil }
 
 import akka.actor.ExtendedActorSystem
 import akka.annotation.InternalApi
@@ -27,7 +27,7 @@ private object ConfigServicesParser {
       .entrySet()
       .asScala
       .map { en =>
-        (en.getKey, config.getConfig(en.getKey))
+        (en.getKey, config.getConfig(ConfigUtil.quoteString(en.getKey)))
       }
       .toMap
 

--- a/akka-discovery/src/test/scala/akka/discovery/config/ConfigServiceDiscoverySpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/config/ConfigServiceDiscoverySpec.scala
@@ -38,7 +38,7 @@ akka {
             }
           ]
         },
-        service2 = {
+        "service2.domain.com" = {
           endpoints = []
         }
       }

--- a/akka-discovery/src/test/scala/akka/discovery/config/ConfigServiceDiscoverySpec.scala
+++ b/akka-discovery/src/test/scala/akka/discovery/config/ConfigServiceDiscoverySpec.scala
@@ -70,7 +70,11 @@ class ConfigServiceDiscoverySpec
         ResolvedTarget(host = "cat", port = Some(1233), address = None),
         ResolvedTarget(host = "dog", port = None, address = None))
     }
-
+    "return no resolved targets if no endpoints" in {
+      val result = discovery.lookup("service2.domain.com", 100.millis).futureValue
+      result.serviceName shouldEqual "service2.domain.com"
+      result.addresses shouldEqual immutable.Seq.empty
+    }
     "return no resolved targets if not in config" in {
       val result = discovery.lookup("dontexist", 100.millis).futureValue
       result.serviceName shouldEqual "dontexist"


### PR DESCRIPTION
References #30672 

We are using gRPC with config-based discovery and are currently having a problem whereby the name of the service is used during certificate validation. I was using a moniker for the service but when I changing to the full service name that is in the certificate, then the discovery parsing blew up. This little fix hopefully is enough to address the issue, please let me know if I need to update any documentation.  