### PR TITLE
ForkJoinPoolStarvationSpec pending on JDK 17, #31117

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/dispatch/ForkJoinPoolStarvationSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/dispatch/ForkJoinPoolStarvationSpec.scala
@@ -51,6 +51,10 @@ class ForkJoinPoolStarvationSpec extends AkkaSpec(ForkJoinPoolStarvationSpec.con
   "AkkaForkJoinPool" must {
 
     "not starve tasks arriving from external dispatchers under high internal traffic" in {
+      // TODO issue #31117: starvation with JDK 17 FJP
+      if (System.getProperty("java.specification.version") == "17")
+        pending
+
       // Two busy actors that will occupy the threads of the dispatcher
       // Since they submit to the local task queue via fork, they can starve external submissions
       system.actorOf(Props(new SelfBusyActor).withDispatcher("actorhang.task-dispatcher"))


### PR DESCRIPTION
This is consistently failing on JDK 17 so marking it as pending until we have decided what to do about it.

See #31117
