### PR TITLE
Create unique media driver dir for Aeron stream tests, #30845

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamConcistencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamConcistencySpec.scala
@@ -13,7 +13,6 @@ import scala.concurrent.duration._
 
 import com.typesafe.config.ConfigFactory
 import io.aeron.Aeron
-import io.aeron.driver.MediaDriver
 import org.agrona.IoUtil
 
 import akka.Done
@@ -54,7 +53,7 @@ abstract class AeronStreamConsistencySpec
 
   import AeronStreamConsistencySpec._
 
-  val driver = MediaDriver.launchEmbedded()
+  val driver = startDriver()
 
   val aeron = {
     val ctx = new Aeron.Context

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamLatencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamLatencySpec.scala
@@ -19,7 +19,6 @@ import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 import io.aeron.Aeron
 import io.aeron.CncFileDescriptor
-import io.aeron.driver.MediaDriver
 import org.HdrHistogram.Histogram
 import org.agrona.IoUtil
 import org.agrona.concurrent.ManyToOneConcurrentArrayQueue
@@ -46,7 +45,7 @@ object AeronStreamLatencySpec extends MultiNodeConfig {
        akka.test.AeronStreamLatencySpec.totalMessagesFactor = 1.0
        akka.test.AeronStreamLatencySpec.repeatCount = 1
        akka {
-         loglevel = ERROR
+         loglevel = INFO
          testconductor.barrier-timeout = ${barrierTimeout.toSeconds}s
          actor {
            provider = remote
@@ -81,7 +80,7 @@ abstract class AeronStreamLatencySpec
 
   var plots = LatencyPlots()
 
-  val driver = MediaDriver.launchEmbedded()
+  val driver = startDriver()
 
   val pool = new EnvelopeBufferPool(1024 * 1024, 128)
 

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamMaxThroughputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamMaxThroughputSpec.scala
@@ -15,7 +15,6 @@ import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 import io.aeron.Aeron
 import io.aeron.CncFileDescriptor
-import io.aeron.driver.MediaDriver
 import org.agrona.IoUtil
 
 import akka.actor._
@@ -77,7 +76,7 @@ abstract class AeronStreamMaxThroughputSpec
 
   var plot = PlotResult()
 
-  val driver = MediaDriver.launchEmbedded()
+  val driver = startDriver()
 
   val pool = new EnvelopeBufferPool(1024 * 1024, 128)
 

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamMultiNodeSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamMultiNodeSpec.scala
@@ -4,11 +4,27 @@
 
 package akka.remote.artery.aeron
 
+import java.util.UUID
+
+import io.aeron.CommonContext
+import io.aeron.driver.MediaDriver
+
 import akka.remote.artery.UdpPortActor
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
 
 abstract class AeronStreamMultiNodeSpec(config: MultiNodeConfig) extends MultiNodeSpec(config) {
+
+  def startDriver(): MediaDriver = {
+    val driverContext = new MediaDriver.Context
+    // create a random name but include the actor system name for easier debugging
+    val uniquePart = UUID.randomUUID().toString
+    val randomName = s"${CommonContext.getAeronDirectoryName}-${system.name}-$uniquePart"
+    driverContext.aeronDirectoryName(randomName)
+    val d = MediaDriver.launchEmbedded(driverContext)
+    log.info("Started embedded media driver in directory [{}]", d.aeronDirectoryName)
+    d
+  }
 
   def channel(roleName: RoleName) = {
     val n = node(roleName)


### PR DESCRIPTION
When we started setting `aeron.dir` they fail with:
```
java.nio.file.FileSystemException: /opt/volumes/media-driver: Device or resource busy
```

which I think is because they end up using the same directory

References #30845
