### PR TITLE
typo in scaladoc Concat$

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/TraversalBuilder.scala
@@ -56,7 +56,7 @@ import akka.util.unused
 @InternalApi private[akka] object Concat {
 
   /**
-   * An optimizatzion to remove cheaply recognizable patterns of redundancy, for example PushNotUsed immediately
+   * An optimization to remove cheaply recognizable patterns of redundancy, for example PushNotUsed immediately
    * followed by a Pop. It also rotates the tree to make it more left-leaning, which makes the tree more readable
    * and require less stack-space when traversing. This is only a single rotation, otherwise this implementation
    * would be O(N^2).


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
