### PR TITLE
cp .jvmopts-ci instead of mv

### DIFF
--- a/.github/workflows/binary-compatibility-checks.yml
+++ b/.github/workflows/binary-compatibility-checks.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Report MiMa Binary Issues
         run: |-
-          mv .jvmopts-ci .jvmopts
+          cp .jvmopts-ci .jvmopts
           sbt "+~ ${{ matrix.scalaVersion }} mimaReportBinaryIssues"
 
       - name: Check correct MiMa filter directories

--- a/.github/workflows/build-test-prValidation.yml
+++ b/.github/workflows/build-test-prValidation.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Code style check
         run: |-
-          mv .jvmopts-ci .jvmopts
+          cp .jvmopts-ci .jvmopts
           sbt \
           -Dsbt.override.build.repos=false \
           -Dsbt.log.noformat=false \
@@ -58,7 +58,7 @@ jobs:
 
       - name: sbt validatePullRequest
         run: |-
-          mv .jvmopts-ci .jvmopts
+          cp .jvmopts-ci .jvmopts
           sbt \
           -Dakka.mima.enabled=false \
           -Dakka.test.multi-in-test=false \

--- a/.github/workflows/multi-node.yml
+++ b/.github/workflows/multi-node.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Multi node test
         run: |
           cat multi-node-test.hosts
-          mv .jvmopts-ci .jvmopts
+          cp .jvmopts-ci .jvmopts
           sbt \
             -Dakka.test.timefactor=2 \
             -Dakka.actor.testkit.typed.timefactor=2 \
@@ -138,7 +138,7 @@ jobs:
       - name: Multi node test with Artery Aeron UDP
         run: |
           cat multi-node-test.hosts
-          mv .jvmopts-ci .jvmopts
+          cp .jvmopts-ci .jvmopts
           sbt \
             -Dakka.test.timefactor=2 \
             -Dakka.actor.testkit.typed.timefactor=2 \

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: sbt akka-cluster-metrics/test
         run: |-
-          mv .jvmopts-ci .jvmopts
+          cp .jvmopts-ci .jvmopts
           sbt \
             -Djava.security.egd=file:/dev/./urandom \
             -Dakka.test.sigar=true \
@@ -100,7 +100,7 @@ jobs:
       - name: sbt ${{ matrix.command }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
-          mv .jvmopts-ci .jvmopts
+          cp .jvmopts-ci .jvmopts
           sbt \
           -Djava.security.egd=file:/dev/./urandom \
           -Dakka.remote.artery.enabled=off \
@@ -165,7 +165,7 @@ jobs:
       - name: Compile and Test
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
-          mv .jvmopts-ci .jvmopts
+          cp .jvmopts-ci .jvmopts
           sbt \
             -Dakka.cluster.assert=on \
             -Dakka.log.timestamps=true \
@@ -199,7 +199,7 @@ jobs:
         if: ${{ startsWith(matrix.jdkVersion, '1.11') }}
         run: |-
           sudo apt-get install graphviz
-          mv .jvmopts-ci .jvmopts
+          cp .jvmopts-ci .jvmopts
           sbt \
             -Dakka.genjavadoc.enabled=true \
             "+~ ${{ matrix.scalaVersion }} doc"
@@ -209,7 +209,7 @@ jobs:
         if: ${{ startsWith(matrix.jdkVersion, '1.11') }}
         run: |-
           sudo apt-get install graphviz
-          mv .jvmopts-ci .jvmopts
+          cp .jvmopts-ci .jvmopts
           sbt \
             -Dakka.build.scalaVersion=${{ matrix.scalaVersion }} \
             "+~ ${{ matrix.scalaVersion }} publishLocal publishM2"
@@ -257,7 +257,7 @@ jobs:
       - name: sbt ${{ matrix.command }}
         # note that this is not running any multi-jvm tests because multi-in-test=false
         run: |-
-          mv .jvmopts-ci .jvmopts
+          cp .jvmopts-ci .jvmopts
           sbt \
           -Djava.security.egd=file:/dev/./urandom \
           -Dakka.remote.artery.transport=aeron-udp \

--- a/.github/workflows/scala3-build.yml
+++ b/.github/workflows/scala3-build.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Compile and run tests on Scala 3
         # note that this is not running any multi-jvm tests (yet) because multi-in-test=false
         run: |
-          mv .jvmopts-ci .jvmopts
+          cp .jvmopts-ci .jvmopts
           sbt \
           -Dakka.log.timestamps=true \
           -Dakka.test.timefactor=2 \

--- a/.github/workflows/scala3-compile.yml
+++ b/.github/workflows/scala3-compile.yml
@@ -47,6 +47,6 @@ jobs:
 
       - name: Compile on Scala 3
         run: |
-          mv .jvmopts-ci .jvmopts
+          cp .jvmopts-ci .jvmopts
           sbt \
           "+~ 3 ${{ matrix.command }}"

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: sbt test
         run: |-
-          mv .jvmopts-ci .jvmopts
+          cp .jvmopts-ci .jvmopts
           sbt \
             -Djava.security.egd=file:/dev/./urandom \
             -Dakka.cluster.assert=on \


### PR DESCRIPTION
* otherwise workflows with several of these steps will fail

https://github.com/akka/akka/actions/runs/3493070360/jobs/5847489376#step:8:105

@ennru if you change this in other repos, pls copy instead