### PR TITLE
Harden ClusterSingletonManagerPreparingForShutdownSpec, #30307

### DIFF
--- a/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerPreparingForShutdownSpec.scala
+++ b/akka-cluster-tools/src/multi-jvm/scala/akka/cluster/singleton/ClusterSingletonManagerPreparingForShutdownSpec.scala
@@ -149,8 +149,8 @@ class ClusterSingletonManagerPreparingForShutdownSpec
 
     "last nodes should shut down" in {
       runOn(second) {
-        Cluster(system).leave(address(second))
         Cluster(system).leave(address(third))
+        Cluster(system).leave(address(second))
       }
       awaitAssert({
         withClue("self member: " + Cluster(system).selfMember) {


### PR DESCRIPTION
References #30307

Send the leave for the third node before its own leave on the second node, otherwise the second node may exit the cluster and stop internal cluster actors before the third node leave is gossiped. https://github.com/akka/akka/issues/30307#issuecomment-1047266789