### PR TITLE
bump: Shaded protobuf-java 3.21.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -323,7 +323,7 @@ lazy val protobufV3 = akkaModule("akka-protobuf-v3")
     // Prevent cyclic task dependencies, see https://github.com/sbt/sbt-assembly/issues/365
     assembly / fullClasspath := (Runtime / managedClasspath).value, // otherwise, there's a cyclic dependency between packageBin and assembly
     assembly / test := {}, // assembly runs tests for unknown reason which introduces another cyclic dependency to packageBin via exportedJars
-    description := "Akka Protobuf V3 is a shaded version of the protobuf runtime. Original POM: https://github.com/protocolbuffers/protobuf/blob/v3.9.0/java/pom.xml")
+    description := s"Akka Protobuf V3 is a shaded version of ${Dependencies.Compile.Provided.protobufRuntime.name} ${Dependencies.Compile.Provided.protobufRuntime.revision}.")
 
 lazy val pki =
   akkaModule("akka-pki")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
   // https://github.com/real-logic/aeron/blob/1.x.y/build.gradle
   val agronaVersion = "1.19.2"
   val nettyVersion = "4.1.99.Final"
-  val protobufJavaVersion = "3.16.1"
+  val protobufJavaVersion = "3.21.12" // also sync with protocVersion in Protobuf.scala
   val logbackVersion = "1.2.12"
   val scalaFortifyVersion = "1.0.22"
   val fortifySCAVersion = "22.1"

--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -33,7 +33,7 @@ object Protobuf {
     // this keeps intellij happy for files that use the shaded protobuf
     Compile / unmanagedJars += (LocalProject("akka-protobuf-v3") / assembly).value,
     protoc := "protoc",
-    protocVersion := "3.11.4",
+    protocVersion := "3.21.12", // also sync with protobufJavaVersion in Dependencies.scala
     generate := {
       val sourceDirs = paths.value
       val targetDirs = outputPaths.value


### PR DESCRIPTION
* CVE-2022-3171 CVE-2022-3509 CVE-2022-3510

For the shaded (internal use)  protobuf I think we can use latest version.