### PR TITLE
Update upper version bound for scala-java8-compat in OSGi

### DIFF
--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -134,7 +134,7 @@ object OSGi {
     versionedImport(packageName, s"$epoch.$major", s"$epoch.${major.toInt + 1}")
   }
   def scalaJava8CompatImport(packageName: String = "scala.compat.java8.*") =
-    versionedImport(packageName, "0.8.0", "1.0.0")
+    versionedImport(packageName, "0.8.0", "2.0.0")
   def scalaParsingCombinatorImport(packageName: String = "scala.util.parsing.combinator.*") =
     versionedImport(packageName, "1.1.0", "1.2.0")
   def sslConfigCoreImport(packageName: String = "com.typesafe.sslconfig") =


### PR DESCRIPTION
Align the version range with the actual versions of the
scala-java8-compat dependency for the different Scala versions.

Fixes #31024