### PR TITLE
Add SinkWithContext

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkWithContextSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SinkWithContextSpec.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.scaladsl
+
+import akka.stream.testkit.StreamSpec
+
+class SinkWithContextSpec extends StreamSpec {
+  "A SinkWithContext" must {
+
+    "respect ordering when using SinkWithContext.fromDataAndContext" in {
+
+      val dataSink = Sink.collection[Int, List[Int]]
+      val contextSink = Sink.collection[Int, List[Int]]
+
+      val sink = SinkWithContext.fromDataAndContext(dataSink, contextSink, Keep.zipFuture)(Concat(_))
+
+      val source = SourceWithContext.fromTuples(Source(List((1, 2), (3, 4), (5, 6))))
+
+      source.runWith(sink).futureValue shouldEqual List((1, 2), (3, 4), (5, 6))
+
+    }
+
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/javadsl/FlowWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/FlowWithContext.scala
@@ -64,6 +64,19 @@ final class FlowWithContext[In, CtxIn, Out, CtxOut, +Mat](
     FlowWithContext.fromPairs(under)
   }
 
+  def to[Mat2](sink: Graph[SinkShape[Pair[Out @uncheckedVariance, CtxOut @uncheckedVariance]], Mat2])
+      : javadsl.SinkWithContext[In, CtxIn, Mat] = {
+    val under = asFlow().to(sink)
+    SinkWithContext.fromPairs(under)
+  }
+
+  def toMat[M, M2](
+      sink: Graph[SinkShape[Pair[Out @uncheckedVariance, CtxOut @uncheckedVariance]], M],
+      combine: function.Function2[Mat, M, M2]): javadsl.SinkWithContext[In, CtxIn, M2] = {
+    val under = asFlow().toMat(sink, combine)
+    SinkWithContext.fromPairs(under)
+  }
+
   /**
    * Transform this flow by the regular flow. The given flow works on the data portion of the stream and
    * ignores the context.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SinkWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SinkWithContext.scala
@@ -1,0 +1,499 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.javadsl
+
+import java.util
+import java.util.Optional
+import java.util.concurrent.CompletionStage
+import java.util.function.BiFunction
+
+import scala.annotation.unchecked.uncheckedVariance
+import scala.util.Try
+
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+
+import akka.actor.ActorRef
+import akka.actor.ClassicActorSystemProvider
+import akka.japi.function.Creator
+import akka.japi.function
+import akka.japi.Pair
+import akka.stream._
+import akka.Done
+import akka.NotUsed
+
+object SinkWithContext {
+
+  /**
+   * Creates a SinkWithContext from a regular sink that operates on `Pair<data, context>` elements.
+   */
+  def fromPairs[In, CtxIn, Mat](under: Sink[Pair[In, CtxIn], Mat]): SinkWithContext[In, CtxIn, Mat] =
+    new SinkWithContext(under)
+
+  /**
+   * A `SinkWithContext` that will invoke the given function for every received element, giving it its previous
+   * output (or the given `zero` value) and the element as input.
+   * The returned [[java.util.concurrent.CompletionStage]] will be completed with value of the final
+   * function evaluation when the input stream ends, or completed with `Failure`
+   * if there is a failure is signaled in the stream.
+   */
+  def fold[U, In, Ctx](zero: Pair[U, Ctx], f: function.Function2[Pair[U, Ctx], Pair[In, Ctx], Pair[U, Ctx]])
+      : SinkWithContext[In, Ctx, CompletionStage[Pair[U, Ctx]]] = {
+    SinkWithContext.fromPairs(Sink.fold(zero, f))
+  }
+
+  /**
+   * A `SinkWithContext` that will invoke the given asynchronous function for every received element, giving it its previous
+   * output (or the given `zero` value) and the element as input.
+   * The returned [[java.util.concurrent.CompletionStage]] will be completed with value of the final
+   * function evaluation when the input stream ends, or completed with `Failure`
+   * if there is a failure is signaled in the stream.
+   */
+  def foldAsync[U, In, Ctx](
+      zero: Pair[U, Ctx],
+      f: function.Function2[Pair[U, Ctx], Pair[In, Ctx], CompletionStage[Pair[U, Ctx]]])
+      : SinkWithContext[In, Ctx, CompletionStage[Pair[U, Ctx]]] =
+    SinkWithContext.fromPairs(Sink.foldAsync(zero, f))
+
+  /**
+   * A `SinkWithContext` that will invoke the given function for every received element, giving it its previous
+   * output (from the second element) and the element as input.
+   * The returned [[java.util.concurrent.CompletionStage]] will be completed with value of the final
+   * function evaluation when the input stream ends, or completed with `Failure`
+   * if there is a failure signaled in the stream.
+   *
+   * If the stream is empty (i.e. completes before signalling any elements),
+   * the reduce operator will fail its downstream with a [[NoSuchElementException]],
+   * which is semantically in-line with that Scala's standard library collections
+   * do in such situations.
+   */
+  def reduce[In, Ctx](f: function.Function2[Pair[In, Ctx], Pair[In, Ctx], Pair[In, Ctx]])
+      : SinkWithContext[In, Ctx, CompletionStage[Pair[In, Ctx]]] =
+    SinkWithContext.fromPairs(Sink.reduce(f))
+
+  /**
+   * Helper to create [[SinkWithContext]] from `Subscriber`.
+   */
+  def fromSubscriber[In, Ctx](subs: Subscriber[Pair[In, Ctx]]): SinkWithContext[In, Ctx, NotUsed] =
+    SinkWithContext.fromPairs(Sink.fromSubscriber(subs))
+
+  /**
+   * A `SinkWithContext` that immediately cancels its upstream after materialization.
+   */
+  def cancelled[In, Ctx](): SinkWithContext[In, Ctx, NotUsed] =
+    SinkWithContext.fromPairs(Sink.cancelled())
+
+  /**
+   * A `SinkWithContext` that will consume the stream and discard the elements.
+   */
+  def ignore[In, Ctx](): SinkWithContext[In, Ctx, CompletionStage[Done]] =
+    SinkWithContext.fromPairs(Sink.ignore())
+
+  /**
+   * A [[SinkWithContext]] that will always backpressure never cancel and never consume any elements from the stream.
+   * */
+  def never[In, Ctx](): SinkWithContext[In, Ctx, CompletionStage[Done]] =
+    SinkWithContext.fromPairs(Sink.never)
+
+  /**
+   * A `SinkWithContext` that materializes into a [[org.reactivestreams.Publisher]].
+   *
+   * If `fanout` is `true`, the materialized `Publisher` will support multiple `Subscriber`s and
+   * the size of the `inputBuffer` configured for this operator becomes the maximum number of elements that
+   * the fastest [[org.reactivestreams.Subscriber]] can be ahead of the slowest one before slowing
+   * the processing down due to back pressure.
+   *
+   * If `fanout` is `false` then the materialized `Publisher` will only support a single `Subscriber` and
+   * reject any additional `Subscriber`s.
+   */
+  def asPublisher[In, Ctx](fanout: AsPublisher): SinkWithContext[In, Ctx, Publisher[Pair[In, Ctx]]] =
+    SinkWithContext.fromPairs(Sink.asPublisher(fanout))
+
+  /**
+   * A `SinkWithContext` that will invoke the given procedure for each received element. The sink is materialized
+   * into a [[java.util.concurrent.CompletionStage]] which will be completed with `Success` when reaching the
+   * normal end of the stream, or completed with `Failure` if there is a failure signaled in
+   * the stream.
+   */
+  def foreach[In, Ctx](f: function.Procedure2[In, Ctx]): SinkWithContext[In, Ctx, CompletionStage[Done]] =
+    SinkWithContext.fromPairs(Sink.foreach((param: Pair[In, Ctx]) => (f.apply _).tupled(param.toScala)))
+
+  /**
+   * A `SinkWithContext` that will invoke the given procedure asynchronously for each received element. The sink is
+   * materialized into a [[java.util.concurrent.CompletionStage]] which will be completed with `Success` when reaching
+   * the normal end of the stream, or completed with `Failure` if there is a failure signaled in
+   * the stream.
+   */
+  def foreachAsync[In, Ctx](parallelism: Int)(
+      f: function.Function2[In, Ctx, CompletionStage[Void]]): SinkWithContext[In, Ctx, CompletionStage[Done]] =
+    SinkWithContext.fromPairs(
+      Sink.foreachAsync(parallelism)((param: Pair[In, Ctx]) => (f.apply _).tupled(param.toScala)))
+
+  /**
+   * A `SinkWithContext` that when the flow is completed, either through a failure or normal
+   * completion, apply the provided function with [[scala.util.Success]]
+   * or [[scala.util.Failure]].
+   */
+  def onComplete[In, Ctx](callback: function.Procedure[Try[Done]]): SinkWithContext[In, Ctx, NotUsed] =
+    SinkWithContext.fromPairs(Sink.onComplete(callback))
+
+  /**
+   * A `SinkWithContext` that materializes into a `CompletionStage` of the first value received.
+   * If the stream completes before signaling at least a single element, the CompletionStage will be failed with a [[NoSuchElementException]].
+   * If the stream signals an error before signaling at least a single element, the CompletionStage will be failed with the streams exception.
+   *
+   * See also [[headOption]].
+   */
+  def head[In, Ctx](): SinkWithContext[In, Ctx, CompletionStage[Pair[In, Ctx]]] =
+    SinkWithContext.fromPairs(Sink.head())
+
+  /**
+   * A `SinkWithContext` that materializes into a `CompletionStage` of the optional first value received.
+   * If the stream completes before signaling at least a single element, the value of the CompletionStage will be an empty [[java.util.Optional]].
+   * If the stream signals an error errors before signaling at least a single element, the CompletionStage will be failed with the streams exception.
+   *
+   * See also [[head]].
+   */
+  def headOption[In, Ctx](): SinkWithContext[In, Ctx, CompletionStage[Optional[Pair[In, Ctx]]]] =
+    SinkWithContext.fromPairs(Sink.headOption())
+
+  /**
+   * A `SinkWithContext` that materializes into a `CompletionStage` of the last value received.
+   * If the stream completes before signaling at least a single element, the CompletionStage will be failed with a [[NoSuchElementException]].
+   * If the stream signals an error errors before signaling at least a single element, the CompletionStage will be failed with the streams exception.
+   *
+   * See also [[lastOption]], [[takeLast]].
+   */
+  def last[In, Ctx](): SinkWithContext[In, Ctx, CompletionStage[Pair[In, Ctx]]] =
+    SinkWithContext.fromPairs(Sink.last())
+
+  /**
+   * A `SinkWithContext` that materializes into a `CompletionStage` of the optional last value received.
+   * If the stream completes before signaling at least a single element, the value of the CompletionStage will be an empty [[java.util.Optional]].
+   * If the stream signals an error errors before signaling at least a single element, the CompletionStage will be failed with the streams exception.
+   *
+   * See also [[head]], [[takeLast]].
+   */
+  def lastOption[In, Ctx](): SinkWithContext[In, Ctx, CompletionStage[Optional[Pair[In, Ctx]]]] =
+    SinkWithContext.fromPairs(Sink.lastOption())
+
+  /**
+   * A `SinkWithContext` that materializes into a a `CompletionStage` of `List<In>` containing the last `n` collected elements.
+   *
+   * If the stream completes before signaling at least n elements, the `CompletionStage` will complete with all elements seen so far.
+   * If the stream never completes the `CompletionStage` will never complete.
+   * If there is a failure signaled in the stream the `CompletionStage` will be completed with failure.
+   */
+  def takeLast[In, Ctx](n: Int): SinkWithContext[In, Ctx, CompletionStage[java.util.List[Pair[In, Ctx]]]] =
+    SinkWithContext.fromPairs(Sink.takeLast(n))
+
+  /**
+   * A `SinkWithContext` that keeps on collecting incoming elements until upstream terminates.
+   * As upstream may be unbounded, `Flow[Pair[In, Ctx]].take` or the stricter `Flow[Pair[In, Ctx]].limit`
+   * (and their variants) may be used to ensure boundedness.
+   * Materializes into a `CompletionStage` of `Seq[T]` containing all the collected elements.
+   * `List` is limited to `Integer.MAX_VALUE` elements, this Sink will cancel the stream
+   * after having received that many elements.
+   *
+   * See also [[Flow.limit]], [[Flow.limitWeighted]], [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
+   */
+  def seq[In, Ctx]: SinkWithContext[In, Ctx, CompletionStage[java.util.List[Pair[In, Ctx]]]] =
+    SinkWithContext.fromPairs(Sink.seq)
+
+  /**
+   * Sends the elements of the stream to the given `ActorRef`.
+   * If the target actor terminates the stream will be canceled.
+   * When the stream is completed successfully the given `onCompleteMessage`
+   * will be sent to the destination actor.
+   * When the stream is completed with failure a [[akka.actor.Status.Failure]]
+   * message will be sent to the destination actor.
+   *
+   * It will request at most `maxInputBufferSize` number of elements from
+   * upstream, but there is no back-pressure signal from the destination actor,
+   * i.e. if the actor is not consuming the messages fast enough the mailbox
+   * of the actor will grow. For potentially slow consumer actors it is recommended
+   * to use a bounded mailbox with zero `mailbox-push-timeout-time` or use a rate
+   * limiting operator in front of this `SinkWithContext`.
+   *
+   */
+  def actorRef[In, Ctx](ref: ActorRef, onCompleteMessage: Any): SinkWithContext[In, Ctx, NotUsed] =
+    SinkWithContext.fromPairs(Sink.actorRef(ref, onCompleteMessage))
+
+  /**
+   * Sends the elements of the stream to the given `ActorRef` that sends back back-pressure signal.
+   * First element is always `onInitMessage`, then stream is waiting for acknowledgement message
+   * `ackMessage` from the given actor which means that it is ready to process
+   * elements. It also requires `ackMessage` message after each stream element
+   * to make backpressure work.
+   *
+   * If the target actor terminates the stream will be canceled.
+   * When the stream is completed successfully the given `onCompleteMessage`
+   * will be sent to the destination actor.
+   * When the stream is completed with failure - result of `onFailureMessage(throwable)`
+   * message will be sent to the destination actor.
+   */
+  def actorRefWithBackpressure[In, Ctx](
+      ref: ActorRef,
+      onInitMessage: Any,
+      ackMessage: Any,
+      onCompleteMessage: Any,
+      onFailureMessage: function.Function[Throwable, Any]): SinkWithContext[In, Ctx, NotUsed] =
+    SinkWithContext.fromPairs(
+      Sink.actorRefWithBackpressure(ref, onInitMessage, ackMessage, onCompleteMessage, onFailureMessage))
+
+  /**
+   * Sends the elements of the stream to the given `ActorRef` that sends back back-pressure signal.
+   * First element is always `onInitMessage`, then stream is waiting for acknowledgement message
+   * from the given actor which means that it is ready to process
+   * elements. It also requires an ack message after each stream element
+   * to make backpressure work. This variant will consider any message as ack message.
+   *
+   * If the target actor terminates the stream will be canceled.
+   * When the stream is completed successfully the given `onCompleteMessage`
+   * will be sent to the destination actor.
+   * When the stream is completed with failure - result of `onFailureMessage(throwable)`
+   * message will be sent to the destination actor.
+   */
+  def actorRefWithBackpressure[In, Ctx](
+      ref: ActorRef,
+      onInitMessage: Any,
+      onCompleteMessage: Any,
+      onFailureMessage: function.Function[Throwable, Any]): SinkWithContext[In, Ctx, NotUsed] =
+    SinkWithContext.fromPairs(Sink.actorRefWithBackpressure(ref, onInitMessage, onCompleteMessage, onFailureMessage))
+
+  /**
+   * Defers the creation of a [[SinkWithContext]] until materialization. The `factory` function
+   * exposes [[Materializer]] which is going to be used during materialization and
+   * [[Attributes]] of the [[SinkWithContext]] returned by this method.
+   */
+  def fromMaterializer[In, Ctx, M](factory: BiFunction[Materializer, Attributes, SinkWithContext[In, Ctx, M]])
+      : SinkWithContext[In, Ctx, CompletionStage[M]] =
+    SinkWithContext.fromPairs(Sink.fromMaterializer((mat, attr) => factory(mat, attr).asSink))
+
+  /**
+   * Combine several sinks with fan-out strategy like `Broadcast` or `Balance` and returns `Sink`.
+   */
+  def combine[T, U, Ctx](
+      output1: SinkWithContext[U, Ctx, _],
+      output2: SinkWithContext[U, Ctx, _],
+      rest: java.util.List[SinkWithContext[U, Ctx, _]],
+      strategy: function.Function[java.lang.Integer, Graph[UniformFanOutShape[Pair[T, Ctx], Pair[U, Ctx]], NotUsed]])
+      : SinkWithContext[T, Ctx, NotUsed] = {
+    val replaced = new util.ArrayList[Sink[Pair[U, Ctx], _]](rest.size())
+    val it = rest.iterator()
+    while (it.hasNext) replaced.add(it.next().asSink)
+
+    SinkWithContext.fromPairs(Sink.combine(output1.asSink, output2.asSink, replaced, strategy))
+  }
+
+  /**
+   * Creates a `SinkWithContext` that is materialized as an [[akka.stream.javadsl.SinkQueueWithCancel]].
+   * [[akka.stream.javadsl.SinkQueueWithCancel.pull]] method is pulling element from the stream and returns ``CompletionStage[Option[Pair[In, Ctx]]]``.
+   * `CompletionStage` completes when element is available.
+   *
+   * Before calling pull method second time you need to ensure that number of pending pulls is less then ``maxConcurrentPulls``
+   * or wait until some of the previous Futures completes.
+   * Pull returns Failed future with ''IllegalStateException'' if there will be more then ``maxConcurrentPulls`` number of pending pulls.
+   *
+   * `SinkWithContext` will request at most number of elements equal to size of `inputBuffer` from
+   * upstream and then stop back pressure.  You can configure size of input
+   * buffer by using [[SinkWithContext.withAttributes]] method.
+   *
+   * For stream completion you need to pull all elements from [[akka.stream.javadsl.SinkQueueWithCancel]] including last None
+   * as completion marker
+   *
+   * @see [[akka.stream.javadsl.SinkQueueWithCancel]]
+   */
+  def queue[In, Ctx](maxConcurrentPulls: Int): SinkWithContext[In, Ctx, SinkQueueWithCancel[Pair[In, Ctx]]] =
+    SinkWithContext.fromPairs(Sink.queue(maxConcurrentPulls))
+
+  /**
+   * Creates a `SinkWithContext` that is materialized as an [[akka.stream.javadsl.SinkQueueWithCancel]].
+   * [[akka.stream.javadsl.SinkQueueWithCancel.pull]] method is pulling element from the stream and returns ``CompletionStage[Option[Pair[In, Ctx]]]``.
+   * `CompletionStage` completes when element is available.
+   *
+   * Before calling pull method second time you need to wait until previous CompletionStage completes.
+   * Pull returns Failed future with ''IllegalStateException'' if previous future has not yet completed.
+   *
+   * `SinkWithContext` will request at most number of elements equal to size of `inputBuffer` from
+   * upstream and then stop back pressure.  You can configure size of input
+   * buffer by using [[SinkWithContext.withAttributes]] method.
+   *
+   * For stream completion you need to pull all elements from [[akka.stream.javadsl.SinkQueueWithCancel]] including last None
+   * as completion marker
+   *
+   * @see [[akka.stream.javadsl.SinkQueueWithCancel]]
+   */
+  def queue[In, Ctx](): SinkWithContext[In, Ctx, SinkQueueWithCancel[Pair[In, Ctx]]] = queue(1)
+
+  /**
+   * Turn a `Future[SinkWithContext]` into a SinkWithContext that will consume the values of the source when the future completes successfully.
+   * If the `Future` is completed with a failure the stream is failed.
+   *
+   * The materialized future value is completed with the materialized value of the future sink or failed with a
+   * [[NeverMaterializedException]] if upstream fails or downstream cancels before the future has completed.
+   */
+  def completionStageSink[In, Ctx, M](
+      future: CompletionStage[SinkWithContext[In, Ctx, M]]): SinkWithContext[In, Ctx, CompletionStage[M]] =
+    SinkWithContext.fromPairs(Sink.completionStageSink(future.thenApply(_.asSink)))
+
+  /**
+   * Defers invoking the `create` function to create a sink until there is a first element passed from upstream.
+   *
+   * The materialized future value is completed with the materialized value of the created sink when that has successfully
+   * been materialized.
+   *
+   * If the `create` function throws or returns or the stream fails to materialize, in this
+   * case the materialized future value is failed with a [[akka.stream.NeverMaterializedException]].
+   */
+  def lazySink[In, Ctx, M](create: Creator[SinkWithContext[In, Ctx, M]]): SinkWithContext[In, Ctx, CompletionStage[M]] =
+    SinkWithContext.fromPairs(Sink.lazySink(() => create.create().asSink))
+
+  /**
+   * Defers invoking the `create` function to create a future sink until there is a first element passed from upstream.
+   *
+   * The materialized future value is completed with the materialized value of the created sink when that has successfully
+   * been materialized.
+   *
+   * If the `create` function throws or returns a future that is failed, or the stream fails to materialize, in this
+   * case the materialized future value is failed with a [[akka.stream.NeverMaterializedException]].
+   */
+  def lazyCompletionStageSink[In, Ctx, M](
+      create: Creator[CompletionStage[SinkWithContext[In, Ctx, M]]]): SinkWithContext[In, Ctx, CompletionStage[M]] =
+    SinkWithContext.fromPairs(Sink.lazyCompletionStageSink(() => create.create().thenApply(_.asSink)))
+}
+
+/**
+ * A Sink that indicates it accepts context along with data portion of a stream typically coming from a
+ * [[FlowWithContext]] or a [[SourceWithContext]]. Since a Sink is meant to be the last part of a stream that
+ * doesn't have an output, filtering/reordering incoming elements is acceptable albeit extremely unusual.
+ *
+ * The [[SinkWithContext]] contains the same creation methods as the standard [[Sink]] and one can also create a
+ * [[SinkWithContext]] from an existing [[Sink]] containing a context by using `SinkWithContext.fromPairs`.
+ *
+ */
+final class SinkWithContext[In, CtxIn, +Mat](delegate: Sink[Pair[In, CtxIn], Mat]) extends GraphDelegate(delegate) {
+
+  /**
+   * Converts this SinkWithContext to its Scala DSL counterpart.
+   */
+  def asScala: scaladsl.SinkWithContext[In, CtxIn, Mat] = {
+    scaladsl.SinkWithContext.fromTuples(
+      scaladsl
+        .Flow[(In, CtxIn)]
+        .toMat(delegate.contramap[(In, CtxIn)] {
+          case (in, ctxIn) =>
+            Pair(in, ctxIn)
+        }) { case (_, mat) => mat })
+  }
+
+  /**
+   * Connect this `SinkWithContext` to a `SourceWithContext` and run it.
+   *
+   * Note that the `ActorSystem` can be used as the `systemProvider` parameter.
+   */
+  def runWith[M](source: Graph[SourceShape[(In, CtxIn)], M], systemProvider: ClassicActorSystemProvider): M =
+    asScala.runWith(source)(SystemMaterializer(systemProvider.classicSystem).materializer)
+
+  /**
+   * Connect this `SinkWithContext` to a `SourceWithContext` and run it.
+   */
+  def runWith[M](source: Graph[SourceShape[(In, CtxIn)], M], materializer: Materializer): M =
+    asScala.runWith(source)(materializer)
+
+  /**
+   * Transform this SinkWithContext by applying a function to each *incoming* upstream element before
+   * it is passed to the [[SinkWithContext]]
+   *
+   * '''Backpressures when''' original [[SinkWithContext]] backpressures
+   *
+   * '''Cancels when''' original [[SinkWithContext]] backpressures
+   */
+  def contramap[In2, Ctx2](f: function.Function2[In2, Ctx2, Pair[In, CtxIn]]): SinkWithContext[In2, Ctx2, Mat] =
+    viaScala(_.contraMap((in2, ctx2) => f(in2, ctx2).toScala))
+
+  /**
+   * Transform the data portion of this SinkWithContext by applying a function to each *incoming* upstream element
+   * before it is passed to the [[SinkWithContext]]
+   *
+   * '''Backpressures when''' original [[SinkWithContext]] backpressures
+   *
+   * '''Cancels when''' original [[SinkWithContext]] cancels
+   */
+  def contramapData[In2](f: function.Function[In2, In]): SinkWithContext[In2, CtxIn, Mat] =
+    viaScala(_.contramapData(in2 => f(in2)))
+
+  /**
+   * Transform only the materialized value of this SinkWithContext, leaving all other properties as they were.
+   */
+  def mapMaterializedValue[Mat2](f: function.Function[Mat, Mat2]): SinkWithContext[In, CtxIn, Mat2] =
+    SinkWithContext.fromPairs(delegate.mapMaterializedValue(f))
+
+  /**
+   * Materializes this SinkWithContext, immediately returning (1) its materialized value, and (2) a new SinkWithContext
+   * that can be consume elements 'into' the pre-materialized one.
+   *
+   * Useful for when you need a materialized value of a SinkWithContext when handing it out to someone to materialize it for you.
+   *
+   * Note that the `ActorSystem` can be used as the `systemProvider` parameter.
+   */
+  def preMaterialize(systemProvider: ClassicActorSystemProvider)
+      : Pair[Mat @uncheckedVariance, SinkWithContext[In @uncheckedVariance, CtxIn @uncheckedVariance, NotUsed]] = {
+    val result = delegate.preMaterialize(systemProvider)
+    Pair(result.first, SinkWithContext.fromPairs(result.second))
+  }
+
+  /**
+   * Materializes this SinkWithContext, immediately returning (1) its materialized value, and (2) a new SinkWithContext
+   * that can be consume elements 'into' the pre-materialized one.
+   *
+   * Useful for when you need a materialized value of a SinkWithContext when handing it out to someone to materialize it for you.
+   *
+   * Prefer the method taking an ActorSystem unless you have special requirements.
+   */
+  def preMaterialize(materializer: Materializer)
+      : Pair[Mat @uncheckedVariance, SinkWithContext[In @uncheckedVariance, CtxIn @uncheckedVariance, NotUsed]] = {
+    val result = delegate.preMaterialize(materializer)
+    Pair(result.first, SinkWithContext.fromPairs(result.second))
+  }
+
+  /**
+   * Context-preserving variant of [[akka.stream.javadsl.Sink.withAttributes]].
+   *
+   * @see [[akka.stream.javadsl.Sink.withAttributes]]
+   */
+  override def withAttributes(attr: Attributes): SinkWithContext[In, CtxIn, Mat] =
+    viaScala(_.withAttributes(attr))
+
+  /**
+   * Put an asynchronous boundary around this `SinkWithContext`
+   */
+  override def async: SinkWithContext[In, CtxIn, Mat] =
+    viaScala(_.async)
+
+  /**
+   * Put an asynchronous boundary around this `SinkWithContext`
+   *
+   * @param dispatcher Run the graph on this dispatcher
+   */
+  override def async(dispatcher: String): SinkWithContext[In, CtxIn, Mat] =
+    viaScala(_.async(dispatcher))
+
+  /**
+   * Put an asynchronous boundary around this `SinkWithContext`
+   *
+   * @param dispatcher      Run the graph on this dispatcher
+   * @param inputBufferSize Set the input buffer to this size for the graph
+   */
+  override def async(dispatcher: String, inputBufferSize: Int): SinkWithContext[In, CtxIn, Mat] =
+    viaScala(_.async(dispatcher, inputBufferSize))
+
+  def asSink: Sink[Pair[In, CtxIn], Mat @uncheckedVariance] = delegate
+
+  private[this] def viaScala[In2, CtxIn2, Mat2](
+      f: scaladsl.SinkWithContext[In, CtxIn, Mat] => scaladsl.SinkWithContext[In2, CtxIn2, Mat2])
+      : SinkWithContext[In2, CtxIn2, Mat2] =
+    f(this.asScala).asJava
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOps.scala
@@ -24,10 +24,13 @@ import ccompat._
  */
 @ccompatUsedUntil213
 trait FlowWithContextOps[+Out, +Ctx, +Mat] {
-  type ReprMat[+O, +C, +M] <: FlowWithContextOps[O, C, M] {
-    type ReprMat[+OO, +CC, +MatMat] = FlowWithContextOps.this.ReprMat[OO, CC, MatMat]
+
+  type Repr[+O, +C] <: FlowWithContextOps[O, C, Mat @uncheckedVariance] {
+    type Repr[+OO, +CC] = FlowWithContextOps.this.Repr[OO, CC]
+    type Closed = FlowWithContextOps.this.Closed
   }
-  type Repr[+O, +C] = ReprMat[O, C, Mat @uncheckedVariance]
+
+  type Closed
 
   /**
    * Transform this flow by the regular flow. The given flow must support manual context propagation by
@@ -58,25 +61,6 @@ trait FlowWithContextOps[+Out, +Ctx, +Mat] {
    *  see https://doc.akka.io/docs/akka/current/stream/stream-context.html.
    */
   @ApiMayChange def unsafeDataVia[Out2, Mat2](viaFlow: Graph[FlowShape[Out, Out2], Mat2]): Repr[Out2, Ctx]
-
-  /**
-   * Transform this flow by the regular flow. The given flow must support manual context propagation by
-   * taking and producing tuples of (data, context).
-   *
-   *  It is up to the implementer to ensure the inner flow does not exhibit any behaviour that is not expected
-   *  by the downstream elements, such as reordering. For more background on these requirements
-   *  see https://doc.akka.io/docs/akka/current/stream/stream-context.html.
-   *
-   * This can be used as an escape hatch for operations that are not (yet) provided with automatic
-   * context propagation here.
-   *
-   * The `combine` function is used to compose the materialized values of this flow and that
-   * flow into the materialized value of the resulting Flow.
-   *
-   * @see [[akka.stream.scaladsl.FlowOpsMat.viaMat]]
-   */
-  def viaMat[Out2, Ctx2, Mat2, Mat3](flow: Graph[FlowShape[(Out, Ctx), (Out2, Ctx2)], Mat2])(
-      combine: (Mat, Mat2) => Mat3): ReprMat[Out2, Ctx2, Mat3]
 
   /**
    * Context-preserving variant of [[akka.stream.scaladsl.FlowOps.map]].

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOpsMat.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/FlowWithContextOpsMat.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.scaladsl
+
+import akka.stream.{ FlowShape, Graph, SinkShape }
+
+import scala.annotation.unchecked.uncheckedVariance
+
+trait FlowWithContextOpsMat[+Out, +Ctx, +Mat] extends FlowWithContextOps[Out, Ctx, Mat] {
+  type Repr[+O, +C] <: ReprMat[O, C, Mat] {
+    type Repr[+OO, +CC] = FlowWithContextOpsMat.this.Repr[OO, CC]
+    type ReprMat[+OO, +CC, +MM] = FlowWithContextOpsMat.this.ReprMat[OO, CC, MM]
+    type Closed = FlowWithContextOpsMat.this.Closed
+    type ClosedMat[+M] = FlowWithContextOpsMat.this.ClosedMat[M]
+  }
+  type ReprMat[+O, +C, +M] <: FlowWithContextOpsMat[O, C, M] {
+    type Repr[+OO, +CC] = FlowWithContextOpsMat.this.ReprMat[OO, CC, M @uncheckedVariance]
+    type ReprMat[+OO, +CC, +MM] = FlowWithContextOpsMat.this.ReprMat[OO, CC, MM]
+    type Closed = FlowWithContextOpsMat.this.ClosedMat[M @uncheckedVariance]
+    type ClosedMat[+MM] = FlowWithContextOpsMat.this.ClosedMat[MM]
+  }
+  type ClosedMat[+M] <: Graph[_, M]
+
+  def to[Mat2](sink: Graph[SinkShape[(Out, Ctx)], Mat2]): Closed
+
+  def alsoTo(that: Graph[SinkShape[(Out, Ctx)], _]): Repr[Out, Ctx] = via(alsoToGraph(that))
+
+  def toMat[Mat2, Mat3](sink: Graph[SinkShape[(Out, Ctx)], Mat2])(combine: (Mat, Mat2) => Mat3): ClosedMat[Mat3]
+
+  /**
+   * Transform this flow by the regular flow. The given flow must support manual context propagation by
+   * taking and producing tuples of (data, context).
+   *
+   *  It is up to the implementer to ensure the inner flow does not exhibit any behaviour that is not expected
+   *  by the downstream elements, such as reordering. For more background on these requirements
+   *  see https://doc.akka.io/docs/akka/current/stream/stream-context.html.
+   *
+   * This can be used as an escape hatch for operations that are not (yet) provided with automatic
+   * context propagation here.
+   *
+   * The `combine` function is used to compose the materialized values of this flow and that
+   * flow into the materialized value of the resulting Flow.
+   *
+   * @see [[akka.stream.scaladsl.FlowOpsMat.viaMat]]
+   */
+  def viaMat[Out2, Ctx2, Mat2, Mat3](flow: Graph[FlowShape[(Out, Ctx), (Out2, Ctx2)], Mat2])(
+      combine: (Mat, Mat2) => Mat3): ReprMat[Out2, Ctx2, Mat3]
+
+  protected def alsoToGraph[M](that: Graph[SinkShape[(Out, Ctx)], M])
+      : Graph[FlowShape[(Out @uncheckedVariance, Ctx @uncheckedVariance), (Out, Ctx)], M] =
+    GraphDSL.createGraph(that) { implicit b => r =>
+      import GraphDSL.Implicits._
+      val bcast = b.add(Broadcast[(Out, Ctx)](2, eagerCancel = true))
+      bcast.out(1) ~> r
+      FlowShape(bcast.in, bcast.out(0))
+    }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Materialization.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Materialization.scala
@@ -5,6 +5,9 @@
 package akka.stream.scaladsl
 
 import akka.NotUsed
+import akka.dispatch.ExecutionContexts
+
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * Convenience functions for often-encountered purposes like keeping only the
@@ -20,4 +23,14 @@ object Keep {
   def right[L, R]: (L, R) => R = _right.asInstanceOf[(L, R) => R]
   def both[L, R]: (L, R) => (L, R) = _both.asInstanceOf[(L, R) => (L, R)]
   def none[L, R]: (L, R) => NotUsed = _none.asInstanceOf[(L, R) => NotUsed]
+  def zip[T, That <: Iterable[T]]: (That, That) => Iterable[(T, T)] =
+    (l: That, r: That) => l.zip(r)
+  def zipFuture[T, That <: Iterable[T]]: (Future[That], Future[That]) => Future[Iterable[(T, T)]] =
+    (l: Future[That], r: Future[That]) => {
+      implicit val ec: ExecutionContext = ExecutionContexts.parasitic
+      for {
+        l_ <- l
+        r_ <- r
+      } yield l_.zip(r_)
+    }
 }

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/SinkWithContext.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/SinkWithContext.scala
@@ -1,0 +1,505 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.scaladsl
+
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.util.Try
+
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+
+import akka.actor.ActorRef
+import akka.Done
+import akka.NotUsed
+import akka.dispatch.ExecutionContexts
+import akka.japi.Pair
+import akka.stream._
+import akka.util.ccompat.Factory
+
+object SinkWithContext {
+
+  /**
+   * Creates a SinkWithContext from a regular sink that operates on a tuple of `(data, context)` elements.
+   */
+  def fromTuples[In, CtxIn, Mat](sink: Sink[(In, CtxIn), Mat]): SinkWithContext[In, CtxIn, Mat] =
+    new SinkWithContext(sink)
+
+  /**
+   * Creates a SinkWithContext from a data sink and a context sink with a fan-in strategy like `Concat` which
+   * controls interaction between the `dataSink` and `contextSink`.
+   * @param dataComesFirst Whether the data sink is fed first into the strategy or the context sink. Important for
+   *                       strategies such as Combine where ordering matters
+   * @return
+   */
+  def fromDataAndContext[In, CtxIn, MatIn, MatCtx, Mat3](
+      dataSink: Graph[SinkShape[In], MatIn],
+      contextSink: Graph[SinkShape[CtxIn], MatCtx],
+      combine: (MatIn, MatCtx) => Mat3,
+      dataComesFirst: Boolean = true)(
+      strategy: Int => Graph[UniformFanInShape[Either[In, CtxIn], Either[In, CtxIn]], NotUsed])
+      : SinkWithContext[In, CtxIn, Mat3] = {
+    SinkWithContext.fromTuples(Sink.fromGraph(GraphDSL.createGraph(dataSink, contextSink)(combine) {
+      implicit b => (dSink, ctxSink) =>
+        import GraphDSL.Implicits._
+
+        val unzip = b.add(Unzip[In, CtxIn]())
+
+        val c = b.add(strategy(2))
+        val p = b.add(new Partition[Either[In, CtxIn]](outputPorts = 2, { in =>
+          if (in.isLeft)
+            0
+          else
+            1
+        }, eagerCancel = true))
+
+        if (dataComesFirst) {
+          unzip.out0.map(Left.apply) ~> c.in(0)
+          unzip.out1.map(Right.apply) ~> c.in(1)
+        } else {
+          unzip.out1.map(Right.apply) ~> c.in(0)
+          unzip.out0.map(Left.apply) ~> c.in(1)
+        }
+
+        c.out ~> p.in
+
+        p.out(0).map(_.asInstanceOf[Left[In, CtxIn]].value) ~> dSink.in
+        p.out(1).map(_.asInstanceOf[Right[In, CtxIn]].value) ~> ctxSink.in
+
+        SinkShape(unzip.in)
+    }))
+  }
+
+  /**
+   * Defers the creation of a [[SinkWithContext]] until materialization. The `factory` function
+   * exposes [[Materializer]] which is going to be used during materialization and
+   * [[Attributes]] of the [[SinkWithContext]] returned by this method.
+   */
+  def fromMaterializer[T, C, M](
+      factory: (Materializer, Attributes) => SinkWithContext[T, C, M]): SinkWithContext[T, C, Future[M]] =
+    new SinkWithContext(Sink.fromMaterializer((mat, attr) => factory(mat, attr).asSink))
+
+  /**
+   * Helper to create [[SinkWithContext]] from `Subscriber`.
+   */
+  def fromSubscriber[T, C](subscriber: Subscriber[(T, C)]): SinkWithContext[T, C, NotUsed] =
+    new SinkWithContext(Sink.fromSubscriber(subscriber))
+
+  /**
+   * A `SinkWithContext` that immediately cancels its upstream after materialization.
+   */
+  def cancelled[T, C]: SinkWithContext[T, C, NotUsed] =
+    new SinkWithContext(Sink.cancelled)
+
+  /**
+   * A `SinkWithContext` that materializes into a `Future` of the first value received.
+   * If the stream completes before signaling at least a single element, the Future will be failed with a [[NoSuchElementException]].
+   * If the stream signals an error errors before signaling at least a single element, the Future will be failed with the streams exception.
+   *
+   * See also [[headOption]].
+   */
+  def head[T, C]: SinkWithContext[T, C, Future[(T, C)]] =
+    new SinkWithContext(Sink.head)
+
+  /**
+   * A `SinkWithContext` that materializes into a `Future` of the optional first value received.
+   * If the stream completes before signaling at least a single element, the value of the Future will be [[None]].
+   * If the stream signals an error errors before signaling at least a single element, the Future will be failed with the streams exception.
+   *
+   * See also [[head]].
+   */
+  def headOption[T, C]: SinkWithContext[T, C, Future[Option[(T, C)]]] =
+    new SinkWithContext(Sink.headOption)
+
+  /**
+   * A `SinkWithContext` that materializes into a `Future` of the last value received.
+   * If the stream completes before signaling at least a single element, the Future will be failed with a [[NoSuchElementException]].
+   * If the stream signals an error, the Future will be failed with the stream's exception.
+   *
+   * See also [[lastOption]], [[takeLast]].
+   */
+  def last[T, C]: SinkWithContext[T, C, Future[(T, C)]] =
+    new SinkWithContext(Sink.last[(T, C)])
+
+  /**
+   * A `SinkWithContext` that materializes into a `Future` of the optional last value received.
+   * If the stream completes before signaling at least a single element, the value of the Future will be [[None]].
+   * If the stream signals an error, the Future will be failed with the stream's exception.
+   *
+   * See also [[last]], [[takeLast]].
+   */
+  def lastOption[T, C]: SinkWithContext[T, C, Future[Option[(T, C)]]] =
+    new SinkWithContext(Sink.lastOption)
+
+  /**
+   * A `SinkWithContext` that materializes into a a `Future` of `immutable.Seq[(T,C)]` containing the last `n` collected elements.
+   *
+   * If the stream completes before signaling at least n elements, the `Future` will complete with all elements seen so far.
+   * If the stream never completes, the `Future` will never complete.
+   * If there is a failure signaled in the stream the `Future` will be completed with failure.
+   */
+  def takeLast[T, C](n: Int): SinkWithContext[T, C, Future[immutable.Seq[(T, C)]]] =
+    new SinkWithContext(Sink.takeLast(n))
+
+  /**
+   * A `SinkWithContext` that keeps on collecting incoming elements until upstream terminates.
+   * As upstream may be unbounded, `Flow[(T,C)].take` or the stricter `Flow[(T,C)].limit` (and their variants)
+   * may be used to ensure boundedness.
+   * Materializes into a `Future` of `Seq[(T,C)]` containing all the collected elements.
+   * `Seq` is limited to `Int.MaxValue` elements, this SinkWithContext will cancel the stream
+   * after having received that many elements.
+   *
+   * See also [[Flow.limit]], [[Flow.limitWeighted]], [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
+   */
+  def seq[T, C]: SinkWithContext[T, C, Future[immutable.Seq[(T, C)]]] =
+    new SinkWithContext(Sink.seq)
+
+  /**
+   * A `SinkWithContext` that keeps on collecting incoming elements until upstream terminates.
+   * As upstream may be unbounded, `Flow[(T,C)].take` or the stricter `Flow[(T,C)].limit` (and their variants)
+   * may be used to ensure boundedness.
+   * Materializes into a `Future` of `That[T]` containing all the collected elements.
+   * `That[T]` is limited to the limitations of the CanBuildFrom associated with it. For example, `Seq` is limited to
+   * `Int.MaxValue` elements. See [The Architecture of Scala 2.13's Collections](https://docs.scala-lang.org/overviews/core/architecture-of-scala-213-collections.html) for more info.
+   * This SinkWithContext will cancel the stream after having received that many elements.
+   *
+   * See also [[Flow.limit]], [[Flow.limitWeighted]], [[Flow.take]], [[Flow.takeWithin]], [[Flow.takeWhile]]
+   */
+  def collection[T, C, That](
+      implicit cbf: Factory[(T, C), That with immutable.Iterable[_]]): SinkWithContext[T, C, Future[That]] =
+    new SinkWithContext(Sink.collection[(T, C), That])
+
+  /**
+   * A `SinkWithContext` that materializes into a [[org.reactivestreams.Publisher]].
+   *
+   * If `fanout` is `true`, the materialized `Publisher` will support multiple `Subscriber`s and
+   * the size of the `inputBuffer` configured for this operator becomes the maximum number of elements that
+   * the fastest [[org.reactivestreams.Subscriber]] can be ahead of the slowest one before slowing
+   * the processing down due to back pressure.
+   *
+   * If `fanout` is `false` then the materialized `Publisher` will only support a single `Subscriber` and
+   * reject any additional `Subscriber`s.
+   */
+  def asPublisher[T, C](fanout: Boolean): SinkWithContext[T, C, Publisher[(T, C)]] =
+    new SinkWithContext(Sink.asPublisher(fanout))
+
+  /**
+   * A `SinkWithContext` that will consume the stream and discard the elements.
+   */
+  def ignore: SinkWithContext[Any, Any, Future[Done]] =
+    new SinkWithContext(Sink.ignore)
+
+  /**
+   * A [[SinkWithContext]] that will always backpressure never cancel and never consume any elements from the stream.
+   * */
+  def never: SinkWithContext[Any, Any, Future[Done]] =
+    new SinkWithContext(Sink.never)
+
+  /**
+   * A `SinkWithContext` that will invoke the given procedure for each received element. The sink is materialized
+   * into a [[scala.concurrent.Future]] which will be completed with `Success` when reaching the
+   * normal end of the stream, or completed with `Failure` if there is a failure signaled in
+   * the stream.
+   */
+  def foreach[T, C](f: (T, C) => Unit): SinkWithContext[T, C, Future[Done]] =
+    new SinkWithContext(Sink.foreach(f.tupled))
+
+  /**
+   * A `SinkWithContext` that will invoke the given procedure asynchronously for each received element. The sink is materialized
+   * into a [[scala.concurrent.Future]] which will be completed with `Success` when reaching the
+   * normal end of the stream, or completed with `Failure` if there is a failure signaled in
+   * the stream.
+   */
+  def foreachAsync[T, C](parallelism: Int)(f: (T, C) => Future[Unit]): SinkWithContext[T, C, Future[Done]] =
+    new SinkWithContext(Sink.foreachAsync(parallelism)(f.tupled))
+
+  /**
+   * Combine several sinks with fan-out strategy like `Broadcast` or `Balance` and returns `SinkWithContext`.
+   */
+  def combine[T, U, C](
+      first: SinkWithContext[U, C, _],
+      second: SinkWithContext[U, C, _],
+      rest: SinkWithContext[U, C, _]*)(
+      strategy: Int => Graph[UniformFanOutShape[(T, C), (U, C)], NotUsed]): SinkWithContext[T, C, NotUsed] =
+    new SinkWithContext(Sink.combine(first.asSink, second.asSink, rest.map(_.asSink): _*)(strategy))
+
+  /**
+   * A `SinkWithContext` that will invoke the given function for every received element, giving it its previous
+   * output (or the given `zero` value) and the element as input.
+   * The returned [[scala.concurrent.Future]] will be completed with value of the final
+   * function evaluation when the input stream ends, or completed with `Failure`
+   * if there is a failure signaled in the stream.
+   *
+   * @see [[#foldAsync]]
+   */
+  def fold[U, T, C](zero: (U, C))(f: ((U, C), (T, C)) => (U, C)): SinkWithContext[T, C, Future[(U, C)]] =
+    new SinkWithContext(Sink.fold(zero)(f))
+
+  /**
+   * A `SinkWithContext` that will invoke the given asynchronous function for every received element, giving it its previous
+   * output (or the given `zero` value) and the element as input.
+   * The returned [[scala.concurrent.Future]] will be completed with value of the final
+   * function evaluation when the input stream ends, or completed with `Failure`
+   * if there is a failure signaled in the stream.
+   *
+   * @see [[#fold]]
+   */
+  def foldAsync[U, T, C](zero: (U, C))(f: ((U, C), (T, C)) => Future[(U, C)]): SinkWithContext[T, C, Future[(U, C)]] =
+    new SinkWithContext(Sink.foldAsync(zero)(f))
+
+  /**
+   * A `SinkWithContext` that will invoke the given function for every received element, giving it its previous
+   * output (from the second element) and the element as input.
+   * The returned [[scala.concurrent.Future]] will be completed with value of the final
+   * function evaluation when the input stream ends, or completed with `Failure`
+   * if there is a failure signaled in the stream.
+   *
+   * If the stream is empty (i.e. completes before signalling any elements),
+   * the reduce operator will fail its downstream with a [[NoSuchElementException]],
+   * which is semantically in-line with that Scala's standard library collections
+   * do in such situations.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   */
+  def reduce[T, C](f: ((T, C), (T, C)) => (T, C)): SinkWithContext[T, C, Future[(T, C)]] =
+    new SinkWithContext(Sink.reduce(f))
+
+  /**
+   * A `SinkWithContext` that when the flow is completed, either through a failure or normal
+   * completion, apply the provided function with [[scala.util.Success]]
+   * or [[scala.util.Failure]].
+   */
+  def onComplete[T, C](callback: Try[Done] => Unit): SinkWithContext[T, C, NotUsed] =
+    new SinkWithContext(Sink.onComplete(callback))
+
+  /**
+   * Sends the elements of the stream to the given `ActorRef` that sends back back-pressure signal.
+   * First element is always `onInitMessage`, then stream is waiting for acknowledgement message
+   * `ackMessage` from the given actor which means that it is ready to process
+   * elements. It also requires `ackMessage` message after each stream element
+   * to make backpressure work.
+   *
+   * If the target actor terminates the stream will be canceled.
+   * When the stream is completed successfully the given `onCompleteMessage`
+   * will be sent to the destination actor.
+   * When the stream is completed with failure - result of `onFailureMessage(throwable)`
+   * function will be sent to the destination actor.
+   */
+  def actorRefWithBackpressure[T, C](
+      ref: ActorRef,
+      onInitMessage: Any,
+      ackMessage: Any,
+      onCompleteMessage: Any,
+      onFailureMessage: Throwable => Any): SinkWithContext[T, C, NotUsed] =
+    new SinkWithContext(
+      Sink.actorRefWithBackpressure(ref, onInitMessage, ackMessage, onCompleteMessage, onFailureMessage))
+
+  /**
+   * Sends the elements of the stream to the given `ActorRef` that sends back back-pressure signal.
+   * First element is always `onInitMessage`, then stream is waiting for acknowledgement message
+   * from the given actor which means that it is ready to process
+   * elements. It also requires an ack message after each stream element
+   * to make backpressure work. This variant will consider any message as ack message.
+   *
+   * If the target actor terminates the stream will be canceled.
+   * When the stream is completed successfully the given `onCompleteMessage`
+   * will be sent to the destination actor.
+   * When the stream is completed with failure - result of `onFailureMessage(throwable)`
+   * function will be sent to the destination actor.
+   */
+  def actorRefWithBackpressure[T, C](
+      ref: ActorRef,
+      onInitMessage: Any,
+      onCompleteMessage: Any,
+      onFailureMessage: Throwable => Any): SinkWithContext[T, C, NotUsed] =
+    new SinkWithContext(Sink.actorRefWithBackpressure(ref, onInitMessage, onCompleteMessage, onFailureMessage))
+
+  /**
+   * Creates a `SinkWithContext` that is materialized as an [[akka.stream.scaladsl.SinkQueueWithCancel]].
+   * [[akka.stream.scaladsl.SinkQueueWithCancel.pull]] method is pulling element from the stream and returns ``Future[Option[(T,C)]``.
+   * `Future` completes when element is available.
+   *
+   * Before calling pull method second time you need to ensure that number of pending pulls is less then ``maxConcurrentPulls``
+   * or wait until some of the previous Futures completes.
+   * Pull returns Failed future with ''IllegalStateException'' if there will be more then ``maxConcurrentPulls`` number of pending pulls.
+   *
+   * `SinkWithContext` will request at most number of elements equal to size of `inputBuffer` from
+   * upstream and then stop back pressure.  You can configure size of input
+   * buffer by using [[SinkWithContext.withAttributes]] method.
+   *
+   * For stream completion you need to pull all elements from [[akka.stream.scaladsl.SinkQueueWithCancel]] including last None
+   * as completion marker
+   *
+   * See also [[akka.stream.scaladsl.SinkQueueWithCancel]]
+   */
+  def queue[T, C](maxConcurrentPulls: Int): SinkWithContext[T, C, SinkQueueWithCancel[(T, C)]] =
+    new SinkWithContext(Sink.queue[(T, C)](maxConcurrentPulls))
+
+  /**
+   * Creates a `SinkWithContext` that is materialized as an [[akka.stream.scaladsl.SinkQueueWithCancel]].
+   * [[akka.stream.scaladsl.SinkQueueWithCancel.pull]] method is pulling element from the stream and returns ``Future[Option[(T,C)]]``.
+   * `Future` completes when element is available.
+   *
+   * Before calling pull method second time you need to wait until previous Future completes.
+   * Pull returns Failed future with ''IllegalStateException'' if previous future has not yet completed.
+   *
+   * `SinkWithContext` will request at most number of elements equal to size of `inputBuffer` from
+   * upstream and then stop back pressure.  You can configure size of input
+   * buffer by using [[SinkWithContext.withAttributes]] method.
+   *
+   * For stream completion you need to pull all elements from [[akka.stream.scaladsl.SinkQueueWithCancel]] including last None
+   * as completion marker
+   *
+   * See also [[akka.stream.scaladsl.SinkQueueWithCancel]]
+   */
+  def queue[T, C](): SinkWithContext[T, C, SinkQueueWithCancel[(T, C)]] = queue(1)
+
+  /**
+   * Turn a `Future[SinkWithContext]` into a SinkWithContext that will consume the values of the source when the future completes successfully.
+   * If the `Future` is completed with a failure the stream is failed.
+   *
+   * The materialized future value is completed with the materialized value of the future sink or failed with a
+   * [[NeverMaterializedException]] if upstream fails or downstream cancels before the future has completed.
+   */
+  def futureSink[T, C, M](future: Future[SinkWithContext[T, C, M]]): SinkWithContext[T, C, Future[M]] =
+    lazyFutureSink[T, C, M](() => future)
+
+  /**
+   * Defers invoking the `create` function to create a sink until there is a first element passed from upstream.
+   *
+   * The materialized future value is completed with the materialized value of the created sink when that has successfully
+   * been materialized.
+   *
+   * If the `create` function throws or returns or the stream fails to materialize, in this
+   * case the materialized future value is failed with a [[akka.stream.NeverMaterializedException]].
+   */
+  def lazySink[T, C, M](create: () => SinkWithContext[T, C, M]): SinkWithContext[T, C, Future[M]] =
+    lazyFutureSink(() => Future.successful(create()))
+
+  /**
+   * Defers invoking the `create` function to create a future sink until there is a first element passed from upstream.
+   *
+   * The materialized future value is completed with the materialized value of the created sink when that has successfully
+   * been materialized.
+   *
+   * If the `create` function throws or returns a future that is failed, or the stream fails to materialize, in this
+   * case the materialized future value is failed with a [[akka.stream.NeverMaterializedException]].
+   */
+  def lazyFutureSink[T, C, M](create: () => Future[SinkWithContext[T, C, M]]): SinkWithContext[T, C, Future[M]] =
+    new SinkWithContext(Sink.lazyFutureSink(() => create().map(_.asSink)(ExecutionContexts.parasitic)))
+}
+
+/**
+ * A Sink that indicates it accepts context along with data portion of a stream typically coming from a
+ * [[FlowWithContext]] or a [[SourceWithContext]]. Since a Sink is meant to be the last part of a stream that
+ * doesn't have an output, filtering/reordering incoming elements is acceptable albeit extremely unusual.
+ *
+ * The [[SinkWithContext]] contains the same creation methods as the standard [[Sink]] and one can also create a
+ * [[SinkWithContext]] from an existing [[Sink]] containing a context by using `SinkWithContext.fromTuples`.
+ *
+ */
+final class SinkWithContext[-In, -CtxIn, +Mat](delegate: Sink[(In, CtxIn), Mat]) extends GraphDelegate(delegate) {
+
+  /**
+   * Transform this SinkWithContext by applying a function to each *incoming* upstream element before
+   * it is passed to the [[SinkWithContext]]
+   *
+   * '''Backpressures when''' original [[SinkWithContext]] backpressures
+   *
+   * '''Cancels when''' original [[SinkWithContext]] cancels
+   */
+  def contraMap[In2, Ctx2](f: (In2, Ctx2) => (In, CtxIn)): SinkWithContext[In2, Ctx2, Mat] =
+    new SinkWithContext(delegate.contramap[(In2, Ctx2)](f.tupled))
+
+  /**
+   * Transform the data portion of this SinkWithContext by applying a function to each *incoming* upstream element
+   * before it is passed to the [[SinkWithContext]]
+   *
+   * '''Backpressures when''' original [[SinkWithContext]] backpressures
+   *
+   * '''Cancels when''' original [[SinkWithContext]] cancels
+   */
+  def contramapData[In2](f: In2 => In): SinkWithContext[In2, CtxIn, Mat] = {
+    val applyOnIn = (tuple: (In2, CtxIn)) => (f(tuple._1), tuple._2)
+    new SinkWithContext(delegate.contramap(applyOnIn))
+  }
+
+  /**
+   * Connect this `SinkWithContext` to a `SourceWithContext` or a Source[(T,C)] and run it. The returned value is
+   * the materialized value of the `SourceWithContext`/`Source`, e.g. the `Subscriber` of a [[Source#subscriber]].
+   *
+   * Note that the `ActorSystem` can be used as the implicit `materializer` parameter to use the
+   * [[akka.stream.SystemMaterializer]] for running the stream.
+   */
+  def runWith[Mat2](source: Graph[SourceShape[(In, CtxIn)], Mat2])(implicit materializer: Materializer): Mat2 =
+    delegate.runWith(source)
+
+  /**
+   * Transform only the materialized value of this SinkWithContext, leaving all other properties as they were.
+   */
+  def mapMaterializedValue[Mat2](f: Mat => Mat2): SinkWithContext[In, CtxIn, Mat2] =
+    new SinkWithContext(delegate.mapMaterializedValue(f))
+
+  /**
+   * Materializes this SinkWithContext, immediately returning (1) its materialized value, and (2) a new SinkWithContext
+   * that can be consume elements 'into' the pre-materialized one.
+   *
+   * Useful for when you need a materialized value of a SinkWithContext when handing it out to someone to materialize it for you.
+   */
+  def preMaterialize()(implicit materializer: Materializer): (Mat, SinkWithContext[In, CtxIn, NotUsed]) = {
+    val (mat, sink) = delegate.preMaterialize()
+    (mat, new SinkWithContext(sink))
+  }
+
+  /**
+   * Context-preserving variant of [[akka.stream.scaladsl.Flow.withAttributes]].
+   *
+   * @see [[akka.stream.scaladsl.Flow.withAttributes]]
+   */
+  override def withAttributes(attr: Attributes): SinkWithContext[In, CtxIn, Mat] =
+    new SinkWithContext(delegate.withAttributes(attr))
+
+  /**
+   * Add the given attributes to this [[SinkWithContext]]. If the specific attribute was already present
+   * on this graph this means the added attribute will be more specific than the existing one.
+   * If this SinkWithContext is a composite of multiple graphs, new attributes on the composite will be
+   * less specific than attributes set directly on the individual graphs of the composite.
+   */
+  override def addAttributes(attr: Attributes): SinkWithContext[In, CtxIn, Mat] =
+    withAttributes(traversalBuilder.attributes and attr)
+
+  /**
+   * Put an asynchronous boundary around this `SinkWithContext`
+   */
+  override def async: SinkWithContext[In, CtxIn, Mat] = super.async.asInstanceOf[SinkWithContext[In, CtxIn, Mat]]
+
+  /**
+   * Put an asynchronous boundary around this `Graph`
+   *
+   * @param dispatcher Run the graph on this dispatcher
+   */
+  override def async(dispatcher: String): SinkWithContext[In, CtxIn, Mat] =
+    super.async(dispatcher).asInstanceOf[SinkWithContext[In, CtxIn, Mat]]
+
+  /**
+   * Put an asynchronous boundary around this `Graph`
+   *
+   * @param dispatcher      Run the graph on this dispatcher
+   * @param inputBufferSize Set the input buffer to this size for the graph
+   */
+  override def async(dispatcher: String, inputBufferSize: Int): SinkWithContext[In, CtxIn, Mat] =
+    super.async(dispatcher, inputBufferSize).asInstanceOf[SinkWithContext[In, CtxIn, Mat]]
+
+  def asSink: Sink[(In, CtxIn), Mat] = delegate
+
+  def asJava[JIn <: In, JCtxIn <: CtxIn, JMat >: Mat]: javadsl.SinkWithContext[JIn, JCtxIn, JMat] = {
+    new javadsl.SinkWithContext(
+      javadsl.Flow
+        .create[Pair[JIn, JCtxIn]]()
+        .toMat(delegate.contramap[Pair[JIn, JCtxIn]](_.toScala), (_, mat: Mat) => mat))
+  }
+
+  override def getAttributes: Attributes = traversalBuilder.attributes
+}


### PR DESCRIPTION
The intention of this PR is to add `SinkWithContext` which is designed to be the `Sink` version of `FlowWithContext`/`SourceWithContext`. Apart providing a convenience `SinkWithContext` type when dealing with data/context portion of a stream (rather than having to use tuple within `Sink` which is what you have to do now) extra convenience functions have been added to make it easier to create and handle `SinkWithContext`, notable ones that aren't boilerplate are

* `SinkWithContext.contramapData`: Allows you to convert just the data part of an already existing `SinkWithContext`. This can be quite a common occurrence considering that the context part of a stream is often not modified during the lifecycle of a stream
* `SinkWithContext.fromDataAndContext`: Likely to be the primary way of constructing a `SinkWithContext`, this allows you to create a `SinkWithContext` from an already existing sinks, controlling the order/concurrency of the data/context sinks.
  * One usecase involving Kafka would be the following
  ```scala
  val sourceWithContext = Consumer.sourceWithOffsetContext(consumerSettings, subscriptions)
  val sinkWithContext = SinkWithContext.fromDataAndContext(FileIO.toPath(...), Committer.sink(committerSettings), Keep.none)(Concat(_))
  sourceWithContext.runWith(sinkWithContext)
  ```
  This would be a very convenient way to construct a stream that persists every Kafka message as a file and if the saving as a file is successful then commit the Kafka cursor so that if the stream is restarted you resume from the correct point.
  * The `strategy` parameter allows you to control whether you care about order (i.e. `Concat(_)`) or if concurrency executing the sinks is fine (i.e. `Merge(_)`). The `dataComesFirst` controls whether for any given `strategy` if data part (or alternately the context part) comes first (this is relevant for strategies like `Concat(_)`)
  * Unfortunately `SinkWithContext.fromDataAndContext` currently doesn't work, see https://discuss.lightbend.com/t/concat-partition-doesnt-appear-to-work-when-combining-sinks/9822 for details
* `Keep.zip`/`Keep.zipFuture` have been added because since we are dealing with Sink's, its somewhat reasonable to assume that when dealing with materialized values from Sink you may want to zip the produced tuples back together
*  A `toCompletionStage` function that is the `SinkWithContext` version of other `toCompletionStage` functions for working with Java created `CompletionStage`.

Note that there already are examples in Alpakka API which have a concept of `SinkWithContext`, i.e. ideally the `chunkUploadSink` parameter in `multiPartUploadWithContext` variants (see https://github.com/akka/alpakka/blob/master/s3/src/main/scala/akka/stream/alpakka/s3/scaladsl/S3.scala#L524-L544) should have the type `SinkWithContext[UploadPartResponse, immutable.Iterable[C], NotUsed]`.

In terms of the PR in general, most of it was largely mechnical/boilerplate. A `FlowWithContextOpsMat` was added since it follows the already existing sturcture of `FlowOpsMat` (and the relevant remainder functions have been filled in as well). Some documentation, tests still need to be filled in (a basic test for `SinkWithContext.fromDataAndContext` has been made which as said earlier is how I found out it doesn't work) but more tests need to be added (is there any guidance here about which additional tests are necessary considering most of the implementation is trivial delegate wrapping?)