### PR TITLE
Introduce new default entity passivation strategy

### DIFF
--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -28,7 +28,7 @@ akka.cluster.sharding {
   # Default is ddata for backwards compatibility.
   remember-entities-store = "ddata"
 
-  # Deprecated: use the `passivation.default.idle-entity.timeout` setting instead.
+  # Deprecated: use the `passivation.default-idle-strategy.idle-entity.timeout` setting instead.
   # Set this to a time duration to have sharding passivate entities when they have not
   # received any message in this length of time. Set to 'off' to disable.
   # It is always disabled if `remember-entities` is enabled.

--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -28,7 +28,7 @@ akka.cluster.sharding {
   # Default is ddata for backwards compatibility.
   remember-entities-store = "ddata"
 
-  # Deprecated: use the `passivation.idle.timeout` for 'idle' `passivation.strategy` instead.
+  # Deprecated: use the `passivation.default.idle-entity.timeout` setting instead.
   # Set this to a time duration to have sharding passivate entities when they have not
   # received any message in this length of time. Set to 'off' to disable.
   # It is always disabled if `remember-entities` is enabled.
@@ -36,87 +36,84 @@ akka.cluster.sharding {
 
   # Automatic entity passivation settings.
   passivation {
-    # Passivation strategy to use. Possible values are:
-    #   - "idle"
-    #   - "least-recently-used"
-    #   - "most-recently-used"
-    #   - "least-frequently-used"
+
+    # Automatic passivation strategy to use.
     # Set to "none" or "off" to disable automatic passivation.
+    # Set to "default-strategy" to switch to the recommended default strategy with an active entity limit.
+    # See the strategy-defaults section for possible passivation strategy settings and default values.
     # Passivation strategies are always disabled if `remember-entities` is enabled.
-    strategy = "idle"
+    strategy = "default-idle-strategy"
 
-    # Idle passivation strategy.
-    # Passivate entities when they have not received a message for a specified length of time.
-    idle {
-      # Passivate idle entities after the timeout.
-      timeout = 120s
-
-      # Check idle entities every interval. Set to "default" to use half the timeout by default.
-      interval = default
+    # Default passivation strategy without active entity limit; time out idle entities after 2 minutes.
+    default-idle-strategy {
+      idle-entity.timeout = 120s
     }
 
-    # Least recently used passivation strategy.
-    # Passivate the least recently used entities when the number of active entities in a shard region
-    # reaches a limit. The per-region limit is divided evenly among the active shards in a region.
-    least-recently-used {
-      # Limit of active entities in a shard region.
-      limit = 100000
+    # Recommended default strategy for automatic passivation with an active entity limit.
+    # Configured with a segmented least recently used (SLRU) replacement policy.
+    default-strategy {
+      # Default limit of 100k active entities in a shard region (in a cluster node).
+      active-entity-limit = 100000
 
-      # Optionally use a "segmented" least recently used strategy.
-      # Disabled when segmented.levels are set to "none" or "off".
-      segmented {
-        # Number of segmented levels.
-        levels = none
-
-        # Fractional proportions for the segmented levels.
-        # If empty then segments are divided evenly by the number of levels.
-        proportions = []
+      # Segmented LRU replacement policy with an 80% "protected" level by default.
+      replacement {
+        policy = least-recently-used
+        least-recently-used {
+          segmented {
+            levels = 2
+            proportions = [0.2, 0.8]
+          }
+        }
       }
+    }
 
-      # Optionally passivate entities when they have not received a message for a specified length of time.
-      idle {
-        # Passivate idle entities after the timeout. Set to "off" to disable.
-        timeout = off
+    strategy-defaults {
+      # Passivate entities when they have not received a message for a specified length of time.
+      idle-entity {
+        # Passivate idle entities after the timeout. Set to "none" or "off" to disable.
+        timeout = none
 
         # Check idle entities every interval. Set to "default" to use half the timeout by default.
         interval = default
       }
-    }
 
-    # Most recently used passivation strategy.
-    # Passivate the most recently used entities when the number of active entities in a shard region
-    # reaches a limit. The per-region limit is divided evenly among the active shards in a region.
-    most-recently-used {
       # Limit of active entities in a shard region.
-      limit = 100000
+      # Passivate entities when the number of active entities in a shard region reaches this limit.
+      # The per-region limit is divided evenly among the active shards in a region.
+      # Set to "none" or "off" to disable limit-based automatic passivation, to only use idle entity timeouts.
+      active-entity-limit = none
 
-      # Optionally passivate entities when they have not received a message for a specified length of time.
-      idle {
-        # Passivate idle entities after the timeout. Set to "off" to disable.
-        timeout = off
+      # Entity replacement settings, for when the active entity limit is reached.
+      replacement {
+        # Entity replacement policy to use when the active entity limit is reached. Possible values are:
+        #   - "least-recently-used"
+        #   - "most-recently-used"
+        #   - "least-frequently-used"
+        # Set to "none" or "off" to disable the replacement policy and ignore the active entity limit.
+        policy = none
 
-        # Check idle entities every interval. Set to "default" to use half the timeout by default.
-        interval = default
-      }
-    }
+        # Least recently used entity replacement policy.
+        least-recently-used {
+          # Optionally use a "segmented" least recently used strategy.
+          # Disabled when segmented.levels are set to "none" or "off".
+          segmented {
+            # Number of segmented levels.
+            levels = none
 
-    # Least frequently used passivation strategy.
-    # Passivate the least frequently used entities when the number of active entities in a shard region
-    # reaches a limit. The per-region limit is divided evenly among the active shards in a region.
-    least-frequently-used {
-      # Limit of active entities in a shard region.
-      limit = 100000
+            # Fractional proportions for the segmented levels.
+            # If empty then segments are divided evenly by the number of levels.
+            proportions = []
+          }
+        }
 
-      # New frequency counts will be "dynamically aged" when enabled.
-      dynamic-aging = off
+        # Most recently used entity replacement policy.
+        most-recently-used {}
 
-      # Optionally passivate entities when they have not received a message for a specified length of time.
-      idle {
-        # Passivate idle entities after the timeout. Set to "off" to disable.
-        timeout = off
-
-        # Check idle entities every interval. Set to "default" to use half the timeout by default.
-        interval = default
+        # Least frequently used entity replacement policy.
+        least-frequently-used {
+          # New frequency counts will be "dynamically aged" when enabled.
+          dynamic-aging = off
+        }
       }
     }
   }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -674,7 +674,8 @@ private[akka] class ShardRegion(
     if (settings.passivationStrategySettings.oldSettingUsed) {
       log.warning(
         "The `akka.cluster.sharding.passivate-idle-entity-after` setting and associated methods are deprecated. " +
-        "See automatic passivation strategies and use the `akka.cluster.sharding.passivation.idle.timeout` setting.")
+        "Use the `akka.cluster.sharding.passivation.default-idle-strategy.idle-entity.timeout` setting instead. " +
+        "See the documentation and reference config for more information on automatic passivation strategies.")
     }
     if (settings.rememberEntities) {
       log.debug("{}: Entities will not be passivated automatically because 'rememberEntities' is enabled.", typeName)

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala
@@ -35,10 +35,8 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
     "allow timeout for (default) idle passivation strategy to be configured (via config)" in {
       settings("""
         #passivation-idle-timeout
-        akka.cluster.sharding {
-          passivation {
-            default-idle-strategy.idle-entity.timeout = 3 minutes
-          }
+        akka.cluster.sharding.passivation {
+          default-idle-strategy.idle-entity.timeout = 3 minutes
         }
         #passivation-idle-timeout
       """).passivationStrategy shouldBe ClusterShardingSettings.IdlePassivationStrategy(
@@ -57,13 +55,11 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
 
     "allow timeout and interval for (default) idle passivation strategy to be configured (via config)" in {
       settings("""
-        akka.cluster.sharding {
-          passivation {
-            default-idle-strategy {
-              idle-entity {
-                timeout = 3 minutes
-                interval = 1 minute
-              }
+        akka.cluster.sharding.passivation {
+          default-idle-strategy {
+            idle-entity {
+              timeout = 3 minutes
+              interval = 1 minute
             }
           }
         }
@@ -84,8 +80,8 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
     "allow new default passivation strategy to be enabled (via config)" in {
       settings("""
         #passivation-new-default-strategy
-        akka.cluster.sharding {
-          passivation.strategy = default-strategy
+        akka.cluster.sharding.passivation {
+          strategy = default-strategy
         }
         #passivation-new-default-strategy
       """).passivationStrategy shouldBe ClusterShardingSettings.LeastRecentlyUsedPassivationStrategy(
@@ -97,12 +93,10 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
     "allow new default passivation strategy limit to be configured (via config)" in {
       settings("""
         #passivation-new-default-strategy-configured
-        akka.cluster.sharding {
-          passivation {
-            strategy = default-strategy
-            default-strategy {
-              active-entity-limit = 1000000
-            }
+        akka.cluster.sharding.passivation {
+          strategy = default-strategy
+          default-strategy {
+            active-entity-limit = 1000000
           }
         }
         #passivation-new-default-strategy-configured
@@ -115,12 +109,10 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
     "allow new default passivation strategy with idle timeout to be configured (via config)" in {
       settings("""
         #passivation-new-default-strategy-with-idle
-        akka.cluster.sharding {
-          passivation {
-            strategy = default-strategy
-            default-strategy {
-              idle-entity.timeout = 30.minutes
-            }
+        akka.cluster.sharding.passivation {
+          strategy = default-strategy
+          default-strategy {
+            idle-entity.timeout = 30.minutes
           }
         }
         #passivation-new-default-strategy-with-idle
@@ -132,17 +124,17 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
 
     "allow least recently used passivation strategy to be configured (via config)" in {
       settings("""
-        #passivation-least-recently-used
-        akka.cluster.sharding {
-          passivation {
-            strategy = custom-lru-strategy
-            custom-lru-strategy {
-              active-entity-limit = 1000000
-              replacement.policy = least-recently-used
-            }
+        #custom-passivation-strategy
+        #lru-policy
+        akka.cluster.sharding.passivation {
+          strategy = custom-lru-strategy
+          custom-lru-strategy {
+            active-entity-limit = 1000000
+            replacement.policy = least-recently-used
           }
         }
-        #passivation-least-recently-used
+        #lru-policy
+        #custom-passivation-strategy
       """).passivationStrategy shouldBe ClusterShardingSettings.LeastRecentlyUsedPassivationStrategy(
         limit = 1000000,
         segmented = Nil,
@@ -163,25 +155,23 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
 
     "allow segmented least recently used passivation strategy to be configured (via config)" in {
       settings("""
-        #passivation-segmented-least-recently-used
-        akka.cluster.sharding {
-          passivation {
-            strategy = custom-slru-strategy
-            custom-slru-strategy {
-              active-entity-limit = 1000000
-              replacement {
-                policy = least-recently-used
-                least-recently-used {
-                  segmented {
-                    levels = 2
-                    proportions = [0.2, 0.8]
-                  }
+        #slru-policy
+        akka.cluster.sharding.passivation {
+          strategy = custom-slru-strategy
+          custom-slru-strategy {
+            active-entity-limit = 1000000
+            replacement {
+              policy = least-recently-used
+              least-recently-used {
+                segmented {
+                  levels = 2
+                  proportions = [0.2, 0.8]
                 }
               }
             }
           }
         }
-        #passivation-segmented-least-recently-used
+        #slru-policy
       """).passivationStrategy shouldBe ClusterShardingSettings.LeastRecentlyUsedPassivationStrategy(
         limit = 1000000,
         segmented = List(0.2, 0.8),
@@ -190,22 +180,20 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
 
     "allow 4-level segmented least recently used passivation strategy to be configured (via config)" in {
       settings("""
-        #passivation-s4-least-recently-used
-        akka.cluster.sharding {
-          passivation {
-            strategy = custom-s4lru-strategy
-            custom-s4lru-strategy {
-              active-entity-limit = 1000000
-              replacement {
-                policy = least-recently-used
-                least-recently-used {
-                  segmented.levels = 4
-                }
+        #s4lru-policy
+        akka.cluster.sharding.passivation {
+          strategy = custom-s4lru-strategy
+          custom-s4lru-strategy {
+            active-entity-limit = 1000000
+            replacement {
+              policy = least-recently-used
+              least-recently-used {
+                segmented.levels = 4
               }
             }
           }
         }
-        #passivation-s4-least-recently-used
+        #s4lru-policy
       """).passivationStrategy shouldBe ClusterShardingSettings.LeastRecentlyUsedPassivationStrategy(
         limit = 1000000,
         segmented = List(0.25, 0.25, 0.25, 0.25),
@@ -226,18 +214,14 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
 
     "allow least recently used passivation strategy with idle timeout to be configured (via config)" in {
       settings("""
-        #passivation-least-recently-used-with-idle
-        akka.cluster.sharding {
-          passivation {
-            strategy = custom-lru-with-idle
-            custom-lru-with-idle {
-              active-entity-limit = 1000000
-              replacement.policy = least-recently-used
-              idle-entity.timeout = 30.minutes
-            }
+        akka.cluster.sharding.passivation {
+          strategy = custom-lru-with-idle
+          custom-lru-with-idle {
+            active-entity-limit = 1000000
+            replacement.policy = least-recently-used
+            idle-entity.timeout = 30.minutes
           }
         }
-        #passivation-least-recently-used-with-idle
       """).passivationStrategy shouldBe ClusterShardingSettings.LeastRecentlyUsedPassivationStrategy(
         limit = 1000000,
         segmented = Nil,
@@ -259,17 +243,15 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
 
     "allow most recently used passivation strategy to be configured (via config)" in {
       settings("""
-        #passivation-most-recently-used
-        akka.cluster.sharding {
-          passivation {
-            strategy = custom-mru-strategy
-            custom-mru-strategy {
-              active-entity-limit = 1000000
-              replacement.policy = most-recently-used
-            }
+        #mru-policy
+        akka.cluster.sharding.passivation {
+          strategy = custom-mru-strategy
+          custom-mru-strategy {
+            active-entity-limit = 1000000
+            replacement.policy = most-recently-used
           }
         }
-        #passivation-most-recently-used
+        #mru-policy
       """).passivationStrategy shouldBe ClusterShardingSettings.MostRecentlyUsedPassivationStrategy(
         limit = 1000000,
         idle = None)
@@ -288,18 +270,14 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
 
     "allow most recently used passivation strategy with idle timeout to be configured (via config)" in {
       settings("""
-        #passivation-most-recently-used-with-idle
-        akka.cluster.sharding {
-          passivation {
-            strategy = custom-mru-with-idle
-            custom-mru-with-idle {
-              active-entity-limit = 1000000
-              replacement.policy = most-recently-used
-              idle-entity.timeout = 30.minutes
-            }
+        akka.cluster.sharding.passivation {
+          strategy = custom-mru-with-idle
+          custom-mru-with-idle {
+            active-entity-limit = 1000000
+            replacement.policy = most-recently-used
+            idle-entity.timeout = 30.minutes
           }
         }
-        #passivation-most-recently-used-with-idle
       """).passivationStrategy shouldBe ClusterShardingSettings.MostRecentlyUsedPassivationStrategy(
         limit = 1000000,
         idle = Some(ClusterShardingSettings.IdlePassivationStrategy(timeout = 30.minutes, interval = 15.minutes)))
@@ -319,17 +297,15 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
 
     "allow least frequently used passivation strategy to be configured (via config)" in {
       settings("""
-        #passivation-least-frequently-used
-        akka.cluster.sharding {
-          passivation {
-            strategy = custom-lfu-strategy
-            custom-lfu-strategy {
-              active-entity-limit = 1000000
-              replacement.policy = least-frequently-used
-            }
+        #lfu-policy
+        akka.cluster.sharding.passivation {
+          strategy = custom-lfu-strategy
+          custom-lfu-strategy {
+            active-entity-limit = 1000000
+            replacement.policy = least-frequently-used
           }
         }
-        #passivation-least-frequently-used
+        #lfu-policy
       """).passivationStrategy shouldBe ClusterShardingSettings.LeastFrequentlyUsedPassivationStrategy(
         limit = 1000000,
         dynamicAging = false,
@@ -350,18 +326,14 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
 
     "allow least frequently used passivation strategy with idle timeout to be configured (via config)" in {
       settings("""
-        #passivation-least-frequently-used-with-idle
-        akka.cluster.sharding {
-          passivation {
-            strategy = custom-lfu-with-idle
-            custom-lfu-with-idle {
-              active-entity-limit = 1000000
-              replacement.policy = least-frequently-used
-              idle-entity.timeout = 30.minutes
-            }
+        akka.cluster.sharding.passivation {
+          strategy = custom-lfu-with-idle
+          custom-lfu-with-idle {
+            active-entity-limit = 1000000
+            replacement.policy = least-frequently-used
+            idle-entity.timeout = 30.minutes
           }
         }
-        #passivation-least-frequently-used-with-idle
       """).passivationStrategy shouldBe ClusterShardingSettings.LeastFrequentlyUsedPassivationStrategy(
         limit = 1000000,
         dynamicAging = false,
@@ -383,22 +355,20 @@ class ClusterShardingSettingsSpec extends AnyWordSpec with Matchers {
 
     "allow least frequently used passivation strategy with dynamic aging to be configured (via config)" in {
       settings("""
-        #passivation-least-frequently-used-with-dynamic-aging
-        akka.cluster.sharding {
-          passivation {
-            strategy = custom-lfu-with-dynamic-aging
-            custom-lfu-with-dynamic-aging {
-              active-entity-limit = 1000
-              replacement {
-                policy = least-frequently-used
-                least-frequently-used {
-                  dynamic-aging = on
-                }
+        #lfuda-policy
+        akka.cluster.sharding.passivation {
+          strategy = custom-lfu-with-dynamic-aging
+          custom-lfu-with-dynamic-aging {
+            active-entity-limit = 1000
+            replacement {
+              policy = least-frequently-used
+              least-frequently-used {
+                dynamic-aging = on
               }
             }
           }
         }
-        #passivation-least-frequently-used-with-dynamic-aging
+        #lfuda-policy
       """).passivationStrategy shouldBe ClusterShardingSettings.LeastFrequentlyUsedPassivationStrategy(
         limit = 1000,
         dynamicAging = true,

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/IdleSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/IdleSpec.scala
@@ -13,8 +13,7 @@ object IdleSpec {
   val config: Config = ConfigFactory.parseString("""
     akka.cluster.sharding {
       passivation {
-        strategy = idle
-        idle.timeout = 1s
+        default-idle-strategy.idle-entity.timeout = 1s
       }
     }
     """).withFallback(EntityPassivationSpec.config)

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/LeastRecentlyUsedSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/LeastRecentlyUsedSpec.scala
@@ -14,8 +14,11 @@ object LeastRecentlyUsedSpec {
   val config: Config = ConfigFactory.parseString("""
     akka.cluster.sharding {
       passivation {
-        strategy = least-recently-used
-        least-recently-used.limit = 10
+        strategy = lru
+        lru {
+          active-entity-limit = 10
+          replacement.policy = least-recently-used
+        }
       }
     }
     """).withFallback(EntityPassivationSpec.config)
@@ -23,12 +26,17 @@ object LeastRecentlyUsedSpec {
   val segmentedConfig: Config = ConfigFactory.parseString("""
     akka.cluster.sharding {
       passivation {
-        strategy = least-recently-used
-        least-recently-used {
-          limit = 10
-          segmented {
-            levels = 2
-            proportions = [0.2, 0.8]
+        strategy = slru
+        slru {
+          active-entity-limit = 10
+          replacement {
+            policy = least-recently-used
+            least-recently-used {
+              segmented {
+                levels = 2
+                proportions = [0.2, 0.8]
+              }
+            }
           }
         }
       }
@@ -38,10 +46,11 @@ object LeastRecentlyUsedSpec {
   val idleConfig: Config = ConfigFactory.parseString("""
     akka.cluster.sharding {
       passivation {
-        strategy = least-recently-used
-        least-recently-used {
-          limit = 3
-          idle.timeout = 1s
+        strategy = lru-idle
+        lru-idle {
+          active-entity-limit = 3
+          replacement.policy = least-recently-used
+          idle-entity.timeout = 1s
         }
       }
     }
@@ -238,19 +247,17 @@ class LeastRecentlyUsedWithIdleSpec
     "passivate entities when they haven't seen messages for the configured timeout" in {
       val region = start()
 
-      val idleTimeout = settings.passivationStrategySettings.leastRecentlyUsedSettings.idleSettings.get.timeout
-
       val lastSendNanoTime1 = System.nanoTime()
       region ! Envelope(shard = 1, id = 1, message = "A")
       region ! Envelope(shard = 1, id = 2, message = "B")
 
       // keep entity 3 active to prevent idle passivation
       region ! Envelope(shard = 1, id = 3, message = "C")
-      Thread.sleep((idleTimeout / 2).toMillis)
+      Thread.sleep((configuredIdleTimeout / 2).toMillis)
       region ! Envelope(shard = 1, id = 3, message = "D")
-      Thread.sleep((idleTimeout / 2).toMillis)
+      Thread.sleep((configuredIdleTimeout / 2).toMillis)
       region ! Envelope(shard = 1, id = 3, message = "E")
-      Thread.sleep((idleTimeout / 2).toMillis)
+      Thread.sleep((configuredIdleTimeout / 2).toMillis)
       val lastSendNanoTime2 = System.nanoTime()
       region ! Envelope(shard = 1, id = 3, message = "F")
 
@@ -262,13 +269,13 @@ class LeastRecentlyUsedWithIdleSpec
       expectReceived(id = 3, message = "F")
       val passivate1 = expectReceived(id = 1, message = Stop)
       val passivate2 = expectReceived(id = 2, message = Stop)
-      val passivate3 = expectReceived(id = 3, message = Stop, within = idleTimeout * 2)
+      val passivate3 = expectReceived(id = 3, message = Stop, within = configuredIdleTimeout * 2)
 
       // note: touched timestamps are when the shard receives the message, not the entity itself
       // so look at the time from before sending the last message until receiving the passivate message
-      (passivate1.nanoTime - lastSendNanoTime1).nanos should be > idleTimeout
-      (passivate2.nanoTime - lastSendNanoTime1).nanos should be > idleTimeout
-      (passivate3.nanoTime - lastSendNanoTime2).nanos should be > idleTimeout
+      (passivate1.nanoTime - lastSendNanoTime1).nanos should be > configuredIdleTimeout
+      (passivate2.nanoTime - lastSendNanoTime1).nanos should be > configuredIdleTimeout
+      (passivate3.nanoTime - lastSendNanoTime2).nanos should be > configuredIdleTimeout
     }
   }
 }

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/MostRecentlyUsedSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/MostRecentlyUsedSpec.scala
@@ -14,8 +14,11 @@ object MostRecentlyUsedSpec {
   val config: Config = ConfigFactory.parseString("""
     akka.cluster.sharding {
       passivation {
-        strategy = most-recently-used
-        most-recently-used.limit = 10
+        strategy = mru
+        mru {
+          active-entity-limit = 10
+          replacement.policy = most-recently-used
+        }
       }
     }
     """).withFallback(EntityPassivationSpec.config)
@@ -23,10 +26,11 @@ object MostRecentlyUsedSpec {
   val idleConfig: Config = ConfigFactory.parseString("""
     akka.cluster.sharding {
       passivation {
-        strategy = most-recently-used
-        most-recently-used {
-          limit = 3
-          idle.timeout = 1s
+        strategy = mru-idle
+        mru-idle {
+          active-entity-limit = 3
+          replacement.policy = most-recently-used
+          idle-entity.timeout = 1s
         }
       }
     }
@@ -141,7 +145,7 @@ class MostRecentlyUsedSpec extends AbstractEntityPassivationSpec(MostRecentlyUse
   }
 }
 
-class MostRecentlyUsedWithIdleEntityPassivationSpec
+class MostRecentlyUsedWithIdleSpec
     extends AbstractEntityPassivationSpec(MostRecentlyUsedSpec.idleConfig, expectedEntities = 3) {
 
   import EntityPassivationSpec.Entity.Envelope
@@ -151,19 +155,17 @@ class MostRecentlyUsedWithIdleEntityPassivationSpec
     "passivate entities when they haven't seen messages for the configured timeout" in {
       val region = start()
 
-      val idleTimeout = settings.passivationStrategySettings.mostRecentlyUsedSettings.idleSettings.get.timeout
-
       val lastSendNanoTime1 = System.nanoTime()
       region ! Envelope(shard = 1, id = 1, message = "A")
       region ! Envelope(shard = 1, id = 2, message = "B")
 
       // keep entity 3 active to prevent idle passivation
       region ! Envelope(shard = 1, id = 3, message = "C")
-      Thread.sleep((idleTimeout / 2).toMillis)
+      Thread.sleep((configuredIdleTimeout / 2).toMillis)
       region ! Envelope(shard = 1, id = 3, message = "D")
-      Thread.sleep((idleTimeout / 2).toMillis)
+      Thread.sleep((configuredIdleTimeout / 2).toMillis)
       region ! Envelope(shard = 1, id = 3, message = "E")
-      Thread.sleep((idleTimeout / 2).toMillis)
+      Thread.sleep((configuredIdleTimeout / 2).toMillis)
       val lastSendNanoTime2 = System.nanoTime()
       region ! Envelope(shard = 1, id = 3, message = "F")
 
@@ -175,13 +177,13 @@ class MostRecentlyUsedWithIdleEntityPassivationSpec
       expectReceived(id = 3, message = "F")
       val passivate1 = expectReceived(id = 1, message = Stop)
       val passivate2 = expectReceived(id = 2, message = Stop)
-      val passivate3 = expectReceived(id = 3, message = Stop, within = idleTimeout * 2)
+      val passivate3 = expectReceived(id = 3, message = Stop, within = configuredIdleTimeout * 2)
 
       // note: touched timestamps are when the shard receives the message, not the entity itself
       // so look at the time from before sending the last message until receiving the passivate message
-      (passivate1.nanoTime - lastSendNanoTime1).nanos should be > idleTimeout
-      (passivate2.nanoTime - lastSendNanoTime1).nanos should be > idleTimeout
-      (passivate3.nanoTime - lastSendNanoTime2).nanos should be > idleTimeout
+      (passivate1.nanoTime - lastSendNanoTime1).nanos should be > configuredIdleTimeout
+      (passivate2.nanoTime - lastSendNanoTime1).nanos should be > configuredIdleTimeout
+      (passivate3.nanoTime - lastSendNanoTime2).nanos should be > configuredIdleTimeout
     }
   }
 }

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -320,6 +320,7 @@ Idle entity timeouts can be enabled and configured for any passivation strategy.
 
 Automatic passivation strategies can limit the number of active entities. Limit-based passivation strategies use a
 replacement policy to determine which active entities should be passivated when the active entity limit is exceeded.
+The configurable limit is for a whole shard region and is divided evenly among the active shards in each region.
 
 A recommended passivation strategy, which will become the new default passivation strategy in future versions of Akka
 Cluster Sharding, can be enabled with configuration:
@@ -331,23 +332,45 @@ entity limit can be configured:
 
 @@snip [passivation new default strategy configured](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #passivation-new-default-strategy-configured type=conf }
 
+Or using the `withActiveEntityLimit` method on `ClusterShardingSettings.PassivationStrategySettings`.
+
 An [idle entity timeout](#idle-entity-passivation) can also be enabled and configured for this strategy:
 
 @@snip [passivation new default strategy with idle](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #passivation-new-default-strategy-with-idle type=conf }
 
-Custom passivation strategies can be created with configurable replacement policies, active entity limits, and idle entity timeouts.
+Or using the `withIdleEntityPassivation` method on `ClusterShardingSettings.PassivationStrategySettings`.
+
+If the default strategy is not appropriate for particular workloads and access patterns, a [custom passivation
+strategy](#custom-passivation-strategies) can be created with configurable replacement policies, active entity limits,
+and idle entity timeouts.
+
+### Custom passivation strategies
+
+To configure a custom passivation strategy, create a configuration section for the strategy under
+`akka.cluster.sharding.passivation` and select this strategy using the `strategy` setting. The strategy needs a
+_replacement policy_ to be chosen, an _active entity limit_ to be set, and can optionally [passivate idle
+entities](#idle-entity-passivation). For example, a custom strategy can be configured to use the [least recently used
+policy](#least-recently-used-policy):
+
+@@snip [custom passivation strategy](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #custom-passivation-strategy type=conf }
+
+The active entity limit and replacement policy can also be configured using the `withPassivationStrategy` method on
+`ClusterShardingSettings`, passing custom `ClusterShardingSettings.PassivationStrategySettings`.
 
 ### Least recently used policy
 
 The **least recently used** policy passivates those entities that have the least recent activity when the number of
-active entities passes the specified limit. The configurable limit is for a whole shard region and is divided evenly
-among the active shards in each region. Configure automatic passivation to use the least recently used policy, and set
-the limit for active entities in a shard region:
+active entities passes the specified limit.
 
-@@snip [passivation least recently used](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #passivation-least-recently-used type=conf }
+**When to use**: the least recently used policy should be used when access patterns are recency biased, where entities
+that were recently accessed are likely to be accessed again. See the [segmented least recently used
+policy](#segmented-least-recently-used-policy) for a variation that also distinguishes frequency of access.
 
-Or enable the least recently used policy and set the active entity limit using the `withPassivationStrategy` method on
-`ClusterShardingSettings`, passing custom `ClusterShardingSettings.PassivationStrategySettings`.
+Configure a passivation strategy to use the least recently used policy:
+
+@@snip [LRU policy](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #lru-policy type=conf }
+
+Or using the `withLeastRecentlyUsedReplacement` method on `ClusterShardingSettings.PassivationStrategySettings`.
 
 #### Segmented least recently used policy
 
@@ -362,54 +385,66 @@ to the level below. Only the least recently used entities in the lowest level wi
 higher levels are considered "protected", where entities will have additional opportunities to be accessed before being
 considered for passivation.
 
+**When to use**: the segmented least recently used policy can be used for workloads where some entities are more
+popular than others, to prioritize those entities that are accessed more frequently.
+
 To configure a segmented least recently used (SLRU) policy, with two levels and a protected segment limited to 80% of
 the total limit:
 
-@@snip [passivation segmented least recently used](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #passivation-segmented-least-recently-used type=conf }
+@@snip [SLRU policy](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #slru-policy type=conf }
 
 Or to configure a 4-level segmented least recently used (S4LRU) policy, with 4 evenly divided levels:
 
-@@snip [passivation segmented least recently used](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #passivation-s4-least-recently-used type=conf }
+@@snip [S4LRU policy](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #s4lru-policy type=conf }
 
-Or using the `withPassivationStrategy` method on `ClusterShardingSettings`.
+Or using custom `ClusterShardingSettings.PassivationStrategySettings.LeastRecentlyUsedSettings`.
 
 ### Most recently used policy
 
 The **most recently used** policy passivates those entities that have the most recent activity when the number of
-active entities passes a specified limit. The configurable limit is for a whole shard region and is divided evenly
-among the active shards in each region. This policy is most useful when the older an entity is, the more likely that
-entity will be accessed again; as seen in cyclic access patterns. Configure automatic passivation to use the most
-recently used policy, and set the limit for active entities in a shard region:
+active entities passes the specified limit.
 
-@@snip [passivation most recently used](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #passivation-most-recently-used type=conf }
+**When to use**: the most recently used policy is most useful when the older an entity is, the more likely that entity
+will be accessed again; as seen in cyclic access patterns.
 
-Or enable the most recently used policy and set the active entity limit using the `withPassivationStrategy` method on
-`ClusterShardingSettings`, passing custom `ClusterShardingSettings.PassivationStrategySettings`.
+Configure a passivation strategy to use the most recently used policy:
+
+@@snip [MRU policy](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #mru-policy type=conf }
+
+Or using the `withMostRecentlyUsedReplacement` method on `ClusterShardingSettings.PassivationStrategySettings`.
 
 ### Least frequently used policy
 
 The **least frequently used** policy passivates those entities that have the least frequent activity when the number of
-active entities passes a specified limit. The configurable limit is for a whole shard region and is divided evenly
-among the active shards in each region. Configure automatic passivation to use the least frequently used policy, and
-set the limit for active entities in a shard region:
+active entities passes the specified limit.
 
-@@snip [passivation least frequently used](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #passivation-least-frequently-used type=conf }
+**When to use**: the least frequently used policy should be used when access patterns are frequency biased, where some
+entities are much more popular than others and should be prioritized. See the [least frequently used with dynamic aging
+policy](#least-frequently-used-with-dynamic-aging-policy) for a variation that also handles shifts in popularity.
 
-Or enable the least frequently used policy and set the active entity limit using the `withPassivationStrategy` method
-on `ClusterShardingSettings`, passing custom `ClusterShardingSettings.PassivationStrategySettings`.
+Configure automatic passivation to use the least frequently used policy:
 
-#### Dynamic aging for least frequently policy
+@@snip [LFU policy](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #lfu-policy type=conf }
+
+Or using the `withLeastFrequentlyUsedReplacement` method on `ClusterShardingSettings.PassivationStrategySettings`.
+
+#### Least frequently used with dynamic aging policy
 
 A variation of the least frequently used policy can be enabled that uses "dynamic aging" to adapt to shifts in the set
 of popular entities, which is useful for smaller active entity limits and when shifts in popularity are common. If
 entities were frequently accessed in the past but then become unpopular, they can still remain active for a long time
 given their high frequency counts. Dynamic aging effectively increases the frequencies for recently accessed entities
-so they can more easily become higher priority over entities that are no longer accessed. Configure dynamic aging with
-the least frequently used policy:
+so they can more easily become higher priority over entities that are no longer accessed.
 
-@@snip [passivation least frequently used with dynamic aging](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #passivation-least-frequently-used-with-dynamic-aging type=conf }
+**When to use**: the least frequently used with dynamic aging policy can be used when workloads are frequency biased
+(there are some entities that are much more popular), but which entities are most popular changes over time. Shifts in
+popularity can have more impact on a least frequently used policy if the active entity limit is small.
 
-Or when using the `withPassivationStrategy` method on `ClusterShardingSettings`.
+Configure dynamic aging with the least frequently used policy:
+
+@@snip [LFUDA policy](/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ClusterShardingSettingsSpec.scala) { #lfuda-policy type=conf }
+
+Or using custom `ClusterShardingSettings.PassivationStrategySettings.LeastFrequentlyUsedSettings`.
 
 
 ## Sharding State 

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -289,7 +289,10 @@ The stop message is only sent locally, from the shard to the entity so does not 
 ## Automatic Passivation
 
 Entities are automatically passivated based on a passivation strategy. The default passivation strategy is to
-passivate idle entities when they haven't received a message within a specified interval.
+[passivate idle entities](#idle-entity-passivation) when they haven't received a message within a specified interval,
+and this is the current default strategy to maintain compatibility with earlier versions. It's recommended to switch to
+a [passivation strategy with an active entity limit](#active-entity-limits) and a pre-configured default strategy is
+provided. Active entity limits and idle entity timeouts can also be used together.
 
 Automatic passivation can be disabled by setting `akka.cluster.sharding.passivation.strategy = none`. It is disabled
 automatically if @ref:[Remembering Entities](#remembering-entities) is enabled.


### PR DESCRIPTION
Follow up to #30951.

Rework the passivation settings to allow for named strategies and a pre-configured default strategy. The old strategy is named `default-idle-strategy` while the new strategy is just `default-strategy`, and can be switched to easily. What was referred to as a strategy before is now a _replacement policy_ — which is useful for the more advanced strategies which will also introduce an admission area and policy.

Recommended default strategy is now described in the docs. And it will be easy to extend this to the adaptive strategies.

Suggestions for better names or approach for any of this are welcome.