### PR TITLE
chore: ignore FilteredPayload in replay

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -117,7 +117,7 @@ object EventSourcedBehaviorSpec {
 
   sealed trait Event extends CborSerializable
   final case class Incremented(delta: Int) extends Event
-  final case object FilteredEvent extends Event
+  case object FilteredEvent extends Event
 
   final case class State(value: Int, history: Vector[Int]) extends CborSerializable
 

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -29,6 +29,7 @@ import akka.actor.typed.SupervisorStrategy
 import akka.actor.typed.Terminated
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
+import akka.persistence.FilteredPayload
 import akka.persistence.{ SnapshotMetadata => ClassicSnapshotMetadata }
 import akka.persistence.{ SnapshotSelectionCriteria => ClassicSnapshotSelectionCriteria }
 import akka.persistence.SelectedSnapshot
@@ -40,6 +41,8 @@ import akka.persistence.query.Sequence
 import akka.persistence.snapshot.SnapshotStore
 import akka.persistence.testkit.PersistenceTestKitPlugin
 import akka.persistence.testkit.query.scaladsl.PersistenceTestKitReadJournal
+import akka.persistence.typed.EventAdapter
+import akka.persistence.typed.EventSeq
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.RecoveryCompleted
 import akka.persistence.typed.SnapshotCompleted
@@ -109,9 +112,12 @@ object EventSourcedBehaviorSpec {
   case object LogThenStop extends Command
   case object Fail extends Command
   case object StopIt extends Command
+  case object PersistFilteredEvent extends Command
+  final case class GetLastSequenceNumber(replyTo: ActorRef[Long]) extends Command
 
   sealed trait Event extends CborSerializable
   final case class Incremented(delta: Int) extends Event
+  final case object FilteredEvent extends Event
 
   final case class State(value: Int, history: Vector[Int]) extends CborSerializable
 
@@ -263,19 +269,50 @@ object EventSourcedBehaviorSpec {
           case StopIt =>
             Effect.none.thenStop()
 
+          case PersistFilteredEvent =>
+            // FilteredEvent will be converted FilteredPayload in eventAdapter
+            Effect.persist(FilteredEvent)
+
+          case GetLastSequenceNumber(replyTo) =>
+            replyTo ! EventSourcedBehavior.lastSequenceNumber(ctx)
+            Effect.none
+
         },
       eventHandler = (state, evt) =>
         evt match {
           case Incremented(delta) =>
             probe ! ((state, evt))
             State(state.value + delta, state.history :+ state.value)
-        }).receiveSignal {
-      case (_, RecoveryCompleted) => ()
-      case (_, SnapshotCompleted(metadata)) =>
-        snapshotProbe ! Success(metadata)
-      case (_, SnapshotFailed(_, failure)) =>
-        snapshotProbe ! Failure(failure)
-    }
+          case FilteredEvent =>
+            state
+
+        })
+      .receiveSignal {
+        case (_, RecoveryCompleted) => ()
+        case (_, SnapshotCompleted(metadata)) =>
+          snapshotProbe ! Success(metadata)
+        case (_, SnapshotFailed(_, failure)) =>
+          snapshotProbe ! Failure(failure)
+      }
+      // need a way to store FilteredPayload
+      .eventAdapter(new EventAdapter[Event, Any] {
+        override def toJournal(e: Event): Any =
+          e match {
+            case FilteredEvent => FilteredPayload
+            case _             => e
+          }
+
+        override def manifest(event: Event): String = ""
+
+        override def fromJournal(p: Any, manifest: String): EventSeq[Event] =
+          p match {
+            case FilteredPayload =>
+              throw new IllegalStateException("Unexpected FilteredPayload")
+            case e: Event => EventSeq.single(e)
+            case _ =>
+              throw new IllegalStateException(s"Unexpected event type $p")
+          }
+      })
   }
 }
 
@@ -319,6 +356,26 @@ class EventSourcedBehaviorSpec
       c2 ! Increment
       c2 ! GetValue(probe.ref)
       probe.expectMessage(State(4, Vector(0, 1, 2, 3)))
+    }
+
+    "exclude FilteredEvent in replay of persisted events" in {
+      val pid = nextPid()
+      val c = spawn(counter(pid))
+
+      val probe = TestProbe[State]()
+      val seqNrProbe = TestProbe[Long]()
+      c ! Increment
+      c ! PersistFilteredEvent
+      c ! Increment
+      c ! GetValue(probe.ref)
+      probe.expectMessage(10.seconds, State(2, Vector(0, 1)))
+
+      val c2 = spawn(counter(pid))
+      c2 ! Increment
+      c2 ! GetValue(probe.ref)
+      probe.expectMessage(State(3, Vector(0, 1, 2)))
+      c2 ! GetLastSequenceNumber(seqNrProbe.ref)
+      seqNrProbe.expectMessage(4L) // seqNr 2 was used for FilteredPayload
     }
 
     "handle Terminated signal" in {

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingEvents.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingEvents.scala
@@ -8,22 +8,29 @@ import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
-import akka.actor.typed.{ Behavior, Signal }
 import akka.actor.typed.internal.PoisonPill
 import akka.actor.typed.internal.UnstashException
-import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, Behaviors, LoggerOps }
-import akka.annotation.{ InternalApi, InternalStableApi }
+import akka.actor.typed.scaladsl.AbstractBehavior
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.LoggerOps
+import akka.actor.typed.Behavior
+import akka.actor.typed.Signal
+import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
 import akka.event.Logging
-import akka.persistence._
 import akka.persistence.JournalProtocol._
+import akka.persistence._
 import akka.persistence.typed.EmptyEventSeq
+import akka.persistence.typed.EventSeq
 import akka.persistence.typed.EventsSeq
 import akka.persistence.typed.RecoveryCompleted
 import akka.persistence.typed.RecoveryFailed
 import akka.persistence.typed.ReplicaId
 import akka.persistence.typed.SingleEventSeq
 import akka.persistence.typed.internal.BehaviorSetup.SnapshotWithoutRetention
-import akka.persistence.typed.internal.EventSourcedBehaviorImpl.{ GetSeenSequenceNr, GetState }
+import akka.persistence.typed.internal.EventSourcedBehaviorImpl.GetSeenSequenceNr
+import akka.persistence.typed.internal.EventSourcedBehaviorImpl.GetState
 import akka.persistence.typed.internal.ReplayingEvents.ReplayingState
 import akka.persistence.typed.internal.Running.WithSeqNrAccessible
 import akka.persistence.typed.internal.Running.startReplicationStream
@@ -122,7 +129,10 @@ private[akka] final class ReplayingEvents[C, E, S](
         case ReplayedMessage(repr) =>
           var eventForErrorReporting: OptionVal[Any] = OptionVal.None
           try {
-            val eventSeq = setup.eventAdapter.fromJournal(repr.payload, repr.manifest)
+            val eventSeq =
+              if (repr.payload == FilteredPayload) EventSeq.empty // ignore FilteredPayload
+              else setup.eventAdapter.fromJournal(repr.payload, repr.manifest)
+
             def handleEvent(event: E): Unit = {
               eventForErrorReporting = OptionVal.Some(event)
               state = state.copy(seqNr = repr.sequenceNr, eventsReplayed = state.eventsReplayed + 1)

--- a/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/Eventsourced.scala
@@ -635,6 +635,7 @@ private[persistence] trait Eventsourced
       }
 
       {
+        case PersistentRepr(FilteredPayload, _) => // ignore
         case PersistentRepr(payload, _) if recoveryRunning && _receiveRecover.isDefinedAt(payload) =>
           _receiveRecover(payload)
         case s: SnapshotOffer if _receiveRecover.isDefinedAt(s) =>

--- a/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala
@@ -70,7 +70,7 @@ object PersistentActorSpec {
   class Behavior1PersistentActor(name: String) extends ExamplePersistentActor(name) {
     val receiveCommand: Receive = commonBehavior.orElse {
       case Cmd(data) =>
-        persistAll(Seq(Evt(s"${data}-1"), Evt(s"${data}-2")))(updateState)
+        persistAll(List(Evt(s"${data}-1"), Evt(s"${data}-2")))(updateState)
       case d: DeleteMessagesSuccess =>
         val replyTo = askedForDelete.getOrElse(
           throw new RuntimeException("Received DeleteMessagesSuccess without anyone asking for delete!"))
@@ -100,8 +100,8 @@ object PersistentActorSpec {
   class Behavior2PersistentActor(name: String) extends ExamplePersistentActor(name) {
     val receiveCommand: Receive = commonBehavior.orElse {
       case Cmd(data) =>
-        persistAll(Seq(Evt(s"${data}-1"), Evt(s"${data}-2")))(updateState)
-        persistAll(Seq(Evt(s"${data}-3"), Evt(s"${data}-4")))(updateState)
+        persistAll(List(Evt(s"${data}-1"), Evt(s"${data}-2")))(updateState)
+        persistAll(List(Evt(s"${data}-3"), Evt(s"${data}-4")))(updateState)
     }
   }
   class Behavior2PersistentActorWithInmemRuntimePluginConfig(name: String, val providedConfig: Config)
@@ -111,7 +111,7 @@ object PersistentActorSpec {
   class Behavior3PersistentActor(name: String) extends ExamplePersistentActor(name) {
     val receiveCommand: Receive = commonBehavior.orElse {
       case Cmd(data) =>
-        persistAll(Seq(Evt(s"${data}-11"), Evt(s"${data}-12")))(updateState)
+        persistAll(List(Evt(s"${data}-11"), Evt(s"${data}-12")))(updateState)
         updateState(Evt(s"${data}-10"))
     }
   }
@@ -185,7 +185,7 @@ object PersistentActorSpec {
     val newBehavior: Receive = {
       case Cmd(data) =>
         context.unbecome()
-        persistAll(Seq(Evt(s"${data}-31"), Evt(s"${data}-32")))(updateState)
+        persistAll(List(Evt(s"${data}-31"), Evt(s"${data}-32")))(updateState)
         updateState(Evt(s"${data}-30"))
     }
 
@@ -204,7 +204,7 @@ object PersistentActorSpec {
   class ChangeBehaviorInCommandHandlerLastPersistentActor(name: String) extends ExamplePersistentActor(name) {
     val newBehavior: Receive = {
       case Cmd(data) =>
-        persistAll(Seq(Evt(s"${data}-31"), Evt(s"${data}-32")))(updateState)
+        persistAll(List(Evt(s"${data}-31"), Evt(s"${data}-32")))(updateState)
         updateState(Evt(s"${data}-30"))
         context.unbecome()
     }
@@ -229,7 +229,7 @@ object PersistentActorSpec {
     }
 
     private def handleCmd(cmd: Cmd): Unit = {
-      persistAll(Seq(Evt(s"${cmd.data}-41"), Evt(s"${cmd.data}-42")))(updateState)
+      persistAll(List(Evt(s"${cmd.data}-41"), Evt(s"${cmd.data}-42")))(updateState)
     }
 
     def receiveCommand: Receive = commonBehavior.orElse {
@@ -1262,7 +1262,7 @@ abstract class PersistentActorSpec(config: Config) extends PersistenceSpec(confi
         persistentActor ! i
       }
 
-      val all: Seq[String] = this.receiveN(40).asInstanceOf[Seq[String]] // each command = 1 reply + 3 event-replies
+      val all: List[String] = this.receiveN(40).asInstanceOf[List[String]] // each command = 1 reply + 3 event-replies
 
       val replies = all.filter(r => r.count(_ == '-') == 1)
       replies should equal(commands.map(_.data))


### PR DESCRIPTION
* mostly for sanity, in case someone use it in a way that we didn't intended, such as starting a persistent actor for a pid that has the FilteredPayload in the journal

See https://github.com/akka/akka/pull/31985