### PR TITLE
doc: Fix erlang.org link

### DIFF
--- a/akka-docs/src/main/paradox/general/message-delivery-reliability.md
+++ b/akka-docs/src/main/paradox/general/message-delivery-reliability.md
@@ -96,13 +96,13 @@ Akka embraces distributed computing and makes the fallibility of communication
 explicit through message passing, therefore it does not try to lie and emulate
 a leaky abstraction. This is a model that has been used with great success in
 Erlang and requires the users to design their applications around it. You can
-read more about this approach in the [Erlang documentation](https://erlang.org/faq/academic.html) (section 10.8 and
+read more about this approach in the [Erlang documentation](https://www.erlang.org/faq/academic.html) (section 10.8 and
 10.9), Akka follows it closely.
 
 Another angle on this issue is that by providing only basic guarantees those
 use cases which do not need stronger reliability do not pay the cost of their
 implementation; it is always possible to add stronger reliability on top of
-basic ones, but it is not possible to retro-actively remove reliability in order
+basic ones, but it is not possible to retroactively remove reliability in order
 to gain more performance.
 
 <a id="message-ordering"></a>


### PR DESCRIPTION
This was actually the only link really invalid.