### PR TITLE
fix: EventSourcedBehaviorRetentionSpec fail

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRetentionSpec.scala
@@ -279,13 +279,21 @@ class EventSourcedBehaviorRetentionSpec
       snapshotSignalProbe.expectSnapshotCompleted(9)
       deleteSnapshotSignalProbe.expectDeleteSnapshotCompleted(3)
 
-      (1 to 10).foreach(_ => persistentActor ! Increment)
+      (1 to 3).foreach(_ => persistentActor ! Increment)
       persistentActor ! GetValue(replyProbe.ref)
-      replyProbe.expectMessage(State(20, (0 until 20).toVector))
+      replyProbe.expectMessage(State(13, (0 until 13).toVector))
       snapshotSignalProbe.expectSnapshotCompleted(12)
       deleteSnapshotSignalProbe.expectDeleteSnapshotCompleted(6)
+
+      (1 to 3).foreach(_ => persistentActor ! Increment)
+      persistentActor ! GetValue(replyProbe.ref)
+      replyProbe.expectMessage(State(16, (0 until 16).toVector))
       snapshotSignalProbe.expectSnapshotCompleted(15)
       deleteSnapshotSignalProbe.expectDeleteSnapshotCompleted(9)
+
+      (1 to 4).foreach(_ => persistentActor ! Increment)
+      persistentActor ! GetValue(replyProbe.ref)
+      replyProbe.expectMessage(State(20, (0 until 20).toVector))
       snapshotSignalProbe.expectSnapshotCompleted(18)
       deleteSnapshotSignalProbe.expectDeleteSnapshotCompleted(12)
 


### PR DESCRIPTION
References #31796

The changes in #31785 means that retention deletes can be skipped if one is already in progress. The test expected that the retention/deletes they are always run and fired off events that should trigger 3 deletes at once, if the deletes complete or not before the next retention is triggered depends on how fast the machine is (hint ci is slow)

This fix runs the events in batches verifying each delete before triggering the next making it deterministic again.

Verified by sneaking strategic Thread.sleeps into the testkit snapshot store operations.