### PR TITLE
Remove final modifier from private methods

### DIFF
--- a/akka-actor/src/main/java/akka/dispatch/AbstractBoundedNodeQueue.java
+++ b/akka-actor/src/main/java/akka/dispatch/AbstractBoundedNodeQueue.java
@@ -35,29 +35,29 @@ public abstract class AbstractBoundedNodeQueue<T> {
         setEnq(n);
     }
 
-    private final void setEnq(Node<T> n) {
+    private void setEnq(Node<T> n) {
         Unsafe.instance.putObjectVolatile(this, enqOffset, n);
     }
 
     @SuppressWarnings("unchecked")
-    private final Node<T> getEnq() {
+    private Node<T> getEnq() {
         return (Node<T>)Unsafe.instance.getObjectVolatile(this, enqOffset);
     }
 
-    private final boolean casEnq(Node<T> old, Node<T> nju) {
+    private boolean casEnq(Node<T> old, Node<T> nju) {
         return Unsafe.instance.compareAndSwapObject(this, enqOffset, old, nju);
     }
 
-    private final void setDeq(Node<T> n) {
+    private void setDeq(Node<T> n) {
         Unsafe.instance.putObjectVolatile(this, deqOffset, n);
     }
 
     @SuppressWarnings("unchecked")
-    private final Node<T> getDeq() {
+    private Node<T> getDeq() {
         return (Node<T>)Unsafe.instance.getObjectVolatile(this, deqOffset);
     }
 
-    private final boolean casDeq(Node<T> old, Node<T> nju) {
+    private boolean casDeq(Node<T> old, Node<T> nju) {
         return Unsafe.instance.compareAndSwapObject(this, deqOffset, old, nju);
     }
 

--- a/akka-docs/src/test/java/jdocs/io/japi/SimpleEchoHandler.java
+++ b/akka-docs/src/test/java/jdocs/io/japi/SimpleEchoHandler.java
@@ -58,7 +58,7 @@ public class SimpleEchoHandler extends AbstractActor {
         .build();
   }
 
-  private final Receive buffering() {
+  private Receive buffering() {
     return receiveBuilder()
         .match(
             Received.class,
@@ -91,7 +91,7 @@ public class SimpleEchoHandler extends AbstractActor {
 
   private long transferred;
   private long stored = 0;
-  private Queue<ByteString> storage = new LinkedList<ByteString>();
+  private Queue<ByteString> storage = new LinkedList<>();
 
   private boolean suspended = false;
   private boolean closing = false;


### PR DESCRIPTION
`Final` modifier is unnecessary for private methods. It can be removed

Kind regards