### PR TITLE
Enable StreamRefsSpec 'cancel before emit' test with debug logging

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamRefsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamRefsSpec.scala
@@ -21,7 +21,6 @@ import akka.stream.impl.streamref.{ SinkRefImpl, SourceRefImpl }
 import akka.stream.testkit.TestPublisher
 import akka.stream.testkit.Utils.TE
 import akka.stream.testkit.scaladsl._
-import akka.testkit.GHExcludeTest
 import akka.testkit.{ AkkaSpec, TestKit, TestProbe }
 import akka.util.ByteString
 
@@ -171,7 +170,7 @@ object StreamRefsSpec {
   def config(): Config = {
     ConfigFactory.parseString(s"""
     akka {
-      loglevel = INFO
+      loglevel = DEBUG
 
       actor {
         provider = remote
@@ -350,7 +349,7 @@ class StreamRefsSpec extends AkkaSpec(StreamRefsSpec.config()) {
     }
 
     // FIXME https://github.com/akka/akka/issues/30844
-    "pass cancellation upstream across remoting before elements has been emitted" taggedAs GHExcludeTest in {
+    "pass cancellation upstream across remoting before elements has been emitted" in {
       val remoteProbe = TestProbe()(remoteSystem)
       remoteActor.tell("give-nothing-watch", remoteProbe.ref)
       val sourceRef = remoteProbe.expectMsgType[SourceRef[String]]

--- a/akka-stream/src/main/scala/akka/stream/impl/streamref/SourceRefImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/streamref/SourceRefImpl.scala
@@ -304,7 +304,7 @@ private[stream] final class SourceRefStageImpl[Out](val initialPartnerRef: Optio
           state match {
             case WaitingForCancelAck(partner, cause) =>
               verifyPartner(sender, partner)
-              log.debug(s"[$stageActorName] Got cancellation ack from remote, canceling", stageActorName)
+              log.debug(s"[{}] Got cancellation ack from remote, canceling", stageActorName)
               cancelStage(cause)
             case other =>
               throw new IllegalStateException(s"[$stageActorName] Got an Ack when in state $other")


### PR DESCRIPTION
Refs #30844

Not sure it's an important test to fix, but there's little information in the test failure, and no obvious way to reproduce.
