### PR TITLE
Avoid BoxesRuntime indirection in LruBoundedCache key comparison

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/LruBoundedCache.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/LruBoundedCache.scala
@@ -23,7 +23,7 @@ private[akka] case class CacheStatistics(entries: Int, maxProbeDistance: Int, av
  * to kick out entires that are considered old. The implementation tries to keep the map close to full, only evicting
  * old entries when needed.
  */
-private[akka] abstract class LruBoundedCache[K: ClassTag, V <: AnyRef: ClassTag](
+private[akka] abstract class LruBoundedCache[K <: AnyRef: ClassTag, V <: AnyRef: ClassTag](
     capacity: Int,
     evictAgeThreshold: Int) {
   require(capacity > 0, "Capacity must be larger than zero")


### PR DESCRIPTION
I analyzed a profile of akka-cluster system and noticed a hot
code path:

```
Method	Count	Percentage
akka.actor.ActorRef.equals	3318	7.269142293789025 %
```

```
Stack Trace	Count	Percentage
boolean akka.actor.ActorRef.equals(Object):0	3318	100 %
boolean scala.runtime.BoxesRunTime.equals2(Object, Object):0	3222	97.1 %
   boolean scala.runtime.BoxesRunTime.equals(Object, Object):0	3222	97.1 %
   Object akka.remote.artery.LruBoundedCache.findOrCalculate$1(int, int, Object, int):0	3222	97.1 %
   Object akka.remote.artery.LruBoundedCache.getOrCompute(Object):0	3222	97.1 %
   void akka.remote.artery.HeaderBuilderImpl.setRecipientActorRef(ActorRef):0	3222	97.1 %
   void akka.remote.artery.Encoder$$anon$1.onPush():0	3222	97.1 %
   void akka.stream.impl.fusing.GraphInterpreter.processPush$$original(GraphInterpreter$Connection):0	3222	97.1 %
   void akka.stream.impl.fusing.GraphInterpreter.processPush(GraphInterpreter$Connection):0	3222	97.1 %
   int akka.stream.impl.fusing.GraphInterpreter.execute(int):0	3207	96.7 %
      int akka.stream.impl.fusing.GraphInterpreterShell.runBatch(int):0	3207	96.7 %
      int akka.stream.impl.fusing.GraphInterpreterShell$AsyncInput.execute(int):0	3207	96.7 %
      int akka.stream.impl.fusing.GraphInterpreterShell.processEvent(ActorGraphInterpreter$BoundaryEvent, int):0	3207	96.7 %
      void akka.stream.impl.fusing.ActorGraphInterpreter.akka$stream$impl$fusing$ActorGraphInterpreter$$processEvent(ActorGraphInterpreter$BoundaryEvent):0	3207	96.7 %
      Object akka.stream.impl.fusing.ActorGraphInterpreter$$anonfun$receive$1.applyOrElse(Object, Function1):0	3015	90.9 %
```

By restricting the key type of `LruBoundedCache` to `AnyRef`, we can
avoid the indirection through `BoxesRuntime`, we remove some overhead
and potentially unlock some JVM optimizations here.