### PR TITLE
RecipeSplitter formatting

### DIFF
--- a/akka-docs/src/test/scala/docs/stream/cookbook/RecipeSplitter.scala
+++ b/akka-docs/src/test/scala/docs/stream/cookbook/RecipeSplitter.scala
@@ -6,13 +6,13 @@ package docs.stream.cookbook
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.scaladsl.{ Sink, Source }
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class RecipeSplitter extends AnyWordSpec with BeforeAndAfterAll with Matchers with ScalaFutures{
+class RecipeSplitter extends AnyWordSpec with BeforeAndAfterAll with Matchers with ScalaFutures {
 
   implicit val system = ActorSystem("Test")
 


### PR DESCRIPTION
No clear how this was not detected before, but we missed it.

Bad formatting was introduced in https://github.com/akka/akka/pull/31203