### PR TITLE
Allow initial state to be null while using EventSourcedBehaviorTestKit

### DIFF
--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
@@ -8,7 +8,6 @@ import scala.collection.immutable
 import scala.concurrent.Await
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
-
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.testkit.typed.scaladsl.SerializationTestKit
 import akka.actor.typed.ActorRef
@@ -26,6 +25,7 @@ import akka.persistence.testkit.scaladsl.EventSourcedBehaviorTestKit.Serializati
 import akka.persistence.testkit.scaladsl.PersistenceTestKit
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.internal.EventSourcedBehaviorImpl
+import akka.persistence.typed.internal.EventSourcedBehaviorImpl.StateWrapper
 import akka.stream.scaladsl.Sink
 
 /**
@@ -99,7 +99,7 @@ import akka.stream.scaladsl.Sink
     PersistenceQuery(system).readJournalFor[CurrentEventsByPersistenceIdQuery](PersistenceTestKitReadJournal.Identifier)
 
   private val probe = actorTestKit.createTestProbe[Any]()
-  private val stateProbe = actorTestKit.createTestProbe[State]()
+  private val stateProbe = actorTestKit.createTestProbe[StateWrapper[State]]()
   private var actor: ActorRef[Command] = actorTestKit.spawn(behavior)
   private def internalActor = actor.unsafeUpcast[Any]
   private val persistenceId: PersistenceId = {
@@ -175,7 +175,7 @@ import akka.stream.scaladsl.Sink
 
   override def getState(): State = {
     internalActor ! EventSourcedBehaviorImpl.GetState(stateProbe.ref)
-    stateProbe.receiveMessage()
+    stateProbe.receiveMessage().s
   }
 
   private def preCommandCheck(command: Command): Unit = {
@@ -212,7 +212,7 @@ import akka.stream.scaladsl.Sink
     internalActor ! EventSourcedBehaviorImpl.GetState(stateProbe.ref)
     try {
       val state = stateProbe.receiveMessage()
-      RestartResultImpl(state)
+      RestartResultImpl(state.s)
     } catch {
       case NonFatal(_) =>
         throw new IllegalStateException("Could not restart. Maybe exception from event handler. See logs.")

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
@@ -175,7 +175,7 @@ import akka.stream.scaladsl.Sink
 
   override def getState(): State = {
     internalActor ! EventSourcedBehaviorImpl.GetState(stateProbe.ref)
-    stateProbe.receiveMessage().s
+    stateProbe.receiveMessage().currentState
   }
 
   private def preCommandCheck(command: Command): Unit = {
@@ -212,7 +212,7 @@ import akka.stream.scaladsl.Sink
     internalActor ! EventSourcedBehaviorImpl.GetState(stateProbe.ref)
     try {
       val state = stateProbe.receiveMessage()
-      RestartResultImpl(state.s)
+      RestartResultImpl(state.currentState)
     } catch {
       case NonFatal(_) =>
         throw new IllegalStateException("Could not restart. Maybe exception from event handler. See logs.")

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/EventSourcedBehaviorTestKitImpl.scala
@@ -25,7 +25,7 @@ import akka.persistence.testkit.scaladsl.EventSourcedBehaviorTestKit.Serializati
 import akka.persistence.testkit.scaladsl.PersistenceTestKit
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.internal.EventSourcedBehaviorImpl
-import akka.persistence.typed.internal.EventSourcedBehaviorImpl.StateWrapper
+import akka.persistence.typed.internal.EventSourcedBehaviorImpl.GetStateReply
 import akka.stream.scaladsl.Sink
 
 /**
@@ -99,7 +99,7 @@ import akka.stream.scaladsl.Sink
     PersistenceQuery(system).readJournalFor[CurrentEventsByPersistenceIdQuery](PersistenceTestKitReadJournal.Identifier)
 
   private val probe = actorTestKit.createTestProbe[Any]()
-  private val stateProbe = actorTestKit.createTestProbe[StateWrapper[State]]()
+  private val stateProbe = actorTestKit.createTestProbe[GetStateReply[State]]()
   private var actor: ActorRef[Command] = actorTestKit.spawn(behavior)
   private def internalActor = actor.unsafeUpcast[Any]
   private val persistenceId: PersistenceId = {

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
@@ -4,8 +4,8 @@
 
 package akka.persistence.testkit.javadsl
 
-import java.util.{List => JList}
-import java.util.function.{Function => JFunction}
+import java.util.{ List => JList }
+import java.util.function.{ Function => JFunction }
 import scala.reflect.ClassTag
 import com.typesafe.config.Config
 import akka.actor.typed.ActorRef

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/javadsl/EventSourcedBehaviorTestKit.scala
@@ -4,13 +4,10 @@
 
 package akka.persistence.testkit.javadsl
 
-import java.util.{ List => JList }
-import java.util.function.{ Function => JFunction }
-
+import java.util.{List => JList}
+import java.util.function.{Function => JFunction}
 import scala.reflect.ClassTag
-
 import com.typesafe.config.Config
-
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKit.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKit.scala
@@ -6,10 +6,8 @@ package akka.persistence.testkit.scaladsl
 
 import scala.collection.immutable
 import scala.reflect.ClassTag
-
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem

--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKitSpec.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKitSpec.scala
@@ -27,32 +27,23 @@ object EventSourcedBehaviorTestKitSpec {
 
   object TestCounter {
     sealed trait Command
-
     case object Increment extends Command with CborSerializable
-
     final case class IncrementWithConfirmation(replyTo: ActorRef[Done]) extends Command with CborSerializable
-
     final case class IncrementWithNoReply(replyTo: ActorRef[Done]) extends Command with CborSerializable
-
     final case class IncrementWithAsyncReply(replyTo: ActorRef[Done]) extends Command with CborSerializable
-
     case class IncrementSeveral(n: Int) extends Command with CborSerializable
-
     final case class GetValue(replyTo: ActorRef[State]) extends Command with CborSerializable
 
     private case class AsyncReply(replyTo: ActorRef[Done]) extends Command with CborSerializable
 
     sealed trait Event
-
     final case class Incremented(delta: Int) extends Event with CborSerializable
 
     sealed trait State
-
     final case class RealState(value: Int, history: Vector[Int]) extends State with CborSerializable
     final case class NullState() extends State with CborSerializable
 
     case object IncrementWithNotSerializableEvent extends Command with CborSerializable
-
     final case class NotSerializableEvent(delta: Int) extends Event
 
     case object IncrementWithNotSerializableState extends Command with CborSerializable
@@ -73,9 +64,9 @@ object EventSourcedBehaviorTestKitSpec {
       Behaviors.setup(ctx => counter(ctx, persistenceId, emptyState))
 
     private def counter(
-                         ctx: ActorContext[Command],
-                         persistenceId: PersistenceId,
-                         emptyState: State): EventSourcedBehavior[Command, Event, State] = {
+         ctx: ActorContext[Command],
+         persistenceId: PersistenceId,
+         emptyState: State): EventSourcedBehavior[Command, Event, State] = {
       EventSourcedBehavior.withEnforcedReplies[Command, Event, State](
         persistenceId,
         emptyState,

--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKitSpec.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKitSpec.scala
@@ -15,7 +15,7 @@ import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
-import akka.persistence.testkit.scaladsl.EventSourcedBehaviorTestKitSpec.TestCounter.{NotSerializableState, NullState}
+import akka.persistence.testkit.scaladsl.EventSourcedBehaviorTestKitSpec.TestCounter.{ NotSerializableState, NullState }
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.internal.JournalFailureException
 import akka.persistence.typed.scaladsl.Effect
@@ -64,9 +64,9 @@ object EventSourcedBehaviorTestKitSpec {
       Behaviors.setup(ctx => counter(ctx, persistenceId, emptyState))
 
     private def counter(
-         ctx: ActorContext[Command],
-         persistenceId: PersistenceId,
-         emptyState: State): EventSourcedBehavior[Command, Event, State] = {
+        ctx: ActorContext[Command],
+        persistenceId: PersistenceId,
+        emptyState: State): EventSourcedBehavior[Command, Event, State] = {
       EventSourcedBehavior.withEnforcedReplies[Command, Event, State](
         persistenceId,
         emptyState,
@@ -119,7 +119,7 @@ object EventSourcedBehaviorTestKitSpec {
             NotSerializableState(value + delta, history :+ value)
           case (state: NotSerializableState, _) =>
             throw new IllegalStateException(state.toString)
-          case (null, _) => NullState()
+          case (null, _)        => NullState()
           case (NullState(), _) => NullState()
         })
     }
@@ -127,7 +127,7 @@ object EventSourcedBehaviorTestKitSpec {
 }
 
 class EventSourcedBehaviorTestKitSpec
-  extends ScalaTestWithActorTestKit(EventSourcedBehaviorTestKit.config)
+    extends ScalaTestWithActorTestKit(EventSourcedBehaviorTestKit.config)
     with AnyWordSpecLike
     with LogCapturing {
 
@@ -137,7 +137,9 @@ class EventSourcedBehaviorTestKitSpec
   private val behavior = TestCounter(persistenceId)
 
   private def createTestKitNull() = {
-    EventSourcedBehaviorTestKit[TestCounter.Command, TestCounter.Event, TestCounter.State](system, TestCounter(persistenceId, null))
+    EventSourcedBehaviorTestKit[TestCounter.Command, TestCounter.Event, TestCounter.State](
+      system,
+      TestCounter(persistenceId, null))
   }
 
   private def createTestKit() = {

--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKitSpec.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/EventSourcedBehaviorTestKitSpec.scala
@@ -5,9 +5,7 @@
 package akka.persistence.testkit.scaladsl
 
 import java.io.NotSerializableException
-
 import org.scalatest.wordspec.AnyWordSpecLike
-
 import akka.Done
 import akka.actor.testkit.typed.TestException
 import akka.actor.testkit.typed.scaladsl.LogCapturing
@@ -17,7 +15,7 @@ import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
-import akka.persistence.testkit.scaladsl.EventSourcedBehaviorTestKitSpec.TestCounter.NotSerializableState
+import akka.persistence.testkit.scaladsl.EventSourcedBehaviorTestKitSpec.TestCounter.{NotSerializableState, NullState}
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.internal.JournalFailureException
 import akka.persistence.typed.scaladsl.Effect
@@ -29,22 +27,32 @@ object EventSourcedBehaviorTestKitSpec {
 
   object TestCounter {
     sealed trait Command
+
     case object Increment extends Command with CborSerializable
+
     final case class IncrementWithConfirmation(replyTo: ActorRef[Done]) extends Command with CborSerializable
+
     final case class IncrementWithNoReply(replyTo: ActorRef[Done]) extends Command with CborSerializable
+
     final case class IncrementWithAsyncReply(replyTo: ActorRef[Done]) extends Command with CborSerializable
+
     case class IncrementSeveral(n: Int) extends Command with CborSerializable
+
     final case class GetValue(replyTo: ActorRef[State]) extends Command with CborSerializable
 
     private case class AsyncReply(replyTo: ActorRef[Done]) extends Command with CborSerializable
 
     sealed trait Event
+
     final case class Incremented(delta: Int) extends Event with CborSerializable
 
     sealed trait State
+
     final case class RealState(value: Int, history: Vector[Int]) extends State with CborSerializable
+    final case class NullState() extends State with CborSerializable
 
     case object IncrementWithNotSerializableEvent extends Command with CborSerializable
+
     final case class NotSerializableEvent(delta: Int) extends Event
 
     case object IncrementWithNotSerializableState extends Command with CborSerializable
@@ -65,9 +73,9 @@ object EventSourcedBehaviorTestKitSpec {
       Behaviors.setup(ctx => counter(ctx, persistenceId, emptyState))
 
     private def counter(
-        ctx: ActorContext[Command],
-        persistenceId: PersistenceId,
-        emptyState: State): EventSourcedBehavior[Command, Event, State] = {
+                         ctx: ActorContext[Command],
+                         persistenceId: PersistenceId,
+                         emptyState: State): EventSourcedBehavior[Command, Event, State] = {
       EventSourcedBehavior.withEnforcedReplies[Command, Event, State](
         persistenceId,
         emptyState,
@@ -120,25 +128,38 @@ object EventSourcedBehaviorTestKitSpec {
             NotSerializableState(value + delta, history :+ value)
           case (state: NotSerializableState, _) =>
             throw new IllegalStateException(state.toString)
+          case (null, _) => NullState()
+          case (NullState(), _) => NullState()
         })
     }
   }
 }
 
 class EventSourcedBehaviorTestKitSpec
-    extends ScalaTestWithActorTestKit(EventSourcedBehaviorTestKit.config)
+  extends ScalaTestWithActorTestKit(EventSourcedBehaviorTestKit.config)
     with AnyWordSpecLike
     with LogCapturing {
+
   import EventSourcedBehaviorTestKitSpec._
 
   private val persistenceId = PersistenceId.ofUniqueId("test")
   private val behavior = TestCounter(persistenceId)
+
+  private def createTestKitNull() = {
+    EventSourcedBehaviorTestKit[TestCounter.Command, TestCounter.Event, TestCounter.State](system, TestCounter(persistenceId, null))
+  }
 
   private def createTestKit() = {
     EventSourcedBehaviorTestKit[TestCounter.Command, TestCounter.Event, TestCounter.State](system, behavior)
   }
 
   "EventSourcedBehaviorTestKit" must {
+
+    "handle null state" in {
+      val eventSourcedTestKit = createTestKitNull()
+      val result = eventSourcedTestKit.runCommand(TestCounter.Increment)
+      result.state shouldBe NullState()
+    }
 
     "run commands" in {
       val eventSourcedTestKit = createTestKit()

--- a/akka-persistence-typed/src/main/mima-filters/2.6.17.backwards.excludes/pr-30823-null-state-actor-message.excludes
+++ b/akka-persistence-typed/src/main/mima-filters/2.6.17.backwards.excludes/pr-30823-null-state-actor-message.excludes
@@ -1,0 +1,7 @@
+# this is an internal api to avoid sending state as null vioa an Actor message
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.typed.internal.EventSourcedBehaviorImpl#GetState.this")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.typed.internal.EventSourcedBehaviorImpl#GetState.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.typed.internal.EventSourcedBehaviorImpl#GetState.unapply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.typed.internal.EventSourcedBehaviorImpl#GetState.replyTo")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.typed.internal.EventSourcedBehaviorImpl#GetState.copy")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.typed.internal.EventSourcedBehaviorImpl#GetState.copy$default$1")

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -72,9 +72,12 @@ private[akka] object EventSourcedBehaviorImpl {
    * Used by EventSourcedBehaviorTestKit to retrieve the state.
    * Can't be a Signal because those are not stashed.
    */
-  final case class GetState[State](replyTo: ActorRef[StateWrapper[State]]) extends InternalProtocol
+  final case class GetState[State](replyTo: ActorRef[GetStateReply[State]]) extends InternalProtocol
 
-  final case class StateWrapper[State](currentState: State)
+  /**
+   * Used to send a state being `null` as an Actor message
+   */
+  final case class GetStateReply[State](currentState: State)
 
   /**
    * Used to start the replication stream at the correct sequence number

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -74,7 +74,7 @@ private[akka] object EventSourcedBehaviorImpl {
    */
   final case class GetState[State](replyTo: ActorRef[StateWrapper[State]]) extends InternalProtocol
 
-  final case class StateWrapper[State](s: State)
+  final case class StateWrapper[State](currentState: State)
 
   /**
    * Used to start the replication stream at the correct sequence number

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -72,7 +72,9 @@ private[akka] object EventSourcedBehaviorImpl {
    * Used by EventSourcedBehaviorTestKit to retrieve the state.
    * Can't be a Signal because those are not stashed.
    */
-  final case class GetState[State](replyTo: ActorRef[State]) extends InternalProtocol
+  final case class GetState[State](replyTo: ActorRef[StateWrapper[State]]) extends InternalProtocol
+
+  final case class StateWrapper[State](s: State)
 
   /**
    * Used to start the replication stream at the correct sequence number

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -9,15 +9,14 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.atomic.AtomicReference
-
 import scala.annotation.tailrec
 import scala.collection.immutable
 import akka.actor.UnhandledMessage
 import akka.actor.typed.eventstream.EventStream
-import akka.actor.typed.{ Behavior, Signal }
+import akka.actor.typed.{Behavior, Signal}
 import akka.actor.typed.internal.PoisonPill
-import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, Behaviors, LoggerOps }
-import akka.annotation.{ InternalApi, InternalStableApi }
+import akka.actor.typed.scaladsl.{AbstractBehavior, ActorContext, Behaviors, LoggerOps}
+import akka.annotation.{InternalApi, InternalStableApi}
 import akka.event.Logging
 import akka.persistence.DeleteMessagesFailure
 import akka.persistence.DeleteMessagesSuccess
@@ -32,32 +31,20 @@ import akka.persistence.SaveSnapshotFailure
 import akka.persistence.SaveSnapshotSuccess
 import akka.persistence.SnapshotProtocol
 import akka.persistence.journal.Tagged
-import akka.persistence.query.{ EventEnvelope, PersistenceQuery }
+import akka.persistence.query.{EventEnvelope, PersistenceQuery}
 import akka.persistence.query.scaladsl.EventsByPersistenceIdQuery
 import akka.persistence.typed.ReplicaId
 import akka.persistence.typed.ReplicationId
-import akka.persistence.typed.{
-  DeleteEventsCompleted,
-  DeleteEventsFailed,
-  DeleteSnapshotsCompleted,
-  DeleteSnapshotsFailed,
-  DeletionTarget,
-  EventRejectedException,
-  PersistenceId,
-  SnapshotCompleted,
-  SnapshotFailed,
-  SnapshotMetadata,
-  SnapshotSelectionCriteria
-}
-import akka.persistence.typed.internal.EventSourcedBehaviorImpl.{ GetSeenSequenceNr, GetState }
+import akka.persistence.typed.{DeleteEventsCompleted, DeleteEventsFailed, DeleteSnapshotsCompleted, DeleteSnapshotsFailed, DeletionTarget, EventRejectedException, PersistenceId, SnapshotCompleted, SnapshotFailed, SnapshotMetadata, SnapshotSelectionCriteria}
+import akka.persistence.typed.internal.EventSourcedBehaviorImpl.{GetSeenSequenceNr, GetState, StateWrapper}
 import akka.persistence.typed.internal.InternalProtocol.ReplicatedEventEnvelope
 import akka.persistence.typed.internal.JournalInteractions.EventToPersist
 import akka.persistence.typed.internal.Running.WithSeqNrAccessible
 import akka.persistence.typed.scaladsl.Effect
 import akka.stream.scaladsl.Keep
-import akka.stream.{ RestartSettings, SystemMaterializer, WatchedActorTerminatedException }
+import akka.stream.{RestartSettings, SystemMaterializer, WatchedActorTerminatedException}
 import akka.stream.scaladsl.Source
-import akka.stream.scaladsl.{ RestartSource, Sink }
+import akka.stream.scaladsl.{RestartSource, Sink}
 import akka.stream.typed.scaladsl.ActorFlow
 import akka.util.OptionVal
 import akka.util.unused
@@ -384,7 +371,7 @@ private[akka] object Running {
 
     // Used by EventSourcedBehaviorTestKit to retrieve the state.
     def onGetState(get: GetState[S]): Behavior[InternalProtocol] = {
-      get.replyTo ! state.state
+      get.replyTo ! StateWrapper(state.state)
       this
     }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -13,10 +13,10 @@ import scala.annotation.tailrec
 import scala.collection.immutable
 import akka.actor.UnhandledMessage
 import akka.actor.typed.eventstream.EventStream
-import akka.actor.typed.{Behavior, Signal}
+import akka.actor.typed.{ Behavior, Signal }
 import akka.actor.typed.internal.PoisonPill
-import akka.actor.typed.scaladsl.{AbstractBehavior, ActorContext, Behaviors, LoggerOps}
-import akka.annotation.{InternalApi, InternalStableApi}
+import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, Behaviors, LoggerOps }
+import akka.annotation.{ InternalApi, InternalStableApi }
 import akka.event.Logging
 import akka.persistence.DeleteMessagesFailure
 import akka.persistence.DeleteMessagesSuccess
@@ -31,20 +31,32 @@ import akka.persistence.SaveSnapshotFailure
 import akka.persistence.SaveSnapshotSuccess
 import akka.persistence.SnapshotProtocol
 import akka.persistence.journal.Tagged
-import akka.persistence.query.{EventEnvelope, PersistenceQuery}
+import akka.persistence.query.{ EventEnvelope, PersistenceQuery }
 import akka.persistence.query.scaladsl.EventsByPersistenceIdQuery
 import akka.persistence.typed.ReplicaId
 import akka.persistence.typed.ReplicationId
-import akka.persistence.typed.{DeleteEventsCompleted, DeleteEventsFailed, DeleteSnapshotsCompleted, DeleteSnapshotsFailed, DeletionTarget, EventRejectedException, PersistenceId, SnapshotCompleted, SnapshotFailed, SnapshotMetadata, SnapshotSelectionCriteria}
-import akka.persistence.typed.internal.EventSourcedBehaviorImpl.{GetSeenSequenceNr, GetState, StateWrapper}
+import akka.persistence.typed.{
+  DeleteEventsCompleted,
+  DeleteEventsFailed,
+  DeleteSnapshotsCompleted,
+  DeleteSnapshotsFailed,
+  DeletionTarget,
+  EventRejectedException,
+  PersistenceId,
+  SnapshotCompleted,
+  SnapshotFailed,
+  SnapshotMetadata,
+  SnapshotSelectionCriteria
+}
+import akka.persistence.typed.internal.EventSourcedBehaviorImpl.{ GetSeenSequenceNr, GetState, StateWrapper }
 import akka.persistence.typed.internal.InternalProtocol.ReplicatedEventEnvelope
 import akka.persistence.typed.internal.JournalInteractions.EventToPersist
 import akka.persistence.typed.internal.Running.WithSeqNrAccessible
 import akka.persistence.typed.scaladsl.Effect
 import akka.stream.scaladsl.Keep
-import akka.stream.{RestartSettings, SystemMaterializer, WatchedActorTerminatedException}
+import akka.stream.{ RestartSettings, SystemMaterializer, WatchedActorTerminatedException }
 import akka.stream.scaladsl.Source
-import akka.stream.scaladsl.{RestartSource, Sink}
+import akka.stream.scaladsl.{ RestartSource, Sink }
 import akka.stream.typed.scaladsl.ActorFlow
 import akka.util.OptionVal
 import akka.util.unused

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -48,7 +48,7 @@ import akka.persistence.typed.{
   SnapshotMetadata,
   SnapshotSelectionCriteria
 }
-import akka.persistence.typed.internal.EventSourcedBehaviorImpl.{ GetSeenSequenceNr, GetState, StateWrapper }
+import akka.persistence.typed.internal.EventSourcedBehaviorImpl.{ GetSeenSequenceNr, GetState, GetStateReply }
 import akka.persistence.typed.internal.InternalProtocol.ReplicatedEventEnvelope
 import akka.persistence.typed.internal.JournalInteractions.EventToPersist
 import akka.persistence.typed.internal.Running.WithSeqNrAccessible
@@ -383,7 +383,7 @@ private[akka] object Running {
 
     // Used by EventSourcedBehaviorTestKit to retrieve the state.
     def onGetState(get: GetState[S]): Behavior[InternalProtocol] = {
-      get.replyTo ! StateWrapper(state.state)
+      get.replyTo ! GetStateReply(state.state)
       this
     }
 


### PR DESCRIPTION
If the initial state is `null`, the EventSourcedBehaviorTestKit is not usabla as it will try to sent the state (which is `null`) as an actor message which is not allowed.

Solution: wrap the state in a message, thanks @johanandren !