### PR TITLE
=str Make use of `statefulMap` to implement `zipWithIndex`.

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/ZipWithIndexBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/ZipWithIndexBenchmark.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2018-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.remote.artery.BenchTestSourceSameElement
+import akka.stream.scaladsl._
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+import scala.collection.immutable
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object ZipWithIndexBenchmark {
+  final val OperationsPerInvocation = 100000
+}
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+class ZipWithIndexBenchmark {
+  import ZipWithIndexBenchmark._
+
+  private val config = ConfigFactory.parseString("""
+    akka.actor.default-dispatcher {
+      executor = "fork-join-executor"
+      fork-join-executor {
+        parallelism-factor = 1
+      }
+    }
+    """)
+
+  private implicit val system: ActorSystem = ActorSystem("ZipWithIndexBenchmark", config)
+
+  @TearDown
+  def shutdown(): Unit = {
+    Await.result(system.terminate(), 5.seconds)
+  }
+
+  def createSource(count: Int): Source[Int, NotUsed] = Source.fromGraph(new BenchTestSourceSameElement(count, 1))
+
+  private val newZipWithIndex =
+    createSource(OperationsPerInvocation).zipWithIndex.toMat(Sink.ignore)(Keep.right)
+
+  private val oldZipWithIndex = createSource(OperationsPerInvocation)
+    .statefulMapConcat[(Int, Long)] { () =>
+      var index: Long = 0L
+      elem => {
+        val zipped = (elem, index)
+        index += 1
+        immutable.Iterable[(Int, Long)](zipped)
+      }
+    }
+    .toMat(Sink.ignore)(Keep.right)
+
+  @Benchmark
+  @OperationsPerInvocation(OperationsPerInvocation)
+  def benchOldZipWithIndex(): Unit =
+    Await.result(oldZipWithIndex.run(), Duration.Inf)
+
+  @Benchmark
+  @OperationsPerInvocation(OperationsPerInvocation)
+  def benchNewZipWithIndex(): Unit =
+    Await.result(newZipWithIndex.run(), Duration.Inf)
+
+}

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -2981,16 +2981,9 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    */
-  def zipWithIndex: Repr[(Out, Long)] = {
-    statefulMapConcat[(Out, Long)] { () =>
-      var index: Long = 0L
-      elem => {
-        val zipped = (elem, index)
-        index += 1
-        immutable.Iterable[(Out, Long)](zipped)
-      }
-    }
-  }
+  def zipWithIndex: Repr[(Out, Long)] =
+    statefulMap[Long, (Out, Long)](() => 0L)((index, out) => (index + 1L, (out, index)), _ => None)
+      .withAttributes(DefaultAttributes.zipWithIndex)
 
   /**
    * Interleave is a deterministic merge of the given [[Source]] with elements of this [[Flow]].


### PR DESCRIPTION
Motivation:
Make code more simpler.

Result:
Simpler code and no performance regression.

```
Jmh/run -i 3 -wi 3 -f1 -t1 .*ZipWithIndexBenchmark.* 

[info] Benchmark                                    Mode  Cnt           Score            Error  Units
[info] ZipWithIndexBenchmark.benchNewZipWithIndex  thrpt    3  6501714129.146 锟斤拷 4044285303.660  ops/s
[info] ZipWithIndexBenchmark.benchOldZipWithIndex  thrpt    3  6146967182.338 锟斤拷  801852805.114  ops/s
```