### PR TITLE
Add unsafeViaData to FlowWithContext and SourceWithContext

### DIFF
--- a/akka-docs/src/main/paradox/stream/stream-context.md
+++ b/akka-docs/src/main/paradox/stream/stream-context.md
@@ -62,7 +62,11 @@ produces elements of type `Bar` with contexts of type `Ctx`. The
 reason for this is that `flow` might reorder the elements flowing
 through it, making `via` challenging to implement.
 
-There is a @ref[Flow.asFlowWithContext](operators/Flow/asFlowWithContext.md)
+Due to this there is a `unsafeDataVia` that can be used instead however no
+protection is offered to prevent reordering or dropping/duplicating elements
+from stream so use this operation with great care.
+
+There is also a @ref[Flow.asFlowWithContext](operators/Flow/asFlowWithContext.md)
 which can be used when the types used in the inner
 @apidoc[Flow] have room to hold the context. If this is not the
 case, a better solution is usually to build the flow from the ground

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceWithContextSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceWithContextSpec.scala
@@ -135,5 +135,17 @@ class SourceWithContextSpec extends StreamSpec {
         .expectNext((Message("a", 2L), 2L))
         .expectError(boom)
     }
+
+    "keep the same order for data and context when using unsafeDataVia" in {
+      val data = List(("1", 1), ("2", 2), ("3", 3), ("4", 4))
+
+      SourceWithContext
+        .fromTuples(Source(data))
+        .unsafeDataVia(Flow.fromFunction[String, Int] { _.toInt })
+        .runWith(TestSink.probe[(Int, Int)])
+        .request(4)
+        .expectNext((1, 1), (2, 2), (3, 3), (4, 4))
+        .expectComplete()
+    }
   }
 }

--- a/akka-stream/src/main/mima-filters/2.6.18.backwards.excludes/flow-with-context-ops.excludes
+++ b/akka-stream/src/main/mima-filters/2.6.18.backwards.excludes/flow-with-context-ops.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.stream.scaladsl.FlowWithContextOps.unsafeDataVia")

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContext.scala
@@ -46,6 +46,21 @@ final class FlowWithContext[-In, -CtxIn, +Out, +CtxOut, +Mat](delegate: Flow[(In
   override def via[Out2, Ctx2, Mat2](viaFlow: Graph[FlowShape[(Out, CtxOut), (Out2, Ctx2)], Mat2]): Repr[Out2, Ctx2] =
     new FlowWithContext(delegate.via(viaFlow))
 
+  override def unsafeDataVia[Out2, Mat2](viaFlow: Graph[FlowShape[Out, Out2], Mat2]): Repr[Out2, CtxOut] =
+    FlowWithContext.fromTuples(Flow.fromGraph(GraphDSL.createGraph(delegate) { implicit b => d =>
+      import GraphDSL.Implicits._
+
+      val bcast = b.add(Broadcast[(Out, CtxOut)](2))
+      val zipper = b.add(Zip[Out2, CtxOut]())
+
+      d ~> bcast.in
+
+      bcast.out(0).map { case (dataOut, _) => dataOut }.via(viaFlow) ~> zipper.in0
+      bcast.out(1).map { case (_, ctxOut) => ctxOut } ~> zipper.in1
+
+      FlowShape(d.in, zipper.out)
+    }))
+
   override def viaMat[Out2, Ctx2, Mat2, Mat3](flow: Graph[FlowShape[(Out, CtxOut), (Out2, Ctx2)], Mat2])(
       combine: (Mat, Mat2) => Mat3): FlowWithContext[In, CtxIn, Out2, Ctx2, Mat3] =
     new FlowWithContext(delegate.viaMat(flow)(combine))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
@@ -9,6 +9,7 @@ import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import akka.NotUsed
+import akka.annotation.ApiMayChange
 import akka.dispatch.ExecutionContexts
 import akka.event.{ LogMarker, LoggingAdapter, MarkerLoggingAdapter }
 import akka.stream._
@@ -55,7 +56,7 @@ trait FlowWithContextOps[+Out, +Ctx, +Mat] {
    * `unsafeDataVia` otherwise the context will no longer properly correspond to the data.
    * @see [[akka.stream.scaladsl.FlowOps.via]]
    */
-  def unsafeDataVia[Out2, Mat2](viaFlow: Graph[FlowShape[Out, Out2], Mat2]): Repr[Out2, Ctx]
+  @ApiMayChange def unsafeDataVia[Out2, Mat2](viaFlow: Graph[FlowShape[Out, Out2], Mat2]): Repr[Out2, Ctx]
 
   /**
    * Transform this flow by the regular flow. The given flow must support manual context propagation by

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
@@ -48,13 +48,14 @@ trait FlowWithContextOps[+Out, +Ctx, +Mat] {
    * Transform this flow by the regular flow. The given flow works on the data portion of the stream and
    * ignores the context.
    *
-   *  It is up to the implementer to ensure the inner flow does not exhibit any behaviour that is not expected
-   *  by the downstream elements, such as reordering. For more background on these requirements
-   *  see https://doc.akka.io/docs/akka/current/stream/stream-context.html.
+   * The given flow *must* not re-order, drop or emit multiple elements for one incoming
+   * element, the sequence of incoming contexts is re-combined with the outgoing
+   * elements of the stream. If a flow not fulfilling this requirement is used the stream
+   * will not fail but continue running in a corrupt state and re-combine incorrect pairs
+   * of elements and contexts.
    *
-   * When using `unsafeDataVia` one must be careful to not change the order of the data with the supplied
-   * `unsafeDataVia` otherwise the context will no longer properly correspond to the data.
-   * @see [[akka.stream.scaladsl.FlowOps.via]]
+   * For more background on these requirements
+   *  see https://doc.akka.io/docs/akka/current/stream/stream-context.html.
    */
   @ApiMayChange def unsafeDataVia[Out2, Mat2](viaFlow: Graph[FlowShape[Out, Out2], Mat2]): Repr[Out2, Ctx]
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
@@ -44,6 +44,20 @@ trait FlowWithContextOps[+Out, +Ctx, +Mat] {
   def via[Out2, Ctx2, Mat2](flow: Graph[FlowShape[(Out, Ctx), (Out2, Ctx2)], Mat2]): Repr[Out2, Ctx2]
 
   /**
+   * Transform this flow by the regular flow. The given flow works on the data portion of the stream and
+   * ignores the context.
+   *
+   *  It is up to the implementer to ensure the inner flow does not exhibit any behaviour that is not expected
+   *  by the downstream elements, such as reordering. For more background on these requirements
+   *  see https://doc.akka.io/docs/akka/current/stream/stream-context.html.
+   *
+   * When using `unsafeDataVia` one must be careful to not change the order of the data with the supplied
+   * `unsafeDataVia` otherwise the context will no longer properly correspond to the data.
+   * @see [[akka.stream.scaladsl.FlowOps.via]]
+   */
+  def unsafeDataVia[Out2, Mat2](viaFlow: Graph[FlowShape[Out, Out2], Mat2]): Repr[Out2, Ctx]
+
+  /**
    * Transform this flow by the regular flow. The given flow must support manual context propagation by
    * taking and producing tuples of (data, context).
    *

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
@@ -52,7 +52,7 @@ trait FlowWithContextOps[+Out, +Ctx, +Mat] {
    * element, the sequence of incoming contexts is re-combined with the outgoing
    * elements of the stream. If a flow not fulfilling this requirement is used the stream
    * will not fail but continue running in a corrupt state and re-combine incorrect pairs
-   * of elements and contexts.
+   * of elements and contexts or deadlock.
    *
    * For more background on these requirements
    *  see https://doc.akka.io/docs/akka/current/stream/stream-context.html.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/SourceWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/SourceWithContext.scala
@@ -33,6 +33,21 @@ final class SourceWithContext[+Out, +Ctx, +Mat] private[stream] (delegate: Sourc
   override def via[Out2, Ctx2, Mat2](viaFlow: Graph[FlowShape[(Out, Ctx), (Out2, Ctx2)], Mat2]): Repr[Out2, Ctx2] =
     new SourceWithContext(delegate.via(viaFlow))
 
+  override def unsafeDataVia[Out2, Mat2](viaFlow: Graph[FlowShape[Out, Out2], Mat2]): Repr[Out2, Ctx] =
+    SourceWithContext.fromTuples(Source.fromGraph(GraphDSL.createGraph(delegate) { implicit b => d =>
+      import GraphDSL.Implicits._
+
+      val bcast = b.add(Broadcast[(Out, Ctx)](2))
+      val zipper = b.add(Zip[Out2, Ctx]())
+
+      d ~> bcast.in
+
+      bcast.out(0).map { case (dataOut, _) => dataOut }.via(viaFlow) ~> zipper.in0
+      bcast.out(1).map { case (_, ctxOut) => ctxOut } ~> zipper.in1
+
+      SourceShape(zipper.out)
+    }))
+
   override def viaMat[Out2, Ctx2, Mat2, Mat3](flow: Graph[FlowShape[(Out, Ctx), (Out2, Ctx2)], Mat2])(
       combine: (Mat, Mat2) => Mat3): SourceWithContext[Out2, Ctx2, Mat3] =
     new SourceWithContext(delegate.viaMat(flow)(combine))


### PR DESCRIPTION
This PR adds `viaData` operators to `SourceWithContext`/`FlowWithContext` as convenience methods for wanting to transform the data part of the stream (i.e. ignoring the context) with a `Flow`.

The context of adding these convenience functions is that I am currently working with kafka where due to working with offsets you typically have `SourceWithContext[ByteString, CommittableOffset,_]` and/or `FlowWithContext[ByteString, CommittableOffset, _, _, _]`. Due to wanting to do things such as compress the `ByteString` with `Compression.gzip` and other common operations on the data part of the stream I believe that there is in this being added to Akka since they cover common usecases.

With the above example you can easily cover this usecase without having to write a custom graph, i.e.

```scala
val myKafkaSource: SourceWithContext[ByteString, CommittableOffset, NotUsed] = ???
myKafkaSource.viaData(Compression.gzip)
```

Due to reusing existing constructs and it being an initial implementation I haven't added tests for this new functionality however I can add it easily if requested.