### PR TITLE
chore: multi-node testkit throttle not implemented in Artery

### DIFF
--- a/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Conductor.scala
+++ b/akka-multi-node-testkit/src/main/scala/akka/remote/testconductor/Conductor.scala
@@ -15,6 +15,8 @@ import scala.util.control.NoStackTrace
 
 import RemoteConnection.getAddrString
 import language.postfixOps
+import scala.annotation.nowarn
+
 import org.jboss.netty.channel.{
   Channel,
   ChannelHandlerContext,
@@ -125,6 +127,7 @@ trait Conductor { this: TestConductorExt =>
    * @param direction can be either `Direction.Send`, `Direction.Receive` or `Direction.Both`
    * @param rateMBit is the maximum data rate in MBit
    */
+  @deprecated("Throttle is not implemented, use blackhole and passThrough.", "2.8.0")
   def throttle(node: RoleName, target: RoleName, direction: Direction, rateMBit: Double): Future[Done] = {
     import Settings.QueryTimeout
     requireTestConductorTranport()
@@ -145,6 +148,7 @@ trait Conductor { this: TestConductorExt =>
    * @param target is the symbolic name of the other node to which connectivity shall be impeded
    * @param direction can be either `Direction.Send`, `Direction.Receive` or `Direction.Both`
    */
+  @nowarn("msg=deprecated")
   def blackhole(node: RoleName, target: RoleName, direction: Direction): Future[Done] =
     throttle(node, target, direction, 0f)
 
@@ -167,6 +171,7 @@ trait Conductor { this: TestConductorExt =>
    * @param target is the symbolic name of the other node to which connectivity shall be impeded
    * @param direction can be either `Direction.Send`, `Direction.Receive` or `Direction.Both`
    */
+  @nowarn("msg=deprecated")
   def passThrough(node: RoleName, target: RoleName, direction: Direction): Future[Done] =
     throttle(node, target, direction, -1f)
 

--- a/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/ArteryTransport.scala
@@ -668,7 +668,6 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
 
   private[remote] def isShutdown: Boolean = hasBeenShutdown.get()
 
-  @nowarn // ThrottleMode from classic is deprecated, we can replace when removing classic
   override def managementCommand(cmd: Any): Future[Boolean] = {
     cmd match {
       case SetThrottle(address, direction, Blackhole) =>
@@ -677,6 +676,10 @@ private[remote] abstract class ArteryTransport(_system: ExtendedActorSystem, _pr
         testState.passThrough(localAddress.address, address, direction)
       case TestManagementCommands.FailInboundStreamOnce(ex) =>
         testState.failInboundStreamOnce(ex)
+      case SetThrottle(_, _, _) =>
+        log.warning("Throttle is not implemented.")
+      case _ =>
+        log.warning("Unhandled management command [{}]", cmd.getClass.getName)
     }
     Future.successful(true)
   }


### PR DESCRIPTION
This has always been the case but showed up after removing classic remoting #31765 
I'm surprised but that means that the TestConductorSpec was previously only running with classic.

multi-node test failure:
```
2022-11-30T02:52:42.0237412Z [0m[[0m[0minfo[0m] [0m[0m[[34mJVM-2[0m] scala.MatchError: SetThrottle(akka://TestConductorSpec@test-node1:5000,Send,TokenBucket(1000,1249.9999720603228,0,0)) (of class akka.remote.testkit.SetThrottle)[0m
2022-11-30T02:52:42.0239423Z [0m[[0m[0minfo[0m] [0m[0m[[34mJVM-2[0m] 	at akka.remote.artery.ArteryTransport.managementCommand(ArteryTransport.scala:673)[0m
```