### PR TITLE
Update Jackson to 2.14.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -3,8 +3,8 @@ pullRequests.frequency = "@monthly"
 
 updates.pin  = [
   { groupId = "org.scalatest", artifactId = "scalatest", version = "3.2." }
-  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-core", version = "2.13." }
-  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-databind", version = "2.13." }
+  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-core", version = "2.14." }
+  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-databind", version = "2.14." }
 ]
 
 updates.ignore = [

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,8 +26,8 @@ object Dependencies {
   val logbackVersion = "1.2.12"
   val scalaFortifyVersion = "1.0.22"
   val fortifySCAVersion = "22.1"
-  val jacksonCoreVersion = "2.13.5"
-  val jacksonDatabindVersion = jacksonCoreVersion
+  val jacksonCoreVersion = "2.14.3" // https://github.com/FasterXML/jackson-core/tags
+  val jacksonDatabindVersion = jacksonCoreVersion // https://github.com/FasterXML/jackson-databind/tags
 
   val scala212Version = "2.12.17"
   val scala213Version = "2.13.10"


### PR DESCRIPTION
Jackson 2.14 is the current stable version. Before Akka's next minor release, we should revisit and see if Akka should go to Jackson 2.15.

Opening as draft so that main can stay open for fixes to the recent release.

References
- https://github.com/akka/akka/pull/31595
