### PR TITLE
doc: No longer suggest Kryo serialization

### DIFF
--- a/akka-docs/src/main/paradox/serialization.md
+++ b/akka-docs/src/main/paradox/serialization.md
@@ -278,12 +278,6 @@ switch to the new serializer.
 As an optional third step the old serializer can be completely removed if it was not used for persistent events.
 It must still be possible to deserialize the events that were stored with the old serializer.
 
-## External Akka Serializers
-
-* [Kryo serializer for Akka](https://github.com/altoo-ag/akka-kryo-serialization) (not suitable for serializing for Persistence)
-
-* [Twitter Chill Scala extensions for Kryo](https://github.com/twitter/chill) (not suitable for serializing for Persistence)
-
 ### Verification
 
 Normally, messages sent between local actors (i.e. same JVM) do not undergo serialization. For testing, sometimes, it may be desirable to force serialization on all messages (both remote and local). If you want to do this in order to verify that your messages are serializable you can enable the following config option:

--- a/akka-docs/src/main/paradox/serialization.md
+++ b/akka-docs/src/main/paradox/serialization.md
@@ -280,9 +280,9 @@ It must still be possible to deserialize the events that were stored with the ol
 
 ## External Akka Serializers
 
-* [Kryo serializer for Akka](https://github.com/altoo-ag/akka-kryo-serialization)
+* [Kryo serializer for Akka](https://github.com/altoo-ag/akka-kryo-serialization) (not suitable for serializing for Persistence)
 
-* [Twitter Chill Scala extensions for Kryo](https://github.com/twitter/chill)
+* [Twitter Chill Scala extensions for Kryo](https://github.com/twitter/chill) (not suitable for serializing for Persistence)
 
 ### Verification
 


### PR DESCRIPTION
These recommendations are likely vestiges of a pre-Jackson past.

Kryo as a serialization format is likely still OK for remoting serialization, but its maintainers have stated that they do not want to have backward/forward-compatibility hold back development, which makes its use for persistence problematic as any version upgrade may render persisted states/events unreadable.  A Chill maintainer has commented that [one "should never store kryo data beyond the life of a single process"](https://github.com/twitter/chill/pull/514#issuecomment-756338962).

If you have used Kryo as a persistence serialization, it is recommended to explore other serialization options.