### PR TITLE
jackson: don't fail serializing empty beans

### DIFF
--- a/akka-serialization-jackson/src/main/resources/reference.conf
+++ b/akka-serialization-jackson/src/main/resources/reference.conf
@@ -47,6 +47,7 @@ akka.serialization.jackson {
     # but WRITE_DATES_AS_TIMESTAMPS=on has better performance.
     WRITE_DATES_AS_TIMESTAMPS = off
     WRITE_DURATIONS_AS_TIMESTAMPS = off
+    FAIL_ON_EMPTY_BEANS = off
   }
 
   # Configuration of the ObjectMapper deserialization features.


### PR DESCRIPTION
Notably, case objects.

It's not entirely clear to me why this started failing on Scala 3,
`AccountExampleSpec` picks `JacksonCborSerializer` both for Scala 2
and Scala 3, but only on 3 seems to require this option.

fixes  #31032