### PR TITLE
Add most recently used entity passivation strategy

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/RecencyListSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/RecencyListSpec.scala
@@ -92,6 +92,18 @@ class RecencyListSpec extends AnyWordSpec with Matchers {
       clock.tick() // time = 14
       recency.removeMostRecentWithin(3.seconds) shouldBe List("r", "k", "q", "p")
       check(recency, List("n", "o"))
+
+      clock.tick() // time = 15
+      recency.update("s").update("t").update("u").update("v").update("w").update("x").update("y").update("z")
+      check(recency, List("n", "o", "s", "t", "u", "v", "w", "x", "y", "z"))
+
+      clock.tick() // time = 16
+      recency.removeLeastRecent(3, skip = 3) shouldBe List("t", "u", "v")
+      check(recency, List("n", "o", "s", "w", "x", "y", "z"))
+
+      clock.tick() // time = 17
+      recency.removeMostRecent(3, skip = 2) shouldBe List("x", "w", "s")
+      check(recency, List("n", "o", "y", "z"))
     }
 
   }

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
@@ -72,7 +72,8 @@ object ClusterShardingSettings {
       passivationStrategySettings = new ClassicShardingSettings.PassivationStrategySettings(
         strategy = settings.passivationStrategySettings.strategy,
         idleTimeout = settings.passivationStrategySettings.idleTimeout,
-        leastRecentlyUsedLimit = settings.passivationStrategySettings.leastRecentlyUsedLimit),
+        leastRecentlyUsedLimit = settings.passivationStrategySettings.leastRecentlyUsedLimit,
+        mostRecentlyUsedLimit = settings.passivationStrategySettings.mostRecentlyUsedLimit),
       shardRegionQueryTimeout = settings.shardRegionQueryTimeout,
       new ClassicShardingSettings.TuningParameters(
         bufferSize = settings.tuningParameters.bufferSize,
@@ -169,19 +170,28 @@ object ClusterShardingSettings {
       val strategy: String,
       val idleTimeout: FiniteDuration,
       val leastRecentlyUsedLimit: Int,
+      val mostRecentlyUsedLimit: Int,
       private[akka] val oldSettingUsed: Boolean) {
 
-    def this(strategy: String, idleTimeout: FiniteDuration, leastRecentlyUsedLimit: Int) =
-      this(strategy, idleTimeout, leastRecentlyUsedLimit, oldSettingUsed = false)
+    def this(strategy: String, idleTimeout: FiniteDuration, leastRecentlyUsedLimit: Int, mostRecentlyUsedLimit: Int) =
+      this(strategy, idleTimeout, leastRecentlyUsedLimit, mostRecentlyUsedLimit, oldSettingUsed = false)
 
     def this(classic: ClassicShardingSettings.PassivationStrategySettings) =
-      this(classic.strategy, classic.idleTimeout, classic.leastRecentlyUsedLimit, classic.oldSettingUsed)
+      this(
+        classic.strategy,
+        classic.idleTimeout,
+        classic.leastRecentlyUsedLimit,
+        classic.mostRecentlyUsedLimit,
+        classic.oldSettingUsed)
 
     def withIdleStrategy(timeout: FiniteDuration): PassivationStrategySettings =
       copy(strategy = "idle", idleTimeout = timeout)
 
     def withLeastRecentlyUsedStrategy(limit: Int): PassivationStrategySettings =
       copy(strategy = "least-recently-used", leastRecentlyUsedLimit = limit)
+
+    def withMostRecentlyUsedStrategy(limit: Int): PassivationStrategySettings =
+      copy(strategy = "most-recently-used", mostRecentlyUsedLimit = limit)
 
     private[akka] def withOldIdleStrategy(timeout: FiniteDuration): PassivationStrategySettings =
       copy(strategy = "idle", idleTimeout = timeout, oldSettingUsed = true)
@@ -190,8 +200,14 @@ object ClusterShardingSettings {
         strategy: String,
         idleTimeout: FiniteDuration = idleTimeout,
         leastRecentlyUsedLimit: Int = leastRecentlyUsedLimit,
+        mostRecentlyUsedLimit: Int = mostRecentlyUsedLimit,
         oldSettingUsed: Boolean = oldSettingUsed): PassivationStrategySettings =
-      new PassivationStrategySettings(strategy, idleTimeout, leastRecentlyUsedLimit, oldSettingUsed)
+      new PassivationStrategySettings(
+        strategy,
+        idleTimeout,
+        leastRecentlyUsedLimit,
+        mostRecentlyUsedLimit,
+        oldSettingUsed)
   }
 
   object PassivationStrategySettings {
@@ -199,6 +215,7 @@ object ClusterShardingSettings {
       strategy = "none",
       idleTimeout = Duration.Zero,
       leastRecentlyUsedLimit = 0,
+      mostRecentlyUsedLimit = 0,
       oldSettingUsed = false)
 
     def oldDefault(idleTimeout: FiniteDuration): PassivationStrategySettings =
@@ -530,6 +547,9 @@ final class ClusterShardingSettings(
 
   def withLeastRecentlyUsedPassivationStrategy(limit: Int): ClusterShardingSettings =
     copy(passivationStrategySettings = passivationStrategySettings.withLeastRecentlyUsedStrategy(limit))
+
+  def withMostRecentlyUsedPassivationStrategy(limit: Int): ClusterShardingSettings =
+    copy(passivationStrategySettings = passivationStrategySettings.withMostRecentlyUsedStrategy(limit))
 
   def withShardRegionQueryTimeout(duration: FiniteDuration): ClusterShardingSettings =
     copy(shardRegionQueryTimeout = duration)

--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -39,6 +39,7 @@ akka.cluster.sharding {
     # Passivation strategy to use. Possible values are:
     #   - "idle"
     #   - "least-recently-used"
+    #   - "most-recently-used"
     # Set to "none" or "off" to disable automatic passivation.
     # Passivation strategies are always disabled if `remember-entities` is enabled.
     strategy = "idle"
@@ -54,6 +55,14 @@ akka.cluster.sharding {
     # Passivate the least recently used entities when the number of active entities in a shard region
     # reaches a limit. The per-region limit is divided evenly among the active shards in a region.
     least-recently-used {
+      # Limit of active entities in a shard region.
+      limit = 100000
+    }
+
+    # Most recently used passivation strategy.
+    # Passivate the most recently used entities when the number of active entities in a shard region
+    # reaches a limit. The per-region limit is divided evenly among the active shards in a region.
+    most-recently-used {
       # Limit of active entities in a shard region.
       limit = 100000
     }

--- a/akka-cluster-sharding/src/test/resources/arc-trace-database.conf
+++ b/akka-cluster-sharding/src/test/resources/arc-trace-database.conf
@@ -18,6 +18,14 @@
 #   ║ LRU 4M │ 20.24 % │ 43,704,979 │  34,857,131 │   30,857,131 ║
 #   ╟────────┼─────────┼────────────┼─────────────┼──────────────╢
 #   ║ LRU 8M │ 43.03 % │ 43,704,979 │  24,896,638 │   16,896,638 ║
+#   ╟────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║ MRU 1M │ 11.92 % │ 43,704,979 │  38,493,369 │   37,493,369 ║
+#   ╟────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║ MRU 2M │ 25.67 % │ 43,704,979 │  32,486,285 │   30,486,285 ║
+#   ╟────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║ MRU 4M │ 41.82 % │ 43,704,979 │  25,429,608 │   21,429,608 ║
+#   ╟────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║ MRU 8M │ 68.01 % │ 43,704,979 │  13,980,246 │    5,980,246 ║
 #   ╚════════╧═════════╧════════════╧═════════════╧══════════════╝
 #
 
@@ -54,7 +62,35 @@ akka.cluster.sharding {
         regions = 10
         pattern = arc-database
         strategy = lru-800k
-      }
+      },
+      {
+        name = "MRU 1M"
+        shards = 100
+        regions = 10
+        pattern = arc-database
+        strategy = mru-100k
+      },
+      {
+        name = "MRU 2M"
+        shards = 100
+        regions = 10
+        pattern = arc-database
+        strategy = mru-200k
+      },
+      {
+        name = "MRU 4M"
+        shards = 100
+        regions = 10
+        pattern = arc-database
+        strategy = mru-400k
+      },
+      {
+        name = "MRU 8M"
+        shards = 100
+        regions = 10
+        pattern = arc-database
+        strategy = mru-800k
+      },
     ]
 
     print-detailed-stats = true
@@ -91,6 +127,34 @@ akka.cluster.sharding {
     lru-800k {
       strategy = least-recently-used
       least-recently-used {
+        per-region-limit = 800000
+      }
+    }
+
+    mru-100k {
+      strategy = most-recently-used
+      most-recently-used {
+        per-region-limit = 100000
+      }
+    }
+
+    mru-200k {
+      strategy = most-recently-used
+      most-recently-used {
+        per-region-limit = 200000
+      }
+    }
+
+    mru-400k {
+      strategy = most-recently-used
+      most-recently-used {
+        per-region-limit = 400000
+      }
+    }
+
+    mru-800k {
+      strategy = most-recently-used
+      most-recently-used {
         per-region-limit = 800000
       }
     }

--- a/akka-cluster-sharding/src/test/resources/arc-trace-search.conf
+++ b/akka-cluster-sharding/src/test/resources/arc-trace-search.conf
@@ -16,6 +16,12 @@
 #   ║ LRU 500k │  7.53 % │ 37,656,092 │  34,822,122 │   34,322,122 ║
 #   ╟──────────┼─────────┼────────────┼─────────────┼──────────────╢
 #   ║   LRU 1M │ 25.37 % │ 37,656,092 │  28,102,287 │   27,102,287 ║
+#   ╟──────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║ MRU 250k │  5.25 % │ 37,656,092 │  35,680,111 │   35,430,111 ║
+#   ╟──────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║ MRU 500k │ 10.50 % │ 37,656,092 │  33,702,975 │   33,202,975 ║
+#   ╟──────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║   MRU 1M │ 20.79 % │ 37,656,092 │  29,826,997 │   28,826,997 ║
 #   ╚══════════╧═════════╧════════════╧═════════════╧══════════════╝
 #
 
@@ -45,6 +51,27 @@ akka.cluster.sharding {
         regions = 10
         pattern = arc-search-merged
         strategy = lru-100k
+      },
+      {
+        name = "MRU 250k"
+        shards = 100
+        regions = 10
+        pattern = arc-search-merged
+        strategy = mru-25k
+      },
+      {
+        name = "MRU 500k"
+        shards = 100
+        regions = 10
+        pattern = arc-search-merged
+        strategy = mru-50k
+      },
+      {
+        name = "MRU 1M"
+        shards = 100
+        regions = 10
+        pattern = arc-search-merged
+        strategy = mru-100k
       }
     ]
 
@@ -75,6 +102,27 @@ akka.cluster.sharding {
     lru-100k {
       strategy = least-recently-used
       least-recently-used {
+        per-region-limit = 100000
+      }
+    }
+
+    mru-25k {
+      strategy = most-recently-used
+      most-recently-used {
+        per-region-limit = 25000
+      }
+    }
+
+    mru-50k {
+      strategy = most-recently-used
+      most-recently-used {
+        per-region-limit = 50000
+      }
+    }
+
+    mru-100k {
+      strategy = most-recently-used
+      most-recently-used {
         per-region-limit = 100000
       }
     }

--- a/akka-cluster-sharding/src/test/resources/reference.conf
+++ b/akka-cluster-sharding/src/test/resources/reference.conf
@@ -21,6 +21,10 @@ akka.cluster.sharding {
         sequence {
           start = 1
         }
+        loop {
+          start = 1
+          end = 1000000
+        }
         uniform {
           min = 1
           max = 10000000

--- a/akka-cluster-sharding/src/test/resources/synthetic-loop.conf
+++ b/akka-cluster-sharding/src/test/resources/synthetic-loop.conf
@@ -1,14 +1,14 @@
 #
-# Run with synthetically generated access events with a scrambled zipfian distribution.
+# Run with synthetically generated access events with a looping scan through ids.
 #
-# > akka-cluster-sharding/Test/runMain akka.cluster.sharding.passivation.simulator.Simulator synthetic-zipfian
+# > akka-cluster-sharding/Test/runMain akka.cluster.sharding.passivation.simulator.Simulator synthetic-loop
 #
 #   ╔══════════╤═════════╤════════════╤═════════════╤══════════════╗
 #   ║      Run │  Active │   Accesses │ Activations │ Passivations ║
 #   ╠══════════╪═════════╪════════════╪═════════════╪══════════════╣
-#   ║ LRU 100k │ 40.47 % │ 50,000,000 │  29,764,380 │   29,664,380 ║
+#   ║ LRU 500k │  0.00 % │ 10,000,000 │  10,000,000 │    9,500,000 ║
 #   ╟──────────┼─────────┼────────────┼─────────────┼──────────────╢
-#   ║ MRU 100k │ 10.08 % │ 50,000,000 │  44,960,042 │   44,860,042 ║
+#   ║ MRU 500k │ 45.00 % │ 10,000,000 │   5,500,000 │    5,000,000 ║
 #   ╚══════════╧═════════╧════════════╧═════════════╧══════════════╝
 #
 
@@ -16,53 +16,52 @@ akka.cluster.sharding {
   passivation.simulator {
     runs = [
       {
-        name = "LRU 100k"
+        name = "LRU 500k"
         shards = 100
         regions = 10
-        pattern = scrambled-zipfian
-        strategy = lru-10k
+        pattern = loop-1M
+        strategy = lru-50k
       },
       {
-        name = "MRU 100k"
+        name = "MRU 500k"
         shards = 100
         regions = 10
-        pattern = scrambled-zipfian
-        strategy = mru-10k
+        pattern = loop-1M
+        strategy = mru-50k
       }
     ]
 
     print-detailed-stats = true
 
-    # scrambled zipfian distribution
-    # generate 50M events over 10M ids
-    scrambled-zipfian {
+    # looping sequence of ids
+    # generate 10M events over 1M ids
+    loop-1M {
       pattern = synthetic
       synthetic {
-        events = 50000000
-        generator = zipfian
-        zipfian {
-          min = 1
-          max = 10000000
-          scrambled = true
+        events = 10000000
+        generator = loop
+        loop {
+          start = 1
+          end = 1000000
         }
       }
     }
 
-    # LRU strategy with 10k limit in each of 10 regions
-    # total limit across cluster of 100k (1% of id space)
-    lru-10k {
+    # LRU strategy with 50k limit in each of 10 regions
+    # total limit across cluster of 500k (50% of id space)
+    lru-50k {
       strategy = least-recently-used
       least-recently-used {
-        per-region-limit = 10000
+        per-region-limit = 50000
       }
     }
 
-    # MRU strategy with 10k limit in each of 10 regions
-    # total limit across cluster of 100k (1% of id space)
-    mru-10k {
+    # MRU strategy with 50k limit in each of 10 regions
+    # total limit across cluster of 500k (50% of id space)
+    mru-50k {
       strategy = most-recently-used
       most-recently-used {
-        per-region-limit = 10000
+        per-region-limit = 50000
       }
     }
   }

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala
@@ -67,6 +67,25 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
         .passivationStrategy shouldBe ClusterShardingSettings.LeastRecentlyUsedPassivationStrategy(42000)
     }
 
+    "allow most recently used passivation strategy to be configured (via config)" in {
+      settings("""
+        #passivation-most-recently-used
+        akka.cluster.sharding {
+          passivation {
+            strategy = most-recently-used
+            most-recently-used.limit = 1000000
+          }
+        }
+        #passivation-most-recently-used
+      """).passivationStrategy shouldBe ClusterShardingSettings.MostRecentlyUsedPassivationStrategy(1000000)
+    }
+
+    "allow most recently used passivation strategy to be configured (via factory method)" in {
+      defaultSettings
+        .withMostRecentlyUsedPassivationStrategy(limit = 42000)
+        .passivationStrategy shouldBe ClusterShardingSettings.MostRecentlyUsedPassivationStrategy(42000)
+    }
+
     "disable automatic passivation if `remember-entities` is enabled (via config)" in {
       settings("""
         akka.cluster.sharding.remember-entities = on

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/simulator/Simulator.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/simulator/Simulator.scala
@@ -6,7 +6,11 @@ package akka.cluster.sharding.passivation.simulator
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.cluster.sharding.internal.{ EntityPassivationStrategy, LeastRecentlyUsedEntityPassivationStrategy }
+import akka.cluster.sharding.internal.{
+  EntityPassivationStrategy,
+  LeastRecentlyUsedEntityPassivationStrategy,
+  MostRecentlyUsedEntityPassivationStrategy
+}
 import akka.stream.scaladsl.{ Flow, Source }
 import com.typesafe.config.ConfigFactory
 
@@ -76,6 +80,8 @@ object Simulator {
         generator match {
           case SimulatorSettings.PatternSettings.Synthetic.Sequence(start) =>
             new SyntheticGenerator.Sequence(start, events)
+          case SimulatorSettings.PatternSettings.Synthetic.Loop(start, end) =>
+            new SyntheticGenerator.Loop(start, end, events)
           case SimulatorSettings.PatternSettings.Synthetic.Uniform(min, max) =>
             new SyntheticGenerator.Uniform(min, max, events)
           case SimulatorSettings.PatternSettings.Synthetic.Exponential(mean) =>
@@ -98,6 +104,8 @@ object Simulator {
       runSettings.strategy match {
         case SimulatorSettings.StrategySettings.LeastRecentlyUsed(perRegionLimit) =>
           () => new LeastRecentlyUsedEntityPassivationStrategy(perRegionLimit)
+        case SimulatorSettings.StrategySettings.MostRecentlyUsed(perRegionLimit) =>
+          () => new MostRecentlyUsedEntityPassivationStrategy(perRegionLimit)
       }
   }
 

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/simulator/SimulatorSettings.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/simulator/SimulatorSettings.scala
@@ -45,11 +45,13 @@ object SimulatorSettings {
 
   object StrategySettings {
     final case class LeastRecentlyUsed(perRegionLimit: Int) extends StrategySettings
+    final case class MostRecentlyUsed(perRegionLimit: Int) extends StrategySettings
 
     def apply(simulatorConfig: Config, strategy: String): StrategySettings = {
       val config = simulatorConfig.getConfig(strategy).withFallback(simulatorConfig.getConfig("strategy-defaults"))
       lowerCase(config.getString("strategy")) match {
         case "least-recently-used" => LeastRecentlyUsed(config.getInt("least-recently-used.per-region-limit"))
+        case "most-recently-used"  => MostRecentlyUsed(config.getInt("most-recently-used.per-region-limit"))
         case _                     => sys.error(s"Unknown strategy for [$strategy]")
       }
     }
@@ -63,6 +65,7 @@ object SimulatorSettings {
     object Synthetic {
       sealed trait Generator
       final case class Sequence(start: Long) extends Generator
+      final case class Loop(start: Long, end: Long) extends Generator
       final case class Uniform(min: Long, max: Long) extends Generator
       final case class Exponential(mean: Double) extends Generator
       final case class Hotspot(min: Long, max: Long, hot: Double, rate: Double) extends Generator
@@ -74,6 +77,10 @@ object SimulatorSettings {
           case "sequence" =>
             val start = config.getLong("sequence.start")
             Sequence(start)
+          case "loop" =>
+            val start = config.getLong("loop.start")
+            val end = config.getLong("loop.end")
+            Loop(start, end)
           case "uniform" =>
             val min = config.getLong("uniform.min")
             val max = config.getLong("uniform.max")

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -325,6 +325,20 @@ passivation strategy, and set the limit for active entities in a shard region:
 Or enable the least recently used passivation strategy and set the active entity limit using the
 `withLeastRecentlyUsedPassivationStrategy` method on `ClusterShardingSettings`.
 
+#### Most recently used passivation strategy
+
+The **most recently used** passivation strategy passivates those entities that have the most recent activity when the
+number of active entities passes a specified limit. The configurable limit is for a whole shard region and is divided
+evenly among the active shards in each region. This strategy is most useful when the older an entity is, the more
+likely that entity will be accessed again; as seen in cyclic access patterns. Configure automatic passivation to use
+the most recently used passivation strategy, and set the limit for active entities in a shard region:
+
+@@snip [passivation most recently used](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #passivation-most-recently-used type=conf }
+
+Or enable the most recently used passivation strategy and set the active entity limit using the
+`withMostRecentlyUsedPassivationStrategy` method on `ClusterShardingSettings`.
+
+
 ## Sharding State 
 
 There are two types of state managed:


### PR DESCRIPTION
Add most recently used entity passivation strategy, to accompany the least recently used strategy.

Interesting how well it performs on the access pattern traces — shows that a standard least recently used strategy is not always that effective, given more cyclic patterns. Frequency based strategies, and variations on LRU, will be next.