### PR TITLE
Fix StackOverflowError in multi-jvm tests, #30885

### DIFF
--- a/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/ClusterMetricsExtensionSpec.scala
+++ b/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/ClusterMetricsExtensionSpec.scala
@@ -81,8 +81,7 @@ class ClusterMetricsEnabledMultiJvmNode4 extends ClusterMetricsEnabledSpec
 class ClusterMetricsEnabledMultiJvmNode5 extends ClusterMetricsEnabledSpec
 
 abstract class ClusterMetricsEnabledSpec
-    extends MultiNodeSpec(ClusterMetricsEnabledConfig)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(ClusterMetricsEnabledConfig)
     with RedirectLogging {
   import ClusterMetricsEnabledConfig._
 
@@ -139,8 +138,7 @@ class ClusterMetricsDisabledMultiJvmNode4 extends ClusterMetricsDisabledSpec
 class ClusterMetricsDisabledMultiJvmNode5 extends ClusterMetricsDisabledSpec
 
 abstract class ClusterMetricsDisabledSpec
-    extends MultiNodeSpec(ClusterMetricsDisabledConfig)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(ClusterMetricsDisabledConfig)
     with RedirectLogging {
 
   val metricsView = new ClusterMetricsView(cluster.system)

--- a/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/ClusterMetricsExtensionSpec.scala
+++ b/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/ClusterMetricsExtensionSpec.scala
@@ -12,7 +12,6 @@ import com.typesafe.config.ConfigFactory
 import akka.cluster.MemberStatus
 import akka.cluster.MultiNodeClusterSpec
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 
 trait ClusterMetricsCommonConfig extends MultiNodeConfig {
   import ConfigFactory._

--- a/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/ClusterMetricsRoutingSpec.scala
+++ b/akka-cluster-metrics/src/multi-jvm/scala/akka/cluster/metrics/ClusterMetricsRoutingSpec.scala
@@ -20,7 +20,7 @@ import akka.cluster.MultiNodeClusterSpec
 import akka.cluster.routing.ClusterRouterPool
 import akka.cluster.routing.ClusterRouterPoolSettings
 import akka.pattern.ask
-import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
+import akka.remote.testkit.MultiNodeConfig
 import akka.routing.ActorRefRoutee
 import akka.routing.FromConfig
 import akka.routing.GetRoutees
@@ -121,8 +121,7 @@ class AdaptiveLoadBalancingRouterMultiJvmNode3 extends AdaptiveLoadBalancingRout
 
 @nowarn
 abstract class AdaptiveLoadBalancingRouterSpec
-    extends MultiNodeSpec(AdaptiveLoadBalancingRouterConfig)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(AdaptiveLoadBalancingRouterConfig)
     with RedirectLogging
     with ImplicitSender
     with DefaultTimeout {

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/RandomizedBrainResolverIntegrationSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/RandomizedBrainResolverIntegrationSpec.scala
@@ -98,8 +98,7 @@ class RandomizedSplitBrainResolverIntegrationSpecMultiJvmNode8 extends Randomize
 class RandomizedSplitBrainResolverIntegrationSpecMultiJvmNode9 extends RandomizedSplitBrainResolverIntegrationSpec
 
 class RandomizedSplitBrainResolverIntegrationSpec
-    extends MultiNodeSpec(RandomizedSplitBrainResolverIntegrationSpec)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(RandomizedSplitBrainResolverIntegrationSpec)
     with ImplicitSender
     with BeforeAndAfterEach {
   import GlobalRegistry._

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/SplitBrainResolverIntegrationSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/SplitBrainResolverIntegrationSpec.scala
@@ -82,8 +82,7 @@ class SplitBrainResolverIntegrationSpecMultiJvmNode8 extends SplitBrainResolverI
 class SplitBrainResolverIntegrationSpecMultiJvmNode9 extends SplitBrainResolverIntegrationSpec
 
 class SplitBrainResolverIntegrationSpec
-    extends MultiNodeSpec(SplitBrainResolverIntegrationSpec)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(SplitBrainResolverIntegrationSpec)
     with ImplicitSender
     with BeforeAndAfterEach {
   import GlobalRegistry._

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/MultiNodeClusterShardingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/MultiNodeClusterShardingSpec.scala
@@ -79,8 +79,7 @@ object MultiNodeClusterShardingSpec {
  * for new or refactored multi-node sharding specs
  */
 abstract class MultiNodeClusterShardingSpec(val config: MultiNodeClusterShardingConfig)
-    extends MultiNodeSpec(config)
-    with MultiNodeClusterSpec {
+    extends MultiNodeClusterSpec(config) {
 
   import MultiNodeClusterShardingSpec._
   import config._

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/MultiNodeClusterShardingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/MultiNodeClusterShardingSpec.scala
@@ -13,7 +13,6 @@ import akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
 import akka.persistence.Persistence
 import akka.persistence.journal.leveldb.{ SharedLeveldbJournal, SharedLeveldbStore }
 import akka.remote.testconductor.RoleName
-import akka.remote.testkit.MultiNodeSpec
 import akka.serialization.jackson.CborSerializable
 import akka.testkit.{ TestActors, TestProbe }
 import akka.util.ccompat._

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientHandoverSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientHandoverSpec.scala
@@ -40,10 +40,9 @@ class ClusterClientHandoverSpecMultiJvmNode3 extends ClusterClientHandoverSpec
 
 @nowarn("msg=deprecated")
 class ClusterClientHandoverSpec
-    extends MultiNodeSpec(ClusterClientHandoverSpec)
+    extends MultiNodeClusterSpec(ClusterClientHandoverSpec)
     with STMultiNodeSpec
-    with ImplicitSender
-    with MultiNodeClusterSpec {
+    with ImplicitSender {
 
   import ClusterClientHandoverSpec._
 

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientHandoverSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/client/ClusterClientHandoverSpec.scala
@@ -12,7 +12,7 @@ import com.typesafe.config.ConfigFactory
 import akka.actor.{ ActorPath, ActorRef }
 import akka.cluster.{ Cluster, MultiNodeClusterSpec }
 import akka.remote.testconductor.RoleName
-import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec, STMultiNodeSpec }
+import akka.remote.testkit.{ MultiNodeConfig, STMultiNodeSpec }
 import akka.testkit.{ ImplicitSender, TestActors }
 
 object ClusterClientHandoverSpec extends MultiNodeConfig {

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerLeaseSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerLeaseSpec.scala
@@ -15,7 +15,7 @@ import akka.cluster.singleton.ClusterSingletonManagerLeaseSpec.ImportantSingleto
 import akka.coordination.lease.TestLeaseActor
 import akka.coordination.lease.TestLeaseActorClient
 import akka.coordination.lease.TestLeaseActorClientExt
-import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec, STMultiNodeSpec }
+import akka.remote.testkit.{ MultiNodeConfig, STMultiNodeSpec }
 import akka.testkit._
 
 object ClusterSingletonManagerLeaseSpec extends MultiNodeConfig {
@@ -74,10 +74,9 @@ class ClusterSingletonManagerLeaseMultiJvmNode4 extends ClusterSingletonManagerL
 class ClusterSingletonManagerLeaseMultiJvmNode5 extends ClusterSingletonManagerLeaseSpec
 
 class ClusterSingletonManagerLeaseSpec
-    extends MultiNodeSpec(ClusterSingletonManagerLeaseSpec)
+    extends MultiNodeClusterSpec(ClusterSingletonManagerLeaseSpec)
     with STMultiNodeSpec
-    with ImplicitSender
-    with MultiNodeClusterSpec {
+    with ImplicitSender {
 
   import ClusterSingletonManagerLeaseSpec._
   import ClusterSingletonManagerLeaseSpec.ImportantSingleton._

--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerPreparingForShutdownSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerPreparingForShutdownSpec.scala
@@ -13,7 +13,6 @@ import akka.cluster.MemberStatus
 import akka.cluster.MemberStatus.Removed
 import akka.cluster.MultiNodeClusterSpec
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.testkit.STMultiNodeSpec
 import akka.testkit._
 import com.typesafe.config.ConfigFactory
@@ -63,8 +62,7 @@ class ClusterSingletonManagerPreparingForShutdownMultiJvmNode2 extends ClusterSi
 class ClusterSingletonManagerPreparingForShutdownMultiJvmNode3 extends ClusterSingletonManagerPreparingForShutdownSpec
 
 class ClusterSingletonManagerPreparingForShutdownSpec
-    extends MultiNodeSpec(ClusterSingletonManagerPreparingForShutdownSpec)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(ClusterSingletonManagerPreparingForShutdownSpec)
     with STMultiNodeSpec
     with ImplicitSender {
   import ClusterSingletonManagerPreparingForShutdownSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/AttemptSysMsgRedeliverySpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/AttemptSysMsgRedeliverySpec.scala
@@ -12,7 +12,7 @@ import akka.actor.ActorRef
 import akka.actor.Identify
 import akka.actor.PoisonPill
 import akka.actor.Props
-import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
+import akka.remote.testkit.MultiNodeConfig
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.testkit._
 
@@ -38,8 +38,7 @@ class AttemptSysMsgRedeliveryMultiJvmNode2 extends AttemptSysMsgRedeliverySpec
 class AttemptSysMsgRedeliveryMultiJvmNode3 extends AttemptSysMsgRedeliverySpec
 
 class AttemptSysMsgRedeliverySpec
-    extends MultiNodeSpec(AttemptSysMsgRedeliveryMultiJvmSpec)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(AttemptSysMsgRedeliveryMultiJvmSpec)
     with ImplicitSender
     with DefaultTimeout {
   import AttemptSysMsgRedeliveryMultiJvmSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClientDowningNodeThatIsUnreachableSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClientDowningNodeThatIsUnreachableSpec.scala
@@ -5,7 +5,6 @@
 package akka.cluster
 
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 final case class ClientDowningNodeThatIsUnreachableMultiNodeConfig(failureDetectorPuppet: Boolean)
@@ -38,8 +37,7 @@ class ClientDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode4
 
 abstract class ClientDowningNodeThatIsUnreachableSpec(
     multiNodeConfig: ClientDowningNodeThatIsUnreachableMultiNodeConfig)
-    extends MultiNodeSpec(multiNodeConfig)
-    with MultiNodeClusterSpec {
+    extends MultiNodeClusterSpec(multiNodeConfig) {
 
   def this(failureDetectorPuppet: Boolean) =
     this(ClientDowningNodeThatIsUnreachableMultiNodeConfig(failureDetectorPuppet))

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClientDowningNodeThatIsUpSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClientDowningNodeThatIsUpSpec.scala
@@ -5,7 +5,6 @@
 package akka.cluster
 
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 final case class ClientDowningNodeThatIsUpMultiNodeConfig(failureDetectorPuppet: Boolean) extends MultiNodeConfig {
@@ -36,8 +35,7 @@ class ClientDowningNodeThatIsUpWithAccrualFailureDetectorMultiJvmNode4
     extends ClientDowningNodeThatIsUpSpec(failureDetectorPuppet = false)
 
 abstract class ClientDowningNodeThatIsUpSpec(multiNodeConfig: ClientDowningNodeThatIsUpMultiNodeConfig)
-    extends MultiNodeSpec(multiNodeConfig)
-    with MultiNodeClusterSpec {
+    extends MultiNodeClusterSpec(multiNodeConfig) {
 
   def this(failureDetectorPuppet: Boolean) = this(ClientDowningNodeThatIsUpMultiNodeConfig(failureDetectorPuppet))
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterAccrualFailureDetectorSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterAccrualFailureDetectorSpec.scala
@@ -9,7 +9,6 @@ import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.testkit._
 
@@ -31,8 +30,7 @@ class ClusterAccrualFailureDetectorMultiJvmNode2 extends ClusterAccrualFailureDe
 class ClusterAccrualFailureDetectorMultiJvmNode3 extends ClusterAccrualFailureDetectorSpec
 
 abstract class ClusterAccrualFailureDetectorSpec
-    extends MultiNodeSpec(ClusterAccrualFailureDetectorMultiJvmSpec)
-    with MultiNodeClusterSpec {
+    extends MultiNodeClusterSpec(ClusterAccrualFailureDetectorMultiJvmSpec) {
 
   import ClusterAccrualFailureDetectorMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterDeathWatchSpec.scala
@@ -18,7 +18,6 @@ import akka.cluster.MultiNodeClusterSpec.EndActor
 import akka.remote.RemoteActorRef
 import akka.remote.RemoteWatcher
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 import akka.testkit.TestEvent._
 
@@ -53,8 +52,7 @@ class ClusterDeathWatchMultiJvmNode4 extends ClusterDeathWatchSpec
 class ClusterDeathWatchMultiJvmNode5 extends ClusterDeathWatchSpec
 
 abstract class ClusterDeathWatchSpec
-    extends MultiNodeSpec(ClusterDeathWatchMultiJvmSpec)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(ClusterDeathWatchMultiJvmSpec)
     with ImplicitSender
     with ScalaFutures {
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterShutdownSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterShutdownSpec.scala
@@ -6,7 +6,6 @@ package akka.cluster
 
 import akka.cluster.MemberStatus.Removed
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.util.ccompat._
 import org.scalatest.concurrent.Eventually
 
@@ -27,10 +26,7 @@ class ClusterShutdownSpecMultiJvmNode3 extends ClusterShutdownSpec
 class ClusterShutdownSpecMultiJvmNode4 extends ClusterShutdownSpec
 
 @ccompatUsedUntil213
-abstract class ClusterShutdownSpec
-    extends MultiNodeSpec(ClusterShutdownSpec)
-    with MultiNodeClusterSpec
-    with Eventually {
+abstract class ClusterShutdownSpec extends MultiNodeClusterSpec(ClusterShutdownSpec) with Eventually {
 
   import ClusterShutdownSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterWatcherNoClusterWatcheeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterWatcherNoClusterWatcheeSpec.scala
@@ -20,7 +20,6 @@ import akka.remote.RemoteWatcher.Heartbeat
 import akka.remote.RemoteWatcher.Stats
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit.ImplicitSender
 import akka.testkit.TestProbe
 
@@ -90,8 +89,7 @@ private object ClusterWatcherNoClusterWatcheeSpec {
 }
 
 abstract class ClusterWatcherNoClusterWatcheeSpec(multiNodeConfig: ClusterWatcherNoClusterWatcheeConfig)
-    extends MultiNodeSpec(multiNodeConfig)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(multiNodeConfig)
     with ImplicitSender
     with ScalaFutures {
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ConvergenceSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ConvergenceSpec.scala
@@ -11,7 +11,6 @@ import language.postfixOps
 
 import akka.actor.Address
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 final case class ConvergenceMultiNodeConfig(failureDetectorPuppet: Boolean) extends MultiNodeConfig {
@@ -38,8 +37,7 @@ class ConvergenceWithAccrualFailureDetectorMultiJvmNode3 extends ConvergenceSpec
 class ConvergenceWithAccrualFailureDetectorMultiJvmNode4 extends ConvergenceSpec(failureDetectorPuppet = false)
 
 abstract class ConvergenceSpec(multiNodeConfig: ConvergenceMultiNodeConfig)
-    extends MultiNodeSpec(multiNodeConfig)
-    with MultiNodeClusterSpec {
+    extends MultiNodeClusterSpec(multiNodeConfig) {
 
   def this(failureDetectorPuppet: Boolean) = this(ConvergenceMultiNodeConfig(failureDetectorPuppet))
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/DeterministicOldestWhenJoiningSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/DeterministicOldestWhenJoiningSpec.scala
@@ -13,7 +13,6 @@ import akka.actor.Address
 import akka.cluster.ClusterEvent.CurrentClusterState
 import akka.cluster.ClusterEvent.MemberUp
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 object DeterministicOldestWhenJoiningMultiJvmSpec extends MultiNodeConfig {
@@ -36,8 +35,7 @@ class DeterministicOldestWhenJoiningMultiJvmNode2 extends DeterministicOldestWhe
 class DeterministicOldestWhenJoiningMultiJvmNode3 extends DeterministicOldestWhenJoiningSpec
 
 abstract class DeterministicOldestWhenJoiningSpec
-    extends MultiNodeSpec(DeterministicOldestWhenJoiningMultiJvmSpec)
-    with MultiNodeClusterSpec {
+    extends MultiNodeClusterSpec(DeterministicOldestWhenJoiningMultiJvmSpec) {
 
   import DeterministicOldestWhenJoiningMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/DisallowJoinOfTwoClustersSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/DisallowJoinOfTwoClustersSpec.scala
@@ -5,7 +5,6 @@
 package akka.cluster
 
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 object DisallowJoinOfTwoClustersMultiJvmSpec extends MultiNodeConfig {
@@ -24,9 +23,7 @@ class DisallowJoinOfTwoClustersMultiJvmNode3 extends DisallowJoinOfTwoClustersSp
 class DisallowJoinOfTwoClustersMultiJvmNode4 extends DisallowJoinOfTwoClustersSpec
 class DisallowJoinOfTwoClustersMultiJvmNode5 extends DisallowJoinOfTwoClustersSpec
 
-abstract class DisallowJoinOfTwoClustersSpec
-    extends MultiNodeSpec(DisallowJoinOfTwoClustersMultiJvmSpec)
-    with MultiNodeClusterSpec {
+abstract class DisallowJoinOfTwoClustersSpec extends MultiNodeClusterSpec(DisallowJoinOfTwoClustersMultiJvmSpec) {
 
   import DisallowJoinOfTwoClustersMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/DowningWhenOtherHasQuarantinedThisActorSystemSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/DowningWhenOtherHasQuarantinedThisActorSystemSpec.scala
@@ -12,7 +12,6 @@ import scala.concurrent.duration._
 import akka.remote.artery.ArterySettings
 import akka.remote.artery.ThisActorSystemQuarantinedEvent
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter
 import akka.testkit.LongRunningTest
 import com.typesafe.config.ConfigFactory
@@ -49,8 +48,7 @@ class DowningWhenOtherHasQuarantinedThisActorSystemMultiJvmNode3
     extends DowningWhenOtherHasQuarantinedThisActorSystemSpec
 
 abstract class DowningWhenOtherHasQuarantinedThisActorSystemSpec
-    extends MultiNodeSpec(DowningWhenOtherHasQuarantinedThisActorSystemSpec)
-    with MultiNodeClusterSpec {
+    extends MultiNodeClusterSpec(DowningWhenOtherHasQuarantinedThisActorSystemSpec) {
   import DowningWhenOtherHasQuarantinedThisActorSystemSpec._
 
   "Cluster node downed by other" must {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/InitialHeartbeatSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/InitialHeartbeatSpec.scala
@@ -11,7 +11,6 @@ import language.postfixOps
 
 import akka.cluster.ClusterEvent.CurrentClusterState
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.testkit._
 
@@ -31,7 +30,7 @@ class InitialHeartbeatMultiJvmNode1 extends InitialHeartbeatSpec
 class InitialHeartbeatMultiJvmNode2 extends InitialHeartbeatSpec
 class InitialHeartbeatMultiJvmNode3 extends InitialHeartbeatSpec
 
-abstract class InitialHeartbeatSpec extends MultiNodeSpec(InitialHeartbeatMultiJvmSpec) with MultiNodeClusterSpec {
+abstract class InitialHeartbeatSpec extends MultiNodeClusterSpec(InitialHeartbeatMultiJvmSpec) {
 
   import InitialHeartbeatMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/JoinInProgressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/JoinInProgressSpec.scala
@@ -9,7 +9,6 @@ import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 object JoinInProgressMultiJvmSpec extends MultiNodeConfig {
@@ -31,7 +30,7 @@ object JoinInProgressMultiJvmSpec extends MultiNodeConfig {
 class JoinInProgressMultiJvmNode1 extends JoinInProgressSpec
 class JoinInProgressMultiJvmNode2 extends JoinInProgressSpec
 
-abstract class JoinInProgressSpec extends MultiNodeSpec(JoinInProgressMultiJvmSpec) with MultiNodeClusterSpec {
+abstract class JoinInProgressSpec extends MultiNodeClusterSpec(JoinInProgressMultiJvmSpec) {
 
   import JoinInProgressMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/JoinSeedNodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/JoinSeedNodeSpec.scala
@@ -10,7 +10,6 @@ import com.typesafe.config.ConfigFactory
 
 import akka.actor.Address
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 import akka.util.Version
 
@@ -35,7 +34,7 @@ class JoinSeedNodeMultiJvmNode3 extends JoinSeedNodeSpec
 class JoinSeedNodeMultiJvmNode4 extends JoinSeedNodeSpec
 class JoinSeedNodeMultiJvmNode5 extends JoinSeedNodeSpec
 
-abstract class JoinSeedNodeSpec extends MultiNodeSpec(JoinSeedNodeMultiJvmSpec) with MultiNodeClusterSpec {
+abstract class JoinSeedNodeSpec extends MultiNodeClusterSpec(JoinSeedNodeMultiJvmSpec) {
 
   import JoinSeedNodeMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/LargeMessageClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/LargeMessageClusterSpec.scala
@@ -15,7 +15,6 @@ import akka.remote.RARP
 import akka.remote.artery.ArterySettings
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.serialization.SerializerWithStringManifest
 import akka.testkit._
 import akka.util.unused
@@ -86,8 +85,7 @@ class LargeMessageClusterMultiJvmNode2 extends LargeMessageClusterSpec
 class LargeMessageClusterMultiJvmNode3 extends LargeMessageClusterSpec
 
 abstract class LargeMessageClusterSpec
-    extends MultiNodeSpec(LargeMessageClusterMultiJvmSpec)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(LargeMessageClusterMultiJvmSpec)
     with ImplicitSender {
   import LargeMessageClusterMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/LeaderDowningAllOtherNodesSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/LeaderDowningAllOtherNodesSpec.scala
@@ -9,7 +9,6 @@ import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 object LeaderDowningAllOtherNodesMultiJvmSpec extends MultiNodeConfig {
@@ -37,9 +36,7 @@ class LeaderDowningAllOtherNodesMultiJvmNode4 extends LeaderDowningAllOtherNodes
 class LeaderDowningAllOtherNodesMultiJvmNode5 extends LeaderDowningAllOtherNodesSpec
 class LeaderDowningAllOtherNodesMultiJvmNode6 extends LeaderDowningAllOtherNodesSpec
 
-abstract class LeaderDowningAllOtherNodesSpec
-    extends MultiNodeSpec(LeaderDowningAllOtherNodesMultiJvmSpec)
-    with MultiNodeClusterSpec {
+abstract class LeaderDowningAllOtherNodesSpec extends MultiNodeClusterSpec(LeaderDowningAllOtherNodesMultiJvmSpec) {
 
   import LeaderDowningAllOtherNodesMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/LeaderDowningNodeThatIsUnreachableSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/LeaderDowningNodeThatIsUnreachableSpec.scala
@@ -10,7 +10,6 @@ import com.typesafe.config.ConfigFactory
 import language.postfixOps
 
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 final case class LeaderDowningNodeThatIsUnreachableMultiNodeConfig(failureDetectorPuppet: Boolean)
@@ -48,8 +47,7 @@ class LeaderDowningNodeThatIsUnreachableWithAccrualFailureDetectorMultiJvmNode4
 
 abstract class LeaderDowningNodeThatIsUnreachableSpec(
     multiNodeConfig: LeaderDowningNodeThatIsUnreachableMultiNodeConfig)
-    extends MultiNodeSpec(multiNodeConfig)
-    with MultiNodeClusterSpec {
+    extends MultiNodeClusterSpec(multiNodeConfig) {
 
   def this(failureDetectorPuppet: Boolean) =
     this(LeaderDowningNodeThatIsUnreachableMultiNodeConfig(failureDetectorPuppet))

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/LeaderElectionSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/LeaderElectionSpec.scala
@@ -9,7 +9,6 @@ import scala.concurrent.duration._
 import language.postfixOps
 
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 final case class LeaderElectionMultiNodeConfig(failureDetectorPuppet: Boolean) extends MultiNodeConfig {
@@ -35,8 +34,7 @@ class LeaderElectionWithAccrualFailureDetectorMultiJvmNode4 extends LeaderElecti
 class LeaderElectionWithAccrualFailureDetectorMultiJvmNode5 extends LeaderElectionSpec(failureDetectorPuppet = false)
 
 abstract class LeaderElectionSpec(multiNodeConfig: LeaderElectionMultiNodeConfig)
-    extends MultiNodeSpec(multiNodeConfig)
-    with MultiNodeClusterSpec {
+    extends MultiNodeClusterSpec(multiNodeConfig) {
 
   def this(failureDetectorPuppet: Boolean) = this(LeaderElectionMultiNodeConfig(failureDetectorPuppet))
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/LeaderLeavingSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/LeaderLeavingSpec.scala
@@ -13,7 +13,6 @@ import akka.actor.Deploy
 import akka.actor.Props
 import akka.cluster.MemberStatus._
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 object LeaderLeavingMultiJvmSpec extends MultiNodeConfig {
@@ -33,7 +32,7 @@ class LeaderLeavingMultiJvmNode1 extends LeaderLeavingSpec
 class LeaderLeavingMultiJvmNode2 extends LeaderLeavingSpec
 class LeaderLeavingMultiJvmNode3 extends LeaderLeavingSpec
 
-abstract class LeaderLeavingSpec extends MultiNodeSpec(LeaderLeavingMultiJvmSpec) with MultiNodeClusterSpec {
+abstract class LeaderLeavingSpec extends MultiNodeClusterSpec(LeaderLeavingMultiJvmSpec) {
 
   import ClusterEvent._
   import LeaderLeavingMultiJvmSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MBeanSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MBeanSpec.scala
@@ -14,7 +14,6 @@ import javax.management.ObjectName
 import language.postfixOps
 
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 object MBeanMultiJvmSpec extends MultiNodeConfig {
@@ -36,7 +35,7 @@ class MBeanMultiJvmNode2 extends MBeanSpec
 class MBeanMultiJvmNode3 extends MBeanSpec
 class MBeanMultiJvmNode4 extends MBeanSpec
 
-abstract class MBeanSpec extends MultiNodeSpec(MBeanMultiJvmSpec) with MultiNodeClusterSpec {
+abstract class MBeanSpec extends MultiNodeClusterSpec(MBeanMultiJvmSpec) {
 
   import MBeanMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MemberWeaklyUpSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MemberWeaklyUpSpec.scala
@@ -11,7 +11,6 @@ import com.typesafe.config.ConfigFactory
 
 import akka.cluster.MemberStatus.WeaklyUp
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.testkit._
 
@@ -36,7 +35,7 @@ class MemberWeaklyUpMultiJvmNode3 extends MemberWeaklyUpSpec
 class MemberWeaklyUpMultiJvmNode4 extends MemberWeaklyUpSpec
 class MemberWeaklyUpMultiJvmNode5 extends MemberWeaklyUpSpec
 
-abstract class MemberWeaklyUpSpec extends MultiNodeSpec(MemberWeaklyUpSpec) with MultiNodeClusterSpec {
+abstract class MemberWeaklyUpSpec extends MultiNodeClusterSpec(MemberWeaklyUpSpec) {
 
   import MemberWeaklyUpSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MembershipChangeListenerExitingSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MembershipChangeListenerExitingSpec.scala
@@ -9,7 +9,6 @@ import akka.actor.Deploy
 import akka.actor.Props
 import akka.cluster.MemberStatus._
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 object MembershipChangeListenerExitingMultiJvmSpec extends MultiNodeConfig {
@@ -25,8 +24,7 @@ class MembershipChangeListenerExitingMultiJvmNode2 extends MembershipChangeListe
 class MembershipChangeListenerExitingMultiJvmNode3 extends MembershipChangeListenerExitingSpec
 
 abstract class MembershipChangeListenerExitingSpec
-    extends MultiNodeSpec(MembershipChangeListenerExitingMultiJvmSpec)
-    with MultiNodeClusterSpec {
+    extends MultiNodeClusterSpec(MembershipChangeListenerExitingMultiJvmSpec) {
 
   import ClusterEvent._
   import MembershipChangeListenerExitingMultiJvmSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MembershipChangeListenerUpSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MembershipChangeListenerUpSpec.scala
@@ -8,7 +8,6 @@ import akka.actor.Actor
 import akka.actor.Deploy
 import akka.actor.Props
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 object MembershipChangeListenerUpMultiJvmSpec extends MultiNodeConfig {
@@ -23,9 +22,7 @@ class MembershipChangeListenerUpMultiJvmNode1 extends MembershipChangeListenerUp
 class MembershipChangeListenerUpMultiJvmNode2 extends MembershipChangeListenerUpSpec
 class MembershipChangeListenerUpMultiJvmNode3 extends MembershipChangeListenerUpSpec
 
-abstract class MembershipChangeListenerUpSpec
-    extends MultiNodeSpec(MembershipChangeListenerUpMultiJvmSpec)
-    with MultiNodeClusterSpec {
+abstract class MembershipChangeListenerUpSpec extends MultiNodeClusterSpec(MembershipChangeListenerUpMultiJvmSpec) {
 
   import ClusterEvent._
   import MembershipChangeListenerUpMultiJvmSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MinMembersBeforeUpSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MinMembersBeforeUpSpec.scala
@@ -9,7 +9,6 @@ import com.typesafe.config.ConfigFactory
 import akka.cluster.MemberStatus._
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 import akka.util.ccompat._
 
@@ -104,9 +103,7 @@ abstract class MinMembersOfRoleBeforeUpSpec extends MinMembersBeforeUpBase(MinMe
   }
 }
 
-abstract class MinMembersBeforeUpBase(multiNodeConfig: MultiNodeConfig)
-    extends MultiNodeSpec(multiNodeConfig)
-    with MultiNodeClusterSpec {
+abstract class MinMembersBeforeUpBase(multiNodeConfig: MultiNodeConfig) extends MultiNodeClusterSpec(multiNodeConfig) {
 
   def first: RoleName
   def second: RoleName

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcClusterSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 
 import akka.cluster.MemberStatus.Up
-import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
+import akka.remote.testkit.MultiNodeConfig
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 
 class MultiDcSpecConfig(crossDcConnections: Int = 5) extends MultiNodeConfig {
@@ -50,7 +50,7 @@ class MultiDcFewCrossDcMultiJvmNode3 extends MultiDcSpec(MultiDcFewCrossDcConnec
 class MultiDcFewCrossDcMultiJvmNode4 extends MultiDcSpec(MultiDcFewCrossDcConnectionsConfig)
 class MultiDcFewCrossDcMultiJvmNode5 extends MultiDcSpec(MultiDcFewCrossDcConnectionsConfig)
 
-abstract class MultiDcSpec(config: MultiDcSpecConfig) extends MultiNodeSpec(config) with MultiNodeClusterSpec {
+abstract class MultiDcSpec(config: MultiDcSpecConfig) extends MultiNodeClusterSpec(config) {
 
   import config._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcHeartbeatTakingOverSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcHeartbeatTakingOverSpec.scala
@@ -14,7 +14,7 @@ import akka.actor.ActorRef
 import akka.actor.ActorSelection
 import akka.annotation.InternalApi
 import akka.remote.testconductor.RoleName
-import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
+import akka.remote.testkit.MultiNodeConfig
 import akka.testkit._
 import akka.util.ccompat._
 
@@ -66,9 +66,7 @@ class MultiDcHeartbeatTakingOverSpecMultiJvmNode3 extends MultiDcHeartbeatTaking
 class MultiDcHeartbeatTakingOverSpecMultiJvmNode4 extends MultiDcHeartbeatTakingOverSpec
 class MultiDcHeartbeatTakingOverSpecMultiJvmNode5 extends MultiDcHeartbeatTakingOverSpec
 
-abstract class MultiDcHeartbeatTakingOverSpec
-    extends MultiNodeSpec(MultiDcHeartbeatTakingOverSpecMultiJvmSpec)
-    with MultiNodeClusterSpec {
+abstract class MultiDcHeartbeatTakingOverSpec extends MultiNodeClusterSpec(MultiDcHeartbeatTakingOverSpecMultiJvmSpec) {
 
   "A 2-dc cluster" must {
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcJoin2Spec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcJoin2Spec.scala
@@ -12,7 +12,6 @@ import akka.actor.Address
 import akka.cluster.ClusterEvent.InitialStateAsEvents
 import akka.cluster.ClusterEvent.MemberUp
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 // Similar to MultiDcJoinSpec, but slightly different scenario
@@ -63,7 +62,7 @@ class MultiDcJoin2MultiJvmNode3 extends MultiDcJoin2Spec
 class MultiDcJoin2MultiJvmNode4 extends MultiDcJoin2Spec
 class MultiDcJoin2MultiJvmNode5 extends MultiDcJoin2Spec
 
-abstract class MultiDcJoin2Spec extends MultiNodeSpec(MultiDcJoin2MultiJvmSpec) with MultiNodeClusterSpec {
+abstract class MultiDcJoin2Spec extends MultiNodeClusterSpec(MultiDcJoin2MultiJvmSpec) {
   import MultiDcJoin2MultiJvmSpec._
 
   "Joining a multi-dc cluster, scenario 2" must {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcJoinSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcJoinSpec.scala
@@ -11,7 +11,6 @@ import com.typesafe.config.ConfigFactory
 import akka.cluster.ClusterEvent.InitialStateAsEvents
 import akka.cluster.ClusterEvent.MemberUp
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 // reproducer for issue #29280
@@ -62,7 +61,7 @@ class MultiDcJoinMultiJvmNode3 extends MultiDcJoinSpec
 class MultiDcJoinMultiJvmNode4 extends MultiDcJoinSpec
 class MultiDcJoinMultiJvmNode5 extends MultiDcJoinSpec
 
-abstract class MultiDcJoinSpec extends MultiNodeSpec(MultiDcJoinMultiJvmSpec) with MultiNodeClusterSpec {
+abstract class MultiDcJoinSpec extends MultiNodeClusterSpec(MultiDcJoinMultiJvmSpec) {
   import MultiDcJoinMultiJvmSpec._
 
   "Joining a multi-dc cluster" must {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcLastNodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcLastNodeSpec.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 
 import com.typesafe.config.ConfigFactory
 
-import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
+import akka.remote.testkit.MultiNodeConfig
 
 object MultiDcLastNodeSpec extends MultiNodeConfig {
   val first = role("first")
@@ -33,7 +33,7 @@ class MultiDcLastNodeMultiJvmNode1 extends MultiDcLastNodeSpec
 class MultiDcLastNodeMultiJvmNode2 extends MultiDcLastNodeSpec
 class MultiDcLastNodeMultiJvmNode3 extends MultiDcLastNodeSpec
 
-abstract class MultiDcLastNodeSpec extends MultiNodeSpec(MultiDcLastNodeSpec) with MultiNodeClusterSpec {
+abstract class MultiDcLastNodeSpec extends MultiNodeClusterSpec(MultiDcLastNodeSpec) {
 
   import MultiDcLastNodeSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcSplitBrainSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcSplitBrainSpec.scala
@@ -12,7 +12,7 @@ import com.typesafe.config.ConfigFactory
 import akka.actor.ActorSystem
 import akka.cluster.ClusterEvent._
 import akka.remote.testconductor.RoleName
-import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
+import akka.remote.testkit.MultiNodeConfig
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.testkit.TestProbe
 
@@ -63,7 +63,7 @@ class MultiDcSplitBrainMultiJvmNode3 extends MultiDcSplitBrainSpec
 class MultiDcSplitBrainMultiJvmNode4 extends MultiDcSplitBrainSpec
 class MultiDcSplitBrainMultiJvmNode5 extends MultiDcSplitBrainSpec
 
-abstract class MultiDcSplitBrainSpec extends MultiNodeSpec(MultiDcSplitBrainMultiJvmSpec) with MultiNodeClusterSpec {
+abstract class MultiDcSplitBrainSpec extends MultiNodeClusterSpec(MultiDcSplitBrainMultiJvmSpec) {
 
   import MultiDcSplitBrainMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcSunnyWeatherSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcSunnyWeatherSpec.scala
@@ -13,7 +13,7 @@ import com.typesafe.config.ConfigFactory
 import akka.actor.ActorRef
 import akka.annotation.InternalApi
 import akka.remote.testconductor.RoleName
-import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
+import akka.remote.testkit.MultiNodeConfig
 import akka.testkit._
 
 object MultiDcSunnyWeatherMultiJvmSpec extends MultiNodeConfig {
@@ -62,9 +62,7 @@ class MultiDcSunnyWeatherMultiJvmNode3 extends MultiDcSunnyWeatherSpec
 class MultiDcSunnyWeatherMultiJvmNode4 extends MultiDcSunnyWeatherSpec
 class MultiDcSunnyWeatherMultiJvmNode5 extends MultiDcSunnyWeatherSpec
 
-abstract class MultiDcSunnyWeatherSpec
-    extends MultiNodeSpec(MultiDcSunnyWeatherMultiJvmSpec)
-    with MultiNodeClusterSpec {
+abstract class MultiDcSunnyWeatherSpec extends MultiNodeClusterSpec(MultiDcSunnyWeatherMultiJvmSpec) {
 
   "A normal cluster" must {
     "be healthy" taggedAs LongRunningTest in {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
@@ -20,6 +20,7 @@ import akka.cluster.ClusterEvent.{ MemberEvent, MemberRemoved }
 import akka.event.Logging.ErrorLevel
 import akka.remote.DefaultFailureDetectorRegistry
 import akka.remote.testconductor.RoleName
+import akka.remote.testkit.MultiNodeConfig
 import akka.remote.testkit.{ MultiNodeSpec, STMultiNodeSpec }
 import akka.serialization.jackson.CborSerializable
 import akka.testkit._
@@ -91,8 +92,11 @@ object MultiNodeClusterSpec {
   }
 }
 
-trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec with WatchedByCoroner {
-  self: MultiNodeSpec =>
+abstract class MultiNodeClusterSpec(multiNodeconfig: MultiNodeConfig)
+    extends MultiNodeSpec(multiNodeconfig)
+    with Suite
+    with STMultiNodeSpec
+    with WatchedByCoroner {
 
   override def initialParticipants: Int = roles.size
 
@@ -101,11 +105,11 @@ trait MultiNodeClusterSpec extends Suite with STMultiNodeSpec with WatchedByCoro
   override protected def atStartup(): Unit = {
     startCoroner()
     muteLog()
-    self.atStartup()
+    super.atStartup()
   }
 
   override protected def afterTermination(): Unit = {
-    self.afterTermination()
+    super.afterTermination()
     stopCoroner()
   }
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeChurnSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeChurnSpec.scala
@@ -12,7 +12,7 @@ import com.typesafe.config.ConfigFactory
 import akka.actor._
 import akka.event.Logging.Info
 import akka.remote.RARP
-import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
+import akka.remote.testkit.MultiNodeConfig
 import akka.testkit._
 import akka.testkit.TestKit
 
@@ -51,12 +51,11 @@ class NodeChurnMultiJvmNode2 extends NodeChurnSpec
 class NodeChurnMultiJvmNode3 extends NodeChurnSpec
 
 abstract class NodeChurnSpec
-    extends MultiNodeSpec({
+    extends MultiNodeClusterSpec({
       // Aeron media driver must be started before ActorSystem
       SharedMediaDriverSupport.startMediaDriver(NodeChurnMultiJvmSpec)
       NodeChurnMultiJvmSpec
     })
-    with MultiNodeClusterSpec
     with ImplicitSender {
 
   import NodeChurnMultiJvmSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeDowningAndBeingRemovedSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeDowningAndBeingRemovedSpec.scala
@@ -9,7 +9,6 @@ import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 object NodeDowningAndBeingRemovedMultiJvmSpec extends MultiNodeConfig {
@@ -28,9 +27,7 @@ class NodeDowningAndBeingRemovedMultiJvmNode1 extends NodeDowningAndBeingRemoved
 class NodeDowningAndBeingRemovedMultiJvmNode2 extends NodeDowningAndBeingRemovedSpec
 class NodeDowningAndBeingRemovedMultiJvmNode3 extends NodeDowningAndBeingRemovedSpec
 
-abstract class NodeDowningAndBeingRemovedSpec
-    extends MultiNodeSpec(NodeDowningAndBeingRemovedMultiJvmSpec)
-    with MultiNodeClusterSpec {
+abstract class NodeDowningAndBeingRemovedSpec extends MultiNodeClusterSpec(NodeDowningAndBeingRemovedMultiJvmSpec) {
 
   import NodeDowningAndBeingRemovedMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExitingAndBeingRemovedSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExitingAndBeingRemovedSpec.scala
@@ -7,7 +7,6 @@ package akka.cluster
 import scala.concurrent.duration._
 
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 object NodeLeavingAndExitingAndBeingRemovedMultiJvmSpec extends MultiNodeConfig {
@@ -23,8 +22,7 @@ class NodeLeavingAndExitingAndBeingRemovedMultiJvmNode2 extends NodeLeavingAndEx
 class NodeLeavingAndExitingAndBeingRemovedMultiJvmNode3 extends NodeLeavingAndExitingAndBeingRemovedSpec
 
 abstract class NodeLeavingAndExitingAndBeingRemovedSpec
-    extends MultiNodeSpec(NodeLeavingAndExitingAndBeingRemovedMultiJvmSpec)
-    with MultiNodeClusterSpec {
+    extends MultiNodeClusterSpec(NodeLeavingAndExitingAndBeingRemovedMultiJvmSpec) {
 
   import NodeLeavingAndExitingAndBeingRemovedMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExitingSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeLeavingAndExitingSpec.scala
@@ -9,7 +9,6 @@ import akka.actor.Deploy
 import akka.actor.Props
 import akka.cluster.MemberStatus._
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 object NodeLeavingAndExitingMultiJvmSpec extends MultiNodeConfig {
@@ -24,9 +23,7 @@ class NodeLeavingAndExitingMultiJvmNode1 extends NodeLeavingAndExitingSpec
 class NodeLeavingAndExitingMultiJvmNode2 extends NodeLeavingAndExitingSpec
 class NodeLeavingAndExitingMultiJvmNode3 extends NodeLeavingAndExitingSpec
 
-abstract class NodeLeavingAndExitingSpec
-    extends MultiNodeSpec(NodeLeavingAndExitingMultiJvmSpec)
-    with MultiNodeClusterSpec {
+abstract class NodeLeavingAndExitingSpec extends MultiNodeClusterSpec(NodeLeavingAndExitingMultiJvmSpec) {
 
   import ClusterEvent._
   import NodeLeavingAndExitingMultiJvmSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeMembershipSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeMembershipSpec.scala
@@ -5,7 +5,6 @@
 package akka.cluster
 
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 import akka.util.ccompat._
 
@@ -22,7 +21,7 @@ class NodeMembershipMultiJvmNode1 extends NodeMembershipSpec
 class NodeMembershipMultiJvmNode2 extends NodeMembershipSpec
 class NodeMembershipMultiJvmNode3 extends NodeMembershipSpec
 
-abstract class NodeMembershipSpec extends MultiNodeSpec(NodeMembershipMultiJvmSpec) with MultiNodeClusterSpec {
+abstract class NodeMembershipSpec extends MultiNodeClusterSpec(NodeMembershipMultiJvmSpec) {
 
   import NodeMembershipMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeUpSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/NodeUpSpec.scala
@@ -12,7 +12,6 @@ import scala.concurrent.duration._
 import akka.actor.Actor
 import akka.actor.Props
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 object NodeUpMultiJvmSpec extends MultiNodeConfig {
@@ -25,7 +24,7 @@ object NodeUpMultiJvmSpec extends MultiNodeConfig {
 class NodeUpMultiJvmNode1 extends NodeUpSpec
 class NodeUpMultiJvmNode2 extends NodeUpSpec
 
-abstract class NodeUpSpec extends MultiNodeSpec(NodeUpMultiJvmSpec) with MultiNodeClusterSpec {
+abstract class NodeUpSpec extends MultiNodeClusterSpec(NodeUpMultiJvmSpec) {
 
   import ClusterEvent._
   import NodeUpMultiJvmSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/QuickRestartSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/QuickRestartSpec.scala
@@ -35,10 +35,7 @@ class QuickRestartMultiJvmNode1 extends QuickRestartSpec
 class QuickRestartMultiJvmNode2 extends QuickRestartSpec
 class QuickRestartMultiJvmNode3 extends QuickRestartSpec
 
-abstract class QuickRestartSpec
-    extends MultiNodeSpec(QuickRestartMultiJvmSpec)
-    with MultiNodeClusterSpec
-    with ImplicitSender {
+abstract class QuickRestartSpec extends MultiNodeClusterSpec(QuickRestartMultiJvmSpec) with ImplicitSender {
 
   import QuickRestartMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/RemoteFeaturesWithClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/RemoteFeaturesWithClusterSpec.scala
@@ -63,8 +63,7 @@ class ClassicClusterRemoteFeaturesMultiJvmNode3
     extends ClusterRemoteFeaturesSpec(new ClusterRemoteFeaturesConfig(false))
 
 abstract class ClusterRemoteFeaturesSpec(multiNodeConfig: ClusterRemoteFeaturesConfig)
-    extends MultiNodeSpec(multiNodeConfig)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(multiNodeConfig)
     with ImplicitSender
     with ScalaFutures {
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartFirstSeedNodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartFirstSeedNodeSpec.scala
@@ -43,8 +43,7 @@ class RestartFirstSeedNodeMultiJvmNode2 extends RestartFirstSeedNodeSpec
 class RestartFirstSeedNodeMultiJvmNode3 extends RestartFirstSeedNodeSpec
 
 abstract class RestartFirstSeedNodeSpec
-    extends MultiNodeSpec(RestartFirstSeedNodeMultiJvmSpec)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(RestartFirstSeedNodeMultiJvmSpec)
     with ImplicitSender {
 
   import RestartFirstSeedNodeMultiJvmSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNode2Spec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNode2Spec.scala
@@ -46,10 +46,7 @@ object RestartNode2SpecMultiJvmSpec extends MultiNodeConfig {
 class RestartNode2SpecMultiJvmNode1 extends RestartNode2SpecSpec
 class RestartNode2SpecMultiJvmNode2 extends RestartNode2SpecSpec
 
-abstract class RestartNode2SpecSpec
-    extends MultiNodeSpec(RestartNode2SpecMultiJvmSpec)
-    with MultiNodeClusterSpec
-    with ImplicitSender {
+abstract class RestartNode2SpecSpec extends MultiNodeClusterSpec(RestartNode2SpecMultiJvmSpec) with ImplicitSender {
 
   import RestartNode2SpecMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNode3Spec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNode3Spec.scala
@@ -46,10 +46,7 @@ class RestartNode3MultiJvmNode1 extends RestartNode3Spec
 class RestartNode3MultiJvmNode2 extends RestartNode3Spec
 class RestartNode3MultiJvmNode3 extends RestartNode3Spec
 
-abstract class RestartNode3Spec
-    extends MultiNodeSpec(RestartNode3MultiJvmSpec)
-    with MultiNodeClusterSpec
-    with ImplicitSender {
+abstract class RestartNode3Spec extends MultiNodeClusterSpec(RestartNode3MultiJvmSpec) with ImplicitSender {
 
   import RestartNode3MultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/RestartNodeSpec.scala
@@ -66,10 +66,7 @@ class RestartNodeMultiJvmNode1 extends RestartNodeSpec
 class RestartNodeMultiJvmNode2 extends RestartNodeSpec
 class RestartNodeMultiJvmNode3 extends RestartNodeSpec
 
-abstract class RestartNodeSpec
-    extends MultiNodeSpec(RestartNodeMultiJvmSpec)
-    with MultiNodeClusterSpec
-    with ImplicitSender {
+abstract class RestartNodeSpec extends MultiNodeClusterSpec(RestartNodeMultiJvmSpec) with ImplicitSender {
 
   import RestartNodeMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SingletonClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SingletonClusterSpec.scala
@@ -11,7 +11,6 @@ import com.typesafe.config.ConfigFactory
 
 import akka.actor.Address
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 final case class SingletonClusterMultiNodeConfig(failureDetectorPuppet: Boolean) extends MultiNodeConfig {
@@ -40,8 +39,7 @@ class SingletonClusterWithAccrualFailureDetectorMultiJvmNode2
     extends SingletonClusterSpec(failureDetectorPuppet = false)
 
 abstract class SingletonClusterSpec(multiNodeConfig: SingletonClusterMultiNodeConfig)
-    extends MultiNodeSpec(multiNodeConfig)
-    with MultiNodeClusterSpec {
+    extends MultiNodeClusterSpec(multiNodeConfig) {
 
   def this(failureDetectorPuppet: Boolean) = this(SingletonClusterMultiNodeConfig(failureDetectorPuppet))
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SplitBrainQuarantineSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SplitBrainQuarantineSpec.scala
@@ -9,7 +9,6 @@ import akka.actor.Identify
 import akka.actor.RootActorPath
 import akka.remote.artery.ArterySettings
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter
 import akka.testkit.LongRunningTest
 import com.typesafe.config.ConfigFactory
@@ -42,7 +41,7 @@ class SplitBrainQuarantineMultiJvmNode2 extends SplitBrainQuarantineSpec
 class SplitBrainQuarantineMultiJvmNode3 extends SplitBrainQuarantineSpec
 class SplitBrainQuarantineMultiJvmNode4 extends SplitBrainQuarantineSpec
 
-abstract class SplitBrainQuarantineSpec extends MultiNodeSpec(SplitBrainQuarantineSpec) with MultiNodeClusterSpec {
+abstract class SplitBrainQuarantineSpec extends MultiNodeClusterSpec(SplitBrainQuarantineSpec) {
   import SplitBrainQuarantineSpec._
 
   // reproduces the scenario where cluster is partitioned and each side (incorrectly) downs the other,

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SplitBrainSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SplitBrainSpec.scala
@@ -10,7 +10,6 @@ import com.typesafe.config.ConfigFactory
 import language.postfixOps
 
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.testkit._
 
@@ -48,8 +47,7 @@ class SplitBrainWithAccrualFailureDetectorMultiJvmNode4 extends SplitBrainSpec(f
 class SplitBrainWithAccrualFailureDetectorMultiJvmNode5 extends SplitBrainSpec(failureDetectorPuppet = false)
 
 abstract class SplitBrainSpec(multiNodeConfig: SplitBrainMultiNodeConfig)
-    extends MultiNodeSpec(multiNodeConfig)
-    with MultiNodeClusterSpec {
+    extends MultiNodeClusterSpec(multiNodeConfig) {
 
   def this(failureDetectorPuppet: Boolean) = this(SplitBrainMultiNodeConfig(failureDetectorPuppet))
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StreamRefSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StreamRefSpec.scala
@@ -14,7 +14,6 @@ import com.typesafe.config.ConfigFactory
 import akka.Done
 import akka.actor.{ Actor, ActorIdentity, ActorLogging, ActorRef, Identify, Props }
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.serialization.jackson.CborSerializable
 import akka.stream.Materializer
@@ -141,7 +140,7 @@ class StreamRefMultiJvmNode1 extends StreamRefSpec
 class StreamRefMultiJvmNode2 extends StreamRefSpec
 class StreamRefMultiJvmNode3 extends StreamRefSpec
 
-abstract class StreamRefSpec extends MultiNodeSpec(StreamRefSpec) with MultiNodeClusterSpec with ImplicitSender {
+abstract class StreamRefSpec extends MultiNodeClusterSpec(StreamRefSpec) with ImplicitSender {
   import StreamRefSpec._
 
   "A cluster with Stream Refs" must {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/StressSpec.scala
@@ -433,11 +433,7 @@ class StressMultiJvmNode8 extends StressSpec
 class StressMultiJvmNode9 extends StressSpec
 class StressMultiJvmNode10 extends StressSpec
 
-abstract class StressSpec
-    extends MultiNodeSpec(StressMultiJvmSpec)
-    with MultiNodeClusterSpec
-    with BeforeAndAfterEach
-    with ImplicitSender {
+abstract class StressSpec extends MultiNodeClusterSpec(StressMultiJvmSpec) with BeforeAndAfterEach with ImplicitSender {
 
   import StressMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SunnyWeatherSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SunnyWeatherSpec.scala
@@ -13,7 +13,6 @@ import com.typesafe.config.ConfigFactory
 import akka.actor.Actor
 import akka.actor.Props
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 object SunnyWeatherMultiJvmSpec extends MultiNodeConfig {
@@ -47,7 +46,7 @@ class SunnyWeatherMultiJvmNode3 extends SunnyWeatherSpec
 class SunnyWeatherMultiJvmNode4 extends SunnyWeatherSpec
 class SunnyWeatherMultiJvmNode5 extends SunnyWeatherSpec
 
-abstract class SunnyWeatherSpec extends MultiNodeSpec(SunnyWeatherMultiJvmSpec) with MultiNodeClusterSpec {
+abstract class SunnyWeatherSpec extends MultiNodeClusterSpec(SunnyWeatherMultiJvmSpec) {
 
   import ClusterEvent._
   import SunnyWeatherMultiJvmSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/SurviveNetworkInstabilitySpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/SurviveNetworkInstabilitySpec.scala
@@ -20,7 +20,6 @@ import akka.remote.RARP
 import akka.remote.artery.QuarantinedEvent
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.serialization.jackson.CborSerializable
 import akka.testkit._
@@ -81,8 +80,7 @@ class SurviveNetworkInstabilityMultiJvmNode7 extends SurviveNetworkInstabilitySp
 class SurviveNetworkInstabilityMultiJvmNode8 extends SurviveNetworkInstabilitySpec
 
 abstract class SurviveNetworkInstabilitySpec
-    extends MultiNodeSpec(SurviveNetworkInstabilityMultiJvmSpec)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(SurviveNetworkInstabilityMultiJvmSpec)
     with ImplicitSender {
 
   import SurviveNetworkInstabilityMultiJvmSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/TransitionSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/TransitionSpec.scala
@@ -12,7 +12,6 @@ import language.implicitConversions
 import akka.actor.Address
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.testkit._
 
 object TransitionMultiJvmSpec extends MultiNodeConfig {
@@ -34,10 +33,7 @@ class TransitionMultiJvmNode1 extends TransitionSpec
 class TransitionMultiJvmNode2 extends TransitionSpec
 class TransitionMultiJvmNode3 extends TransitionSpec
 
-abstract class TransitionSpec
-    extends MultiNodeSpec(TransitionMultiJvmSpec)
-    with MultiNodeClusterSpec
-    with ImplicitSender {
+abstract class TransitionSpec extends MultiNodeClusterSpec(TransitionMultiJvmSpec) with ImplicitSender {
 
   import TransitionMultiJvmSpec._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/UnreachableNodeJoinsAgainSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/UnreachableNodeJoinsAgainSpec.scala
@@ -18,7 +18,6 @@ import akka.cluster.MultiNodeClusterSpec.EndActor
 import akka.remote.RARP
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.testkit._
 import akka.util.ccompat._
@@ -43,9 +42,7 @@ class UnreachableNodeJoinsAgainMultiJvmNode2 extends UnreachableNodeJoinsAgainSp
 class UnreachableNodeJoinsAgainMultiJvmNode3 extends UnreachableNodeJoinsAgainSpec
 class UnreachableNodeJoinsAgainMultiJvmNode4 extends UnreachableNodeJoinsAgainSpec
 
-abstract class UnreachableNodeJoinsAgainSpec
-    extends MultiNodeSpec(UnreachableNodeJoinsAgainMultiNodeConfig)
-    with MultiNodeClusterSpec {
+abstract class UnreachableNodeJoinsAgainSpec extends MultiNodeClusterSpec(UnreachableNodeJoinsAgainMultiNodeConfig) {
 
   import UnreachableNodeJoinsAgainMultiNodeConfig._
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingGroupSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingGroupSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Await
 import akka.actor.{ Actor, ActorRef, Props }
 import akka.cluster.MultiNodeClusterSpec
 import akka.pattern.ask
-import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
+import akka.remote.testkit.MultiNodeConfig
 import akka.routing.{ Broadcast, ConsistentHashingGroup, GetRoutees, Routees }
 import akka.routing.ConsistentHashingRouter.ConsistentHashMapping
 import akka.testkit._
@@ -41,8 +41,7 @@ class ClusterConsistentHashingGroupMultiJvmNode2 extends ClusterConsistentHashin
 class ClusterConsistentHashingGroupMultiJvmNode3 extends ClusterConsistentHashingGroupSpec
 
 abstract class ClusterConsistentHashingGroupSpec
-    extends MultiNodeSpec(ClusterConsistentHashingGroupMultiJvmSpec)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(ClusterConsistentHashingGroupMultiJvmSpec)
     with ImplicitSender
     with DefaultTimeout {
   import ClusterConsistentHashingGroupMultiJvmSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingRouterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterConsistentHashingRouterSpec.scala
@@ -15,7 +15,6 @@ import akka.actor.Props
 import akka.cluster.MultiNodeClusterSpec
 import akka.pattern.ask
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.routing.ActorRefRoutee
 import akka.routing.ConsistentHashingPool
 import akka.routing.ConsistentHashingRouter.ConsistentHashMapping
@@ -61,8 +60,7 @@ class ClusterConsistentHashingRouterMultiJvmNode2 extends ClusterConsistentHashi
 class ClusterConsistentHashingRouterMultiJvmNode3 extends ClusterConsistentHashingRouterSpec
 
 abstract class ClusterConsistentHashingRouterSpec
-    extends MultiNodeSpec(ClusterConsistentHashingRouterMultiJvmSpec)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(ClusterConsistentHashingRouterMultiJvmSpec)
     with ImplicitSender
     with DefaultTimeout {
   import ClusterConsistentHashingRouterMultiJvmSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterRoundRobinSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/ClusterRoundRobinSpec.scala
@@ -18,7 +18,6 @@ import akka.actor.Terminated
 import akka.cluster.MultiNodeClusterSpec
 import akka.pattern.ask
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter.Direction
 import akka.routing.ActorRefRoutee
 import akka.routing.ActorSelectionRoutee
@@ -105,8 +104,7 @@ class ClusterRoundRobinMultiJvmNode3 extends ClusterRoundRobinSpec
 class ClusterRoundRobinMultiJvmNode4 extends ClusterRoundRobinSpec
 
 abstract class ClusterRoundRobinSpec
-    extends MultiNodeSpec(ClusterRoundRobinMultiJvmSpec)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(ClusterRoundRobinMultiJvmSpec)
     with ImplicitSender
     with DefaultTimeout {
   import ClusterRoundRobinMultiJvmSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/UseRoleIgnoredSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/routing/UseRoleIgnoredSpec.scala
@@ -14,7 +14,6 @@ import akka.actor._
 import akka.cluster.MultiNodeClusterSpec
 import akka.pattern.ask
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.routing.GetRoutees
 import akka.routing.RoundRobinGroup
 import akka.routing.RoundRobinPool
@@ -59,8 +58,7 @@ class UseRoleIgnoredMultiJvmNode2 extends UseRoleIgnoredSpec
 class UseRoleIgnoredMultiJvmNode3 extends UseRoleIgnoredSpec
 
 abstract class UseRoleIgnoredSpec
-    extends MultiNodeSpec(UseRoleIgnoredMultiJvmSpec)
-    with MultiNodeClusterSpec
+    extends MultiNodeClusterSpec(UseRoleIgnoredMultiJvmSpec)
     with ImplicitSender
     with DefaultTimeout {
   import akka.cluster.routing.UseRoleIgnoredMultiJvmSpec._

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/sbr/DownAllIndirectlyConnected5NodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/sbr/DownAllIndirectlyConnected5NodeSpec.scala
@@ -12,7 +12,6 @@ import akka.cluster.Cluster
 import akka.cluster.MemberStatus
 import akka.cluster.MultiNodeClusterSpec
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter
 
 object DownAllIndirectlyConnected5NodeSpec extends MultiNodeConfig {
@@ -48,9 +47,7 @@ class DownAllIndirectlyConnected5NodeSpecMultiJvmNode3 extends DownAllIndirectly
 class DownAllIndirectlyConnected5NodeSpecMultiJvmNode4 extends DownAllIndirectlyConnected5NodeSpec
 class DownAllIndirectlyConnected5NodeSpecMultiJvmNode5 extends DownAllIndirectlyConnected5NodeSpec
 
-class DownAllIndirectlyConnected5NodeSpec
-    extends MultiNodeSpec(DownAllIndirectlyConnected5NodeSpec)
-    with MultiNodeClusterSpec {
+class DownAllIndirectlyConnected5NodeSpec extends MultiNodeClusterSpec(DownAllIndirectlyConnected5NodeSpec) {
   import DownAllIndirectlyConnected5NodeSpec._
 
   "A 5-node cluster with keep-one-indirectly-connected = off" should {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/sbr/DownAllUnstable5NodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/sbr/DownAllUnstable5NodeSpec.scala
@@ -12,7 +12,6 @@ import akka.cluster.Cluster
 import akka.cluster.MemberStatus
 import akka.cluster.MultiNodeClusterSpec
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter
 
 object DownAllUnstable5NodeSpec extends MultiNodeConfig {
@@ -54,7 +53,7 @@ class DownAllUnstable5NodeSpecMultiJvmNode3 extends DownAllUnstable5NodeSpec
 class DownAllUnstable5NodeSpecMultiJvmNode4 extends DownAllUnstable5NodeSpec
 class DownAllUnstable5NodeSpecMultiJvmNode5 extends DownAllUnstable5NodeSpec
 
-class DownAllUnstable5NodeSpec extends MultiNodeSpec(DownAllUnstable5NodeSpec) with MultiNodeClusterSpec {
+class DownAllUnstable5NodeSpec extends MultiNodeClusterSpec(DownAllUnstable5NodeSpec) {
   import DownAllUnstable5NodeSpec._
 
   "A 5-node cluster with down-all-when-unstable" should {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/sbr/IndirectlyConnected3NodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/sbr/IndirectlyConnected3NodeSpec.scala
@@ -12,7 +12,6 @@ import akka.cluster.Cluster
 import akka.cluster.MemberStatus
 import akka.cluster.MultiNodeClusterSpec
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter
 
 object IndirectlyConnected3NodeSpec extends MultiNodeConfig {
@@ -44,7 +43,7 @@ class IndirectlyConnected3NodeSpecMultiJvmNode1 extends IndirectlyConnected3Node
 class IndirectlyConnected3NodeSpecMultiJvmNode2 extends IndirectlyConnected3NodeSpec
 class IndirectlyConnected3NodeSpecMultiJvmNode3 extends IndirectlyConnected3NodeSpec
 
-class IndirectlyConnected3NodeSpec extends MultiNodeSpec(IndirectlyConnected3NodeSpec) with MultiNodeClusterSpec {
+class IndirectlyConnected3NodeSpec extends MultiNodeClusterSpec(IndirectlyConnected3NodeSpec) {
   import IndirectlyConnected3NodeSpec._
 
   "A 3-node cluster" should {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/sbr/IndirectlyConnected5NodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/sbr/IndirectlyConnected5NodeSpec.scala
@@ -12,7 +12,6 @@ import akka.cluster.Cluster
 import akka.cluster.MemberStatus
 import akka.cluster.MultiNodeClusterSpec
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter
 
 object IndirectlyConnected5NodeSpec extends MultiNodeConfig {
@@ -48,7 +47,7 @@ class IndirectlyConnected5NodeSpecMultiJvmNode3 extends IndirectlyConnected5Node
 class IndirectlyConnected5NodeSpecMultiJvmNode4 extends IndirectlyConnected5NodeSpec
 class IndirectlyConnected5NodeSpecMultiJvmNode5 extends IndirectlyConnected5NodeSpec
 
-class IndirectlyConnected5NodeSpec extends MultiNodeSpec(IndirectlyConnected5NodeSpec) with MultiNodeClusterSpec {
+class IndirectlyConnected5NodeSpec extends MultiNodeClusterSpec(IndirectlyConnected5NodeSpec) {
   import IndirectlyConnected5NodeSpec._
 
   "A 5-node cluster" should {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/sbr/LeaseMajority5NodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/sbr/LeaseMajority5NodeSpec.scala
@@ -10,7 +10,6 @@ import scala.concurrent.duration._
 import akka.cluster.MemberStatus
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
-import akka.remote.testkit.MultiNodeSpec
 import akka.remote.transport.ThrottlerTransportAdapter
 import com.typesafe.config.ConfigFactory
 
@@ -70,7 +69,7 @@ class LeaseMajority5NodeSpecMultiJvmNode3 extends LeaseMajority5NodeSpec
 class LeaseMajority5NodeSpecMultiJvmNode4 extends LeaseMajority5NodeSpec
 class LeaseMajority5NodeSpecMultiJvmNode5 extends LeaseMajority5NodeSpec
 
-class LeaseMajority5NodeSpec extends MultiNodeSpec(LeaseMajority5NodeSpec) with MultiNodeClusterSpec {
+class LeaseMajority5NodeSpec extends MultiNodeClusterSpec(LeaseMajority5NodeSpec) {
   import LeaseMajority5NodeSpec._
 
   private val testLeaseName = "LeaseMajority5NodeSpec-akka-sbr"


### PR DESCRIPTION
* trait mixin changed in Scala 2.13.7, probably fixing a previous bug
* simplify MultiNodeClusterSpec usage by making it an abstract class

References #30885
