### PR TITLE
Preserve message if recovery fails #30808

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -270,6 +270,7 @@ private[persistence] trait Eventsourced
   /** INTERNAL API. */
   override protected[akka] def aroundPreRestart(reason: Throwable, message: Option[Any]): Unit = {
     try {
+      if (recoveryRunning) message.foreach(self.forward(_))
       internalStash.unstashAll()
       unstashAll(unstashFilterPredicate)
     } finally {


### PR DESCRIPTION
If recovery fails, the triggering message is not the root cause and can be re-used

References #30808
