### PR TITLE
Skip mima check for Scala 3 for now

### DIFF
--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -26,42 +26,46 @@ object MiMa extends AutoPlugin {
       projectName: String,
       organization: String,
       scalaBinaryVersion: String): Set[sbt.ModuleID] = {
+    if (scalaBinaryVersion.startsWith("3")) {
+      // No binary compatibility for 3.0 artifacts for now - experimental
+      Set.empty
+    } else {
+      val versions: Seq[String] = {
+        val firstPatchOf25 =
+          if (scalaBinaryVersion.startsWith("2.13")) 25
+          else if (projectName.contains("discovery")) 19
+          else if (projectName.contains("coordination")) 22
+          else 0
 
-    val versions: Seq[String] = {
-      val firstPatchOf25 =
-        if (scalaBinaryVersion.startsWith("2.13")) 25
-        else if (projectName.contains("discovery")) 19
-        else if (projectName.contains("coordination")) 22
-        else 0
+        val akka25Previous =
+          if (!(projectName.contains("typed") || projectName.contains("jackson"))) {
+            // 2.5.18 is the only release built with Scala 2.12.7, which due to
+            // https://github.com/scala/bug/issues/11207 produced many more
+            // static methods than expected. These are hard to filter out, so
+            // we exclude it here and rely on the checks for 2.5.17 and 2.5.19.
+            // Additionally, 2.5.30 had some problems related to
+            // https://github.com/akka/akka/issues/28807
+            expandVersions(2, 5, ((firstPatchOf25 to latestPatchOf25).toSet - 18 - 30).toList)
+          } else {
+            Nil
+          }
+        val akka26Previous = expandVersions(2, 6, 0 to latestPatchOf26)
 
-      val akka25Previous =
-        if (!(projectName.contains("typed") || projectName.contains("jackson"))) {
-          // 2.5.18 is the only release built with Scala 2.12.7, which due to
-          // https://github.com/scala/bug/issues/11207 produced many more
-          // static methods than expected. These are hard to filter out, so
-          // we exclude it here and rely on the checks for 2.5.17 and 2.5.19.
-          // Additionally, 2.5.30 had some problems related to
-          // https://github.com/akka/akka/issues/28807
-          expandVersions(2, 5, ((firstPatchOf25 to latestPatchOf25).toSet - 18 - 30).toList)
-        } else {
-          Nil
-        }
-      val akka26Previous = expandVersions(2, 6, 0 to latestPatchOf26)
+        akka25Previous ++ akka26Previous
+      }
 
-      akka25Previous ++ akka26Previous
+      val akka25PromotedArtifacts = Set("akka-distributed-data")
+
+      // check against all binary compatible artifacts
+      versions.map { v =>
+        val adjustedProjectName =
+          if (akka25PromotedArtifacts(projectName) && v.startsWith("2.4"))
+            projectName + "-experimental"
+          else
+            projectName
+        organization %% adjustedProjectName % v
+      }.toSet
     }
-
-    val akka25PromotedArtifacts = Set("akka-distributed-data")
-
-    // check against all binary compatible artifacts
-    versions.map { v =>
-      val adjustedProjectName =
-        if (akka25PromotedArtifacts(projectName) && v.startsWith("2.4"))
-          projectName + "-experimental"
-        else
-          projectName
-      organization %% adjustedProjectName % v
-    }.toSet
   }
 
   private def expandVersions(major: Int, minor: Int, patches: immutable.Seq[Int]): immutable.Seq[String] =


### PR DESCRIPTION
Was breaking the build trying to download old Akka artifacts for Scala 3

Should fix https://github.com/akka/akka/runs/4022493168?check_suite_focus=true
