### PR TITLE
fix: misleading shard handoff timeout message (#32172)

### DIFF
--- a/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
+++ b/akka-cluster-sharding/src/main/scala/akka/cluster/sharding/Shard.scala
@@ -870,7 +870,6 @@ private[akka] class Shard(
         replyTo ! ShardStopped(shardId)
         context.stop(self)
       } else if (activeEntities.nonEmpty && !preparingForShutdown) {
-        val entityHandOffTimeout = (settings.tuningParameters.handOffTimeout - 5.seconds).max(1.seconds)
         log.debug(
           "{}: Starting HandOffStopper for shard [{}] to terminate [{}] entities.",
           typeName,
@@ -878,9 +877,16 @@ private[akka] class Shard(
           activeEntities.size)
         activeEntities.foreach(context.unwatch)
         handOffStopper = Some(
-          context.watch(context.actorOf(
-            HandOffStopper.props(typeName, shardId, replyTo, activeEntities, handOffStopMessage, entityHandOffTimeout),
-            "HandOffStopper")))
+          context.watch(
+            context.actorOf(
+              HandOffStopper.props(
+                typeName,
+                shardId,
+                replyTo,
+                activeEntities,
+                handOffStopMessage,
+                settings.tuningParameters.handOffTimeout),
+              "HandOffStopper")))
 
         //During hand off we only care about watching for termination of the hand off stopper
         context.become {


### PR DESCRIPTION
Refs #32172

changed misleading message and moved all the logic for calculating timeouts to HandOffStopper.

timers.cancel(StopTimeoutWarning) is there to avoid unnecessary warning  for small timeouts