### PR TITLE
Make StreamConverters.asOutputStream ignore empty arrays

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamConvertersSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamConvertersSpec.scala
@@ -341,4 +341,30 @@ class StreamConvertersSpec extends StreamSpec with DefaultTimeout {
       is.close()
     }
   }
+
+  "OutputStream Source" must {
+    "ignore empty arrays" in {
+      val source =
+        StreamConverters.asOutputStream().withAttributes(ActorAttributes.dispatcher("akka.test.stream-dispatcher"))
+
+      val (out, result) = source.toMat(Sink.seq)(Keep.both).run()
+
+      out.write(1)
+      out.write(Array[Byte](2, 3, 4))
+      out.write(Array[Byte]())
+      out.write(5)
+      out.write(Array(6, 7, 8), 0, 3)
+      out.write(Array(), 0, 0)
+      out.write(9)
+      out.close()
+
+      result.futureValue should contain theSameElementsInOrderAs Seq(
+        ByteString(1),
+        ByteString(2, 3, 4),
+        ByteString(5),
+        ByteString(6, 7, 8),
+        ByteString(9),
+      )
+    }
+  }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamConvertersSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamConvertersSpec.scala
@@ -363,8 +363,7 @@ class StreamConvertersSpec extends StreamSpec with DefaultTimeout {
         ByteString(2, 3, 4),
         ByteString(5),
         ByteString(6, 7, 8),
-        ByteString(9)
-      )
+        ByteString(9))
     }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamConvertersSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamConvertersSpec.scala
@@ -363,7 +363,7 @@ class StreamConvertersSpec extends StreamSpec with DefaultTimeout {
         ByteString(2, 3, 4),
         ByteString(5),
         ByteString(6, 7, 8),
-        ByteString(9),
+        ByteString(9)
       )
     }
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSourceStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/OutputStreamSourceStage.scala
@@ -92,7 +92,9 @@ private[akka] class OutputStreamAdapter(
 
   @scala.throws(classOf[IOException])
   override def write(b: Array[Byte], off: Int, len: Int): Unit = {
-    sendData(ByteString.fromArray(b, off, len))
+    if (b.nonEmpty) {
+      sendData(ByteString.fromArray(b, off, len))
+    }
   }
 
   @scala.throws(classOf[IOException])


### PR DESCRIPTION
Fixes #30805
