### PR TITLE
=str Make SingleConsumerMultiProducer the default mailbox for stream.

### DIFF
--- a/akka-stream/src/main/resources/reference.conf
+++ b/akka-stream/src/main/resources/reference.conf
@@ -19,6 +19,14 @@ akka {
       # or full dispatcher configuration to be used by ActorMaterializer when creating Actors.
       dispatcher = "akka.actor.default-dispatcher"
 
+      # FQCN of the MailboxType. The Class of the FQCN must have a public
+      # constructor with
+      # (akka.actor.ActorSystem.Settings, com.typesafe.config.Config) parameters.
+      # defaults to the single consumber mailbox for better performance.
+      mailbox {
+        mailbox-type = "akka.dispatch.SingleConsumerOnlyUnboundedMailbox"
+      }
+
       # Fully qualified config path which holds the dispatcher configuration
       # or full dispatcher configuration to be used by stream operators that
       # perform blocking operations

--- a/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/ActorMaterializerImpl.scala
@@ -52,7 +52,9 @@ import akka.util.OptionVal
     val effectiveProps = props.dispatcher match {
       case Dispatchers.DefaultDispatcherId =>
         // the caller said to use the default dispatcher, but that can been trumped by the dispatcher attribute
-        props.withDispatcher(context.effectiveAttributes.mandatoryAttribute[ActorAttributes.Dispatcher].dispatcher)
+        props
+          .withDispatcher(context.effectiveAttributes.mandatoryAttribute[ActorAttributes.Dispatcher].dispatcher)
+          .withMailbox(PhasedFusingActorMaterializer.Mailbox)
       case _ => props
     }
 
@@ -189,6 +191,7 @@ private[akka] class SubFusingActorMaterializerImpl(
     Props(new StreamSupervisor(haveShutDown))
       .withDeploy(Deploy.local)
       .withDispatcher(attributes.mandatoryAttribute[ActorAttributes.Dispatcher].dispatcher)
+      .withMailbox(PhasedFusingActorMaterializer.Mailbox)
   private[stream] val baseName = "StreamSupervisor"
   private val actorName = SeqActorName(baseName)
   def nextName(): String = actorName.next()


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References https://github.com/akka/akka/issues/31463
Test it locally, just a little faster
```
[info] Benchmark                                                                (mailbox)  (parallelism)   Mode  Cnt       Score       Error  Units
[info] StreamMailboxBenchmark.mapAsyncUnordered                akka.actor.default-mailbox             12  thrpt    5  667962.091 锟斤拷 17476.736  ops/s
[info] StreamMailboxBenchmark.mapAsyncUnordered  akka.stream.materializer.default-mailbox             12  thrpt    5  683336.943 锟斤拷 23024.154  ops/s
```

and

```scala
[info] StreamMailboxBenchmark.mapAsyncUnordered                akka.actor.default-mailbox              4  thrpt   20  646113.594 锟斤拷 4001.453  ops/s
[info] StreamMailboxBenchmark.mapAsyncUnordered  akka.stream.materializer.default-mailbox              4  thrpt   20  692772.475 锟斤拷 2404.489  ops/s
```