### PR TITLE
Add support for wildcard suffix in WildcardIndex #30413

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/WildcardIndexSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/WildcardIndexSpec.scala
@@ -61,7 +61,7 @@ class WildcardIndexSpec extends AnyWordSpec with Matchers {
     }
 
     "fail when a double wildcard is used as a suffix" in {
-      an [IllegalArgumentException] should be thrownBy emptyIndex.insert(Array("a**"), 1)
+      an[IllegalArgumentException] should be thrownBy emptyIndex.insert(Array("a**"), 1)
     }
 
     "never find anything when emptyIndex" in {

--- a/akka-actor-tests/src/test/scala/akka/util/WildcardIndexSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/WildcardIndexSpec.scala
@@ -60,6 +60,10 @@ class WildcardIndexSpec extends AnyWordSpec with Matchers {
       tree2.find(Array("b", "cc", "x")) shouldBe None
     }
 
+    "fail when a double wildcard is used as a suffix" in {
+      an [IllegalArgumentException] should be thrownBy emptyIndex.insert(Array("a**"), 1)
+    }
+
     "never find anything when emptyIndex" in {
       emptyIndex.find(Array("a")) shouldBe None
       emptyIndex.find(Array("a", "b")) shouldBe None

--- a/akka-actor-tests/src/test/scala/akka/util/WildcardIndexSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/WildcardIndexSpec.scala
@@ -39,6 +39,27 @@ class WildcardIndexSpec extends AnyWordSpec with Matchers {
       tree2.find(Array("a", "x", "y")) shouldBe None
     }
 
+    "match all elements in the subArray when it contains a wildcard suffix" in {
+      val tree1 = emptyIndex.insert(Array("a*"), 1).insert(Array("b", "c*"), 2)
+      tree1.find(Array("z")) shouldBe None
+      tree1.find(Array("a")).get shouldBe 1
+      tree1.find(Array("aa")).get shouldBe 1
+      tree1.find(Array("aa", "b")) shouldBe None
+      tree1.find(Array("b", "c")).get shouldBe 2
+      tree1.find(Array("b", "cc")).get shouldBe 2
+      tree1.find(Array("b", "x")) shouldBe None
+
+      val tree2 = emptyIndex.insert(Array("a", "b*"), 1).insert(Array("b", "c*", "d"), 2)
+      tree2.find(Array("z")) shouldBe None
+      tree2.find(Array("a", "b")).get shouldBe 1
+      tree2.find(Array("a", "bb")).get shouldBe 1
+      tree2.find(Array("a", "c")) shouldBe None
+      tree2.find(Array("b", "c", "d")).get shouldBe 2
+      tree2.find(Array("b", "cc", "d")).get shouldBe 2
+      tree2.find(Array("b", "c", "x")) shouldBe None
+      tree2.find(Array("b", "cc", "x")) shouldBe None
+    }
+
     "never find anything when emptyIndex" in {
       emptyIndex.find(Array("a")) shouldBe None
       emptyIndex.find(Array("a", "b")) shouldBe None

--- a/akka-actor/src/main/mima-filters/2.6.16.backwards.excludes/30750-wildcard-suffix-in-wildcardindex.excludes
+++ b/akka-actor/src/main/mima-filters/2.6.16.backwards.excludes/30750-wildcard-suffix-in-wildcardindex.excludes
@@ -1,0 +1,7 @@
+# internal actor class
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.util.WildcardTree.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.util.WildcardTree.unapply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.util.WildcardTree.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.util.WildcardTree.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.util.WildcardTree.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.util.WildcardTree.this")

--- a/akka-actor/src/main/scala/akka/util/WildcardIndex.scala
+++ b/akka-actor/src/main/scala/akka/util/WildcardIndex.scala
@@ -54,7 +54,10 @@ private[akka] final case class WildcardTree[T](
       copy(data = Some(d))
     } else {
       val e = elems.next()
-      if (e != "*" && e != "**" && e.endsWith("*"))
+      if (e != "**" && e.endsWith("**"))
+        throw new IllegalArgumentException(
+          "double wildcard can't be used as a suffix (e.g. /user/actor**), only as a full subPath element (e.g. /user/actor/**)")
+      else if (e != "*" && e != "**" && e.endsWith("*"))
         copy(
           wildcardSuffixChildren = wildcardSuffixChildren
             .updated(e.stripSuffix("*"), wildcardSuffixChildren.getOrElse(e, WildcardTree[T]()).insert(elems, d)))

--- a/akka-actor/src/main/scala/akka/util/WildcardIndex.scala
+++ b/akka-actor/src/main/scala/akka/util/WildcardIndex.scala
@@ -44,7 +44,8 @@ private[akka] object WildcardTree {
 
 private[akka] final case class WildcardTree[T](
     data: Option[T] = None,
-    children: Map[String, WildcardTree[T]] = HashMap[String, WildcardTree[T]]()) {
+    children: Map[String, WildcardTree[T]] = HashMap[String, WildcardTree[T]](),
+    wildcardSuffixChildren: Map[String, WildcardTree[T]] = HashMap[String, WildcardTree[T]]()) {
 
   def isEmpty: Boolean = data.isEmpty && children.isEmpty
 
@@ -53,18 +54,31 @@ private[akka] final case class WildcardTree[T](
       copy(data = Some(d))
     } else {
       val e = elems.next()
-      copy(children = children.updated(e, children.getOrElse(e, WildcardTree[T]()).insert(elems, d)))
+      if (e != "*" && e != "**" && e.endsWith("*"))
+        copy(
+          wildcardSuffixChildren = wildcardSuffixChildren
+            .updated(e.stripSuffix("*"), wildcardSuffixChildren.getOrElse(e, WildcardTree[T]()).insert(elems, d)))
+      else
+        copy(children = children.updated(e, children.getOrElse(e, WildcardTree[T]()).insert(elems, d)))
     }
 
   @tailrec def findWithSingleWildcard(elems: Iterator[String]): WildcardTree[T] =
     if (!elems.hasNext) this
     else {
-      children.get(elems.next()) match {
+      val nextElement = elems.next()
+      children.get(nextElement) match {
         case Some(branch) => branch.findWithSingleWildcard(elems)
         case None =>
           children.get("*") match {
             case Some(branch) => branch.findWithSingleWildcard(elems)
-            case None         => WildcardTree[T]()
+            case None =>
+              val maybeWildcardSuffixMatchingBranch = wildcardSuffixChildren.collectFirst {
+                case (key, branch) if nextElement.startsWith(key) => branch
+              }
+              maybeWildcardSuffixMatchingBranch match {
+                case Some(branch) => branch.findWithSingleWildcard(elems)
+                case None         => WildcardTree[T]()
+              }
           }
       }
     }

--- a/akka-docs/src/main/paradox/remoting-artery.md
+++ b/akka-docs/src/main/paradox/remoting-artery.md
@@ -681,6 +681,7 @@ akka.remote.artery.large-message-destinations = [
    "/user/largeMessagesGroup/*",
    "/user/anotherGroup/*/largeMesssages",
    "/user/thirdGroup/**",
+   "/temp/session-ask-actor*"
 ]
 ```
 
@@ -693,6 +694,7 @@ This means that all messages sent to the following actors will pass through the 
  * `/user/anotherGroup/actor2/largeMessages`
  * `/user/thirdGroup/actor3/`
  * `/user/thirdGroup/actor4/actor5`
+ * `/temp/session-ask-actor$abc`
 
 Messages destined for actors not matching any of these patterns are sent using the default channel as before.
 


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Resolves #30413

Please consider this a draft. I'd like to get feedback on the implementation especially around the points @johanandren mentioned in https://github.com/akka/akka/issues/30413#issuecomment-934369333 . Once that's all figured out I'd also update the documentation.

A few things to note:

As far as I can see the WildCardIndex is used in three places:
- [`largeMessageDestinations: WildcardIndex[NotUsed]`](https://github.com/akka/akka/blob/main/akka-remote/src/main/scala/akka/remote/artery/Association.scala#L140)
- [`priorityMessageDestinations: WildcardIndex[NotUsed]`](https://github.com/akka/akka/blob/main/akka-remote/src/main/scala/akka/remote/artery/Association.scala#L141)
- [`private val deployments = new AtomicReference(WildcardIndex[Deploy]())`](https://github.com/akka/akka/blob/main/akka-actor/src/main/scala/akka/actor/Deployer.scala#L220)

There shouldn't be any performance implications when there are no wildcard suffixes (only an additional find operation on an empty Map)

I've added a test case to the `LargeMessagesSpec`. It feels like it doesn't quite belong there but as it verifies the original issue it might be still worth having it. Additionally I've used the [reproducing test case from the original issue](https://github.com/an-tex/akka-samples/blob/2.6/akka-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/LargeMessageSpec.scala) to manually verify this fix in a more end-2-end scenario.

The bincomp issues around the [WildcardTree](https://github.com/akka/akka/blob/main/akka-actor/src/main/scala/akka/util/WildcardIndex.scala#L45) shouldn't be an issue as the `WildcardTree` is only used within [WildcardIndex](https://github.com/akka/akka/blob/main/akka-actor/src/main/scala/akka/util/WildcardIndex.scala#L10) which signatures haven't changed