### PR TITLE
correct outdated external reference to erlang.org

### DIFF
--- a/akka-docs/src/main/paradox/general/message-delivery-reliability.md
+++ b/akka-docs/src/main/paradox/general/message-delivery-reliability.md
@@ -96,8 +96,8 @@ Akka embraces distributed computing and makes the fallibility of communication
 explicit through message passing, therefore it does not try to lie and emulate
 a leaky abstraction. This is a model that has been used with great success in
 Erlang and requires the users to design their applications around it. You can
-read more about this approach in the [Erlang documentation](https://erlang.org/faq/academic.html) (section 10.9 and
-10.10), Akka follows it closely.
+read more about this approach in the [Erlang documentation](https://erlang.org/faq/academic.html) (section 10.8 and
+10.9), Akka follows it closely.
 
 Another angle on this issue is that by providing only basic guarantees those
 use cases which do not need stronger reliability do not pay the cost of their


### PR DESCRIPTION
Section "Discussion: Why No Guaranteed Delivery?" mentions section 10.10 of the Erlang Academic FAQ "Academic and Historical Questions" that is currently titled as "10.10 What limits does Erlang have?". Section 10.10 of the FAQ has been changed and is not related to the topic of guaranteed delivery anymore.

FAQ topics "10.8 Is the order of message reception guaranteed?" and "10.9 If I send a message, is it guaranteed to reach the receiver?" seem to match the original intended references.