### PR TITLE
Value not def for underlying state store

### DIFF
--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/query/PersistenceTestKitReadJournalProvider.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/query/PersistenceTestKitReadJournalProvider.scala
@@ -9,9 +9,9 @@ import com.typesafe.config.Config
 
 class PersistenceTestKitReadJournalProvider(system: ExtendedActorSystem, config: Config, configPath: String)
     extends ReadJournalProvider {
-  private val _scaladslReadJournal = 
+  private val _scaladslReadJournal =
     new scaladsl.PersistenceTestKitReadJournal(system, config, configPath)
-  override def scaladslReadJournal(): scaladsl.PersistenceTestKitReadJournal = 
+  override def scaladslReadJournal(): scaladsl.PersistenceTestKitReadJournal =
     _scaladslReadJournal
 
   override def javadslReadJournal(): javadsl.PersistenceTestKitReadJournal =

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/query/PersistenceTestKitReadJournalProvider.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/query/PersistenceTestKitReadJournalProvider.scala
@@ -9,10 +9,11 @@ import com.typesafe.config.Config
 
 class PersistenceTestKitReadJournalProvider(system: ExtendedActorSystem, config: Config, configPath: String)
     extends ReadJournalProvider {
-
-  override def scaladslReadJournal(): scaladsl.PersistenceTestKitReadJournal =
+  private val _scaladslReadJournal = 
     new scaladsl.PersistenceTestKitReadJournal(system, config, configPath)
+  override def scaladslReadJournal(): scaladsl.PersistenceTestKitReadJournal = 
+    _scaladslReadJournal
 
   override def javadslReadJournal(): javadsl.PersistenceTestKitReadJournal =
-    new javadsl.PersistenceTestKitReadJournal(scaladslReadJournal())
+    new javadsl.PersistenceTestKitReadJournal(_scaladslReadJournal)
 }

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/PersistenceTestKitDurableStateStoreProvider.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/PersistenceTestKitDurableStateStoreProvider.scala
@@ -14,7 +14,7 @@ import akka.persistence.testkit.state.javadsl.{
 }
 
 class PersistenceTestKitDurableStateStoreProvider(system: ExtendedActorSystem) extends DurableStateStoreProvider {
-  private def _scaladslDurableStateStore[T]() = new PersistenceTestKitDurableStateStore[T](system)
+  private val _scaladslDurableStateStore[T]() = new PersistenceTestKitDurableStateStore[T](system)
   override def scaladslDurableStateStore(): DurableStateStore[Any] = _scaladslDurableStateStore[Any]()
 
   override def javadslDurableStateStore(): JDurableStateStore[AnyRef] =

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/PersistenceTestKitDurableStateStoreProvider.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/PersistenceTestKitDurableStateStoreProvider.scala
@@ -14,7 +14,7 @@ import akka.persistence.testkit.state.javadsl.{
 }
 
 class PersistenceTestKitDurableStateStoreProvider(system: ExtendedActorSystem) extends DurableStateStoreProvider {
-  private val _scaladslDurableStateStore[T]() = new PersistenceTestKitDurableStateStore[T](system)
+  private val _scaladslDurableStateStore[T] = new PersistenceTestKitDurableStateStore[T](system)
   override def scaladslDurableStateStore(): DurableStateStore[Any] = _scaladslDurableStateStore[Any]()
 
   override def javadslDurableStateStore(): JDurableStateStore[AnyRef] =

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/PersistenceTestKitDurableStateStoreProvider.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/PersistenceTestKitDurableStateStoreProvider.scala
@@ -14,7 +14,7 @@ import akka.persistence.testkit.state.javadsl.{
 }
 
 class PersistenceTestKitDurableStateStoreProvider(system: ExtendedActorSystem) extends DurableStateStoreProvider {
-  private val _scaladslDurableStateStore[T] = new PersistenceTestKitDurableStateStore[T](system)
+  private val _scaladslDurableStateStore = new PersistenceTestKitDurableStateStore[T](system)
   override def scaladslDurableStateStore(): DurableStateStore[Any] = _scaladslDurableStateStore[Any]()
 
   override def javadslDurableStateStore(): JDurableStateStore[AnyRef] =

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/PersistenceTestKitDurableStateStoreProvider.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/PersistenceTestKitDurableStateStoreProvider.scala
@@ -14,9 +14,10 @@ import akka.persistence.testkit.state.javadsl.{
 }
 
 class PersistenceTestKitDurableStateStoreProvider(system: ExtendedActorSystem) extends DurableStateStoreProvider {
-  private val _scaladslDurableStateStore = new PersistenceTestKitDurableStateStore(system)
-  override def scaladslDurableStateStore(): DurableStateStore[Any] = _scaladslDurableStateStore[Any]()
+  private val _scaladslDurableStateStore = new PersistenceTestKitDurableStateStore[Any](system)
+  override def scaladslDurableStateStore(): DurableStateStore[Any] = _scaladslDurableStateStore
 
   override def javadslDurableStateStore(): JDurableStateStore[AnyRef] =
-    new JPersistenceTestKitDurableStateStore[AnyRef](_scaladslDurableStateStore())
+    new JPersistenceTestKitDurableStateStore[AnyRef](
+      _scaladslDurableStateStore.asInstanceOf[PersistenceTestKitDurableStateStore[AnyRef]])
 }

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/PersistenceTestKitDurableStateStoreProvider.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/PersistenceTestKitDurableStateStoreProvider.scala
@@ -14,7 +14,7 @@ import akka.persistence.testkit.state.javadsl.{
 }
 
 class PersistenceTestKitDurableStateStoreProvider(system: ExtendedActorSystem) extends DurableStateStoreProvider {
-  private val _scaladslDurableStateStore = new PersistenceTestKitDurableStateStore[T](system)
+  private val _scaladslDurableStateStore = new PersistenceTestKitDurableStateStore(system)
   override def scaladslDurableStateStore(): DurableStateStore[Any] = _scaladslDurableStateStore[Any]()
 
   override def javadslDurableStateStore(): JDurableStateStore[AnyRef] =


### PR DESCRIPTION
If you call the java wrapper API then you get a different state store than the one that is actually used by the primary scala implementation. This yields empty results for the java
