### PR TITLE
fix: Only one retention cycle in progress at a time, #31785

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorWatchSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorWatchSpec.scala
@@ -75,7 +75,8 @@ class EventSourcedBehaviorWatchSpec
       stashState = new StashState(context.asInstanceOf[ActorContext[InternalProtocol]], settings),
       replication = None,
       publishEvents = false,
-      internalLoggerFactory = () => logger)
+      internalLoggerFactory = () => logger,
+      retentionInProgress = false)
 
   "A typed persistent parent actor watching a child" must {
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
@@ -7,9 +7,13 @@ package akka.persistence.typed.internal
 import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 
+import org.slf4j.Logger
+import org.slf4j.MDC
+
 import akka.actor.Cancellable
 import akka.actor.typed.Signal
 import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.LoggerOps
 import akka.actor.{ ActorRef => ClassicActorRef }
 import akka.annotation.InternalApi
 import akka.persistence._
@@ -20,8 +24,6 @@ import akka.persistence.typed.SnapshotAdapter
 import akka.persistence.typed.scaladsl.EventSourcedBehavior
 import akka.persistence.typed.scaladsl.RetentionCriteria
 import akka.util.OptionVal
-import org.slf4j.Logger
-import org.slf4j.MDC
 
 /**
  * INTERNAL API
@@ -56,7 +58,8 @@ private[akka] final class BehaviorSetup[C, E, S](
     val stashState: StashState,
     val replication: Option[ReplicationSetup],
     val publishEvents: Boolean,
-    private val internalLoggerFactory: () => Logger) {
+    private val internalLoggerFactory: () => Logger,
+    private var retentionInProgress: Boolean) {
 
   import BehaviorSetup._
   import InternalProtocol.RecoveryTickEvent
@@ -170,6 +173,110 @@ private[akka] final class BehaviorSetup[C, E, S](
         else if (snapshotWhen(state, event, sequenceNr)) SnapshotWithoutRetention
         else NoSnapshot
       case unexpected => throw new IllegalStateException(s"Unexpected retention criteria: $unexpected")
+    }
+  }
+
+  // The retention process for SnapshotCountRetentionCriteria looks like this:
+  // 1. Save snapshot after persisting events when shouldSnapshotAfterPersist returned SnapshotWithRetention.
+  // 2. Delete events (when deleteEventsOnSnapshot=true), runs in background.
+  // 3. Delete snapshots (when isOnlyOneSnapshot=false), runs in background.
+
+  def isRetentionInProgress(): Boolean =
+    retentionInProgress
+
+  def retentionProgressSaveSnapshot(sequenceNr: Long): Unit = {
+    retention match {
+      case SnapshotCountRetentionCriteriaImpl(_, _, _) =>
+        internalLogger.debug("Starting retention at seqNr [{}], saving snapshot.", sequenceNr)
+        retentionInProgress = true
+      case _ =>
+    }
+  }
+
+  def retentionProgressSaveSnapshotEnd(sequenceNr: Long, success: Boolean): Unit = {
+    retention match {
+      case SnapshotCountRetentionCriteriaImpl(_, _, deleteEvents) if retentionInProgress =>
+        if (!success) {
+          internalLogger.debug("Retention at seqNr [{}] is completed, saving snapshot failed.", sequenceNr)
+          retentionInProgress = false
+        } else if (deleteEvents) {
+          internalLogger.debug("Retention at seqNr [{}], saving snapshot was successful.", sequenceNr)
+        } else if (isOnlyOneSnapshot) {
+          // no delete of events and no delete of snapshots => done
+          internalLogger.debug("Retention at seqNr [{}] is completed, saving snapshot was successful.", sequenceNr)
+          retentionInProgress = false
+        } else {
+          internalLogger.debug("Retention at seqNr [{}], saving snapshot was successful.", sequenceNr)
+        }
+      case _ =>
+    }
+  }
+
+  def retentionProgressDeleteEvents(sequenceNr: Long, deleteToSequenceNr: Long): Unit = {
+    retention match {
+      case SnapshotCountRetentionCriteriaImpl(_, _, true) if retentionInProgress =>
+        if (deleteToSequenceNr > 0) {
+          internalLogger.debug2(
+            "Retention at seqNr [{}], deleting events to seqNr [{}].",
+            sequenceNr,
+            deleteToSequenceNr)
+        } else {
+          internalLogger.debug("Retention is completed, no events to delete.")
+          retentionInProgress = false
+        }
+      case _ =>
+    }
+  }
+
+  def retentionProgressDeleteEventsEnd(deleteToSequenceNr: Long, success: Boolean): Unit = {
+    retention match {
+      case SnapshotCountRetentionCriteriaImpl(_, _, true) if retentionInProgress =>
+        if (!success) {
+          internalLogger.debug(
+            "Retention at seqNr [{}] is completed, deleting events to seqNr [{}] failed.",
+            deleteToSequenceNr)
+          retentionInProgress = false
+        } else if (isOnlyOneSnapshot) {
+          // no delete of snapshots => done
+          internalLogger.debug(
+            "Retention is completed, deleting events to seqNr [{}] was successful.",
+            deleteToSequenceNr)
+          retentionInProgress = false
+        } else {
+          internalLogger.debug("Retention, deleting events to seqNr [{}] was successful.", deleteToSequenceNr)
+        }
+      case _ =>
+    }
+  }
+
+  def retentionProgressDeleteSnapshots(deleteToSequenceNr: Long): Unit = {
+    retention match {
+      case SnapshotCountRetentionCriteriaImpl(_, _, _) if retentionInProgress =>
+        if (deleteToSequenceNr > 0) {
+          internalLogger.debug("Retention, deleting snapshots to seqNr [{}].", deleteToSequenceNr)
+        } else {
+          internalLogger.debug("Retention is completed, no snapshots to delete.")
+          retentionInProgress = false
+        }
+      case _ =>
+    }
+  }
+
+  def retentionProgressDeleteSnapshotsEnd(deleteToSequenceNr: Long, success: Boolean): Unit = {
+    retention match {
+      case SnapshotCountRetentionCriteriaImpl(_, _, _) if retentionInProgress =>
+        if (success) {
+          // delete snapshot is last step => done
+          internalLogger.debug(
+            "Retention is completed, deleting snapshots to seqNr [{}] was successful.",
+            deleteToSequenceNr)
+          retentionInProgress = false
+        } else {
+          internalLogger.debug("Retention is completed, deleting snapshots to seqNr [{}] failed.", deleteToSequenceNr)
+          retentionInProgress = false
+        }
+
+      case _ =>
     }
   }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
@@ -184,7 +184,7 @@ private[akka] final class BehaviorSetup[C, E, S](
   def isRetentionInProgress(): Boolean =
     retentionInProgress
 
-  def retentionProgressSaveSnapshot(sequenceNr: Long): Unit = {
+  def retentionProgressSaveSnapshotStarted(sequenceNr: Long): Unit = {
     retention match {
       case SnapshotCountRetentionCriteriaImpl(_, _, _) =>
         internalLogger.debug("Starting retention at seqNr [{}], saving snapshot.", sequenceNr)
@@ -193,7 +193,7 @@ private[akka] final class BehaviorSetup[C, E, S](
     }
   }
 
-  def retentionProgressSaveSnapshotEnd(sequenceNr: Long, success: Boolean): Unit = {
+  def retentionProgressSaveSnapshotEnded(sequenceNr: Long, success: Boolean): Unit = {
     retention match {
       case SnapshotCountRetentionCriteriaImpl(_, _, deleteEvents) if retentionInProgress =>
         if (!success) {
@@ -212,7 +212,7 @@ private[akka] final class BehaviorSetup[C, E, S](
     }
   }
 
-  def retentionProgressDeleteEvents(sequenceNr: Long, deleteToSequenceNr: Long): Unit = {
+  def retentionProgressDeleteEventsStarted(sequenceNr: Long, deleteToSequenceNr: Long): Unit = {
     retention match {
       case SnapshotCountRetentionCriteriaImpl(_, _, true) if retentionInProgress =>
         if (deleteToSequenceNr > 0) {
@@ -228,7 +228,7 @@ private[akka] final class BehaviorSetup[C, E, S](
     }
   }
 
-  def retentionProgressDeleteEventsEnd(deleteToSequenceNr: Long, success: Boolean): Unit = {
+  def retentionProgressDeleteEventsEnded(deleteToSequenceNr: Long, success: Boolean): Unit = {
     retention match {
       case SnapshotCountRetentionCriteriaImpl(_, _, true) if retentionInProgress =>
         if (!success) {
@@ -249,7 +249,7 @@ private[akka] final class BehaviorSetup[C, E, S](
     }
   }
 
-  def retentionProgressDeleteSnapshots(deleteToSequenceNr: Long): Unit = {
+  def retentionProgressDeleteSnapshotsStarted(deleteToSequenceNr: Long): Unit = {
     retention match {
       case SnapshotCountRetentionCriteriaImpl(_, _, _) if retentionInProgress =>
         if (deleteToSequenceNr > 0) {
@@ -262,7 +262,7 @@ private[akka] final class BehaviorSetup[C, E, S](
     }
   }
 
-  def retentionProgressDeleteSnapshotsEnd(deleteToSequenceNr: Long, success: Boolean): Unit = {
+  def retentionProgressDeleteSnapshotsEnded(deleteToSequenceNr: Long, success: Boolean): Unit = {
     retention match {
       case SnapshotCountRetentionCriteriaImpl(_, _, _) if retentionInProgress =>
         if (success) {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -196,7 +196,8 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
             stashState = stashState,
             replication = replication,
             publishEvents = publishEvents,
-            internalLoggerFactory = () => internalLogger())
+            internalLoggerFactory = () => internalLogger(),
+            retentionInProgress = false)
 
           // needs to accept Any since we also can get messages from the journal
           // not part of the user facing Command protocol

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ExternalInteractions.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ExternalInteractions.scala
@@ -212,10 +212,10 @@ private[akka] trait SnapshotInteractions[C, E, S] {
   }
 
   /** Deletes the snapshots up to and including the `sequenceNr`. */
-  protected def internalDeleteSnapshots(fromSequenceNr: Long, toSequenceNr: Long): Unit = {
+  protected def internalDeleteSnapshots(toSequenceNr: Long): Unit = {
     if (toSequenceNr > 0) {
-      val snapshotCriteria = SnapshotSelectionCriteria(minSequenceNr = fromSequenceNr, maxSequenceNr = toSequenceNr)
-      setup.internalLogger.debug2("Deleting snapshots from sequenceNr [{}] to [{}]", fromSequenceNr, toSequenceNr)
+      val snapshotCriteria = SnapshotSelectionCriteria(minSequenceNr = 0L, maxSequenceNr = toSequenceNr)
+      setup.internalLogger.debug("Deleting snapshots to sequenceNr [{}]", toSequenceNr)
       setup.snapshotStore
         .tell(SnapshotProtocol.DeleteSnapshots(setup.persistenceId.id, snapshotCriteria), setup.selfClassic)
     }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/RetentionCriteriaImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/RetentionCriteriaImpl.scala
@@ -34,16 +34,6 @@ import akka.persistence.typed.scaladsl
     math.max(0, lastSequenceNr - (keepNSnapshots.toLong * snapshotEveryNEvents))
   }
 
-  /**
-   * Should only be used when `BehaviorSetup.isOnlyOneSnapshot` is true.
-   */
-  def deleteLowerSequenceNr(upperSequenceNr: Long): Long = {
-    // We could use 0 as fromSequenceNr to delete all older snapshots, but that might be inefficient for
-    // large ranges depending on how it's implemented in the snapshot plugin. Therefore we use the
-    // same window as defined for how much to keep in the retention criteria
-    math.max(0, upperSequenceNr - (keepNSnapshots.toLong * snapshotEveryNEvents))
-  }
-
   override def withDeleteEventsOnSnapshot: SnapshotCountRetentionCriteriaImpl =
     copy(deleteEventsOnSnapshot = true)
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RetentionCriteriaSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RetentionCriteriaSpec.scala
@@ -28,24 +28,12 @@ class RetentionCriteriaSpec extends TestSuite with Matchers with AnyWordSpecLike
 
     "have valid sequenceNr range based on keepNSnapshots" in {
       val criteria = RetentionCriteria.snapshotEvery(3, 2).asInstanceOf[SnapshotCountRetentionCriteriaImpl]
-      val expected = List(
-        1 -> (0 -> 0),
-        3 -> (0 -> 0),
-        4 -> (0 -> 0),
-        6 -> (0 -> 0),
-        7 -> (0 -> 1),
-        9 -> (0 -> 3),
-        10 -> (0 -> 4),
-        12 -> (0 -> 6),
-        13 -> (1 -> 7),
-        15 -> (3 -> 9),
-        18 -> (6 -> 12),
-        20 -> (8 -> 14))
+      val expected =
+        List(1 -> 0, 3 -> 0, 4 -> 0, 6 -> 0, 7 -> 1, 9 -> 3, 10 -> 4, 12 -> 6, 13 -> 7, 15 -> 9, 18 -> 12, 20 -> 14)
       expected.foreach {
-        case (seqNr, (lower, upper)) =>
+        case (seqNr, upper) =>
           withClue(s"seqNr=$seqNr:") {
             criteria.deleteUpperSequenceNr(seqNr) should ===(upper)
-            criteria.deleteLowerSequenceNr(upper) should ===(lower)
           }
       }
     }


### PR DESCRIPTION
On top of https://github.com/akka/akka/pull/31784 but otherwise ready for review.

* Keep track of retention steps, including detailed debug logging.
* If retention is in progress when a new retention is triggered it will skip that retention cycle.
* Had to include that as mutable state in BehaviorSetup rather than in the RunningState because the background tasks of deleting events and snapshots can't easily update the RunningState.
* Also changed so that snapshot deletion always use 0 as lower sequence number.
  * This is important because otherwise some snapshots may be left behind when retention is skipped. That could probably already happen in failure scenarios previously.

The retention process for SnapshotCountRetentionCriteria looks like this:
1. Save snapshot after persisting events when shouldSnapshotAfterPersist returned SnapshotWithRetention.
2. Delete events (when deleteEventsOnSnapshot=true), runs in background.
3. Delete snapshots (when isOnlyOneSnapshot=false), runs in background.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #31785
