### PR TITLE
Remove unnecessary todo in PatternSpec

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
@@ -52,7 +52,7 @@ class PatternSpec extends AkkaSpec {
 
   "pattern.after" must {
     "be completed successfully eventually" in {
-      // TODO after is unfortunately shadowed by ScalaTest, fix as part of #3759
+      // after is unfortunately shadowed by ScalaTest, fix as part of #3759
       val f = akka.pattern.after(1 second, using = system.scheduler)(Future.successful(5))
 
       val r = Future.firstCompletedOf(Seq(Promise[Int]().future, f))
@@ -60,7 +60,7 @@ class PatternSpec extends AkkaSpec {
     }
 
     "be completed abnormally eventually" in {
-      // TODO after is unfortunately shadowed by ScalaTest, fix as part of #3759
+      // after is unfortunately shadowed by ScalaTest, fix as part of #3759
       val f = akka.pattern.after(1 second, using = system.scheduler)(Future.failed(new IllegalStateException("Mexico")))
 
       val r = Future.firstCompletedOf(Seq(Promise[Int]().future, f))

--- a/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/pattern/PatternSpec.scala
@@ -52,7 +52,7 @@ class PatternSpec extends AkkaSpec {
 
   "pattern.after" must {
     "be completed successfully eventually" in {
-      // after is unfortunately shadowed by ScalaTest, fix as part of #3759
+      // after is unfortunately shadowed by ScalaTest
       val f = akka.pattern.after(1 second, using = system.scheduler)(Future.successful(5))
 
       val r = Future.firstCompletedOf(Seq(Promise[Int]().future, f))
@@ -60,7 +60,7 @@ class PatternSpec extends AkkaSpec {
     }
 
     "be completed abnormally eventually" in {
-      // after is unfortunately shadowed by ScalaTest, fix as part of #3759
+      // after is unfortunately shadowed by ScalaTest
       val f = akka.pattern.after(1 second, using = system.scheduler)(Future.failed(new IllegalStateException("Mexico")))
 
       val r = Future.firstCompletedOf(Seq(Promise[Int]().future, f))


### PR DESCRIPTION
A little suggestion :) .

I was checking todo items in the project and found these two.

I think it's better to leave only a comment. Todo items should indicate the problems, but in this case, it's just a note.

Or we can rename import `import akka.pattern.{after => patternAfter)`.
