### PR TITLE
[Akka 30800] Improve performance of JoinConfigCompatChecker

### DIFF
--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/JoinConfigCompatCheckerClusterSharding.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/JoinConfigCompatCheckerClusterSharding.scala
@@ -17,8 +17,8 @@ import akka.cluster.{ ConfigValidation, JoinConfigCompatChecker, Valid }
 @InternalApi
 private[akka] final class JoinConfigCompatCheckerClusterSharding extends JoinConfigCompatChecker {
 
-  override def requiredKeys: im.Seq[String] =
-    im.Seq("akka.cluster.sharding.number-of-shards")
+  override def requiredKeys: im.Set[String] =
+    im.Set("akka.cluster.sharding.number-of-shards")
 
   override def check(toCheck: Config, actualConfig: Config): ConfigValidation = {
     if (toCheck.hasPath(requiredKeys.head))

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/JoinConfigCompatCheckSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/JoinConfigCompatCheckSharding.scala
@@ -17,8 +17,8 @@ import akka.cluster.{ ConfigValidation, JoinConfigCompatChecker }
 @InternalApi
 final class JoinConfigCompatCheckSharding extends JoinConfigCompatChecker {
 
-  override def requiredKeys: im.Seq[String] =
-    im.Seq("akka.cluster.sharding.state-store-mode")
+  override def requiredKeys: im.Set[String] =
+    im.Set("akka.cluster.sharding.state-store-mode")
 
   override def check(toCheck: Config, actualConfig: Config): ConfigValidation =
     JoinConfigCompatChecker.fullMatch(requiredKeys, toCheck, actualConfig)

--- a/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistConfigCompatChecker.scala
+++ b/akka-cluster-typed/src/main/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistConfigCompatChecker.scala
@@ -17,7 +17,7 @@ import akka.cluster.{ ConfigValidation, JoinConfigCompatChecker, Valid }
 @InternalApi
 private[akka] final class ClusterReceptionistConfigCompatChecker extends JoinConfigCompatChecker {
 
-  override def requiredKeys = "akka.cluster.typed.receptionist.distributed-key-count" :: Nil
+  override def requiredKeys = Set("akka.cluster.typed.receptionist.distributed-key-count")
 
   override def check(toCheck: Config, actualConfig: Config): ConfigValidation =
     if (toCheck.hasPath(requiredKeys.head))

--- a/akka-cluster/src/main/scala/akka/cluster/JoinConfigCompatCheckCluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/JoinConfigCompatCheckCluster.scala
@@ -29,7 +29,7 @@ import akka.cluster.sbr.SplitBrainResolverProvider
 final class JoinConfigCompatCheckCluster extends JoinConfigCompatChecker {
   import JoinConfigCompatCheckCluster._
 
-  override def requiredKeys: im.Seq[String] = List(DowningProviderPath, SbrStrategyPath)
+  override def requiredKeys: im.Set[String] = Set(DowningProviderPath, SbrStrategyPath)
 
   override def check(toCheck: Config, actualConfig: Config): ConfigValidation = {
     val toCheckDowningProvider = toCheck.getString(DowningProviderPath)
@@ -40,11 +40,11 @@ final class JoinConfigCompatCheckCluster extends JoinConfigCompatChecker {
             LightbendSbrProviderClass))
         Valid
       else
-        JoinConfigCompatChecker.checkEquality(List(DowningProviderPath), toCheck, actualConfig)
+        JoinConfigCompatChecker.checkEquality(Set(DowningProviderPath), toCheck, actualConfig)
 
     val sbrStrategyResult =
       if (toCheck.hasPath(SbrStrategyPath) && actualConfig.hasPath(SbrStrategyPath))
-        JoinConfigCompatChecker.checkEquality(List(SbrStrategyPath), toCheck, actualConfig)
+        JoinConfigCompatChecker.checkEquality(Set(SbrStrategyPath), toCheck, actualConfig)
       else Valid
 
     downingProviderResult ++ sbrStrategyResult

--- a/akka-cluster/src/main/scala/akka/cluster/JoinConfigCompatChecker.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/JoinConfigCompatChecker.scala
@@ -38,7 +38,7 @@ object JoinConfigCompatChecker {
   /**
    * Checks that all `requiredKeys` are available in `toCheck` Config.
    *
-   * @param requiredKeys - a Seq of required keys
+   * @param requiredKeys - a Set of required keys
    * @param toCheck - the Config instance to be checked
    */
   def exists(requiredKeys: im.Set[String], toCheck: Config): ConfigValidation = {
@@ -57,7 +57,7 @@ object JoinConfigCompatChecker {
    * Checks that all `requiredKeys` are available in `toCheck` Config
    * and its values match exactly the values in `currentConfig`.
    *
-   * @param requiredKeys - a Seq of required keys
+   * @param requiredKeys - a Set of required keys
    * @param toCheck - the Config instance to be checked
    * @param actualConfig - the Config instance containing the expected values
    */
@@ -113,7 +113,7 @@ object JoinConfigCompatChecker {
   /**
    * INTERNAL API
    * Removes sensitive keys, as defined in 'akka.cluster.configuration-compatibility-check.sensitive-config-paths',
-   * from the passed `requiredKeys` Seq.
+   * from the passed `requiredKeys` Set.
    */
   @InternalApi
   private[cluster] def removeSensitiveKeys(
@@ -126,7 +126,7 @@ object JoinConfigCompatChecker {
 
   /**
    * INTERNAL API
-   * Builds a Seq of keys using the passed `Config` not including any sensitive keys,
+   * Builds a Set of keys using the passed `Config` not including any sensitive keys,
    * as defined in 'akka.cluster.configuration-compatibility-check.sensitive-config-paths'.
    */
   @InternalApi

--- a/akka-cluster/src/main/scala/akka/cluster/JoinConfigCompatChecker.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/JoinConfigCompatChecker.scala
@@ -81,9 +81,10 @@ object JoinConfigCompatChecker {
     // retrieve all incompatible keys
     // NOTE: we only check the key if effectively required
     // because config may contain more keys than required for this checker
+    val keySet = keys.toSet
     val incompatibleKeys =
       toCheck.entrySet().asScala.collect {
-        case entry if keys.contains(entry.getKey) && !checkCompat(entry) => s"${entry.getKey} is incompatible"
+        case entry if keySet.contains(entry.getKey) && !checkCompat(entry) => s"${entry.getKey} is incompatible"
       }
 
     if (incompatibleKeys.isEmpty) Valid
@@ -102,9 +103,10 @@ object JoinConfigCompatChecker {
   @ccompatUsedUntil213
   private[cluster] def filterWithKeys(requiredKeys: im.Seq[String], config: Config): Config = {
 
+    val requiredKeySet = requiredKeys.toSet
     val filtered =
       config.entrySet().asScala.collect {
-        case e if requiredKeys.contains(e.getKey) => (e.getKey, e.getValue)
+        case e if requiredKeySet.contains(e.getKey) => (e.getKey, e.getValue)
       }
 
     ConfigFactory.parseMap(filtered.toMap.asJava)

--- a/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatCheckerRollingUpdateSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatCheckerRollingUpdateSpec.scala
@@ -62,7 +62,7 @@ class JoinConfigCompatCheckerRollingUpdateSpec
 }
 
 class JoinConfigCompatRollingUpdateChecker extends JoinConfigCompatChecker {
-  override def requiredKeys: im.Seq[String] = im.Seq("akka.cluster.new-configuration")
+  override def requiredKeys: im.Set[String] = im.Set("akka.cluster.new-configuration")
   override def check(toCheck: Config, actualConfig: Config): ConfigValidation = {
     if (toCheck.hasPath(requiredKeys.head))
       JoinConfigCompatChecker.fullMatch(requiredKeys, toCheck, actualConfig)

--- a/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatCheckerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatCheckerSpec.scala
@@ -629,14 +629,14 @@ class JoinConfigCompatCheckerSpec extends AkkaSpec with ClusterTestKit {
 }
 
 class JoinConfigCompatCheckerTest extends JoinConfigCompatChecker {
-  override def requiredKeys = im.Seq("akka.cluster.config-compat-test")
+  override def requiredKeys = im.Set("akka.cluster.config-compat-test")
 
   override def check(toValidate: Config, actualConfig: Config): ConfigValidation =
     JoinConfigCompatChecker.fullMatch(requiredKeys, toValidate, actualConfig)
 }
 
 class JoinConfigCompatCheckerExtraTest extends JoinConfigCompatChecker {
-  override def requiredKeys = im.Seq("akka.cluster.config-compat-test-extra")
+  override def requiredKeys = im.Set("akka.cluster.config-compat-test-extra")
 
   override def check(toValidate: Config, actualConfig: Config): ConfigValidation =
     JoinConfigCompatChecker.fullMatch(requiredKeys, toValidate, actualConfig)
@@ -646,7 +646,7 @@ class JoinConfigCompatCheckerExtraTest extends JoinConfigCompatChecker {
 class RogueJoinConfigCompatCheckerTest extends JoinConfigCompatChecker {
 
   override def requiredKeys =
-    im.Seq("akka.cluster.sensitive.properties.password", "akka.cluster.sensitive.properties.username")
+    im.Set("akka.cluster.sensitive.properties.password", "akka.cluster.sensitive.properties.username")
 
   /** this check always returns Valid. The goal is to try to make the cluster leak those properties */
   override def check(toValidate: Config, actualConfig: Config): ConfigValidation =

--- a/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatPreDefinedChecksSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatPreDefinedChecksSpec.scala
@@ -15,7 +15,7 @@ class JoinConfigCompatPreDefinedChecksSpec extends AnyWordSpec with Matchers {
   // Test for some of the pre-build helpers we offer
   "JoinConfigCompatChecker.exists" must {
 
-    val requiredKeys = im.Seq(
+    val requiredKeys = im.Set(
       "akka.cluster.min-nr-of-members",
       "akka.cluster.retry-unsuccessful-join-after",
       "akka.cluster.allow-weakly-up-members")
@@ -57,7 +57,7 @@ class JoinConfigCompatPreDefinedChecksSpec extends AnyWordSpec with Matchers {
 
   "JoinConfigCompatChecker.fullMatch" must {
 
-    val requiredKeys = im.Seq(
+    val requiredKeys = im.Set(
       "akka.cluster.min-nr-of-members",
       "akka.cluster.retry-unsuccessful-join-after",
       "akka.cluster.allow-weakly-up-members")


### PR DESCRIPTION
Fixes https://github.com/akka/akka/issues/30800

When profiling our app, while it's trying to join the cluster, I found that it's spending most of the time in `JoinConfigCompatChecker` doing `List.contains(..)`. 

Converting `JoinConfigCompatChecker.requiredKeys` from `Seq` to `Set` should improve performance.