### PR TITLE
Inline classic section for configuration-reference

### DIFF
--- a/akka-remote/src/main/resources/reference.conf
+++ b/akka-remote/src/main/resources/reference.conf
@@ -268,465 +268,467 @@ akka {
 
 akka {
 
-  remote.classic {
-    #//#classic
+  remote {
+  #//#classic
+    classic {
 
-    ### Configuration for classic remoting. Classic remoting is deprecated, use artery.
-
-
-    # If set to a nonempty string remoting will use the given dispatcher for
-    # its internal actors otherwise the default dispatcher is used. Please note
-    # that since remoting can load arbitrary 3rd party drivers (see
-    # "enabled-transport" and "adapters" entries) it is not guaranteed that
-    # every module will respect this setting.
-    use-dispatcher = "akka.remote.default-remote-dispatcher"
-
-    # Settings for the failure detector to monitor connections.
-    # For TCP it is not important to have fast failure detection, since
-    # most connection failures are captured by TCP itself.
-    # The default DeadlineFailureDetector will trigger if there are no heartbeats within
-    # the duration heartbeat-interval + acceptable-heartbeat-pause, i.e. 124 seconds
-    # with the default settings.
-    transport-failure-detector {
-
-      # FQCN of the failure detector implementation.
-      # It must implement akka.remote.FailureDetector and have
-      # a public constructor with a com.typesafe.config.Config and
-      # akka.actor.EventStream parameter.
-      implementation-class = "akka.remote.DeadlineFailureDetector"
-
-      # How often keep-alive heartbeat messages should be sent to each connection.
-      heartbeat-interval = 4 s
-
-      # Number of potentially lost/delayed heartbeats that will be
-      # accepted before considering it to be an anomaly.
-      # A margin to the `heartbeat-interval` is important to be able to survive sudden,
-      # occasional, pauses in heartbeat arrivals, due to for example garbage collect or
-      # network drop.
-      acceptable-heartbeat-pause = 120 s
-    }
+      ### Configuration for classic remoting. Classic remoting is deprecated, use artery.
 
 
-    # Timeout after which the startup of the remoting subsystem is considered
-    # to be failed. Increase this value if your transport drivers (see the
-    # enabled-transports section) need longer time to be loaded.
-    startup-timeout = 10 s
+      # If set to a nonempty string remoting will use the given dispatcher for
+      # its internal actors otherwise the default dispatcher is used. Please note
+      # that since remoting can load arbitrary 3rd party drivers (see
+      # "enabled-transport" and "adapters" entries) it is not guaranteed that
+      # every module will respect this setting.
+      use-dispatcher = "akka.remote.default-remote-dispatcher"
 
-    # Timout after which the graceful shutdown of the remoting subsystem is
-    # considered to be failed. After the timeout the remoting system is
-    # forcefully shut down. Increase this value if your transport drivers
-    # (see the enabled-transports section) need longer time to stop properly.
-    shutdown-timeout = 10 s
+      # Settings for the failure detector to monitor connections.
+      # For TCP it is not important to have fast failure detection, since
+      # most connection failures are captured by TCP itself.
+      # The default DeadlineFailureDetector will trigger if there are no heartbeats within
+      # the duration heartbeat-interval + acceptable-heartbeat-pause, i.e. 124 seconds
+      # with the default settings.
+      transport-failure-detector {
 
-    # Before shutting down the drivers, the remoting subsystem attempts to flush
-    # all pending writes. This setting controls the maximum time the remoting is
-    # willing to wait before moving on to shut down the drivers.
-    flush-wait-on-shutdown = 2 s
+        # FQCN of the failure detector implementation.
+        # It must implement akka.remote.FailureDetector and have
+        # a public constructor with a com.typesafe.config.Config and
+        # akka.actor.EventStream parameter.
+        implementation-class = "akka.remote.DeadlineFailureDetector"
 
-    # Reuse inbound connections for outbound messages
-    use-passive-connections = on
+        # How often keep-alive heartbeat messages should be sent to each connection.
+        heartbeat-interval = 4 s
 
-    # Controls the backoff interval after a refused write is reattempted.
-    # (Transports may refuse writes if their internal buffer is full)
-    backoff-interval = 5 ms
+        # Number of potentially lost/delayed heartbeats that will be
+        # accepted before considering it to be an anomaly.
+        # A margin to the `heartbeat-interval` is important to be able to survive sudden,
+        # occasional, pauses in heartbeat arrivals, due to for example garbage collect or
+        # network drop.
+        acceptable-heartbeat-pause = 120 s
+      }
 
-    # Acknowledgment timeout of management commands sent to the transport stack.
-    command-ack-timeout = 30 s
 
-    # The timeout for outbound associations to perform the handshake.
-    # If the transport is akka.remote.classic.netty.tcp or akka.remote.classic.netty.ssl
-    # the configured connection-timeout for the transport will be used instead.
-    handshake-timeout = 15 s
+      # Timeout after which the startup of the remoting subsystem is considered
+      # to be failed. Increase this value if your transport drivers (see the
+      # enabled-transports section) need longer time to be loaded.
+      startup-timeout = 10 s
 
-    ### Security settings
+      # Timout after which the graceful shutdown of the remoting subsystem is
+      # considered to be failed. After the timeout the remoting system is
+      # forcefully shut down. Increase this value if your transport drivers
+      # (see the enabled-transports section) need longer time to stop properly.
+      shutdown-timeout = 10 s
 
-    # Enable untrusted mode for full security of server managed actors, prevents
-    # system messages to be send by clients, e.g. messages like 'Create',
-    # 'Suspend', 'Resume', 'Terminate', 'Supervise', 'Link' etc.
-    untrusted-mode = off
+      # Before shutting down the drivers, the remoting subsystem attempts to flush
+      # all pending writes. This setting controls the maximum time the remoting is
+      # willing to wait before moving on to shut down the drivers.
+      flush-wait-on-shutdown = 2 s
 
-    # When 'untrusted-mode=on' inbound actor selections are by default discarded.
-    # Actors with paths defined in this list are granted permission to receive actor
-    # selections messages.
-    # E.g. trusted-selection-paths = ["/user/receptionist", "/user/namingService"]
-    trusted-selection-paths = []
+      # Reuse inbound connections for outbound messages
+      use-passive-connections = on
 
-    ### Logging
+      # Controls the backoff interval after a refused write is reattempted.
+      # (Transports may refuse writes if their internal buffer is full)
+      backoff-interval = 5 ms
 
-    # If this is "on", Akka will log all inbound messages at DEBUG level,
-    # if off then they are not logged
-    log-received-messages = off
+      # Acknowledgment timeout of management commands sent to the transport stack.
+      command-ack-timeout = 30 s
 
-    # If this is "on", Akka will log all outbound messages at DEBUG level,
-    # if off then they are not logged
-    log-sent-messages = off
+      # The timeout for outbound associations to perform the handshake.
+      # If the transport is akka.remote.classic.netty.tcp or akka.remote.classic.netty.ssl
+      # the configured connection-timeout for the transport will be used instead.
+      handshake-timeout = 15 s
 
-    # Sets the log granularity level at which Akka logs remoting events. This setting
-    # can take the values OFF, ERROR, WARNING, INFO, DEBUG, or ON. For compatibility
-    # reasons the setting "on" will default to "debug" level. Please note that the effective
-    # logging level is still determined by the global logging level of the actor system:
-    # for example debug level remoting events will be only logged if the system
-    # is running with debug level logging.
-    # Failures to deserialize received messages also fall under this flag.
-    log-remote-lifecycle-events = on
+      ### Security settings
 
-    # Logging of message types with payload size in bytes larger than
-    # this value. Maximum detected size per message type is logged once,
-    # with an increase threshold of 10%.
-    # By default this feature is turned off. Activate it by setting the property to
-    # a value in bytes, such as 1000b. Note that for all messages larger than this
-    # limit there will be extra performance and scalability cost.
-    log-frame-size-exceeding = off
+      # Enable untrusted mode for full security of server managed actors, prevents
+      # system messages to be send by clients, e.g. messages like 'Create',
+      # 'Suspend', 'Resume', 'Terminate', 'Supervise', 'Link' etc.
+      untrusted-mode = off
 
-    # Log warning if the number of messages in the backoff buffer in the endpoint
-    # writer exceeds this limit. It can be disabled by setting the value to off.
-    log-buffer-size-exceeding = 50000
+      # When 'untrusted-mode=on' inbound actor selections are by default discarded.
+      # Actors with paths defined in this list are granted permission to receive actor
+      # selections messages.
+      # E.g. trusted-selection-paths = ["/user/receptionist", "/user/namingService"]
+      trusted-selection-paths = []
 
-    # After failed to establish an outbound connection, the remoting will mark the
-    # address as failed. This configuration option controls how much time should
-    # be elapsed before reattempting a new connection. While the address is
-    # gated, all messages sent to the address are delivered to dead-letters.
-    # Since this setting limits the rate of reconnects setting it to a
-    # very short interval (i.e. less than a second) may result in a storm of
-    # reconnect attempts.
-    retry-gate-closed-for = 5 s
+      ### Logging
 
-    # After catastrophic communication failures that result in the loss of system
-    # messages or after the remote DeathWatch triggers the remote system gets
-    # quarantined to prevent inconsistent behavior.
-    # This setting controls how long the Quarantine marker will be kept around
-    # before being removed to avoid long-term memory leaks.
-    # WARNING: DO NOT change this to a small value to re-enable communication with
-    # quarantined nodes. Such feature is not supported and any behavior between
-    # the affected systems after lifting the quarantine is undefined.
-    prune-quarantine-marker-after = 5 d
+      # If this is "on", Akka will log all inbound messages at DEBUG level,
+      # if off then they are not logged
+      log-received-messages = off
 
-    # If system messages have been exchanged between two systems (i.e. remote death
-    # watch or remote deployment has been used) a remote system will be marked as
-    # quarantined after the two system has no active association, and no
-    # communication happens during the time configured here.
-    # The only purpose of this setting is to avoid storing system message redelivery
-    # data (sequence number state, etc.) for an undefined amount of time leading to long
-    # term memory leak. Instead, if a system has been gone for this period,
-    # or more exactly
-    # - there is no association between the two systems (TCP connection, if TCP transport is used)
-    # - neither side has been attempting to communicate with the other
-    # - there are no pending system messages to deliver
-    # for the amount of time configured here, the remote system will be quarantined and all state
-    # associated with it will be dropped.
-    #
-    # Maximum value depends on the scheduler's max limit (default 248 days) and if configured
-    # to a longer duration this feature will effectively be disabled. Setting the value to
-    # 'off' will also disable the feature. Note that if disabled there is a risk of a long
-    # term memory leak.
-    quarantine-after-silence = 2 d
+      # If this is "on", Akka will log all outbound messages at DEBUG level,
+      # if off then they are not logged
+      log-sent-messages = off
 
-    # This setting defines the maximum number of unacknowledged system messages
-    # allowed for a remote system. If this limit is reached the remote system is
-    # declared to be dead and its UID marked as tainted.
-    system-message-buffer-size = 20000
+      # Sets the log granularity level at which Akka logs remoting events. This setting
+      # can take the values OFF, ERROR, WARNING, INFO, DEBUG, or ON. For compatibility
+      # reasons the setting "on" will default to "debug" level. Please note that the effective
+      # logging level is still determined by the global logging level of the actor system:
+      # for example debug level remoting events will be only logged if the system
+      # is running with debug level logging.
+      # Failures to deserialize received messages also fall under this flag.
+      log-remote-lifecycle-events = on
 
-    # This setting defines the maximum idle time after an individual
-    # acknowledgement for system messages is sent. System message delivery
-    # is guaranteed by explicit acknowledgement messages. These acks are
-    # piggybacked on ordinary traffic messages. If no traffic is detected
-    # during the time period configured here, the remoting will send out
-    # an individual ack.
-    system-message-ack-piggyback-timeout = 0.3 s
+      # Logging of message types with payload size in bytes larger than
+      # this value. Maximum detected size per message type is logged once,
+      # with an increase threshold of 10%.
+      # By default this feature is turned off. Activate it by setting the property to
+      # a value in bytes, such as 1000b. Note that for all messages larger than this
+      # limit there will be extra performance and scalability cost.
+      log-frame-size-exceeding = off
 
-    # This setting defines the time after internal management signals
-    # between actors (used for DeathWatch and supervision) that have not been
-    # explicitly acknowledged or negatively acknowledged are resent.
-    # Messages that were negatively acknowledged are always immediately
-    # resent.
-    resend-interval = 2 s
+      # Log warning if the number of messages in the backoff buffer in the endpoint
+      # writer exceeds this limit. It can be disabled by setting the value to off.
+      log-buffer-size-exceeding = 50000
 
-    # Maximum number of unacknowledged system messages that will be resent
-    # each 'resend-interval'. If you watch many (> 1000) remote actors you can
-    # increase this value to for example 600, but a too large limit (e.g. 10000)
-    # may flood the connection and might cause false failure detection to trigger.
-    # Test such a configuration by watching all actors at the same time and stop
-    # all watched actors at the same time.
-    resend-limit = 200
+      # After failed to establish an outbound connection, the remoting will mark the
+      # address as failed. This configuration option controls how much time should
+      # be elapsed before reattempting a new connection. While the address is
+      # gated, all messages sent to the address are delivered to dead-letters.
+      # Since this setting limits the rate of reconnects setting it to a
+      # very short interval (i.e. less than a second) may result in a storm of
+      # reconnect attempts.
+      retry-gate-closed-for = 5 s
 
-    # WARNING: this setting should not be not changed unless all of its consequences
-    # are properly understood which assumes experience with remoting internals
-    # or expert advice.
-    # This setting defines the time after redelivery attempts of internal management
-    # signals are stopped to a remote system that has been not confirmed to be alive by
-    # this system before.
-    initial-system-message-delivery-timeout = 3 m
+      # After catastrophic communication failures that result in the loss of system
+      # messages or after the remote DeathWatch triggers the remote system gets
+      # quarantined to prevent inconsistent behavior.
+      # This setting controls how long the Quarantine marker will be kept around
+      # before being removed to avoid long-term memory leaks.
+      # WARNING: DO NOT change this to a small value to re-enable communication with
+      # quarantined nodes. Such feature is not supported and any behavior between
+      # the affected systems after lifting the quarantine is undefined.
+      prune-quarantine-marker-after = 5 d
 
-    ### Transports and adapters
+      # If system messages have been exchanged between two systems (i.e. remote death
+      # watch or remote deployment has been used) a remote system will be marked as
+      # quarantined after the two system has no active association, and no
+      # communication happens during the time configured here.
+      # The only purpose of this setting is to avoid storing system message redelivery
+      # data (sequence number state, etc.) for an undefined amount of time leading to long
+      # term memory leak. Instead, if a system has been gone for this period,
+      # or more exactly
+      # - there is no association between the two systems (TCP connection, if TCP transport is used)
+      # - neither side has been attempting to communicate with the other
+      # - there are no pending system messages to deliver
+      # for the amount of time configured here, the remote system will be quarantined and all state
+      # associated with it will be dropped.
+      #
+      # Maximum value depends on the scheduler's max limit (default 248 days) and if configured
+      # to a longer duration this feature will effectively be disabled. Setting the value to
+      # 'off' will also disable the feature. Note that if disabled there is a risk of a long
+      # term memory leak.
+      quarantine-after-silence = 2 d
 
-    # List of the transport drivers that will be loaded by the remoting.
-    # A list of fully qualified config paths must be provided where
-    # the given configuration path contains a transport-class key
-    # pointing to an implementation class of the Transport interface.
-    # If multiple transports are provided, the address of the first
-    # one will be used as a default address.
-    enabled-transports = ["akka.remote.classic.netty.tcp"]
+      # This setting defines the maximum number of unacknowledged system messages
+      # allowed for a remote system. If this limit is reached the remote system is
+      # declared to be dead and its UID marked as tainted.
+      system-message-buffer-size = 20000
 
-    # Transport drivers can be augmented with adapters by adding their
-    # name to the applied-adapters setting in the configuration of a
-    # transport. The available adapters should be configured in this
-    # section by providing a name, and the fully qualified name of
-    # their corresponding implementation. The class given here
-    # must implement akka.akka.remote.transport.TransportAdapterProvider
-    # and have public constructor without parameters.
-    adapters {
-      gremlin = "akka.remote.transport.FailureInjectorProvider"
-      trttl = "akka.remote.transport.ThrottlerProvider"
-    }
+      # This setting defines the maximum idle time after an individual
+      # acknowledgement for system messages is sent. System message delivery
+      # is guaranteed by explicit acknowledgement messages. These acks are
+      # piggybacked on ordinary traffic messages. If no traffic is detected
+      # during the time period configured here, the remoting will send out
+      # an individual ack.
+      system-message-ack-piggyback-timeout = 0.3 s
 
-    ### Default configuration for the Netty based transport drivers
+      # This setting defines the time after internal management signals
+      # between actors (used for DeathWatch and supervision) that have not been
+      # explicitly acknowledged or negatively acknowledged are resent.
+      # Messages that were negatively acknowledged are always immediately
+      # resent.
+      resend-interval = 2 s
 
-    netty.tcp {
-      # The class given here must implement the akka.remote.transport.Transport
-      # interface and offer a public constructor which takes two arguments:
-      #  1) akka.actor.ExtendedActorSystem
-      #  2) com.typesafe.config.Config
-      transport-class = "akka.remote.transport.netty.NettyTransport"
+      # Maximum number of unacknowledged system messages that will be resent
+      # each 'resend-interval'. If you watch many (> 1000) remote actors you can
+      # increase this value to for example 600, but a too large limit (e.g. 10000)
+      # may flood the connection and might cause false failure detection to trigger.
+      # Test such a configuration by watching all actors at the same time and stop
+      # all watched actors at the same time.
+      resend-limit = 200
+
+      # WARNING: this setting should not be not changed unless all of its consequences
+      # are properly understood which assumes experience with remoting internals
+      # or expert advice.
+      # This setting defines the time after redelivery attempts of internal management
+      # signals are stopped to a remote system that has been not confirmed to be alive by
+      # this system before.
+      initial-system-message-delivery-timeout = 3 m
+
+      ### Transports and adapters
+
+      # List of the transport drivers that will be loaded by the remoting.
+      # A list of fully qualified config paths must be provided where
+      # the given configuration path contains a transport-class key
+      # pointing to an implementation class of the Transport interface.
+      # If multiple transports are provided, the address of the first
+      # one will be used as a default address.
+      enabled-transports = ["akka.remote.classic.netty.tcp"]
 
       # Transport drivers can be augmented with adapters by adding their
-      # name to the applied-adapters list. The last adapter in the
-      # list is the adapter immediately above the driver, while
-      # the first one is the top of the stack below the standard
-      # Akka protocol
-      applied-adapters = []
-
-      # The default remote server port clients should connect to.
-      # Default is 2552 (AKKA), use 0 if you want a random available port
-      # This port needs to be unique for each actor system on the same machine.
-      port = 2552
-
-      # The hostname or ip clients should connect to.
-      # InetAddress.getLocalHost.getHostAddress is used if empty
-      hostname = ""
-
-      # Use this setting to bind a network interface to a different port
-      # than remoting protocol expects messages at. This may be used
-      # when running akka nodes in a separated networks (under NATs or docker containers).
-      # Use 0 if you want a random available port. Examples:
-      #
-      # akka.remote.classic.netty.tcp.port = 2552
-      # akka.remote.classic.netty.tcp.bind-port = 2553
-      # Network interface will be bound to the 2553 port, but remoting protocol will
-      # expect messages sent to port 2552.
-      #
-      # akka.remote.classic.netty.tcp.port = 0
-      # akka.remote.classic.netty.tcp.bind-port = 0
-      # Network interface will be bound to a random port, and remoting protocol will
-      # expect messages sent to the bound port.
-      #
-      # akka.remote.classic.netty.tcp.port = 2552
-      # akka.remote.classic.netty.tcp.bind-port = 0
-      # Network interface will be bound to a random port, but remoting protocol will
-      # expect messages sent to port 2552.
-      #
-      # akka.remote.classic.netty.tcp.port = 0
-      # akka.remote.classic.netty.tcp.bind-port = 2553
-      # Network interface will be bound to the 2553 port, and remoting protocol will
-      # expect messages sent to the bound port.
-      #
-      # akka.remote.classic.netty.tcp.port = 2552
-      # akka.remote.classic.netty.tcp.bind-port = ""
-      # Network interface will be bound to the 2552 port, and remoting protocol will
-      # expect messages sent to the bound port.
-      #
-      # akka.remote.classic.netty.tcp.port if empty
-      bind-port = ""
-
-      # Use this setting to bind a network interface to a different hostname or ip
-      # than remoting protocol expects messages at.
-      # Use "0.0.0.0" to bind to all interfaces.
-      # akka.remote.classic.netty.tcp.hostname if empty
-      bind-hostname = ""
-
-      # Enables SSL support on this transport
-      enable-ssl = false
-
-      # Sets the connectTimeoutMillis of all outbound connections,
-      # i.e. how long a connect may take until it is timed out
-      connection-timeout = 15 s
-
-      # If set to "<id.of.dispatcher>" then the specified dispatcher
-      # will be used to accept inbound connections, and perform IO. If "" then
-      # dedicated threads will be used.
-      # Please note that the Netty driver only uses this configuration and does
-      # not read the "akka.remote.use-dispatcher" entry. Instead it has to be
-      # configured manually to point to the same dispatcher if needed.
-      use-dispatcher-for-io = ""
-
-      # Sets the high water mark for the in and outbound sockets,
-      # set to 0b for platform default
-      write-buffer-high-water-mark = 0b
-
-      # Sets the low water mark for the in and outbound sockets,
-      # set to 0b for platform default
-      write-buffer-low-water-mark = 0b
-
-      # Sets the send buffer size of the Sockets,
-      # set to 0b for platform default
-      send-buffer-size = 256000b
-
-      # Sets the receive buffer size of the Sockets,
-      # set to 0b for platform default
-      receive-buffer-size = 256000b
-
-      # Maximum message size the transport will accept, but at least
-      # 32000 bytes.
-      # Please note that UDP does not support arbitrary large datagrams,
-      # so this setting has to be chosen carefully when using UDP.
-      # Both send-buffer-size and receive-buffer-size settings has to
-      # be adjusted to be able to buffer messages of maximum size.
-      maximum-frame-size = 128000b
-
-      # Sets the size of the connection backlog
-      backlog = 4096
-
-      # Enables the TCP_NODELAY flag, i.e. disables Nagle’s algorithm
-      tcp-nodelay = on
-
-      # Enables TCP Keepalive, subject to the O/S kernel’s configuration
-      tcp-keepalive = on
-
-      # Enables SO_REUSEADDR, which determines when an ActorSystem can open
-      # the specified listen port (the meaning differs between *nix and Windows)
-      # Valid values are "on", "off" and "off-for-windows"
-      # due to the following Windows bug: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4476378
-      # "off-for-windows" of course means that it's "on" for all other platforms
-      tcp-reuse-addr = off-for-windows
-
-      # Used to configure the number of I/O worker threads on server sockets
-      server-socket-worker-pool {
-        # Min number of threads to cap factor-based number to
-        pool-size-min = 2
-
-        # The pool size factor is used to determine thread pool size
-        # using the following formula: ceil(available processors * factor).
-        # Resulting size is then bounded by the pool-size-min and
-        # pool-size-max values.
-        pool-size-factor = 1.0
-
-        # Max number of threads to cap factor-based number to
-        pool-size-max = 2
+      # name to the applied-adapters setting in the configuration of a
+      # transport. The available adapters should be configured in this
+      # section by providing a name, and the fully qualified name of
+      # their corresponding implementation. The class given here
+      # must implement akka.akka.remote.transport.TransportAdapterProvider
+      # and have public constructor without parameters.
+      adapters {
+        gremlin = "akka.remote.transport.FailureInjectorProvider"
+        trttl = "akka.remote.transport.ThrottlerProvider"
       }
 
-      # Used to configure the number of I/O worker threads on client sockets
-      client-socket-worker-pool {
-        # Min number of threads to cap factor-based number to
-        pool-size-min = 2
+      ### Default configuration for the Netty based transport drivers
 
-        # The pool size factor is used to determine thread pool size
-        # using the following formula: ceil(available processors * factor).
-        # Resulting size is then bounded by the pool-size-min and
-        # pool-size-max values.
-        pool-size-factor = 1.0
+      netty.tcp {
+        # The class given here must implement the akka.remote.transport.Transport
+        # interface and offer a public constructor which takes two arguments:
+        #  1) akka.actor.ExtendedActorSystem
+        #  2) com.typesafe.config.Config
+        transport-class = "akka.remote.transport.netty.NettyTransport"
 
-        # Max number of threads to cap factor-based number to
-        pool-size-max = 2
+        # Transport drivers can be augmented with adapters by adding their
+        # name to the applied-adapters list. The last adapter in the
+        # list is the adapter immediately above the driver, while
+        # the first one is the top of the stack below the standard
+        # Akka protocol
+        applied-adapters = []
+
+        # The default remote server port clients should connect to.
+        # Default is 2552 (AKKA), use 0 if you want a random available port
+        # This port needs to be unique for each actor system on the same machine.
+        port = 2552
+
+        # The hostname or ip clients should connect to.
+        # InetAddress.getLocalHost.getHostAddress is used if empty
+        hostname = ""
+
+        # Use this setting to bind a network interface to a different port
+        # than remoting protocol expects messages at. This may be used
+        # when running akka nodes in a separated networks (under NATs or docker containers).
+        # Use 0 if you want a random available port. Examples:
+        #
+        # akka.remote.classic.netty.tcp.port = 2552
+        # akka.remote.classic.netty.tcp.bind-port = 2553
+        # Network interface will be bound to the 2553 port, but remoting protocol will
+        # expect messages sent to port 2552.
+        #
+        # akka.remote.classic.netty.tcp.port = 0
+        # akka.remote.classic.netty.tcp.bind-port = 0
+        # Network interface will be bound to a random port, and remoting protocol will
+        # expect messages sent to the bound port.
+        #
+        # akka.remote.classic.netty.tcp.port = 2552
+        # akka.remote.classic.netty.tcp.bind-port = 0
+        # Network interface will be bound to a random port, but remoting protocol will
+        # expect messages sent to port 2552.
+        #
+        # akka.remote.classic.netty.tcp.port = 0
+        # akka.remote.classic.netty.tcp.bind-port = 2553
+        # Network interface will be bound to the 2553 port, and remoting protocol will
+        # expect messages sent to the bound port.
+        #
+        # akka.remote.classic.netty.tcp.port = 2552
+        # akka.remote.classic.netty.tcp.bind-port = ""
+        # Network interface will be bound to the 2552 port, and remoting protocol will
+        # expect messages sent to the bound port.
+        #
+        # akka.remote.classic.netty.tcp.port if empty
+        bind-port = ""
+
+        # Use this setting to bind a network interface to a different hostname or ip
+        # than remoting protocol expects messages at.
+        # Use "0.0.0.0" to bind to all interfaces.
+        # akka.remote.classic.netty.tcp.hostname if empty
+        bind-hostname = ""
+
+        # Enables SSL support on this transport
+        enable-ssl = false
+
+        # Sets the connectTimeoutMillis of all outbound connections,
+        # i.e. how long a connect may take until it is timed out
+        connection-timeout = 15 s
+
+        # If set to "<id.of.dispatcher>" then the specified dispatcher
+        # will be used to accept inbound connections, and perform IO. If "" then
+        # dedicated threads will be used.
+        # Please note that the Netty driver only uses this configuration and does
+        # not read the "akka.remote.use-dispatcher" entry. Instead it has to be
+        # configured manually to point to the same dispatcher if needed.
+        use-dispatcher-for-io = ""
+
+        # Sets the high water mark for the in and outbound sockets,
+        # set to 0b for platform default
+        write-buffer-high-water-mark = 0b
+
+        # Sets the low water mark for the in and outbound sockets,
+        # set to 0b for platform default
+        write-buffer-low-water-mark = 0b
+
+        # Sets the send buffer size of the Sockets,
+        # set to 0b for platform default
+        send-buffer-size = 256000b
+
+        # Sets the receive buffer size of the Sockets,
+        # set to 0b for platform default
+        receive-buffer-size = 256000b
+
+        # Maximum message size the transport will accept, but at least
+        # 32000 bytes.
+        # Please note that UDP does not support arbitrary large datagrams,
+        # so this setting has to be chosen carefully when using UDP.
+        # Both send-buffer-size and receive-buffer-size settings has to
+        # be adjusted to be able to buffer messages of maximum size.
+        maximum-frame-size = 128000b
+
+        # Sets the size of the connection backlog
+        backlog = 4096
+
+        # Enables the TCP_NODELAY flag, i.e. disables Nagle’s algorithm
+        tcp-nodelay = on
+
+        # Enables TCP Keepalive, subject to the O/S kernel’s configuration
+        tcp-keepalive = on
+
+        # Enables SO_REUSEADDR, which determines when an ActorSystem can open
+        # the specified listen port (the meaning differs between *nix and Windows)
+        # Valid values are "on", "off" and "off-for-windows"
+        # due to the following Windows bug: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4476378
+        # "off-for-windows" of course means that it's "on" for all other platforms
+        tcp-reuse-addr = off-for-windows
+
+        # Used to configure the number of I/O worker threads on server sockets
+        server-socket-worker-pool {
+          # Min number of threads to cap factor-based number to
+          pool-size-min = 2
+
+          # The pool size factor is used to determine thread pool size
+          # using the following formula: ceil(available processors * factor).
+          # Resulting size is then bounded by the pool-size-min and
+          # pool-size-max values.
+          pool-size-factor = 1.0
+
+          # Max number of threads to cap factor-based number to
+          pool-size-max = 2
+        }
+
+        # Used to configure the number of I/O worker threads on client sockets
+        client-socket-worker-pool {
+          # Min number of threads to cap factor-based number to
+          pool-size-min = 2
+
+          # The pool size factor is used to determine thread pool size
+          # using the following formula: ceil(available processors * factor).
+          # Resulting size is then bounded by the pool-size-min and
+          # pool-size-max values.
+          pool-size-factor = 1.0
+
+          # Max number of threads to cap factor-based number to
+          pool-size-max = 2
+        }
+
+
       }
 
+      netty.ssl = ${akka.remote.classic.netty.tcp}
+      netty.ssl = {
+        # Enable SSL/TLS encryption.
+        # This must be enabled on both the client and server to work.
+        enable-ssl = true
 
-    }
-
-    netty.ssl = ${akka.remote.classic.netty.tcp}
-    netty.ssl = {
-      # Enable SSL/TLS encryption.
-      # This must be enabled on both the client and server to work.
-      enable-ssl = true
-
-      # Factory of SSLEngine.
-      # Must implement akka.remote.transport.netty.SSLEngineProvider and have a public
-      # constructor with an ActorSystem parameter.
-      # The default ConfigSSLEngineProvider is configured by properties in section
-      # akka.remote.classic.netty.ssl.security
-      #
-      # The SSLEngineProvider can also be defined via ActorSystemSetup with
-      # SSLEngineProviderSetup  when starting the ActorSystem. That is useful when
-      # the SSLEngineProvider implementation requires other external constructor
-      # parameters or is created before the ActorSystem is created.
-      # If such SSLEngineProviderSetup is defined this config property is not used.
-      ssl-engine-provider = akka.remote.transport.netty.ConfigSSLEngineProvider
-
-      security {
-        # This is the Java Key Store used by the server connection
-        key-store = "keystore"
-
-        # This password is used for decrypting the key store
-        key-store-password = "changeme"
-
-        # This password is used for decrypting the key
-        key-password = "changeme"
-
-        # This is the Java Key Store used by the client connection
-        trust-store = "truststore"
-
-        # This password is used for decrypting the trust store
-        trust-store-password = "changeme"
-
-        # Protocol to use for SSL encryption.
-        protocol = "TLSv1.2"
-
-        # Example: ["TLS_DHE_RSA_WITH_AES_128_GCM_SHA256", 
-        #   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        #   "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
-        #   "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"]
-        # When doing rolling upgrades, make sure to include both the algorithm used 
-        # by old nodes and the preferred algorithm.
-        # If you use a JDK 8 prior to 8u161 you need to install
-        # the JCE Unlimited Strength Jurisdiction Policy Files to use AES 256.
-        # More info here:
-        # https://www.oracle.com/java/technologies/javase-jce-all-downloads.html
-        enabled-algorithms = ["TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
-          "TLS_RSA_WITH_AES_128_CBC_SHA"]
-
-        # There are two options, and the default SecureRandom is recommended:
-        # "" or "SecureRandom" => (default)
-        # "SHA1PRNG" => Can be slow because of blocking issues on Linux
+        # Factory of SSLEngine.
+        # Must implement akka.remote.transport.netty.SSLEngineProvider and have a public
+        # constructor with an ActorSystem parameter.
+        # The default ConfigSSLEngineProvider is configured by properties in section
+        # akka.remote.classic.netty.ssl.security
         #
-        # Setting a value here may require you to supply the appropriate cipher
-        # suite (see enabled-algorithms section above)
-        random-number-generator = ""
+        # The SSLEngineProvider can also be defined via ActorSystemSetup with
+        # SSLEngineProviderSetup  when starting the ActorSystem. That is useful when
+        # the SSLEngineProvider implementation requires other external constructor
+        # parameters or is created before the ActorSystem is created.
+        # If such SSLEngineProviderSetup is defined this config property is not used.
+        ssl-engine-provider = akka.remote.transport.netty.ConfigSSLEngineProvider
 
-        # Require mutual authentication between TLS peers
-        #
-        # Without mutual authentication only the peer that actively establishes a connection (TLS client side)
-        # checks if the passive side (TLS server side) sends over a trusted certificate. With the flag turned on,
-        # the passive side will also request and verify a certificate from the connecting peer.
-        #
-        # To prevent man-in-the-middle attacks this setting is enabled by default.
-        #
-        # Note: Nodes that are configured with this setting to 'on' might not be able to receive messages from nodes that
-        # run on older versions of akka-remote. This is because in versions of Akka < 2.4.12 the active side of the remoting
-        # connection will not send over certificates even if asked.
-        #
-        # However, starting with Akka 2.4.12, even with this setting "off", the active side (TLS client side)
-        # will use the given key-store to send over a certificate if asked. A rolling upgrade from versions of
-        # Akka < 2.4.12 can therefore work like this:
-        #   - upgrade all nodes to an Akka version >= 2.4.12, in the best case the latest version, but keep this setting at "off"
-        #   - then switch this flag to "on" and do again a rolling upgrade of all nodes
-        # The first step ensures that all nodes will send over a certificate when asked to. The second
-        # step will ensure that all nodes finally enforce the secure checking of client certificates.
-        require-mutual-authentication = on
+        security {
+          # This is the Java Key Store used by the server connection
+          key-store = "keystore"
+
+          # This password is used for decrypting the key store
+          key-store-password = "changeme"
+
+          # This password is used for decrypting the key
+          key-password = "changeme"
+
+          # This is the Java Key Store used by the client connection
+          trust-store = "truststore"
+
+          # This password is used for decrypting the trust store
+          trust-store-password = "changeme"
+
+          # Protocol to use for SSL encryption.
+          protocol = "TLSv1.2"
+
+          # Example: ["TLS_DHE_RSA_WITH_AES_128_GCM_SHA256", 
+          #   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+          #   "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+          #   "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"]
+          # When doing rolling upgrades, make sure to include both the algorithm used 
+          # by old nodes and the preferred algorithm.
+          # If you use a JDK 8 prior to 8u161 you need to install
+          # the JCE Unlimited Strength Jurisdiction Policy Files to use AES 256.
+          # More info here:
+          # https://www.oracle.com/java/technologies/javase-jce-all-downloads.html
+          enabled-algorithms = ["TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_RSA_WITH_AES_128_CBC_SHA"]
+
+          # There are two options, and the default SecureRandom is recommended:
+          # "" or "SecureRandom" => (default)
+          # "SHA1PRNG" => Can be slow because of blocking issues on Linux
+          #
+          # Setting a value here may require you to supply the appropriate cipher
+          # suite (see enabled-algorithms section above)
+          random-number-generator = ""
+
+          # Require mutual authentication between TLS peers
+          #
+          # Without mutual authentication only the peer that actively establishes a connection (TLS client side)
+          # checks if the passive side (TLS server side) sends over a trusted certificate. With the flag turned on,
+          # the passive side will also request and verify a certificate from the connecting peer.
+          #
+          # To prevent man-in-the-middle attacks this setting is enabled by default.
+          #
+          # Note: Nodes that are configured with this setting to 'on' might not be able to receive messages from nodes that
+          # run on older versions of akka-remote. This is because in versions of Akka < 2.4.12 the active side of the remoting
+          # connection will not send over certificates even if asked.
+          #
+          # However, starting with Akka 2.4.12, even with this setting "off", the active side (TLS client side)
+          # will use the given key-store to send over a certificate if asked. A rolling upgrade from versions of
+          # Akka < 2.4.12 can therefore work like this:
+          #   - upgrade all nodes to an Akka version >= 2.4.12, in the best case the latest version, but keep this setting at "off"
+          #   - then switch this flag to "on" and do again a rolling upgrade of all nodes
+          # The first step ensures that all nodes will send over a certificate when asked to. The second
+          # step will ensure that all nodes finally enforce the secure checking of client certificates.
+          require-mutual-authentication = on
+        }
       }
-    }
 
-    ### Default configuration for the failure injector transport adapter
+      ### Default configuration for the failure injector transport adapter
 
-    gremlin {
-      # Enable debug logging of the failure injector transport adapter
-      debug = off
-    }
+      gremlin {
+        # Enable debug logging of the failure injector transport adapter
+        debug = off
+      }
 
-    backoff-remote-dispatcher {
-      type = Dispatcher
-      executor = "fork-join-executor"
-      fork-join-executor {
-        # Min number of threads to cap factor-based parallelism number to
-        parallelism-min = 2
-        parallelism-max = 2
+      backoff-remote-dispatcher {
+        type = Dispatcher
+        executor = "fork-join-executor"
+        fork-join-executor {
+          # Min number of threads to cap factor-based parallelism number to
+          parallelism-min = 2
+          parallelism-max = 2
+        }
       }
     }
   }


### PR DESCRIPTION
https://doc.akka.io/docs/akka/current/general/configuration-reference.html#default-configuration 
completely misses the `classic {}` key for `netty` configuration. 

By making the classic key an extra object and setting the 'inline-anchor' at the right place, this `classic {` should be visible on the reference config page.
Because of this, all configuration keys have to be indented 2 spaces. 

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
