### PR TITLE
Scala 3: enable akka-cluster tests

### DIFF
--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -21,7 +21,7 @@ jobs:
           - akka-testkit/test akka-actor-tests/test
           - akka-actor-testkit-typed/test akka-actor-typed-tests/test
           - akka-bench-jmh/test
-          - akka-cluster/Test/compile akka-cluster-tools/test akka-cluster-typed/test akka-distributed-data/test akka-cluster-metrics/test akka-cluster-sharding/Test/compile akka-cluster-sharding-typed/test
+          - akka-cluster/test akka-cluster-tools/test akka-cluster-typed/test akka-distributed-data/test akka-cluster-metrics/test akka-cluster-sharding/Test/compile akka-cluster-sharding-typed/test
           - akka-discovery/test akka-coordination/test
           - akka-persistence/test akka-persistence-shared/test akka-persistence-query/test akka-persistence-typed/test akka-persistence-testkit/test
           - akka-pki/test akka-slf4j/test


### PR DESCRIPTION
closes #30689

Looks like it has been fixed with https://github.com/akka/akka/pull/30886