### PR TITLE
Update headers for cross-compiled sources

### DIFF
--- a/akka-actor-tests/src/test/scala-2.12/akka/util/LineNumberSpec.scala
+++ b/akka-actor-tests/src/test/scala-2.12/akka/util/LineNumberSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2014-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.util

--- a/akka-actor-tests/src/test/scala-2.12/akka/util/TypedMultiMapSpec.scala
+++ b/akka-actor-tests/src/test/scala-2.12/akka/util/TypedMultiMapSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.util

--- a/akka-actor-tests/src/test/scala-3/akka/util/LineNumberSpec.scala
+++ b/akka-actor-tests/src/test/scala-3/akka/util/LineNumberSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2014-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.util

--- a/akka-actor-typed/src/main/scala-2.12/akka/actor/typed/internal/receptionist/Platform.scala
+++ b/akka-actor-typed/src/main/scala-2.12/akka/actor/typed/internal/receptionist/Platform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.actor.typed.internal.receptionist

--- a/akka-actor-typed/src/main/scala-3/akka/actor/typed/internal/receptionist/Platform.scala
+++ b/akka-actor-typed/src/main/scala-3/akka/actor/typed/internal/receptionist/Platform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.actor.typed.internal.receptionist

--- a/akka-actor/src/main/scala-2.12/akka/compat/Future.scala
+++ b/akka-actor/src/main/scala-2.12/akka/compat/Future.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.compat

--- a/akka-actor/src/main/scala-2.12/akka/compat/PartialFunction.scala
+++ b/akka-actor/src/main/scala-2.12/akka/compat/PartialFunction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.compat

--- a/akka-actor/src/main/scala-2.12/akka/dispatch/internal/SameThreadExecutionContext.scala
+++ b/akka-actor/src/main/scala-2.12/akka/dispatch/internal/SameThreadExecutionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.dispatch.internal

--- a/akka-actor/src/main/scala-2.12/akka/dispatch/internal/ScalaBatchable.scala
+++ b/akka-actor/src/main/scala-2.12/akka/dispatch/internal/ScalaBatchable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.dispatch.internal

--- a/akka-actor/src/main/scala-2.12/akka/util/ByteIterator.scala
+++ b/akka-actor/src/main/scala-2.12/akka/util/ByteIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.util

--- a/akka-actor/src/main/scala-2.12/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala-2.12/akka/util/ByteString.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.util

--- a/akka-actor/src/main/scala-2.12/akka/util/ccompat/CompatImpl.scala
+++ b/akka-actor/src/main/scala-2.12/akka/util/ccompat/CompatImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.util.ccompat

--- a/akka-actor/src/main/scala-2.12/akka/util/ccompat/ccompatUsedUntil213.scala
+++ b/akka-actor/src/main/scala-2.12/akka/util/ccompat/ccompatUsedUntil213.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.util.ccompat

--- a/akka-actor/src/main/scala-2.12/akka/util/ccompat/package.scala
+++ b/akka-actor/src/main/scala-2.12/akka/util/ccompat/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.util

--- a/akka-actor/src/main/scala-3/akka/dispatch/internal/ScalaBatchable.scala
+++ b/akka-actor/src/main/scala-3/akka/dispatch/internal/ScalaBatchable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.dispatch.internal

--- a/akka-actor/src/main/scala-3/akka/util/ByteIterator.scala
+++ b/akka-actor/src/main/scala-3/akka/util/ByteIterator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.util

--- a/akka-actor/src/main/scala-3/akka/util/ByteString.scala
+++ b/akka-actor/src/main/scala-3/akka/util/ByteString.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.util

--- a/akka-cluster-typed/src/main/scala-2.12/akka/cluster/typed/internal/receptionist/ClusterReceptionistProtocol.scala
+++ b/akka-cluster-typed/src/main/scala-2.12/akka/cluster/typed/internal/receptionist/ClusterReceptionistProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2021-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.typed.internal.receptionist

--- a/akka-cluster-typed/src/main/scala-3/akka/cluster/typed/internal/receptionist/ClusterReceptionistProtocol.scala
+++ b/akka-cluster-typed/src/main/scala-3/akka/cluster/typed/internal/receptionist/ClusterReceptionistProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2021-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.typed.internal.receptionist

--- a/akka-distributed-data/src/main/scala-3/akka/cluster/ddata/GSet.scala
+++ b/akka-distributed-data/src/main/scala-3/akka/cluster/ddata/GSet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cluster.ddata

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorTimersSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorTimersSpec.scala
@@ -4,10 +4,6 @@
 
 package akka.persistence.typed.state.scaladsl
 
-/*
- * Copyright (C) 2017-2021 Lightbend Inc. <https://www.lightbend.com>
- */
-
 import akka.actor.testkit.typed.scaladsl._
 import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/NullEmptyStateSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/NullEmptyStateSpec.scala
@@ -4,10 +4,6 @@
 
 package akka.persistence.typed.state.scaladsl
 
-/*
- * Copyright (C) 2018-2021 Lightbend Inc. <https://www.lightbend.com>
- */
-
 import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.scaladsl._
 import akka.actor.typed.ActorRef

--- a/akka-persistence/src/main/scala-3/akka/persistence/TraitOrder.scala
+++ b/akka-persistence/src/main/scala-3/akka/persistence/TraitOrder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2021-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.persistence

--- a/akka-stream/src/main/scala-2.12/akka/stream/impl/ImplicitExtensionIdApply.scala
+++ b/akka-stream/src/main/scala-2.12/akka/stream/impl/ImplicitExtensionIdApply.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.stream.impl

--- a/akka-stream/src/main/scala-3/akka/stream/impl/ImplicitExtensionIdApply.scala
+++ b/akka-stream/src/main/scala-3/akka/stream/impl/ImplicitExtensionIdApply.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.stream.impl

--- a/plugins/serialversion-remover-plugin/src/main/scala/akka/Plugin.scala
+++ b/plugins/serialversion-remover-plugin/src/main/scala/akka/Plugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2021-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka


### PR DESCRIPTION
Headers in cross-compiled sources were missed in the recent update to the copyright year.
