### PR TITLE
Reset effect in durable state. #30446

### DIFF
--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/DurableStateStoreQueryUsageCompileOnlySpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/DurableStateStoreQueryUsageCompileOnlySpec.scala
@@ -19,12 +19,14 @@ object DurableStateStoreQueryUsageCompileOnlySpec {
     import akka.persistence.query.scaladsl.DurableStateStoreQuery
     import akka.persistence.query.DurableStateChange
     import akka.persistence.query.UpdatedDurableState
+    import akka.persistence.query.DeletedDurableState
 
     val durableStateStoreQuery =
       DurableStateStoreRegistry(system).durableStateStoreFor[DurableStateStoreQuery[Record]](pluginId)
     val source: Source[DurableStateChange[Record], NotUsed] = durableStateStoreQuery.changes("tag", offset)
     source.map {
-      case UpdatedDurableState(persistenceId, revision, value, offset, timestamp) => value
+      case UpdatedDurableState(persistenceId, revision, value, offset, timestamp) => Some(value)
+      case _: DeletedDurableState[_]                                              => None
     }
     //#get-durable-state-store-query-example
   }

--- a/akka-docs/src/test/java/jdocs/dispatcher/MyUnboundedMailbox.java
+++ b/akka-docs/src/test/java/jdocs/dispatcher/MyUnboundedMailbox.java
@@ -41,7 +41,7 @@ public class MyUnboundedMailbox
     }
 
     public void cleanUp(ActorRef owner, MessageQueue deadLetters) {
-      while(!queue.isEmpty()) {
+      while (!queue.isEmpty()) {
         deadLetters.enqueue(owner, dequeue());
       }
     }

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/DurableStateChange.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/DurableStateChange.scala
@@ -9,8 +9,7 @@ import akka.annotation.DoNotInherit
 /**
  * The `DurableStateStoreQuery` stream elements for `DurableStateStoreQuery`.
  *
- * The implementation can be a [[UpdatedDurableState]] or a `DeletedDurableState`.
- * `DeletedDurableState` is not implemented yet, see issue https://github.com/akka/akka/issues/30446
+ * The implementation can be a [[UpdatedDurableState]] or a [[DeletedDurableState]].
  *
  * Not for user extension
  *
@@ -50,6 +49,28 @@ final class UpdatedDurableState[A](
     val persistenceId: String,
     val revision: Long,
     val value: A,
+    override val offset: Offset,
+    val timestamp: Long)
+    extends DurableStateChange[A]
+
+object DeletedDurableState {
+
+  def unapply[A](arg: DeletedDurableState[A]): Option[(String, Long, Offset, Long)] =
+    Some((arg.persistenceId, arg.revision, arg.offset, arg.timestamp))
+}
+
+/**
+ *
+ * @param persistenceId The persistence id of the origin entity.
+ * @param revision The revision number from the origin entity.
+ * @param offset The offset that can be used in next `changes` or `currentChanges` query.
+ * @param timestamp The time the state was stored, in milliseconds since midnight, January 1, 1970 UTC
+ *   (same as `System.currentTimeMillis`).
+ * @tparam A the type of the value
+ */
+final class DeletedDurableState[A](
+    val persistenceId: String,
+    val revision: Long,
     override val offset: Offset,
     val timestamp: Long)
     extends DurableStateChange[A]

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/DurableStateStoreQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/scaladsl/DurableStateStoreQuery.scala
@@ -26,8 +26,8 @@ trait DurableStateStoreQuery[A] extends DurableStateStore[A] {
    * This will return changes that occurred up to when the `Source` returned by this call is materialized. Changes to
    * objects made since materialization are not guaranteed to be included in the results.
    *
-   * The [[DurableStateChange]] elements can be [[akka.persistence.query.UpdatedDurableState]] or `DeletedDurableState`.
-   * `DeletedDurableState` is not implemented yet, see issue https://github.com/akka/akka/issues/30446.
+   * The [[DurableStateChange]] elements can be [[akka.persistence.query.UpdatedDurableState]] or
+   * [[akka.persistence.query.DeletedDurableState]].
    *
    * @param tag The tag to get changes for.
    * @param offset The offset to get changes since. Must either be [[akka.persistence.query.NoOffset]] to get
@@ -48,8 +48,8 @@ trait DurableStateStoreQuery[A] extends DurableStateStore[A] {
    * in quick succession are likely to be skipped, with only the last update resulting in a change from this
    * source.
    *
-   * The [[DurableStateChange]] elements can be [[akka.persistence.query.UpdatedDurableState]] or `DeletedDurableState`.
-   * `DeletedDurableState` is not implemented yet, see issue https://github.com/akka/akka/issues/30446.
+   * The [[DurableStateChange]] elements can be [[akka.persistence.query.UpdatedDurableState]] or
+   * [[akka.persistence.query.DeletedDurableState]].
    *
    * @param tag The tag to get changes for.
    * @param offset The offset to get changes since. Must either be [[akka.persistence.query.NoOffset]] to get

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
@@ -9,12 +9,15 @@ import scala.concurrent.Future
 import akka.{ Done, NotUsed }
 import akka.actor.ExtendedActorSystem
 import akka.persistence.Persistence
-import akka.persistence.query.DurableStateChange
+import akka.persistence.query.{
+  DeletedDurableState,
+  DurableStateChange,
+  NoOffset,
+  Offset,
+  Sequence,
+  UpdatedDurableState
+}
 import akka.persistence.query.scaladsl.{ DurableStateStorePagedPersistenceIdsQuery, DurableStateStoreQuery }
-import akka.persistence.query.UpdatedDurableState
-import akka.persistence.query.Offset
-import akka.persistence.query.NoOffset
-import akka.persistence.query.Sequence
 import akka.persistence.query.typed.scaladsl.DurableStateStoreBySliceQuery
 import akka.persistence.state.scaladsl.{ DurableStateUpdateStore, GetObjectResult }
 import akka.persistence.typed.PersistenceId
@@ -23,7 +26,6 @@ import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Source
 import akka.stream.typed.scaladsl.ActorSource
 import akka.stream.OverflowStrategy
-
 import scala.collection.immutable
 
 object PersistenceTestKitDurableStateStore {
@@ -51,22 +53,27 @@ class PersistenceTestKitDurableStateStore[A](val system: ExtendedActorSystem)
 
   override def getObject(persistenceId: String): Future[GetObjectResult[A]] = this.synchronized {
     Future.successful(store.get(persistenceId) match {
-      case Some(record) => GetObjectResult(Some(record.value), record.revision)
-      case None         => GetObjectResult(None, 0)
+      case Some(Record(_, _, revision, Some(value), _, _)) => GetObjectResult(Some(value), revision)
+      case Some(Record(_, _, revision, None, _, _))        => GetObjectResult(None, revision)
+      case None                                            => GetObjectResult(None, 0)
     })
   }
 
   override def upsertObject(persistenceId: String, revision: Long, value: A, tag: String): Future[Done] =
     this.synchronized {
       val globalOffset = lastGlobalOffset.incrementAndGet()
-      val record = Record(globalOffset, persistenceId, revision, value, tag)
+      val record = Record(globalOffset, persistenceId, revision, Some(value), tag)
       store = store + (persistenceId -> record)
       publisher ! record
       Future.successful(Done)
     }
 
   override def deleteObject(persistenceId: String): Future[Done] = this.synchronized {
-    store = store - persistenceId
+    store = store.get(persistenceId) match {
+      case Some(record) => store + (persistenceId -> record.copy(value = None))
+      case None         => store
+    }
+
     Future.successful(Done)
   }
 
@@ -188,9 +195,15 @@ private final case class Record[A](
     globalOffset: Long,
     persistenceId: String,
     revision: Long,
-    value: A,
+    value: Option[A],
     tag: String,
     timestamp: Long = System.currentTimeMillis) {
-  def toDurableStateChange: DurableStateChange[A] =
-    new UpdatedDurableState(persistenceId, revision, value, Sequence(globalOffset), timestamp)
+  def toDurableStateChange: DurableStateChange[A] = {
+    value match {
+      case Some(v) =>
+        new UpdatedDurableState(persistenceId, revision, v, Sequence(globalOffset), timestamp)
+      case None =>
+        new DeletedDurableState(persistenceId, revision, Sequence(globalOffset), timestamp)
+    }
+  }
 }

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorReplySpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorReplySpec.scala
@@ -31,6 +31,7 @@ object DurableStateBehaviorReplySpec {
   final case class IncrementReplyLater(replyTo: ActorRef[Done]) extends Command[Done]
   final case class ReplyNow(replyTo: ActorRef[Done]) extends Command[Done]
   final case class GetValue(replyTo: ActorRef[State]) extends Command[State]
+  final case class ResetWithConfirmation(replyTo: ActorRef[Done]) extends Command[Done]
   case object Increment extends Command[Nothing]
   case class IncrementBy(by: Int) extends Command[Nothing]
 
@@ -60,6 +61,9 @@ object DurableStateBehaviorReplySpec {
 
           case GetValue(replyTo) =>
             Effect.reply(replyTo)(state)
+
+          case ResetWithConfirmation(replyTo) =>
+            Effect.reset[State]().thenReply(replyTo)(_ => Done)
 
           case _ => ???
 
@@ -107,6 +111,21 @@ class DurableStateBehaviorReplySpec
       val queryProbe = TestProbe[State]()
       c ! GetValue(queryProbe.ref)
       queryProbe.expectMessage(State(1))
+    }
+
+    "reset state thenReply" in {
+      val c = spawn(counter(nextPid()))
+      val updateProbe = TestProbe[Done]()
+      c ! IncrementWithConfirmation(updateProbe.ref)
+      updateProbe.expectMessage(Done)
+
+      val resetProbe = TestProbe[Done]()
+      c ! ResetWithConfirmation(resetProbe.ref)
+      resetProbe.expectMessage(Done)
+
+      val queryProbe = TestProbe[State]()
+      c ! GetValue(queryProbe.ref)
+      queryProbe.expectMessage(State(0))
     }
   }
 }

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorReplySpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorReplySpec.scala
@@ -31,7 +31,7 @@ object DurableStateBehaviorReplySpec {
   final case class IncrementReplyLater(replyTo: ActorRef[Done]) extends Command[Done]
   final case class ReplyNow(replyTo: ActorRef[Done]) extends Command[Done]
   final case class GetValue(replyTo: ActorRef[State]) extends Command[State]
-  final case class ResetWithConfirmation(replyTo: ActorRef[Done]) extends Command[Done]
+  final case class DeleteWithConfirmation(replyTo: ActorRef[Done]) extends Command[Done]
   case object Increment extends Command[Nothing]
   case class IncrementBy(by: Int) extends Command[Nothing]
 
@@ -62,8 +62,8 @@ object DurableStateBehaviorReplySpec {
           case GetValue(replyTo) =>
             Effect.reply(replyTo)(state)
 
-          case ResetWithConfirmation(replyTo) =>
-            Effect.reset[State]().thenReply(replyTo)(_ => Done)
+          case DeleteWithConfirmation(replyTo) =>
+            Effect.delete[State]().thenReply(replyTo)(_ => Done)
 
           case _ => ???
 
@@ -113,15 +113,15 @@ class DurableStateBehaviorReplySpec
       queryProbe.expectMessage(State(1))
     }
 
-    "reset state thenReply" in {
+    "delete state thenReply" in {
       val c = spawn(counter(nextPid()))
       val updateProbe = TestProbe[Done]()
       c ! IncrementWithConfirmation(updateProbe.ref)
       updateProbe.expectMessage(Done)
 
-      val resetProbe = TestProbe[Done]()
-      c ! ResetWithConfirmation(resetProbe.ref)
-      resetProbe.expectMessage(Done)
+      val deleteProbe = TestProbe[Done]()
+      c ! DeleteWithConfirmation(deleteProbe.ref)
+      deleteProbe.expectMessage(Done)
 
       val queryProbe = TestProbe[State]()
       c ! GetValue(queryProbe.ref)

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateBehaviorImpl.scala
@@ -176,6 +176,8 @@ private[akka] final case class DurableStateBehaviorImpl[Command, State](
   final case class GetFailure(cause: Throwable) extends InternalProtocol
   case object UpsertSuccess extends InternalProtocol
   final case class UpsertFailure(cause: Throwable) extends InternalProtocol
+  case object DeleteSuccess extends InternalProtocol
+  final case class DeleteFailure(cause: Throwable) extends InternalProtocol
   case object RecoveryTimeout extends InternalProtocol
   final case class IncomingCommand[C](c: C) extends InternalProtocol
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateStoreInteractions.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateStoreInteractions.scala
@@ -56,7 +56,10 @@ private[akka] trait DurableStateStoreInteractions[C, S] {
     newRunningState
   }
 
-  protected def internalDelete(ctx: ActorContext[InternalProtocol], cmd: Any): Running.RunningState[S] = {
+  protected def internalDelete(
+      ctx: ActorContext[InternalProtocol],
+      cmd: Any,
+      state: Running.RunningState[S]): Running.RunningState[S] = {
 
     val persistenceId = setup.persistenceId.id
 
@@ -67,7 +70,7 @@ private[akka] trait DurableStateStoreInteractions[C, S] {
       case Failure(cause) => InternalProtocol.DeleteFailure(cause)
     }
 
-    Running.RunningState(revision = 0, state = setup.emptyState, receivedPoisonPill = false)
+    state.copy(state = setup.emptyState)
   }
 
   // FIXME These hook methods are for Telemetry. What more parameters are needed? persistenceId?

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/EffectImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/EffectImpl.scala
@@ -73,7 +73,7 @@ private[akka] final case class Persist[State](newState: State) extends EffectImp
 
 /** INTERNAL API */
 @InternalApi
-private[akka] case class Reset[State]() extends EffectImpl[State]
+private[akka] case class Delete[State]() extends EffectImpl[State]
 
 /** INTERNAL API */
 @InternalApi

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/EffectImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/EffectImpl.scala
@@ -73,6 +73,10 @@ private[akka] final case class Persist[State](newState: State) extends EffectImp
 
 /** INTERNAL API */
 @InternalApi
+private[akka] case class Reset[State]() extends EffectImpl[State]
+
+/** INTERNAL API */
+@InternalApi
 private[akka] case object Unhandled extends EffectImpl[Nothing]
 
 /** INTERNAL API */

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Recovering.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Recovering.scala
@@ -5,7 +5,6 @@
 package akka.persistence.typed.state.internal
 
 import scala.concurrent.duration._
-
 import akka.actor.typed.Behavior
 import akka.actor.typed.Signal
 import akka.actor.typed.internal.PoisonPill
@@ -88,6 +87,8 @@ private[akka] class Recovering[C, S](
       case RecoveryPermitGranted       => Behaviors.unhandled // should not happen, we already have the permit
       case UpsertSuccess               => Behaviors.unhandled
       case _: UpsertFailure            => Behaviors.unhandled
+      case DeleteSuccess               => Behaviors.unhandled
+      case _: DeleteFailure            => Behaviors.unhandled
     }
   }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Running.scala
@@ -141,8 +141,8 @@ private[akka] object Running {
         case _: PersistNothing.type =>
           (applySideEffects(sideEffects, state), true)
 
-        case _: Reset[_] =>
-          val nextState = internalDelete(setup.context, msg)
+        case _: Delete[_] =>
+          val nextState = internalDelete(setup.context, msg, state)
           (applySideEffects(sideEffects, nextState), true)
 
         case _: Unhandled.type =>

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Running.scala
@@ -141,6 +141,10 @@ private[akka] object Running {
         case _: PersistNothing.type =>
           (applySideEffects(sideEffects, state), true)
 
+        case _: Reset[_] =>
+          val nextState = internalDelete(setup.context, msg)
+          (applySideEffects(sideEffects, nextState), true)
+
         case _: Unhandled.type =>
           import akka.actor.typed.scaladsl.adapter._
           setup.context.system.toClassic.eventStream
@@ -194,6 +198,8 @@ private[akka] object Running {
         case RecoveryPermitGranted             => Behaviors.unhandled
         case _: GetSuccess[_]                  => Behaviors.unhandled
         case _: GetFailure                     => Behaviors.unhandled
+        case DeleteSuccess                     => Behaviors.unhandled
+        case DeleteFailure(_)                  => Behaviors.unhandled
       }
     }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/Effect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/Effect.scala
@@ -26,11 +26,11 @@ object Effect {
   def persist[State](state: State): EffectBuilder[State] = Persist(state)
 
   /**
-   * Reset to the initial state and delete the persisted state.
+   * Delete the persisted state.
    *
    * Side effects can be chained with `thenRun`
    */
-  def reset[State](): EffectBuilder[State] = Reset()
+  def delete[State](): EffectBuilder[State] = Delete()
 
   /**
    * Do not persist anything

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/Effect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/scaladsl/Effect.scala
@@ -25,7 +25,12 @@ object Effect {
    */
   def persist[State](state: State): EffectBuilder[State] = Persist(state)
 
-  // FIXME add delete effect
+  /**
+   * Reset to the initial state and delete the persisted state.
+   *
+   * Side effects can be chained with `thenRun`
+   */
+  def reset[State](): EffectBuilder[State] = Reset()
 
   /**
    * Do not persist anything

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/DurableStatePersistentBehaviorCompileOnly.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/DurableStatePersistentBehaviorCompileOnly.scala
@@ -30,7 +30,7 @@ object DurableStatePersistentBehaviorCompileOnly {
     final case object Increment extends Command[Nothing]
     final case class IncrementBy(value: Int) extends Command[Nothing]
     final case class GetValue(replyTo: ActorRef[State]) extends Command[State]
-    final case object Reset extends Command[Nothing]
+    final case object Delete extends Command[Nothing]
     //#command
 
     //#state
@@ -45,7 +45,7 @@ object DurableStatePersistentBehaviorCompileOnly {
         case Increment         => Effect.persist(state.copy(value = state.value + 1))
         case IncrementBy(by)   => Effect.persist(state.copy(value = state.value + by))
         case GetValue(replyTo) => Effect.reply(replyTo)(state)
-        case Reset             => Effect.reset[State]()
+        case Delete            => Effect.delete[State]()
       }
     //#command-handler
 

--- a/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/DurableStatePersistentBehaviorCompileOnly.scala
+++ b/akka-persistence-typed/src/test/scala/docs/akka/persistence/typed/DurableStatePersistentBehaviorCompileOnly.scala
@@ -30,6 +30,7 @@ object DurableStatePersistentBehaviorCompileOnly {
     final case object Increment extends Command[Nothing]
     final case class IncrementBy(value: Int) extends Command[Nothing]
     final case class GetValue(replyTo: ActorRef[State]) extends Command[State]
+    final case object Reset extends Command[Nothing]
     //#command
 
     //#state
@@ -44,6 +45,7 @@ object DurableStatePersistentBehaviorCompileOnly {
         case Increment         => Effect.persist(state.copy(value = state.value + 1))
         case IncrementBy(by)   => Effect.persist(state.copy(value = state.value + by))
         case GetValue(replyTo) => Effect.reply(replyTo)(state)
+        case Reset             => Effect.reset[State]()
       }
     //#command-handler
 


### PR DESCRIPTION
* Add reset effect to the state dsl.
* The effect calls deleteObject in the durable state store.
* The effect updates state to the empty state.

https://github.com/akka/akka/issues/30446

References #30446
