### PR TITLE
=str Skip the iterator creation when iterable is empty.

### DIFF
--- a/akka-bench-jmh/src/main/scala/akka/stream/StatefulMapConcatBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/stream/StatefulMapConcatBenchmark.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl._
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object StatefulMapConcatBenchmark {
+  final val OperationsPerInvocation = 100000
+
+}
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Array(Mode.Throughput))
+class StatefulMapConcatBenchmark {
+
+  import StatefulMapConcatBenchmark._
+
+  private val config = ConfigFactory.parseString("""
+   akka.actor.default-dispatcher {
+     executor = "fork-join-executor"
+     fork-join-executor {
+       parallelism-factor = 1
+     }
+   }
+   """)
+
+  private implicit val system: ActorSystem = ActorSystem("StatefulMapConcatBenchmark", config)
+
+  @TearDown
+  def shutdown(): Unit = {
+    Await.result(system.terminate(), 5.seconds)
+  }
+
+  private val emptyArray = new Array[Int](0)
+  private val statefulMapConcatEmptyArray =
+    Source.repeat(0).take(OperationsPerInvocation).mapConcat(_ => emptyArray).toMat(Sink.ignore)(Keep.right)
+
+  @Benchmark
+  @OperationsPerInvocation(OperationsPerInvocation)
+  def benchConcatEmptyArray(): Unit =
+    Await.result(statefulMapConcatEmptyArray.run(), Duration.Inf)
+
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/Ops.scala
@@ -2351,8 +2351,16 @@ private[akka] final class StatefulMapConcat[In, Out](val f: () => In => Iterable
 
     override def onPush(): Unit =
       try {
-        currentIterator = plainFun(grab(in)).iterator
-        pushPull(shouldResumeContext = false)
+        val iterable = plainFun(grab(in))
+        if ((iterable.isEmpty): @nowarn("msg=deprecated")) {
+          if (!isClosed(in))
+            pull(in)
+          else
+            completeStage()
+        } else {
+          currentIterator = iterable.iterator
+          pushPull(shouldResumeContext = false)
+        }
       } catch handleException
 
     override def onUpstreamFinish(): Unit = onFinish()


### PR DESCRIPTION
Motivation:
When the result iterable is empty, we can skip the iterator creation.

Result:
Better performance when the iterable is empty.

I benchmarked with 100% empty iterable

```
Jmh/run -i 3 -wi 3 -f1 -t1 .*StatefulMapConcatBenchmark.*

[info] StatefulMapConcatBenchmark.bench  thrpt    3  20244383.890 锟斤拷 293235.214  ops/s

baseline

[info] StatefulMapConcatBenchmark.bench  thrpt    3  18170728.177 锟斤拷 1067858.198  ops/s

```