### PR TITLE
chore: Java API factory method for ExternalShardAllocation

### DIFF
--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ExternalShardAllocationCompileOnlyTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ExternalShardAllocationCompileOnlyTest.java
@@ -17,8 +17,6 @@ import akka.cluster.sharding.typed.ShardingEnvelope;
 import akka.cluster.sharding.typed.javadsl.ClusterSharding;
 import akka.cluster.sharding.typed.javadsl.Entity;
 import akka.cluster.sharding.typed.javadsl.EntityTypeKey;
-import akka.util.Timeout;
-import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 
 public class ExternalShardAllocationCompileOnlyTest {
@@ -35,8 +33,7 @@ public class ExternalShardAllocationCompileOnlyTest {
         sharding.init(
             Entity.of(typeKey, ctx -> Counter.create(ctx.getEntityId()))
                 .withAllocationStrategy(
-                    new ExternalShardAllocationStrategy(
-                        system, typeKey.name(), Timeout.create(Duration.ofSeconds(5)))));
+                    ExternalShardAllocationStrategy.create(system, typeKey.name())));
     // #entity
 
     // #client

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ExternalShardAllocationCompileOnlySpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ExternalShardAllocationCompileOnlySpec.scala
@@ -28,7 +28,7 @@ class ExternalShardAllocationCompileOnlySpec {
   val TypeKey = EntityTypeKey[Counter.Command]("Counter")
 
   val entity = Entity(TypeKey)(createBehavior = entityContext => Counter(entityContext.entityId))
-    .withAllocationStrategy(new ExternalShardAllocationStrategy(system, TypeKey.name))
+    .withAllocationStrategy(ExternalShardAllocationStrategy(system, TypeKey.name))
   // #entity
 
   val shardRegion: ActorRef[ShardingEnvelope[Counter.Command]] =

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/external/ExternalShardAllocationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/external/ExternalShardAllocationStrategy.scala
@@ -34,6 +34,18 @@ object ExternalShardAllocationStrategy {
 
   type ShardRegion = ActorRef
 
+  /**
+   * Scala API
+   */
+  def apply(systemProvider: ClassicActorSystemProvider, typeName: String): ExternalShardAllocationStrategy =
+    new ExternalShardAllocationStrategy(systemProvider, typeName)
+
+  /**
+   * Java API
+   */
+  def create(systemProvider: ClassicActorSystemProvider, typeName: String): ExternalShardAllocationStrategy =
+    apply(systemProvider, typeName)
+
   // local only messages
   private[akka] final case class GetShardLocation(shard: ShardId)
   private[akka] case object GetShardLocations

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ExternalShardAllocationSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ExternalShardAllocationSpec.scala
@@ -95,7 +95,7 @@ abstract class ExternalShardAllocationSpec
       entityProps = Props[GiveMeYourHome](),
       extractEntityId = extractEntityId,
       extractShardId = extractShardId,
-      allocationStrategy = new ExternalShardAllocationStrategy(system, typeName))
+      allocationStrategy = ExternalShardAllocationStrategy(system, typeName))
 
     "start cluster sharding" in {
       shardRegion


### PR DESCRIPTION
* for use without the timeout parameter
* Scala API has default parameter value, but added apply
