### PR TITLE
Avoid submaterialization for lazy future and lazy single 

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Stages.scala
@@ -146,6 +146,8 @@ import akka.stream.Attributes._
     val lazyFlow = name("lazyFlow")
     val futureFlow = name("futureFlow")
     val lazySource = name("lazySource")
+    val lazyFuture = name("lazyFuture")
+    val lazySingle = name("lazySingle")
     val outputStreamSink = name("outputStreamSink") and IODispatcher
     val inputStreamSink = name("inputStreamSink")
     val fileSink = name("fileSink") and IODispatcher

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -339,7 +339,7 @@ object Source {
    * is failed with a [[akka.stream.NeverMaterializedException]]
    */
   def lazySingle[T](create: Creator[T]): Source[T, NotUsed] =
-    lazySource(() => single(create.create())).mapMaterializedValue(_ => NotUsed)
+    scaladsl.Source.lazySingle(() => create.create()).asJava
 
   /**
    * Defers invoking the `create` function to create a future element until there is downstream demand.
@@ -356,13 +356,9 @@ object Source {
    * is failed with a [[akka.stream.NeverMaterializedException]]
    */
   def lazyCompletionStage[T](create: Creator[CompletionStage[T]]): Source[T, NotUsed] =
-    scaladsl.Source
-      .lazySource { () =>
-        val f = create.create().toScala
-        scaladsl.Source.future(f)
-      }
-      .mapMaterializedValue(_ => NotUsed.notUsed())
-      .asJava
+    scaladsl.Source.lazyFuture { () =>
+      create.create().toScala
+    }.asJava
 
   /**
    * Defers invoking the `create` function to create a future source until there is downstream demand.

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -534,7 +534,7 @@ object Source {
    * the laziness and will trigger the factory immediately.
    */
   def lazySingle[T](create: () => T): Source[T, NotUsed] =
-    lazySource(() => single(create())).mapMaterializedValue(_ => NotUsed)
+    single(()).map(_ => create()).withAttributes(DefaultAttributes.lazySingle)
 
   /**
    * Defers invoking the `create` function to create a future element until there is downstream demand.
@@ -546,10 +546,7 @@ object Source {
    * the laziness and will trigger the factory immediately.
    */
   def lazyFuture[T](create: () => Future[T]): Source[T, NotUsed] =
-    lazySource { () =>
-      val f = create()
-      future(f)
-    }.mapMaterializedValue(_ => NotUsed)
+    single(()).mapAsyncUnordered(1)(_ => create()).withAttributes(DefaultAttributes.lazyFuture)
 
   /**
    * Defers invoking the `create` function to create a future source until there is downstream demand.


### PR DESCRIPTION
References #31729

Same benefit as #31733 but by removing code instead of adding more.

Also covers lazySingle and corresponding methods in Java DSL.