### PR TITLE
chore: renovate GH workflows

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   check-binary-compatibility:
     name: Check / Binary Compatibility
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     strategy:
       fail-fast: false

--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2
         with:
           server_address: smtp.gmail.com
           server_port: 465

--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -28,13 +28,13 @@ jobs:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.11
 
       - name: Report MiMa Binary Issues
         run: sbt -jvm-opts .jvmopts-ci "+~ ${{ matrix.scalaVersion }} mimaReportBinaryIssues"

--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -37,10 +37,14 @@ jobs:
           jvm: adopt:1.11
 
       - name: Report MiMa Binary Issues
-        run: sbt -jvm-opts .jvmopts-ci "+~ ${{ matrix.scalaVersion }} mimaReportBinaryIssues"
+        run: |-
+          mv .jvmopts-ci .jvmopts
+          sbt "+~ ${{ matrix.scalaVersion }} mimaReportBinaryIssues"
 
       - name: Check correct MiMa filter directories
-        run: sbt -jvm-opts .jvmopts-ci checkMimaFilterDirectories
+        run: |
+          mv .jvmopts-ci .jvmopts
+          sbt checkMimaFilterDirectories
 
       - name: Email on failure
         if: ${{ failure() }}

--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -9,6 +9,9 @@ on:
       - v2.6.*
       - v2.7.*
 
+permissions:
+  contents: read
+
 jobs:
   check-binary-compatibility:
     name: Check / Binary Compatibility

--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -23,7 +23,7 @@ jobs:
         scalaVersion: [ "2.12", "2.13" ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -34,7 +34,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Report MiMa Binary Issues
         run: sbt -jvm-opts .jvmopts-ci "+~ ${{ matrix.scalaVersion }} mimaReportBinaryIssues"

--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -43,7 +43,6 @@ jobs:
 
       - name: Check correct MiMa filter directories
         run: |
-          mv .jvmopts-ci .jvmopts
           sbt checkMimaFilterDirectories
 
       - name: Email on failure

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   check-code-style:
     name: Check / Code Style
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0
@@ -36,7 +36,7 @@ jobs:
 
   pull-request-validation:
     name: Check / Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check-code-style:
     name: Check / Code Style

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -29,7 +29,8 @@ jobs:
 
       - name: Code style check
         run: |-
-          sbt -jvm-opts .jvmopts-ci \
+          mv .jvmopts-ci .jvmopts
+          sbt \
           -Dsbt.override.build.repos=false \
           -Dsbt.log.noformat=false \
           verifyCodeStyle
@@ -54,7 +55,8 @@ jobs:
 
       - name: sbt validatePullRequest
         run: |-
-          sbt -jvm-opts .jvmopts-ci \
+          mv .jvmopts-ci .jvmopts
+          sbt \
           -Dakka.mima.enabled=false \
           -Dakka.test.multi-in-test=false \
           -Dakka.test.timefactor=2 \

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -19,13 +19,13 @@ jobs:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.11
 
       - name: Code style check
         run: |-
@@ -44,13 +44,13 @@ jobs:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.11
 
       - name: sbt validatePullRequest
         run: |-

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -25,7 +25,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Code style check
         run: |-
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -50,7 +50,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: sbt validatePullRequest
         run: |-

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -3,7 +3,7 @@ name: Dependency License Scanning
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 0' # At 00:00 on Sunday
+    - cron: '0 0 * * 6' # At 00:00 on saturdays
 
 jobs:
   fossa:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2
         with:
           server_address: smtp.gmail.com
           server_port: 465

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: FOSSA policy check
         run: |-
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
           fossa analyze && fossa test
         env:
           FOSSA_API_KEY: "${{secrets.FOSSA_API_KEY}}"

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -17,13 +17,13 @@ jobs:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v13
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.11
 
       - name: FOSSA policy check
         run: |-

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'akka/akka'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -23,7 +23,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: FOSSA policy check
         run: |-

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * 6' # At 00:00 on saturdays
 
+permissions:
+  contents: read
+
 jobs:
   fossa:
     name: Fossa

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   fossa:
     name: Fossa
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     steps:
       - name: Checkout

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -5,6 +5,9 @@ on:
     - cron:  '0 6 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate-links:
     runs-on: ubuntu-22.04

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -20,7 +20,7 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK 11
         uses: coursier/setup-action@v1

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -23,7 +23,7 @@ jobs:
         uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.0
         with:
           jvm: adopt:11
           apps: cs

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 2 * * 1,3,5'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.
   group: ci-multi-node-${{ github.ref }}

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   run-multi-node-tests:
     name: Multi Node Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     steps:
       - name: Checkout
@@ -96,7 +96,7 @@ jobs:
 
   run-multi-node-aeron-tests:
     name: Multi Node Test with Artery Aeron UDP transport
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     steps:
       - name: Checkout

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Multi node test
         run: |
           cat multi-node-test.hosts
-          sbt -jvm-opts .jvmopts-ci \
+          mv .jvmopts-ci .jvmopts
+          sbt \
             -Dakka.test.timefactor=2 \
             -Dakka.actor.testkit.typed.timefactor=2 \
             -Dakka.test.tags.exclude=gh-exclude,timing \
@@ -134,7 +135,8 @@ jobs:
       - name: Multi node test with Artery Aeron UDP
         run: |
           cat multi-node-test.hosts
-          sbt -jvm-opts .jvmopts-ci \
+          mv .jvmopts-ci .jvmopts
+          sbt \
             -Dakka.test.timefactor=2 \
             -Dakka.actor.testkit.typed.timefactor=2 \
             -Dakka.cluster.assert=on \

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository == 'akka/akka'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
           java-version: adopt@1.11.0-9
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Multi node test
         run: |
@@ -100,7 +100,7 @@ jobs:
     if: github.repository == 'akka/akka'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -129,7 +129,7 @@ jobs:
           java-version: adopt@1.11.0-9
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Multi node test with Artery Aeron UDP
         run: |

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -40,13 +40,13 @@ jobs:
           # Start 10 pods. At most 10 MultiJvmNode (akka.cluster.StressSpec is currently disabled).
           ./kubernetes/setup.sh 10 multi-node-test.hosts tcp
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.11.0.9
 
       - name: Multi node test
         run: |
@@ -123,13 +123,13 @@ jobs:
           # Start 10 pods. At most 10 MultiJvmNode (akka.cluster.StressSpec is currently disabled).
           ./kubernetes/setup.sh 10 multi-node-test.hosts udp
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.11.0.9
 
       - name: Multi node test with Artery Aeron UDP
         run: |

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2
         with:
           server_address: smtp.gmail.com
           server_port: 465
@@ -157,7 +157,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2
         with:
           server_address: smtp.gmail.com
           server_port: 465

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Test Reports
         # Makes it easier to spot failures instead of looking at the logs.
         if: ${{ failure() }}
-        uses: marcospereira/action-surefire-report@v1
+        uses: scacap/action-surefire-report@482f012643ed0560e23ef605a79e8e87ca081648
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'
           fail_if_no_tests: false
@@ -170,7 +170,7 @@ jobs:
       - name: Test Reports
         # Makes it easier to spot failures instead of looking at the logs.
         if: ${{ failure() }}
-        uses: marcospereira/action-surefire-report@v1
+        uses: scacap/action-surefire-report@482f012643ed0560e23ef605a79e8e87ca081648
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'
           fail_if_no_tests: false

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -18,13 +18,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.11
 
       - name: sbt akka-cluster-metrics/test
         run: |-
@@ -85,13 +85,13 @@ jobs:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.11
 
       - name: sbt ${{ matrix.command }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
@@ -132,13 +132,13 @@ jobs:
         # binary version is required and Akka build will set the right
         # full version from it.
         scalaVersion: ["2.12", "2.13"]
-        jdkVersion: ["adopt@1.8.0", "adopt@1.11", "openjdk@1.17.0"]
+        jdkVersion: ["adopt:1.8.0", "adopt:1.11", "temurin:1.17.0"]
         include:
-          - jdkVersion: adopt@1.8.0
+          - jdkVersion: adopt:1.8.0
             extraOpts: ""
-          - jdkVersion: adopt@1.11
+          - jdkVersion: adopt:1.11
             extraOpts: ""
-          - jdkVersion: openjdk@1.17.0
+          - jdkVersion: temurin:1.17.0
             extraopts: ""
     steps:
       - name: Checkout
@@ -146,13 +146,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK ${{ matrix.jdkVersion }}
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: ${{ matrix.jdkVersion }}
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK ${{ matrix.jdkVersion }}
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: ${{ matrix.jdkVersion }}
 
       - name: Compile and Test
         # note that this is not running any multi-jvm tests because multi-in-test=false
@@ -235,13 +235,13 @@ jobs:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.11
 
       - name: sbt ${{ matrix.command }}
         # note that this is not running any multi-jvm tests because multi-in-test=false

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -28,7 +28,8 @@ jobs:
 
       - name: sbt akka-cluster-metrics/test
         run: |-
-          sbt -jvm-opts .jvmopts-ci \
+          mv .jvmopts-ci .jvmopts
+          sbt \
             -Djava.security.egd=file:/dev/./urandom \
             -Dakka.test.sigar=true \
             -Dakka.cluster.assert=on \
@@ -96,7 +97,8 @@ jobs:
       - name: sbt ${{ matrix.command }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
-          sbt -jvm-opts .jvmopts-ci \
+          mv .jvmopts-ci .jvmopts
+          sbt \
           -Djava.security.egd=file:/dev/./urandom \
           -Dakka.remote.artery.enabled=off \
           -Dakka.test.timefactor=2 \
@@ -157,7 +159,8 @@ jobs:
       - name: Compile and Test
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
-          sbt -jvm-opts .jvmopts-ci \
+          mv .jvmopts-ci .jvmopts
+          sbt \
             -Dakka.cluster.assert=on \
             -Dakka.log.timestamps=true \
             -Dakka.test.timefactor=2 \
@@ -190,7 +193,8 @@ jobs:
         if: ${{ startsWith(matrix.jdkVersion, 'adopt@1.11') }}
         run: |-
           sudo apt-get install graphviz
-          sbt -jvm-opts .jvmopts-ci \
+          mv .jvmopts-ci .jvmopts
+          sbt \
             -Dakka.genjavadoc.enabled=true \
             "+~ ${{ matrix.scalaVersion }} doc"
 
@@ -199,7 +203,8 @@ jobs:
         if: ${{ startsWith(matrix.jdkVersion, 'adopt@1.11') }}
         run: |-
           sudo apt-get install graphviz
-          sbt -jvm-opts .jvmopts-ci \
+          mv .jvmopts-ci .jvmopts
+          sbt \
             -Dakka.build.scalaVersion=${{ matrix.scalaVersion }} \
             "+~ ${{ matrix.scalaVersion }} publishLocal publishM2"
 
@@ -246,7 +251,8 @@ jobs:
       - name: sbt ${{ matrix.command }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
-          sbt -jvm-opts .jvmopts-ci \
+          mv .jvmopts-ci .jvmopts
+          sbt \
           -Djava.security.egd=file:/dev/./urandom \
           -Dakka.remote.artery.transport=aeron-udp \
           -Dakka.test.timefactor=2 \

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -9,7 +9,7 @@ jobs:
 
   akka-cluster-metrics-sigar:
     name: Akka Cluster Metrics Test with Sigar
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     steps:
 
@@ -69,7 +69,7 @@ jobs:
 
   akka-classic-remoting-tests:
     name: Akka Classic Remoting Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     strategy:
       fail-fast: false
@@ -123,7 +123,7 @@ jobs:
 
   jdk-nightly-build:
     name: JDK ${{ matrix.jdkVersion }} / Scala ${{ matrix.scalaVersion }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     strategy:
       fail-fast: false
@@ -220,7 +220,7 @@ jobs:
 
   akka-artery-aeron-tests:
     name: Akka Artery Aeron Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2
         with:
           server_address: smtp.gmail.com
           server_port: 465
@@ -108,7 +108,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2
         with:
           server_address: smtp.gmail.com
           server_port: 465
@@ -205,7 +205,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2
         with:
           server_address: smtp.gmail.com
           server_port: 465
@@ -260,7 +260,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2
         with:
           server_address: smtp.gmail.com
           server_port: 465

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   akka-cluster-metrics-sigar:

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -24,7 +24,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: sbt akka-cluster-metrics/test
         run: |-
@@ -80,7 +80,7 @@ jobs:
           - akka-cluster-typed/test akka-cluster-sharding-typed/test
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -91,7 +91,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: sbt ${{ matrix.command }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
@@ -142,7 +142,7 @@ jobs:
             extraopts: ""
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -152,7 +152,7 @@ jobs:
           java-version: ${{ matrix.jdkVersion }}
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Compile and Test
         # note that this is not running any multi-jvm tests because multi-in-test=false
@@ -230,7 +230,7 @@ jobs:
           - akka-cluster/test akka-cluster-typed/test
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -241,7 +241,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: sbt ${{ matrix.command }}
         # note that this is not running any multi-jvm tests because multi-in-test=false

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   documentation:
     name: Documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     steps:
       - name: Checkout

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,6 +10,9 @@ on:
       - docs/v*
     tags: ["*"]
 
+permissions:
+  contents: read
+
 jobs:
   documentation:
     name: Documentation

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,10 +21,12 @@ jobs:
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+
       - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
+        uses: coursier/setup-action@v1.3.0
         with:
-          java-version: adopt@1.11
+          jvm: adopt:1.11
+
       - name: Publish
         run: |-
           eval "$(ssh-agent -s)"

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository == 'akka/akka'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2
         with:
           server_address: smtp.gmail.com
           server_port: 465

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ on:
       - test-publish-snapshots
     tags: ["*"]
 
+permissions:
+  contents: read
+
 jobs:
   sbt:
     name: sbt publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2
         with:
           server_address: smtp.gmail.com
           server_port: 465

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,12 @@ jobs:
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+
       - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
+        uses: coursier/setup-action@v1.3.0
         with:
-          java-version: adopt@1.11.0-9
+          jvm: adopt:1.11.0.9
+
       - name: Publish
         run: |-
           sudo apt-get install graphviz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'akka/akka'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   sbt:
     name: sbt publish
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     steps:
       - name: Checkout

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Compile and run tests on Scala 3
         # note that this is not running any multi-jvm tests (yet) because multi-in-test=false

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     strategy:
       matrix:

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2
         with:
           server_address: smtp.gmail.com
           server_port: 465

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -48,7 +48,8 @@ jobs:
       - name: Compile and run tests on Scala 3
         # note that this is not running any multi-jvm tests (yet) because multi-in-test=false
         run: |
-          sbt -jvm-opts .jvmopts-ci \
+          mv .jvmopts-ci .jvmopts
+          sbt \
           -Dakka.log.timestamps=true \
           -Dakka.test.timefactor=2 \
           -Dakka.actor.testkit.typed.timefactor=2 \

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -5,6 +5,8 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -37,13 +37,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.11
 
       - name: Compile and run tests on Scala 3
         # note that this is not running any multi-jvm tests (yet) because multi-in-test=false

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -3,6 +3,9 @@ name: Compile Akka with Scala 3
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.
   group: ci-scala3-${{ github.ref }}

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   compile:
     name: Compile
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     strategy:
       matrix:

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -40,7 +40,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: Compile on Scala 3
         run: |

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -34,13 +34,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.11
 
       - name: Compile on Scala 3
         run: |

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -44,5 +44,6 @@ jobs:
 
       - name: Compile on Scala 3
         run: |
-          sbt -jvm-opts .jvmopts-ci \
+          mv .jvmopts-ci .jvmopts
+          sbt \
           "+~ 3 ${{ matrix.command }}"

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Test Reports
         # Makes it easier to spot failures instead of looking at the logs.
         if: ${{ failure() }}
-        uses: marcospereira/action-surefire-report@v1
+        uses: scacap/action-surefire-report@482f012643ed0560e23ef605a79e8e87ca081648
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'
           fail_if_no_tests: false

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -9,7 +9,7 @@ jobs:
 
   akka-timing-sensitive-tests:
     name: Akka Tests taggedAs TimingTest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka'
     steps:
 

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -28,7 +28,8 @@ jobs:
 
       - name: sbt test
         run: |-
-          sbt -jvm-opts .jvmopts-ci \
+          mv .jvmopts-ci .jvmopts
+          sbt \
             -Djava.security.egd=file:/dev/./urandom \
             -Dakka.cluster.assert=on \
             -Dakka.test.timefactor=2 \

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -24,7 +24,7 @@ jobs:
           java-version: adopt@1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
 
       - name: sbt test
         run: |-

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -18,13 +18,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.11
 
       - name: sbt test
         run: |-

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Email on failure
         if: ${{ failure() }}
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2
         with:
           server_address: smtp.gmail.com
           server_port: 465

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   akka-timing-sensitive-tests:


### PR DESCRIPTION
Update to current versions of GH actions before Node 12 is discontinued.
* Replace `olafurpg/setup-scala` with `coursier/setup-action`
* Ubuntu-22.04 while at it
* Locking "privately owned" actions to their git hash 
* The sbt launcher doesn't have `-jvm-opts` any more, rename the file before launching sbt
* Current Fossa CLI install URL
* Explicit permissions (see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)