### PR TITLE
Improve timestamp order for eventsBySlices in Persistence TestKit, #31029

### DIFF
--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/EventStorage.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/EventStorage.scala
@@ -5,10 +5,11 @@
 package akka.persistence.testkit
 
 import akka.NotUsed
-
 import java.util.{ List => JList }
+
 import scala.collection.immutable
 import scala.util.{ Failure, Success, Try }
+
 import akka.annotation.InternalApi
 import akka.persistence.PersistentRepr
 import akka.persistence.journal.Tagged
@@ -105,7 +106,8 @@ private[testkit] trait EventStorage extends TestKitStorage[JournalOperation, Per
   }
 
   def tryRead(processId: String, predicate: PersistentRepr => Boolean): immutable.Seq[PersistentRepr] = {
-    val batch = readAll().filter(predicate).toVector.sortBy(_.timestamp)
+    import EventStorage.persistentReprOrdering
+    val batch = readAll().filter(predicate).toVector.sorted
 
     currentPolicy.tryProcess(processId, ReadEvents(batch)) match {
       case ProcessingSuccess  => batch
@@ -152,6 +154,18 @@ private[testkit] trait EventStorage extends TestKitStorage[JournalOperation, Per
 
 object EventStorage {
   object JournalPolicies extends DefaultPolicies[JournalOperation]
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] implicit val persistentReprOrdering: Ordering[PersistentRepr] =
+    Ordering.fromLessThan[PersistentRepr] { (a, b) =>
+      if (a eq b) false
+      else if (a.timestamp != b.timestamp) a.timestamp < b.timestamp
+      else if (a.persistenceId != b.persistenceId) a.persistenceId.compareTo(b.persistenceId) < 0
+      else if (a.sequenceNr != b.sequenceNr) a.sequenceNr < b.sequenceNr
+      else false
+    }
 }
 
 /**

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/PersistenceTestKitPlugin.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/PersistenceTestKitPlugin.scala
@@ -5,16 +5,18 @@
 package akka.persistence.testkit
 
 import akka.actor.ActorLogging
-
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.util.Try
+
 import com.typesafe.config.{ Config, ConfigFactory }
+
 import akka.annotation.InternalApi
 import akka.persistence._
 import akka.persistence.journal.AsyncWriteJournal
 import akka.persistence.journal.Tagged
 import akka.persistence.snapshot.SnapshotStore
+import akka.persistence.testkit.internal.CurrentTime
 import akka.persistence.testkit.internal.{ InMemStorageExtension, SnapshotStorageEmulatorExtension }
 import akka.util.unused
 
@@ -34,9 +36,10 @@ class PersistenceTestKitPlugin(@unused cfg: Config, cfgPath: String) extends Asy
 
   override def asyncWriteMessages(messages: immutable.Seq[AtomicWrite]): Future[immutable.Seq[Try[Unit]]] = {
     Future.fromTry(Try(messages.map(aw => {
+      val timestamp = CurrentTime.now()
       val data = aw.payload.map(pl =>
         pl.payload match {
-          case _ => pl.withTimestamp(System.currentTimeMillis())
+          case _ => pl.withTimestamp(timestamp)
         })
 
       val result: Try[Unit] = storage.tryAdd(data)

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/CurrentTime.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/internal/CurrentTime.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2021-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.testkit.internal
+
+import java.util.concurrent.atomic.AtomicLong
+
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object CurrentTime {
+  private val previous = new AtomicLong(System.currentTimeMillis())
+
+  /**
+   * `System.currentTimeMillis` but always increasing.
+   */
+  def now(): Long = {
+    val current = System.currentTimeMillis()
+    val prev = previous.get()
+    if (current > prev) {
+      previous.compareAndSet(prev, current)
+      current
+    } else {
+      previous.compareAndSet(prev, prev + 1)
+      prev + 1
+    }
+  }
+}

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
@@ -5,7 +5,9 @@
 package akka.persistence.testkit.state.scaladsl
 
 import java.util.concurrent.atomic.AtomicLong
+
 import scala.concurrent.Future
+
 import akka.{ Done, NotUsed }
 import akka.actor.ExtendedActorSystem
 import akka.persistence.Persistence
@@ -23,8 +25,9 @@ import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Source
 import akka.stream.typed.scaladsl.ActorSource
 import akka.stream.OverflowStrategy
-
 import scala.collection.immutable
+
+import akka.persistence.testkit.internal.CurrentTime
 
 object PersistenceTestKitDurableStateStore {
   val Identifier = "akka.persistence.testkit.state"
@@ -190,7 +193,7 @@ private final case class Record[A](
     revision: Long,
     value: A,
     tag: String,
-    timestamp: Long = System.currentTimeMillis) {
+    timestamp: Long = CurrentTime.now()) {
   def toDurableStateChange: DurableStateChange[A] =
     new UpdatedDurableState(persistenceId, revision, value, Sequence(globalOffset), timestamp)
 }


### PR DESCRIPTION
* probably the failing test produced the same timestamps for two events and then
  the order wasn't defined
* sort by timestamp and sequence number
* use monotonic increasing timestamps (could otherwise move backwards)

References #31029
