### PR TITLE
build: break dependency from akka-stream-tests -> akka-remote

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -435,7 +435,7 @@ lazy val streamTestkit = akkaModule("akka-stream-testkit")
 
 lazy val streamTests = akkaModule("akka-stream-tests")
   .configs(akka.Jdk9.TestJdk9)
-  .dependsOn(streamTestkit % "test->test", remote % "test->test", stream % "TestJdk9->CompileJdk9")
+  .dependsOn(streamTestkit % "test->test", stream % "TestJdk9->CompileJdk9")
   .settings(Dependencies.streamTests)
   .enablePlugins(NoPublish, Jdk9)
   .disablePlugins(MimaPlugin)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -375,6 +375,7 @@ object Dependencies {
 
   lazy val streamTests = l ++= Seq(
         TestDependencies.scalatest.value,
+        TestDependencies.scalatestJUnit.value,
         TestDependencies.scalatestScalaCheck.value,
         TestDependencies.junit,
         TestDependencies.commonsIo,


### PR DESCRIPTION
Probably a left-over from the past.