### PR TITLE
Removing unnecessary @SuppressWarnings("unchecked")

### DIFF
--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/Aggregator.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/Aggregator.java
@@ -78,7 +78,6 @@ public class Aggregator<Reply, Aggregate> extends AbstractBehavior<Aggregator.Co
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public Receive<Command> createReceive() {
     return newReceiveBuilder()
         .onMessage(WrappedReply.class, this::onReply)

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/TailChopping.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/TailChopping.java
@@ -91,7 +91,6 @@ public class TailChopping<Reply> extends AbstractBehavior<TailChopping.Command> 
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public Receive<Command> createReceive() {
     return newReceiveBuilder()
         .onMessage(WrappedReply.class, this::onReply)

--- a/akka-actor/src/main/java/akka/dispatch/AbstractBoundedNodeQueue.java
+++ b/akka-actor/src/main/java/akka/dispatch/AbstractBoundedNodeQueue.java
@@ -61,7 +61,6 @@ public abstract class AbstractBoundedNodeQueue<T> {
         return Unsafe.instance.compareAndSwapObject(this, deqOffset, old, nju);
     }
 
-    @SuppressWarnings("unchecked")
     protected final Node<T> peekNode() {
         for(;;) {
           final Node<T> deq = getDeq();

--- a/akka-docs/src/test/java/jdocs/future/FutureDocTest.java
+++ b/akka-docs/src/test/java/jdocs/future/FutureDocTest.java
@@ -41,7 +41,6 @@ public class FutureDocTest extends AbstractJavaTest {
   private final ActorSystem<Void> system = toTyped(actorSystemResource.getSystem());
 
   @Test(expected = java.util.concurrent.CompletionException.class)
-  @SuppressWarnings("unchecked")
   public void useAfter() throws Exception {
     final ExecutionContext ec = system.executionContext();
     // #after


### PR DESCRIPTION
There are some unnecessary annotations `@SuppressWarnings("unchecked")`. It can be removed.