### PR TITLE
Remove optional traits in EventsBySliceQuery

### DIFF
--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/EventsBySliceQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/EventsBySliceQuery.scala
@@ -22,7 +22,7 @@ import akka.stream.scaladsl.Source
  * API May Change
  */
 @ApiMayChange
-trait EventsBySliceQuery extends ReadJournal with EventTimestampQuery with LoadEventQuery {
+trait EventsBySliceQuery extends ReadJournal {
 
   /**
    * Query events for given slices. A slice is deterministically defined based on the persistence id. The purpose is to


### PR DESCRIPTION
* EventTimestampQuery and LoadEventQuery are optional, and it was an
  oversight to add them to EventsBySliceQuery
* javadsl is ok

Follow up on https://github.com/akka/akka/pull/30882 (not included in release yet)