### PR TITLE
Fix compilation error in ActorContextDelegateSpec with Scala 2.12

### DIFF
--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsAskWithStatusTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsAskWithStatusTest.java
@@ -213,7 +213,8 @@ public class InteractionPatternsAskWithStatusTest extends JUnitSuite {
 
         cookies.whenComplete(
             (cookiesReply, failure) -> {
-              if (cookiesReply != null) System.out.println("Yay, " + cookiesReply.count + " cookies!");
+              if (cookiesReply != null)
+                System.out.println("Yay, " + cookiesReply.count + " cookies!");
               else System.out.println("Boo! didn't get cookies in time. " + failure);
             });
         // #standalone-ask-with-status-fail-future

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextDelegateSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextDelegateSpec.scala
@@ -29,22 +29,22 @@ object ActorContextDelegateSpec {
       case Ping =>
         monitor ! ResponseFrom(PingTag, Ping)
         Behaviors.same
-      case msg @ Pong =>
+      case Pong =>
         monitor ! ForwardTo(PongTag)
-        context.delegate(pong(monitor), msg)
+        context.delegate(pong(monitor), Pong)
     }
 
   def pong(monitor: ActorRef[Event])(implicit context: ActorContext[PingPongCommand]): Behavior[PingPongCommand] =
     Behaviors.receiveMessage[PingPongCommand] {
-      case msg @ Ping =>
+      case Ping =>
         monitor ! ForwardTo(PingTag)
-        context.delegate(ping(monitor), msg)
+        context.delegate(ping(monitor), Ping)
       case Pong =>
         monitor ! ResponseFrom(PongTag, Pong)
         Behaviors.same
-      case msg @ UnPingable =>
+      case UnPingable =>
         monitor ! ForwardTo(PingTag)
-        context.delegate(ping(monitor), msg)
+        context.delegate(ping(monitor), UnPingable)
     }
 }
 


### PR DESCRIPTION
```
[error] /Users/patrik/dev/akka/akka-actor-typed-tests/src/test/scala/akka/actor/typed/scaladsl/ActorContextDelegateSpec.scala:32:18: The value matched by ActorContextDelegateSpec.this.Pong is bound to msg, which may be used under the
[error] unsound assumption that it has type akka.actor.typed.scaladsl.ActorContextDelegateSpec.Pong.type, whereas we can only safely
[error] count on it having type akka.actor.typed.scaladsl.ActorContextDelegateSpec.PingPongCommand, as the pattern is matched using `==` (see scala/bug#1503).
[error]       case msg @ Pong =>
```
