### PR TITLE
Update ambiguous comment with maximum-large-frame-size

### DIFF
--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -852,8 +852,9 @@ akka {
         buffer-pool-size = 128
 
         # Maximum serialized message size for the large messages, including header data.
-        # It is currently restricted to 1/8th the size of a term buffer that can be
-        # configured by setting the 'aeron.term.buffer.length' system property.
+        # If the value of akka.remote.artery.transport is set to aeron-udp, it is currently
+        # restricted to 1/8th the size of a term buffer that can be configured by setting the
+        # 'aeron.term.buffer.length' system property.
         # See 'large-message-destinations'.
         maximum-large-frame-size = 2 MiB
 


### PR DESCRIPTION
In reference.conf, Comment attached with `akka.remote.artery.advance.maximum-large-frame-size`
is misleading. Here I updated the comment.
 
It closes #30893 
