### PR TITLE
=str Avoid subMaterialization when the provided recover source is empty.

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowRecoverWithSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowRecoverWithSpec.scala
@@ -39,6 +39,19 @@ class FlowRecoverWithSpec extends StreamSpec {
         .expectComplete()
     }
 
+    "recover with empty source" in {
+      Source(1 to 4)
+        .map { a =>
+          if (a == 3) throw ex else a
+        }
+        .recoverWith { case _: Throwable => Source.empty }
+        .runWith(TestSink[Int]())
+        .request(2)
+        .expectNextN(1 to 2)
+        .request(1)
+        .expectComplete()
+    }
+
     "cancel substream if parent is terminated when there is a handler" in {
       Source(1 to 4)
         .map { a =>


### PR DESCRIPTION
Extracted from pr https://github.com/akka/akka/pull/31639
onTop of https://github.com/akka/akka/pull/31675

1. avoid the materialization when the provided recovered to source is emtpy
2. make use of `NotApplied`.