### PR TITLE
Add javadsl for Effect.delete() in durable state

### DIFF
--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/Effect.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/javadsl/Effect.scala
@@ -34,7 +34,12 @@ import akka.persistence.typed.state.internal.SideEffect
    */
   final def persist(state: State): EffectBuilder[State] = Persist(state)
 
-  // FIXME add delete effect
+  /**
+   * Delete the persisted state.
+   *
+   * Side effects can be chained with `thenRun`.
+   */
+  def delete(): EffectBuilder[State] = Delete().asInstanceOf[EffectBuilder[State]]
 
   /**
    * Do not persist anything

--- a/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/DurableStatePersistentBehaviorTest.java
+++ b/akka-persistence-typed/src/test/java/jdocs/akka/persistence/typed/DurableStatePersistentBehaviorTest.java
@@ -96,6 +96,9 @@ public class DurableStatePersistentBehaviorTest {
         }
       }
 
+      public enum Delete implements Command<Void> {
+        INSTANCE
+      }
       // #command
 
       // #state
@@ -140,6 +143,8 @@ public class DurableStatePersistentBehaviorTest {
                 (state, command) -> Effect().persist(new State(state.get() + command.value)))
             .onCommand(
                 GetValue.class, (state, command) -> Effect().reply(command.replyTo, state.get()))
+            .onCommand(
+                Delete.class, (state, command) -> Effect().delete())
             .build();
       }
       // #command-handler


### PR DESCRIPTION
References #32026

It looks like an oversight in #31529 that no javadsl was added.