### PR TITLE
updated scala versions

### DIFF
--- a/akka-actor-testkit-typed/src/main/mima-filters/2.6.18.backwards.excludes/product-iterator-type-signature-with-scala-2.13.7.excludes
+++ b/akka-actor-testkit-typed/src/main/mima-filters/2.6.18.backwards.excludes/product-iterator-type-signature-with-scala-2.13.7.excludes
@@ -1,0 +1,4 @@
+# Scala 2.13.7 generates different binary when using type wildcards, see https://github.com/scala/bug/issues/12488
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.actor.testkit.typed.Effect#SpawnedAnonymousAdapter.productIterator")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit.theSameElementsAs")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit.theSameElementsInOrderAs")

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/WithMdcBehaviorInterceptor.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/WithMdcBehaviorInterceptor.scala
@@ -54,7 +54,7 @@ import akka.annotation.InternalApi
           // eliminate that interceptor
           loop(i.nestedBehavior)
 
-        case i: InterceptorImpl[T, T] =>
+        case i: InterceptorImpl[T @unchecked, T @unchecked] =>
           val nested = i.nestedBehavior
           val inner = loop(nested)
           if (inner eq nested) i

--- a/akka-actor/src/main/scala/akka/util/PrettyByteString.scala
+++ b/akka-actor/src/main/scala/akka/util/PrettyByteString.scala
@@ -17,7 +17,7 @@ private[akka] object PrettyByteString {
   }
 
   def formatBytes(bs: ByteString, maxBytes: Int = 16 * 5): Iterator[String] = {
-    def asHex(b: Byte): String = b.formatted("%02X")
+    def asHex(b: Byte): String = "%02X".format(b)
     def asASCII(b: Byte): Char =
       if (b >= 0x20 && b < 0x7f) b.toChar
       else '.'

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -175,7 +175,7 @@ private[cluster] object StressMultiJvmSpec extends MultiNodeConfig {
   }
 
   implicit class FormattedDouble(val d: Double) extends AnyVal {
-    def form: String = d.formatted("%.2f")
+    def form: String = "%.2f".format(d)
   }
 
   final case class ClusterResult(address: Address, duration: Duration, clusterStats: GossipStats)

--- a/akka-persistence-shared/src/test/scala/akka/persistence/journal/leveldb/SharedLeveldbJournalSpec.scala
+++ b/akka-persistence-shared/src/test/scala/akka/persistence/journal/leveldb/SharedLeveldbJournalSpec.scala
@@ -4,8 +4,8 @@
 
 package akka.persistence.journal.leveldb
 
+import scala.annotation.nowarn
 import com.typesafe.config.ConfigFactory
-
 import akka.actor._
 import akka.persistence._
 import akka.testkit.{ AkkaSpec, TestProbe }
@@ -90,7 +90,9 @@ class SharedLeveldbJournalSpec extends AkkaSpec(SharedLeveldbJournalSpec.config)
       val probeB = new TestProbe(systemB)
 
       val storeConfig = system.settings.config.getConfig("akka.persistence.journal.leveldb-shared")
-      system.actorOf(Props(classOf[SharedLeveldbStore], storeConfig), "store")
+      @nowarn
+      val sharedLeveldbStoreCls = classOf[SharedLeveldbStore]
+      system.actorOf(Props(sharedLeveldbStoreCls, storeConfig), "store")
       val storePath = RootActorPath(system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress) / "user" / "store"
 
       val appA = systemA.actorOf(Props(classOf[ExampleApp], probeA.ref, storePath))

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/RemoteRestartedQuarantinedSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/classic/RemoteRestartedQuarantinedSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.remote.classic
 
+import scala.annotation.nowarn
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.language.postfixOps
@@ -96,7 +97,9 @@ abstract class RemoteRestartedQuarantinedSpec extends RemotingMultiNodeSpec(Remo
       runOn(second) {
         val address = system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
         val firstAddress = node(first).address
-        system.eventStream.subscribe(testActor, classOf[ThisActorSystemQuarantinedEvent])
+        @nowarn
+        val thisActorSystemQuarantinedEventCls = classOf[ThisActorSystemQuarantinedEvent]
+        system.eventStream.subscribe(testActor, thisActorSystemQuarantinedEventCls)
 
         val (_, ref) = identifyWithUid(first, "subject")
 

--- a/akka-remote/src/main/scala/akka/remote/artery/tcp/TcpFraming.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/tcp/TcpFraming.scala
@@ -75,7 +75,7 @@ import akka.util.ByteString
         else
           throw new FramingException(
             "Stream didn't start with expected magic bytes, " +
-            s"got [${(magic ++ reader.remainingData).take(10).map(_.formatted("%02x")).mkString(" ")}] " +
+            s"got [${(magic ++ reader.remainingData).take(10).map("%02x".format(_)).mkString(" ")}] " +
             "Connection is rejected. Probably invalid accidental access.")
       }
     }

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteMessageSerializationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteMessageSerializationSpec.scala
@@ -36,7 +36,7 @@ class RemoteMessageSerializationSpec extends ArteryMultiNodeSpec with ImplicitSe
       object Unserializable
       EventFilter[NotSerializableException](pattern = ".*No configured serialization.*", occurrences = 1).intercept {
         verifySend(Unserializable) {
-          expectNoMessage(1.second) // No AssocitionErrorEvent should be published
+          expectNoMessage(1.second) // No AssociationErrorEvent should be published
         }
       }
     }
@@ -56,7 +56,7 @@ class RemoteMessageSerializationSpec extends ArteryMultiNodeSpec with ImplicitSe
       EventFilter[OversizedPayloadException](start = "Failed to serialize oversized message", occurrences = 1)
         .intercept {
           verifySend(oversized) {
-            expectNoMessage(1.second) // No AssocitionErrorEvent should be published
+            expectNoMessage(1.second) // No AssociationErrorEvent should be published
           }
         }
       droppedProbe.expectMsgType[Dropped].message should ===(oversized)
@@ -68,7 +68,7 @@ class RemoteMessageSerializationSpec extends ArteryMultiNodeSpec with ImplicitSe
       EventFilter[OversizedPayloadException](pattern = ".*Discarding oversized payload received.*", occurrences = 1)
         .intercept {
           verifySend(maxPayloadBytes + 1) {
-            expectNoMessage(1.second) // No AssocitionErrorEvent should be published
+            expectNoMessage(1.second) // No AssociationErrorEvent should be published
           }
         }
     }

--- a/akka-remote/src/test/scala/akka/remote/artery/RemoteMessageSerializationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/RemoteMessageSerializationSpec.scala
@@ -102,15 +102,20 @@ class RemoteMessageSerializationSpec extends ArteryMultiNodeSpec with ImplicitSe
         case x => testActor ! x
       }
     }))
-    localSystem.eventStream.subscribe(eventForwarder, classOf[AssociationErrorEvent])
-    localSystem.eventStream.subscribe(eventForwarder, classOf[DisassociatedEvent])
+    @nowarn
+    val associationErrorEventCls = classOf[AssociationErrorEvent]
+    @nowarn
+    val disassociatedEventCls = classOf[DisassociatedEvent]
+
+    localSystem.eventStream.subscribe(eventForwarder, associationErrorEventCls)
+    localSystem.eventStream.subscribe(eventForwarder, disassociatedEventCls)
     try {
       bigBounceHere ! msg
       afterSend
       expectNoMessage(500.millis)
     } finally {
-      localSystem.eventStream.unsubscribe(eventForwarder, classOf[AssociationErrorEvent])
-      localSystem.eventStream.unsubscribe(eventForwarder, classOf[DisassociatedEvent])
+      localSystem.eventStream.unsubscribe(eventForwarder, associationErrorEventCls)
+      localSystem.eventStream.unsubscribe(eventForwarder, disassociatedEventCls)
       eventForwarder ! PoisonPill
       bigBounceOther ! PoisonPill
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/DslConsistencySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/DslConsistencySpec.scala
@@ -7,6 +7,8 @@ package akka.stream
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 
+import scala.annotation.nowarn
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -92,6 +94,7 @@ class DslConsistencySpec extends AnyWordSpec with Matchers {
     sSubSourceClass -> Set(),
     sRunnableGraphClass -> Set("builder"))
 
+  @nowarn
   def materializing(m: Method): Boolean = m.getParameterTypes.contains(classOf[ActorMaterializer])
 
   def assertHasMethod(c: Class[_], name: String): Unit = {

--- a/project/AkkaDisciplinePlugin.scala
+++ b/project/AkkaDisciplinePlugin.scala
@@ -92,7 +92,7 @@ object AkkaDisciplinePlugin extends AutoPlugin {
     if (enabled) {
       nowarnSettings ++ Seq(
         Compile / scalacOptions ++= Seq("-Xfatal-warnings"),
-        Test / scalacOptions --= testUndicipline,
+        Test / scalacOptions --= testUndiscipline,
         Compile / javacOptions ++= (
             if (scalaVersion.value.startsWith("3.")) {
               Seq()
@@ -131,7 +131,7 @@ object AkkaDisciplinePlugin extends AutoPlugin {
       nowarnSettings ++ Seq(Compile / scalacOptions += "-deprecation")
     }
 
-  val testUndicipline = Seq("-Ywarn-dead-code" // '???' used in compile only specs
+  val testUndiscipline = Seq("-Ywarn-dead-code" // '???' used in compile only specs
   )
 
   /**

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
   val jacksonVersion = "2.11.4"
 
   val scala212Version = "2.12.15"
-  val scala213Version = "2.13.6"
+  val scala213Version = "2.13.7"
   // To get the fix for https://github.com/lampepfl/dotty/issues/13106
   // and restored static forwarders
   val scala3Version = "3.1.1-RC1"


### PR DESCRIPTION
Supersedes #30868

The error message in #30868 is mentioning Scala 2.12.16, but that's an error emitted by Scala 2.13 compiler. 
Then I noticed that we were still using 2.12.15 in the 2.12 build, so decide to update both versions. 