### PR TITLE
Clear CurrentClusterState in ReadView when self removed, #31164

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/ClusterReadView.scala
@@ -63,12 +63,16 @@ import akka.dispatch.UnboundedMessageQueueSemantics
 
         // make sure that final state has member status Removed
         override def postStop(): Unit = {
+          selfRemoved() // make sure it ends as Removed even though MemberRemoved message didn't make it
+        }
+
+        private def selfRemoved(): Unit = {
           val oldState = _state.get()
-          val selfRemoved = oldState.selfMember.copy(MemberStatus.Removed)
+          // keepig latestStats, but otherwise clear everything
           val newState = oldState.copy(
-            clusterState =
-              oldState.clusterState.copy(members = oldState.clusterState.members - selfRemoved + selfRemoved),
-            selfMember = selfRemoved)
+            clusterState = CurrentClusterState(),
+            reachability = Reachability.empty,
+            selfMember = oldState.selfMember.copy(MemberStatus.Removed))
           _state.set(newState)
         }
 
@@ -81,14 +85,14 @@ import akka.dispatch.UnboundedMessageQueueSemantics
                 _state.set(oldState.copy(clusterState = oldClusterState.copy(seenBy = seenBy)))
               case ReachabilityChanged(reachability) =>
                 _state.set(oldState.copy(reachability = reachability))
+              case MemberRemoved(member, _) if member.address == selfAddress =>
+                selfRemoved()
               case MemberRemoved(member, _) =>
-                val newSelfMember = if (member.address == selfAddress) member else oldState.selfMember
                 _state.set(
                   oldState.copy(
                     clusterState = oldClusterState.copy(
                       members = oldClusterState.members - member,
-                      unreachable = oldClusterState.unreachable - member),
-                    selfMember = newSelfMember))
+                      unreachable = oldClusterState.unreachable - member)))
               case UnreachableMember(member) =>
                 // replace current member with new member (might have different status, only address is used in equals)
                 _state.set(


### PR DESCRIPTION
* changed behavior in refactoring of ReadView, https://github.com/akka/akka/pull/31144
* MultiDcHeartbeatTakingOverSpec failed

References #31164
