### PR TITLE
migrate-SBT-Dependencies 

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -118,63 +118,63 @@ object Dependencies {
     val logback = "ch.qos.logback" % "logback-classic" % logbackVersion // EPL 1.0
 
     object Docs {
-      val sprayJson = "io.spray" %% "spray-json" % "1.3.6" % "test"
-      val gson = "com.google.code.gson" % "gson" % "2.8.9" % "test"
+      val sprayJson = "io.spray" %% "spray-json" % "1.3.6" % Test
+      val gson = "com.google.code.gson" % "gson" % "2.8.9" % Test
     }
 
-    object Test {
-      val commonsMath = "org.apache.commons" % "commons-math" % "2.2" % "test" // ApacheV2
-      val commonsIo = "commons-io" % "commons-io" % "2.11.0" % "test" // ApacheV2
-      val commonsCodec = "commons-codec" % "commons-codec" % "1.15" % "test" // ApacheV2
+    object TestDependencies {
+      val commonsMath = "org.apache.commons" % "commons-math" % "2.2" % Test // ApacheV2
+      val commonsIo = "commons-io" % "commons-io" % "2.11.0" % Test // ApacheV2
+      val commonsCodec = "commons-codec" % "commons-codec" % "1.15" % Test // ApacheV2
       val junit = "junit" % "junit" % junitVersion % "test" // Common Public License 1.0
-      val logback = Compile.logback % "test" // EPL 1.0
+      val logback = Compile.logback % Test // EPL 1.0
 
-      val scalatest = Def.setting { "org.scalatest" %% "scalatest" % scalaTestVersion.value % "test" } // ApacheV2
+      val scalatest = Def.setting { "org.scalatest" %% "scalatest" % scalaTestVersion.value % Test } // ApacheV2
 
       // The 'scalaTestPlus' projects are independently versioned,
       // but the version of each module starts with the scalatest
       // version it was intended to work with
       val scalatestJUnit = Def.setting {
-        "org.scalatestplus" %% "junit-4-13" % (scalaTestVersion.value + ".0") % "test"
+        "org.scalatestplus" %% "junit-4-13" % (scalaTestVersion.value + ".0") % Test
       } // ApacheV2
       val scalatestTestNG = Def.setting {
-        "org.scalatestplus" %% "testng-6-7" % (scalaTestVersion.value + ".0") % "test"
+        "org.scalatestplus" %% "testng-6-7" % (scalaTestVersion.value + ".0") % Test
       } // ApacheV2
       val scalatestScalaCheck = Def.setting {
-        "org.scalatestplus" %% s"scalacheck-${scalaTestScalaCheckVersion.value}" % (scalaTestVersion.value + ".0") % "test"
+        "org.scalatestplus" %% s"scalacheck-${scalaTestScalaCheckVersion.value}" % (scalaTestVersion.value + ".0") % Test
       } // ApacheV2
       val scalatestMockito = Def.setting {
-        "org.scalatestplus" %% "mockito-3-4" % (scalaTestVersion.value + ".0") % "test"
+        "org.scalatestplus" %% "mockito-3-4" % (scalaTestVersion.value + ".0") % Test
       } // ApacheV2
 
-      val pojosr = "com.googlecode.pojosr" % "de.kalpatec.pojosr.framework" % "0.2.1" % "test" // ApacheV2
-      val tinybundles = "org.ops4j.pax.tinybundles" % "tinybundles" % "3.0.0" % "test" // ApacheV2
-      val log4j = "log4j" % "log4j" % "1.2.17" % "test" // ApacheV2
+      val pojosr = "com.googlecode.pojosr" % "de.kalpatec.pojosr.framework" % "0.2.1" % Test // ApacheV2
+      val tinybundles = "org.ops4j.pax.tinybundles" % "tinybundles" % "3.0.0" % Test // ApacheV2
+      val log4j = "log4j" % "log4j" % "1.2.17" % Test // ApacheV2
 
       // in-memory filesystem for file related tests
-      val jimfs = "com.google.jimfs" % "jimfs" % "1.1" % "test" // ApacheV2
+      val jimfs = "com.google.jimfs" % "jimfs" % "1.1" % Test // ApacheV2
 
       // docker utils
-      val dockerClient = "com.spotify" % "docker-client" % "8.16.0" % "test" // ApacheV2
+      val dockerClient = "com.spotify" % "docker-client" % "8.16.0" % Test // ApacheV2
 
       // metrics, measurements, perf testing
-      val metrics = "io.dropwizard.metrics" % "metrics-core" % "4.2.4" % "test" // ApacheV2
-      val metricsJvm = "io.dropwizard.metrics" % "metrics-jvm" % "4.2.4" % "test" // ApacheV2
-      val latencyUtils = "org.latencyutils" % "LatencyUtils" % "2.0.3" % "test" // Free BSD
-      val hdrHistogram = "org.hdrhistogram" % "HdrHistogram" % "2.1.12" % "test" // CC0
+      val metrics = "io.dropwizard.metrics" % "metrics-core" % "4.2.4" % Test // ApacheV2
+      val metricsJvm = "io.dropwizard.metrics" % "metrics-jvm" % "4.2.4" % Test // ApacheV2
+      val latencyUtils = "org.latencyutils" % "LatencyUtils" % "2.0.3" % Test // Free BSD
+      val hdrHistogram = "org.hdrhistogram" % "HdrHistogram" % "2.1.12" % Test // CC0
       val metricsAll = Seq(metrics, metricsJvm, latencyUtils, hdrHistogram)
 
       // sigar logging
-      val slf4jJul = "org.slf4j" % "jul-to-slf4j" % slf4jVersion % "test" // MIT
-      val slf4jLog4j = "org.slf4j" % "log4j-over-slf4j" % slf4jVersion % "test" // MIT
+      val slf4jJul = "org.slf4j" % "jul-to-slf4j" % slf4jVersion % Test // MIT
+      val slf4jLog4j = "org.slf4j" % "log4j-over-slf4j" % slf4jVersion % Test // MIT
 
       // reactive streams tck
-      val reactiveStreamsTck = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion % "test" // CC0
+      val reactiveStreamsTck = "org.reactivestreams" % "reactive-streams-tck" % reactiveStreamsVersion % Test // CC0
 
-      val protobufRuntime = "com.google.protobuf" % "protobuf-java" % protobufJavaVersion % "test"
+      val protobufRuntime = "com.google.protobuf" % "protobuf-java" % protobufJavaVersion % Test
 
       // YCSB (Yahoo Cloud Serving Benchmark https://ycsb.site)
-      val ycsb = "site.ycsb" % "core" % "0.17.0" % "test" // ApacheV2
+      val ycsb = "site.ycsb" % "core" % "0.17.0" % Test // ApacheV2
     }
 
     object Provided {
@@ -207,21 +207,21 @@ object Dependencies {
 
   val actorTyped = l ++= Seq(slf4jApi)
 
-  val discovery = l ++= Seq(Test.junit, Test.scalatest.value)
+  val discovery = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest.value)
 
-  val coordination = l ++= Seq(Test.junit, Test.scalatest.value)
+  val coordination = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest.value)
 
-  val testkit = l ++= Seq(Test.junit, Test.scalatest.value) ++ Test.metricsAll
+  val testkit = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest.value) ++ TestDependencies.metricsAll
 
   val actorTests = l ++= Seq(
-        Test.junit,
-        Test.scalatest.value,
-        Test.scalatestJUnit.value,
-        Test.scalatestScalaCheck.value,
-        Test.commonsCodec,
-        Test.commonsMath,
-        Test.jimfs,
-        Test.dockerClient,
+        TestDependencies.junit,
+        TestDependencies.scalatest.value,
+        TestDependencies.scalatestJUnit.value,
+        TestDependencies.scalatestScalaCheck.value,
+        TestDependencies.commonsCodec,
+        TestDependencies.commonsMath,
+        TestDependencies.jimfs,
+        TestDependencies.dockerClient,
         Provided.activation // dockerClient needs javax.activation.DataSource in JDK 11+
       )
 
@@ -229,74 +229,74 @@ object Dependencies {
         Provided.logback,
         Provided.junit,
         Provided.scalatest.value,
-        Test.scalatestJUnit.value)
+        TestDependencies.scalatestJUnit.value)
 
   val pki = l ++=
       Seq(
         asnOne,
         // pull up slf4j version from the one provided transitively in asnOne to fix unidoc
         Compile.slf4jApi,
-        Test.scalatest.value)
+        TestDependencies.scalatest.value)
 
   val remoteDependencies = Seq(netty, aeronDriver, aeronClient)
   val remoteOptionalDependencies = remoteDependencies.map(_ % "optional")
 
-  val remote = l ++= Seq(agrona, Test.junit, Test.scalatest.value, Test.jimfs, Test.protobufRuntime) ++ remoteOptionalDependencies
+  val remote = l ++= Seq(agrona, TestDependencies.junit, TestDependencies.scalatest.value, TestDependencies.jimfs, TestDependencies.protobufRuntime) ++ remoteOptionalDependencies
 
-  val remoteTests = l ++= Seq(Test.junit, Test.scalatest.value) ++ remoteDependencies
+  val remoteTests = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest.value) ++ remoteDependencies
 
   val multiNodeTestkit = l ++= Seq(netty)
 
-  val cluster = l ++= Seq(Test.junit, Test.scalatest.value)
+  val cluster = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest.value)
 
-  val clusterTools = l ++= Seq(Test.junit, Test.scalatest.value)
+  val clusterTools = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest.value)
 
   val clusterSharding = l ++= Seq(
         Provided.levelDBmultiJVM,
         Provided.levelDBNative,
-        Test.junit,
-        Test.scalatest.value,
-        Test.commonsIo,
-        Test.ycsb)
+        TestDependencies.junit,
+        TestDependencies.scalatest.value,
+        TestDependencies.commonsIo,
+        TestDependencies.ycsb)
 
   val clusterMetrics = l ++= Seq(
         Provided.sigarLoader,
-        Test.slf4jJul,
-        Test.slf4jLog4j,
-        Test.logback,
-        Test.scalatestMockito.value)
+        TestDependencies.slf4jJul,
+        TestDependencies.slf4jLog4j,
+        TestDependencies.logback,
+        TestDependencies.scalatestMockito.value)
 
-  val distributedData = l ++= Seq(lmdb, Test.junit, Test.scalatest.value)
+  val distributedData = l ++= Seq(lmdb, TestDependencies.junit, TestDependencies.scalatest.value)
 
-  val slf4j = l ++= Seq(slf4jApi, Test.logback)
+  val slf4j = l ++= Seq(slf4jApi, TestDependencies.logback)
 
   val persistence = l ++= Seq(
         Provided.levelDB,
         Provided.levelDBNative,
-        Test.scalatest.value,
-        Test.scalatestJUnit.value,
-        Test.junit,
-        Test.commonsIo,
-        Test.commonsCodec)
+        TestDependencies.scalatest.value,
+        TestDependencies.scalatestJUnit.value,
+        TestDependencies.junit,
+        TestDependencies.commonsIo,
+        TestDependencies.commonsCodec)
 
   val persistenceQuery = l ++= Seq(
-        Test.scalatest.value,
-        Test.junit,
-        Test.commonsIo,
+        TestDependencies.scalatest.value,
+        TestDependencies.junit,
+        TestDependencies.commonsIo,
         Provided.levelDB,
         Provided.levelDBNative)
 
   val persistenceTck = l ++= Seq(
-        Test.scalatest.value.withConfigurations(Some("compile")),
-        Test.junit.withConfigurations(Some("compile")),
+        TestDependencies.scalatest.value.withConfigurations(Some("compile")),
+        TestDependencies.junit.withConfigurations(Some("compile")),
         Provided.levelDB,
         Provided.levelDBNative)
 
-  val persistenceTestKit = l ++= Seq(Test.scalatest.value, Test.logback)
+  val persistenceTestKit = l ++= Seq(TestDependencies.scalatest.value, TestDependencies.logback)
 
-  val persistenceTypedTests = l ++= Seq(Test.scalatest.value, Test.logback)
+  val persistenceTypedTests = l ++= Seq(TestDependencies.scalatest.value, TestDependencies.logback)
 
-  val persistenceShared = l ++= Seq(Provided.levelDB, Provided.levelDBNative, Test.logback)
+  val persistenceShared = l ++= Seq(Provided.levelDB, Provided.levelDBNative, TestDependencies.logback)
 
   val jackson = l ++= Seq(
         jacksonCore,
@@ -307,8 +307,8 @@ object Dependencies {
         jacksonParameterNames,
         jacksonCbor,
         lz4Java,
-        Test.junit,
-        Test.scalatest.value) ++
+        TestDependencies.junit,
+        TestDependencies.scalatest.value) ++
       (
         // jackson-module-scala is only available for Scala 3 from 2.13.0 onwards.
         // since we don't depend on it ourselves, but provide it as a transitive
@@ -316,7 +316,7 @@ object Dependencies {
         // and depend on 2.13.0-rc1 for our tests. Eventually we should consider
         // whether to update all jackson artifacts for Scala 3.
         if (scalaVersion.value.startsWith("3."))
-          Seq("com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.0-rc1" % "test")
+          Seq("com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.0-rc1" % Test)
         else
           Seq(jacksonScala)
       )
@@ -324,36 +324,36 @@ object Dependencies {
   val osgi = l ++= Seq(
         osgiCore,
         osgiCompendium,
-        Test.logback,
-        Test.commonsIo,
-        Test.pojosr,
-        Test.tinybundles,
-        Test.scalatest.value,
-        Test.junit)
+        TestDependencies.logback,
+        TestDependencies.commonsIo,
+        TestDependencies.pojosr,
+        TestDependencies.tinybundles,
+        TestDependencies.scalatest.value,
+        TestDependencies.junit)
 
-  val docs = l ++= Seq(Test.scalatest.value, Test.junit, Docs.sprayJson, Docs.gson, Provided.levelDB)
+  val docs = l ++= Seq(TestDependencies.scalatest.value, TestDependencies.junit, Docs.sprayJson, Docs.gson, Provided.levelDB)
 
   val benchJmh = l ++= Seq(logback, Provided.levelDB, Provided.levelDBNative, Compile.jctools)
 
   // akka stream
 
-  lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, sslConfigCore, Test.scalatest.value)
+  lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, sslConfigCore, TestDependencies.scalatest.value)
 
-  lazy val streamTestkit = l ++= Seq(Test.scalatest.value, Test.scalatestScalaCheck.value, Test.junit)
+  lazy val streamTestkit = l ++= Seq(TestDependencies.scalatest.value, TestDependencies.scalatestScalaCheck.value, TestDependencies.junit)
 
   lazy val streamTests = l ++= Seq(
-        Test.scalatest.value,
-        Test.scalatestScalaCheck.value,
-        Test.junit,
-        Test.commonsIo,
-        Test.jimfs)
+        TestDependencies.scalatest.value,
+        TestDependencies.scalatestScalaCheck.value,
+        TestDependencies.junit,
+        TestDependencies.commonsIo,
+        TestDependencies.jimfs)
 
   lazy val streamTestsTck = l ++= Seq(
-        Test.scalatest.value,
-        Test.scalatestTestNG.value,
-        Test.scalatestScalaCheck.value,
-        Test.junit,
-        Test.reactiveStreamsTck)
+        TestDependencies.scalatest.value,
+        TestDependencies.scalatestTestNG.value,
+        TestDependencies.scalatestScalaCheck.value,
+        TestDependencies.junit,
+        TestDependencies.reactiveStreamsTck)
 
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -241,7 +241,12 @@ object Dependencies {
   val remoteDependencies = Seq(netty, aeronDriver, aeronClient)
   val remoteOptionalDependencies = remoteDependencies.map(_ % "optional")
 
-  val remote = l ++= Seq(agrona, TestDependencies.junit, TestDependencies.scalatest.value, TestDependencies.jimfs, TestDependencies.protobufRuntime) ++ remoteOptionalDependencies
+  val remote = l ++= Seq(
+        agrona,
+        TestDependencies.junit,
+        TestDependencies.scalatest.value,
+        TestDependencies.jimfs,
+        TestDependencies.protobufRuntime) ++ remoteOptionalDependencies
 
   val remoteTests = l ++= Seq(TestDependencies.junit, TestDependencies.scalatest.value) ++ remoteDependencies
 
@@ -331,7 +336,12 @@ object Dependencies {
         TestDependencies.scalatest.value,
         TestDependencies.junit)
 
-  val docs = l ++= Seq(TestDependencies.scalatest.value, TestDependencies.junit, Docs.sprayJson, Docs.gson, Provided.levelDB)
+  val docs = l ++= Seq(
+        TestDependencies.scalatest.value,
+        TestDependencies.junit,
+        Docs.sprayJson,
+        Docs.gson,
+        Provided.levelDB)
 
   val benchJmh = l ++= Seq(logback, Provided.levelDB, Provided.levelDBNative, Compile.jctools)
 
@@ -339,7 +349,10 @@ object Dependencies {
 
   lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, sslConfigCore, TestDependencies.scalatest.value)
 
-  lazy val streamTestkit = l ++= Seq(TestDependencies.scalatest.value, TestDependencies.scalatestScalaCheck.value, TestDependencies.junit)
+  lazy val streamTestkit = l ++= Seq(
+        TestDependencies.scalatest.value,
+        TestDependencies.scalatestScalaCheck.value,
+        TestDependencies.junit)
 
   lazy val streamTests = l ++= Seq(
         TestDependencies.scalatest.value,


### PR DESCRIPTION
- Rename Test object to TestDependencies, to avoid duplicate import
- Replaced 'test' with Test

References #27040
