### PR TITLE
aeron.dir also for normal multi-node tests, #30601

### DIFF
--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -62,6 +62,10 @@ jobs:
             -Dmultinode.Xms512M \
             -Dmultinode.Xmx512M \
             -Dmultinode.Xlog:gc \
+            -Daeron.dir=/opt/volumes/media-driver \
+            -Dmultinode.Daeron.dir=/opt/volumes/media-driver \
+            -Daeron.term.buffer.length=33554432 \
+            -Dmultinode.Daeron.term.buffer.length=33554432 \
             multiNodeTest
 
       - name: Email on failure


### PR DESCRIPTION
Needed here also since there are a few Aeron tests in this run also.

Failed with
```
must start echo (on node 'second', class akka.remote.artery.aeron.AeronStreamLatencySpecMultiJvmNode2) *** FAILED *** (114 milliseconds)
1501
[info] [JVM-2]   io.aeron.exceptions.RegistrationException: ERROR - java.io.UncheckedIOException : java.io.IOException: No space left on device, 
```

References #30601
