### PR TITLE
Increase timeout in OutboundIdleShutdownSpec, #30984

### DIFF
--- a/akka-remote/src/test/scala/akka/remote/artery/OutboundIdleShutdownSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/OutboundIdleShutdownSpec.scala
@@ -10,6 +10,7 @@ import scala.concurrent.duration._
 
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.Span
+import org.scalatest.time.Span.convertSpanToDuration
 
 import akka.actor.ActorRef
 import akka.actor.ActorSystem
@@ -195,7 +196,8 @@ class OutboundIdleShutdownSpec extends ArteryMultiNodeSpec(s"""
 
         def remoteEcho = system.actorSelection(RootActorPath(remoteAddress) / "user" / "echo")
 
-        val echoRef = remoteEcho.resolveOne(remainingOrDefault).futureValue
+        // use little less resolve timeout than the patience timeout for good error messages
+        val echoRef = remoteEcho.resolveOne(convertSpanToDuration(patience.timeout) - 200.millis).futureValue
         val localProbe = new TestProbe(localSystem)
 
         echoRef.tell("ping", localProbe.ref)


### PR DESCRIPTION
* With the timefactor on ci it had a timeout of 6 seconds for the resolve, now that will be based on the patience setting instead, which results in 5*2*2=20 seconds
* Not sure if this is the root cause for the test failures, but should eliminate that it is just caused by slow startup.
* In logs we can see that the there is a valid response, but it arrives too late ``` [akka://OutboundIdleShutdownSpec@localhost:49507/temp/_user_echo$b] received dead letter: ActorIdentity(None,Some(Actor[akka://OutboundIdleShutdownSpec-remote-1/user/echo#772428728])) ```

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #30984
