### PR TITLE
fix: Replaying a replicated event sourced actor from snapshot caused bug

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -159,9 +159,8 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
           }
         case None => (0L, Map.empty[ReplicaId, Long], VersionVector.empty)
       }
-      val seenPerReplicaWithDefault = seenPerReplica.withDefaultValue(0L)
 
-      setup.internalLogger.debugN("Snapshot recovered from {} {} {}", seqNr, seenPerReplicaWithDefault, version)
+      setup.internalLogger.debugN("Snapshot recovered from {} {} {}", seqNr, seenPerReplica, version)
 
       setup.cancelRecoveryTimer()
 
@@ -175,7 +174,7 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
           receivedPoisonPill,
           System.nanoTime(),
           version,
-          seenPerReplicaWithDefault,
+          seenPerReplica,
           eventsReplayed = 0))
     }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -153,13 +153,15 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
           state = setup.snapshotAdapter.fromJournal(snapshot)
           setup.internalLogger.debug("Loaded snapshot with metadata [{}]", metadata)
           metadata.metadata match {
-            case Some(rm: ReplicatedSnapshotMetadata) => (metadata.sequenceNr, rm.seenPerReplica, rm.version)
-            case _                                    => (metadata.sequenceNr, Map.empty[ReplicaId, Long].withDefaultValue(0L), VersionVector.empty)
+            case Some(rm: ReplicatedSnapshotMetadata) =>
+              (metadata.sequenceNr, rm.seenPerReplica, rm.version)
+            case _ => (metadata.sequenceNr, Map.empty[ReplicaId, Long], VersionVector.empty)
           }
-        case None => (0L, Map.empty[ReplicaId, Long].withDefaultValue(0L), VersionVector.empty)
+        case None => (0L, Map.empty[ReplicaId, Long], VersionVector.empty)
       }
+      val seenPerReplicaWithDefault = seenPerReplica.withDefaultValue(0L)
 
-      setup.internalLogger.debugN("Snapshot recovered from {} {} {}", seqNr, seenPerReplica, version)
+      setup.internalLogger.debugN("Snapshot recovered from {} {} {}", seqNr, seenPerReplicaWithDefault, version)
 
       setup.cancelRecoveryTimer()
 
@@ -173,7 +175,7 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
           receivedPoisonPill,
           System.nanoTime(),
           version,
-          seenPerReplica,
+          seenPerReplicaWithDefault,
           eventsReplayed = 0))
     }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/Running.scala
@@ -334,7 +334,7 @@ private[akka] object Running {
           replication.allReplicas.mkString(", "))
         this
       } else {
-        val expectedSequenceNumber = state.seenPerReplica(originReplicaId) + 1
+        val expectedSequenceNumber = state.seenPerReplica.getOrElse(originReplicaId, 0L) + 1
         if (expectedSequenceNumber > event.sequenceNumber) {
           // already seen
           if (log.isDebugEnabled)
@@ -388,7 +388,7 @@ private[akka] object Running {
     }
 
     def onGetSeenSequenceNr(get: GetSeenSequenceNr): Behavior[InternalProtocol] = {
-      get.replyTo ! state.seenPerReplica(get.replica)
+      get.replyTo ! state.seenPerReplica.getOrElse(get.replica, 0L)
       this
     }
 
@@ -667,7 +667,7 @@ private[akka] object Running {
     }
 
     def onGetSeenSequenceNr(get: GetSeenSequenceNr): PersistingEvents = {
-      get.replyTo ! state.seenPerReplica(get.replica)
+      get.replyTo ! state.seenPerReplica.getOrElse(get.replica, 0L)
       this
     }
 


### PR DESCRIPTION
'seenPerReplica' is expected to have a default value of 0L but when loading replica metadata from DB this was missed.

Didn't figure out how to cover with a test yet.