### PR TITLE
Hardening of ReplicatedEventSourcingSpec, #30842

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/ReplicatedEventSourcingSpec.scala
@@ -202,6 +202,8 @@ class ReplicatedEventSourcingSpec
       r1 ! StoreMe("Event", replyProbe.ref)
       eventProbeR1.expectMessage(EventAndContext("Event", ReplicaId("R1"), recoveryRunning = false, false))
       replyProbe.expectMessage(Done)
+      r1 ! Stop
+      replyProbe.expectTerminated(r1)
 
       val recoveryProbe = createTestProbe[EventAndContext]()
       spawn(testBehavior(entityId, "R1", recoveryProbe.ref))
@@ -370,6 +372,11 @@ class ReplicatedEventSourcingSpec
         EventAndContext("from r1", ReplicaId("R1"), recoveryRunning = false, concurrent = false))
       eventProbeR1.expectMessage(
         EventAndContext("from r2", ReplicaId("R2"), recoveryRunning = false, concurrent = true))
+
+      r1 ! Stop
+      r2 ! Stop
+      probe.expectTerminated(r1)
+      probe.expectTerminated(r2)
 
       // take 2
       val eventProbeR1Take2 = createTestProbe[EventAndContext]()


### PR DESCRIPTION
* from logs it looks like the replicated event from the first
  incarnation of the actor isn't stored before the second
  incarnation is replayed
* stop and wait for termination before starting second incarnation

References #30842

<details>
  <summary>logs</summary>

```
2021-11-12 11:24:57,557 [INFO ] [akka.actor.testkit.typed.scaladsl.LogCapturing] [] [] [] [] - Logging finished for test [akka.persistence.typed.ReplicatedEventSourcingSpec: ReplicatedEventSourcing should receive each event only once] that [Succeeded] 
1040
2021-11-12 11:24:57,558 [INFO ] [akka.actor.testkit.typed.scaladsl.LogCapturing] [] [] [] [] - Logging started for test [akka.persistence.typed.ReplicatedEventSourcingSpec: ReplicatedEventSourcing should set concurrent on replay of events] 
1041
2021-11-12 11:24:57,559 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [get-permit] [ReplicatedEventSourcingSpec|e-9|R1] - Initializing snapshot recovery: Recovery(SnapshotSelectionCriteria(9223372036854775807,9223372036854775807,0,0),9223372036854775807,9223372036854775807) 
1042
2021-11-12 11:24:57,560 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [load-snap] [ReplicatedEventSourcingSpec|e-9|R1] - Snapshot recovered from 0 Map() VersionVector() 
1043
2021-11-12 11:24:57,560 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [replay-evt] [ReplicatedEventSourcingSpec|e-9|R1] - Replaying events: from: 1, to: 9223372036854775807 
1044
2021-11-12 11:24:57,560 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [replay-evt] [ReplicatedEventSourcingSpec|e-9|R1] - Recovery successful, recovered until sequenceNr: [0] 
1045
2021-11-12 11:24:57,560 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [get-permit] [ReplicatedEventSourcingSpec|e-9|R2] - Initializing snapshot recovery: Recovery(SnapshotSelectionCriteria(9223372036854775807,9223372036854775807,0,0),9223372036854775807,9223372036854775807) 
1046
2021-11-12 11:24:57,560 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [replay-evt] [ReplicatedEventSourcingSpec|e-9|R1] - Returning recovery permit, reason: replay completed successfully 
1047
2021-11-12 11:24:57,560 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [replay-evt] [ReplicatedEventSourcingSpec|e-9|R1] - Recovery for persistenceId [PersistenceId(ReplicatedEventSourcingSpec|e-9|R1)] took 424.0 μs 
1048
2021-11-12 11:24:57,560 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [load-snap] [ReplicatedEventSourcingSpec|e-9|R2] - Snapshot recovered from 0 Map() VersionVector() 
1049
2021-11-12 11:24:57,560 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [replay-evt] [ReplicatedEventSourcingSpec|e-9|R2] - Replaying events: from: 1, to: 9223372036854775807 
1050
2021-11-12 11:24:57,560 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [replay-evt] [ReplicatedEventSourcingSpec|e-9|R2] - Recovery successful, recovered until sequenceNr: [0] 
1051
2021-11-12 11:24:57,561 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [replay-evt] [ReplicatedEventSourcingSpec|e-9|R2] - Returning recovery permit, reason: replay completed successfully 
1052
2021-11-12 11:24:57,561 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [replay-evt] [ReplicatedEventSourcingSpec|e-9|R2] - Recovery for persistenceId [PersistenceId(ReplicatedEventSourcingSpec|e-9|R2)] took 336.0 μs 
1053
2021-11-12 11:24:57,563 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [running-cmd] [ReplicatedEventSourcingSpec|e-9|R2] - Handled command [akka.persistence.typed.ReplicatedEventSourcingSpec$StoreMe], resulting effect: [Persist(java.lang.String)], side effects: [1] 
1054

>>>
2021-11-12 11:24:57,563 [TRACE] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [running-cmd] [ReplicatedEventSourcingSpec|e-9|R2] - Event persisted [String]. Version vector after: [VersionVector(R2 -> 1)] 
1055
2021-11-12 11:24:57,563 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [running-cmd] [ReplicatedEventSourcingSpec|e-9|R1] - Handled command [akka.persistence.typed.ReplicatedEventSourcingSpec$StoreMe], resulting effect: [Persist(java.lang.String)], side effects: [1] 
1056
2021-11-12 11:24:57,563 [TRACE] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [running-cmd] [ReplicatedEventSourcingSpec|e-9|R1] - Event persisted [String]. Version vector after: [VersionVector(R1 -> 1)] 
1057
2021-11-12 11:24:57,564 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [persist-evt] [ReplicatedEventSourcingSpec|e-9|R2] - Received Journal response: WriteMessagesSuccessful after: 644504 nanos 
1058
2021-11-12 11:24:57,564 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [persist-evt] [ReplicatedEventSourcingSpec|e-9|R2] - Received Journal response: WriteMessageSuccess(PersistentRepr(ReplicatedEventSourcingSpec|e-9|R2,1,ff9fe865-70fe-456f-a10e-1d1431b7727b,0,Some(ReplicatedEventMetadata(ReplicaId(R2),1,VersionVector(R2 -> 1),false))),200) after: 664404 nanos 
1059
2021-11-12 11:24:57,564 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [persist-evt] [ReplicatedEventSourcingSpec|e-9|R1] - Received Journal response: WriteMessagesSuccessful after: 607603 nanos 
1060
2021-11-12 11:24:57,564 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [persist-evt] [ReplicatedEventSourcingSpec|e-9|R1] - Received Journal response: WriteMessageSuccess(PersistentRepr(ReplicatedEventSourcingSpec|e-9|R1,1,84f5b222-6a11-4252-8339-6c1db5f5303c,0,Some(ReplicatedEventMetadata(ReplicaId(R1),1,VersionVector(R1 -> 1),false))),199) after: 615003 nanos 
1061
2021-11-12 11:24:57,564 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [running-cmd] [ReplicatedEventSourcingSpec|e-9|R2] - Replica Some(ReplicationSetup(ReplicaId(R2),Map(ReplicaId(R1) -> akka.persistence.testkit.query, ReplicaId(R2) -> akka.persistence.testkit.query, ReplicaId(R3) -> akka.persistence.testkit.query),akka.persistence.typed.internal.ReplicationContextImpl@37901f4c)) received replicated event. Replica seqs nrs: Map(). Envelope ReplicatedEventEnvelope(ReplicatedEvent(from r1,ReplicaId(R1),1,VersionVector(R1 -> 1)),Actor[akka://ReplicatedEventSourcingSpec/temp/$w$G#0]) 
1062
2021-11-12 11:24:57,564 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [running-cmd] [ReplicatedEventSourcingSpec|e-9|R2] - Saving event [1] from [ReplicaId(R1)] as first time 
1063

>>>
2021-11-12 11:24:57,564 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [running-cmd] [ReplicatedEventSourcingSpec|e-9|R2] - Processing event [String] with version [VersionVector(R1 -> 1)]. Local version: VersionVector(R2 -> 1). Updated version VersionVector(R1 -> 1, R2 -> 1). Concurrent? true 
1064
2021-11-12 11:24:57,564 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [running-cmd] [ReplicatedEventSourcingSpec|e-9|R1] - Replica Some(ReplicationSetup(ReplicaId(R1),Map(ReplicaId(R1) -> akka.persistence.testkit.query, ReplicaId(R2) -> akka.persistence.testkit.query, ReplicaId(R3) -> akka.persistence.testkit.query),akka.persistence.typed.internal.ReplicationContextImpl@26ba3f49)) received replicated event. Replica seqs nrs: Map(). Envelope ReplicatedEventEnvelope(ReplicatedEvent(from r2,ReplicaId(R2),1,VersionVector(R2 -> 1)),Actor[akka://ReplicatedEventSourcingSpec/temp/$v$H#0]) 
1065
2021-11-12 11:24:57,564 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [running-cmd] [ReplicatedEventSourcingSpec|e-9|R1] - Saving event [1] from [ReplicaId(R2)] as first time 
1066

>>>
2021-11-12 11:24:57,565 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [running-cmd] [ReplicatedEventSourcingSpec|e-9|R1] - Processing event [String] with version [VersionVector(R2 -> 1)]. Local version: VersionVector(R1 -> 1). Updated version VersionVector(R1 -> 1, R2 -> 1). Concurrent? true 
1067
2021-11-12 11:24:57,565 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$x] [get-permit] [ReplicatedEventSourcingSpec|e-9|R1] - Initializing snapshot recovery: Recovery(SnapshotSelectionCriteria(9223372036854775807,9223372036854775807,0,0),9223372036854775807,9223372036854775807) 
1068
2021-11-12 11:24:57,565 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$x] [load-snap] [ReplicatedEventSourcingSpec|e-9|R1] - Snapshot recovered from 0 Map() VersionVector() 
1069
2021-11-12 11:24:57,565 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$x] [replay-evt] [ReplicatedEventSourcingSpec|e-9|R1] - Replaying events: from: 1, to: 9223372036854775807 
1070
2021-11-12 11:24:57,566 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [persist-evt] [ReplicatedEventSourcingSpec|e-9|R2] - Received Journal response: WriteMessagesSuccessful after: 2065311 nanos 
1071
2021-11-12 11:24:57,566 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$w] [persist-evt] [ReplicatedEventSourcingSpec|e-9|R2] - Received Journal response: WriteMessageSuccess(PersistentRepr(ReplicatedEventSourcingSpec|e-9|R2,2,ff9fe865-70fe-456f-a10e-1d1431b7727b,0,Some(ReplicatedEventMetadata(ReplicaId(R1),1,VersionVector(R1 -> 1, R2 -> 1),true))),200) after: 2101011 nanos 
1072
2021-11-12 11:24:57,566 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [persist-evt] [ReplicatedEventSourcingSpec|e-9|R1] - Received Journal response: WriteMessagesSuccessful after: 896004 nanos 
1073
2021-11-12 11:24:57,566 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$v] [persist-evt] [ReplicatedEventSourcingSpec|e-9|R1] - Received Journal response: WriteMessageSuccess(PersistentRepr(ReplicatedEventSourcingSpec|e-9|R1,2,84f5b222-6a11-4252-8339-6c1db5f5303c,0,Some(ReplicatedEventMetadata(ReplicaId(R2),1,VersionVector(R1 -> 1, R2 -> 1),true))),199) after: 921905 nanos 
1074
2021-11-12 11:24:57,566 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$x] [replay-evt] [ReplicatedEventSourcingSpec|e-9|R1] - Recovery successful, recovered until sequenceNr: [1] 
1075
2021-11-12 11:24:57,566 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$x] [replay-evt] [ReplicatedEventSourcingSpec|e-9|R1] - Returning recovery permit, reason: replay completed successfully 
1076
2021-11-12 11:24:57,567 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$x] [replay-evt] [ReplicatedEventSourcingSpec|e-9|R1] - Recovery for persistenceId [PersistenceId(ReplicatedEventSourcingSpec|e-9|R1)] took 1.095 ms 
1077


2021-11-12 11:24:57,568 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$x] [running-cmd] [ReplicatedEventSourcingSpec|e-9|R1] - Replica Some(ReplicationSetup(ReplicaId(R1),Map(ReplicaId(R1) -> akka.persistence.testkit.query, ReplicaId(R2) -> akka.persistence.testkit.query, ReplicaId(R3) -> akka.persistence.testkit.query),akka.persistence.typed.internal.ReplicationContextImpl@341180de)) received replicated event. Replica seqs nrs: Map(). Envelope ReplicatedEventEnvelope(ReplicatedEvent(from r2,ReplicaId(R2),1,VersionVector(R2 -> 1)),Actor[akka://ReplicatedEventSourcingSpec/temp/$x$I#0]) 
1078
2021-11-12 11:24:57,569 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$x] [running-cmd] [ReplicatedEventSourcingSpec|e-9|R1] - Saving event [1] from [ReplicaId(R2)] as first time 
1079
2021-11-12 11:24:57,569 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$x] [running-cmd] [ReplicatedEventSourcingSpec|e-9|R1] - Processing event [String] with version [VersionVector(R2 -> 1)]. Local version: VersionVector(). Updated version VersionVector(R2 -> 1). Concurrent? false 
1080
2021-11-12 11:24:57,570 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$x] [persist-evt] [ReplicatedEventSourcingSpec|e-9|R1] - Received Journal response: WriteMessagesSuccessful after: 342902 nanos 
1081
2021-11-12 11:24:57,570 [DEBUG] [akka.persistence.typed.internal.EventSourcedBehaviorImpl] [] [akka://ReplicatedEventSourcingSpec/user/$x] [persist-evt] [ReplicatedEventSourcingSpec|e-9|R1] - Received Journal response: WriteMessageSuccess(PersistentRepr(ReplicatedEventSourcingSpec|e-9|R1,2,302df68e-840d-4a9c-91a2-eb271ac7649a,0,Some(ReplicatedEventMetadata(ReplicaId(R2),1,VersionVector(R2 -> 1),false))),201) after: 396902 nanos 
1082
2021-11-12 11:24:57,570 [INFO ] [akka.actor.testkit.typed.scaladsl.LogCapturing] [] [] [] [] - Logging finished for test [akka.persistence.typed.ReplicatedEventSourcingSpec: ReplicatedEventSourcing should set concurrent on replay of events] that [Failed(java.lang.AssertionError: expected EventAndContext(from r2,ReplicaId(R2),true,true), found EventAndContext(from r2,ReplicaId(R2),false,false))] 
1083
<-- [akka.persistence.typed.ReplicatedEventSourcingSpec: ReplicatedEventSourcing should set concurrent on replay of events] End of log messages of test that [Failed(java.lang.AssertionError: expected EventAndContext(from r2,ReplicaId(R2),true,true), found EventAndContext(from r2,ReplicaId(R2),false,false))]
1084

[info] - should set concurrent on replay of events *** FAILED *** (47 milliseconds)
1113
[info]   java.lang.AssertionError: expected EventAndContext(from r2,ReplicaId(R2),true,true), found EventAndContext(from r2,ReplicaId(R2),false,false)
1114
[info]   at akka.actor.testkit.typed.internal.TestProbeImpl.assertFail(TestProbeImpl.scala:399)
1115
[info]   at akka.actor.testkit.typed.internal.TestProbeImpl.expectMessage_internal(TestProbeImpl.scala:170)
1116
[info]   at akka.actor.testkit.typed.internal.TestProbeImpl.expectMessage(TestProbeImpl.scala:149)
1117
[info]   at akka.persistence.typed.ReplicatedEventSourcingSpec.$anonfun$new$21(ReplicatedEventSourcingSpec.scala:380)
```
</details>