### PR TITLE
Make sure ActorContext.ask compile with multiple parameters (#26514)

### DIFF
--- a/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
+++ b/akka-cluster-sharding-typed/src/test/scala/akka/cluster/sharding/typed/scaladsl/ClusterShardingSpec.scala
@@ -304,18 +304,14 @@ class ClusterShardingSpec
 
       peterRef ! StopPlz()
 
-      // FIXME #26514: doesn't compile with Scala 2.13.0-M5
-      /*
       // make sure request with multiple parameters compile
       Behaviors.setup[TheReply] { ctx =>
-        ctx.ask(aliceRef)(WhoAreYou2(17, _)) {
+        ctx.ask[WhoAreYou2, String](peterRef, WhoAreYou2(17, _)) {
           case Success(name) => TheReply(name)
           case Failure(ex)   => TheReply(ex.getMessage)
         }
-
         Behaviors.empty
       }
-     */
     }
 
     "EntityRef - AskTimeoutException" in {


### PR DESCRIPTION
References #26514 

Issue was closed four years ago, but this code is still here.

I think it can be removed. It was done before [changing params in ActorContext.ask](https://github.com/akka/akka/pull/27523) .

I can do something like that
<img width="943" alt="Screenshot 2023-10-13 at 01 14 16" src="https://github.com/akka/akka/assets/4740207/6c687a86-351a-4bbf-a708-42f4988cc85d">

Should I do it? I'm not sure.

Kind regards
