### PR TITLE
fix java docs for Source.actorRef

### DIFF
--- a/akka-docs/src/test/java/jdocs/stream/operators/SourceDocExamples.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/SourceDocExamples.java
@@ -16,7 +16,6 @@ import akka.stream.javadsl.Source;
 
 // #actor-ref-imports
 import akka.actor.ActorRef;
-import akka.actor.Status.Success;
 import akka.stream.OverflowStrategy;
 import akka.stream.CompletionStrategy;
 import akka.stream.javadsl.Sink;
@@ -99,7 +98,7 @@ public class SourceDocExamples {
     actorRef.tell("hello", ActorRef.noSender());
 
     // The stream completes successfully with the following message
-    actorRef.tell(new Success(CompletionStrategy.draining()), ActorRef.noSender());
+    actorRef.tell(Done.done(), ActorRef.noSender());
     // #actor-ref
   }
 


### PR DESCRIPTION
Pointed out by a poster on gitter.  The stage completes on a `Done`, which is not the message sent which purports to complete the stream.
