### PR TITLE
Akka 30782  flatMapPrefix, avoid exception instantiation is postStop

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/FlatMapPrefix.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/FlatMapPrefix.scala
@@ -44,7 +44,9 @@ import akka.util.OptionVal
 
       override def postStop(): Unit = {
         //this covers the case when the nested flow was never materialized
-        matPromise.tryFailure(new AbruptStageTerminationException(this))
+        if (!matPromise.isCompleted) {
+          matPromise.failure(new AbruptStageTerminationException(this))
+        }
         super.postStop()
       }
 


### PR DESCRIPTION
References #30782
