### PR TITLE
Fix RecipeAdhocSource test, #31674

### DIFF
--- a/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeAdhocSourceTest.java
+++ b/akka-docs/src/test/java/jdocs/stream/javadsl/cookbook/RecipeAdhocSourceTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class RecipeAdhocSourceTest extends RecipeTest {
   static ActorSystem system;
@@ -208,7 +209,7 @@ public class RecipeAdhocSourceTest extends RecipeTest {
         assertEquals(1, startedCount.get());
 
         Thread.sleep(500);
-        assertEquals(true, shutdown.isCompleted());
+        assertTrue(shutdown.isCompleted());
 
         Thread.sleep(500);
         probe.requestNext("a");
@@ -223,7 +224,7 @@ public class RecipeAdhocSourceTest extends RecipeTest {
         assertEquals(4, startedCount.get()); // startCount == 4, which means "re"-tried 3 times
 
         Thread.sleep(500);
-        assertEquals(TimeoutException.class, probe.expectError().getClass());
+        assertTrue(probe.expectError() instanceof TimeoutException);
         probe.request(1); // send demand
         probe.expectNoMessage(FiniteDuration.create(200, "milliseconds")); // but no more restart
       }

--- a/akka-docs/src/test/scala/docs/stream/cookbook/RecipeAdhocSource.scala
+++ b/akka-docs/src/test/scala/docs/stream/cookbook/RecipeAdhocSource.scala
@@ -118,7 +118,7 @@ class RecipeAdhocSource extends RecipeSpec {
       startedCount.get() should be(4) //startCount == 4, which means "re"-tried 3 times
 
       Thread.sleep(500)
-      sink.expectError().getClass should be(classOf[TimeoutException])
+      sink.expectError() shouldBe a[TimeoutException]
       sink.request(1) //send demand
       sink.expectNoMessage(200.milliseconds) //but no more restart
     }


### PR DESCRIPTION
* started failing because of the new stream timeout classes

References #31674
