### PR TITLE
chore: More Serializer constructor alternatives, #29765

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
@@ -686,11 +686,13 @@ private[akka] class Constructor4Serializer extends ConstructorSerializer {
   override def identifier = 100004
 }
 
-private[akka] class Constructor5Serializer(@unused system: ExtendedActorSystem, @unused binding: String) extends ConstructorSerializer {
+private[akka] class Constructor5Serializer(@unused system: ExtendedActorSystem, @unused binding: String)
+    extends ConstructorSerializer {
   override def identifier = 100005
 }
 
-private[akka] class Constructor6Serializer(@unused system: ActorSystem, @unused binding: String) extends ConstructorSerializer {
+private[akka] class Constructor6Serializer(@unused system: ActorSystem, @unused binding: String)
+    extends ConstructorSerializer {
   override def identifier = 100006
 }
 

--- a/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/serialization/SerializeSpec.scala
@@ -33,6 +33,14 @@ object SerializationTests {
           test = "akka.serialization.NoopSerializer"
           test2 = "akka.serialization.NoopSerializer2"
           other = "other.SerializerOutsideAkkaPackage"
+
+          constructor1 = "akka.serialization.Constructor1Serializer"
+          constructor2 = "akka.serialization.Constructor2Serializer"
+          constructor3 = "akka.serialization.Constructor3Serializer"
+          constructor4 = "akka.serialization.Constructor4Serializer"
+          constructor5 = "akka.serialization.Constructor5Serializer"
+          constructor6 = "akka.serialization.Constructor6Serializer"
+          constructor7 = "akka.serialization.Constructor7Serializer"
         }
 
         serialization-bindings {
@@ -45,6 +53,14 @@ object SerializationTests {
           "akka.serialization.SerializationTests$$D" = test
           "akka.serialization.SerializationTests$$Marker2" = test2
           "akka.serialization.SerializationTests$$AbstractOther" = other
+
+          "akka.serialization.ConstructorSerializer$$No1" = constructor1
+          "akka.serialization.ConstructorSerializer$$No2" = constructor2
+          "akka.serialization.ConstructorSerializer$$No3" = constructor3
+          "akka.serialization.ConstructorSerializer$$No4" = constructor4
+          "akka.serialization.ConstructorSerializer$$No5" = constructor5
+          "akka.serialization.ConstructorSerializer$$No6" = constructor6
+          "akka.serialization.ConstructorSerializer$$No7" = constructor7
         }
       }
     }
@@ -292,6 +308,16 @@ class SerializeSpec extends AkkaSpec(SerializationTests.serializeConf) {
           """))
         shutdown(sys)
       }.getMessage should include).regex("Serializer identifier \\[9999\\].*is not unique")
+    }
+
+    "look for various constructors" in {
+      ser.serializerFor(classOf[ConstructorSerializer.No1]).getClass should ===(classOf[Constructor1Serializer])
+      ser.serializerFor(classOf[ConstructorSerializer.No2]).getClass should ===(classOf[Constructor2Serializer])
+      ser.serializerFor(classOf[ConstructorSerializer.No3]).getClass should ===(classOf[Constructor3Serializer])
+      ser.serializerFor(classOf[ConstructorSerializer.No4]).getClass should ===(classOf[Constructor4Serializer])
+      ser.serializerFor(classOf[ConstructorSerializer.No5]).getClass should ===(classOf[Constructor5Serializer])
+      ser.serializerFor(classOf[ConstructorSerializer.No6]).getClass should ===(classOf[Constructor6Serializer])
+      ser.serializerFor(classOf[ConstructorSerializer.No7]).getClass should ===(classOf[Constructor7Serializer])
     }
   }
 }
@@ -620,4 +646,55 @@ class DeadlockSerializer(system: ExtendedActorSystem) extends Serializer {
   def toBinary(o: AnyRef): Array[Byte] = Array.empty[Byte]
 
   def fromBinary(bytes: Array[Byte], clazz: Option[Class[_]]): AnyRef = null
+}
+
+object ConstructorSerializer {
+  class No1
+  class No2
+  class No3
+  class No4
+  class No5
+  class No6
+  class No7
+}
+
+private[akka] abstract class ConstructorSerializer extends SerializerWithStringManifest {
+
+  def toBinary(o: AnyRef): Array[Byte] = {
+    Array.empty[Byte]
+  }
+
+  override def manifest(o: AnyRef): String = "test"
+
+  override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef =
+    "Test"
+}
+
+private[akka] class Constructor1Serializer(@unused system: ExtendedActorSystem) extends ConstructorSerializer {
+  override def identifier = 100001
+}
+
+private[akka] class Constructor2Serializer(@unused system: ActorSystem) extends ConstructorSerializer {
+  override def identifier = 100002
+}
+
+private[akka] class Constructor3Serializer(@unused system: ClassicActorSystemProvider) extends ConstructorSerializer {
+  override def identifier = 100003
+}
+
+private[akka] class Constructor4Serializer extends ConstructorSerializer {
+  override def identifier = 100004
+}
+
+private[akka] class Constructor5Serializer(@unused system: ExtendedActorSystem, @unused binding: String) extends ConstructorSerializer {
+  override def identifier = 100005
+}
+
+private[akka] class Constructor6Serializer(@unused system: ActorSystem, @unused binding: String) extends ConstructorSerializer {
+  override def identifier = 100006
+}
+
+private[akka] class Constructor7Serializer(@unused system: ClassicActorSystemProvider, @unused binding: String)
+    extends ConstructorSerializer {
+  override def identifier = 100007
 }

--- a/akka-actor/src/main/scala/akka/serialization/Serialization.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serialization.scala
@@ -399,9 +399,8 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
                     case _: NoSuchMethodException =>
                       if (bindingName == "") {
                         // compatibility with (public) serializerOf method without bindingName
-                        throw new NoSuchMethodException(
-                          s"The serializer [$fqn] doesn't have a matching constructor, " +
-                          s"see API documentation of ${classOf[Serializer].getName}")
+                        throw new NoSuchMethodException(s"The serializer [$fqn] doesn't have a matching constructor, " +
+                        s"see API documentation of ${classOf[Serializer].getName}")
                       } else
                         system.dynamicAccess
                           .createInstanceFor[Serializer](

--- a/akka-actor/src/main/scala/akka/serialization/Serialization.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serialization.scala
@@ -389,13 +389,38 @@ class Serialization(val system: ExtendedActorSystem) extends Extension {
 
     system.dynamicAccess.createInstanceFor[Serializer](fqn, List(classOf[ExtendedActorSystem] -> system)).recoverWith {
       case _: NoSuchMethodException =>
-        system.dynamicAccess.createInstanceFor[Serializer](fqn, Nil).recoverWith {
-          case e: NoSuchMethodException =>
-            if (bindingName == "") throw e // compatibility with (public) serializerOf method without bindingName
-            else
-              system.dynamicAccess.createInstanceFor[Serializer](
-                fqn,
-                List(classOf[ExtendedActorSystem] -> system, classOf[String] -> bindingName))
+        system.dynamicAccess.createInstanceFor[Serializer](fqn, List(classOf[ActorSystem] -> system)).recoverWith {
+          case _: NoSuchMethodException =>
+            system.dynamicAccess
+              .createInstanceFor[Serializer](fqn, List(classOf[ClassicActorSystemProvider] -> system))
+              .recoverWith {
+                case _: NoSuchMethodException =>
+                  system.dynamicAccess.createInstanceFor[Serializer](fqn, Nil).recoverWith {
+                    case e: NoSuchMethodException =>
+                      if (bindingName == "")
+                        throw e // compatibility with (public) serializerOf method without bindingName
+                      else
+                        system.dynamicAccess
+                          .createInstanceFor[Serializer](
+                            fqn,
+                            List(classOf[ExtendedActorSystem] -> system, classOf[String] -> bindingName))
+                          .recoverWith {
+                            case _: NoSuchMethodException =>
+                              system.dynamicAccess
+                                .createInstanceFor[Serializer](
+                                  fqn,
+                                  List(classOf[ActorSystem] -> system, classOf[String] -> bindingName))
+                                .recoverWith {
+                                  case _: NoSuchMethodException =>
+                                    system.dynamicAccess.createInstanceFor[Serializer](
+                                      fqn,
+                                      List(
+                                        classOf[ClassicActorSystemProvider] -> system,
+                                        classOf[String] -> bindingName))
+                                }
+                          }
+                  }
+              }
         }
     }
   }

--- a/akka-actor/src/main/scala/akka/serialization/Serializer.scala
+++ b/akka-actor/src/main/scala/akka/serialization/Serializer.scala
@@ -24,15 +24,19 @@ import akka.util.ClassLoaderObjectInputStream
  * A Serializer represents a bimap between an object and an array of bytes representing that object.
  *
  * Serializers are loaded using reflection during [[akka.actor.ActorSystem]]
- * start-up, where two constructors are tried in order:
+ * start-up, where constructors are tried in order:
  *
  * <ul>
  * <li>taking exactly one argument of type [[akka.actor.ExtendedActorSystem]];
  * this should be the preferred one because all reflective loading of classes
  * during deserialization should use ExtendedActorSystem.dynamicAccess (see
- * [[akka.actor.DynamicAccess]]), and</li>
- * <li>without arguments, which is only an option if the serializer does not
- * load classes using reflection.</li>
+ * [[akka.actor.DynamicAccess]])</li>
+ * <li>taking exactly one argument of type [[akka.actor.ActorSystem]]
+ * <li>taking exactly one argument of type [[akka.actor.ClassicActorSystemProvider]]
+ * <li>without arguments</li>
+ * <li>taking two arguments of type [[akka.actor.ExtendedActorSystem]] and `String` where the second `String` argument is the binding name
+ * <li>taking two arguments of type [[akka.actor.ActorSystem]] and `String` where the second `String` argument is the binding name
+ * <li>taking two arguments of type [[akka.actor.ClassicActorSystemProvider]] and `String` where the second `String` argument is the binding name
  * </ul>
  *
  * <b>Be sure to always use the </b>[[akka.actor.DynamicAccess]]<b> for loading classes!</b> This is necessary to
@@ -104,11 +108,19 @@ object Serializers {
  * you used `includeManifest=true`, otherwise it will be the empty string.
  *
  * Serializers are loaded using reflection during [[akka.actor.ActorSystem]]
- * start-up, where two constructors are tried in order:
+ * start-up, where constructors are tried in order:
  *
  * <ul>
- * <li>taking exactly one argument of type [[akka.actor.ExtendedActorSystem]], and</li>
+ * <li>taking exactly one argument of type [[akka.actor.ExtendedActorSystem]];
+ * this should be the preferred one because all reflective loading of classes
+ * during deserialization should use ExtendedActorSystem.dynamicAccess (see
+ * [[akka.actor.DynamicAccess]])</li>
+ * <li>taking exactly one argument of type [[akka.actor.ActorSystem]]
+ * <li>taking exactly one argument of type [[akka.actor.ClassicActorSystemProvider]]
  * <li>without arguments</li>
+ * <li>taking two arguments of type [[akka.actor.ExtendedActorSystem]] and `String` where the second `String` argument is the binding name
+ * <li>taking two arguments of type [[akka.actor.ActorSystem]] and `String` where the second `String` argument is the binding name
+ * <li>taking two arguments of type [[akka.actor.ClassicActorSystemProvider]] and `String` where the second `String` argument is the binding name
  * </ul>
  *
  * <b>Be sure to always use the </b>[[akka.actor.DynamicAccess]]<b> for loading classes!</b> This is necessary to


### PR DESCRIPTION
As mentioned in the issue, one reason can be for use with testkit if ExtendedActorSystem isn't needed in the serializer.

References #29765
