### PR TITLE
Harden LocalPubSubSpec, #30749

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/pubsub/LocalPubSubSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/pubsub/LocalPubSubSpec.scala
@@ -8,7 +8,6 @@ import scala.concurrent.duration._
 
 import org.scalatest.wordspec.AnyWordSpecLike
 
-import akka.testkit.GHExcludeTest
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.typed.internal.pubsub.TopicImpl
@@ -17,9 +16,8 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
 
   "A pub-sub topic running locally" must {
 
-    // Excluded in GH Actions: https://github.com/akka/akka/issues/30466
-    "publish to all local subscriber actors of a topic" taggedAs GHExcludeTest in {
-      val fruitTopic = testKit.spawn(Topic[String]("fruit"))
+    "publish to all local subscriber actors of a topic" in {
+      val fruitTopic = testKit.spawn(Topic[String]("fruit1"))
 
       try {
         val probe1 = testKit.createTestProbe[String]()
@@ -50,8 +48,9 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
     }
 
     "publish to all subscriber actors across several instances of the same topic" in {
-      val fruitTopic1 = testKit.spawn(Topic[String]("fruit"))
-      val fruitTopic2 = testKit.spawn(Topic[String]("fruit"))
+      // using different topic name than in the previous test to avoid interference
+      val fruitTopic1 = testKit.spawn(Topic[String]("fruit2"))
+      val fruitTopic2 = testKit.spawn(Topic[String]("fruit2"))
 
       try {
         val probe1 = testKit.createTestProbe[String]()
@@ -74,10 +73,10 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
           statsProbe.expectMessageType[TopicImpl.TopicStats].topicInstanceCount should ===(1)
         }
 
-        fruitTopic1 ! Topic.Publish("banana")
-        probe1.expectMessage("banana")
-        probe2.expectMessage("banana")
-        probe3.expectMessage("banana")
+        fruitTopic1 ! Topic.Publish("apple")
+        probe1.expectMessage("apple")
+        probe2.expectMessage("apple")
+        probe3.expectMessage("apple")
 
       } finally {
         testKit.stop(fruitTopic1)
@@ -87,7 +86,7 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
 
     "doesn't publish across topics unsubscribe" in {
       val fruitTopic =
-        testKit.spawn(Topic[String]("fruit"))
+        testKit.spawn(Topic[String]("fruit3"))
 
       val veggieTopic =
         testKit.spawn(Topic[String]("veggies"))
@@ -118,7 +117,7 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
     }
 
     "doesn't publish after unsubscribe" in {
-      val fruitTopic = testKit.spawn(Topic[String]("fruit"))
+      val fruitTopic = testKit.spawn(Topic[String]("fruit4"))
 
       try {
         val probe1 = testKit.createTestProbe[String]()
@@ -137,7 +136,7 @@ class LocalPubSubSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike wit
           statsProbe.expectMessageType[TopicImpl.TopicStats].localSubscriberCount should ===(0)
         }
 
-        fruitTopic ! Topic.Publish("banana")
+        fruitTopic ! Topic.Publish("orange")
         probe1.expectNoMessage(200.millis)
 
       } finally {


### PR DESCRIPTION
* from the logs we can see that an ActorRef from previous test is still active
* probably counted in the TopicStats

References #30749
