### PR TITLE
fix: Don't double close on cancel in statefulMap

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowStatefulMapSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowStatefulMapSpec.scala
@@ -202,10 +202,7 @@ class FlowStatefulMapSpec extends StreamSpec {
       val promise = Promise[Done]()
       Source
         .single(1)
-        .statefulMap(() => -1)((_, elem) => {
-          throw ex
-          (elem, elem)
-        }, _ => {
+        .statefulMap(() => -1)((_, _) => throw ex, _ => {
           promise.complete(Success(Done))
           None
         })
@@ -343,6 +340,43 @@ class FlowStatefulMapSpec extends StreamSpec {
       sink.expectNext("two2")
       sink.cancel()
       source.expectCancellation()
+    }
+
+    "not allow null state" in {
+      EventFilter[NullPointerException](occurrences = 1).intercept {
+        Source
+          .single("one")
+          .statefulMap(() => null: String)((s, t) => (s, t), _ => None)
+          .runWith(Sink.head)
+          .failed
+          .futureValue shouldBe a[NullPointerException]
+      }
+    }
+
+    "not allow null next state" in {
+      EventFilter[NullPointerException](occurrences = 1).intercept {
+        Source
+          .single("one")
+          .statefulMap(() => "state")((_, t) => (null, t), _ => None)
+          .runWith(Sink.seq)
+          .failed
+          .futureValue shouldBe a[NullPointerException]
+      }
+    }
+
+    "not allow null state on restart" in {
+      val counter = new AtomicInteger(0)
+      EventFilter[NullPointerException](occurrences = 1).intercept {
+        Source
+          .single("one")
+          .statefulMap(() => if (counter.incrementAndGet() == 1) "state" else null)(
+            (_, _) => throw TE("boom"),
+            _ => None)
+          .withAttributes(ActorAttributes.supervisionStrategy(Supervision.restartingDecider))
+          .runWith(Sink.head)
+          .failed
+          .futureValue shouldBe a[NullPointerException]
+      }
     }
 
   }

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -717,7 +717,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream and a state to pass to the next mapping function. The state can be the same for each mapping return,
    * be a new immutable state but it is also safe to use a mutable state. The returned `T` MUST NOT be `null` as it is
-   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allow and will fail the stream.
+   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allowed and will fail the stream.
    *
    * For stateless variant see [[map]].
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -717,7 +717,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream and a state to pass to the next mapping function. The state can be the same for each mapping return,
    * be a new immutable state but it is also safe to use a mutable state. The returned `T` MUST NOT be `null` as it is
-   * illegal as stream element - according to the Reactive Streams specification.
+   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allow and will fail the stream.
    *
    * For stateless variant see [[map]].
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2409,7 +2409,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream and a state to pass to the next mapping function. The state can be the same for each mapping return,
    * be a new immutable state but it is also safe to use a mutable state. The returned `T` MUST NOT be `null` as it is
-   * illegal as stream element - according to the Reactive Streams specification.
+   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allow and will fail the stream.
    *
    * For stateless variant see [[map]].
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2409,7 +2409,7 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream and a state to pass to the next mapping function. The state can be the same for each mapping return,
    * be a new immutable state but it is also safe to use a mutable state. The returned `T` MUST NOT be `null` as it is
-   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allow and will fail the stream.
+   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allowed and will fail the stream.
    *
    * For stateless variant see [[map]].
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -203,7 +203,7 @@ final class SubFlow[In, Out, Mat](
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream and a state to pass to the next mapping function. The state can be the same for each mapping return,
    * be a new immutable state but it is also safe to use a mutable state. The returned `T` MUST NOT be `null` as it is
-   * illegal as stream element - according to the Reactive Streams specification.
+   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allow and will fail the stream.
    *
    * For stateless variant see [[map]].
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubFlow.scala
@@ -203,7 +203,7 @@ final class SubFlow[In, Out, Mat](
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream and a state to pass to the next mapping function. The state can be the same for each mapping return,
    * be a new immutable state but it is also safe to use a mutable state. The returned `T` MUST NOT be `null` as it is
-   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allow and will fail the stream.
+   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allowed and will fail the stream.
    *
    * For stateless variant see [[map]].
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -194,7 +194,7 @@ final class SubSource[Out, Mat](
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream and a state to pass to the next mapping function. The state can be the same for each mapping return,
    * be a new immutable state but it is also safe to use a mutable state. The returned `T` MUST NOT be `null` as it is
-   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allow and will fail the stream.
+   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allowed and will fail the stream.
    *
    * For stateless variant see [[map]].
    *

--- a/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/SubSource.scala
@@ -194,7 +194,7 @@ final class SubSource[Out, Mat](
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream and a state to pass to the next mapping function. The state can be the same for each mapping return,
    * be a new immutable state but it is also safe to use a mutable state. The returned `T` MUST NOT be `null` as it is
-   * illegal as stream element - according to the Reactive Streams specification.
+   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allow and will fail the stream.
    *
    * For stateless variant see [[map]].
    *

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1004,7 +1004,7 @@ trait FlowOps[+Out, +Mat] {
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream and a state to pass to the next mapping function. The state can be the same for each mapping return,
    * be a new immutable state but it is also safe to use a mutable state. The returned `T` MUST NOT be `null` as it is
-   * illegal as stream element - according to the Reactive Streams specification.
+   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allow and will fail the stream.
    *
    * For stateless variant see [[FlowOps.map]].
    *

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1004,7 +1004,7 @@ trait FlowOps[+Out, +Mat] {
    * the mapping function for mapping the first element. The mapping function returns a mapped element to emit
    * downstream and a state to pass to the next mapping function. The state can be the same for each mapping return,
    * be a new immutable state but it is also safe to use a mutable state. The returned `T` MUST NOT be `null` as it is
-   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allow and will fail the stream.
+   * illegal as stream element - according to the Reactive Streams specification. A `null` state is not allowed and will fail the stream.
    *
    * For stateless variant see [[FlowOps.map]].
    *


### PR DESCRIPTION
Follow up to #31361 

Also:
 * emit on restart if returning element
 * simplify by using presence of state to know if need closing instead of separate boolean


