### PR TITLE
add missing .withAllocationStrategy(ExternalShardAllocationStrategy) example for Java

### DIFF
--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ExternalShardAllocationCompileOnlyTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ExternalShardAllocationCompileOnlyTest.java
@@ -9,12 +9,15 @@ import akka.actor.Address;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.ActorSystem;
 import akka.cluster.sharding.external.ExternalShardAllocation;
+import akka.cluster.sharding.external.ExternalShardAllocationStrategy;
 import akka.cluster.sharding.external.javadsl.ExternalShardAllocationClient;
 import akka.cluster.sharding.typed.ShardingEnvelope;
 import akka.cluster.sharding.typed.javadsl.ClusterSharding;
 import akka.cluster.sharding.typed.javadsl.Entity;
 import akka.cluster.sharding.typed.javadsl.EntityTypeKey;
+import akka.util.Timeout;
 
+import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 
 import static jdocs.akka.cluster.sharding.typed.ShardingCompileOnlyTest.Counter;
@@ -31,7 +34,7 @@ public class ExternalShardAllocationCompileOnlyTest {
 
     ActorRef<ShardingEnvelope<Counter.Command>> shardRegion =
             sharding.init(Entity.of(typeKey, ctx -> Counter.create(ctx.getEntityId()))
-                    .withAllocationStrategy(new ExternalShardAllocationStrategy(system, typeKey.name(), new Timeout(new FiniteDuration(5, TimeUnit.SECONDS)))));
+                    .withAllocationStrategy(new ExternalShardAllocationStrategy(system, typeKey.name(), Timeout.create(Duration.ofSeconds(5)))));
     // #entity
 
     // #client

--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ExternalShardAllocationCompileOnlyTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ExternalShardAllocationCompileOnlyTest.java
@@ -30,7 +30,8 @@ public class ExternalShardAllocationCompileOnlyTest {
     EntityTypeKey<Counter.Command> typeKey = EntityTypeKey.create(Counter.Command.class, "Counter");
 
     ActorRef<ShardingEnvelope<Counter.Command>> shardRegion =
-        sharding.init(Entity.of(typeKey, ctx -> Counter.create(ctx.getEntityId())));
+            sharding.init(Entity.of(typeKey, ctx -> Counter.create(ctx.getEntityId()))
+                    .withAllocationStrategy(new ExternalShardAllocationStrategy(system, typeKey.name(), new Timeout(new FiniteDuration(5, TimeUnit.SECONDS)))));
     // #entity
 
     // #client


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
The [Java] sample source code is missing .withAllocationStrategy when illustrating how to use ExternalShardAllocationStrategy as described [here](https://doc.akka.io/docs/akka/current/typed/cluster-sharding.html#external-shard-allocation).
