### PR TITLE
MiMa for 2.7.0 and JDK9 classes

### DIFF
--- a/project/Jdk9MiMa.scala
+++ b/project/Jdk9MiMa.scala
@@ -15,12 +15,15 @@ object Jdk9MiMa extends AutoPlugin {
 
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(
-      // now we have two class directories under target but mima only understands one
+      // compiled jdk9+ only sources end up in a separate class directory
+      // so for those we now have two class directories under target but mima only understands one
       // so merge regular class directory with jdk9 class directory and have mima check those
       prepForMima := {
+        (Compile / compile).value
+        (CompileJdk9 / compile).value
         val destination = file((Compile / classDirectory).value.getParent) / "classesForMima"
         val log = streams.value.log
-        println("Special handling of JDK9 only classes and MiMa check")
+        streams.value.log.debug("Special handling of JDK9 only classes for MiMa check triggered")
         val allClassDirectories = (Compile / productDirectories).value ++ (CompileJdk9 / productDirectories).value
         if (destination.exists()) {
           IO.delete(destination)

--- a/project/Jdk9MiMa.scala
+++ b/project/Jdk9MiMa.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+ */
+import akka.Jdk9.CompileJdk9
+import akka.{ Jdk9, MiMa }
+import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport.{ mimaCurrentClassfiles, mimaReportBinaryIssues }
+import sbt._
+import sbt.Keys._
+import sbt.PluginTrigger.AllRequirements
+import sbt.{ AutoPlugin, Compile, Def, IO }
+
+object Jdk9MiMa extends AutoPlugin {
+
+  val prepForMima = taskKey[File]("Prepare a merged class directory for mima")
+
+  override def projectSettings: Seq[Def.Setting[_]] =
+    Seq(
+      // now we have two class directories under target but mima only understands one
+      // so merge regular class directory with jdk9 class directory and have mima check those
+      prepForMima := {
+        val destination = file((Compile / classDirectory).value.getParent) / "classesForMima"
+        val log = streams.value.log
+        println("Special handling of JDK9 only classes and MiMa check")
+        val allClassDirectories = (Compile / productDirectories).value ++ (CompileJdk9 / productDirectories).value
+        if (destination.exists()) {
+          IO.delete(destination)
+        }
+        destination.mkdirs()
+        allClassDirectories.foreach { directory =>
+          IO.copyDirectory(directory, destination)
+        }
+        destination
+      },
+      mimaCurrentClassfiles := prepForMima.value)
+
+  override def trigger = AllRequirements
+  override def requires = MiMa && Jdk9
+
+}

--- a/project/Jdk9MiMa.scala
+++ b/project/Jdk9MiMa.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
+
 import akka.Jdk9.CompileJdk9
 import akka.{ Jdk9, MiMa }
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport.{ mimaCurrentClassfiles, mimaReportBinaryIssues }

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -40,25 +40,20 @@ object MiMa extends AutoPlugin {
       projectName: String,
       organization: String,
       scalaBinaryVersion: String): Set[sbt.ModuleID] = {
-    if (scalaBinaryVersion.startsWith("3")) {
-      // No binary compatibility for 3.0 artifacts for now - experimental
-      Set.empty
-    } else {
-      val versions: Seq[String] = {
+    val akka27Previous = expandVersions(2, 7, 0 to latestPatchOf27)
+    val versions: Seq[String] =
+      if (scalaBinaryVersion.startsWith("3")) {
+        // was experimental before 2.7.0
+        akka27Previous
+      } else {
         val akka26Previous = expandVersions(2, 6, firstPatchOf26 to latestPatchOf26)
-        // FIXME during milestone phase we check latest milestone but when final it should be replaced with
-        // val akka27Previous = expandVersions(2, 7, 0 to latestPatchOf27)
-        // FIXME why can't the snapshot be used here? List("2.7.0-M1")
-        val akka27Previous = Nil
-
         akka26Previous ++ akka27Previous
       }
 
-      // check against all binary compatible artifacts
-      versions.map { v =>
-        organization %% projectName % v
-      }.toSet
-    }
+    // check against all binary compatible artifacts
+    versions.map { v =>
+      organization %% projectName % v
+    }.toSet
   }
 
   private def expandVersions(major: Int, minor: Int, patches: immutable.Seq[Int]): immutable.Seq[String] =

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -15,6 +15,7 @@ object MiMa extends AutoPlugin {
   //  akka-pki artifact was added in Akka 2.6.6
   private val firstPatchOf26 = 6
   private val latestPatchOf26 = 20
+  private val firstPatchOf27 = 0
   private val latestPatchOf27 = 0
 
   override def requires = MimaPlugin
@@ -40,7 +41,7 @@ object MiMa extends AutoPlugin {
       projectName: String,
       organization: String,
       scalaBinaryVersion: String): Set[sbt.ModuleID] = {
-    val akka27Previous = expandVersions(2, 7, 0 to latestPatchOf27)
+    val akka27Previous = expandVersions(2, 7, firstPatchOf27 to latestPatchOf27)
     val versions: Seq[String] =
       if (scalaBinaryVersion.startsWith("3")) {
         // was experimental before 2.7.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.33")
 // sbt-osgi 0.9.5 is available but breaks including jdk9-only classes
 // sbt-osgi 0.9.6 is available but breaks populating akka-protobuf-v3
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.4")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.1")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")


### PR DESCRIPTION
Discovered something strange when trying to bump MiMa check to cover 2.7.0: 

The MiMa plgin looks at classes in a single directory (`mimaCurrentClassfiles`), but our tricky JDK9+ only sources setup compile to a different directory under `target/` (`target/scala-2.13/CompileJdk9-classes` vs the usual `target/scala-2.13/classes`). 

This should mean that MiMa never covered those JDK9+ classes, however MiMa didn't fail until we added 2.7.0 to the MiMa check. I haven't been able to figure out why it didn't fail before with what to MiMa looks like classes being removed.

To workaround this I've added another plugin which is triggered by the JDK9 plugin and merges the regular class directory and the Jdk9 class directory into a separate directory, only for mima to do its binary compatibility check on.

Verified by triggering mima failures in both regular classes and JDK9 only classes.