### PR TITLE
Remove fixme part about guards and pattern matching from StyleGuide

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
@@ -460,39 +460,10 @@ object StyleGuideDocExamples {
       final case class GetValue(replyTo: ActorRef[Value]) extends Command
       final case class Value(n: Int)
       //#messages-sealed
-
-      def apply(countDownFrom: Int, notifyWhenZero: ActorRef[Done]): Behavior[Command] =
-        new CountDown(notifyWhenZero).counterWithGuard(countDownFrom)
     }
 
     private class CountDown(notifyWhenZero: ActorRef[Done]) {
       import CountDown._
-
-      private def counterWithGuard(remaining: Int): Behavior[Command] = {
-        // no exhaustiveness check because of guard condition
-        // FIXME not true anymore since Scala 2.13.5
-        Behaviors.receiveMessagePartial {
-          case Down if remaining == 1 =>
-            notifyWhenZero.tell(Done)
-            zero
-          case Down =>
-            counter(remaining - 1)
-        }
-      }
-
-      @nowarn
-      private def counter(remaining: Int): Behavior[Command] = {
-        // `@unchecked` for Scala 3, which doesn't support @nowarn
-        Behaviors.receiveMessage(x =>
-          (x: @unchecked) match {
-            case Down =>
-              if (remaining == 1) {
-                notifyWhenZero.tell(Done)
-                zero
-              } else
-                counter(remaining - 1)
-          })
-      }
 
       //#pattern-match-unhandled
       private val zero: Behavior[Command] = {

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
@@ -462,11 +462,10 @@ object StyleGuideDocExamples {
       //#messages-sealed
     }
 
-    private class CountDown(notifyWhenZero: ActorRef[Done]) {
+    private class CountDown() {
       import CountDown._
 
       //#pattern-match-unhandled
-      private val zero: Behavior[Command] = {
         Behaviors.receiveMessage {
           case GetValue(replyTo) =>
             replyTo ! Value(0)
@@ -474,7 +473,6 @@ object StyleGuideDocExamples {
           case Down =>
             Behaviors.unhandled
         }
-      }
       //#pattern-match-unhandled
 
       @nowarn

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
@@ -462,10 +462,11 @@ object StyleGuideDocExamples {
       //#messages-sealed
     }
 
-    private class CountDown() {
+    class CountDown() {
       import CountDown._
 
       //#pattern-match-unhandled
+      val zero: Behavior[Command] = {
         Behaviors.receiveMessage {
           case GetValue(replyTo) =>
             replyTo ! Value(0)
@@ -473,12 +474,13 @@ object StyleGuideDocExamples {
           case Down =>
             Behaviors.unhandled
         }
+      }
       //#pattern-match-unhandled
 
       @nowarn
       object partial {
         //#pattern-match-partial
-        private val zero: Behavior[Command] = {
+        val zero: Behavior[Command] = {
           Behaviors.receiveMessagePartial {
             case GetValue(replyTo) =>
               replyTo ! Value(0)

--- a/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
+++ b/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala
@@ -469,7 +469,6 @@ object StyleGuideDocExamples {
       import CountDown._
 
       private def counterWithGuard(remaining: Int): Behavior[Command] = {
-        //#pattern-match-guard
         // no exhaustiveness check because of guard condition
         // FIXME not true anymore since Scala 2.13.5
         Behaviors.receiveMessagePartial {
@@ -479,12 +478,10 @@ object StyleGuideDocExamples {
           case Down =>
             counter(remaining - 1)
         }
-        //#pattern-match-guard
       }
 
       @nowarn
       private def counter(remaining: Int): Behavior[Command] = {
-        //#pattern-match-without-guard
         // `@unchecked` for Scala 3, which doesn't support @nowarn
         Behaviors.receiveMessage(x =>
           (x: @unchecked) match {
@@ -495,7 +492,6 @@ object StyleGuideDocExamples {
               } else
                 counter(remaining - 1)
           })
-        //#pattern-match-without-guard
       }
 
       //#pattern-match-unhandled

--- a/akka-docs/src/main/paradox/typed/style-guide.md
+++ b/akka-docs/src/main/paradox/typed/style-guide.md
@@ -390,17 +390,6 @@ in the pattern match and return `Behaviors.unhandled`.
 Scala
 :  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #pattern-match-unhandled }
 
-One thing to be aware of is the exhaustiveness check is not enabled when there is a guard condition in any of the
-pattern match cases.
-
-Scala
-:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #pattern-match-guard }
-
-Therefore, for the purposes of exhaustivity checking, it is be better to not use guards and instead move the `if`s after the `=>`.
-
-Scala
-:  @@snip [StyleGuideDocExamples.scala](/akka-actor-typed-tests/src/test/scala/docs/akka/typed/StyleGuideDocExamples.scala) { #pattern-match-without-guard }
-
 It's recommended to use the `sealed` trait and total functions with exhaustiveness check to detect mistakes
 of forgetting to handle some messages. Sometimes that can be inconvenient and then you can use a `PartialFunction`
 with `Behaviors.receivePartial` or `Behaviors.receiveMessagePartial`


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #30311 
