### PR TITLE
typed javadsl: introduce AbstractOnMessageBehavior

### DIFF
--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OnMessageIntroTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OnMessageIntroTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.akka.typed;
+
+// #imports
+import akka.actor.typed.ActorRef;
+import akka.actor.typed.Behavior;
+import akka.actor.typed.javadsl.AbstractOnMessageBehavior;
+import akka.actor.typed.javadsl.ActorContext;
+import akka.actor.typed.javadsl.Behaviors;
+
+// #imports
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public interface OnMessageIntroTest {
+	// #chatroom-behavior
+	public class ChatRoom {
+		// #chatroom-behavior
+		// #chatroom-protocol
+		static interface RoomCommand {}
+
+		public static final class GetSession implements RoomCommand {
+			public final String screenName;
+			public final ActorRef<SessionEvent> replyTo;
+
+			public GetSession(String screenName, ActorRef<SessionEvent> replyTo) {
+				this.screenName = screenName;
+				this.replyTo = replyTo;
+			}
+		}
+		// #chatroom-protocol
+		// #chatroom-behavior
+		private static final class PublishSessionMessage implements RoomCommand {
+			public final String screenName;
+			public final String message;
+
+			public PublishSessionMessage(String screenName, String message) {
+				this.screenName = screenName;
+				this.message = message;
+			}
+		}
+		// #chatroom-behavior
+		// #chatroom-protocol
+		
+		static interface SessionEvent {}
+
+		public static final SessionGranted implements SessionEvent {
+			public final ActorRef<PostMessage> handle;
+
+			public SessionGranted(ActorRef<PostMessage> handle) {
+				this.handle = handle;
+			}
+		}
+
+		public static final SessionDenied implements SessionEvent {
+			public final String reason;
+
+			public SessionDenied(String reason) {
+				this.reason = reason;
+			}
+		}
+
+		public static final class MessagePosted implements SessionEvent {
+			public final String screenName;
+			public final String message;
+
+			public MessagePosted(String screenName, String message) {
+				this.screenName = screenName;
+				this.message = message;
+			}
+		}
+
+		static interface SessionCommand {}
+
+		public static final class PostMessage implements SessionCommand {
+			public final String message;
+
+			public PostMessage(String message) {
+				this.message = message;
+			}
+		}
+
+		private static final class NotifyClient implements SessionCommand {
+			final MessagePosted message;
+
+			NotifyClient(MessagePosted message) {
+				this.message = message;
+			}
+		}
+		// #chatroom-protocol
+		// #chatroom-behavior
+
+		public static Behavior<RoomCommand> create() {
+			return Behaviors.setup(ChatRoomBehavior::new)
+		}
+
+		public static class ChatRoomBehavior extends AbstractOnMessageBehavior<RoomCommand> {
+			final List<ActorRef<SessionCommand>> sessions = new ArrayList<>();
+
+			private ChatRoomBehavior(ActorContext<RoomCommand> context) {
+				super(context);
+			}
+
+			@Override
+			public Behavior<RoomCommand> onMessage(RoomCommand msg) {
+				/* From Java 16 onward, various features broadly described as "pattern matching"
+				 * may prove useful here in lieu of the explicit instanceof checks and casts here:
+				 *
+				 * Java 16 onward: JEP 394 (https://openjdk.java.net/jeps/394) =>
+				 *   if (msg instanceof GetSession gs) {
+				 *     return onGetSession(gs);
+				 *   } else if (msg instanceof PublishSessionMessage psm) {
+				 *     return onPublishSessionMessage(psm);
+				 *   }
+				 *
+				 * Java 17 onward: JEP 406 (https://openjdk.org/jeps/406) =>
+				 *   switch(msg) {
+				 *     // NB: default clause omitted for brevity - JEP 409 (https://openjdk.org/jeps/409)
+				 *     // may allow not including a default clause
+				 *     case GetSession gs:
+				 *       return onGetSession(gs);
+				 *
+				 *     case PublishSessionMessage psm:
+				 *       return onPublishSessionMessage(psm);
+				 *   }
+				 *
+				 * JEPs 420 and 427 make possibly-useful extensions to JEP 406 in post-17 Java versions.
+				 *
+				 * TODO: when we're comfortable with requiring JDK17 for development, replace this with
+				 * JEP406 example
+				 */
+				if (msg instanceof GetSession) {
+					return onGetSession((GetSession)msg);
+				} else if (msg instanceof PublishSessionMessage) {
+					return onPublishSessionMessage((PublishSessionMessage)msg);
+				}
+
+				// for completeness
+				return Behaviors.unhandled();
+			}
+
+			private Behavior<RoomCommand> onGetSession(GetSession gs) throws UnsupportedEncodingException {
+				ActorRef<SessionEvent> client = gs.replyTo;
+				ActorRef<SessionCommand> ses =
+					getContext().spawn(
+						SessionBehavior.create(getContext().getSelf(), gs.screenName, client),
+						URLEncoder.encode(gs.screenName, StandardCharsets.UTF_8.name())
+					);
+
+				// narrow to only expose PostMessage
+				client.tell(new SessionGranted(ses.narrow()));
+				sessions.add(ses);
+
+				return this;
+			}
+
+			private Behavior<RoomCommand> onPublishSessionMessage(PublishSessionMessage pub) {
+				NotifyClient notification =
+					new NotifyClient(new MessagePosted(pub.screenName, pub.message));
+
+				sessions.forEach(s -> s.tell(notification));
+				return this;
+			}
+		}
+
+		static class SessionBehavior extends AbstractOnMessageBehavior<SessionCommand> {
+			private final ActorRef<RoomCommand> room;
+			private final String screenName;
+			private final ActorRef<SessionEvent> client;
+
+			public static Behavior<SessionCommand> create(
+				ActorRef<RoomCommand> room,
+				String screenName,
+				ActorRef<SessionEvent> client
+			) {
+				return Behaviors.setup(context -> new SessionBehavior(context, room, screenName, client));
+			}
+
+			private SessionBehavior(
+				ActorContext<SessionCommand> context,
+				ActorRef<RoomCommand> room,
+				String screenName,
+				ActorRef<SessionEvent> client
+			) {
+				super(context);
+				this.room = room;
+				this.screenName = screenName;
+				this.client = client;
+			}
+
+			@Override
+			public Behavior<SessionCommand> onMessage(SessionCommand msg) {
+				// TODO: JEP406ify
+				if (msg instanceof PostMessage) {
+					// from client, publish to others via the room
+					room.tell(new PublishSessionMessage(screenName, ((PostMessage)msg).message));
+					return Behaviors.same();
+				} else if (msg instanceof NotifyClient) {
+					// published from the room
+					client.tell(((NotifyClient)msg).message);
+					return Behaviors.same();
+				}
+			}
+		}
+	}
+	// #chatroom-behavior
+
+  // #chatroom-gabbler
+  public class Gabbler extends AbstractBehavior<ChatRoom.SessionEvent> {
+    public static Behavior<ChatRoom.SessionEvent> create() {
+      return Behaviors.setup(Gabbler::new);
+    }
+
+    private Gabbler(ActorContext<ChatRoom.SessionEvent> context) {
+      super(context);
+    }
+
+    @Override
+    public Receive<ChatRoom.SessionEvent> createReceive() {
+      ReceiveBuilder<ChatRoom.SessionEvent> builder = newReceiveBuilder();
+      return builder
+          .onMessage(ChatRoom.SessionDenied.class, this::onSessionDenied)
+          .onMessage(ChatRoom.SessionGranted.class, this::onSessionGranted)
+          .onMessage(ChatRoom.MessagePosted.class, this::onMessagePosted)
+          .build();
+    }
+
+    private Behavior<ChatRoom.SessionEvent> onSessionDenied(ChatRoom.SessionDenied message) {
+      getContext().getLog().info("cannot start chat room session: {}", message.reason);
+      return Behaviors.stopped();
+    }
+
+    private Behavior<ChatRoom.SessionEvent> onSessionGranted(ChatRoom.SessionGranted message) {
+      message.handle.tell(new ChatRoom.PostMessage("Hello World!"));
+      return Behaviors.same();
+    }
+
+    private Behavior<ChatRoom.SessionEvent> onMessagePosted(ChatRoom.MessagePosted message) {
+      getContext()
+          .getLog()
+          .info("message has been posted by '{}': {}", message.screenName, message.message);
+      return Behaviors.stopped();
+    }
+  }
+  // #chatroom-gabbler
+
+  // #chatroom-main
+  public class Main {
+    public static Behavior<Void> create() {
+      return Behaviors.setup(
+          context -> {
+            ActorRef<ChatRoom.RoomCommand> chatRoom = context.spawn(ChatRoom.create(), "chatRoom");
+            ActorRef<ChatRoom.SessionEvent> gabbler = context.spawn(Gabbler.create(), "gabbler");
+            context.watch(gabbler);
+            chatRoom.tell(new ChatRoom.GetSession("ol’ Gabbler", gabbler));
+
+            return Behaviors.receive(Void.class)
+                .onSignal(Terminated.class, sig -> Behaviors.stopped())
+                .build();
+          });
+    }
+
+    public static void main(String[] args) {
+      ActorSystem.create(Main.create(), "ChatRoomDemo");
+    }
+  }
+  // #chatroom-main
+}

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OnMessageIntroTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OnMessageIntroTest.java
@@ -115,6 +115,7 @@ public interface OnMessageIntroTest {
 
       @Override
       public Behavior<RoomCommand> onMessage(RoomCommand msg) throws UnsupportedEncodingException {
+        // #chatroom-behavior
         /* From Java 16 onward, various features broadly described as "pattern matching"
          * may prove useful here in lieu of the explicit instanceof checks and casts:
          *
@@ -126,23 +127,26 @@ public interface OnMessageIntroTest {
          *   }
          *
          * Java 17 onward: JEP 406 (https://openjdk.org/jeps/406) =>
-         *   switch(msg) {
-         *     // NB: default clause omitted for brevity - JEP 409 (https://openjdk.org/jeps/409)
-         *     // may allow not including a default clause
-         *     case GetSession gs:
-         *       return onGetSession(gs);
-         *
-         *     case PublishSessionMessage psm:
-         *       return onPublishSessionMessage(psm);
-         *   }
+         // #chatroom-behavior
+        // uses Java 17-onward features
+        switch(msg) {
+          // NB: JEP 409 (https://openjdk.org/jeps/409) may allow not including a default clause
+          case GetSession gs:
+            return onGetSession(gs);
+
+          case PublishSessionMessage psm:
+            return onPublishSessionMessage(psm);
+
+          default:
+            // for completeness, should never happen
+        }
+        // #chatroom-behavior
          *
          * JEPs 420 and 427 make possibly-useful extensions to JEP 406 in post-17 Java versions.
-         */
-		// #chatroom-behavior
-        /* TODO: when we're comfortable with requiring JDK17 for development, replace this with
+         *
+         * TODO: when we're comfortable with requiring JDK17 for development, replace this with
          * JEP406 example
-		 */
-		// #chatroom-behavior
+         */
         if (msg instanceof GetSession) {
           return onGetSession((GetSession) msg);
         } else if (msg instanceof PublishSessionMessage) {
@@ -150,6 +154,7 @@ public interface OnMessageIntroTest {
         }
 
         // for completeness
+        // #chatroom-behavior
         return Behaviors.unhandled();
       }
 
@@ -201,9 +206,8 @@ public interface OnMessageIntroTest {
 
       @Override
       public Behavior<SessionCommand> onMessage(SessionCommand msg) {
-		// #chatroom-behavior
+        // #chatroom-behavior
         // TODO: JEP406ify
-		// #chatroom-behavior
         if (msg instanceof PostMessage) {
           // from client, publish to others via the room
           room.tell(new PublishSessionMessage(screenName, ((PostMessage) msg).message));
@@ -215,12 +219,33 @@ public interface OnMessageIntroTest {
         }
 
         // for completeness
+        /*
+        // #chatroom-behavior
+        switch (msg) {
+          case PostMessage pm:
+            // from client, publish to others via the room
+            room.tell(new PublishSessionMessage(screenName, pm.message);
+            return Behaviors.same();
+
+          case NotifyClient nc:
+            // published from the room
+            client.tell(nc.message);
+            return Behaviors.same();
+
+          default:
+            // for completeness, should never happen
+        }
+        // #chatroom-behavior
+        */
+        // #chatroom-behavior
+
         return Behaviors.unhandled();
       }
     }
   }
   // #chatroom-behavior
 
+  // NB: leaving the gabbler as an AbstractBehavior, as the point should be made by now
   // #chatroom-gabbler
   public class Gabbler extends AbstractBehavior<ChatRoom.SessionEvent> {
     public static Behavior<ChatRoom.SessionEvent> create() {

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OnMessageIntroTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OnMessageIntroTest.java
@@ -118,7 +118,7 @@ public interface OnMessageIntroTest {
       @Override
       public Behavior<RoomCommand> onMessage(RoomCommand msg) throws UnsupportedEncodingException {
         /* From Java 16 onward, various features broadly described as "pattern matching"
-         * may prove useful here in lieu of the explicit instanceof checks and casts here:
+         * may prove useful here in lieu of the explicit instanceof checks and casts:
          *
          * Java 16 onward: JEP 394 (https://openjdk.java.net/jeps/394) =>
          *   if (msg instanceof GetSession gs) {

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OnMessageIntroTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OnMessageIntroTest.java
@@ -43,7 +43,6 @@ public interface OnMessageIntroTest {
       }
     }
     // #chatroom-protocol
-    // #chatroom-behavior
     private static final class PublishSessionMessage implements RoomCommand {
       public final String screenName;
       public final String message;
@@ -53,7 +52,6 @@ public interface OnMessageIntroTest {
         this.message = message;
       }
     }
-    // #chatroom-behavior
     // #chatroom-protocol
 
     static interface SessionEvent {}
@@ -139,10 +137,12 @@ public interface OnMessageIntroTest {
          *   }
          *
          * JEPs 420 and 427 make possibly-useful extensions to JEP 406 in post-17 Java versions.
-         *
-         * TODO: when we're comfortable with requiring JDK17 for development, replace this with
-         * JEP406 example
          */
+		// #chatroom-behavior
+        /* TODO: when we're comfortable with requiring JDK17 for development, replace this with
+         * JEP406 example
+		 */
+		// #chatroom-behavior
         if (msg instanceof GetSession) {
           return onGetSession((GetSession) msg);
         } else if (msg instanceof PublishSessionMessage) {
@@ -201,7 +201,9 @@ public interface OnMessageIntroTest {
 
       @Override
       public Behavior<SessionCommand> onMessage(SessionCommand msg) {
+		// #chatroom-behavior
         // TODO: JEP406ify
+		// #chatroom-behavior
         if (msg instanceof PostMessage) {
           // from client, publish to others via the room
           room.tell(new PublishSessionMessage(screenName, ((PostMessage) msg).message));

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AbstractOnMessageBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AbstractOnMessageBehavior.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.javadsl
+
+import akka.actor.typed.{ Behavior, ExtensibleBehavior, MessageAdaptionFailure, Signal, TypedActorContext }
+
+/**
+ * An actor `Behavior` can be implemented by extending this class and implementing the abstract
+ * method [[AbstractOnMessageBehavior#onMessage]].  Mutable state can be defined as instance
+ * variables of the class.
+ *
+ * This is an object-oriented style of defining a `Behavior`.  A more functional style alternative
+ * is provided by the factory methods in [[Behaviors]], for example [[Behaviors.receiveMessage]].
+ *
+ * An alternative object-oriented style is found in [[AbstractBehavior]], which uses builders to
+ * define the `Behavior`.  In contrast to extending [[AbstractBehavior]], extending this class
+ * should have reduced overhead, though depending on the complexity of the protocol handled by
+ * this actor and on the Java version in use, the `onMessage` and `onSignal` methods may be overly
+ * complex.
+ *
+ * Instances of this behavior should be created via [[Behaviors.setup]] and the [[ActorContext]] should
+ * be passed as a constructor parameter from the factory function.  This is important because a new
+ * instance should be created when restart supervision is used.
+ *
+ * When switching behavior to another behavior which requires a context, the original `ActorContext` can
+ * be used or a `Behaviors.setup` can be used: either will end up using the same `ActorContext` instance.
+ *
+ * It must not be created with an `ActorContext` of another actor (e.g. the parent actor).  Doing so
+ * will be detected at runtime and throw an `IllegalStateException` when the first message is received.
+ *
+ * @see [[Behaviors.setup]]
+ */
+abstract class AbstractOnMessageBehavior[T](context: ActorContext[T]) extends ExtensibleBehavior[T] {
+  if (context eq null)
+    throw new IllegalArgumentException(
+      "context must not be null.  Wrap in Behaviors.setup and " +
+      "pass the context to the constructor of AbstractOnMessageBehavior.")
+
+  /**
+   * Implement this to define how messages are processed.  To indicate no change in behavior beyond
+   * changes due to updating instance variables of this class, one may return either `this` or [[Behaviors.same]].
+   */
+  @throws(classOf[Exception])
+  def onMessage(message: T): Behavior[T]
+
+  /**
+   * Override this to handle a signal.  The default implementation handles only `MessageAdaptionFailure` and
+   * otherwise ignores the signal.
+   */
+  @throws(classOf[Exception])
+  def onSignal(signal: Signal): Behavior[T] = {
+    signal match {
+      case maf: MessageAdaptionFailure => throw maf.exception
+      case _ => this
+    }
+  }
+
+  protected def getContext: ActorContext[T] = context
+
+  @throws(classOf[Exception])
+  override final def receive(ctx: TypedActorContext[T], msg: T): Behavior[T] = {
+    checkRightContext(ctx)
+    onMessage(msg)
+  }
+
+  @throws(classOf[Exception])
+  override final def receiveSignal(ctx: TypedActorContext[T], signal: Signal): Behavior[T] = {
+    checkRightContext(ctx)
+    onSignal(signal)
+  }
+
+  private def checkRightContext(ctx: TypedActorContext[T]): Unit =
+    if (ctx.asJava ne context)
+      throw new IllegalStateException(
+        s"Actor [${ctx.asJava.getSelf}] of AbstractOnMessageBehavior class " +
+        s"[${getClass.getName}] was created with the wrong ActorContext [${context.asJava.getSelf}]. " +
+        "Wrap in Behaviors.setup and pass the context to the constructor of AbstractOnMessageBehavior.")
+}

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AbstractOnMessageBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AbstractOnMessageBehavior.scala
@@ -53,7 +53,7 @@ abstract class AbstractOnMessageBehavior[T](context: ActorContext[T]) extends Ex
   def onSignal(signal: Signal): Behavior[T] = {
     signal match {
       case maf: MessageAdaptionFailure => throw maf.exception
-      case _ => this
+      case _                           => this
     }
   }
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AbstractOnMessageBehavior.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/javadsl/AbstractOnMessageBehavior.scala
@@ -52,12 +52,12 @@ abstract class AbstractOnMessageBehavior[T](context: ActorContext[T]) extends Ex
   @throws(classOf[Exception])
   def onSignal(signal: Signal): Behavior[T] = {
     signal match {
-      case maf: MessageAdaptionFailure => throw maf.exception
-      case _                           => this
+      case _: MessageAdaptionFailure => Behaviors.unhandled
+      case _                         => this
     }
   }
 
-  protected def getContext: ActorContext[T] = context
+  final protected def getContext: ActorContext[T] = context
 
   @throws(classOf[Exception])
   override final def receive(ctx: TypedActorContext[T], msg: T): Behavior[T] = {

--- a/akka-docs/src/main/paradox/typed/actors.md
+++ b/akka-docs/src/main/paradox/typed/actors.md
@@ -412,6 +412,25 @@ former simply speaks more languages than the latter. The opposite would be
 problematic, so passing an @scala[`ActorRef[PublishSessionMessage]`]@java[`ActorRef<PublishSessionMessage>`] where
 @scala[`ActorRef[RoomCommand]`]@java[`ActorRef<RoomCommand>`] is required will lead to a type error.
 
+#### AbstractOnMessageBehavior API
+
+@java[The `AbstractBehavior` API typically makes heavy use of builders which allows `instanceof` checks and casts to be
+performed "behind the scenes".  In some cases, it may be preferred to use a more "direct" style where a `Behavior`
+is, essentially, a function converting a message into a successor `Behavior`.  In contrast to builders, this style
+may have sufficiently reduced runtime overhead to be worth a little extra verbosity (recently-added Java features
+under the "pattern-matching" umbrella may substantially reduce that verbosity).]
+
+@java[To support this style, an alternative API for defining behavior in an object-oriented style is available by
+extending @apidoc(typed.javadsl.AbstractOnMessageBehavior).]
+
+@java[Here's the `AbstractOnMessageBehavior`-based implementation of the chat room protocol:]
+
+Scala
+: The Java API exposes the `AbstractOnMessageBehavior` API as the semantic equivalent of the Scala `AbstractBehavior` API
+
+Java
+: @@snip [OnMessageIntroTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OnMessageIntroTest.java) {  #chatroom-behavior }
+
 #### Try it out
 
 In order to see this chat room in action we need to write a client Actor that can use it

--- a/akka-docs/src/main/paradox/typed/actors.md
+++ b/akka-docs/src/main/paradox/typed/actors.md
@@ -412,24 +412,23 @@ former simply speaks more languages than the latter. The opposite would be
 problematic, so passing an @scala[`ActorRef[PublishSessionMessage]`]@java[`ActorRef<PublishSessionMessage>`] where
 @scala[`ActorRef[RoomCommand]`]@java[`ActorRef<RoomCommand>`] is required will lead to a type error.
 
+@@@ div {.group-java}
 #### AbstractOnMessageBehavior API
 
-@java[The `AbstractBehavior` API typically makes heavy use of builders which allows `instanceof` checks and casts to be
+The `AbstractBehavior` API typically makes heavy use of builders which allows `instanceof` checks and casts to be
 performed "behind the scenes".  In some cases, it may be preferred to use a more "direct" style where a `Behavior`
 is, essentially, a function converting a message into a successor `Behavior`.  In contrast to builders, this style
 may have sufficiently reduced runtime overhead to be worth a little extra verbosity (recently-added Java features
-under the "pattern-matching" umbrella may substantially reduce that verbosity).]
+under the "pattern-matching" umbrella may substantially reduce that verbosity).
 
-@java[To support this style, an alternative API for defining behavior in an object-oriented style is available by
-extending @apidoc(typed.javadsl.AbstractOnMessageBehavior).]
+To support this style, an alternative API for defining behavior in an object-oriented style is available by
+extending @java[@javadoc[AbstractOnMessageBehavior](akka.actor.typed.javadsl.AbstractOnMessageBehavior)].
 
-@java[Here's the `AbstractOnMessageBehavior`-based implementation of the chat room protocol:]
-
-Scala
-: The Java API exposes the `AbstractOnMessageBehavior` API as the semantic equivalent of the Scala `AbstractBehavior` API
+Here's the `AbstractOnMessageBehavior`-based implementation of the chat room protocol:
 
 Java
 : @@snip [OnMessageIntroTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OnMessageIntroTest.java) {  #chatroom-behavior }
+@@@
 
 #### Try it out
 

--- a/akka-docs/src/main/paradox/typed/actors.md
+++ b/akka-docs/src/main/paradox/typed/actors.md
@@ -415,19 +415,23 @@ problematic, so passing an @scala[`ActorRef[PublishSessionMessage]`]@java[`Actor
 @@@ div {.group-java}
 #### AbstractOnMessageBehavior API
 
-The `AbstractBehavior` API typically makes heavy use of builders which allows `instanceof` checks and casts to be
-performed "behind the scenes".  In some cases, it may be preferred to use a more "direct" style where a `Behavior`
-is, essentially, a function converting a message into a successor `Behavior`.  In contrast to builders, this style
-may have sufficiently reduced runtime overhead to be worth a little extra verbosity (recently-added Java features
-under the "pattern-matching" umbrella may substantially reduce that verbosity).
+The `AbstractBehavior` API makes use of builders like `ReceiveBuilder`.  The benefit of these builders is that
+`instanceof` checks and casts are performed "behind the scenes", but this imposes some runtime overhead.  Pattern-matching
+features introduced in Java 17 and refined in subsequent versions allow the Java compiler to perform some of the
+work of the builders at compile-time, eliminating this runtime overhead without an increase in verbosity.  Users
+of earlier Java versions may also find eliminating this runtime overhead to be worth the verbosity of explicitly
+performing `instanceof` checks and casts.  Users of other JVM languages with pattern-matching support (such as Kotlin) may
+also prefer not using builders (note that the Scala DSL's `AbstractBehavior` does not make use of builders).
 
-To support this style, an alternative API for defining behavior in an object-oriented style is available by
-extending @java[@javadoc[AbstractOnMessageBehavior](akka.actor.typed.javadsl.AbstractOnMessageBehavior)].
+To support this "direct" style, an alternative API for defining behavior in an object-oriented style is available by
+extending @java[@javadoc[AbstractOnMessageBehavior](akka.actor.typed.javadsl.AbstractOnMessageBehavior)] and
+implementing the @java[@javadoc[onMessage](akka.actor.typed.javadsl.AbstractOnMessageBehavior#onMessage(T))] method.
 
 Here's the `AbstractOnMessageBehavior`-based implementation of the chat room protocol:
 
 Java
 : @@snip [OnMessageIntroTest.java](/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/OnMessageIntroTest.java) {  #chatroom-behavior }
+
 @@@
 
 #### Try it out

--- a/akka-docs/src/main/paradox/typed/actors.md
+++ b/akka-docs/src/main/paradox/typed/actors.md
@@ -415,13 +415,11 @@ problematic, so passing an @scala[`ActorRef[PublishSessionMessage]`]@java[`Actor
 @@@ div {.group-java}
 #### AbstractOnMessageBehavior API
 
-The `AbstractBehavior` API makes use of builders like `ReceiveBuilder`.  The benefit of these builders is that
-`instanceof` checks and casts are performed "behind the scenes", but this imposes some runtime overhead.  Pattern-matching
-features introduced in Java 17 and refined in subsequent versions allow the Java compiler to perform some of the
-work of the builders at compile-time, eliminating this runtime overhead without an increase in verbosity.  Users
-of earlier Java versions may also find eliminating this runtime overhead to be worth the verbosity of explicitly
-performing `instanceof` checks and casts.  Users of other JVM languages with pattern-matching support (such as Kotlin) may
-also prefer not using builders (note that the Scala DSL's `AbstractBehavior` does not make use of builders).
+The `AbstractBehavior` API makes use of a builder on receipt of the first message by the actor.  The `Receive` built
+by this builder performs `instanceof` checks and casts "behind the scenes".  Pattern-matching features introduced in Java
+17 and refined in subsequent versions improve the ergonomics of expressing this logic directly in code.  Users of other
+JVM languages (such as Kotlin) may also prefer to not use a builder while using the Java DSL (note that the Scala DSL's
+`AbstractBehavior` does not make use of builders).
 
 To support this "direct" style, an alternative API for defining behavior in an object-oriented style is available by
 extending @java[@javadoc[AbstractOnMessageBehavior](akka.actor.typed.javadsl.AbstractOnMessageBehavior)] and

--- a/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
+++ b/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
@@ -841,7 +841,8 @@ public class ActorDocTest extends AbstractJavaTest {
         // using timeout from above
         CompletableFuture<Object> future2 = ask(actorB, "another request", t).toCompletableFuture();
 
-        CompletableFuture<Result> transformed = future1.thenCombine(future2, (x, s) -> new Result((String) x, (String) s));
+        CompletableFuture<Result> transformed =
+            future1.thenCombine(future2, (x, s) -> new Result((String) x, (String) s));
 
         pipe(transformed, system.dispatcher()).to(actorC);
         // #ask-pipe

--- a/akka-docs/src/test/java/jdocs/stream/operators/SourceOrFlow.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/SourceOrFlow.java
@@ -15,7 +15,6 @@ import akka.japi.pf.PFBuilder;
 import akka.stream.Attributes;
 import akka.stream.javadsl.Flow;
 
-
 // #zip
 // #zip-with
 // #zip-with-index
@@ -162,16 +161,17 @@ class SourceOrFlow {
 
     // #concatLazy
   }
-  
+
   void concatAllLazyExample() {
     // #concatAllLazy
     Source<Integer, NotUsed> sourceA = Source.from(Arrays.asList(1, 2, 3));
     Source<Integer, NotUsed> sourceB = Source.from(Arrays.asList(4, 5, 6));
-    Source<Integer, NotUsed> sourceC = Source.from(Arrays.asList(7, 8 , 9));
-    sourceA.concatAllLazy(sourceB, sourceC)
+    Source<Integer, NotUsed> sourceC = Source.from(Arrays.asList(7, 8, 9));
+    sourceA
+        .concatAllLazy(sourceB, sourceC)
         .fold(new StringJoiner(","), (joiner, input) -> joiner.add(String.valueOf(input)))
         .runForeach(System.out::println, system);
-    //prints 1,2,3,4,5,6,7,8,9
+    // prints 1,2,3,4,5,6,7,8,9
     // #concatAllLazy
   }
 
@@ -184,19 +184,20 @@ class SourceOrFlow {
 
     // #interleave
   }
-  
+
   void interleaveAllExample() {
     // #interleaveAll
     Source<Integer, NotUsed> sourceA = Source.from(Arrays.asList(1, 2, 7, 8));
     Source<Integer, NotUsed> sourceB = Source.from(Arrays.asList(3, 4, 9));
     Source<Integer, NotUsed> sourceC = Source.from(Arrays.asList(5, 6));
-    sourceA.interleaveAll(Arrays.asList(sourceB, sourceC), 2, false)
-        .fold(new StringJoiner(","),(joiner, input) -> joiner.add(String.valueOf(input)))
+    sourceA
+        .interleaveAll(Arrays.asList(sourceB, sourceC), 2, false)
+        .fold(new StringJoiner(","), (joiner, input) -> joiner.add(String.valueOf(input)))
         .runForeach(System.out::println, system);
-    //prints 1,2,3,4,5,6,7,8,9
+    // prints 1,2,3,4,5,6,7,8,9
     // #interleaveAll
   }
-  
+
   void mergeExample() {
     // #merge
     Source<Integer, NotUsed> sourceA = Source.from(Arrays.asList(1, 2, 3, 4));
@@ -206,13 +207,14 @@ class SourceOrFlow {
 
     // #merge
   }
-  
+
   void mergeAllExample() {
     // #merge-all
     Source<Integer, NotUsed> sourceA = Source.from(Arrays.asList(1, 2, 3));
     Source<Integer, NotUsed> sourceB = Source.from(Arrays.asList(4, 5, 6));
     Source<Integer, NotUsed> sourceC = Source.from(Arrays.asList(7, 8, 9, 10));
-    sourceA.mergeAll(Arrays.asList(sourceB, sourceC), false)
+    sourceA
+        .mergeAll(Arrays.asList(sourceB, sourceC), false)
         .runForeach(System.out::println, system);
     // merging is not deterministic, can for example print 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
     // #merge-all


### PR DESCRIPTION
References #31531

Basically adapts the Scala `AbstractBehavior` API for Java.  As Java incorporates pattern matching features, this style of defining behavior may become more ergonomic than the existing builder-based approaches.

TODO: mostly docs (do we have a good way to do paradox keyed by Java version?)