### PR TITLE
Clarify docs around cluster shutdown

### DIFF
--- a/akka-docs/src/main/paradox/additional/rolling-updates.md
+++ b/akka-docs/src/main/paradox/additional/rolling-updates.md
@@ -168,9 +168,8 @@ If you need to change any of the following aspects of sharding it will require a
  * The `extractShardId` function
  * The role that the shard regions run on
  * The persistence mode - It's important to use the same mode on all nodes in the cluster
- * If the [`number-of-shards`](https://doc.akka.io/docs/akka/current/typed/cluster-sharding.html#shard-allocation) is changed.  Note
- that changing the number of nodes in a cluster does not require changing the number of shards, though as the number of nodes
- approaches the number of shards, it's worth considering increasing the number of shards.
+ * The [`number-of-shards`](https://doc.akka.io/docs/akka/current/typed/cluster-sharding.html#shard-allocation) - Note: changing the number
+ of nodes in the cluster does not require changing the number of shards.
  
 ### Cluster configuration change
 

--- a/akka-docs/src/main/paradox/additional/rolling-updates.md
+++ b/akka-docs/src/main/paradox/additional/rolling-updates.md
@@ -167,9 +167,11 @@ If you need to change any of the following aspects of sharding it will require a
 
  * The `extractShardId` function
  * The role that the shard regions run on
- * The persistence mode - It's important to use the same mode on all nodes in the cluster 
- * If the [amount of nodes](https://doc.akka.io/docs/akka/2.5/cluster-sharding.html#an-example) is changed, the [`number-of-shards`](https://doc.akka.io/docs/akka/current/typed/cluster-sharding.html#shard-allocation) may be adapted as well
-
+ * The persistence mode - It's important to use the same mode on all nodes in the cluster
+ * If the [`number-of-shards`](https://doc.akka.io/docs/akka/current/typed/cluster-sharding.html#shard-allocation) is changed.  Note
+ that changing the number of nodes in a cluster does not require changing the number of shards, though as the number of nodes
+ approaches the number of shards, it's worth considering increasing the number of shards.
+ 
 ### Cluster configuration change
 
 * A full restart is required if you change the [SBR strategy](https://doc.akka.io/docs/akka/current/split-brain-resolver.html#strategies)

--- a/akka-docs/src/main/paradox/additional/rolling-updates.md
+++ b/akka-docs/src/main/paradox/additional/rolling-updates.md
@@ -168,7 +168,7 @@ If you need to change any of the following aspects of sharding it will require a
  * The `extractShardId` function
  * The role that the shard regions run on
  * The persistence mode - It's important to use the same mode on all nodes in the cluster
- * The [`number-of-shards`](https://doc.akka.io/docs/akka/current/typed/cluster-sharding.html#shard-allocation) - Note: changing the number
+ * The @ref:[`number-of-shards`](../typed/cluster-sharding.md#basic-example) - Note: changing the number
  of nodes in the cluster does not require changing the number of shards.
  
 ### Cluster configuration change


### PR DESCRIPTION
Previous docs could give the impression that changing the number of cluster nodes required a full shutdown.  This clarifies that the shutdown is only needed if changing the number of shards and that adjusting the number of shards is not required for changing the number of nodes.