### PR TITLE
fix: typed actor dead letter address (#29795)

### DIFF
--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -120,12 +120,12 @@ class AskSpec extends ScalaTestWithActorTestKit("""
     }
 
     "fail the future if the actor has terminated" in {
-      implicit val timeout = Timeout(10 millis)
       val actor: ActorRef[Msg] = spawn(behavior)
 
       val deadLetterProbe = createDeadLetterProbe()
       val probe = createTestProbe[Any]()
       actor ! Stop(probe.ref)
+      implicit val timeout: Timeout = 10.millis
 
       val answer: Future[String] = actor.ask(Foo("bar", _))
       val result = answer.failed.futureValue
@@ -144,13 +144,13 @@ class AskSpec extends ScalaTestWithActorTestKit("""
     }
 
     "publish dead-letter if the context.ask has completed on timeout" in {
-      implicit val timeout = Timeout(1 millis)
       val actor: ActorRef[Msg] = spawn(behavior)
 
+      implicit val timeout: Timeout = 1.millis
       val mockActor: ActorRef[Proxy] = spawn(Behaviors.receive[Proxy]((context, msg) =>
         msg match {
           case ProxyMsg(s) =>
-            context.ask[Msg, String](actor, Bar(s, timeout.duration.+(10 millis), _)) {
+            context.ask[Msg, String](actor, Bar(s, 10.millis, _)) {
               case Success(result) => ProxyReply(result)
               case Failure(ex)     => throw ex
             }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -4,8 +4,9 @@
 
 package akka.actor.typed
 
-import scala.concurrent.{ExecutionContext, Future, TimeoutException}
+import scala.concurrent.{ ExecutionContext, Future, TimeoutException }
 import scala.concurrent.duration._
+import scala.language.postfixOps
 import scala.util.Success
 import scala.util.Failure
 
@@ -119,7 +120,7 @@ class AskSpec extends ScalaTestWithActorTestKit("""
     }
 
     "fail the future if the actor has terminated" in {
-      implicit val timeout = Timeout(10.millis)
+      implicit val timeout = Timeout(10 millis)
       val actor: ActorRef[Msg] = spawn(behavior)
 
       val deadLetterProbe = createDeadLetterProbe()
@@ -143,13 +144,13 @@ class AskSpec extends ScalaTestWithActorTestKit("""
     }
 
     "publish dead-letter if the context.ask has completed on timeout" in {
-      implicit val timeout = Timeout(1.millis)
+      implicit val timeout = Timeout(1 millis)
       val actor: ActorRef[Msg] = spawn(behavior)
 
       val mockActor: ActorRef[Proxy] = spawn(Behaviors.receive[Proxy]((context, msg) =>
         msg match {
           case ProxyMsg(s) =>
-            context.ask[Msg, String](actor, Bar(s, timeout.duration.+(10.millis), _)) {
+            context.ask[Msg, String](actor, Bar(s, timeout.duration.+(10 millis), _)) {
               case Success(result) => ProxyReply(result)
               case Failure(ex)     => throw ex
             }

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -6,7 +6,6 @@ package akka.actor.typed
 
 import scala.concurrent.{ ExecutionContext, Future, TimeoutException }
 import scala.concurrent.duration._
-import scala.language.postfixOps
 import scala.util.Success
 import scala.util.Failure
 

--- a/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
+++ b/akka-actor-typed-tests/src/test/scala/akka/actor/typed/AskSpec.scala
@@ -4,11 +4,10 @@
 
 package akka.actor.typed
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.concurrent.TimeoutException
+import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 import scala.concurrent.duration._
 import scala.util.Success
+import scala.util.Failure
 
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -16,6 +15,7 @@ import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.LoggingTestKit
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
+import akka.actor.typed.internal.adapter.ActorRefAdapter
 import akka.actor.typed.internal.adapter.ActorSystemAdapter
 import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.scaladsl.Behaviors
@@ -27,7 +27,12 @@ import akka.util.Timeout
 object AskSpec {
   sealed trait Msg
   final case class Foo(s: String, replyTo: ActorRef[String]) extends Msg
+  final case class Bar(s: String, duration: FiniteDuration, replyTo: ActorRef[String]) extends Msg
   final case class Stop(replyTo: ActorRef[Unit]) extends Msg
+  sealed trait Proxy
+  final case class ProxyMsg(s: String) extends Proxy
+  final case class ProxyReply(s: String) extends Proxy
+
 }
 
 class AskSpec extends ScalaTestWithActorTestKit("""
@@ -43,6 +48,9 @@ class AskSpec extends ScalaTestWithActorTestKit("""
   val behavior: Behavior[Msg] = receive[Msg] {
     case (_, foo: Foo) =>
       foo.replyTo ! "foo"
+      Behaviors.same
+    case (ctx, bar: Bar) =>
+      ctx.scheduleOnce(bar.duration, bar.replyTo, "bar")
       Behaviors.same
     case (_, Stop(r)) =>
       r ! (())
@@ -111,6 +119,63 @@ class AskSpec extends ScalaTestWithActorTestKit("""
       }
     }
 
+    "fail the future if the actor has terminated" in {
+      implicit val timeout = Timeout(10.millis)
+      val actor: ActorRef[Msg] = spawn(behavior)
+
+      val deadLetterProbe = createDeadLetterProbe()
+      val probe = createTestProbe[Any]()
+      actor ! Stop(probe.ref)
+
+      val answer: Future[String] = actor.ask(Foo("bar", _))
+      val result = answer.failed.futureValue
+      result shouldBe a[TimeoutException]
+      result.getMessage should startWith("Ask timed out on")
+
+      val deadLetter = deadLetterProbe.receiveMessage()
+      deadLetter.message match {
+        case Foo(s, _) => s should ===("bar")
+        case _         => fail(s"unexpected DeadLetter: $deadLetter")
+      }
+
+      val deadLettersRef = system.classicSystem.deadLetters
+      deadLetter.recipient shouldNot equal(deadLettersRef)
+      deadLetter.recipient should equal(ActorRefAdapter.toClassic(actor))
+    }
+
+    "publish dead-letter if the context.ask has completed on timeout" in {
+      implicit val timeout = Timeout(1.nanosecond)
+      val actor: ActorRef[Msg] = spawn(behavior)
+
+      val mockActor: ActorRef[Proxy] = spawn(Behaviors.receive[Proxy]((context, msg) =>
+        msg match {
+          case ProxyMsg(s) =>
+            context.ask[Msg, String](actor, Bar(s, 10.millis, _)) {
+              case Success(result) => ProxyReply(result)
+              case Failure(ex)     => throw ex
+            }
+            Behaviors.same
+          case ProxyReply(s) =>
+            println(s"receive reply message: ${s}")
+            Behaviors.same
+        }))
+
+      mockActor ! ProxyMsg("foo")
+
+      val deadLetterProbe = createDeadLetterProbe()
+
+      val deadLetter = deadLetterProbe.receiveMessage()
+      deadLetter.message match {
+        case s: String => s should ===("bar")
+        case _         => fail(s"unexpected DeadLetter: $deadLetter")
+      }
+
+      val deadLettersRef = system.classicSystem.deadLetters
+      deadLetter.recipient shouldNot equal(deadLettersRef)
+      deadLetter.recipient shouldNot equal(ActorRefAdapter.toClassic(actor))
+      deadLetter.recipient shouldNot equal(ActorRefAdapter.toClassic(mockActor))
+    }
+
     "transform a replied akka.actor.Status.Failure to a failed future" in {
       // It's unlikely but possible that this happens, since the receiving actor would
       // have to accept a message with an actoref that accepts AnyRef or be doing crazy casting
@@ -128,9 +193,8 @@ class AskSpec extends ScalaTestWithActorTestKit("""
 
         val legacyActor = classicSystem.actorOf(akka.actor.Props(new LegacyActor))
 
-        import scaladsl.AskPattern._
-
         import akka.actor.typed.scaladsl.adapter._
+        import scaladsl.AskPattern._
         implicit val timeout: Timeout = 3.seconds
         val typedLegacy: ActorRef[AnyRef] = legacyActor
         typedLegacy.ask(Ping.apply).failed.futureValue should ===(ex)

--- a/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
+++ b/akka-actor/src/main/scala/akka/pattern/AskSupport.scala
@@ -610,7 +610,7 @@ private[akka] final class PromiseActorRef(
 
   override def !(message: Any)(implicit sender: ActorRef = Actor.noSender): Unit = state match {
     case Stopped | _: StoppedWithPath =>
-      provider.deadLetters ! message
+      provider.deadLetters ! DeadLetter(message, if (sender eq Actor.noSender) provider.deadLetters else sender, this)
       onComplete(message, alreadyCompleted = true)
     case _ =>
       if (message == null) throw InvalidMessageException("Message is null")


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->

## Motivation

Attach the necessary information before sending the message to DeadLetter to correctly display the destination in the DeadLetter. 

References #29795

## How does this PR fix work?

In classic Actors, when an Actor dies, its Mailbox is "swap" to a `deadLetterMailbox` Mailbox. 

<img width="638" alt="截屏2023-09-17 05 18 26" src="https://github.com/akka/akka/assets/26020358/b578b7fc-4dcf-47fd-a13b-881916706cfd">

When an Actor sends a message to another ActorRef, it essentially enqueues the message to that Actor's mailbox.

When an Actor sends a message to a dead Actor, it means that the message would enqueue to the "deadLetterMailbox",the dead mailbox will transform the message into a DeadLetter event and then publish it to the EventBus. This is how DeadLetters work in classic Actors.


In Typed actor, it basiclly same, but the `sender` variable cannot be passed implicitly.

In the Ask pattern, there are some differences. When an Actor uses ask to request another Actor, it essentially creates a temporary PromiseActorRef to receive the response from the target Actor.

When the PromiseActorRef receives a `tell` call, it checks if the current Future has already completed and, if so, emits a DeadLetter event. This is done to ensure consistent behavior with the tell method (i.e., sending DeadLetter events to the EventBus via DeadLetterActorRef).

However, the PromiseActorRef directly sends the message without transforming it into a DeadLetter event, resulting in distorted logs.

This PR converts the message into a DeadLetter event before sending it from PromiseActorRef to DeadLetterActorRef.