### PR TITLE
Fixed testkit durable state store current changes non completion

### DIFF
--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
@@ -90,10 +90,10 @@ class PersistenceTestKitDurableStateStore[A](val system: ExtendedActorSystem)
     val currentGlobalOffset = lastGlobalOffset.get()
     changes(tag, offset).takeWhile(_.offset match {
       case Sequence(fromOffset) =>
-        fromOffset <= currentGlobalOffset
+        fromOffset < currentGlobalOffset
       case offset =>
         throw new UnsupportedOperationException(s"$offset not supported in PersistenceTestKitDurableStateStore.")
-    })
+    }, inclusive = true)
   }
 }
 


### PR DESCRIPTION
PersistenceTestKitDurableStateStore.currentChanges was correctly only returning the current changes, however it was not completing until an addition change was made. This fixes that.