### PR TITLE
=str Implement Source.never as a dedicated GraphStage.

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -500,6 +500,18 @@ import scala.util.control.NonFatal
   }
 
   @InternalApi
+  private[akka] object NeverSource extends GraphStage[SourceShape[Nothing]] {
+    private val out = Outlet[Nothing]("NeverSource.out")
+    val shape: SourceShape[Nothing] = SourceShape(out)
+    override def initialAttributes: Attributes = DefaultAttributes.neverSource
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic with OutHandler =
+      new GraphStageLogic(shape) with OutHandler {
+        override def onPull(): Unit = ()
+        setHandler(out, this)
+      }
+  }
+
+  @InternalApi
   private[akka] object NeverSink extends GraphStageWithMaterializedValue[SinkShape[Any], Future[Done]] {
     private val in = Inlet[Any]("NeverSink.in")
     val shape: SinkShape[Any] = SinkShape(in)

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -498,8 +498,7 @@ object Source {
    * This stream could be useful in tests.
    */
   def never[T]: Source[T, NotUsed] = _never
-  private[this] val _never: Source[Nothing, NotUsed] =
-    future(Future.never).withAttributes(DefaultAttributes.neverSource)
+  private[this] val _never: Source[Nothing, NotUsed] = fromGraph(GraphStages.NeverSource)
 
   /**
    * Emits a single value when the given `CompletionStage` is successfully completed and then completes the stream.


### PR DESCRIPTION
Using a more straightforward implementation will reduce the `AsyncCallback` in FutureSource.