### PR TITLE
Rename method typed.javadsl.FishingOutcomes.continue  due to compilation error in Java (#29951)

### DIFF
--- a/akka-actor-testkit-typed/src/main/mima-filters/2.6.19.backwards.excludes/rename-fishing-outcomes-continue-java.excludes
+++ b/akka-actor-testkit-typed/src/main/mima-filters/2.6.19.backwards.excludes/rename-fishing-outcomes-continue-java.excludes
@@ -1,0 +1,2 @@
+# FishingOutcomes.continue() cannot be used in Java code due to reserved word, see https://github.com/akka/akka/issues/29951
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.actor.testkit.typed.javadsl.FishingOutcomes.continue")

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/javadsl/TestProbe.scala
@@ -24,7 +24,7 @@ object FishingOutcomes {
   /**
    * Consume this message and continue with the next
    */
-  def continue(): FishingOutcome = FishingOutcome.Continue
+  def continueAndCollect(): FishingOutcome = FishingOutcome.Continue
 
   /**
    * Consume this message and continue with the next
@@ -200,7 +200,7 @@ abstract class TestProbe[M] extends RecipientRef[M] { this: InternalRecipientRef
    * Java API: Allows for flexible matching of multiple messages within a timeout, the fisher function is fed each incoming
    * message, and returns one of the following effects to decide on what happens next:
    *
-   *  * [[FishingOutcomes.continue]] - continue with the next message given that the timeout has not been reached
+   *  * [[FishingOutcomes.continueAndCollect]] - continue with the next message given that the timeout has not been reached
    *  * [[FishingOutcomes.complete]] - successfully complete and return the message
    *  * [[FishingOutcomes.fail]] - fail the test with a custom message
    *


### PR DESCRIPTION
References #29951 

I didn't find any mentions of the method in the docs. Did I miss something? 
