### PR TITLE
Make node app version field public API

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/Member.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Member.scala
@@ -26,7 +26,7 @@ class Member private[cluster] (
     private[cluster] val upNumber: Int, // INTERNAL API
     val status: MemberStatus,
     val roles: Set[String],
-    private[akka] val appVersion: Version) // INTERNAL API
+    val appVersion: Version)
     extends Serializable {
 
   lazy val dataCenter: DataCenter = roles


### PR DESCRIPTION
In #27300 we added node app version to make it possible to detect and handle rolling updates more intelligently, for example to not allocate new shards to old nodes during a rolling upgrade.

The field was however kept as an internal API. Since it will also be useful to users this opens up for accessing it (from the cluster `Member` objects).
