### PR TITLE
=str Remove unneeded `hasNext` checking in IterableSource.

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/GraphStages.scala
@@ -323,9 +323,9 @@ import akka.stream.stage._
           if (currentIterator.hasNext) {
             if (isAvailable(out)) {
               push(out, currentIterator.next())
-            }
-            if (!currentIterator.hasNext) {
-              completeStage()
+              if (!currentIterator.hasNext) {
+                completeStage()
+              }
             }
           } else {
             completeStage()


### PR DESCRIPTION
Motivation:
Remove the unneeded checking  and only checking it after one element has been pushed.
