### PR TITLE
=doc Make the zipWithIndexExample start with 0

### DIFF
--- a/akka-docs/src/test/java/jdocs/stream/operators/flow/StatefulMapConcat.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/flow/StatefulMapConcat.java
@@ -24,22 +24,23 @@ public class StatefulMapConcat {
                 () -> {
                   // variables we close over with lambdas must be final, so we use a container,
                   // a 1 element array, for the actual value.
-                  long[] counter = {0};
+                  final long[] index = {0L};
 
                   // we return the function that will be invoked for each element
                   return (element) -> {
-                    counter[0] += 1;
+                    final Pair<String, Long> zipped = new Pair<>(element, index[0]);
+                    index[0] += 1;
                     // we return an iterable with the single element
-                    return Arrays.asList(new Pair<String, Long>(element, counter[0]));
+                    return Collections.singletonList(zipped);
                   };
                 });
 
     letterAndIndex.runForeach(System.out::println, system);
     // prints
-    // Pair(a,1)
-    // Pair(b,2)
-    // Pair(c,3)
-    // Pair(d,4)
+    // Pair(a,0)
+    // Pair(b,1)
+    // Pair(c,2)
+    // Pair(d,3)
     // #zip-with-index
   }
 

--- a/akka-docs/src/test/scala/docs/stream/operators/flow/StatefulMapConcat.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/flow/StatefulMapConcat.scala
@@ -15,22 +15,23 @@ class StatefulMapConcat {
   def zipWithIndex(): Unit = {
     // #zip-with-index
     val letterAndIndex = Source("a" :: "b" :: "c" :: "d" :: Nil).statefulMapConcat { () =>
-      var counter = 0L
+      var index = 0L
 
       // we return the function that will be invoked for each element
       { element =>
-        counter += 1
+        val zipped = (element, index)
+        index += 1
         // we return an iterable with the single element
-        (element, counter) :: Nil
+        zipped :: Nil
       }
     }
 
     letterAndIndex.runForeach(println)
     // prints
-    // (a,1)
-    // (b,2)
-    // (c,3)
-    // (d,4)
+    // (a,0)
+    // (b,1)
+    // (c,2)
+    // (d,3)
     // #zip-with-index
   }
 


### PR DESCRIPTION
I think the index should start with 0, the current example starting with `1` did make me wonder for a while.
