### PR TITLE
chore: link to current instead of 2.6

### DIFF
--- a/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
+++ b/akka-cluster/src/main/scala/akka/cluster/Cluster.scala
@@ -140,7 +140,7 @@ class Cluster(val system: ExtendedActorSystem) extends Extension {
           "auto-down-unreachable-after") != "off"))
       logWarning(
         "auto-down has been removed in Akka 2.6.0. See " +
-        "https://doc.akka.io/docs/akka/2.6/typed/cluster.html#downing for alternatives.")
+        "https://doc.akka.io/docs/akka/current/typed/cluster.html#downing for alternatives.")
   }
 
   // ========================================================


### PR DESCRIPTION
There are other 2.6 links to migration guides, both those can remain.