### PR TITLE
chore: fix jdk8 compilation errors in doc sampes

### DIFF
--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/AggregatorTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/AggregatorTest.java
@@ -4,11 +4,6 @@
 
 package jdocs.akka.typed;
 
-import static jdocs.akka.typed.AggregatorTest.IllustrateUsage.Hotel1;
-import static jdocs.akka.typed.AggregatorTest.IllustrateUsage.Hotel2;
-import static jdocs.akka.typed.AggregatorTest.IllustrateUsage.HotelCustomer;
-import static org.junit.Assert.assertEquals;
-
 import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
@@ -30,6 +25,13 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.scalatestplus.junit.JUnitSuite;
+
+// format: OFF
+import static org.junit.Assert.assertEquals;
+import static jdocs.akka.typed.AggregatorTest.IllustrateUsage.Hotel1;
+import static jdocs.akka.typed.AggregatorTest.IllustrateUsage.Hotel2;
+import static jdocs.akka.typed.AggregatorTest.IllustrateUsage.HotelCustomer;
+// format: ON
 
 public class AggregatorTest extends JUnitSuite {
   @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();

--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java
@@ -4,9 +4,6 @@
 
 package jdocs.akka.typed;
 
-import static jdocs.akka.typed.InteractionPatternsTest.Samples.*;
-import static org.junit.Assert.assertEquals;
-
 import akka.Done;
 import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
@@ -14,10 +11,22 @@ import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.ActorSystem;
 import akka.actor.typed.Behavior;
-import akka.actor.typed.javadsl.*;
+import akka.actor.typed.javadsl.AbstractBehavior;
+import akka.actor.typed.javadsl.ActorContext;
+import akka.actor.typed.javadsl.AskPattern;
+import akka.actor.typed.javadsl.Behaviors;
+import akka.actor.typed.javadsl.Receive;
+import akka.actor.typed.javadsl.TimerScheduler;
 import java.net.URI;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -25,6 +34,10 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.scalatestplus.junit.JUnitSuite;
+
+import static jdocs.akka.typed.InteractionPatternsTest.Samples.Printer;
+import static jdocs.akka.typed.InteractionPatternsTest.Samples.Buncher;
+import static org.junit.Assert.assertEquals;
 
 public class InteractionPatternsTest extends JUnitSuite {
 

--- a/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/ReplicatedShardingTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/akka/cluster/sharding/typed/ReplicatedShardingTest.java
@@ -4,9 +4,6 @@
 
 package akka.cluster.sharding.typed;
 
-import static akka.cluster.sharding.typed.ReplicatedShardingTest.ProxyActor.ALL_REPLICAS;
-import static org.junit.Assert.assertEquals;
-
 import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
@@ -25,15 +22,30 @@ import akka.persistence.testkit.PersistenceTestKitPlugin;
 import akka.persistence.testkit.query.javadsl.PersistenceTestKitReadJournal;
 import akka.persistence.typed.ReplicaId;
 import akka.persistence.typed.ReplicationId;
-import akka.persistence.typed.javadsl.*;
+import akka.persistence.typed.javadsl.CommandHandler;
+import akka.persistence.typed.javadsl.EventHandler;
+import akka.persistence.typed.javadsl.ReplicatedEventSourcedBehavior;
+import akka.persistence.typed.javadsl.ReplicatedEventSourcing;
+import akka.persistence.typed.javadsl.ReplicationContext;
 import com.typesafe.config.ConfigFactory;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.scalatestplus.junit.JUnitSuite;
+
+// format: OFF
+import static akka.cluster.sharding.typed.ReplicatedShardingTest.ProxyActor.ALL_REPLICAS;
+import static org.junit.Assert.assertEquals;
+// format: ON
 
 public class ReplicatedShardingTest extends JUnitSuite {
 

--- a/akka-persistence-typed-tests/src/test/java/jdocs/akka/persistence/typed/ReplicatedAuctionExampleTest.java
+++ b/akka-persistence-typed-tests/src/test/java/jdocs/akka/persistence/typed/ReplicatedAuctionExampleTest.java
@@ -4,10 +4,6 @@
 
 package jdocs.akka.persistence.typed;
 
-import static jdocs.akka.persistence.typed.AuctionEntity.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
@@ -41,6 +37,12 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.scalatestplus.junit.JUnitSuite;
+
+// format: OFF
+import static jdocs.akka.persistence.typed.AuctionEntity.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+// format: ON
 
 public class ReplicatedAuctionExampleTest extends JUnitSuite {
   @ClassRule


### PR DESCRIPTION
* the updated java formatter changed the order of the imports in a way that didn't work with JDK 8

https://github.com/akka/akka/issues/31760