### PR TITLE
use a non-rc version of jackson-scala-module

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -318,10 +318,10 @@ object Dependencies {
         // jackson-module-scala is only available for Scala 3 from 2.13.0 onwards.
         // since we don't depend on it ourselves, but provide it as a transitive
         // dependency for convenience, we can leave it out for Scala 3 for now,
-        // and depend on 2.13.0-rc1 for our tests. Eventually we should consider
+        // and depend on 2.13.2 for our tests. Eventually we should consider
         // whether to update all jackson artifacts for Scala 3.
         if (scalaVersion.value.startsWith("3."))
-          Seq("com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.0-rc1" % Test)
+          Seq("com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.2" % Test)
         else
           Seq(jacksonScala)
       )


### PR DESCRIPTION
Just seems tidier to not use 2.13.0-rc1 when testing jackson module (scala 3 only).

I'm not sure why jackson-module-scala is not needed for runtime - since it is referenced in https://github.com/akka/akka/blob/main/akka-serialization-jackson/src/main/resources/reference.conf#L20
