### PR TITLE
more hardening of MessageAdapterSpec, #30698

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/MessageAdapterSpec.scala
@@ -46,7 +46,7 @@ class MessageAdapterSpec
     deadLetterProbe.fishForMessage(deadLetterProbe.remainingOrDefault, s"looking for DeadLetter $expectedMessage") {
       deadLetter =>
         deadLetter.message match {
-          case AdaptMessage(msg, _) =>
+          case AdaptMessage(msg, _) if msg.getClass == expectedMessage.getClass =>
             msg shouldBe expectedMessage
             FishingOutcomes.complete
           case msg if msg.getClass == expectedMessage.getClass =>


### PR DESCRIPTION
It failed again after previous fix in https://github.com/akka/akka/pull/30702

In the log it's clear that it still get a message "hello" from previous test case:

```
2021-09-24 00:25:32,193 INFO  akka.actor.LocalActorRef akkaDeadLetter - Message [akka.actor.typed.scaladsl.MessageAdapterSpec$Pong$4] wrapped in [akka.actor.typed.internal.AdaptMessage] to Actor[akka://MessageAdapterSpec/user/$f#435493756] was not delivered. [4] dead letters encountered. If this is not an expected behavior then Actor[akka://MessageAdapterSpec/user/$f#435493756] may have terminated unexpectedly. This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' and 'akka.log-dead-letters-during-shutdown'. MDC: {akkaAddress=akka://MessageAdapterSpec, sourceThread=MessageAdapterSpec-akka.actor.default-dispatcher-10, akkaSource=akka://MessageAdapterSpec/user/$f, sourceActorSystem=MessageAdapterSpec, akkaMessageClass=akka.actor.typed.scaladsl.MessageAdapterSpec$Pong$4, akkaTimestamp=00:25:32.193UTC}

Pong(hello) was not equal to Pong(hello-4) (MessageAdapterSpec.scala:50)
```

References #30698
