### PR TITLE
Added support for context propagation to ActorFlow #31308

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/ActorFlow/askWithContext.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorFlow/askWithContext.md
@@ -1,0 +1,51 @@
+# ActorFlow.askWithContext
+
+Use the "Ask Pattern" to send each stream element (without the context) as an `ask` to the target actor (of the new actors API), and expect a reply that will be emitted downstream.
+
+@ref[Actor interop operators](../index.md#actor-interop-operators)
+
+## Dependency
+
+This operator is included in:
+
+@@dependency[sbt,Maven,Gradle] {
+  bomGroup=com.typesafe.akka bomArtifact=akka-bom_$scala.binary.version$ bomVersionSymbols=AkkaVersion
+  symbol1=AkkaVersion
+  value1="$akka.version$"
+  group="com.typesafe.akka"
+  artifact="akka-stream-typed_$scala.binary.version$"
+  version=AkkaVersion
+}
+
+## Signature
+
+@apidoc[ActorFlow.askWithContext](ActorFlow$) { scala="#askWithContext%5BI,Q,A,Ctx](ref:akka.actor.typed.ActorRef%5BQ])(makeMessage:(I,akka.actor.typed.ActorRef%5BA])=%3EQ)(implicittimeout:akka.util.Timeout):akka.stream.scaladsl.Flow%5B(I,Ctx),(A,Ctx),akka.NotUsed]" java="#askWithContext(akka.actor.typed.ActorRef,java.time.Duration,java.util.function.BiFunction)" }
+
+## Description
+
+Use the @ref[Ask pattern](../../../typed/interaction-patterns.md#request-response-with-ask-from-outside-an-actor) to send a request-reply message to the target `ref` actor.
+The stream context is not sent, instead it is locally recombined to the actor's reply.
+
+If any of the asks times out it will fail the stream with an @apidoc[AskTimeoutException].
+
+The `ask` operator requires
+
+* the actor `ref`,
+* a `makeMessage` function to create the message sent to the actor from the incoming element, and the actor ref accepting the actor's reply message 
+* a timeout.
+
+## Reactive Streams semantics
+
+@@@div { .callout }
+
+**emits** when the futures (in submission order) created by the ask pattern internally are completed
+
+**backpressures** when the number of futures reaches the configured parallelism and the downstream backpressures
+
+**completes** when upstream completes and all futures have been completed and all elements have been emitted
+
+**fails** when the passed-in actor terminates, or when any of the `ask`s exceed a timeout
+
+**cancels** when downstream cancels
+
+@@@

--- a/akka-docs/src/main/paradox/stream/operators/ActorFlow/askWithStatusAndContext.md
+++ b/akka-docs/src/main/paradox/stream/operators/ActorFlow/askWithStatusAndContext.md
@@ -1,0 +1,51 @@
+# ActorFlow.askWithContext
+
+Use the "Ask Pattern" to send each stream element (without the context) as an `ask` to the target actor (of the new actors API), and expect a reply of Type @scala[`StatusReply[T]`]@java[`StatusReply<T>`] where the T will be unwrapped and emitted downstream.
+
+@ref[Actor interop operators](../index.md#actor-interop-operators)
+
+## Dependency
+
+This operator is included in:
+
+@@dependency[sbt,Maven,Gradle] {
+  bomGroup=com.typesafe.akka bomArtifact=akka-bom_$scala.binary.version$ bomVersionSymbols=AkkaVersion
+  symbol1=AkkaVersion
+  value1="$akka.version$"
+  group="com.typesafe.akka"
+  artifact="akka-stream-typed_$scala.binary.version$"
+  version=AkkaVersion
+}
+
+## Signature
+
+@apidoc[ActorFlow.askWithStatusAndContext](ActorFlow$) { scala="#askWithStatusAndContext[I,Q,A,Ctx](parallelism:Int)(ref:akka.actor.typed.ActorRef[Q])(makeMessage:(I,akka.actor.typed.ActorRef[akka.pattern.StatusReply[A]])=&gt;Q)(implicittimeout:akka.util.Timeout):akka.stream.scaladsl.Flow[(I,Ctx),(A,Ctx),akka.NotUsed]" java ="#askWithStatusAndContext[I,Q,A,Ctx](parallelism:Int,ref:akka.actor.typed.ActorRef[Q],timeout:java.time.Duration,makeMessage:java.util.function.BiFunction[I,akka.actor.typed.ActorRef[akka.pattern.StatusReply[A]],Q])" }
+
+## Description
+
+Use the @ref[Ask pattern](../../../typed/interaction-patterns.md#request-response-with-ask-from-outside-an-actor) to send a request-reply message to the target `ref` actor when you expect the reply to be `akka.pattern.StatusReply`.
+The stream context is not sent, instead it is locally recombined to the actor's reply.
+
+If any of the asks times out it will fail the stream with an @apidoc[AskTimeoutException].
+
+The `ask` operator requires
+
+* the actor `ref`,
+* a `makeMessage` function to create the message sent to the actor from the incoming element, and the actor ref accepting the actor's reply message 
+* a timeout.
+
+## Reactive Streams semantics
+
+@@@div { .callout }
+
+**emits** when the futures (in submission order) created by the ask pattern internally are completed
+
+**backpressures** when the number of futures reaches the configured parallelism and the downstream backpressures
+
+**completes** when upstream completes and all futures have been completed and all elements have been emitted
+
+**fails** when the passed-in actor terminates, or when any of the `ask`s exceed a timeout
+
+**cancels** when downstream cancels
+
+@@@

--- a/akka-docs/src/main/paradox/stream/operators/index.md
+++ b/akka-docs/src/main/paradox/stream/operators/index.md
@@ -328,7 +328,9 @@ Operators meant for inter-operating between Akka Streams and Actors:
 |ActorSink|<a name="actorrefwithbackpressure"></a>@ref[actorRefWithBackpressure](ActorSink/actorRefWithBackpressure.md)|Sends the elements of the stream to the given @java[`ActorRef<T>`]@scala[`ActorRef[T]`] of the new actors API with backpressure, to be able to signal demand when the actor is ready to receive more elements.|
 |Source/Flow|<a name="ask"></a>@ref[ask](Source-or-Flow/ask.md)|Use the "Ask Pattern" to send a request-reply message to the target `ref` actor (of the classic actors API).|
 |ActorFlow|<a name="ask"></a>@ref[ask](ActorFlow/ask.md)|Use the "Ask Pattern" to send each stream element as an `ask` to the target actor (of the new actors API), and expect a reply that will be emitted downstream.|
+|ActorFlow|<a name="askwithcontext"></a>@ref[askWithContext](ActorFlow/askWithContext.md)|Use the "Ask Pattern" to send each stream element (without the context) as an `ask` to the target actor (of the new actors API), and expect a reply that will be emitted downstream.|
 |ActorFlow|<a name="askwithstatus"></a>@ref[askWithStatus](ActorFlow/askWithStatus.md)|Use the "Ask Pattern" to send each stream element as an `ask` to the target actor (of the new actors API),  and expect a reply of Type @scala[`StatusReply[T]`]@java[`StatusReply<T>`] where the T will be unwrapped and emitted downstream.|
+|ActorFlow|<a name="askwithstatusandcontext"></a>@ref[askWithStatusAndContext](ActorFlow/askWithStatusAndContext.md)|Use the "Ask Pattern" to send each stream element (without the context) as an `ask` to the target actor (of the new actors API), and expect a reply of Type @scala[`StatusReply[T]`]@java[`StatusReply<T>`] where the T will be unwrapped and emitted downstream.|
 |PubSub|<a name="sink"></a>@ref[sink](PubSub/sink.md)|A sink that will publish emitted messages to a @apidoc[akka.actor.typed.pubsub.Topic$].|
 |PubSub|<a name="source"></a>@ref[source](PubSub/source.md)|A source that will subscribe to a @apidoc[akka.actor.typed.pubsub.Topic$] and stream messages published to the topic. |
 |Source/Flow|<a name="watch"></a>@ref[watch](Source-or-Flow/watch.md)|Watch a specific `ActorRef` and signal a failure downstream once the actor terminates.|
@@ -379,7 +381,9 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 * [asJavaStream](StreamConverters/asJavaStream.md)
 * [ask](Source-or-Flow/ask.md)
 * [ask](ActorFlow/ask.md)
+* [askWithContext](ActorFlow/askWithContext.md)
 * [askWithStatus](ActorFlow/askWithStatus.md)
+* [askWithStatusAndContext](ActorFlow/askWithStatusAndContext.md)
 * [asOutputStream](StreamConverters/asOutputStream.md)
 * [asPublisher](Sink/asPublisher.md)
 * [asSourceWithContext](Source/asSourceWithContext.md)
@@ -514,6 +518,7 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 * [orElse](Source-or-Flow/orElse.md)
 * [Partition](Partition.md)
 * [prefixAndTail](Source-or-Flow/prefixAndTail.md)
+* [preMaterialize](Source-or-Flow/preMaterialize.md)
 * [preMaterialize](Sink/preMaterialize.md)
 * [prepend](Source-or-Flow/prepend.md)
 * [prependLazy](Source-or-Flow/prependLazy.md)

--- a/akka-stream-typed/src/test/java/docs/javadsl/ActorFlowCompileTest.java
+++ b/akka-stream-typed/src/test/java/docs/javadsl/ActorFlowCompileTest.java
@@ -83,5 +83,28 @@ public class ActorFlowCompileTest {
 
     Source.repeat("hello").via(askFlow).map(reply -> reply.msg).runWith(Sink.seq(), system);
     // #ask
+
+    // #askWithContext
+
+    // method reference notation
+    Flow<akka.japi.Pair<String, Long>, akka.japi.Pair<Reply, Long>, NotUsed> askFlowWithContext =
+        ActorFlow.askWithContext(actorRef, timeout, Asking::new);
+
+    // explicit creation of the sent message
+    Flow<akka.japi.Pair<String, Long>, akka.japi.Pair<Reply, Long>, NotUsed>
+        askFlowExplicitWithContext =
+            ActorFlow.askWithContext(actorRef, timeout, (msg, replyTo) -> new Asking(msg, replyTo));
+
+    Flow<akka.japi.Pair<String, Long>, akka.japi.Pair<String, Long>, NotUsed>
+        askFlowExplicitWithStatusAndContext =
+            ActorFlow.askWithStatusAndContext(
+                actorWithStatusRef, timeout, (msg, replyTo) -> new AskingWithStatus(msg, replyTo));
+
+    Source.repeat("hello")
+        .zipWithIndex()
+        .via(askFlowWithContext)
+        .map(pair -> pair.first().msg)
+        .runWith(Sink.seq(), system);
+    // #askWithContext
   }
 }


### PR DESCRIPTION
This merge request adds support for context propagation in `ActorFlow` by expanding the API with:
- `askWithContext`
- `askWithStatusAndContext`

References #31308 

