### PR TITLE
Replace deprecated Resolver.sonatypeRepo on Resolver.sonatypeOssRepos for sbt 1.7.+

### DIFF
--- a/akka-docs/src/main/paradox/project/links.md
+++ b/akka-docs/src/main/paradox/project/links.md
@@ -45,7 +45,7 @@ The use of Akka SNAPSHOTs, nightlies and milestone releases is discouraged unles
 Make sure that you add the repository to the sbt resolvers:
 
 ```
-resolvers += Resolver.sonatypeRepo("snapshots")
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 ```
 
 Define the library dependencies with the complete version. For example:

--- a/project/AkkaBuild.scala
+++ b/project/AkkaBuild.scala
@@ -86,7 +86,7 @@ object AkkaBuild {
     else Seq.empty,
     // should we be allowed to use artifacts from sonatype snapshots
     if (System.getProperty("akka.build.useSnapshotSonatypeResolver", "false").toBoolean)
-      resolvers += Resolver.sonatypeRepo("snapshots")
+      resolvers ++= Resolver.sonatypeOssRepos("snapshots")
     else Seq.empty,
     pomIncludeRepository := (_ => false) // do not leak internal repositories during staging
   )


### PR DESCRIPTION
There is a warning on startup after updating sbt in #31484 

<img width="1728" alt="sbt" src="https://user-images.githubusercontent.com/4740207/187286674-dd29570f-5bbd-4c00-a0f0-d6dd65eab921.png">

It can be fixed. There are some details in the [sbt issue](https://github.com/sbt/sbt/issues/6987) .