### PR TITLE
feat: Lazy deserialization of EventEnvelope

### DIFF
--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/EventEnvelope.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/EventEnvelope.scala
@@ -4,10 +4,11 @@
 
 package akka.persistence.query.typed
 
-import java.util.{ Set => JSet }
+import java.util.{Set => JSet}
 import java.util.Optional
 
 import akka.annotation.ApiMayChange
+import akka.annotation.InternalApi
 import akka.annotation.InternalStableApi
 import akka.persistence.query.Offset
 import akka.util.HashCode
@@ -309,8 +310,17 @@ final class EventEnvelope[Event] private (
   def withEvent(event: Event): EventEnvelope[Event] =
     copy(_eventOption = Option(event))
 
+  def withEventOption(eventOption: Option[Event]): EventEnvelope[Event] =
+    copy(_eventOption = eventOption)
+
   def withTags(tags: Set[String]): EventEnvelope[Event] =
     copy(tags = tags)
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka]  def isEventDeserialized: Boolean =
+    _eventOption.isDefined || serializedEvent.isEmpty
 
   private def copy(
       offset: Offset = offset,

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/EventEnvelope.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/EventEnvelope.scala
@@ -309,6 +309,9 @@ final class EventEnvelope[Event] private (
   def withEvent(event: Event): EventEnvelope[Event] =
     copy(_eventOption = Option(event))
 
+  def withTags(tags: Set[String]): EventEnvelope[Event] =
+    copy(tags = tags)
+
   private def copy(
       offset: Offset = offset,
       persistenceId: String = persistenceId,

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/EventEnvelope.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/EventEnvelope.scala
@@ -4,7 +4,7 @@
 
 package akka.persistence.query.typed
 
-import java.util.{Set => JSet}
+import java.util.{ Set => JSet }
 import java.util.Optional
 
 import akka.annotation.ApiMayChange
@@ -304,8 +304,16 @@ final class EventEnvelope[Event] private (
    */
   def getTags(): JSet[String] = tags.asJava
 
-  def withPersistenceId(persistenceId: String): EventEnvelope[Event] =
-    copy(persistenceId = persistenceId)
+  /**
+   * `entityType` and `slice` should be derived from the `persistenceId`, but must be explicitly defined
+   * when changing the `persistenceId` of the envelope.
+   * The `slice` should be calculated with [[akka.persistence.Persistence.sliceForPersistenceId]] for
+   * the given `persistenceId`.
+   * The `entityType` should be extracted from the `persistenceId` with
+   * `akka.persistence.typed.PersistenceId.extractEntityType`.
+   */
+  def withPersistenceId(persistenceId: String, entityType: String, slice: Int): EventEnvelope[Event] =
+    copy(persistenceId = persistenceId, entityType = entityType, slice = slice)
 
   def withEvent(event: Event): EventEnvelope[Event] =
     copy(_eventOption = Option(event))
@@ -319,7 +327,7 @@ final class EventEnvelope[Event] private (
   /**
    * INTERNAL API
    */
-  @InternalApi private[akka]  def isEventDeserialized: Boolean =
+  @InternalApi private[akka] def isEventDeserialized: Boolean =
     _eventOption.isDefined || serializedEvent.isEmpty
 
   private def copy(

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/EventEnvelope.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/EventEnvelope.scala
@@ -247,6 +247,9 @@ final class EventEnvelope[Event] private (
       filtered = false,
       source = "")
 
+  def isEventDefined: Boolean =
+    _eventOption.isDefined || serializedEvent.isDefined
+
   def eventOption: Option[Event] = {
     if (serializedEvent.isDefined && _eventOption.isEmpty)
       throw new IllegalStateException(

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/internal/WithSerializedEvent.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/internal/WithSerializedEvent.scala
@@ -4,16 +4,16 @@
 
 package akka.persistence.query.typed.internal
 
-import akka.annotation.InternalApi
+import akka.annotation.InternalStableApi
 
 /**
  * INTERNAL API: Can be implemented by `ReadJournal` if it supports emitting `EventEnvelope` that
  * has not deserialized the event, i.e. envelope with [[akka.persistence.query.typed.EventEnvelope.SerializedEvent]].
  */
-@InternalApi private[akka] trait WithSerializedEvent {
+@InternalStableApi private[akka] trait WithSerializedEvent[Self] {
 
-  def useSerializedEvent: Boolean
+  @InternalStableApi private[akka] def useSerializedEvent: Boolean
 
-  def withSerializedEvent(): WithSerializedEvent
+  @InternalStableApi private[akka] def withSerializedEvent(): Self
 
 }

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/internal/WithSerializedEvent.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/internal/WithSerializedEvent.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query.typed.internal
+
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API: Can be implemented by `ReadJournal` if it supports emitting `EventEnvelope` that
+ * has not deserialized the event, i.e. envelope with [[akka.persistence.query.typed.EventEnvelope.SerializedEvent]].
+ */
+@InternalApi private[akka] trait WithSerializedEvent {
+
+  def useSerializedEvent: Boolean
+
+  def withSerializedEvent(): WithSerializedEvent
+
+}

--- a/akka-persistence-query/src/test/scala/akka/persistence/query/internal/QuerySerializerSpec.scala
+++ b/akka-persistence-query/src/test/scala/akka/persistence/query/internal/QuerySerializerSpec.scala
@@ -21,7 +21,7 @@ class QuerySerializerSpec extends AkkaSpec {
 
   private val serialization = SerializationExtension(system)
 
-  def serializationRoundTrip[T<:AnyRef](obj: T): T = {
+  def serializationRoundTrip[T <: AnyRef](obj: T): T = {
     val serializer = serialization.findSerializerFor(obj).asInstanceOf[SerializerWithStringManifest]
     val manifest = serializer.manifest(obj)
     val bytes = serialization.serialize(obj).get


### PR DESCRIPTION
In some cases we deserialize the payload followed by serializing it again when sending to grpc or writing to journal.

It would be used in persistence plugin and Projections, if enabled by some config.

We need something for the EventWriter also, because that is not writing EventEnvelope.