### PR TITLE
Fix imports referenced in quickstart.

### DIFF
--- a/akka-docs/src/test/java/jdocs/stream/QuickStartDocTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/QuickStartDocTest.java
@@ -20,9 +20,9 @@ import java.math.BigInteger;
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+// #other-imports
 
 import jdocs.AbstractJavaTest;
-// #other-imports
 
 import org.junit.*;
 


### PR DESCRIPTION
`jdocs.AbstractJavaTest;` is appearing as a suggestion of import to execute code samples of the quickstart, but this class is not present in the dependency library of Akka used in the quickstart, also it seems to not be used at all for quickstart purposes, only on the code that validates the documentation.
