### PR TITLE
fix: starting Sharding with separate Coordinator role, #31637

### DIFF
--- a/akka-cluster-sharding/src/main/resources/reference.conf
+++ b/akka-cluster-sharding/src/main/resources/reference.conf
@@ -366,8 +366,9 @@ akka.cluster.sharding {
   coordinator-singleton = ${akka.cluster.singleton}
 
 
-  # Copies the role for the coordinator singleton from the shards role instead of using the one provided in the
-  # "akka.cluster.sharding.coordinator-singleton.role"
+  # By default, the role for the coordinator singleton is the same as the role for the shards
+  # "akka.cluster.sharding.role". Set this to off to use the role from
+  # "akka.cluster.sharding.coordinator-singleton.role" for the coordinator singleton.
   coordinator-singleton-role-override = on
 
   coordinator-state {

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -1248,6 +1248,17 @@ final class ClusterShardingSettings(
   private[akka] def shouldHostShard(cluster: Cluster): Boolean =
     role.forall(cluster.selfMember.roles.contains)
 
+  /** If true, this node should run the shard coordinator, otherwise just a shard proxy or shard region on this node. */
+  @InternalApi
+  private[akka] def shouldHostCoordinator(cluster: Cluster): Boolean =
+      coordinatorSingletonRole.forall(cluster.selfMember.roles.contains)
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] def coordinatorSingletonRole: Option[String] =
+    if (coordinatorSingletonOverrideRole) role else coordinatorSingletonSettings.role
+
   @InternalApi
   private[akka] val passivationStrategy: ClusterShardingSettings.PassivationStrategy =
     ClusterShardingSettings.PassivationStrategy(this)

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ClusterShardingSettings.scala
@@ -1251,7 +1251,7 @@ final class ClusterShardingSettings(
   /** If true, this node should run the shard coordinator, otherwise just a shard proxy or shard region on this node. */
   @InternalApi
   private[akka] def shouldHostCoordinator(cluster: Cluster): Boolean =
-      coordinatorSingletonRole.forall(cluster.selfMember.roles.contains)
+    coordinatorSingletonRole.forall(cluster.selfMember.roles.contains)
 
   /**
    * INTERNAL API

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -1532,10 +1532,8 @@ private[akka] class DDataShardCoordinator(
     extends ShardCoordinator(settings, allocationStrategy)
     with Stash
     with Timers {
-
   import DDataShardCoordinator._
   import ShardCoordinator.Internal._
-
   import akka.cluster.ddata.Replicator.Update
 
   private val verboseDebug = context.system.settings.config.getBoolean("akka.cluster.sharding.verbose-debug-logging")

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardRegion.scala
@@ -632,6 +632,7 @@ private[akka] class ShardRegion(
 
   // sort by age, oldest first
   val ageOrdering = Member.ageOrdering
+  // membersByAge is only used for tracking where coordinator is running
   var membersByAge: immutable.SortedSet[Member] = immutable.SortedSet.empty(ageOrdering)
   // membersByAge contains members with these status
   private val memberStatusOfInterest: Set[MemberStatus] =
@@ -711,7 +712,7 @@ private[akka] class ShardRegion(
   }
 
   def matchingRole(member: Member): Boolean =
-    member.hasRole(targetDcRole) && role.forall(member.hasRole)
+    member.hasRole(targetDcRole) && coordinatorSingletonRole.forall(member.hasRole)
 
   /**
    * When leaving the coordinator singleton is started rather quickly on next

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/DDataRememberEntitiesShardStore.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/DDataRememberEntitiesShardStore.scala
@@ -82,7 +82,6 @@ private[akka] final class DDataRememberEntitiesShardStore(
     extends Actor
     with Stash
     with ActorLogging {
-
   import DDataRememberEntitiesShardStore._
 
   implicit val ec: ExecutionContext = context.dispatcher

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingCoordinatorRoleSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingCoordinatorRoleSpec.scala
@@ -68,7 +68,7 @@ class DDataRememberClusterShardingCoordinatorRoleSpecMultiJvmNode2
 class DDataRememberClusterShardingCoordinatorRoleSpecMultiJvmNode3
     extends DDataRememberClusterShardingCoordinatorRoleSpec
 class DDataRememberClusterShardingCoordinatorRoleSpecMultiJvmNode4
-  extends DDataRememberClusterShardingCoordinatorRoleSpec
+    extends DDataRememberClusterShardingCoordinatorRoleSpec
 
 abstract class ClusterShardingCoordinatorRoleSpec(multiNodeConfig: ClusterShardingCoordinatorRoleSpecConfig)
     extends MultiNodeClusterShardingSpec(multiNodeConfig)

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingCoordinatorRoleSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingCoordinatorRoleSpec.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2019-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import scala.concurrent.duration._
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+
+import akka.actor.ActorRef
+import akka.actor.PoisonPill
+import akka.actor.Props
+import akka.cluster.sharding.MultiNodeClusterShardingSpec.EntityActor
+import akka.testkit._
+
+class ClusterShardingCoordinatorRoleSpecConfig(
+    mode: String,
+    rememberEntities: Boolean,
+    rememberEntitiesStore: String = ClusterShardingSettings.RememberEntitiesStoreDData)
+    extends MultiNodeClusterShardingConfig(
+      mode,
+      rememberEntities,
+      rememberEntitiesStore = rememberEntitiesStore,
+      additionalConfig = """
+  akka.cluster.sharding {
+    role = shard
+    coordinator-singleton-role-override = off
+    coordinator-singleton.role = coordinator
+    entity-restart-backoff = 100 ms
+  }  
+  """) {
+
+  val first = role("first")
+  val second = role("second")
+  val third = role("third")
+  val fourth = role("fourth")
+
+  val coordinatorConfig: Config = ConfigFactory.parseString("""akka.cluster.roles = [ "coordinator" ]""")
+  val shardConfig: Config = ConfigFactory.parseString("""akka.cluster.roles = [ "shard" ]""")
+
+  nodeConfig(first, second)(coordinatorConfig)
+
+  nodeConfig(third, fourth)(shardConfig)
+
+}
+
+class DDataClusterShardingCoordinatorRoleSpec
+    extends ClusterShardingCoordinatorRoleSpec(
+      new ClusterShardingCoordinatorRoleSpecConfig(
+        ClusterShardingSettings.StateStoreModeDData,
+        rememberEntities = false))
+class DDataClusterShardingCoordinatorRoleSpecMultiJvmNode1 extends DDataClusterShardingCoordinatorRoleSpec
+class DDataClusterShardingCoordinatorRoleSpecMultiJvmNode2 extends DDataClusterShardingCoordinatorRoleSpec
+class DDataClusterShardingCoordinatorRoleSpecMultiJvmNode3 extends DDataClusterShardingCoordinatorRoleSpec
+class DDataClusterShardingCoordinatorRoleSpecMultiJvmNode4 extends DDataClusterShardingCoordinatorRoleSpec
+
+class DDataRememberClusterShardingCoordinatorRoleSpec
+    extends ClusterShardingCoordinatorRoleSpec(
+      new ClusterShardingCoordinatorRoleSpecConfig(
+        ClusterShardingSettings.StateStoreModeDData,
+        rememberEntities = true))
+class DDataRememberClusterShardingCoordinatorRoleSpecMultiJvmNode1
+    extends DDataRememberClusterShardingCoordinatorRoleSpec
+class DDataRememberClusterShardingCoordinatorRoleSpecMultiJvmNode2
+    extends DDataRememberClusterShardingCoordinatorRoleSpec
+class DDataRememberClusterShardingCoordinatorRoleSpecMultiJvmNode3
+    extends DDataRememberClusterShardingCoordinatorRoleSpec
+class DDataRememberClusterShardingCoordinatorRoleSpecMultiJvmNode4
+  extends DDataRememberClusterShardingCoordinatorRoleSpec
+
+abstract class ClusterShardingCoordinatorRoleSpec(multiNodeConfig: ClusterShardingCoordinatorRoleSpecConfig)
+    extends MultiNodeClusterShardingSpec(multiNodeConfig)
+    with ImplicitSender {
+
+  import multiNodeConfig._
+
+  def startSharding(probe: ActorRef): ActorRef = {
+    startSharding(
+      system,
+      typeName = "Entity",
+      entityProps = Props(new EntityActor(probe)),
+      settings = ClusterShardingSettings(system).withRememberEntities(multiNodeConfig.rememberEntities),
+      extractEntityId = MultiNodeClusterShardingSpec.intExtractEntityId,
+      extractShardId = MultiNodeClusterShardingSpec.intExtractShardId)
+  }
+
+  private lazy val region = ClusterSharding(system).shardRegion("Entity")
+
+  private val entityProbe = TestProbe()
+
+  s"Cluster sharding (${multiNodeConfig.mode}, remember ${multiNodeConfig.rememberEntities}) with separate coordinator role" must {
+
+    "use nodes with shard role" in within(30.seconds) {
+      startPersistenceIfNeeded(startOn = first, setStoreOn = Seq(first, second, third))
+
+      join(first, first)
+      join(second, first)
+      join(third, first)
+      startSharding(entityProbe.ref)
+
+      runOn(third) {
+        region ! 1
+        expectMsg(1)
+        lastSender.path.address.hasLocalScope should ===(true)
+        entityProbe.expectMsg(EntityActor.Started(lastSender))
+      }
+      runOn(first, second) {
+        region ! 1
+        expectMsg(1)
+        lastSender.path should be(node(third) / "system" / "sharding" / "Entity" / "1" / "1")
+        entityProbe.expectNoMessage()
+      }
+
+      enterBarrier("first-ok")
+
+      if (rememberEntities) {
+        runOn(third) {
+          region ! 2
+          expectMsg(2)
+          watch(lastSender)
+          val ref = lastSender
+          ref ! PoisonPill
+          expectTerminated(ref)
+          entityProbe.expectMsg(EntityActor.Started(ref))
+          // and then started again by remember entities
+          // not same ActorRef, but same path
+          entityProbe.expectMsgType[EntityActor.Started].ref.path should be(ref.path)
+        }
+        runOn(first, second) {
+          entityProbe.expectNoMessage()
+        }
+
+      }
+
+      enterBarrier("after-1")
+    }
+
+    if (rememberEntities) {
+      "restart remembered entities" in {
+        join(fourth, second)
+
+        runOn(first) {
+          cluster.leave(third)
+          cluster.leave(first)
+        }
+        enterBarrier("first left")
+
+        runOn(fourth) {
+          // started by remember entities on new node
+          entityProbe.expectMsgType[EntityActor.Started](20.seconds)
+        }
+        runOn(second) {
+          entityProbe.expectNoMessage()
+        }
+
+        enterBarrier("after-2")
+      }
+    }
+
+  }
+}

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
@@ -1455,7 +1455,8 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
   require(!cluster.isTerminated, "Cluster node must not be terminated")
   require(
     roles.subsetOf(cluster.selfRoles),
-    s"This cluster member [$selfAddress] with roles [${cluster.selfRoles.mkString(", ")}] doesn't have all the roles [${roles.mkString(", ")}]")
+    s"This cluster member [$selfAddress] with roles [${cluster.selfRoles
+      .mkString(", ")}] doesn't have all the roles [${roles.mkString(", ")}]")
 
   private val payloadSizeAggregator = {
     val sizeExceeding = settings.logDataSizeExceeding.getOrElse(Int.MaxValue)

--- a/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
+++ b/akka-distributed-data/src/main/scala/akka/cluster/ddata/Replicator.scala
@@ -1455,7 +1455,7 @@ final class Replicator(settings: ReplicatorSettings) extends Actor with ActorLog
   require(!cluster.isTerminated, "Cluster node must not be terminated")
   require(
     roles.subsetOf(cluster.selfRoles),
-    s"This cluster member [${selfAddress}] doesn't have all the roles [${roles.mkString(", ")}]")
+    s"This cluster member [$selfAddress] with roles [${cluster.selfRoles.mkString(", ")}] doesn't have all the roles [${roles.mkString(", ")}]")
 
   private val payloadSizeAggregator = {
     val sizeExceeding = settings.logDataSizeExceeding.getOrElse(Int.MaxValue)


### PR DESCRIPTION
* this feature was completely broken
* note that the ddata replicator is used for both
  DDataShardCoordinator and DDataRememberEntities
  - the DDataShardCoordinator replicator can be on the same role as the coordinator
  - for remmeber entities it's both the CoordinatorStore and the ShardStore, to not complicate
    that too much I used a replicator without role for remember entities when those two roles
    are different

Original contribution in https://github.com/akka/akka/pull/31487

References #31637
