### PR TITLE
Add short-circuit support in retry pattern

### DIFF
--- a/akka-actor/src/main/scala/akka/pattern/Patterns.scala
+++ b/akka-actor/src/main/scala/akka/pattern/Patterns.scala
@@ -604,11 +604,11 @@ object Patterns {
       ec: ExecutionContext): CompletionStage[T] =
     scalaRetry(
       () => attempt.call().toScala,
+      (ex) => shouldRetry.test(ex),
       attempts,
       minBackoff.asScala,
       maxBackoff.asScala,
-      randomFactor,
-      (ex) => shouldRetry.test(ex))(ec, scheduler).toJava
+      randomFactor)(ec, scheduler).toJava
 
   /**
    * Returns an internally retrying [[scala.concurrent.Future]]
@@ -718,8 +718,8 @@ object Patterns {
 
     scalaRetry(
       () => attempt.call().toScala,
+      (ex) => shouldRetry.test(ex),
       attempts,
-      (attempted) => delayFunction.apply(attempted).asScala.map(_.asScala),
-      (ex) => shouldRetry.test(ex))(context, scheduler).toJava
+      (attempted) => delayFunction.apply(attempted).asScala.map(_.asScala))(context, scheduler).toJava
   }
 }

--- a/akka-actor/src/main/scala/akka/pattern/Patterns.scala
+++ b/akka-actor/src/main/scala/akka/pattern/Patterns.scala
@@ -6,6 +6,7 @@ package akka.pattern
 
 import java.util.Optional
 import java.util.concurrent.{ Callable, CompletionStage, TimeUnit }
+import java.util.function.Predicate
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext
@@ -459,7 +460,7 @@ object Patterns {
    * The first attempt will be made immediately, each subsequent attempt will be made immediately
    * if the previous attempt failed.
    *
-   * If attempts are exhausted the returned completion operator is simply the result of invoking attempt.
+   * If attempts are exhausted the returned completion CompletionStage is simply the result of invoking attempt.
    * Note that the attempt function will be invoked on the given execution context for subsequent tries
    * and therefore must be thread safe (not touch unsafe mutable state).
    */
@@ -467,6 +468,25 @@ object Patterns {
     require(attempt != null, "Parameter attempt should not be null.")
     scalaRetry(() => attempt.call().toScala, attempts)(ec).toJava
   }
+
+  /**
+   * Returns an internally retrying [[java.util.concurrent.CompletionStage]]
+   * The first attempt will be made immediately, each subsequent attempt will be made immediately
+   * if the previous attempt failed and the provided predicate tests true for the failure's exception.
+   * If the predicate tests false, the failed attempt will be returned.  This allows for short-circuiting
+   * in situations where the retries cannot be expected to succeed (e.g. in a situation where the legality
+   * of arguments can only be determined asynchronously).
+   *
+   * If attempts are exhausted, the returned CompletionStage is that of the last attempt.
+   * Note that the attempt function will be executed on the given execution context for subsequent tries
+   * and therefore must be thread safe (not touch unsafe mutable state).
+   */
+  def retry[T](
+      attempt: Callable[CompletionStage[T]],
+      shouldRetry: Predicate[Throwable],
+      attempts: Int,
+      ec: ExecutionContext): CompletionStage[T] =
+    scalaRetry(() => attempt.call().toScala, (ex) => shouldRetry.test(ex), attempts)(ec).toJava
 
   /**
    * Returns an internally retrying [[java.util.concurrent.CompletionStage]]
@@ -502,6 +522,36 @@ object Patterns {
 
   /**
    * Returns an internally retrying [[java.util.concurrent.CompletionStage]]
+   * The first attempt will be made immediately, each subsequent attempt will be made with a backoff time
+   * if the preceding attempt failed and the provided predicate tests true for the failure's exception.
+   * If the predicate tests false, the failed attempt will be returned.  This allows for short-circuiting
+   * in situations where the retries cannot be expected to succeed (e.g. in a situation where the legality of
+   * arguments can only be determined asynchronously).
+   *
+   * If attempts are exhausted, the returned CompletionStage is that of the last attempt.
+   * Note that the attempt function will be executed on the actor system's dispatcher for subsequent tries
+   * and therefore must be thread safe (not touch unsafe mutable state).
+   */
+  def retry[T](
+      attempt: Callable[CompletionStage[T]],
+      attempts: Int,
+      minBackoff: java.time.Duration,
+      maxBackoff: java.time.Duration,
+      randomFactor: Double,
+      shouldRetry: Predicate[Throwable],
+      system: ClassicActorSystemProvider): CompletionStage[T] =
+    retry(
+      attempt,
+      attempts,
+      minBackoff,
+      maxBackoff,
+      randomFactor,
+      shouldRetry,
+      system.classicSystem.scheduler,
+      system.classicSystem.dispatcher)
+
+  /**
+   * Returns an internally retrying [[java.util.concurrent.CompletionStage]]
    * The first attempt will be made immediately, each subsequent attempt will be made with a backoff time,
    * if the previous attempt failed.
    *
@@ -509,8 +559,7 @@ object Patterns {
    * Note that the attempt function will be invoked on the given execution context for subsequent tries and
    * therefore must be thread safe (not touch unsafe mutable state).
    *
-   * @param minBackoff   minimum (initial) duration until the child actor will
-   *                     started again, if it is terminated
+   * @param minBackoff   minimum (initial) duration until the  attempt will be retried
    * @param maxBackoff   the exponential back-off is capped to this duration
    * @param randomFactor after calculation of the exponential back-off an additional
    *                     random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay.
@@ -531,6 +580,35 @@ object Patterns {
       ec,
       scheduler).toJava
   }
+
+  /**
+   * Returns an internally retrying [[java.util.concurrent.CompletionStage]]
+   * The first attempt will be made immediately, each subsequent attempt will be made with a backoff time
+   * if the preceding attempt failed and the provided predicate tests true for the failure's exception.
+   * If the predicate tests false, the failed attempt will be returned.  This allows for short-circuiting
+   * in situations where the retries cannot be expected to succeed (e.g. in a situation where the legality of
+   * arguments can only be determined asynchronously).
+   *
+   * If attempts are exhausted, the returned CompletionStage is that of the last attempt.
+   * Note that the attempt function will be executed on the given execution context for subsequent tries
+   * and therefore must be thread safe (not touch unsafe mutable state).
+   */
+  def retry[T](
+      attempt: Callable[CompletionStage[T]],
+      attempts: Int,
+      minBackoff: java.time.Duration,
+      maxBackoff: java.time.Duration,
+      randomFactor: Double,
+      shouldRetry: Predicate[Throwable],
+      scheduler: Scheduler,
+      ec: ExecutionContext): CompletionStage[T] =
+    scalaRetry(
+      () => attempt.call().toScala,
+      attempts,
+      minBackoff.asScala,
+      maxBackoff.asScala,
+      randomFactor,
+      (ex) => shouldRetry.test(ex))(ec, scheduler).toJava
 
   /**
    * Returns an internally retrying [[scala.concurrent.Future]]
@@ -556,7 +634,7 @@ object Patterns {
    * The first attempt will be made immediately, and each subsequent attempt will be made after 'delay'.
    * A scheduler (eg context.system.scheduler) must be provided to delay each retry
    *
-   * If attempts are exhausted the returned completion operator is simply the result of invoking attempt.
+   * If attempts are exhausted the returned CompletionStage is simply the result of invoking attempt.
    * Note that the attempt function will be invoked on the given execution context for subsequent tries
    * and therefore must be thread safe (not touch unsafe mutable state).
    */
@@ -572,7 +650,7 @@ object Patterns {
    * The first attempt will be made immediately, and each subsequent attempt will be made after 'delay'.
    * A scheduler (eg context.system.scheduler) must be provided to delay each retry
    *
-   * If attempts are exhausted the returned completion operator is simply the result of invoking attempt.
+   * If attempts are exhausted the returned CompletionStage is simply the result of invoking attempt.
    * Note that the attempt function will be invoked on the given execution context for subsequent tries
    * and therefore must be thread safe (not touch unsafe mutable state).
    */
@@ -611,5 +689,37 @@ object Patterns {
       () => attempt.call().toScala,
       attempts,
       attempted => delayFunction.apply(attempted).asScala.map(_.asScala))(context, scheduler).toJava
+  }
+
+  /**
+   * Returns an internally retrying [[java.util.concurrent.CompletionStage]]
+   * The first attempt will be made immediately, any subsequent attempt will be made after the delay
+   * returned by the delay function (which can return an empty [[Optional]] for an immediate retry; it must never
+   * return `null`).
+   * A scheduler (e.g. context.system().scheduler()) must be provided to delay retries.
+   *
+   * If attempts are exhausted, the returned CompletionStage is that of the last attempt.
+   * Note that the attempt function will be invoked on the given execution context for subsequent tries and therefore
+   * must be thread safe (not touch unsafe mutable state).
+   *
+   * If an attempt fails, the exception from the failure will be tested with the provided predicate; if that predicate
+   * tests true, a retry will be attempted, if false, the most recent failure is returned.  This allows for
+   * short-circuiting in situations where the retries cannot be expected to succeed (e.g. in a situation where the
+   * legality of arguments can only be determined asynchronously).
+   */
+  def retry[T](
+      attempt: Callable[CompletionStage[T]],
+      attempts: Int,
+      delayFunction: java.util.function.IntFunction[Optional[java.time.Duration]],
+      shouldRetry: Predicate[Throwable],
+      scheduler: Scheduler,
+      context: ExecutionContext): CompletionStage[T] = {
+    import scala.compat.java8.OptionConverters._
+
+    scalaRetry(
+      () => attempt.call().toScala,
+      attempts,
+      (attempted) => delayFunction.apply(attempted).asScala.map(_.asScala),
+      (ex) => shouldRetry.test(ex))(context, scheduler).toJava
   }
 }

--- a/akka-actor/src/main/scala/akka/pattern/RetrySupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/RetrySupport.scala
@@ -38,6 +38,32 @@ trait RetrySupport {
 
   /**
    * Given a function from Unit to Future, returns an internally retrying Future.
+   * The first attempt will be made immediately, each subsequent attempt will be made immediately
+   * if the preceding attempt failed and the 'shouldRetry' predicate, when applied to the failure's
+   * exception evaluates to 'true'.  If the predicate evaluates to 'false', the failed attempt will
+   * be returned.  This allows for short-circuiting in situations where the retries cannot be expected
+   * to succeed (e.g. in a situation where the legality of arguments can only be determined asynchronously).
+   *
+   * If attempts are exhausted, the returned future is the that of the last attempt.
+   * Note that the attempt function will be invoked on the given execution context for subsequent tries and
+   * therefore must be thread safe (not touch unsafe mutable state).
+   *
+   * <b>Example usage</b>
+   *
+   * {{{
+   * def possiblyFailing(): Future[Something] = ???
+   * val withRetry: Future[Something] = retry(
+   *   attempt = possiblyFailing,
+   *   attempts = 10,
+   *   shouldRetry = { (ex) => ex.isInstanceOf[IllegalArgumentException] })
+   * }}}
+   */
+  def retry[T](attempt: () => Future[T], shouldRetry: Throwable => Boolean, attempts: Int)(
+      implicit ec: ExecutionContext): Future[T] =
+    RetrySupport.retry(attempt, attempts, ConstantFun.scalaAnyToNone, attempted = 0, shouldRetry)(ec, null)
+
+  /**
+   * Given a function from Unit to Future, returns an internally retrying Future.
    * The first attempt will be made immediately, each subsequent attempt will be made with a backoff time,
    * if the previous attempt failed.
    *
@@ -85,6 +111,48 @@ trait RetrySupport {
 
   /**
    * Given a function from Unit to Future, returns an internally retrying Future.
+   * The first attempt will be made immediately, each subsequent attempt will made with a backoff time
+   * if the preceding attempt failed and the 'shouldRetry' predicate, when applied to the failure's
+   * exception evaluates to 'true'.  If the predicate evaluates to 'false', the failed attempt will
+   * be returned.  This allows for short-circuiting in situations where the retries cannot be expected to
+   * succeed (e.g. in a situation where the legality of arguments can only be determined asynchronously).
+   *
+   * If attempts are exhausted, the returned future is that of the last attempt.
+   * Note that the attempt function will be invoked on the given execution context for subsequent tries
+   * and therefore must be thread safe (not touch unsafe mutable state).
+   *
+   * <b>Example usage:</b>
+   * {{{
+   * protected def sendAndReceive(req: HttpRequest): Future[HttpResponse]
+   * private val sendReceiveRetry: HttpRequest => Future[HttpResponse] = (req: HttpRequest) => retry[HttpResponse](
+   *   attempt = () => sendAndReceive(req),
+   *   attempts = 10,
+   *   minBackoff = 1.second,
+   *   maxBackoff = 10.seconds,
+   *   randomFactor = 0.2,
+   *   shouldRetry = ex => !ex.isInstanceOf[IllegalArgumentException])
+   * }}}
+   */
+  def retry[T](
+      attempt: () => Future[T],
+      attempts: Int,
+      minBackoff: FiniteDuration,
+      maxBackoff: FiniteDuration,
+      randomFactor: Double,
+      shouldRetry: Throwable => Boolean)(implicit ec: ExecutionContext, scheduler: Scheduler): Future[T] = {
+    require(minBackoff > Duration.Zero, "Parameter minBackoff must be > 0")
+    require(maxBackoff >= minBackoff, "Parameter maxBackoff must be >= minBackoff")
+    require(0.0 <= randomFactor && randomFactor <= 1.0, "randomFactor must be between 0.0 and 1.0")
+
+    retry(
+      attempt,
+      attempts,
+      attempted => Some(BackoffSupervisor.calculateDelay(attempted, minBackoff, maxBackoff, randomFactor)),
+      shouldRetry)
+  }
+
+  /**
+   * Given a function from Unit to Future, returns an internally retrying Future.
    * The first attempt will be made immediately, each subsequent attempt will be made after 'delay'.
    * A scheduler (eg context.system.scheduler) must be provided to delay each retry.
    *
@@ -116,7 +184,7 @@ trait RetrySupport {
    * Returns [[None]] for no delay.
    * A scheduler (eg context.system.scheduler) must be provided to delay each retry.
    * You could provide a function to generate the next delay duration after first attempt,
-   * this function should never return `null`, otherwise an [[IllegalArgumentException]] will be through.
+   * this function should never return `null`, otherwise an [[IllegalArgumentException]] will be thrown.
    *
    * If attempts are exhausted the returned future is simply the result of invoking attempt.
    * Note that the attempt function will be invoked on the given execution context for subsequent
@@ -138,7 +206,46 @@ trait RetrySupport {
       implicit
       ec: ExecutionContext,
       scheduler: Scheduler): Future[T] = {
-    RetrySupport.retry(attempt, attempts, delayFunction, attempted = 0)
+    RetrySupport.retry(attempt, attempts, delayFunction, attempted = 0, RetrySupport.alwaysRetry)
+  }
+
+  /**
+   * Given a function from Unit to Future, returns an internally retrying Future.
+   * The first attempt will be made immediately, any subsequent attempt will be made after
+   * the 'delay' return by `delayFunction`(the input next attempt count start from 1).
+   * Returns [[None]] for no delay.
+   * A scheduler (eg context.system.scheduler) must be provided to delay each retry.
+   * You could provide a function to generate the next delay duration after first attempt,
+   * this function should never return `null`, otherwise an [[IllegalArgumentException]] will be thrown.
+   *
+   * If attempts are exhausted the returned future is simply the result of invoking attempt.
+   * Note that the attempt function will be invoked on the given execution context for subsequent
+   * tries and therefore must be thread safe (not touch unsafe mutable state).
+   *
+   * If an attempt fails, the exception from the failure will be passed to the 'shouldRetry' predicate;
+   * if the predicate evaluates 'true', a retry will be attempted.  This allows for short-circuiting
+   * in situations where the retries cannot be expected to succeed (e.g. in a situation where the
+   * legality of arguments can only be determined asynchronously).
+   *
+   * <b>Example usage:</b>
+   *
+   * // retry with backoff
+   * {{{
+   * protected val sendAndReceive: HttpRequest => Future[HttpResponse] = { (req) => ??? }
+   * private val sendReceiveRetry: HttpRequest => Future[HttpResponse] = (req: HttpRequest) => retry[HttpResponse](
+   *   attempt = () => sendAndReceive(req),
+   *   attempts = 10,
+   *   delayFunction = attempted => Option(2.seconds * attempted),
+   *   shouldRetry = ex => !ex.isInstanceOf[IllegalArgumentException]
+   * )
+   * }}}
+   */
+  def retry[T](
+      attempt: () => Future[T],
+      attempts: Int,
+      delayFunction: Int => Option[FiniteDuration],
+      shouldRetry: Throwable => Boolean)(implicit ec: ExecutionContext, scheduler: Scheduler): Future[T] = {
+    RetrySupport.retry(attempt, attempts, delayFunction, attempted = 0, shouldRetry)
   }
 }
 
@@ -146,13 +253,14 @@ object RetrySupport extends RetrySupport {
 
   private def retry[T](attempt: () => Future[T], maxAttempts: Int, attempted: Int)(
       implicit ec: ExecutionContext): Future[T] =
-    retry(attempt, maxAttempts, ConstantFun.scalaAnyToNone, attempted)(ec, null)
+    retry(attempt, maxAttempts, ConstantFun.scalaAnyToNone, attempted, alwaysRetry)(ec, null)
 
   private def retry[T](
       attempt: () => Future[T],
       maxAttempts: Int,
       delayFunction: Int => Option[FiniteDuration],
-      attempted: Int)(implicit ec: ExecutionContext, scheduler: Scheduler): Future[T] = {
+      attempted: Int,
+      decider: Throwable => Boolean)(implicit ec: ExecutionContext, scheduler: Scheduler): Future[T] = {
 
     def tryAttempt(): Future[T] = {
       try {
@@ -171,17 +279,17 @@ object RetrySupport extends RetrySupport {
       else {
         val nextAttempt = attempted + 1
         result.recoverWith {
-          case NonFatal(_) =>
+          case NonFatal(ex) if decider(ex) =>
             delayFunction(nextAttempt) match {
               case Some(delay) =>
                 if (delay.length < 1)
-                  retry(attempt, maxAttempts, delayFunction, nextAttempt)
+                  retry(attempt, maxAttempts, delayFunction, nextAttempt, decider)
                 else
                   after(delay, scheduler) {
-                    retry(attempt, maxAttempts, delayFunction, nextAttempt)
+                    retry(attempt, maxAttempts, delayFunction, nextAttempt, decider)
                   }
               case None =>
-                retry(attempt, maxAttempts, delayFunction, nextAttempt)
+                retry(attempt, maxAttempts, delayFunction, nextAttempt, decider)
               case null =>
                 Future.failed(new IllegalArgumentException("The delayFunction of retry should not return null."))
             }
@@ -192,5 +300,9 @@ object RetrySupport extends RetrySupport {
     } else {
       tryAttempt()
     }
+  }
+
+  private val alwaysRetry: Throwable => Boolean = { _ =>
+    true
   }
 }


### PR DESCRIPTION
There are situations where the nature of failure of a future indicates that any retry (regardless of delay) is extremely likely to fail in the same way.  In such a situation, the retry is unlikely to be of value and it may be better to surface the failure more quickly.

Consider, for instance, an API which validates inputs asynchronously (e.g. imagine that the validations to perform are dynamically obtained from a server, but the validations themselves only change on a fairly long timeframe).  It is unlikely that the validations change from one retry to another, so retrying the validations is unlikely to change the result.  However, we'd like the API calls to be retried if they fail for some other reason that's more amenable to retries.

This change adds support for classifying failed futures as "should retry" or "should not retry" based on the nature of the failure (in HTTP terms, think of the difference between 4xx and 5xx, ignoring that Akka HTTP will give successful futures for 4xx/5xx responses).

An alternative approach in the current API is to have a `recoverWith` as part of the attempt which transforms the "should not retry" failures into distinguished successes so that no more attempts are performed, and a `flatMap` outside of the retry transforms those distinguished successes back to a failure:

```scala
// implementation of the new API in this PR in terms of the old
def retry[T](
    attempt: () => Future[T],
    attempts: Int,
    delayFunction: Int => Option[FiniteDuration],
    shouldRetry: Throwable => Boolean)(implicit ec: ExecutionContext, scheduler: Scheduler): Future[T] =
  retry(
    () => {
      val baseFuture: Future[Try[T]] = attempt().map(Success(_))
      baseFuture.recoverWith {
        case ex if !(shouldRetry(ex)) => Future.successful(Failure(ex))
        case _ => baseFuture
      }
    },
    attempts,
    delayFunction).flatMap(Future.fromTry(_))
```