### PR TITLE
Remove unused import in PersistenceTestKitDurableStateStoreSpec

### DIFF
--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStoreSpec.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStoreSpec.scala
@@ -10,7 +10,6 @@ import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.persistence.query.NoOffset
 import akka.persistence.query.Sequence
 import akka.persistence.query.UpdatedDurableState
-import akka.persistence.testkit.state.scaladsl.PersistenceTestKitDurableStateStore
 import akka.persistence.testkit.PersistenceTestKitDurableStateStorePlugin
 import akka.stream.scaladsl.Sink
 import akka.stream.testkit.scaladsl.TestSink


### PR DESCRIPTION
* fails in Scala 2.12 build
* PersistenceTestKitDurableStateStoreSpec.scala:13:48: imported `PersistenceTestKitDurableStateStore` is permanently hidden by definition of object PersistenceTestKitDurableStateStore in package scaladsl
