### PR TITLE
stream: optimize JsonFraming

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/JsonFramingSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/JsonFramingSpec.scala
@@ -123,7 +123,7 @@ class JsonFramingSpec extends AkkaSpec {
         """.stripMargin,
         """{ "na""",
         """me": "jack""",
-        """"}]"""").map(ByteString(_))
+        """"}]""").map(ByteString(_))
 
       val result = Source.apply(input).via(JsonFraming.objectScanner(Int.MaxValue)).runFold(Seq.empty[String]) {
         case (acc, entry) => acc ++ Seq(entry.utf8String)


### PR DESCRIPTION
The main speed up comes from simplifying the scanning loops and
a branchless design while looking for the start of the next object.

The top-level structure now must not contain strings, this was allowed
before but not documented anywhere. It might just have been a typo in the test
which required that strings were allowed before?

Before:

```
Benchmark                                     Mode  Cnt        Score        Error  Units
JsonFramingBenchmark.counting_1              thrpt    6  1971401.881 ± 301564.309  ops/s
JsonFramingBenchmark.counting_long_document  thrpt    6      178.897 ±      2.233  ops/s
JsonFramingBenchmark.counting_offer_5        thrpt    6  1992239.782 ±  17570.805  ops/s
```

After:

```
Benchmark                                     Mode  Cnt        Score        Error  Units
JsonFramingBenchmark.counting_1              thrpt    6  4398726.866 ±  75724.465  ops/s
JsonFramingBenchmark.counting_long_document  thrpt    6      434.432 ±    127.319  ops/s
JsonFramingBenchmark.counting_offer_5        thrpt    6  4648134.441 ± 425532.359  ops/s
```