### PR TITLE
Optional akka-remote dependency from akka-persistence-query, #30980

### DIFF
--- a/akka-persistence-query/src/main/scala/akka/persistence/query/internal/QuerySerializer.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/internal/QuerySerializer.scala
@@ -35,7 +35,7 @@ import akka.serialization.Serializers
     extends SerializerWithStringManifest
     with BaseSerializer {
 
-  private val payloadSupport = new WrappedPayloadSupport(system)
+  private lazy val payloadSupport = new WrappedPayloadSupport(system)
   private lazy val serialization = SerializationExtension(system)
 
   private final val EventEnvelopeManifest = "a"

--- a/build.sbt
+++ b/build.sbt
@@ -295,7 +295,7 @@ lazy val persistenceQuery = akkaModule("akka-persistence-query")
     stream,
     persistence % "compile->compile;test->test",
     remote % "provided",
-    protobufV3 % "provided",
+    protobufV3,
     streamTestkit % "test")
   .settings(Dependencies.persistenceQuery)
   .settings(AutomaticModuleName.settings("akka.persistence.query"))


### PR DESCRIPTION
* akka-protobuf-v3 is anyway a dependency from akka-stream
* akka-remote can remain provided by adding lazy on the WrappedPayloadSupport
* tested with a sample with only akka-persistence and akka-persistence-query

References #30980
