### PR TITLE
Reenable JoinConfigCompatCheckerRollingUpdateSpec #30939

### DIFF
--- a/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatCheckerRollingUpdateSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatCheckerRollingUpdateSpec.scala
@@ -6,10 +6,8 @@ package akka.cluster
 
 import scala.collection.{ immutable => im }
 import scala.concurrent.duration._
-
 import com.typesafe.config.{ Config, ConfigFactory }
-
-import akka.testkit.GHExcludeTest
+import akka.testkit.LongRunningTest
 
 object JoinConfigCompatCheckerRollingUpdateSpec {
 
@@ -47,17 +45,16 @@ class JoinConfigCompatCheckerRollingUpdateSpec
 
   import JoinConfigCompatCheckerRollingUpdateSpec._
 
-  // FIXME https://github.com/akka/akka/issues/30939 (tag as LongRunningTest instead when fixed)
   "A Node" must {
     val timeout = 20.seconds
-    "NOT be allowed to re-join a cluster if it has a new, additional configuration the others do not have and not the old" taggedAs GHExcludeTest in {
+    "NOT be allowed to re-join a cluster if it has a new, additional configuration the others do not have and not the old" taggedAs LongRunningTest in {
       // confirms the 2 attempted re-joins fail with both nodes being terminated
       upgradeCluster(3, v1Config, v2ConfigIncompatible, timeout, timeout, enforced = true, shouldRejoin = false)
     }
-    "be allowed to re-join a cluster if it has a new, additional property and checker the others do not have" taggedAs GHExcludeTest in {
+    "be allowed to re-join a cluster if it has a new, additional property and checker the others do not have" taggedAs LongRunningTest in {
       upgradeCluster(3, v1Config, v2Config, timeout, timeout * 3, enforced = true, shouldRejoin = true)
     }
-    "be allowed to re-join a cluster if it has a new, additional configuration the others do not have and configured to NOT enforce it" taggedAs GHExcludeTest in {
+    "be allowed to re-join a cluster if it has a new, additional configuration the others do not have and configured to NOT enforce it" taggedAs LongRunningTest in {
       upgradeCluster(3, v1Config, v2Config, timeout, timeout * 3, enforced = false, shouldRejoin = true)
     }
   }


### PR DESCRIPTION
References #30939

The hardening in #30955 to `ClusterTestKit.quitAndRestart` should apply also to this test.