### PR TITLE
Harden PersistentStartEntitySpec, #30393

### DIFF
--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesAndStartEntitySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/RememberEntitiesAndStartEntitySpec.scala
@@ -4,6 +4,9 @@
 
 package akka.cluster.sharding
 
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
 import akka.actor.Actor
 import akka.actor.ActorRef
 import akka.actor.PoisonPill
@@ -17,12 +20,8 @@ import akka.cluster.sharding.ShardRegion.StartEntityAck
 import akka.testkit.AkkaSpec
 import akka.testkit.ImplicitSender
 import akka.testkit.WithLogCapturing
-import com.typesafe.config.ConfigFactory
-import org.scalatest.wordspec.AnyWordSpecLike
 
-import akka.testkit.GHExcludeTest
-
-object PersistentStartEntitySpec {
+object RememberEntitiesAndStartEntitySpec {
   class EntityActor extends Actor {
     override def receive: Receive = {
       case "give-me-shard" => sender() ! context.parent
@@ -49,20 +48,21 @@ object PersistentStartEntitySpec {
       akka.actor.provider = cluster
       akka.remote.artery.canonical.port = 0
       akka.remote.classic.netty.tcp.port = 0
-      akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
       akka.cluster.sharding.verbose-debug-logging = on
       akka.cluster.sharding.fail-on-invalid-entity-state-transition = on
+      # no leaks between test runs thank you
+      akka.cluster.sharding.distributed-data.durable.keys = []
     """.stripMargin)
 }
 
-// this test covers remember entities + StartEntity for the deprecated persistent state store
-class PersistentStartEntitySpec
-    extends AkkaSpec(PersistentStartEntitySpec.config)
+// this test covers remember entities + StartEntity
+class RememberEntitiesAndStartEntitySpec
+    extends AkkaSpec(RememberEntitiesAndStartEntitySpec.config)
     with AnyWordSpecLike
     with ImplicitSender
     with WithLogCapturing {
 
-  import PersistentStartEntitySpec._
+  import RememberEntitiesAndStartEntitySpec._
 
   override def atStartup(): Unit = {
     // Form a one node cluster
@@ -71,16 +71,13 @@ class PersistentStartEntitySpec
     awaitAssert(cluster.readView.members.count(_.status == MemberStatus.Up) should ===(1))
   }
 
-  "Persistent Shard" must {
+  "Sharding" must {
 
-    // FIXME https://github.com/akka/akka/issues/30393
-    "remember entities started with StartEntity" taggedAs GHExcludeTest in {
+    "remember entities started with StartEntity" in {
       val sharding = ClusterSharding(system).start(
         s"startEntity",
         Props[EntityActor](),
-        ClusterShardingSettings(system)
-          .withRememberEntities(true)
-          .withStateStoreMode(ClusterShardingSettings.StateStoreModePersistence),
+        ClusterShardingSettings(system).withRememberEntities(true),
         extractEntityId,
         extractShardId)
 


### PR DESCRIPTION
* use default state store mode, instead of deprecated
* renamed to RememberEntitiesAndStartEntitySpec
* remove GhExcludeTest

I don't think this should change anything, but let's see if it starts failing again.

References #30393
