### PR TITLE
fix: EventSourcedBehaviorStashSpec failure fixes 

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
@@ -579,7 +579,6 @@ class EventSourcedBehaviorStashSpec
       c ! "ping"
       probe.expectMessage("pong")
 
-
       c ! "start-stashing"
       // make sure write completes before sending more commands so that they are not auto-stashed by ESB
       probe.expectMessage("started-stashing")

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorStashSpec.scala
@@ -579,7 +579,9 @@ class EventSourcedBehaviorStashSpec
       c ! "ping"
       probe.expectMessage("pong")
 
+
       c ! "start-stashing"
+      // make sure write completes before sending more commands so that they are not auto-stashed by ESB
       probe.expectMessage("started-stashing")
 
       val limit = system.settings.config.getInt("akka.persistence.typed.stash-capacity")
@@ -612,6 +614,7 @@ class EventSourcedBehaviorStashSpec
       probe.expectMessage("pong")
 
       c ! "start-stashing"
+      // make sure write completes before sending more commands so that they are not auto-stashed by ESB
       probe.expectMessage("started-stashing")
 
       LoggingTestKit.warn("Stash buffer is full, dropping message").expect {


### PR DESCRIPTION
References #31493

Could repeat the two different failures (and one more) by delaying completion of the in-mem journal writes some 20ms