### PR TITLE
wip: experiment with EntityRef at ActorSystem level

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/EntitySpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/EntitySpec.scala
@@ -1,0 +1,286 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed
+
+import scala.concurrent.duration.DurationInt
+import scala.util.Failure
+import scala.util.Success
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.typed.EntityEnvelope.StartEntity
+import akka.actor.typed.scaladsl.Behaviors
+import akka.pattern.AskTimeoutException
+import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+object EntitySpec {
+
+  val config = ConfigFactory.parseString(s"""
+      akka.coordinated-shutdown.terminate-actor-system = off
+      akka.coordinated-shutdown.run-by-actor-system-terminate = off
+    """)
+
+  sealed trait TestProtocol
+  final case class ReplyPlz(toMe: ActorRef[String]) extends TestProtocol
+  final case class WhoAreYou(replyTo: ActorRef[String]) extends TestProtocol
+  case object StopPlz extends TestProtocol
+  case object PassivatePlz extends TestProtocol
+
+  sealed trait IdTestProtocol
+  final case class IdReplyPlz(id: String, toMe: ActorRef[String]) extends IdTestProtocol
+  final case class IdWhoAreYou(id: String, replyTo: ActorRef[String]) extends IdTestProtocol
+  case object IdStopPlz extends IdTestProtocol
+
+  def behavior(context: EntityContext[TestProtocol], stopProbe: Option[ActorRef[String]] = None) = {
+
+    val entityManager = context.manager
+    Behaviors
+      .receivePartial[TestProtocol] {
+        case (ctx, PassivatePlz) =>
+          entityManager ! Entity.Passivate(ctx.self)
+          Behaviors.same
+
+        case (_, StopPlz) =>
+          stopProbe.foreach(_ ! "StopPlz")
+          Behaviors.stopped
+
+        case (_, WhoAreYou(replyTo)) =>
+          replyTo ! s"I'm ${context.entityId}"
+          Behaviors.same
+
+        case (_, ReplyPlz(toMe)) =>
+          toMe ! "Hello!"
+          Behaviors.same
+      }
+      .receiveSignal {
+        case (_, PostStop) =>
+          stopProbe.foreach(_ ! "PostStop")
+          Behaviors.same
+      }
+  }
+
+  def behaviorWithId(context: EntityContext[IdTestProtocol]) = Behaviors.receive[IdTestProtocol] {
+    case (_, IdStopPlz) =>
+      Behaviors.stopped
+
+    case (_, IdWhoAreYou(_, replyTo)) =>
+      replyTo ! s"I'm ${context.entityId}"
+      Behaviors.same
+
+    case (_, IdReplyPlz(_, toMe)) =>
+      toMe ! "Hello!"
+      Behaviors.same
+  }
+
+}
+class EntitySpec extends ScalaTestWithActorTestKit(EntitySpec.config) with AnyWordSpecLike with LogCapturing {
+
+  import EntitySpec._
+
+  val m = Map.empty[Int, Int]
+
+  def entityWithEnvelope(
+      entityKey: EntityTypeKey[TestProtocol],
+      stopProbe: TestProbe[String]): Entity[TestProtocol, EntityEnvelope[TestProtocol]] =
+    Entity(entityKey)(ctx => behavior(ctx, Some(stopProbe.ref))).withStopMessage(StopPlz)
+
+  def entityWithEnvelope(entityKey: EntityTypeKey[TestProtocol]): Entity[TestProtocol, EntityEnvelope[TestProtocol]] =
+    Entity(entityKey)(ctx => behavior(ctx, None)).withStopMessage(StopPlz)
+
+  def entityWithoutEnvelope(entityKey: EntityTypeKey[IdTestProtocol]) =
+    Entity(entityKey)(ctx => behaviorWithId(ctx))
+      .withMessageExtractor(EntityMessageExtractor.noEnvelope[IdTestProtocol](IdStopPlz) {
+        case IdReplyPlz(id, _)  => id
+        case IdWhoAreYou(id, _) => id
+        case other              => throw new IllegalArgumentException(s"Unexpected message $other")
+      })
+      .withStopMessage(IdStopPlz)
+
+  "Local entity" must {
+
+    "send message via entity manager using envelopes" in {
+      val key = EntityTypeKey[TestProtocol]("envelope")
+      val entityRef = system.initEntity(entityWithEnvelope(key))
+      val p = TestProbe[String]()
+      entityRef ! EntityEnvelope("test", ReplyPlz(p.ref))
+      p.expectMessage("Hello!")
+    }
+
+    "send messages via entity manager without envelopes" in {
+      val key = EntityTypeKey[IdTestProtocol]("no-envelope")
+      val entityRef = system.initEntity(entityWithoutEnvelope(key))
+      val p = TestProbe[String]()
+      entityRef ! IdReplyPlz("test", p.ref)
+      p.expectMessage("Hello!")
+    }
+
+    "be able to passivate with custom stop message" in {
+      val stopProbe = TestProbe[String]()
+      val key = EntityTypeKey[TestProtocol]("passivate-test")
+      val entityRef = system.initEntity(entityWithEnvelope(key, stopProbe))
+
+      val p = TestProbe[String]()
+
+      entityRef ! EntityEnvelope(s"test1", ReplyPlz(p.ref))
+      p.expectMessage("Hello!")
+
+      entityRef ! EntityEnvelope(s"test1", PassivatePlz)
+      stopProbe.expectMessage("StopPlz")
+      stopProbe.expectMessage("PostStop")
+
+      entityRef ! EntityEnvelope(s"test1", ReplyPlz(p.ref))
+      p.expectMessage("Hello!")
+
+    }
+
+    "be able to passivate with PoisonPill" in {
+      val stopProbe = TestProbe[String]()
+      val p = TestProbe[String]()
+      val key = EntityTypeKey[TestProtocol]("passivate-test-poison")
+
+      val entityRef = system.initEntity(Entity(key)(ctx => behavior(ctx, Some(stopProbe.ref))))
+      // no StopPlz stopMessage
+
+      entityRef ! EntityEnvelope(s"test4", ReplyPlz(p.ref))
+      p.expectMessage("Hello!")
+
+      entityRef ! EntityEnvelope(s"test4", PassivatePlz)
+      // no StopPlz
+      stopProbe.expectMessage("PostStop")
+
+      entityRef ! EntityEnvelope(s"test4", ReplyPlz(p.ref))
+      p.expectMessage("Hello!")
+    }
+
+    "fail if init if typeName already in use, but with a different type" in {
+
+      val key = EntityTypeKey[TestProtocol]("unique-name")
+      system.initEntity(entityWithEnvelope(key))
+
+      val ex = intercept[Exception] {
+        val duplicatedKey = EntityTypeKey[IdTestProtocol]("unique-name")
+        system.initEntity(entityWithoutEnvelope(duplicatedKey))
+      }
+
+      ex.getMessage should include("already initialized")
+    }
+
+    "EntityRef - tell" in {
+
+      val key = EntityTypeKey[TestProtocol]("with-envelope-for-tell")
+      system.initEntity(entityWithEnvelope(key).withStopMessage(StopPlz))
+
+      val charlieRef = system.entityRefFor(key, "charlie")
+      val p = TestProbe[String]()
+
+      charlieRef ! WhoAreYou(p.ref)
+      p.receiveMessage() should startWith("I'm charlie")
+
+      charlieRef.tell(WhoAreYou(p.ref))
+      p.receiveMessage() should startWith("I'm charlie")
+
+      charlieRef ! StopPlz
+    }
+
+    "EntityRef - tell without envelope" in {
+
+      val key = EntityTypeKey[IdTestProtocol]("without-envelope-for-tell")
+
+      system.initEntity(entityWithoutEnvelope(key))
+
+      val charlieRef = system.entityRefFor(key, "charlie")
+      val p = TestProbe[String]()
+
+      charlieRef ! IdWhoAreYou("charlie", p.ref)
+      p.receiveMessage() should startWith("I'm charlie")
+
+      charlieRef.tell(IdWhoAreYou("charlie", p.ref))
+      p.receiveMessage() should startWith("I'm charlie")
+
+      charlieRef ! IdStopPlz
+    }
+
+    "EntityRef - ask" in {
+      val key = EntityTypeKey[TestProtocol]("entity-ref-ask")
+      system.initEntity(entityWithEnvelope(key))
+
+      val bobRef = system.entityRefFor(key, "bob")
+
+      val replyBob = bobRef.ask(WhoAreYou(_)).futureValue.asInstanceOf[String]
+      replyBob should startWith("I'm bob")
+
+      val aliceRef = system.entityRefFor(key, "alice")
+      val replyAlice = aliceRef.ask(WhoAreYou(_)).futureValue.asInstanceOf[String]
+      replyAlice should startWith("I'm alice")
+
+      bobRef ! StopPlz
+      aliceRef ! StopPlz
+    }
+
+    "EntityRef - ActorContext.ask" in {
+      val key = EntityTypeKey[TestProtocol]("actor-context-ask")
+      system.initEntity(entityWithEnvelope(key))
+      val peterRef = system.entityRefFor(key, "peter")
+
+      val p = TestProbe[String]()
+
+      spawn(Behaviors.setup[String] { ctx =>
+        ctx.ask(peterRef, WhoAreYou.apply) {
+          case Success(name) => name
+          case Failure(ex)   => ex.getMessage
+        }
+
+        Behaviors.receiveMessage[String] { reply =>
+          p.ref ! reply
+          Behaviors.same
+        }
+      })
+
+      val response = p.receiveMessage()
+      response should startWith("I'm peter")
+
+      peterRef ! StopPlz
+    }
+
+    "EntityRef - AskTimeoutException" in {
+      val ignorantKey = EntityTypeKey[TestProtocol]("ignorant")
+
+      system.initEntity(Entity(ignorantKey)(_ => Behaviors.ignore[TestProtocol]).withStopMessage(StopPlz))
+
+      val ref = system.entityRefFor(ignorantKey, "sloppy")
+
+      val reply = ref.ask(WhoAreYou(_))(Timeout(10.millis))
+      val exc = reply.failed.futureValue
+
+      exc.getClass should ===(classOf[AskTimeoutException])
+      exc.getMessage should startWith("Ask timed out on")
+      exc.getMessage should include(ignorantKey.toString)
+      exc.getMessage should include("sloppy") // the entity id
+      exc.getMessage should include(ref.toString)
+      exc.getMessage should include(s"[${classOf[WhoAreYou].getName}]") // message class
+      exc.getMessage should include("[10 ms]") // timeout
+    }
+
+    "handle typed StartEntity message" in {
+
+      val probe = TestProbe[String]()
+      val key = EntityTypeKey[TestProtocol]("start-entity")
+      val entity = Entity(key) { ctx =>
+        Behaviors.setup { _ =>
+          probe ! s"${ctx.entityId} just started her day"
+          behavior(ctx)
+        }
+      }
+      val managerRef = system.initEntity(entity)
+
+      managerRef ! StartEntity("Alice")
+      probe.expectMessage("Alice just started her day")
+    }
+
+  }
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/ActorSystem.scala
@@ -10,13 +10,13 @@ import scala.concurrent.{ ExecutionContextExecutor, Future }
 
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.slf4j.Logger
-
 import akka.{ Done, actor => classic }
 import akka.actor.{ Address, BootstrapSetup, ClassicActorSystemProvider }
 import akka.actor.setup.ActorSystemSetup
 import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.internal.{ EventStreamExtension, InternalRecipientRef }
 import akka.actor.typed.internal.adapter.{ ActorSystemAdapter, GuardianStartupBehavior, PropsAdapter }
+import akka.actor.typed.internal.entity.EntityExtension
 import akka.actor.typed.receptionist.Receptionist
 import akka.annotation.DoNotInherit
 import akka.util.Helpers.Requiring
@@ -169,6 +169,14 @@ abstract class ActorSystem[-T] extends ActorRef[T] with Extensions with ClassicA
    */
   def receptionist: ActorRef[Receptionist.Command] =
     Receptionist(this).ref
+
+  // TODO: adds docs
+  def initEntity[M, E](entity: Entity[M, E]): ActorRef[E] =
+    EntityExtension(this).initEntity(entity)
+
+  // TODO: adds docs
+  def entityRefFor[M](typeKey: EntityTypeKey[M], entityId: String): EntityRef[M] =
+    EntityExtension(this).entityRefFor(typeKey, entityId)
 
   /**
    * Main event bus of this actor system, used for example for logging.

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Entity.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Entity.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed
+
+import scala.reflect.ClassTag
+
+import akka.actor.typed.Entity.EntityCommand
+import akka.actor.typed.Entity.EntitySettings
+import akka.annotation.DoNotInherit
+import akka.annotation.InternalApi
+
+object Entity {
+
+  @DoNotInherit trait EntityCommand
+
+  final case class Passivate[M](entity: ActorRef[M]) extends EntityCommand
+
+  trait EntitySettings
+  def apply[M](typeKey: EntityTypeKey[M])(
+      createBehavior: EntityContext[M] => Behavior[M]): Entity[M, EntityEnvelope[M]] =
+    new Entity(createBehavior, typeKey, None, Props.empty, None, None)
+}
+
+final class Entity[M, E] private[akka] (
+    val createBehavior: EntityContext[M] => Behavior[M],
+    val typeKey: EntityTypeKey[M],
+    val stopMessage: Option[M],
+    val entityProps: Props,
+    val settings: Option[EntitySettings],
+    val messageExtractor: Option[EntityMessageExtractor[E, M]]) {
+
+  /**
+   * [[akka.actor.typed.Props]] of the entity actors, such as dispatcher settings.
+   */
+  def withEntityProps(newEntityProps: Props): Entity[M, E] =
+    copy(entityProps = newEntityProps)
+
+  /**
+   * Additional settings, typically loaded from configuration.
+   */
+  def withSettings(newSettings: EntitySettings): Entity[M, E] =
+    copy(settings = Option(newSettings))
+
+  /**
+   * Message sent to an entity to tell it to stop, e.g. when rebalanced or passivated.
+   * If this is not defined it will be stopped automatically.
+   * It can be useful to define a custom stop message if the entity needs to perform
+   * some asynchronous cleanup or interactions before stopping.
+   */
+  def withStopMessage(newStopMessage: M): Entity[M, E] =
+    copy(stopMessage = Option(newStopMessage))
+
+  /**
+   * If a `messageExtractor` is not specified the messages are sent to the entities by wrapping
+   * them in [[EntityEnvelope]] with the entityId of the recipient actor. That envelope
+   * is used by the [[EnvelopeMessageExtractor]] for extracting entityId.
+   *
+   * If used with cluster sharding, the number of shards is then defined by `numberOfShards` in `ClusterShardingSettings`,
+   * which by default is configured with `akka.cluster.sharding.number-of-shards`.
+   */
+  def withMessageExtractor[Envelope](newExtractor: EntityMessageExtractor[Envelope, M]): Entity[M, Envelope] =
+    new Entity(createBehavior, typeKey, stopMessage, entityProps, settings, Option(newExtractor))
+
+  private def copy(
+      createBehavior: EntityContext[M] => Behavior[M] = createBehavior,
+      typeKey: EntityTypeKey[M] = typeKey,
+      stopMessage: Option[M] = stopMessage,
+      entityProps: Props = entityProps,
+      settings: Option[EntitySettings] = settings): Entity[M, E] = {
+    new Entity(createBehavior, typeKey, stopMessage, entityProps, settings, messageExtractor)
+  }
+}
+
+/**
+ * The key of an entity type, the `name` must be unique.
+ *
+ * Not for user extension.
+ */
+@DoNotInherit trait EntityTypeKey[-T] {
+
+  /**
+   * Name of the entity type.
+   */
+  def name: String
+
+}
+
+object EntityTypeKey {
+
+  /**
+   * Creates an `EntityTypeKey`. The `name` must be unique.
+   */
+  def apply[T](name: String)(implicit tTag: ClassTag[T]): EntityTypeKey[T] =
+    EntityTypeKeyImpl(name, implicitly[ClassTag[T]].runtimeClass.getName)
+
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] final case class EntityTypeKeyImpl[T](name: String, messageClassName: String)
+    extends EntityTypeKey[T] {
+
+  override def toString: String = s"EntityTypeKey[$messageClassName]($name)"
+
+}
+
+final class EntityContext[M](
+    val entityTypeKey: EntityTypeKey[M],
+    val entityId: String,
+    val manager: ActorRef[EntityCommand])

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/EntityEnvelope.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/EntityEnvelope.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed
+
+import akka.actor.InvalidMessageException
+import akka.actor.WrappedMessage
+import akka.util.unused
+
+object EntityEnvelope {
+
+  final case class StartEntity(entityId: String)
+
+  /** Allows starting a specific Entity by its entity identifier */
+  object StartEntity {
+
+    /**
+     * Returns [[EntityEnvelope]] which can be sent in order to wake up the
+     * specified (by `entityId`) Entity, ''without'' delivering a real message to it.
+     */
+    def apply[M](entityId: String): EntityEnvelope[M] = {
+      // StartEntity isn't really of type M, but erased and StartEntity is only handled internally, not delivered to the entity
+      new EntityEnvelope[M](entityId, new StartEntity(entityId).asInstanceOf[M])
+    }
+  }
+}
+final case class EntityEnvelope[M](entityId: String, message: M) extends WrappedMessage {
+  if (message == null) throw InvalidMessageException("[null] is not an allowed message")
+}
+
+object EntityMessageExtractor {
+
+  /**
+   * Scala API:
+   *
+   * Create the default message extractor, using envelopes to identify what entity a message is for.
+   */
+  def apply[M](numberOfShards: Int): EntityMessageExtractor[EntityEnvelope[M], M] =
+    new EnvelopeMessageExtractor[M](numberOfShards)
+
+  /**
+   * Scala API: Create a message extractor for a protocol where the entity id is available in each message.
+   */
+  def noEnvelope[M](@unused stopMessage: M)(extractEntityId: M => String): EntityMessageExtractor[M, M] =
+    new NoEnvelopeMessageExtractor[M]() {
+      def entityId(message: M): String = extractEntityId(message)
+    }
+}
+trait EntityMessageExtractor[E, M] {
+
+  /**
+   * Extract the entity id from an incoming `message`. If `null` is returned
+   * the message will be `unhandled`, i.e. posted as `Unhandled` messages on the event stream
+   */
+  def entityId(message: E): String
+
+  /**
+   * Extract the message to send to the entity from an incoming `message`.
+   * Note that the extracted message does not have to be the same as the incoming
+   * message to support wrapping in message envelope that is unwrapped before
+   * sending to the entity actor.
+   */
+  def unwrapMessage(message: E): M
+}
+
+/**
+ * Default message extractor type, using envelopes to identify what entity a message is for.
+ *
+ * @tparam M The type of message accepted by the entity actor
+ */
+final class EnvelopeMessageExtractor[M](val numberOfShards: Int) extends EntityMessageExtractor[EntityEnvelope[M], M] {
+
+  override def entityId(envelope: EntityEnvelope[M]): String = envelope.entityId
+
+  override def unwrapMessage(envelope: EntityEnvelope[M]): M = envelope.message
+}
+
+/**
+ * Default message extractor type, using a property of the message to identify what entity a message is for.
+ *
+ * @tparam M The type of message accepted by the entity actor
+ */
+abstract class NoEnvelopeMessageExtractor[M]() extends EntityMessageExtractor[M, M] {
+
+  override final def unwrapMessage(message: M): M = message
+
+  override def toString = s"NoEnvelopeMessageExtractor()"
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/EntityRef.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/EntityRef.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed
+
+import scala.concurrent.Future
+
+import akka.actor.typed.internal.InternalRecipientRef
+import akka.annotation.DoNotInherit
+import akka.pattern.StatusReply
+import akka.util.Timeout
+
+/**
+ * A reference to an Entity, which allows `ActorRef`-like usage.
+ *
+ * An [[EntityRef]] is NOT an [[ActorRef]]–by design–in order to be explicit about the fact that the life-cycle
+ * of an Entity is very different than a plain Actors. Most notably, this is shown by features of Entities
+ * such as managed lifecycle or passivation. Both of which are aimed to be completely
+ * transparent to users of such Entity. In other words, if this were to be a plain ActorRef, it would be possible to
+ * apply DeathWatch to it, which in turn would then trigger when the Actor stopped, breaking the illusion that
+ * Entity refs are "always there". Please note that while not encouraged, it is possible to expose an Actor's `self`
+ * [[ActorRef]] and watch it in case such notification is desired.
+ * Not for user extension.
+ *
+ */
+@DoNotInherit trait EntityRef[-M] extends RecipientRef[M] { this: InternalRecipientRef[M] =>
+
+  /**
+   * The identifier for the particular entity referenced by this EntityRef.
+   *
+   * {{{
+   * system.entityRefFor(typeKey, "someId").entityId == "someId"  // always true
+   * }}}
+   */
+  def entityId: String
+
+  /**
+   * The EntityTypeKey associated with this EntityRef.
+   */
+  def typeKey: EntityTypeKey[M]
+
+  /**
+   * Send a message to the entity referenced by this EntityRef using *at-most-once*
+   * messaging semantics.
+   *
+   * Example usage:
+   * {{{
+   * val target: EntityRef[String] = ...
+   * target.tell("Hello")
+   * }}}
+   */
+  def tell(msg: M): Unit
+
+  /**
+   * Send a message to the entity referenced by this EntityRef using *at-most-once*
+   * messaging semantics.
+   *
+   * Example usage:
+   * {{{
+   * val target: EntityRef[String] = ...
+   * target ! "Hello"
+   * }}}
+   */
+  def !(msg: M): Unit = this.tell(msg)
+
+  /**
+   * Allows to "ask" the [[EntityRef]] for a reply.
+   * See [[akka.actor.typed.scaladsl.AskPattern]] for a complete write-up of this pattern
+   *
+   * Note that if you are inside of an actor you should prefer [[akka.actor.typed.scaladsl.ActorContext.ask]]
+   * as that provides better safety.
+   *
+   * Example usage:
+   * {{{
+   * case class Request(msg: String, replyTo: ActorRef[Reply])
+   * case class Reply(msg: String)
+   *
+   * implicit val timeout = Timeout(3.seconds)
+   * val target: EntityRef[Request] = ...
+   * val f: Future[Reply] = target.ask(Request("hello", _))
+   * }}}
+   *
+   * Please note that an implicit [[akka.util.Timeout]] must be available to use this pattern.
+   *
+   * @tparam Res The response protocol, what the other actor sends back
+   */
+  def ask[Res](f: ActorRef[Res] => M)(implicit timeout: Timeout): Future[Res]
+
+  /**
+   * The same as [[ask]] but only for requests that result in a response of type [[akka.pattern.StatusReply]].
+   * If the response is a [[akka.pattern.StatusReply.Success]] the returned future is completed successfully with the wrapped response.
+   * If the status response is a [[akka.pattern.StatusReply.Error]] the returned future will be failed with the
+   * exception in the error (normally a [[akka.pattern.StatusReply.ErrorMessage]]).
+   */
+  def askWithStatus[Res](f: ActorRef[StatusReply[Res]] => M)(implicit timeout: Timeout): Future[Res]
+
+  /**
+   * Allows to "ask" the [[EntityRef]] for a reply.
+   * See [[akka.actor.typed.scaladsl.AskPattern]] for a complete write-up of this pattern
+   *
+   * Note that if you are inside of an actor you should prefer [[akka.actor.typed.scaladsl.ActorContext.ask]]
+   * as that provides better safety.
+   *
+   * Example usage:
+   * {{{
+   * case class Request(msg: String, replyTo: ActorRef[Reply])
+   * case class Reply(msg: String)
+   *
+   * implicit val timeout = Timeout(3.seconds)
+   * val target: EntityRef[Request] = ...
+   * val f: Future[Reply] = target ? (replyTo => Request("hello", replyTo))
+   * }}}
+   *
+   * Please note that an implicit [[akka.util.Timeout]] must be available to use this pattern.
+   *
+   * Note: it is preferable to use the non-symbolic ask method as it easier allows for wildcards for
+   * the `replyTo: ActorRef`.
+   *
+   * @tparam Res The response protocol, what the other actor sends back
+   */
+  def ?[Res](message: ActorRef[Res] => M)(implicit timeout: Timeout): Future[Res] =
+    this.ask(message)(timeout)
+
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/entity/EntityExtension.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/entity/EntityExtension.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.internal.entity
+
+import scala.collection.immutable
+
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Entity
+import akka.actor.typed.EntityRef
+import akka.actor.typed.EntityTypeKey
+import akka.actor.typed.Extension
+import akka.actor.typed.ExtensionId
+import akka.annotation.DoNotInherit
+import akka.annotation.InternalApi
+
+object EntityExtension extends ExtensionId[EntityExtension] {
+
+  /**
+   * Create the extension, will be invoked at most one time per actor system where the extension is registered.
+   */
+  override def createExtension(system: ActorSystem[_]): EntityExtension =
+    new EntityExtensionImpl(system)
+
+  def get(system: ActorSystem[_]): EntityExtension = apply(system)
+
+}
+
+@DoNotInherit
+abstract class EntityExtension extends Extension {
+  def initEntity[M, E](entity: Entity[M, E]): ActorRef[E]
+  def entityRefFor[M](typeKey: EntityTypeKey[M], entityId: String): EntityRef[M]
+}
+
+@InternalApi
+private[akka] class EntityExtensionImpl(system: ActorSystem[_]) extends EntityExtension {
+
+  val provider: EntityProvider =
+    if (system.settings.classicSettings.ProviderSelectionType.hasCluster) {
+      system.dynamicAccess
+        .createInstanceFor[EntityProvider](
+          "akka.cluster.sharding.typed.internal.ClusterShardingEntityProvider",
+          immutable.Seq((classOf[ActorSystem[_]], system)))
+        .recover {
+          case e =>
+            throw new RuntimeException(
+              "ShardedEntityProvider could not be loaded dynamically. Make sure you have " +
+              "'akka-cluster-typed' in the classpath.",
+              e)
+        }
+        .get
+    } else {
+      new LocalEntityProvider(system)
+    }
+
+  override def initEntity[M, E](entity: Entity[M, E]): ActorRef[E] =
+    provider.initEntity(entity)
+
+  override def entityRefFor[M](typeKey: EntityTypeKey[M], entityId: String): EntityRef[M] =
+    provider.entityRefFor(typeKey, entityId)
+
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/entity/EntityManager.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/entity/EntityManager.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.internal.entity
+
+import java.net.URLEncoder
+
+import akka.actor.typed.ActorRef
+import akka.actor.typed.Behavior
+import akka.actor.typed.Entity
+import akka.actor.typed.Entity.Passivate
+import akka.actor.typed.EntityContext
+import akka.actor.typed.EntityEnvelope
+import akka.actor.typed.EntityTypeKey
+import akka.actor.typed.Terminated
+import akka.actor.typed.scaladsl.Behaviors
+import akka.annotation.InternalApi
+import akka.util.ByteString
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] object EntityManager {
+
+  def encodeEntityId(typeKey: EntityTypeKey[_], entityId: String) =
+    URLEncoder.encode(s"${typeKey.name}-$entityId", ByteString.UTF_8)
+
+  def behavior[M, E](entity: Entity[M, E]): Behavior[Any] = {
+
+    // key will be the entityName and buffer vector contains an envelope so we keep track of entityID
+    var entityMessageBuffers: Map[String, Vector[EntityEnvelope[M]]] = Map.empty
+
+    Behaviors.setup[Any] { ctx =>
+      def lookupEntityRef(id: String) = {
+
+        val entityName = encodeEntityId(entity.typeKey, id)
+        val entityRef =
+          ctx.child(entityName) match {
+            case Some(entityChildRef) =>
+              ctx.log.debug("Found entity instance {}", entityChildRef.path)
+              entityChildRef
+            case None =>
+              ctx.log.debug("No entity found, creating one..")
+              val entityContext = new EntityContext[M](entity.typeKey, id, ctx.self)
+              ctx.spawn(entity.createBehavior(entityContext), entityName)
+          }
+
+        ctx.watch(entityRef)
+        entityRef.asInstanceOf[ActorRef[M]]
+      }
+
+      def deliverToEntity(entityId: String, message: M) = {
+        val entityName = encodeEntityId(entity.typeKey, entityId)
+
+        entityMessageBuffers.get(entityName) match {
+          case Some(buffer) => // if it has a buffer, it means that entity is passivating
+            val newBuffer = buffer :+ EntityEnvelope(entityId, message)
+            entityMessageBuffers = entityMessageBuffers + (entityName -> newBuffer)
+          case None =>
+            lookupEntityRef(entityId) ! message
+        }
+      }
+
+      Behaviors
+        .receiveMessage[Any] {
+
+          case Passivate(actor: ActorRef[M] @unchecked) if ctx.child(actor.path.name).isDefined =>
+            ctx.log.debug("Received passivation request for {}", actor)
+            // start to buffer message for this entity
+            entityMessageBuffers = entityMessageBuffers + (actor.path.name -> Vector.empty)
+
+            entity.stopMessage match {
+              case Some(stopMsg) =>
+                actor ! stopMsg
+                Behaviors.same
+              case None =>
+                ctx.stop(actor)
+                Behaviors.same
+            }
+
+          case env: EntityEnvelope[M] @unchecked =>
+            deliverToEntity(env.entityId, env.message)
+            Behaviors.same
+
+          case unwrapped: E @unchecked if entity.messageExtractor.isDefined =>
+            val msgExtractor = entity.messageExtractor.get
+            val id = msgExtractor.entityId(unwrapped)
+            val msg = msgExtractor.unwrapMessage(unwrapped)
+            deliverToEntity(id, msg)
+            Behaviors.same
+
+          case _ => Behaviors.unhandled
+
+        }
+        .receiveSignal {
+          case (_, Terminated(actor)) =>
+            val entityName = actor.path.name
+            entityMessageBuffers.get(entityName).foreach { buffer =>
+              // re-instantiate it and deliver messages directly, if any
+              if (buffer.nonEmpty) {
+
+                ctx.log.debug("Re-instantiating entity for id {}", buffer.head.entityId)
+                val entityRef = lookupEntityRef(buffer.head.entityId)
+
+                ctx.log.debug("Delivering {} buffered messages to entity {}", buffer.length, entityRef.path)
+                entityRef ! buffer.head.message
+
+                buffer.tail.foreach { env =>
+                  entityRef ! env.message
+                }
+              }
+            }
+
+            // all messages are delivered (if any), we can remove buffer for this entity
+            entityMessageBuffers = entityMessageBuffers - entityName
+
+            Behaviors.same
+        }
+
+    }
+  }
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/entity/EntityProvider.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/entity/EntityProvider.scala
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.internal.entity
+
+import java.net.URLEncoder
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.concurrent.Future
+
+import akka.actor.ActorRefProvider
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Entity
+import akka.actor.typed.EntityEnvelope
+import akka.actor.typed.EntityRef
+import akka.actor.typed.EntityTypeKey
+import akka.actor.typed.EntityTypeKeyImpl
+import akka.actor.typed.internal.InternalRecipientRef
+import akka.actor.typed.internal.adapter.ActorRefAdapter
+import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
+import akka.pattern.AskTimeoutException
+import akka.pattern.PromiseActorRef
+import akka.pattern.StatusReply
+import akka.util.ByteString
+import akka.util.Timeout
+
+/**
+ * Marker interface to use with dynamic access
+ *
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] trait EntityProvider {
+
+  def initEntity[M, E](entity: Entity[M, E]): ActorRef[E]
+
+  def entityRefFor[M](typeKey: EntityTypeKey[M], entityId: String): EntityRef[M]
+}
+
+private[akka] class LocalEntityProvider(system: ActorSystem[_]) extends EntityProvider {
+
+  private val typeNames: ConcurrentHashMap[String, String] = new ConcurrentHashMap
+  private val entityManagers: ConcurrentHashMap[String, ActorRef[_]] = new ConcurrentHashMap
+  private val hasExtractor: ConcurrentHashMap[String, Boolean] = new ConcurrentHashMap()
+
+  override def initEntity[M, E](entity: Entity[M, E]): ActorRef[E] = {
+
+    val typeKey = entity.typeKey
+    val messageClassName = typeKey.asInstanceOf[EntityTypeKeyImpl[M]].messageClassName
+
+    typeNames.putIfAbsent(typeKey.name, messageClassName) match {
+      case existingMessageClassName: String if messageClassName != existingMessageClassName =>
+        throw new IllegalArgumentException(s"[${typeKey.name}] already initialized for [$existingMessageClassName]")
+      case _ => ()
+    }
+
+    hasExtractor.putIfAbsent(typeKey.name, entity.messageExtractor.isDefined)
+
+    val encodedEntityName = URLEncoder.encode(entity.typeKey.name, ByteString.UTF_8)
+
+    val entityManager =
+      entityManagers.computeIfAbsent(
+        encodedEntityName,
+        new java.util.function.Function[String, ActorRef[_]] {
+          override def apply(t: String): ActorRef[_] = {
+            system.systemActorOf(
+              EntityManager.behavior(entity),
+              // we don't have two levels like in sharding (sharding/region)
+              // but only an entity manager per declared entity.
+              // It's path is therefore set to entity-manager-{entity-name}
+              "entity-manager-" + encodedEntityName)
+          }
+        })
+    entityManager.asInstanceOf[ActorRef[E]]
+  }
+
+  override def entityRefFor[M](typeKey: EntityTypeKey[M], entityId: String): EntityRef[M] = {
+    val managerRef = entityManagers.get(typeKey.name).asInstanceOf[ActorRef[Any]]
+    EntityRefImpl[M](entityId, typeKey, managerRef)
+  }
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi
+  private[akka] case class EntityRefImpl[M](
+      entityId: String,
+      typeKey: EntityTypeKey[M],
+      entityManagerRef: ActorRef[Any])
+      extends EntityRef[M]
+      with InternalRecipientRef[M] {
+
+    /**
+     * Converts incoming message to what the EntityManager expects.
+     * It may be returned as is or wrapped in an EntityEnvelope.
+     */
+    private def toEntityMessage(msg: M): Any =
+      if (hasExtractor.get(typeKey.name)) msg
+      else EntityEnvelope(entityId, msg)
+
+    override def tell(msg: M): Unit =
+      entityManagerRef ! toEntityMessage(msg)
+
+    override val refPrefix = EntityManager.encodeEntityId(typeKey, entityId)
+
+    override def ask[Res](message: ActorRef[Res] => M)(implicit timeout: Timeout): Future[Res] = {
+      val replyTo = new EntityPromiseRef[Res](timeout)
+      replyTo.ask(message(replyTo.ref))
+    }
+
+    override def askWithStatus[Res](func: ActorRef[StatusReply[Res]] => M)(implicit timeout: Timeout): Future[Res] =
+      StatusReply.flattenStatusFuture(ask[StatusReply[Res]](func))
+
+    override def provider: ActorRefProvider =
+      entityManagerRef.asInstanceOf[InternalRecipientRef[_]].provider
+
+    override def isTerminated: Boolean =
+      entityManagerRef.asInstanceOf[InternalRecipientRef[_]].isTerminated
+
+    override def hashCode(): Int =
+      // 3 and 5 chosen as primes which are +/- 1 from a power-of-two
+      ((entityId.hashCode * 3) + typeKey.hashCode) * 5
+
+    override def equals(other: Any): Boolean =
+      other match {
+        case eri: EntityRefImpl[_] => (eri.entityId == entityId) && (eri.typeKey == typeKey)
+        case _                     => false
+      }
+
+    override def toString: String = s"EntityRef($typeKey, $entityId)"
+
+    /** Similar to [[akka.actor.typed.scaladsl.AskPattern.PromiseRef]] and to
+     * akka.cluster.sharding.typed.internal.EntityRefImpl.EntityPromiseRef
+     * but for a local `EntityRef` target.
+     */
+    @InternalApi
+    private final class EntityPromiseRef[U](timeout: Timeout) {
+
+      // Note: _promiseRef mustn't have a type pattern, since it can be null
+      private[this] val (_ref: ActorRef[U], _future: Future[U], _promiseRef) =
+        if (isTerminated)
+          (
+            ActorRefAdapter[U](provider.deadLetters),
+            Future.failed[U](
+              new AskTimeoutException(s"Recipient of [${EntityRefImpl.this}] had already been terminated.")),
+            null)
+        else if (timeout.duration.length <= 0)
+          (
+            ActorRefAdapter[U](provider.deadLetters),
+            Future.failed[U](
+              new IllegalArgumentException(
+                s"Timeout length must be positive, question not sent to [${EntityRefImpl.this}]")),
+            null)
+        else {
+          // note that the real messageClassName will be set afterwards, replyTo pattern
+          val a =
+            PromiseActorRef(provider, timeout, targetName = EntityRefImpl.this, messageClassName = "unknown", refPrefix)
+          val b = ActorRefAdapter[U](a)
+          (b, a.result.future.asInstanceOf[Future[U]], a)
+        }
+
+      val ref: ActorRef[U] = _ref
+      val future: Future[U] = _future
+
+      @InternalStableApi
+      private[akka] def ask(message: M): Future[U] = {
+        if (_promiseRef ne null) _promiseRef.messageClassName = message.getClass.getName
+        entityManagerRef ! toEntityMessage(message)
+        future
+      }
+    }
+  }
+
+}

--- a/akka-cluster-sharding-typed/src/main/java/akka/cluster/sharding/typed/internal/protobuf/ShardingMessages.java
+++ b/akka-cluster-sharding-typed/src/main/java/akka/cluster/sharding/typed/internal/protobuf/ShardingMessages.java
@@ -847,11 +847,1460 @@ public final class ShardingMessages {
 
   }
 
+  public interface EntityEnvelopeOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:akka.cluster.sharding.typed.EntityEnvelope)
+      akka.protobufv3.internal.MessageOrBuilder {
+
+    /**
+     * <code>required string entityId = 1;</code>
+     * @return Whether the entityId field is set.
+     */
+    boolean hasEntityId();
+    /**
+     * <code>required string entityId = 1;</code>
+     * @return The entityId.
+     */
+    java.lang.String getEntityId();
+    /**
+     * <code>required string entityId = 1;</code>
+     * @return The bytes for entityId.
+     */
+    akka.protobufv3.internal.ByteString
+        getEntityIdBytes();
+
+    /**
+     * <code>required .Payload message = 2;</code>
+     * @return Whether the message field is set.
+     */
+    boolean hasMessage();
+    /**
+     * <code>required .Payload message = 2;</code>
+     * @return The message.
+     */
+    akka.remote.ContainerFormats.Payload getMessage();
+    /**
+     * <code>required .Payload message = 2;</code>
+     */
+    akka.remote.ContainerFormats.PayloadOrBuilder getMessageOrBuilder();
+  }
+  /**
+   * Protobuf type {@code akka.cluster.sharding.typed.EntityEnvelope}
+   */
+  public  static final class EntityEnvelope extends
+      akka.protobufv3.internal.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:akka.cluster.sharding.typed.EntityEnvelope)
+      EntityEnvelopeOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use EntityEnvelope.newBuilder() to construct.
+    private EntityEnvelope(akka.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private EntityEnvelope() {
+      entityId_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        akka.protobufv3.internal.GeneratedMessageV3.UnusedPrivateParameter unused) {
+      return new EntityEnvelope();
+    }
+
+    @java.lang.Override
+    public final akka.protobufv3.internal.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private EntityEnvelope(
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      akka.protobufv3.internal.UnknownFieldSet.Builder unknownFields =
+          akka.protobufv3.internal.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              akka.protobufv3.internal.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              entityId_ = bs;
+              break;
+            }
+            case 18: {
+              akka.remote.ContainerFormats.Payload.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000002) != 0)) {
+                subBuilder = message_.toBuilder();
+              }
+              message_ = input.readMessage(akka.remote.ContainerFormats.Payload.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(message_);
+                message_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000002;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new akka.protobufv3.internal.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final akka.protobufv3.internal.Descriptors.Descriptor
+        getDescriptor() {
+      return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_EntityEnvelope_descriptor;
+    }
+
+    @java.lang.Override
+    protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_EntityEnvelope_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope.class, akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int ENTITYID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object entityId_;
+    /**
+     * <code>required string entityId = 1;</code>
+     * @return Whether the entityId field is set.
+     */
+    public boolean hasEntityId() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>required string entityId = 1;</code>
+     * @return The entityId.
+     */
+    public java.lang.String getEntityId() {
+      java.lang.Object ref = entityId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        akka.protobufv3.internal.ByteString bs = 
+            (akka.protobufv3.internal.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          entityId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>required string entityId = 1;</code>
+     * @return The bytes for entityId.
+     */
+    public akka.protobufv3.internal.ByteString
+        getEntityIdBytes() {
+      java.lang.Object ref = entityId_;
+      if (ref instanceof java.lang.String) {
+        akka.protobufv3.internal.ByteString b = 
+            akka.protobufv3.internal.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        entityId_ = b;
+        return b;
+      } else {
+        return (akka.protobufv3.internal.ByteString) ref;
+      }
+    }
+
+    public static final int MESSAGE_FIELD_NUMBER = 2;
+    private akka.remote.ContainerFormats.Payload message_;
+    /**
+     * <code>required .Payload message = 2;</code>
+     * @return Whether the message field is set.
+     */
+    public boolean hasMessage() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <code>required .Payload message = 2;</code>
+     * @return The message.
+     */
+    public akka.remote.ContainerFormats.Payload getMessage() {
+      return message_ == null ? akka.remote.ContainerFormats.Payload.getDefaultInstance() : message_;
+    }
+    /**
+     * <code>required .Payload message = 2;</code>
+     */
+    public akka.remote.ContainerFormats.PayloadOrBuilder getMessageOrBuilder() {
+      return message_ == null ? akka.remote.ContainerFormats.Payload.getDefaultInstance() : message_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasEntityId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasMessage()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!getMessage().isInitialized()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(akka.protobufv3.internal.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, entityId_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        output.writeMessage(2, getMessage());
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, entityId_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += akka.protobufv3.internal.CodedOutputStream
+          .computeMessageSize(2, getMessage());
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope)) {
+        return super.equals(obj);
+      }
+      akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope other = (akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope) obj;
+
+      if (hasEntityId() != other.hasEntityId()) return false;
+      if (hasEntityId()) {
+        if (!getEntityId()
+            .equals(other.getEntityId())) return false;
+      }
+      if (hasMessage() != other.hasMessage()) return false;
+      if (hasMessage()) {
+        if (!getMessage()
+            .equals(other.getMessage())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasEntityId()) {
+        hash = (37 * hash) + ENTITYID_FIELD_NUMBER;
+        hash = (53 * hash) + getEntityId().hashCode();
+      }
+      if (hasMessage()) {
+        hash = (37 * hash) + MESSAGE_FIELD_NUMBER;
+        hash = (53 * hash) + getMessage().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope parseFrom(
+        java.nio.ByteBuffer data)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope parseFrom(
+        java.nio.ByteBuffer data,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope parseFrom(
+        akka.protobufv3.internal.ByteString data)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope parseFrom(
+        akka.protobufv3.internal.ByteString data,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope parseFrom(byte[] data)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope parseFrom(
+        byte[] data,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope parseFrom(
+        java.io.InputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope parseDelimitedFrom(
+        java.io.InputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope parseFrom(
+        akka.protobufv3.internal.CodedInputStream input)
+        throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope parseFrom(
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code akka.cluster.sharding.typed.EntityEnvelope}
+     */
+    public static final class Builder extends
+        akka.protobufv3.internal.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:akka.cluster.sharding.typed.EntityEnvelope)
+        akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelopeOrBuilder {
+      public static final akka.protobufv3.internal.Descriptors.Descriptor
+          getDescriptor() {
+        return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_EntityEnvelope_descriptor;
+      }
+
+      @java.lang.Override
+      protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_EntityEnvelope_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope.class, akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope.Builder.class);
+      }
+
+      // Construct using akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (akka.protobufv3.internal.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+          getMessageFieldBuilder();
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        entityId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        if (messageBuilder_ == null) {
+          message_ = null;
+        } else {
+          messageBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public akka.protobufv3.internal.Descriptors.Descriptor
+          getDescriptorForType() {
+        return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_EntityEnvelope_descriptor;
+      }
+
+      @java.lang.Override
+      public akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope getDefaultInstanceForType() {
+        return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope build() {
+        akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope buildPartial() {
+        akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope result = new akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.entityId_ = entityId_;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          if (messageBuilder_ == null) {
+            result.message_ = message_;
+          } else {
+            result.message_ = messageBuilder_.build();
+          }
+          to_bitField0_ |= 0x00000002;
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          akka.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(akka.protobufv3.internal.Message other) {
+        if (other instanceof akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope) {
+          return mergeFrom((akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope other) {
+        if (other == akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope.getDefaultInstance()) return this;
+        if (other.hasEntityId()) {
+          bitField0_ |= 0x00000001;
+          entityId_ = other.entityId_;
+          onChanged();
+        }
+        if (other.hasMessage()) {
+          mergeMessage(other.getMessage());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        if (!hasEntityId()) {
+          return false;
+        }
+        if (!hasMessage()) {
+          return false;
+        }
+        if (!getMessage().isInitialized()) {
+          return false;
+        }
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
+          parsedMessage = (akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object entityId_ = "";
+      /**
+       * <code>required string entityId = 1;</code>
+       * @return Whether the entityId field is set.
+       */
+      public boolean hasEntityId() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>required string entityId = 1;</code>
+       * @return The entityId.
+       */
+      public java.lang.String getEntityId() {
+        java.lang.Object ref = entityId_;
+        if (!(ref instanceof java.lang.String)) {
+          akka.protobufv3.internal.ByteString bs =
+              (akka.protobufv3.internal.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            entityId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>required string entityId = 1;</code>
+       * @return The bytes for entityId.
+       */
+      public akka.protobufv3.internal.ByteString
+          getEntityIdBytes() {
+        java.lang.Object ref = entityId_;
+        if (ref instanceof String) {
+          akka.protobufv3.internal.ByteString b = 
+              akka.protobufv3.internal.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          entityId_ = b;
+          return b;
+        } else {
+          return (akka.protobufv3.internal.ByteString) ref;
+        }
+      }
+      /**
+       * <code>required string entityId = 1;</code>
+       * @param value The entityId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setEntityId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        entityId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required string entityId = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearEntityId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        entityId_ = getDefaultInstance().getEntityId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required string entityId = 1;</code>
+       * @param value The bytes for entityId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setEntityIdBytes(
+          akka.protobufv3.internal.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        entityId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private akka.remote.ContainerFormats.Payload message_;
+      private akka.protobufv3.internal.SingleFieldBuilderV3<
+          akka.remote.ContainerFormats.Payload, akka.remote.ContainerFormats.Payload.Builder, akka.remote.ContainerFormats.PayloadOrBuilder> messageBuilder_;
+      /**
+       * <code>required .Payload message = 2;</code>
+       * @return Whether the message field is set.
+       */
+      public boolean hasMessage() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <code>required .Payload message = 2;</code>
+       * @return The message.
+       */
+      public akka.remote.ContainerFormats.Payload getMessage() {
+        if (messageBuilder_ == null) {
+          return message_ == null ? akka.remote.ContainerFormats.Payload.getDefaultInstance() : message_;
+        } else {
+          return messageBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>required .Payload message = 2;</code>
+       */
+      public Builder setMessage(akka.remote.ContainerFormats.Payload value) {
+        if (messageBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          message_ = value;
+          onChanged();
+        } else {
+          messageBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>required .Payload message = 2;</code>
+       */
+      public Builder setMessage(
+          akka.remote.ContainerFormats.Payload.Builder builderForValue) {
+        if (messageBuilder_ == null) {
+          message_ = builderForValue.build();
+          onChanged();
+        } else {
+          messageBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>required .Payload message = 2;</code>
+       */
+      public Builder mergeMessage(akka.remote.ContainerFormats.Payload value) {
+        if (messageBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) != 0) &&
+              message_ != null &&
+              message_ != akka.remote.ContainerFormats.Payload.getDefaultInstance()) {
+            message_ =
+              akka.remote.ContainerFormats.Payload.newBuilder(message_).mergeFrom(value).buildPartial();
+          } else {
+            message_ = value;
+          }
+          onChanged();
+        } else {
+          messageBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000002;
+        return this;
+      }
+      /**
+       * <code>required .Payload message = 2;</code>
+       */
+      public Builder clearMessage() {
+        if (messageBuilder_ == null) {
+          message_ = null;
+          onChanged();
+        } else {
+          messageBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+      /**
+       * <code>required .Payload message = 2;</code>
+       */
+      public akka.remote.ContainerFormats.Payload.Builder getMessageBuilder() {
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return getMessageFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>required .Payload message = 2;</code>
+       */
+      public akka.remote.ContainerFormats.PayloadOrBuilder getMessageOrBuilder() {
+        if (messageBuilder_ != null) {
+          return messageBuilder_.getMessageOrBuilder();
+        } else {
+          return message_ == null ?
+              akka.remote.ContainerFormats.Payload.getDefaultInstance() : message_;
+        }
+      }
+      /**
+       * <code>required .Payload message = 2;</code>
+       */
+      private akka.protobufv3.internal.SingleFieldBuilderV3<
+          akka.remote.ContainerFormats.Payload, akka.remote.ContainerFormats.Payload.Builder, akka.remote.ContainerFormats.PayloadOrBuilder> 
+          getMessageFieldBuilder() {
+        if (messageBuilder_ == null) {
+          messageBuilder_ = new akka.protobufv3.internal.SingleFieldBuilderV3<
+              akka.remote.ContainerFormats.Payload, akka.remote.ContainerFormats.Payload.Builder, akka.remote.ContainerFormats.PayloadOrBuilder>(
+                  getMessage(),
+                  getParentForChildren(),
+                  isClean());
+          message_ = null;
+        }
+        return messageBuilder_;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:akka.cluster.sharding.typed.EntityEnvelope)
+    }
+
+    // @@protoc_insertion_point(class_scope:akka.cluster.sharding.typed.EntityEnvelope)
+    private static final akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope();
+    }
+
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final akka.protobufv3.internal.Parser<EntityEnvelope>
+        PARSER = new akka.protobufv3.internal.AbstractParser<EntityEnvelope>() {
+      @java.lang.Override
+      public EntityEnvelope parsePartialFrom(
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws akka.protobufv3.internal.InvalidProtocolBufferException {
+        return new EntityEnvelope(input, extensionRegistry);
+      }
+    };
+
+    public static akka.protobufv3.internal.Parser<EntityEnvelope> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.protobufv3.internal.Parser<EntityEnvelope> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.EntityEnvelope getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface StartEntityOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:akka.cluster.sharding.typed.StartEntity)
+      akka.protobufv3.internal.MessageOrBuilder {
+
+    /**
+     * <code>required string entityId = 1;</code>
+     * @return Whether the entityId field is set.
+     */
+    boolean hasEntityId();
+    /**
+     * <code>required string entityId = 1;</code>
+     * @return The entityId.
+     */
+    java.lang.String getEntityId();
+    /**
+     * <code>required string entityId = 1;</code>
+     * @return The bytes for entityId.
+     */
+    akka.protobufv3.internal.ByteString
+        getEntityIdBytes();
+  }
+  /**
+   * Protobuf type {@code akka.cluster.sharding.typed.StartEntity}
+   */
+  public  static final class StartEntity extends
+      akka.protobufv3.internal.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:akka.cluster.sharding.typed.StartEntity)
+      StartEntityOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use StartEntity.newBuilder() to construct.
+    private StartEntity(akka.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private StartEntity() {
+      entityId_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        akka.protobufv3.internal.GeneratedMessageV3.UnusedPrivateParameter unused) {
+      return new StartEntity();
+    }
+
+    @java.lang.Override
+    public final akka.protobufv3.internal.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private StartEntity(
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      akka.protobufv3.internal.UnknownFieldSet.Builder unknownFields =
+          akka.protobufv3.internal.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              akka.protobufv3.internal.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              entityId_ = bs;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new akka.protobufv3.internal.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final akka.protobufv3.internal.Descriptors.Descriptor
+        getDescriptor() {
+      return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_StartEntity_descriptor;
+    }
+
+    @java.lang.Override
+    protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_StartEntity_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity.class, akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int ENTITYID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object entityId_;
+    /**
+     * <code>required string entityId = 1;</code>
+     * @return Whether the entityId field is set.
+     */
+    public boolean hasEntityId() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>required string entityId = 1;</code>
+     * @return The entityId.
+     */
+    public java.lang.String getEntityId() {
+      java.lang.Object ref = entityId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        akka.protobufv3.internal.ByteString bs = 
+            (akka.protobufv3.internal.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          entityId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>required string entityId = 1;</code>
+     * @return The bytes for entityId.
+     */
+    public akka.protobufv3.internal.ByteString
+        getEntityIdBytes() {
+      java.lang.Object ref = entityId_;
+      if (ref instanceof java.lang.String) {
+        akka.protobufv3.internal.ByteString b = 
+            akka.protobufv3.internal.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        entityId_ = b;
+        return b;
+      } else {
+        return (akka.protobufv3.internal.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      if (!hasEntityId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(akka.protobufv3.internal.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, entityId_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, entityId_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity)) {
+        return super.equals(obj);
+      }
+      akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity other = (akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity) obj;
+
+      if (hasEntityId() != other.hasEntityId()) return false;
+      if (hasEntityId()) {
+        if (!getEntityId()
+            .equals(other.getEntityId())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasEntityId()) {
+        hash = (37 * hash) + ENTITYID_FIELD_NUMBER;
+        hash = (53 * hash) + getEntityId().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity parseFrom(
+        java.nio.ByteBuffer data)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity parseFrom(
+        java.nio.ByteBuffer data,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity parseFrom(
+        akka.protobufv3.internal.ByteString data)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity parseFrom(
+        akka.protobufv3.internal.ByteString data,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity parseFrom(byte[] data)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity parseFrom(
+        byte[] data,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity parseFrom(
+        java.io.InputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity parseDelimitedFrom(
+        java.io.InputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity parseFrom(
+        akka.protobufv3.internal.CodedInputStream input)
+        throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity parseFrom(
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code akka.cluster.sharding.typed.StartEntity}
+     */
+    public static final class Builder extends
+        akka.protobufv3.internal.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:akka.cluster.sharding.typed.StartEntity)
+        akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntityOrBuilder {
+      public static final akka.protobufv3.internal.Descriptors.Descriptor
+          getDescriptor() {
+        return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_StartEntity_descriptor;
+      }
+
+      @java.lang.Override
+      protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_StartEntity_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity.class, akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity.Builder.class);
+      }
+
+      // Construct using akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (akka.protobufv3.internal.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        entityId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+
+      @java.lang.Override
+      public akka.protobufv3.internal.Descriptors.Descriptor
+          getDescriptorForType() {
+        return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.internal_static_akka_cluster_sharding_typed_StartEntity_descriptor;
+      }
+
+      @java.lang.Override
+      public akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity getDefaultInstanceForType() {
+        return akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity build() {
+        akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity buildPartial() {
+        akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity result = new akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.entityId_ = entityId_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          akka.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(akka.protobufv3.internal.Message other) {
+        if (other instanceof akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity) {
+          return mergeFrom((akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity other) {
+        if (other == akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity.getDefaultInstance()) return this;
+        if (other.hasEntityId()) {
+          bitField0_ |= 0x00000001;
+          entityId_ = other.entityId_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        if (!hasEntityId()) {
+          return false;
+        }
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
+          parsedMessage = (akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object entityId_ = "";
+      /**
+       * <code>required string entityId = 1;</code>
+       * @return Whether the entityId field is set.
+       */
+      public boolean hasEntityId() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>required string entityId = 1;</code>
+       * @return The entityId.
+       */
+      public java.lang.String getEntityId() {
+        java.lang.Object ref = entityId_;
+        if (!(ref instanceof java.lang.String)) {
+          akka.protobufv3.internal.ByteString bs =
+              (akka.protobufv3.internal.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            entityId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>required string entityId = 1;</code>
+       * @return The bytes for entityId.
+       */
+      public akka.protobufv3.internal.ByteString
+          getEntityIdBytes() {
+        java.lang.Object ref = entityId_;
+        if (ref instanceof String) {
+          akka.protobufv3.internal.ByteString b = 
+              akka.protobufv3.internal.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          entityId_ = b;
+          return b;
+        } else {
+          return (akka.protobufv3.internal.ByteString) ref;
+        }
+      }
+      /**
+       * <code>required string entityId = 1;</code>
+       * @param value The entityId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setEntityId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        entityId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required string entityId = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearEntityId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        entityId_ = getDefaultInstance().getEntityId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required string entityId = 1;</code>
+       * @param value The bytes for entityId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setEntityIdBytes(
+          akka.protobufv3.internal.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        entityId_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:akka.cluster.sharding.typed.StartEntity)
+    }
+
+    // @@protoc_insertion_point(class_scope:akka.cluster.sharding.typed.StartEntity)
+    private static final akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity();
+    }
+
+    public static akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final akka.protobufv3.internal.Parser<StartEntity>
+        PARSER = new akka.protobufv3.internal.AbstractParser<StartEntity>() {
+      @java.lang.Override
+      public StartEntity parsePartialFrom(
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+          throws akka.protobufv3.internal.InvalidProtocolBufferException {
+        return new StartEntity(input, extensionRegistry);
+      }
+    };
+
+    public static akka.protobufv3.internal.Parser<StartEntity> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.protobufv3.internal.Parser<StartEntity> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.cluster.sharding.typed.internal.protobuf.ShardingMessages.StartEntity getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   private static final akka.protobufv3.internal.Descriptors.Descriptor
     internal_static_akka_cluster_sharding_typed_ShardingEnvelope_descriptor;
   private static final 
     akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_akka_cluster_sharding_typed_ShardingEnvelope_fieldAccessorTable;
+  private static final akka.protobufv3.internal.Descriptors.Descriptor
+    internal_static_akka_cluster_sharding_typed_EntityEnvelope_descriptor;
+  private static final 
+    akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+      internal_static_akka_cluster_sharding_typed_EntityEnvelope_fieldAccessorTable;
+  private static final akka.protobufv3.internal.Descriptors.Descriptor
+    internal_static_akka_cluster_sharding_typed_StartEntity_descriptor;
+  private static final 
+    akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+      internal_static_akka_cluster_sharding_typed_StartEntity_fieldAccessorTable;
 
   public static akka.protobufv3.internal.Descriptors.FileDescriptor
       getDescriptor() {
@@ -864,8 +2313,11 @@ public final class ShardingMessages {
       "\n\026ShardingMessages.proto\022\033akka.cluster.s" +
       "harding.typed\032\026ContainerFormats.proto\"?\n" +
       "\020ShardingEnvelope\022\020\n\010entityId\030\001 \002(\t\022\031\n\007m" +
-      "essage\030\002 \002(\0132\010.PayloadB1\n-akka.cluster.s" +
-      "harding.typed.internal.protobufH\001"
+      "essage\030\002 \002(\0132\010.Payload\"=\n\016EntityEnvelope" +
+      "\022\020\n\010entityId\030\001 \002(\t\022\031\n\007message\030\002 \002(\0132\010.Pa" +
+      "yload\"\037\n\013StartEntity\022\020\n\010entityId\030\001 \002(\tB1" +
+      "\n-akka.cluster.sharding.typed.internal.p" +
+      "rotobufH\001"
     };
     descriptor = akka.protobufv3.internal.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -878,6 +2330,18 @@ public final class ShardingMessages {
       akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
         internal_static_akka_cluster_sharding_typed_ShardingEnvelope_descriptor,
         new java.lang.String[] { "EntityId", "Message", });
+    internal_static_akka_cluster_sharding_typed_EntityEnvelope_descriptor =
+      getDescriptor().getMessageTypes().get(1);
+    internal_static_akka_cluster_sharding_typed_EntityEnvelope_fieldAccessorTable = new
+      akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_akka_cluster_sharding_typed_EntityEnvelope_descriptor,
+        new java.lang.String[] { "EntityId", "Message", });
+    internal_static_akka_cluster_sharding_typed_StartEntity_descriptor =
+      getDescriptor().getMessageTypes().get(2);
+    internal_static_akka_cluster_sharding_typed_StartEntity_fieldAccessorTable = new
+      akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_akka_cluster_sharding_typed_StartEntity_descriptor,
+        new java.lang.String[] { "EntityId", });
     akka.remote.ContainerFormats.getDescriptor();
   }
 

--- a/akka-cluster-sharding-typed/src/main/protobuf/ShardingMessages.proto
+++ b/akka-cluster-sharding-typed/src/main/protobuf/ShardingMessages.proto
@@ -14,3 +14,13 @@ message ShardingEnvelope {
   required string entityId = 1;
   required Payload message = 2;
 }
+
+
+message EntityEnvelope {
+  required string entityId = 1;
+  required Payload message = 2;
+}
+
+message StartEntity {
+  required string entityId = 1;
+}

--- a/akka-cluster-sharding-typed/src/main/resources/reference.conf
+++ b/akka-cluster-sharding-typed/src/main/resources/reference.conf
@@ -41,6 +41,10 @@ akka.actor {
   }
   serialization-bindings {
     "akka.cluster.sharding.typed.ShardingEnvelope" = typed-sharding
+    # message from akka-actor-typed exceptionally added here
+    # EntityEnvelope is only deser/ser when used in the context of cluster sharding
+    "akka.actor.typed.EntityEnvelope" = typed-sharding
+    "akka.actor.typed.EntityEnvelope$StartEntity" = typed-sharding
   }
 }
 

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ShardingMessageExtractor.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ShardingMessageExtractor.scala
@@ -4,7 +4,9 @@
 
 package akka.cluster.sharding.typed
 
-import akka.actor.{ InvalidMessageException, WrappedMessage }
+import akka.actor.InvalidMessageException
+import akka.actor.WrappedMessage
+import akka.actor.typed.EntityMessageExtractor
 import akka.util.unused
 
 object ShardingMessageExtractor {
@@ -38,7 +40,7 @@ object ShardingMessageExtractor {
  *           envelope.
  * @tparam M The type of message accepted by the entity actor
  */
-abstract class ShardingMessageExtractor[E, M] {
+abstract class ShardingMessageExtractor[E, M] extends EntityMessageExtractor[E, M] {
 
   /**
    * Extract the entity id from an incoming `message`. If `null` is returned

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingEntityProvider.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingEntityProvider.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding.typed.internal
+
+import java.net.URLEncoder
+
+import scala.concurrent.Future
+
+import akka.actor.ActorRefProvider
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Entity
+import akka.actor.typed.Entity.EntityCommand
+import akka.actor.typed.EntityContext
+import akka.actor.typed.EntityEnvelope
+import akka.actor.typed.EntityRef
+import akka.actor.typed.EntityTypeKey
+import akka.actor.typed.internal.InternalRecipientRef
+import akka.actor.typed.internal.entity.EntityProvider
+import akka.cluster.sharding.ShardRegion.HashCodeMessageExtractor
+import akka.cluster.sharding.ShardRegion.{ StartEntity => ClassicStartEntity }
+import akka.cluster.sharding.typed.ClusterShardingSettings
+import akka.cluster.sharding.typed.ShardingEnvelope
+import akka.cluster.sharding.typed.ShardingMessageExtractor
+import akka.cluster.sharding.typed.internal.{ EntityTypeKeyImpl => ShardedEntityTypeKeyImpl }
+import akka.cluster.sharding.typed.scaladsl.ClusterSharding
+import akka.cluster.sharding.typed.scaladsl.{ Entity => ShardedEntity }
+import akka.cluster.sharding.typed.scaladsl.{ EntityContext => ShardedEntityContext }
+import akka.cluster.sharding.typed.scaladsl.{ EntityRef => ShardedEntityRef }
+import akka.cluster.sharding.typed.scaladsl.{ EntityTypeKey => ShardedEntityTypeKey }
+import akka.pattern.StatusReply
+import akka.util.ByteString
+import akka.util.Timeout
+
+class ClusterShardingEntityProvider(system: ActorSystem[_]) extends EntityProvider {
+
+  import EntityAdapter._
+
+  private val sharding = ClusterSharding(system)
+
+  override def initEntity[M, E](entity: Entity[M, E]): ActorRef[E] = {
+
+    // TODO: convert EntitySettings to ClusterShardingSettings
+    val clusterSettings = entity.settings.map(_ => ClusterShardingSettings(system))
+
+    val shardingMessageExtractor = entity.messageExtractor.map {
+      case shardingExtractor: ShardingMessageExtractor[E, M] @unchecked => shardingExtractor
+      case messageExtractor                                             =>
+        // fall back to number of shards defined in settings
+        val numberOfShards = ClusterShardingSettings(system).numberOfShards
+        new ShardingMessageExtractor[E, M] {
+          override def entityId(message: E): String = messageExtractor.entityId(message)
+          override def shardId(entityId: String): String = HashCodeMessageExtractor.shardId(entityId, numberOfShards)
+          override def unwrapMessage(message: E): M = messageExtractor.unwrapMessage(message)
+        }
+    }
+
+    val shardedEntity: ShardedEntity[M, E] =
+      new ShardedEntity(
+        ctx => entity.createBehavior(toEntityContext(ctx)),
+        toShardedEntityTypeKey(entity.typeKey),
+        entity.stopMessage,
+        entity.entityProps,
+        clusterSettings,
+        shardingMessageExtractor,
+        None,
+        None,
+        None)
+
+    sharding.init(shardedEntity)
+  }
+
+  override def entityRefFor[M](typeKey: EntityTypeKey[M], entityId: String): EntityRef[M] =
+    toEntityRef(sharding.entityRefFor(toShardedEntityTypeKey(typeKey), entityId))
+
+}
+
+private[akka] object EntityAdapter {
+
+  def toShardedEntityTypeKey[M](typeKey: EntityTypeKey[M]): ShardedEntityTypeKey[M] =
+    typeKey match {
+      case shardedTypeKey: ShardedEntityTypeKey[M] @unchecked => shardedTypeKey
+      case typeKeyImpl: akka.actor.typed.EntityTypeKeyImpl[M] @unchecked =>
+        ShardedEntityTypeKeyImpl(typeKey.name, typeKeyImpl.messageClassName)
+
+      case _ =>
+        // won't happen, but need it to make compiler happy
+        throw new IllegalArgumentException(s"Unknown entity type key [$typeKey]")
+    }
+
+  def toEntityTypeKey[M](typeKey: ShardedEntityTypeKey[M]): EntityTypeKey[M] = {
+    val impl = typeKey.asInstanceOf[ShardedEntityTypeKeyImpl[M]]
+    akka.actor.typed.EntityTypeKeyImpl[M](typeKey.name, impl.messageClassName)
+  }
+
+  def toEntityContext[M](ctx: ShardedEntityContext[M]): EntityContext[M] = {
+    val typeKey = toEntityTypeKey(ctx.entityTypeKey)
+    // FIXME: needs proper conversion
+    val managerRef: ActorRef[EntityCommand] = ctx.shard.asInstanceOf[ActorRef[EntityCommand]]
+    new EntityContext(typeKey, ctx.entityId, managerRef)
+  }
+
+  def toEntityRef[M](shardedEntity: ShardedEntityRef[M]): EntityRef[M] = new ShardedEntityRefWrapper(shardedEntity)
+
+  private[akka] class ShardedEntityRefWrapper[-M](delegate: ShardedEntityRef[M])
+      extends EntityRef[M]
+      with InternalRecipientRef[M] {
+
+    override def entityId: String = delegate.entityId
+
+    override def typeKey: EntityTypeKey[M] = toEntityTypeKey(delegate.typeKey)
+
+    private def convertMessage[Msg](msg: Msg): Msg = {
+      val convertedMsg =
+        msg match {
+          case EntityEnvelope.StartEntity(entityId) => ClassicStartEntity(entityId)
+          case entityEnv: EntityEnvelope[_]         => ShardingEnvelope(entityEnv.entityId, entityEnv.message)
+          case _                                    => msg
+        }
+      convertedMsg.asInstanceOf[Msg]
+    }
+
+    override def tell(msg: M): Unit =
+      delegate.tell(convertMessage(msg))
+
+    override def ask[Res](f: ActorRef[Res] => M)(implicit timeout: Timeout): Future[Res] =
+      delegate.ask { (ar: ActorRef[Res]) =>
+        convertMessage(f(ar))
+      }(timeout)
+
+    override def askWithStatus[Res](f: ActorRef[StatusReply[Res]] => M)(implicit timeout: Timeout): Future[Res] =
+      delegate.askWithStatus { (ar: ActorRef[StatusReply[Res]]) =>
+        convertMessage(f(ar))
+      }(timeout)
+
+    override def provider: ActorRefProvider =
+      delegate.asInstanceOf[InternalRecipientRef[M]].provider
+
+    override def isTerminated: Boolean =
+      delegate.asInstanceOf[InternalRecipientRef[M]].isTerminated
+
+    override def refPrefix: String =
+      URLEncoder.encode(s"${typeKey.name}-$entityId", ByteString.UTF_8)
+
+    override def toString: String = delegate.toString
+    override def hashCode(): Int = delegate.hashCode()
+    override def equals(obj: Any): Boolean = delegate.equals(obj)
+  }
+}

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -19,6 +19,7 @@ import akka.actor.InternalActorRef
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
+import akka.actor.typed.EntityEnvelope
 import akka.actor.typed.Props
 import akka.actor.typed.TypedActorContext
 import akka.actor.typed.internal.InternalRecipientRef
@@ -34,6 +35,7 @@ import akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
 import akka.cluster.sharding.ShardRegion
 import akka.cluster.sharding.ShardRegion.{ StartEntity => ClassicStartEntity }
 import akka.cluster.sharding.typed.scaladsl.EntityContext
+import akka.cluster.sharding.typed.ShardingEnvelope
 import akka.cluster.typed.Cluster
 import akka.event.Logging
 import akka.event.LoggingAdapter
@@ -53,6 +55,7 @@ import akka.util.JavaDurationConverters._
     extends ShardingMessageExtractor[Any, M] {
   override def entityId(message: Any): String = {
     message match {
+      case EntityEnvelope(entityId, _)   => entityId
       case ShardingEnvelope(entityId, _) => entityId //also covers ClassicStartEntity in ShardingEnvelope
       case ClassicStartEntity(entityId)  => entityId
       case msg                           => delegate.entityId(msg.asInstanceOf[E])
@@ -63,6 +66,7 @@ import akka.util.JavaDurationConverters._
 
   override def unwrapMessage(message: Any): M = {
     message match {
+      case EntityEnvelope(_, msg: M @unchecked)   => msg
       case ShardingEnvelope(_, msg: M @unchecked) =>
         //also covers ClassicStartEntity in ShardingEnvelope
         msg

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/ClusterSharding.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/scaladsl/ClusterSharding.scala
@@ -7,9 +7,11 @@ package scaladsl
 
 import scala.concurrent.Future
 import scala.reflect.ClassTag
+
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
+import akka.actor.typed.Entity.EntityCommand
 import akka.actor.typed.Extension
 import akka.actor.typed.ExtensionId
 import akka.actor.typed.ExtensionSetup
@@ -39,7 +41,7 @@ object ClusterSharding extends ExtensionId[ClusterSharding] {
    *
    * Not for user extension.
    */
-  @DoNotInherit trait ShardCommand
+  @DoNotInherit trait ShardCommand extends EntityCommand
 
   /**
    * The entity can request passivation by sending the [[Passivate]] message
@@ -384,7 +386,7 @@ object StartEntity {
  *
  * Not for user extension.
  */
-@DoNotInherit trait EntityTypeKey[-T] {
+@DoNotInherit trait EntityTypeKey[-T] extends akka.actor.typed.EntityTypeKey[T] {
 
   /**
    * Name of the entity type.
@@ -527,7 +529,6 @@ object EntityTypeKey {
   @InternalApi private[akka] def asJava: javadsl.EntityRef[M]
 
 }
-
 object ClusterShardingSetup {
   def apply[T <: Extension](createExtension: ActorSystem[_] => ClusterSharding): ClusterShardingSetup =
     new ClusterShardingSetup(createExtension(_))

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ExternalShardAllocationCompileOnlyTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ExternalShardAllocationCompileOnlyTest.java
@@ -33,8 +33,11 @@ public class ExternalShardAllocationCompileOnlyTest {
     EntityTypeKey<Counter.Command> typeKey = EntityTypeKey.create(Counter.Command.class, "Counter");
 
     ActorRef<ShardingEnvelope<Counter.Command>> shardRegion =
-            sharding.init(Entity.of(typeKey, ctx -> Counter.create(ctx.getEntityId()))
-                    .withAllocationStrategy(new ExternalShardAllocationStrategy(system, typeKey.name(), Timeout.create(Duration.ofSeconds(5)))));
+        sharding.init(
+            Entity.of(typeKey, ctx -> Counter.create(ctx.getEntityId()))
+                .withAllocationStrategy(
+                    new ExternalShardAllocationStrategy(
+                        system, typeKey.name(), Timeout.create(Duration.ofSeconds(5)))));
     // #entity
 
     // #client

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/LocalEntityWithClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/LocalEntityWithClusterShardingSpec.scala
@@ -1,0 +1,395 @@
+/*
+ * Copyright (C) 2017-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding.typed.scaladsl
+
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+
+import akka.actor.testkit.typed.scaladsl.ActorTestKit
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.{ Entity => LocalEntity }
+import akka.actor.typed.EntityEnvelope
+import akka.actor.typed.EntityMessageExtractor
+import akka.actor.typed.{ EntityTypeKey => LocalEntityTypeKey }
+import akka.actor.typed.PostStop
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter._
+import akka.cluster.MemberStatus
+import akka.cluster.typed.Cluster
+import akka.cluster.typed.Join
+import akka.cluster.typed.Leave
+import akka.pattern.AskTimeoutException
+import akka.serialization.jackson.CborSerializable
+import akka.util.Timeout
+import akka.util.ccompat._
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+@ccompatUsedUntil213
+object LocalEntityWithClusterShardingSpec {
+  val config = ConfigFactory.parseString(s"""
+      akka.actor.provider = cluster
+
+      akka.remote.classic.netty.tcp.port = 0
+      akka.remote.artery.canonical.port = 0
+      akka.remote.artery.canonical.hostname = 127.0.0.1
+
+      akka.cluster.jmx.multi-mbeans-in-same-jvm = on
+
+      akka.cluster.sharding.number-of-shards = 10
+
+      akka.coordinated-shutdown.terminate-actor-system = off
+      akka.coordinated-shutdown.run-by-actor-system-terminate = off
+    """)
+
+  sealed trait TestProtocol extends CborSerializable
+  final case class ReplyPlz(toMe: ActorRef[String]) extends TestProtocol
+  final case class WhoAreYou(replyTo: ActorRef[String]) extends TestProtocol
+  final case class WhoAreYou2(x: Int, replyTo: ActorRef[String]) extends TestProtocol
+  final case class StopPlz() extends TestProtocol
+  final case class PassivatePlz() extends TestProtocol
+
+  sealed trait IdTestProtocol extends CborSerializable
+  final case class IdReplyPlz(id: String, toMe: ActorRef[String]) extends IdTestProtocol
+  final case class IdWhoAreYou(id: String, replyTo: ActorRef[String]) extends IdTestProtocol
+  final case class IdStopPlz() extends IdTestProtocol
+
+  final case class TheReply(s: String)
+
+  val typeKeyWithEnvelopes = LocalEntityTypeKey[TestProtocol]("envelope")
+  val typeKeyWithoutEnvelopes = LocalEntityTypeKey[IdTestProtocol]("no-envelope")
+
+  def behavior(shard: ActorRef[ClusterSharding.ShardCommand], stopProbe: Option[ActorRef[String]] = None) =
+    Behaviors
+      .receivePartial[TestProtocol] {
+        case (ctx, PassivatePlz()) =>
+          shard ! ClusterSharding.Passivate(ctx.self)
+          Behaviors.same
+
+        case (_, StopPlz()) =>
+          stopProbe.foreach(_ ! "StopPlz")
+          Behaviors.stopped
+
+        case (ctx, WhoAreYou(replyTo)) =>
+          val address = Cluster(ctx.system).selfMember.address
+          replyTo ! s"I'm ${ctx.self.path.name} at ${address.host.get}:${address.port.get} responding to $replyTo"
+          Behaviors.same
+
+        case (_, ReplyPlz(toMe)) =>
+          toMe ! "Hello!"
+          Behaviors.same
+      }
+      .receiveSignal {
+        case (_, PostStop) =>
+          stopProbe.foreach(_ ! "PostStop")
+          Behaviors.same
+      }
+
+  def behaviorWithId() = Behaviors.receive[IdTestProtocol] {
+    case (_, IdStopPlz()) =>
+      Behaviors.stopped
+
+    case (ctx, IdWhoAreYou(_, replyTo)) =>
+      val address = Cluster(ctx.system).selfMember.address
+      replyTo ! s"I'm ${ctx.self.path.name} at ${address.host.get}:${address.port.get}"
+      Behaviors.same
+
+    case (_, IdReplyPlz(_, toMe)) =>
+      toMe ! "Hello!"
+      Behaviors.same
+  }
+
+  val idTestProtocolMessageExtractor = EntityMessageExtractor.noEnvelope[IdTestProtocol](IdStopPlz()) {
+    case IdReplyPlz(id, _)  => id
+    case IdWhoAreYou(id, _) => id
+    case other              => throw new IllegalArgumentException(s"Unexpected message $other")
+  }
+}
+
+class LocalEntityWithClusterShardingSpec
+    extends ScalaTestWithActorTestKit(ClusterShardingSpec.config)
+    with AnyWordSpecLike
+    with LogCapturing {
+
+  import LocalEntityWithClusterShardingSpec._
+
+  val sharding = ClusterSharding(system)
+
+  val system2 = ActorSystem(Behaviors.ignore[Any], name = system.name, config = system.settings.config)
+  val sharding2 = ClusterSharding(system2)
+
+  override def afterAll(): Unit = {
+    ActorTestKit.shutdown(system2)
+    super.afterAll()
+  }
+
+  private val shardingRefSystem1WithEnvelope: ActorRef[EntityEnvelope[TestProtocol]] =
+    system.initEntity(LocalEntity(typeKeyWithEnvelopes)(ctx => behavior(ctx.manager)).withStopMessage(StopPlz()))
+
+  private val shardingRefSystem2WithEnvelope: ActorRef[EntityEnvelope[TestProtocol]] =
+    system2.initEntity(LocalEntity(typeKeyWithEnvelopes)(ctx => behavior(ctx.manager)).withStopMessage(StopPlz()))
+
+  private val shardingRefSystem1WithoutEnvelope: ActorRef[IdTestProtocol] = system.initEntity(
+    LocalEntity(typeKeyWithoutEnvelopes)(_ => behaviorWithId())
+      .withMessageExtractor(EntityMessageExtractor.noEnvelope[IdTestProtocol](IdStopPlz()) {
+        case IdReplyPlz(id, _)  => id
+        case IdWhoAreYou(id, _) => id
+        case other              => throw new IllegalArgumentException(s"Unexpected message $other")
+      })
+      .withStopMessage(IdStopPlz()))
+
+  private val shardingRefSystem2WithoutEnvelope: ActorRef[IdTestProtocol] = system2.initEntity(
+    LocalEntity(typeKeyWithoutEnvelopes)(_ => behaviorWithId())
+      .withMessageExtractor(idTestProtocolMessageExtractor)
+      .withStopMessage(IdStopPlz()))
+
+  def totalEntityCount1(): Int = {
+    import akka.pattern.ask
+    implicit val timeout: Timeout = Timeout(6.seconds)
+    val statsBefore =
+      (shardingRefSystem1WithEnvelope.toClassic ? akka.cluster.sharding.ShardRegion.GetClusterShardingStats(5.seconds))
+        .mapTo[akka.cluster.sharding.ShardRegion.ClusterShardingStats]
+    val totalCount = statsBefore.futureValue.regions.values.flatMap(_.stats.values).sum
+    totalCount
+  }
+
+  "Typed cluster sharding" must {
+
+    "join cluster" in {
+      Cluster(system).manager ! Join(Cluster(system).selfMember.address)
+      Cluster(system2).manager ! Join(Cluster(system).selfMember.address)
+
+      eventually {
+        Cluster(system).state.members.unsorted.map(_.status) should ===(Set[MemberStatus](MemberStatus.Up))
+        Cluster(system).state.members.size should ===(2)
+      }
+      eventually {
+        Cluster(system2).state.members.unsorted.map(_.status) should ===(Set[MemberStatus](MemberStatus.Up))
+        Cluster(system2).state.members.size should ===(2)
+      }
+
+    }
+
+    "send messages via cluster sharding, using envelopes" in {
+      (1 to 10).foreach { n =>
+        val p = TestProbe[String]()
+        shardingRefSystem1WithEnvelope ! EntityEnvelope(s"test$n", ReplyPlz(p.ref))
+        p.expectMessage("Hello!")
+      }
+      (11 to 21).foreach { n =>
+        val p = TestProbe[String]()(system2)
+        shardingRefSystem2WithEnvelope ! EntityEnvelope(s"test$n", ReplyPlz(p.ref))
+        p.expectMessage("Hello!")
+      }
+    }
+
+    "send messages via cluster sharding, without envelopes" in {
+      (1 to 10).foreach { n =>
+        val p = TestProbe[String]()
+        shardingRefSystem1WithoutEnvelope ! IdReplyPlz(s"test$n", p.ref)
+        p.expectMessage("Hello!")
+      }
+      (11 to 21).foreach { n =>
+        val p = TestProbe[String]()(system2)
+        shardingRefSystem2WithoutEnvelope ! IdReplyPlz(s"test$n", p.ref)
+        p.expectMessage("Hello!")
+      }
+    }
+
+    "be able to passivate with custom stop message" in {
+      val stopProbe = TestProbe[String]()
+      val p = TestProbe[String]()
+      val typeKey3 = LocalEntityTypeKey[TestProtocol]("passivate-test")
+
+      val shardingRef3: ActorRef[EntityEnvelope[TestProtocol]] =
+        system.initEntity(
+          LocalEntity(typeKey3)(ctx => behavior(ctx.manager, Some(stopProbe.ref))).withStopMessage(StopPlz()))
+
+      shardingRef3 ! EntityEnvelope(s"test1", ReplyPlz(p.ref))
+      p.expectMessage("Hello!")
+
+      shardingRef3 ! EntityEnvelope(s"test1", PassivatePlz())
+      stopProbe.expectMessage("StopPlz")
+      stopProbe.expectMessage("PostStop")
+
+      shardingRef3 ! EntityEnvelope(s"test1", ReplyPlz(p.ref))
+      p.expectMessage("Hello!")
+    }
+
+    "be able to passivate with PoisonPill" in {
+      val stopProbe = TestProbe[String]()
+      val p = TestProbe[String]()
+      val typeKey4 = LocalEntityTypeKey[TestProtocol]("passivate-test-poison")
+
+      val shardingRef4: ActorRef[EntityEnvelope[TestProtocol]] =
+        system.initEntity(LocalEntity(typeKey4)(ctx => behavior(ctx.manager, Some(stopProbe.ref))))
+      // no StopPlz stopMessage
+
+      shardingRef4 ! EntityEnvelope(s"test4", ReplyPlz(p.ref))
+      p.expectMessage("Hello!")
+
+      shardingRef4 ! EntityEnvelope(s"test4", PassivatePlz())
+      // no StopPlz
+      stopProbe.expectMessage("PostStop")
+
+      shardingRef4 ! EntityEnvelope(s"test4", ReplyPlz(p.ref))
+      p.expectMessage("Hello!")
+    }
+
+    "fail if init sharding for already used typeName, but with a different type" in {
+      // sharding has been already initialized with LocalEntityTypeKey[TestProtocol]("envelope")
+      val ex = intercept[Exception] {
+        system.initEntity(
+          LocalEntity(LocalEntityTypeKey[IdTestProtocol]("envelope"))(_ => behaviorWithId())
+            .withStopMessage(IdStopPlz()))
+      }
+
+      ex.getMessage should include("already initialized")
+    }
+
+    "EntityRef - tell" in {
+      val charlieRef = system.entityRefFor(typeKeyWithEnvelopes, "charlie")
+
+      val p = TestProbe[String]()
+
+      charlieRef ! WhoAreYou(p.ref)
+      p.receiveMessage() should startWith("I'm charlie")
+
+      charlieRef.tell(WhoAreYou(p.ref))
+      p.receiveMessage() should startWith("I'm charlie")
+
+      charlieRef ! StopPlz()
+    }
+
+    "EntityRef - ask" in {
+      val bobRef = system.entityRefFor(typeKeyWithEnvelopes, "bob")
+      val aliceRef = system.entityRefFor(typeKeyWithEnvelopes, "alice")
+
+      val reply1 = bobRef.ask(WhoAreYou(_))
+      val response = reply1.futureValue.asInstanceOf[String]
+      response should startWith("I'm bob")
+      // typekey and entity id encoded in promise ref path
+      response should include(s"${typeKeyWithEnvelopes.name}-bob")
+
+      val reply2 = aliceRef.ask(WhoAreYou(_))
+      reply2.futureValue.asInstanceOf[String] should startWith("I'm alice")
+
+      bobRef ! StopPlz()
+    }
+
+    "EntityRef - ActorContext.ask" in {
+      val peterRef = system.entityRefFor(typeKeyWithEnvelopes, "peter")
+
+      val p = TestProbe[TheReply]()
+
+      spawn(Behaviors.setup[TheReply] { ctx =>
+        ctx.ask(peterRef, WhoAreYou.apply) {
+          case Success(name) => TheReply(name)
+          case Failure(ex)   => TheReply(ex.getMessage)
+        }
+
+        Behaviors.receiveMessage[TheReply] { reply =>
+          p.ref ! reply
+          Behaviors.same
+        }
+      })
+
+      val response = p.receiveMessage()
+      response.s should startWith("I'm peter")
+      // typekey and entity id encoded in promise ref path
+      response.s should include(s"${typeKeyWithEnvelopes.name}-peter")
+
+      peterRef ! StopPlz()
+
+      // FIXME #26514: doesn't compile with Scala 2.13.0-M5
+      /*
+      // make sure request with multiple parameters compile
+      Behaviors.setup[TheReply] { ctx =>
+        ctx.ask(aliceRef)(WhoAreYou2(17, _)) {
+          case Success(name) => TheReply(name)
+          case Failure(ex)   => TheReply(ex.getMessage)
+        }
+
+        Behaviors.empty
+      }
+     */
+    }
+
+    "EntityRef - AskTimeoutException" in {
+      val ignorantKey = LocalEntityTypeKey[TestProtocol]("ignorant")
+
+      system.initEntity(LocalEntity(ignorantKey)(_ => Behaviors.ignore[TestProtocol]).withStopMessage(StopPlz()))
+
+      val ref = system.entityRefFor(ignorantKey, "sloppy")
+
+      val reply = ref.ask(WhoAreYou(_))(Timeout(10.millis))
+      val exc = reply.failed.futureValue
+      exc.getClass should ===(classOf[AskTimeoutException])
+      exc.getMessage should startWith("Ask timed out on")
+      exc.getMessage should include(ignorantKey.toString)
+      exc.getMessage should include("sloppy") // the entity id
+      exc.getMessage should include(ref.toString)
+      exc.getMessage should include(s"[${classOf[WhoAreYou].getName}]") // message class
+      exc.getMessage should include("[10 ms]") // timeout
+    }
+
+    "handle classic StartEntity message" in {
+      // it is normally using envelopes, but the classic StartEntity message can be sent internally,
+      // e.g. for remember entities
+
+      val totalCountBefore = totalEntityCount1()
+
+      val p = TestProbe[Any]()
+      shardingRefSystem1WithEnvelope.toClassic
+        .tell(akka.cluster.sharding.ShardRegion.StartEntity("startEntity-1"), p.ref.toClassic)
+      p.expectMessageType[akka.cluster.sharding.ShardRegion.StartEntityAck]
+
+      eventually {
+        val totalCountAfter = totalEntityCount1()
+        totalCountAfter should ===(totalCountBefore + 1)
+      }
+    }
+
+    "handle typed StartEntity message" in {
+      val totalCountBefore = totalEntityCount1()
+
+      shardingRefSystem1WithEnvelope ! EntityEnvelope.StartEntity("startEntity-2")
+
+      eventually {
+        val totalCountAfter = totalEntityCount1()
+        totalCountAfter should ===(totalCountBefore + 1)
+      }
+    }
+
+    "use the stopMessage for leaving/rebalance" in {
+      // use many entities to reduce the risk that all are hashed to the same shard/node
+      val numberOfEntities = 100
+      val probe1 = TestProbe[String]()
+      (1 to numberOfEntities).foreach { n =>
+        shardingRefSystem1WithEnvelope ! EntityEnvelope(s"test$n", WhoAreYou(probe1.ref))
+      }
+      val replies1 = probe1.receiveMessages(numberOfEntities, 10.seconds)
+
+      Cluster(system2).manager ! Leave(Cluster(system2).selfMember.address)
+
+      eventually {
+        // if it wouldn't receive the StopPlz and stop the leaving would take longer and this would fail
+        Cluster(system2).isTerminated should ===(true)
+      }
+
+      val probe2 = TestProbe[String]()
+      (1 to numberOfEntities).foreach { n =>
+        shardingRefSystem1WithEnvelope ! EntityEnvelope(s"test$n", WhoAreYou(probe2.ref))
+      }
+      val replies2 = probe2.receiveMessages(numberOfEntities, 10.seconds)
+      replies2 should !==(replies1) // different addresses
+    }
+  }
+}

--- a/akka-cluster/src/main/java/akka/cluster/protobuf/msg/ClusterMessages.java
+++ b/akka-cluster/src/main/java/akka/cluster/protobuf/msg/ClusterMessages.java
@@ -361,7 +361,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code Join}
    */
-  public  static final class Join extends
+  public static final class Join extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:Join)
       JoinOrBuilder {
@@ -476,6 +476,7 @@ public final class ClusterMessages {
      * <code>required .UniqueAddress node = 1;</code>
      * @return Whether the node field is set.
      */
+    @java.lang.Override
     public boolean hasNode() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -483,12 +484,14 @@ public final class ClusterMessages {
      * <code>required .UniqueAddress node = 1;</code>
      * @return The node.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress getNode() {
       return node_ == null ? akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress.getDefaultInstance() : node_;
     }
     /**
      * <code>required .UniqueAddress node = 1;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.UniqueAddressOrBuilder getNodeOrBuilder() {
       return node_ == null ? akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress.getDefaultInstance() : node_;
     }
@@ -534,6 +537,7 @@ public final class ClusterMessages {
      * <code>optional string appVersion = 3;</code>
      * @return Whether the appVersion field is set.
      */
+    @java.lang.Override
     public boolean hasAppVersion() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -541,6 +545,7 @@ public final class ClusterMessages {
      * <code>optional string appVersion = 3;</code>
      * @return The appVersion.
      */
+    @java.lang.Override
     public java.lang.String getAppVersion() {
       java.lang.Object ref = appVersion_;
       if (ref instanceof java.lang.String) {
@@ -559,6 +564,7 @@ public final class ClusterMessages {
      * <code>optional string appVersion = 3;</code>
      * @return The bytes for appVersion.
      */
+    @java.lang.Override
     public akka.protobufv3.internal.ByteString
         getAppVersionBytes() {
       java.lang.Object ref = appVersion_;
@@ -1382,7 +1388,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code Welcome}
    */
-  public  static final class Welcome extends
+  public static final class Welcome extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:Welcome)
       WelcomeOrBuilder {
@@ -1490,6 +1496,7 @@ public final class ClusterMessages {
      * <code>required .UniqueAddress from = 1;</code>
      * @return Whether the from field is set.
      */
+    @java.lang.Override
     public boolean hasFrom() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -1497,12 +1504,14 @@ public final class ClusterMessages {
      * <code>required .UniqueAddress from = 1;</code>
      * @return The from.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress getFrom() {
       return from_ == null ? akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress.getDefaultInstance() : from_;
     }
     /**
      * <code>required .UniqueAddress from = 1;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.UniqueAddressOrBuilder getFromOrBuilder() {
       return from_ == null ? akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress.getDefaultInstance() : from_;
     }
@@ -1513,6 +1522,7 @@ public final class ClusterMessages {
      * <code>required .Gossip gossip = 2;</code>
      * @return Whether the gossip field is set.
      */
+    @java.lang.Override
     public boolean hasGossip() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -1520,12 +1530,14 @@ public final class ClusterMessages {
      * <code>required .Gossip gossip = 2;</code>
      * @return The gossip.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.Gossip getGossip() {
       return gossip_ == null ? akka.cluster.protobuf.msg.ClusterMessages.Gossip.getDefaultInstance() : gossip_;
     }
     /**
      * <code>required .Gossip gossip = 2;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.GossipOrBuilder getGossipOrBuilder() {
       return gossip_ == null ? akka.cluster.protobuf.msg.ClusterMessages.Gossip.getDefaultInstance() : gossip_;
     }
@@ -2241,7 +2253,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code InitJoin}
    */
-  public  static final class InitJoin extends
+  public static final class InitJoin extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:InitJoin)
       InitJoinOrBuilder {
@@ -2330,6 +2342,7 @@ public final class ClusterMessages {
      * <code>optional string currentConfig = 1;</code>
      * @return Whether the currentConfig field is set.
      */
+    @java.lang.Override
     public boolean hasCurrentConfig() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -2337,6 +2350,7 @@ public final class ClusterMessages {
      * <code>optional string currentConfig = 1;</code>
      * @return The currentConfig.
      */
+    @java.lang.Override
     public java.lang.String getCurrentConfig() {
       java.lang.Object ref = currentConfig_;
       if (ref instanceof java.lang.String) {
@@ -2355,6 +2369,7 @@ public final class ClusterMessages {
      * <code>optional string currentConfig = 1;</code>
      * @return The bytes for currentConfig.
      */
+    @java.lang.Override
     public akka.protobufv3.internal.ByteString
         getCurrentConfigBytes() {
       java.lang.Object ref = currentConfig_;
@@ -2867,7 +2882,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code InitJoinAck}
    */
-  public  static final class InitJoinAck extends
+  public static final class InitJoinAck extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:InitJoinAck)
       InitJoinAckOrBuilder {
@@ -2975,6 +2990,7 @@ public final class ClusterMessages {
      * <code>required .Address address = 1;</code>
      * @return Whether the address field is set.
      */
+    @java.lang.Override
     public boolean hasAddress() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -2982,12 +2998,14 @@ public final class ClusterMessages {
      * <code>required .Address address = 1;</code>
      * @return The address.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.Address getAddress() {
       return address_ == null ? akka.cluster.protobuf.msg.ClusterMessages.Address.getDefaultInstance() : address_;
     }
     /**
      * <code>required .Address address = 1;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.AddressOrBuilder getAddressOrBuilder() {
       return address_ == null ? akka.cluster.protobuf.msg.ClusterMessages.Address.getDefaultInstance() : address_;
     }
@@ -2998,6 +3016,7 @@ public final class ClusterMessages {
      * <code>required .ConfigCheck configCheck = 2;</code>
      * @return Whether the configCheck field is set.
      */
+    @java.lang.Override
     public boolean hasConfigCheck() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -3005,12 +3024,14 @@ public final class ClusterMessages {
      * <code>required .ConfigCheck configCheck = 2;</code>
      * @return The configCheck.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.ConfigCheck getConfigCheck() {
       return configCheck_ == null ? akka.cluster.protobuf.msg.ClusterMessages.ConfigCheck.getDefaultInstance() : configCheck_;
     }
     /**
      * <code>required .ConfigCheck configCheck = 2;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.ConfigCheckOrBuilder getConfigCheckOrBuilder() {
       return configCheck_ == null ? akka.cluster.protobuf.msg.ClusterMessages.ConfigCheck.getDefaultInstance() : configCheck_;
     }
@@ -3732,7 +3753,7 @@ public final class ClusterMessages {
   /**
    * Protobuf type {@code ConfigCheck}
    */
-  public  static final class ConfigCheck extends
+  public static final class ConfigCheck extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:ConfigCheck)
       ConfigCheckOrBuilder {
@@ -3939,14 +3960,14 @@ public final class ClusterMessages {
      * <code>required .ConfigCheck.Type type = 1;</code>
      * @return Whether the type field is set.
      */
-    public boolean hasType() {
+    @java.lang.Override public boolean hasType() {
       return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>required .ConfigCheck.Type type = 1;</code>
      * @return The type.
      */
-    public akka.cluster.protobuf.msg.ClusterMessages.ConfigCheck.Type getType() {
+    @java.lang.Override public akka.cluster.protobuf.msg.ClusterMessages.ConfigCheck.Type getType() {
       @SuppressWarnings("deprecation")
       akka.cluster.protobuf.msg.ClusterMessages.ConfigCheck.Type result = akka.cluster.protobuf.msg.ClusterMessages.ConfigCheck.Type.valueOf(type_);
       return result == null ? akka.cluster.protobuf.msg.ClusterMessages.ConfigCheck.Type.UncheckedConfig : result;
@@ -3958,6 +3979,7 @@ public final class ClusterMessages {
      * <code>optional string clusterConfig = 2;</code>
      * @return Whether the clusterConfig field is set.
      */
+    @java.lang.Override
     public boolean hasClusterConfig() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -3965,6 +3987,7 @@ public final class ClusterMessages {
      * <code>optional string clusterConfig = 2;</code>
      * @return The clusterConfig.
      */
+    @java.lang.Override
     public java.lang.String getClusterConfig() {
       java.lang.Object ref = clusterConfig_;
       if (ref instanceof java.lang.String) {
@@ -3983,6 +4006,7 @@ public final class ClusterMessages {
      * <code>optional string clusterConfig = 2;</code>
      * @return The bytes for clusterConfig.
      */
+    @java.lang.Override
     public akka.protobufv3.internal.ByteString
         getClusterConfigBytes() {
       java.lang.Object ref = clusterConfig_;
@@ -4348,13 +4372,14 @@ public final class ClusterMessages {
        * <code>required .ConfigCheck.Type type = 1;</code>
        * @return Whether the type field is set.
        */
-      public boolean hasType() {
+      @java.lang.Override public boolean hasType() {
         return ((bitField0_ & 0x00000001) != 0);
       }
       /**
        * <code>required .ConfigCheck.Type type = 1;</code>
        * @return The type.
        */
+      @java.lang.Override
       public akka.cluster.protobuf.msg.ClusterMessages.ConfigCheck.Type getType() {
         @SuppressWarnings("deprecation")
         akka.cluster.protobuf.msg.ClusterMessages.ConfigCheck.Type result = akka.cluster.protobuf.msg.ClusterMessages.ConfigCheck.Type.valueOf(type_);
@@ -4572,7 +4597,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code Heartbeat}
    */
-  public  static final class Heartbeat extends
+  public static final class Heartbeat extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:Heartbeat)
       HeartbeatOrBuilder {
@@ -4677,6 +4702,7 @@ public final class ClusterMessages {
      * <code>required .Address from = 1;</code>
      * @return Whether the from field is set.
      */
+    @java.lang.Override
     public boolean hasFrom() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -4684,12 +4710,14 @@ public final class ClusterMessages {
      * <code>required .Address from = 1;</code>
      * @return The from.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.Address getFrom() {
       return from_ == null ? akka.cluster.protobuf.msg.ClusterMessages.Address.getDefaultInstance() : from_;
     }
     /**
      * <code>required .Address from = 1;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.AddressOrBuilder getFromOrBuilder() {
       return from_ == null ? akka.cluster.protobuf.msg.ClusterMessages.Address.getDefaultInstance() : from_;
     }
@@ -4700,6 +4728,7 @@ public final class ClusterMessages {
      * <code>optional int64 sequenceNr = 2;</code>
      * @return Whether the sequenceNr field is set.
      */
+    @java.lang.Override
     public boolean hasSequenceNr() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -4707,6 +4736,7 @@ public final class ClusterMessages {
      * <code>optional int64 sequenceNr = 2;</code>
      * @return The sequenceNr.
      */
+    @java.lang.Override
     public long getSequenceNr() {
       return sequenceNr_;
     }
@@ -4717,6 +4747,7 @@ public final class ClusterMessages {
      * <code>optional sint64 creationTime = 3;</code>
      * @return Whether the creationTime field is set.
      */
+    @java.lang.Override
     public boolean hasCreationTime() {
       return ((bitField0_ & 0x00000004) != 0);
     }
@@ -4724,6 +4755,7 @@ public final class ClusterMessages {
      * <code>optional sint64 creationTime = 3;</code>
      * @return The creationTime.
      */
+    @java.lang.Override
     public long getCreationTime() {
       return creationTime_;
     }
@@ -5249,6 +5281,7 @@ public final class ClusterMessages {
        * <code>optional int64 sequenceNr = 2;</code>
        * @return Whether the sequenceNr field is set.
        */
+      @java.lang.Override
       public boolean hasSequenceNr() {
         return ((bitField0_ & 0x00000002) != 0);
       }
@@ -5256,6 +5289,7 @@ public final class ClusterMessages {
        * <code>optional int64 sequenceNr = 2;</code>
        * @return The sequenceNr.
        */
+      @java.lang.Override
       public long getSequenceNr() {
         return sequenceNr_;
       }
@@ -5286,6 +5320,7 @@ public final class ClusterMessages {
        * <code>optional sint64 creationTime = 3;</code>
        * @return Whether the creationTime field is set.
        */
+      @java.lang.Override
       public boolean hasCreationTime() {
         return ((bitField0_ & 0x00000004) != 0);
       }
@@ -5293,6 +5328,7 @@ public final class ClusterMessages {
        * <code>optional sint64 creationTime = 3;</code>
        * @return The creationTime.
        */
+      @java.lang.Override
       public long getCreationTime() {
         return creationTime_;
       }
@@ -5421,7 +5457,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code HeartBeatResponse}
    */
-  public  static final class HeartBeatResponse extends
+  public static final class HeartBeatResponse extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:HeartBeatResponse)
       HeartBeatResponseOrBuilder {
@@ -5526,6 +5562,7 @@ public final class ClusterMessages {
      * <code>required .UniqueAddress from = 1;</code>
      * @return Whether the from field is set.
      */
+    @java.lang.Override
     public boolean hasFrom() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -5533,12 +5570,14 @@ public final class ClusterMessages {
      * <code>required .UniqueAddress from = 1;</code>
      * @return The from.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress getFrom() {
       return from_ == null ? akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress.getDefaultInstance() : from_;
     }
     /**
      * <code>required .UniqueAddress from = 1;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.UniqueAddressOrBuilder getFromOrBuilder() {
       return from_ == null ? akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress.getDefaultInstance() : from_;
     }
@@ -5549,6 +5588,7 @@ public final class ClusterMessages {
      * <code>optional int64 sequenceNr = 2;</code>
      * @return Whether the sequenceNr field is set.
      */
+    @java.lang.Override
     public boolean hasSequenceNr() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -5556,6 +5596,7 @@ public final class ClusterMessages {
      * <code>optional int64 sequenceNr = 2;</code>
      * @return The sequenceNr.
      */
+    @java.lang.Override
     public long getSequenceNr() {
       return sequenceNr_;
     }
@@ -5566,6 +5607,7 @@ public final class ClusterMessages {
      * <code>optional int64 creationTime = 3;</code>
      * @return Whether the creationTime field is set.
      */
+    @java.lang.Override
     public boolean hasCreationTime() {
       return ((bitField0_ & 0x00000004) != 0);
     }
@@ -5573,6 +5615,7 @@ public final class ClusterMessages {
      * <code>optional int64 creationTime = 3;</code>
      * @return The creationTime.
      */
+    @java.lang.Override
     public long getCreationTime() {
       return creationTime_;
     }
@@ -6098,6 +6141,7 @@ public final class ClusterMessages {
        * <code>optional int64 sequenceNr = 2;</code>
        * @return Whether the sequenceNr field is set.
        */
+      @java.lang.Override
       public boolean hasSequenceNr() {
         return ((bitField0_ & 0x00000002) != 0);
       }
@@ -6105,6 +6149,7 @@ public final class ClusterMessages {
        * <code>optional int64 sequenceNr = 2;</code>
        * @return The sequenceNr.
        */
+      @java.lang.Override
       public long getSequenceNr() {
         return sequenceNr_;
       }
@@ -6135,6 +6180,7 @@ public final class ClusterMessages {
        * <code>optional int64 creationTime = 3;</code>
        * @return Whether the creationTime field is set.
        */
+      @java.lang.Override
       public boolean hasCreationTime() {
         return ((bitField0_ & 0x00000004) != 0);
       }
@@ -6142,6 +6188,7 @@ public final class ClusterMessages {
        * <code>optional int64 creationTime = 3;</code>
        * @return The creationTime.
        */
+      @java.lang.Override
       public long getCreationTime() {
         return creationTime_;
       }
@@ -6272,7 +6319,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code GossipEnvelope}
    */
-  public  static final class GossipEnvelope extends
+  public static final class GossipEnvelope extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:GossipEnvelope)
       GossipEnvelopeOrBuilder {
@@ -6386,6 +6433,7 @@ public final class ClusterMessages {
      * <code>required .UniqueAddress from = 1;</code>
      * @return Whether the from field is set.
      */
+    @java.lang.Override
     public boolean hasFrom() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -6393,12 +6441,14 @@ public final class ClusterMessages {
      * <code>required .UniqueAddress from = 1;</code>
      * @return The from.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress getFrom() {
       return from_ == null ? akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress.getDefaultInstance() : from_;
     }
     /**
      * <code>required .UniqueAddress from = 1;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.UniqueAddressOrBuilder getFromOrBuilder() {
       return from_ == null ? akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress.getDefaultInstance() : from_;
     }
@@ -6409,6 +6459,7 @@ public final class ClusterMessages {
      * <code>required .UniqueAddress to = 2;</code>
      * @return Whether the to field is set.
      */
+    @java.lang.Override
     public boolean hasTo() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -6416,12 +6467,14 @@ public final class ClusterMessages {
      * <code>required .UniqueAddress to = 2;</code>
      * @return The to.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress getTo() {
       return to_ == null ? akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress.getDefaultInstance() : to_;
     }
     /**
      * <code>required .UniqueAddress to = 2;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.UniqueAddressOrBuilder getToOrBuilder() {
       return to_ == null ? akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress.getDefaultInstance() : to_;
     }
@@ -6432,6 +6485,7 @@ public final class ClusterMessages {
      * <code>required bytes serializedGossip = 3;</code>
      * @return Whether the serializedGossip field is set.
      */
+    @java.lang.Override
     public boolean hasSerializedGossip() {
       return ((bitField0_ & 0x00000004) != 0);
     }
@@ -6439,6 +6493,7 @@ public final class ClusterMessages {
      * <code>required bytes serializedGossip = 3;</code>
      * @return The serializedGossip.
      */
+    @java.lang.Override
     public akka.protobufv3.internal.ByteString getSerializedGossip() {
       return serializedGossip_;
     }
@@ -7110,6 +7165,7 @@ public final class ClusterMessages {
        * <code>required bytes serializedGossip = 3;</code>
        * @return Whether the serializedGossip field is set.
        */
+      @java.lang.Override
       public boolean hasSerializedGossip() {
         return ((bitField0_ & 0x00000004) != 0);
       }
@@ -7117,6 +7173,7 @@ public final class ClusterMessages {
        * <code>required bytes serializedGossip = 3;</code>
        * @return The serializedGossip.
        */
+      @java.lang.Override
       public akka.protobufv3.internal.ByteString getSerializedGossip() {
         return serializedGossip_;
       }
@@ -7275,7 +7332,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code GossipStatus}
    */
-  public  static final class GossipStatus extends
+  public static final class GossipStatus extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:GossipStatus)
       GossipStatusOrBuilder {
@@ -7402,6 +7459,7 @@ public final class ClusterMessages {
      * <code>required .UniqueAddress from = 1;</code>
      * @return Whether the from field is set.
      */
+    @java.lang.Override
     public boolean hasFrom() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -7409,12 +7467,14 @@ public final class ClusterMessages {
      * <code>required .UniqueAddress from = 1;</code>
      * @return The from.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress getFrom() {
       return from_ == null ? akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress.getDefaultInstance() : from_;
     }
     /**
      * <code>required .UniqueAddress from = 1;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.UniqueAddressOrBuilder getFromOrBuilder() {
       return from_ == null ? akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress.getDefaultInstance() : from_;
     }
@@ -7460,6 +7520,7 @@ public final class ClusterMessages {
      * <code>required .VectorClock version = 3;</code>
      * @return Whether the version field is set.
      */
+    @java.lang.Override
     public boolean hasVersion() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -7467,12 +7528,14 @@ public final class ClusterMessages {
      * <code>required .VectorClock version = 3;</code>
      * @return The version.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.VectorClock getVersion() {
       return version_ == null ? akka.cluster.protobuf.msg.ClusterMessages.VectorClock.getDefaultInstance() : version_;
     }
     /**
      * <code>required .VectorClock version = 3;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.VectorClockOrBuilder getVersionOrBuilder() {
       return version_ == null ? akka.cluster.protobuf.msg.ClusterMessages.VectorClock.getDefaultInstance() : version_;
     }
@@ -7483,6 +7546,7 @@ public final class ClusterMessages {
      * <code>optional bytes seenDigest = 4;</code>
      * @return Whether the seenDigest field is set.
      */
+    @java.lang.Override
     public boolean hasSeenDigest() {
       return ((bitField0_ & 0x00000004) != 0);
     }
@@ -7490,6 +7554,7 @@ public final class ClusterMessages {
      * <code>optional bytes seenDigest = 4;</code>
      * @return The seenDigest.
      */
+    @java.lang.Override
     public akka.protobufv3.internal.ByteString getSeenDigest() {
       return seenDigest_;
     }
@@ -8297,6 +8362,7 @@ public final class ClusterMessages {
        * <code>optional bytes seenDigest = 4;</code>
        * @return Whether the seenDigest field is set.
        */
+      @java.lang.Override
       public boolean hasSeenDigest() {
         return ((bitField0_ & 0x00000008) != 0);
       }
@@ -8304,6 +8370,7 @@ public final class ClusterMessages {
        * <code>optional bytes seenDigest = 4;</code>
        * @return The seenDigest.
        */
+      @java.lang.Override
       public akka.protobufv3.internal.ByteString getSeenDigest() {
         return seenDigest_;
       }
@@ -8573,7 +8640,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code Gossip}
    */
-  public  static final class Gossip extends
+  public static final class Gossip extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:Gossip)
       GossipOrBuilder {
@@ -8758,12 +8825,14 @@ public final class ClusterMessages {
     /**
      * <code>repeated .UniqueAddress allAddresses = 1;</code>
      */
+    @java.lang.Override
     public java.util.List<akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress> getAllAddressesList() {
       return allAddresses_;
     }
     /**
      * <code>repeated .UniqueAddress allAddresses = 1;</code>
      */
+    @java.lang.Override
     public java.util.List<? extends akka.cluster.protobuf.msg.ClusterMessages.UniqueAddressOrBuilder> 
         getAllAddressesOrBuilderList() {
       return allAddresses_;
@@ -8771,18 +8840,21 @@ public final class ClusterMessages {
     /**
      * <code>repeated .UniqueAddress allAddresses = 1;</code>
      */
+    @java.lang.Override
     public int getAllAddressesCount() {
       return allAddresses_.size();
     }
     /**
      * <code>repeated .UniqueAddress allAddresses = 1;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.UniqueAddress getAllAddresses(int index) {
       return allAddresses_.get(index);
     }
     /**
      * <code>repeated .UniqueAddress allAddresses = 1;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.UniqueAddressOrBuilder getAllAddressesOrBuilder(
         int index) {
       return allAddresses_.get(index);
@@ -8863,12 +8935,14 @@ public final class ClusterMessages {
     /**
      * <code>repeated .Member members = 4;</code>
      */
+    @java.lang.Override
     public java.util.List<akka.cluster.protobuf.msg.ClusterMessages.Member> getMembersList() {
       return members_;
     }
     /**
      * <code>repeated .Member members = 4;</code>
      */
+    @java.lang.Override
     public java.util.List<? extends akka.cluster.protobuf.msg.ClusterMessages.MemberOrBuilder> 
         getMembersOrBuilderList() {
       return members_;
@@ -8876,18 +8950,21 @@ public final class ClusterMessages {
     /**
      * <code>repeated .Member members = 4;</code>
      */
+    @java.lang.Override
     public int getMembersCount() {
       return members_.size();
     }
     /**
      * <code>repeated .Member members = 4;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.Member getMembers(int index) {
       return members_.get(index);
     }
     /**
      * <code>repeated .Member members = 4;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.MemberOrBuilder getMembersOrBuilder(
         int index) {
       return members_.get(index);
@@ -8899,6 +8976,7 @@ public final class ClusterMessages {
      * <code>required .GossipOverview overview = 5;</code>
      * @return Whether the overview field is set.
      */
+    @java.lang.Override
     public boolean hasOverview() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -8906,12 +8984,14 @@ public final class ClusterMessages {
      * <code>required .GossipOverview overview = 5;</code>
      * @return The overview.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.GossipOverview getOverview() {
       return overview_ == null ? akka.cluster.protobuf.msg.ClusterMessages.GossipOverview.getDefaultInstance() : overview_;
     }
     /**
      * <code>required .GossipOverview overview = 5;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.GossipOverviewOrBuilder getOverviewOrBuilder() {
       return overview_ == null ? akka.cluster.protobuf.msg.ClusterMessages.GossipOverview.getDefaultInstance() : overview_;
     }
@@ -8922,6 +9002,7 @@ public final class ClusterMessages {
      * <code>required .VectorClock version = 6;</code>
      * @return Whether the version field is set.
      */
+    @java.lang.Override
     public boolean hasVersion() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -8929,12 +9010,14 @@ public final class ClusterMessages {
      * <code>required .VectorClock version = 6;</code>
      * @return The version.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.VectorClock getVersion() {
       return version_ == null ? akka.cluster.protobuf.msg.ClusterMessages.VectorClock.getDefaultInstance() : version_;
     }
     /**
      * <code>required .VectorClock version = 6;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.VectorClockOrBuilder getVersionOrBuilder() {
       return version_ == null ? akka.cluster.protobuf.msg.ClusterMessages.VectorClock.getDefaultInstance() : version_;
     }
@@ -8944,12 +9027,14 @@ public final class ClusterMessages {
     /**
      * <code>repeated .Tombstone tombstones = 7;</code>
      */
+    @java.lang.Override
     public java.util.List<akka.cluster.protobuf.msg.ClusterMessages.Tombstone> getTombstonesList() {
       return tombstones_;
     }
     /**
      * <code>repeated .Tombstone tombstones = 7;</code>
      */
+    @java.lang.Override
     public java.util.List<? extends akka.cluster.protobuf.msg.ClusterMessages.TombstoneOrBuilder> 
         getTombstonesOrBuilderList() {
       return tombstones_;
@@ -8957,18 +9042,21 @@ public final class ClusterMessages {
     /**
      * <code>repeated .Tombstone tombstones = 7;</code>
      */
+    @java.lang.Override
     public int getTombstonesCount() {
       return tombstones_.size();
     }
     /**
      * <code>repeated .Tombstone tombstones = 7;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.Tombstone getTombstones(int index) {
       return tombstones_.get(index);
     }
     /**
      * <code>repeated .Tombstone tombstones = 7;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.TombstoneOrBuilder getTombstonesOrBuilder(
         int index) {
       return tombstones_.get(index);
@@ -11103,7 +11191,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code GossipOverview}
    */
-  public  static final class GossipOverview extends
+  public static final class GossipOverview extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:GossipOverview)
       GossipOverviewOrBuilder {
@@ -11226,6 +11314,7 @@ public final class ClusterMessages {
      * <code>repeated int32 seen = 1;</code>
      * @return A list containing the seen.
      */
+    @java.lang.Override
     public java.util.List<java.lang.Integer>
         getSeenList() {
       return seen_;
@@ -11259,12 +11348,14 @@ public final class ClusterMessages {
     /**
      * <code>repeated .ObserverReachability observerReachability = 2;</code>
      */
+    @java.lang.Override
     public java.util.List<akka.cluster.protobuf.msg.ClusterMessages.ObserverReachability> getObserverReachabilityList() {
       return observerReachability_;
     }
     /**
      * <code>repeated .ObserverReachability observerReachability = 2;</code>
      */
+    @java.lang.Override
     public java.util.List<? extends akka.cluster.protobuf.msg.ClusterMessages.ObserverReachabilityOrBuilder> 
         getObserverReachabilityOrBuilderList() {
       return observerReachability_;
@@ -11272,18 +11363,21 @@ public final class ClusterMessages {
     /**
      * <code>repeated .ObserverReachability observerReachability = 2;</code>
      */
+    @java.lang.Override
     public int getObserverReachabilityCount() {
       return observerReachability_.size();
     }
     /**
      * <code>repeated .ObserverReachability observerReachability = 2;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.ObserverReachability getObserverReachability(int index) {
       return observerReachability_.get(index);
     }
     /**
      * <code>repeated .ObserverReachability observerReachability = 2;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.ObserverReachabilityOrBuilder getObserverReachabilityOrBuilder(
         int index) {
       return observerReachability_.get(index);
@@ -12139,7 +12233,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code ObserverReachability}
    */
-  public  static final class ObserverReachability extends
+  public static final class ObserverReachability extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:ObserverReachability)
       ObserverReachabilityOrBuilder {
@@ -12244,6 +12338,7 @@ public final class ClusterMessages {
      * <code>required int32 addressIndex = 1;</code>
      * @return Whether the addressIndex field is set.
      */
+    @java.lang.Override
     public boolean hasAddressIndex() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -12251,6 +12346,7 @@ public final class ClusterMessages {
      * <code>required int32 addressIndex = 1;</code>
      * @return The addressIndex.
      */
+    @java.lang.Override
     public int getAddressIndex() {
       return addressIndex_;
     }
@@ -12261,6 +12357,7 @@ public final class ClusterMessages {
      * <code>required int64 version = 4;</code>
      * @return Whether the version field is set.
      */
+    @java.lang.Override
     public boolean hasVersion() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -12268,6 +12365,7 @@ public final class ClusterMessages {
      * <code>required int64 version = 4;</code>
      * @return The version.
      */
+    @java.lang.Override
     public long getVersion() {
       return version_;
     }
@@ -12277,12 +12375,14 @@ public final class ClusterMessages {
     /**
      * <code>repeated .SubjectReachability subjectReachability = 2;</code>
      */
+    @java.lang.Override
     public java.util.List<akka.cluster.protobuf.msg.ClusterMessages.SubjectReachability> getSubjectReachabilityList() {
       return subjectReachability_;
     }
     /**
      * <code>repeated .SubjectReachability subjectReachability = 2;</code>
      */
+    @java.lang.Override
     public java.util.List<? extends akka.cluster.protobuf.msg.ClusterMessages.SubjectReachabilityOrBuilder> 
         getSubjectReachabilityOrBuilderList() {
       return subjectReachability_;
@@ -12290,18 +12390,21 @@ public final class ClusterMessages {
     /**
      * <code>repeated .SubjectReachability subjectReachability = 2;</code>
      */
+    @java.lang.Override
     public int getSubjectReachabilityCount() {
       return subjectReachability_.size();
     }
     /**
      * <code>repeated .SubjectReachability subjectReachability = 2;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.SubjectReachability getSubjectReachability(int index) {
       return subjectReachability_.get(index);
     }
     /**
      * <code>repeated .SubjectReachability subjectReachability = 2;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.SubjectReachabilityOrBuilder getSubjectReachabilityOrBuilder(
         int index) {
       return subjectReachability_.get(index);
@@ -12737,6 +12840,7 @@ public final class ClusterMessages {
        * <code>required int32 addressIndex = 1;</code>
        * @return Whether the addressIndex field is set.
        */
+      @java.lang.Override
       public boolean hasAddressIndex() {
         return ((bitField0_ & 0x00000001) != 0);
       }
@@ -12744,6 +12848,7 @@ public final class ClusterMessages {
        * <code>required int32 addressIndex = 1;</code>
        * @return The addressIndex.
        */
+      @java.lang.Override
       public int getAddressIndex() {
         return addressIndex_;
       }
@@ -12774,6 +12879,7 @@ public final class ClusterMessages {
        * <code>required int64 version = 4;</code>
        * @return Whether the version field is set.
        */
+      @java.lang.Override
       public boolean hasVersion() {
         return ((bitField0_ & 0x00000002) != 0);
       }
@@ -12781,6 +12887,7 @@ public final class ClusterMessages {
        * <code>required int64 version = 4;</code>
        * @return The version.
        */
+      @java.lang.Override
       public long getVersion() {
         return version_;
       }
@@ -13138,7 +13245,7 @@ public final class ClusterMessages {
   /**
    * Protobuf type {@code SubjectReachability}
    */
-  public  static final class SubjectReachability extends
+  public static final class SubjectReachability extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:SubjectReachability)
       SubjectReachabilityOrBuilder {
@@ -13243,6 +13350,7 @@ public final class ClusterMessages {
      * <code>required int32 addressIndex = 1;</code>
      * @return Whether the addressIndex field is set.
      */
+    @java.lang.Override
     public boolean hasAddressIndex() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -13250,6 +13358,7 @@ public final class ClusterMessages {
      * <code>required int32 addressIndex = 1;</code>
      * @return The addressIndex.
      */
+    @java.lang.Override
     public int getAddressIndex() {
       return addressIndex_;
     }
@@ -13260,14 +13369,14 @@ public final class ClusterMessages {
      * <code>required .ReachabilityStatus status = 3;</code>
      * @return Whether the status field is set.
      */
-    public boolean hasStatus() {
+    @java.lang.Override public boolean hasStatus() {
       return ((bitField0_ & 0x00000002) != 0);
     }
     /**
      * <code>required .ReachabilityStatus status = 3;</code>
      * @return The status.
      */
-    public akka.cluster.protobuf.msg.ClusterMessages.ReachabilityStatus getStatus() {
+    @java.lang.Override public akka.cluster.protobuf.msg.ClusterMessages.ReachabilityStatus getStatus() {
       @SuppressWarnings("deprecation")
       akka.cluster.protobuf.msg.ClusterMessages.ReachabilityStatus result = akka.cluster.protobuf.msg.ClusterMessages.ReachabilityStatus.valueOf(status_);
       return result == null ? akka.cluster.protobuf.msg.ClusterMessages.ReachabilityStatus.Reachable : result;
@@ -13279,6 +13388,7 @@ public final class ClusterMessages {
      * <code>required int64 version = 4;</code>
      * @return Whether the version field is set.
      */
+    @java.lang.Override
     public boolean hasVersion() {
       return ((bitField0_ & 0x00000004) != 0);
     }
@@ -13286,6 +13396,7 @@ public final class ClusterMessages {
      * <code>required int64 version = 4;</code>
      * @return The version.
      */
+    @java.lang.Override
     public long getVersion() {
       return version_;
     }
@@ -13680,6 +13791,7 @@ public final class ClusterMessages {
        * <code>required int32 addressIndex = 1;</code>
        * @return Whether the addressIndex field is set.
        */
+      @java.lang.Override
       public boolean hasAddressIndex() {
         return ((bitField0_ & 0x00000001) != 0);
       }
@@ -13687,6 +13799,7 @@ public final class ClusterMessages {
        * <code>required int32 addressIndex = 1;</code>
        * @return The addressIndex.
        */
+      @java.lang.Override
       public int getAddressIndex() {
         return addressIndex_;
       }
@@ -13717,13 +13830,14 @@ public final class ClusterMessages {
        * <code>required .ReachabilityStatus status = 3;</code>
        * @return Whether the status field is set.
        */
-      public boolean hasStatus() {
+      @java.lang.Override public boolean hasStatus() {
         return ((bitField0_ & 0x00000002) != 0);
       }
       /**
        * <code>required .ReachabilityStatus status = 3;</code>
        * @return The status.
        */
+      @java.lang.Override
       public akka.cluster.protobuf.msg.ClusterMessages.ReachabilityStatus getStatus() {
         @SuppressWarnings("deprecation")
         akka.cluster.protobuf.msg.ClusterMessages.ReachabilityStatus result = akka.cluster.protobuf.msg.ClusterMessages.ReachabilityStatus.valueOf(status_);
@@ -13759,6 +13873,7 @@ public final class ClusterMessages {
        * <code>required int64 version = 4;</code>
        * @return Whether the version field is set.
        */
+      @java.lang.Override
       public boolean hasVersion() {
         return ((bitField0_ & 0x00000004) != 0);
       }
@@ -13766,6 +13881,7 @@ public final class ClusterMessages {
        * <code>required int64 version = 4;</code>
        * @return The version.
        */
+      @java.lang.Override
       public long getVersion() {
         return version_;
       }
@@ -13872,7 +13988,7 @@ public final class ClusterMessages {
   /**
    * Protobuf type {@code Tombstone}
    */
-  public  static final class Tombstone extends
+  public static final class Tombstone extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:Tombstone)
       TombstoneOrBuilder {
@@ -13964,6 +14080,7 @@ public final class ClusterMessages {
      * <code>required int32 addressIndex = 1;</code>
      * @return Whether the addressIndex field is set.
      */
+    @java.lang.Override
     public boolean hasAddressIndex() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -13971,6 +14088,7 @@ public final class ClusterMessages {
      * <code>required int32 addressIndex = 1;</code>
      * @return The addressIndex.
      */
+    @java.lang.Override
     public int getAddressIndex() {
       return addressIndex_;
     }
@@ -13981,6 +14099,7 @@ public final class ClusterMessages {
      * <code>required int64 timestamp = 2;</code>
      * @return Whether the timestamp field is set.
      */
+    @java.lang.Override
     public boolean hasTimestamp() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -13988,6 +14107,7 @@ public final class ClusterMessages {
      * <code>required int64 timestamp = 2;</code>
      * @return The timestamp.
      */
+    @java.lang.Override
     public long getTimestamp() {
       return timestamp_;
     }
@@ -14351,6 +14471,7 @@ public final class ClusterMessages {
        * <code>required int32 addressIndex = 1;</code>
        * @return Whether the addressIndex field is set.
        */
+      @java.lang.Override
       public boolean hasAddressIndex() {
         return ((bitField0_ & 0x00000001) != 0);
       }
@@ -14358,6 +14479,7 @@ public final class ClusterMessages {
        * <code>required int32 addressIndex = 1;</code>
        * @return The addressIndex.
        */
+      @java.lang.Override
       public int getAddressIndex() {
         return addressIndex_;
       }
@@ -14388,6 +14510,7 @@ public final class ClusterMessages {
        * <code>required int64 timestamp = 2;</code>
        * @return Whether the timestamp field is set.
        */
+      @java.lang.Override
       public boolean hasTimestamp() {
         return ((bitField0_ & 0x00000002) != 0);
       }
@@ -14395,6 +14518,7 @@ public final class ClusterMessages {
        * <code>required int64 timestamp = 2;</code>
        * @return The timestamp.
        */
+      @java.lang.Override
       public long getTimestamp() {
         return timestamp_;
       }
@@ -14545,7 +14669,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code Member}
    */
-  public  static final class Member extends
+  public static final class Member extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:Member)
       MemberOrBuilder {
@@ -14680,6 +14804,7 @@ public final class ClusterMessages {
      * <code>required int32 addressIndex = 1;</code>
      * @return Whether the addressIndex field is set.
      */
+    @java.lang.Override
     public boolean hasAddressIndex() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -14687,6 +14812,7 @@ public final class ClusterMessages {
      * <code>required int32 addressIndex = 1;</code>
      * @return The addressIndex.
      */
+    @java.lang.Override
     public int getAddressIndex() {
       return addressIndex_;
     }
@@ -14697,6 +14823,7 @@ public final class ClusterMessages {
      * <code>required int32 upNumber = 2;</code>
      * @return Whether the upNumber field is set.
      */
+    @java.lang.Override
     public boolean hasUpNumber() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -14704,6 +14831,7 @@ public final class ClusterMessages {
      * <code>required int32 upNumber = 2;</code>
      * @return The upNumber.
      */
+    @java.lang.Override
     public int getUpNumber() {
       return upNumber_;
     }
@@ -14714,14 +14842,14 @@ public final class ClusterMessages {
      * <code>required .MemberStatus status = 3;</code>
      * @return Whether the status field is set.
      */
-    public boolean hasStatus() {
+    @java.lang.Override public boolean hasStatus() {
       return ((bitField0_ & 0x00000004) != 0);
     }
     /**
      * <code>required .MemberStatus status = 3;</code>
      * @return The status.
      */
-    public akka.cluster.protobuf.msg.ClusterMessages.MemberStatus getStatus() {
+    @java.lang.Override public akka.cluster.protobuf.msg.ClusterMessages.MemberStatus getStatus() {
       @SuppressWarnings("deprecation")
       akka.cluster.protobuf.msg.ClusterMessages.MemberStatus result = akka.cluster.protobuf.msg.ClusterMessages.MemberStatus.valueOf(status_);
       return result == null ? akka.cluster.protobuf.msg.ClusterMessages.MemberStatus.Joining : result;
@@ -14733,6 +14861,7 @@ public final class ClusterMessages {
      * <code>repeated int32 rolesIndexes = 4 [packed = true];</code>
      * @return A list containing the rolesIndexes.
      */
+    @java.lang.Override
     public java.util.List<java.lang.Integer>
         getRolesIndexesList() {
       return rolesIndexes_;
@@ -14760,6 +14889,7 @@ public final class ClusterMessages {
      * <code>optional int32 appVersionIndex = 5;</code>
      * @return Whether the appVersionIndex field is set.
      */
+    @java.lang.Override
     public boolean hasAppVersionIndex() {
       return ((bitField0_ & 0x00000008) != 0);
     }
@@ -14767,6 +14897,7 @@ public final class ClusterMessages {
      * <code>optional int32 appVersionIndex = 5;</code>
      * @return The appVersionIndex.
      */
+    @java.lang.Override
     public int getAppVersionIndex() {
       return appVersionIndex_;
     }
@@ -15235,6 +15366,7 @@ public final class ClusterMessages {
        * <code>required int32 addressIndex = 1;</code>
        * @return Whether the addressIndex field is set.
        */
+      @java.lang.Override
       public boolean hasAddressIndex() {
         return ((bitField0_ & 0x00000001) != 0);
       }
@@ -15242,6 +15374,7 @@ public final class ClusterMessages {
        * <code>required int32 addressIndex = 1;</code>
        * @return The addressIndex.
        */
+      @java.lang.Override
       public int getAddressIndex() {
         return addressIndex_;
       }
@@ -15272,6 +15405,7 @@ public final class ClusterMessages {
        * <code>required int32 upNumber = 2;</code>
        * @return Whether the upNumber field is set.
        */
+      @java.lang.Override
       public boolean hasUpNumber() {
         return ((bitField0_ & 0x00000002) != 0);
       }
@@ -15279,6 +15413,7 @@ public final class ClusterMessages {
        * <code>required int32 upNumber = 2;</code>
        * @return The upNumber.
        */
+      @java.lang.Override
       public int getUpNumber() {
         return upNumber_;
       }
@@ -15309,13 +15444,14 @@ public final class ClusterMessages {
        * <code>required .MemberStatus status = 3;</code>
        * @return Whether the status field is set.
        */
-      public boolean hasStatus() {
+      @java.lang.Override public boolean hasStatus() {
         return ((bitField0_ & 0x00000004) != 0);
       }
       /**
        * <code>required .MemberStatus status = 3;</code>
        * @return The status.
        */
+      @java.lang.Override
       public akka.cluster.protobuf.msg.ClusterMessages.MemberStatus getStatus() {
         @SuppressWarnings("deprecation")
         akka.cluster.protobuf.msg.ClusterMessages.MemberStatus result = akka.cluster.protobuf.msg.ClusterMessages.MemberStatus.valueOf(status_);
@@ -15430,6 +15566,7 @@ public final class ClusterMessages {
        * <code>optional int32 appVersionIndex = 5;</code>
        * @return Whether the appVersionIndex field is set.
        */
+      @java.lang.Override
       public boolean hasAppVersionIndex() {
         return ((bitField0_ & 0x00000010) != 0);
       }
@@ -15437,6 +15574,7 @@ public final class ClusterMessages {
        * <code>optional int32 appVersionIndex = 5;</code>
        * @return The appVersionIndex.
        */
+      @java.lang.Override
       public int getAppVersionIndex() {
         return appVersionIndex_;
       }
@@ -15783,6 +15921,7 @@ public final class ClusterMessages {
        * <code>required int32 hashIndex = 1;</code>
        * @return Whether the hashIndex field is set.
        */
+      @java.lang.Override
       public boolean hasHashIndex() {
         return ((bitField0_ & 0x00000001) != 0);
       }
@@ -15790,6 +15929,7 @@ public final class ClusterMessages {
        * <code>required int32 hashIndex = 1;</code>
        * @return The hashIndex.
        */
+      @java.lang.Override
       public int getHashIndex() {
         return hashIndex_;
       }
@@ -15800,6 +15940,7 @@ public final class ClusterMessages {
        * <code>required int64 timestamp = 2;</code>
        * @return Whether the timestamp field is set.
        */
+      @java.lang.Override
       public boolean hasTimestamp() {
         return ((bitField0_ & 0x00000002) != 0);
       }
@@ -15807,6 +15948,7 @@ public final class ClusterMessages {
        * <code>required int64 timestamp = 2;</code>
        * @return The timestamp.
        */
+      @java.lang.Override
       public long getTimestamp() {
         return timestamp_;
       }
@@ -15977,23 +16119,23 @@ public final class ClusterMessages {
       }
 
       @java.lang.Override
-      public Version.Builder newBuilderForType() { return newBuilder(); }
-      public static Version.Builder newBuilder() {
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder() {
         return DEFAULT_INSTANCE.toBuilder();
       }
       public static Builder newBuilder(akka.cluster.protobuf.msg.ClusterMessages.VectorClock.Version prototype) {
         return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
       }
       @java.lang.Override
-      public Version.Builder toBuilder() {
+      public Builder toBuilder() {
         return this == DEFAULT_INSTANCE
-            ? new Version.Builder() : new Version.Builder().mergeFrom(this);
+            ? new Builder() : new Builder().mergeFrom(this);
       }
 
       @java.lang.Override
-      protected Version.Builder newBuilderForType(
+      protected Builder newBuilderForType(
           akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
-        Version.Builder builder = new Version.Builder(parent);
+        Builder builder = new Builder(parent);
         return builder;
       }
       /**
@@ -16170,6 +16312,7 @@ public final class ClusterMessages {
          * <code>required int32 hashIndex = 1;</code>
          * @return Whether the hashIndex field is set.
          */
+        @java.lang.Override
         public boolean hasHashIndex() {
           return ((bitField0_ & 0x00000001) != 0);
         }
@@ -16177,6 +16320,7 @@ public final class ClusterMessages {
          * <code>required int32 hashIndex = 1;</code>
          * @return The hashIndex.
          */
+        @java.lang.Override
         public int getHashIndex() {
           return hashIndex_;
         }
@@ -16207,6 +16351,7 @@ public final class ClusterMessages {
          * <code>required int64 timestamp = 2;</code>
          * @return Whether the timestamp field is set.
          */
+        @java.lang.Override
         public boolean hasTimestamp() {
           return ((bitField0_ & 0x00000002) != 0);
         }
@@ -16214,6 +16359,7 @@ public final class ClusterMessages {
          * <code>required int64 timestamp = 2;</code>
          * @return The timestamp.
          */
+        @java.lang.Override
         public long getTimestamp() {
           return timestamp_;
         }
@@ -16302,6 +16448,7 @@ public final class ClusterMessages {
      * <code>optional int64 timestamp = 1;</code>
      * @return Whether the timestamp field is set.
      */
+    @java.lang.Override
     public boolean hasTimestamp() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -16313,6 +16460,7 @@ public final class ClusterMessages {
      * <code>optional int64 timestamp = 1;</code>
      * @return The timestamp.
      */
+    @java.lang.Override
     public long getTimestamp() {
       return timestamp_;
     }
@@ -16322,12 +16470,14 @@ public final class ClusterMessages {
     /**
      * <code>repeated .VectorClock.Version versions = 2;</code>
      */
+    @java.lang.Override
     public java.util.List<akka.cluster.protobuf.msg.ClusterMessages.VectorClock.Version> getVersionsList() {
       return versions_;
     }
     /**
      * <code>repeated .VectorClock.Version versions = 2;</code>
      */
+    @java.lang.Override
     public java.util.List<? extends akka.cluster.protobuf.msg.ClusterMessages.VectorClock.VersionOrBuilder> 
         getVersionsOrBuilderList() {
       return versions_;
@@ -16335,18 +16485,21 @@ public final class ClusterMessages {
     /**
      * <code>repeated .VectorClock.Version versions = 2;</code>
      */
+    @java.lang.Override
     public int getVersionsCount() {
       return versions_.size();
     }
     /**
      * <code>repeated .VectorClock.Version versions = 2;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.VectorClock.Version getVersions(int index) {
       return versions_.get(index);
     }
     /**
      * <code>repeated .VectorClock.Version versions = 2;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.VectorClock.VersionOrBuilder getVersionsOrBuilder(
         int index) {
       return versions_.get(index);
@@ -16747,6 +16900,7 @@ public final class ClusterMessages {
        * <code>optional int64 timestamp = 1;</code>
        * @return Whether the timestamp field is set.
        */
+      @java.lang.Override
       public boolean hasTimestamp() {
         return ((bitField0_ & 0x00000001) != 0);
       }
@@ -16758,6 +16912,7 @@ public final class ClusterMessages {
        * <code>optional int64 timestamp = 1;</code>
        * @return The timestamp.
        */
+      @java.lang.Override
       public long getTimestamp() {
         return timestamp_;
       }
@@ -17095,7 +17250,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code Empty}
    */
-  public  static final class Empty extends
+  public static final class Empty extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:Empty)
       EmptyOrBuilder {
@@ -17585,7 +17740,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code Address}
    */
-  public  static final class Address extends
+  public static final class Address extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:Address)
       AddressOrBuilder {
@@ -17693,6 +17848,7 @@ public final class ClusterMessages {
      * <code>required string system = 1;</code>
      * @return Whether the system field is set.
      */
+    @java.lang.Override
     public boolean hasSystem() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -17700,6 +17856,7 @@ public final class ClusterMessages {
      * <code>required string system = 1;</code>
      * @return The system.
      */
+    @java.lang.Override
     public java.lang.String getSystem() {
       java.lang.Object ref = system_;
       if (ref instanceof java.lang.String) {
@@ -17718,6 +17875,7 @@ public final class ClusterMessages {
      * <code>required string system = 1;</code>
      * @return The bytes for system.
      */
+    @java.lang.Override
     public akka.protobufv3.internal.ByteString
         getSystemBytes() {
       java.lang.Object ref = system_;
@@ -17738,6 +17896,7 @@ public final class ClusterMessages {
      * <code>required string hostname = 2;</code>
      * @return Whether the hostname field is set.
      */
+    @java.lang.Override
     public boolean hasHostname() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -17745,6 +17904,7 @@ public final class ClusterMessages {
      * <code>required string hostname = 2;</code>
      * @return The hostname.
      */
+    @java.lang.Override
     public java.lang.String getHostname() {
       java.lang.Object ref = hostname_;
       if (ref instanceof java.lang.String) {
@@ -17763,6 +17923,7 @@ public final class ClusterMessages {
      * <code>required string hostname = 2;</code>
      * @return The bytes for hostname.
      */
+    @java.lang.Override
     public akka.protobufv3.internal.ByteString
         getHostnameBytes() {
       java.lang.Object ref = hostname_;
@@ -17783,6 +17944,7 @@ public final class ClusterMessages {
      * <code>required uint32 port = 3;</code>
      * @return Whether the port field is set.
      */
+    @java.lang.Override
     public boolean hasPort() {
       return ((bitField0_ & 0x00000004) != 0);
     }
@@ -17790,6 +17952,7 @@ public final class ClusterMessages {
      * <code>required uint32 port = 3;</code>
      * @return The port.
      */
+    @java.lang.Override
     public int getPort() {
       return port_;
     }
@@ -17800,6 +17963,7 @@ public final class ClusterMessages {
      * <code>optional string protocol = 4;</code>
      * @return Whether the protocol field is set.
      */
+    @java.lang.Override
     public boolean hasProtocol() {
       return ((bitField0_ & 0x00000008) != 0);
     }
@@ -17807,6 +17971,7 @@ public final class ClusterMessages {
      * <code>optional string protocol = 4;</code>
      * @return The protocol.
      */
+    @java.lang.Override
     public java.lang.String getProtocol() {
       java.lang.Object ref = protocol_;
       if (ref instanceof java.lang.String) {
@@ -17825,6 +17990,7 @@ public final class ClusterMessages {
      * <code>optional string protocol = 4;</code>
      * @return The bytes for protocol.
      */
+    @java.lang.Override
     public akka.protobufv3.internal.ByteString
         getProtocolBytes() {
       java.lang.Object ref = protocol_;
@@ -18430,6 +18596,7 @@ public final class ClusterMessages {
        * <code>required uint32 port = 3;</code>
        * @return Whether the port field is set.
        */
+      @java.lang.Override
       public boolean hasPort() {
         return ((bitField0_ & 0x00000004) != 0);
       }
@@ -18437,6 +18604,7 @@ public final class ClusterMessages {
        * <code>required uint32 port = 3;</code>
        * @return The port.
        */
+      @java.lang.Override
       public int getPort() {
         return port_;
       }
@@ -18655,7 +18823,7 @@ public final class ClusterMessages {
    *
    * Protobuf type {@code UniqueAddress}
    */
-  public  static final class UniqueAddress extends
+  public static final class UniqueAddress extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:UniqueAddress)
       UniqueAddressOrBuilder {
@@ -18760,6 +18928,7 @@ public final class ClusterMessages {
      * <code>required .Address address = 1;</code>
      * @return Whether the address field is set.
      */
+    @java.lang.Override
     public boolean hasAddress() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -18767,12 +18936,14 @@ public final class ClusterMessages {
      * <code>required .Address address = 1;</code>
      * @return The address.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.Address getAddress() {
       return address_ == null ? akka.cluster.protobuf.msg.ClusterMessages.Address.getDefaultInstance() : address_;
     }
     /**
      * <code>required .Address address = 1;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.AddressOrBuilder getAddressOrBuilder() {
       return address_ == null ? akka.cluster.protobuf.msg.ClusterMessages.Address.getDefaultInstance() : address_;
     }
@@ -18783,6 +18954,7 @@ public final class ClusterMessages {
      * <code>required uint32 uid = 2;</code>
      * @return Whether the uid field is set.
      */
+    @java.lang.Override
     public boolean hasUid() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -18790,6 +18962,7 @@ public final class ClusterMessages {
      * <code>required uint32 uid = 2;</code>
      * @return The uid.
      */
+    @java.lang.Override
     public int getUid() {
       return uid_;
     }
@@ -18804,6 +18977,7 @@ public final class ClusterMessages {
      * <code>optional uint32 uid2 = 3;</code>
      * @return Whether the uid2 field is set.
      */
+    @java.lang.Override
     public boolean hasUid2() {
       return ((bitField0_ & 0x00000004) != 0);
     }
@@ -18815,6 +18989,7 @@ public final class ClusterMessages {
      * <code>optional uint32 uid2 = 3;</code>
      * @return The uid2.
      */
+    @java.lang.Override
     public int getUid2() {
       return uid2_;
     }
@@ -19343,6 +19518,7 @@ public final class ClusterMessages {
        * <code>required uint32 uid = 2;</code>
        * @return Whether the uid field is set.
        */
+      @java.lang.Override
       public boolean hasUid() {
         return ((bitField0_ & 0x00000002) != 0);
       }
@@ -19350,6 +19526,7 @@ public final class ClusterMessages {
        * <code>required uint32 uid = 2;</code>
        * @return The uid.
        */
+      @java.lang.Override
       public int getUid() {
         return uid_;
       }
@@ -19384,6 +19561,7 @@ public final class ClusterMessages {
        * <code>optional uint32 uid2 = 3;</code>
        * @return Whether the uid2 field is set.
        */
+      @java.lang.Override
       public boolean hasUid2() {
         return ((bitField0_ & 0x00000004) != 0);
       }
@@ -19395,6 +19573,7 @@ public final class ClusterMessages {
        * <code>optional uint32 uid2 = 3;</code>
        * @return The uid2.
        */
+      @java.lang.Override
       public int getUid2() {
         return uid2_;
       }
@@ -19517,7 +19696,7 @@ public final class ClusterMessages {
   /**
    * Protobuf type {@code ClusterRouterPool}
    */
-  public  static final class ClusterRouterPool extends
+  public static final class ClusterRouterPool extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:ClusterRouterPool)
       ClusterRouterPoolOrBuilder {
@@ -19625,6 +19804,7 @@ public final class ClusterMessages {
      * <code>required .Pool pool = 1;</code>
      * @return Whether the pool field is set.
      */
+    @java.lang.Override
     public boolean hasPool() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -19632,12 +19812,14 @@ public final class ClusterMessages {
      * <code>required .Pool pool = 1;</code>
      * @return The pool.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.Pool getPool() {
       return pool_ == null ? akka.cluster.protobuf.msg.ClusterMessages.Pool.getDefaultInstance() : pool_;
     }
     /**
      * <code>required .Pool pool = 1;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.PoolOrBuilder getPoolOrBuilder() {
       return pool_ == null ? akka.cluster.protobuf.msg.ClusterMessages.Pool.getDefaultInstance() : pool_;
     }
@@ -19648,6 +19830,7 @@ public final class ClusterMessages {
      * <code>required .ClusterRouterPoolSettings settings = 2;</code>
      * @return Whether the settings field is set.
      */
+    @java.lang.Override
     public boolean hasSettings() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -19655,12 +19838,14 @@ public final class ClusterMessages {
      * <code>required .ClusterRouterPoolSettings settings = 2;</code>
      * @return The settings.
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.ClusterRouterPoolSettings getSettings() {
       return settings_ == null ? akka.cluster.protobuf.msg.ClusterMessages.ClusterRouterPoolSettings.getDefaultInstance() : settings_;
     }
     /**
      * <code>required .ClusterRouterPoolSettings settings = 2;</code>
      */
+    @java.lang.Override
     public akka.cluster.protobuf.msg.ClusterMessages.ClusterRouterPoolSettingsOrBuilder getSettingsOrBuilder() {
       return settings_ == null ? akka.cluster.protobuf.msg.ClusterMessages.ClusterRouterPoolSettings.getDefaultInstance() : settings_;
     }
@@ -20388,7 +20573,7 @@ public final class ClusterMessages {
   /**
    * Protobuf type {@code Pool}
    */
-  public  static final class Pool extends
+  public static final class Pool extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:Pool)
       PoolOrBuilder {
@@ -20488,6 +20673,7 @@ public final class ClusterMessages {
      * <code>required uint32 serializerId = 1;</code>
      * @return Whether the serializerId field is set.
      */
+    @java.lang.Override
     public boolean hasSerializerId() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -20495,6 +20681,7 @@ public final class ClusterMessages {
      * <code>required uint32 serializerId = 1;</code>
      * @return The serializerId.
      */
+    @java.lang.Override
     public int getSerializerId() {
       return serializerId_;
     }
@@ -20505,6 +20692,7 @@ public final class ClusterMessages {
      * <code>required string manifest = 2;</code>
      * @return Whether the manifest field is set.
      */
+    @java.lang.Override
     public boolean hasManifest() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -20512,6 +20700,7 @@ public final class ClusterMessages {
      * <code>required string manifest = 2;</code>
      * @return The manifest.
      */
+    @java.lang.Override
     public java.lang.String getManifest() {
       java.lang.Object ref = manifest_;
       if (ref instanceof java.lang.String) {
@@ -20530,6 +20719,7 @@ public final class ClusterMessages {
      * <code>required string manifest = 2;</code>
      * @return The bytes for manifest.
      */
+    @java.lang.Override
     public akka.protobufv3.internal.ByteString
         getManifestBytes() {
       java.lang.Object ref = manifest_;
@@ -20550,6 +20740,7 @@ public final class ClusterMessages {
      * <code>required bytes data = 3;</code>
      * @return Whether the data field is set.
      */
+    @java.lang.Override
     public boolean hasData() {
       return ((bitField0_ & 0x00000004) != 0);
     }
@@ -20557,6 +20748,7 @@ public final class ClusterMessages {
      * <code>required bytes data = 3;</code>
      * @return The data.
      */
+    @java.lang.Override
     public akka.protobufv3.internal.ByteString getData() {
       return data_;
     }
@@ -20952,6 +21144,7 @@ public final class ClusterMessages {
        * <code>required uint32 serializerId = 1;</code>
        * @return Whether the serializerId field is set.
        */
+      @java.lang.Override
       public boolean hasSerializerId() {
         return ((bitField0_ & 0x00000001) != 0);
       }
@@ -20959,6 +21152,7 @@ public final class ClusterMessages {
        * <code>required uint32 serializerId = 1;</code>
        * @return The serializerId.
        */
+      @java.lang.Override
       public int getSerializerId() {
         return serializerId_;
       }
@@ -21073,6 +21267,7 @@ public final class ClusterMessages {
        * <code>required bytes data = 3;</code>
        * @return Whether the data field is set.
        */
+      @java.lang.Override
       public boolean hasData() {
         return ((bitField0_ & 0x00000004) != 0);
       }
@@ -21080,6 +21275,7 @@ public final class ClusterMessages {
        * <code>required bytes data = 3;</code>
        * @return The data.
        */
+      @java.lang.Override
       public akka.protobufv3.internal.ByteString getData() {
         return data_;
       }
@@ -21242,7 +21438,7 @@ public final class ClusterMessages {
   /**
    * Protobuf type {@code ClusterRouterPoolSettings}
    */
-  public  static final class ClusterRouterPoolSettings extends
+  public static final class ClusterRouterPoolSettings extends
       akka.protobufv3.internal.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:ClusterRouterPoolSettings)
       ClusterRouterPoolSettingsOrBuilder {
@@ -21359,6 +21555,7 @@ public final class ClusterMessages {
      * <code>required uint32 totalInstances = 1;</code>
      * @return Whether the totalInstances field is set.
      */
+    @java.lang.Override
     public boolean hasTotalInstances() {
       return ((bitField0_ & 0x00000001) != 0);
     }
@@ -21366,6 +21563,7 @@ public final class ClusterMessages {
      * <code>required uint32 totalInstances = 1;</code>
      * @return The totalInstances.
      */
+    @java.lang.Override
     public int getTotalInstances() {
       return totalInstances_;
     }
@@ -21376,6 +21574,7 @@ public final class ClusterMessages {
      * <code>required uint32 maxInstancesPerNode = 2;</code>
      * @return Whether the maxInstancesPerNode field is set.
      */
+    @java.lang.Override
     public boolean hasMaxInstancesPerNode() {
       return ((bitField0_ & 0x00000002) != 0);
     }
@@ -21383,6 +21582,7 @@ public final class ClusterMessages {
      * <code>required uint32 maxInstancesPerNode = 2;</code>
      * @return The maxInstancesPerNode.
      */
+    @java.lang.Override
     public int getMaxInstancesPerNode() {
       return maxInstancesPerNode_;
     }
@@ -21393,6 +21593,7 @@ public final class ClusterMessages {
      * <code>required bool allowLocalRoutees = 3;</code>
      * @return Whether the allowLocalRoutees field is set.
      */
+    @java.lang.Override
     public boolean hasAllowLocalRoutees() {
       return ((bitField0_ & 0x00000004) != 0);
     }
@@ -21400,6 +21601,7 @@ public final class ClusterMessages {
      * <code>required bool allowLocalRoutees = 3;</code>
      * @return The allowLocalRoutees.
      */
+    @java.lang.Override
     public boolean getAllowLocalRoutees() {
       return allowLocalRoutees_;
     }
@@ -21410,6 +21612,7 @@ public final class ClusterMessages {
      * <code>optional string useRole = 4;</code>
      * @return Whether the useRole field is set.
      */
+    @java.lang.Override
     public boolean hasUseRole() {
       return ((bitField0_ & 0x00000008) != 0);
     }
@@ -21417,6 +21620,7 @@ public final class ClusterMessages {
      * <code>optional string useRole = 4;</code>
      * @return The useRole.
      */
+    @java.lang.Override
     public java.lang.String getUseRole() {
       java.lang.Object ref = useRole_;
       if (ref instanceof java.lang.String) {
@@ -21435,6 +21639,7 @@ public final class ClusterMessages {
      * <code>optional string useRole = 4;</code>
      * @return The bytes for useRole.
      */
+    @java.lang.Override
     public akka.protobufv3.internal.ByteString
         getUseRoleBytes() {
       java.lang.Object ref = useRole_;
@@ -21935,6 +22140,7 @@ public final class ClusterMessages {
        * <code>required uint32 totalInstances = 1;</code>
        * @return Whether the totalInstances field is set.
        */
+      @java.lang.Override
       public boolean hasTotalInstances() {
         return ((bitField0_ & 0x00000001) != 0);
       }
@@ -21942,6 +22148,7 @@ public final class ClusterMessages {
        * <code>required uint32 totalInstances = 1;</code>
        * @return The totalInstances.
        */
+      @java.lang.Override
       public int getTotalInstances() {
         return totalInstances_;
       }
@@ -21972,6 +22179,7 @@ public final class ClusterMessages {
        * <code>required uint32 maxInstancesPerNode = 2;</code>
        * @return Whether the maxInstancesPerNode field is set.
        */
+      @java.lang.Override
       public boolean hasMaxInstancesPerNode() {
         return ((bitField0_ & 0x00000002) != 0);
       }
@@ -21979,6 +22187,7 @@ public final class ClusterMessages {
        * <code>required uint32 maxInstancesPerNode = 2;</code>
        * @return The maxInstancesPerNode.
        */
+      @java.lang.Override
       public int getMaxInstancesPerNode() {
         return maxInstancesPerNode_;
       }
@@ -22009,6 +22218,7 @@ public final class ClusterMessages {
        * <code>required bool allowLocalRoutees = 3;</code>
        * @return Whether the allowLocalRoutees field is set.
        */
+      @java.lang.Override
       public boolean hasAllowLocalRoutees() {
         return ((bitField0_ & 0x00000004) != 0);
       }
@@ -22016,6 +22226,7 @@ public final class ClusterMessages {
        * <code>required bool allowLocalRoutees = 3;</code>
        * @return The allowLocalRoutees.
        */
+      @java.lang.Override
       public boolean getAllowLocalRoutees() {
         return allowLocalRoutees_;
       }


### PR DESCRIPTION
This is just an experiment. Still very hacky and very incomplete. 

The main idea is to have Entities directly available at ActorSystem level and not only when using cluster sharding. 
This is very similar to Orleans' Virtual Actors where actor instantiation and lifecycle is managed by the actor system instead of by the user. 

The basic API in this PR look as following:

```scala
val typeKey = akka.actor.typed.EntityTypeKey[Foo]("my-foo-entity")
system.initEntity(akka.actor.typed.Entity(typeKey)(ctx => behavior(ctx.shard)))

val entity: EntityRef[Foo] = system.entityRefFor(typeKey, "abc")
```

Note: `akka.actor.typed.EntityTypeKey` and `akka.actor.typed.Entity`. New types in akka-actor-typed, so not reusing the existing sharding types.

Like with cluster sharding, the Entity is an Actor that is managed by Akka. Akka would know if there is one already instantiated for id "abc" and decide if the Actor needs to start or not. Akka would also be responsible for passivating that same Actor. 

If the current Actor System is using cluster, then the above would result in a clustered entity (sharded) instead of a local Entity. So there is two possible code paths behind `system.initEntity` and `system.entityRefFor`. 

* For non-clustered actor systems, this entity will be a local actor managed by Akka. Not implemented yet. 
* For clustered actor system, the `akka.actor.typed.Entity` needs to be converted to a `akka.cluster.sharding.typed.scaladsl.Entity` (or javadsl) and registered as a cluster sharding entity. The current conversion is incomplete and only support the most basic configs. 

The approach in this PR (duplicating and converting types) is a little heavy and fastidious, but gives a clean API to the users. 

Another approach for local entities can be to not try to make then transparent. We could introduce a `LocalEntity` type to be used directly on the Actor System with similar functionality as a sharded entity (managed instantiation, passivation, etc), but explicitly local. 

That will simplify things a lot, IMO. Not sure if it's worth the complexity of duplicating the types and do all the conversion. If an user starts with a LocalEntity and later decide to move to Sharded Entity, the code refactoring should be minimal. 

We could also imagine a situation in which we do have an Akka Cluster, but we want a particular actor to be a local entity. In that case, it will be good to have an explicit LocalEntity.

Also, such LocalEntity overlaps with some of the functionality provided by the Receptionist. If we can get an instance of an actor by using a type key and an ID, we may not need to use Receptionist. Or course, their might be valid cases for Receptionist. 




