### PR TITLE
Optimize flatMapConcat for iterable and empty source.

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -272,6 +272,7 @@ object Source {
     apply(new immutable.Iterable[T] {
       override def iterator: Iterator[T] = f()
       override def toString: String = "() => Iterator"
+      override def hasDefiniteSize: Boolean = false
     })
 
   /**

--- a/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
+++ b/akka-stream/src/main/scala/akka/stream/stage/GraphStage.scala
@@ -101,7 +101,7 @@ abstract class AbstractGraphStageWithMaterializedValue[+S <: Shape, M] extends G
  * A GraphStage consists of a [[Shape]] which describes its input and output ports and a factory function that
  * creates a [[GraphStageLogic]] which implements the processing logic that ties the ports together.
  */
-abstract class GraphStage[S <: Shape] extends GraphStageWithMaterializedValue[S, NotUsed] {
+abstract class GraphStage[+S <: Shape] extends GraphStageWithMaterializedValue[S, NotUsed] {
   final override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, NotUsed) =
     (createLogic(inheritedAttributes), NotUsed)
 


### PR DESCRIPTION
A follow up of https://github.com/akka/akka/pull/31372.

refs: https://github.com/akka/akka/issues/21462

Draft status, just make the test pass and the `SupervisionStrategy` is not handle

If this is acceptable I will try with `Source.fromFuture` later in a separated pr.

single source case is already done in : https://github.com/akka/akka/pull/25242

>jmh:run -prof gc -i 5 -wi 5 -f2 -t1 akka.stream.FlatMapConcatBenchmark
for oneElementList:
```
main branch:
[info] FlatMapConcatBenchmark.oneElementList                                     thrpt   10    379866.207 锟斤拷   4994.706   ops/s
this branch:
[info] FlatMapConcatBenchmark.oneElementList                                     thrpt   10   4807136.226 锟斤拷  49006.261   ops/s
```

Run with main branch:
![image](https://user-images.githubusercontent.com/501740/190855869-e0e2e66b-74e1-4bf6-8246-8a5be844245a.png)


Run with this branch:
![image](https://user-images.githubusercontent.com/501740/190855110-1b1363e3-911e-4982-977e-9295f85b6a8d.png)
