### PR TITLE
remove info log showing Slf4jLogger started to avoid slf4j warning at the top #31395

### DIFF
--- a/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
@@ -104,10 +104,6 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
       }
 
     case InitializeLogger(_) =>
-      if (log.isInfoEnabled) {
-        Thread.sleep(30L)
-        log.info("Slf4jLogger started")
-      }
       sender() ! LoggerInitialized
   }
 

--- a/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
@@ -104,7 +104,10 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
       }
 
     case InitializeLogger(_) =>
-      log.info("Slf4jLogger started")
+      if (log.isInfoEnabled) {
+        Thread.sleep(30L)
+        log.info("Slf4jLogger started")
+      }
       sender() ! LoggerInitialized
   }
 


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #31395

This would significantly enlarge the change to get slf4j warning silent
