### PR TITLE
perf: Skip delete snapshots in retention when plugin only keeps one snapshot

### DIFF
--- a/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java
+++ b/akka-actor-typed-tests/src/test/java/jdocs/akka/typed/InteractionPatternsTest.java
@@ -4,6 +4,10 @@
 
 package jdocs.akka.typed;
 
+import static jdocs.akka.typed.InteractionPatternsTest.Samples.Buncher;
+import static jdocs.akka.typed.InteractionPatternsTest.Samples.Printer;
+import static org.junit.Assert.assertEquals;
+
 import akka.Done;
 import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
@@ -34,10 +38,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.scalatestplus.junit.JUnitSuite;
-
-import static jdocs.akka.typed.InteractionPatternsTest.Samples.Printer;
-import static jdocs.akka.typed.InteractionPatternsTest.Samples.Buncher;
-import static org.junit.Assert.assertEquals;
 
 public class InteractionPatternsTest extends JUnitSuite {
 

--- a/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/PersistenceTestKitPlugin.scala
+++ b/akka-persistence-testkit/src/main/scala/akka/persistence/testkit/PersistenceTestKitPlugin.scala
@@ -132,7 +132,8 @@ object PersistenceTestKitSnapshotPlugin {
     Map(
       "akka.persistence.snapshot-store.plugin" -> PluginId,
       s"$PluginId.class" -> classOf[PersistenceTestKitSnapshotPlugin].getName,
-      s"$PluginId.snapshot-is-optional" -> false // fallback isn't used by the testkit
+      s"$PluginId.snapshot-is-optional" -> false, // fallback isn't used by the testkit
+      s"$PluginId.only-one-snapshot" -> false // fallback isn't used by the testkit
     ).asJava)
 
 }

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionOnlyOneSnapshotSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionOnlyOneSnapshotSpec.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2017-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.scaladsl
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.util.Success
+import scala.util.Try
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import akka.actor.testkit.typed.scaladsl._
+import akka.actor.typed.scaladsl.Behaviors
+import akka.persistence.testkit.PersistenceTestKitPlugin
+import akka.persistence.testkit.PersistenceTestKitSnapshotPlugin
+import akka.persistence.typed.DeleteEventsCompleted
+import akka.persistence.typed.EventSourcedSignal
+import akka.persistence.typed.PersistenceId
+
+object EventSourcedBehaviorRetentionOnlyOneSnapshotSpec {
+  private val config = ConfigFactory.parseString(s"""
+    ${PersistenceTestKitSnapshotPlugin.PluginId} {
+      only-one-snapshot = on
+    }
+    """).withFallback(PersistenceTestKitPlugin.config.withFallback(PersistenceTestKitSnapshotPlugin.config))
+}
+
+class EventSourcedBehaviorRetentionOnlyOneSnapshotSpec
+    extends ScalaTestWithActorTestKit(EventSourcedBehaviorRetentionOnlyOneSnapshotSpec.config)
+    with AnyWordSpecLike
+    with LogCapturing {
+
+  import EventSourcedBehaviorRetentionSpec._
+
+  val pidCounter = new AtomicInteger(0)
+  private def nextPid(): PersistenceId = PersistenceId.ofUniqueId(s"c${pidCounter.incrementAndGet()}")
+
+  "EventSourcedBehavior with retention and only-one-snapshot" must {
+
+    "snapshot every N sequence nrs" in {
+      val pid = nextPid()
+      val c = spawn(Behaviors.setup[Command](ctx =>
+        counter(ctx, pid).withRetention(RetentionCriteria.snapshotEvery(numberOfEvents = 2))))
+
+      val replyProbe = TestProbe[State]()
+
+      c ! Increment
+      c ! GetValue(replyProbe.ref)
+      replyProbe.expectMessage(State(1, Vector(0)))
+      c ! StopIt
+      val watchProbe = TestProbe()
+      watchProbe.expectTerminated(c)
+
+      // no snapshot should have happened
+      val probeC2 = TestProbe[(State, Event)]()
+      val snapshotProbe = createTestProbe[WrappedSignal]()
+
+      val c2 = spawn(
+        Behaviors.setup[Command](ctx =>
+          counter(ctx, pid, probe = Some(probeC2.ref), snapshotSignalProbe = Some(snapshotProbe.ref))
+            .withRetention(RetentionCriteria.snapshotEvery(numberOfEvents = 2))))
+      probeC2.expectMessage[(State, Event)]((State(0, Vector()), Incremented(1)))
+
+      c2 ! Increment
+      snapshotProbe.expectSnapshotCompleted(2)
+      c2 ! StopIt
+      watchProbe.expectTerminated(c2)
+
+      val probeC3 = TestProbe[(State, Event)]()
+      val c3 = spawn(Behaviors.setup[Command](ctx =>
+        counter(ctx, pid, Some(probeC3.ref)).withRetention(RetentionCriteria.snapshotEvery(numberOfEvents = 2))))
+      // this time it should have been snapshotted so no events to replay
+      probeC3.expectNoMessage()
+      c3 ! GetValue(replyProbe.ref)
+      replyProbe.expectMessage(State(2, Vector(0, 1)))
+    }
+
+    "not delete snapshots" in {
+      val pid = nextPid()
+      val snapshotSignalProbe = TestProbe[WrappedSignal]()
+      val deleteSnapshotSignalProbe = TestProbe[WrappedSignal]()
+      val replyProbe = TestProbe[State]()
+
+      val persistentActor = spawn(
+        Behaviors.setup[Command](
+          ctx =>
+            counter(
+              ctx,
+              pid,
+              snapshotSignalProbe = Some(snapshotSignalProbe.ref),
+              deleteSnapshotSignalProbe = Some(deleteSnapshotSignalProbe.ref))
+              .withRetention(RetentionCriteria.snapshotEvery(numberOfEvents = 3, keepNSnapshots = 2))))
+
+      (1 to 10).foreach(_ => persistentActor ! Increment)
+      persistentActor ! GetValue(replyProbe.ref)
+      replyProbe.expectMessage(State(10, (0 until 10).toVector))
+      snapshotSignalProbe.expectSnapshotCompleted(3)
+      snapshotSignalProbe.expectSnapshotCompleted(6)
+      snapshotSignalProbe.expectSnapshotCompleted(9)
+      // this is the difference compared to EventSourcedBehaviorRetentionSpec
+      deleteSnapshotSignalProbe.expectNoMessage()
+
+      (1 to 10).foreach(_ => persistentActor ! Increment)
+      persistentActor ! GetValue(replyProbe.ref)
+      replyProbe.expectMessage(State(20, (0 until 20).toVector))
+      snapshotSignalProbe.expectSnapshotCompleted(12)
+      snapshotSignalProbe.expectSnapshotCompleted(15)
+      snapshotSignalProbe.expectSnapshotCompleted(18)
+      // this is the difference compared to EventSourcedBehaviorRetentionSpec
+      deleteSnapshotSignalProbe.expectNoMessage()
+
+      snapshotSignalProbe.expectNoMessage()
+    }
+
+    "optionally delete old events" in {
+      val pid = nextPid()
+      val snapshotSignalProbe = TestProbe[WrappedSignal]()
+      val deleteSnapshotSignalProbe = TestProbe[WrappedSignal]()
+      val eventProbe = TestProbe[Try[EventSourcedSignal]]()
+      val replyProbe = TestProbe[State]()
+
+      val persistentActor = spawn(
+        Behaviors.setup[Command](ctx =>
+          counter(
+            ctx,
+            pid,
+            snapshotSignalProbe = Some(snapshotSignalProbe.ref),
+            deleteSnapshotSignalProbe = Some(deleteSnapshotSignalProbe.ref),
+            eventSignalProbe = Some(eventProbe.ref)).withRetention(
+            // tests the Java API as well
+            RetentionCriteria.snapshotEvery(numberOfEvents = 3).withDeleteEventsOnSnapshot)))
+
+      (1 to 10).foreach(_ => persistentActor ! Increment)
+      persistentActor ! GetValue(replyProbe.ref)
+      replyProbe.expectMessage(State(10, (0 until 10).toVector))
+      snapshotSignalProbe.expectSnapshotCompleted(3)
+      snapshotSignalProbe.expectSnapshotCompleted(6)
+      snapshotSignalProbe.expectSnapshotCompleted(9)
+
+      eventProbe.expectMessageType[Success[DeleteEventsCompleted]].value.toSequenceNr shouldEqual 3
+      eventProbe.expectMessageType[Success[DeleteEventsCompleted]].value.toSequenceNr shouldEqual 6
+      eventProbe.expectMessageType[Success[DeleteEventsCompleted]].value.toSequenceNr shouldEqual 9
+      deleteSnapshotSignalProbe.expectNoMessage()
+
+      // one at a time since snapshotting+event-deletion switches to running state before deleting events so ordering
+      // if sending many commands in one go is not deterministic
+      persistentActor ! Increment // 11
+      persistentActor ! Increment // 12
+      snapshotSignalProbe.expectSnapshotCompleted(12)
+      eventProbe.expectMessageType[Success[DeleteEventsCompleted]].value.toSequenceNr shouldEqual 12
+      deleteSnapshotSignalProbe.expectNoMessage()
+
+      persistentActor ! Increment // 13
+      persistentActor ! Increment // 14
+      persistentActor ! Increment // 11
+      persistentActor ! Increment // 15
+      snapshotSignalProbe.expectSnapshotCompleted(15)
+      eventProbe.expectMessageType[Success[DeleteEventsCompleted]].value.toSequenceNr shouldEqual 15
+      deleteSnapshotSignalProbe.expectNoMessage()
+
+      persistentActor ! Increment // 16
+      persistentActor ! Increment // 17
+      persistentActor ! Increment // 18
+      snapshotSignalProbe.expectSnapshotCompleted(18)
+      eventProbe.expectMessageType[Success[DeleteEventsCompleted]].value.toSequenceNr shouldEqual 18
+      deleteSnapshotSignalProbe.expectNoMessage()
+
+      eventProbe.expectNoMessage()
+      snapshotSignalProbe.expectNoMessage()
+    }
+
+  }
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
@@ -67,8 +67,10 @@ private[akka] final class BehaviorSetup[C, E, S](
   val journal: ClassicActorRef = persistence.journalFor(settings.journalPluginId)
   val snapshotStore: ClassicActorRef = persistence.snapshotStoreFor(settings.snapshotPluginId)
 
-  val isSnapshotOptional: Boolean =
-    Persistence(context.system.classicSystem).configFor(snapshotStore).getBoolean("snapshot-is-optional")
+  val (isSnapshotOptional: Boolean, isOnlyOneSnapshot: Boolean) = {
+    val snapshotStoreConfig = Persistence(context.system.classicSystem).configFor(snapshotStore)
+    (snapshotStoreConfig.getBoolean("snapshot-is-optional"), snapshotStoreConfig.getBoolean("only-one-snapshot"))
+  }
 
   if (isSnapshotOptional && (retention match {
         case SnapshotCountRetentionCriteriaImpl(_, _, true) => true

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
@@ -87,6 +87,20 @@ private[akka] final class BehaviorSetup[C, E, S](
 
   private var mdcPhase = PersistenceMdc.Initializing
 
+  if (isOnlyOneSnapshot) {
+    retention match {
+      case SnapshotCountRetentionCriteriaImpl(_, keepNSnapshots, _) if keepNSnapshots > 1 =>
+        // not using internalLogger because it's probably not good to use mdc from the constructor
+        internalLoggerFactory().warn(
+          "Retention has been defined with keepNSnapshots [{}] for persistenceId [{}]," +
+          "but the snapshot store [{}] will only keep one snapshot. You can silence this warning and benefit from " +
+          "a performance optimization by defining the retention criteria without the keepNSnapshots parameter.",
+          keepNSnapshots,
+          persistenceId)
+      case _ =>
+    }
+  }
+
   def internalLogger: Logger = {
     PersistenceMdc.setMdc(persistenceId, mdcPhase)
     internalLoggerFactory()

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/RetentionCriteriaImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/RetentionCriteriaImpl.scala
@@ -21,7 +21,7 @@ import akka.persistence.typed.scaladsl
     with scaladsl.SnapshotCountRetentionCriteria {
 
   require(snapshotEveryNEvents > 0, s"'snapshotEveryNEvents' must be greater than 0, was [$snapshotEveryNEvents]")
-  require(keepNSnapshots > 0 || keepNSnapshots == -1, s"'keepNSnapshots' must be greater than 0, was [$keepNSnapshots]")
+  require(keepNSnapshots > 0, s"'keepNSnapshots' must be greater than 0, was [$keepNSnapshots]")
 
   def snapshotWhen(currentSequenceNr: Long): Boolean =
     currentSequenceNr % snapshotEveryNEvents == 0

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/RetentionCriteria.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/javadsl/RetentionCriteria.scala
@@ -39,6 +39,18 @@ object RetentionCriteria {
   def snapshotEvery(numberOfEvents: Int, keepNSnapshots: Int): SnapshotCountRetentionCriteria =
     SnapshotCountRetentionCriteriaImpl(numberOfEvents, keepNSnapshots, deleteEventsOnSnapshot = false)
 
+  /**
+   * Save snapshots automatically every `numberOfEvents`.
+   *
+   * Use [[SnapshotCountRetentionCriteria.withDeleteEventsOnSnapshot]] to
+   * delete old events. Events are not deleted by default.
+   *
+   * If multiple events are persisted with a single Effect, the snapshot will happen after
+   * all of the events are persisted rather than precisely every `numberOfEvents`.
+   */
+  def snapshotEvery(numberOfEvents: Int): SnapshotCountRetentionCriteria =
+    snapshotEvery(numberOfEvents, keepNSnapshots = 1)
+
 }
 
 @DoNotInherit abstract class SnapshotCountRetentionCriteria extends RetentionCriteria {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/RetentionCriteria.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/RetentionCriteria.scala
@@ -39,6 +39,18 @@ object RetentionCriteria {
   def snapshotEvery(numberOfEvents: Int, keepNSnapshots: Int): SnapshotCountRetentionCriteria =
     SnapshotCountRetentionCriteriaImpl(numberOfEvents, keepNSnapshots, deleteEventsOnSnapshot = false)
 
+  /**
+   * Save snapshots automatically every `numberOfEvents`.
+   *
+   * Use [[SnapshotCountRetentionCriteria.withDeleteEventsOnSnapshot]] to
+   * delete old events. Events are not deleted by default.
+   *
+   * If multiple events are persisted with a single Effect the snapshot will happen after
+   * all of the events are persisted rather than precisely every `numberOfEvents`.
+   */
+  def snapshotEvery(numberOfEvents: Int): SnapshotCountRetentionCriteria =
+    snapshotEvery(numberOfEvents, keepNSnapshots = 1)
+
 }
 
 @DoNotInherit trait SnapshotCountRetentionCriteria extends RetentionCriteria {

--- a/akka-persistence/src/main/resources/reference.conf
+++ b/akka-persistence/src/main/resources/reference.conf
@@ -176,6 +176,11 @@ akka.persistence {
       # result in wrong recovered state if snapshot load fails.
       snapshot-is-optional = false
 
+      # Some snapshot store plugins only store the latest snapshot and can set this
+      # to true. That enables optimizations in retention strategies based on that
+      # old snapshots don't have to be deleted.
+      only-one-snapshot = false
+
     }
 
   fsm {


### PR DESCRIPTION
* which is the case for akka-persistence-r2dbc

To recap, a sketchy summary of the retention process:

* PersistingEvents
  - shouldSnapshotAfterPersist parameter, which is SnapshotWithRetention for the retention process
  - onMessage, onJournalResponse, WriteMessageSuccess => StoringSnapshot

* StoringSnapshot
  - onSaveSnapshotResponse, SaveSnapshotSuccess
    - internalDeleteEvents (runs in background)
    - applySideEffects => HandlingCommands

* HandlingCommands
  - onMessage, onDeleteEventsJournalResponse, DeleteMessagesSuccess
    - internalDeleteSnapshots (runs in background)
