### PR TITLE
fix: Bypass circuit breaker from EventWriter

### DIFF
--- a/akka-persistence/src/main/mima-filters/2.8.5.backwards.excludes/bypassCircuitBreaker.excludes
+++ b/akka-persistence/src/main/mima-filters/2.8.5.backwards.excludes/bypassCircuitBreaker.excludes
@@ -1,0 +1,5 @@
+# WriteMessages is internal
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.JournalProtocol#WriteMessages.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.persistence.JournalProtocol#WriteMessages.this")
+ProblemFilters.exclude[MissingTypesProblem]("akka.persistence.JournalProtocol$WriteMessages$")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.persistence.JournalProtocol#WriteMessages.unapply")

--- a/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/JournalProtocol.scala
@@ -31,6 +31,14 @@ private[persistence] object JournalProtocol {
   final case class DeleteMessagesTo(persistenceId: String, toSequenceNr: Long, persistentActor: ActorRef)
       extends Request
 
+  object WriteMessages {
+    def apply(
+        messages: immutable.Seq[PersistentEnvelope],
+        persistentActor: ActorRef,
+        actorInstanceId: Int): WriteMessages =
+      WriteMessages(messages, persistentActor, actorInstanceId, bypassCircuitBreaker = false)
+  }
+
   /**
    * Request to write messages.
    *
@@ -40,7 +48,8 @@ private[persistence] object JournalProtocol {
   final case class WriteMessages(
       messages: immutable.Seq[PersistentEnvelope],
       persistentActor: ActorRef,
-      actorInstanceId: Int)
+      actorInstanceId: Int,
+      bypassCircuitBreaker: Boolean)
       extends Request
       with NoSerializationVerificationNeeded
 

--- a/akka-persistence/src/main/scala/akka/persistence/journal/PersistencePluginProxy.scala
+++ b/akka-persistence/src/main/scala/akka/persistence/journal/PersistencePluginProxy.scala
@@ -189,7 +189,7 @@ final class PersistencePluginProxy(config: Config) extends Actor with Stash with
 
     case req: JournalProtocol.Request =>
       req match { // exhaustive match
-        case WriteMessages(messages, persistentActor, actorInstanceId) =>
+        case WriteMessages(messages, persistentActor, actorInstanceId, _) =>
           val atomicWriteCount = messages.count(_.isInstanceOf[AtomicWrite])
           persistentActor ! WriteMessagesFailed(timeoutException(), atomicWriteCount)
           messages.foreach {


### PR DESCRIPTION
* otherwise the duplicate key violates, which are expected, will trip the circuit breaker
* if other error then subsequent request will not bypass the circuit breaker, until there is a success again

Refs https://github.com/akka/akka-projection/issues/1025