### PR TITLE
fix: Record timestamp should not be reused

### DIFF
--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStore.scala
@@ -76,7 +76,7 @@ class PersistenceTestKitDurableStateStore[A](val system: ExtendedActorSystem)
     store.get(persistenceId) match {
       case Some(record) =>
         val globalOffset = lastGlobalOffset.incrementAndGet()
-        val updatedRecord = record.copy[A](globalOffset = globalOffset, value = None, revision = revision)
+        val updatedRecord = Record[A](globalOffset, persistenceId, revision, None, record.tag)
         store = store + (persistenceId -> updatedRecord)
         publisher ! updatedRecord
       case None => //ignore

--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStoreSpec.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/state/scaladsl/PersistenceTestKitDurableStateStoreSpec.scala
@@ -88,6 +88,7 @@ class PersistenceTestKitDurableStateStoreSpec
       val deletedDurableState = testSink.request(1).expectNext().asInstanceOf[DeletedDurableState[Record]]
       deletedDurableState.persistenceId should be(persistenceId)
       deletedDurableState.revision should be(2L)
+      deletedDurableState.timestamp should be >= updatedDurableState.timestamp
     }
 
     "find tagged current state changes ordered by upsert" in {


### PR DESCRIPTION
Follow up to #31677 