### PR TITLE
feat: Query traits for using snapshots as starting point

### DIFF
--- a/akka-docs/src/main/paradox/persistence-query.md
+++ b/akka-docs/src/main/paradox/persistence-query.md
@@ -174,7 +174,9 @@ If your usage does not require a live stream, you can use the @apidoc[currentEve
 Query events for given entity type and slices. A slice is deterministically defined based on the persistence id.
 The purpose is to evenly distribute all persistence ids over the slices.
 
-See @apidoc[akka.persistence.query.typed.*.EventsBySliceQuery] and @apidoc[akka.persistence.query.typed.*.CurrentEventsBySliceQuery]. 
+See @apidoc[akka.persistence.query.typed.*.EventsBySliceQuery] and @apidoc[akka.persistence.query.typed.*.CurrentEventsBySliceQuery].
+
+A variation of these are @apidoc[akka.persistence.query.typed.*.EventsBySliceStartingFromSnapshotsQuery] and @apidoc[akka.persistence.query.typed.*.CurrentEventsBySliceStartingFromSnapshotsQuery].
 
 @apidoc[akka.persistence.query.typed.*.EventsBySliceFirehoseQuery] can give better scalability when many
 consumers retrieve the same events, for example many Projections of the same entity type. The purpose is

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/CurrentEventsByPersistenceIdStartingFromSnapshotQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/CurrentEventsByPersistenceIdStartingFromSnapshotQuery.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.typed.javadsl
+
+import akka.NotUsed
+import akka.annotation.ApiMayChange
+import akka.persistence.query.javadsl.ReadJournal
+import akka.persistence.query.typed.EventEnvelope
+import akka.stream.javadsl.Source
+
+/**
+ * A plugin may optionally support this query by implementing this trait.
+ */
+@ApiMayChange
+trait CurrentEventsByPersistenceIdStartingFromSnapshotQuery extends ReadJournal {
+
+  /**
+   * Same as [[CurrentEventsByPersistenceIdTypedQuery]] but with the purpose to use snapshot as starting point
+   * and thereby reducing number of events that have to be loaded.
+   */
+  def currentEventsByPersistenceIdStartingFromSnapshot[Snapshot, Event](
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long,
+      transformSnapshot: java.util.function.Function[Snapshot, Event]): Source[EventEnvelope[Event], NotUsed]
+
+}

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/CurrentEventsBySliceStartingFromSnapshotsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/CurrentEventsBySliceStartingFromSnapshotsQuery.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.typed.javadsl
+
+import akka.NotUsed
+import akka.annotation.ApiMayChange
+import akka.japi.Pair
+import akka.persistence.query.Offset
+import akka.persistence.query.javadsl.ReadJournal
+import akka.persistence.query.typed.EventEnvelope
+import akka.stream.javadsl.Source
+
+/**
+ * A plugin may optionally support this query by implementing this trait.
+ *
+ * API May Change
+ */
+@ApiMayChange
+trait CurrentEventsBySliceStartingFromSnapshotsQuery extends ReadJournal {
+
+  /**
+   * Same as [[EventsBySliceStartingFromSnapshotsQuery]] but with the purpose to use snapshots as starting points
+   * and thereby reducing number of events that have to be loaded. This can be useful if the consumer start
+   * from zero without any previously processed offset or if it has been disconnected for a long while and
+   * its offset is far behind.
+   *
+   * Same type of query as [[EventsBySliceStartingFromSnapshotsQuery.eventsBySlicesStartingFromSnapshots]] but
+   * the event stream is completed immediately when it reaches the end of the "result set".
+   */
+  def currentEventsBySlicesStartingFromSnapshots[Snapshot, Event](
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      offset: Offset,
+      transformSnapshot: java.util.function.Function[Snapshot, Event]): Source[EventEnvelope[Event], NotUsed]
+
+  def sliceForPersistenceId(persistenceId: String): Int
+
+  def sliceRanges(numberOfRanges: Int): java.util.List[Pair[Integer, Integer]]
+}

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/EventsByPersistenceIdStartingFromSnapshotQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/EventsByPersistenceIdStartingFromSnapshotQuery.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.typed.javadsl
+
+import akka.NotUsed
+import akka.annotation.ApiMayChange
+import akka.persistence.query.javadsl.ReadJournal
+import akka.persistence.query.typed.EventEnvelope
+import akka.stream.javadsl.Source
+
+/**
+ * A plugin may optionally support this query by implementing this trait.
+ */
+@ApiMayChange
+trait EventsByPersistenceIdStartingFromSnapshotQuery extends ReadJournal {
+
+  /**
+   * Same as [[EventsByPersistenceIdTypedQuery]] but with the purpose to use snapshot as starting point
+   * and thereby reducing number of events that have to be loaded.
+   */
+  def eventsByPersistenceIdStartingFromSnapshot[Snapshot, Event](
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long,
+      transformSnapshot: java.util.function.Function[Snapshot, Event]): Source[EventEnvelope[Event], NotUsed]
+
+}

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/EventsBySliceFirehoseQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/EventsBySliceFirehoseQuery.scala
@@ -46,6 +46,7 @@ object EventsBySliceFirehoseQuery {
 final class EventsBySliceFirehoseQuery(delegate: scaladsl.EventsBySliceFirehoseQuery)
     extends ReadJournal
     with EventsBySliceQuery
+    with EventsBySliceStartingFromSnapshotsQuery
     with EventTimestampQuery
     with LoadEventQuery {
 
@@ -58,6 +59,14 @@ final class EventsBySliceFirehoseQuery(delegate: scaladsl.EventsBySliceFirehoseQ
       maxSlice: Int,
       offset: Offset): Source[EventEnvelope[Event], NotUsed] =
     delegate.eventsBySlices(entityType, minSlice, maxSlice, offset).asJava
+
+  override def eventsBySlicesStartingFromSnapshots[Snapshot, Event](
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      offset: Offset,
+      transformSnapshot: java.util.function.Function[Snapshot, Event]): Source[EventEnvelope[Event], NotUsed] =
+    delegate.eventsBySlicesStartingFromSnapshots(entityType, minSlice, maxSlice, offset, transformSnapshot(_)).asJava
 
   override def sliceRanges(numberOfRanges: Int): util.List[Pair[Integer, Integer]] = {
     import akka.util.ccompat.JavaConverters._

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/EventsBySliceStartingFromSnapshotsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/EventsBySliceStartingFromSnapshotsQuery.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.typed.javadsl
+
+import akka.NotUsed
+import akka.annotation.ApiMayChange
+import akka.japi.Pair
+import akka.persistence.query.Offset
+import akka.persistence.query.javadsl.ReadJournal
+import akka.persistence.query.typed.EventEnvelope
+import akka.stream.javadsl.Source
+
+/**
+ * A plugin may optionally support this query by implementing this trait.
+ *
+ * `EventsBySliceQuery` that is using a timestamp based offset should also implement [[EventTimestampQuery]] and
+ * [[LoadEventQuery]].
+ *
+ * See also [[EventsBySliceFirehoseQuery]].
+ *
+ * API May Change
+ */
+@ApiMayChange
+trait EventsBySliceStartingFromSnapshotsQuery extends ReadJournal {
+
+  /**
+   * Same as [[EventsBySliceQuery]] but with the purpose to use snapshots as starting points and thereby reducing number of
+   * events that have to be loaded. This can be useful if the consumer start from zero without any previously processed
+   * offset or if it has been disconnected for a long while and its offset is far behind.
+   */
+  def eventsBySlicesStartingFromSnapshots[Snapshot, Event](
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      offset: Offset,
+      transformSnapshot: java.util.function.Function[Snapshot, Event]): Source[EventEnvelope[Event], NotUsed]
+
+  def sliceForPersistenceId(persistenceId: String): Int
+
+  def sliceRanges(numberOfRanges: Int): java.util.List[Pair[Integer, Integer]]
+
+}

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/CurrentEventsByPersistenceIdStartingFromSnapshotQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/CurrentEventsByPersistenceIdStartingFromSnapshotQuery.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.typed.scaladsl
+
+import akka.NotUsed
+import akka.annotation.ApiMayChange
+import akka.persistence.query.scaladsl.ReadJournal
+import akka.persistence.query.typed.EventEnvelope
+import akka.stream.scaladsl.Source
+
+/**
+ * A plugin may optionally support this query by implementing this trait.
+ */
+@ApiMayChange
+trait CurrentEventsByPersistenceIdStartingFromSnapshotQuery extends ReadJournal {
+
+  /**
+   * Same as [[CurrentEventsByPersistenceIdTypedQuery]] but with the purpose to use snapshot as starting point
+   * and thereby reducing number of events that have to be loaded.
+   */
+  def currentEventsByPersistenceIdStartingFromSnapshot[Snapshot, Event](
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long,
+      transformSnapshot: Snapshot => Event): Source[EventEnvelope[Event], NotUsed]
+
+}

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/CurrentEventsBySliceStartingFromSnapshotsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/CurrentEventsBySliceStartingFromSnapshotsQuery.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.typed.scaladsl
+
+import scala.collection.immutable
+
+import akka.NotUsed
+import akka.annotation.ApiMayChange
+import akka.persistence.query.Offset
+import akka.persistence.query.scaladsl.ReadJournal
+import akka.persistence.query.typed.EventEnvelope
+import akka.stream.scaladsl.Source
+
+/**
+ * A plugin may optionally support this query by implementing this trait.
+ *
+ * API May Change
+ */
+@ApiMayChange
+trait CurrentEventsBySliceStartingFromSnapshotsQuery extends ReadJournal {
+
+  /**
+   * Same as [[EventsBySliceStartingFromSnapshotsQuery]] but with the purpose to use snapshots as starting points
+   * and thereby reducing number of events that have to be loaded. This can be useful if the consumer start
+   * from zero without any previously processed offset or if it has been disconnected for a long while and
+   * its offset is far behind.
+   *
+   * Same type of query as [[EventsBySliceStartingFromSnapshotsQuery.eventsBySlicesStartingFromSnapshots]] but
+   * the event stream is completed immediately when it reaches the end of the "result set".
+   */
+  def currentEventsBySlicesStartingFromSnapshots[Snapshot, Event](
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      offset: Offset,
+      transformSnapshot: Snapshot => Event): Source[EventEnvelope[Event], NotUsed]
+
+  def sliceForPersistenceId(persistenceId: String): Int
+
+  def sliceRanges(numberOfRanges: Int): immutable.Seq[Range]
+}

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/EventsByPersistenceIdStartingFromSnapshotQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/EventsByPersistenceIdStartingFromSnapshotQuery.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.typed.scaladsl
+
+import akka.NotUsed
+import akka.annotation.ApiMayChange
+import akka.persistence.query.scaladsl.ReadJournal
+import akka.persistence.query.typed.EventEnvelope
+import akka.stream.scaladsl.Source
+
+/**
+ * A plugin may optionally support this query by implementing this trait.
+ */
+@ApiMayChange
+trait EventsByPersistenceIdStartingFromSnapshotQuery extends ReadJournal {
+
+  /**
+   * Same as [[EventsByPersistenceIdTypedQuery]] but with the purpose to use snapshot as starting point
+   * and thereby reducing number of events that have to be loaded.
+   */
+  def eventsByPersistenceIdStartingFromSnapshot[Snapshot, Event](
+      persistenceId: String,
+      fromSequenceNr: Long,
+      toSequenceNr: Long,
+      transformSnapshot: Snapshot => Event): Source[EventEnvelope[Event], NotUsed]
+
+}

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/EventsBySliceFirehoseQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/EventsBySliceFirehoseQuery.scala
@@ -48,6 +48,7 @@ object EventsBySliceFirehoseQuery {
 final class EventsBySliceFirehoseQuery(system: ExtendedActorSystem, config: Config, cfgPath: String)
     extends ReadJournal
     with EventsBySliceQuery
+    with EventsBySliceStartingFromSnapshotsQuery
     with EventTimestampQuery
     with LoadEventQuery {
 
@@ -58,9 +59,22 @@ final class EventsBySliceFirehoseQuery(system: ExtendedActorSystem, config: Conf
       entityType: String,
       minSlice: Int,
       maxSlice: Int,
-      offset: Offset): Source[EventEnvelope[Event], NotUsed] = {
+      offset: Offset): Source[EventEnvelope[Event], NotUsed] =
     EventsBySliceFirehose(system).eventsBySlices(cfgPath, entityType, minSlice, maxSlice, offset)
-  }
+
+  override def eventsBySlicesStartingFromSnapshots[Snapshot, Event](
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      offset: Offset,
+      transformSnapshot: Snapshot => Event): Source[EventEnvelope[Event], NotUsed] =
+    EventsBySliceFirehose(system).eventsBySlicesStartingFromSnapshots(
+      cfgPath,
+      entityType,
+      minSlice,
+      maxSlice,
+      offset,
+      transformSnapshot)
 
   override def sliceForPersistenceId(persistenceId: String): Int =
     persistenceExt.sliceForPersistenceId(persistenceId)

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/EventsBySliceStartingFromSnapshotsQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/EventsBySliceStartingFromSnapshotsQuery.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.typed.scaladsl
+
+import scala.collection.immutable
+
+import akka.NotUsed
+import akka.annotation.ApiMayChange
+import akka.persistence.query.Offset
+import akka.persistence.query.scaladsl.ReadJournal
+import akka.persistence.query.typed.EventEnvelope
+import akka.stream.scaladsl.Source
+
+/**
+ * A plugin may optionally support this query by implementing this trait.
+ *
+ * `EventsBySliceStartingFromSnapshotsQuery` that is using a timestamp based offset should also implement [[EventTimestampQuery]] and
+ * [[LoadEventQuery]].
+ *
+ * See also [[EventsBySliceFirehoseQuery]].
+ *
+ * API May Change
+ */
+@ApiMayChange
+trait EventsBySliceStartingFromSnapshotsQuery extends ReadJournal {
+
+  /**
+   * Same as [[EventsBySliceQuery]] but with the purpose to use snapshots as starting points and thereby reducing number of
+   * events that have to be loaded. This can be useful if the consumer start from zero without any previously processed
+   * offset or if it has been disconnected for a long while and its offset is far behind.
+   */
+  def eventsBySlicesStartingFromSnapshots[Snapshot, Event](
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int,
+      offset: Offset,
+      transformSnapshot: Snapshot => Event): Source[EventEnvelope[Event], NotUsed]
+
+  def sliceForPersistenceId(persistenceId: String): Int
+
+  def sliceRanges(numberOfRanges: Int): immutable.Seq[Range]
+
+}


### PR DESCRIPTION
* eventsBySlicesStartingFromSnapshots
* currentEventsBySlicesStartingFromSnapshots
* eventsByPersistenceIdStartingFromSnapshot
* EventsBySliceFirehoseQuery also implementing eventsBySlicesStartingFromSnapshots

Implementation in https://github.com/akka/akka-persistence-r2dbc/pull/410
