### PR TITLE
LoggingReceiveSpec fail fix

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/event/LoggingReceiveSpec.scala
@@ -159,9 +159,11 @@ class LoggingReceiveSpec extends AnyWordSpec with BeforeAndAfterAll {
           }
         })
         actor ! "buh"
-        expectMsg(
-          Logging
-            .Info(actor.path.toString, actor.underlyingActor.getClass, "received handled message buh from " + self))
+        fishForSpecificMessage() {
+          case Logging.Info(src, _, msg)
+              if src == actor.path.toString && msg == "received handled message buh from " + self =>
+            ()
+        }
         expectMsg("x")
       }
     }


### PR DESCRIPTION
References #30691

Didn't figure out where that dead letter came from (shared actor system and therefore logging infra for all test cases) but for the test case in particular we can fish for log entries from the actor under test.