### PR TITLE
Fix compilation on Scala 2.12

### DIFF
--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/TestKitStorage.scala
@@ -157,7 +157,7 @@ sealed trait InMemStorage[K, R] extends InternalReprSupport[R] {
     eventsMap.keys.foreach(removePreservingSeqNumber)
   }
 
-  def keys(): immutable.Seq[K] = eventsMap.keys.toSeq
+  def keys(): immutable.Seq[K] = eventsMap.keys.toList
 
   private def getLastSeqNumber(elems: immutable.Seq[R]): Long =
     elems.lastOption.map(reprToSeqNum).getOrElse(0L)


### PR DESCRIPTION
Problem introduced with https://github.com/akka/akka/pull/30878 ,
but apparently we don't compile on 2.12 in CI anymore