### PR TITLE
Honor timeout parameter when stopping actors #30715

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/ActorTestKit.scala
@@ -255,7 +255,7 @@ final class ActorTestKit private[akka] (
     try {
       Await.result(internalTestKitGuardian.ask { (x: ActorRef[ActorTestKitGuardian.Ack.type]) =>
         ActorTestKitGuardian.StopActor(ref, x)
-      }, max)
+      }(Timeout(max), scheduler), max)
     } catch {
       case _: TimeoutException =>
         assert(false, s"timeout ($max) during stop() waiting for actor [${ref.path}] to stop")


### PR DESCRIPTION
Fix for #30715
Previously the timeout for the call to `internalTestKitGuardian.ask` was implicitly evaluating to `testKitSettings.DefaultTimeout` so only the lesser of the `max` parameter and the default timeout would apply.
Such a small fix that there doesn't seem to me to be much value in a test case for it, but let me know.