### PR TITLE
bump: use ssl-config 0.6.1 even for Scala 2 (was 0.4.3)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,13 +38,7 @@ object Dependencies {
 
   val reactiveStreamsVersion = "1.0.4"
 
-  val sslConfigVersion = Def.setting {
-    if (scalaVersion.value.startsWith("3.")) {
-      "0.6.1"
-    } else {
-      "0.4.3"
-    }
-  }
+  val sslConfigVersion = "0.6.1"
 
   val scalaTestVersion = "3.2.12"
 
@@ -81,9 +75,7 @@ object Dependencies {
     val reactiveStreams = "org.reactivestreams" % "reactive-streams" % reactiveStreamsVersion // MIT-0
 
     // ssl-config
-    val sslConfigCore = Def.setting {
-      "com.typesafe" %% "ssl-config-core" % sslConfigVersion.value // ApacheV2
-    }
+    val sslConfigCore = "com.typesafe" %% "ssl-config-core" % sslConfigVersion // ApacheV2
 
     val lmdb = "org.lmdbjava" % "lmdbjava" % "0.7.0" // ApacheV2, OpenLDAP Public License
 
@@ -309,7 +301,7 @@ object Dependencies {
 
   // akka stream
 
-  lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, sslConfigCore.value, TestDependencies.scalatest)
+  lazy val stream = l ++= Seq[sbt.ModuleID](reactiveStreams, sslConfigCore, TestDependencies.scalatest)
 
   lazy val streamTestkit = l ++= Seq(
         TestDependencies.scalatest,


### PR DESCRIPTION
This does the easy bit of #31822 by picking the current version of ssl-config not only for Scala 3, but even for Scala 2.

ssl-config is pulled in to Akka Streams and downstream to Akka HTTP (but all use is deprecated there).

References 
- #31822
