### PR TITLE
Use parasitic context by default in Classic pipe pattern

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/pattern/PipeToSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/PipeToSpec.scala
@@ -24,7 +24,7 @@ class PipeToSpec extends AkkaSpec {
     }
 
     "work with an implicit ExecutionContext" in {
-      import system.dispatcher  // installs an EC in implicit scope
+      import system.dispatcher // installs an EC in implicit scope
 
       val p = TestProbe()
       future42().pipeTo(p.ref)


### PR DESCRIPTION
Inspired by a side discussion in #31906, makes the default `ExecutionContext` for the Classic pipe pattern for Scala futures the `parasitic` (aka "same thread") context.

The Typed `context.pipeToSelf` counterpart only uses the parasitic context (the Classic pipe pattern is still required for piping a future to an actor that's not `self`).  For Java futures, the `ExecutionContext` setting has no effect, but the use of `whenComplete` in both Classic and Typed has effectively the same semantics.

A local run of MiMa reported no binary issues (a little surprisingly...).  Since existing source code is putting a context in the implicit scope (most likely the context/system `dispatcher`), new/edited code is required in order to take advantage of this, but this does remove a reason to have an implicit `ExecutionContext` in an actor.