### PR TITLE
Add least frequently used entity passivation strategy

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/FrequencyListSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/FrequencyListSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2016-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class FrequencyListSpec extends AnyWordSpec with Matchers {
+
+  private def check(frequencyList: FrequencyList[String], expectedLeastToMostFrequent: List[String]): Unit = {
+    expectedLeastToMostFrequent.forall(frequencyList.contains)
+    frequencyList.size shouldBe expectedLeastToMostFrequent.size
+    frequencyList.leastToMostFrequent.toList shouldBe expectedLeastToMostFrequent
+    frequencyList.mostToLeastFrequent.toList shouldBe expectedLeastToMostFrequent.reverse
+  }
+
+  "FrequencyList" must {
+
+    "track frequency of elements" in {
+      val frequency = new FrequencyList[String]
+
+      check(frequency, Nil)
+
+      frequency.update("a")
+      check(frequency, List( /* 1: */ "a"))
+
+      frequency.update("b").update("c")
+      check(frequency, List( /* 1: */ "a", "b", "c"))
+
+      frequency.update("a").update("c")
+      check(frequency, List( /* 1: */ "b", /* 2: */ "a", "c"))
+
+      frequency.update("d").update("e").update("f").update("g")
+      check(frequency, List( /* 1: */ "b", "d", "e", "f", "g", /* 2: */ "a", "c"))
+
+      frequency.update("c").update("f")
+      check(frequency, List( /* 1: */ "b", "d", "e", "g", /* 2: */ "a", "f", /* 3: */ "c"))
+
+      frequency.remove("d").remove("g").remove("b").remove("f")
+      check(frequency, List( /* 1: */ "e", /* 2: */ "a", /* 3: */ "c"))
+
+      frequency.update("e").update("h").update("i")
+      check(frequency, List( /* 1: */ "h", "i", /* 2: */ "a", "e", /* 3: */ "c"))
+
+      frequency.removeLeastFrequent(3) shouldBe List("h", "i", "a")
+      check(frequency, List( /* 2: */ "e", /* 3: */ "c"))
+
+      frequency.update("j").update("k").update("l").update("m")
+      check(frequency, List( /* 1: */ "j", "k", "l", "m", /* 2: */ "e", /* 3: */ "c"))
+
+      frequency.removeLeastFrequent(skip = OptionVal.Some("j")) shouldBe List("k")
+      check(frequency, List( /* 1: */ "j", "l", "m", /* 2: */ "e", /* 3: */ "c"))
+
+      frequency.removeLeastFrequent(2, skip = OptionVal.Some("l")) shouldBe List("j", "m")
+      check(frequency, List( /* 1: */ "l", /* 2: */ "e", /* 3: */ "c"))
+
+      frequency.update("n").update("o").update("p").update("e").update("o").update("l")
+      check(frequency, List( /* 1: */ "n", "p", /* 2: */ "o", "l", /* 3: */ "c", "e"))
+
+      frequency.removeMostFrequent(3) shouldBe List("e", "c", "l")
+      check(frequency, List( /* 1: */ "n", "p", /* 2: */ "o"))
+
+      frequency.update("q").update("r").update("p").update("o").update("n")
+      check(frequency, List( /* 1: */ "q", "r", /* 2: */ "p", "n", /* 3: */ "o"))
+
+      frequency.removeMostFrequent(skip = OptionVal.Some("o")) shouldBe List("n")
+      check(frequency, List( /* 1: */ "q", "r", /* 2: */ "p", /* 3: */ "o"))
+
+      frequency.removeMostFrequent(2, skip = OptionVal.Some("p")) shouldBe List("o", "r")
+      check(frequency, List( /* 1: */ "q", /* 2: */ "p"))
+    }
+
+  }
+}

--- a/akka-actor-tests/src/test/scala/akka/util/RecencyListSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/RecencyListSpec.scala
@@ -104,6 +104,18 @@ class RecencyListSpec extends AnyWordSpec with Matchers {
       clock.tick() // time = 17
       recency.removeMostRecent(3, skip = 2) shouldBe List("x", "w", "s")
       check(recency, List("n", "o", "y", "z"))
+
+      clock.tick() // time = 18
+      recency.removeLeastRecent(10) shouldBe List("n", "o", "y", "z")
+      check(recency, Nil)
+
+      clock.tick() // time = 19
+      recency.update("a").update("b").update("c")
+      check(recency, List("a", "b", "c"))
+
+      clock.tick() // time = 20
+      recency.removeMostRecent(10) shouldBe List("c", "b", "a")
+      check(recency, Nil)
     }
 
   }

--- a/akka-actor/src/main/scala/akka/util/FrequencyList.scala
+++ b/akka-actor/src/main/scala/akka/util/FrequencyList.scala
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+import akka.annotation.InternalApi
+
+import scala.collection.{ immutable, mutable, AbstractIterator }
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] object FrequencyList {
+  def empty[A]: FrequencyList[A] = new FrequencyList[A]
+
+  private final class FrequencyNode[A](val count: Int) {
+    var lessFrequent, moreFrequent: OptionVal[FrequencyNode[A]] = OptionVal.None
+    var leastRecent, mostRecent: OptionVal[Node[A]] = OptionVal.None
+  }
+
+  private final class Node[A](val value: A) {
+    var frequencyNode: OptionVal[FrequencyNode[A]] = OptionVal.None
+    var lessRecent, moreRecent: OptionVal[Node[A]] = OptionVal.None
+  }
+}
+
+/**
+ * INTERNAL API
+ *
+ * Mutable non-thread-safe frequency list.
+ * Used for tracking frequency of elements for implementing least/most frequently used eviction policies.
+ * Implemented using a doubly-linked list of doubly-linked lists, with lookup, so that all operations are constant time.
+ */
+@InternalApi
+private[akka] final class FrequencyList[A] {
+  import FrequencyList.{ FrequencyNode, Node }
+
+  private var leastFrequent, mostFrequent: OptionVal[FrequencyNode[A]] = OptionVal.None
+  private val lookupNode = mutable.Map.empty[A, Node[A]]
+
+  def size: Int = lookupNode.size
+
+  def update(value: A): FrequencyList[A] = {
+    if (lookupNode.contains(value)) {
+      val node = lookupNode(value)
+      increaseFrequency(node)
+    } else {
+      val node = new Node(value)
+      addAsLeastFrequent(node)
+      lookupNode += value -> node
+    }
+    this
+  }
+
+  def remove(value: A): FrequencyList[A] = {
+    if (lookupNode.contains(value)) {
+      val node = lookupNode(value)
+      removeFromCurrentPosition(node)
+      lookupNode -= value
+    }
+    this
+  }
+
+  def contains(value: A): Boolean = lookupNode.contains(value)
+
+  private def leastNode: OptionVal[Node[A]] =
+    if (leastFrequent.isDefined) leastFrequent.get.leastRecent else OptionVal.None
+
+  private def mostNode: OptionVal[Node[A]] =
+    if (mostFrequent.isDefined) mostFrequent.get.mostRecent else OptionVal.None
+
+  private val lessDirection: Node[A] => OptionVal[Node[A]] = { node =>
+    if (node.lessRecent.isDefined) node.lessRecent
+    else if (node.frequencyNode.isDefined && node.frequencyNode.get.lessFrequent.isDefined)
+      node.frequencyNode.get.lessFrequent.get.mostRecent
+    else OptionVal.None
+  }
+
+  private val moreDirection: Node[A] => OptionVal[Node[A]] = { node =>
+    if (node.moreRecent.isDefined) node.moreRecent
+    else if (node.frequencyNode.isDefined && node.frequencyNode.get.moreFrequent.isDefined)
+      node.frequencyNode.get.moreFrequent.get.leastRecent
+    else OptionVal.None
+  }
+
+  def removeLeastFrequent(n: Int = 1, skip: OptionVal[A] = OptionVal.none[A]): immutable.Seq[A] =
+    removeWhile(start = leastNode, next = moreDirection, limit = n, skip = skip)
+
+  def removeMostFrequent(n: Int = 1, skip: OptionVal[A] = OptionVal.none[A]): immutable.Seq[A] =
+    removeWhile(start = mostNode, next = lessDirection, limit = n, skip = skip)
+
+  def leastToMostFrequent: Iterator[A] = iterator(start = leastNode, shift = moreDirection)
+
+  def mostToLeastFrequent: Iterator[A] = iterator(start = mostNode, shift = lessDirection)
+
+  private def hasFrequency(frequencyNode: OptionVal[FrequencyNode[A]], count: Int): Boolean =
+    frequencyNode.isDefined && frequencyNode.get.count == count
+
+  private def addAsLeastFrequent(node: Node[A]): Unit = {
+    if (hasFrequency(leastFrequent, count = 1)) {
+      addToFrequency(node, leastFrequent.get)
+    } else {
+      val frequencyOne = new FrequencyNode[A](count = 1)
+      frequencyOne.moreFrequent = leastFrequent
+      if (leastFrequent.isDefined) leastFrequent.get.lessFrequent = OptionVal.Some(frequencyOne)
+      leastFrequent = OptionVal.Some(frequencyOne)
+      if (mostFrequent.isEmpty) mostFrequent = leastFrequent
+      addToFrequency(node, frequencyOne)
+    }
+  }
+
+  private def increaseFrequency(node: Node[A]): Unit = {
+    if (node.frequencyNode.isDefined) {
+      val currentFrequencyNode = node.frequencyNode.get
+      val nextCount = currentFrequencyNode.count + 1
+      val nextFrequencyNode =
+        if (hasFrequency(currentFrequencyNode.moreFrequent, nextCount)) {
+          currentFrequencyNode.moreFrequent.get
+        } else {
+          val frequencyNode = new FrequencyNode[A](nextCount)
+          frequencyNode.lessFrequent = OptionVal.Some(currentFrequencyNode)
+          frequencyNode.moreFrequent = currentFrequencyNode.moreFrequent
+          currentFrequencyNode.moreFrequent = OptionVal.Some(frequencyNode)
+          if (frequencyNode.moreFrequent.isDefined)
+            frequencyNode.moreFrequent.get.lessFrequent = OptionVal.Some(frequencyNode)
+          else mostFrequent = OptionVal.Some(frequencyNode)
+          frequencyNode
+        }
+      removeFromCurrentPosition(node)
+      addToFrequency(node, nextFrequencyNode)
+    }
+  }
+
+  private def addToFrequency(node: Node[A], frequencyNode: FrequencyNode[A]): Unit = {
+    node.frequencyNode = OptionVal.Some(frequencyNode)
+    node.moreRecent = OptionVal.None
+    node.lessRecent = frequencyNode.mostRecent
+    if (frequencyNode.mostRecent.isDefined) frequencyNode.mostRecent.get.moreRecent = OptionVal.Some(node)
+    frequencyNode.mostRecent = OptionVal.Some(node)
+    if (frequencyNode.leastRecent.isEmpty) frequencyNode.leastRecent = frequencyNode.mostRecent
+  }
+
+  private def removeFromCurrentPosition(node: Node[A]): Unit = {
+    if (node.frequencyNode.isDefined) {
+      val frequencyNode = node.frequencyNode.get
+      if (node.lessRecent.isEmpty) frequencyNode.leastRecent = node.moreRecent
+      else node.lessRecent.get.moreRecent = node.moreRecent
+      if (node.moreRecent.isEmpty) frequencyNode.mostRecent = node.lessRecent
+      else node.moreRecent.get.lessRecent = node.lessRecent
+      if (frequencyNode.mostRecent.isEmpty) {
+        if (frequencyNode.lessFrequent.isEmpty) leastFrequent = frequencyNode.moreFrequent
+        else frequencyNode.lessFrequent.get.moreFrequent = frequencyNode.moreFrequent
+        if (frequencyNode.moreFrequent.isEmpty) mostFrequent = frequencyNode.lessFrequent
+        else frequencyNode.moreFrequent.get.lessFrequent = frequencyNode.lessFrequent
+      }
+    }
+  }
+
+  private def removeWhile(
+      start: OptionVal[Node[A]],
+      next: Node[A] => OptionVal[Node[A]],
+      limit: Int,
+      skip: OptionVal[A]): immutable.Seq[A] = {
+    var count = 0
+    var node = start
+    val values = mutable.ListBuffer.empty[A]
+    while (node.isDefined && (count < limit)) {
+      if (!skip.contains(node.get.value)) {
+        count += 1
+        removeFromCurrentPosition(node.get)
+        lookupNode -= node.get.value
+        values += node.get.value
+      }
+      node = next(node.get)
+    }
+    values.result()
+  }
+
+  private def iterator(start: OptionVal[Node[A]], shift: Node[A] => OptionVal[Node[A]]): Iterator[A] =
+    new AbstractIterator[A] {
+      private[this] var current = start
+      override def hasNext: Boolean = current.isDefined
+      override def next(): A = {
+        val value = current.get.value
+        current = shift(current.get)
+        value
+      }
+    }
+}

--- a/akka-actor/src/main/scala/akka/util/RecencyList.scala
+++ b/akka-actor/src/main/scala/akka/util/RecencyList.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration.FiniteDuration
 private[akka] object RecencyList {
   def empty[A]: RecencyList[A] = new RecencyList[A](new NanoClock)
 
-  private class Node[A](val value: A) {
+  private final class Node[A](val value: A) {
     var lessRecent, moreRecent: OptionVal[Node[A]] = OptionVal.None
     var timestamp: Long = 0L
   }
@@ -41,7 +41,7 @@ private[akka] object RecencyList {
  * Implemented using a doubly-linked list plus hash map for lookup, so that all operations are constant time.
  */
 @InternalApi
-private[akka] class RecencyList[A](clock: RecencyList.Clock) {
+private[akka] final class RecencyList[A](clock: RecencyList.Clock) {
   import RecencyList.Node
 
   private var leastRecent, mostRecent: OptionVal[Node[A]] = OptionVal.None

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
@@ -73,7 +73,8 @@ object ClusterShardingSettings {
         strategy = settings.passivationStrategySettings.strategy,
         idleTimeout = settings.passivationStrategySettings.idleTimeout,
         leastRecentlyUsedLimit = settings.passivationStrategySettings.leastRecentlyUsedLimit,
-        mostRecentlyUsedLimit = settings.passivationStrategySettings.mostRecentlyUsedLimit),
+        mostRecentlyUsedLimit = settings.passivationStrategySettings.mostRecentlyUsedLimit,
+        leastFrequentlyUsedLimit = settings.passivationStrategySettings.leastFrequentlyUsedLimit),
       shardRegionQueryTimeout = settings.shardRegionQueryTimeout,
       new ClassicShardingSettings.TuningParameters(
         bufferSize = settings.tuningParameters.bufferSize,
@@ -171,10 +172,22 @@ object ClusterShardingSettings {
       val idleTimeout: FiniteDuration,
       val leastRecentlyUsedLimit: Int,
       val mostRecentlyUsedLimit: Int,
+      val leastFrequentlyUsedLimit: Int,
       private[akka] val oldSettingUsed: Boolean) {
 
-    def this(strategy: String, idleTimeout: FiniteDuration, leastRecentlyUsedLimit: Int, mostRecentlyUsedLimit: Int) =
-      this(strategy, idleTimeout, leastRecentlyUsedLimit, mostRecentlyUsedLimit, oldSettingUsed = false)
+    def this(
+        strategy: String,
+        idleTimeout: FiniteDuration,
+        leastRecentlyUsedLimit: Int,
+        mostRecentlyUsedLimit: Int,
+        leastFrequentlyUsedLimit: Int) =
+      this(
+        strategy,
+        idleTimeout,
+        leastRecentlyUsedLimit,
+        mostRecentlyUsedLimit,
+        leastFrequentlyUsedLimit,
+        oldSettingUsed = false)
 
     def this(classic: ClassicShardingSettings.PassivationStrategySettings) =
       this(
@@ -182,6 +195,7 @@ object ClusterShardingSettings {
         classic.idleTimeout,
         classic.leastRecentlyUsedLimit,
         classic.mostRecentlyUsedLimit,
+        classic.leastFrequentlyUsedLimit,
         classic.oldSettingUsed)
 
     def withIdleStrategy(timeout: FiniteDuration): PassivationStrategySettings =
@@ -193,6 +207,9 @@ object ClusterShardingSettings {
     def withMostRecentlyUsedStrategy(limit: Int): PassivationStrategySettings =
       copy(strategy = "most-recently-used", mostRecentlyUsedLimit = limit)
 
+    def withLeastFrequentlyUsedStrategy(limit: Int): PassivationStrategySettings =
+      copy(strategy = "least-frequently-used", leastFrequentlyUsedLimit = limit)
+
     private[akka] def withOldIdleStrategy(timeout: FiniteDuration): PassivationStrategySettings =
       copy(strategy = "idle", idleTimeout = timeout, oldSettingUsed = true)
 
@@ -201,12 +218,14 @@ object ClusterShardingSettings {
         idleTimeout: FiniteDuration = idleTimeout,
         leastRecentlyUsedLimit: Int = leastRecentlyUsedLimit,
         mostRecentlyUsedLimit: Int = mostRecentlyUsedLimit,
+        leastFrequentlyUsedLimit: Int = leastFrequentlyUsedLimit,
         oldSettingUsed: Boolean = oldSettingUsed): PassivationStrategySettings =
       new PassivationStrategySettings(
         strategy,
         idleTimeout,
         leastRecentlyUsedLimit,
         mostRecentlyUsedLimit,
+        leastFrequentlyUsedLimit,
         oldSettingUsed)
   }
 
@@ -216,6 +235,7 @@ object ClusterShardingSettings {
       idleTimeout = Duration.Zero,
       leastRecentlyUsedLimit = 0,
       mostRecentlyUsedLimit = 0,
+      leastFrequentlyUsedLimit = 0,
       oldSettingUsed = false)
 
     def oldDefault(idleTimeout: FiniteDuration): PassivationStrategySettings =
@@ -550,6 +570,9 @@ final class ClusterShardingSettings(
 
   def withMostRecentlyUsedPassivationStrategy(limit: Int): ClusterShardingSettings =
     copy(passivationStrategySettings = passivationStrategySettings.withMostRecentlyUsedStrategy(limit))
+
+  def withLeastFrequentlyUsedPassivationStrategy(limit: Int): ClusterShardingSettings =
+    copy(passivationStrategySettings = passivationStrategySettings.withLeastFrequentlyUsedStrategy(limit))
 
   def withShardRegionQueryTimeout(duration: FiniteDuration): ClusterShardingSettings =
     copy(shardRegionQueryTimeout = duration)

--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -40,6 +40,7 @@ akka.cluster.sharding {
     #   - "idle"
     #   - "least-recently-used"
     #   - "most-recently-used"
+    #   - "least-frequently-used"
     # Set to "none" or "off" to disable automatic passivation.
     # Passivation strategies are always disabled if `remember-entities` is enabled.
     strategy = "idle"
@@ -63,6 +64,14 @@ akka.cluster.sharding {
     # Passivate the most recently used entities when the number of active entities in a shard region
     # reaches a limit. The per-region limit is divided evenly among the active shards in a region.
     most-recently-used {
+      # Limit of active entities in a shard region.
+      limit = 100000
+    }
+
+    # Least frequently used passivation strategy.
+    # Passivate the least frequently used entities when the number of active entities in a shard region
+    # reaches a limit. The per-region limit is divided evenly among the active shards in a region.
+    least-frequently-used {
       # Limit of active entities in a shard region.
       limit = 100000
     }

--- a/akka-cluster-sharding/src/test/resources/arc-trace-database.conf
+++ b/akka-cluster-sharding/src/test/resources/arc-trace-database.conf
@@ -26,6 +26,14 @@
 #   ║ MRU 4M │ 41.82 % │ 43,704,979 │  25,429,608 │   21,429,608 ║
 #   ╟────────┼─────────┼────────────┼─────────────┼──────────────╢
 #   ║ MRU 8M │ 68.01 % │ 43,704,979 │  13,980,246 │    5,980,246 ║
+#   ╟────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║ LFU 1M │  6.13 % │ 43,704,979 │  41,026,869 │   40,026,869 ║
+#   ╟────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║ LFU 2M │ 23.39 % │ 43,704,979 │  33,482,361 │   31,482,361 ║
+#   ╟────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║ LFU 4M │ 39.06 % │ 43,704,979 │  26,632,624 │   22,632,624 ║
+#   ╟────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║ LFU 8M │ 57.55 % │ 43,704,979 │  18,552,089 │   10,552,089 ║
 #   ╚════════╧═════════╧════════════╧═════════════╧══════════════╝
 #
 
@@ -91,6 +99,34 @@ akka.cluster.sharding {
         pattern = arc-database
         strategy = mru-800k
       },
+      {
+        name = "LFU 1M"
+        shards = 100
+        regions = 10
+        pattern = arc-database
+        strategy = lfu-100k
+      },
+      {
+        name = "LFU 2M"
+        shards = 100
+        regions = 10
+        pattern = arc-database
+        strategy = lfu-200k
+      },
+      {
+        name = "LFU 4M"
+        shards = 100
+        regions = 10
+        pattern = arc-database
+        strategy = lfu-400k
+      },
+      {
+        name = "LFU 8M"
+        shards = 100
+        regions = 10
+        pattern = arc-database
+        strategy = lfu-800k
+      },
     ]
 
     print-detailed-stats = true
@@ -155,6 +191,34 @@ akka.cluster.sharding {
     mru-800k {
       strategy = most-recently-used
       most-recently-used {
+        per-region-limit = 800000
+      }
+    }
+
+    lfu-100k {
+      strategy = least-frequently-used
+      least-frequently-used {
+        per-region-limit = 100000
+      }
+    }
+
+    lfu-200k {
+      strategy = least-frequently-used
+      least-frequently-used {
+        per-region-limit = 200000
+      }
+    }
+
+    lfu-400k {
+      strategy = least-frequently-used
+      least-frequently-used {
+        per-region-limit = 400000
+      }
+    }
+
+    lfu-800k {
+      strategy = least-frequently-used
+      least-frequently-used {
         per-region-limit = 800000
       }
     }

--- a/akka-cluster-sharding/src/test/resources/arc-trace-search.conf
+++ b/akka-cluster-sharding/src/test/resources/arc-trace-search.conf
@@ -22,6 +22,12 @@
 #   ║ MRU 500k │ 10.50 % │ 37,656,092 │  33,702,975 │   33,202,975 ║
 #   ╟──────────┼─────────┼────────────┼─────────────┼──────────────╢
 #   ║   MRU 1M │ 20.79 % │ 37,656,092 │  29,826,997 │   28,826,997 ║
+#   ╟──────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║ LFU 250k │  9.04 % │ 37,656,092 │  34,253,102 │   34,003,102 ║
+#   ╟──────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║ LFU 500k │ 16.42 % │ 37,656,092 │  31,471,765 │   30,971,765 ║
+#   ╟──────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║   LFU 1M │ 27.43 % │ 37,656,092 │  27,328,351 │   26,328,351 ║
 #   ╚══════════╧═════════╧════════════╧═════════════╧══════════════╝
 #
 
@@ -72,7 +78,28 @@ akka.cluster.sharding {
         regions = 10
         pattern = arc-search-merged
         strategy = mru-100k
-      }
+      },
+      {
+        name = "LFU 250k"
+        shards = 100
+        regions = 10
+        pattern = arc-search-merged
+        strategy = lfu-25k
+      },
+      {
+        name = "LFU 500k"
+        shards = 100
+        regions = 10
+        pattern = arc-search-merged
+        strategy = lfu-50k
+      },
+      {
+        name = "LFU 1M"
+        shards = 100
+        regions = 10
+        pattern = arc-search-merged
+        strategy = lfu-100k
+      },
     ]
 
     print-detailed-stats = true
@@ -123,6 +150,27 @@ akka.cluster.sharding {
     mru-100k {
       strategy = most-recently-used
       most-recently-used {
+        per-region-limit = 100000
+      }
+    }
+
+    lfu-25k {
+      strategy = least-frequently-used
+      least-frequently-used {
+        per-region-limit = 25000
+      }
+    }
+
+    lfu-50k {
+      strategy = least-frequently-used
+      least-frequently-used {
+        per-region-limit = 50000
+      }
+    }
+
+    lfu-100k {
+      strategy = least-frequently-used
+      least-frequently-used {
         per-region-limit = 100000
       }
     }

--- a/akka-cluster-sharding/src/test/resources/synthetic-zipfian.conf
+++ b/akka-cluster-sharding/src/test/resources/synthetic-zipfian.conf
@@ -9,6 +9,8 @@
 #   ║ LRU 100k │ 40.47 % │ 50,000,000 │  29,764,380 │   29,664,380 ║
 #   ╟──────────┼─────────┼────────────┼─────────────┼──────────────╢
 #   ║ MRU 100k │ 10.08 % │ 50,000,000 │  44,960,042 │   44,860,042 ║
+#   ╟──────────┼─────────┼────────────┼─────────────┼──────────────╢
+#   ║ LFU 100k │ 46.82 % │ 50,000,000 │  26,589,475 │   26,489,475 ║
 #   ╚══════════╧═════════╧════════════╧═════════════╧══════════════╝
 #
 
@@ -28,7 +30,14 @@ akka.cluster.sharding {
         regions = 10
         pattern = scrambled-zipfian
         strategy = mru-10k
-      }
+      },
+      {
+        name = "LFU 100k"
+        shards = 100
+        regions = 10
+        pattern = scrambled-zipfian
+        strategy = lfu-10k
+      },
     ]
 
     print-detailed-stats = true
@@ -62,6 +71,15 @@ akka.cluster.sharding {
     mru-10k {
       strategy = most-recently-used
       most-recently-used {
+        per-region-limit = 10000
+      }
+    }
+
+    # LFU strategy with 10k limit in each of 10 regions
+    # total limit across cluster of 100k (1% of id space)
+    lfu-10k {
+      strategy = least-frequently-used
+      least-frequently-used {
         per-region-limit = 10000
       }
     }

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala
@@ -86,6 +86,25 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
         .passivationStrategy shouldBe ClusterShardingSettings.MostRecentlyUsedPassivationStrategy(42000)
     }
 
+    "allow least frequently used passivation strategy to be configured (via config)" in {
+      settings("""
+        #passivation-least-frequently-used
+        akka.cluster.sharding {
+          passivation {
+            strategy = least-frequently-used
+            least-frequently-used.limit = 1000000
+          }
+        }
+        #passivation-least-frequently-used
+      """).passivationStrategy shouldBe ClusterShardingSettings.LeastFrequentlyUsedPassivationStrategy(1000000)
+    }
+
+    "allow least frequently used passivation strategy to be configured (via factory method)" in {
+      defaultSettings
+        .withLeastFrequentlyUsedPassivationStrategy(limit = 42000)
+        .passivationStrategy shouldBe ClusterShardingSettings.LeastFrequentlyUsedPassivationStrategy(42000)
+    }
+
     "disable automatic passivation if `remember-entities` is enabled (via config)" in {
       settings("""
         akka.cluster.sharding.remember-entities = on

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/simulator/Simulator.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/simulator/Simulator.scala
@@ -8,6 +8,7 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.cluster.sharding.internal.{
   EntityPassivationStrategy,
+  LeastFrequentlyUsedEntityPassivationStrategy,
   LeastRecentlyUsedEntityPassivationStrategy,
   MostRecentlyUsedEntityPassivationStrategy
 }
@@ -106,6 +107,8 @@ object Simulator {
           () => new LeastRecentlyUsedEntityPassivationStrategy(perRegionLimit)
         case SimulatorSettings.StrategySettings.MostRecentlyUsed(perRegionLimit) =>
           () => new MostRecentlyUsedEntityPassivationStrategy(perRegionLimit)
+        case SimulatorSettings.StrategySettings.LeastFrequentlyUsed(perRegionLimit) =>
+          () => new LeastFrequentlyUsedEntityPassivationStrategy(perRegionLimit)
       }
   }
 

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/simulator/SimulatorSettings.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/simulator/SimulatorSettings.scala
@@ -46,13 +46,15 @@ object SimulatorSettings {
   object StrategySettings {
     final case class LeastRecentlyUsed(perRegionLimit: Int) extends StrategySettings
     final case class MostRecentlyUsed(perRegionLimit: Int) extends StrategySettings
+    final case class LeastFrequentlyUsed(perRegionLimit: Int) extends StrategySettings
 
     def apply(simulatorConfig: Config, strategy: String): StrategySettings = {
       val config = simulatorConfig.getConfig(strategy).withFallback(simulatorConfig.getConfig("strategy-defaults"))
       lowerCase(config.getString("strategy")) match {
-        case "least-recently-used" => LeastRecentlyUsed(config.getInt("least-recently-used.per-region-limit"))
-        case "most-recently-used"  => MostRecentlyUsed(config.getInt("most-recently-used.per-region-limit"))
-        case _                     => sys.error(s"Unknown strategy for [$strategy]")
+        case "least-recently-used"   => LeastRecentlyUsed(config.getInt("least-recently-used.per-region-limit"))
+        case "most-recently-used"    => MostRecentlyUsed(config.getInt("most-recently-used.per-region-limit"))
+        case "least-frequently-used" => LeastFrequentlyUsed(config.getInt("least-frequently-used.per-region-limit"))
+        case _                       => sys.error(s"Unknown strategy for [$strategy]")
       }
     }
   }

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -338,6 +338,18 @@ the most recently used passivation strategy, and set the limit for active entiti
 Or enable the most recently used passivation strategy and set the active entity limit using the
 `withMostRecentlyUsedPassivationStrategy` method on `ClusterShardingSettings`.
 
+#### Least frequently used passivation strategy
+
+The **least frequently used** passivation strategy passivates those entities that have the least frequent activity when
+the number of active entities passes a specified limit. The configurable limit is for a whole shard region and is
+divided evenly among the active shards in each region. Configure automatic passivation to use the least frequently used
+passivation strategy, and set the limit for active entities in a shard region:
+
+@@snip [passivation least frequently used](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #passivation-least-frequently-used type=conf }
+
+Or enable the least frequently used passivation strategy and set the active entity limit using the
+`withLeastFrequentlyUsedPassivationStrategy` method on `ClusterShardingSettings`.
+
 
 ## Sharding State 
 


### PR DESCRIPTION
Next up in the basic passivation strategies: least frequently used.

Adds a frequency list, a doubly-linked list (frequencies) of doubly-linked lists (recency of the same frequency count).

Will also look at extending this LFU strategy with an idle timeout, for avoiding popular entities from the more distant past staying around for too long and taking up active slots. Then strategies that combine recency and frequency.