### PR TITLE
Tag CircuitBreaker tests as time sensitive

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerMTSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerMTSpec.scala
@@ -52,14 +52,14 @@ class CircuitBreakerMTSpec extends AkkaSpec {
           }
     }
 
-    "allow many calls while in closed state with no errors" in {
+    "allow many calls while in closed state with no errors" taggedAs TimingTest in {
       val futures = testCallsWithBreaker(newBreaker)
       val result = Await.result(Future.sequence(futures), 5.second.dilated)
       result.size should ===(numberOfTestCalls)
       result.toSet should ===(Set("succeed"))
     }
 
-    "transition to open state upon reaching failure limit and fail-fast" in {
+    "transition to open state upon reaching failure limit and fail-fast" taggedAs TimingTest in {
       val breaker = newBreaker
       openBreaker(breaker)
       val futures = testCallsWithBreaker(breaker)
@@ -68,7 +68,7 @@ class CircuitBreakerMTSpec extends AkkaSpec {
       result.toSet should ===(Set("CBO"))
     }
 
-    "allow a single call through in half-open state" in {
+    "allow a single call through in half-open state" taggedAs TimingTest in {
       val breaker = newBreaker
       val halfOpenLatch = new TestLatch(1)
       breaker.onHalfOpen(halfOpenLatch.countDown())
@@ -84,7 +84,7 @@ class CircuitBreakerMTSpec extends AkkaSpec {
       result.toSet should ===(Set("succeed", "CBO"))
     }
 
-    "recover and reset the breaker after the reset timeout" in {
+    "recover and reset the breaker after the reset timeout" taggedAs TimingTest in {
       val breaker = newBreaker
 
       val halfOpenLatch = new TestLatch(1)

--- a/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/CircuitBreakerSpec.scala
@@ -95,7 +95,7 @@ class CircuitBreakerSpec extends AkkaSpec {
   def sayHi = "hi"
 
   "A synchronous circuit breaker that is open" must {
-    "throw exceptions when called before reset timeout" in {
+    "throw exceptions when called before reset timeout" taggedAs TimingTest in {
       val breaker = longResetTimeoutCb()
 
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
@@ -107,13 +107,13 @@ class CircuitBreakerSpec extends AkkaSpec {
       e.remainingDuration should be <= longResetTimeout
     }
 
-    "transition to half-open on reset timeout" in {
+    "transition to half-open on reset timeout" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
       checkLatch(breaker.halfOpenLatch)
     }
 
-    "still be in open state after calling success method" in {
+    "still be in open state after calling success method" taggedAs TimingTest in {
       val breaker = longResetTimeoutCb()
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
       checkLatch(breaker.openLatch)
@@ -121,7 +121,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       breaker().isOpen should ===(true)
     }
 
-    "still be in open state after calling fail method" in {
+    "still be in open state after calling fail method" taggedAs TimingTest in {
       val breaker = longResetTimeoutCb()
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
       checkLatch(breaker.openLatch)
@@ -129,13 +129,13 @@ class CircuitBreakerSpec extends AkkaSpec {
       breaker().isOpen should ===(true)
     }
 
-    "invoke onHalfOpen during transition to half-open state" in {
+    "invoke onHalfOpen during transition to half-open state" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
       checkLatch(breaker.halfOpenLatch)
     }
 
-    "invoke onCallBreakerOpen when called before reset timeout" in {
+    "invoke onCallBreakerOpen when called before reset timeout" taggedAs TimingTest in {
       val breaker = longResetTimeoutCb()
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
       checkLatch(breaker.openLatch)
@@ -143,7 +143,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       checkLatch(breaker.callBreakerOpenLatch)
     }
 
-    "invoke onCallFailure when call results in exception" in {
+    "invoke onCallFailure when call results in exception" taggedAs TimingTest in {
       val breaker = longResetTimeoutCb()
 
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
@@ -155,7 +155,7 @@ class CircuitBreakerSpec extends AkkaSpec {
   }
 
   "A synchronous circuit breaker that is half-open" must {
-    "pass through next call and close on success" in {
+    "pass through next call and close on success" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
       checkLatch(breaker.halfOpenLatch)
@@ -164,7 +164,7 @@ class CircuitBreakerSpec extends AkkaSpec {
     }
 
     "pass through next call and close on exception" when {
-      "exception is defined as call succeeded" in {
+      "exception is defined as call succeeded" taggedAs TimingTest in {
         val breaker = shortResetTimeoutCb()
         intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
         checkLatch(breaker.halfOpenLatch)
@@ -176,7 +176,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       }
     }
 
-    "open on exception in call" in {
+    "open on exception in call" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
       checkLatch(breaker.halfOpenLatch)
@@ -186,7 +186,7 @@ class CircuitBreakerSpec extends AkkaSpec {
     }
 
     "open on even number" when {
-      "even number is defined as failure" in {
+      "even number is defined as failure" taggedAs TimingTest in {
         val breaker = shortResetTimeoutCb()
         intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
         checkLatch(breaker.halfOpenLatch)
@@ -196,7 +196,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       }
     }
 
-    "open on calling fail method" in {
+    "open on calling fail method" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
       checkLatch(breaker.halfOpenLatch)
@@ -205,7 +205,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       checkLatch(breaker.openLatch)
     }
 
-    "close on calling success method" in {
+    "close on calling success method" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
       checkLatch(breaker.halfOpenLatch)
@@ -213,7 +213,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       checkLatch(breaker.closedLatch)
     }
 
-    "pass through next call and invoke onCallSuccess on success" in {
+    "pass through next call and invoke onCallSuccess on success" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
 
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
@@ -227,7 +227,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       success.value should (be > Duration.Zero and be < shortResetTimeout)
     }
 
-    "pass through next call and invoke onCallFailure on failure" in {
+    "pass through next call and invoke onCallFailure on failure" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
 
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
@@ -244,7 +244,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       failure.value should (be > Duration.Zero and be < shortResetTimeout)
     }
 
-    "pass through next call and invoke onCallTimeout on timeout" in {
+    "pass through next call and invoke onCallTimeout on timeout" taggedAs TimingTest in {
       val breaker = shortCallTimeoutCb()
 
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
@@ -258,7 +258,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       timeout.value should (be > Duration.Zero and be < (shortCallTimeout * 2).dilated)
     }
 
-    "pass through next call and invoke onCallBreakerOpen while executing other" in {
+    "pass through next call and invoke onCallBreakerOpen while executing other" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
 
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
@@ -270,7 +270,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       checkLatch(breaker.callBreakerOpenLatch)
     }
 
-    "pass through next call and invoke onCallSuccess after transition to open state" in {
+    "pass through next call and invoke onCallSuccess after transition to open state" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
 
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
@@ -282,12 +282,12 @@ class CircuitBreakerSpec extends AkkaSpec {
   }
 
   "A synchronous circuit breaker that is closed" must {
-    "allow calls through" in {
+    "allow calls through" taggedAs TimingTest in {
       val breaker = longCallTimeoutCb()
       breaker().withSyncCircuitBreaker(sayHi) should ===("hi")
     }
 
-    "increment failure count on failure" in {
+    "increment failure count on failure" taggedAs TimingTest in {
       val breaker = longCallTimeoutCb()
       breaker().currentFailureCount should ===(0)
       intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
@@ -296,7 +296,7 @@ class CircuitBreakerSpec extends AkkaSpec {
     }
 
     "increment failure count on even number" when {
-      "even number is considered failure" in {
+      "even number is considered failure" taggedAs TimingTest in {
         val breaker = longCallTimeoutCb()
         breaker().currentFailureCount should ===(0)
         val result = breaker().withSyncCircuitBreaker(2, evenNumberIsFailure)
@@ -307,7 +307,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       }
     }
 
-    "increment failure count on fail method" in {
+    "increment failure count on fail method" taggedAs TimingTest in {
       val breaker = longCallTimeoutCb()
       breaker().currentFailureCount should ===(0)
       breaker().fail()
@@ -315,7 +315,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       breaker().currentFailureCount should ===(1)
     }
 
-    "reset failure count after success" in {
+    "reset failure count after success" taggedAs TimingTest in {
       val breaker = multiFailureCb()
       breaker().currentFailureCount should ===(0)
       intercept[TestException] {
@@ -328,7 +328,7 @@ class CircuitBreakerSpec extends AkkaSpec {
     }
 
     "reset failure count after exception in call" when {
-      "exception is defined as Success" in {
+      "exception is defined as Success" taggedAs TimingTest in {
         val breaker = multiFailureCb()
         breaker().currentFailureCount should ===(0)
         intercept[TestException] {
@@ -351,7 +351,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       }
     }
 
-    "reset failure count after success method" in {
+    "reset failure count after success method" taggedAs TimingTest in {
       val breaker = multiFailureCb()
       breaker().currentFailureCount should ===(0)
       intercept[TestException] {
@@ -363,7 +363,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       breaker().currentFailureCount should ===(0)
     }
 
-    "throw TimeoutException on callTimeout" in {
+    "throw TimeoutException on callTimeout" taggedAs TimingTest in {
       val breaker = shortCallTimeoutCb()
       intercept[TimeoutException] {
         breaker().withSyncCircuitBreaker {
@@ -373,7 +373,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       breaker().currentFailureCount should ===(1)
     }
 
-    "increment failure count on callTimeout before call finishes" in {
+    "increment failure count on callTimeout before call finishes" taggedAs TimingTest in {
       val breaker = shortCallTimeoutCb()
       Future {
         breaker().withSyncCircuitBreaker {
@@ -385,7 +385,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       }
     }
 
-    "invoke onCallSuccess if call succeeds" in {
+    "invoke onCallSuccess if call succeeds" taggedAs TimingTest in {
       val breaker = shortCallTimeoutCb()
 
       breaker().withSyncCircuitBreaker(sayHi)
@@ -395,7 +395,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       success.value should (be > Duration.Zero and be < shortCallTimeout)
     }
 
-    "invoke onCallTimeout if call timeouts" in {
+    "invoke onCallTimeout if call timeouts" taggedAs TimingTest in {
       val breaker = shortCallTimeoutCb()
 
       intercept[TimeoutException](breaker().withSyncCircuitBreaker(Thread.sleep(250.millis.dilated.toMillis)))
@@ -405,7 +405,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       timeout.value should (be > Duration.Zero and be < (shortCallTimeout * 2))
     }
 
-    "invoke onCallFailure if call fails" in {
+    "invoke onCallFailure if call fails" taggedAs TimingTest in {
       val breaker = shortCallTimeoutCb()
 
       intercept[TestException](breaker().withSyncCircuitBreaker(throwException))
@@ -415,7 +415,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       failure.value should (be > Duration.Zero and be < shortCallTimeout)
     }
 
-    "invoke onOpen if call fails and breaker transits to open state" in {
+    "invoke onOpen if call fails and breaker transits to open state" taggedAs TimingTest in {
       val breaker = shortCallTimeoutCb()
 
       intercept[TestException](breaker().withSyncCircuitBreaker(throwException))
@@ -424,7 +424,7 @@ class CircuitBreakerSpec extends AkkaSpec {
   }
 
   "An asynchronous circuit breaker that is open" must {
-    "throw exceptions when called before reset timeout" in {
+    "throw exceptions when called before reset timeout" taggedAs TimingTest in {
       val breaker = longResetTimeoutCb()
       breaker().withCircuitBreaker(Future(throwException))
 
@@ -433,13 +433,13 @@ class CircuitBreakerSpec extends AkkaSpec {
       intercept[CircuitBreakerOpenException] { Await.result(breaker().withCircuitBreaker(Future(sayHi)), awaitTimeout) }
     }
 
-    "transition to half-open on reset timeout" in {
+    "transition to half-open on reset timeout" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
       breaker().withCircuitBreaker(Future(throwException))
       checkLatch(breaker.halfOpenLatch)
     }
 
-    "increase the reset timeout after it transits to open again" in {
+    "increase the reset timeout after it transits to open again" taggedAs TimingTest in {
       val breaker = nonOneFactorCb()
       breaker().withCircuitBreaker(Future(throwException))
       checkLatch(breaker.openLatch)
@@ -461,14 +461,14 @@ class CircuitBreakerSpec extends AkkaSpec {
       shortRemainingDuration should be < longRemainingDuration
     }
 
-    "invoke onHalfOpen during transition to half-open state" in {
+    "invoke onHalfOpen during transition to half-open state" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
 
       intercept[TestException] { Await.result(breaker().withCircuitBreaker(Future(throwException)), awaitTimeout) }
       checkLatch(breaker.halfOpenLatch)
     }
 
-    "invoke onCallBreakerOpen when called before reset timeout" in {
+    "invoke onCallBreakerOpen when called before reset timeout" taggedAs TimingTest in {
       val breaker = longResetTimeoutCb()
 
       breaker().withCircuitBreaker(Future(throwException))
@@ -478,7 +478,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       checkLatch(breaker.callBreakerOpenLatch)
     }
 
-    "invoke onCallFailure when call results in exception" in {
+    "invoke onCallFailure when call results in exception" taggedAs TimingTest in {
       val breaker = longResetTimeoutCb()
 
       breaker().withCircuitBreaker(Future(throwException))
@@ -490,7 +490,7 @@ class CircuitBreakerSpec extends AkkaSpec {
   }
 
   "An asynchronous circuit breaker that is half-open" must {
-    "pass through next call and close on success" in {
+    "pass through next call and close on success" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
       breaker().withCircuitBreaker(Future(throwException))
       checkLatch(breaker.halfOpenLatch)
@@ -499,7 +499,7 @@ class CircuitBreakerSpec extends AkkaSpec {
     }
 
     "pass through next call and close on exception" when {
-      "exception is defined as call succeeded" in {
+      "exception is defined as call succeeded" taggedAs TimingTest in {
         val breaker = shortResetTimeoutCb()
         breaker().withCircuitBreaker(Future(throwException))
         checkLatch(breaker.halfOpenLatch)
@@ -509,7 +509,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       }
     }
 
-    "re-open on exception in call" in {
+    "re-open on exception in call" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
       breaker().withCircuitBreaker(Future(throwException))
       checkLatch(breaker.halfOpenLatch)
@@ -519,7 +519,7 @@ class CircuitBreakerSpec extends AkkaSpec {
     }
 
     "re-open on even number" when {
-      "even number is defined as failure" in {
+      "even number is defined as failure" taggedAs TimingTest in {
         val breaker = shortResetTimeoutCb()
         intercept[TestException] { breaker().withSyncCircuitBreaker(throwException) }
         checkLatch(breaker.halfOpenLatch)
@@ -529,7 +529,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       }
     }
 
-    "re-open on async failure" in {
+    "re-open on async failure" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
       breaker().withCircuitBreaker(Future(throwException))
       checkLatch(breaker.halfOpenLatch)
@@ -539,7 +539,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       checkLatch(breaker.openLatch)
     }
 
-    "pass through next call and invoke onCallSuccess on success" in {
+    "pass through next call and invoke onCallSuccess on success" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
 
       breaker().withCircuitBreaker(Future(throwException))
@@ -553,7 +553,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       success.value should (be > Duration.Zero and be < shortResetTimeout)
     }
 
-    "pass through next call and invoke onCallFailure on failure" in {
+    "pass through next call and invoke onCallFailure on failure" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
 
       breaker().withCircuitBreaker(Future(throwException))
@@ -570,7 +570,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       failure.value should (be > Duration.Zero and be < shortResetTimeout)
     }
 
-    "pass through next call and invoke onCallTimeout on timeout" in {
+    "pass through next call and invoke onCallTimeout on timeout" taggedAs TimingTest in {
       val breaker = shortCallTimeoutCb()
 
       breaker().withCircuitBreaker(Future(throwException))
@@ -584,7 +584,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       timeout.value should (be > Duration.Zero and be < (shortCallTimeout * 2).dilated)
     }
 
-    "pass through next call and invoke onCallBreakerOpen while executing other" in {
+    "pass through next call and invoke onCallBreakerOpen while executing other" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
 
       breaker().withCircuitBreaker(Future(throwException))
@@ -595,7 +595,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       checkLatch(breaker.callBreakerOpenLatch)
     }
 
-    "pass through next call and invoke onOpen after transition to open state" in {
+    "pass through next call and invoke onOpen after transition to open state" taggedAs TimingTest in {
       val breaker = shortResetTimeoutCb()
 
       breaker().withCircuitBreaker(Future(throwException))
@@ -607,12 +607,12 @@ class CircuitBreakerSpec extends AkkaSpec {
   }
 
   "An asynchronous circuit breaker that is closed" must {
-    "allow calls through" in {
+    "allow calls through" taggedAs TimingTest in {
       val breaker = longCallTimeoutCb()
       Await.result(breaker().withCircuitBreaker(Future(sayHi)), awaitTimeout) should ===("hi")
     }
 
-    "increment failure count on exception" in {
+    "increment failure count on exception" taggedAs TimingTest in {
       val breaker = longCallTimeoutCb()
       intercept[TestException] { Await.result(breaker().withCircuitBreaker(Future(throwException)), awaitTimeout) }
       checkLatch(breaker.openLatch)
@@ -620,7 +620,7 @@ class CircuitBreakerSpec extends AkkaSpec {
     }
 
     "increment failure count on even number" when {
-      "even number is considered failure" in {
+      "even number is considered failure" taggedAs TimingTest in {
         val breaker = longCallTimeoutCb()
         breaker().currentFailureCount should ===(0)
         val result =
@@ -631,31 +631,28 @@ class CircuitBreakerSpec extends AkkaSpec {
       }
     }
 
-    "increment failure count on async failure" in {
+    "increment failure count on async failure" taggedAs TimingTest in {
       val breaker = longCallTimeoutCb()
       breaker().withCircuitBreaker(Future(throwException))
       checkLatch(breaker.openLatch)
       breaker().currentFailureCount should ===(1)
     }
 
-    "reset failure count after success" in {
+    "reset failure count after success" taggedAs TimingTest in {
       val breaker = multiFailureCb()
       breaker().withCircuitBreaker(Future(sayHi))
       for (_ <- 1 to 4) breaker().withCircuitBreaker(Future(throwException))
-      awaitCond(breaker().currentFailureCount == 4, awaitTimeout)
+      awaitAssert(breaker().currentFailureCount shouldBe 4, awaitTimeout)
       breaker().withCircuitBreaker(Future(sayHi))
-      awaitCond(breaker().currentFailureCount == 0, awaitTimeout)
+      awaitAssert(breaker().currentFailureCount shouldBe 0, awaitTimeout)
     }
 
     "reset failure count after exception in call" when {
-      "exception is defined as Success" in {
+      "exception is defined as Success" taggedAs TimingTest in {
         val breaker: Breaker = multiFailureCb()
 
         for (_ <- 1 to 4) breaker().withCircuitBreaker(Future(throwException))
-        awaitCond(
-          breaker().currentFailureCount == 4,
-          awaitTimeout,
-          message = s"Current failure count: ${breaker().currentFailureCount}")
+        awaitAssert(breaker().currentFailureCount shouldBe 4, awaitTimeout)
 
         val harmlessException = new TestException
         val harmlessExceptionAsSuccess: Try[String] => Boolean = {
@@ -664,11 +661,11 @@ class CircuitBreakerSpec extends AkkaSpec {
         }
 
         breaker().withCircuitBreaker(Future(throw harmlessException), harmlessExceptionAsSuccess)
-        awaitCond(breaker().currentFailureCount == 0, awaitTimeout)
+        awaitAssert(breaker().currentFailureCount shouldBe 0, awaitTimeout)
       }
     }
 
-    "increment failure count on callTimeout" in {
+    "increment failure count on callTimeout" taggedAs TimingTest in {
       val breaker = shortCallTimeoutCb()
 
       val fut = breaker().withCircuitBreaker(Future {
@@ -685,7 +682,7 @@ class CircuitBreakerSpec extends AkkaSpec {
 
     }
 
-    "invoke onCallSuccess if call succeeds" in {
+    "invoke onCallSuccess if call succeeds" taggedAs TimingTest in {
       val breaker = shortCallTimeoutCb()
 
       breaker().withCircuitBreaker(Future(sayHi))
@@ -695,7 +692,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       success.value should (be > Duration.Zero and be < shortCallTimeout)
     }
 
-    "invoke onCallTimeout if call timeouts" in {
+    "invoke onCallTimeout if call timeouts" taggedAs TimingTest in {
       val breaker = shortCallTimeoutCb()
 
       breaker().withCircuitBreaker(Future(Thread.sleep(250.millis.dilated.toMillis)))
@@ -705,7 +702,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       timeout.value should (be > Duration.Zero and be < (shortCallTimeout * 2).dilated)
     }
 
-    "invoke onCallFailure if call fails" in {
+    "invoke onCallFailure if call fails" taggedAs TimingTest in {
       val breaker = shortCallTimeoutCb()
 
       breaker().withCircuitBreaker(Future(throwException))
@@ -715,7 +712,7 @@ class CircuitBreakerSpec extends AkkaSpec {
       failure.value should (be > Duration.Zero and be < shortCallTimeout)
     }
 
-    "invoke onOpen if call fails and breaker transits to open state" in {
+    "invoke onOpen if call fails and breaker transits to open state" taggedAs TimingTest in {
       val breaker = shortCallTimeoutCb()
 
       breaker().withCircuitBreaker(Future(throwException))


### PR DESCRIPTION
References #31229

I was in doubt if I should tag all tests with `TimingTest`, but decide to do so to have them all run on the same job in GH Actions. 

I didn't touch the `CircuitBreakerStressSpec` as timing is not so important here. We bombard the actor with messages, let it internally use CB and then verified it never fail. Since it is expect to never fail, it will return 0 whenever we call it. 