### PR TITLE
Eagerly fail stream on failed future in Source.future

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/SourceSpec.scala
@@ -500,4 +500,12 @@ class SourceSpec extends StreamSpec with DefaultTimeout {
       Await.result(result, 4.seconds) shouldBe Done
     }
   }
+
+  "Source.future" must {
+    "fail on failed future, even with no demand" in {
+      val result = Source.future(Future.failed(new RuntimeException("BOOM!"))).runWith(Sink.never)
+
+      (the[RuntimeException] thrownBy (Await.result(result, 1.second))).getMessage shouldBe "BOOM!"
+    }
+  }
 }


### PR DESCRIPTION
The Scaladoc for `Source.future` says:

> The stream fails if the Future is completed with a failure.

However, in the current implementation, if there is never demand from downstream, the stream does not fail.

This is a behavior change: for instance in the current implementation:

```scala
Source.never
  .concat(Source.future(Future.failed(new RuntimeException))
  .runWith(Sink.ignore)
```

never fails, but would with this change.  If this is a big problem, I guess we can introduce a new `Source.eagerlyFailingFuture` (or whatever) with this implementation and leave `Source.future` as is (with updated Scaladoc to specifically say that the stream will only fail once there is demand on the source).