### PR TITLE
=str Optimize performance of MapAsyncUnordered(1).

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/MapAsyncOneBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/MapAsyncOneBenchmark.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2014-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.remote.artery.BenchTestSource
+import akka.remote.artery.LatchSink
+import akka.stream.impl.fusing.MapAsyncUnordered
+import akka.stream.impl.fusing.MapAsyncUnordered1
+import akka.stream.scaladsl._
+import akka.stream.testkit.scaladsl.StreamTestKit
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+object MapAsyncOneBenchmark {
+  final val OperationsPerInvocation = 100000
+}
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+class MapAsyncOneBenchmark {
+  import MapAsyncBenchmark._
+
+  val config = ConfigFactory.parseString("""
+    akka.actor.default-dispatcher {
+      executor = "fork-join-executor"
+      fork-join-executor {
+        parallelism-factor = 1
+      }
+    }
+    """)
+
+  implicit val system: ActorSystem = ActorSystem("MapAsyncBenchmark", config)
+  import system.dispatcher
+
+  var testSource: Source[java.lang.Integer, NotUsed] = _
+  @Param(Array("false", "true"))
+  var spawn = false
+
+  @Setup
+  def setup(): Unit = {
+    // eager init of materializer
+    SystemMaterializer(system).materializer
+    testSource = Source.fromGraph(new BenchTestSource(OperationsPerInvocation))
+  }
+
+  @TearDown
+  def shutdown(): Unit = {
+    Await.result(system.terminate(), 5.seconds)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(OperationsPerInvocation)
+  def mapAsyncUnordered(): Unit = {
+    val latch = new CountDownLatch(1)
+
+    testSource
+      .via(MapAsyncUnordered(1, (elem => if (spawn) Future(elem) else Future.successful(elem))))
+      .runWith(new LatchSink(OperationsPerInvocation, latch))
+
+    awaitLatch(latch)
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(OperationsPerInvocation)
+  def mapAsyncUnordered1(): Unit = {
+    val latch = new CountDownLatch(1)
+
+    testSource
+      .via(MapAsyncUnordered1((elem => if (spawn) Future(elem) else Future.successful(elem))))
+      .runWith(new LatchSink(OperationsPerInvocation, latch))
+
+    awaitLatch(latch)
+  }
+
+  private def awaitLatch(latch: CountDownLatch): Unit = {
+    if (!latch.await(30, TimeUnit.SECONDS)) {
+      StreamTestKit.printDebugDump(SystemMaterializer(system).materializer.supervisor)
+      throw new RuntimeException("Latch didn't complete in time")
+    }
+  }
+
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1262,7 +1262,8 @@ trait FlowOps[+Out, +Mat] {
    *
    * @see [[#mapAsync]] and [[#mapAsyncPartitioned]]
    */
-  def mapAsyncUnordered[T](parallelism: Int)(f: Out => Future[T]): Repr[T] = via(MapAsyncUnordered(parallelism, f))
+  def mapAsyncUnordered[T](parallelism: Int)(f: Out => Future[T]): Repr[T] =
+    if (parallelism == 1) via(MapAsyncUnordered1(f)) else via(MapAsyncUnordered(parallelism, f))
 
   /**
    * Use the `ask` pattern to send a request-reply message to the target `ref` actor.


### PR DESCRIPTION
Run with 
> jmh:run -i 20 -wi 20 -f1 -t1 .*MapAsyncBenchmark.*
I adjusted it a little to just run with `1`.

>jmh:run -i 20 -wi 20 -f1 -t1 .MapAsyncOneBenchmark.

Before:
```
[info] Iteration  20: 2022-09-11 17:14:30,867 INFO  akka.actor.CoordinatedShutdown  - Running CoordinatedShutdown with reason [ActorSystemTerminateReason] MDC: {akkaAddress=akka://MapAsyncBenchmark, akkaUid=-6827262736314033361, sourceThread=akka.stream.MapAsyncBenchmark.mapAsyncUnordered-jmh-worker-1, akkaSource=CoordinatedShutdown(akka://MapAsyncBenchmark), sourceActorSystem=MapAsyncBenchmark, akkaTimestamp=09:14:30.864UTC}
[info] 306857.968 ops/s
[info] Result "akka.stream.MapAsyncBenchmark.mapAsyncUnordered":
[info]   319643.963 锟斤拷(99.9%) 25725.842 ops/s [Average]
[info]   (min, avg, max) = (282843.475, 319643.963, 363219.309), stdev = 29625.918
[info]   CI (99.9%): [293918.121, 345369.805] (assumes normal distribution)
[info] # Run complete. Total time: 00:13:31
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                            (parallelism)  (spawn)   Mode  Cnt         Score        Error  Units
[info] MapAsyncBenchmark.mapAsyncUnordered              1    false  thrpt   20  15452906.430 锟斤拷 244116.496  ops/s
[info] MapAsyncBenchmark.mapAsyncUnordered              1     true  thrpt   20    319643.963 锟斤拷  25725.842  ops/s
```

after 

```
[info] Iteration  20: 2022-09-11 17:31:28,159 INFO  akka.actor.CoordinatedShutdown  - Running CoordinatedShutdown with reason [ActorSystemTerminateReason] MDC: {akkaAddress=akka://MapAsyncBenchmark, akkaUid=-5508069858145503529, sourceThread=akka.stream.MapAsyncBenchmark.mapAsyncUnordered-jmh-worker-1, akkaSource=CoordinatedShutdown(akka://MapAsyncBenchmark), sourceActorSystem=MapAsyncBenchmark, akkaTimestamp=09:31:28.157UTC}
[info] 356229.926 ops/s
[info] Result "akka.stream.MapAsyncBenchmark.mapAsyncUnordered":
[info]   341701.873 锟斤拷(99.9%) 21521.068 ops/s [Average]
[info]   (min, avg, max) = (288813.936, 341701.873, 367134.275), stdev = 24783.694
[info]   CI (99.9%): [320180.805, 363222.940] (assumes normal distribution)
[info] # Run complete. Total time: 00:13:31
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                            (parallelism)  (spawn)   Mode  Cnt         Score        Error  Units
[info] MapAsyncBenchmark.mapAsyncUnordered              1    false  thrpt   20  19811428.492 锟斤拷 119502.131  ops/s
[info] MapAsyncBenchmark.mapAsyncUnordered              1     true  thrpt   20    393896.158 锟斤拷 19592.226  ops/s


```