### PR TITLE
fix: AsyncDnsResolverIntegrationSpec failing with timeout from config

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/io/dns/AsyncDnsResolverIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/AsyncDnsResolverIntegrationSpec.scala
@@ -42,7 +42,9 @@ object AsyncDnsResolverIntegrationSpec {
   """)
 }
 
-class AsyncDnsResolverIntegrationSpec extends DockerBindDnsService(AsyncDnsResolverIntegrationSpec.conf) with WithLogCapturing {
+class AsyncDnsResolverIntegrationSpec
+    extends DockerBindDnsService(AsyncDnsResolverIntegrationSpec.conf)
+    with WithLogCapturing {
   import AsyncDnsResolverIntegrationSpec._
 
   override implicit val patience: PatienceConfig =
@@ -205,4 +207,3 @@ class AsyncDnsResolverIntegrationSpec extends DockerBindDnsService(AsyncDnsResol
 
   }
 }
-

--- a/akka-actor-tests/src/test/scala/akka/io/dns/AsyncDnsResolverIntegrationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/io/dns/AsyncDnsResolverIntegrationSpec.scala
@@ -21,27 +21,34 @@ import akka.testkit.SocketUtil.Both
 import akka.testkit.WithLogCapturing
 import akka.util.Timeout
 
-/*
-These tests rely on a DNS server with 2 zones configured, foo.test and bar.example.
-
-The configuration to start a bind DNS server in Docker with this configuration
-is included, and the test will automatically start this container when the
-test starts and tear it down when it finishes.
+/**
+ * These tests rely on a DNS server with 2 zones configured, foo.test and bar.example.
+ *
+ * The configuration to start a bind DNS server in Docker with this configuration
+ * is included, and the test will automatically start this container when the
+ * test starts and tear it down when it finishes.
  */
-class AsyncDnsResolverIntegrationSpec extends DockerBindDnsService(ConfigFactory.parseString(s"""
+object AsyncDnsResolverIntegrationSpec {
+  lazy val dockerDnsServerPort: Int = SocketUtil.temporaryLocalPort(Both)
+  implicit val defaultTimeout: Timeout = Timeout(10.seconds)
+  def conf = ConfigFactory.parseString(s"""
     akka.loglevel = DEBUG
     akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
     akka.io.dns.resolver = async-dns
-    akka.io.dns.async-dns.nameservers = ["localhost:${AsyncDnsResolverIntegrationSpec.dockerDnsServerPort}"]
+    akka.io.dns.async-dns.nameservers = ["localhost:${dockerDnsServerPort}"]
     akka.io.dns.async-dns.search-domains = ["foo.test", "test"]
     akka.io.dns.async-dns.ndots = 2
-  """)) with WithLogCapturing {
+    akka.io.dns.async-dns.resolve-timeout = ${defaultTimeout.duration.toSeconds}s
+  """)
+}
 
-  implicit val timeout: Timeout = Timeout(10.seconds)
+class AsyncDnsResolverIntegrationSpec extends DockerBindDnsService(AsyncDnsResolverIntegrationSpec.conf) with WithLogCapturing {
+  import AsyncDnsResolverIntegrationSpec._
+
   override implicit val patience: PatienceConfig =
-    PatienceConfig(timeout.duration + 1.second, Span(100, Millis))
+    PatienceConfig(defaultTimeout.duration + 1.second, Span(100, Millis))
 
-  val hostPort = AsyncDnsResolverIntegrationSpec.dockerDnsServerPort
+  override val hostPort = dockerDnsServerPort
 
   "Resolver" must {
     if (!dockerAvailable()) {
@@ -199,6 +206,3 @@ class AsyncDnsResolverIntegrationSpec extends DockerBindDnsService(ConfigFactory
   }
 }
 
-object AsyncDnsResolverIntegrationSpec {
-  lazy val dockerDnsServerPort: Int = SocketUtil.temporaryLocalPort(Both)
-}


### PR DESCRIPTION
Refs #27839

Code timeouts were fixed in #30710 but the timeout here is the default dns lookup failure of 5s from config, use the overriden timeout for that as well.