### PR TITLE
adjust cpu requests for failing ClusterSingletonManagerSpec, #30253

### DIFF
--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerSpec.scala
@@ -43,7 +43,8 @@ object ClusterSingletonManagerSpec extends MultiNodeConfig {
     akka.remote.log-remote-lifecycle-events = off
     akka.cluster.downing-provider-class = akka.cluster.testkit.AutoDowning
     akka.cluster.testkit.auto-down-unreachable-after = 0s
-                                          """))
+    akka.remote.artery.advanced.aeron.idle-cpu-level = 3
+    """))
 
   nodeConfig(first, second, third, fourth, fifth, sixth)(ConfigFactory.parseString("akka.cluster.roles =[worker]"))
 

--- a/kubernetes/create-cluster-gke.sh
+++ b/kubernetes/create-cluster-gke.sh
@@ -64,7 +64,7 @@ gcloud container clusters create $CLUSTER_NAME \
   --cluster-version $CLUSTER_VERSION  \
   --enable-ip-alias \
   --image-type cos \
-  --machine-type n1-standard-4 \
+  --machine-type n2-standard-4 \
   --num-nodes 5 \
   --no-enable-autoupgrade
 

--- a/kubernetes/test-node-base.yaml
+++ b/kubernetes/test-node-base.yaml
@@ -19,8 +19,8 @@ spec:
         command: ["sleep", "infinity"]
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1"
+            memory: "4Gi"
+            cpu: "1800m"
           limits:
             memory: "4Gi"
         lifecycle:


### PR DESCRIPTION
* ClusterSingletonManagerSpec is failing with Artery aeron-udp because of
  starvation slowness
* we use 5 nodes with 4 vCPU each
* ClusterSingletonManagerSpec uses 8 pods
* my thinking is that with the previous cpu request 1 it might
  schedule too many pods on the same node (if it doesn't distribute
  them evenly)
* with this new cpu request it should still be able to schedule 2 pods
  per node and that covers all tests except the StressSpec, which is
  anyway disabled
* also changed to n2 series and reduced idle-cpu-level

Refs #30253
