### PR TITLE
Cleanup cross building

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The versions of scala specified here are only used as `-Dakka.build.scalaVersion=...`
+        # The versions of scala specified here are only used as `+~...`
         # which ignores the PATCH portion of the version id. These Scala versions don't need
         # to be fully defined here then since Akka build handles which patch version will be used.
         scalaVersion: [ "2.12", "2.13" ]
@@ -37,4 +37,4 @@ jobs:
         uses: coursier/cache-action@v6.2
 
       - name: Report MiMa Binary Issues
-        run: sbt -jvm-opts .jvmopts-ci -Dakka.build.scalaVersion=${{ matrix.scalaVersion }} mimaReportBinaryIssues
+        run: sbt -jvm-opts .jvmopts-ci "+~ ${{ matrix.scalaVersion }} mimaReportBinaryIssues"

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -144,7 +144,6 @@ jobs:
         # note that this is not running any multi-jvm tests (yet) because multi-in-test=false
         run: |-
           sbt -jvm-opts .jvmopts-ci \
-            -Dakka.build.scalaVersion=${{ matrix.scalaVersion }} \
             -Dakka.cluster.assert=on \
             -Dakka.log.timestamps=true \
             -Dakka.test.timefactor=2 \
@@ -156,7 +155,7 @@ jobs:
             -Dmultinode.Xmx256M \
             -Dmultinode.XX:+AlwaysActAsServerClassMachine \
             ${{ matrix.extraOpts }} \
-            clean Test/compile test checkTestsHaveRun
+            "+~ ${{ matrix.scalaVersion }} clean Test/compile test checkTestsHaveRun"
 
       - name: Test Reports
         # Makes it easier to spot failures instead of looking at the logs.
@@ -175,16 +174,15 @@ jobs:
         run: |-
           sudo apt-get install graphviz
           sbt -jvm-opts .jvmopts-ci \
-            -Dakka.build.scalaVersion=${{ matrix.scalaVersion }} \
             -Dakka.genjavadoc.enabled=true \
-            doc
+            "+~ ${{ matrix.scalaVersion }} doc"
 
       - name: Publish
         run: |-
           sudo apt-get install graphviz
           sbt -jvm-opts .jvmopts-ci \
             -Dakka.build.scalaVersion=${{ matrix.scalaVersion }} \
-            publishLocal publishM2
+            "+~ ${{ matrix.scalaVersion }} publishLocal publishM2"
 
       - name: Email on failure
         if: ${{ failure() }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -33,6 +33,6 @@ jobs:
           chmod 600 /tmp/id_rsa
           ssh-add /tmp/id_rsa
           # using Scala 2.13 here to avoid the infamous problem with missing AskSupport in classpath
-          sbt -Dakka.build.scalaVersion=2.13.0 -Dakka.genjavadoc.enabled=true publishRsync
+          sbt -Dakka.genjavadoc.enabled=true "+~ 2.13 publishRsync"
         env:
           SCP_SECRET: ${{ secrets.SCP_SECRET }}

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -48,7 +48,6 @@ jobs:
         # note that this is not running any multi-jvm tests (yet) because multi-in-test=false
         run: |
           sbt -jvm-opts .jvmopts-ci \
-          -Dakka.build.scalaVersion=3.0 \
           -Dakka.log.timestamps=true \
           -Dakka.test.timefactor=2 \
           -Dakka.actor.testkit.typed.timefactor=2 \
@@ -59,4 +58,4 @@ jobs:
           -Dmultinode.Xmx256M \
           -Dmultinode.Xlog:gc \
           -Dmultinode.XX:+AlwaysActAsServerClassMachine \
-          ${{ matrix.command }}
+          "+~ 3 ${{ matrix.command }}"

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -45,5 +45,4 @@ jobs:
       - name: Compile on Scala 3
         run: |
           sbt -jvm-opts .jvmopts-ci \
-          -Dakka.build.scalaVersion=3.0 \
-          ${{ matrix.command }}
+          "+~ 3 ${{ matrix.command }}"

--- a/build.sbt
+++ b/build.sbt
@@ -208,7 +208,7 @@ lazy val docs = akkaModule("akka-docs")
     cluster,
     clusterMetrics,
     slf4j,
-    //osgi,
+    osgi,
     persistenceTck,
     persistenceQuery,
     distributedData,

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ import akka.{ AutomaticModuleName, CopyrightHeaderForBuild, Paradox, ScalafixIgn
 
 ThisBuild / scalafixScalaBinaryVersion := scalaBinaryVersion.value
 
+scalaVersion := Dependencies.allScalaVersions.head
+
 enablePlugins(
   UnidocRoot,
   UnidocWithPrValidation,

--- a/build.sbt
+++ b/build.sbt
@@ -99,8 +99,7 @@ lazy val root = Project(id = "akka", base = file("."))
         serialversionRemoverPlugin))
   .settings(Compile / headerCreate / unmanagedSources := (baseDirectory.value / "project").**("*.scala").get)
   .enablePlugins(CopyrightHeaderForBuild)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions := Nil)
+  //.settings(crossScalaVersions := Nil)
 
 lazy val actor = akkaModule("akka-actor")
   .settings(Dependencies.actor)
@@ -113,8 +112,6 @@ lazy val actor = akkaModule("akka-actor")
   .settings(VersionGenerator.settings)
   .settings(serialversionRemoverPluginSettings)
   .enablePlugins(BoilerplatePlugin)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions += akka.Dependencies.scala3Version)
 
 lazy val actorTests = akkaModule("akka-actor-tests")
   .dependsOn(testkit % "compile->compile;test->test")
@@ -150,8 +147,6 @@ lazy val cluster = akkaModule("akka-cluster")
   .settings(Test / parallelExecution := false)
   .configs(MultiJvm)
   .enablePlugins(MultiNodeScalaTest)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val clusterMetrics = akkaModule("akka-cluster-metrics")
   .dependsOn(
@@ -214,7 +209,7 @@ lazy val docs = akkaModule("akka-docs")
     cluster,
     clusterMetrics,
     slf4j,
-    osgi,
+    //osgi,
     persistenceTck,
     persistenceQuery,
     distributedData,
@@ -263,8 +258,6 @@ lazy val jackson = akkaModule("akka-serialization-jackson")
   .settings(OSGi.jackson)
   .settings(javacOptions += "-parameters")
   .enablePlugins(ScaladocNoVerificationOfDiagrams)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val multiNodeTestkit = akkaModule("akka-multi-node-testkit")
   .dependsOn(remote, testkit)
@@ -278,7 +271,10 @@ lazy val osgi = akkaModule("akka-osgi")
   .settings(Dependencies.osgi)
   .settings(AutomaticModuleName.settings("akka.osgi"))
   .settings(OSGi.osgi)
-  .settings(Test / parallelExecution := false)
+  .settings(
+    Test / parallelExecution := false,
+    crossScalaVersions -= akka.Dependencies.scala3Version
+  )
 
 lazy val persistence = akkaModule("akka-persistence")
   .dependsOn(actor, stream, testkit % "test->test")
@@ -287,8 +283,6 @@ lazy val persistence = akkaModule("akka-persistence")
   .settings(OSGi.persistence)
   .settings(Protobuf.settings)
   .settings(Test / fork := true)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val persistenceQuery = akkaModule("akka-persistence-query")
   .dependsOn(
@@ -344,8 +338,6 @@ lazy val persistenceTypedTests = akkaModule("akka-persistence-typed-tests")
   .settings(javacOptions += "-parameters") // for Jackson
   .disablePlugins(MimaPlugin)
   .enablePlugins(NoPublish)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val protobuf = akkaModule("akka-protobuf")
   .settings(OSGi.protobuf)
@@ -408,8 +400,6 @@ lazy val remote =
     .settings(Test / parallelExecution := false)
     .settings(serialversionRemoverPluginSettings)
     .enablePlugins(Jdk9)
-    // TODO https://github.com/akka/akka/issues/30243
-    .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val remoteTests = akkaModule("akka-remote-tests")
   .dependsOn(
@@ -424,8 +414,6 @@ lazy val remoteTests = akkaModule("akka-remote-tests")
   .configs(MultiJvm)
   .enablePlugins(MultiNodeScalaTest, NoPublish)
   .disablePlugins(MimaPlugin)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val slf4j = akkaModule("akka-slf4j")
   .dependsOn(actor, testkit % "test->test")
@@ -446,8 +434,6 @@ lazy val streamTestkit = akkaModule("akka-stream-testkit")
   .settings(Dependencies.streamTestkit)
   .settings(AutomaticModuleName.settings("akka.stream.testkit"))
   .settings(OSGi.streamTestkit)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val streamTests = akkaModule("akka-stream-tests")
   .configs(akka.Jdk9.TestJdk9)
@@ -509,8 +495,6 @@ lazy val persistenceTyped = akkaModule("akka-persistence-typed")
   // To be able to import ContainerFormats.proto
   .settings(Protobuf.importPath := Some(baseDirectory.value / ".." / "akka-remote" / "src" / "main" / "protobuf"))
   .settings(OSGi.persistenceTyped)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val clusterTyped = akkaModule("akka-cluster-typed")
   .dependsOn(
@@ -552,8 +536,6 @@ lazy val clusterShardingTyped = akkaModule("akka-cluster-sharding-typed")
   .settings(Protobuf.importPath := Some(baseDirectory.value / ".." / "akka-remote" / "src" / "main" / "protobuf"))
   .configs(MultiJvm)
   .enablePlugins(MultiNodeScalaTest)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val streamTyped = akkaModule("akka-stream-typed")
   .dependsOn(
@@ -569,8 +551,6 @@ lazy val actorTestkitTyped = akkaModule("akka-actor-testkit-typed")
   .dependsOn(actorTyped, slf4j, testkit % "compile->compile;test->test")
   .settings(AutomaticModuleName.settings("akka.actor.testkit.typed"))
   .settings(Dependencies.actorTestkitTyped)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val actorTypedTests = akkaModule("akka-actor-typed-tests")
   .dependsOn(actorTyped % "compile->CompileJdk9", actorTestkitTyped % "compile->compile;test->test")
@@ -583,16 +563,12 @@ lazy val discovery = akkaModule("akka-discovery")
   .settings(Dependencies.discovery)
   .settings(AutomaticModuleName.settings("akka.discovery"))
   .settings(OSGi.discovery)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val coordination = akkaModule("akka-coordination")
   .dependsOn(actor, testkit % "test->test", actorTests % "test->test")
   .settings(Dependencies.coordination)
   .settings(AutomaticModuleName.settings("akka.coordination"))
   .settings(OSGi.coordination)
-  // TODO https://github.com/akka/akka/issues/30243
-  .settings(crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val billOfMaterials = Project("akka-bill-of-materials", file("akka-bill-of-materials"))
   .enablePlugins(BillOfMaterialsPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,6 @@ lazy val root = Project(id = "akka", base = file("."))
         serialversionRemoverPlugin))
   .settings(Compile / headerCreate / unmanagedSources := (baseDirectory.value / "project").**("*.scala").get)
   .enablePlugins(CopyrightHeaderForBuild)
-  //.settings(crossScalaVersions := Nil)
 
 lazy val actor = akkaModule("akka-actor")
   .settings(Dependencies.actor)
@@ -271,10 +270,7 @@ lazy val osgi = akkaModule("akka-osgi")
   .settings(Dependencies.osgi)
   .settings(AutomaticModuleName.settings("akka.osgi"))
   .settings(OSGi.osgi)
-  .settings(
-    Test / parallelExecution := false,
-    crossScalaVersions -= akka.Dependencies.scala3Version
-  )
+  .settings(Test / parallelExecution := false, crossScalaVersions -= akka.Dependencies.scala3Version)
 
 lazy val persistence = akkaModule("akka-persistence")
   .dependsOn(actor, stream, testkit % "test->test")

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -290,12 +290,10 @@ object AkkaBuild {
   def majorMinor(version: String): Option[String] = """\d+\.\d+""".r.findFirstIn(version)
 
   // So we can `sbt "+~ 2.13 clean compile"`
-  val switchVersion: Command = Command.args("+~", "<version> <args>")({
-    (initialState: State, args: Seq[String]) => {
+  val switchVersion: Command = Command.args("+~", "<version> <args>")({ (initialState: State, args: Seq[String]) =>
+    {
       val requestedVersionPrefix = args.head
-      val requestedVersion = Dependencies.allScalaVersions
-        .filter(_.startsWith(requestedVersionPrefix))
-        .head
+      val requestedVersion = Dependencies.allScalaVersions.filter(_.startsWith(requestedVersionPrefix)).head
 
       def run(state: State, command: String): State = {
         val parsed = s"++ $requestedVersion $command".foldLeft(Cross.switchVersion.parser(state))((p, i) => p.derive(i))

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -289,7 +289,13 @@ object AkkaBuild {
 
   def majorMinor(version: String): Option[String] = """\d+\.\d+""".r.findFirstIn(version)
 
-  // So we can `sbt "+~ 2.13 clean compile"`
+  // So we can `sbt "+~ 3 clean compile"`
+  //
+  // The advantage over `++` is twofold:
+  // * `++` also requires the patch version, `+~` finds the first supported Scala version that matches the prefix (if any)
+  // * When subprojects need to be excluded, ++ needs to be specified for each command
+  //
+  // So the `++` equivalent of the above example is `sbt "++ 3.1.1-RC1 clean" "++ 3.1.1-RC1 compile"`
   val switchVersion: Command = Command.args("+~", "<version> <args>")({ (initialState: State, args: Seq[String]) =>
     {
       val requestedVersionPrefix = args.head

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -27,7 +27,7 @@ object AkkaBuild {
 
   val parallelExecutionByDefault = false // TODO: enable this once we're sure it does not break things
 
-  lazy val buildSettings = Def.settings(organization := "com.typesafe.akka", Dependencies.Versions)
+  lazy val buildSettings = Def.settings(organization := "com.typesafe.akka")
 
   lazy val rootSettings = Def.settings(
     commands += switchVersion,
@@ -124,6 +124,7 @@ object AkkaBuild {
   final val DefaultJavacOptions = Seq("-encoding", "UTF-8", "-Xlint:unchecked", "-XDignore.symbol.file")
 
   lazy val defaultSettings: Seq[Setting[_]] = Def.settings(
+    Dependencies.Versions,
     resolverSettings,
     TestExtras.Filter.settings,
     // compile options

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
   val scalaCheckVersion = "1.15.1"
 
   val Versions =
-    Seq(crossScalaVersions := allScalaVersions, java8CompatVersion := {
+    Seq(crossScalaVersions := allScalaVersions, scalaVersion := allScalaVersions.head, java8CompatVersion := {
       CrossVersion.partialVersion(scalaVersion.value) match {
         // java8-compat is only used in a couple of places for 2.13,
         // it is probably possible to remove the dependency if needed.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,6 +32,7 @@ object Dependencies {
   // To get the fix for https://github.com/lampepfl/dotty/issues/13106
   // and restored static forwarders
   val scala3Version = "3.1.1-RC1"
+  val allScalaVersions = Seq(scala213Version, scala212Version, scala3Version)
 
   val reactiveStreamsVersion = "1.0.3"
 
@@ -55,15 +56,7 @@ object Dependencies {
 
   val Versions =
     Seq(
-      crossScalaVersions := Seq(scala212Version, scala213Version),
-      scalaVersion := {
-        System.getProperty("akka.build.scalaVersion", "default") match {
-          case v if v.startsWith("2.13") => scala213Version
-          case v if v.startsWith("2.12") => scala212Version
-          case v if v.startsWith("3.")   => scala3Version
-          case "default"                 => scala213Version
-        }
-      },
+      crossScalaVersions := allScalaVersions,
       java8CompatVersion := {
         CrossVersion.partialVersion(scalaVersion.value) match {
           // java8-compat is only used in a couple of places for 2.13,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,17 +55,15 @@ object Dependencies {
   val scalaCheckVersion = "1.15.1"
 
   val Versions =
-    Seq(
-      crossScalaVersions := allScalaVersions,
-      java8CompatVersion := {
-        CrossVersion.partialVersion(scalaVersion.value) match {
-          // java8-compat is only used in a couple of places for 2.13,
-          // it is probably possible to remove the dependency if needed.
-          case Some((3, _))            => "1.0.0"
-          case Some((2, n)) if n >= 13 => "1.0.0"
-          case _                       => "0.8.0"
-        }
-      })
+    Seq(crossScalaVersions := allScalaVersions, java8CompatVersion := {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        // java8-compat is only used in a couple of places for 2.13,
+        // it is probably possible to remove the dependency if needed.
+        case Some((3, _))            => "1.0.0"
+        case Some((2, n)) if n >= 13 => "1.0.0"
+        case _                       => "0.8.0"
+      }
+    })
 
   object Compile {
     // Compile

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.6


### PR DESCRIPTION
Previously, because of our `akka.build.scalaVersion`, it was not possible to have a depending module build for fewer Scala versions than a dependent module (e.g. building `akka-actor` for Scala 3 but not `akka-osgi`).

The obvious alternative, using the regular `++`, has the disadvantage that you'll need to keep the patch versions of Scala versions consistent between `crossScalaVersions` and the CI scripts.

This PR introduces a custom `+~` command that fixes both these limitations: you only have to provide a version prefix (like `sbt "+~ 2.13 compile"`) and there is no more trouble when `akka-osgi` has fewer `crossScalaVersions` as `akka-actor` (because it uses `++` under the hood rather than setting `scalaVersion` directly).