### PR TITLE
chore: adapt link validator for Scala 2.13.8

### DIFF
--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -46,10 +46,10 @@ site-link-validator {
     "https://javadoc.io/static/"
     # GitHub will block with "429 Too Many Requests"
     "https://github.com/"
-    "https://www.scala-lang.org/api/2.13.7/scala/runtime/AbstractFunction1.html"
-    "https://www.scala-lang.org/api/2.13.7/scala/runtime/AbstractFunction2.html"
-    "https://www.scala-lang.org/api/2.13.7/scala/runtime/AbstractFunction3.html"
-    "https://www.scala-lang.org/api/2.13.7/scala/runtime/AbstractPartialFunction.html"
+    "https://www.scala-lang.org/api/2.13.8/scala/runtime/AbstractFunction1.html"
+    "https://www.scala-lang.org/api/2.13.8/scala/runtime/AbstractFunction2.html"
+    "https://www.scala-lang.org/api/2.13.8/scala/runtime/AbstractFunction3.html"
+    "https://www.scala-lang.org/api/2.13.8/scala/runtime/AbstractPartialFunction.html"
   ]
 
   non-https-whitelist = [


### PR DESCRIPTION
Follow-up to #31111
