### PR TITLE
Fail #31028 partition hub deadlock

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
@@ -678,45 +678,43 @@ class HubSpec extends StreamSpec {
 
     }
 
-    (0 to 500).foreach { i =>
-      s"properly signal error to consumers ($i)" in assertAllStagesStopped {
-        val upstream = TestPublisher.probe[Int]()
-        val source = Source
-          .fromPublisher(upstream)
-          .runWith(PartitionHub.sink((size, elem) => elem % size, startAfterNrOfConsumers = 2, bufferSize = 8))
+    "properly signal error to consumers" in assertAllStagesStopped {
+      val upstream = TestPublisher.probe[Int]()
+      val source = Source
+        .fromPublisher(upstream)
+        .runWith(PartitionHub.sink((size, elem) => elem % size, startAfterNrOfConsumers = 2, bufferSize = 8))
 
-        val downstream1 = TestSubscriber.probe[Int]()
-        source.runWith(Sink.fromSubscriber(downstream1))
-        val downstream2 = TestSubscriber.probe[Int]()
-        source.runWith(Sink.fromSubscriber(downstream2))
+      val downstream1 = TestSubscriber.probe[Int]()
+      source.runWith(Sink.fromSubscriber(downstream1))
+      val downstream2 = TestSubscriber.probe[Int]()
+      source.runWith(Sink.fromSubscriber(downstream2))
 
-        downstream1.request(4)
-        downstream2.request(8)
+      downstream1.request(4)
+      downstream2.request(8)
 
-        // to make sure downstream subscriptions are done before
-        // starting to send elements
-        Thread.sleep(100)
+      // to make sure downstream subscriptions are done before
+      // starting to send elements
+      Thread.sleep(100)
 
-        (0 until 16).foreach(upstream.sendNext(_))
+      (0 until 16).foreach(upstream.sendNext(_))
 
-        downstream1.expectNext(0, 2, 4, 6) // 8, 10, 12, 14 stays in buffer bc no demand
-        // if we don't demand more from downstream 1 here, there is a race condition where
-        // demand from downstream 2 is lost, because the buffer was full with elements for the other partition
-        // however this is likely because of the very fine grained demand logic in this test and not likely
-        // to happen in reality where both downstreams are likely going to keep pulling, or canceling
-        // for a scenario where one dosntream continous back pressures, head of line blocking can anyway happen
-        downstream1.request(1)
-        downstream2.expectNext(1, 3, 5, 7, 9, 11, 13, 15)
-        downstream1.expectNext(8)
+      downstream1.expectNext(0, 2, 4, 6) // 8, 10, 12, 14 stays in buffer bc no demand
+      // if we don't demand more from downstream 1 here, there is a race condition where
+      // demand from downstream 2 is lost, because the buffer was full with elements for the other partition
+      // however this is likely because of the very fine grained demand logic in this test and not likely
+      // to happen in reality where both downstreams are likely going to keep pulling, or canceling
+      // for a scenario where one dosntream continous back pressures, head of line blocking can anyway happen
+      downstream1.request(1)
+      downstream2.expectNext(1, 3, 5, 7, 9, 11, 13, 15)
+      downstream1.expectNext(8)
 
-        downstream1.expectNoMessage(100.millis)
-        downstream2.expectNoMessage(100.millis)
+      downstream1.expectNoMessage(100.millis)
+      downstream2.expectNoMessage(100.millis)
 
-        upstream.sendError(TE("Failed"))
+      upstream.sendError(TE("Failed"))
 
-        downstream1.expectError(TE("Failed"))
-        downstream2.expectError(TE("Failed"))
-      }
+      downstream1.expectError(TE("Failed"))
+      downstream2.expectError(TE("Failed"))
     }
 
     "properly signal completion to consumers arriving after producer finished" in assertAllStagesStopped {

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
@@ -700,7 +700,14 @@ class HubSpec extends StreamSpec {
         (0 until 16).foreach(upstream.sendNext(_))
 
         downstream1.expectNext(0, 2, 4, 6) // 8, 10, 12, 14 stays in buffer bc no demand
+        // if we don't demand more from downstream 1 here, there is a race condition where
+        // demand from downstream 2 is lost, because the buffer was full with elements for the other partition
+        // however this is likely because of the very fine grained demand logic in this test and not likely
+        // to happen in reality where both downstreams are likely going to keep pulling, or canceling
+        // for a scenario where one dosntream continous back pressures, head of line blocking can anyway happen
+        downstream1.request(1)
         downstream2.expectNext(1, 3, 5, 7, 9, 11, 13, 15)
+        downstream1.expectNext(8)
 
         downstream1.expectNoMessage(100.millis)
         downstream2.expectNoMessage(100.millis)

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/HubSpec.scala
@@ -678,7 +678,8 @@ class HubSpec extends StreamSpec {
 
     }
 
-    "properly signal error to consumers" in assertAllStagesStopped {
+    (0 to 500).foreach { i =>
+    s"properly signal error to consumers ($i)" in assertAllStagesStopped {
       val upstream = TestPublisher.probe[Int]()
       val source = Source
         .fromPublisher(upstream)
@@ -698,7 +699,7 @@ class HubSpec extends StreamSpec {
 
       (0 until 16).foreach(upstream.sendNext(_))
 
-      downstream1.expectNext(0, 2, 4, 6)
+      downstream1.expectNext(0, 2, 4, 6) // 8, 10, 12, 14 stays in buffer bc no demand
       downstream2.expectNext(1, 3, 5, 7, 9, 11, 13, 15)
 
       downstream1.expectNoMessage(100.millis)
@@ -708,7 +709,7 @@ class HubSpec extends StreamSpec {
 
       downstream1.expectError(TE("Failed"))
       downstream2.expectError(TE("Failed"))
-    }
+    }}
 
     "properly signal completion to consumers arriving after producer finished" in assertAllStagesStopped {
       val source =


### PR DESCRIPTION
References #31028

After thinking about this for a while I think it will not be a problem in reality and is a consequence of how the test is designed.

Ran some 2000 times with changed test without fail (where it previously would fail every 500 or so)

See explanation of issue in https://github.com/akka/akka/issues/31028#issuecomment-1047007020