### PR TITLE
Log stacktrace on deserialization error

### DIFF
--- a/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Codecs.scala
@@ -681,12 +681,12 @@ private[remote] class Deserializer(
               case OptionVal.Some(a) => a.remoteAddress
               case _                 => "unknown"
             }
-            log.warning(
-              "Failed to deserialize message from [{}] with serializer id [{}] and manifest [{}]. {}",
+            log.error(
+              e,
+              "Failed to deserialize message from [{}] with serializer id [{}] and manifest [{}].",
               from,
               envelope.serializer,
-              envelope.classManifest,
-              e)
+              envelope.classManifest)
             pull(in)
         } finally {
           val buf = envelope.envelopeBuffer

--- a/akka-remote/src/test/scala/akka/remote/artery/SerializationErrorSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SerializationErrorSpec.scala
@@ -59,7 +59,7 @@ class SerializationErrorSpec extends ArteryMultiNodeSpec(ArterySpecSupport.defau
       expectMsg("ping")
 
       EventFilter
-        .warning(pattern = """Failed to deserialize message from \[.*\] with serializer id \[4\]""", occurrences = 1)
+        .error(pattern = """Failed to deserialize message from \[.*\] with serializer id \[4\]""", occurrences = 1)
         .intercept {
           remoteRef ! "boom".getBytes("utf-8")
         }(systemB)


### PR DESCRIPTION
Deserialization errors are usually programming errors that
are not really recoverable, so it seems to make sense to
log at the error level, plus this gives the operator
access to the stacktrace which might be helpful in diagnosing
the problem.