### PR TITLE
Use ssl-config 0.6.1 on Scala 3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,7 +42,13 @@ object Dependencies {
 
   val reactiveStreamsVersion = "1.0.3"
 
-  val sslConfigVersion = "0.4.3"
+  val sslConfigVersion = Def.setting {
+    if (scalaVersion.value.startsWith("3.")) {
+      "0.6.1"
+    } else {
+      "0.4.3"
+    }
+  }
 
   val scalaTestVersion = Def.setting {
     if (scalaVersion.value.startsWith("3.")) {
@@ -93,7 +99,9 @@ object Dependencies {
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion // CC0
 
     // ssl-config
-    val sslConfigCore = ("com.typesafe" %% "ssl-config-core" % sslConfigVersion).cross(CrossVersion.for3Use2_13) // ApacheV2
+    val sslConfigCore = Def.setting {
+      "com.typesafe" %% "ssl-config-core" % sslConfigVersion.value // ApacheV2
+    }
 
     val lmdb = "org.lmdbjava" % "lmdbjava" % "0.7.0" // ApacheV2, OpenLDAP Public License
 
@@ -358,7 +366,7 @@ object Dependencies {
 
   // akka stream
 
-  lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, sslConfigCore, TestDependencies.scalatest.value)
+  lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, sslConfigCore.value, TestDependencies.scalatest.value)
 
   lazy val streamTestkit = l ++= Seq(
         TestDependencies.scalatest.value,


### PR DESCRIPTION
Avoiding `CrossVersion.for3Use2_13`