### PR TITLE
Retry ActorSelection resolve in LargeMessagesStreamSpec, #24143

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/artery/LargeMessagesStreamSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/LargeMessagesStreamSpec.scala
@@ -149,5 +149,9 @@ class LargeMessagesStreamSpec
     }
   }
 
-  def awaitResolve(selection: ActorSelection): ActorRef = Await.result(selection.resolveOne(3.seconds), 3.seconds)
+  def awaitResolve(selection: ActorSelection): ActorRef = {
+    awaitAssert {
+      Await.result(selection.resolveOne(1.second), 1.seconds)
+    }
+  }
 }


### PR DESCRIPTION
* failed with ActorNotFound in aeron-udp multi-node tests

References #24143
