### PR TITLE
enabling shard coordinator to honor the provided role in the  configu…

### DIFF
--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
@@ -827,6 +827,37 @@ final class ClusterShardingSettings(
     val coordinatorSingletonSettings: ClusterSingletonManagerSettings,
     val leaseSettings: Option[LeaseUsageSettings]) {
 
+  @deprecated("Use constructor with coordinatorSingletonOverrideRole", "2.6.19")
+  def this(
+      numberOfShards: Int,
+      role: Option[String],
+      dataCenter: Option[DataCenter],
+      rememberEntities: Boolean,
+      journalPluginId: String,
+      snapshotPluginId: String,
+      passivationStrategySettings: ClusterShardingSettings.PassivationStrategySettings,
+      shardRegionQueryTimeout: FiniteDuration,
+      stateStoreMode: ClusterShardingSettings.StateStoreMode,
+      rememberEntitiesStoreMode: ClusterShardingSettings.RememberEntitiesStoreMode,
+      tuningParameters: ClusterShardingSettings.TuningParameters,
+      coordinatorSingletonSettings: ClusterSingletonManagerSettings,
+      leaseSettings: Option[LeaseUsageSettings]) =
+    this(
+      numberOfShards,
+      role,
+      dataCenter,
+      rememberEntities,
+      journalPluginId,
+      snapshotPluginId,
+      passivationStrategySettings,
+      shardRegionQueryTimeout,
+      stateStoreMode,
+      rememberEntitiesStoreMode,
+      tuningParameters,
+      true,
+      coordinatorSingletonSettings,
+      leaseSettings)
+
   @deprecated("Use constructor with passivationStrategySettings", "2.6.18")
   def this(
       numberOfShards: Int,

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
@@ -827,7 +827,7 @@ final class ClusterShardingSettings(
     val coordinatorSingletonSettings: ClusterSingletonManagerSettings,
     val leaseSettings: Option[LeaseUsageSettings]) {
 
-  @deprecated("Use constructor with coordinatorSingletonOverrideRole", "2.6.19")
+  @deprecated("Use constructor with coordinatorSingletonOverrideRole", "2.6.20")
   def this(
       numberOfShards: Int,
       role: Option[String],

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ClusterShardingSettings.scala
@@ -53,6 +53,7 @@ object ClusterShardingSettings {
       stateStoreMode = StateStoreMode.byName(classicSettings.stateStoreMode),
       rememberEntitiesStoreMode = RememberEntitiesStoreMode.byName(classicSettings.rememberEntitiesStore),
       new TuningParameters(classicSettings.tuningParameters),
+      classicSettings.coordinatorSingletonOverrideRole,
       new ClusterSingletonManagerSettings(
         classicSettings.coordinatorSingletonSettings.singletonName,
         classicSettings.coordinatorSingletonSettings.role,
@@ -98,6 +99,7 @@ object ClusterShardingSettings {
         coordinatorStateReadMajorityPlus = settings.tuningParameters.coordinatorStateReadMajorityPlus,
         leastShardAllocationAbsoluteLimit = settings.tuningParameters.leastShardAllocationAbsoluteLimit,
         leastShardAllocationRelativeLimit = settings.tuningParameters.leastShardAllocationRelativeLimit),
+      coordinatorSingletonOverrideRole = settings.coordinatorSingletonOverrideRole,
       new ClassicClusterSingletonManagerSettings(
         settings.coordinatorSingletonSettings.singletonName,
         settings.coordinatorSingletonSettings.role,
@@ -821,6 +823,7 @@ final class ClusterShardingSettings(
     val stateStoreMode: ClusterShardingSettings.StateStoreMode,
     val rememberEntitiesStoreMode: ClusterShardingSettings.RememberEntitiesStoreMode,
     val tuningParameters: ClusterShardingSettings.TuningParameters,
+    val coordinatorSingletonOverrideRole: Boolean,
     val coordinatorSingletonSettings: ClusterSingletonManagerSettings,
     val leaseSettings: Option[LeaseUsageSettings]) {
 
@@ -851,6 +854,7 @@ final class ClusterShardingSettings(
       stateStoreMode,
       rememberEntitiesStoreMode,
       tuningParameters,
+      true,
       coordinatorSingletonSettings,
       leaseSettings)
 
@@ -995,6 +999,7 @@ final class ClusterShardingSettings(
       stateStoreMode: ClusterShardingSettings.StateStoreMode = stateStoreMode,
       rememberEntitiesStoreMode: ClusterShardingSettings.RememberEntitiesStoreMode = rememberEntitiesStoreMode,
       tuningParameters: ClusterShardingSettings.TuningParameters = tuningParameters,
+      coordinatorSingletonOverrideRole: Boolean = coordinatorSingletonOverrideRole,
       coordinatorSingletonSettings: ClusterSingletonManagerSettings = coordinatorSingletonSettings,
       passivationStrategySettings: ClusterShardingSettings.PassivationStrategySettings = passivationStrategySettings,
       shardRegionQueryTimeout: FiniteDuration = shardRegionQueryTimeout,
@@ -1011,6 +1016,7 @@ final class ClusterShardingSettings(
       stateStoreMode,
       rememberEntitiesStoreMode,
       tuningParameters,
+      coordinatorSingletonOverrideRole,
       coordinatorSingletonSettings,
       leaseSettings)
 }

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
@@ -139,6 +139,7 @@ private[akka] final class ShardedDaemonProcessImpl(system: ActorSystem[_])
         StateStoreModeDData,
         RememberEntitiesStoreModeDData, // not used as remembered entities is off
         shardingBaseSettings.tuningParameters,
+        shardingBaseSettings.coordinatorSingletonOverrideRole,
         shardingBaseSettings.coordinatorSingletonSettings,
         shardingBaseSettings.leaseSettings)
     }

--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -358,9 +358,16 @@ akka.cluster.sharding {
 
   # Settings for the coordinator singleton. Same layout as akka.cluster.singleton.
   # The "role" of the singleton configuration is not used. The singleton role will
-  # be the same as "akka.cluster.sharding.role".
+  # be the same as "akka.cluster.sharding.role" if
+  # "akka.cluster.sharding.coordinator-singleton-role-override" is enabled. Disabling it will allow to
+  # use separate nodes for the shard coordinator and the shards themselves.
   # A lease can be configured in these settings for the coordinator singleton
   coordinator-singleton = ${akka.cluster.singleton}
+
+
+  # Copies the role for the coordinator singleton from the shards role instead of using the one provided in the
+  # "akka.cluster.sharding.coordinator-singleton.role"
+  coordinator-singleton-role-override = on
 
   coordinator-state {
     # State updates are required to be written to a majority of nodes plus this

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterSharding.scala
@@ -805,7 +805,13 @@ private[akka] class ClusterShardingGuardian extends Actor {
                 .withFinalStopMessage(_ == ShardCoordinator.Internal.Terminate)
                 .props
                 .withDeploy(Deploy.local)
-            val singletonSettings = settings.coordinatorSingletonSettings.withSingletonName("singleton").withRole(role)
+
+            val singletonSettings = if (settings.coordinatorSingletonOverrideRole) {
+              settings.coordinatorSingletonSettings.withSingletonName("singleton").withRole(role)
+            } else {
+              settings.coordinatorSingletonSettings.withSingletonName("singleton")
+            }
+
             context.actorOf(
               ClusterSingletonManager
                 .props(singletonProps, terminationMessage = ShardCoordinator.Internal.Terminate, singletonSettings)

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -1127,6 +1127,34 @@ final class ClusterShardingSettings(
     val coordinatorSingletonSettings: ClusterSingletonManagerSettings,
     val leaseSettings: Option[LeaseUsageSettings])
     extends NoSerializationVerificationNeeded {
+  @deprecated(
+    "Use the ClusterShardingSettings factory methods or the constructor including coordinatorSingletonOverrideRole instead",
+    "2.6.19")
+  def this(
+      role: Option[String],
+      rememberEntities: Boolean,
+      journalPluginId: String,
+      snapshotPluginId: String,
+      stateStoreMode: String,
+      rememberEntitiesStore: String,
+      passivationStrategySettings: ClusterShardingSettings.PassivationStrategySettings,
+      shardRegionQueryTimeout: FiniteDuration,
+      tuningParameters: ClusterShardingSettings.TuningParameters,
+      coordinatorSingletonSettings: ClusterSingletonManagerSettings,
+      leaseSettings: Option[LeaseUsageSettings]) =
+    this(
+      role,
+      rememberEntities,
+      journalPluginId,
+      snapshotPluginId,
+      stateStoreMode,
+      rememberEntitiesStore,
+      passivationStrategySettings,
+      shardRegionQueryTimeout,
+      tuningParameters,
+      true,
+      coordinatorSingletonSettings,
+      leaseSettings)
 
   @deprecated(
     "Use the ClusterShardingSettings factory methods or the constructor including passivationStrategySettings instead",
@@ -1153,7 +1181,7 @@ final class ClusterShardingSettings(
       ClusterShardingSettings.PassivationStrategySettings.oldDefault(passivateIdleEntityAfter),
       shardRegionQueryTimeout,
       tuningParameters,
-      false,
+      true,
       coordinatorSingletonSettings,
       leaseSettings)
 

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -1129,7 +1129,7 @@ final class ClusterShardingSettings(
     extends NoSerializationVerificationNeeded {
   @deprecated(
     "Use the ClusterShardingSettings factory methods or the constructor including coordinatorSingletonOverrideRole instead",
-    "2.6.19")
+    "2.6.20")
   def this(
       role: Option[String],
       rememberEntities: Boolean,

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -107,6 +107,7 @@ object ClusterShardingSettings {
       passivationStrategySettings = passivationStrategySettings,
       shardRegionQueryTimeout = config.getDuration("shard-region-query-timeout", MILLISECONDS).millis,
       tuningParameters,
+      config.getBoolean("coordinator-singleton-role-override"),
       coordinatorSingletonSettings,
       lease)
   }
@@ -1122,6 +1123,7 @@ final class ClusterShardingSettings(
     val passivationStrategySettings: ClusterShardingSettings.PassivationStrategySettings,
     val shardRegionQueryTimeout: FiniteDuration,
     val tuningParameters: ClusterShardingSettings.TuningParameters,
+    val coordinatorSingletonOverrideRole: Boolean,
     val coordinatorSingletonSettings: ClusterSingletonManagerSettings,
     val leaseSettings: Option[LeaseUsageSettings])
     extends NoSerializationVerificationNeeded {
@@ -1151,6 +1153,7 @@ final class ClusterShardingSettings(
       ClusterShardingSettings.PassivationStrategySettings.oldDefault(passivateIdleEntityAfter),
       shardRegionQueryTimeout,
       tuningParameters,
+      false,
       coordinatorSingletonSettings,
       leaseSettings)
 
@@ -1335,6 +1338,7 @@ final class ClusterShardingSettings(
       passivationStrategySettings: ClusterShardingSettings.PassivationStrategySettings = passivationStrategySettings,
       shardRegionQueryTimeout: FiniteDuration = shardRegionQueryTimeout,
       tuningParameters: ClusterShardingSettings.TuningParameters = tuningParameters,
+      coordinatorSingletonOverrideRole: Boolean = coordinatorSingletonOverrideRole,
       coordinatorSingletonSettings: ClusterSingletonManagerSettings = coordinatorSingletonSettings,
       leaseSettings: Option[LeaseUsageSettings] = leaseSettings): ClusterShardingSettings =
     new ClusterShardingSettings(
@@ -1347,6 +1351,7 @@ final class ClusterShardingSettings(
       passivationStrategySettings,
       shardRegionQueryTimeout,
       tuningParameters,
+      coordinatorSingletonOverrideRole,
       coordinatorSingletonSettings,
       leaseSettings)
 }

--- a/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
+++ b/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
@@ -841,8 +841,7 @@ public class ActorDocTest extends AbstractJavaTest {
         // using timeout from above
         CompletableFuture<Object> future2 = ask(actorB, "another request", t).toCompletableFuture();
 
-        CompletableFuture<Result> transformed =
-            future1.thenCombine(future2, (x, s) -> new Result((String) x, (String) s));
+        CompletableFuture<Result> transformed = future1.thenCombine(future2, (x, s) -> new Result((String) x, (String) s));
 
         pipe(transformed, system.dispatcher()).to(actorC);
         // #ask-pipe

--- a/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
+++ b/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
@@ -841,7 +841,8 @@ public class ActorDocTest extends AbstractJavaTest {
         // using timeout from above
         CompletableFuture<Object> future2 = ask(actorB, "another request", t).toCompletableFuture();
 
-        CompletableFuture<Result> transformed = future1.thenCombine(future2, (x, s) -> new Result((String) x, (String) s));
+        CompletableFuture<Result> transformed =
+            future1.thenCombine(future2, (x, s) -> new Result((String) x, (String) s));
 
         pipe(transformed, system.dispatcher()).to(actorC);
         // #ask-pipe


### PR DESCRIPTION
enabling shard coordinator to honor the provided role in the  configuration

Relevant context is https://discuss.lightbend.com/t/run-shardcoordinator-in-a-node-with-different-role/9672 

Running akka cluster we may want to specify the node that the coordinator should be created in. This lets us to use a non-spot VM for the coordinators and spot-VM's to host the workers. This helps to reduce cost of running an akka cluster while providing best uptime guarantees due to removing the risk of coordinator actor being recreated upon spot VM shut down.


Additional boolean flag is used to toggle to keep the default behavior as is.