### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+
+# No need to enforce an editor config for Java/Scala files, as the build automatically styles
+[*.conf]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
We have the applyCodeStyle to ensure consistent formatting of Java/Scala files, but other files (most notably `conf`s) don't have style settings enforced.

https://editorconfig.org is supported by nearly every tool commonly used to edit such files (unfortunately, there isn't an sbt plugin AFAICT for enforcing this), so having an `.editorconfig` in the repo at least signals to tools that when editing a `conf` file that we like 2 spaces as an indent.

TODO: maybe update CONTRIBUTING.md to suggest using an editorconfig-supporting editor (depending on editor, this may mean a plugin: VSCode, IntelliJ, and Github all support out of the box)
