### PR TITLE
Minor build preparation for 2.7.0-M1

### DIFF
--- a/project/OSGi.scala
+++ b/project/OSGi.scala
@@ -125,7 +125,7 @@ object OSGi {
       "!scala.util.parsing.*",
       scalaImport(scalaVersion),
       "*")
-  def akkaImport(packageName: String = "akka.*") = versionedImport(packageName, "2.6", "2.7")
+  def akkaImport(packageName: String = "akka.*") = versionedImport(packageName, "2.7", "2.8")
   def configImport(packageName: String = "com.typesafe.config.*") = versionedImport(packageName, "1.4.0", "1.5.0")
   def scalaImport(version: String) = {
     val packageName = "scala.*"

--- a/project/Paradox.scala
+++ b/project/Paradox.scala
@@ -27,11 +27,11 @@ object Paradox {
         "extref.github.base_url" -> (GitHub.url(version.value) + "/%s"), // for links to our sources
         "extref.samples.base_url" -> "https://developer.lightbend.com/start/?group=akka&amp;project=%s",
         "extref.ecs.base_url" -> "https://example.lightbend.com/v1/download/%s",
-        "scaladoc.akka.base_url" -> "https://doc.akka.io/api/akka/2.6",
+        "scaladoc.akka.base_url" -> "https://doc.akka.io/api/akka/2.7",
         "scaladoc.akka.http.base_url" -> "https://doc.akka.io/api/akka-http/current",
         "javadoc.java.base_url" -> "https://docs.oracle.com/en/java/javase/11/docs/api/java.base/",
         "javadoc.java.link_style" -> "direct",
-        "javadoc.akka.base_url" -> "https://doc.akka.io/japi/akka/2.6",
+        "javadoc.akka.base_url" -> "https://doc.akka.io/japi/akka/2.7",
         "javadoc.akka.link_style" -> "direct",
         "javadoc.akka.http.base_url" -> "https://doc.akka.io/japi/akka-http/current",
         "javadoc.akka.http.link_style" -> "frames",


### PR DESCRIPTION
There are also things in MiMa.scala but I think we should first cut 2.7.0-M1 and then bump the versions in MiMa and remove the checks there for 2.5.