### PR TITLE
build: disable CiReleasePlugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,10 @@ enablePlugins(
   CopyrightHeaderInPr,
   JavaFormatterPlugin,
   JdkOptions)
-disablePlugins(MimaPlugin)
+disablePlugins(
+  MimaPlugin,
+  com.geirsson.CiReleasePlugin // we use publishSigned, but use a pgp utility from CiReleasePlugin
+)
 
 addCommandAlias("verifyCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; headerCheckAll")
 addCommandAlias("applyCodeStyle", "headerCreateAll; scalafmtAll; scalafmtSbt")
@@ -540,6 +543,7 @@ def akkaModule(name: String): Project =
     .settings(akka.AkkaBuild.defaultSettings)
     .settings(fortifySettings(name))
     .enablePlugins(BootstrapGenjavadoc)
+    .disablePlugins(com.geirsson.CiReleasePlugin) // we use publishSigned, but use a pgp utility from CiReleasePlugin
 
 /* Command aliases one can run locally against a module
   - where three or more tasks should be checked for faster turnaround

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -21,6 +21,9 @@ object Publish extends AutoPlugin {
 
   lazy val setupGpg = taskKey[Unit]("setup gpg before publishSigned")
 
+  lazy val setupGpgOnce =
+    CiReleasePlugin.setupGpg()
+
   override lazy val projectSettings = Seq(
       publishRsyncHost := "akkarepo@gustav.akka.io",
       organizationName := "Lightbend Inc.",
@@ -54,9 +57,7 @@ object Publish extends AutoPlugin {
     }
 
     Def.settings(
-      setupGpg := {
-        CiReleasePlugin.setupGpg()
-      },
+      setupGpg := setupGpgOnce,
       publishSigned := publishSigned.dependsOn(setupGpg).value,
       publishTo := (if (isSnapshot.value)
                       Some(


### PR DESCRIPTION
* otherwise it will override publishTo
* we still want the plugin dependency because we use a pgp utility
* also init gpg only once
