### PR TITLE
fix: DownSelfQuarantinedByRemote should not be triggered by harmless quarantine, #31095

### DIFF
--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/DowningWhenOtherHasQuarantinedThisActorSystemSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/DowningWhenOtherHasQuarantinedThisActorSystemSpec.scala
@@ -8,18 +8,23 @@ import scala.concurrent.duration._
 
 import com.typesafe.config.ConfigFactory
 
+import akka.actor.ActorIdentity
 import akka.actor.ActorRef
 import akka.actor.Identify
 import akka.actor.RootActorPath
+import akka.remote.RARP
 import akka.remote.artery.ThisActorSystemQuarantinedEvent
 import akka.remote.testkit.Direction
 import akka.remote.testkit.MultiNodeConfig
+import akka.testkit.EventFilter
 import akka.testkit.LongRunningTest
+import akka.testkit.TestEvent.Mute
 
 object DowningWhenOtherHasQuarantinedThisActorSystemSpec extends MultiNodeConfig {
   val first = role("first")
   val second = role("second")
   val third = role("third")
+  val fourth = role("fourth")
 
   commonConfig(
     debugConfig(on = false)
@@ -28,14 +33,8 @@ object DowningWhenOtherHasQuarantinedThisActorSystemSpec extends MultiNodeConfig
         ConfigFactory.parseString("""
         akka.remote.artery.enabled = on
         akka.cluster.downing-provider-class = "akka.cluster.sbr.SplitBrainResolverProvider"
-        # speed up decision
-        akka.cluster.split-brain-resolver.stable-after = 5s
+        akka.cluster.split-brain-resolver.stable-after = 10s
         """)))
-
-  // exaggerate the timing issue by ,making the second node decide slower
-  // this is to more consistently repeat the scenario where the other side completes downing
-  // while the isolated part still has not made a decision and then see quarantined connections from the other nodes
-  nodeConfig(second)(ConfigFactory.parseString("akka.cluster.split-brain-resolver.stable-after = 15s"))
 
   testTransport(on = true)
 }
@@ -46,57 +45,57 @@ class DowningWhenOtherHasQuarantinedThisActorSystemMultiJvmNode2
     extends DowningWhenOtherHasQuarantinedThisActorSystemSpec
 class DowningWhenOtherHasQuarantinedThisActorSystemMultiJvmNode3
     extends DowningWhenOtherHasQuarantinedThisActorSystemSpec
+class DowningWhenOtherHasQuarantinedThisActorSystemMultiJvmNode4
+    extends DowningWhenOtherHasQuarantinedThisActorSystemSpec
 
 abstract class DowningWhenOtherHasQuarantinedThisActorSystemSpec
     extends MultiNodeClusterSpec(DowningWhenOtherHasQuarantinedThisActorSystemSpec) {
   import DowningWhenOtherHasQuarantinedThisActorSystemSpec._
 
+  muteDeadLetters(classOf[ActorIdentity])()
+  system.eventStream.publish(Mute(EventFilter.info(pattern = ".*Ignoring received gossip from unknown.*")))
+
   "Cluster node downed by other" must {
 
     "join cluster" taggedAs LongRunningTest in {
-      awaitClusterUp(first, second, third)
+      awaitClusterUp(first, second, third, fourth)
       enterBarrier("after-1")
     }
 
-    "down itself" taggedAs LongRunningTest in {
+    "down itself with DownSelfQuarantinedByRemote when other has quarantined" taggedAs LongRunningTest in {
+      runOn(first, second) {
+        system.eventStream.subscribe(testActor, classOf[ThisActorSystemQuarantinedEvent])
+      }
       runOn(first) {
-        testConductor.blackhole(first, second, Direction.Both).await
-        testConductor.blackhole(third, second, Direction.Both).await
+        val secondUniqueAddress = cluster.state.members.find(_.address == address(second)).get.uniqueAddress
+        RARP(system).provider
+          .quarantine(secondUniqueAddress.address, Some(secondUniqueAddress.longUid), "Quarantine from test")
       }
-      enterBarrier("blackhole")
-
-      within(15.seconds) {
-        runOn(first) {
-          awaitAssert {
-            cluster.state.unreachable.map(_.address) should ===(Set(address(second)))
-          }
-          awaitAssert {
-            // second downed and removed
-            cluster.state.members.map(_.address) should ===(Set(address(first), address(third)))
-          }
-        }
-        runOn(second) {
-          awaitAssert {
-            cluster.state.unreachable.map(_.address) should ===(Set(address(first), address(third)))
-          }
-        }
-      }
-      enterBarrier("down-second")
-
-      runOn(first) {
-        testConductor.passThrough(first, second, Direction.Both).await
-        testConductor.passThrough(third, second, Direction.Both).await
-      }
-      enterBarrier("pass-through")
+      enterBarrier("quarantined")
 
       runOn(second) {
-        within(10.seconds) {
+        within(5.seconds) { // this is shorter than split-brain-resolver.stable-after, so it's not normal downing
           awaitAssert {
             // try to ping first (Cluster Heartbeat messages will not trigger the Quarantine message)
             system.actorSelection(RootActorPath(first) / "user").tell(Identify(None), ActorRef.noSender)
             // shutting down itself triggered by ThisActorSystemQuarantinedEvent
             cluster.isTerminated should ===(true)
           }
+        }
+        expectMsgType[ThisActorSystemQuarantinedEvent]
+      }
+      enterBarrier("second-shutdown")
+
+      runOn(first) {
+        expectNoMessage(1.second) // no ThisActorSystemQuarantinedEvent
+      }
+      enterBarrier("wait")
+
+      runOn(first) {
+        val sel = system.actorSelection(RootActorPath(second) / "user")
+        (1 to 15).foreach { _ =>
+          sel.tell(Identify(None), ActorRef.noSender) // try to ping second
+          expectNoMessage(200.millis) // no ThisActorSystemQuarantinedEvent
         }
       }
 
@@ -114,14 +113,55 @@ abstract class DowningWhenOtherHasQuarantinedThisActorSystemSpec
       }
 
       runOn(first) {
+        expectNoMessage(1.second) // no ThisActorSystemQuarantinedEvent
+      }
+      enterBarrier("wait")
+
+      runOn(first) {
         val sel = system.actorSelection(RootActorPath(third) / "user")
-        (1 to 25).foreach { _ =>
+        (1 to 15).foreach { _ =>
           sel.tell(Identify(None), ActorRef.noSender) // try to ping third
           expectNoMessage(200.millis) // no ThisActorSystemQuarantinedEvent
         }
       }
 
-      enterBarrier("after-2")
+      enterBarrier("after-3")
+    }
+
+    "not be triggered by another node shutting down during network partition" taggedAs LongRunningTest in {
+      runOn(first) {
+        system.eventStream.subscribe(testActor, classOf[ThisActorSystemQuarantinedEvent])
+      }
+      enterBarrier("subscribing")
+
+      runOn(first) {
+        testConductor.blackhole(first, fourth, Direction.Both).await
+      }
+      enterBarrier("blackhole")
+
+      runOn(third) {
+        cluster.shutdown()
+      }
+
+      runOn(first) {
+        expectNoMessage(2.second) // no ThisActorSystemQuarantinedEvent
+        testConductor.passThrough(first, fourth, Direction.Both).await
+      }
+
+      runOn(first) {
+        expectNoMessage(1.second) // no ThisActorSystemQuarantinedEvent
+      }
+      enterBarrier("wait")
+
+      runOn(first) {
+        val sel = system.actorSelection(RootActorPath(fourth) / "user")
+        (1 to 15).foreach { _ =>
+          sel.tell(Identify(None), ActorRef.noSender) // try to ping fourth
+          expectNoMessage(200.millis) // no ThisActorSystemQuarantinedEvent
+        }
+      }
+
+      enterBarrier("after-4")
     }
 
   }

--- a/akka-remote/src/main/mima-filters/2.8.4.backwards.excludes/issue-31095-quarantine-harmless.excludes
+++ b/akka-remote/src/main/mima-filters/2.8.4.backwards.excludes/issue-31095-quarantine-harmless.excludes
@@ -1,0 +1,3 @@
+# #31095 internals
+ProblemFilters.exclude[Problem]("akka.remote.artery.AssociationState#QuarantinedTimestamp*")
+ProblemFilters.exclude[MissingTypesProblem]("akka.remote.artery.AssociationState$QuarantinedTimestamp$")

--- a/akka-remote/src/main/scala/akka/remote/artery/Association.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/Association.scala
@@ -528,13 +528,13 @@ private[remote] class Association(
         current.uniqueRemoteAddress() match {
           case Some(peer) if peer.uid == u =>
             if (!current.isQuarantined(u)) {
-              val newState = current.newQuarantined()
+              val newState = current.newQuarantined(harmless)
               if (swapState(current, newState)) {
                 // quarantine state change was performed
                 if (harmless) {
                   log.info(
-                    "Association to [{}] having UID [{}] has been stopped. All " +
-                    "messages to this UID will be delivered to dead letters. Reason: {}",
+                    "Association to [{}] having UID [{}] has been stopped. Harmless quarantine. " +
+                    "All messages to this UID will be delivered to dead letters. Reason: {}",
                     remoteAddress,
                     u,
                     reason)
@@ -558,6 +558,7 @@ private[remote] class Association(
                 send(ClearSystemMessageDelivery(current.incarnation), OptionVal.None, OptionVal.None)
                 if (!harmless) {
                   // try to tell the other system that we have quarantined it
+                  log.info("Sending Quarantined to [{}]", peer)
                   sendControl(Quarantined(localAddress, peer))
                 }
                 setupStopQuarantinedTimer()

--- a/akka-remote/src/main/scala/akka/remote/artery/InboundQuarantineCheck.scala
+++ b/akka-remote/src/main/scala/akka/remote/artery/InboundQuarantineCheck.scala
@@ -42,10 +42,13 @@ private[remote] class InboundQuarantineCheck(inboundContext: InboundContext)
                   association.remoteAddress,
                   env.originUid)
               // avoid starting outbound stream for heartbeats
-              if (!env.message.isInstanceOf[Quarantined] && !isHeartbeat(env.message))
+              if (!env.message.isInstanceOf[Quarantined] && !isHeartbeat(env.message) &&
+                  !association.associationState.isQuarantinedHarmless(env.originUid)) {
+                log.info("Sending Quarantined to [{}]", association.remoteAddress)
                 inboundContext.sendControl(
                   association.remoteAddress,
                   Quarantined(inboundContext.localAddress, UniqueAddress(association.remoteAddress, env.originUid)))
+              }
               pull(in)
             } else
               push(out, env)

--- a/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/TestContext.scala
@@ -93,7 +93,7 @@ private[remote] class TestOutboundContext(
   }
 
   override def quarantine(reason: String): Unit = synchronized {
-    _associationState = _associationState.newQuarantined()
+    _associationState = _associationState.newQuarantined(harmless = false)
   }
 
   override def isOrdinaryMessageStreamActive(): Boolean = true


### PR DESCRIPTION
* the harmless flag was taken into account in the immediate Quarantined message but it was always sent for later attempts from InboundQuarantineCheck

References #31095
