### PR TITLE
Support idle entity timeouts in limit-based passivation strategies

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/FrequencyListSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/FrequencyListSpec.scala
@@ -7,6 +7,19 @@ package akka.util
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.concurrent.duration._
+
+object FrequencyListSpec {
+  // controlled clock for testing recency windows
+  // durations are always in seconds
+  class TestClock extends RecencyList.Clock {
+    private var time = 0L
+    def tick(): Unit = time += 1
+    override def currentTime(): Long = time
+    override def earlierTime(duration: FiniteDuration): Long = currentTime() - duration.toSeconds
+  }
+}
+
 class FrequencyListSpec extends AnyWordSpec with Matchers {
 
   private def check(frequencyList: FrequencyList[String], expectedLeastToMostFrequent: List[String]): Unit = {
@@ -16,10 +29,17 @@ class FrequencyListSpec extends AnyWordSpec with Matchers {
     frequencyList.mostToLeastFrequent.toList shouldBe expectedLeastToMostFrequent.reverse
   }
 
+  private def checkRecency(frequencyList: FrequencyList[String], expectedLeastToMostRecent: List[String]): Unit = {
+    expectedLeastToMostRecent.forall(frequencyList.contains)
+    frequencyList.size shouldBe expectedLeastToMostRecent.size
+    frequencyList.overallLeastToMostRecent.toList shouldBe expectedLeastToMostRecent
+    frequencyList.overallMostToLeastRecent.toList shouldBe expectedLeastToMostRecent.reverse
+  }
+
   "FrequencyList" must {
 
     "track frequency of elements" in {
-      val frequency = new FrequencyList[String]
+      val frequency = FrequencyList.empty[String]
 
       check(frequency, Nil)
 
@@ -70,6 +90,83 @@ class FrequencyListSpec extends AnyWordSpec with Matchers {
 
       frequency.removeMostFrequent(2, skip = OptionVal.Some("p")) shouldBe List("o", "r")
       check(frequency, List( /* 1: */ "q", /* 2: */ "p"))
+    }
+
+    "track overall recency of elements when enabled" in {
+      val clock = new RecencyListSpec.TestClock
+      val frequency = new FrequencyList[String](OptionVal.Some(clock))
+
+      check(frequency, Nil)
+
+      clock.tick() // time = 1
+      frequency.update("a")
+      check(frequency, List( /* 1: */ "a"))
+      checkRecency(frequency, List("a"))
+
+      clock.tick() // time = 2
+      frequency.update("b").update("c")
+      check(frequency, List( /* 1: */ "a", "b", "c"))
+      checkRecency(frequency, List("a", "b", "c"))
+
+      clock.tick() // time = 3
+      frequency.update("a").update("c")
+      check(frequency, List( /* 1: */ "b", /* 2: */ "a", "c"))
+      checkRecency(frequency, List("b", "a", "c"))
+
+      clock.tick() // time = 4
+      frequency.update("d").update("e").update("f")
+      check(frequency, List( /* 1: */ "b", "d", "e", "f", /* 2: */ "a", "c"))
+      checkRecency(frequency, List("b", "a", "c", "d", "e", "f"))
+
+      clock.tick() // time = 5
+      frequency.update("c").update("f")
+      check(frequency, List( /* 1: */ "b", "d", "e", /* 2: */ "a", "f", /* 3: */ "c"))
+      checkRecency(frequency, List("b", "a", "d", "e", "c", "f"))
+
+      clock.tick() // time = 6
+      frequency.remove("d").remove("b").remove("f")
+      check(frequency, List( /* 1: */ "e", /* 2: */ "a", /* 3: */ "c"))
+      checkRecency(frequency, List("a", "e", "c"))
+
+      clock.tick() // time = 7
+      frequency.update("e").update("h").update("i")
+      check(frequency, List( /* 1: */ "h", "i", /* 2: */ "a", "e", /* 3: */ "c"))
+      checkRecency(frequency, List("a", "c", "e", "h", "i"))
+
+      clock.tick() // time = 8
+      frequency.removeOverallLeastRecent()
+      check(frequency, List( /* 1: */ "h", "i", /* 2: */ "e", /* 3: */ "c"))
+      checkRecency(frequency, List("c", "e", "h", "i"))
+
+      clock.tick() // time = 9
+      frequency.update("i").update("j").update("k")
+      check(frequency, List( /* 1: */ "h", "j", "k", /* 2: */ "e", "i", /* 3: */ "c"))
+      checkRecency(frequency, List("c", "e", "h", "i", "j", "k"))
+
+      clock.tick() // time = 10
+      frequency.removeOverallMostRecent()
+      check(frequency, List( /* 1: */ "h", "j", /* 2: */ "e", "i", /* 3: */ "c"))
+      checkRecency(frequency, List("c", "e", "h", "i", "j"))
+
+      clock.tick() // time = 11
+      frequency.removeOverallLeastRecentOutside(3.seconds)
+      check(frequency, List( /* 1: */ "j", /* 2: */ "i"))
+      checkRecency(frequency, List("i", "j"))
+
+      clock.tick() // time = 12
+      frequency.update("l").update("m")
+      check(frequency, List( /* 1: */ "j", "l", "m", /* 2: */ "i"))
+      checkRecency(frequency, List("i", "j", "l", "m"))
+
+      clock.tick() // time = 13
+      frequency.removeOverallMostRecentWithin(3.seconds)
+      check(frequency, List( /* 1: */ "j", /* 2: */ "i"))
+      checkRecency(frequency, List("i", "j"))
+
+      clock.tick() // time = 14
+      frequency.update("n").update("o").update("n")
+      check(frequency, List( /* 1: */ "j", "o", /* 2: */ "i", "n"))
+      checkRecency(frequency, List("i", "j", "o", "n"))
     }
 
   }

--- a/akka-actor/src/main/scala/akka/util/FrequencyList.scala
+++ b/akka-actor/src/main/scala/akka/util/FrequencyList.scala
@@ -7,13 +7,18 @@ package akka.util
 import akka.annotation.InternalApi
 
 import scala.collection.{ immutable, mutable, AbstractIterator }
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * INTERNAL API
  */
 @InternalApi
 private[akka] object FrequencyList {
-  def empty[A]: FrequencyList[A] = new FrequencyList[A]
+  def empty[A]: FrequencyList[A] = new FrequencyList[A](OptionVal.None)
+
+  object withOverallRecency {
+    def empty[A]: FrequencyList[A] = new FrequencyList[A](OptionVal.Some(new RecencyList.NanoClock))
+  }
 
   private final class FrequencyNode[A](val count: Int) {
     var lessFrequent, moreFrequent: FrequencyNode[A] = this
@@ -25,6 +30,8 @@ private[akka] object FrequencyList {
   private final class Node[A](val value: A, initialFrequency: FrequencyNode[A]) {
     var frequency: FrequencyNode[A] = initialFrequency
     var lessRecent, moreRecent: Node[A] = this
+    var overallLessRecent, overallMoreRecent: Node[A] = this
+    var timestamp: Long = 0L
   }
 }
 
@@ -34,9 +41,11 @@ private[akka] object FrequencyList {
  * Mutable non-thread-safe frequency list.
  * Used for tracking frequency of elements for implementing least/most frequently used eviction policies.
  * Implemented using a doubly-linked list of doubly-linked lists, with lookup, so that all operations are constant time.
+ * Elements with the same frequency are stored in order of update (recency within the same frequency count).
+ * Overall recency can also be enabled, to support time-based eviction policies, without using a secondary recency list.
  */
 @InternalApi
-private[akka] final class FrequencyList[A] {
+private[akka] final class FrequencyList[A](clock: OptionVal[RecencyList.Clock]) {
   import FrequencyList.{ FrequencyNode, Node }
 
   private val zero = new FrequencyNode[A](count = 0)
@@ -48,8 +57,10 @@ private[akka] final class FrequencyList[A] {
     if (lookupNode.contains(value)) {
       val node = lookupNode(value)
       increaseFrequency(node)
+      addAsOverallMostRecent(node)
     } else {
       val node = addAsLeastFrequent(value)
+      addAsOverallMostRecent(node)
       lookupNode += value -> node
     }
     this
@@ -91,6 +102,38 @@ private[akka] final class FrequencyList[A] {
   def leastToMostFrequent: Iterator[A] = iterator(start = leastNode, shift = moreFrequent)
 
   def mostToLeastFrequent: Iterator[A] = iterator(start = mostNode, shift = lessFrequent)
+
+  private def overallLeastRecent: Node[A] = zero.empty.overallMoreRecent
+  private def overallMostRecent: Node[A] = zero.empty.overallLessRecent
+
+  private val overallLessRecent: Node[A] => Node[A] = _.overallLessRecent
+  private val overallMoreRecent: Node[A] => Node[A] = _.overallMoreRecent
+
+  def removeOverallLeastRecent(n: Int = 1): immutable.Seq[A] = {
+    if (clock.isEmpty) throw new UnsupportedOperationException("Overall recency is not enabled for this FrequencyList")
+    removeWhile(start = overallLeastRecent, next = overallMoreRecent, limit = n)
+  }
+
+  def removeOverallMostRecent(n: Int = 1): immutable.Seq[A] = {
+    if (clock.isEmpty) throw new UnsupportedOperationException("Overall recency is not enabled for this FrequencyList")
+    removeWhile(start = overallMostRecent, next = overallLessRecent, limit = n)
+  }
+
+  def removeOverallLeastRecentOutside(duration: FiniteDuration): immutable.Seq[A] = {
+    if (clock.isEmpty) throw new UnsupportedOperationException("Overall recency is not enabled for this FrequencyList")
+    val min = clock.get.earlierTime(duration)
+    removeWhile(start = overallLeastRecent, next = overallMoreRecent, continueWhile = _.timestamp < min)
+  }
+
+  def removeOverallMostRecentWithin(duration: FiniteDuration): immutable.Seq[A] = {
+    if (clock.isEmpty) throw new UnsupportedOperationException("Overall recency is not enabled for this FrequencyList")
+    val max = clock.get.earlierTime(duration)
+    removeWhile(start = overallMostRecent, next = overallLessRecent, continueWhile = _.timestamp > max)
+  }
+
+  def overallLeastToMostRecent: Iterator[A] = iterator(start = overallLeastRecent, shift = overallMoreRecent)
+
+  def overallMostToLeastRecent: Iterator[A] = iterator(start = overallMostRecent, shift = overallLessRecent)
 
   private def addAsLeastFrequent(value: A): Node[A] = {
     val frequency = if (leastFrequent.count == 1) {
@@ -136,6 +179,15 @@ private[akka] final class FrequencyList[A] {
     node.lessRecent.moreRecent = node
   }
 
+  private def addAsOverallMostRecent(node: Node[A]): Unit =
+    if (clock.isDefined) {
+      node.overallMoreRecent = zero.empty
+      node.overallLessRecent = overallMostRecent
+      node.overallMoreRecent.overallLessRecent = node
+      node.overallLessRecent.overallMoreRecent = node
+      node.timestamp = clock.get.currentTime()
+    }
+
   private def removeFromCurrentPosition(node: Node[A]): Unit = {
     node.lessRecent.moreRecent = node.moreRecent
     node.moreRecent.lessRecent = node.lessRecent
@@ -143,17 +195,24 @@ private[akka] final class FrequencyList[A] {
       node.frequency.lessFrequent.moreFrequent = node.frequency.moreFrequent
       node.frequency.moreFrequent.lessFrequent = node.frequency.lessFrequent
     }
+    if (clock.isDefined) {
+      node.overallLessRecent.overallMoreRecent = node.overallMoreRecent
+      node.overallMoreRecent.overallLessRecent = node.overallLessRecent
+    }
   }
+
+  private val continueToLimit: Node[A] => Boolean = _ => true
 
   private def removeWhile(
       start: Node[A],
       next: Node[A] => Node[A],
-      limit: Int,
-      skip: OptionVal[A]): immutable.Seq[A] = {
+      limit: Int = size,
+      continueWhile: Node[A] => Boolean = continueToLimit,
+      skip: OptionVal[A] = OptionVal.none[A]): immutable.Seq[A] = {
     var count = 0
     var node = start
     val values = mutable.ListBuffer.empty[A]
-    while ((node ne zero.empty) && (count < limit)) {
+    while ((node ne zero.empty) && (count < limit) && continueWhile(node)) {
       if (!skip.contains(node.value)) {
         count += 1
         removeFromCurrentPosition(node)

--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -50,6 +50,9 @@ akka.cluster.sharding {
     idle {
       # Passivate idle entities after the timeout.
       timeout = 120s
+
+      # Check idle entities every interval. Set to "default" to use half the timeout by default.
+      interval = default
     }
 
     # Least recently used passivation strategy.
@@ -58,6 +61,15 @@ akka.cluster.sharding {
     least-recently-used {
       # Limit of active entities in a shard region.
       limit = 100000
+
+      # Optionally passivate entities when they have not received a message for a specified length of time.
+      idle {
+        # Passivate idle entities after the timeout. Set to "off" to disable.
+        timeout = off
+
+        # Check idle entities every interval. Set to "default" to use half the timeout by default.
+        interval = default
+      }
     }
 
     # Most recently used passivation strategy.
@@ -66,6 +78,15 @@ akka.cluster.sharding {
     most-recently-used {
       # Limit of active entities in a shard region.
       limit = 100000
+
+      # Optionally passivate entities when they have not received a message for a specified length of time.
+      idle {
+        # Passivate idle entities after the timeout. Set to "off" to disable.
+        timeout = off
+
+        # Check idle entities every interval. Set to "default" to use half the timeout by default.
+        interval = default
+      }
     }
 
     # Least frequently used passivation strategy.
@@ -74,6 +95,15 @@ akka.cluster.sharding {
     least-frequently-used {
       # Limit of active entities in a shard region.
       limit = 100000
+
+      # Optionally passivate entities when they have not received a message for a specified length of time.
+      idle {
+        # Passivate idle entities after the timeout. Set to "off" to disable.
+        timeout = off
+
+        # Check idle entities every interval. Set to "default" to use half the timeout by default.
+        interval = default
+      }
     }
   }
 

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/simulator/Simulator.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/simulator/Simulator.scala
@@ -104,11 +104,11 @@ object Simulator {
     def strategyCreator(runSettings: SimulatorSettings.RunSettings): () => EntityPassivationStrategy =
       runSettings.strategy match {
         case SimulatorSettings.StrategySettings.LeastRecentlyUsed(perRegionLimit) =>
-          () => new LeastRecentlyUsedEntityPassivationStrategy(perRegionLimit)
+          () => new LeastRecentlyUsedEntityPassivationStrategy(perRegionLimit, idleCheck = None)
         case SimulatorSettings.StrategySettings.MostRecentlyUsed(perRegionLimit) =>
-          () => new MostRecentlyUsedEntityPassivationStrategy(perRegionLimit)
+          () => new MostRecentlyUsedEntityPassivationStrategy(perRegionLimit, idleCheck = None)
         case SimulatorSettings.StrategySettings.LeastFrequentlyUsed(perRegionLimit) =>
-          () => new LeastFrequentlyUsedEntityPassivationStrategy(perRegionLimit)
+          () => new LeastFrequentlyUsedEntityPassivationStrategy(perRegionLimit, idleCheck = None)
       }
   }
 

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -325,6 +325,13 @@ passivation strategy, and set the limit for active entities in a shard region:
 Or enable the least recently used passivation strategy and set the active entity limit using the
 `withLeastRecentlyUsedPassivationStrategy` method on `ClusterShardingSettings`.
 
+Passivating idle entities (when they have not received a message for a specified length of time) can also be enabled by configuring the least recently used passivation strategy with an idle timeout:
+
+@@snip [passivation least recently used with idle](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #passivation-least-recently-used-with-idle type=conf }
+
+Or enable the least recently used passivation strategy with both an active entity limit and an idle timeout using the
+`withLeastRecentlyUsedPassivationStrategy` method on `ClusterShardingSettings`.
+
 #### Most recently used passivation strategy
 
 The **most recently used** passivation strategy passivates those entities that have the most recent activity when the
@@ -338,6 +345,13 @@ the most recently used passivation strategy, and set the limit for active entiti
 Or enable the most recently used passivation strategy and set the active entity limit using the
 `withMostRecentlyUsedPassivationStrategy` method on `ClusterShardingSettings`.
 
+Passivating idle entities (when they have not received a message for a specified length of time) can also be enabled by configuring the most recently used passivation strategy with an idle timeout:
+
+@@snip [passivation most recently used with idle](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #passivation-most-recently-used-with-idle type=conf }
+
+Or enable the most recently used passivation strategy with both an active entity limit and an idle timeout using the
+`withMostRecentlyUsedPassivationStrategy` method on `ClusterShardingSettings`.
+
 #### Least frequently used passivation strategy
 
 The **least frequently used** passivation strategy passivates those entities that have the least frequent activity when
@@ -348,6 +362,13 @@ passivation strategy, and set the limit for active entities in a shard region:
 @@snip [passivation least frequently used](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #passivation-least-frequently-used type=conf }
 
 Or enable the least frequently used passivation strategy and set the active entity limit using the
+`withLeastFrequentlyUsedPassivationStrategy` method on `ClusterShardingSettings`.
+
+Passivating idle entities (when they have not received a message for a specified length of time) can also be enabled by configuring the least frequently used passivation strategy with an idle timeout:
+
+@@snip [passivation least frequently used with idle](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #passivation-least-frequently-used-with-idle type=conf }
+
+Or enable the least frequently used passivation strategy with both an active entity limit and an idle timeout using the
 `withLeastFrequentlyUsedPassivationStrategy` method on `ClusterShardingSettings`.
 
 


### PR DESCRIPTION
Support idle timeouts for all of the passivation strategies. Off by default, but can be enabled for strategies such as least-frequently-used as a way to prevent cache pollution, or in any of the strategies to also have time-based passivation to free memory.

To enable this, the frequency list data structure is extended to also support an overall recency order, weaving through the same nodes to avoid overhead of having an additional recency list. I think I'll follow up with abstracting out the double-linked list operations, to make it easier to combine frequency and recency structures, as there will be some other variations as well.

Broken down into separate settings for each passivation strategy, to make it simpler to extend these with more customisations that will be supported next. But there's some duplication introduced in adding the idle variation to all of the strategies.