### PR TITLE
Simplify entity activity tracking for passivation strategies

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -807,7 +807,6 @@ private[akka] class Shard(
       case Active(_) =>
         if (verboseDebug)
           log.debug("{}: Request to start entity [{}] (Already started)", typeName, entityId)
-        passivationStrategy.entityTouched(entityId)
         ackTo.foreach(_ ! ShardRegion.StartEntityAck(entityId, shardId))
       case _: RememberingStart =>
         entities.rememberingStart(entityId, ackTo)
@@ -1053,8 +1052,9 @@ private[akka] class Shard(
             case Active(ref) =>
               if (verboseDebug)
                 log.debug("{}: Delivering message of type [{}] to [{}]", typeName, payload.getClass.getName, entityId)
-              passivationStrategy.entityTouched(entityId)
+              val entitiesToPassivate = passivationStrategy.entityTouched(entityId)
               ref.tell(payload, snd)
+              passivateEntities(entitiesToPassivate)
             case RememberingStart(_) | RememberingStop | Passivating(_) =>
               appendToMessageBuffer(entityId, msg, snd)
             case state @ (WaitingForRestart | RememberedButNotCreated) =>
@@ -1069,7 +1069,10 @@ private[akka] class Shard(
             case NoState =>
               if (!rememberEntities) {
                 // don't buffer if remember entities not enabled
-                getOrCreateEntity(entityId).tell(payload, snd)
+                val ref = getOrCreateEntity(entityId)
+                val entitiesToPassivate = passivationStrategy.entityTouched(entityId)
+                ref.tell(payload, snd)
+                passivateEntities(entitiesToPassivate)
               } else {
                 if (entities.pendingRememberedEntitiesExist()) {
                   // No actor running and write in progress for some other entity id (can only happen with remember entities enabled)
@@ -1110,8 +1113,6 @@ private[akka] class Shard(
         context.watchWith(a, EntityTerminated(a))
         log.debug("{}: Started entity [{}] with entity id [{}] in shard [{}]", typeName, a, id, shardId)
         entities.addEntity(id, a)
-        val entitiesToPassivate = passivationStrategy.entityCreated(id)
-        passivateEntities(entitiesToPassivate)
         entityCreated(id)
         a
     }

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/simulator/Simulator.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/simulator/Simulator.scala
@@ -211,7 +211,7 @@ object Simulator {
         Nil
       } else {
         activeEntities += entityId
-        val passivateEntities = strategy.entityCreated(entityId)
+        val passivateEntities = strategy.entityTouched(entityId)
         passivateEntities.foreach(activeEntities.remove)
         val passivated =
           if (passivateEntities.isEmpty) Nil


### PR DESCRIPTION
Fixes #30952. Reproduced the test failure with a sleep to delay termination. Updated to remove the entity-created tracking altogether, which was not used specially anyway, and only track entity-touched on message delivery. This avoids the possible double access tracking for frequency-based strategies when an entity is restarted due to buffered messages. Also a general simplification which is an improvement.

This PR or #30951 will need to be updated, depending on which is merged first.