### PR TITLE
fix: Follow up to #31777 mima filters for Scala 3

### DIFF
--- a/akka-stream/src/main/mima-filters/2.7.0.backwards.excludes/31777-mandatory-attributes.excludes
+++ b/akka-stream/src/main/mima-filters/2.7.0.backwards.excludes/31777-mandatory-attributes.excludes
@@ -1,3 +1,11 @@
 # no longer anonymous subclasses, internal and may change.
 ProblemFilters.exclude[FinalClassProblem]("akka.stream.Attributes$NestedMaterializationCancellationPolicy")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.Attributes#NestedMaterializationCancellationPolicy.this")
+
+# breaking changes for Scala 3 but very unlikely to be used anywhere
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.Attributes.fromProduct")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.Attributes.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.Attributes._1")
+ProblemFilters.exclude[MissingTypesProblem]("akka.stream.Attributes$")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.stream.Attributes.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.Attributes.fromProduct")


### PR DESCRIPTION
Binary breaking changes, but very unlikely anyone is using those Scala 3 case class of 'Attributes'

References #31777
