### PR TITLE
chore: remove unnecessary string interpolation

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/actor/ActorMailboxSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorMailboxSpec.scala
@@ -16,7 +16,8 @@ import akka.util.Helpers.ConfigOps
 import akka.util.unused
 
 object ActorMailboxSpec {
-  val mailboxConf = ConfigFactory.parseString(s"""
+  val mailboxConf =
+    ConfigFactory.parseString("""
     unbounded-dispatcher {
       mailbox-type = "akka.dispatch.UnboundedMailbox"
     }

--- a/akka-actor-tests/src/test/scala/akka/actor/ActorMailboxSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/actor/ActorMailboxSpec.scala
@@ -17,7 +17,7 @@ import akka.util.unused
 
 object ActorMailboxSpec {
   val mailboxConf =
-    ConfigFactory.parseString("""
+    ConfigFactory.parseString(s"""
     unbounded-dispatcher {
       mailbox-type = "akka.dispatch.UnboundedMailbox"
     }

--- a/akka-bench-jmh/src/main/scala/akka/actor/TellOnlyBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/TellOnlyBenchmark.scala
@@ -31,7 +31,7 @@ class TellOnlyBenchmark {
   def setup(): Unit = {
     system = ActorSystem(
       "TellOnlyBenchmark",
-      ConfigFactory.parseString("""
+      ConfigFactory.parseString(s"""
           | akka {
           |   log-dead-letters = off
           |   actor {

--- a/akka-bench-jmh/src/main/scala/akka/actor/TellOnlyBenchmark.scala
+++ b/akka-bench-jmh/src/main/scala/akka/actor/TellOnlyBenchmark.scala
@@ -31,7 +31,8 @@ class TellOnlyBenchmark {
   def setup(): Unit = {
     system = ActorSystem(
       "TellOnlyBenchmark",
-      ConfigFactory.parseString(s"""| akka {
+      ConfigFactory.parseString("""
+          | akka {
           |   log-dead-letters = off
           |   actor {
           |     default-dispatcher {

--- a/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingRememberEntitiesPerfSpec.scala
+++ b/akka-cluster-sharding-typed/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingRememberEntitiesPerfSpec.scala
@@ -62,7 +62,7 @@ object ClusterShardingRememberEntitiesPerfSpec {
 object ClusterShardingRememberEntitiesPerfSpecConfig
     extends MultiNodeClusterShardingConfig(
       rememberEntities = true,
-      additionalConfig = s"""
+      additionalConfig = """
     akka.loglevel = DEBUG 
     akka.testconductor.barrier-timeout = 3 minutes
     akka.remote.artery.advanced.outbound-message-queue-size = 10000

--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -33,7 +33,7 @@ import akka.util.ccompat._
 
 @ccompatUsedUntil213
 object ClusterShardingSpec {
-  val config = ConfigFactory.parseString(s"""
+  val config = ConfigFactory.parseString("""
       akka.actor.provider = cluster
 
       akka.remote.artery.canonical.port = 0

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingCustomShardAllocationSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingCustomShardAllocationSpec.scala
@@ -63,7 +63,7 @@ object ClusterShardingCustomShardAllocationSpec {
 abstract class ClusterShardingCustomShardAllocationSpecConfig(mode: String)
     extends MultiNodeClusterShardingConfig(
       mode,
-      additionalConfig = s"""
+      additionalConfig = """
       akka.cluster.sharding.rebalance-interval = 1 s
       akka.persistence.journal.leveldb-shared.store.native = off
       """) {

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingGetStateSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingGetStateSpec.scala
@@ -30,7 +30,8 @@ object ClusterShardingGetStateSpec {
   val shardTypeName = "Ping"
 }
 
-object ClusterShardingGetStateSpecConfig extends MultiNodeClusterShardingConfig(additionalConfig = s"""
+object ClusterShardingGetStateSpecConfig
+    extends MultiNodeClusterShardingConfig(additionalConfig = """
     akka.cluster.sharding {
       coordinator-failure-backoff = 3s
       shard-failure-backoff = 3s

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingMinMembersSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingMinMembersSpec.scala
@@ -16,7 +16,7 @@ import akka.util.ccompat._
 abstract class ClusterShardingMinMembersSpecConfig(mode: String)
     extends MultiNodeClusterShardingConfig(
       mode,
-      additionalConfig = s"""
+      additionalConfig = """
         akka.cluster.sharding.rebalance-interval = 120s #disable rebalance
         akka.cluster.min-nr-of-members = 3
         """) {

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingQueriesSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingQueriesSpec.scala
@@ -29,7 +29,8 @@ object ClusterShardingQueriesSpec {
   val shardTypeName = "DatatypeA"
 }
 
-object ClusterShardingQueriesSpecConfig extends MultiNodeClusterShardingConfig(additionalConfig = s"""
+object ClusterShardingQueriesSpecConfig
+    extends MultiNodeClusterShardingConfig(additionalConfig = """
         akka.log-dead-letters-during-shutdown = off
         akka.cluster.sharding {
           shard-region-query-timeout = 2ms

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingRememberEntitiesSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/ClusterShardingRememberEntitiesSpec.scala
@@ -37,7 +37,7 @@ abstract class ClusterShardingRememberEntitiesSpecConfig(
       mode,
       rememberEntities,
       rememberEntitiesStore = rememberEntitiesStore,
-      additionalConfig = s"""
+      additionalConfig = """
       akka.testconductor.barrier-timeout = 60 s
       akka.test.single-expect-default = 60 s
       akka.persistence.journal.leveldb-shared.store.native = off

--- a/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/MultiDcClusterShardingSpec.scala
+++ b/akka-cluster-sharding/src/multi-jvm/scala/akka/cluster/sharding/MultiDcClusterShardingSpec.scala
@@ -48,7 +48,7 @@ object MultiDcClusterShardingSpec {
 object MultiDcClusterShardingSpecConfig
     extends MultiNodeClusterShardingConfig(
       loglevel = "DEBUG", //issue #23741
-      additionalConfig = s"""
+      additionalConfig = """
     akka.cluster {
       debug.verbose-heartbeat-logging = on
       debug.verbose-gossip-logging = on

--- a/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ShardRegionSpec.scala
+++ b/akka-cluster-sharding/src/test/scala/akka/cluster/sharding/ShardRegionSpec.scala
@@ -23,7 +23,9 @@ object ShardRegionSpec {
        """
 
   val config =
-    ConfigFactory.parseString(tempConfig).withFallback(ConfigFactory.parseString(s"""
+    ConfigFactory
+      .parseString(tempConfig)
+      .withFallback(ConfigFactory.parseString("""
         akka.loglevel = DEBUG
         akka.loggers = ["akka.testkit.SilenceAllTestEventListener"]
         akka.actor.provider = "cluster"

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ActorRefIgnoreSerializationSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ActorRefIgnoreSerializationSpec.scala
@@ -21,7 +21,7 @@ class ActorRefIgnoreSerializationSpec extends AnyWordSpec with ScalaFutures with
   private var system1: ActorSystem[String] = _
   private var system2: ActorSystem[String] = _
 
-  val config = ConfigFactory.parseString(s"""
+  val config = ConfigFactory.parseString("""
       akka {
         loglevel = debug
         actor.provider = cluster

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/ClusterSingletonApiSpec.scala
@@ -21,7 +21,7 @@ import akka.serialization.jackson.CborSerializable
 
 object ClusterSingletonApiSpec {
 
-  val config = ConfigFactory.parseString(s"""
+  val config = ConfigFactory.parseString("""
       akka.actor.provider = cluster
       akka.remote.artery.canonical.port = 0
       akka.remote.artery.canonical.hostname = 127.0.0.1

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/GroupRouterSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/GroupRouterSpec.scala
@@ -22,7 +22,7 @@ import akka.actor.typed.scaladsl.Routers
 import akka.serialization.jackson.CborSerializable
 
 object GroupRouterSpec {
-  def config = ConfigFactory.parseString(s"""
+  def config = ConfigFactory.parseString("""
     akka {
       loglevel = debug
       actor.provider = cluster

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteContextAskSpec.scala
@@ -24,7 +24,7 @@ import akka.serialization.jackson.CborSerializable
 import akka.util.Timeout
 
 object RemoteContextAskSpec {
-  def config = ConfigFactory.parseString(s"""
+  def config = ConfigFactory.parseString("""
     akka {
       loglevel = debug
       actor.provider = cluster

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteDeployNotAllowedSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteDeployNotAllowedSpec.scala
@@ -15,7 +15,7 @@ import akka.actor.typed.ActorSystem
 import akka.actor.typed.scaladsl.Behaviors
 
 object RemoteDeployNotAllowedSpec {
-  def config = ConfigFactory.parseString(s"""
+  def config = ConfigFactory.parseString("""
     akka {
       loglevel = warning
       actor {

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteMessageSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/RemoteMessageSpec.scala
@@ -18,7 +18,7 @@ import akka.serialization.jackson.CborSerializable
 import akka.testkit.AkkaSpec
 
 object RemoteMessageSpec {
-  def config = ConfigFactory.parseString(s"""
+  def config = ConfigFactory.parseString("""
     akka {
       loglevel = debug
       actor.provider = cluster

--- a/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
+++ b/akka-cluster-typed/src/test/scala/akka/cluster/typed/internal/receptionist/ClusterReceptionistSpec.scala
@@ -35,7 +35,7 @@ import akka.testkit.GHExcludeAeronTest
 import akka.testkit.LongRunningTest
 
 object ClusterReceptionistSpec {
-  val config = ConfigFactory.parseString(s"""
+  val config = ConfigFactory.parseString("""
       akka.loglevel = DEBUG # issue #24960
       akka.actor.provider = cluster
       akka.remote.artery.canonical.port = 0

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/BasicClusterExampleSpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.time.{ Millis, Seconds, Span }
 import scala.concurrent.duration._
 
 object BasicClusterExampleSpec {
-  val configSystem1 = ConfigFactory.parseString(s"""
+  val configSystem1 = ConfigFactory.parseString("""
 akka.loglevel = DEBUG
 #config-seeds
 akka {
@@ -50,7 +50,7 @@ akka {
 #config-seeds
      """)
 
-  val configSystem2 = ConfigFactory.parseString(s"""
+  val configSystem2 = ConfigFactory.parseString("""
         akka.remote.artery.canonical.port = 0
      """).withFallback(configSystem1)
 
@@ -140,7 +140,7 @@ class BasicClusterConfigSpec extends AnyWordSpec with ScalaFutures with Eventual
 }
 
 object BasicClusterManualSpec {
-  val clusterConfig = ConfigFactory.parseString(s"""
+  val clusterConfig = ConfigFactory.parseString("""
 akka.loglevel = DEBUG
 akka.cluster.jmx.multi-mbeans-in-same-jvm = on
 #config

--- a/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/DistributedPubSubExample.scala
+++ b/akka-cluster-typed/src/test/scala/docs/akka/cluster/typed/DistributedPubSubExample.scala
@@ -285,7 +285,7 @@ object DistributedPubSubExample {
   import akka.actor.testkit.typed.scaladsl.TestProbe
   import Ontology._
 
-  val config: Config = ConfigFactory.parseString(s"""
+  val config: Config = ConfigFactory.parseString("""
         akka.actor.provider = "cluster"
         akka.cluster.pub-sub.max-delta-elements = 500
         akka.cluster.jmx.enabled = off

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterWatcherNoClusterWatcheeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/ClusterWatcherNoClusterWatcheeSpec.scala
@@ -35,7 +35,7 @@ class ClusterWatcherNoClusterWatcheeConfig(val useUnsafe: Boolean) extends Multi
       akka.actor.allow-java-serialization = on
      """)))
 
-  nodeConfig(remoting)(ConfigFactory.parseString(s"""
+  nodeConfig(remoting)(ConfigFactory.parseString("""
       akka.actor.provider = remote"""))
 
   nodeConfig(clustered)(ConfigFactory.parseString("""

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/InitialMembersOfNewDcSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/InitialMembersOfNewDcSpec.scala
@@ -12,7 +12,7 @@ import akka.remote.testkit._
 import akka.testkit.ImplicitSender
 
 object InitialMembersOfNewDcSpec extends MultiNodeConfig {
-  commonConfig(ConfigFactory.parseString(s"""
+  commonConfig(ConfigFactory.parseString("""
     akka.actor.provider = cluster
     akka.actor.warn-about-java-serializer-usage = off
     akka.cluster {

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/LargeMessageClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/LargeMessageClusterSpec.scala
@@ -29,7 +29,7 @@ object LargeMessageClusterMultiJvmSpec extends MultiNodeConfig {
 
   // Note that this test uses default configuration,
   // not MultiNodeClusterSpec.clusterConfig
-  commonConfig(ConfigFactory.parseString("""
+  commonConfig(ConfigFactory.parseString(s"""
     akka {
       cluster.debug.verbose-heartbeat-logging = on
       loggers = ["akka.testkit.TestEventListener"]

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/LargeMessageClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/LargeMessageClusterSpec.scala
@@ -29,7 +29,7 @@ object LargeMessageClusterMultiJvmSpec extends MultiNodeConfig {
 
   // Note that this test uses default configuration,
   // not MultiNodeClusterSpec.clusterConfig
-  commonConfig(ConfigFactory.parseString(s"""
+  commonConfig(ConfigFactory.parseString("""
     akka {
       cluster.debug.verbose-heartbeat-logging = on
       loggers = ["akka.testkit.TestEventListener"]

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcLastNodeSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiDcLastNodeSpec.scala
@@ -15,7 +15,7 @@ object MultiDcLastNodeSpec extends MultiNodeConfig {
   val second = role("second")
   val third = role("third")
 
-  commonConfig(ConfigFactory.parseString(s"""
+  commonConfig(ConfigFactory.parseString("""
       akka.loglevel = INFO
     """).withFallback(MultiNodeClusterSpec.clusterConfig))
 

--- a/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
+++ b/akka-cluster/src/multi-jvm/scala/akka/cluster/MultiNodeClusterSpec.scala
@@ -38,7 +38,8 @@ object MultiNodeClusterSpec {
   def clusterConfig(failureDetectorPuppet: Boolean): Config =
     if (failureDetectorPuppet) clusterConfigWithFailureDetectorPuppet else clusterConfig
 
-  def clusterConfig: Config = ConfigFactory.parseString(s"""
+  def clusterConfig: Config =
+    ConfigFactory.parseString("""
     akka.actor.provider = cluster
     akka.actor.warn-about-java-serializer-usage = off
     akka.cluster {

--- a/akka-cluster/src/test/scala/akka/cluster/ClusterDeathWatchNotificationSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/ClusterDeathWatchNotificationSpec.scala
@@ -15,7 +15,7 @@ import akka.testkit._
 
 object ClusterDeathWatchNotificationSpec {
 
-  val config = ConfigFactory.parseString(s"""
+  val config = ConfigFactory.parseString("""
     akka {
         loglevel = INFO
         actor {

--- a/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatCheckerRollingUpdateSpec.scala
+++ b/akka-cluster/src/test/scala/akka/cluster/JoinConfigCompatCheckerRollingUpdateSpec.scala
@@ -14,7 +14,7 @@ import akka.testkit.LongRunningTest
 
 object JoinConfigCompatCheckerRollingUpdateSpec {
 
-  val baseConfig = ConfigFactory.parseString(s"""
+  val baseConfig = ConfigFactory.parseString("""
       akka.log-dead-letters = off
       akka.log-dead-letters-during-shutdown = off
       akka.cluster.downing-provider-class = akka.cluster.testkit.AutoDowning

--- a/akka-persistence-shared/src/test/scala/akka/persistence/journal/leveldb/PersistencePluginProxySpec.scala
+++ b/akka-persistence-shared/src/test/scala/akka/persistence/journal/leveldb/PersistencePluginProxySpec.scala
@@ -13,7 +13,7 @@ import akka.testkit.{ AkkaSpec, TestProbe }
 
 object PersistencePluginProxySpec {
   lazy val config =
-    ConfigFactory.parseString(s"""
+    ConfigFactory.parseString("""
       akka {
         actor {
           provider = remote

--- a/akka-persistence-shared/src/test/scala/akka/persistence/journal/leveldb/SharedLeveldbJournalSpec.scala
+++ b/akka-persistence-shared/src/test/scala/akka/persistence/journal/leveldb/SharedLeveldbJournalSpec.scala
@@ -13,7 +13,7 @@ import akka.persistence._
 import akka.testkit.{ AkkaSpec, TestProbe }
 
 object SharedLeveldbJournalSpec {
-  val config = ConfigFactory.parseString(s"""
+  val config = ConfigFactory.parseString("""
       akka {
         actor {
           provider = remote

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/internal/EventWriterFillGapsSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/internal/EventWriterFillGapsSpec.scala
@@ -19,7 +19,7 @@ import akka.persistence.JournalProtocol
 
 object EventWriterFillGapsSpec {
   def config =
-    ConfigFactory.parseString(s"""
+    ConfigFactory.parseString("""
       akka.persistence.journal.inmem.delay-writes=10ms
     """).withFallback(ConfigFactory.load()).resolve()
 }

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/internal/EventWriterSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/internal/EventWriterSpec.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration.DurationInt
 
 object EventWriterSpec {
   def config =
-    ConfigFactory.parseString(s"""
+    ConfigFactory.parseString("""
       akka.persistence.journal.inmem.delay-writes=10ms
     """).withFallback(ConfigFactory.load()).resolve()
 }

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorInterceptorSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorInterceptorSpec.scala
@@ -23,7 +23,7 @@ object EventSourcedBehaviorInterceptorSpec {
 
   val journalId = "event-sourced-behavior-interceptor-spec"
 
-  def config: Config = ConfigFactory.parseString(s"""
+  def config: Config = ConfigFactory.parseString("""
         akka.loglevel = INFO
         akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
         akka.persistence.journal.inmem.test-serialization = on

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRecoveryTimeoutSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorRecoveryTimeoutSpec.scala
@@ -32,7 +32,7 @@ object EventSourcedBehaviorRecoveryTimeoutSpec {
       .withFallback(ConfigFactory.parseString("""
         akka.persistence.journal.stepping-inmem.recovery-event-timeout=1s
         """))
-      .withFallback(ConfigFactory.parseString(s"""
+      .withFallback(ConfigFactory.parseString("""
         akka.loglevel = INFO
         """))
 

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedBehaviorSpec.scala
@@ -749,7 +749,7 @@ class EventSourcedBehaviorSpec
       // new ActorSystem without snapshot plugin config
       val testkit2 = ActorTestKit(
         ActorTestKitBase.testNameFromCallStack(),
-        ConfigFactory.parseString(s"""
+        ConfigFactory.parseString("""
           akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
           """))
       try {
@@ -771,7 +771,7 @@ class EventSourcedBehaviorSpec
       // new ActorSystem without snapshot plugin config
       val testkit2 = ActorTestKit(
         ActorTestKitBase.testNameFromCallStack(),
-        ConfigFactory.parseString(s"""
+        ConfigFactory.parseString("""
           akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
           """))
       try {

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedStashOverflowSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedStashOverflowSpec.scala
@@ -41,7 +41,9 @@ object EventSourcedStashOverflowSpec {
   }
 
   def conf =
-    SteppingInmemJournal.config("EventSourcedStashOverflow").withFallback(ConfigFactory.parseString(s"""
+    SteppingInmemJournal
+      .config("EventSourcedStashOverflow")
+      .withFallback(ConfigFactory.parseString("""
        akka.persistence {
          typed {
            stash-capacity = 1000 # enough to fail on stack size

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/NullEmptyStateSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/NullEmptyStateSpec.scala
@@ -16,7 +16,7 @@ import akka.persistence.typed.RecoveryCompleted
 
 object NullEmptyStateSpec {
 
-  private val conf = ConfigFactory.parseString(s"""
+  private val conf = ConfigFactory.parseString("""
       akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
       akka.persistence.journal.inmem.test-serialization = on
     """)

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/PerformanceSpec.scala
@@ -117,7 +117,7 @@ class PerformanceSpec
     extends ScalaTestWithActorTestKit(
       PersistenceTestKitPlugin.config
         .withFallback(PersistenceTestKitSnapshotPlugin.config)
-        .withFallback(ConfigFactory.parseString(s"""
+        .withFallback(ConfigFactory.parseString("""
       akka.persistence.publish-plugin-commands = on
       akka.actor.testkit.typed.single-expect-default = 10s
       """))

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/PrimitiveStateSpec.scala
@@ -15,7 +15,7 @@ import akka.persistence.typed.RecoveryCompleted
 
 object PrimitiveStateSpec {
 
-  private val conf = ConfigFactory.parseString(s"""
+  private val conf = ConfigFactory.parseString("""
       akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
       akka.persistence.journal.inmem.test-serialization = on
     """)

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorInterceptorSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorInterceptorSpec.scala
@@ -21,7 +21,8 @@ import akka.persistence.typed.PersistenceId
 
 object DurableStateBehaviorInterceptorSpec {
 
-  def conf: Config = PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString(s"""
+  def conf: Config =
+    PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString("""
     akka.loglevel = INFO
     """))
 

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorReplySpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorReplySpec.scala
@@ -21,7 +21,8 @@ import akka.persistence.typed.PersistenceId
 import akka.serialization.jackson.CborSerializable
 
 object DurableStateBehaviorReplySpec {
-  def conf: Config = PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString(s"""
+  def conf: Config =
+    PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString("""
     akka.loglevel = INFO
     """))
 

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorSpec.scala
@@ -20,7 +20,8 @@ import akka.serialization.jackson.CborSerializable
 
 object DurableStateBehaviorSpec {
 
-  def conf: Config = PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString(s"""
+  def conf: Config =
+    PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString("""
     akka.loglevel = INFO
     """))
 

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorTimersSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateBehaviorTimersSpec.scala
@@ -21,7 +21,8 @@ import akka.persistence.typed.PersistenceId
 
 object DurableStateBehaviorTimersSpec {
 
-  def conf: Config = PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString(s"""
+  def conf: Config =
+    PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString("""
     akka.loglevel = INFO
     """))
 

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateRevisionSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateRevisionSpec.scala
@@ -20,7 +20,8 @@ import akka.persistence.typed.state.RecoveryCompleted
 
 object DurableStateRevisionSpec {
 
-  def conf: Config = PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString(s"""
+  def conf: Config =
+    PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString("""
     akka.loglevel = INFO
     """))
 

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/NullEmptyStateSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/NullEmptyStateSpec.scala
@@ -17,7 +17,8 @@ import akka.persistence.typed.PersistenceId
 
 object NullEmptyStateSpec {
 
-  def conf: Config = PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString(s"""
+  def conf: Config =
+    PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString("""
     akka.loglevel = INFO
     """))
 }

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/PrimitiveStateSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/PrimitiveStateSpec.scala
@@ -16,7 +16,8 @@ import akka.persistence.typed.PersistenceId
 
 object PrimitiveStateSpec {
 
-  def conf: Config = PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString(s"""
+  def conf: Config =
+    PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString("""
     akka.loglevel = INFO
     """))
 }

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/ManyRecoveriesSpec.scala
@@ -49,7 +49,8 @@ object ManyRecoveriesSpec {
     (1 to n).map(mapper).toSet
 }
 
-class ManyRecoveriesSpec extends ScalaTestWithActorTestKit(s"""
+class ManyRecoveriesSpec
+    extends ScalaTestWithActorTestKit("""
     akka.actor.default-dispatcher {
       type = Dispatcher
       executor = "thread-pool-executor"
@@ -59,7 +60,9 @@ class ManyRecoveriesSpec extends ScalaTestWithActorTestKit(s"""
     }
     akka.persistence.max-concurrent-recoveries = 3
     akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
-    """) with AnyWordSpecLike with LogCapturing {
+    """)
+    with AnyWordSpecLike
+    with LogCapturing {
 
   import ManyRecoveriesSpec._
 

--- a/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
+++ b/akka-persistence-typed/src/test/scala/akka/persistence/typed/internal/RecoveryPermitterSpec.scala
@@ -69,12 +69,15 @@ object RecoveryPermitterSpec {
     }
 }
 
-class RecoveryPermitterSpec extends ScalaTestWithActorTestKit(s"""
+class RecoveryPermitterSpec
+    extends ScalaTestWithActorTestKit("""
       akka.persistence.max-concurrent-recoveries = 3
       akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
       akka.persistence.journal.inmem.test-serialization = on
       akka.loggers = ["akka.testkit.TestEventListener"]
-      """) with AnyWordSpecLike with LogCapturing {
+      """)
+    with AnyWordSpecLike
+    with LogCapturing {
 
   import RecoveryPermitterSpec._
 

--- a/akka-persistence/src/test/scala/akka/persistence/AtLeastOnceDeliveryFailureSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/AtLeastOnceDeliveryFailureSpec.scala
@@ -15,7 +15,8 @@ import akka.actor._
 import akka.testkit._
 
 object AtLeastOnceDeliveryFailureSpec {
-  val config = ConfigFactory.parseString(s"""
+  val config = ConfigFactory.parseString(
+    """
       akka.persistence.sender.chaos.live-processing-failure-rate = 0.3
       akka.persistence.sender.chaos.replay-processing-failure-rate = 0.1
       akka.persistence.destination.chaos.confirm-failure-rate = 0.3

--- a/akka-persistence/src/test/scala/akka/persistence/ManyRecoveriesSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/ManyRecoveriesSpec.scala
@@ -40,7 +40,8 @@ object ManyRecoveriesSpec {
 
 }
 
-class ManyRecoveriesSpec extends PersistenceSpec(ConfigFactory.parseString(s"""
+class ManyRecoveriesSpec
+    extends PersistenceSpec(ConfigFactory.parseString("""
     akka.actor.default-dispatcher {
       type = Dispatcher
       executor = "thread-pool-executor"
@@ -51,7 +52,8 @@ class ManyRecoveriesSpec extends PersistenceSpec(ConfigFactory.parseString(s"""
     akka.persistence.max-concurrent-recoveries = 3
     akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
     akka.actor.warn-about-java-serializer-usage = off
-  """)) with ImplicitSender {
+  """))
+    with ImplicitSender {
   import ManyRecoveriesSpec._
 
   "Many persistent actors" must {

--- a/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/PersistentActorSpec.scala
@@ -1697,7 +1697,8 @@ class InmemPersistentActorWithRuntimePluginConfigSpec
 
   val providedActorConfig: Config = {
     ConfigFactory
-      .parseString(s"""
+      .parseString(
+        """
          | custom.persistence.snapshot-store.local.dir = target/snapshots-InmemPersistentActorWithRuntimePluginConfigSpec/
      """.stripMargin)
       .withValue(

--- a/akka-persistence/src/test/scala/akka/persistence/RecoveryPermitterSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/RecoveryPermitterSpec.scala
@@ -44,11 +44,13 @@ object RecoveryPermitterSpec {
 
 }
 
-class RecoveryPermitterSpec extends PersistenceSpec(ConfigFactory.parseString(s"""
+class RecoveryPermitterSpec
+    extends PersistenceSpec(ConfigFactory.parseString("""
     akka.persistence.max-concurrent-recoveries = 3
     akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
     akka.actor.warn-about-java-serializer-usage = off
-  """)) with ImplicitSender {
+  """))
+    with ImplicitSender {
   import RecoveryPermitter._
   import RecoveryPermitterSpec._
 

--- a/akka-persistence/src/test/scala/akka/persistence/TimerPersistentActorSpec.scala
+++ b/akka-persistence/src/test/scala/akka/persistence/TimerPersistentActorSpec.scala
@@ -79,10 +79,12 @@ object TimerPersistentActorSpec {
 
 }
 
-class TimerPersistentActorSpec extends PersistenceSpec(ConfigFactory.parseString(s"""
+class TimerPersistentActorSpec
+    extends PersistenceSpec(ConfigFactory.parseString("""
     akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
     akka.actor.warn-about-java-serializer-usage = off
-  """)) with ImplicitSender {
+  """))
+    with ImplicitSender {
   import TimerPersistentActorSpec._
 
   system.eventStream.publish(Mute(EventFilter[ActorInitializationException]()))

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteNodeRestartDeathWatchSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemoteNodeRestartDeathWatchSpec.scala
@@ -26,7 +26,9 @@ object RemoteNodeRestartDeathWatchConfig extends MultiNodeConfig {
   val first = role("first")
   val second = role("second")
 
-  commonConfig(debugConfig(on = false).withFallback(ConfigFactory.parseString(s"""
+  commonConfig(
+    debugConfig(on = false)
+      .withFallback(ConfigFactory.parseString("""
       akka.loglevel = INFO
       akka.remote.use-unsafe-remote-features-outside-cluster = on
     """)))

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemotingMultiNodeSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/RemotingMultiNodeSpec.scala
@@ -14,7 +14,7 @@ import akka.testkit.{ DefaultTimeout, ImplicitSender }
 object RemotingMultiNodeSpec {
 
   def commonConfig =
-    ConfigFactory.parseString(s"""
+    ConfigFactory.parseString("""
         akka.actor.warn-about-java-serializer-usage = off
       """).withFallback(ArterySpecSupport.tlsConfig) // TLS only used if transport=tls-tcp
 

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanInThrougputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanInThrougputSpec.scala
@@ -29,7 +29,10 @@ object FanInThroughputSpec extends MultiNodeConfig {
 
   val barrierTimeout = 5.minutes
 
-  commonConfig(debugConfig(on = false).withFallback(ConfigFactory.parseString(s"""
+  commonConfig(
+    debugConfig(on = false)
+      .withFallback(
+        ConfigFactory.parseString("""
        # for serious measurements you should increase the totalMessagesFactor (20)
        akka.test.FanInThroughputSpec.totalMessagesFactor = 10.0
        akka.test.FanInThroughputSpec.real-message = off
@@ -37,7 +40,9 @@ object FanInThroughputSpec extends MultiNodeConfig {
        akka.remote.artery.advanced {
          # inbound-lanes = 4
        }
-       """)).withFallback(MaxThroughputSpec.cfg).withFallback(RemotingMultiNodeSpec.commonConfig))
+       """))
+      .withFallback(MaxThroughputSpec.cfg)
+      .withFallback(RemotingMultiNodeSpec.commonConfig))
 
 }
 

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanOutThrougputSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/FanOutThrougputSpec.scala
@@ -30,12 +30,17 @@ object FanOutThroughputSpec extends MultiNodeConfig {
 
   val barrierTimeout = 5.minutes
 
-  commonConfig(debugConfig(on = false).withFallback(ConfigFactory.parseString(s"""
+  commonConfig(
+    debugConfig(on = false)
+      .withFallback(
+        ConfigFactory.parseString("""
        # for serious measurements you should increase the totalMessagesFactor (20)
        akka.test.FanOutThroughputSpec.totalMessagesFactor = 10.0
        akka.test.FanOutThroughputSpec.real-message = off
        akka.test.FanOutThroughputSpec.actor-selection = off
-       """)).withFallback(MaxThroughputSpec.cfg).withFallback(RemotingMultiNodeSpec.commonConfig))
+       """))
+      .withFallback(MaxThroughputSpec.cfg)
+      .withFallback(RemotingMultiNodeSpec.commonConfig))
 
 }
 

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/HandshakeRestartReceiverSpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/HandshakeRestartReceiverSpec.scala
@@ -23,7 +23,9 @@ object HandshakeRestartReceiverSpec extends MultiNodeConfig {
   val first = role("first")
   val second = role("second")
 
-  commonConfig(debugConfig(on = false).withFallback(ConfigFactory.parseString(s"""
+  commonConfig(
+    debugConfig(on = false)
+      .withFallback(ConfigFactory.parseString("""
        akka {
          loglevel = INFO
          actor.provider = remote

--- a/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamConcistencySpec.scala
+++ b/akka-remote-tests/src/multi-jvm/scala/akka/remote/artery/aeron/AeronStreamConcistencySpec.scala
@@ -35,7 +35,7 @@ object AeronStreamConsistencySpec extends MultiNodeConfig {
 
   val barrierTimeout = 5.minutes
 
-  commonConfig(debugConfig(on = false).withFallback(ConfigFactory.parseString(s"""
+  commonConfig(debugConfig(on = false).withFallback(ConfigFactory.parseString("""
        akka {
          loglevel = INFO
          actor {

--- a/akka-remote/src/test/scala/akka/remote/RemoteRouterSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/RemoteRouterSpec.scala
@@ -23,7 +23,7 @@ object RemoteRouterSpec {
   }
 }
 
-class RemoteRouterSpec extends AkkaSpec(s"""
+class RemoteRouterSpec extends AkkaSpec("""
     akka.actor.provider = remote
     akka.remote.use-unsafe-remote-features-outside-cluster = on
     akka.remote.artery.canonical {

--- a/akka-remote/src/test/scala/akka/remote/artery/ArterySpecSupport.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/ArterySpecSupport.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 
 object ArterySpecSupport {
   // same for all artery enabled remoting tests
-  private val staticArteryRemotingConfig = ConfigFactory.parseString(s"""
+  private val staticArteryRemotingConfig = ConfigFactory.parseString("""
     akka {
       actor {
         provider = remote

--- a/akka-remote/src/test/scala/akka/remote/artery/BindCanonicalAddressSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/BindCanonicalAddressSpec.scala
@@ -46,7 +46,7 @@ trait BindCanonicalAddressBehaviors {
     val commonConfig = BindCanonicalAddressSpec.commonConfig(transport)
 
     "bind to a random port" in {
-      val config = ConfigFactory.parseString(s"""
+      val config = ConfigFactory.parseString("""
         akka.remote.artery.canonical.port = 0
       """)
 
@@ -82,7 +82,7 @@ trait BindCanonicalAddressBehaviors {
     }
 
     "bind to a specified bind hostname and remoting aspects from canonical hostname" in {
-      val config = ConfigFactory.parseString(s"""
+      val config = ConfigFactory.parseString("""
         akka.remote.artery.canonical.port = 0
         akka.remote.artery.canonical.hostname = "127.0.0.1"
         akka.remote.artery.bind.hostname = "localhost"
@@ -109,7 +109,7 @@ trait BindCanonicalAddressBehaviors {
     }
 
     "bind to all interfaces" in {
-      val config = ConfigFactory.parseString(s"""
+      val config = ConfigFactory.parseString("""
         akka.remote.artery.bind.hostname = "0.0.0.0"
       """)
 

--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeDenySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeDenySpec.scala
@@ -14,7 +14,7 @@ import akka.testkit._
 
 object HandshakeDenySpec {
 
-  val commonConfig = ConfigFactory.parseString(s"""
+  val commonConfig = ConfigFactory.parseString("""
      akka.loglevel = WARNING
      akka.remote.artery.advanced.handshake-timeout = 2s
      akka.remote.artery.advanced.aeron.image-liveness-timeout = 1.9s

--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeFailureSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeFailureSpec.scala
@@ -15,7 +15,7 @@ import akka.testkit.TestProbe
 
 object HandshakeFailureSpec {
 
-  val commonConfig = ConfigFactory.parseString(s"""
+  val commonConfig = ConfigFactory.parseString("""
      akka.remote.artery.advanced.handshake-timeout = 2s
      akka.remote.artery.advanced.aeron.image-liveness-timeout = 1.9s
   """).withFallback(ArterySpecSupport.defaultConfig)

--- a/akka-remote/src/test/scala/akka/remote/artery/HandshakeRetrySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/HandshakeRetrySpec.scala
@@ -13,7 +13,7 @@ import akka.testkit.ImplicitSender
 import akka.testkit.TestActors
 
 object HandshakeRetrySpec {
-  val commonConfig = ConfigFactory.parseString(s"""
+  val commonConfig = ConfigFactory.parseString("""
      akka.remote.artery.advanced.handshake-timeout = 10s
      akka.remote.artery.advanced.aeron.image-liveness-timeout = 7s
   """).withFallback(ArterySpecSupport.defaultConfig)

--- a/akka-remote/src/test/scala/akka/remote/artery/LateConnectSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/LateConnectSpec.scala
@@ -16,7 +16,7 @@ import akka.testkit.TestProbe
 
 object LateConnectSpec {
 
-  val config = ConfigFactory.parseString(s"""
+  val config = ConfigFactory.parseString("""
      akka.remote.artery.advanced.handshake-timeout = 3s
      akka.remote.artery.advanced.aeron.image-liveness-timeout = 2.9s
   """).withFallback(ArterySpecSupport.defaultConfig)

--- a/akka-remote/src/test/scala/akka/remote/artery/OutboundIdleShutdownSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/OutboundIdleShutdownSpec.scala
@@ -22,7 +22,8 @@ import akka.testkit.ImplicitSender
 import akka.testkit.TestActors
 import akka.testkit.TestProbe
 
-class OutboundIdleShutdownSpec extends ArteryMultiNodeSpec(s"""
+class OutboundIdleShutdownSpec
+    extends ArteryMultiNodeSpec("""
   akka.loglevel=INFO
   akka.remote.artery.advanced.stop-idle-outbound-after = 1 s
   akka.remote.artery.advanced.connection-timeout = 2 s
@@ -30,7 +31,9 @@ class OutboundIdleShutdownSpec extends ArteryMultiNodeSpec(s"""
   akka.remote.artery.advanced.compression {
     actor-refs.advertisement-interval = 5 seconds
   }
-  """) with ImplicitSender with Eventually {
+  """)
+    with ImplicitSender
+    with Eventually {
 
   override implicit val patience: PatienceConfig = {
     import akka.testkit.TestDuration

--- a/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/SystemMessageDeliverySpec.scala
@@ -37,7 +37,7 @@ object SystemMessageDeliverySpec {
 
   case class TestSysMsg(s: String) extends SystemMessageDelivery.AckedDeliveryMessage
 
-  val safe = ConfigFactory.parseString(s"""
+  val safe = ConfigFactory.parseString("""
        akka.loglevel = INFO
        akka.remote.artery.advanced.stop-idle-outbound-after = 1000 ms
        akka.remote.artery.advanced.inject-handshake-interval = 500 ms

--- a/akka-remote/src/test/scala/akka/remote/artery/compress/CompressionIntegrationSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/compress/CompressionIntegrationSpec.scala
@@ -19,7 +19,7 @@ import akka.testkit._
 
 object CompressionIntegrationSpec {
 
-  val commonConfig = ConfigFactory.parseString(s"""
+  val commonConfig = ConfigFactory.parseString("""
      akka {
        loglevel = INFO
 

--- a/akka-remote/src/test/scala/akka/remote/artery/compress/HandshakeShouldDropCompressionTableSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/compress/HandshakeShouldDropCompressionTableSpec.scala
@@ -19,7 +19,7 @@ import akka.testkit._
 import akka.util.Timeout
 
 object HandshakeShouldDropCompressionTableSpec {
-  val commonConfig = ConfigFactory.parseString(s"""
+  val commonConfig = ConfigFactory.parseString("""
      akka {
        remote.artery.advanced.handshake-timeout = 10s
        remote.artery.advanced.aeron.image-liveness-timeout = 7s

--- a/akka-remote/src/test/scala/akka/remote/artery/tcp/TlsTcpSpec.scala
+++ b/akka-remote/src/test/scala/akka/remote/artery/tcp/TlsTcpSpec.scala
@@ -65,7 +65,7 @@ object TlsTcpSpec {
   def resourcePath(name: String): String = getClass.getClassLoader.getResource(name).getPath
 
   lazy val config: Config = {
-    ConfigFactory.parseString(s"""
+    ConfigFactory.parseString("""
       akka.remote.artery {
         transport = tls-tcp
         large-message-destinations = [ "/user/large" ]

--- a/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/akka/serialization/jackson/JacksonSerializerSpec.scala
@@ -861,7 +861,8 @@ abstract class JacksonSerializerSpec(serializerName: String)
     }
 
     // TODO: Consider moving the migrations Specs to a separate Spec
-    "deserialize with migrations" in withSystem(s"""
+    "deserialize with migrations" in withSystem(
+      """
         akka.serialization.jackson.migrations {
           ## Usually the key is a FQCN but we're hacking the name to use multiple migrations for the
           ## same type in a single test.
@@ -1087,7 +1088,8 @@ abstract class JacksonSerializerSpec(serializerName: String)
     }
 
     // TODO: Consider moving the migrations Specs to a separate Spec
-    "deserialize with migrations" in withSystem(s"""
+    "deserialize with migrations" in withSystem(
+      """
         akka.serialization.jackson.migrations {
           ## Usually the key is a FQCN but we're hacking the name to use multiple migrations for the
           ## same type in a single test.

--- a/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala
+++ b/akka-serialization-jackson/src/test/scala/doc/akka/serialization/jackson/SerializationDocSpec.scala
@@ -193,7 +193,8 @@ class SerializationDocSpec
     extends TestKit(
       ActorSystem(
         "SerializationDocSpec",
-        ConfigFactory.parseString(s"""
+        ConfigFactory.parseString(
+          """
     akka.serialization.jackson.migrations {
         # migrations for Java classes
         "jdoc.akka.serialization.jackson.v2b.ItemAdded" = "jdoc.akka.serialization.jackson.v2b.ItemAddedMigration"

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamRefsSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/StreamRefsSpec.scala
@@ -168,7 +168,7 @@ object StreamRefsSpec {
   final case class BulkSinkMsg(dataSink: SinkRef[ByteString])
 
   def config(): Config = {
-    ConfigFactory.parseString(s"""
+    ConfigFactory.parseString("""
     akka {
       loglevel = DEBUG
 


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->

Accidentally found some chores to do.

The regular expression `[^s]"""(.*\$+.*)"""` is showing that without any incorrect modifications.

Unexpectedly, there have been some line break modifications, and it is uncertain whether these changes were made by scalafmt or IDEA.