### PR TITLE
pending DurableShardingSpec, #30489

### DIFF
--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/delivery/DurableShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/delivery/DurableShardingSpec.scala
@@ -83,6 +83,7 @@ class DurableShardingSpec
 
     // GHExclude tracked in https://github.com/akka/akka/issues/30489
     "load initial state and resend unconfirmed" taggedAs GHExcludeTest in {
+      pending // FIXME issue #30489, this could be a real problem
       nextId()
       val typeKey = EntityTypeKey[SequencedMessage[TestConsumer.Job]](s"TestConsumer-$idCount")
       val consumerProbe = createTestProbe[TestConsumer.JobDelivery]()


### PR DESCRIPTION
* this could be a real problem
* make pending for now, and marking issue as bug
* the ShardingConsumerController is supposed to switch when the
  producer is changed, but that doesn't seem to happen in the failed test,
  (see missing log entry "Starting ConsumerController for producerId")

See #30489
