### PR TITLE
fix: Refactor concurrency in AsyncDnsResolver

### DIFF
--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
@@ -297,8 +297,8 @@ private[akka] object AsyncDnsResolver {
 
     private def activelyResolving(searchName: String): Receive = {
       // stash resolution requests because we won't do anything with them while actively resolving
-      case _: DnsResolutionActor.Resolve => log.info("stashing Resolve"); stash()
-      case _: ResolveWithFirstResolver   => log.info("stashing ResolveWithFirstResolver"); stash()
+      case _: DnsResolutionActor.Resolve => stash()
+      case _: ResolveWithFirstResolver   => stash()
 
       case resolved: DnsProtocol.Resolved =>
         // Check whether this is the final resolution or we need to unstash and try another resolution
@@ -374,13 +374,13 @@ private[akka] object AsyncDnsResolver {
 
             ipv4Recs.flatMap { v4 =>
               ipv6Recs.map { v6 =>
-                DnsProtocol.Resolved(name, v4.rrs ++ v6.rrs, v4.additionalRecs ++ v6.additionalRecs)
+                DnsProtocol.Resolved(searchName, v4.rrs ++ v6.rrs, v4.additionalRecs ++ v6.additionalRecs)
               }(ExecutionContexts.parasitic)
             }(ExecutionContexts.parasitic)
 
           case Srv =>
             sendQuestion(resolver, requestId => SrvQuestion(requestId, searchName)).map { answer =>
-              DnsProtocol.Resolved(name, answer.rrs, answer.additionalRecs)
+              DnsProtocol.Resolved(searchName, answer.rrs, answer.additionalRecs)
             }(ExecutionContexts.parasitic)
         }
 

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
@@ -7,19 +7,20 @@ package akka.io.dns.internal
 import java.net.{ Inet4Address, Inet6Address, InetAddress, InetSocketAddress }
 
 import scala.collection.immutable
-import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Future
-import scala.util.Try
+import scala.concurrent.Promise
+import scala.util.{ Failure, Success, Try }
 import scala.util.control.NonFatal
 
-import akka.actor.{ Actor, ActorLogging, ActorRef, ActorRefFactory }
+import akka.actor.{ Actor, ActorLogging, ActorRef, ActorRefFactory, Status }
 import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
 import akka.io.SimpleDnsCache
 import akka.io.dns._
 import akka.io.dns.CachePolicy.{ Never, Ttl }
 import akka.io.dns.DnsProtocol.{ Ip, RequestType, Srv }
 import akka.io.dns.internal.DnsClient._
-import akka.pattern.{ ask, pipe }
+import akka.pattern.ask
 import akka.pattern.AskTimeoutException
 import akka.util.{ Helpers, Timeout }
 import akka.util.PrettyDuration._
@@ -36,8 +37,6 @@ private[io] final class AsyncDnsResolver(
     with ActorLogging {
 
   import AsyncDnsResolver._
-
-  implicit val ec: ExecutionContextExecutor = context.dispatcher
 
   // avoid ever looking up localhost by pre-populating cache
   {
@@ -93,17 +92,28 @@ private[io] final class AsyncDnsResolver(
           log.debug("{} cached {}", mode, resolved)
           sender() ! resolved
         case None =>
-          resolveWithResolvers(name, mode, resolvers)
-            .map { resolved =>
-              if (resolved.records.nonEmpty) {
-                val minTtl = (positiveCachePolicy +: resolved.records.map(_.ttl)).min
-                cache.put((name, mode), resolved, minTtl)
-              } else if (negativeCachePolicy != Never) cache.put((name, mode), resolved, negativeCachePolicy)
-              log.debug(s"{} resolved {}", mode, resolved)
-              resolved
+          val replyTo = sender()
+          resolveWithResolvers(name, mode, resolvers).onComplete {
+            _ match {
+              case Success(resolved) =>
+                if (resolved.records.nonEmpty) {
+                  val minTtl = (positiveCachePolicy +: resolved.records.map(_.ttl)).min
+                  cache.put((name, mode), resolved, minTtl) // thread-safe structure, safe in callback
+                } else if (negativeCachePolicy != Never) {
+                  cache.put((name, mode), resolved, negativeCachePolicy) // thread-safe structure, safe in callback
+                }
+
+                log.debug("{} resolved {}", mode, resolved)
+                replyTo ! resolved
+
+              case Failure(f) =>
+                replyTo ! Status.Failure(f)
             }
-            .pipeTo(sender())
+          }(ExecutionContexts.parasitic)
       }
+
+    case Internal.Resolve(name, requestType, resolver, promise) =>
+      resolvePromise(name, requestType, resolver, promise)
   }
 
   private def resolveWithResolvers(
@@ -127,7 +137,7 @@ private[io] final class AsyncDnsResolver(
         case Nil =>
           Future.failed(ResolveFailedException(s"Failed to resolve $name with nameservers: $nameServers"))
         case head :: tail =>
-          resolveWithSearch(name, requestType, head).recoverWith {
+          resolveWithSearch(name, requestType, head, settings, self).recoverWith {
             case NonFatal(t) =>
               t match {
                 case _: AskTimeoutException =>
@@ -136,90 +146,39 @@ private[io] final class AsyncDnsResolver(
                   log.info("Resolve of {} failed. Trying next name server {}", name, t.getMessage)
               }
               resolveWithResolvers(name, requestType, tail)
-          }
+          }(ExecutionContexts.parasitic)
       }
     }
 
-  private def sendQuestion(resolver: ActorRef, message: DnsQuestion): Future[Answer] = {
-    val result = (resolver ? message).mapTo[Answer]
-    result.failed.foreach { _ =>
-      resolver ! DropRequest(message.id)
-    }
-    result
-  }
-
-  private def resolveWithSearch(
+  private def resolvePromise(
       name: String,
       requestType: RequestType,
-      resolver: ActorRef): Future[DnsProtocol.Resolved] = {
-    if (settings.SearchDomains.nonEmpty) {
-      val nameWithSearch = settings.SearchDomains.map(sd => name + "." + sd)
-      // ndots is a heuristic used to try and work out whether the name passed in is a fully qualified domain name,
-      // or a name relative to one of the search names. The idea is to prevent the cost of doing a lookup that is
-      // obviously not going to resolve. So, if a host has less than ndots dots in it, then we don't try and resolve it,
-      // instead, we go directly to the search domains, or at least that's what the man page for resolv.conf says. In
-      // practice, Linux appears to implement something slightly different, if the name being searched contains less
-      // than ndots dots, then it should be searched last, rather than first. This means if the heuristic wrongly
-      // identifies a domain as being relative to the search domains, it will still be looked up if it doesn't resolve
-      // at any of the search domains, albeit with the latency of having to have done all the searches first.
-      val toResolve = if (name.count(_ == '.') >= settings.NDots) {
-        name :: nameWithSearch
-      } else {
-        nameWithSearch :+ name
-      }
-      resolveFirst(toResolve, requestType, resolver)
-    } else {
-      resolve(name, requestType, resolver)
-    }
-  }
-
-  private def resolveFirst(
-      searchNames: List[String],
-      requestType: RequestType,
-      resolver: ActorRef): Future[DnsProtocol.Resolved] = {
-    searchNames match {
-      case searchName :: Nil =>
-        resolve(searchName, requestType, resolver)
-      case searchName :: remaining =>
-        resolve(searchName, requestType, resolver).flatMap { resolved =>
-          if (resolved.records.isEmpty) resolveFirst(remaining, requestType, resolver)
-          else Future.successful(resolved)
-        }
-      case Nil =>
-        // This can't happen
-        Future.failed(new IllegalStateException("Failed to 'resolveFirst': 'searchNames' must not be empty"))
-    }
-  }
-
-  private def resolve(name: String, requestType: RequestType, resolver: ActorRef): Future[DnsProtocol.Resolved] = {
+      resolver: ActorRef,
+      promise: Promise[DnsProtocol.Resolved]): Unit = {
     log.debug("Attempting to resolve {} with {}", name, resolver)
     val caseFoldedName = Helpers.toRootLowerCase(name)
     requestType match {
       case Ip(ipv4, ipv6) =>
-        val ipv4Recs: Future[Answer] =
-          if (ipv4)
-            sendQuestion(resolver, Question4(nextId(), caseFoldedName))
-          else
-            Empty
+        val ipv4Recs =
+          if (ipv4) sendQuestion(resolver, Question4(nextId(), caseFoldedName))
+          else Empty
 
         val ipv6Recs =
-          if (ipv6)
-            sendQuestion(resolver, Question6(nextId(), caseFoldedName))
-          else
-            Empty
+          if (ipv6) sendQuestion(resolver, Question6(nextId(), caseFoldedName))
+          else Empty
 
-        for {
-          ipv4 <- ipv4Recs
-          ipv6 <- ipv6Recs
-        } yield DnsProtocol.Resolved(name, ipv4.rrs ++ ipv6.rrs, ipv4.additionalRecs ++ ipv6.additionalRecs)
+        promise.completeWith(ipv4Recs.flatMap { v4 =>
+          ipv6Recs.map { v6 =>
+            DnsProtocol.Resolved(name, v4.rrs ++ v6.rrs, v4.additionalRecs ++ v6.additionalRecs)
+          }(ExecutionContexts.parasitic)
+        }(ExecutionContexts.parasitic))
 
       case Srv =>
-        sendQuestion(resolver, SrvQuestion(nextId(), caseFoldedName)).map(answer => {
+        promise.completeWith(sendQuestion(resolver, SrvQuestion(nextId(), caseFoldedName)).map { answer =>
           DnsProtocol.Resolved(name, answer.rrs, answer.additionalRecs)
-        })
+        }(ExecutionContexts.parasitic))
     }
   }
-
 }
 
 /**
@@ -247,4 +206,75 @@ private[akka] object AsyncDnsResolver {
     Future.successful(Answer(-1, immutable.Seq.empty[ResourceRecord], immutable.Seq.empty[ResourceRecord]))
 
   case class ResolveFailedException(msg: String) extends Exception(msg)
+
+  // Internal commands to avoid calling private methods in future callbacks
+  private[akka] object Internal {
+    case class Resolve(
+        name: String,
+        requestType: RequestType,
+        resolver: ActorRef,
+        promise: Promise[DnsProtocol.Resolved])
+  }
+
+  // These methods are not in the class so that we can be sure they don't access actor state
+  private def resolveWithSearch(
+      name: String,
+      requestType: RequestType,
+      resolver: ActorRef,
+      settings: DnsSettings,
+      self: ActorRef): Future[DnsProtocol.Resolved] = {
+    if (settings.SearchDomains.nonEmpty) {
+      val nameWithSearch = settings.SearchDomains.map(sd => name + "." + sd)
+      // ndots is a heuristic used to try and work out whether the name passed in is a fully qualified domain name,
+      // or a name relative to one of the search names. The idea is to prevent the cost of doing a lookup that is
+      // obviously not going to resolve. So, if a host has less than ndots dots in it, then we don't try and resolve it,
+      // instead, we go directly to the search domains, or at least that's what the man page for resolv.conf says. In
+      // practice, Linux appears to implement something slightly different, if the name being searched contains less
+      // than ndots dots, then it should be searched last, rather than first. This means if the heuristic wrongly
+      // identifies a domain as being relative to the search domains, it will still be looked up if it doesn't resolve
+      // at any of the search domains, albeit with the latency of having to have done all the searches first.
+      val toResolve = if (name.count(_ == '.') >= settings.NDots) {
+        name :: nameWithSearch
+      } else {
+        nameWithSearch :+ name
+      }
+      resolveFirst(toResolve, requestType, resolver, self)
+    } else {
+      val selfCmd = Internal.Resolve(name, requestType, resolver, Promise())
+      self ! selfCmd
+      selfCmd.promise.future
+    }
+  }
+
+  private def resolveFirst(
+      searchNames: List[String],
+      requestType: RequestType,
+      resolver: ActorRef,
+      self: ActorRef): Future[DnsProtocol.Resolved] =
+    searchNames.headOption match {
+      case Some(searchName) =>
+        val selfCmd = Internal.Resolve(searchName, requestType, resolver, Promise())
+        self ! selfCmd
+
+        if (searchNames.tail.isEmpty) {
+          selfCmd.promise.future
+        } else {
+          selfCmd.promise.future.flatMap { resolved =>
+            if (resolved.records.isEmpty) resolveFirst(searchNames.tail, requestType, resolver, self)
+            else selfCmd.promise.future
+          }(ExecutionContexts.parasitic)
+        }
+
+      case None =>
+        // can't happen
+        Future.failed(new IllegalStateException("Failed to 'resolveFirst': 'searchNames' must not be empty"))
+    }
+
+  private def sendQuestion(resolver: ActorRef, message: DnsQuestion)(implicit timeout: Timeout): Future[Answer] = {
+    val result = (resolver ? message).mapTo[Answer]
+    result.failed.foreach { _ =>
+      resolver ! DropRequest(message.id)
+    }(ExecutionContexts.parasitic)
+    result
+  }
 }

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
@@ -7,16 +7,17 @@ package akka.io.dns.internal
 import java.net.{ Inet4Address, Inet6Address, InetAddress, InetSocketAddress }
 
 import scala.collection.immutable
-import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Future
-import scala.util.Try
+import scala.concurrent.duration.Duration
+import scala.util.{ Failure, Success, Try }
 import scala.util.control.NonFatal
 
-import akka.actor.{ Actor, ActorLogging, ActorRef, ActorRefFactory }
+import akka.actor.{ Actor, ActorLogging, ActorRef, ActorRefFactory, Props, ReceiveTimeout, Stash, Status }
 import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
 import akka.io.SimpleDnsCache
 import akka.io.dns._
-import akka.io.dns.CachePolicy.{ Never, Ttl }
+import akka.io.dns.CachePolicy.{ CachePolicy, Never, Ttl }
 import akka.io.dns.DnsProtocol.{ Ip, RequestType, Srv }
 import akka.io.dns.internal.DnsClient._
 import akka.pattern.{ ask, pipe }
@@ -36,8 +37,6 @@ private[io] final class AsyncDnsResolver(
     with ActorLogging {
 
   import AsyncDnsResolver._
-
-  implicit val ec: ExecutionContextExecutor = context.dispatcher
 
   // avoid ever looking up localhost by pre-populating cache
   {
@@ -75,14 +74,9 @@ private[io] final class AsyncDnsResolver(
     settings.SearchDomains,
     settings.NDots)
 
-  private var requestId: Short = 0
-
-  private def nextId(): Short = {
-    requestId = (requestId + 1).toShort
-    requestId
-  }
-
   private val resolvers: List[ActorRef] = clientFactory(context, nameServers)
+
+  private val requestIdInjector: ActorRef = context.actorOf(injectorProps, "requestIdInjector")
 
   // only supports DnsProtocol, not the deprecated Dns protocol
   // AsyncDnsManager converts between the protocols to support the deprecated protocol
@@ -93,133 +87,13 @@ private[io] final class AsyncDnsResolver(
           log.debug("{} cached {}", mode, resolved)
           sender() ! resolved
         case None =>
-          resolveWithResolvers(name, mode, resolvers)
-            .map { resolved =>
-              if (resolved.records.nonEmpty) {
-                val minTtl = (positiveCachePolicy +: resolved.records.map(_.ttl)).min
-                cache.put((name, mode), resolved, minTtl)
-              } else if (negativeCachePolicy != Never) cache.put((name, mode), resolved, negativeCachePolicy)
-              log.debug(s"{} resolved {}", mode, resolved)
-              resolved
-            }
-            .pipeTo(sender())
+          context.actorOf(DnsResolutionActor.props(settings, resolvers, requestIdInjector, name, mode, sender()))
+        // resolution actor will handle replying
       }
+
+    case CachePut(name, mode, resolved, ttl) =>
+      cache.put(name -> mode, resolved, ttl)
   }
-
-  private def resolveWithResolvers(
-      name: String,
-      requestType: RequestType,
-      resolvers: List[ActorRef]): Future[DnsProtocol.Resolved] =
-    if (isInetAddress(name)) {
-      Future.fromTry {
-        Try {
-          val address = InetAddress.getByName(name) // only checks validity, since known to be IP address
-          val record = address match {
-            case _: Inet4Address           => ARecord(name, Ttl.effectivelyForever, address)
-            case ipv6address: Inet6Address => AAAARecord(name, Ttl.effectivelyForever, ipv6address)
-            case unexpected                => throw new IllegalArgumentException(s"Unexpected address: $unexpected")
-          }
-          DnsProtocol.Resolved(name, record :: Nil)
-        }
-      }
-    } else {
-      resolvers match {
-        case Nil =>
-          Future.failed(ResolveFailedException(s"Failed to resolve $name with nameservers: $nameServers"))
-        case head :: tail =>
-          resolveWithSearch(name, requestType, head).recoverWith {
-            case NonFatal(t) =>
-              t match {
-                case _: AskTimeoutException =>
-                  log.info("Resolve of {} timed out after {}. Trying next name server", name, timeout.duration.pretty)
-                case _ =>
-                  log.info("Resolve of {} failed. Trying next name server {}", name, t.getMessage)
-              }
-              resolveWithResolvers(name, requestType, tail)
-          }
-      }
-    }
-
-  private def sendQuestion(resolver: ActorRef, message: DnsQuestion): Future[Answer] = {
-    val result = (resolver ? message).mapTo[Answer]
-    result.failed.foreach { _ =>
-      resolver ! DropRequest(message.id)
-    }
-    result
-  }
-
-  private def resolveWithSearch(
-      name: String,
-      requestType: RequestType,
-      resolver: ActorRef): Future[DnsProtocol.Resolved] = {
-    if (settings.SearchDomains.nonEmpty) {
-      val nameWithSearch = settings.SearchDomains.map(sd => name + "." + sd)
-      // ndots is a heuristic used to try and work out whether the name passed in is a fully qualified domain name,
-      // or a name relative to one of the search names. The idea is to prevent the cost of doing a lookup that is
-      // obviously not going to resolve. So, if a host has less than ndots dots in it, then we don't try and resolve it,
-      // instead, we go directly to the search domains, or at least that's what the man page for resolv.conf says. In
-      // practice, Linux appears to implement something slightly different, if the name being searched contains less
-      // than ndots dots, then it should be searched last, rather than first. This means if the heuristic wrongly
-      // identifies a domain as being relative to the search domains, it will still be looked up if it doesn't resolve
-      // at any of the search domains, albeit with the latency of having to have done all the searches first.
-      val toResolve = if (name.count(_ == '.') >= settings.NDots) {
-        name :: nameWithSearch
-      } else {
-        nameWithSearch :+ name
-      }
-      resolveFirst(toResolve, requestType, resolver)
-    } else {
-      resolve(name, requestType, resolver)
-    }
-  }
-
-  private def resolveFirst(
-      searchNames: List[String],
-      requestType: RequestType,
-      resolver: ActorRef): Future[DnsProtocol.Resolved] = {
-    searchNames match {
-      case searchName :: Nil =>
-        resolve(searchName, requestType, resolver)
-      case searchName :: remaining =>
-        resolve(searchName, requestType, resolver).flatMap { resolved =>
-          if (resolved.records.isEmpty) resolveFirst(remaining, requestType, resolver)
-          else Future.successful(resolved)
-        }
-      case Nil =>
-        // This can't happen
-        Future.failed(new IllegalStateException("Failed to 'resolveFirst': 'searchNames' must not be empty"))
-    }
-  }
-
-  private def resolve(name: String, requestType: RequestType, resolver: ActorRef): Future[DnsProtocol.Resolved] = {
-    log.debug("Attempting to resolve {} with {}", name, resolver)
-    val caseFoldedName = Helpers.toRootLowerCase(name)
-    requestType match {
-      case Ip(ipv4, ipv6) =>
-        val ipv4Recs: Future[Answer] =
-          if (ipv4)
-            sendQuestion(resolver, Question4(nextId(), caseFoldedName))
-          else
-            Empty
-
-        val ipv6Recs =
-          if (ipv6)
-            sendQuestion(resolver, Question6(nextId(), caseFoldedName))
-          else
-            Empty
-
-        for {
-          ipv4 <- ipv4Recs
-          ipv6 <- ipv6Recs
-        } yield DnsProtocol.Resolved(name, ipv4.rrs ++ ipv6.rrs, ipv4.additionalRecs ++ ipv6.additionalRecs)
-
-      case Srv =>
-        sendQuestion(resolver, SrvQuestion(nextId(), caseFoldedName)).map(answer => {
-          DnsProtocol.Resolved(name, answer.rrs, answer.additionalRecs)
-        })
-    }
-  }
-
 }
 
 /**
@@ -247,4 +121,242 @@ private[akka] object AsyncDnsResolver {
     Future.successful(Answer(-1, immutable.Seq.empty[ResourceRecord], immutable.Seq.empty[ResourceRecord]))
 
   case class ResolveFailedException(msg: String) extends Exception(msg)
+
+  private final case class CachePut(name: String, mode: RequestType, resolved: DnsProtocol.Resolved, ttl: CachePolicy)
+
+  private final case class DnsQuestionPreInjection(resolver: ActorRef, inject: Short => DnsQuestion, timeout: Timeout)
+
+  private val injectorProps = Props(new RequestIdInjector())
+
+  // tracks and injects a request ID before forwarding to the resolver
+  private class RequestIdInjector extends Actor {
+    private var requestId: Short = 0
+
+    private def nextId(): Short = {
+      requestId = (requestId + 1).toShort
+      requestId
+    }
+
+    override def receive: Receive = {
+      case DnsQuestionPreInjection(resolver, inject, timeout) =>
+        implicit val tmout = timeout
+        val question = inject(nextId())
+        val forwardAnswerTo = sender()
+        val result = (resolver ? question).mapTo[Answer]
+
+        result.onComplete {
+          case Success(answer) => forwardAnswerTo ! answer
+          case Failure(_)      => resolver ! DropRequest(question.id)
+        }(ExecutionContexts.parasitic)
+    }
+  }
+
+  private object DnsResolutionActor {
+    def props(
+        settings: DnsSettings,
+        resolvers: List[ActorRef],
+        requestIdInjector: ActorRef,
+        name: String,
+        mode: RequestType,
+        answerTo: ActorRef) =
+      Props(new DnsResolutionActor(settings, resolvers, requestIdInjector, name, mode, answerTo))
+
+    final case class AnswerWithFailure(ex: Throwable)
+    final case class ResolveWithFirstResolver(remainingResolvers: List[ActorRef])
+    final case class Resolve(searchName: String, resolver: ActorRef)
+  }
+
+  private class DnsResolutionActor(
+      settings: DnsSettings,
+      resolvers: List[ActorRef],
+      requestIdInjector: ActorRef,
+      name: String,
+      mode: RequestType,
+      answerTo: ActorRef)
+      extends Actor
+      with ActorLogging
+      with Stash {
+    import DnsResolutionActor._
+
+    private implicit val timeout = Timeout(settings.ResolveTimeout)
+
+    if (isInetAddress(name)) {
+      // eagerly resolve
+      Try {
+        val address = InetAddress.getByName(name) // only checks validity, since known to be IP address
+        address match {
+          case _: Inet4Address    => ARecord(name, Ttl.effectivelyForever, address)
+          case ipv6: Inet6Address => AAAARecord(name, Ttl.effectivelyForever, ipv6)
+          case unexpected         => throw new IllegalArgumentException(s"Unexpected address: $unexpected")
+        }
+      }.fold(answerWithFailure(_), record => { self ! DnsProtocol.Resolved(name, record :: Nil) })
+    } else if (resolvers.isEmpty) {
+      failToResolve()
+    } else {
+      self ! ResolveWithFirstResolver(resolvers)
+    }
+
+    private def failToResolve(): Unit =
+      answerWithFailure(ResolveFailedException(s"Failed to resolve $name with nameservers ${settings.NameServers}"))
+
+    private def answerWithFailure(ex: Throwable): Unit = answer(Status.Failure(ex))
+
+    private def answer(withMsg: Any): Unit = {
+      answerTo ! withMsg
+
+      context.stop(self)
+    }
+
+    // the fully-qualified domain names (FQDNs), in the order we want to attempt for any given resolver
+    private val namesToResolve = {
+      val nameWithSearch = settings.SearchDomains.map(sd => s"${name}.${sd}")
+
+      // ndots is a heuristic used to attempt to work out if `name` is an FQDN or a name relative to a search
+      // name.  The goal is to not incur the cost of a lookup that's unlikely to resolve because we need to
+      // relativize it.  If the name being searched contains less than ndots dots, then we look it up last,
+      // rather than first.
+      if (name.count(_ == '.') >= settings.NDots) {
+        // assume fully-qualified, so try `name` first
+        (name :: nameWithSearch).map(Helpers.toRootLowerCase)
+      } else {
+        // assume relative, so try `name` last
+        (nameWithSearch :+ name).map(Helpers.toRootLowerCase)
+      }
+    }
+
+    override def receive: Receive = notActivelyResolving
+
+    private val notActivelyResolving: Receive = {
+      case resolved: DnsProtocol.Resolved =>
+        if (resolved.records.nonEmpty) {
+          val minTtl = (settings.PositiveCachePolicy +: resolved.records.map(_.ttl)).min
+          context.parent ! CachePut(name, mode, resolved, minTtl)
+        } else if (settings.NegativeCachePolicy != Never) {
+          context.parent ! CachePut(name, mode, resolved, settings.NegativeCachePolicy)
+        }
+
+        log.debug("{} resolved {}", mode, resolved)
+
+        answer(resolved)
+
+      case ResolveWithFirstResolver(remainingResolvers) =>
+        remainingResolvers.headOption match {
+          case Some(resolver) =>
+            // send a Resolve message for each of the search names (in order... thank you self-send guarantee)
+            // then send a ResolveWithFirstResolver to move on to the next resolver
+            // all but the first of these will be stashed by the `activelyResolving` behavior
+            namesToResolve.foreach { searchName =>
+              self ! DnsResolutionActor.Resolve(searchName, resolver)
+            }
+
+            self ! ResolveWithFirstResolver(remainingResolvers.tail)
+
+          case _ => failToResolve() // exhausted the resolvers
+        }
+
+      case DnsResolutionActor.Resolve(searchName, resolver) =>
+        log.debug("Attempting to resolve {} with {}", searchName, resolver)
+
+        implicit val ec = context.dispatcher // In order to get pipeTo
+        resolvedFut(searchName, resolver, None).pipeTo(self)
+
+        context.become(activelyResolving(searchName))
+    }
+
+    private def activelyResolving(searchName: String): Receive = {
+      // stash resolution requests because we won't do anything with them while actively resolving
+      case _: DnsResolutionActor.Resolve => log.info("stashing Resolve"); stash()
+      case _: ResolveWithFirstResolver   => log.info("stashing ResolveWithFirstResolver"); stash()
+
+      case resolved: DnsProtocol.Resolved =>
+        // Check whether this is the final resolution or we need to unstash and try another resolution
+        log.info("resolved {}", resolved)
+        if (resolved.records.isEmpty) {
+          unstashAll()
+          context.become(resolveNextName(resolved))
+        } else {
+          // will update parent cache, answer, and stop
+          notActivelyResolving(resolved)
+        }
+
+      case Status.Failure(ex) =>
+        ex match {
+          case _: AskTimeoutException =>
+            log.info("Resolve of {} timed out after {}.  Trying next name server", searchName, timeout.duration.pretty)
+          case _ =>
+            log.info("Resolve of {} failed.  Trying next name server.  Exception: {}", name, ex.getMessage)
+        }
+
+        unstashAll()
+        context.setReceiveTimeout(settings.ResolveTimeout)
+        context.become(nextNameServer)
+    }
+
+    // will not move on to the next server, since we have a fallback resolution
+    def resolveNextName(fallbackResolution: DnsProtocol.Resolved): Receive = {
+      case _: ResolveWithFirstResolver =>
+        // We're done with this server, so answer, update parent cache (maybe), and stop
+        notActivelyResolving(fallbackResolution)
+
+      case DnsResolutionActor.Resolve(searchName, resolver) =>
+        log.debug("Attempting to resolve {} with {}", searchName, resolver)
+
+        implicit val ec = context.dispatcher // In order to get pipeTo
+        resolvedFut(searchName, resolver, Some(fallbackResolution)).pipeTo(self)
+
+        context.become(activelyResolving(searchName))
+    }
+
+    // drop pending resolves for the current resolver until we get a switch to the next resolver
+    private val nextNameServer: Receive = {
+      case _: DnsResolutionActor.Resolve => () // do nothing aka drop it
+      case switchResolver: ResolveWithFirstResolver =>
+        context.setReceiveTimeout(Duration.Undefined)
+
+        notActivelyResolving(switchResolver)
+        context.become(notActivelyResolving)
+
+      case ReceiveTimeout =>
+        // shouldn't happen
+        log.warning("Expected there to be a stashed ResolveWithFirstResolver message, but there wasn't")
+        failToResolve()
+    }
+
+    private def sendQuestion(resolver: ActorRef, inject: Short => DnsQuestion): Future[Answer] =
+      (requestIdInjector ? DnsQuestionPreInjection(resolver, inject, timeout)).mapTo[Answer]
+
+    private def resolvedFut(
+        searchName: String,
+        resolver: ActorRef,
+        fallbackResolved: Option[DnsProtocol.Resolved]): Future[DnsProtocol.Resolved] = {
+      val questionFut =
+        mode match {
+          case Ip(ipv4, ipv6) =>
+            val ipv4Recs =
+              if (ipv4) sendQuestion(resolver, requestId => Question4(requestId, searchName))
+              else Empty
+
+            val ipv6Recs =
+              if (ipv6) sendQuestion(resolver, requestId => Question6(requestId, searchName))
+              else Empty
+
+            ipv4Recs.flatMap { v4 =>
+              ipv6Recs.map { v6 =>
+                DnsProtocol.Resolved(name, v4.rrs ++ v6.rrs, v4.additionalRecs ++ v6.additionalRecs)
+              }(ExecutionContexts.parasitic)
+            }(ExecutionContexts.parasitic)
+
+          case Srv =>
+            sendQuestion(resolver, requestId => SrvQuestion(requestId, searchName)).map { answer =>
+              DnsProtocol.Resolved(name, answer.rrs, answer.additionalRecs)
+            }(ExecutionContexts.parasitic)
+        }
+
+      fallbackResolved.fold(questionFut) { fallback =>
+        questionFut.recover {
+          case _ => fallback
+        }(ExecutionContexts.parasitic)
+      }
+    }
+  }
 }

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
@@ -182,7 +182,6 @@ private[akka] object AsyncDnsResolver {
         cacheActor: ActorRef): Props =
       Props(new DnsResolutionActor(settings, requestIdInjector, name, mode, answerTo, cacheActor))
 
-    final case class AnswerWithFailure(ex: Throwable)
     final case class ResolveWithFirstResolver(remainingResolvers: List[ActorRef])
     final case class Resolve(searchName: String, resolver: ActorRef)
   }

--- a/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
+++ b/akka-actor/src/main/scala/akka/io/dns/internal/AsyncDnsResolver.scala
@@ -168,7 +168,7 @@ private[akka] object AsyncDnsResolver {
         { answerTo ! Status.Failure(failToResolve(name, settings.NameServers)) }
       } else {
         // spawn an actor to actually use a resolver
-        spawner: (Props => ActorRef) =>
+        (spawner: (Props => ActorRef)) =>
           {
             val propsForSpawn = props(settings, requestIdInjector, name, mode, answerTo, cacheActor)
             spawner(propsForSpawn) ! ResolveWithFirstResolver(resolvers)
@@ -197,7 +197,7 @@ private[akka] object AsyncDnsResolver {
         mode: RequestType,
         answerTo: ActorRef,
         cacheActor: ActorRef,
-        settings: DnsSettings): Any => Unit = { _: Any =>
+        settings: DnsSettings): Any => Unit = { (_: Any) =>
       Try {
         val address = InetAddress.getByName(name) // only checks validity, since known to be IP address
         address match {
@@ -226,7 +226,7 @@ private[akka] object AsyncDnsResolver {
       with Stash {
     import DnsResolutionActor._
 
-    private implicit val timeout = Timeout(settings.ResolveTimeout)
+    private implicit val timeout: Timeout = Timeout(settings.ResolveTimeout)
 
     private def failToResolve(): Unit =
       answerWithFailure(DnsResolutionActor.failToResolve(name, settings.NameServers))


### PR DESCRIPTION
References #31905 

Future callbacks in `AsyncDnsResolver` will, in situations where multiple resolution attempts for a request are being made (e.g. failing over to a different DNS server or if there are multiple search domains), close over actor state which is not otherwise synchronized, thus breaking the actor model's single threaded illusion.

This change moves such resolution attempts to explicit actor messages.
