### PR TITLE
akka-stream: Add a PartitionEither implementation

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphPartitionEitherSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphPartitionEitherSpec.scala
@@ -4,14 +4,12 @@
 
 package akka.stream.scaladsl
 
-//import akka.stream.{ActorAttributes, ClosedShape, OverflowStrategy, Supervision}
-import akka.stream.ClosedShape
+import akka.stream.{ ClosedShape, OverflowStrategy }
 
-//import akka.stream.testkit.Utils.TE
 import akka.stream.testkit._
 
-//import scala.concurrent.Await
-//import scala.concurrent.duration._
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class GraphPartitionEitherSpec extends StreamSpec("""
     akka.stream.materializer.initial-input-buffer-size = 2
@@ -26,8 +24,8 @@ class GraphPartitionEitherSpec extends StreamSpec("""
         .fromGraph(GraphDSL.createGraph(Sink.seq[String], Sink.seq[Int])(Tuple2.apply) { implicit b => (sink1, sink2) =>
           val partition = b.add(PartitionEither[String, Int]())
           Source(List(Left("one"), Right(2), Left("three"), Right(4))) ~> partition.in
-          partition.out.left ~> sink1.in
-          partition.out.right ~> sink2.in
+          partition.out0 ~> sink1.in
+          partition.out1 ~> sink2.in
           ClosedShape
         })
         .run()
@@ -36,51 +34,41 @@ class GraphPartitionEitherSpec extends StreamSpec("""
       s2.futureValue.toSet should ===(Set(2, 4))
     }
 
-    //              @TODO
-    // @TODO                    TODO
-    // @TODO the rest to follow TODO
-    // @TODO                    TODO
-    //              @TODO
-    /*
     "complete stage after upstream completes" in {
       val c1 = TestSubscriber.probe[String]()
-      val c2 = TestSubscriber.probe[String]()
+      val c2 = TestSubscriber.probe[Int]()
 
       RunnableGraph
         .fromGraph(GraphDSL.create() { implicit b =>
-          val partition = b.add(Partition[String](2, {
-            case s if (s.length > 4) => 0
-            case _                   => 1
-          }))
-          Source(List("this", "is", "just", "another", "test")) ~> partition.in
-          partition.out(0) ~> Sink.fromSubscriber(c1)
-          partition.out(1) ~> Sink.fromSubscriber(c2)
+          val partition = b.add(PartitionEither[String, Int]())
+          Source(List(Left("forty"), Left("two"), Right(4), Right(2))) ~> partition.in
+          partition.out0 ~> Sink.fromSubscriber(c1)
+          partition.out1 ~> Sink.fromSubscriber(c2)
           ClosedShape
         })
         .run()
 
-      c1.request(1)
-      c2.request(4)
-      c1.expectNext("another")
-      c2.expectNext("this")
-      c2.expectNext("is")
-      c2.expectNext("just")
-      c2.expectNext("test")
+      c1.request(2)
+      c2.request(2)
+      c1.expectNext("forty")
+      c1.expectNext("two")
+      c2.expectNext(4)
+      c2.expectNext(2)
       c1.expectComplete()
       c2.expectComplete()
 
     }
 
     "remember first pull even though first element targeted another out" in {
-      val c1 = TestSubscriber.probe[Int]()
+      val c1 = TestSubscriber.probe[String]()
       val c2 = TestSubscriber.probe[Int]()
 
       RunnableGraph
         .fromGraph(GraphDSL.create() { implicit b =>
-          val partition = b.add(Partition[Int](2, { case l if l < 6 => 0; case _ => 1 }))
-          Source(List(6, 3)) ~> partition.in
-          partition.out(0) ~> Sink.fromSubscriber(c1)
-          partition.out(1) ~> Sink.fromSubscriber(c2)
+          val partition = b.add(PartitionEither[String, Int]())
+          Source(List(Right(6), Left("three"))) ~> partition.in
+          partition.out0 ~> Sink.fromSubscriber(c1)
+          partition.out1 ~> Sink.fromSubscriber(c2)
           ClosedShape
         })
         .run()
@@ -89,22 +77,24 @@ class GraphPartitionEitherSpec extends StreamSpec("""
       c1.expectNoMessage(1.seconds)
       c2.request(1)
       c2.expectNext(6)
-      c1.expectNext(3)
+      c1.expectNext("three")
       c1.expectComplete()
       c2.expectComplete()
     }
 
     "cancel upstream when all downstreams cancel if eagerCancel is false" in {
-      val p1 = TestPublisher.probe[Int]()
+      val p1 = TestPublisher.probe[Either[Int, Int]]()
       val c1 = TestSubscriber.probe[Int]()
       val c2 = TestSubscriber.probe[Int]()
 
+      def either(i: Int): Either[Int, Int] = Either.cond(i >= 6, i, i)
+
       RunnableGraph
         .fromGraph(GraphDSL.create() { implicit b =>
-          val partition = b.add(new Partition[Int](2, { case l if l < 6 => 0; case _ => 1 }, false))
+          val partition = b.add(new PartitionEither[Int, Int](false))
           Source.fromPublisher(p1.getPublisher) ~> partition.in
-          partition.out(0) ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink.fromSubscriber(c1)
-          partition.out(1) ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink.fromSubscriber(c2)
+          partition.out0 ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink.fromSubscriber(c1)
+          partition.out1 ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink.fromSubscriber(c2)
           ClosedShape
         })
         .run()
@@ -114,30 +104,32 @@ class GraphPartitionEitherSpec extends StreamSpec("""
       val sub2 = c2.expectSubscription()
       sub1.request(3)
       sub2.request(3)
-      p1Sub.sendNext(1)
-      p1Sub.sendNext(8)
+      p1Sub.sendNext(either(1))
+      p1Sub.sendNext(either(8))
       c1.expectNext(1)
       c2.expectNext(8)
-      p1Sub.sendNext(2)
+      p1Sub.sendNext(either(2))
       c1.expectNext(2)
       sub1.cancel()
-      p1Sub.sendNext(9)
+      p1Sub.sendNext(either(9))
       c2.expectNext(9)
       sub2.cancel()
       p1Sub.expectCancellation()
     }
 
     "cancel upstream when any downstream cancel if eagerCancel is true" in {
-      val p1 = TestPublisher.probe[Int]()
+      val p1 = TestPublisher.probe[Either[Int, Int]]()
       val c1 = TestSubscriber.probe[Int]()
       val c2 = TestSubscriber.probe[Int]()
 
+      def either(i: Int): Either[Int, Int] = Either.cond(i >= 6, i, i)
+
       RunnableGraph
         .fromGraph(GraphDSL.create() { implicit b =>
-          val partition = b.add(new Partition[Int](2, { case l if l < 6 => 0; case _ => 1 }, true))
+          val partition = b.add(new PartitionEither[Int, Int](true))
           Source.fromPublisher(p1.getPublisher) ~> partition.in
-          partition.out(0) ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink.fromSubscriber(c1)
-          partition.out(1) ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink.fromSubscriber(c2)
+          partition.out0 ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink.fromSubscriber(c1)
+          partition.out1 ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink.fromSubscriber(c2)
           ClosedShape
         })
         .run()
@@ -147,8 +139,8 @@ class GraphPartitionEitherSpec extends StreamSpec("""
       val sub2 = c2.expectSubscription()
       sub1.request(3)
       sub2.request(3)
-      p1Sub.sendNext(1)
-      p1Sub.sendNext(8)
+      p1Sub.sendNext(either(1))
+      p1Sub.sendNext(either(8))
       c1.expectNext(1)
       c2.expectNext(8)
       sub1.cancel()
@@ -159,15 +151,15 @@ class GraphPartitionEitherSpec extends StreamSpec("""
       val c1 = TestSubscriber.probe[String]()
       val c2 = TestSubscriber.probe[String]()
 
+      def either(s: String): Either[String, String] =
+        Either.cond(s != "a" && s != "b", s, s)
+
       RunnableGraph
         .fromGraph(GraphDSL.create() { implicit b =>
-          val partition = b.add(Partition[String](2, {
-            case s if s == "a" || s == "b" => 0
-            case _                         => 1
-          }))
-          Source(List("a", "b", "c", "d")) ~> partition.in
-          partition.out(0) ~> Sink.fromSubscriber(c1)
-          partition.out(1) ~> Sink.fromSubscriber(c2)
+          val partition = b.add(PartitionEither[String, String]())
+          Source(List("a", "b", "c", "d").map(either)) ~> partition.in
+          partition.out0 ~> Sink.fromSubscriber(c1)
+          partition.out1 ~> Sink.fromSubscriber(c2)
           ClosedShape
         })
         .run()
@@ -185,15 +177,15 @@ class GraphPartitionEitherSpec extends StreamSpec("""
       val c1 = TestSubscriber.probe[String]()
       val c2 = TestSubscriber.probe[String]()
 
+      def either(s: String): Either[String, String] =
+        Either.cond(s != "a" && s != "b", s, s)
+
       RunnableGraph
         .fromGraph(GraphDSL.create() { implicit b =>
-          val partition = b.add(Partition[String](2, {
-            case s if s == "a" || s == "b" => 0
-            case _                         => 1
-          }))
-          Source(List("a", "b", "c")) ~> partition.in
-          partition.out(0) ~> Sink.fromSubscriber(c1)
-          partition.out(1) ~> Sink.fromSubscriber(c2)
+          val partition = b.add(PartitionEither[String, String]())
+          Source(List("a", "b", "c").map(either)) ~> partition.in
+          partition.out0 ~> Sink.fromSubscriber(c1)
+          partition.out1 ~> Sink.fromSubscriber(c2)
           ClosedShape
         })
         .run()
@@ -213,12 +205,14 @@ class GraphPartitionEitherSpec extends StreamSpec("""
       val s = Sink.seq[Int]
       val input = Set(5, 2, 9, 1, 1, 1, 10)
 
+      def either(l: Int): Either[Int, Int] = Either.cond(l >= 4, l, l)
+
       val g = RunnableGraph.fromGraph(GraphDSL.createGraph(s) { implicit b => sink =>
-        val partition = b.add(Partition[Int](2, { case l if l < 4 => 0; case _ => 1 }))
+        val partition = b.add(PartitionEither[Int, Int]())
         val merge = b.add(Merge[Int](2))
-        Source(input) ~> partition.in
-        partition.out(0) ~> merge.in(0)
-        partition.out(1) ~> merge.in(1)
+        Source(input).map(either) ~> partition.in
+        partition.out0 ~> merge.in(0)
+        partition.out1 ~> merge.in(1)
         merge.out ~> sink.in
 
         ClosedShape
@@ -235,12 +229,14 @@ class GraphPartitionEitherSpec extends StreamSpec("""
       val c1 = TestSubscriber.probe[Int]()
       val c2 = TestSubscriber.probe[Int]()
 
+      def either(l: Int): Either[Int, Int] = Either.cond(l >= 6, l, l)
+
       RunnableGraph
         .fromGraph(GraphDSL.create() { implicit b =>
-          val partition = b.add(Partition[Int](2, { case l if l < 6 => 0; case _ => 1 }))
-          Source(List(6)) ~> partition.in
-          partition.out(0) ~> Sink.fromSubscriber(c1)
-          partition.out(1) ~> Sink.fromSubscriber(c2)
+          val partition = b.add(PartitionEither[Int, Int]())
+          Source(List(6)).map(either) ~> partition.in
+          partition.out0 ~> Sink.fromSubscriber(c1)
+          partition.out1 ~> Sink.fromSubscriber(c2)
           ClosedShape
         })
         .run()
@@ -252,97 +248,5 @@ class GraphPartitionEitherSpec extends StreamSpec("""
       c1.expectComplete()
       c2.expectComplete()
     }
-
-    "must fail stage if partitioner outcome is out of bound" in {
-
-      val c1 = TestSubscriber.probe[Int]()
-
-      RunnableGraph
-        .fromGraph(GraphDSL.create() { implicit b =>
-          val partition = b.add(Partition[Int](2, { case l if l < 0 => -1; case _ => 0 }))
-          Source(List(-3)) ~> partition.in
-          partition.out(0) ~> Sink.fromSubscriber(c1)
-          partition.out(1) ~> Sink.ignore
-          ClosedShape
-        })
-        .run()
-
-      c1.request(1)
-      c1.expectError(
-        Partition.PartitionOutOfBoundsException(
-          "partitioner must return an index in the range [0,1]. returned: [-1] for input [java.lang.Integer]."))
-    }
-
-    "partition to three subscribers, with Resume supervision" in {
-
-      val (s1, s2, s3) = RunnableGraph
-        .fromGraph(GraphDSL.createGraph(Sink.seq[Int], Sink.seq[Int], Sink.seq[Int])(Tuple3.apply) {
-          implicit b => (sink1, sink2, sink3) =>
-            val partition = b.add(Partition[Int](3, {
-              case g if g > 3  => 0
-              case l if l < 3  => 1
-              case e if e == 3 => throw TE("Resume")
-            }))
-            Source(List(1, 2, 3, 4, 5)) ~> partition.in
-            partition.out(0) ~> sink1.in
-            partition.out(1) ~> sink2.in
-            partition.out(2) ~> sink3.in
-            ClosedShape
-        })
-        .withAttributes(ActorAttributes.supervisionStrategy(_ => Supervision.Resume))
-        .run()
-
-      s1.futureValue.toSet should ===(Set(4, 5))
-      s2.futureValue.toSet should ===(Set(1, 2))
-      s3.futureValue.toSet should ===(Set())
-    }
-
-    "partition to three subscribers, with Restart supervision" in {
-      val (s1, s2, s3) = RunnableGraph
-        .fromGraph(GraphDSL.createGraph(Sink.seq[Int], Sink.seq[Int], Sink.seq[Int])(Tuple3.apply) {
-          implicit b => (sink1, sink2, sink3) =>
-            val partition = b.add(Partition[Int](3, {
-              case g if g > 3  => 0
-              case l if l < 3  => 1
-              case e if e == 3 => throw TE("Restart")
-            }))
-            Source(List(1, 2, 3, 4, 5)) ~> partition.in
-            partition.out(0) ~> sink1.in
-            partition.out(1) ~> sink2.in
-            partition.out(2) ~> sink3.in
-            ClosedShape
-        })
-        .withAttributes(ActorAttributes.supervisionStrategy(_ => Supervision.Restart))
-        .run()
-
-      s1.futureValue.toSet should ===(Set(4, 5))
-      s2.futureValue.toSet should ===(Set(1, 2))
-      s3.futureValue.toSet should ===(Set())
-    }
-
-    "support supervision for PartitionOutOfBoundsException" in {
-
-      val (s1, s2, s3) = RunnableGraph
-        .fromGraph(GraphDSL.createGraph(Sink.seq[Int], Sink.seq[Int], Sink.seq[Int])(Tuple3.apply) {
-          implicit b => (sink1, sink2, sink3) =>
-            val partition = b.add(Partition[Int](3, {
-              case g if g > 3  => 0
-              case l if l < 3  => 1
-              case e if e == 3 => -1 // out of bounds
-            }))
-            Source(List(1, 2, 3, 4, 5)) ~> partition.in
-            partition.out(0) ~> sink1.in
-            partition.out(1) ~> sink2.in
-            partition.out(2) ~> sink3.in
-            ClosedShape
-        })
-        .withAttributes(ActorAttributes.supervisionStrategy(_ => Supervision.Resume))
-        .run()
-
-      s1.futureValue.toSet should ===(Set(4, 5))
-      s2.futureValue.toSet should ===(Set(1, 2))
-      s3.futureValue.toSet should ===(Set())
-    }
-   */
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphPartitionEitherSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/GraphPartitionEitherSpec.scala
@@ -1,0 +1,348 @@
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.scaladsl
+
+//import akka.stream.{ActorAttributes, ClosedShape, OverflowStrategy, Supervision}
+import akka.stream.ClosedShape
+
+//import akka.stream.testkit.Utils.TE
+import akka.stream.testkit._
+
+//import scala.concurrent.Await
+//import scala.concurrent.duration._
+
+class GraphPartitionEitherSpec extends StreamSpec("""
+    akka.stream.materializer.initial-input-buffer-size = 2
+  """) {
+
+  "A partition either" must {
+    import GraphDSL.Implicits._
+
+    "partition to two subscribers" in {
+
+      val (s1, s2) = RunnableGraph
+        .fromGraph(GraphDSL.createGraph(Sink.seq[String], Sink.seq[Int])(Tuple2.apply) { implicit b => (sink1, sink2) =>
+          val partition = b.add(PartitionEither[String, Int]())
+          Source(List(Left("one"), Right(2), Left("three"), Right(4))) ~> partition.in
+          partition.out.left ~> sink1.in
+          partition.out.right ~> sink2.in
+          ClosedShape
+        })
+        .run()
+
+      s1.futureValue.toSet should ===(Set("one", "three"))
+      s2.futureValue.toSet should ===(Set(2, 4))
+    }
+
+    //              @TODO
+    // @TODO                    TODO
+    // @TODO the rest to follow TODO
+    // @TODO                    TODO
+    //              @TODO
+    /*
+    "complete stage after upstream completes" in {
+      val c1 = TestSubscriber.probe[String]()
+      val c2 = TestSubscriber.probe[String]()
+
+      RunnableGraph
+        .fromGraph(GraphDSL.create() { implicit b =>
+          val partition = b.add(Partition[String](2, {
+            case s if (s.length > 4) => 0
+            case _                   => 1
+          }))
+          Source(List("this", "is", "just", "another", "test")) ~> partition.in
+          partition.out(0) ~> Sink.fromSubscriber(c1)
+          partition.out(1) ~> Sink.fromSubscriber(c2)
+          ClosedShape
+        })
+        .run()
+
+      c1.request(1)
+      c2.request(4)
+      c1.expectNext("another")
+      c2.expectNext("this")
+      c2.expectNext("is")
+      c2.expectNext("just")
+      c2.expectNext("test")
+      c1.expectComplete()
+      c2.expectComplete()
+
+    }
+
+    "remember first pull even though first element targeted another out" in {
+      val c1 = TestSubscriber.probe[Int]()
+      val c2 = TestSubscriber.probe[Int]()
+
+      RunnableGraph
+        .fromGraph(GraphDSL.create() { implicit b =>
+          val partition = b.add(Partition[Int](2, { case l if l < 6 => 0; case _ => 1 }))
+          Source(List(6, 3)) ~> partition.in
+          partition.out(0) ~> Sink.fromSubscriber(c1)
+          partition.out(1) ~> Sink.fromSubscriber(c2)
+          ClosedShape
+        })
+        .run()
+
+      c1.request(1)
+      c1.expectNoMessage(1.seconds)
+      c2.request(1)
+      c2.expectNext(6)
+      c1.expectNext(3)
+      c1.expectComplete()
+      c2.expectComplete()
+    }
+
+    "cancel upstream when all downstreams cancel if eagerCancel is false" in {
+      val p1 = TestPublisher.probe[Int]()
+      val c1 = TestSubscriber.probe[Int]()
+      val c2 = TestSubscriber.probe[Int]()
+
+      RunnableGraph
+        .fromGraph(GraphDSL.create() { implicit b =>
+          val partition = b.add(new Partition[Int](2, { case l if l < 6 => 0; case _ => 1 }, false))
+          Source.fromPublisher(p1.getPublisher) ~> partition.in
+          partition.out(0) ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink.fromSubscriber(c1)
+          partition.out(1) ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink.fromSubscriber(c2)
+          ClosedShape
+        })
+        .run()
+
+      val p1Sub = p1.expectSubscription()
+      val sub1 = c1.expectSubscription()
+      val sub2 = c2.expectSubscription()
+      sub1.request(3)
+      sub2.request(3)
+      p1Sub.sendNext(1)
+      p1Sub.sendNext(8)
+      c1.expectNext(1)
+      c2.expectNext(8)
+      p1Sub.sendNext(2)
+      c1.expectNext(2)
+      sub1.cancel()
+      p1Sub.sendNext(9)
+      c2.expectNext(9)
+      sub2.cancel()
+      p1Sub.expectCancellation()
+    }
+
+    "cancel upstream when any downstream cancel if eagerCancel is true" in {
+      val p1 = TestPublisher.probe[Int]()
+      val c1 = TestSubscriber.probe[Int]()
+      val c2 = TestSubscriber.probe[Int]()
+
+      RunnableGraph
+        .fromGraph(GraphDSL.create() { implicit b =>
+          val partition = b.add(new Partition[Int](2, { case l if l < 6 => 0; case _ => 1 }, true))
+          Source.fromPublisher(p1.getPublisher) ~> partition.in
+          partition.out(0) ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink.fromSubscriber(c1)
+          partition.out(1) ~> Flow[Int].buffer(16, OverflowStrategy.backpressure) ~> Sink.fromSubscriber(c2)
+          ClosedShape
+        })
+        .run()
+
+      val p1Sub = p1.expectSubscription()
+      val sub1 = c1.expectSubscription()
+      val sub2 = c2.expectSubscription()
+      sub1.request(3)
+      sub2.request(3)
+      p1Sub.sendNext(1)
+      p1Sub.sendNext(8)
+      c1.expectNext(1)
+      c2.expectNext(8)
+      sub1.cancel()
+      p1Sub.expectCancellation()
+    }
+
+    "handle upstream completes and downstream cancel" in {
+      val c1 = TestSubscriber.probe[String]()
+      val c2 = TestSubscriber.probe[String]()
+
+      RunnableGraph
+        .fromGraph(GraphDSL.create() { implicit b =>
+          val partition = b.add(Partition[String](2, {
+            case s if s == "a" || s == "b" => 0
+            case _                         => 1
+          }))
+          Source(List("a", "b", "c", "d")) ~> partition.in
+          partition.out(0) ~> Sink.fromSubscriber(c1)
+          partition.out(1) ~> Sink.fromSubscriber(c2)
+          ClosedShape
+        })
+        .run()
+
+      c1.request(10)
+      c2.request(1)
+      c1.expectNext("a")
+      c1.expectNext("b")
+      c2.expectNext("c")
+      c2.cancel()
+      c1.expectComplete()
+    }
+
+    "handle upstream completes and downstream pulls" in {
+      val c1 = TestSubscriber.probe[String]()
+      val c2 = TestSubscriber.probe[String]()
+
+      RunnableGraph
+        .fromGraph(GraphDSL.create() { implicit b =>
+          val partition = b.add(Partition[String](2, {
+            case s if s == "a" || s == "b" => 0
+            case _                         => 1
+          }))
+          Source(List("a", "b", "c")) ~> partition.in
+          partition.out(0) ~> Sink.fromSubscriber(c1)
+          partition.out(1) ~> Sink.fromSubscriber(c2)
+          ClosedShape
+        })
+        .run()
+
+      c1.request(10)
+      // no demand from c2 yet
+      c1.expectNext("a")
+      c1.expectNext("b")
+      c2.request(1)
+      c2.expectNext("c")
+
+      c1.expectComplete()
+      c2.expectComplete()
+    }
+
+    "work with merge" in {
+      val s = Sink.seq[Int]
+      val input = Set(5, 2, 9, 1, 1, 1, 10)
+
+      val g = RunnableGraph.fromGraph(GraphDSL.createGraph(s) { implicit b => sink =>
+        val partition = b.add(Partition[Int](2, { case l if l < 4 => 0; case _ => 1 }))
+        val merge = b.add(Merge[Int](2))
+        Source(input) ~> partition.in
+        partition.out(0) ~> merge.in(0)
+        partition.out(1) ~> merge.in(1)
+        merge.out ~> sink.in
+
+        ClosedShape
+      })
+
+      val result = Await.result(g.run(), remainingOrDefault)
+
+      result.toSet should be(input)
+
+    }
+
+    "stage completion is waiting for pending output" in {
+
+      val c1 = TestSubscriber.probe[Int]()
+      val c2 = TestSubscriber.probe[Int]()
+
+      RunnableGraph
+        .fromGraph(GraphDSL.create() { implicit b =>
+          val partition = b.add(Partition[Int](2, { case l if l < 6 => 0; case _ => 1 }))
+          Source(List(6)) ~> partition.in
+          partition.out(0) ~> Sink.fromSubscriber(c1)
+          partition.out(1) ~> Sink.fromSubscriber(c2)
+          ClosedShape
+        })
+        .run()
+
+      c1.request(1)
+      c1.expectNoMessage(1.second)
+      c2.request(1)
+      c2.expectNext(6)
+      c1.expectComplete()
+      c2.expectComplete()
+    }
+
+    "must fail stage if partitioner outcome is out of bound" in {
+
+      val c1 = TestSubscriber.probe[Int]()
+
+      RunnableGraph
+        .fromGraph(GraphDSL.create() { implicit b =>
+          val partition = b.add(Partition[Int](2, { case l if l < 0 => -1; case _ => 0 }))
+          Source(List(-3)) ~> partition.in
+          partition.out(0) ~> Sink.fromSubscriber(c1)
+          partition.out(1) ~> Sink.ignore
+          ClosedShape
+        })
+        .run()
+
+      c1.request(1)
+      c1.expectError(
+        Partition.PartitionOutOfBoundsException(
+          "partitioner must return an index in the range [0,1]. returned: [-1] for input [java.lang.Integer]."))
+    }
+
+    "partition to three subscribers, with Resume supervision" in {
+
+      val (s1, s2, s3) = RunnableGraph
+        .fromGraph(GraphDSL.createGraph(Sink.seq[Int], Sink.seq[Int], Sink.seq[Int])(Tuple3.apply) {
+          implicit b => (sink1, sink2, sink3) =>
+            val partition = b.add(Partition[Int](3, {
+              case g if g > 3  => 0
+              case l if l < 3  => 1
+              case e if e == 3 => throw TE("Resume")
+            }))
+            Source(List(1, 2, 3, 4, 5)) ~> partition.in
+            partition.out(0) ~> sink1.in
+            partition.out(1) ~> sink2.in
+            partition.out(2) ~> sink3.in
+            ClosedShape
+        })
+        .withAttributes(ActorAttributes.supervisionStrategy(_ => Supervision.Resume))
+        .run()
+
+      s1.futureValue.toSet should ===(Set(4, 5))
+      s2.futureValue.toSet should ===(Set(1, 2))
+      s3.futureValue.toSet should ===(Set())
+    }
+
+    "partition to three subscribers, with Restart supervision" in {
+      val (s1, s2, s3) = RunnableGraph
+        .fromGraph(GraphDSL.createGraph(Sink.seq[Int], Sink.seq[Int], Sink.seq[Int])(Tuple3.apply) {
+          implicit b => (sink1, sink2, sink3) =>
+            val partition = b.add(Partition[Int](3, {
+              case g if g > 3  => 0
+              case l if l < 3  => 1
+              case e if e == 3 => throw TE("Restart")
+            }))
+            Source(List(1, 2, 3, 4, 5)) ~> partition.in
+            partition.out(0) ~> sink1.in
+            partition.out(1) ~> sink2.in
+            partition.out(2) ~> sink3.in
+            ClosedShape
+        })
+        .withAttributes(ActorAttributes.supervisionStrategy(_ => Supervision.Restart))
+        .run()
+
+      s1.futureValue.toSet should ===(Set(4, 5))
+      s2.futureValue.toSet should ===(Set(1, 2))
+      s3.futureValue.toSet should ===(Set())
+    }
+
+    "support supervision for PartitionOutOfBoundsException" in {
+
+      val (s1, s2, s3) = RunnableGraph
+        .fromGraph(GraphDSL.createGraph(Sink.seq[Int], Sink.seq[Int], Sink.seq[Int])(Tuple3.apply) {
+          implicit b => (sink1, sink2, sink3) =>
+            val partition = b.add(Partition[Int](3, {
+              case g if g > 3  => 0
+              case l if l < 3  => 1
+              case e if e == 3 => -1 // out of bounds
+            }))
+            Source(List(1, 2, 3, 4, 5)) ~> partition.in
+            partition.out(0) ~> sink1.in
+            partition.out(1) ~> sink2.in
+            partition.out(2) ~> sink3.in
+            ClosedShape
+        })
+        .withAttributes(ActorAttributes.supervisionStrategy(_ => Supervision.Resume))
+        .run()
+
+      s1.futureValue.toSet should ===(Set(4, 5))
+      s2.futureValue.toSet should ===(Set(1, 2))
+      s3.futureValue.toSet should ===(Set())
+    }
+   */
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Graph.scala
@@ -282,6 +282,48 @@ object Partition {
 
 }
 
+object PartitionEither {
+
+  /**
+   * Create a new `PartitionEither` operator with the specified input types, `eagerCancel` is `false`.
+   */
+  def create[A, B](): Graph[FanOutShape2[Either[A, B], A, B], NotUsed] =
+    new scaladsl.PartitionEither(eagerCancel = false)
+
+  /**
+   * Create a new `PartitionEither` operator with the specified input types.
+   *
+   * @param eagerCancel this operator cancels, when any (true) or all (false) of the downstreams cancel
+   */
+  def create[A, B](eagerCancel: Boolean): Graph[FanOutShape2[Either[A, B], A, B], NotUsed] =
+    new scaladsl.PartitionEither(eagerCancel)
+
+  /**
+   * Create a new `PartitionEither` operator with the specified input type, `eagerCancel` is `false`.
+   *
+   * @param clazzA a type hint for this method
+   * @param clazzB a type hint for this method
+   */
+  def create[A, B](
+      @unused clazzA: Class[A],
+      @unused clazzB: Class[B]): Graph[FanOutShape2[Either[A, B], A, B], NotUsed] =
+    new scaladsl.PartitionEither(eagerCancel = false)
+
+  /**
+   * Create a new `PartitionEither` operator with the specified input type.
+   *
+   * @param clazzA a type hint for this method
+   * @param clazzB a type hint for this method
+   * @param eagerCancel this operator cancels, when any (true) or all (false) of the downstreams cancel
+   */
+  def create[A, B](
+      @unused clazzA: Class[A],
+      @unused clazzB: Class[B],
+      eagerCancel: Boolean): Graph[FanOutShape2[Either[A, B], A, B], NotUsed] =
+    new scaladsl.PartitionEither(eagerCancel)
+
+}
+
 /**
  * Fan-out the stream to several streams. Each upstream element is emitted to the first available downstream consumer.
  * It will not shutdown until the subscriptions for at least

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -894,7 +894,7 @@ final class Partition[T](val outputPorts: Int, val partitioner: T => Int, val ea
 }
 
 object PartitionEither {
-  case class Outlets[A, B](left: Outlet[A], right: Outlet[B])
+  final class Outlets[A, B](val left: Outlet[A], val right: Outlet[B])
 
   /**
    * Create a new `PartitionEither` operator with the specified input types.
@@ -925,7 +925,7 @@ final class PartitionEither[A, B](val eagerCancel: Boolean) // @TODO do i need t
 
   val in: Inlet[Either[A, B]] = Inlet[Either[A, B]]("PartitionEither.in")
 
-  val out: Outlets[A, B] = Outlets(
+  val out: Outlets[A, B] = new Outlets(
     left = Outlet[A]("PartitionEither.out.left"),
     right = Outlet[B]("PartitionEither.out.right")
   )

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -896,9 +896,12 @@ final class Partition[T](val outputPorts: Int, val partitioner: T => Int, val ea
 object PartitionEither {
   final class Outlets[A, B](val left: Outlet[A], val right: Outlet[B])
 
-  final class PartitionEitherShape[-I, +O0, +O1](_init: FanOutShape.Init[I @uncheckedVariance]) extends FanOutShape2[I, O0, O1](_init) {
-    override protected def construct(init: FanOutShape.Init[I @uncheckedVariance]): FanOutShape[I] = new PartitionEitherShape(init)
-    override def deepCopy(): PartitionEitherShape[I, O0, O1] = super.deepCopy().asInstanceOf[PartitionEitherShape[I, O0, O1]]
+  final class PartitionEitherShape[-I, +O0, +O1](_init: FanOutShape.Init[I @uncheckedVariance])
+      extends FanOutShape2[I, O0, O1](_init) {
+    override protected def construct(init: FanOutShape.Init[I @uncheckedVariance]): FanOutShape[I] =
+      new PartitionEitherShape(init)
+    override def deepCopy(): PartitionEitherShape[I, O0, O1] =
+      super.deepCopy().asInstanceOf[PartitionEitherShape[I, O0, O1]]
 
     val out: Outlets[O0 @uncheckedVariance, O1 @uncheckedVariance] = new Outlets(out0, out1)
   }
@@ -932,12 +935,11 @@ final class PartitionEither[A, B](val eagerCancel: Boolean) // @TODO do i need t
 
   val in: Inlet[Either[A, B]] = Inlet[Either[A, B]]("PartitionEither.in")
 
-  val out: Outlets[A, B] = new Outlets(
-    left = Outlet[A]("PartitionEither.out.left"),
-    right = Outlet[B]("PartitionEither.out.right")
-  )
+  val out: Outlets[A, B] =
+    new Outlets(left = Outlet[A]("PartitionEither.out.left"), right = Outlet[B]("PartitionEither.out.right"))
 
-  override val shape: PartitionEitherShape[Either[A, B], A, B] = new PartitionEitherShape(FanOutShape.Ports(in, out.left :: out.right :: Nil))
+  override val shape: PartitionEitherShape[Either[A, B], A, B] = new PartitionEitherShape(
+    FanOutShape.Ports(in, out.left :: out.right :: Nil))
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with InHandler {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -918,8 +918,7 @@ object PartitionEither {
  *
  * '''Cancels when''' all downstreams have cancelled (eagerCancel=false) or one downstream cancels (eagerCancel=true)
  */
-final class PartitionEither[A, B](val eagerCancel: Boolean) // @TODO do i need to think about variance?
-    extends GraphStage[FanOutShape2[Either[A, B], A, B]] {
+final class PartitionEither[A, B](val eagerCancel: Boolean) extends GraphStage[FanOutShape2[Either[A, B], A, B]] {
   val in: Inlet[Either[A, B]] = Inlet[Either[A, B]]("PartitionEither.in")
   val out0: Outlet[A] = Outlet[A]("PartitionEither.out0")
   val out1: Outlet[B] = Outlet[B]("PartitionEither.out1")

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -896,6 +896,13 @@ final class Partition[T](val outputPorts: Int, val partitioner: T => Int, val ea
 object PartitionEither {
   final class Outlets[A, B](val left: Outlet[A], val right: Outlet[B])
 
+  final class PartitionEitherShape[-I, +O0, +O1](_init: FanOutShape.Init[I @uncheckedVariance]) extends FanOutShape2[I, O0, O1](_init) {
+    override protected def construct(init: FanOutShape.Init[I @uncheckedVariance]): FanOutShape[I] = new PartitionEitherShape(init)
+    override def deepCopy(): PartitionEitherShape[I, O0, O1] = super.deepCopy().asInstanceOf[PartitionEitherShape[I, O0, O1]]
+
+    val out: Outlets[O0 @uncheckedVariance, O1 @uncheckedVariance] = new Outlets(out0, out1)
+  }
+
   /**
    * Create a new `PartitionEither` operator with the specified input types.
    *
@@ -920,7 +927,7 @@ object PartitionEither {
  * '''Cancels when''' all downstreams have cancelled (eagerCancel=false) or one downstream cancels (eagerCancel=true)
  */
 final class PartitionEither[A, B](val eagerCancel: Boolean) // @TODO do i need to think about variance?
-    extends GraphStage[FanOutShape2[Either[A, B], A, B]] {
+    extends GraphStage[PartitionEither.PartitionEitherShape[Either[A, B], A, B]] {
   import PartitionEither._
 
   val in: Inlet[Either[A, B]] = Inlet[Either[A, B]]("PartitionEither.in")
@@ -930,7 +937,7 @@ final class PartitionEither[A, B](val eagerCancel: Boolean) // @TODO do i need t
     right = Outlet[B]("PartitionEither.out.right")
   )
 
-  override val shape: FanOutShape2[Either[A, B], A, B] = new FanOutShape2(in, out.left, out.right)
+  override val shape: PartitionEitherShape[Either[A, B], A, B] = new PartitionEitherShape(FanOutShape.Ports(in, out.left :: out.right :: Nil))
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with InHandler {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Graph.scala
@@ -894,15 +894,11 @@ final class Partition[T](val outputPorts: Int, val partitioner: T => Int, val ea
 }
 
 object PartitionEither {
-  final case class PartitionOutOfBoundsException(msg: String) extends IndexOutOfBoundsException(msg) with NoStackTrace
 
   /**
-   * Create a new `Partition` operator with the specified input type. This method sets `eagerCancel` to `false`.
-   * To specify a different value for the `eagerCancel` parameter, then instantiate Partition using the constructor.
+   * Create a new `PartitionEither` operator with the specified input types.
    *
-   * If `eagerCancel` is true, partition cancels upstream if any of its downstreams cancel, if false, when all have cancelled.
-   *
-   * @param eagerCancel TODO
+   * @param eagerCancel if true, partition cancels upstream if any of its downstreams cancel, if false, when all have cancelled.
    */
   def apply[A, B](eagerCancel: Boolean = false): PartitionEither[A, B] =
     new PartitionEither(eagerCancel = eagerCancel)


### PR DESCRIPTION
This adds a `PartitionEither` implementation, splitting the inlet's `Either[A, B]` into two outlets, `A` and `B`.

`out0` receives all `Left` inner values.
`out1` receives all `Right` inner values.

If y'all accept, does this need doc somewhere?