### PR TITLE
use Scala `3.1.1-RC1` instead of `NIGHTLY` version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
   val scala213Version = "2.13.6"
   // To get the fix for https://github.com/lampepfl/dotty/issues/13106
   // and restored static forwarders
-  val scala3Version = "3.1.1-RC1-bin-20211007-c041327-NIGHTLY"
+  val scala3Version = "3.1.1-RC1"
 
   val reactiveStreamsVersion = "1.0.3"
 


### PR DESCRIPTION
because can't use akka 2.6.17 with non-nightly Scala 3

```
[error] error while loading package$,
[error] class file akka/actor/package.class is broken, reading aborted with class dotty.tools.tasty.UnpickleException
[error] TASTy signature has wrong version.
[error]  expected: {majorVersion: 28, minorVersion: 1}
[error]  found   : {majorVersion: 28, minorVersion: 2 [unstable release: 1]}
[error] 
[error] This TASTy file was produced by an unstable release.
[error] To read this TASTy file, your tooling must be at the same version.
[error] The TASTy file was produced by Scala 3.1.1-RC1-bin-20211007-c041327-NIGHTLY-git-c041327.
[error] error while loading ActorSystem$,
[error] class file akka/actor/ActorSystem.class is broken, reading aborted with class dotty.tools.tasty.UnpickleException
[error] TASTy signature has wrong version.
[error]  expected: {majorVersion: 28, minorVersion: 1}
[error]  found   : {majorVersion: 28, minorVersion: 2 [unstable release: 1]}
[error] 
[error] This TASTy file was produced by an unstable release.
[error] To read this TASTy file, your tooling must be at the same version.
[error] The TASTy file was produced by Scala 3.1.1-RC1-bin-20211007-c041327-NIGHTLY-git-c041327.
```


