### PR TITLE
build: archive test result for later analysis

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -167,7 +167,6 @@ jobs:
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'
           fail_if_no_tests: false
-          skip_publishing: true
 
       # Archive test results so we can do some diagnostics later
       - name: Upload test results

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -169,6 +169,14 @@ jobs:
           fail_if_no_tests: false
           skip_publishing: true
 
+      # Archive test results so we can do some diagnostics later
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: success() || failure()        # run this step even if previous step failed
+        with:
+          name: test-results-${{ matrix.jdkVersion }}-${{ matrix.scalaVersion }}
+          path: '**/target/test-reports/TEST-*.xml'
+
       - name: Docs
         # Docs generation requires JDK 11. Checks with `startsWith` helps
         # the check to be more resilient if the JDK version changes to a


### PR DESCRIPTION
Keep test result xmls as artifacts for later analysis.

Also actually publish test results with the `action-surefire-report` action.