### PR TITLE
fix: Avoid turning all stream timeouts to TcpIdleTimeoutException

### DIFF
--- a/akka-stream/src/main/mima-filters/2.9.0.backwards.excludes/tcp-idle-timeout.excludes
+++ b/akka-stream/src/main/mima-filters/2.9.0.backwards.excludes/tcp-idle-timeout.excludes
@@ -1,0 +1,2 @@
+# Internal API changed
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.stream.impl.Timers#IdleTimeoutBidi.this")

--- a/akka-stream/src/main/scala/akka/stream/StreamTimeoutException.scala
+++ b/akka-stream/src/main/scala/akka/stream/StreamTimeoutException.scala
@@ -15,7 +15,7 @@ import akka.annotation.DoNotInherit
  * Not for user extension
  */
 @DoNotInherit
-sealed class StreamTimeoutException(msg: String) extends TimeoutException(msg) with NoStackTrace
+class StreamTimeoutException(msg: String) extends TimeoutException(msg) with NoStackTrace
 
 final class InitialTimeoutException(msg: String) extends StreamTimeoutException(msg)
 

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Tcp.scala
@@ -5,7 +5,6 @@
 package akka.stream.scaladsl
 
 import java.net.InetSocketAddress
-import java.util.concurrent.TimeoutException
 import javax.net.ssl.SSLEngine
 import javax.net.ssl.SSLSession
 
@@ -394,7 +393,7 @@ final class Tcp(system: ExtendedActorSystem) extends akka.actor.Extension {
 }
 
 final class TcpIdleTimeoutException(msg: String, @unused timeout: Duration)
-    extends TimeoutException(msg: String)
+    extends StreamTimeoutException(msg: String)
     with NoStackTrace // only used from a single stage
 
 object TcpAttributes {


### PR DESCRIPTION
Not entirely sure this is the right thing but in https://github.com/akka/akka-http/pull/4289 we noticed that `StreamIdleTimeoutException`s in the stream not originating from the TCP idle timeouts would still be turned into `TcpIdleTimeoutException`. 

This also eliminates at least one operator in each TCP stream materialization.