### PR TITLE
Only compile with Scala 3 in PR validation

### DIFF
--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -23,7 +23,7 @@ jobs:
           - akka-bench-jmh/test
           - akka-cluster/Test/compile akka-cluster-tools/test akka-cluster-typed/test akka-distributed-data/test akka-cluster-metrics/Test/compile akka-cluster-sharding/Test/compile akka-cluster-sharding-typed/Test/compile
           - akka-discovery/test akka-coordination/test
-          - akka-persistence/test akka-persistence-typed/test akka-persistence-shared/test akka-persistence-query/test
+          - akka-persistence/test akka-persistence-shared/test akka-persistence-query/test
           - akka-pki/test akka-slf4j/test
           - akka-serialization-jackson/test
           - akka-stream/test akka-stream-testkit/test akka-stream-tests/test

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -1,7 +1,6 @@
-name: Build Akka with Scala 3
+name: Build and test Akka with Scala 3
 
 on:
-  pull_request:
   schedule:
     - cron: "0 0 * * *"
 
@@ -22,13 +21,11 @@ jobs:
           - akka-testkit/test akka-actor-tests/test
           - akka-actor-testkit-typed/test akka-actor-typed-tests/test
           - akka-bench-jmh/test
-          - akka-cluster/Test/compile akka-cluster-tools/test akka-cluster-typed/test akka-distributed-data/test akka-cluster-metrics/Test/compile akka-cluster-sharding/Test/compile
-          - akka-coordination/test
-          - akka-discovery/test
-          - akka-persistence/test akka-persistence-shared/test akka-persistence-query/test
-          - akka-pki/test
+          - akka-cluster/Test/compile akka-cluster-tools/test akka-cluster-typed/test akka-distributed-data/test akka-cluster-metrics/Test/compile akka-cluster-sharding/Test/compile akka-cluster-sharding-typed/Test/compile
+          - akka-discovery/test akka-coordination/test
+          - akka-persistence/test akka-persistence-typed/test akka-persistence-shared/test akka-persistence-query/test
+          - akka-pki/test akka-slf4j/test
           - akka-serialization-jackson/test
-          - akka-slf4j/test
           - akka-stream/test akka-stream-testkit/test akka-stream-tests/test
           - akka-stream-tests-tck/test
           - akka-remote/test akka-remote-tests/test akka-protobuf/test akka-protobuf-v3/test
@@ -56,7 +53,7 @@ jobs:
           -Dakka.test.timefactor=2 \
           -Dakka.actor.testkit.typed.timefactor=2 \
           -Dakka.test.multi-in-test=false \
-          -Dakka.test.tags.exclude=performance,timing,long-running,gh-exclude \
+          -Dakka.test.tags.exclude=gh-exclude \
           -Dmultinode.XX:MetaspaceSize=128M \
           -Dmultinode.Xms256M \
           -Dmultinode.Xmx256M \

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -21,7 +21,7 @@ jobs:
           - akka-testkit/test akka-actor-tests/test
           - akka-actor-testkit-typed/test akka-actor-typed-tests/test
           - akka-bench-jmh/test
-          - akka-cluster/Test/compile akka-cluster-tools/test akka-cluster-typed/test akka-distributed-data/test akka-cluster-metrics/Test/compile akka-cluster-sharding/Test/compile akka-cluster-sharding-typed/Test/compile
+          - akka-cluster/Test/compile akka-cluster-tools/test akka-cluster-typed/test akka-distributed-data/test akka-cluster-metrics/Test/compile akka-cluster-sharding/Test/compile
           - akka-discovery/test akka-coordination/test
           - akka-persistence/test akka-persistence-shared/test akka-persistence-query/test
           - akka-pki/test akka-slf4j/test

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -21,7 +21,7 @@ jobs:
           - akka-bench-jmh/Test/compile
           - akka-cluster/Test/compile akka-cluster-tools/Test/compile akka-cluster-typed/Test/compile akka-distributed-data/Test/compile akka-cluster-metrics/Test/compile akka-cluster-sharding/Test/compile akka-cluster-sharding-typed/Test/compile
           - akka-discovery/Test/compile akka-coordination/Test/compile
-          - akka-persistence/Test/compile akka-persistence-typed/Test/compile akka-persistence-shared/Test/compile akka-persistence-query/Test/compile
+          - akka-persistence/Test/compile akka-persistence-shared/Test/compile akka-persistence-query/Test/compile
           - akka-pki/Test/compile akka-slf4j/Test/compile
           - akka-serialization-jackson/Test/compile
           - akka-stream/Test/compile akka-stream-testkit/Test/compile akka-stream-tests/Test/compile

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -1,0 +1,49 @@
+name: Compile Akka with Scala 3
+
+on:
+  pull_request:
+
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ci-scala3-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile:
+    name: Compile
+    runs-on: ubuntu-20.04
+    if: github.repository == 'akka/akka'
+    strategy:
+      matrix:
+        command:
+          - akka-testkit/Test/compile akka-actor-tests/Test/compile
+          - akka-actor-testkit-typed/Test/compile akka-actor-typed-tests/Test/compile
+          - akka-bench-jmh/Test/compile
+          - akka-cluster/Test/compile akka-cluster-tools/Test/compile akka-cluster-typed/Test/compile akka-distributed-data/Test/compile akka-cluster-metrics/Test/compile akka-cluster-sharding/Test/compile akka-cluster-sharding-typed/Test/compile
+          - akka-discovery/Test/compile akka-coordination/Test/compile
+          - akka-persistence/Test/compile akka-persistence-typed/Test/compile akka-persistence-shared/Test/compile akka-persistence-query/Test/compile
+          - akka-pki/Test/compile akka-slf4j/Test/compile
+          - akka-serialization-jackson/Test/compile
+          - akka-stream/Test/compile akka-stream-testkit/Test/compile akka-stream-tests/Test/compile
+          - akka-stream-tests-tck/Test/compile
+          - akka-remote/Test/compile akka-remote-tests/Test/compile akka-protobuf/Test/compile akka-protobuf-v3/Test/compile
+      fail-fast: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6.2
+
+      - name: Compile on Scala 3
+        run: |
+          sbt -jvm-opts .jvmopts-ci \
+          -Dakka.build.scalaVersion=3.0 \
+          ${{ matrix.command }}

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -19,7 +19,7 @@ jobs:
           - akka-testkit/Test/compile akka-actor-tests/Test/compile
           - akka-actor-testkit-typed/Test/compile akka-actor-typed-tests/Test/compile
           - akka-bench-jmh/Test/compile
-          - akka-cluster/Test/compile akka-cluster-tools/Test/compile akka-cluster-typed/Test/compile akka-distributed-data/Test/compile akka-cluster-metrics/Test/compile akka-cluster-sharding/Test/compile akka-cluster-sharding-typed/Test/compile
+          - akka-cluster/Test/compile akka-cluster-tools/Test/compile akka-cluster-typed/Test/compile akka-distributed-data/Test/compile akka-cluster-metrics/Test/compile akka-cluster-sharding/Test/compile
           - akka-discovery/Test/compile akka-coordination/Test/compile
           - akka-persistence/Test/compile akka-persistence-shared/Test/compile akka-persistence-query/Test/compile
           - akka-pki/Test/compile akka-slf4j/Test/compile


### PR DESCRIPTION
* seems to be much more test failures in the Scala 3 job
* let's not block PR validation by that, we still have full nightlies
  with Scala 3

