### PR TITLE
Added durable state current persistence ids query

### DIFF
--- a/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/CurrentDurableStatePersistenceIdsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/CurrentDurableStatePersistenceIdsQuery.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.javadsl
+
+import java.util.Optional
+
+import akka.NotUsed
+import akka.persistence.state.javadsl.DurableStateStore
+import akka.stream.javadsl.Source
+
+/**
+ * A plugin may optionally support this query by implementing this trait.
+ */
+trait CurrentDurableStatePersistenceIdsQuery[A] extends DurableStateStore[A] {
+
+  /**
+   * Get the current persistence ids.
+   *
+   * Not all durable state plugins may support in database paging, and may simply use drop/take Akka streams operators
+   * to manipulate the result set according to the paging parameters.
+   *
+   * @param afterId The ID to start returning results from, or empty to return all ids. This should be an id returned
+   *                from a previous invocation of this command. Callers should not assume that ids are returned in
+   *                sorted order.
+   * @param limit The maximum results to return. Use Long.MAX_VALUE to return all results. Must be greater than zero.
+   * @return A source containing all the persistence ids, limited as specified.
+   */
+  def currentPersistenceIds(afterId: Optional[String], limit: Long): Source[String, NotUsed]
+
+}

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/CurrentDurableStatePersistenceIdsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/CurrentDurableStatePersistenceIdsQuery.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2015-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.scaladsl
+
+import akka.NotUsed
+import akka.persistence.state.scaladsl.DurableStateStore
+import akka.stream.scaladsl.Source
+
+/**
+ * A plugin may optionally support this query by implementing this trait.
+ */
+trait CurrentDurableStatePersistenceIdsQuery[A] extends DurableStateStore[A] {
+
+  /**
+   * Get the current persistence ids.
+   *
+   * Not all durable state plugins may support in database paging, and may simply use drop/take Akka streams operators
+   * to manipulate the result set according to the paging parameters.
+   *
+   * @param afterId The ID to start returning results from, or [[None]] to return all ids. This should be an id
+   *                returned from a previous invocation of this command. Callers should not assume that ids are
+   *                returned in sorted order.
+   * @param limit The maximum results to return. Use Long.MaxValue to return all results. Must be greater than zero.
+   * @return A source containing all the persistence ids, limited as specified.
+   */
+  def currentPersistenceIds(afterId: Option[String], limit: Long): Source[String, NotUsed]
+}


### PR DESCRIPTION
Fixes #30795

Adds a query for durable state objects to get all persistence IDs.

I only provided the current persistence ids query - a continuous stream would be much harder to implement, since it would require tracking all persistence ids to know if one is new.

This query does provide paging, using the persistence offset abstraction. This allows databases to implement it in a way that makes sense for them, for many, the offset will be the persistence id itself, since the persistence id is the primary key and so the index will be sorted by persistence id, and this will allow the database to jump straight to the right location in the index.

I also included a limit parameter - not strictly necessary as long as the database is streaming returned results, but will perform a little better even when streaming as it will eliminate buffered and in flight results when the stream is cancelled from being loaded at all.