### PR TITLE
Add Fold with resource for Sink

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/Sink/foldResource.md
+++ b/akka-docs/src/main/paradox/stream/operators/Sink/foldResource.md
@@ -1,0 +1,83 @@
+# foldResource
+
+Handle elements with the help of a resource that can be opened, handle each element (in a blocking way) and closed.
+
+@ref[Sink operators](../index.md#sink-operators)
+
+## Signature
+
+@apidoc[Sink.foldResource](Sink$) { scala="
+#foldResource%5BR%2C%20T%5D%28create%3A%20%28%29%20%3D%3E%20R%29%28f%3A%20%28R%2C%20T%29%20%3D%3E%20Unit%2C%20close%3A%20R%20%3D%3E%20Unit%29%3A%20Sink%5BT%2C%20Future%5BDone%5D%5D"
+java="#foldResource(akka.japi.function.Creator,akka.japi.function.Procedure2,akka.japi.function.Procedure)" }
+
+1. `create`: Open or Create the resource.
+2. `f`: Handle each element inputs with the help of resource.
+3. `close`: Close the resource, invoked on end of stream or if the stream fails.
+
+## Description
+
+Handle each stream element with the help of a resource.
+The functions are by default called on Akka's dispatcher for blocking IO to avoid interfering with other stream
+operations.
+See @ref:[Blocking Needs Careful Management](../../../typed/dispatchers.md#blocking-needs-careful-management) for an
+explanation on why this is important.
+The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
+the function `f` for handling every stream element.
+
+The `close` function is called when upstream or current stage completes normally or exceptionally, and will be called
+only once.
+
+- upstream completes or fails
+- current stage completes or fails
+- shutdowns abruptly
+
+You can do some clean-up here.
+
+Early completion can be done with combination of the @apidoc[Flow.takeWhile](Flow) operator.
+
+See also :
+
+- @ref:[unfoldResource](../Source/unfoldResource.md), @ref:[unfoldResourceAsync](../Source/unfoldResourceAsync.md) Source operators
+- @ref:[mapWithResource](../Source-or-Flow/mapWithResource.md) Source & Flow operators
+- @ref:[asInputStream](../StreamConverters/asInputStream.md) Create a sink which materializes into an `InputStream`  
+- @ref:[fromOutputStream](../StreamConverters/fromOutputStream.md) Create a sink that wraps an `OutputStream`
+
+You can configure the default dispatcher for this Sink by changing the `akka.stream.materializer.blocking-io-dispatcher`
+or set it for a given Sink by using ActorAttributes.
+
+## Examples
+
+Imagine we have a database API which may potentially block when we perform an insert,
+and the database connection can be reused for each insert operation.
+
+Scala
+:   @@snip [FoldResource.scala](/akka-docs/src/test/scala/docs/stream/operators/sink/FoldResource.scala) {
+#foldResource-blocking-api }
+
+Java
+:   @@snip [FoldResource.java](/akka-docs/src/test/java/jdocs/stream/operators/sink/FoldResource.java) {
+#foldResource-blocking-api }
+
+Let's see how we make use of the API above safely through `foldResource`:
+
+Scala
+:   @@snip [FoldResource.scala](/akka-docs/src/test/scala/docs/stream/operators/sink/FoldResource.scala) { #foldResource
+}
+
+Java
+:   @@snip [FoldResource.java](/akka-docs/src/test/java/jdocs/stream/operators/sink/FoldResource.java) { #foldResource }
+
+In this example we accept inserts from a Source and execute the insert operation in the Sink, once done the connection
+is closed.
+
+## Reactive Streams semantics
+
+@@@div { .callout }
+
+**backpressures** when the previous function invocation has not yet completed
+
+**completes** upstream completes
+
+**cancels** never
+
+@@@

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapWithResource.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapWithResource.md
@@ -7,6 +7,7 @@ Map elements with the help of a resource that can be opened, transform each elem
 ## Signature
 
 @apidoc[Flow.mapWithResource](Flow) { scala="#mapWithResource%5BS%2C%20T%5D%28create%3A%20%28%29%20%3D%3E%20S%29%28f%3A%20%28S%2C%20Out%29%20%3D%3E%20T%2C%20close%3A%20S%20%3D%3E%20Option%5BT%5D%29%3A%20Repr%5BT%5D" java="#mapWithResource(akka.japi.function.Creator,akka.japi.function.Function2,akka.japi.function.Function)" }
+
 1. `create`: Open or Create the resource.
 2. `f`: Transform each element inputs with the help of resource.
 3. `close`: Close the resource, invoked on end of stream or if the stream fails, optionally outputting a last element.
@@ -18,15 +19,20 @@ The functions are by default called on Akka's dispatcher for blocking IO to avoi
 See @ref:[Blocking Needs Careful Management](../../../typed/dispatchers.md#blocking-needs-careful-management) for an explanation on why this is important.
 The resource creation function is invoked once when the stream is materialized and the returned resource is passed to the mapping function for mapping the first element. The mapping function returns a mapped element to emit downstream. The returned T MUST NOT be null as it is illegal as stream element - according to the Reactive Streams specification.
 
-The close function is called when upstream or downstream completes normally or exceptionally, and will be called only once.  
+The `close` function is called when upstream or downstream completes normally or exceptionally, and will be called only once.  
+
  - upstream completes or fails, the optional value returns by `close` will be emitted to downstream if defined.
  - downstream cancels or fails, the optional value returns by `close` will be ignored.
  - shutdowns abruptly, the optional value returns by `close` will be ignored.  
+
 You can do some clean-up here.
 
 Early completion can be done with combination of the @apidoc[Flow.takeWhile](Flow) operator.
 
-See also @ref:[unfoldResource](../Source/unfoldResource.md), @ref:[unfoldResourceAsync](../Source/unfoldResourceAsync.md). 
+See also: 
+
+  - @ref:[unfoldResource](../Source/unfoldResource.md), @ref:[unfoldResourceAsync](../Source/unfoldResourceAsync.md) Source operators.
+  - @ref:[foldResource](../Sink/foldResource.md) Sink operator.
 
 You can configure the default dispatcher for this Source by changing the `akka.stream.materializer.blocking-io-dispatcher`
 or set it for a given Source by using ActorAttributes.
@@ -37,18 +43,18 @@ Imagine we have a database API which may potentially block when we perform a que
 and the database connection can be reused for each query.
 
 Scala
-:   @@snip [UnfoldResource.scala](/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapWithResource.scala) { #mapWithResource-blocking-api }
+:   @@snip [MapWithResource.scala](/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapWithResource.scala) { #mapWithResource-blocking-api }
 
 Java
-:   @@snip [UnfoldResource.java](/akka-docs/src/test/java/jdocs/stream/operators/sourceorflow/MapWithResource.java) { #mapWithResource-blocking-api }
+:   @@snip [MapWithResource.java](/akka-docs/src/test/java/jdocs/stream/operators/sourceorflow/MapWithResource.java) { #mapWithResource-blocking-api }
 
 Let's see how we make use of the API above safely through `mapWithResource`:
 
 Scala
-:   @@snip [UnfoldResource.scala](/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapWithResource.scala) { #mapWithResource }
+:   @@snip [MapWithResource.scala](/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapWithResource.scala) { #mapWithResource }
 
 Java
-:   @@snip [UnfoldResource.java](/akka-docs/src/test/java/jdocs/stream/operators/sourceorflow/MapWithResource.java) { #mapWithResource }
+:   @@snip [MapWithResource.java](/akka-docs/src/test/java/jdocs/stream/operators/sourceorflow/MapWithResource.java) { #mapWithResource }
 
 In this example we retrieve data form two tables with the same shared connection, and transform the results 
 to individual records with @scala[`mapConcat(identity)`]@java[`mapConcat(elems -> elems)`], once done the connection is closed.

--- a/akka-docs/src/main/paradox/stream/operators/index.md
+++ b/akka-docs/src/main/paradox/stream/operators/index.md
@@ -61,6 +61,7 @@ These built-in sinks are available from @scala[`akka.stream.scaladsl.Sink`] @jav
 |Sink|<a name="combine"></a>@ref[combine](Sink/combine.md)|Combine several sinks into one using a user specified strategy|
 |Sink|<a name="completionstagesink"></a>@ref[completionStageSink](Sink/completionStageSink.md)|Streams the elements to the given future sink once it successfully completes. |
 |Sink|<a name="fold"></a>@ref[fold](Sink/fold.md)|Fold over emitted element with a function, where each invocation will get the new element and the result from the previous fold invocation.|
+|Sink|<a name="foldresource"></a>@ref[foldResource](Sink/foldResource.md)|Handle elements with the help of a resource that can be opened, handle each element (in a blocking way) and closed.|
 |Sink|<a name="foreach"></a>@ref[foreach](Sink/foreach.md)|Invoke a given procedure for each element received.|
 |Sink|<a name="foreachasync"></a>@ref[foreachAsync](Sink/foreachAsync.md)|Invoke a given procedure asynchronously for each element received.|
 |Sink|<a name="foreachparallel"></a>@ref[foreachParallel](Sink/foreachParallel.md)|Like `foreach` but allows up to `parallellism` procedure calls to happen in parallel.|
@@ -442,6 +443,7 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 * [fold](Source-or-Flow/fold.md)
 * [fold](Sink/fold.md)
 * [foldAsync](Source-or-Flow/foldAsync.md)
+* [foldResource](Sink/foldResource.md)
 * [foreach](Sink/foreach.md)
 * [foreachAsync](Sink/foreachAsync.md)
 * [foreachParallel](Sink/foreachParallel.md)

--- a/akka-docs/src/test/java/jdocs/stream/operators/sink/FoldResource.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/sink/FoldResource.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.stream.operators.sink;
+
+import akka.actor.ActorSystem;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+
+import java.net.URL;
+import java.util.Arrays;
+
+public interface FoldResource {
+  // #foldResource-blocking-api
+  interface DBDriver {
+    Connection create(URL url, String userName, String password);
+  }
+
+  interface Connection {
+    void close();
+  }
+
+  interface Database {
+    // blocking insert
+    DBResult doInsert(Connection connection, String query);
+  }
+
+  interface DBResult {
+    boolean isSuccess();
+
+    int affectedCount();
+  }
+
+  // #foldResource-blocking-api
+
+  default void foldResourceExample() {
+    final ActorSystem system = null;
+    final URL url = null;
+    final String userName = "Akka";
+    final String password = "Hakking";
+    final DBDriver dbDriver = null;
+    // #foldResource
+    // some database for JVM
+    final Database db = null;
+    Source.from(
+            Arrays.asList(
+                "INSERT INTO t1 (a, b, c) VALUES (1, 2, 3);",
+                "INSERT INTO t2 (a, b, c) VALUES (4, 5, 6);"))
+        .runWith(
+            Sink.foldResource(
+                () -> dbDriver.create(url, userName, password),
+                (connection, query) -> db.doInsert(connection, query),
+                Connection::close),
+            system);
+    // #foldResource
+  }
+}

--- a/akka-docs/src/test/java/jdocs/stream/operators/sourceorflow/MapWithResource.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/sourceorflow/MapWithResource.java
@@ -51,8 +51,8 @@ public interface MapWithResource {
     final Database db = null;
     Source.from(
             Arrays.asList(
-                "SELECT * FROM shop ORDER BY article-0000 order by gmtModified desc limit 100;",
-                "SELECT * FROM shop ORDER BY article-0001 order by gmtModified desc limit 100;"))
+                "SELECT * FROM article-0000 ORDER BY gmtModified DESC LIMIT 100;",
+                "SELECT * FROM article-0001 ORDER BY gmtModified DESC LIMIT 100;"))
         .mapWithResource(
             () -> dbDriver.create(url, userName, password),
             (connection, query) -> db.doQuery(connection, query).toList(),

--- a/akka-docs/src/test/scala/docs/stream/operators/sink/FoldResource.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/sink/FoldResource.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.stream.operators.sink
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+
+import java.net.URL
+
+object FoldResource {
+  implicit val actorSystem: ActorSystem = ???
+
+  //#foldResource-blocking-api
+  trait DBDriver {
+    def create(url: URL, userName: String, password: String): Connection
+  }
+  trait Connection {
+    def close(): Unit
+  }
+  trait Database {
+    //blocking insert
+    def doInsert(connection: Connection, query: String): DBResult = ???
+  }
+  trait DBResult {
+    def isSuccess: Boolean
+    def affectedCount: Int
+  }
+
+  //#foldResource-blocking-api
+  val url: URL = ???
+  val userName = "Akka"
+  val password = "Hakking"
+  val dbDriver: DBDriver = ???
+  def foldResourceExample(): Unit = {
+    //#foldResource
+    //some database for JVM
+    val db: Database = ???
+    Source(List("INSERT INTO t1 (a, b, c) VALUES (1, 2, 3);", "INSERT INTO t2 (a, b, c) VALUES (4, 5, 6);")).runWith(
+      Sink.foldResource(() => dbDriver.create(url, userName, password))(
+        (connection, query) => db.doInsert(connection, query),
+        _.close()))
+    //#foldResource
+  }
+}

--- a/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapWithResource.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapWithResource.scala
@@ -41,8 +41,8 @@ object MapWithResource {
     val db: Database = ???
     Source(
       List(
-        "SELECT * FROM shop ORDER BY article-0000 order by gmtModified desc limit 100;",
-        "SELECT * FROM shop ORDER BY article-0001 order by gmtModified desc limit 100;"))
+        "SELECT * FROM article-0000 ORDER BY gmtModified DESC LIMIT 100;",
+        "SELECT * FROM article-0001 ORDER BY gmtModified DESC LIMIT 100;"))
       .mapWithResource(() => dbDriver.create(url, userName, password))(
         (connection, query) => db.doQuery(connection, query).toList(),
         conn => {

--- a/akka-stream-tests/src/test/scala/akka/stream/DslFactoriesConsistencySpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/DslFactoriesConsistencySpec.scala
@@ -55,9 +55,13 @@ class DslFactoriesConsistencySpec extends AnyWordSpec with Matchers {
       (classOf[Boolean],                                   classOf[akka.stream.javadsl.AsPublisher]) ::
       (classOf[scala.Function0[_]],                        classOf[akka.japi.function.Creator[_]]) ::
       (classOf[scala.Function0[_]],                        classOf[java.util.concurrent.Callable[_]]) ::
+      (classOf[scala.Function0[_]],                        classOf[java.util.function.Supplier[_]]) ::
+      (classOf[scala.Function1[_, Unit]],                  classOf[java.util.function.Consumer[_]]) ::
       (classOf[scala.Function1[_, Unit]],                  classOf[akka.japi.function.Procedure[_]]) ::
       (classOf[scala.Function1[_, _]],                     classOf[akka.japi.function.Function[_, _]]) ::
       (classOf[scala.Function2[_, _, _]],                  classOf[java.util.function.BiFunction[_, _, _]]) :: // setup
+      (classOf[scala.Function2[_, _, Unit]],               classOf[java.util.function.BiConsumer[_, _]]) ::
+      (classOf[scala.Function2[_, _, Unit]],               classOf[akka.japi.function.Procedure2[_, _]]) ::
       (classOf[scala.Function1[scala.Function1[_, _], _]], classOf[akka.japi.function.Function2[_, _, _]]) ::
       (classOf[akka.stream.scaladsl.Source[_, _]],         classOf[akka.stream.javadsl.Source[_, _]]) ::
       (classOf[akka.stream.scaladsl.Sink[_, _]],           classOf[akka.stream.javadsl.Sink[_, _]]) ::

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FoldResourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FoldResourceSpec.scala
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2016-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.scaladsl
+
+import java.io._
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.annotation.nowarn
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.Promise
+import scala.util.Success
+import scala.util.control.NoStackTrace
+
+import com.google.common.jimfs.Configuration
+import com.google.common.jimfs.Jimfs
+
+import akka.Done
+import akka.stream.AbruptTerminationException
+import akka.stream.ActorAttributes
+import akka.stream.ActorAttributes._
+import akka.stream.ActorMaterializer
+import akka.stream.Supervision
+import akka.stream.Supervision._
+import akka.stream.SystemMaterializer
+import akka.stream.impl.PhasedFusingActorMaterializer
+import akka.stream.impl.StreamSupervisor
+import akka.stream.impl.StreamSupervisor.Children
+import akka.stream.testkit.StreamSpec
+import akka.stream.testkit.Utils._
+import akka.stream.testkit.scaladsl.TestSource
+import akka.testkit.EventFilter
+import akka.util.ByteString
+
+class FoldResourceSpec extends StreamSpec(UnboundedMailboxConfig) {
+
+  private val fs = Jimfs.newFileSystem("FoldResourceSpec", Configuration.unix())
+  private val ex = new Exception("TEST") with NoStackTrace
+
+  private val manyLines = {
+    val b = ListBuffer[String]()
+    b.append("a" * 1000 + "\n")
+    b.append("b" * 1000 + "\n")
+    b.append("c" * 1000 + "\n")
+    b.append("d" * 1000 + "\n")
+    b.append("e" * 1000 + "\n")
+    b.append("f" * 1000 + "\n")
+    b.toList
+  }
+
+  private def newBufferWriter(path: Path) =
+    Files.newBufferedWriter(path, StandardCharsets.UTF_8, StandardOpenOption.APPEND)
+
+  "FoldResource" must {
+    "can write contents to a file" in {
+      targetFile { path =>
+        val completion = Source(manyLines).runWith(
+          Sink
+            .foldResource(() => newBufferWriter(path))((writer, line) => writer.write(line), writer => writer.close()))
+        completion.futureValue shouldBe Done
+        checkFileContents(path, manyLines.mkString(""))
+      }
+    }
+
+    "continue when Strategy is Resume and exception happened" in {
+      targetFile { path =>
+        val completion = Source(manyLines).runWith(
+          Sink
+            .foldResource[BufferedWriter, String](() => newBufferWriter(path))((writer, line) => {
+              if (line.contains("b")) throw TE("")
+              writer.write(line)
+            }, writer => writer.close())
+            .withAttributes(supervisionStrategy(resumingDecider)))
+        completion.futureValue shouldBe Done
+        checkFileContents(path, (manyLines.take(1) ++ manyLines.drop(2)).mkString(""))
+      }
+    }
+
+    "close and open stream again when Strategy is Restart" in {
+      targetFile { path =>
+        val completion = Source(manyLines).runWith(
+          Sink
+            .foldResource[BufferedWriter, String](() => newBufferWriter(path))((writer, line) => {
+              if (line.contains("b")) throw TE("")
+              writer.write(line)
+            }, writer => writer.close())
+            .withAttributes(supervisionStrategy(stoppingDecider)))
+        completion.failed.futureValue shouldBe a[TE]
+        checkFileContents(path, manyLines.take(1).mkString(""))
+      }
+    }
+
+    "work with ByteString as well" in {
+      targetFile { path =>
+        val completion = Source(manyLines)
+          .map(ByteString(_))
+          .runWith(
+            Sink.foldResource(() => newBufferWriter(path))(
+              (writer, bs) => writer.write(bs.utf8String),
+              writer => writer.close()))
+        completion.futureValue shouldBe Done
+        checkFileContents(path, manyLines.mkString(""))
+      }
+    }
+
+    "use dedicated blocking-io-dispatcher by default" in {
+      targetFile { path =>
+        val (pub, completion) = TestSource[String]()
+          .toMat(Sink
+            .foldResource(() => newBufferWriter(path))((writer, line) => writer.write(line), writer => writer.close()))(
+            Keep.both)
+          .run()
+
+        SystemMaterializer(system).materializer
+          .asInstanceOf[PhasedFusingActorMaterializer]
+          .supervisor
+          .tell(StreamSupervisor.GetChildren, testActor)
+        val ref = expectMsgType[Children].children.find(_.path.toString contains "foldResourceSink").get
+        val subscription = pub.expectSubscription()
+        subscription.expectRequest()
+        subscription.sendNext("hello")
+        try assertDispatcher(ref, ActorAttributes.IODispatcher.dispatcher)
+        finally {
+          subscription.sendComplete()
+        }
+        completion.futureValue shouldBe Done
+        checkFileContents(path, "hello")
+      }
+
+    }
+
+    "fail when create throws exception" in {
+      val (pub, completion) = TestSource[String]()
+        .toMat(
+          Sink.foldResource[BufferedWriter, String](() => throw ex)(
+            (writer, line) => writer.write(line),
+            writer => writer.close()))(Keep.both)
+        .run()
+      pub.expectCancellationWithCause(ex)
+      completion.failed.futureValue shouldBe (ex)
+    }
+
+    "fail when close throws exception" in {
+      val completion =
+        Source.single(1).runWith(Sink.foldResource(() => Iterator("a"))((_, _) => (), _ => throw TE("")))
+      completion.failed.futureValue shouldBe a[TE]
+    }
+
+    "not close the resource twice when read fails" in {
+      val closedCounter = new AtomicInteger(0)
+      val completion = Source
+        .repeat(1)
+        .runWith(
+          Sink.foldResource(() => 23)( // the best resource there is
+            (_, _) => throw TE("failing read"),
+            _ => {
+              closedCounter.incrementAndGet()
+              None
+            }))
+      completion.failed.futureValue shouldBe a[TE]
+      closedCounter.get() should ===(1)
+    }
+
+    "not close the resource twice when read fails and then close fails" in {
+      val closedCounter = new AtomicInteger(0)
+      val completion = Source
+        .repeat(1)
+        .runWith(Sink.foldResource(() => 23)((_, _) => throw TE("failing read"), _ => {
+          closedCounter.incrementAndGet()
+          if (closedCounter.get == 1) throw TE("boom")
+          None
+        }))
+
+      completion.failed.futureValue shouldBe a[TE]
+      closedCounter.get() should ===(1)
+    }
+
+    "will close the resource when upstream complete" in {
+      val closedCounter = new AtomicInteger(0)
+      val (pub, completion) = TestSource[Int]()
+        .toMat(Sink.foldResource(() => 23)((_, _) => (), _ => {
+          closedCounter.incrementAndGet()
+        }))(Keep.both)
+        .run()
+      pub.sendNext(1)
+      pub.sendComplete()
+      completion.futureValue shouldBe Done
+      closedCounter.get shouldBe (1)
+    }
+
+    "will close the resource when upstream fail" in {
+      val closedCounter = new AtomicInteger(0)
+      val (pub, completion) = TestSource[Int]()
+        .toMat(Sink.foldResource(() => 23)((_, _) => (), _ => {
+          closedCounter.incrementAndGet()
+        }))(Keep.both)
+        .run()
+      pub.sendNext(1)
+      pub.sendError(ex)
+      completion.failed.futureValue shouldBe ex
+      closedCounter.get shouldBe (1)
+    }
+
+    "will close the resource on abrupt materializer termination" in {
+      @nowarn("msg=deprecated")
+      val mat = ActorMaterializer()
+      targetFile { path =>
+        val promise = Promise[Done]()
+        val matVal = TestSource[String]().runWith(Sink.foldResource(() => {
+          newBufferWriter(path)
+        })((writer, str) => writer.write(str), writer => {
+          writer.close()
+          promise.complete(Success(Done))
+        }))(mat)
+        mat.shutdown()
+        matVal.failed.futureValue shouldBe an[AbruptTerminationException]
+        promise.future.futureValue shouldBe Done
+      }
+    }
+
+    "not allow null resource" in {
+      EventFilter[NullPointerException](occurrences = 1).intercept {
+        Source
+          .single("one")
+          .runWith(Sink.foldResource(() => null: String)((_, _) => (), _ => None))
+          .failed
+          .futureValue shouldBe a[NullPointerException]
+      }
+    }
+
+    "not allow null resource on restart" in {
+      val counter = new AtomicInteger(0)
+      EventFilter[NullPointerException](occurrences = 1).intercept {
+        Source
+          .single("one")
+          .runWith(
+            Sink
+              .foldResource[String, String](() => if (counter.incrementAndGet() == 1) "state" else null)(
+                (_, _) => throw TE("boom"),
+                _ => None)
+              .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider)))
+          .failed
+          .futureValue shouldBe a[NullPointerException]
+      }
+    }
+
+  }
+  private def targetFile(block: Path => Unit, create: Boolean = true): Unit = {
+    val targetFile = Files.createTempFile(fs.getPath("/"), "fold-resource", ".tmp")
+    if (!create) Files.delete(targetFile)
+    try block(targetFile)
+    finally Files.delete(targetFile)
+  }
+
+  def checkFileContents(f: Path, contents: String): Unit = {
+    val out = Files.readAllBytes(f)
+    new String(out) should ===(contents)
+  }
+
+  override def afterTermination(): Unit = {
+    fs.close()
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -149,6 +149,7 @@ import akka.stream.Attributes._
     val outputStreamSink = name("outputStreamSink") and IODispatcher
     val inputStreamSink = name("inputStreamSink")
     val fileSink = name("fileSink") and IODispatcher
+    val foldResourceSink = name("foldResourceSink") and IODispatcher
     val fromJavaStream = name("fromJavaStream")
 
     val inputBoundary = name("input-boundary")

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -755,6 +755,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream. The returned `T` MUST NOT be `null` as it is illegal as stream element - according to the Reactive Streams specification.
+   * A `null` resource is not allowed and will fail the stream.
    *
    * The `close` function is called only once when the upstream or downstream finishes or fails. You can do some clean-up here,
    * and if the returned value is not empty, it will be emitted to the downstream if available, otherwise the value will be dropped.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2447,6 +2447,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream. The returned `T` MUST NOT be `null` as it is illegal as stream element - according to the Reactive Streams specification.
+   * A `null` resource is not allowed and will fail the stream.
    *
    * The `close` function is called only once when the upstream or downstream finishes or fails. You can do some clean-up here,
    * and if the returned value is not empty, it will be emitted to the downstream if available, otherwise the value will be dropped.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -241,6 +241,7 @@ final class SubFlow[In, Out, Mat](
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream. The returned `T` MUST NOT be `null` as it is illegal as stream element - according to the Reactive Streams specification.
+   * A `null` resource is not allowed and will fail the stream.
    *
    * The `close` function is called only once when the upstream or downstream finishes or fails. You can do some clean-up here,
    * and if the returned value is not empty, it will be emitted to the downstream if available, otherwise the value will be dropped.

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -232,6 +232,7 @@ final class SubSource[Out, Mat](
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream. The returned `T` MUST NOT be `null` as it is illegal as stream element - according to the Reactive Streams specification.
+   * A `null` resource is not allowed and will fail the stream.
    *
    * The `close` function is called only once when the upstream or downstream finishes or fails. You can do some clean-up here,
    * and if the returned value is not empty, it will be emitted to the downstream if available, otherwise the value will be dropped.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1037,6 +1037,7 @@ trait FlowOps[+Out, +Mat] {
    * The resource creation function is invoked once when the stream is materialized and the returned resource is passed to
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream. The returned `T` MUST NOT be `null` as it is illegal as stream element - according to the Reactive Streams specification.
+   * A `null` resource is not allowed and will fail the stream.
    *
    * The `close` function is called only once when the upstream or downstream finishes or fails. You can do some clean-up here,
    * and if the returned value is not empty, it will be emitted to the downstream if available, otherwise the value will be dropped.


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/akka/akka/issues/21526

Should this method be named with `foldResource` ,`foldWithResource` or `toResource`?
I personally prefer `foldWithResource`

previous prs:
https://github.com/akka/akka/pull/21554
https://github.com/akka/akka/pull/26393

built on top of https://github.com/akka/akka/pull/31361


NOTE:
I built it with `statefulMap` but not a new `FoldResourceSink` or `FoldResourceAsyncSink`, which will introduce more weight for review.
The current implementation generates one `()` allocation per element. 

Fixed some documents in `mapWithResource.md` too.