### PR TITLE
Add slice utilities to Persistence

### DIFF
--- a/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
@@ -462,7 +462,7 @@ class Persistence(val system: ExtendedActorSystem) extends Extension {
     math.abs(persistenceId.hashCode % numberOfSlices)
 
   /**
-   * Scala API: Slit the total number of slices into ranges by the given `numberOfRanges`.
+   * Scala API: Split the total number of slices into ranges by the given `numberOfRanges`.
    *
    * For example, `numberOfSlices` is 128 and given 4 `numberOfRanges` this method will
    * return ranges (0 to 31), (32 to 63), (64 to 93) and (94 to 127).
@@ -478,7 +478,7 @@ class Persistence(val system: ExtendedActorSystem) extends Extension {
   }
 
   /**
-   * Java API: Slit the total number of slices into ranges by the given `numberOfRanges`.
+   * Java API: Split the total number of slices into ranges by the given `numberOfRanges`.
    *
    * For example, `numberOfSlices` is 128 and given 4 `numberOfRanges` this method will
    * return ranges (0 to 31), (32 to 63), (64 to 93) and (94 to 127).

--- a/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Persistence.scala
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Consumer
 
 import scala.annotation.tailrec
+import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
@@ -17,6 +18,7 @@ import akka.actor._
 import akka.annotation.InternalApi
 import akka.annotation.InternalStableApi
 import akka.event.{ Logging, LoggingAdapter }
+import akka.japi.Pair
 import akka.persistence.journal.{ EventAdapters, IdentityEventAdapters }
 import akka.util.Collections.EmptyImmutableSeq
 import akka.util.Helpers.ConfigOps
@@ -439,6 +441,51 @@ class Persistence(val system: ExtendedActorSystem) extends Extension {
 
       PluginHolder(pluginActorFactory, adapters, config)
     }
+  }
+
+  /**
+   * A slice is deterministically defined based on the persistence id.
+   * `numberOfSlices` is not configurable because changing the value would result in
+   * different slice for a persistence id than what was used before, which would
+   * result in invalid eventsBySlices.
+   *
+   * `numberOfSlices` is 128
+   */
+  final def numberOfSlices: Int = 128
+
+  /**
+   * A slice is deterministically defined based on the persistence id. The purpose is to
+   * evenly distribute all persistence ids over the slices and be able to query the
+   * events for a range of slices.
+   */
+  final def sliceForPersistenceId(persistenceId: String): Int =
+    math.abs(persistenceId.hashCode % numberOfSlices)
+
+  /**
+   * Scala API: Slit the total number of slices into ranges by the given `numberOfRanges`.
+   *
+   * For example, `numberOfSlices` is 128 and given 4 `numberOfRanges` this method will
+   * return ranges (0 to 31), (32 to 63), (64 to 93) and (94 to 127).
+   */
+  final def sliceRanges(numberOfRanges: Int): immutable.IndexedSeq[Range] = {
+    val rangeSize = numberOfSlices / numberOfRanges
+    require(
+      numberOfRanges * rangeSize == numberOfSlices,
+      s"numberOfRanges [$numberOfRanges] must be a whole number divisor of numberOfSlices [$numberOfSlices].")
+    (0 until numberOfRanges).map { i =>
+      (i * rangeSize until i * rangeSize + rangeSize)
+    }.toVector
+  }
+
+  /**
+   * Java API: Slit the total number of slices into ranges by the given `numberOfRanges`.
+   *
+   * For example, `numberOfSlices` is 128 and given 4 `numberOfRanges` this method will
+   * return ranges (0 to 31), (32 to 63), (64 to 93) and (94 to 127).
+   */
+  final def getSliceRanges(numberOfRanges: Int): java.util.List[Pair[Integer, Integer]] = {
+    import akka.util.ccompat.JavaConverters._
+    sliceRanges(numberOfRanges).map(range => Pair(Integer.valueOf(range.min), Integer.valueOf(range.max))).asJava
   }
 
 }

--- a/akka-persistence/src/test/scala/akka/persistence/SliceRangesSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/SliceRangesSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence
+
+import java.util
+import java.util.UUID
+
+import akka.japi.Pair
+import akka.testkit.ImplicitSender
+
+class SliceRangesSpec extends PersistenceSpec(PersistenceSpec.config("inmem", "LoadJournalSpec")) with ImplicitSender {
+
+  private val persistence = Persistence(system)
+
+  "Persistence slices" must {
+    "have fixed numberOfSlices" in {
+      persistence.numberOfSlices should ===(128)
+    }
+
+    "be deterministic from persistence id" in {
+      persistence.sliceForPersistenceId("pid-1") should ===(111)
+      persistence.sliceForPersistenceId("pid-2") should ===(112)
+      persistence.sliceForPersistenceId("pid-6712") should ===(92)
+    }
+
+    "be within the numberOfSlices" in {
+      val pid = s"pid-${UUID.randomUUID()}"
+      withClue(s"$pid ") {
+        val slice = persistence.sliceForPersistenceId(pid)
+        slice should be >= 0
+        slice should be < persistence.numberOfSlices
+      }
+    }
+
+    "create ranges" in {
+      persistence.sliceRanges(4) should ===(Vector(0 to 31, 32 to 63, 64 to 95, 96 to 127))
+      persistence.sliceRanges(1) should ===(Vector(0 to 127))
+    }
+
+    "create ranges for Java" in {
+      persistence.getSliceRanges(4) shouldBe
+      util.Arrays.asList(Pair.create(0, 31), Pair.create(32, 63), Pair.create(64, 95), Pair.create(96, 127))
+    }
+  }
+}


### PR DESCRIPTION
* These will be used by a persistence plugin when it supports
  eventsBySlices
* Good to have these implementations in a single place in Akka rather
  than duplicating it in different plugins
* The numberOfSlices is hardcoded to 128 with the motivation described in
  doc comment, but by placing it in the Persistence extension we have the
  possiblity to make it configurable in the future if that is necessary

