### PR TITLE
ci: permit checks and PR writes to attach surefire reports

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -7,6 +7,9 @@ on:
 
 permissions:
   contents: read
+  # scacap/action-surefire-report (see https://github.com/ScaCap/action-surefire-report/pull/88/files)
+  checks: write
+  pull-requests: write
 
 jobs:
 
@@ -50,6 +53,8 @@ jobs:
       - name: Test Reports
         # Makes it easier to spot failures instead of looking at the logs.
         if: ${{ failure() }}
+        # https://github.com/ScaCap/action-surefire-report/releases/
+        # v1.0.13
         uses: scacap/action-surefire-report@482f012643ed0560e23ef605a79e8e87ca081648
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'
@@ -179,6 +184,8 @@ jobs:
       - name: Test Reports
         # Makes it easier to spot failures instead of looking at the logs.
         if: ${{ failure() }}
+        # https://github.com/ScaCap/action-surefire-report/releases/
+        # v1.0.13
         uses: scacap/action-surefire-report@482f012643ed0560e23ef605a79e8e87ca081648
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'

--- a/.github/workflows/timing-tests.yml
+++ b/.github/workflows/timing-tests.yml
@@ -7,6 +7,9 @@ on:
 
 permissions:
   contents: read
+  # scacap/action-surefire-report (see https://github.com/ScaCap/action-surefire-report/pull/88/files)
+  checks: write
+  pull-requests: write
 
 jobs:
 
@@ -49,6 +52,8 @@ jobs:
       - name: Test Reports
         # Makes it easier to spot failures instead of looking at the logs.
         if: ${{ failure() }}
+        # https://github.com/ScaCap/action-surefire-report/releases/
+        # v1.0.13
         uses: scacap/action-surefire-report@482f012643ed0560e23ef605a79e8e87ca081648
         with:
           report_paths: '**/target/test-reports/TEST-*.xml'


### PR DESCRIPTION
My understanding is that `checks: write` is what these workflows really require here.

References #31759 
