### PR TITLE
Re-use command and event handler instances in Java EventSourcedBehavior

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/EventSourcedBehavior.scala
@@ -199,11 +199,13 @@ abstract class EventSourcedBehavior[Command, Event, State] private[akka] (
       else tags.asScala.toSet
     }
 
+    val commandHandlerInstance = commandHandler()
+    val eventHandlerInstance = eventHandler()
     val behavior = new internal.EventSourcedBehaviorImpl[Command, Event, State](
       persistenceId,
       emptyState,
-      (state, cmd) => commandHandler()(state, cmd).asInstanceOf[EffectImpl[Event, State]],
-      eventHandler()(_, _),
+      (state, cmd) => commandHandlerInstance(state, cmd).asInstanceOf[EffectImpl[Event, State]],
+      eventHandlerInstance(_, _),
       getClass)
       .snapshotWhen(snapshotWhen)
       .withRetention(retentionCriteria.asScala)


### PR DESCRIPTION
Refs #31505

Has a slight risk that someone based their command handling on some transient state in the behavior class, but all our examples are written as if the command and event handler factory methods are called only once.