### PR TITLE
=str Add IterableSource.

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ReverseArrowSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/ReverseArrowSpec.scala
@@ -217,7 +217,7 @@ class ReverseArrowSpec extends StreamSpec {
             src ~> f
             sink2 <~ f
             (the[IllegalArgumentException] thrownBy (s <~ f <~ src)).getMessage should include(
-              "[StatefulMapConcat.out] is already connected")
+              "[IterableSource.out] is already connected")
             ClosedShape
           })
           .run(),

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -346,7 +346,7 @@ object Source {
    * beginning) regardless of when they subscribed.
    */
   def apply[T](iterable: immutable.Iterable[T]): Source[T, NotUsed] =
-    single(iterable).mapConcat(ConstantFun.scalaIdentityFunction).withAttributes(DefaultAttributes.iterableSource)
+    fromGraph(new IterableSource[T](iterable))
 
   /**
    * Starts a new `Source` from the given `Future`. The stream will consist of
@@ -409,8 +409,7 @@ object Source {
    * Create a `Source` that will continually emit the given element.
    */
   def repeat[T](element: T): Source[T, NotUsed] = {
-    val next = Some((element, element))
-    unfold(element)(_ => next).withAttributes(DefaultAttributes.repeat)
+    fromIterator(() => Iterator.continually(element)).withAttributes(DefaultAttributes.repeat)
   }
 
   /**


### PR DESCRIPTION
I think the `single(iterable).mapConcat(ConstantFun.scalaIdentityFunction).withAttributes(DefaultAttributes.iterableSource)` is too long

The current `Source.fromIterable` is implemented with a `single` and  `StatefulMapConcat`, when the upstream's `SingleSource` is completed, the internal state of `StatefulMapConcat` is discarded and completed, and the `restartingDecider` will not make it purpose because `isClosed(in)` is true.

I think this can enable further optimization in the FlattenMerge, but PR will change the current behavior of `Source.fromIterable`   .

More optimization can be done in `FlatMapMerge`
