### PR TITLE
Hardening of JoinConfigCompatCheckerRollingUpdateSpec, #30769

### DIFF
--- a/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatCheckerRollingUpdateSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatCheckerRollingUpdateSpec.scala
@@ -17,13 +17,14 @@ object JoinConfigCompatCheckerRollingUpdateSpec {
       akka.log-dead-letters = off
       akka.log-dead-letters-during-shutdown = off
       akka.remote.log-remote-lifecycle-events = off
-      akka.cluster.jmx.enabled = off
-      akka.cluster.gossip-interval                   = 100 ms
-      akka.cluster.leader-actions-interval           = 100 ms
-      akka.cluster.unreachable-nodes-reaper-interval = 100 ms
-      akka.cluster.periodic-tasks-initial-delay      = 100 ms
-      akka.cluster.publish-stats-interval            = 0 s
-      failure-detector.heartbeat-interval            = 100 ms
+      akka.cluster {
+        jmx.enabled                         = off
+        gossip-interval                     = 200 ms
+        leader-actions-interval             = 200 ms
+        unreachable-nodes-reaper-interval   = 500 ms
+        periodic-tasks-initial-delay        = 300 ms
+        publish-stats-interval              = 0 s # always, when it happens
+      }
     """).withFallback(JoinConfigCompatCheckerSpec.baseConfig)
 
   val v1Config: Config = baseConfig.withFallback(JoinConfigCompatCheckerSpec.configWithChecker)
@@ -47,7 +48,7 @@ class JoinConfigCompatCheckerRollingUpdateSpec
   import JoinConfigCompatCheckerRollingUpdateSpec._
 
   "A Node" must {
-    val timeout = 15.seconds
+    val timeout = 20.seconds
     "NOT be allowed to re-join a cluster if it has a new, additional configuration the others do not have and not the old" taggedAs LongRunningTest in {
       // confirms the 2 attempted re-joins fail with both nodes being terminated
       upgradeCluster(3, v1Config, v2ConfigIncompatible, timeout, timeout, enforced = true, shouldRejoin = false)

--- a/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatCheckerSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatCheckerSpec.scala
@@ -20,6 +20,7 @@ object JoinConfigCompatCheckerSpec {
      akka.remote.classic.netty.tcp.port = 0
      akka.remote.artery.canonical.port = 0
      akka.cluster.jmx.multi-mbeans-in-same-jvm = on
+     akka.remote.artery.advanced.aeron.idle-cpu-level = 3
      """)
 
   val configWithChecker: Config =


### PR DESCRIPTION
* fails frequently in the aeron-udp multi-node tests
* could be that it requires more resources since it's starting
  many actor systems in same jvm
* noticed heartbeat send delay in logs, but not unreachable
* adjusting config to what we have in some other tests

References #30769
