### PR TITLE
Add slice queries to Persistence TestKit

### DIFF
--- a/akka-docs/src/test/java/jdocs/persistence/testkit/PersistenceTestKitPolicySampleTest.java
+++ b/akka-docs/src/test/java/jdocs/persistence/testkit/PersistenceTestKitPolicySampleTest.java
@@ -56,7 +56,7 @@ public class PersistenceTestKitPolicySampleTest extends AbstractJavaTest {
 
   static class SampleEventStoragePolicy implements ProcessingPolicy<JournalOperation> {
     @Override
-    public ProcessingResult tryProcess(String persistenceId, JournalOperation processingUnit) {
+    public ProcessingResult tryProcess(String processId, JournalOperation processingUnit) {
       if (processingUnit instanceof WriteEvents) {
         return StorageFailure.create();
       } else {

--- a/akka-docs/src/test/java/jdocs/persistence/testkit/TestKitExamples.java
+++ b/akka-docs/src/test/java/jdocs/persistence/testkit/TestKitExamples.java
@@ -29,7 +29,7 @@ public class TestKitExamples {
     int count = 1;
 
     @Override
-    public ProcessingResult tryProcess(String persistenceId, JournalOperation processingUnit) {
+    public ProcessingResult tryProcess(String processId, JournalOperation processingUnit) {
       // check the type of operation and react with success or with reject or with failure.
       // if you return ProcessingSuccess the operation will be performed, otherwise not.
       if (count < 10) {
@@ -64,7 +64,7 @@ public class TestKitExamples {
     int count = 1;
 
     @Override
-    public ProcessingResult tryProcess(String persistenceId, SnapshotOperation processingUnit) {
+    public ProcessingResult tryProcess(String processId, SnapshotOperation processingUnit) {
       // check the type of operation and react with success or with failure.
       // if you return ProcessingSuccess the operation will be performed, otherwise not.
       if (count < 10) {

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/ProcessingPolicy.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/ProcessingPolicy.scala
@@ -22,10 +22,11 @@ trait ProcessingPolicy[U] {
    * If you need this operation to succeed return [[ProcessingSuccess]],
    * otherwise you should return some of the [[ProcessingFailure]]'s.
    *
+   * @param processId persistenceId or other id of the processing operation
    * @param processingUnit details about current operation to be executed
    * @return needed result of processing the operation
    */
-  def tryProcess(persistenceId: String, processingUnit: U): ProcessingResult
+  def tryProcess(processId: String, processingUnit: U): ProcessingResult
 
 }
 

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/query/javadsl/PersistenceTestKitReadJournal.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/query/javadsl/PersistenceTestKitReadJournal.scala
@@ -3,7 +3,9 @@
  */
 
 package akka.persistence.testkit.query.javadsl
+
 import akka.NotUsed
+import akka.japi.Pair
 import akka.persistence.query.EventEnvelope
 import akka.persistence.query.Offset
 import akka.persistence.query.javadsl.{
@@ -12,6 +14,8 @@ import akka.persistence.query.javadsl.{
   EventsByPersistenceIdQuery,
   ReadJournal
 }
+import akka.persistence.query.typed
+import akka.persistence.query.typed.javadsl.CurrentEventsBySliceQuery
 import akka.stream.javadsl.Source
 import akka.persistence.testkit.query.scaladsl
 
@@ -23,7 +27,8 @@ final class PersistenceTestKitReadJournal(delegate: scaladsl.PersistenceTestKitR
     extends ReadJournal
     with EventsByPersistenceIdQuery
     with CurrentEventsByPersistenceIdQuery
-    with CurrentEventsByTagQuery {
+    with CurrentEventsByTagQuery
+    with CurrentEventsBySliceQuery {
 
   override def eventsByPersistenceId(
       persistenceId: String,
@@ -40,4 +45,21 @@ final class PersistenceTestKitReadJournal(delegate: scaladsl.PersistenceTestKitR
   override def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] =
     delegate.currentEventsByTag(tag, offset).asJava
 
+  override def currentEventsBySlices[Event](
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      offset: Offset): Source[typed.EventEnvelope[Event], NotUsed] =
+    delegate.currentEventsBySlices(entityType, minSlice, maxSlice, offset).asJava
+
+  override def sliceForPersistenceId(persistenceId: String): Int =
+    delegate.sliceForPersistenceId(persistenceId)
+
+  override def sliceRanges(numberOfRanges: Int): java.util.List[Pair[Integer, Integer]] = {
+    import akka.util.ccompat.JavaConverters._
+    delegate
+      .sliceRanges(numberOfRanges)
+      .map(range => Pair(Integer.valueOf(range.min), Integer.valueOf(range.max)))
+      .asJava
+  }
 }

--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/query/CurrentEventsBySlicesSpec.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/query/CurrentEventsBySlicesSpec.scala
@@ -4,41 +4,48 @@
 
 package akka.persistence.testkit.query
 
+import org.scalatest.wordspec.AnyWordSpecLike
+
 import akka.Done
 import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.typed.ActorRef
+import akka.persistence.Persistence
 import akka.persistence.query.NoOffset
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.testkit.query.EventsByPersistenceIdSpec.Command
 import akka.persistence.testkit.query.EventsByPersistenceIdSpec.testBehaviour
 import akka.persistence.testkit.query.scaladsl.PersistenceTestKitReadJournal
 import akka.stream.scaladsl.Sink
-import org.scalatest.wordspec.AnyWordSpecLike
 
-class CurrentEventsByTagSpec
+class CurrentEventsBySlicesSpec
     extends ScalaTestWithActorTestKit(EventsByPersistenceIdSpec.config)
     with LogCapturing
     with AnyWordSpecLike {
 
   implicit val classic: akka.actor.ActorSystem = system.classicSystem
 
-  private val queries =
+  val queries =
     PersistenceQuery(system).readJournalFor[PersistenceTestKitReadJournal](PersistenceTestKitReadJournal.Identifier)
 
-  def setupEmpty(persistenceId: String): ActorRef[Command] = {
-    spawn(
-      testBehaviour(persistenceId).withTagger(evt =>
-        if (evt.indexOf('-') > 0) Set(evt.split('-')(1), "all")
-        else Set("all")))
+  def setup(persistenceId: String): ActorRef[Command] = {
+    val probe = createTestProbe[Done]()
+    val ref = spawn(testBehaviour(persistenceId))
+    ref ! Command(s"$persistenceId-1", probe.ref)
+    ref ! Command(s"$persistenceId-2", probe.ref)
+    ref ! Command(s"$persistenceId-3", probe.ref)
+    probe.expectMessage(Done)
+    probe.expectMessage(Done)
+    probe.expectMessage(Done)
+    ref
   }
 
   "Persistent test kit currentEventsByTag query" must {
 
-    "find tagged events ordered by insert time" in {
+    "find eventsBySlices ordered by insert time" in {
       val probe = createTestProbe[Done]()
-      val ref1 = setupEmpty("taggedpid-1")
-      val ref2 = setupEmpty("taggedpid-2")
+      val ref1 = spawn(testBehaviour("Test|pid-1"))
+      val ref2 = spawn(testBehaviour("Test|pid-2"))
       ref1 ! Command("evt-1", probe.ref)
       ref1 ! Command("evt-2", probe.ref)
       ref1 ! Command("evt-3", probe.ref)
@@ -48,8 +55,11 @@ class CurrentEventsByTagSpec
       ref1 ! Command("evt-5", probe.ref)
       probe.receiveMessage()
 
-      queries.currentEventsByTag("all", NoOffset).runWith(Sink.seq).futureValue.map(_.event) should ===(
-        Seq("evt-1", "evt-2", "evt-3", "evt-4", "evt-5"))
+      queries
+        .currentEventsBySlices[String]("Test", 0, Persistence(system).numberOfSlices - 1, NoOffset)
+        .runWith(Sink.seq)
+        .futureValue
+        .map(_.event) should ===(Seq("evt-1", "evt-2", "evt-3", "evt-4", "evt-5"))
     }
   }
 


### PR DESCRIPTION
* Add currentEventsBySlices to Persistence TestKit
* Add DurableStateStoreBySliceQuery to Persistence TestKit 
* to make it feature comatible with corresponding tagged queries
* simplifies some usage in downstream projects

Split in two commits if you prefer to review them separately.