### PR TITLE
Use cos_containerd image in multi-node tests, #31698

### DIFF
--- a/kubernetes/create-cluster-gke.sh
+++ b/kubernetes/create-cluster-gke.sh
@@ -63,7 +63,7 @@ fi
 gcloud container clusters create $CLUSTER_NAME \
   --cluster-version $CLUSTER_VERSION  \
   --enable-ip-alias \
-  --image-type cos \
+  --image-type cos_containerd \
   --machine-type n2-standard-8 \
   --num-nodes 5 \
   --no-enable-autoupgrade


### PR DESCRIPTION
Error message:
Creation of node pools using node images based on Docker container runtimes is not supported in GKE v1.23. This is to prepare for the removal of Dockershim in Kubernetes v1.24. We recommend that you migrate to image types based on Containerd

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #31698
