### PR TITLE
docs: fix ConsumerController java doc

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/ConsumerController.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/ConsumerController.scala
@@ -58,7 +58,7 @@ object ConsumerController {
    * Initial message from the consumer actor. The `deliverTo` is typically constructed
    * as a message adapter to map the [[Delivery]] to the protocol of the consumer actor.
    *
-   * If the producer is restarted it should send a new `Start` message to the
+   * If the consumer is restarted it should send a new `Start` message to the
    * `ConsumerController`.
    */
   final case class Start[A](deliverTo: ActorRef[Delivery[A]]) extends Command[A]

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/ConsumerController.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/delivery/ConsumerController.scala
@@ -114,7 +114,7 @@ object ConsumerController {
 
   /**
    * Register the `ConsumerController` to the given `producerController`. It will
-   * retry the registration until the `ProducerConsumer` has acknowledged by sending its
+   * retry the registration until the `ProducerController` has acknowledged by sending its
    * first message.
    *
    * Alternatively, this registration can be done on the producer side with the


### PR DESCRIPTION
## First Commit 

Looks like a documentation error.

the example code like this:

https://github.com/akka/akka/blob/5a1bccf5aa98556c2a366413d7ae22334894ba9c/akka-cluster-sharding-typed/src/test/java/jdocs/delivery/PointToPointDocExample.java#L111-L121

## Second Commit

i am not sure there is object name like `ProducerConsumer`, i think it is `ProducerController`, because it would send reply when receive `RegisterConsumer`