### PR TITLE
=fmt Preserve line endings when format.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -5,6 +5,7 @@ style = defaultWithAlign
 docstrings                 = JavaDoc
 indentOperator             = spray
 maxColumn                  = 120
+lineEndings                = preserve
 rewrite.rules              = [RedundantParens, SortImports, AvoidInfix]
 unindentTopLevelOperators  = true
 align.tokens               = [{code = "=>", owner = "Case"}]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/501740/155964480-3cd28f12-48c4-4e43-8cf6-3a9594c042fa.png)
Without it after I do a `scalafmtAll` on Windows , many file changes