### PR TITLE
Use random port in cluster metrics tests, #31103

### DIFF
--- a/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/TestUtil.scala
+++ b/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/TestUtil.scala
@@ -159,6 +159,8 @@ object MetricsConfig {
       }
     }
     akka.actor.provider = remote
+    akka.remote.classic.netty.tcp.port = 0
+    akka.remote.artery.canonical.port = 0
   """
 
   /** Test w/o cluster, with collection disabled. */
@@ -169,6 +171,8 @@ object MetricsConfig {
       }
     }
     akka.actor.provider = remote
+    akka.remote.classic.netty.tcp.port = 0
+    akka.remote.artery.canonical.port = 0
   """
 
   /** Test in cluster, with manual collection activation, collector mock, fast. */
@@ -184,6 +188,8 @@ object MetricsConfig {
       }
     }
     akka.actor.provider = "cluster"
+    akka.remote.classic.netty.tcp.port = 0
+    akka.remote.artery.canonical.port = 0
   """
 }
 

--- a/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/protobuf/MessageSerializerSpec.scala
+++ b/akka-cluster-metrics/src/test/scala/akka/cluster/metrics/protobuf/MessageSerializerSpec.scala
@@ -12,6 +12,8 @@ import akka.testkit.AkkaSpec
 
 class MessageSerializerSpec extends AkkaSpec("""
      akka.actor.provider = cluster
+     akka.remote.classic.netty.tcp.port = 0
+     akka.remote.artery.canonical.port = 0
   """) {
 
   val serializer = new MessageSerializer(system.asInstanceOf[ExtendedActorSystem])


### PR DESCRIPTION
References #31103
