### PR TITLE
feat: Include exception type in StatusReply toString when not text

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/pattern/StatusReplySpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/StatusReplySpec.scala
@@ -54,6 +54,10 @@ class StatusReplySpec extends AkkaSpec with ScalaFutures {
       }
     }
 
+    "include exception type in toString for non text-error" in {
+      StatusReply.Error(TestException("boho!")).toString should include("TestException")
+    }
+
     "transform scala.util.Try" in {
       StatusReply.fromTry(scala.util.Success("woho")) should matchPattern {
         case StatusReply.Success("woho") =>

--- a/akka-actor/src/main/scala/akka/pattern/StatusReply.scala
+++ b/akka-actor/src/main/scala/akka/pattern/StatusReply.scala
@@ -13,6 +13,7 @@ import akka.Done
 import akka.actor.InvalidMessageException
 import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts
+import akka.pattern.StatusReply.ErrorMessage
 
 /**
  * Generic top-level message type for replies that signal failure or success. Convenient to use together with the
@@ -53,8 +54,9 @@ final class StatusReply[+T] private (private val status: Try[T]) {
   override def hashCode(): Int = status.hashCode
 
   override def toString: String = status match {
-    case ScalaSuccess(t)  => s"Success($t)"
-    case ScalaFailure(ex) => s"Error(${ex.getMessage})"
+    case ScalaSuccess(t)                => s"Success($t)"
+    case ScalaFailure(ex: ErrorMessage) => s"Error(${ex.getMessage})"
+    case ScalaFailure(ex)               => s"Error(${ex.getClass.getName}: ${ex.getMessage})"
   }
 
 }


### PR DESCRIPTION
Helps making test assertions easier to understand when using custom exception and they do not match as expected, this is what you can get currently:

`java.lang.AssertionError: expected Error(text text text), found Error(text text text)`