### PR TITLE
docs: Fix java-example for standalone ask with status fail future in typed/interaction-patterns.md

### DIFF
--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsAskWithStatusTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsAskWithStatusTest.java
@@ -213,7 +213,7 @@ public class InteractionPatternsAskWithStatusTest extends JUnitSuite {
 
         cookies.whenComplete(
             (cookiesReply, failure) -> {
-              if (cookies != null) System.out.println("Yay, " + cookiesReply.count + " cookies!");
+              if (cookiesReply != null) System.out.println("Yay, " + cookiesReply.count + " cookies!");
               else System.out.println("Boo! didn't get cookies in time. " + failure);
             });
         // #standalone-ask-with-status-fail-future


### PR DESCRIPTION
I think it's a small typo. 
