### PR TITLE
Wildcard subscription of ddata changes

### DIFF
--- a/akka-distributed-data/src/main/scala-2/akka/cluster/ddata/GSet.scala
+++ b/akka-distributed-data/src/main/scala-2/akka/cluster/ddata/GSet.scala
@@ -98,4 +98,7 @@ object GSetKey {
 }
 
 @SerialVersionUID(1L)
-final case class GSetKey[A](_id: String) extends Key[GSet[A]](_id) with ReplicatedDataSerialization
+final case class GSetKey[A](_id: String) extends Key[GSet[A]](_id) with ReplicatedDataSerialization {
+  override def withId(newId: Key.KeyId): GSetKey[A] =
+    GSetKey(newId)
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Flag.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Flag.scala
@@ -56,4 +56,7 @@ object FlagKey {
 }
 
 @SerialVersionUID(1L)
-final case class FlagKey(_id: String) extends Key[Flag](_id) with ReplicatedDataSerialization
+final case class FlagKey(_id: String) extends Key[Flag](_id) with ReplicatedDataSerialization {
+  override def withId(newId: Key.KeyId): FlagKey =
+    FlagKey(newId)
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/GCounter.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/GCounter.scala
@@ -164,4 +164,7 @@ object GCounterKey {
 }
 
 @SerialVersionUID(1L)
-final case class GCounterKey(_id: String) extends Key[GCounter](_id) with ReplicatedDataSerialization
+final case class GCounterKey(_id: String) extends Key[GCounter](_id) with ReplicatedDataSerialization {
+  override def withId(newId: Key.KeyId): GCounterKey =
+    GCounterKey(newId)
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Key.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Key.scala
@@ -17,7 +17,7 @@ object Key {
 
   type KeyId = String
 
-  final case class UnspecificKey(_id: KeyId) extends Key[ReplicatedData](_id) with ReplicatedDataSerialization // FIXME serialization
+  final case class UnspecificKey(_id: KeyId) extends Key[ReplicatedData](_id) with ReplicatedDataSerialization
 
 }
 
@@ -31,7 +31,6 @@ object Key {
  */
 abstract class Key[+T <: ReplicatedData](val id: Key.KeyId) extends Serializable {
 
-  // FIXME override this with concrete Key types in Akka's known types
   def withId(newId: Key.KeyId): Key[ReplicatedData] =
     UnspecificKey(newId)
 

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Key.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Key.scala
@@ -4,6 +4,8 @@
 
 package akka.cluster.ddata
 
+import akka.cluster.ddata.Key.UnspecificKey
+
 object Key {
 
   /**
@@ -14,6 +16,8 @@ object Key {
   private[akka] type KeyR = Key[ReplicatedData]
 
   type KeyId = String
+
+  final case class UnspecificKey(_id: KeyId) extends Key[ReplicatedData](_id) with ReplicatedDataSerialization // FIXME serialization
 
 }
 
@@ -26,6 +30,10 @@ object Key {
  * and you can create your own keys.
  */
 abstract class Key[+T <: ReplicatedData](val id: Key.KeyId) extends Serializable {
+
+  // FIXME override this with concrete Key types in Akka's known types
+  def withId(newId: Key.KeyId): Key[ReplicatedData] =
+    UnspecificKey(newId)
 
   override final def equals(o: Any): Boolean = o match {
     case k: Key[_] => id == k.id

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWMap.scala
@@ -215,4 +215,7 @@ object LWWMapKey {
 }
 
 @SerialVersionUID(1L)
-final case class LWWMapKey[A, B](_id: String) extends Key[LWWMap[A, B]](_id) with ReplicatedDataSerialization
+final case class LWWMapKey[A, B](_id: String) extends Key[LWWMap[A, B]](_id) with ReplicatedDataSerialization {
+  override def withId(newId: Key.KeyId): LWWMapKey[A, B] =
+    LWWMapKey(newId)
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWRegister.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/LWWRegister.scala
@@ -223,4 +223,7 @@ object LWWRegisterKey {
 }
 
 @SerialVersionUID(1L)
-final case class LWWRegisterKey[A](_id: String) extends Key[LWWRegister[A]](_id) with ReplicatedDataSerialization
+final case class LWWRegisterKey[A](_id: String) extends Key[LWWRegister[A]](_id) with ReplicatedDataSerialization {
+  override def withId(newId: Key.KeyId): LWWRegisterKey[A] =
+    LWWRegisterKey(newId)
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMap.scala
@@ -586,4 +586,7 @@ object ORMapKey {
 @SerialVersionUID(1L)
 final case class ORMapKey[A, B <: ReplicatedData](_id: String)
     extends Key[ORMap[A, B]](_id)
-    with ReplicatedDataSerialization
+    with ReplicatedDataSerialization {
+  override def withId(newId: Key.KeyId): ORMapKey[A, B] =
+    ORMapKey(newId)
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMultiMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORMultiMap.scala
@@ -364,4 +364,7 @@ object ORMultiMapKey {
 }
 
 @SerialVersionUID(1L)
-final case class ORMultiMapKey[A, B](_id: String) extends Key[ORMultiMap[A, B]](_id) with ReplicatedDataSerialization
+final case class ORMultiMapKey[A, B](_id: String) extends Key[ORMultiMap[A, B]](_id) with ReplicatedDataSerialization {
+  override def withId(newId: Key.KeyId): ORMultiMapKey[A, B] =
+    ORMultiMapKey(newId)
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORSet.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/ORSet.scala
@@ -567,4 +567,7 @@ object ORSetKey {
 }
 
 @SerialVersionUID(1L)
-final case class ORSetKey[A](_id: String) extends Key[ORSet[A]](_id) with ReplicatedDataSerialization
+final case class ORSetKey[A](_id: String) extends Key[ORSet[A]](_id) with ReplicatedDataSerialization {
+  override def withId(newId: Key.KeyId): ORSetKey[A] =
+    ORSetKey(newId)
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounter.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounter.scala
@@ -239,4 +239,7 @@ object PNCounterKey {
 }
 
 @SerialVersionUID(1L)
-final case class PNCounterKey(_id: String) extends Key[PNCounter](_id) with ReplicatedDataSerialization
+final case class PNCounterKey(_id: String) extends Key[PNCounter](_id) with ReplicatedDataSerialization {
+  override def withId(newId: Key.KeyId): PNCounterKey =
+    PNCounterKey(newId)
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounterMap.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/PNCounterMap.scala
@@ -201,4 +201,7 @@ object PNCounterMapKey {
 }
 
 @SerialVersionUID(1L)
-final case class PNCounterMapKey[A](_id: String) extends Key[PNCounterMap[A]](_id) with ReplicatedDataSerialization
+final case class PNCounterMapKey[A](_id: String) extends Key[PNCounterMap[A]](_id) with ReplicatedDataSerialization {
+  override def withId(newId: Key.KeyId): PNCounterMapKey[A] =
+    PNCounterMapKey(newId)
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
@@ -739,6 +739,10 @@ object Replicator {
    * when the value of the given `key` is changed. Current value is also
    * sent as a [[Changed]] message to a new subscriber.
    *
+   * In addition to subscribing to individual keys it is possible to subscribe to all keys with a given prefix
+   * by using a `*` at the end of the key `id`. For example `GCounterKey("counter-*")`. Notifications will be
+   * sent for all matching keys, also new keys added later.
+   *
    * Subscribers will be notified periodically with the configured `notify-subscribers-interval`,
    * and it is also possible to send an explicit `FlushChanges` message to
    * the `Replicator` to notify the subscribers immediately.

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
@@ -295,6 +295,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
   private val ORMultiMapManifest = "K"
   private val ORMultiMapKeyManifest = "k"
   private val VersionVectorManifest = "L"
+  private val UnspecificKeyManifest = "m"
 
   private val fromBinaryMap = collection.immutable.HashMap[String, Array[Byte] => AnyRef](
     GSetManifest -> gsetFromBinary,
@@ -327,7 +328,9 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
     ORMapKeyManifest -> (bytes => ORMapKey(keyIdFromBinary(bytes))),
     LWWMapKeyManifest -> (bytes => LWWMapKey(keyIdFromBinary(bytes))),
     PNCounterMapKeyManifest -> (bytes => PNCounterMapKey(keyIdFromBinary(bytes))),
-    ORMultiMapKeyManifest -> (bytes => ORMultiMapKey(keyIdFromBinary(bytes))))
+    ORMultiMapKeyManifest -> (bytes => ORMultiMapKey(keyIdFromBinary(bytes))),
+    UnspecificKeyManifest -> (bytes => Key.UnspecificKey(keyIdFromBinary(bytes)))
+  )
 
   override def manifest(obj: AnyRef): String = obj match {
     case _: ORSet[_]                     => ORSetManifest
@@ -363,6 +366,8 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
     case _: ORSet.DeltaGroup[_]       => ORSetDeltaGroupManifest
     case _: ORMap.DeltaGroup[_, _]    => ORMapDeltaGroupManifest
     case _: ORSet.FullStateDeltaOp[_] => ORSetFullManifest
+
+    case _: Key.UnspecificKey => UnspecificKeyManifest
 
     case _ =>
       throw new IllegalArgumentException(s"Can't serialize object of type ${obj.getClass} in [${getClass.getName}]")

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializer.scala
@@ -329,8 +329,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem)
     LWWMapKeyManifest -> (bytes => LWWMapKey(keyIdFromBinary(bytes))),
     PNCounterMapKeyManifest -> (bytes => PNCounterMapKey(keyIdFromBinary(bytes))),
     ORMultiMapKeyManifest -> (bytes => ORMultiMapKey(keyIdFromBinary(bytes))),
-    UnspecificKeyManifest -> (bytes => Key.UnspecificKey(keyIdFromBinary(bytes)))
-  )
+    UnspecificKeyManifest -> (bytes => Key.UnspecificKey(keyIdFromBinary(bytes))))
 
   override def manifest(obj: AnyRef): String = obj match {
     case _: ORSet[_]                     => ORSetManifest

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/WildcardSubscribeSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/WildcardSubscribeSpec.scala
@@ -19,7 +19,7 @@ object WildcardSubscribeSpec extends MultiNodeConfig {
   val second = role("second")
 
   commonConfig(ConfigFactory.parseString("""
-    akka.loglevel = DEBUG
+    akka.loglevel = INFO
     akka.actor.provider = "cluster"
     akka.cluster.distributed-data {
       gossip-interval = 500 millis

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/WildcardSubscribeSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/WildcardSubscribeSpec.scala
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.ddata
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
+
+import akka.cluster.Cluster
+import akka.remote.testconductor.RoleName
+import akka.remote.testkit.MultiNodeConfig
+import akka.remote.testkit.MultiNodeSpec
+import akka.testkit._
+
+object WildcardSubscribeSpec extends MultiNodeConfig {
+  val first = role("first")
+  val second = role("second")
+
+  commonConfig(ConfigFactory.parseString("""
+    akka.loglevel = DEBUG
+    akka.actor.provider = "cluster"
+    akka.cluster.distributed-data {
+      gossip-interval = 500 millis
+      notify-subscribers-interval = 100 millis
+      expire-keys-after-inactivity {
+        "expiry-*" = 2 seconds
+      }
+    }
+    
+    """))
+
+}
+
+class WildcardSubscribeSpecMultiJvmNode1 extends WildcardSubscribeSpec
+class WildcardSubscribeSpecMultiJvmNode2 extends WildcardSubscribeSpec
+
+class WildcardSubscribeSpec extends MultiNodeSpec(WildcardSubscribeSpec) with STMultiNodeSpec with ImplicitSender {
+  import WildcardSubscribeSpec._
+  import Replicator._
+
+  override def initialParticipants: Int = roles.size
+
+  private val cluster = Cluster(system)
+  private implicit val selfUniqueAddress: SelfUniqueAddress = DistributedData(system).selfUniqueAddress
+  private val replicator = system.actorOf(Replicator.props(ReplicatorSettings(system)), "replicator")
+
+  private val KeyA = GCounterKey("counter-A")
+  private val KeyB = GCounterKey("counter-B")
+  private val KeyOtherA = GCounterKey("other-A")
+  private val KeyExpiryA = GCounterKey("expiry-A")
+
+  def join(from: RoleName, to: RoleName): Unit = {
+    runOn(from) {
+      cluster.join(node(to).address)
+    }
+    enterBarrier(from.name + "-joined")
+  }
+
+  "Replicator wildcard subscriptions" must {
+
+    "notify changed entry" in {
+      join(first, first)
+
+      runOn(first) {
+        val subscriberProbe = TestProbe()
+        replicator ! Subscribe(GCounterKey("counter-*"), subscriberProbe.ref)
+
+        replicator ! Update(KeyA, GCounter.empty, WriteLocal)(_ :+ 1)
+        expectMsgType[UpdateSuccess[_]]
+        val chg1 = subscriberProbe.expectMsgType[Changed[GCounter]]
+        chg1.key should ===(KeyA)
+        chg1.get(KeyA).value should ===(1)
+
+        replicator ! Update(KeyA, GCounter.empty, WriteLocal)(_ :+ 1)
+        expectMsgType[UpdateSuccess[_]]
+        val chg2 = subscriberProbe.expectMsgType[Changed[GCounter]]
+        chg2.key should ===(KeyA)
+        chg2.get(KeyA).value should ===(2)
+
+        replicator ! Update(KeyB, GCounter.empty, WriteLocal)(_ :+ 1)
+        expectMsgType[UpdateSuccess[_]]
+        val chg3 = subscriberProbe.expectMsgType[Changed[GCounter]]
+        chg3.key should ===(KeyB)
+        chg3.get(KeyB).value should ===(1)
+
+        replicator ! Update(KeyOtherA, GCounter.empty, WriteLocal)(_ :+ 1)
+        expectMsgType[UpdateSuccess[_]]
+        subscriberProbe.expectNoMessage(200.millis)
+
+        // another subscriber
+        val subscriberProbe2 = TestProbe()
+        replicator ! Subscribe(GCounterKey("counter-*"), subscriberProbe2.ref)
+        subscriberProbe.expectNoMessage(200.millis)
+        subscriberProbe2.receiveN(2).foreach {
+          case chg: Changed[GCounter] @unchecked =>
+            if (chg.key == KeyA)
+              chg.get(KeyA).value should ===(2)
+            else if (chg.key == KeyB)
+              chg.get(KeyB).value should ===(1)
+            else
+              fail(s"unexpected change ${chg.key}")
+          case other =>
+            fail(s"Unexpected $other")
+        }
+        subscriberProbe2.expectNoMessage()
+
+        replicator ! Update(KeyB, GCounter.empty, WriteLocal)(_ :+ 10)
+        expectMsgType[UpdateSuccess[_]]
+        val chg4 = subscriberProbe.expectMsgType[Changed[GCounter]]
+        chg4.key should ===(KeyB)
+        chg4.get(KeyB).value should ===(11)
+        val chg5 = subscriberProbe2.expectMsgType[Changed[GCounter]]
+        chg5.key should ===(KeyB)
+        chg5.get(KeyB).value should ===(11)
+
+        // unsubscribe
+        replicator ! Unsubscribe(GCounterKey("counter-*"), subscriberProbe.ref)
+        replicator ! Update(KeyB, GCounter.empty, WriteLocal)(_ :+ 5)
+        expectMsgType[UpdateSuccess[_]]
+        subscriberProbe.expectNoMessage(200.millis)
+        val chg6 = subscriberProbe2.expectMsgType[Changed[GCounter]]
+        chg6.key should ===(KeyB)
+        chg6.get(KeyB).value should ===(16)
+      }
+
+      enterBarrier("done-1")
+    }
+
+    "notify expired entry" in {
+      runOn(first) {
+        val subscriberProbe = TestProbe()
+        replicator ! Subscribe(GCounterKey("expiry-*"), subscriberProbe.ref)
+
+        replicator ! Update(KeyExpiryA, GCounter.empty, WriteLocal)(_ :+ 1)
+        expectMsgType[UpdateSuccess[_]]
+        subscriberProbe.expectMsgType[Changed[GCounter]]
+
+        replicator ! Get(KeyExpiryA, ReadLocal)
+        expectMsgType[GetSuccess[GCounter]].get(KeyExpiryA).value should ===(1)
+
+        expectNoMessage(5.seconds)
+        replicator ! Get(KeyExpiryA, ReadLocal)
+        expectMsg(NotFound(KeyExpiryA, None))
+        subscriberProbe.expectMsg(Expired[GCounter](KeyExpiryA))
+
+        // same key can be used again
+        replicator ! Update(KeyExpiryA, GCounter.empty, WriteLocal)(_ :+ 2)
+        expectMsgType[UpdateSuccess[_]]
+        subscriberProbe.expectMsgType[Changed[GCounter]]
+        replicator ! Get(KeyExpiryA, ReadLocal)
+        expectMsgType[GetSuccess[GCounter]].get(KeyExpiryA).value should ===(2)
+      }
+
+      enterBarrier("done-2")
+    }
+
+    "notify when changed from another node" in {
+      runOn(first) {
+        replicator ! Update(KeyOtherA, GCounter.empty, WriteLocal)(_ :+ 1)
+        expectMsgType[UpdateSuccess[_]]
+        enterBarrier("updated-1")
+
+        enterBarrier("second-joined")
+
+        enterBarrier("received-1")
+
+        replicator ! Update(KeyOtherA, GCounter.empty, WriteLocal)(_ :+ 1)
+        expectMsgType[UpdateSuccess[_]]
+        enterBarrier("updated-2")
+
+        enterBarrier("received-2")
+      }
+      runOn(second) {
+        enterBarrier("updated-1")
+
+        // it's possible to subscribe before join
+        val subscriberProbe = TestProbe()
+        replicator ! Subscribe(GCounterKey("other-*"), subscriberProbe.ref)
+
+        join(second, first)
+
+        val chg1 = subscriberProbe.expectMsgType[Changed[GCounter]](10.seconds)
+        chg1.key should ===(KeyOtherA)
+        chg1.get(KeyOtherA).value should ===(2) // it was also incremented once in earlier test
+        enterBarrier("received-1")
+
+        enterBarrier("updated-2")
+
+        val chg2 = subscriberProbe.expectMsgType[Changed[GCounter]]
+        chg2.key should ===(KeyOtherA)
+        chg2.get(KeyOtherA).value should ===(3)
+        enterBarrier("received-2")
+      }
+    }
+
+    enterBarrier("done-3")
+  }
+}

--- a/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/WildcardSubscribeSpec.scala
+++ b/akka-distributed-data/src/multi-jvm/scala/akka/cluster/ddata/WildcardSubscribeSpec.scala
@@ -71,6 +71,7 @@ class WildcardSubscribeSpec extends MultiNodeSpec(WildcardSubscribeSpec) with ST
         expectMsgType[UpdateSuccess[_]]
         val chg1 = subscriberProbe.expectMsgType[Changed[GCounter]]
         chg1.key should ===(KeyA)
+        chg1.key.getClass should ===(KeyA.getClass)
         chg1.get(KeyA).value should ===(1)
 
         replicator ! Update(KeyA, GCounter.empty, WriteLocal)(_ :+ 1)

--- a/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializerSpec.scala
+++ b/akka-distributed-data/src/test/scala/akka/cluster/ddata/protobuf/ReplicatedDataSerializerSpec.scala
@@ -85,6 +85,8 @@ class ReplicatedDataSerializerSpec
       checkSameContent(GSet() + "a" + "b", GSet() + "b" + "a")
       checkSameContent(GSet() + ref1 + ref2 + ref3, GSet() + ref2 + ref1 + ref3)
       checkSameContent(GSet() + ref1 + ref2 + ref3, GSet() + ref3 + ref2 + ref1)
+
+      checkSerialization(GSetKey[String]("id"))
     }
 
     "serialize ORSet" in {
@@ -114,6 +116,8 @@ class ReplicatedDataSerializerSpec
       val s5 = ORSet().add(address1, "a").add(address2, ref1)
       val s6 = ORSet().add(address2, ref1).add(address1, "a")
       checkSameContent(s5.merge(s6), s6.merge(s5))
+
+      checkSerialization(ORSetKey[String]("id"))
     }
 
     "serialize ORSet with ActorRef message sent between two systems" in {
@@ -176,6 +180,7 @@ class ReplicatedDataSerializerSpec
     "serialize Flag" in {
       checkSerialization(Flag())
       checkSerialization(Flag().switchOn)
+      checkSerialization(FlagKey("id"))
     }
 
     "serialize LWWRegister" in {
@@ -183,6 +188,7 @@ class ReplicatedDataSerializerSpec
       checkSerialization(
         LWWRegister(address1, "value2", LWWRegister.defaultClock[String])
           .withValue(address2, "value3", LWWRegister.defaultClock[String]))
+      checkSerialization(LWWRegisterKey[String]("id"))
     }
 
     "serialize GCounter" in {
@@ -196,6 +202,8 @@ class ReplicatedDataSerializerSpec
       checkSameContent(
         GCounter().increment(address1, 2).increment(address3, 5),
         GCounter().increment(address3, 5).increment(address1, 2))
+
+      checkSerialization(GCounterKey("id"))
     }
 
     "serialize PNCounter" in {
@@ -214,6 +222,8 @@ class ReplicatedDataSerializerSpec
       checkSameContent(
         PNCounter().increment(address1, 2).decrement(address1, 1).increment(address3, 5),
         PNCounter().increment(address3, 5).increment(address1, 2).decrement(address1, 1))
+
+      checkSerialization(PNCounterKey("id"))
     }
 
     "serialize ORMap" in {
@@ -222,6 +232,8 @@ class ReplicatedDataSerializerSpec
       checkSerialization(ORMap().put(address1, 1L, GSet() + "A"))
       // use Flag for this test as object key because it is serializable
       checkSerialization(ORMap().put(address1, Flag(), GSet() + "A"))
+
+      checkSerialization(ORMapKey[UniqueAddress, GSet[String]]("id"))
     }
 
     "serialize ORMap delta" in {
@@ -259,6 +271,8 @@ class ReplicatedDataSerializerSpec
         LWWMap()
           .put(address1, "a", "value1", LWWRegister.defaultClock[Any])
           .put(address2, "b", 17, LWWRegister.defaultClock[Any]))
+
+      checkSerialization(LWWMapKey[UniqueAddress, String]("id"))
     }
 
     "serialize PNCounterMap" in {
@@ -269,6 +283,8 @@ class ReplicatedDataSerializerSpec
       checkSerialization(PNCounterMap().increment(address1, Flag(), 3))
       checkSerialization(
         PNCounterMap().increment(address1, "a", 3).decrement(address2, "a", 2).increment(address2, "b", 5))
+
+      checkSerialization(PNCounterMapKey[String]("id"))
     }
 
     "serialize ORMultiMap" in {
@@ -292,6 +308,8 @@ class ReplicatedDataSerializerSpec
       val m3 = ORMultiMap.empty[String, String].addBinding(address1, "a", "A1")
       val d3 = m3.resetDelta.addBinding(address1, "a", "A2").addBinding(address1, "a", "A3").delta.get
       checkSerialization(d3)
+
+      checkSerialization(ORMultiMapKey[String, String]("id"))
     }
 
     "serialize ORMultiMap withValueDeltas" in {
@@ -327,6 +345,10 @@ class ReplicatedDataSerializerSpec
       val v1 = VersionVector().increment(address1).increment(address1)
       val v2 = VersionVector().increment(address2)
       checkSameContent(v1.merge(v2), v2.merge(v1))
+    }
+
+    "serialize UnspecificKey" in {
+      checkSerialization(Key.UnspecificKey("id"))
     }
 
   }

--- a/akka-docs/src/main/paradox/typed/distributed-data.md
+++ b/akka-docs/src/main/paradox/typed/distributed-data.md
@@ -176,6 +176,10 @@ configurable `akka.cluster.distributed-data.notify-subscribers-interval`.
 The subscriber is automatically unsubscribed if the subscriber is terminated. A subscriber can
 also be de-registered with the `replicatorAdapter.unsubscribe(key)` function.
 
+In addition to subscribing to individual keys it is possible to subscribe to all keys with a given prefix
+by using a `*` at the end of the key `id`. For example `GCounterKey("counter-*")`. Notifications will be
+sent for all matching keys, also new keys added later.
+
 ### Delete
 
 A data entry can be deleted by sending a `Replicator.Delete` message to the local


### PR DESCRIPTION
* Subscribe to keys starting with a given prefix.
* Useful together with the new expiry feature, for example.
* Also fixed a bug in the (non-released) exiry feature, gossip was broken.

TODO:
- [x] ~mima~
- [x] reference and api docs
- [x] FIXMEs
