### PR TITLE
null mdcForMessage always fail in runtime

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/Behaviors.scala
@@ -383,7 +383,7 @@ object Behaviors {
     }
 
     val mdcForMessageFun: T => Map[String, String] =
-      if (mdcForMessage == null) Map.empty
+      if (mdcForMessage == null) _ => Map.empty
       else { message =>
         asScalaMap(mdcForMessage.apply(message))
       }


### PR DESCRIPTION
In WithMdcBehaviorInterceptor `mdcForMessage(msg)` called on EmptyMap and always failed

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
