### PR TITLE
fix: Avoid StackOverflowError when stash contains many read-only commands, #29933

### DIFF
--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedStashOverflowSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/scaladsl/EventSourcedStashOverflowSpec.scala
@@ -44,7 +44,7 @@ object EventSourcedStashOverflowSpec {
     SteppingInmemJournal.config("EventSourcedStashOverflow").withFallback(ConfigFactory.parseString(s"""
        akka.persistence {
          typed {
-           stash-capacity = 1000 # enough to fail on stack size
+           stash-capacity = 5000 # enough to fail on stack size
            stash-overflow-strategy = "drop"
          }
        }

--- a/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateStashOverflowSpec.scala
+++ b/akka-persistence-typed-tests/src/test/scala/akka/persistence/typed/state/scaladsl/DurableStateStashOverflowSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2020-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.typed.state.scaladsl
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import akka.Done
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorRef
+import akka.actor.typed.Behavior
+import akka.persistence.testkit.PersistenceTestKitDurableStateStorePlugin
+import akka.persistence.typed.PersistenceId
+
+// Reproducer for #29401
+object DurableStateStashOverflowSpec {
+
+  object Stasher {
+    sealed trait Command
+    final case class First(replyTo: ActorRef[Done]) extends Command
+    final case class Hey(replyTo: ActorRef[Done]) extends Command
+    case object UnstashThem extends Command
+    final case class State(stashing: Boolean)
+
+    def apply(persistenceId: PersistenceId): Behavior[Command] =
+      DurableStateBehavior[Command, State](
+        persistenceId,
+        emptyState = State(stashing = true),
+        commandHandler = { (state, command) =>
+          command match {
+            case First(replyTo) =>
+              Effect.reply(replyTo)(Done)
+            case Hey(replyTo) =>
+              if (state.stashing)
+                Effect.stash()
+              else
+                Effect.reply(replyTo)(Done)
+            case UnstashThem =>
+              Effect.persist(state.copy(stashing = false)).thenUnstashAll()
+          }
+        })
+  }
+
+  def conf: Config = PersistenceTestKitDurableStateStorePlugin.config.withFallback(ConfigFactory.parseString(s"""
+    akka.persistence {
+           typed {
+             stash-capacity = 5000 # enough to fail on stack size
+             stash-overflow-strategy = "drop"
+           }
+         }
+    """))
+}
+
+class DurableStateStashOverflowSpec
+    extends ScalaTestWithActorTestKit(DurableStateStashOverflowSpec.conf)
+    with AnyWordSpecLike
+    with LogCapturing {
+
+  import DurableStateStashOverflowSpec.Stasher
+
+  "Stashing in a busy durable state behavior" must {
+
+    "not cause stack overflow" in {
+      val ref = spawn(Stasher(PersistenceId.ofUniqueId("id-1")))
+
+      val probe = testKit.createTestProbe[Done]()
+
+      ref.tell(Stasher.First(probe.ref))
+      probe.expectMessage(Done)
+      // now we know that recovery is completed, so that we don't use internal stash during recovery in this test
+
+      val droppedMessageProbe = testKit.createDroppedMessageProbe()
+      val stashCapacity = testKit.config.getInt("akka.persistence.typed.stash-capacity")
+
+      for (_ <- 0 until (stashCapacity)) {
+        ref.tell(Stasher.Hey(probe.ref))
+      }
+
+      droppedMessageProbe.expectNoMessage()
+      ref.tell(Stasher.Hey(probe.ref))
+      droppedMessageProbe.receiveMessage()
+
+      ref.tell(Stasher.UnstashThem)
+      probe.receiveMessages(stashCapacity)
+    }
+
+  }
+
+}

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/EventSourcedBehaviorImpl.scala
@@ -313,6 +313,7 @@ private[akka] final case class EventSourcedBehaviorImpl[Command, Event, State](
   final case class SnapshotterResponse(msg: akka.persistence.SnapshotProtocol.Response) extends InternalProtocol
   final case class RecoveryTickEvent(snapshot: Boolean) extends InternalProtocol
   final case class IncomingCommand[C](c: C) extends InternalProtocol
+  case object ContinueUnstash extends InternalProtocol
 
   final case class ReplicatedEventEnvelope[E](event: ReplicatedEvent[E], ack: ActorRef[ReplicatedEventAck.type])
       extends InternalProtocol

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingEvents.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingEvents.scala
@@ -111,6 +111,7 @@ private[akka] final class ReplayingEvents[C, E, S](
       case get: GetState[S @unchecked]                => stashInternal(get)
       case get: GetSeenSequenceNr                     => stashInternal(get)
       case RecoveryPermitGranted                      => Behaviors.unhandled // should not happen, we already have the permit
+      case ContinueUnstash                            => Behaviors.unhandled
     }
   }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/ReplayingSnapshot.scala
@@ -73,6 +73,7 @@ private[akka] class ReplayingSnapshot[C, E, S](override val setup: BehaviorSetup
           case get: GetState[S @unchecked] => stashInternal(get)
           case get: GetSeenSequenceNr      => stashInternal(get)
           case RecoveryPermitGranted       => Behaviors.unhandled // should not happen, we already have the permit
+          case ContinueUnstash             => Behaviors.unhandled
         }
         .receiveSignal(returnPermitOnStop.orElse {
           case (_, PoisonPill) =>

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/StashManagement.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/internal/StashManagement.scala
@@ -80,6 +80,13 @@ private[akka] trait StashManagement[C, E, S] {
   }
 
   /**
+   * @return false if `tryUnstashOne` will unstash a message
+   */
+  protected def isStashEmpty: Boolean =
+    if (stashState.isUnstashAllInProgress) stashState.userStashBuffer.isEmpty
+    else stashState.internalStashBuffer.isEmpty
+
+  /**
    * Subsequent `tryUnstashOne` will drain the user stash buffer before using the
    * internal stash buffer. It will unstash as many commands as are in the buffer when
    * `unstashAll` was called, i.e. if subsequent commands stash more, those will

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateBehaviorImpl.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/DurableStateBehaviorImpl.scala
@@ -183,5 +183,6 @@ private[akka] final case class DurableStateBehaviorImpl[Command, State](
   final case class DeleteFailure(cause: Throwable) extends InternalProtocol
   case object RecoveryTimeout extends InternalProtocol
   final case class IncomingCommand[C](c: C) extends InternalProtocol
+  case object ContinueUnstash extends InternalProtocol
 
 }

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Recovering.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Recovering.scala
@@ -90,7 +90,7 @@ private[akka] class Recovering[C, S](
       case _: UpsertFailure            => Behaviors.unhandled
       case DeleteSuccess               => Behaviors.unhandled
       case _: DeleteFailure            => Behaviors.unhandled
-      case ContinueUnstash => Behaviors.unhandled
+      case ContinueUnstash             => Behaviors.unhandled
     }
   }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Recovering.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/Recovering.scala
@@ -90,6 +90,7 @@ private[akka] class Recovering[C, S](
       case _: UpsertFailure            => Behaviors.unhandled
       case DeleteSuccess               => Behaviors.unhandled
       case _: DeleteFailure            => Behaviors.unhandled
+      case ContinueUnstash => Behaviors.unhandled
     }
   }
 

--- a/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/StashManagement.scala
+++ b/akka-persistence-typed/src/main/scala/akka/persistence/typed/state/internal/StashManagement.scala
@@ -80,6 +80,13 @@ private[akka] trait StashManagement[C, S] {
   }
 
   /**
+   * @return false if `tryUnstashOne` will unstash a message
+   */
+  protected def isStashEmpty: Boolean =
+    if (stashState.isUnstashAllInProgress) stashState.userStashBuffer.isEmpty
+    else stashState.internalStashBuffer.isEmpty
+
+  /**
    * Subsequent `tryUnstashOne` will drain the user stash buffer before using the
    * internal stash buffer. It will unstash as many commands as are in the buffer when
    * `unstashAll` was called, i.e. if subsequent commands stash more, those will


### PR DESCRIPTION
References #29933

I'll do the same for Durable State but let's review the approach first.
