### PR TITLE
chore: mapAsyncPartitioned follow up

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncPartitioned.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncPartitioned.md
@@ -18,7 +18,7 @@ Up to `parallelism` futures can be processed concurrently; additionally no more 
 Regardless of completion order, results will be emitted in order of the incoming elements which gave rise to the @scala[future] @java[`CompletionStage`].
 
 If a @scala[`Future`] @java[`CompletionStage`] completes with `null`, that result is not emitted.
-If a @scala[`Future`] @java[`CompletionStage`] completes with failure, the stream's supervision strategy may fail the stream or drop the element.
+If a @scala[`Future`] @java[`CompletionStage`] completes with failure, the stream's is failed.
 
 If `parallelism` is 1, this stage is equivalent to @ref[`mapAsyncUnordered`](mapAsyncUnordered.md).  If `perPartition` is greater-than or equal to `parallelism`, this stage is equivalent to @ref[`mapAsync`](mapAsync.md).
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncPartitioned.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncPartitioned.md
@@ -11,7 +11,7 @@ Pass incoming elements to a function that extracts a partitioning key from the e
 
 ## Description
 
-Pass incoming elements to a function that assigns a partitioning key, then to function that returns a @scala[`Future`] @java[`CompletionStage`] result. When the @scala[Future] @java[`CompletionStage`] completes successfully, the result is passed downstream.
+Pass incoming elements to a function that assigns a partitioning key, then to function that returns a @scala[`Future`] @java[`CompletionStage`] result. When the @scala[Future] @java[CompletionStage] completes successfully, the result is passed downstream.
 
 Up to `parallelism` futures can be processed concurrently; additionally no more than `perPartition` @scala[Futures] @java[CompletionStages] with the same partitioning key will be incomplete at any time. When `perPartition` is limiting elements, the operator will still pull in and buffer up to a total `parallelism` of elements before it applies backpressure upstream.
 
@@ -122,6 +122,6 @@ Notes:
 
 **backpressures** when downstream backgpressures and completed and incomplete @scala[`Future`] @java[`CompletionStage`] has reached the configured `parallelism`
 
-**completes** when upstream completes and all @scala[Futures] @java[CompletionStage] have completed and all results have been emitted
+**completes** when upstream completes and all @scala[Futures] @java[CompletionStages] have completed and all results have been emitted
 
 @@@

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncPartitioned.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncPartitioned.md
@@ -1,6 +1,6 @@
 # mapAsyncPartitioned
 
-Pass incoming elements to a function that extracts a partitioning key from the element, then to a function that returns a @scala[`Future`] @java[`CompletionStage`] result, bounding the number of incomplete @scala[futures] @java[`CompletionStage` s] per partitioning key.
+Pass incoming elements to a function that extracts a partitioning key from the element, then to a function that returns a @scala[`Future`] @java[`CompletionStage`] result, bounding the number of incomplete @scala[Futures] @java[CompletionStages] per partitioning key.
 
 @ref[Asynchronous operators](../index.md#asynchronous-operators)
 
@@ -11,24 +11,21 @@ Pass incoming elements to a function that extracts a partitioning key from the e
 
 ## Description
 
-Pass incoming elements to a function that assigns a partitioning key, then to function that returns a @scala[`Future`] @java[`CompletionStage`] result.  When the @scala[future] @java[`CompletionStage`] completes successfully, the result is passed downstream.
+Pass incoming elements to a function that assigns a partitioning key, then to function that returns a @scala[`Future`] @java[`CompletionStage`] result. When the @scala[Future] @java[`CompletionStage`] completes successfully, the result is passed downstream.
 
-Up to `parallelism` futures can be processed concurrently; additionally no more than `perPartition` @scala[futures] @java[`CompletionStage` s] with the same partitioning key will be incomplete at any time.
+Up to `parallelism` futures can be processed concurrently; additionally no more than `perPartition` @scala[Futures] @java[CompletionStages] with the same partitioning key will be incomplete at any time. When `perPartition` is limiting elements, the operator will still pull in and buffer up to a total `parallelism` of elements before it applies backpressure upstream.
 
 Regardless of completion order, results will be emitted in order of the incoming elements which gave rise to the @scala[future] @java[`CompletionStage`].
 
-If a @scala[`Future`] @java[`CompletionStage`] completes with `null`, that result is not emitted.
+If a @scala[`Future`] @java[`CompletionStage`] completes with `null`, that result is dropped and not emitted.
 If a @scala[`Future`] @java[`CompletionStage`] completes with failure, the stream's is failed.
 
-If `parallelism` is 1, this stage is equivalent to @ref[`mapAsyncUnordered`](mapAsyncUnordered.md).  If `perPartition` is greater-than or equal to `parallelism`, this stage is equivalent to @ref[`mapAsync`](mapAsync.md).
-
-@@@ warning
-Care may need to be taken using this operator between a fan-out and a fan-in (including within a @apidoc[SubFlow](SubFlow)) to ensure that the fan-in preserves ordering.
-@@@
+If `parallelism` is 1 this stage is equivalent to @ref[`mapAsyncUnordered`](mapAsyncUnordered.md) which should be preferred for such uses. 
+It is not possible to specify a `perPartition` greater or equal to `parallelism`, for such scenarios with no limit per partition, instead use @ref[`mapAsync`](mapAsync.md).
 
 ## Examples
 
-Imagine you are consuming messages from a broker (for instance, Apache Kafka via [Alpakka Kafka](https://doc.akka.io/docs/alpakka-kafka/current/)).  This broker's semantics are such that acknowledging one message implies an acknowledgement of all messages delivered before that message; this in turn means that in order to ensure at-least-once processing of messages from the broker, they must be acknowledged in the order they were received.  These messages represent business events produced by some other service(s) and each concerns a particular entity.  You may process messages for different entities simultaneously, but can only process one message for a given entity at a time:
+Imagine you are consuming messages from a broker (for instance, Apache Kafka via [Alpakka Kafka](https://doc.akka.io/docs/alpakka-kafka/current/)). This broker's semantics are such that acknowledging one message implies an acknowledgement of all messages delivered before that message; this in turn means that in order to ensure at-least-once processing of messages from the broker, they must be acknowledged in the order they were received. These messages represent business events produced by some other service(s) and each concerns a particular entity. You may process messages for different entities simultaneously, but can only process one message for a given entity at a time:
 
 Scala
 :   @@snip [MapAsyncs.scala](/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapAsyncs.scala) { #mapAsyncPartitioned }
@@ -121,10 +118,10 @@ Notes:
 
 @@@div { .callout }
 
-**emits** when the @scala[`Future`] @java[`CompletionStage`] returned by the provided function completes successfully and all @scala[futures] @java[`CompletionStage` s] from elements preceding this one have completed and been emitted (if successful)
+**emits** when the next in order @scala[`Future`] @java[`CompletionStage`] returned by the provided function completes successfully
 
-**backpressures** when the number of elements for which no @scala[`Future`] @java[`CompletionStage`] has completed reaches the configured parallelism and the downstream backpressures
+**backpressures** when downstream backgpressures and completed and incomplete @scala[`Future`] @java[`CompletionStage`] has reached the configured `parallelism`
 
-**completes** when upstream completes and all @scala[`Future` s] @java[`CompletionStage` s] have completed and all results have been emitted
+**completes** when upstream completes and all @scala[Futures] @java[CompletionStage] have completed and all results have been emitted
 
 @@@

--- a/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapAsyncs.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapAsyncs.scala
@@ -185,7 +185,7 @@ object MapAsyncPartitioned extends App {
         println(s"Received event $event at offset $count from message broker")
         event
     }
-    .mapAsyncPartitioned(10, 1)(partitioner) { (event, partition) =>
+    .mapAsyncPartitioned(parallelism = 10, perPartition = 1)(partitioner) { (event, partition) =>
       println(s"Processing event $event from partition $partition")
 
       // processing result is "partition-sequenceNr"

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/BoundedBufferSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/BoundedBufferSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.impl
+
+import akka.stream.testkit.StreamSpec
+
+import scala.annotation.nowarn
+
+@nowarn("msg=deprecated")
+class BoundedBufferSpec extends StreamSpec {
+
+  for (size <- List(1, 3, 4)) {
+
+    s"BoundedBuffer of size $size" must {
+
+      "start as empty" in {
+        val buf = new BoundedBuffer(size)
+        buf.isEmpty should be(true)
+        buf.isFull should be(false)
+      }
+
+      "become nonempty after enqueueing" in {
+        val buf = new BoundedBuffer[String](size)
+        buf.enqueue("test")
+        buf.isEmpty should be(false)
+        buf.isFull should be(size == 1)
+      }
+
+      "become full after size elements are enqueued" in {
+        val buf = new BoundedBuffer[String](size)
+        for (_ <- 1 to size) buf.enqueue("test")
+        buf.isEmpty should be(false)
+        buf.isFull should be(true)
+      }
+
+      "become empty after enqueueing and tail drop" in {
+        val buf = new BoundedBuffer[String](size)
+        buf.enqueue("test")
+        buf.dropTail()
+        buf.isEmpty should be(true)
+        buf.isFull should be(false)
+      }
+
+      "become empty after enqueueing and head drop" in {
+        val buf = new BoundedBuffer[String](size)
+        buf.enqueue("test")
+        buf.dropHead()
+        buf.isEmpty should be(true)
+        buf.isFull should be(false)
+      }
+
+      "drop head properly" in {
+        val buf = new BoundedBuffer[Int](size)
+        for (elem <- 1 to size) buf.enqueue(elem)
+        buf.dropHead()
+        for (elem <- 2 to size) buf.dequeue() should be(elem)
+      }
+
+      "drop tail properly" in {
+        val buf = new BoundedBuffer[Int](size)
+        for (elem <- 1 to size) buf.enqueue(elem)
+        buf.dropTail()
+        for (elem <- 1 to size - 1) buf.dequeue() should be(elem)
+      }
+
+      "become non-full after tail dropped from full buffer" in {
+        val buf = new BoundedBuffer[String](size)
+        for (_ <- 1 to size) buf.enqueue("test")
+        buf.dropTail()
+        buf.isEmpty should be(size == 1)
+        buf.isFull should be(false)
+      }
+
+      "become non-full after head dropped from full buffer" in {
+        val buf = new BoundedBuffer[String](size)
+        for (_ <- 1 to size) buf.enqueue("test")
+        buf.dropHead()
+        buf.isEmpty should be(size == 1)
+        buf.isFull should be(false)
+      }
+
+      "peek shows head of queue" in {
+        val buf = new BoundedBuffer[Int](size)
+        for (n <- 1 to size) {
+          buf.enqueue(n)
+          buf.peek() should ===(1)
+        }
+      }
+
+      "work properly with full-range filling/draining cycles" in {
+        val buf = new BoundedBuffer[Int](size)
+
+        for (_ <- 1 to 10) {
+          buf.isEmpty should be(true)
+          buf.isFull should be(false)
+          for (elem <- 1 to size) buf.enqueue(elem)
+          buf.isEmpty should be(false)
+          buf.isFull should be(true)
+          for (elem <- 1 to size) buf.dequeue() should be(elem)
+        }
+      }
+
+      "work when indexes wrap around at Int.MaxValue" in {
+        import language.reflectiveCalls
+        val buf = new BoundedBuffer[Int](size)
+
+        try {
+          val cheat = buf.asInstanceOf[{ def readIdx_=(l: Long): Unit; def writeIdx_=(l: Long): Unit }]
+          cheat.readIdx_=(Int.MaxValue)
+          cheat.writeIdx_=(Int.MaxValue)
+
+          for (_ <- 1 to 10) {
+            buf.isEmpty should be(true)
+            buf.isFull should be(false)
+            for (elem <- 1 to size) buf.enqueue(elem)
+            buf.isEmpty should be(false)
+            buf.isFull should be(true)
+            for (elem <- 1 to size) buf.dequeue() should be(elem)
+          }
+        } catch {
+          case _: NoSuchMethodException =>
+          // our 'cheat' doesn't work on Scala 3
+        }
+      }
+
+    }
+  }
+
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/ChainedBufferSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/ChainedBufferSpec.scala
@@ -5,149 +5,156 @@
 package akka.stream.impl
 
 import akka.stream.testkit.StreamSpec
-import scala.annotation.tailrec
 import org.scalatest.compatible.Assertion
+
+import scala.annotation.tailrec
 
 class ChainedBufferSpec extends StreamSpec {
   val doNothing: Any => Unit = _ => ()
 
-  val random = scala.util.Random.nextInt(16)
-  val headCapacity = random / 4 + 1
-  val tailCapacity = random % 4 + 1
+  Seq(1, 2, 8).foreach { headCapacity =>
+    Seq(1, 2, 8).foreach { tailCapacity =>
+      def buffers[T](callback: T => Unit = doNothing): (Buffer[T], Buffer[T], ChainedBuffer[T]) = {
+        val headBuffer = FixedSizeBuffer[T](headCapacity)
+        val tailBuffer = FixedSizeBuffer[T](tailCapacity)
 
-  def buffers[T](callback: T => Unit = doNothing): (Buffer[T], Buffer[T], ChainedBuffer[T]) = {
-    val headBuffer = FixedSizeBuffer[T](headCapacity)
-    val tailBuffer = FixedSizeBuffer[T](tailCapacity)
-
-    (headBuffer, tailBuffer, new ChainedBuffer(headBuffer, tailBuffer, callback))
-  }
-
-  s"ChainedBuffer of head-capacity $headCapacity and tail-capacity $tailCapacity" must {
-    s"have capacity of $headCapacity + $tailCapacity" in {
-      val (_, _, chainedBuffer) = buffers[Int]()
-
-      chainedBuffer.capacity shouldBe (headCapacity + tailCapacity)
-    }
-
-    "report empty until first enqueue" in {
-      val (_, _, chainedBuffer) = buffers[Int]()
-
-      chainedBuffer.isEmpty shouldBe true
-
-      chainedBuffer.enqueue(1)
-
-      chainedBuffer.isEmpty shouldBe false
-    }
-
-    "not report full until capacity elements have been enqueued" in {
-      val (_, _, chainedBuffer) = buffers[Int]()
-
-      (0 until chainedBuffer.capacity).foreach { n =>
-        assert(!chainedBuffer.isFull, s"buffer was full after $n enqueues")
-        chainedBuffer.enqueue(n)
+        (headBuffer, tailBuffer, new ChainedBuffer(headBuffer, tailBuffer, callback))
       }
 
-      chainedBuffer.isFull shouldBe true
-    }
+      s"ChainedBuffer of head-capacity $headCapacity and tail-capacity $tailCapacity" must {
+        s"have capacity of $headCapacity + $tailCapacity" in {
+          val (_, _, chainedBuffer) = buffers[Int]()
 
-    "not report empty unless as many drops as enqueues have been performed" in {
-      val (_, _, chainedBuffer) = buffers[Int]()
-      var enqueues = 0
-      var drops = 0
-
-      @tailrec
-      def iter: Assertion = {
-        assert(enqueues >= drops, "BAD TEST: should not drop more than enqueue!")
-
-        if (enqueues == drops) {
-          assert(chainedBuffer.isEmpty, s"buffer was not empty after $enqueues enqueues and $drops drops")
-        } else {
-          assert(!chainedBuffer.isEmpty, s"buffer was empty after $enqueues enqueues and $drops drops")
+          chainedBuffer.capacity shouldBe (headCapacity + tailCapacity)
         }
 
-        if (enqueues > 16 && drops > 16) succeed
-        else {
-          if (chainedBuffer.isEmpty || (!chainedBuffer.isFull && scala.util.Random.nextBoolean())) {
-            chainedBuffer.enqueue(enqueues)
-            enqueues += 1
-          } else {
-            if (scala.util.Random.nextBoolean()) chainedBuffer.dropHead()
-            else chainedBuffer.dropTail()
+        "report empty until first enqueue" in {
+          val (_, _, chainedBuffer) = buffers[Int]()
 
-            drops += 1
+          chainedBuffer.isEmpty shouldBe true
+
+          chainedBuffer.enqueue(1)
+
+          chainedBuffer.isEmpty shouldBe false
+        }
+
+        "not report full until capacity elements have been enqueued" in {
+          val (_, _, chainedBuffer) = buffers[Int]()
+
+          (0 until chainedBuffer.capacity).foreach { n =>
+            assert(!chainedBuffer.isFull, s"buffer was full after $n enqueues")
+            chainedBuffer.enqueue(n)
+          }
+
+          chainedBuffer.isFull shouldBe true
+        }
+
+        "not report empty unless as many drops as enqueues have been performed" in {
+          val (_, _, chainedBuffer) = buffers[Int]()
+          var enqueues = 0
+          var drops = 0
+
+          @tailrec
+          def iter: Assertion = {
+            assert(enqueues >= drops, "BAD TEST: should not drop more than enqueue!")
+
+            if (enqueues == drops) {
+              assert(chainedBuffer.isEmpty, s"buffer was not empty after $enqueues enqueues and $drops drops")
+            } else {
+              assert(!chainedBuffer.isEmpty, s"buffer was empty after $enqueues enqueues and $drops drops")
+            }
+
+            if (enqueues > 16 && drops > 16) succeed
+            else {
+              if (chainedBuffer.isEmpty || (!chainedBuffer.isFull && scala.util.Random.nextBoolean())) {
+                chainedBuffer.enqueue(enqueues)
+                enqueues += 1
+              } else {
+                if (scala.util.Random.nextBoolean()) chainedBuffer.dropHead()
+                else chainedBuffer.dropTail()
+
+                drops += 1
+              }
+
+              iter
+            }
           }
 
           iter
         }
-      }
 
-      iter
-    }
+        "drop head" in {
+          var hitWith = -1
+          val (head, tail, chainedBuffer) = buffers[Int] {
+            hitWith = _
+          }
+          (0 until chainedBuffer.capacity).foreach(chainedBuffer.enqueue)
+          hitWith = -1
+          chainedBuffer.isFull shouldBe true
 
-    "drop head" in {
-      var hitWith = -1
-      val (head, tail, chainedBuffer) = buffers[Int] { hitWith = _ }
-      (0 until chainedBuffer.capacity).foreach(chainedBuffer.enqueue)
-      hitWith = -1
-      chainedBuffer.isFull shouldBe true
+          chainedBuffer.dropHead()
 
-      chainedBuffer.dropHead()
+          hitWith shouldBe headCapacity
+          chainedBuffer.isFull shouldBe false
+          assert(head.isFull, "head buffer should still be full")
+          assert(!tail.isFull, "tail buffer should not be full")
+          (1 until chainedBuffer.capacity).foreach { i =>
+            chainedBuffer.dequeue() shouldBe i
+          }
+          chainedBuffer.isEmpty shouldBe true
+        }
 
-      hitWith shouldBe headCapacity
-      chainedBuffer.isFull shouldBe false
-      assert(head.isFull, "head buffer should still be full")
-      assert(!tail.isFull, "tail buffer should not be full")
-      (1 until chainedBuffer.capacity).foreach { i =>
-        chainedBuffer.dequeue() shouldBe i
-      }
-      chainedBuffer.isEmpty shouldBe true
-    }
+        "drop tail" in {
+          var hitWith = -1
+          val (head, tail, chainedBuffer) = buffers[Int] {
+            hitWith = _
+          }
+          (0 until chainedBuffer.capacity).foreach(chainedBuffer.enqueue)
+          hitWith = -1
+          chainedBuffer.isFull shouldBe true
 
-    "drop tail" in {
-      var hitWith = -1
-      val (head, tail, chainedBuffer) = buffers[Int] { hitWith = _ }
-      (0 until chainedBuffer.capacity).foreach(chainedBuffer.enqueue)
-      hitWith = -1
-      chainedBuffer.isFull shouldBe true
+          chainedBuffer.dropTail()
 
-      chainedBuffer.dropTail()
+          hitWith shouldBe -1
+          chainedBuffer.isFull shouldBe false
+          assert(head.isFull, "head buffer should still be full")
+          assert(!tail.isFull, "tail buffer should not be full")
+          (0 until chainedBuffer.capacity - 1).foreach { i =>
+            chainedBuffer.dequeue() shouldBe i
+          }
+          chainedBuffer.isEmpty shouldBe true
+        }
 
-      hitWith shouldBe -1
-      chainedBuffer.isFull shouldBe false
-      assert(head.isFull, "head buffer should still be full")
-      assert(!tail.isFull, "tail buffer should not be full")
-      (0 until chainedBuffer.capacity - 1).foreach { i =>
-        chainedBuffer.dequeue() shouldBe i
-      }
-      chainedBuffer.isEmpty shouldBe true
-    }
+        "dequeue" in {
+          var sum = 0
+          val (head, _, chainedBuffer) = buffers[Int] {
+            sum += _
+          }
+          sum shouldBe 0
+          val numEnqueues = 1 + scala.util.Random.nextInt(chainedBuffer.capacity)
+          (1 to numEnqueues).foreach(chainedBuffer.enqueue)
 
-    "dequeue" in {
-      var sum = 0
-      val (head, _, chainedBuffer) = buffers[Int] { sum += _ }
-      sum shouldBe 0
-      val numEnqueues = 1 + scala.util.Random.nextInt(chainedBuffer.capacity)
-      (1 to numEnqueues).foreach(chainedBuffer.enqueue)
+          // sum of 1 .. numEnqueues
+          val allSum = (numEnqueues * (numEnqueues + 1) / 2)
 
-      // sum of 1 .. numEnqueues
-      val allSum = (numEnqueues * (numEnqueues + 1) / 2)
+          if (numEnqueues < headCapacity) {
+            head.isFull shouldBe false
+            sum shouldBe allSum
+          } else {
+            head.isFull shouldBe true
+            sum shouldBe (headCapacity * (headCapacity + 1) / 2)
+          }
 
-      if (numEnqueues < headCapacity) {
-        head.isFull shouldBe false
-        sum shouldBe allSum
-      } else {
-        head.isFull shouldBe true
-        sum shouldBe (headCapacity * (headCapacity + 1) / 2)
-      }
-
-      var preSum = sum
-      (1 to numEnqueues).foreach { i =>
-        chainedBuffer.dequeue() shouldBe i
-        if (i > (numEnqueues - headCapacity)) {
-          sum shouldBe allSum
-        } else {
-          sum shouldBe preSum + (i + headCapacity)
-          preSum = sum
+          var preSum = sum
+          (1 to numEnqueues).foreach { i =>
+            chainedBuffer.dequeue() shouldBe i
+            if (i > (numEnqueues - headCapacity)) {
+              sum shouldBe allSum
+            } else {
+              sum shouldBe preSum + (i + headCapacity)
+              preSum = sum
+            }
+          }
         }
       }
     }

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/FixedBufferSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/FixedBufferSpec.scala
@@ -84,6 +84,14 @@ class FixedBufferSpec extends StreamSpec {
         buf.isFull should be(false)
       }
 
+      "peek shows head of queue" in {
+        val buf = FixedSizeBuffer[Int](size)
+        for (n <- 1 to size) {
+          buf.enqueue(n)
+          buf.peek() should ===(1)
+        }
+      }
+
       "work properly with full-range filling/draining cycles" in {
         val buf = FixedSizeBuffer[Int](size)
 

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/PartitionedBufferSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/PartitionedBufferSpec.scala
@@ -9,13 +9,12 @@ import akka.stream.testkit.StreamSpec
 class PartitionedBufferSpec extends StreamSpec {
   val doNothing: Any => Unit = _ => ()
 
-  val linearCapacity = scala.util.Random.nextInt(32) + 1
+  /*
   val capacityPerPartition = scala.util.Random.nextInt((linearCapacity / 2).max(1)) + 1
   val numPartitions = {
     val q = linearCapacity / capacityPerPartition
     if (q * capacityPerPartition == linearCapacity) q else q + 1
   }
-
   def makePartitionBuffer[T](hardCapacity: Int, callback: T => Unit): Buffer[T] =
     if (capacityPerPartition < hardCapacity) {
       val headBuffer = FixedSizeBuffer[T](capacityPerPartition)
@@ -25,91 +24,92 @@ class PartitionedBufferSpec extends StreamSpec {
     } else {
       FixedSizeBuffer[T](hardCapacity)
     }
+   */
 
-  def buffer(callback: Int => Unit = doNothing): PartitionedBuffer[Int, Int] =
-    new PartitionedBuffer(linearBuffer = Buffer(linearCapacity, 32), partitioner = { x =>
-      (x % numPartitions).abs
-    }, makePartitionBuffer = { (k, c) =>
-      callback(k); makePartitionBuffer(c, doNothing)
-    })
-
-  s"PartitionedBuffer of capacity $linearCapacity and per-partition capacity $capacityPerPartition" must {
-    s"have capacity $linearCapacity" in {
-      val partitionBuffer = buffer()
-
-      partitionBuffer.capacity shouldBe linearCapacity
+  "PartitionedBuffer" must {
+    "have capacity 4" in {
+      val partitionBuffer = new PartitionedBuffer(4)
+      partitionBuffer.capacity shouldBe 4
     }
 
     "partition enqueued elements" in {
-      val partitionBuffer = buffer()
+      val partitionBuffer = new PartitionedBuffer[Int, Int](6)
 
-      val elem = scala.util.Random.nextInt()
-      partitionBuffer.enqueue(elem)
+      // odd/even
+      partitionBuffer.addPartition(0, Buffer(2, 8))
+      partitionBuffer.addPartition(1, Buffer(2, 8))
 
-      partitionBuffer.peekPartition(partitionBuffer.partitioner(elem)) should contain(elem)
+      (0 to 5).foreach(n => partitionBuffer.enqueue(n % 2, n))
+
+      // last element enqueued for each partition
+      partitionBuffer.peekPartition(0) should contain(4)
+      partitionBuffer.peekPartition(1) should contain(5)
+
+      // capacity is constant but buffer is full
+      partitionBuffer.capacity should ===(6)
+      partitionBuffer.isFull should ===(true)
     }
 
     "support dropHead'ing from partition sub-buffers" in {
-      val partitionBuffer = buffer()
+      val partitionBuffer = new PartitionedBuffer[Int, Int](6)
 
-      val elem = scala.util.Random.nextInt()
-      partitionBuffer.enqueue(elem)
-      val key = partitionBuffer.partitioner(elem)
-      val enqueueSecond = linearCapacity > 1
-      val nextElem = {
-        val x = elem + numPartitions
-        if (x > elem) x else x - numPartitions
-      }
+      // odd/even
+      partitionBuffer.addPartition(0, Buffer(2, 8))
+      partitionBuffer.addPartition(1, Buffer(2, 8))
 
-      if (enqueueSecond) {
-        partitionBuffer.enqueue(nextElem)
-      }
+      (0 to 3).foreach(n => partitionBuffer.enqueue(n % 2, n))
 
-      partitionBuffer.dropOnlyPartitionHead(key)
+      // this drops it from the per partition buffer, but keeps it
+      // in the linear queue - use case is the MapAsyncPartitioned where
+      // we want to move on with executing elems for the partition, but
+      // keep the completed result for emitting once out is ready
+      partitionBuffer.dropOnlyPartitionHead(0) should ===(true) // dropping 0
+      partitionBuffer.dequeue() should ===(0) // elem still in linear buffer
 
-      partitionBuffer.dequeue() shouldBe elem
-      partitionBuffer.peekPartition(key) should be(if (enqueueSecond) Some(nextElem) else None)
+      partitionBuffer.peekPartition(0) should contain(2)
+
+      partitionBuffer.dropOnlyPartitionHead(1) should ===(true) // dropping 1
+      partitionBuffer.dequeue() should ===(1) // elem still in linear buffer
+
+      partitionBuffer.peekPartition(1) should contain(3)
+
+      partitionBuffer.dropOnlyPartitionHead(0) should ===(true) // dropping 2
+      partitionBuffer.peekPartition(0) shouldBe empty // nothing left in partition 0
     }
 
     "dequeue from partition sub-buffers when dequeueing" in {
-      val partitionBuffer = buffer()
+      val partitionBuffer = new PartitionedBuffer[Int, Int](6)
 
-      val elem = scala.util.Random.nextInt()
-      partitionBuffer.enqueue(elem)
-      val key = partitionBuffer.partitioner(elem)
-      val enqueueSecond = linearCapacity > 1 && scala.util.Random.nextBoolean()
-      val nextElem = {
-        val x = elem + numPartitions
-        if (x > elem) x else x - numPartitions
-      }
+      // odd/even
+      partitionBuffer.addPartition(0, Buffer(2, 8))
+      partitionBuffer.addPartition(1, Buffer(2, 8))
 
-      if (enqueueSecond) {
-        partitionBuffer.enqueue(nextElem)
-      }
+      (0 to 5).foreach(n => partitionBuffer.enqueue(n % 2, n))
 
-      partitionBuffer.dequeue() shouldBe elem
-      partitionBuffer.peekPartition(key) shouldNot contain(elem)
+      (0 to 4).foreach(n => partitionBuffer.dequeue() should ===(n))
+
+      partitionBuffer.peek() should ===(5)
+
+      // FIXME now the partition buffer for parition 0 should be empty but it is not
+      partitionBuffer.peekPartition(0) shouldBe empty // nothing left in partition 0, we dequeued all
+      partitionBuffer.peekPartition(1) should contain(5)
     }
 
     "clear sub-buffers when clearing" in {
-      val partitionBuffer = buffer()
+      val partitionBuffer = new PartitionedBuffer[Int, Int](6)
 
-      val elem = scala.util.Random.nextInt()
-      partitionBuffer.enqueue(elem)
-      val key = partitionBuffer.partitioner(elem)
+      // odd/even
+      partitionBuffer.addPartition(0, Buffer(2, 8))
+      partitionBuffer.addPartition(1, Buffer(2, 8))
 
+      partitionBuffer.enqueue(0, 0)
+      partitionBuffer.enqueue(1, 1)
       partitionBuffer.clear()
 
       partitionBuffer.isEmpty shouldBe true
-      partitionBuffer.peekPartition(key) shouldBe empty
+      partitionBuffer.peekPartition(0) shouldBe empty
+      partitionBuffer.peekPartition(1) shouldBe empty
     }
 
-    "not support dropTail" in {
-      val partitionBuffer = buffer()
-
-      an[UnsupportedOperationException] shouldBe thrownBy {
-        partitionBuffer.dropTail()
-      }
-    }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/PartitionedBufferSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/PartitionedBufferSpec.scala
@@ -7,24 +7,6 @@ package akka.stream.impl
 import akka.stream.testkit.StreamSpec
 
 class PartitionedBufferSpec extends StreamSpec {
-  val doNothing: Any => Unit = _ => ()
-
-  /*
-  val capacityPerPartition = scala.util.Random.nextInt((linearCapacity / 2).max(1)) + 1
-  val numPartitions = {
-    val q = linearCapacity / capacityPerPartition
-    if (q * capacityPerPartition == linearCapacity) q else q + 1
-  }
-  def makePartitionBuffer[T](hardCapacity: Int, callback: T => Unit): Buffer[T] =
-    if (capacityPerPartition < hardCapacity) {
-      val headBuffer = FixedSizeBuffer[T](capacityPerPartition)
-      val tailBuffer = new BoundedBuffer.DynamicQueue[T](hardCapacity - capacityPerPartition)
-
-      new ChainedBuffer(headBuffer, tailBuffer, callback)
-    } else {
-      FixedSizeBuffer[T](hardCapacity)
-    }
-   */
 
   "PartitionedBuffer" must {
     "have capacity 4" in {

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/PartitionedBufferSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/PartitionedBufferSpec.scala
@@ -81,8 +81,8 @@ class PartitionedBufferSpec extends StreamSpec {
       val partitionBuffer = new PartitionedBuffer[Int, Int](6)
 
       // odd/even
-      partitionBuffer.addPartition(0, Buffer(2, 8))
-      partitionBuffer.addPartition(1, Buffer(2, 8))
+      partitionBuffer.addPartition(0, Buffer(4, 8))
+      partitionBuffer.addPartition(1, Buffer(4, 8))
 
       (0 to 5).foreach(n => partitionBuffer.enqueue(n % 2, n))
 
@@ -90,7 +90,6 @@ class PartitionedBufferSpec extends StreamSpec {
 
       partitionBuffer.peek() should ===(5)
 
-      // FIXME now the partition buffer for parition 0 should be empty but it is not
       partitionBuffer.peekPartition(0) shouldBe empty // nothing left in partition 0, we dequeued all
       partitionBuffer.peekPartition(1) should contain(5)
     }

--- a/akka-stream/src/main/scala/akka/stream/impl/Buffers.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Buffers.scala
@@ -342,7 +342,7 @@ private[impl] final class PartitionedBuffer[K, V](size: Int) {
       case Some(pbuf) =>
         // value could have been removed through dropOnlyPartitionHead
         if (pbuf.peek() == value) {
-          pbuf.dequeue()
+          pbuf.dropHead()
           if (pbuf.isEmpty) {
             partitionBuffers.remove(key)
           }
@@ -356,7 +356,7 @@ private[impl] final class PartitionedBuffer[K, V](size: Int) {
   def dropOnlyPartitionHead(key: K): Boolean =
     partitionBuffers.get(key) match {
       case Some(pbuf) =>
-        pbuf.dequeue()
+        pbuf.dropHead()
         if (pbuf.isEmpty) {
           partitionBuffers.remove(key)
         }


### PR DESCRIPTION
Left over feedback from original review applied, nothing huge, keeping the two custom buffers.:

 * no random values in tests
 * object level callbacks avoided for at least the partition buffer
 * flattening a pyramid of callbacks
 * a (locally) frequently failing test changed to be more stable
 * some clarifications to docs
 * some de-generalization of the partition buffer to make it easier to reason about