### PR TITLE
stream: try to guard against unlimited looping in TlsActor.doUnwrap

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
@@ -414,12 +414,13 @@ import akka.util.ByteString
             flushToUser()
             handshakeFinished()
             transportInChoppingBlock.putBack(transportInBuffer)
+          case NEED_UNWRAP
+              if transportInBuffer.hasRemaining &&
+              userOutBuffer.position() == 0 &&
+              transportInBuffer.position() == oldInPosition =>
+            throw new IllegalStateException("SSLEngine trying to loop NEED_UNWRAP without producing output")
           case _ =>
-            if (transportInBuffer.hasRemaining)
-              if (userOutBuffer.position() == 0 && transportInBuffer.position() == oldInPosition)
-                throw new IllegalStateException("SSLEngine trying to loop NEED_UNWRAP without producing output")
-              else
-                doUnwrap(ignoreOutput = false)
+            if (transportInBuffer.hasRemaining) doUnwrap(ignoreOutput = false)
             else flushToUser()
         }
       case CLOSED =>

--- a/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/io/TLSActor.scala
@@ -395,6 +395,7 @@ import akka.util.ByteString
 
   @tailrec
   private def doUnwrap(ignoreOutput: Boolean): Unit = {
+    val oldInPosition = transportInBuffer.position()
     val result = engine.unwrap(transportInBuffer, userOutBuffer)
     if (ignoreOutput) userOutBuffer.clear()
     lastHandshakeStatus = result.getHandshakeStatus
@@ -415,7 +416,7 @@ import akka.util.ByteString
             transportInChoppingBlock.putBack(transportInBuffer)
           case _ =>
             if (transportInBuffer.hasRemaining)
-              if (userOutBuffer.position() == 0)
+              if (userOutBuffer.position() == 0 && transportInBuffer.position() == oldInPosition)
                 throw new IllegalStateException("SSLEngine trying to loop NEED_UNWRAP without producing output")
               else
                 doUnwrap(ignoreOutput = false)


### PR DESCRIPTION
Similar as before in `doWrap` we check if we have made any progress before
looping.

Refs #29922