### PR TITLE
PREVIEW =str Make use of TireMap instead of List to reduce contention.

### DIFF
--- a/akka-stream/src/main/mima-filters/2.6.18.backwards.excludes/on-feedback-dispatched.excludes
+++ b/akka-stream/src/main/mima-filters/2.6.18.backwards.excludes/on-feedback-dispatched.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.stage.GraphStageLogic.onFeedbackDispatched")

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphInterpreter.scala
@@ -467,13 +467,13 @@ import akka.stream.stage._
           handler(evt)
           if (promise ne GraphStageLogic.NoPromise) {
             promise.success(Done)
-            logic.onFeedbackDispatched()
+            logic.onFeedbackDispatched(promise)
           }
         } catch {
           case NonFatal(ex) =>
             if (promise ne GraphStageLogic.NoPromise) {
               promise.failure(ex)
-              logic.onFeedbackDispatched()
+              logic.onFeedbackDispatched(promise)
             }
             logic.failStage(ex)
         }


### PR DESCRIPTION
Try with TrieMap
Currently the`invokeWithFeedback` method of  AsyncCallback is guard by the `asyncCallbacksInProgress` but not the `currentState` is there any reason for that?
