### PR TITLE
perf: Avoid many System.nanoTime calls in sharding passivation strategies

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/FrequencyListSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/FrequencyListSpec.scala
@@ -9,17 +9,6 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.duration._
 
-object FrequencyListSpec {
-  // controlled clock for testing recency windows
-  // durations are always in seconds
-  class TestClock extends RecencyList.Clock {
-    private var time = 0L
-    def tick(): Unit = time += 1
-    override def currentTime(): Long = time
-    override def earlierTime(duration: FiniteDuration): Long = currentTime() - duration.toSeconds
-  }
-}
-
 class FrequencyListSpec extends AnyWordSpec with Matchers {
 
   private def check(frequencyList: FrequencyList[String], expectedLeastToMostFrequent: List[String]): Unit = {
@@ -93,7 +82,7 @@ class FrequencyListSpec extends AnyWordSpec with Matchers {
     }
 
     "track overall recency of elements when enabled" in {
-      val clock = new RecencyListSpec.TestClock
+      val clock = new TestClock
       val frequency = new FrequencyList[String](dynamicAging = false, OptionVal.Some(clock))
 
       check(frequency, Nil)

--- a/akka-actor-tests/src/test/scala/akka/util/RecencyListSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/RecencyListSpec.scala
@@ -9,17 +9,6 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.duration._
 
-object RecencyListSpec {
-  // controlled clock for testing recency windows
-  // durations are always in seconds
-  class TestClock extends RecencyList.Clock {
-    private var time = 0L
-    def tick(): Unit = time += 1
-    override def currentTime(): Long = time
-    override def earlierTime(duration: FiniteDuration): Long = currentTime() - duration.toSeconds
-  }
-}
-
 class RecencyListSpec extends AnyWordSpec with Matchers {
 
   private def check(recencyList: RecencyList[String], expectedLeastToMostRecent: List[String]): Unit = {
@@ -32,8 +21,8 @@ class RecencyListSpec extends AnyWordSpec with Matchers {
   "RecencyList" must {
 
     "track recency of elements" in {
-      val clock = new RecencyListSpec.TestClock
-      val recency = new RecencyList[String](clock)
+      val clock = new TestClock
+      val recency = RecencyList[String](clock)
 
       check(recency, Nil)
 

--- a/akka-actor-tests/src/test/scala/akka/util/ScheduledClockSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/ScheduledClockSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2016-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+import scala.concurrent.duration._
+
+import akka.testkit.AkkaSpec
+import akka.testkit.TimingTest
+
+class ScheduledClockSpec extends AkkaSpec {
+
+  "ScheduledClock" must {
+
+    "update at given interval" taggedAs TimingTest in {
+      val interval = 100.millis
+      val clock = new ScheduledClock(interval, system.scheduler, system.dispatcher)
+      val t1 = clock.currentTime()
+      // interval is much smaller but to avoid flaky test due to pauses we sleep longer
+      Thread.sleep(2000)
+      val t2 = clock.currentTime()
+      (t2 - t1) shouldBe >=(interval.toNanos)
+
+      Thread.sleep(2000)
+      val t3 = clock.currentTime()
+      (t3 - t2) shouldBe >=(interval.toNanos)
+    }
+
+    "increment each call to to currentTime" in {
+      val interval = 10.seconds // don't update
+      val clock = new ScheduledClock(interval, system.scheduler, system.dispatcher)
+      val t1 = clock.currentTime()
+      val t2 = clock.currentTime()
+      val t3 = clock.currentTime()
+      (t2 - t1) shouldBe 1L
+      (t3 - t2) shouldBe 1L
+    }
+
+    "not go backwards" taggedAs TimingTest in {
+      val interval = 20.millis
+      val clock = new ScheduledClock(interval, system.scheduler, system.dispatcher)
+
+      // run a few threads updating in the background
+      val backgroundTasks =
+        (1 to 3).map { _ =>
+          system.scheduler.scheduleWithFixedDelay(10.millis, 10.millis) { () =>
+            (1 to 1000).foreach { _ =>
+              clock.currentTime()
+            }
+          }(system.dispatcher)
+        }
+      try {
+        var t = clock.currentTime()
+        (1 to 1000000).foreach { n =>
+          val t2 = clock.currentTime()
+          (t2 - t) shouldBe >=(0L)
+          t = t2
+          if (n % 100000 == 0)
+            Thread.sleep(10)
+        }
+      } finally {
+        backgroundTasks.foreach(_.cancel())
+      }
+    }
+
+  }
+}

--- a/akka-actor-tests/src/test/scala/akka/util/SegmentedRecencyListSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/SegmentedRecencyListSpec.scala
@@ -9,17 +9,6 @@ import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.duration._
 
-object SegmentedRecencyListSpec {
-  // controlled clock for testing recency windows
-  // durations are always in seconds
-  class TestClock extends RecencyList.Clock {
-    private var time = 0L
-    def tick(): Unit = time += 1
-    override def currentTime(): Long = time
-    override def earlierTime(duration: FiniteDuration): Long = currentTime() - duration.toSeconds
-  }
-}
-
 class SegmentedRecencyListSpec extends AnyWordSpec with Matchers {
 
   private def check(recency: SegmentedRecencyList[String], expectedSegments: List[List[String]]): Unit = {
@@ -120,7 +109,7 @@ class SegmentedRecencyListSpec extends AnyWordSpec with Matchers {
     }
 
     "remove overall least recent elements" in {
-      val clock = new SegmentedRecencyListSpec.TestClock
+      val clock = new TestClock
       val recency = new SegmentedRecencyList[String](initialLimits = List(5, 5), OptionVal.Some(clock))
 
       check(recency, Nil)

--- a/akka-actor-tests/src/test/scala/akka/util/TestClock.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/TestClock.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * Controlled clock for testing recency windows.
+ * Durations are always in seconds.
+ */
+class TestClock extends Clock {
+  private var time = 0L
+
+  def tick(): Unit = time += 1
+
+  override def currentTime(): Long = time
+
+  override def earlierTime(duration: FiniteDuration): Long = currentTime() - duration.toSeconds
+}

--- a/akka-actor/src/main/mima-filters/2.6.20.backward.excludes/passivation-clock.excludes
+++ b/akka-actor/src/main/mima-filters/2.6.20.backward.excludes/passivation-clock.excludes
@@ -1,0 +1,6 @@
+# internal changes of RecencyList and friends, adding ScheduledClock
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.util.FrequencyList#withOverallRecency.empty")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.util.FrequencyList#withOverallRecency.empty$default$1")
+ProblemFilters.exclude[MissingClassProblem]("akka.util.RecencyList$Clock")
+ProblemFilters.exclude[MissingClassProblem]("akka.util.RecencyList$NanoClock")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.util.SegmentedRecencyList#withOverallRecency.empty")

--- a/akka-actor/src/main/mima-filters/2.7.0.backward.excludes/passivation-clock.excludes
+++ b/akka-actor/src/main/mima-filters/2.7.0.backward.excludes/passivation-clock.excludes
@@ -1,0 +1,6 @@
+# internal changes of RecencyList and friends, adding ScheduledClock
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.util.FrequencyList#withOverallRecency.empty")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.util.FrequencyList#withOverallRecency.empty$default$1")
+ProblemFilters.exclude[MissingClassProblem]("akka.util.RecencyList$Clock")
+ProblemFilters.exclude[MissingClassProblem]("akka.util.RecencyList$NanoClock")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.util.SegmentedRecencyList#withOverallRecency.empty")

--- a/akka-actor/src/main/resources/reference.conf
+++ b/akka-actor/src/main/resources/reference.conf
@@ -849,6 +849,10 @@ akka {
     shutdown-timeout = 5s
   }
 
+  # How frequent the clock for recency-based strategies is updated. Can be set to 0 for usage of
+  # `System.nanoTime` for each call but that might have some overhead for high message throughput.
+  scheduled-clock-interval = 1 s
+
   io {
 
     # By default the select loops run on dedicated threads, hence using a

--- a/akka-actor/src/main/scala/akka/util/Clock.scala
+++ b/akka-actor/src/main/scala/akka/util/Clock.scala
@@ -81,9 +81,13 @@ import akka.annotation.InternalApi
 
   @tailrec private def update(): Unit = {
     val current = time.get()
-    val now = math.max(System.nanoTime(), current) // never backwards
-    if (time.compareAndSet(current, now)) {
-      updatedTime = now
+    val now = System.nanoTime()
+    val newTime =
+      if (now - current >= 0L) now // the diff also handles the case of Long.MaxValue overflow to negative
+      else current
+
+    if (time.compareAndSet(current, newTime)) {
+      updatedTime = newTime
       maxIncrementReached = false
     } else {
       // concurrent update via currentTime(), try again

--- a/akka-actor/src/main/scala/akka/util/Clock.scala
+++ b/akka-actor/src/main/scala/akka/util/Clock.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.annotation.tailrec
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+
+import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
+import akka.actor.ExtendedActorSystem
+import akka.actor.Extension
+import akka.actor.ExtensionId
+import akka.actor.ExtensionIdProvider
+import akka.actor.Scheduler
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object Clock extends ExtensionId[Clock] with ExtensionIdProvider {
+  override def get(system: ActorSystem): Clock = super.get(system)
+
+  override def get(system: ClassicActorSystemProvider): Clock = super.get(system)
+
+  override def lookup = Clock
+
+  override def createExtension(system: ExtendedActorSystem): Clock = {
+    import scala.concurrent.duration._
+    val interval = system.settings.config.getDuration("akka.scheduled-clock-interval", TimeUnit.MILLISECONDS).millis
+    if (interval > Duration.Zero)
+      new ScheduledClock(interval, system.scheduler, system.dispatcher)
+    else new NanoClock
+  }
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] trait Clock extends Extension {
+  def currentTime(): Long
+
+  def earlierTime(duration: FiniteDuration): Long
+}
+
+/**
+ * INTERNAL API: Clock backed by `System.nanoTime`.
+ */
+@InternalApi private[akka] final class NanoClock extends Clock {
+  override def currentTime(): Long = System.nanoTime()
+
+  override def earlierTime(duration: FiniteDuration): Long = currentTime() - duration.toNanos
+}
+
+/**
+ * INTERNAL API: Clock backed by `System.nanoTime` but only calls `nanoTime` with the given interval using the `scheduler`.
+ * This has the benefit of not calling `nanoTime` to often when exact timestamps are not needed.
+ * The `currentTime` never moves backwards (but overflows to negative in same way as `nanoTime`).
+ * Subsequent calls to `currentTime` will increment the "time" with 1, unless for very high frequency where it may
+ * keep the same time value until next background update.
+ */
+@InternalApi private[akka] final class ScheduledClock(
+    updateInterval: FiniteDuration,
+    scheduler: Scheduler,
+    executionContext: ExecutionContext)
+    extends Clock {
+  private val time = new AtomicLong(System.nanoTime())
+  @volatile private var updatedTime = time.get()
+
+  private val maxIncrement = math.max(updateInterval.toNanos - 100000, 0L)
+  @volatile var maxIncrementReached = false
+
+  scheduler.scheduleWithFixedDelay(updateInterval, updateInterval) { () =>
+    update()
+  }(executionContext)
+
+  @tailrec private def update(): Unit = {
+    val current = time.get()
+    val now = math.max(System.nanoTime(), current) // never backwards
+    if (time.compareAndSet(current, now)) {
+      updatedTime = now
+      maxIncrementReached = false
+    } else {
+      // concurrent update via currentTime(), try again
+      update()
+    }
+  }
+
+  override def currentTime(): Long = {
+    if (maxIncrementReached) {
+      time.get()
+    } else {
+      val now = time.incrementAndGet()
+      if (now - updatedTime >= maxIncrement)
+        maxIncrementReached = true
+      now
+    }
+  }
+
+  override def earlierTime(duration: FiniteDuration): Long =
+    time.get() - duration.toNanos
+}

--- a/akka-actor/src/main/scala/akka/util/FrequencyList.scala
+++ b/akka-actor/src/main/scala/akka/util/FrequencyList.scala
@@ -18,8 +18,8 @@ private[akka] object FrequencyList {
     new FrequencyList[A](dynamicAging, clock = OptionVal.None)
 
   object withOverallRecency {
-    def empty[A](dynamicAging: Boolean = false): FrequencyList[A] =
-      new FrequencyList[A](dynamicAging, OptionVal.Some(new RecencyList.NanoClock))
+    def empty[A](clock: Clock, dynamicAging: Boolean = false): FrequencyList[A] =
+      new FrequencyList[A](dynamicAging, OptionVal.Some(clock))
   }
 
   private final class FrequencyNode[A](val priority: Long) {
@@ -51,7 +51,7 @@ private[akka] object FrequencyList {
  * Dynamic aging can be enabled for least frequently used policies, to automatically 'age' the whole cache on evictions.
  */
 @InternalApi
-private[akka] final class FrequencyList[A](dynamicAging: Boolean, clock: OptionVal[RecencyList.Clock]) {
+private[akka] final class FrequencyList[A](dynamicAging: Boolean, clock: OptionVal[Clock]) {
   import FrequencyList.{ FrequencyNode, Node }
 
   private val frequency = new DoubleLinkedList[FrequencyNode[A]](

--- a/akka-actor/src/main/scala/akka/util/SegmentedRecencyList.scala
+++ b/akka-actor/src/main/scala/akka/util/SegmentedRecencyList.scala
@@ -18,8 +18,8 @@ private[akka] object SegmentedRecencyList {
     new SegmentedRecencyList[A](limits, OptionVal.None)
 
   object withOverallRecency {
-    def empty[A](limits: immutable.Seq[Int]): SegmentedRecencyList[A] =
-      new SegmentedRecencyList[A](limits, OptionVal.Some(new RecencyList.NanoClock))
+    def empty[A](clock: Clock, limits: immutable.Seq[Int]): SegmentedRecencyList[A] =
+      new SegmentedRecencyList[A](limits, OptionVal.Some(clock))
   }
 
   private final class Node[A](val value: A) {
@@ -38,9 +38,7 @@ private[akka] object SegmentedRecencyList {
  * Implemented using doubly-linked lists plus hash map for lookup, so that all operations are constant time.
  */
 @InternalApi
-private[akka] final class SegmentedRecencyList[A](
-    initialLimits: immutable.Seq[Int],
-    clock: OptionVal[RecencyList.Clock]) {
+private[akka] final class SegmentedRecencyList[A](initialLimits: immutable.Seq[Int], clock: OptionVal[Clock]) {
   import SegmentedRecencyList.Node
 
   private var limits: immutable.IndexedSeq[Int] = initialLimits.toIndexedSeq

--- a/akka-bench-jmh/src/main/scala/akka/util/ClockBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/util/ClockBenchmark.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+
+import akka.actor.ActorSystem
+
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 10, timeUnit = TimeUnit.SECONDS)
+class ClockBenchmark {
+
+  private val system: ActorSystem = ActorSystem("ClockBenchmark")
+  private val _nanoClock = new NanoClock
+  private val _scheduledClock = new ScheduledClock(1.second, system.scheduler, system.dispatcher)
+
+  @Benchmark
+  def nanoClock(): Long = {
+    _nanoClock.currentTime()
+  }
+
+  @Benchmark
+  def scheduledClock(): Long = {
+    _scheduledClock.currentTime()
+  }
+
+  @TearDown
+  def shutdown(): Unit = {
+    Await.result(system.terminate(), 5.seconds)
+  }
+
+}

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -6,6 +6,7 @@ package akka.cluster.sharding
 
 import java.net.URLEncoder
 import java.util
+
 import akka.actor.Actor
 import akka.actor.ActorLogging
 import akka.actor.ActorRef
@@ -33,11 +34,11 @@ import akka.coordination.lease.scaladsl.Lease
 import akka.coordination.lease.scaladsl.LeaseProvider
 import akka.event.LoggingAdapter
 import akka.pattern.pipe
+import akka.util.Clock
 import akka.util.MessageBufferMap
 import akka.util.OptionVal
 import akka.util.PrettyDuration._
 import akka.util.unused
-
 import scala.collection.immutable.Set
 import scala.concurrent.duration._
 
@@ -458,7 +459,7 @@ private[akka] class Shard(
   private var handOffStopper: Option[ActorRef] = None
   private var preparingForShutdown = false
 
-  private val passivationStrategy = EntityPassivationStrategy(settings)
+  private val passivationStrategy = EntityPassivationStrategy(settings, clock = () => Clock(context.system))
 
   import context.dispatcher
   private val passivateIntervalTask = passivationStrategy.scheduledInterval.map { interval =>

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/EntityPassivationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/EntityPassivationStrategy.scala
@@ -11,9 +11,10 @@ import akka.util.FastFrequencySketch
 import akka.util.FrequencySketch
 import akka.util.OptionVal
 import akka.util.{ FrequencyList, RecencyList, SegmentedRecencyList }
-
 import scala.collection.immutable
 import scala.concurrent.duration.FiniteDuration
+
+import akka.util.Clock
 
 /**
  * INTERNAL API
@@ -26,26 +27,26 @@ private[akka] object EntityPassivationStrategy {
     val none: PassivateEntities = immutable.Seq.empty[EntityId]
   }
 
-  def apply(settings: ClusterShardingSettings): EntityPassivationStrategy = {
+  def apply(settings: ClusterShardingSettings, clock: () => Clock): EntityPassivationStrategy = {
     settings.passivationStrategy match {
       case ClusterShardingSettings.IdlePassivationStrategy(timeout, interval) =>
-        new IdleEntityPassivationStrategy(new IdleCheck(timeout, interval))
+        new IdleEntityPassivationStrategy(new IdleCheck(timeout, interval), clock())
       case ClusterShardingSettings.LeastRecentlyUsedPassivationStrategy(limit, segmented, idle) =>
         val idleCheck = idle.map(idle => new IdleCheck(idle.timeout, idle.interval))
-        if (segmented.isEmpty) new LeastRecentlyUsedEntityPassivationStrategy(limit, idleCheck)
-        else new SegmentedLeastRecentlyUsedEntityPassivationStrategy(limit, segmented, idleCheck)
+        if (segmented.isEmpty) new LeastRecentlyUsedEntityPassivationStrategy(limit, idleCheck, clock())
+        else new SegmentedLeastRecentlyUsedEntityPassivationStrategy(limit, segmented, idleCheck, clock)
       case ClusterShardingSettings.MostRecentlyUsedPassivationStrategy(limit, idle) =>
         val idleCheck = idle.map(idle => new IdleCheck(idle.timeout, idle.interval))
-        new MostRecentlyUsedEntityPassivationStrategy(limit, idleCheck)
+        new MostRecentlyUsedEntityPassivationStrategy(limit, idleCheck, clock())
       case ClusterShardingSettings.LeastFrequentlyUsedPassivationStrategy(limit, dynamicAging, idle) =>
         val idleCheck = idle.map(idle => new IdleCheck(idle.timeout, idle.interval))
-        new LeastFrequentlyUsedEntityPassivationStrategy(limit, dynamicAging, idleCheck)
+        new LeastFrequentlyUsedEntityPassivationStrategy(limit, dynamicAging, idleCheck, clock)
       case composite: ClusterShardingSettings.CompositePassivationStrategy =>
-        val main = ActiveEntities(composite.mainStrategy, composite.idle.isDefined)
+        val main = ActiveEntities(composite.mainStrategy, composite.idle.isDefined, clock)
         if (main eq NoActiveEntities) DisabledEntityPassivationStrategy
         else {
           val initialLimit = composite.limit
-          val window = ActiveEntities(composite.windowStrategy, composite.idle.isDefined)
+          val window = ActiveEntities(composite.windowStrategy, composite.idle.isDefined, clock)
           val initialWindowProportion = if (window eq NoActiveEntities) 0.0 else composite.initialWindowProportion
           val minimumWindowProportion = if (window eq NoActiveEntities) 0.0 else composite.minimumWindowProportion
           val maximumWindowProportion = if (window eq NoActiveEntities) 0.0 else composite.maximumWindowProportion
@@ -143,11 +144,12 @@ private[akka] final class IdleCheck(val timeout: FiniteDuration, val interval: F
  * @param idleCheck passivate idle entities after the given timeout, checking every interval
  */
 @InternalApi
-private[akka] final class IdleEntityPassivationStrategy(idleCheck: IdleCheck) extends EntityPassivationStrategy {
+private[akka] final class IdleEntityPassivationStrategy(idleCheck: IdleCheck, clock: Clock)
+    extends EntityPassivationStrategy {
 
   import EntityPassivationStrategy.PassivateEntities
 
-  private val recencyList = RecencyList.empty[EntityId]
+  private val recencyList = RecencyList[EntityId](clock)
 
   override val scheduledInterval: Option[FiniteDuration] = Some(idleCheck.interval)
 
@@ -201,12 +203,15 @@ private[akka] abstract class LimitBasedEntityPassivationStrategy(initialLimit: I
  * @param initialLimit initial active entity capacity for a shard region
  * @param idleCheck optionally passivate idle entities after the given timeout, checking every interval
  */
-private[akka] final class LeastRecentlyUsedEntityPassivationStrategy(initialLimit: Int, idleCheck: Option[IdleCheck])
+private[akka] final class LeastRecentlyUsedEntityPassivationStrategy(
+    initialLimit: Int,
+    idleCheck: Option[IdleCheck],
+    clock: Clock)
     extends LimitBasedEntityPassivationStrategy(initialLimit) {
 
   import EntityPassivationStrategy.PassivateEntities
 
-  val active = new LeastRecentlyUsedReplacementPolicy(initialLimit)
+  val active = new LeastRecentlyUsedReplacementPolicy(initialLimit, clock)
 
   override protected def passivateEntitiesOnLimitUpdate(): PassivateEntities = active.updateLimit(perShardLimit)
 
@@ -238,12 +243,13 @@ private[akka] final class LeastRecentlyUsedEntityPassivationStrategy(initialLimi
 private[akka] final class SegmentedLeastRecentlyUsedEntityPassivationStrategy(
     initialLimit: Int,
     proportions: immutable.Seq[Double],
-    idleCheck: Option[IdleCheck])
+    idleCheck: Option[IdleCheck],
+    clock: () => Clock)
     extends LimitBasedEntityPassivationStrategy(initialLimit) {
 
   import EntityPassivationStrategy.PassivateEntities
 
-  val active = new SegmentedLeastRecentlyUsedReplacementPolicy(initialLimit, proportions, idleCheck.isDefined)
+  val active = new SegmentedLeastRecentlyUsedReplacementPolicy(initialLimit, proportions, idleCheck.isDefined, clock)
 
   override protected def passivateEntitiesOnLimitUpdate(): PassivateEntities = active.updateLimit(perShardLimit)
 
@@ -268,12 +274,15 @@ private[akka] final class SegmentedLeastRecentlyUsedEntityPassivationStrategy(
  * @param idleCheck optionally passivate idle entities after the given timeout, checking every interval
  */
 @InternalApi
-private[akka] final class MostRecentlyUsedEntityPassivationStrategy(initialLimit: Int, idleCheck: Option[IdleCheck])
+private[akka] final class MostRecentlyUsedEntityPassivationStrategy(
+    initialLimit: Int,
+    idleCheck: Option[IdleCheck],
+    clock: Clock)
     extends LimitBasedEntityPassivationStrategy(initialLimit) {
 
   import EntityPassivationStrategy.PassivateEntities
 
-  val active = new MostRecentlyUsedReplacementPolicy(initialLimit)
+  val active = new MostRecentlyUsedReplacementPolicy(initialLimit, clock)
 
   override protected def passivateEntitiesOnLimitUpdate(): PassivateEntities = active.updateLimit(perShardLimit)
 
@@ -302,12 +311,13 @@ private[akka] final class MostRecentlyUsedEntityPassivationStrategy(initialLimit
 private[akka] final class LeastFrequentlyUsedEntityPassivationStrategy(
     initialLimit: Int,
     dynamicAging: Boolean,
-    idleCheck: Option[IdleCheck])
+    idleCheck: Option[IdleCheck],
+    clock: () => Clock)
     extends LimitBasedEntityPassivationStrategy(initialLimit) {
 
   import EntityPassivationStrategy.PassivateEntities
 
-  val active = new LeastFrequentlyUsedReplacementPolicy(initialLimit, dynamicAging, idleCheck.isDefined)
+  val active = new LeastFrequentlyUsedReplacementPolicy(initialLimit, dynamicAging, idleCheck.isDefined, clock)
 
   override protected def passivateEntitiesOnLimitUpdate(): PassivateEntities = active.updateLimit(perShardLimit)
 
@@ -327,15 +337,18 @@ private[akka] final class LeastFrequentlyUsedEntityPassivationStrategy(
  */
 @InternalApi
 private[akka] object ActiveEntities {
-  def apply(strategy: ClusterShardingSettings.PassivationStrategy, idleEnabled: Boolean): ActiveEntities =
+  def apply(
+      strategy: ClusterShardingSettings.PassivationStrategy,
+      idleEnabled: Boolean,
+      clock: () => Clock): ActiveEntities =
     strategy match {
       case ClusterShardingSettings.LeastRecentlyUsedPassivationStrategy(_, segmented, _) =>
-        if (segmented.isEmpty) new LeastRecentlyUsedReplacementPolicy(initialLimit = 0)
-        else new SegmentedLeastRecentlyUsedReplacementPolicy(initialLimit = 0, segmented, idleEnabled)
+        if (segmented.isEmpty) new LeastRecentlyUsedReplacementPolicy(initialLimit = 0, clock())
+        else new SegmentedLeastRecentlyUsedReplacementPolicy(initialLimit = 0, segmented, idleEnabled, clock)
       case ClusterShardingSettings.MostRecentlyUsedPassivationStrategy(_, _) =>
-        new MostRecentlyUsedReplacementPolicy(initialLimit = 0)
+        new MostRecentlyUsedReplacementPolicy(initialLimit = 0, clock())
       case ClusterShardingSettings.LeastFrequentlyUsedPassivationStrategy(_, dynamicAging, _) =>
-        new LeastFrequentlyUsedReplacementPolicy(initialLimit = 0, dynamicAging, idleEnabled)
+        new LeastFrequentlyUsedReplacementPolicy(initialLimit = 0, dynamicAging, idleEnabled, clock)
       case _ => NoActiveEntities
     }
 }
@@ -423,11 +436,11 @@ private[akka] object NoActiveEntities extends ActiveEntities {
  * @param initialLimit initial active entity capacity for a shard
  */
 @InternalApi
-private[akka] final class LeastRecentlyUsedReplacementPolicy(initialLimit: Int) extends ActiveEntities {
+private[akka] final class LeastRecentlyUsedReplacementPolicy(initialLimit: Int, clock: Clock) extends ActiveEntities {
   import EntityPassivationStrategy.PassivateEntities
 
   private var limit = initialLimit
-  private val recencyList = RecencyList.empty[EntityId]
+  private val recencyList = RecencyList[EntityId](clock)
 
   override def size: Int = recencyList.size
 
@@ -472,7 +485,8 @@ private[akka] final class LeastRecentlyUsedReplacementPolicy(initialLimit: Int) 
 private[akka] final class SegmentedLeastRecentlyUsedReplacementPolicy(
     initialLimit: Int,
     proportions: immutable.Seq[Double],
-    idleEnabled: Boolean)
+    idleEnabled: Boolean,
+    clock: () => Clock)
     extends ActiveEntities {
 
   import EntityPassivationStrategy.PassivateEntities
@@ -485,7 +499,7 @@ private[akka] final class SegmentedLeastRecentlyUsedReplacementPolicy(
   }
 
   private val segmentedRecencyList =
-    if (idleEnabled) SegmentedRecencyList.withOverallRecency.empty[EntityId](segmentLimits)
+    if (idleEnabled) SegmentedRecencyList.withOverallRecency.empty[EntityId](clock(), segmentLimits)
     else SegmentedRecencyList.empty[EntityId](segmentLimits)
 
   override def size: Int = segmentedRecencyList.size
@@ -522,11 +536,11 @@ private[akka] final class SegmentedLeastRecentlyUsedReplacementPolicy(
  * @param initialLimit initial active entity capacity for a shard
  */
 @InternalApi
-private[akka] final class MostRecentlyUsedReplacementPolicy(initialLimit: Int) extends ActiveEntities {
+private[akka] final class MostRecentlyUsedReplacementPolicy(initialLimit: Int, clock: Clock) extends ActiveEntities {
   import EntityPassivationStrategy.PassivateEntities
 
   private var limit = initialLimit
-  private val recencyList = RecencyList.empty[EntityId]
+  private val recencyList = RecencyList[EntityId](clock)
 
   override def size: Int = recencyList.size
 
@@ -568,7 +582,8 @@ private[akka] final class MostRecentlyUsedReplacementPolicy(initialLimit: Int) e
 private[akka] final class LeastFrequentlyUsedReplacementPolicy(
     initialLimit: Int,
     dynamicAging: Boolean,
-    idleEnabled: Boolean)
+    idleEnabled: Boolean,
+    clock: () => Clock)
     extends ActiveEntities {
 
   import EntityPassivationStrategy.PassivateEntities
@@ -576,7 +591,7 @@ private[akka] final class LeastFrequentlyUsedReplacementPolicy(
   private var limit = initialLimit
 
   private val frequencyList =
-    if (idleEnabled) FrequencyList.withOverallRecency.empty[EntityId](dynamicAging)
+    if (idleEnabled) FrequencyList.withOverallRecency.empty[EntityId](clock(), dynamicAging)
     else FrequencyList.empty[EntityId](dynamicAging)
 
   override def size: Int = frequencyList.size

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/CompositeSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/CompositeSpec.scala
@@ -380,7 +380,7 @@ class CompositeWithIdleSpec extends AbstractEntityPassivationSpec(CompositeSpec.
     "passivate entities when they haven't seen messages for the configured timeout" in {
       val region = start()
 
-      val lastSendNanoTime1 = System.nanoTime()
+      val lastSendNanoTime1 = clock.currentTime()
       region ! Envelope(shard = 1, id = 1, message = "A")
       region ! Envelope(shard = 1, id = 2, message = "B")
 
@@ -391,7 +391,7 @@ class CompositeWithIdleSpec extends AbstractEntityPassivationSpec(CompositeSpec.
       Thread.sleep((configuredIdleTimeout / 2).toMillis)
       region ! Envelope(shard = 1, id = 3, message = "E")
       Thread.sleep((configuredIdleTimeout / 2).toMillis)
-      val lastSendNanoTime2 = System.nanoTime()
+      val lastSendNanoTime2 = clock.currentTime()
       region ! Envelope(shard = 1, id = 3, message = "F")
 
       expectReceived(id = 1, message = "A")

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/IdleSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/IdleSpec.scala
@@ -6,7 +6,6 @@ package akka.cluster.sharding.passivation
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-
 import scala.concurrent.duration._
 
 object IdleSpec {
@@ -28,7 +27,7 @@ class IdleSpec extends AbstractEntityPassivationSpec(IdleSpec.config, expectedEn
     "passivate entities when they haven't seen messages for the configured duration" in {
       val region = start()
 
-      val lastSendNanoTime1 = System.nanoTime()
+      val lastSendNanoTime1 = clock.currentTime()
       region ! Envelope(shard = 1, id = 1, message = "A")
       region ! Envelope(shard = 2, id = 2, message = "B")
       Thread.sleep((configuredIdleTimeout / 2).toMillis)
@@ -36,7 +35,7 @@ class IdleSpec extends AbstractEntityPassivationSpec(IdleSpec.config, expectedEn
       Thread.sleep((configuredIdleTimeout / 2).toMillis)
       region ! Envelope(shard = 2, id = 2, message = "D")
       Thread.sleep((configuredIdleTimeout / 2).toMillis)
-      val lastSendNanoTime2 = System.nanoTime()
+      val lastSendNanoTime2 = clock.currentTime()
       region ! Envelope(shard = 2, id = 2, message = "E")
 
       expectReceived(id = 1, message = "A")

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/LeastFrequentlyUsedSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/LeastFrequentlyUsedSpec.scala
@@ -293,7 +293,7 @@ class LeastFrequentlyUsedWithIdleSpec
     "passivate entities when they haven't seen messages for the configured timeout" in {
       val region = start()
 
-      val lastSendNanoTime1 = System.nanoTime()
+      val lastSendNanoTime1 = clock.currentTime()
       region ! Envelope(shard = 1, id = 1, message = "A")
       region ! Envelope(shard = 1, id = 2, message = "B")
 
@@ -304,7 +304,7 @@ class LeastFrequentlyUsedWithIdleSpec
       Thread.sleep((configuredIdleTimeout / 2).toMillis)
       region ! Envelope(shard = 1, id = 3, message = "E")
       Thread.sleep((configuredIdleTimeout / 2).toMillis)
-      val lastSendNanoTime2 = System.nanoTime()
+      val lastSendNanoTime2 = clock.currentTime()
       region ! Envelope(shard = 1, id = 3, message = "F")
 
       expectReceived(id = 1, message = "A")

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/LeastRecentlyUsedSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/LeastRecentlyUsedSpec.scala
@@ -253,7 +253,7 @@ class LeastRecentlyUsedWithIdleSpec
     "passivate entities when they haven't seen messages for the configured timeout" in {
       val region = start()
 
-      val lastSendNanoTime1 = System.nanoTime()
+      val lastSendNanoTime1 = clock.currentTime()
       region ! Envelope(shard = 1, id = 1, message = "A")
       region ! Envelope(shard = 1, id = 2, message = "B")
 
@@ -264,7 +264,7 @@ class LeastRecentlyUsedWithIdleSpec
       Thread.sleep((configuredIdleTimeout / 2).toMillis)
       region ! Envelope(shard = 1, id = 3, message = "E")
       Thread.sleep((configuredIdleTimeout / 2).toMillis)
-      val lastSendNanoTime2 = System.nanoTime()
+      val lastSendNanoTime2 = clock.currentTime()
       region ! Envelope(shard = 1, id = 3, message = "F")
 
       expectReceived(id = 1, message = "A")

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/MostRecentlyUsedSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/passivation/MostRecentlyUsedSpec.scala
@@ -156,7 +156,7 @@ class MostRecentlyUsedWithIdleSpec
     "passivate entities when they haven't seen messages for the configured timeout" in {
       val region = start()
 
-      val lastSendNanoTime1 = System.nanoTime()
+      val lastSendNanoTime1 = clock.currentTime()
       region ! Envelope(shard = 1, id = 1, message = "A")
       region ! Envelope(shard = 1, id = 2, message = "B")
 
@@ -167,7 +167,7 @@ class MostRecentlyUsedWithIdleSpec
       Thread.sleep((configuredIdleTimeout / 2).toMillis)
       region ! Envelope(shard = 1, id = 3, message = "E")
       Thread.sleep((configuredIdleTimeout / 2).toMillis)
-      val lastSendNanoTime2 = System.nanoTime()
+      val lastSendNanoTime2 = clock.currentTime()
       region ! Envelope(shard = 1, id = 3, message = "F")
 
       expectReceived(id = 1, message = "A")


### PR DESCRIPTION
* The recency based passivation strategies (new default) is calling System.nanoTime for each message.
* Add a ScheduledClock that updates the time once per second, but still increments time for subsequent calls
