### PR TITLE
fix: Sharding entity-recovery-constant-rate-strategy rate per entity type

### DIFF
--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -341,9 +341,10 @@ akka.cluster.sharding {
   # entity actors at a fix rate. The default strategy "all".
   entity-recovery-strategy = "all"
 
-  # Default settings for the constant rate entity recovery strategy
+  # Default settings for the constant rate entity recovery strategy.
   entity-recovery-constant-rate-strategy {
     # Sets the frequency at which a batch of entity actors is started.
+    # The frequency is per sharding region (entity type).
     frequency = 100 ms
     # Sets the number of entity actors to be restart at a particular interval
     number-of-entities = 5


### PR DESCRIPTION
* The throttling by the RememberEntityStarter was per Shard, which wasn't very useful or expected since there are typically many shards started at the same time.
* This changes it to be per entity type (region).
* That is also the case for rebalance.
