### PR TITLE
Allow `Restart{Source,Flow,Sink}` to fail on certain errors

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/RestartSpec.scala
@@ -363,13 +363,13 @@ class RestartSpec
       val created = new AtomicInteger()
       val settings = shortRestartSettings.withRestartOn {
         case TE("failed") => false
-        case _ => true
+        case _            => true
       }
       val probe = RestartSource
         .withBackoff(settings) { () =>
           created.incrementAndGet()
           Source(List("a", "b", "c")).map {
-            case "c" => throw TE("failed")
+            case "c"   => throw TE("failed")
             case other => other
           }
         }
@@ -638,14 +638,14 @@ class RestartSpec
       val created = new AtomicInteger()
       val settings = shortRestartSettings.withRestartOn {
         case TE("failed") => false
-        case _ => true
+        case _            => true
       }
       val probe = RestartSink
         .withBackoff(settings) { () =>
           created.incrementAndGet()
           Sink.foreach[String] {
             case "c" => throw TE("failed")
-            case _ =>
+            case _   =>
           }
         }
         .runWith(TestSource.probe[String])
@@ -1005,13 +1005,13 @@ class RestartSpec
       val created = new AtomicInteger(0)
       val settings = shortRestartSettings.withRestartOn {
         case TE("failed") => false
-        case _ => true
+        case _            => true
       }
       val probe = Source(List("a", "b", "c", "d"))
         .via(RestartFlow.onFailuresWithBackoff(settings) { () =>
           created.incrementAndGet()
           Flow[String].map {
-            case "c" => throw TE("failed")
+            case "c"   => throw TE("failed")
             case other => other
           }
         })

--- a/akka-stream/src/main/mima-filters/2.6.19.backwards.excludes/pr-31492-restart-on.excludes
+++ b/akka-stream/src/main/mima-filters/2.6.19.backwards.excludes/pr-31492-restart-on.excludes
@@ -1,0 +1,2 @@
+# added "restartOn" constructor argument
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.RestartSettings.this")

--- a/akka-stream/src/main/scala/akka/stream/RestartSettings.scala
+++ b/akka-stream/src/main/scala/akka/stream/RestartSettings.scala
@@ -46,11 +46,7 @@ final class RestartSettings private (
   def withMaxRestarts(count: Int, within: java.time.Duration): RestartSettings =
     copy(maxRestarts = count, maxRestartsWithin = within.asScala)
 
-  /** Scala API: Decides whether the failure should restart the stream */
-  def withRestartOn(restartOn: Throwable => Boolean): RestartSettings =
-    copy(restartOn = restartOn)
-
-  /** Java API: Decides whether the failure should restart the stream */
+  /** Decides whether the failure should restart the stream */
   def withRestartOn(restartOn: java.util.function.Predicate[Throwable]): RestartSettings =
     copy(restartOn = restartOn.asScala)
 

--- a/akka-stream/src/main/scala/akka/stream/RestartSettings.scala
+++ b/akka-stream/src/main/scala/akka/stream/RestartSettings.scala
@@ -46,7 +46,7 @@ final class RestartSettings private (
   def withMaxRestarts(count: Int, within: java.time.Duration): RestartSettings =
     copy(maxRestarts = count, maxRestartsWithin = within.asScala)
 
-  /** Decides whether the failure should restart the stream */
+  /** Decides whether the failure should restart the stream or make the surrounding stream fail */
   def withRestartOn(restartOn: java.util.function.Predicate[Throwable]): RestartSettings =
     copy(restartOn = restartOn.asScala)
 

--- a/akka-stream/src/main/scala/akka/stream/RestartSettings.scala
+++ b/akka-stream/src/main/scala/akka/stream/RestartSettings.scala
@@ -6,9 +6,9 @@ package akka.stream
 
 import scala.compat.java8.FunctionConverters._
 import scala.concurrent.duration.FiniteDuration
-
 import akka.event.Logging
 import akka.event.Logging.LogLevel
+import akka.util.ConstantFun
 import akka.util.JavaDurationConverters._
 
 final class RestartSettings private (
@@ -84,7 +84,7 @@ object RestartSettings {
       maxRestarts = Int.MaxValue,
       maxRestartsWithin = minBackoff,
       logSettings = LogSettings.defaultSettings,
-      restartOn = _ => true)
+      restartOn = ConstantFun.anyToTrue)
 
   /** Java API */
   def create(minBackoff: java.time.Duration, maxBackoff: java.time.Duration, randomFactor: Double): RestartSettings =
@@ -95,7 +95,7 @@ object RestartSettings {
       maxRestarts = Int.MaxValue,
       maxRestartsWithin = minBackoff.asScala,
       logSettings = LogSettings.defaultSettings,
-      restartOn = _ => true)
+      restartOn = ConstantFun.anyToTrue)
 
   /** Java API */
   def createLogSettings(logLevel: LogLevel): LogSettings =

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala
@@ -290,7 +290,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
        * Upstream in this context is the wrapped stage.
        */
       override def onUpstreamFailure(ex: Throwable) = {
-        if (finishing || maxRestartsReached()) {
+        if (finishing || maxRestartsReached() || !settings.restartOn(ex)) {
           fail(out, ex)
         } else {
           logIt(s"Restarting stream due to failure [${restartCount + 1}]: $ex", OptionVal.Some(ex))

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/RestartFlow.scala
@@ -366,7 +366,7 @@ private abstract class RestartWithBackoffLogic[S <: Shape](
        * onlyOnFailures is thus racy so a delay to cancellation is added in the case of a flow.
        */
       override def onDownstreamFinish(cause: Throwable) = {
-        if (finishing || maxRestartsReached() || onlyOnFailures) {
+        if (finishing || maxRestartsReached() || onlyOnFailures || !settings.restartOn(cause)) {
           cancel(in, cause)
         } else {
           scheduleRestartTimer()


### PR DESCRIPTION
Adds `restartOn: Throwable => Boolean` used to decide whether the graph should be restarted.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #30859
