### PR TITLE
review patience config

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ScalaTestWithActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ScalaTestWithActorTestKit.scala
@@ -66,7 +66,9 @@ abstract class ScalaTestWithActorTestKit(testKit: ActorTestKit)
     this(ActorTestKit(ActorTestKitBase.testNameFromCallStack(), config, settings))
 
   /**
-   * `PatienceConfig` from [[akka.actor.testkit.typed.TestKitSettings#DefaultTimeout]]
+   * `PatienceConfig` from [[akka.actor.testkit.typed.TestKitSettings#DefaultTimeout]].
+   * `DefaultTimeout` is dilated with [[akka.actor.testkit.typed.TestKitSettings#TestTimeFactor]],
+   * which means that the patience is also dilated.
    */
   implicit val patience: PatienceConfig =
     PatienceConfig(testKit.testKitSettings.DefaultTimeout.duration, Span(100, org.scalatest.time.Millis))

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/ActorSystemSpec.scala
@@ -7,13 +7,14 @@ package internal
 
 import scala.concurrent.Future
 import scala.concurrent.Promise
-import scala.concurrent.duration._
 import scala.util.control.NonFatal
+
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
 import akka.Done
 import akka.actor.dungeon.Dispatch
 import akka.actor.{ Address, CoordinatedShutdown, InvalidMessageException }
@@ -22,6 +23,9 @@ import akka.actor.testkit.typed.scaladsl.TestInbox
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.scaladsl.Behaviors
 import com.typesafe.config.ConfigFactory
+import org.scalatest.time.Span
+
+import akka.actor.testkit.typed.TestKitSettings
 
 class ActorSystemSpec
     extends AnyWordSpec
@@ -31,7 +35,9 @@ class ActorSystemSpec
     with Eventually
     with LogCapturing {
 
-  override implicit val patienceConfig: PatienceConfig = PatienceConfig(1.second)
+  private val testKitSettings = TestKitSettings(ConfigFactory.load().getConfig("akka.actor.testkit.typed"))
+  override implicit val patienceConfig: PatienceConfig =
+    PatienceConfig(testKitSettings.SingleExpectDefaultTimeout, Span(100, org.scalatest.time.Millis))
   def system[T](behavior: Behavior[T], name: String, props: Props = Props.empty) =
     ActorSystem(behavior, name, ConfigFactory.empty(), props)
   def suite = "adapter"

--- a/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/MultiDcClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/MultiDcClusterShardingSpec.scala
@@ -56,8 +56,10 @@ abstract class MultiDcClusterShardingSpec
   import MultiDcClusterShardingSpecConfig._
   import MultiDcPinger._
 
-  override implicit def patienceConfig: PatienceConfig =
-    PatienceConfig(testKitSettings.DefaultTimeout.duration, 100.millis)
+  override implicit def patienceConfig: PatienceConfig = {
+    import akka.testkit.TestDuration
+    PatienceConfig(testKitSettings.DefaultTimeout.duration.dilated, 100.millis)
+  }
 
   val typeKey = EntityTypeKey[Command]("ping")
   val entityId = "ping-1"

--- a/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/ReplicatedShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/typed/ReplicatedShardingSpec.scala
@@ -118,8 +118,10 @@ abstract class ReplicatedShardingSpec
     with Eventually {
   import ReplicatedShardingSpec._
 
-  implicit val patience: PatienceConfig =
-    PatienceConfig(testKitSettings.DefaultTimeout.duration * 2, Span(500, org.scalatest.time.Millis))
+  implicit val patience: PatienceConfig = {
+    import akka.testkit.TestDuration
+    PatienceConfig(testKitSettings.DefaultTimeout.duration.dilated * 2, Span(500, org.scalatest.time.Millis))
+  }
 
   "Replicated sharding" should {
     "form cluster" in {

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ExternalShardAllocationSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ExternalShardAllocationSpec.scala
@@ -7,6 +7,7 @@ package akka.cluster.sharding
 import scala.concurrent.duration._
 
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.Span
 
 import akka.actor.{ Actor, ActorLogging, Address, Props }
 import akka.cluster.Cluster
@@ -74,7 +75,10 @@ abstract class ExternalShardAllocationSpec
   import ExternalShardAllocationSpec.GiveMeYourHome._
   import ExternalShardAllocationSpecConfig._
 
-  override implicit val patienceConfig: PatienceConfig = PatienceConfig(5.second)
+  override implicit val patienceConfig: PatienceConfig = {
+    import akka.testkit.TestDuration
+    PatienceConfig(testKitSettings.DefaultTimeout.duration.dilated, Span(100, org.scalatest.time.Millis))
+  }
 
   val typeName = "home"
   val initiallyOnForth = "on-forth"

--- a/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/MultiNodeTypedClusterSpec.scala
+++ b/akka-cluster-typed/src/multi-jvm/scala/akka/cluster/typed/MultiNodeTypedClusterSpec.scala
@@ -92,7 +92,8 @@ trait MultiNodeTypedClusterSpec extends Suite with STMultiNodeSpec with WatchedB
   private lazy val spawnActor =
     system.actorOf(PropsAdapter(SpawnProtocol()), "testSpawn").toTyped[SpawnProtocol.Command]
   def spawn[T](behavior: Behavior[T], name: String): ActorRef[T] = {
-    implicit val timeout: Timeout = testKitSettings.DefaultTimeout
+    import akka.testkit.TestDuration
+    implicit val timeout: Timeout = testKitSettings.DefaultTimeout.duration.dilated
     val f: Future[ActorRef[T]] = spawnActor.ask(SpawnProtocol.Spawn(behavior, name, Props.empty, _))
 
     Await.result(f, timeout.duration * 2)

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ActorSystemSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ActorSystemSpec.scala
@@ -8,7 +8,6 @@ import java.nio.charset.StandardCharsets
 
 import scala.concurrent.Future
 import scala.concurrent.Promise
-import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 import com.typesafe.config.ConfigFactory
@@ -23,6 +22,7 @@ import akka.Done
 import akka.actor.CoordinatedShutdown
 import akka.actor.ExtendedActorSystem
 import akka.actor.InvalidMessageException
+import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.TestInbox
 import akka.actor.typed.ActorRef
@@ -68,7 +68,9 @@ class ActorSystemSpec
     with Eventually
     with LogCapturing {
 
-  implicit val patience: PatienceConfig = PatienceConfig(3.seconds, Span(100, org.scalatest.time.Millis))
+  private val testKitSettings = TestKitSettings(ConfigFactory.load().getConfig("akka.actor.testkit.typed"))
+  override implicit val patienceConfig: PatienceConfig =
+    PatienceConfig(testKitSettings.SingleExpectDefaultTimeout, Span(100, org.scalatest.time.Millis))
 
   val config = ConfigFactory.parseString("""
       akka.actor.provider = cluster

--- a/akka-remote/src/test/scala/akka/remote/artery/OutboundIdleShutdownSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/OutboundIdleShutdownSpec.scala
@@ -31,8 +31,10 @@ class OutboundIdleShutdownSpec extends ArteryMultiNodeSpec(s"""
   }
   """) with ImplicitSender with Eventually {
 
-  override implicit val patience: PatienceConfig =
-    PatienceConfig(testKitSettings.DefaultTimeout.duration * 2, Span(200, org.scalatest.time.Millis))
+  override implicit val patience: PatienceConfig = {
+    import akka.testkit.TestDuration
+    PatienceConfig(testKitSettings.DefaultTimeout.duration.dilated * 2, Span(200, org.scalatest.time.Millis))
+  }
 
   private def isArteryTcp: Boolean =
     RARP(system).provider.transport.asInstanceOf[ArteryTransport].settings.Transport == ArterySettings.Tcp

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/QueueSourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/QueueSourceSpec.scala
@@ -27,8 +27,10 @@ class QueueSourceSpec extends StreamSpec {
   val pause = 300.millis
 
   // more frequent checks than defaults from AkkaSpec
-  implicit val testPatience: PatienceConfig =
-    PatienceConfig(testKitSettings.DefaultTimeout.duration, Span(5, org.scalatest.time.Millis))
+  implicit val testPatience: PatienceConfig = {
+    import akka.testkit.TestDuration
+    PatienceConfig(testKitSettings.DefaultTimeout.duration.dilated, Span(5, org.scalatest.time.Millis))
+  }
 
   def assertSuccess(f: Future[QueueOfferResult]): Unit = {
     f.futureValue should ===(QueueOfferResult.Enqueued)

--- a/akka-testkit/src/main/scala/akka/testkit/TestKitExtension.scala
+++ b/akka-testkit/src/main/scala/akka/testkit/TestKitExtension.scala
@@ -22,7 +22,7 @@ class TestKitSettings(val config: Config) extends Extension {
 
   import akka.util.Helpers._
 
-  val TestTimeFactor = config
+  val TestTimeFactor: Double = config
     .getDouble("akka.test.timefactor")
     .requiring(tf => !tf.isInfinite && tf > 0, "akka.test.timefactor must be positive finite double")
   val SingleExpectDefaultTimeout: FiniteDuration = config.getMillisDuration("akka.test.single-expect-default")

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -60,8 +60,6 @@ abstract class AkkaSpec(_system: ActorSystem)
     with TypeCheckedTripleEquals
     with ScalaFutures {
 
-  implicit val patience: PatienceConfig = PatienceConfig(testKitSettings.DefaultTimeout.duration, Span(100, Millis))
-
   def this(config: Config) =
     this(
       ActorSystem(
@@ -73,6 +71,9 @@ abstract class AkkaSpec(_system: ActorSystem)
   def this(configMap: Map[String, _]) = this(AkkaSpec.mapToConfig(configMap))
 
   def this() = this(ActorSystem(TestKitUtils.testNameFromCallStack(classOf[AkkaSpec], "".r), AkkaSpec.testConf))
+
+  implicit val patience: PatienceConfig =
+    PatienceConfig(testKitSettings.SingleExpectDefaultTimeout.dilated, Span(100, Millis))
 
   val log: LoggingAdapter = Logging(system, Logging.simpleName(this))
 

--- a/akka-testkit/src/test/scala/akka/testkit/AkkaSpecSpec.scala
+++ b/akka-testkit/src/test/scala/akka/testkit/AkkaSpecSpec.scala
@@ -6,16 +6,18 @@ package akka.testkit
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-
 import scala.annotation.nowarn
+
 import com.typesafe.config.ConfigFactory
 import language.postfixOps
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import akka.actor._
 import akka.actor.DeadLetter
 import akka.pattern.ask
+import akka.util.Timeout
 
 @nowarn
 class AkkaSpecSpec extends AnyWordSpec with Matchers {
@@ -66,7 +68,7 @@ class AkkaSpecSpec extends AnyWordSpec with Matchers {
 
       try {
         var locker = Seq.empty[DeadLetter]
-        implicit val timeout = TestKitExtension(system).DefaultTimeout
+        implicit val timeout: Timeout = TestKitExtension(system).DefaultTimeout.duration.dilated(system)
         val davyJones = otherSystem.actorOf(Props(new Actor {
           def receive = {
             case m: DeadLetter => locker :+= m


### PR DESCRIPTION
* take it from testkit settings instead of hard coded
* dilate it
* it's still somewhat confusing since we have both
  classic and typed testkits and they dilate the default
  timeout differently, but don't want to change too much

