### PR TITLE
fix: mapWithResource setting its attributes in non standard way 

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -2204,15 +2204,10 @@ private[akka] object StatefulMap {
  * INTERNAL API
  */
 @InternalApi
-private[akka] final class StatefulMap[S, In, Out](
-    attributes: Attributes,
-    create: () => S,
-    f: (S, In) => (S, Out),
-    onComplete: S => Option[Out])
+private[akka] final class StatefulMap[S, In, Out](create: () => S, f: (S, In) => (S, Out), onComplete: S => Option[Out])
     extends GraphStage[FlowShape[In, Out]] {
   import StatefulMap.NullStateException
 
-  require(attributes != null, "attributes should not be null")
   require(create != null, "create function should not be null")
   require(f != null, "f function should not be null")
   require(onComplete != null, "onComplete function should not be null")
@@ -2220,8 +2215,6 @@ private[akka] final class StatefulMap[S, In, Out](
   private val in = Inlet[In]("StatefulMap.in")
   private val out = Outlet[Out]("StatefulMap.out")
   override val shape: FlowShape[In, Out] = FlowShape(in, out)
-
-  override protected def initialAttributes: Attributes = attributes
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with InHandler with OutHandler {

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1028,8 +1028,8 @@ trait FlowOps[+Out, +Mat] {
    * @param onComplete a function that transforms the ongoing state into an optional output element
    */
   def statefulMap[S, T](create: () => S)(f: (S, Out) => (S, T), onComplete: S => Option[T]): Repr[T] =
-    via(
-      new StatefulMap[S, Out, T](DefaultAttributes.statefulMap and SourceLocation.forLambda(f), create, f, onComplete))
+    via(new StatefulMap[S, Out, T](create, f, onComplete))
+      .withAttributes(DefaultAttributes.statefulMap and SourceLocation.forLambda(f))
 
   /**
    * Transform each stream element with the help of a resource.
@@ -1064,11 +1064,8 @@ trait FlowOps[+Out, +Mat] {
    */
   def mapWithResource[R, T](create: () => R)(f: (R, Out) => T, close: R => Option[T]): Repr[T] =
     via(
-      new StatefulMap[R, Out, T](
-        DefaultAttributes.mapWithResource and SourceLocation.forLambda(f),
-        create,
-        (resource, out) => (resource, f(resource, out)),
-        resource => close(resource)))
+      new StatefulMap[R, Out, T](create, (resource, out) => (resource, f(resource, out)), resource => close(resource)))
+      .withAttributes(DefaultAttributes.mapWithResource and SourceLocation.forLambda(f))
 
   /**
    * Transform each input element into an `Iterable` of output elements that is


### PR DESCRIPTION
References #31584

I did not investigate further how the test could have ever passed when the attributes are passed internally like that, there could be a materializer bug lurking as well, but we should anyway fix the operator, so doing that to start with.