### PR TITLE
ci: use Temurin JDKs everywhere

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.11
 
       - name: Report MiMa Binary Issues
         run: |-

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.11
 
       - name: Code style check
         run: |-
@@ -54,7 +54,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.11
 
       - name: sbt validatePullRequest
         run: |-

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.17
 
       - name: FOSSA policy check
         run: |-

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:11
+          jvm: temurin:1.11
           apps: cs
 
       - name: create the Akka site

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11.0.9
+          jvm: temurin:1.11.0.17
 
       - name: Multi node test
         run: |
@@ -133,7 +133,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11.0.9
+          jvm: temurin:1.11.0.17
 
       - name: Multi node test with Artery Aeron UDP
         run: |

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.11
 
       - name: sbt akka-cluster-metrics/test
         run: |-
@@ -95,7 +95,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.11
 
       - name: sbt ${{ matrix.command }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
@@ -140,10 +140,10 @@ jobs:
         jdkVersion: ["1.8.0", "1.11", "1.17.0"]
         include:
           - jdkVersion: 1.8.0
-            jvmName: adopt:1.8.0
+            jvmName: temurin:1.8.0
             extraOpts: ""
           - jdkVersion: 1.11
-            jvmName: adopt:1.11
+            jvmName: temurin:1.11
             extraOpts: ""
           - jdkVersion: 1.17.0
             jvmName: temurin:1.17.0
@@ -252,7 +252,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.11
 
       - name: sbt ${{ matrix.command }}
         # note that this is not running any multi-jvm tests because multi-in-test=false

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.11
 
       - name: Publish
         run: |-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11.0.9
+          jvm: temurin:1.11.0.17
 
       - name: Publish
         run: |-

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.11
 
       - name: Compile and run tests on Scala 3
         # note that this is not running any multi-jvm tests (yet) because multi-in-test=false

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.11
 
       - name: Compile on Scala 3
         run: |

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.11
 
       - name: sbt test
         run: |-


### PR DESCRIPTION
Good bye, AdoptOpenJDK
Hello Eclipse Temurin https://projects.eclipse.org/projects/adoptium.temurin

References #31730 
