### PR TITLE
fix: Compare required RC and M versions if present

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/AkkaVersionSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/AkkaVersionSpec.scala
@@ -20,21 +20,36 @@ class AkkaVersionSpec extends AnyWordSpec with Matchers {
     "succeed if version is RC and ok" in {
       AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.7-RC10")
       AkkaVersion.require("AkkaVersionSpec", "2.6.0-RC1", "2.6.0-RC1")
+      AkkaVersion.require("AkkaVersionSpec", "2.6.0-RC1", "2.6.0-RC2")
+      AkkaVersion.require("AkkaVersionSpec", "2.6.0-RC1", "2.7.0")
     }
 
     "fail if version is RC and not ok" in {
       intercept[UnsupportedAkkaVersion] {
         AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.6-RC1")
       }
+      intercept[UnsupportedAkkaVersion] {
+        AkkaVersion.require("AkkaVersionSpec", "2.5.6-RC2", "2.5.6-RC1")
+      }
     }
 
     "succeed if version is milestone and ok" in {
       AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.7-M10")
+      AkkaVersion.require("AkkaVersionSpec", "2.5.7-M9", "2.5.7-M9")
+      AkkaVersion.require("AkkaVersionSpec", "2.5.7-M9", "2.5.7-M10")
+      AkkaVersion.require("AkkaVersionSpec", "2.5.7-M9", "2.5.8")
+      AkkaVersion.require("AkkaVersionSpec", "2.5.7-M9", "2.5.7-RC1")
     }
 
     "fail if version is milestone and not ok" in {
       intercept[UnsupportedAkkaVersion] {
         AkkaVersion.require("AkkaVersionSpec", "2.5.6", "2.5.6-M1")
+      }
+      intercept[UnsupportedAkkaVersion] {
+        AkkaVersion.require("AkkaVersionSpec", "2.5.7-M10", "2.5.7-M9")
+      }
+      intercept[UnsupportedAkkaVersion] {
+        AkkaVersion.require("AkkaVersionSpec", "2.5.7-RC1", "2.5.7-M9")
       }
     }
 

--- a/akka-actor/src/main/scala/akka/AkkaVersion.scala
+++ b/akka-actor/src/main/scala/akka/AkkaVersion.scala
@@ -34,21 +34,29 @@ object AkkaVersion {
       currentVersion match {
         case VersionPattern(currentMajorStr, currentMinorStr, currentPatchStr, mOrRc, mOrRcNrStr) =>
           requiredVersion match {
-            case requiredVersion @ VersionPattern(requiredMajorStr, requiredMinorStr, requiredPatchStr, requiredMorRc, requiredMOrRcNrStr) =>
-              def throwUnsupported() = throw new UnsupportedAkkaVersion(
-                s"Current version of Akka is [$currentVersion], but $libraryName requires version [$requiredVersion]")
+            case requiredVersion @ VersionPattern(
+                  requiredMajorStr,
+                  requiredMinorStr,
+                  requiredPatchStr,
+                  requiredMorRc,
+                  requiredMOrRcNrStr) =>
+              def throwUnsupported() =
+                throw new UnsupportedAkkaVersion(
+                  s"Current version of Akka is [$currentVersion], but $libraryName requires version [$requiredVersion]")
               if (requiredMajorStr == currentMajorStr) {
                 if (requiredMinorStr == currentMinorStr) {
                   if (requiredPatchStr == currentPatchStr) {
-                    if (requiredMorRc == null && mOrRc != null) throwUnsupported() // require final but actual is M or RC
+                    if (requiredMorRc == null && mOrRc != null)
+                      throwUnsupported() // require final but actual is M or RC
                     else if (requiredMorRc != null) {
                       (requiredMorRc, requiredMOrRcNrStr, mOrRc, mOrRcNrStr) match {
-                        case ("M", reqN, "M", n) => if (reqN.toInt > n.toInt) throwUnsupported()
-                        case ("M", _, "RC", _) => // RC > M, ok!
-                        case ("RC", _, "M", _) => throwUnsupported()
+                        case ("M", reqN, "M", n)   => if (reqN.toInt > n.toInt) throwUnsupported()
+                        case ("M", _, "RC", _)     => // RC > M, ok!
+                        case ("RC", _, "M", _)     => throwUnsupported()
                         case ("RC", reqN, "RC", n) => if (reqN.toInt > n.toInt) throwUnsupported()
-                        case (_, _, null, _) => // requirement on RC or M but actual is final, ok!
-                        case unexpected => throw new IllegalArgumentException(s"Should never happen, comparing M/RC: $unexpected")
+                        case (_, _, null, _)       => // requirement on RC or M but actual is final, ok!
+                        case unexpected =>
+                          throw new IllegalArgumentException(s"Should never happen, comparing M/RC: $unexpected")
                       }
                     } // same versions, ok!
                   } else if (requiredPatchStr.toInt > currentPatchStr.toInt) throwUnsupported()


### PR DESCRIPTION
Compares M if there is a requirement, sees RC as higher than M, compares RCs if present, treats final release as higher than both M and RC (it did already before).