### PR TITLE
feat: Tagger that can look at state for event sourced behaviour

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorWatchSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorWatchSpec.scala
@@ -64,7 +64,7 @@ class EventSourcedBehaviorWatchSpec
       eventHandler = (state, evt) => state + evt,
       WriterIdentity.newIdentity(),
       pf,
-      _ => Set.empty[String],
+      (_, _) => Set.empty[String],
       NoOpEventAdapter.instance[String],
       NoOpSnapshotAdapter.instance[String],
       snapshotWhen = ConstantFun.scalaAnyThreeToFalse,

--- a/akka-persistence-typed/src/main/mima-filters/2.8.0.backwards.excludes/tags-for-state.excludes
+++ b/akka-persistence-typed/src/main/mima-filters/2.8.0.backwards.excludes/tags-for-state.excludes
@@ -1,0 +1,5 @@
+# internal
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.typed.internal.Running#HandlingCommands.adaptEvent")
+# Bin incompatible, but no way around it because Java DSL is based on inheritance, hopefully nobody made
+# a method like this
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.persistence.typed.scaladsl.EventSourcedBehavior.withTaggerForState")

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/BehaviorSetup.scala
@@ -47,7 +47,7 @@ private[akka] final class BehaviorSetup[C, E, S](
     val eventHandler: EventSourcedBehavior.EventHandler[S, E],
     val writerIdentity: EventSourcedBehaviorImpl.WriterIdentity,
     private val signalHandler: PartialFunction[(S, Signal), Unit],
-    val tagger: E => Set[String],
+    val tagger: (S, E) => Set[String],
     val eventAdapter: EventAdapter[E, Any],
     val snapshotAdapter: SnapshotAdapter[S],
     val snapshotWhen: (S, E, Long) => Boolean,

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -96,7 +96,7 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
     loggerClass: Class[_],
     journalPluginId: Option[String] = None,
     snapshotPluginId: Option[String] = None,
-    tagger: Event => Set[String] = (_: Event) => Set.empty[String],
+    tagger: (State, Event) => Set[String] = (_: State, _: Event) => Set.empty[String],
     eventAdapter: EventAdapter[Event, Any] = NoOpEventAdapter.instance[Event],
     snapshotAdapter: SnapshotAdapter[State] = NoOpSnapshotAdapter.instance[State],
     snapshotWhen: (State, Event, Long) => Boolean = ConstantFun.scalaAnyThreeToFalse,
@@ -270,6 +270,9 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
     copy(retention = criteria)
 
   override def withTagger(tagger: Event => Set[String]): EventSourcedBehavior[Command, Event, State] =
+    copy(tagger = (_, event) => tagger(event))
+
+  override def withTaggerForState(tagger: (State, Event) => Set[String]): EventSourcedBehavior[Command, Event, State] =
     copy(tagger = tagger)
 
   override def eventAdapter(adapter: EventAdapter[Event, _]): EventSourcedBehavior[Command, Event, State] =

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/EventSourcedBehavior.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/scaladsl/EventSourcedBehavior.scala
@@ -191,6 +191,13 @@ object EventSourcedBehavior {
   def withTagger(tagger: Event => Set[String]): EventSourcedBehavior[Command, Event, State]
 
   /**
+   * The `tagger` function should give event tags, which will be used in persistence query.
+   * The state passed to the tagger allows for toggling a tag with one event but keep all events after it tagged
+   * based on a property or the type of the state.
+   */
+  def withTaggerForState(tagger: (State, Event) => Set[String]): EventSourcedBehavior[Command, Event, State]
+
+  /**
    * Transform the event to another type before giving to the journal. Can be used to wrap events
    * in types Journals understand but is of a different type than `Event`.
    */


### PR DESCRIPTION
Makes it possible to use state to "toggle" a tag rather than only emit it only based on some property of the event.