### PR TITLE
sharding example point to non-legacy doc version

### DIFF
--- a/akka-docs/src/main/paradox/additional/rolling-updates.md
+++ b/akka-docs/src/main/paradox/additional/rolling-updates.md
@@ -168,7 +168,7 @@ If you need to change any of the following aspects of sharding it will require a
  * The `extractShardId` function
  * The role that the shard regions run on
  * The persistence mode - It's important to use the same mode on all nodes in the cluster 
- * If the [amount of nodes](https://doc.akka.io/docs/akka/2.5/cluster-sharding.html#an-example) is changed, the [`number-of-shards`](https://doc.akka.io/docs/akka/current/typed/cluster-sharding.html#shard-allocation) may be adapted as well
+ * If the [amount of nodes](https://doc.akka.io/docs/akka/current/cluster-sharding.html#basic-example) is changed, the [`number-of-shards`](https://doc.akka.io/docs/akka/current/typed/cluster-sharding.html#shard-allocation) may be adapted as well
 
 ### Cluster configuration change
 


### PR DESCRIPTION
It was pointing to `2.5` before - thanks @leviramsey for pointing this out!

---

Fix on top of https://github.com/akka/akka/pull/30799