### PR TITLE
Handle publish to topic before receptionist listing arrived

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/pubsub/TopicImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/pubsub/TopicImpl.scala
@@ -81,7 +81,9 @@ private[akka] final class TopicImpl[T](topicName: String, context: ActorContext[
           context.log.trace("Publishing message of type [{}] but no subscribers, dropping", msg.getClass)
           context.system.deadLetters ! Dropped(message, "No topic subscribers known", context.self.toClassic)
         } else {
-          context.log.trace("Publishing message of type [{}] to local subscribers only (topic listing not seen yet)", msg.getClass)
+          context.log.trace(
+            "Publishing message of type [{}] to local subscribers only (topic listing not seen yet)",
+            msg.getClass)
           localSubscribers.foreach(_ ! message)
         }
       } else {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/pubsub/TopicImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/pubsub/TopicImpl.scala
@@ -77,8 +77,13 @@ private[akka] final class TopicImpl[T](topicName: String, context: ActorContext[
 
     case Publish(message) =>
       if (topicInstances.isEmpty) {
-        context.log.trace("Publishing message of type [{}] but no subscribers, dropping", msg.getClass)
-        context.system.deadLetters ! Dropped(message, "No topic subscribers known", context.self.toClassic)
+        if (localSubscribers.isEmpty) {
+          context.log.trace("Publishing message of type [{}] but no subscribers, dropping", msg.getClass)
+          context.system.deadLetters ! Dropped(message, "No topic subscribers known", context.self.toClassic)
+        } else {
+          context.log.trace("Publishing message of type [{}] to local subscribers only (topic listing not seen yet)", msg.getClass)
+          localSubscribers.foreach(_ ! message)
+        }
       } else {
         context.log.trace("Publishing message of type [{}]", msg.getClass)
         val pub = MessagePublished(message)


### PR DESCRIPTION
Refs #31102 
and
Refs #31073

A topic could see a local subscription, inform a requestee about that local subscription,
and receive a publish before the receiptionist has listed the topic itself as a destination.
This fix handles that case by forwarding directly to local subscribers if there are no
known topic actors yet.
