### PR TITLE
Allow 'currentPersistenceIds' for ReadJournal

### DIFF
--- a/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/DurableStateStorePagedPersistenceIdsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/DurableStateStorePagedPersistenceIdsQuery.scala
@@ -7,12 +7,13 @@ package akka.persistence.query.javadsl
 import java.util.Optional
 
 import akka.NotUsed
+import akka.persistence.state.javadsl.DurableStateStore
 import akka.stream.javadsl.Source
 
 /**
- * A ReadJournal may optionally support this query by implementing this trait.
+ * A DurableStateStore may optionally support this query by implementing this trait.
  */
-trait PagedPersistenceIdsQuery extends ReadJournal {
+trait DurableStateStorePagedPersistenceIdsQuery[A] extends DurableStateStore[A] {
 
   /**
    * Get the current persistence ids.

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/PagedPersistenceIdsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/javadsl/PagedPersistenceIdsQuery.scala
@@ -7,18 +7,17 @@ package akka.persistence.query.javadsl
 import java.util.Optional
 
 import akka.NotUsed
-import akka.persistence.state.javadsl.DurableStateStore
 import akka.stream.javadsl.Source
 
 /**
- * A plugin may optionally support this query by implementing this trait.
+ * A plugin (e.g. ReadJournal or DurableStateStore) may optionally support this query by implementing this trait.
  */
-trait CurrentDurableStatePersistenceIdsQuery[A] extends DurableStateStore[A] {
+trait PagedPersistenceIdsQuery {
 
   /**
    * Get the current persistence ids.
    *
-   * Not all durable state plugins may support in database paging, and may simply use drop/take Akka streams operators
+   * Not all plugins may support in database paging, and may simply use drop/take Akka streams operators
    * to manipulate the result set according to the paging parameters.
    *
    * @param afterId The ID to start returning results from, or empty to return all ids. This should be an id returned

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/DurableStateStorePagedPersistenceIdsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/DurableStateStorePagedPersistenceIdsQuery.scala
@@ -5,12 +5,13 @@
 package akka.persistence.query.scaladsl
 
 import akka.NotUsed
+import akka.persistence.state.scaladsl.DurableStateStore
 import akka.stream.scaladsl.Source
 
 /**
- * A plugin ReadJournal may optionally support this query by implementing this trait.
+ * A DurableStateStore may optionally support this query by implementing this trait.
  */
-trait PagedPersistenceIdsQuery extends ReadJournal {
+trait DurableStateStorePagedPersistenceIdsQuery[A] extends DurableStateStore[A] {
 
   /**
    * Get the current persistence ids.

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/PagedPersistenceIdsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/PagedPersistenceIdsQuery.scala
@@ -5,18 +5,17 @@
 package akka.persistence.query.scaladsl
 
 import akka.NotUsed
-import akka.persistence.state.scaladsl.DurableStateStore
 import akka.stream.scaladsl.Source
 
 /**
- * A plugin may optionally support this query by implementing this trait.
+ * A plugin (e.g. ReadJournal or DurableStateStore) may optionally support this query by implementing this trait.
  */
-trait CurrentDurableStatePersistenceIdsQuery[A] extends DurableStateStore[A] {
+trait PagedPersistenceIdsQuery {
 
   /**
    * Get the current persistence ids.
    *
-   * Not all durable state plugins may support in database paging, and may simply use drop/take Akka streams operators
+   * Not all plugins may support in database paging, and may simply use drop/take Akka streams operators
    * to manipulate the result set according to the paging parameters.
    *
    * @param afterId The ID to start returning results from, or [[None]] to return all ids. This should be an id

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
@@ -157,6 +157,8 @@ sealed trait InMemStorage[K, R] extends InternalReprSupport[R] {
     eventsMap.keys.foreach(removePreservingSeqNumber)
   }
 
+  def keys(): immutable.Seq[K] = eventsMap.keys.toSeq
+
   private def getLastSeqNumber(elems: immutable.Seq[R]): Long =
     elems.lastOption.map(reprToSeqNum).getOrElse(0L)
 

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/javadsl/PersistenceTestKitDurableStateStore.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/javadsl/PersistenceTestKitDurableStateStore.scala
@@ -12,7 +12,7 @@ import scala.compat.java8.OptionConverters._
 import akka.{ Done, NotUsed }
 import akka.persistence.query.DurableStateChange
 import akka.persistence.query.Offset
-import akka.persistence.query.javadsl.{ CurrentDurableStatePersistenceIdsQuery, DurableStateStoreQuery }
+import akka.persistence.query.javadsl.{ DurableStateStoreQuery, PagedPersistenceIdsQuery }
 import akka.persistence.state.javadsl.DurableStateUpdateStore
 import akka.persistence.state.javadsl.GetObjectResult
 import akka.persistence.testkit.state.scaladsl.{ PersistenceTestKitDurableStateStore => SStore }
@@ -25,7 +25,7 @@ object PersistenceTestKitDurableStateStore {
 class PersistenceTestKitDurableStateStore[A](stateStore: SStore[A])
     extends DurableStateUpdateStore[A]
     with DurableStateStoreQuery[A]
-    with CurrentDurableStatePersistenceIdsQuery[A] {
+    with PagedPersistenceIdsQuery {
 
   def getObject(persistenceId: String): CompletionStage[GetObjectResult[A]] =
     stateStore.getObject(persistenceId).map(_.toJava)(stateStore.system.dispatcher).toJava

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/javadsl/PersistenceTestKitDurableStateStore.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/javadsl/PersistenceTestKitDurableStateStore.scala
@@ -12,7 +12,7 @@ import scala.compat.java8.OptionConverters._
 import akka.{ Done, NotUsed }
 import akka.persistence.query.DurableStateChange
 import akka.persistence.query.Offset
-import akka.persistence.query.javadsl.{ DurableStateStoreQuery, PagedPersistenceIdsQuery }
+import akka.persistence.query.javadsl.{ DurableStateStorePagedPersistenceIdsQuery, DurableStateStoreQuery }
 import akka.persistence.state.javadsl.DurableStateUpdateStore
 import akka.persistence.state.javadsl.GetObjectResult
 import akka.persistence.testkit.state.scaladsl.{ PersistenceTestKitDurableStateStore => SStore }
@@ -25,7 +25,7 @@ object PersistenceTestKitDurableStateStore {
 class PersistenceTestKitDurableStateStore[A](stateStore: SStore[A])
     extends DurableStateUpdateStore[A]
     with DurableStateStoreQuery[A]
-    with PagedPersistenceIdsQuery {
+    with DurableStateStorePagedPersistenceIdsQuery[A] {
 
   def getObject(persistenceId: String): CompletionStage[GetObjectResult[A]] =
     stateStore.getObject(persistenceId).map(_.toJava)(stateStore.system.dispatcher).toJava

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Future
 import akka.{ Done, NotUsed }
 import akka.actor.ExtendedActorSystem
 import akka.persistence.query.DurableStateChange
-import akka.persistence.query.scaladsl.{ CurrentDurableStatePersistenceIdsQuery, DurableStateStoreQuery }
+import akka.persistence.query.scaladsl.{ DurableStateStoreQuery, PagedPersistenceIdsQuery }
 import akka.persistence.query.UpdatedDurableState
 import akka.persistence.query.Offset
 import akka.persistence.query.NoOffset
@@ -29,7 +29,7 @@ object PersistenceTestKitDurableStateStore {
 class PersistenceTestKitDurableStateStore[A](val system: ExtendedActorSystem)
     extends DurableStateUpdateStore[A]
     with DurableStateStoreQuery[A]
-    with CurrentDurableStatePersistenceIdsQuery[A] {
+    with PagedPersistenceIdsQuery {
 
   private implicit val sys: ExtendedActorSystem = system
   private var store = Map.empty[String, Record[A]]

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
@@ -10,7 +10,7 @@ import scala.concurrent.Future
 import akka.{ Done, NotUsed }
 import akka.actor.ExtendedActorSystem
 import akka.persistence.query.DurableStateChange
-import akka.persistence.query.scaladsl.{ DurableStateStoreQuery, PagedPersistenceIdsQuery }
+import akka.persistence.query.scaladsl.{ DurableStateStorePagedPersistenceIdsQuery, DurableStateStoreQuery }
 import akka.persistence.query.UpdatedDurableState
 import akka.persistence.query.Offset
 import akka.persistence.query.NoOffset
@@ -29,7 +29,7 @@ object PersistenceTestKitDurableStateStore {
 class PersistenceTestKitDurableStateStore[A](val system: ExtendedActorSystem)
     extends DurableStateUpdateStore[A]
     with DurableStateStoreQuery[A]
-    with PagedPersistenceIdsQuery {
+    with DurableStateStorePagedPersistenceIdsQuery[A] {
 
   private implicit val sys: ExtendedActorSystem = system
   private var store = Map.empty[String, Record[A]]

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -707,6 +707,17 @@ class EventSourcedBehaviorSpec
       }
     }
 
+    "allow enumerating all ids" in {
+      val all = queries.currentPersistenceIds(None, Long.MaxValue).runWith(Sink.seq).futureValue
+      all.size should be > 5
+
+      val firstThree = queries.currentPersistenceIds(None, 3).runWith(Sink.seq).futureValue
+      firstThree.size shouldBe 3
+      val others = queries.currentPersistenceIds(Some(firstThree.last), Long.MaxValue).runWith(Sink.seq).futureValue
+
+      firstThree ++ others should contain theSameElementsInOrderAs (all)
+    }
+
     def watcher(toWatch: ActorRef[_]): TestProbe[String] = {
       val probe = TestProbe[String]()
       val w = Behaviors.setup[Any] { ctx =>


### PR DESCRIPTION
This allows `currentPersistenceIds(afterId, limit)` to be mixed in with `ReadJournal` as well as with`DurableStateStore`.

Instead of duplicating `CurrentDurableStatePersistenceIdsQuery` I
renamed it to `PagedPersistenceIdsQuery` and removed the restriction
that it must be a `DurableStateStore`. The downside is that it is less
obvious where it should/can be mixed in, that is now only communicated
through the java/scaladoc and the testkit example.
