### PR TITLE
Use sub-directory for embedded Aeron media driver

### DIFF
--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamMultiNodeSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamMultiNodeSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.remote.artery.aeron
 
+import java.io.File
 import java.util.UUID
 
 import io.aeron.CommonContext
@@ -19,7 +20,7 @@ abstract class AeronStreamMultiNodeSpec(config: MultiNodeConfig) extends MultiNo
     val driverContext = new MediaDriver.Context
     // create a random name but include the actor system name for easier debugging
     val uniquePart = UUID.randomUUID().toString
-    val randomName = s"${CommonContext.getAeronDirectoryName}-${system.name}-$uniquePart"
+    val randomName = s"${CommonContext.getAeronDirectoryName}${File.separator}${system.name}-$uniquePart"
     driverContext.aeronDirectoryName(randomName)
     val d = MediaDriver.launchEmbedded(driverContext)
     log.info("Started embedded media driver in directory [{}]", d.aeronDirectoryName)

--- a/akka-remote/src/main/scala/akka/remote/artery/aeron/ArteryAeronUdpTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/aeron/ArteryAeronUdpTransport.scala
@@ -91,7 +91,7 @@ private[remote] class ArteryAeronUdpTransport(_system: ExtendedActorSystem, _pro
       } else {
         // create a random name but include the actor system name for easier debugging
         val uniquePart = UUID.randomUUID().toString
-        val randomName = s"${CommonContext.getAeronDirectoryName}-${system.name}-$uniquePart"
+        val randomName = s"${CommonContext.getAeronDirectoryName}${File.separator}${system.name}-$uniquePart"
         driverContext.aeronDirectoryName(randomName)
       }
       driverContext.clientLivenessTimeoutNs(settings.Advanced.Aeron.ClientLivenessTimeout.toNanos)


### PR DESCRIPTION
* in multi-node tests we create the volume /opt/volumes/media-driver
  and run with -Daeron.dir=/opt/volumes/media-driver but when starting
  the embedded media driver a unique part is added to the directory name
  so it becomes like
```
  Started embedded media driver in directory [/opt/volumes/media-driver-ClusterLogVerboseEnabledSpec-27c2fe72-c2b2-4ef4-ab87-a783f5d9ece4]
```
* this adds the unique part as a sub-directory instead, so that it's still in in the
  /opt/volumes/media-driver/ volume
* I don't know if this will make things more stable but the defined volume wasn't really
  used as intended

