### PR TITLE
feat: Throttle keep alive messages of ShardedDaemonProcess

### DIFF
--- a/akka-cluster-sharding-typed/src/main/mima-filters/2.6.20.backwards.excludes/keep-alive-throttling.excludes
+++ b/akka-cluster-sharding-typed/src/main/mima-filters/2.6.20.backwards.excludes/keep-alive-throttling.excludes
@@ -1,0 +1,3 @@
+# internal api changes
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.typed.ShardedDaemonProcessSettings.this")
+ProblemFilters.exclude[MissingClassProblem]("akka.cluster.sharding.typed.internal.ShardedDaemonProcessImpl$KeepAlivePinger$StartTick$")

--- a/akka-cluster-sharding-typed/src/main/mima-filters/2.7.0.backwards.excludes/keep-alive-throttling.excludes
+++ b/akka-cluster-sharding-typed/src/main/mima-filters/2.7.0.backwards.excludes/keep-alive-throttling.excludes
@@ -1,0 +1,3 @@
+# internal api changes
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.cluster.sharding.typed.ShardedDaemonProcessSettings.this")
+ProblemFilters.exclude[MissingClassProblem]("akka.cluster.sharding.typed.internal.ShardedDaemonProcessImpl$KeepAlivePinger$StartTick$")

--- a/akka-cluster-sharding-typed/src/main/resources/reference.conf
+++ b/akka-cluster-sharding-typed/src/main/resources/reference.conf
@@ -21,11 +21,19 @@ akka.cluster.sharded-daemon-process {
   # overriding those settings will be ignored.
   sharding = ${akka.cluster.sharding}
 
-  # Each entity is pinged at this interval from each node in the
+  # Each entity is pinged at this interval from a few nodes in the
   # cluster to trigger a start if it has stopped, for example during
   # rebalancing.
+  # See also keep-alive-from-number-of-nodes and keep-alive-throttle-interval
   # Note: How the set of actors is kept alive may change in the future meaning this setting may go away.
   keep-alive-interval = 10s
+
+  # Keep alive messages from this number of nodes.
+  keep-alive-from-number-of-nodes = 3
+
+  # Keep alive messages are sent with this delay between each message.
+  keep-alive-throttle-interval = 100 ms
+
 }
 
 akka.cluster.configuration-compatibility-check.checkers {

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ShardedDaemonProcessSettings.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/ShardedDaemonProcessSettings.scala
@@ -30,19 +30,28 @@ object ShardedDaemonProcessSettings {
    */
   def fromConfig(config: Config): ShardedDaemonProcessSettings = {
     val keepAliveInterval = config.getDuration("keep-alive-interval").asScala
+    val keepAliveFromNumberOfNodes = config.getInt("keep-alive-from-number-of-nodes")
+    val keepAliveThrottleInterval = config.getDuration("keep-alive-throttle-interval").asScala
 
-    new ShardedDaemonProcessSettings(keepAliveInterval, None, None)
+    new ShardedDaemonProcessSettings(
+      keepAliveInterval,
+      None,
+      None,
+      keepAliveFromNumberOfNodes,
+      keepAliveThrottleInterval)
   }
 
 }
 
 /**
- * Not for user constructions, use factory methods to instanciate.
+ * Not for user constructions, use factory methods to instantiate.
  */
 final class ShardedDaemonProcessSettings @InternalApi private[akka] (
     val keepAliveInterval: FiniteDuration,
     val shardingSettings: Option[ClusterShardingSettings],
-    val role: Option[String]) {
+    val role: Option[String],
+    val keepAliveFromNumberOfNodes: Int,
+    val keepAliveThrottleInterval: FiniteDuration) {
 
   /**
    * Scala API: The interval each parent of the sharded set is pinged from each node in the cluster.
@@ -76,10 +85,35 @@ final class ShardedDaemonProcessSettings @InternalApi private[akka] (
   def withRole(role: String): ShardedDaemonProcessSettings =
     copy(role = Option(role))
 
+  /**
+   * Keep alive messages from this number of nodes.
+   */
+  def withKeepAliveFromNumberOfNodes(keepAliveFromNumberOfNodes: Int): ShardedDaemonProcessSettings =
+    copy(keepAliveFromNumberOfNodes = keepAliveFromNumberOfNodes)
+
+  /**
+   * Scala API: Keep alive messages are sent with this delay between each message.
+   */
+  def withKeepAliveThrottleInterval(keepAliveThrottleInterval: FiniteDuration): ShardedDaemonProcessSettings =
+    copy(keepAliveThrottleInterval = keepAliveThrottleInterval)
+
+  /**
+   * Java API: Keep alive messages are sent with this delay between each message.
+   */
+  def withKeepAliveThrottleInterval(keepAliveThrottleInterval: Duration): ShardedDaemonProcessSettings =
+    copy(keepAliveThrottleInterval = keepAliveThrottleInterval.asScala)
+
   private def copy(
       keepAliveInterval: FiniteDuration = keepAliveInterval,
       shardingSettings: Option[ClusterShardingSettings] = shardingSettings,
-      role: Option[String] = role): ShardedDaemonProcessSettings =
-    new ShardedDaemonProcessSettings(keepAliveInterval, shardingSettings, role)
+      role: Option[String] = role,
+      keepAliveFromNumberOfNodes: Int = keepAliveFromNumberOfNodes,
+      keepAliveThrottleInterval: FiniteDuration = keepAliveThrottleInterval): ShardedDaemonProcessSettings =
+    new ShardedDaemonProcessSettings(
+      keepAliveInterval,
+      shardingSettings,
+      role,
+      keepAliveFromNumberOfNodes,
+      keepAliveThrottleInterval)
 
 }

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
@@ -22,7 +22,7 @@ import akka.annotation.InternalApi
 import akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
 import akka.cluster.sharding.ShardRegion.EntityId
 import akka.cluster.sharding.typed.ClusterShardingSettings
-import akka.cluster.sharding.typed.ClusterShardingSettings.{RememberEntitiesStoreModeDData, StateStoreModeDData}
+import akka.cluster.sharding.typed.ClusterShardingSettings.{ RememberEntitiesStoreModeDData, StateStoreModeDData }
 import akka.cluster.sharding.typed.ShardedDaemonProcessSettings
 import akka.cluster.sharding.typed.ShardingEnvelope
 import akka.cluster.sharding.typed.ShardingMessageExtractor

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
@@ -23,7 +23,7 @@ import akka.cluster.MemberStatus
 import akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
 import akka.cluster.sharding.ShardRegion.EntityId
 import akka.cluster.sharding.typed.ClusterShardingSettings
-import akka.cluster.sharding.typed.ClusterShardingSettings.{RememberEntitiesStoreModeDData, StateStoreModeDData}
+import akka.cluster.sharding.typed.ClusterShardingSettings.{ RememberEntitiesStoreModeDData, StateStoreModeDData }
 import akka.cluster.sharding.typed.ShardedDaemonProcessSettings
 import akka.cluster.sharding.typed.ShardingEnvelope
 import akka.cluster.sharding.typed.ShardingMessageExtractor

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ShardedDaemonProcessImpl.scala
@@ -8,17 +8,22 @@ import java.util.function.IntFunction
 import java.util.Optional
 
 import scala.compat.java8.OptionConverters._
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
+
+import akka.Done
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.LoggerOps
 import akka.annotation.InternalApi
+import akka.cluster.Member
 import akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
 import akka.cluster.sharding.ShardRegion.EntityId
 import akka.cluster.sharding.typed.ClusterShardingSettings
-import akka.cluster.sharding.typed.ClusterShardingSettings.{ RememberEntitiesStoreModeDData, StateStoreModeDData }
+import akka.cluster.sharding.typed.ClusterShardingSettings.{RememberEntitiesStoreModeDData, StateStoreModeDData}
 import akka.cluster.sharding.typed.ShardedDaemonProcessSettings
 import akka.cluster.sharding.typed.ShardingEnvelope
 import akka.cluster.sharding.typed.ShardingMessageExtractor
@@ -31,7 +36,7 @@ import akka.cluster.sharding.typed.scaladsl.StartEntity
 import akka.cluster.typed.Cluster
 import akka.cluster.typed.SelfUp
 import akka.cluster.typed.Subscribe
-import akka.util.PrettyDuration
+import akka.stream.scaladsl.Source
 
 /**
  * INTERNAL API
@@ -42,37 +47,64 @@ private[akka] object ShardedDaemonProcessImpl {
   object KeepAlivePinger {
     sealed trait Event
     private case object Tick extends Event
-    private case object StartTick extends Event
+    private case object StartAllDone extends Event
 
     def apply[T](
         settings: ShardedDaemonProcessSettings,
         name: String,
         identities: Set[EntityId],
-        shardingRef: ActorRef[ShardingEnvelope[T]]): Behavior[Event] =
-      Behaviors.setup { context =>
-        Cluster(context.system).subscriptions ! Subscribe(
-          context.messageAdapter[SelfUp](_ => StartTick),
-          classOf[SelfUp])
-        Behaviors.withTimers { timers =>
-          def triggerStartAll(): Unit = {
-            identities.foreach(id => shardingRef ! StartEntity(id))
+        shardingRef: ActorRef[ShardingEnvelope[T]]): Behavior[Event] = {
+      val sortedIdentities = identities.toVector.sorted
+
+      def sendKeepAliveMessages()(implicit sys: ActorSystem[_]): Future[Done] = {
+        if (settings.keepAliveThrottleInterval == Duration.Zero) {
+          sortedIdentities.foreach(id => shardingRef ! StartEntity(id))
+          Future.successful(Done)
+        } else {
+          Source(sortedIdentities).throttle(1, settings.keepAliveThrottleInterval).runForeach { id =>
+            shardingRef ! StartEntity(id)
           }
+        }
+      }
+
+      Behaviors.setup[Event] { context =>
+        implicit val system: ActorSystem[_] = context.system
+        val cluster = Cluster(system)
+
+        cluster.subscriptions ! Subscribe(context.messageAdapter[SelfUp](_ => Tick), classOf[SelfUp])
+
+        def isActive(): Boolean = {
+          implicit val ageOrdering: Ordering[Member] = Member.ageOrdering
+          val sortedMembers = settings.role match {
+            case None       => cluster.state.members.toVector.sorted
+            case Some(role) => cluster.state.members.toVector.filter(_.roles.contains(role)).sorted
+          }
+          sortedMembers.take(settings.keepAliveFromNumberOfNodes).contains(cluster.selfMember)
+        }
+
+        Behaviors.withTimers { timers =>
           Behaviors.receiveMessage {
-            case StartTick =>
-              triggerStartAll()
-              context.log.debug2(
-                s"Starting Sharded Daemon Process KeepAlivePinger for [{}], with ping interval [{}]",
-                name,
-                PrettyDuration.format(settings.keepAliveInterval))
-              timers.startTimerWithFixedDelay(Tick, settings.keepAliveInterval)
-              Behaviors.same
             case Tick =>
-              triggerStartAll()
-              context.log.debug("Periodic ping sent to [{}] processes", identities.size)
+              if (isActive()) {
+                context.log.debug2(
+                  s"Sending periodic keep alive for Sharded Daemon Process [{}] to [{}] processes.",
+                  name,
+                  sortedIdentities.size)
+                context.pipeToSelf(sendKeepAliveMessages()) { _ =>
+                  StartAllDone
+                }
+              } else {
+                timers.startSingleTimer(Tick, settings.keepAliveInterval)
+              }
+              Behaviors.same
+            case StartAllDone =>
+              timers.startSingleTimer(Tick, settings.keepAliveInterval)
               Behaviors.same
           }
         }
       }
+    }
+
   }
 
   final class MessageExtractor[T] extends ShardingMessageExtractor[ShardingEnvelope[T], T] {


### PR DESCRIPTION
* For example to not wake up all projection instances at the same time.
* Also reduce number of pingers in a cluster.
