### PR TITLE
Harden ClusterShardingSpec, #30667

### DIFF
--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -267,27 +267,27 @@ class ClusterShardingSpec
 
     "EntityRef - ask" in {
       val bobRef = sharding.entityRefFor(typeKeyWithEnvelopes, "bob")
-      val charlieRef = sharding.entityRefFor(typeKeyWithEnvelopes, "charlie")
+      val aliceRef = sharding.entityRefFor(typeKeyWithEnvelopes, "alice")
 
-      val reply1 = bobRef ? WhoAreYou // TODO document that WhoAreYou(_) would not work
+      val reply1 = bobRef ? WhoAreYou
       val response = reply1.futureValue
       response should startWith("I'm bob")
       // typekey and entity id encoded in promise ref path
       response should include(s"${typeKeyWithEnvelopes.name}-bob")
 
-      val reply2 = charlieRef.ask(WhoAreYou)
-      reply2.futureValue should startWith("I'm charlie")
+      val reply2 = aliceRef.ask(WhoAreYou)
+      reply2.futureValue should startWith("I'm alice")
 
       bobRef ! StopPlz()
     }
 
     "EntityRef - ActorContext.ask" in {
-      val aliceRef = sharding.entityRefFor(typeKeyWithEnvelopes, "alice")
+      val peterRef = sharding.entityRefFor(typeKeyWithEnvelopes, "peter")
 
       val p = TestProbe[TheReply]()
 
       spawn(Behaviors.setup[TheReply] { ctx =>
-        ctx.ask(aliceRef, WhoAreYou) {
+        ctx.ask(peterRef, WhoAreYou) {
           case Success(name) => TheReply(name)
           case Failure(ex)   => TheReply(ex.getMessage)
         }
@@ -299,11 +299,11 @@ class ClusterShardingSpec
       })
 
       val response = p.receiveMessage()
-      response.s should startWith("I'm alice")
+      response.s should startWith("I'm peter")
       // typekey and entity id encoded in promise ref path
-      response.s should include(s"${typeKeyWithEnvelopes.name}-alice")
+      response.s should include(s"${typeKeyWithEnvelopes.name}-peter")
 
-      aliceRef ! StopPlz()
+      peterRef ! StopPlz()
 
       // FIXME #26514: doesn't compile with Scala 2.13.0-M5
       /*


### PR DESCRIPTION
* in log we can see that the WhoAreYou is delivered to deadLetters,
  which is probably because the same entityId as previous test is used
  and that ends by stopping the actor
* use unique enitiy ids instead

```
2021-09-09 01:11:21,368 INFO  akka.actor.LocalActorRef akkaDeadLetter - Message [akka.cluster.sharding.typed.scaladsl.ClusterShardingSpec$WhoAreYou] from Actor[akka://ClusterShardingSpec@127.0.0.1:35865/deadLetters] to Actor[akka://ClusterShardingSpec/system/sharding/envelope-shard/2/charlie#483188069] was not delivered. [1] dead letters encountered. If this is not an expected behavior then Actor[akka://ClusterShardingSpec/system/sharding/envelope-shard/2/charlie#483188069] may have terminated unexpectedly. This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' and 'akka.log-dead-letters-during-shutdown'. MDC: {akkaAddress=akka://ClusterShardingSpec@127.0.0.1:37819, sourceThread=ClusterShardingSpec-akka.actor.default-dispatcher-6, akkaSource=akka://ClusterShardingSpec/system/sharding/envelope-shard/2/charlie, sourceActorSystem=ClusterShardingSpec, akkaMessageClass=akka.cluster.sharding.typed.scaladsl.ClusterShardingSpec$WhoAreYou, akkaTimestamp=01:11:21.367UTC}
```


References #30667
