### PR TITLE
Fix possible NPE in ClusterShardingLeaseSpec

### DIFF
--- a/akka-coordination/src/test/scala/akka/coordination/lease/TestLease.scala
+++ b/akka-coordination/src/test/scala/akka/coordination/lease/TestLease.scala
@@ -64,15 +64,15 @@ class TestLease(settings: LeaseSettings, system: ExtendedActorSystem) extends Le
   val log = Logging(system, classOf[TestLease])
   val probe = TestProbe()(system)
 
-  log.info("Creating lease {}", settings)
-
-  TestLeaseExt(system).setTestLease(settings.leaseName, this)
-
   val initialPromise = Promise[Boolean]()
 
   private val nextAcquireResult = new AtomicReference[Future[Boolean]](initialPromise.future)
   private val nextCheckLeaseResult = new AtomicReference[Boolean](false)
   private val currentCallBack = new AtomicReference[Option[Throwable] => Unit](_ => ())
+
+  log.info("Creating lease {}", settings)
+
+  TestLeaseExt(system).setTestLease(settings.leaseName, this)
 
   def setNextAcquireResult(next: Future[Boolean]): Unit =
     nextAcquireResult.set(next)


### PR DESCRIPTION
Refs #29145

Set the test lease in the extension after variables have been initialised, otherwise these can be null. https://github.com/akka/akka/issues/29145#issuecomment-1047328813

