### PR TITLE
fix: ClusterShardingHealthCheck should not stall Kubernetes rolling update, #31271

### DIFF
--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -443,6 +443,17 @@ akka.cluster.sharding {
     # Timeout for the local shard region to respond. This should be lower than your monitoring system's
     # timeout for health checks
     timeout = 5s
+
+    # The health check is only performed during this duration after
+    # the member is up. After that the sharding check will not be performed (always returns success).
+    # The purpose is to wait for Cluster Sharding registration to complete on initial startup.
+    # After that, in case of Sharding Coordinator movement or reachability we still want to be ready
+    # because requests can typically be served without involving the coordinator.
+    # Another reason is that when a new entity type is added in a rolling update we don't want to fail
+    # the ready check forever, which would stall the rolling update. Sharding Coordinator is expected
+    # run on the oldest member, but in this scenario that is in the old deployment hasn't started the
+    # coordinator for that entity type.
+    disabled-after = 10s
   }
 }
 # //#sharding-ext-config

--- a/akka-docs/src/main/paradox/typed/cluster-sharding.md
+++ b/akka-docs/src/main/paradox/typed/cluster-sharding.md
@@ -731,6 +731,8 @@ Monitoring of each shard region is off by default. Add them by defining the enti
 akka.cluster.sharding.healthcheck.names = ["counter-1", "HelloWorld"]
 ```
 
+The health check is disabled (always returns success true) after a duration of failing checks after the Cluster member is up. Otherwise, it would stall a Kubernetes rolling update when adding a new entity type in the new version.
+
 See also additional information about how to make @ref:[smooth rolling updates](../additional/rolling-updates.md#cluster-sharding).
 
 ## Inspecting cluster sharding state


### PR DESCRIPTION
* The health check is disabled (always returns success true) after a duration of failing checks after the Cluster member is up. Otherwise, it would stall a Kubernetes rolling update when adding a new entity type in the new version.

References #31271
