### PR TITLE
added new apply method for partition, supporting eagerCancel param, m…

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -766,7 +766,11 @@ object Partition {
    *
    * @param outputPorts number of output ports
    * @param partitioner function deciding which output each element will be targeted
-   */ // FIXME BC add `eagerCancel: Boolean = false` parameter
+   * @param eagerCancel boolean deciding to cancel flow eagerly or not
+   */
+  def apply[T](outputPorts: Int, partitioner: T => Int, eagerCancel: Boolean): Partition[T] =
+    new Partition(outputPorts, partitioner, eagerCancel)
+
   def apply[T](outputPorts: Int, partitioner: T => Int): Partition[T] = new Partition(outputPorts, partitioner, false)
 }
 


### PR DESCRIPTION
…inor fixme

This FIXME has been there for a while (2018). It's currently necessary to use `new` keyword in Scala if you want to pass the `eagerCancel` parameter to the `Partition` component, which seemed inelegant to me (and it also hid functionality).

I created a second apply function with the new parameter, which should avoid breaking any backwards compatibility I hope.