### PR TITLE
Handle ShardsUpdated when waiting for remember entities 

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -6,7 +6,6 @@ package akka.cluster.sharding
 
 import java.net.URLEncoder
 import java.util
-
 import akka.actor.Actor
 import akka.actor.ActorLogging
 import akka.actor.ActorRef
@@ -24,6 +23,7 @@ import akka.cluster.ClusterEvent.InitialStateAsEvents
 import akka.cluster.ClusterEvent.MemberEvent
 import akka.cluster.ClusterEvent.MemberPreparingForShutdown
 import akka.cluster.ClusterEvent.MemberReadyForShutdown
+import akka.cluster.sharding.ShardRegion.ShardsUpdated
 import akka.cluster.sharding.internal.EntityPassivationStrategy
 import akka.cluster.sharding.internal.RememberEntitiesShardStore
 import akka.cluster.sharding.internal.RememberEntitiesShardStore.GetEntities
@@ -700,6 +700,7 @@ private[akka] class Shard(
     case msg: ShardQuery                 => receiveShardQuery(msg)
     case PassivateIntervalTick           => stash()
     case msg: RememberEntityStoreCrashed => rememberEntityStoreCrashed(msg)
+    case msg: ShardsUpdated => shardsUpdated(msg)
     case msg if extractEntityId.isDefinedAt(msg) =>
       deliverMessage(msg, sender())
     case msg =>

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -700,7 +700,7 @@ private[akka] class Shard(
     case msg: ShardQuery                 => receiveShardQuery(msg)
     case PassivateIntervalTick           => stash()
     case msg: RememberEntityStoreCrashed => rememberEntityStoreCrashed(msg)
-    case msg: ShardsUpdated => shardsUpdated(msg)
+    case msg: ShardsUpdated              => shardsUpdated(msg)
     case msg if extractEntityId.isDefinedAt(msg) =>
       deliverMessage(msg, sender())
     case msg =>

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -1025,7 +1025,9 @@ private[akka] class ShardRegion(
       shardsByRef = shardsByRef - ref
       shards = shards - shardId
       startingShards -= shardId
-      shards.values.foreach(_ ! ShardsUpdated(shards.size))
+      if (settings.passivationStrategy != ClusterShardingSettings.NoPassivationStrategy) {
+        shards.values.foreach(_ ! ShardsUpdated(shards.size))
+      }
       if (handingOff.contains(ref)) {
         handingOff = handingOff - ref
         log.debug("{}: Shard [{}] handoff complete", typeName, shardId)
@@ -1367,7 +1369,9 @@ private[akka] class ShardRegion(
             shardsByRef = shardsByRef.updated(shard, id)
             shards = shards.updated(id, shard)
             startingShards += id
-            shards.values.foreach(_ ! ShardsUpdated(shards.size))
+            if (settings.passivationStrategy != ClusterShardingSettings.NoPassivationStrategy) {
+              shards.values.foreach(_ ! ShardsUpdated(shards.size))
+            }
             None
           case Some(_) =>
             None


### PR DESCRIPTION
Corner case where ShardsUpdated would arrive when remember entities is waiting for storage (surprising though, I thought passivation + remember entities was not possible)

Also, don't send such updates if passivation is disabled

References #31091
