### PR TITLE
chore: replace apidoc links; bump link validator

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   validate-links:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checkout GitHub merge
         if: github.event.pull_request
@@ -19,19 +19,17 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1
+        with:
+          jvm: adopt:11
+          apps: cs
 
       - name: create the Akka site
         run: sbt -Dakka.genjavadoc.enabled=true "Javaunidoc/doc; Compile/unidoc; akka-docs/paradox"
 
-      - name: Install Coursier command line tool
-        run: curl -fLo cs https://git.io/coursier-cli-linux && chmod +x cs && ./cs
-
       - name: Run Link Validator
-        run: ./cs launch net.runne::site-link-validator:0.2.2 -- scripts/link-validator.conf
+        run: cs launch net.runne::site-link-validator:0.2.3 -- scripts/link-validator.conf

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -738,8 +738,8 @@ See also additional information about how to make @ref:[smooth rolling updates](
 Two requests to inspect the cluster state are available:
 
 @apidoc[akka.cluster.sharding.typed.GetShardRegionState] which will reply with a 
-@apidoc[akka.cluster.sharding.ShardRegion.CurrentShardRegionState] that contains the identifiers of the shards running in
-a Region and what entities are alive for each of them.
+@scala[@scaladoc[ShardRegion.CurrentShardRegionState](akka.cluster.sharding.ShardRegion.CurrentShardRegionState)]@java[@javadoc[ShardRegion.CurrentShardRegionState](akka.cluster.sharding.ShardRegion)]
+that contains the identifiers of the shards running in a Region and what entities are alive for each of them.
 
 Scala
 :  @@snip [ShardingCompileOnlySpec.scala](/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ShardingCompileOnlySpec.scala) { #get-shard-region-state }
@@ -748,8 +748,8 @@ Java
 :  @@snip [ShardingCompileOnlyTest.java](/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ShardingCompileOnlyTest.java) { #get-shard-region-state }
 
 @apidoc[akka.cluster.sharding.typed.GetClusterShardingStats] which will query all the regions in the cluster and reply with a
-@apidoc[akka.cluster.sharding.ShardRegion.ClusterShardingStats] containing the identifiers of the shards running in each region and a count
-of entities that are alive in each shard.
+@scala[@scaladoc[ShardRegion.ClusterShardingStats](akka.cluster.sharding.ShardRegion.ClusterShardingStats)]@java[@javadoc[ShardRegion.ClusterShardingStats](akka.cluster.sharding.ShardRegion)]
+containing the identifiers of the shards running in each region and a count of entities that are alive in each shard.
 
 Scala
 :  @@snip [ShardingCompileOnlySpec.scala](/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ShardingCompileOnlySpec.scala) { #get-cluster-sharding-stats }


### PR DESCRIPTION
Had yet another look at these two apidoc links that are flagged as broken.
As it turns out, JavaDoc is too lazy about these seemingly inner classes, they do not actually get their own pages -- while they do in ScalaDoc.

https://doc.akka.io/api/akka/2.7/akka/cluster/sharding/ShardRegion$$ClusterShardingStats.html
https://doc.akka.io/japi/akka/2.7/akka/cluster/sharding/ShardRegion$.html

Took the chance and did the GitHub workflow upgrade dance.

Refs #31641 