### PR TITLE
feat: Internal cleanup for buffered/queued messages on failure/cancel

### DIFF
--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Source.scala
@@ -917,7 +917,8 @@ object Source {
       overflowStrategy: OverflowStrategy,
       maxConcurrentOffers: Int): Source[T, SourceQueueWithComplete[T]] =
     Source.fromGraph(
-      new QueueSource(bufferSize, overflowStrategy, maxConcurrentOffers).withAttributes(DefaultAttributes.queueSource))
+      new QueueSource[T](bufferSize, overflowStrategy, maxConcurrentOffers)
+        .withAttributes(DefaultAttributes.queueSource))
 
   /**
    * Start a new `Source` from some resource which can be opened, read and closed.


### PR DESCRIPTION
Alternative or complementary to https://github.com/akka/akka-http/pull/4299 for https://github.com/akka/akka-grpc/issues/1423

Allows for failing buffered requests if the persistent http client fails. Still not water tight for the general case but maybe we can make water tight for Akka HTTP/2 / gRPC, might not want to make it public API for that reason.