### PR TITLE
Fix build.sbt 'Dependencies' import

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import akka.{ AutomaticModuleName, CopyrightHeaderForBuild, Paradox, ScalafixIgnoreFilePlugin }
+import akka.{ AutomaticModuleName, CopyrightHeaderForBuild, Dependencies, Paradox, ScalafixIgnoreFilePlugin }
 
 ThisBuild / scalafixScalaBinaryVersion := scalaBinaryVersion.value
 


### PR DESCRIPTION
Not sure how sbt doesn't trip over this, but it seems to help IntelliJ