### PR TITLE
stream: Add implicit not found message for Materializer

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/Materializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/Materializer.scala
@@ -7,7 +7,7 @@ package akka.stream
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.FiniteDuration
 
-import scala.annotation.nowarn
+import scala.annotation.{ implicitNotFound, nowarn }
 
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
@@ -25,6 +25,7 @@ import akka.event.LoggingAdapter
  *
  * Not for user extension
  */
+@implicitNotFound("A Materializer is required.  You may want to have the ActorSystem in implicit scope")
 @nowarn("msg=deprecated") // Name(symbol) is deprecated but older Scala versions don't have a string signature, since "2.5.8"
 @DoNotInherit
 abstract class Materializer {


### PR DESCRIPTION
References #31360

Whenever an implicit is not found `A Materializer is required.  You may want to have the ActorSystem in implicit scope` will be shown as the compiler error.

Rationale for verbiage:

* `Materializer is required`: clear and unambiguous
* `the ActorSystem`: implies our guidance of a single `ActorSystem` rather than creating an `ActorSystem` per stream or some similar poor practice.

```scala
import akka.stream.scaladsl.{ Keep, Sink, Source }

object ImplicitMessage {
  val stream = Source.single(1).toMat(Sink.foreach(println _))(Keep.right)

  def run() = stream.run()
}
```

gives the following compiler output:

```
[error] /home2/levi/code/akka/akka-stream-tests/src/test/scala/levi-local-compile-implicit.scala:10:25: A Materializer is required.  You may want to have the ActorSystem in implicit scope
[error]   def run() = stream.run()
[error]                         ^
[error] one error found
[error] (akka-stream-tests / Test / compileIncremental) Compilation failed
```