### PR TITLE
Update ssl-config-core 0.6.0 (was 0.4.3) to avoid conflicting scala-parser-combinators 2.x.

### DIFF
--- a/akka-stream/src/main/mima-filters/2.6.x.backwards.excludes/30871-update-ssl-config-core.backwards.excludes
+++ b/akka-stream/src/main/mima-filters/2.6.x.backwards.excludes/30871-update-ssl-config-core.backwards.excludes
@@ -1,0 +1,2 @@
+# internal
+ProblemFilters.exclude[DirectMissingMethodProblem]("com.typesafe.sslconfig.akka.AkkaSSLConfig.validateDefaultTrustManager")

--- a/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/AkkaSSLConfig.scala
+++ b/akka-stream/src/main/scala/com/typesafe/sslconfig/akka/AkkaSSLConfig.scala
@@ -4,8 +4,6 @@
 
 package com.typesafe.sslconfig.akka
 
-import java.security.KeyStore
-import java.security.cert.CertPathValidatorException
 import java.util.Collections
 import javax.net.ssl._
 import com.typesafe.sslconfig.akka.util.AkkaLoggerFactory
@@ -82,7 +80,6 @@ final class AkkaSSLConfig(system: ExtendedActorSystem, val config: SSLConfigSett
   val sslEngineConfigurator = {
     val sslContext = if (config.default) {
       log.info("ssl-config.default is true, using the JDK's default SSLContext")
-      validateDefaultTrustManager(config)
       SSLContext.getDefault
     } else {
       // break out the static methods as much as we can...
@@ -135,40 +132,6 @@ final class AkkaSSLConfig(system: ExtendedActorSystem, val config: SSLConfigSett
     v
   }
 
-  def validateDefaultTrustManager(sslConfig: SSLConfigSettings): Unit = {
-    // If we are using a default SSL context, we can't filter out certificates with weak algorithms
-    // We ALSO don't have access to the trust manager from the SSLContext without doing horrible things
-    // with reflection.
-    //
-    // However, given that the default SSLContextImpl will call out to the TrustManagerFactory and any
-    // configuration with system properties will also apply with the factory, we can use the factory
-    // method to recreate the trust manager and validate the trust certificates that way.
-    //
-    // This is really a last ditch attempt to satisfy https://wiki.mozilla.org/CA:MD5and1024 on root certificates.
-    //
-    // http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/7-b147/sun/security/ssl/SSLContextImpl.java#79
-
-    val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
-    tmf.init(null.asInstanceOf[KeyStore])
-    val trustManager: X509TrustManager = tmf.getTrustManagers()(0).asInstanceOf[X509TrustManager]
-
-    //    val disabledKeyAlgorithms = sslConfig.disabledKeyAlgorithms.getOrElse(Algorithms.disabledKeyAlgorithms) // was Option
-    val disabledKeyAlgorithms = sslConfig.disabledKeyAlgorithms.mkString(",") // TODO Sub optimal, we got a Seq...
-    val constraints =
-      AlgorithmConstraintsParser.parseAll(AlgorithmConstraintsParser.line, disabledKeyAlgorithms).get.toSet
-    val algorithmChecker = new AlgorithmChecker(mkLogger, keyConstraints = constraints, signatureConstraints = Set())
-    for (cert <- trustManager.getAcceptedIssuers) {
-      try {
-        algorithmChecker.checkKeyAlgorithms(cert)
-      } catch {
-        case e: CertPathValidatorException =>
-          log.warning(
-            "You are using ssl-config.default=true and have a weak certificate in your default trust store! (You can modify akka.ssl-config.disabledKeyAlgorithms to remove this message.)",
-            e)
-      }
-    }
-  }
-
   def configureProtocols(existingProtocols: Array[String], sslConfig: SSLConfigSettings): Array[String] = {
     val definedProtocols = sslConfig.enabledProtocols match {
       case Some(configuredProtocols) =>
@@ -181,15 +144,6 @@ final class AkkaSSLConfig(system: ExtendedActorSystem, val config: SSLConfigSett
         Protocols.recommendedProtocols.filter(existingProtocols.contains)
     }
 
-    val allowWeakProtocols = sslConfig.loose.allowWeakProtocols
-    if (!allowWeakProtocols) {
-      val deprecatedProtocols = Protocols.deprecatedProtocols
-      for (deprecatedProtocol <- deprecatedProtocols) {
-        if (definedProtocols.contains(deprecatedProtocol)) {
-          throw new IllegalStateException(s"Weak protocol $deprecatedProtocol found in ssl-config.protocols!")
-        }
-      }
-    }
     definedProtocols
   }
 
@@ -200,18 +154,9 @@ final class AkkaSSLConfig(system: ExtendedActorSystem, val config: SSLConfigSett
         configuredCiphers.filter(existingCiphers.contains(_)).toArray
 
       case None =>
-        Ciphers.recommendedCiphers.filter(existingCiphers.contains(_)).toArray
+        existingCiphers
     }
 
-    val allowWeakCiphers = sslConfig.loose.allowWeakCiphers
-    if (!allowWeakCiphers) {
-      val deprecatedCiphers = Ciphers.deprecatedCiphers
-      for (deprecatedCipher <- deprecatedCiphers) {
-        if (definedCiphers.contains(deprecatedCipher)) {
-          throw new IllegalStateException(s"Weak cipher $deprecatedCipher found in ssl-config.ciphers!")
-        }
-      }
-    }
     definedCiphers
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
 
   val reactiveStreamsVersion = "1.0.3"
 
-  val sslConfigVersion = "0.4.2"
+  val sslConfigVersion = "0.6.0"
 
   val scalaTestVersion = Def.setting {
     if (scalaVersion.value.startsWith("3.")) {
@@ -96,7 +96,7 @@ object Dependencies {
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion // CC0
 
     // ssl-config
-    val sslConfigCore = ("com.typesafe" %% "ssl-config-core" % sslConfigVersion).cross(CrossVersion.for3Use2_13) // ApacheV2
+    val sslConfigCore = "com.typesafe" %% "ssl-config-core" % sslConfigVersion // ApacheV2
 
     val lmdb = "org.lmdbjava" % "lmdbjava" % "0.7.0" // ApacheV2, OpenLDAP Public License
 


### PR DESCRIPTION
Since ssl-config-core 0.4.3 depends on scala-parser-combinators1.1.2, it conflicts with scala-parser-combinators2.x.

References https://github.com/playframework/play-ws/pull/590/files
