### PR TITLE
fix: discard ReceiveTimeout when timeout message is null #32015

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/adpater/ActorAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/adpater/ActorAdapterSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.actor.typed.internal.adpater
+
+import scala.concurrent.duration.DurationInt
+import org.scalatest.wordspec.AnyWordSpecLike
+import akka.actor.testkit.typed.scaladsl._
+import akka.actor.typed._
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter._
+
+class ActorAdapterSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
+
+  sealed trait Command
+  case object Begin extends Command
+  case object End extends Command
+  case object Timeout extends Command
+
+  sealed trait Event
+  case object Ended extends Event
+
+  val interval = 1.second
+
+  def evidence(monitor: ActorRef[Event]): Behavior[Command] =
+    Behaviors.setup { context =>
+      Behaviors.receiveMessage[Command] {
+        case Begin =>
+          context.setReceiveTimeout(100.milliseconds, Timeout)
+          context.cancelReceiveTimeout()
+          context.self.toClassic ! akka.actor.ReceiveTimeout
+          context.self ! End
+          Behaviors.same
+
+        case Timeout =>
+          Behaviors.stopped
+
+        case End =>
+          monitor ! Ended
+          Behaviors.stopped
+      }
+    }
+
+  "An ActorAdapter" must {
+    "not cause actor crash after recieve timeout was cancelled with ReceiveTimeout waiting in mailbox" in {
+      val probe = TestProbe[Event]("evt")
+      val behavior = evidence(probe.ref)
+
+      val ref = spawn(behavior)
+      ref ! Begin
+      probe.expectMessage(Ended)
+    }
+  }
+}

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/adpater/ActorAdapterSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/internal/adpater/ActorAdapterSpec.scala
@@ -21,8 +21,6 @@ class ActorAdapterSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
   sealed trait Event
   case object Ended extends Event
 
-  val interval = 1.second
-
   def evidence(monitor: ActorRef[Event]): Behavior[Command] =
     Behaviors.setup { context =>
       Behaviors.receiveMessage[Command] {

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/ActorAdapter.scala
@@ -90,7 +90,9 @@ import akka.util.OptionVal
             } else Terminated(ActorRefAdapter(ref))
           handleSignal(msg)
         case classic.ReceiveTimeout =>
-          handleMessage(ctx.receiveTimeoutMsg)
+          // discard when null as timeout was cancelled after RecieveTimeout was already enqueued into the mailbox
+          if (ctx.receiveTimeoutMsg != null)
+            handleMessage(ctx.receiveTimeoutMsg)
         case wrapped: AdaptMessage[Any, T] @unchecked =>
           withSafelyAdapted(() => wrapped.adapt()) {
             case AdaptWithRegisteredMessageAdapter(msg) =>


### PR DESCRIPTION
References https://github.com/akka/akka/issues/32015

Approach here is to check if receive message is null and if so stop processing.

Test case may be brittle as it relies on documented behavior but without more advanced knowledge of the project and attempting to test nondeterminism I do not at this time have a better test solution. I welcome suggestions and criticism to make the test case better.