### PR TITLE
perf: SystemMaterializer promise is typically completed

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/SystemMaterializer.scala
+++ b/akka-stream/src/main/scala/akka/stream/SystemMaterializer.scala
@@ -86,8 +86,14 @@ final class SystemMaterializer(system: ExtendedActorSystem) extends Extension {
   }
 
   val materializer: Materializer = {
-    // block on async creation to make it effectively final
-    Await.result(systemMaterializerPromise.future, materializerTimeout.duration)
+    val systemMaterializerFuture = systemMaterializerPromise.future
+    systemMaterializerFuture.value match {
+      case Some(tryMaterializer) =>
+        tryMaterializer.get
+      case None =>
+        // block on async creation to make it effectively final
+        Await.result(systemMaterializerFuture, materializerTimeout.duration)
+    }
   }
 
 }


### PR DESCRIPTION
* less work than Await.result for the normal case
