### PR TITLE
chore: Silence some serializer warnings

### DIFF
--- a/akka-actor/src/main/scala/akka/serialization/Serialization.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serialization.scala
@@ -454,7 +454,10 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
   }
 
   private def warnUnexpectedNonAkkaSerializer(clazz: Class[_], ser: Serializer): Boolean = {
-    if (clazz.getName.startsWith("akka.") && !ser.getClass.getName.startsWith("akka.")) {
+    val className = clazz.getName
+    if (className.startsWith("akka.") && !ser.getClass.getName.startsWith("akka.") &&
+      // no serializers for these in Akka
+      !(className.startsWith("akka.grpc") || className.startsWith("akka.http"))) {
       log.warning(
         "Using serializer [{}] for message [{}]. Note that this serializer " +
         "is not implemented by Akka. It's not recommended to replace serializers for messages " +

--- a/akka-actor/src/main/scala/akka/serialization/Serialization.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serialization.scala
@@ -456,8 +456,8 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
   private def warnUnexpectedNonAkkaSerializer(clazz: Class[_], ser: Serializer): Boolean = {
     val className = clazz.getName
     if (className.startsWith("akka.") && !ser.getClass.getName.startsWith("akka.") &&
-      // no serializers for these in Akka
-      !(className.startsWith("akka.grpc") || className.startsWith("akka.http"))) {
+        // no serializers for these in Akka
+        !(className.startsWith("akka.grpc") || className.startsWith("akka.http"))) {
       log.warning(
         "Using serializer [{}] for message [{}]. Note that this serializer " +
         "is not implemented by Akka. It's not recommended to replace serializers for messages " +


### PR DESCRIPTION
Mostly a fix for an annoying warning in the Kalix internals. We will never have ready serializers for Akka Http or Akka gRPC classes in Akka or either of those projects so no need for that warning there.