### PR TITLE
fix: using createUnhandledMessageProbe to avoid message delivered bef…

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextDelegateSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextDelegateSpec.scala
@@ -7,7 +7,6 @@ package akka.actor.typed.scaladsl
 import akka.actor.UnhandledMessage
 import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.scaladsl.{ FishingOutcomes, LogCapturing, ScalaTestWithActorTestKit, TestProbe }
-import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.{ ActorRef, Behavior }
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -71,8 +70,7 @@ class ActorContextDelegateSpec extends ScalaTestWithActorTestKit with AnyWordSpe
     }
 
     "publish unhandled message to eventStream as UnhandledMessage and switch to delegator behavior" in {
-      val deadLetters = TestProbe[UnhandledMessage]("probeDeadLetters")
-      system.eventStream ! EventStream.Subscribe[UnhandledMessage](deadLetters.ref)
+      val deadLetters = testKit.createUnhandledMessageProbe()
 
       val probe = TestProbe[Event]()
       val behv = Behaviors.setup[PingPongCommand] { implicit context =>


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #31497 
