### PR TITLE
exclude tests using DisposableSys from aeron run

### DIFF
--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -137,10 +137,11 @@ jobs:
           sbt -jvm-opts .jvmopts-ci \
             -Dakka.test.timefactor=2 \
             -Dakka.actor.testkit.typed.timefactor=2 \
+            -Dakka.test.tags.exclude=gh-exclude,timing \
             -Dakka.cluster.assert=on \
             -Dakka.remote.artery.transport=aeron-udp \
             -Dsbt.override.build.repos=false \
-            -Dakka.test.tags.exclude=gh-exclude,gh-exclude-aeron,timing \
+            -Dakka.test.tags.exclude=gh-exclude,timing \
             -Dakka.test.multi-node=true \
             -Dakka.test.multi-node.targetDirName=${PWD}/target/${{ github.run_id }} \
             -Dakka.test.multi-node.java=${JAVA_HOME}/bin/java \

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -137,11 +137,10 @@ jobs:
           sbt -jvm-opts .jvmopts-ci \
             -Dakka.test.timefactor=2 \
             -Dakka.actor.testkit.typed.timefactor=2 \
-            -Dakka.test.tags.exclude=gh-exclude,timing \
             -Dakka.cluster.assert=on \
             -Dakka.remote.artery.transport=aeron-udp \
             -Dsbt.override.build.repos=false \
-            -Dakka.test.tags.exclude=gh-exclude,timing \
+            -Dakka.test.tags.exclude=gh-exclude,gh-exclude-aeron,timing \
             -Dakka.test.multi-node=true \
             -Dakka.test.multi-node.targetDirName=${PWD}/target/${{ github.run_id }} \
             -Dakka.test.multi-node.java=${JAVA_HOME}/bin/java \

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/RandomizedBrainResolverIntegrationSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/RandomizedBrainResolverIntegrationSpec.scala
@@ -24,7 +24,6 @@ import akka.pattern.ask
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
 import akka.remote.testkit.MultiNodeSpec
-import akka.testkit.GHExcludeAeronTest
 import akka.testkit.ImplicitSender
 import akka.testkit.LongRunningTest
 import akka.testkit.TestKit
@@ -405,7 +404,7 @@ class RandomizedSplitBrainResolverIntegrationSpec
   "SplitBrainResolver with lease" must {
 
     for (scenario <- scenarios) {
-      scenario.toString.taggedAs(LongRunningTest, GHExcludeAeronTest) in {
+      scenario.toString taggedAs (LongRunningTest) in {
         DisposableSys(scenario).verify()
       }
     }

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/RandomizedBrainResolverIntegrationSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/RandomizedBrainResolverIntegrationSpec.scala
@@ -405,6 +405,12 @@ class RandomizedSplitBrainResolverIntegrationSpec
 
     for (scenario <- scenarios) {
       scenario.toString taggedAs (LongRunningTest) in {
+        // temporarily disabled for aeron-udp in multi-node: https://github.com/akka/akka/pull/30706/
+        val arteryConfig = system.settings.config.getConfig("akka.remote.artery")
+        if (arteryConfig.getInt("canonical.port") == 6000 &&
+            arteryConfig.getString("transport") == "aeron-udp") {
+          pending
+        }
         DisposableSys(scenario).verify()
       }
     }

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/SplitBrainResolverIntegrationSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/SplitBrainResolverIntegrationSpec.scala
@@ -27,7 +27,6 @@ import akka.pattern.ask
 import akka.remote.testconductor.RoleName
 import akka.remote.testkit.MultiNodeConfig
 import akka.remote.testkit.MultiNodeSpec
-import akka.testkit.GHExcludeAeronTest
 import akka.testkit.ImplicitSender
 import akka.testkit.LongRunningTest
 import akka.testkit.TestKit
@@ -458,7 +457,7 @@ class SplitBrainResolverIntegrationSpec
   "Cluster SplitBrainResolver" must {
 
     for (scenario <- scenarios) {
-      scenario.toString.taggedAs(LongRunningTest, GHExcludeAeronTest) in {
+      scenario.toString taggedAs LongRunningTest in {
         DisposableSys(scenario).verify()
       }
     }

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/SplitBrainResolverIntegrationSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sbr/SplitBrainResolverIntegrationSpec.scala
@@ -458,6 +458,12 @@ class SplitBrainResolverIntegrationSpec
 
     for (scenario <- scenarios) {
       scenario.toString taggedAs LongRunningTest in {
+        // temporarily disabled for aeron-udp in multi-node: https://github.com/akka/akka/pull/30706/
+        val arteryConfig = system.settings.config.getConfig("akka.remote.artery")
+        if (arteryConfig.getInt("canonical.port") == 6000 &&
+            arteryConfig.getString("transport") == "aeron-udp") {
+          pending
+        }
         DisposableSys(scenario).verify()
       }
     }


### PR DESCRIPTION
Seems like the test tags excludes doesn't work for the multi-node tests. [It was run (and failed)](https://pipelines.actions.githubusercontent.com/HzCRUTzQVfQOD2u7c8bhVR9NZoBVF2xIcH3n2SIcJs43R3Lsk9/_apis/pipelines/1/runs/5676/signedlogcontent/2?urlExpires=2022-03-11T07%3A47%3A48.2456077Z&urlSigningMethod=HMACV1&urlSignature=rOaQgk2hO0HNfL1vreVwMH3%2FvT%2FZ%2BSftT23uhAjBuLU%3D) even though `-Dakka.test.tags.exclude=gh-exclude,gh-exclude-aeron,timing` was defined.

Simply reverting two commits to get back to where we had them disabled.

See #30802