### PR TITLE
=sbt Just use `-release 8` for build as starting Scala 2.12.17 always…

### DIFF
--- a/project/JdkOptions.scala
+++ b/project/JdkOptions.scala
@@ -49,8 +49,7 @@ object JdkOptions extends AutoPlugin {
       jdk8home,
       fullJavaHomes,
       if (scalaVersion.startsWith("3.")) Seq("-Xtarget:8")
-      else if (scalaVersion.startsWith("2.13.")) Seq("-release", "8")
-      else Seq("-target:jvm-1.8"),
+      else Seq("-release", "8"),
       // '-release 8' is not enough, for some reason we need the 8 rt.jar
       // explicitly. To test whether this has the desired effect, compile
       // akka-remote and check the invocation of 'ByteBuffer.clear()' in


### PR DESCRIPTION
Sorry for missed this https://github.com/scala/scala/pull/10109 
starting 2.12.17, will always emit Java 8 bytecode , regardless of -release; deprecate -target

Thanks @som-snytt  for the pointer.

Compiles with JDK 11.
![image](https://user-images.githubusercontent.com/501740/195105292-ed64a53c-177e-4025-a29b-5faf12729ce4.png)
