### PR TITLE
perf: streamline recursion in mapAsyncPartitioned

### DIFF
--- a/akka-stream-tests/src/test/scala/akka/stream/impl/PartitionedBufferSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/PartitionedBufferSpec.scala
@@ -92,5 +92,39 @@ class PartitionedBufferSpec extends StreamSpec {
       partitionBuffer.peekPartition(1) shouldBe empty
     }
 
+    "report usage of partitions" in {
+      val partitionBuffer = new PartitionedBuffer[Int, Int](6)
+
+      // odd/even
+      partitionBuffer.addPartition(0, Buffer(2, 8))
+      partitionBuffer.addPartition(1, Buffer(2, 8))
+
+      def sumOfPartitionUsed() =
+        (0 to 1).map { partition => partitionBuffer.usedInPartition(partition) }.sum
+
+      partitionBuffer.usedInPartition(0) shouldBe 0
+      partitionBuffer.usedInPartition(1) shouldBe 0
+      sumOfPartitionUsed() shouldBe partitionBuffer.used      // invariant
+
+      partitionBuffer.enqueue(0, 0)
+
+      partitionBuffer.usedInPartition(0) shouldBe 1
+      sumOfPartitionUsed() shouldBe partitionBuffer.used      // invariant
+
+      partitionBuffer.enqueue(1, 1)
+
+      partitionBuffer.usedInPartition(1) shouldBe 1
+      sumOfPartitionUsed() shouldBe partitionBuffer.used      // invariant
+
+      partitionBuffer.dequeue()
+
+      partitionBuffer.usedInPartition(0) shouldBe 0
+      sumOfPartitionUsed() shouldBe partitionBuffer.used      // invariant
+
+      partitionBuffer.dequeue()
+
+      partitionBuffer.usedInPartition(1) shouldBe 0
+      sumOfPartitionUsed() shouldBe partitionBuffer.used      // invariant
+    }
   }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/PartitionedBufferSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/PartitionedBufferSpec.scala
@@ -100,31 +100,33 @@ class PartitionedBufferSpec extends StreamSpec {
       partitionBuffer.addPartition(1, Buffer(2, 8))
 
       def sumOfPartitionUsed() =
-        (0 to 1).map { partition => partitionBuffer.usedInPartition(partition) }.sum
+        (0 to 1).map { partition =>
+          partitionBuffer.usedInPartition(partition)
+        }.sum
 
       partitionBuffer.usedInPartition(0) shouldBe 0
       partitionBuffer.usedInPartition(1) shouldBe 0
-      sumOfPartitionUsed() shouldBe partitionBuffer.used      // invariant
+      sumOfPartitionUsed() shouldBe partitionBuffer.used // invariant
 
       partitionBuffer.enqueue(0, 0)
 
       partitionBuffer.usedInPartition(0) shouldBe 1
-      sumOfPartitionUsed() shouldBe partitionBuffer.used      // invariant
+      sumOfPartitionUsed() shouldBe partitionBuffer.used // invariant
 
       partitionBuffer.enqueue(1, 1)
 
       partitionBuffer.usedInPartition(1) shouldBe 1
-      sumOfPartitionUsed() shouldBe partitionBuffer.used      // invariant
+      sumOfPartitionUsed() shouldBe partitionBuffer.used // invariant
 
       partitionBuffer.dequeue()
 
       partitionBuffer.usedInPartition(0) shouldBe 0
-      sumOfPartitionUsed() shouldBe partitionBuffer.used      // invariant
+      sumOfPartitionUsed() shouldBe partitionBuffer.used // invariant
 
       partitionBuffer.dequeue()
 
       partitionBuffer.usedInPartition(1) shouldBe 0
-      sumOfPartitionUsed() shouldBe partitionBuffer.used      // invariant
+      sumOfPartitionUsed() shouldBe partitionBuffer.used // invariant
     }
   }
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/Buffers.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Buffers.scala
@@ -332,6 +332,11 @@ private[impl] final class PartitionedBuffer[K, V](size: Int) {
     }
   }
 
+  def usedInPartition(key: K): Int =
+    if (partitionBuffers.contains(key)) {
+      partitionBuffers(key).used
+    } else 0
+
   def addPartition(key: K, buffer: Buffer[V]): Unit = {
     partitionBuffers += (key -> buffer)
   }

--- a/akka-stream/src/main/scala/akka/stream/impl/Buffers.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Buffers.scala
@@ -333,9 +333,10 @@ private[impl] final class PartitionedBuffer[K, V](size: Int) {
   }
 
   def usedInPartition(key: K): Int =
-    if (partitionBuffers.contains(key)) {
-      partitionBuffers(key).used
-    } else 0
+    partitionBuffers.get(key) match {
+      case Some(buffer) => buffer.used
+      case None         => 0
+    }
 
   def addPartition(key: K, buffer: Buffer[V]): Unit = {
     partitionBuffers += (key -> buffer)


### PR DESCRIPTION
In `mapAsyncPartitioned` whenever a future in a given partition completes we dequeue the longest prefix of the partition's queue which has completed before we potentially emit elements downstream and demand more elements from upstream.

When `perPartition` is low (say 1 or 2), this doesn't delay demanding more elements too long and if there are unstarted futures we get a head start.  However there can be situations with larger `perPartition` values where this process materially delays demanding new elements.  Additionally, in the situation where there are no unstarted futures in a partition, we still eagerly dequeue more elements even though there's no gain from starting them earlier.

This change introspects the partition queue: if after dequeuing, there are no unstarted futures for the partition, the stage will move into emission mode rather than attempt to dequeue more.