### PR TITLE
Don't test publishLocal with JDK 17, #31132

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -181,6 +181,8 @@ jobs:
             "+~ ${{ matrix.scalaVersion }} doc"
 
       - name: Publish
+        # Publish (osgi bundle) not working with JDK 17, issue #31132
+        if: ${{ startsWith(matrix.jdkVersion, 'adopt@1.8') || ${{ startsWith(matrix.jdkVersion, 'adopt@1.11') }}
         run: |-
           sudo apt-get install graphviz
           sbt -jvm-opts .jvmopts-ci \


### PR DESCRIPTION
* JDK 17 builds are failing with ConcurrentModificationExceptions for the osgiBundle task

References #31132
