### PR TITLE
fix: SnapshotSerializeSpec test case that was never deterministic removed

### DIFF
--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/CommonUtils.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/CommonUtils.scala
@@ -4,16 +4,16 @@
 
 package akka.persistence.testkit
 
-import java.util.UUID
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 
+import java.util.UUID
 import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
-
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.persistence._
 import akka.testkit.TestKitBase
 
-trait CommonUtils extends AnyWordSpecLike with TestKitBase {
+trait CommonUtils extends AnyWordSpecLike with TestKitBase with LogCapturing {
 
   protected def randomPid() = UUID.randomUUID().toString
 

--- a/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/CommonSnapshotTests.scala
+++ b/akka-persistence-testkit/src/test/scala/akka/persistence/testkit/scaladsl/CommonSnapshotTests.scala
@@ -527,36 +527,6 @@ trait CommonSnapshotTests extends ScalaDslUtils {
 
     }
 
-    "test snapshot events with RetentionCriteria after sending commands" in {
-
-      lazy val tk = new SnapshotTestKit(system)
-
-      val pid = randomPid()
-      val act = system.spawn(
-        eventSourcedBehaviorWithState(pid).withRetention(
-          RetentionCriteria.snapshotEvery(numberOfEvents = 2, keepNSnapshots = 2)),
-        pid)
-
-      act ! Cmd("a")
-      act ! Cmd("b")
-      act ! Cmd("c")
-      act ! Cmd("d")
-      act ! Cmd("e")
-      act ! Cmd("f")
-      act ! Cmd("g")
-      act ! Cmd("h")
-      act ! Cmd("i")
-      act ! Cmd("j")
-      act ! Cmd("k")
-
-      tk.expectNextPersisted(pid, NonEmptyState("ab"))
-      tk.expectNextPersisted(pid, NonEmptyState("abcd"))
-      tk.expectNextPersisted(pid, NonEmptyState("abcdef"))
-      tk.expectNextPersisted(pid, NonEmptyState("abcdefgh"))
-      tk.expectNextPersisted(pid, NonEmptyState("abcdefghij"))
-
-    }
-
     specificTests()
   }
 


### PR DESCRIPTION
References #31803 

The test interacts with both a sequence number counter and a snapshot store that is updated asynchronously via the entity snapshotting and snapshot deletes triggered by retention. Was succeeding by pure chance before, now pretty consistently fails (possibly exaggerated by the changes in #31786 )

Dropping the test case from #29769 for now.