### PR TITLE
build: update to sbt 1.5.8

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.6
+sbt.version=1.5.8


### PR DESCRIPTION
To get latest log4j2. We might want to move to 1.6.x as well, but let's just do this for security.