### PR TITLE
Handle null for StatusReply

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/pattern/StatusReplySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/StatusReplySpec.scala
@@ -36,8 +36,8 @@ class StatusReplySpec extends AkkaSpec with ScalaFutures {
     "not throw exception if null" in {
       (null: StatusReply[_]) match {
         case StatusReply.Success(_) => fail()
-        case StatusReply.Error(_) => fail()
-        case _ =>
+        case StatusReply.Error(_)   => fail()
+        case _                      =>
       }
     }
     "pattern match error with text" in {

--- a/akka-actor-tests/src/test/scala/akka/pattern/StatusReplySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/StatusReplySpec.scala
@@ -33,6 +33,13 @@ class StatusReplySpec extends AkkaSpec with ScalaFutures {
         case _               => fail()
       }
     }
+    "not throw exception if null" in {
+      (null: StatusReply[_]) match {
+        case StatusReply.Success(_) => fail()
+        case StatusReply.Error(_) => fail()
+        case _ =>
+      }
+    }
     "pattern match error with text" in {
       StatusReply.Error("boho!") match {
         case StatusReply.Error(_) =>

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
@@ -246,9 +246,9 @@ import scala.util.Success
       createRequest,
       (ok: StatusReply[Res], failure: Throwable) =>
         ok match {
-          case null                            => applyToResponse(null.asInstanceOf[Res], failure)
           case StatusReply.Success(value: Res) => applyToResponse(value, null)
           case StatusReply.Error(why)          => applyToResponse(null.asInstanceOf[Res], why)
+          case null                            => applyToResponse(null.asInstanceOf[Res], failure)
           case _                               => throw new RuntimeException() // won't happen, compiler exhaustiveness check pleaser
         })
   }

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/ActorContextImpl.scala
@@ -246,9 +246,9 @@ import scala.util.Success
       createRequest,
       (ok: StatusReply[Res], failure: Throwable) =>
         ok match {
+          case null                            => applyToResponse(null.asInstanceOf[Res], failure)
           case StatusReply.Success(value: Res) => applyToResponse(value, null)
           case StatusReply.Error(why)          => applyToResponse(null.asInstanceOf[Res], why)
-          case null                            => applyToResponse(null.asInstanceOf[Res], failure)
           case _                               => throw new RuntimeException() // won't happen, compiler exhaustiveness check pleaser
         })
   }

--- a/akka-actor/src/main/scala/akka/pattern/StatusReply.scala
+++ b/akka-actor/src/main/scala/akka/pattern/StatusReply.scala
@@ -118,7 +118,7 @@ object StatusReply {
      */
     def apply[T](value: T): StatusReply[T] = new StatusReply(ScalaSuccess(value))
     def unapply(status: StatusReply[Any]): Option[Any] =
-      if (status.isSuccess) Some(status.getValue)
+      if (status != null && status.isSuccess) Some(status.getValue)
       else None
   }
 
@@ -150,7 +150,7 @@ object StatusReply {
      */
     def apply[T](exception: Throwable): StatusReply[T] = new StatusReply(ScalaFailure(exception))
     def unapply(status: StatusReply[_]): Option[Throwable] =
-      if (status.isError) Some(status.getError)
+      if (status != null && status.isError) Some(status.getError)
       else None
   }
 


### PR DESCRIPTION
Given an actor that is performing a `getContext().askWithStatus(...)` - when a response is not received within the timeout, it results in 

> java.lang.NullPointerException: null
> 	at akka.pattern.StatusReply$Success$.unapply(StatusReply.scala:121)
> 	at akka.actor.typed.internal.ActorContextImpl.$anonfun$askWithStatus$2(ActorContextImpl.scala:248)
> 	at akka.actor.typed.internal.ActorContextImpl.$anonfun$pipeToSelf$3(ActorContextImpl.scala:266)
> 	at akka.actor.typed.internal.AdaptMessage.adapt(InternalMessage.scala:29)
> 	at akka.actor.typed.internal.adapter.ActorAdapter.$anonfun$aroundReceive$1(ActorAdapter.scala:95)
> 	at akka.actor.typed.internal.adapter.ActorAdapter.withSafelyAdapted(ActorAdapter.scala:191)
> 	at akka.actor.typed.internal.adapter.ActorAdapter.aroundReceive(ActorAdapter.scala:95)
> 	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:579)
> 	at akka.actor.ActorCell.invoke(ActorCell.scala:547)
> 	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)
> 	at akka.dispatch.Mailbox.run(Mailbox.scala:231)
> 	at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
> 	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
> 	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
> 	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
> 	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:175)

Note that this is only happening in Scala 2.12, as null is automatically handled in 2.13