### PR TITLE
feat: Collocating shards with consistent hashing

### DIFF
--- a/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ConsistentHashingShardAllocationCompileOnlyTest.java
+++ b/akka-cluster-sharding-typed/src/test/java/jdocs/akka/cluster/sharding/typed/ConsistentHashingShardAllocationCompileOnlyTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package jdocs.akka.cluster.sharding.typed;
+
+import akka.actor.typed.ActorSystem;
+import akka.actor.typed.Behavior;
+import akka.actor.typed.javadsl.AbstractBehavior;
+import akka.actor.typed.javadsl.ActorContext;
+import akka.actor.typed.javadsl.Behaviors;
+import akka.actor.typed.javadsl.Receive;
+import akka.cluster.sharding.ConsistentHashingShardAllocationStrategy;
+import akka.cluster.sharding.typed.ShardingEnvelope;
+import akka.cluster.sharding.typed.ShardingMessageExtractor;
+import akka.cluster.sharding.typed.javadsl.ClusterSharding;
+import akka.cluster.sharding.typed.javadsl.Entity;
+import akka.cluster.sharding.typed.javadsl.EntityTypeKey;
+
+public class ConsistentHashingShardAllocationCompileOnlyTest {
+
+  // #building
+  public static class Building extends AbstractBehavior<Building.Command> {
+
+    static int NUMBER_OF_SHARDS = 100;
+
+    static final class MessageExtractor
+        extends ShardingMessageExtractor<ShardingEnvelope<Building.Command>, Building.Command> {
+      @Override
+      public String entityId(ShardingEnvelope<Command> envelope) {
+        return envelope.entityId();
+      }
+
+      @Override
+      public String shardId(String entityId) {
+        return String.valueOf(Math.abs(entityId.hashCode() % NUMBER_OF_SHARDS));
+      }
+
+      @Override
+      public Command unwrapMessage(ShardingEnvelope<Command> envelope) {
+        return envelope.message();
+      }
+    }
+
+    static EntityTypeKey<Building.Command> typeKey =
+        EntityTypeKey.create(Building.Command.class, "Building");
+
+    public interface Command {}
+
+    public static Behavior<Building.Command> create(String entityId) {
+      return Behaviors.setup(context -> new Building(context, entityId));
+    }
+
+    private Building(ActorContext<Building.Command> context, String entityId) {
+      super(context);
+    }
+
+    @Override
+    public Receive<Building.Command> createReceive() {
+      return newReceiveBuilder().build();
+    }
+  }
+
+  // #building
+
+  // #device
+  public static class Device extends AbstractBehavior<Device.Command> {
+
+    static final class MessageExtractor
+        extends ShardingMessageExtractor<ShardingEnvelope<Device.Command>, Device.Command> {
+      @Override
+      public String entityId(ShardingEnvelope<Command> envelope) {
+        return envelope.entityId();
+      }
+
+      @Override
+      public String shardId(String entityId) {
+        // Use same shardId as the Building to colocate Building and Device
+        // we have the buildingId as prefix in the entityId
+        String buildingId = entityId.split(":")[0];
+        return String.valueOf(Math.abs(buildingId.hashCode() % Building.NUMBER_OF_SHARDS));
+      }
+
+      @Override
+      public Command unwrapMessage(ShardingEnvelope<Command> envelope) {
+        return envelope.message();
+      }
+    }
+
+    static EntityTypeKey<Device.Command> typeKey =
+        EntityTypeKey.create(Device.Command.class, "Device");
+
+    public interface Command {}
+
+    public static Behavior<Device.Command> create(String entityId) {
+      return Behaviors.setup(context -> new Device(context, entityId));
+    }
+
+    private Device(ActorContext<Device.Command> context, String entityId) {
+      super(context);
+    }
+
+    @Override
+    public Receive<Device.Command> createReceive() {
+      return newReceiveBuilder().build();
+    }
+  }
+
+  // #device
+
+  void example() {
+    ActorSystem<?> system = null;
+
+    // #init
+    int rebalanceLimit = 10;
+
+    ClusterSharding.get(system)
+        .init(
+            Entity.of(Building.typeKey, ctx -> Building.create(ctx.getEntityId()))
+                .withMessageExtractor(new Building.MessageExtractor())
+                .withAllocationStrategy(
+                    new ConsistentHashingShardAllocationStrategy(rebalanceLimit)));
+
+    ClusterSharding.get(system)
+        .init(
+            Entity.of(Device.typeKey, ctx -> Device.create(ctx.getEntityId()))
+                .withMessageExtractor(new Device.MessageExtractor())
+                .withAllocationStrategy(
+                    new ConsistentHashingShardAllocationStrategy(rebalanceLimit)));
+    // #init
+  }
+}

--- a/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ConsistentHashingShardAllocationCompileOnlySpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/docs/akka/cluster/sharding/typed/ConsistentHashingShardAllocationCompileOnlySpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.akka.cluster.sharding.typed
+
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.cluster.sharding.ConsistentHashingShardAllocationStrategy
+import akka.cluster.sharding.typed.ShardingEnvelope
+import akka.cluster.sharding.typed.ShardingMessageExtractor
+import akka.cluster.sharding.typed.scaladsl.ClusterSharding
+import akka.cluster.sharding.typed.scaladsl.Entity
+import akka.cluster.sharding.typed.scaladsl.EntityTypeKey
+
+class ConsistentHashingShardAllocationCompileOnlySpec {
+
+  // #building
+  object Building {
+    val TypeKey = EntityTypeKey[Command]("Building")
+
+    val NumberOfShards = 100
+
+    final class MessageExtractor extends ShardingMessageExtractor[ShardingEnvelope[Command], Command] {
+
+      override def entityId(envelope: ShardingEnvelope[Command]): String =
+        envelope.entityId
+
+      override def shardId(entityId: String): String =
+        math.abs(entityId.hashCode % NumberOfShards).toString
+
+      override def unwrapMessage(envelope: ShardingEnvelope[Command]): Command =
+        envelope.message
+    }
+
+    sealed trait Command
+
+    def apply(entityId: String): Behavior[Command] = ???
+  }
+
+  // #building
+
+  // #device
+  object Device {
+    val TypeKey = EntityTypeKey[Command]("Device")
+
+    final class MessageExtractor extends ShardingMessageExtractor[ShardingEnvelope[Command], Command] {
+
+      override def entityId(envelope: ShardingEnvelope[Command]): String =
+        envelope.entityId
+
+      override def shardId(entityId: String): String = {
+        // Use same shardId as the Building to colocate Building and Device
+        // we have the buildingId as prefix in the entityId
+        val buildingId = entityId.split(':').head
+        math.abs(buildingId.hashCode % Building.NumberOfShards).toString
+      }
+
+      override def unwrapMessage(envelope: ShardingEnvelope[Command]): Command =
+        envelope.message
+    }
+
+    sealed trait Command
+
+    def apply(entityId: String): Behavior[Command] = ???
+  }
+
+  // #device
+
+  val system: ActorSystem[_] = ???
+
+  // #init
+  ClusterSharding(system).init(
+    Entity(Building.TypeKey)(createBehavior = entityContext => Building(entityContext.entityId))
+      .withMessageExtractor(new Building.MessageExtractor)
+      .withAllocationStrategy(new ConsistentHashingShardAllocationStrategy(rebalanceLimit = 10)))
+
+  ClusterSharding(system).init(
+    Entity(Device.TypeKey)(createBehavior = entityContext => Device(entityContext.entityId))
+      .withMessageExtractor(new Device.MessageExtractor)
+      .withAllocationStrategy(new ConsistentHashingShardAllocationStrategy(rebalanceLimit = 10)))
+  // #init
+
+}

--- a/akka-cluster-sharding/src/main/mima-filters/2.6.20.backwards.excludes/consistent-hashing-allocation.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.6.20.backwards.excludes/consistent-hashing-allocation.excludes
@@ -1,0 +1,5 @@
+# Internals
+ProblemFilters.exclude[MissingClassProblem]("akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy$")
+ProblemFilters.exclude[MissingClassProblem]("akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy$RegionEntry")
+ProblemFilters.exclude[MissingClassProblem]("akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy$RegionEntry$")
+ProblemFilters.exclude[MissingClassProblem]("akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy$ShardSuitabilityOrdering$")

--- a/akka-cluster-sharding/src/main/mima-filters/2.7.0.backwards.excludes/consistent-hashing-allocation.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.7.0.backwards.excludes/consistent-hashing-allocation.excludes
@@ -1,0 +1,5 @@
+# Internals
+ProblemFilters.exclude[MissingClassProblem]("akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy$")
+ProblemFilters.exclude[MissingClassProblem]("akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy$RegionEntry")
+ProblemFilters.exclude[MissingClassProblem]("akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy$RegionEntry$")
+ProblemFilters.exclude[MissingClassProblem]("akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy$ShardSuitabilityOrdering$")

--- a/akka-cluster-sharding/src/main/mima-filters/2.8.2.backwards.excludes/consistent-hashing-allocation.excludes
+++ b/akka-cluster-sharding/src/main/mima-filters/2.8.2.backwards.excludes/consistent-hashing-allocation.excludes
@@ -1,0 +1,5 @@
+# Internals
+ProblemFilters.exclude[MissingClassProblem]("akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy$")
+ProblemFilters.exclude[MissingClassProblem]("akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy$RegionEntry")
+ProblemFilters.exclude[MissingClassProblem]("akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy$RegionEntry$")
+ProblemFilters.exclude[MissingClassProblem]("akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy$ShardSuitabilityOrdering$")

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategy.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import scala.collection.immutable
+import scala.concurrent.Future
+
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.Address
+import akka.cluster.Cluster
+import akka.cluster.ClusterEvent.CurrentClusterState
+import akka.cluster.Member
+import akka.cluster.sharding.ShardCoordinator.ActorSystemDependentAllocationStrategy
+import akka.cluster.sharding.ShardRegion.ShardId
+import akka.cluster.sharding.internal.ClusterShardAllocationMixin
+import akka.cluster.sharding.internal.ClusterShardAllocationMixin.ShardSuitabilityOrdering
+import akka.routing.ConsistentHash
+
+object ConsistentHashingShardAllocationStrategy {
+  private val emptyRebalanceResult = Future.successful(Set.empty[ShardId])
+}
+
+/**
+ * [[akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy]] that is using consistent
+ * hashing. This can be useful when shards with the same shard id for different entity types
+ * should be best effort collocated to the same nodes.
+ *
+ * When adding or removing nodes it will rebalance according to the new consistent hashing,
+ * but that means that only a few shards will be rebalanced and others remain on the same
+ * location.
+ *
+ * A good explanation of Consistent Hashing:
+ * https://tom-e-white.com/2007/11/consistent-hashing.html
+ *
+ */
+class ConsistentHashingShardAllocationStrategy(rebalanceLimit: Int)
+    extends ActorSystemDependentAllocationStrategy
+    with ClusterShardAllocationMixin {
+  import ConsistentHashingShardAllocationStrategy.emptyRebalanceResult
+
+  @volatile private var cluster: Cluster = _
+
+  private val virtualNodesFactor = 10
+  private var hashedByNodes: Vector[Address] = Vector.empty
+  private var consistentHashing: ConsistentHash[Address] = ConsistentHash(Nil, virtualNodesFactor)
+
+  override def start(system: ActorSystem): Unit = {
+    cluster = Cluster(system)
+  }
+
+  override protected def clusterState: CurrentClusterState = cluster.state
+  override protected def selfMember: Member = cluster.selfMember
+
+  override def allocateShard(
+      requester: ActorRef,
+      shardId: ShardId,
+      currentShardAllocations: Map[ActorRef, IndexedSeq[ShardId]]): Future[ActorRef] = {
+    val nodes = nodesForRegions(currentShardAllocations)
+    if (nodes != hashedByNodes)
+      updateHashing(nodes)
+    val node = consistentHashing.nodeFor(shardId)
+    currentShardAllocations.keysIterator.find(region => nodeForRegion(region) == node) match {
+      case Some(region) => Future.successful(region)
+      case None =>
+        throw new IllegalStateException(s"currentShardAllocations should include region for node [$node]")
+    }
+  }
+
+  override def rebalance(
+      currentShardAllocations: Map[ActorRef, IndexedSeq[ShardId]],
+      rebalanceInProgress: Set[ShardId]): Future[Set[ShardId]] = {
+
+    val sortedRegionEntries = regionEntriesFor(currentShardAllocations).toVector.sorted(ShardSuitabilityOrdering)
+    if (!isAGoodTimeToRebalance(sortedRegionEntries)) {
+      emptyRebalanceResult
+    } else {
+
+      val nodes = nodesForRegions(currentShardAllocations)
+      if (nodes != hashedByNodes)
+        updateHashing(nodes)
+
+      val regionByNode = currentShardAllocations.keysIterator.map(region => nodeForRegion(region) -> region).toMap
+
+      var result = Set.empty[String]
+
+      def lessThanLimit: Boolean =
+        rebalanceLimit <= 0 || result.size < rebalanceLimit
+
+      currentShardAllocations
+      // deterministic order, at least easier to test
+      .toVector.sortBy { case (region, _) => nodeForRegion(region) }(Address.addressOrdering).foreach {
+        case (currentRegion, shardIds) =>
+          shardIds.foreach { shardId =>
+            if (lessThanLimit && !rebalanceInProgress.contains(shardId)) {
+              val node = consistentHashing.nodeFor(shardId)
+              regionByNode.get(node) match {
+                case Some(region) =>
+                  if (region != currentRegion)
+                    result += shardId
+                case None =>
+                  throw new IllegalStateException(s"currentShardAllocations should include region for node [$node]")
+              }
+            }
+          }
+      }
+
+      Future.successful(result)
+    }
+  }
+
+  private def nodesForRegions(
+      currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardId]]): Vector[Address] = {
+    currentShardAllocations.keysIterator.map(nodeForRegion).toVector
+  }
+
+  private def nodeForRegion(region: ActorRef): Address =
+    if (region.path.address.hasLocalScope) selfMember.address
+    else region.path.address
+
+  private def updateHashing(nodes: Vector[Address]): Unit = {
+    hashedByNodes = nodes
+    consistentHashing = ConsistentHash(nodes, virtualNodesFactor)
+  }
+
+}

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategy.scala
@@ -4,6 +4,7 @@
 
 package akka.cluster.sharding
 
+import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.concurrent.Future
 
@@ -68,10 +69,11 @@ class ConsistentHashingShardAllocationStrategy(rebalanceLimit: Int)
   override protected def clusterState: CurrentClusterState = cluster.state
   override protected def selfMember: Member = cluster.selfMember
 
+  @nowarn("msg=never used")
   override def allocateShard(
       requester: ActorRef,
       shardId: ShardId,
-      currentShardAllocations: Map[ActorRef, IndexedSeq[ShardId]]): Future[ActorRef] = {
+      currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardId]]): Future[ActorRef] = {
     val nodes = nodesForRegions(currentShardAllocations)
     updateHashing(nodes)
     val node = consistentHashing.nodeFor(shardId)
@@ -83,7 +85,7 @@ class ConsistentHashingShardAllocationStrategy(rebalanceLimit: Int)
   }
 
   override def rebalance(
-      currentShardAllocations: Map[ActorRef, IndexedSeq[ShardId]],
+      currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardId]],
       rebalanceInProgress: Set[ShardId]): Future[Set[ShardId]] = {
 
     val sortedRegionEntries = regionEntriesFor(currentShardAllocations).toVector.sorted(ShardSuitabilityOrdering)

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategy.scala
@@ -29,7 +29,7 @@ object ConsistentHashingShardAllocationStrategy {
 /**
  * [[akka.cluster.sharding.ShardCoordinator.ShardAllocationStrategy]] that is using consistent
  * hashing. This can be useful when shards with the same shard id for different entity types
- * should be best effort collocated to the same nodes.
+ * should be best effort colocated to the same nodes.
  *
  * When adding or removing nodes it will rebalance according to the new consistent hashing,
  * but that means that only a few shards will be rebalanced and others remain on the same
@@ -37,6 +37,9 @@ object ConsistentHashingShardAllocationStrategy {
  *
  * A good explanation of Consistent Hashing:
  * https://tom-e-white.com/2007/11/consistent-hashing.html
+ *
+ * Create a new instance of this for each entity types, i.e. a `ConsistentHashingShardAllocationStrategy`
+ * instance must not be shared between different entity types.
  *
  * Not intended for public inheritance/implementation
  */

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/ShardCoordinator.scala
@@ -22,7 +22,8 @@ import akka.cluster.ddata.Replicator._
 import akka.cluster.ddata.SelfUniqueAddress
 import akka.cluster.sharding.ShardRegion.ShardId
 import akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy
-import akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy.RegionEntry
+import akka.cluster.sharding.internal.ClusterShardAllocationMixin.RegionEntry
+import akka.cluster.sharding.internal.ClusterShardAllocationMixin.ShardSuitabilityOrdering
 import akka.cluster.sharding.internal.EventSourcedRememberEntitiesCoordinatorStore.MigrationMarker
 import akka.cluster.sharding.internal.{
   EventSourcedRememberEntitiesCoordinatorStore,
@@ -286,8 +287,6 @@ object ShardCoordinator {
   class LeastShardAllocationStrategy(rebalanceThreshold: Int, maxSimultaneousRebalance: Int)
       extends AbstractLeastShardAllocationStrategy
       with Serializable {
-
-    import AbstractLeastShardAllocationStrategy.ShardSuitabilityOrdering
 
     override def rebalance(
         currentShardAllocations: Map[ActorRef, immutable.IndexedSeq[ShardId]],

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/AbstractLeastShardAllocationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/AbstractLeastShardAllocationStrategy.scala
@@ -4,67 +4,28 @@
 
 package akka.cluster.sharding.internal
 
-import java.lang.{ Boolean => JBoolean, Integer => JInteger }
-
-import akka.actor.ActorRef
-import akka.actor.ActorSystem
-import akka.actor.Address
-import akka.annotation.InternalApi
-import akka.cluster.Cluster
-import akka.cluster.ClusterEvent.CurrentClusterState
-import akka.cluster.Member
-import akka.cluster.MemberStatus
-import akka.cluster.sharding.ShardCoordinator.ActorSystemDependentAllocationStrategy
-import akka.cluster.sharding.ShardRegion.ShardId
-import akka.pattern.after
-
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
-/**
- * Common logic for the least shard allocation strategy implementations
- *
- * INTERNAL API
- */
-@InternalApi
-private[akka] object AbstractLeastShardAllocationStrategy {
-  import MemberStatus._
-  private val JoiningCluster: Set[MemberStatus] = Set(Joining, WeaklyUp)
-  private val LeavingClusterStatuses: Set[MemberStatus] = Set(Leaving, Exiting, Down)
-
-  type AllocationMap = Map[ActorRef, immutable.IndexedSeq[ShardId]]
-
-  final case class RegionEntry(region: ActorRef, member: Member, shardIds: immutable.IndexedSeq[ShardId])
-
-  implicit object ShardSuitabilityOrdering extends Ordering[RegionEntry] {
-    override def compare(x: RegionEntry, y: RegionEntry): Int = {
-      val RegionEntry(_, memberX, allocatedShardsX) = x
-      val RegionEntry(_, memberY, allocatedShardsY) = y
-      if (memberX.status != memberY.status) {
-        // prefer allocating to nodes that are not on their way out of the cluster
-        val xIsLeaving = LeavingClusterStatuses(memberX.status)
-        val yIsLeaving = LeavingClusterStatuses(memberY.status)
-        JBoolean.compare(xIsLeaving, yIsLeaving)
-      } else if (memberX.appVersion != memberY.appVersion) {
-        // prefer nodes with the highest rolling update app version
-        memberY.appVersion.compareTo(memberX.appVersion)
-      } else {
-        // prefer the node with the least allocated shards
-        JInteger.compare(allocatedShardsX.size, allocatedShardsY.size)
-      }
-    }
-  }
-}
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.annotation.InternalApi
+import akka.cluster.Cluster
+import akka.cluster.ClusterEvent.CurrentClusterState
+import akka.cluster.Member
+import akka.cluster.sharding.ShardCoordinator.ActorSystemDependentAllocationStrategy
+import akka.cluster.sharding.ShardRegion.ShardId
+import akka.pattern.after
 
 /**
-
- *
- * INTERNAL API
+ * INTERNAL API: Common logic for the least shard allocation strategy implementations
  */
 @InternalApi
-private[akka] abstract class AbstractLeastShardAllocationStrategy extends ActorSystemDependentAllocationStrategy {
-  import AbstractLeastShardAllocationStrategy._
+private[akka] abstract class AbstractLeastShardAllocationStrategy
+    extends ActorSystemDependentAllocationStrategy
+    with ClusterShardAllocationMixin {
+  import ClusterShardAllocationMixin._
 
   @volatile private var system: ActorSystem = _
   @volatile private var cluster: Cluster = _
@@ -74,9 +35,8 @@ private[akka] abstract class AbstractLeastShardAllocationStrategy extends ActorS
     cluster = Cluster(system)
   }
 
-  // protected for testability
-  protected def clusterState: CurrentClusterState = cluster.state
-  protected def selfMember: Member = cluster.selfMember
+  override protected def clusterState: CurrentClusterState = cluster.state
+  override protected def selfMember: Member = cluster.selfMember
 
   override def allocateShard(
       requester: ActorRef,
@@ -93,47 +53,10 @@ private[akka] abstract class AbstractLeastShardAllocationStrategy extends ActorS
     }
   }
 
-  final protected def isAGoodTimeToRebalance(regionEntries: Iterable[RegionEntry]): Boolean = {
-    // Avoid rebalance when rolling update is in progress
-    // (This will ignore versions on members with no shard regions, because of sharding role or not yet completed joining)
-    regionEntries.headOption match {
-      case None => false // empty list of regions, probably not a good time to rebalance...
-      case Some(firstRegion) =>
-        def allNodesSameVersion = {
-          regionEntries.forall(_.member.appVersion == firstRegion.member.appVersion)
-        }
-        // Rebalance requires ack from regions and proxies - no need to rebalance if it cannot be completed
-        // FIXME #29589, we currently only look at same dc but proxies in other dcs may delay complete as well right now
-        def neededMembersReachable =
-          !clusterState.members.exists(m => m.dataCenter == selfMember.dataCenter && clusterState.unreachable(m))
-        // No members in same dc joining, we want that to complete before rebalance, such nodes should reach Up soon
-        def membersInProgressOfJoining =
-          clusterState.members.exists(m => m.dataCenter == selfMember.dataCenter && JoiningCluster(m.status))
-
-        allNodesSameVersion && neededMembersReachable && !membersInProgressOfJoining
-    }
-  }
-
   final protected def mostSuitableRegion(
       regionEntries: Iterable[RegionEntry]): (ActorRef, immutable.IndexedSeq[ShardId]) = {
     val mostSuitableEntry = regionEntries.min(ShardSuitabilityOrdering)
     mostSuitableEntry.region -> mostSuitableEntry.shardIds
-  }
-
-  final protected def regionEntriesFor(currentShardAllocations: AllocationMap): Iterable[RegionEntry] = {
-    val addressToMember: Map[Address, Member] = clusterState.members.iterator.map(m => m.address -> m).toMap
-    currentShardAllocations.flatMap {
-      case (region, shardIds) =>
-        val regionAddress = {
-          if (region.path.address.hasLocalScope) selfMember.address
-          else region.path.address
-        }
-
-        val memberForRegion = addressToMember.get(regionAddress)
-        // if the member is unknown (very unlikely but not impossible) because of view not updated yet
-        // that node is ignored for this invocation
-        memberForRegion.map(member => RegionEntry(region, member, shardIds))
-    }
   }
 
 }

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/ClusterShardAllocationMixin.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/ClusterShardAllocationMixin.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2020-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding.internal
+
+import java.lang.{ Integer => JInteger }
+import java.lang.{ Boolean => JBoolean }
+
+import scala.collection.immutable
+
+import akka.actor.ActorRef
+import akka.actor.Address
+import akka.annotation.InternalApi
+import akka.cluster.ClusterEvent.CurrentClusterState
+import akka.cluster.Member
+import akka.cluster.MemberStatus
+import akka.cluster.sharding.ShardRegion.ShardId
+import akka.cluster.sharding.internal.ClusterShardAllocationMixin.JoiningCluster
+import akka.cluster.sharding.internal.ClusterShardAllocationMixin.RegionEntry
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object ClusterShardAllocationMixin {
+
+  type AllocationMap = Map[ActorRef, immutable.IndexedSeq[ShardId]]
+
+  import MemberStatus._
+
+  val JoiningCluster: Set[MemberStatus] = Set(Joining, WeaklyUp)
+  val LeavingClusterStatuses: Set[MemberStatus] = Set(Leaving, Exiting, Down)
+
+  final case class RegionEntry(region: ActorRef, member: Member, shardIds: immutable.IndexedSeq[ShardId])
+
+  implicit object ShardSuitabilityOrdering extends Ordering[RegionEntry] {
+    override def compare(x: RegionEntry, y: RegionEntry): Int = {
+      val RegionEntry(_, memberX, allocatedShardsX) = x
+      val RegionEntry(_, memberY, allocatedShardsY) = y
+      if (memberX.status != memberY.status) {
+        // prefer allocating to nodes that are not on their way out of the cluster
+        val xIsLeaving = LeavingClusterStatuses(memberX.status)
+        val yIsLeaving = LeavingClusterStatuses(memberY.status)
+        JBoolean.compare(xIsLeaving, yIsLeaving)
+      } else if (memberX.appVersion != memberY.appVersion) {
+        // prefer nodes with the highest rolling update app version
+        memberY.appVersion.compareTo(memberX.appVersion)
+      } else {
+        // prefer the node with the least allocated shards
+        JInteger.compare(allocatedShardsX.size, allocatedShardsY.size)
+      }
+    }
+  }
+
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] trait ClusterShardAllocationMixin {
+  import ClusterShardAllocationMixin.AllocationMap
+
+  protected def clusterState: CurrentClusterState
+
+  protected def selfMember: Member
+
+  final protected def isAGoodTimeToRebalance(regionEntries: Iterable[RegionEntry]): Boolean = {
+    // Avoid rebalance when rolling update is in progress
+    // (This will ignore versions on members with no shard regions, because of sharding role or not yet completed joining)
+    regionEntries.headOption match {
+      case None => false // empty list of regions, probably not a good time to rebalance...
+      case Some(firstRegion) =>
+        def allNodesSameVersion =
+          regionEntries.forall(_.member.appVersion == firstRegion.member.appVersion)
+
+        // Rebalance requires ack from regions and proxies - no need to rebalance if it cannot be completed
+        // FIXME #29589, we currently only look at same dc but proxies in other dcs may delay complete as well right now
+        def neededMembersReachable =
+          !clusterState.members.exists(m => m.dataCenter == selfMember.dataCenter && clusterState.unreachable(m))
+
+        // No members in same dc joining, we want that to complete before rebalance, such nodes should reach Up soon
+        def membersInProgressOfJoining =
+          clusterState.members.exists(m => m.dataCenter == selfMember.dataCenter && JoiningCluster(m.status))
+
+        allNodesSameVersion && neededMembersReachable && !membersInProgressOfJoining
+    }
+  }
+
+  final protected def regionEntriesFor(currentShardAllocations: AllocationMap): Iterable[RegionEntry] = {
+    val addressToMember: Map[Address, Member] = clusterState.members.iterator.map(m => m.address -> m).toMap
+    currentShardAllocations.flatMap {
+      case (region, shardIds) =>
+        val regionAddress = {
+          if (region.path.address.hasLocalScope) selfMember.address
+          else region.path.address
+        }
+
+        val memberForRegion = addressToMember.get(regionAddress)
+        // if the member is unknown (very unlikely but not impossible) because of view not updated yet
+        // that node is ignored for this invocation
+        memberForRegion.map(member => RegionEntry(region, member, shardIds))
+    }
+  }
+}

--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/LeastShardAllocationStrategy.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/internal/LeastShardAllocationStrategy.scala
@@ -9,8 +9,8 @@ import scala.concurrent.Future
 import akka.actor.ActorRef
 import akka.annotation.InternalApi
 import akka.cluster.sharding.ShardRegion.ShardId
-import akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy.RegionEntry
-import akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy.ShardSuitabilityOrdering
+import akka.cluster.sharding.internal.ClusterShardAllocationMixin.RegionEntry
+import akka.cluster.sharding.internal.ClusterShardAllocationMixin.ShardSuitabilityOrdering
 
 /**
  * INTERNAL API

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategySpec.scala
@@ -122,7 +122,7 @@ class ConsistentHashingShardAllocationStrategySpec extends AkkaSpec {
       allocationStrategy.allocateShard(regionA, "10", allocations).futureValue should ===(regionA)
 
       val allocations2 = Map(regionA -> Vector("10"), regionB -> Vector("1", "2"), regionC -> Vector("0"))
-      allocationStrategy.rebalance(allocations2, Set.empty).futureValue should ===(Set.empty)
+      allocationStrategy.rebalance(allocations2, Set.empty).futureValue should ===(Set.empty[String])
     }
 
     "rebalance when node is added" in {
@@ -168,7 +168,7 @@ class ConsistentHashingShardAllocationStrategySpec extends AkkaSpec {
 
       val allocations3 =
         Map(regionA -> Vector("10", "14"), regionB -> Vector("1"), regionC -> Vector("0", "3"), regionD -> Vector("2"))
-      allocationStrategy.rebalance(allocations3, Set.empty).futureValue should ===(Set.empty)
+      allocationStrategy.rebalance(allocations3, Set.empty).futureValue should ===(Set.empty[String])
     }
 
     "not rebalance those that are in progress" in {
@@ -181,7 +181,7 @@ class ConsistentHashingShardAllocationStrategySpec extends AkkaSpec {
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("0", "1"))
       allocationStrategy.rebalance(allocations, Set("0", "1")).futureValue should ===(Set("2", "3"))
       // 10 and 14 are already at right place
-      allocationStrategy.rebalance(allocations, Set("0", "1", "2", "3")).futureValue should ===(Set.empty)
+      allocationStrategy.rebalance(allocations, Set("0", "1", "2", "3")).futureValue should ===(Set.empty[String])
     }
 
     "not rebalance when rolling update in progress" in {

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategySpec.scala
@@ -85,7 +85,7 @@ class ConsistentHashingShardAllocationStrategySpec extends AkkaSpec {
       allocationStrategy.allocateShard(regionA, "10", allocations).futureValue should ===(regionA)
       allocationStrategy.allocateShard(regionA, "14", allocations).futureValue should ===(regionA)
 
-      val allocations2 = allocations.removed(regionC)
+      val allocations2 = allocations - regionC
       allocationStrategy.allocateShard(regionA, "0", allocations2).futureValue should ===(regionA)
       allocationStrategy.allocateShard(regionA, "1", allocations2).futureValue should ===(regionB)
       allocationStrategy.allocateShard(regionA, "2", allocations2).futureValue should ===(regionB)

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategySpec.scala
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cluster.sharding
+
+import scala.collection.immutable.SortedSet
+
+import akka.actor.ActorPath
+import akka.actor.ActorRef
+import akka.actor.ActorRefProvider
+import akka.actor.Address
+import akka.actor.MinimalActorRef
+import akka.actor.RootActorPath
+import akka.cluster.ClusterEvent
+import akka.cluster.ClusterEvent.CurrentClusterState
+import akka.cluster.ClusterSettings
+import akka.cluster.Member
+import akka.cluster.MemberStatus
+import akka.cluster.UniqueAddress
+import akka.testkit.AkkaSpec
+import akka.util.Version
+
+object ConsistentHashingShardAllocationStrategySpec {
+
+  final class DummyActorRef(val path: ActorPath) extends MinimalActorRef {
+    override def provider: ActorRefProvider = ???
+  }
+
+  def newUpMember(host: String, port: Int = 252525, version: Version = Version("1.0.0")) =
+    Member(
+      UniqueAddress(Address("akka", "myapp", host, port), 1L),
+      Set(ClusterSettings.DcRolePrefix + ClusterSettings.DefaultDataCenter),
+      version).copy(MemberStatus.Up)
+
+  def newFakeRegion(idForDebug: String, member: Member): ActorRef =
+    new DummyActorRef(RootActorPath(member.address) / "system" / "fake" / idForDebug)
+}
+
+class ConsistentHashingShardAllocationStrategySpec extends AkkaSpec {
+  import ConsistentHashingShardAllocationStrategySpec._
+
+  val memberA = newUpMember("127.0.0.1")
+  val memberB = newUpMember("127.0.0.2")
+  val memberC = newUpMember("127.0.0.3")
+  val memberD = newUpMember("127.0.0.4")
+
+  val regionA = newFakeRegion("regionA", memberA)
+  val regionB = newFakeRegion("regionB", memberB)
+  val regionC = newFakeRegion("regionC", memberC)
+  val regionD = newFakeRegion("regionD", memberD)
+
+  private val emptyAllocationsABC: Map[ActorRef, Vector[String]] =
+    Map(regionA -> Vector.empty, regionB -> Vector.empty, regionC -> Vector.empty)
+
+  private def strategy(rebalanceLimit: Int = 0) =
+    // we don't really "start" it as we fake the cluster access
+    new ConsistentHashingShardAllocationStrategy(rebalanceLimit) {
+      override protected def clusterState: ClusterEvent.CurrentClusterState =
+        CurrentClusterState(SortedSet(memberA, memberB, memberC))
+      override protected def selfMember: Member = memberA
+    }
+
+  "ConsistentHashingShardAllocationStrategy" must {
+    "allocate to regions" in {
+      val allocationStrategy = strategy()
+      val allocations = emptyAllocationsABC
+      allocationStrategy.allocateShard(regionA, "0", allocations).futureValue should ===(regionC)
+      allocationStrategy.allocateShard(regionA, "1", allocations).futureValue should ===(regionB)
+      allocationStrategy.allocateShard(regionA, "2", allocations).futureValue should ===(regionB)
+      allocationStrategy.allocateShard(regionA, "10", allocations).futureValue should ===(regionA)
+    }
+
+    "allocate to mostly same regions when node is removed" in {
+      val allocationStrategy = strategy()
+      val allocations = emptyAllocationsABC
+      allocationStrategy.allocateShard(regionA, "0", allocations).futureValue should ===(regionC)
+      allocationStrategy.allocateShard(regionA, "1", allocations).futureValue should ===(regionB)
+      allocationStrategy.allocateShard(regionA, "2", allocations).futureValue should ===(regionB)
+      allocationStrategy.allocateShard(regionA, "3", allocations).futureValue should ===(regionC)
+      allocationStrategy.allocateShard(regionA, "10", allocations).futureValue should ===(regionA)
+      allocationStrategy.allocateShard(regionA, "14", allocations).futureValue should ===(regionA)
+
+      val allocations2 = allocations.removed(regionC)
+      allocationStrategy.allocateShard(regionA, "0", allocations2).futureValue should ===(regionA)
+      allocationStrategy.allocateShard(regionA, "1", allocations2).futureValue should ===(regionB)
+      allocationStrategy.allocateShard(regionA, "2", allocations2).futureValue should ===(regionB)
+      allocationStrategy.allocateShard(regionA, "3", allocations2).futureValue should ===(regionB)
+      allocationStrategy.allocateShard(regionA, "10", allocations2).futureValue should ===(regionA)
+      allocationStrategy.allocateShard(regionA, "14", allocations2).futureValue should ===(regionA)
+    }
+
+    "allocate to mostly same regions when node is added" in {
+      val allocationStrategy = strategy()
+      val allocations = emptyAllocationsABC
+      allocationStrategy.allocateShard(regionA, "0", allocations).futureValue should ===(regionC)
+      allocationStrategy.allocateShard(regionA, "1", allocations).futureValue should ===(regionB)
+      allocationStrategy.allocateShard(regionA, "2", allocations).futureValue should ===(regionB)
+      allocationStrategy.allocateShard(regionA, "3", allocations).futureValue should ===(regionC)
+      allocationStrategy.allocateShard(regionA, "10", allocations).futureValue should ===(regionA)
+      allocationStrategy.allocateShard(regionA, "14", allocations).futureValue should ===(regionA)
+
+      val allocations2 = allocations.updated(regionD, Vector.empty)
+      allocationStrategy.allocateShard(regionA, "0", allocations2).futureValue should ===(regionC)
+      allocationStrategy.allocateShard(regionA, "1", allocations2).futureValue should ===(regionB)
+      allocationStrategy.allocateShard(regionA, "2", allocations2).futureValue should ===(regionD)
+      allocationStrategy.allocateShard(regionA, "3", allocations2).futureValue should ===(regionC)
+      allocationStrategy.allocateShard(regionA, "10", allocations2).futureValue should ===(regionA)
+      allocationStrategy.allocateShard(regionA, "14", allocations2).futureValue should ===(regionA)
+    }
+
+    "not rebalance when nodes not changed" in {
+      val allocationStrategy = strategy()
+      val allocations = emptyAllocationsABC
+      allocationStrategy.allocateShard(regionA, "0", allocations).futureValue should ===(regionC)
+      allocationStrategy.allocateShard(regionA, "1", allocations).futureValue should ===(regionB)
+      allocationStrategy.allocateShard(regionA, "2", allocations).futureValue should ===(regionB)
+      allocationStrategy.allocateShard(regionA, "10", allocations).futureValue should ===(regionA)
+
+      val allocations2 = Map(regionA -> Vector("10"), regionB -> Vector("1", "2"), regionC -> Vector("0"))
+      allocationStrategy.rebalance(allocations2, Set.empty).futureValue should ===(Set.empty)
+    }
+
+    "rebalance when node is added" in {
+      val allocationStrategy = strategy()
+      val allocations = emptyAllocationsABC
+      allocationStrategy.allocateShard(regionA, "0", allocations).futureValue should ===(regionC)
+      allocationStrategy.allocateShard(regionA, "1", allocations).futureValue should ===(regionB)
+      allocationStrategy.allocateShard(regionA, "2", allocations).futureValue should ===(regionB)
+      allocationStrategy.allocateShard(regionA, "3", allocations).futureValue should ===(regionC)
+      allocationStrategy.allocateShard(regionA, "10", allocations).futureValue should ===(regionA)
+      allocationStrategy.allocateShard(regionA, "14", allocations).futureValue should ===(regionA)
+
+      val allocations2 = Map(
+        regionA -> Vector("10", "14"),
+        regionB -> Vector("1", "2"),
+        regionC -> Vector("0", "3"),
+        regionD -> Vector.empty)
+      allocationStrategy.rebalance(allocations2, Set.empty).futureValue should ===(Set("2"))
+    }
+
+    "not rebalance more than limit" in {
+      val allocationStrategy = strategy(rebalanceLimit = 2)
+      val allocations = Map(
+        regionA -> Vector("0", "1", "2", "3", "10", "14"),
+        regionB -> Vector.empty,
+        regionC -> Vector.empty,
+        regionD -> Vector.empty)
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("0", "1"))
+
+      val allocations2 = Map(
+        regionA -> Vector("2", "3", "10", "14"),
+        regionB -> Vector("1"),
+        regionC -> Vector("0"),
+        regionD -> Vector.empty)
+      allocationStrategy.rebalance(allocations2, Set.empty).futureValue should ===(Set("2", "3"))
+
+      val allocations3 =
+        Map(regionA -> Vector("10", "14"), regionB -> Vector("1"), regionC -> Vector("0", "3"), regionD -> Vector("2"))
+      allocationStrategy.rebalance(allocations3, Set.empty).futureValue should ===(Set.empty)
+    }
+
+    "not rebalance those that are in progress" in {
+      val allocationStrategy = strategy(rebalanceLimit = 2)
+      val allocations = Map(
+        regionA -> Vector("0", "1", "2", "3", "10", "14"),
+        regionB -> Vector.empty,
+        regionC -> Vector.empty,
+        regionD -> Vector.empty)
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set("0", "1"))
+      allocationStrategy.rebalance(allocations, Set("0", "1")).futureValue should ===(Set("2", "3"))
+      // 10 and 14 are already at right place
+      allocationStrategy.rebalance(allocations, Set("0", "1", "2", "3")).futureValue should ===(Set.empty)
+    }
+
+    "not rebalance when rolling update in progress" in {
+      val allocationStrategy =
+        new ConsistentHashingShardAllocationStrategy(rebalanceLimit = 0) {
+
+          val member1 = newUpMember("127.0.0.1", version = Version("1.0.0"))
+          val member2 = newUpMember("127.0.0.2", version = Version("1.0.1"))
+          val member3 = newUpMember("127.0.0.3", version = Version("1.0.0"))
+
+          // multiple versions to simulate rolling update in progress
+          override protected def clusterState: CurrentClusterState =
+            CurrentClusterState(SortedSet(member1, member2, member3))
+
+          override protected def selfMember: Member = member1
+        }
+      val allocations = Map(regionA -> Vector("0", "1", "2", "3", "10", "14"), regionB -> Vector.empty)
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set.empty[String])
+    }
+
+    "not rebalance when regions are unreachable" in {
+      val allocationStrategy =
+        new ConsistentHashingShardAllocationStrategy(rebalanceLimit = 0) {
+
+          override protected def clusterState: CurrentClusterState =
+            CurrentClusterState(SortedSet(memberA, memberB, memberC), unreachable = Set(memberB))
+          override protected def selfMember: Member = memberB
+        }
+      val allocations =
+        Map(regionA -> Vector("0", "1", "2", "3", "10", "14"), regionB -> Vector.empty, regionC -> Vector.empty)
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set.empty[String])
+    }
+    "not rebalance when members are joining dc" in {
+      val allocationStrategy =
+        new ConsistentHashingShardAllocationStrategy(rebalanceLimit = 0) {
+
+          val member1 = newUpMember("127.0.0.1")
+          val member2 =
+            Member(
+              UniqueAddress(Address("akka", "myapp", "127.0.0.2", 252525), 1L),
+              Set(ClusterSettings.DcRolePrefix + ClusterSettings.DefaultDataCenter),
+              member1.appVersion)
+          val member3 = newUpMember("127.0.0.3")
+
+          override protected def clusterState: CurrentClusterState =
+            CurrentClusterState(SortedSet(member1, member2, member3), unreachable = Set.empty)
+          override protected def selfMember: Member = member2
+        }
+      val allocations =
+        Map(regionA -> Vector("0", "1", "2", "3", "10", "14"), regionB -> Vector.empty, regionC -> Vector.empty)
+      allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set.empty[String])
+
+    }
+
+  }
+}

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategySpec.scala
@@ -137,6 +137,13 @@ class ConsistentHashingShardAllocationStrategySpec extends AkkaSpec {
         regionC -> Vector("0", "3"),
         regionD -> Vector.empty)
       allocationStrategy.rebalance(allocations2, Set.empty).futureValue should ===(Set("2"))
+
+      val allocations3 = Map(
+        regionB -> Vector("2", "1"),
+        regionA -> Vector("10", "14"),
+        regionD -> Vector.empty,
+        regionC -> Vector("3", "0"))
+      allocationStrategy.rebalance(allocations3, Set.empty).futureValue should ===(Set("2"))
     }
 
     "not rebalance more than limit" in {

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ConsistentHashingShardAllocationStrategySpec.scala
@@ -18,6 +18,8 @@ import akka.cluster.ClusterSettings
 import akka.cluster.Member
 import akka.cluster.MemberStatus
 import akka.cluster.UniqueAddress
+import akka.event.Logging
+import akka.event.LoggingAdapter
 import akka.testkit.AkkaSpec
 import akka.util.Version
 
@@ -59,6 +61,8 @@ class ConsistentHashingShardAllocationStrategySpec extends AkkaSpec {
       override protected def clusterState: ClusterEvent.CurrentClusterState =
         CurrentClusterState(SortedSet(memberA, memberB, memberC))
       override protected def selfMember: Member = memberA
+      override protected val log: LoggingAdapter =
+        Logging(system, classOf[ConsistentHashingShardAllocationStrategy])
     }
 
   "ConsistentHashingShardAllocationStrategy" must {
@@ -193,6 +197,9 @@ class ConsistentHashingShardAllocationStrategySpec extends AkkaSpec {
             CurrentClusterState(SortedSet(member1, member2, member3))
 
           override protected def selfMember: Member = member1
+
+          override protected val log: LoggingAdapter =
+            Logging(system, classOf[ConsistentHashingShardAllocationStrategy])
         }
       val allocations = Map(regionA -> Vector("0", "1", "2", "3", "10", "14"), regionB -> Vector.empty)
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set.empty[String])
@@ -205,6 +212,8 @@ class ConsistentHashingShardAllocationStrategySpec extends AkkaSpec {
           override protected def clusterState: CurrentClusterState =
             CurrentClusterState(SortedSet(memberA, memberB, memberC), unreachable = Set(memberB))
           override protected def selfMember: Member = memberB
+          override protected val log: LoggingAdapter =
+            Logging(system, classOf[ConsistentHashingShardAllocationStrategy])
         }
       val allocations =
         Map(regionA -> Vector("0", "1", "2", "3", "10", "14"), regionB -> Vector.empty, regionC -> Vector.empty)
@@ -225,6 +234,8 @@ class ConsistentHashingShardAllocationStrategySpec extends AkkaSpec {
           override protected def clusterState: CurrentClusterState =
             CurrentClusterState(SortedSet(member1, member2, member3), unreachable = Set.empty)
           override protected def selfMember: Member = member2
+          override protected val log: LoggingAdapter =
+            Logging(system, classOf[ConsistentHashingShardAllocationStrategy])
         }
       val allocations =
         Map(regionA -> Vector("0", "1", "2", "3", "10", "14"), regionB -> Vector.empty, regionC -> Vector.empty)

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/DeprecatedLeastShardAllocationStrategySpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/DeprecatedLeastShardAllocationStrategySpec.scala
@@ -4,6 +4,8 @@
 
 package akka.cluster.sharding
 
+import scala.collection.immutable.SortedSet
+
 import akka.actor.ActorRef
 import akka.actor.Address
 import akka.cluster.ClusterEvent.CurrentClusterState
@@ -11,12 +13,10 @@ import akka.cluster.ClusterSettings
 import akka.cluster.Member
 import akka.cluster.MemberStatus
 import akka.cluster.UniqueAddress
-import akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy
-import akka.cluster.sharding.internal.AbstractLeastShardAllocationStrategy.RegionEntry
+import akka.cluster.sharding.internal.ClusterShardAllocationMixin.RegionEntry
+import akka.cluster.sharding.internal.ClusterShardAllocationMixin.ShardSuitabilityOrdering
 import akka.testkit.AkkaSpec
 import akka.util.Version
-
-import scala.collection.immutable.SortedSet
 
 class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
   import LeastShardAllocationStrategySpec._
@@ -192,7 +192,7 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
           RegionEntry(fakeRegionC, newVersionMember2, Vector("ShardId1")))
 
       val sortedRegions =
-        shardsAndMembers.sorted(AbstractLeastShardAllocationStrategy.ShardSuitabilityOrdering).map(_.region)
+        shardsAndMembers.sorted(ShardSuitabilityOrdering).map(_.region)
 
       // only node b has the new version
       sortedRegions should ===(
@@ -209,11 +209,13 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
         new ShardCoordinator.LeastShardAllocationStrategy(rebalanceThreshold = 2, maxSimultaneousRebalance = 100) {
 
           val member1 = newUpMember("127.0.0.1", version = Version("1.0.0"))
-          val member2 = newUpMember("127.0.0.1", version = Version("1.0.1"))
+          val member2 = newUpMember("127.0.0.2", version = Version("1.0.1"))
+          val member3 = newUpMember("127.0.0.3", version = Version("1.0.0"))
 
           // multiple versions to simulate rolling update in progress
           override protected def clusterState: CurrentClusterState =
-            CurrentClusterState(SortedSet(member1, member2))
+            CurrentClusterState(SortedSet(member1, member2, member3))
+
           override protected def selfMember: Member = member1
         }
       val allocations = createAllocations(aCount = 5, bCount = 5)
@@ -227,13 +229,9 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
       val allocationStrategy =
         new ShardCoordinator.LeastShardAllocationStrategy(rebalanceThreshold = 2, maxSimultaneousRebalance = 100) {
 
-          val member1 = newUpMember("127.0.0.1")
-          val member2 = newUpMember("127.0.0.2")
-
-          // multiple versions to simulate rolling update in progress
           override protected def clusterState: CurrentClusterState =
-            CurrentClusterState(SortedSet(member1, member2), unreachable = Set(member2))
-          override protected def selfMember: Member = member1
+            CurrentClusterState(SortedSet(memberA, memberB, memberC), unreachable = Set(memberB))
+          override protected def selfMember: Member = memberB
         }
       val allocations = createAllocations(aCount = 5, bCount = 5)
       allocationStrategy.rebalance(allocations, Set.empty).futureValue should ===(Set.empty[String])
@@ -252,10 +250,10 @@ class DeprecatedLeastShardAllocationStrategySpec extends AkkaSpec {
               UniqueAddress(Address("akka", "myapp", "127.0.0.2", 252525), 1L),
               Set(ClusterSettings.DcRolePrefix + ClusterSettings.DefaultDataCenter),
               member1.appVersion)
+          val member3 = newUpMember("127.0.0.3")
 
-          // multiple versions to simulate rolling update in progress
           override protected def clusterState: CurrentClusterState =
-            CurrentClusterState(SortedSet(member1, member2), unreachable = Set(member2))
+            CurrentClusterState(SortedSet(member1, member2, member3), unreachable = Set.empty)
           override protected def selfMember: Member = member2
         }
       val allocations = createAllocations(aCount = 5, bCount = 5)


### PR DESCRIPTION
* useful when shards with the same shard id for different entity types should be best effort collocated to the same nodes
* primary use case is when using Projections and collocating slice ranges for different Projections to make use of the shared firehose eventsBySlices query
* ShardedDaemonProcess is using the process index as the shard it, which is a perfect fit for this (process index is the selector of slice range)

See https://github.com/akka/akka/pull/31957

TODO:
- [x] reference docs
- [x] try it out together with firehose slice queries in sample app
