### PR TITLE
Revert "!str filter out elements without demands for Flow#collect operator"

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowCollectSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowCollectSpec.scala
@@ -6,16 +6,12 @@ package akka.stream.scaladsl
 
 import java.util.concurrent.ThreadLocalRandom.{ current => random }
 
-import scala.concurrent.duration.DurationInt
-
 import akka.stream.ActorAttributes._
-import akka.stream.Attributes
 import akka.stream.Supervision._
 import akka.stream.testkit.ScriptedTest
 import akka.stream.testkit.StreamSpec
 import akka.stream.testkit.Utils.TE
 import akka.stream.testkit.scaladsl.TestSink
-import akka.stream.testkit.scaladsl.TestSource
 
 class FlowCollectSpec extends StreamSpec with ScriptedTest {
 
@@ -44,37 +40,6 @@ class FlowCollectSpec extends StreamSpec with ScriptedTest {
         .request(1)
         .expectNext(3)
         .request(1)
-        .expectComplete()
-    }
-
-    "filter out elements without demand" in {
-      val (inProbe, outProbe) =
-        TestSource[Int]()
-          .collect({ case elem if elem > 1000 => elem })
-          .toMat(TestSink[Int]())(Keep.both)
-          .addAttributes(Attributes.inputBuffer(1, 1))
-          .run()
-
-      outProbe.ensureSubscription()
-      // none of those should fail even without demand
-      inProbe.sendNext(1).sendNext(2).sendNext(3).sendNext(4).sendNext(5).sendNext(1001).sendNext(1002)
-
-      // now the buffer should be full (1 internal buffer, 1 async buffer at source probe)
-
-      inProbe.expectNoMessage(100.millis).pending shouldBe 0L
-
-      inProbe.sendComplete() // to test later that completion is buffered as well
-
-      outProbe.requestNext(1001)
-      outProbe.requestNext(1002)
-      outProbe.expectComplete()
-    }
-
-    "complete without demand if remaining elements are filtered out with collect" in {
-      Source(1 to 1000)
-        .collect({ case elem if elem > 1000 => elem })
-        .runWith(TestSink.apply[Int]())
-        .ensureSubscription()
         .expectComplete()
     }
 

--- a/akka-stream/src/main/mima-filters/2.6.20.backwards.excludes/pr-31617-collect-filter-without-demands.excludes
+++ b/akka-stream/src/main/mima-filters/2.6.20.backwards.excludes/pr-31617-collect-filter-without-demands.excludes
@@ -1,2 +1,0 @@
-# internal classes
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.fusing.Collect.createLogic")


### PR DESCRIPTION
Reverts https://github.com/akka/akka/pull/31617

It was a mistake to accept this change for `collect`. We didn't realize the full impact and the history that can be read in https://github.com/akka/akka/issues/18170

Actually, it changes the semantics in a way that makes Akka HTTP tests fail https://github.com/akka/akka-http/actions/runs/3249437505/jobs/5331839470

This reverts commit 434c0abe410c3b1480b4c127abacafc9caa5ca64.

