### PR TITLE
Simplify usage of java8-compat and use 1.0.0.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,9 +11,6 @@ import scala.language.implicitConversions
 object Dependencies {
   import DependencyHelpers._
 
-  lazy val java8CompatVersion = settingKey[String]("The version of scala-java8-compat to use.")
-    .withRank(KeyRanks.Invisible) // avoid 'unused key' warning
-
   val junitVersion = "4.13.2"
   val slf4jVersion = "1.7.32"
   // check agrona version when updating this
@@ -67,16 +64,8 @@ object Dependencies {
   val Versions =
     Seq(
       crossScalaVersions := Seq(scala212Version, scala213Version),
-      scalaVersion := getScalaVersion(),
-      java8CompatVersion := {
-        CrossVersion.partialVersion(scalaVersion.value) match {
-          // java8-compat is only used in a couple of places for 2.13,
-          // it is probably possible to remove the dependency if needed.
-          case Some((3, _))            => "1.0.0"
-          case Some((2, n)) if n >= 13 => "1.0.0"
-          case _                       => "0.8.0"
-        }
-      })
+      scalaVersion := getScalaVersion()
+    )
 
   object Compile {
     // Compile
@@ -107,9 +96,8 @@ object Dependencies {
     val junit = "junit" % "junit" % junitVersion // Common Public License 1.0
 
     // For Java 8 Conversions
-    val java8Compat = Def.setting {
-      ("org.scala-lang.modules" %% "scala-java8-compat" % java8CompatVersion.value).cross(CrossVersion.for3Use2_13)
-    } // Scala License
+    val java8Compat =
+      ("org.scala-lang.modules" %% "scala-java8-compat" % "1.0.0").cross(CrossVersion.for3Use2_13) // Scala License
 
     val aeronDriver = "io.aeron" % "aeron-driver" % aeronVersion // ApacheV2
     val aeronClient = "io.aeron" % "aeron-client" % aeronVersion // ApacheV2
@@ -205,7 +193,7 @@ object Dependencies {
   // TODO check if `l ++=` everywhere expensive?
   val l = libraryDependencies
 
-  val actor = l ++= Seq(config, java8Compat.value)
+  val actor = l ++= Seq(config, java8Compat)
 
   val actorTyped = l ++= Seq(slf4jApi)
 


### PR DESCRIPTION
The current behavior in Akka is that the >= 2.13 cross version gets the 1.0.0 version of java8-compat, although everything else still gets 0.8.0. This behavior was last updated in https://github.com/akka/akka/commit/466802c641721447826da39f29c62a7c4bcecc09, and originally added in https://github.com/akka/akka/commit/49322afae0c7c0f96c76d5131207ac55a8f92cd3, but I believe it can be simplified further to always use 1.0.0. 1.0.0 is cross published for 2.11, 2.12, 2.13, and even 3.0, so this shouldn't really be an issue using it across the board.

The main reason for this change is that users that are still on 2.12 are starting to get errors like:

```
[error]         * org.scala-lang.modules:scala-java8-compat_2.12:1.0.0 (early-semver) is selected over 0.8.0
[error]             +- com.github.swagger-akka-http:swagger-akka-http_2.12:2.5.1 (depends on 1.0.0)
[error]             +- com.typesafe.akka:akka-actor_2.12:2.6.16           (depends on 0.8.0)

```

Since much of the ecosystem is bumping to the 1.0.0, but 2.12 of Akka is still pulling in 0.8.0. This will avoid nasty hacks like:

```scala
ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % "always"
```

**NOTE**: There isn't any issue logged with this or anything, but just hit on this today with swagger-akka-http, and thought that this would be a quick fix. If you need an issue created to track this or if this is done for another reason I'm not aware of, just let me know.
