### PR TITLE
Remove migration code about mailbox from Akka 2.2

### DIFF
--- a/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
+++ b/akka-actor/src/main/scala/akka/dispatch/Mailboxes.scala
@@ -117,7 +117,6 @@ private[akka] class Mailboxes(
     }
 
   // don’t care if this happens twice
-  private var mailboxSizeWarningIssued = false
   private var mailboxNonZeroPushTimeoutWarningIssued = false
 
   def getMailboxRequirement(config: Config) = config.getString("mailbox-requirement") match {
@@ -158,16 +157,6 @@ private[akka] class Mailboxes(
     val hasMailboxType =
       dispatcherConfig.hasPath("mailbox-type") &&
       dispatcherConfig.getString("mailbox-type") != Deploy.NoMailboxGiven
-
-    // TODO remove in 2.3
-    if (!hasMailboxType && !mailboxSizeWarningIssued && dispatcherConfig.hasPath("mailbox-size")) {
-      eventStream.publish(
-        Warning(
-          "mailboxes",
-          getClass,
-          s"ignoring setting 'mailbox-size' for dispatcher [$id], you need to specify 'mailbox-type=bounded'"))
-      mailboxSizeWarningIssued = true
-    }
 
     def verifyRequirements(mailboxType: MailboxType): MailboxType = {
       lazy val mqType: Class[_] = getProducedMessageQueueType(mailboxType)
@@ -214,9 +203,6 @@ private[akka] class Mailboxes(
       case null =>
         // It doesn't matter if we create a mailbox type configurator that isn't used due to concurrent lookup.
         val newConfigurator = id match {
-          // TODO RK remove these two for Akka 2.3
-          case "unbounded"                               => UnboundedMailbox()
-          case "bounded"                                 => new BoundedMailbox(settings, config(id))
           case _ if id.startsWith(BoundedCapacityPrefix) =>
             // hack to allow programmatic set of capacity through props in akka-typed but still share
             // mailbox configurators for the same size


### PR DESCRIPTION
There are two old todo-items in `akka.dispatch.Mailboxes.scala`. 
I think it can be removed now.

Some details can be found [in PR](https://github.com/akka/akka/pull/1521/files#r4496245) and in [migration guide - "Changed Configuration Section for Dispatcher & Mailbox" ](https://doc.akka.io/docs/akka/2.2/project/migration-guide-2.1.x-2.2.x.html)